### PR TITLE
bun test: fail on a .snap entry it cannot read instead of adding a duplicate

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1229,10 +1229,9 @@ impl Expect {
                     crate::Error::FailedToWriteSnapshotFile => {
                         global_this.throw(format_args!("Failed write to snapshot file: {test_file_path}"))
                     }
-                    crate::Error::ParseError => match &runner.snapshots.parse_error_message {
-                        Some(message) => global_this.throw(format_args!("{message}")),
-                        None => global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}")),
-                    },
+                    crate::Error::SyntaxError | crate::Error::ParseError => {
+                        global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}"))
+                    }
                     crate::Error::SnapshotCreationNotAllowedInCI => {
                         let snapshot_name = runner.snapshots.last_error_snapshot_name.take();
                         if let Some(name) = snapshot_name {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1229,9 +1229,10 @@ impl Expect {
                     crate::Error::FailedToWriteSnapshotFile => {
                         global_this.throw(format_args!("Failed write to snapshot file: {test_file_path}"))
                     }
-                    crate::Error::SyntaxError | crate::Error::ParseError => {
-                        global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}"))
-                    }
+                    crate::Error::ParseError => match &runner.snapshots.parse_error_message {
+                        Some(message) => global_this.throw(format_args!("{message}")),
+                        None => global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}")),
+                    },
                     crate::Error::SnapshotCreationNotAllowedInCI => {
                         let snapshot_name = runner.snapshots.last_error_snapshot_name.take();
                         if let Some(name) = snapshot_name {

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -41,8 +41,6 @@ pub struct Snapshots {
     snapshot_dir_path: Option<&'static [u8]>,
     inline_snapshots_to_write: IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
     pub(crate) last_error_snapshot_name: Option<Box<[u8]>>,
-    /// Set by `parse_file` with `Error::ParseError`, thrown by `Expect::snapshot`.
-    pub(crate) parse_error_message: Option<String>,
 }
 
 // Re-export the TSV-mandated container name so the field type matches verbatim.
@@ -70,7 +68,6 @@ impl Snapshots {
             snapshot_dir_path: None,
             inline_snapshots_to_write: IndexMap::new(),
             last_error_snapshot_name: None,
-            parse_error_message: None,
         }
     }
 }
@@ -226,7 +223,6 @@ impl Snapshots {
     }
 
     pub(crate) fn parse_file(&mut self, file: &File) -> Result<(), Error> {
-        self.parse_error_message = None;
         if self.file_buf.is_empty() {
             return Ok(());
         }
@@ -267,31 +263,22 @@ impl Snapshots {
             self.file_buf.as_slice(),
         );
 
-        let mut log = bun_ast::Log::init();
-        let result = Self::load_entries(&mut self.values, &source, &mut log);
-        if result.is_ok() && log.errors == 0 {
-            return Ok(());
+        let mut temp_log = bun_ast::Log::init();
+        let result = Self::load_entries(&mut self.values, &source, &mut temp_log);
+        if temp_log.errors > 0 {
+            let _ = temp_log.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                bun_output::error_writer(),
+            ));
+            bun_output::flush();
         }
-
-        // `Expect::snapshot` throws a plain error, so the rendered messages go into its text.
-        let mut message = format!(
-            "Failed to parse snapshot file: {}\n\n",
-            bstr::BStr::new(snapshot_file_path.as_bytes())
-        );
-        log.print(&mut message).expect("infallible: in-memory write");
-        if !log.msgs.is_empty() {
-            message.push('\n');
-        }
-        message.push_str("Fix the file, or run \"bun test --update-snapshots\" to rewrite it.");
-        self.parse_error_message = Some(message);
-        Err(crate::Error::ParseError)
+        result
     }
 
     /// Loads the entries of a `.snap` file into `values`. Any other statement is an error.
     fn load_entries(
         values: &mut HashMap<u64, Box<[u8]>>,
         source: &bun_ast::Source,
-        log: &mut bun_ast::Log,
+        temp_log: &mut bun_ast::Log,
     ) -> Result<(), Error> {
         // SAFETY: VM is thread-local singleton installed before any test runs; lives for the
         // duration of the runner. Per `VirtualMachine::get` doc, callers form a short-lived borrow.
@@ -304,8 +291,9 @@ impl Snapshots {
         let arena = bun_alloc::Arena::new();
 
         let parser =
-            js_parser::Parser::init(opts, log, source, &vm.transpiler.options.define, &arena)?;
-        let mut ast = match parser.parse()? {
+            js_parser::Parser::init(opts, temp_log, source, &vm.transpiler.options.define, &arena)
+                .map_err(|_| crate::Error::ParseError)?;
+        let mut ast = match parser.parse().map_err(|_| crate::Error::ParseError)? {
             bun_js_parser::Result::Ast(ast) => ast,
             _ => return Err(crate::Error::ParseError),
         };
@@ -325,7 +313,7 @@ impl Snapshots {
                 }
                 let Some((name, value)) = Self::exports_assignment(&mut stmt.data, exports_ref)
                 else {
-                    log.add_error(
+                    temp_log.add_error(
                         Some(source),
                         stmt.loc,
                         "Expected a snapshot entry: exports[`name`] = `value`;",
@@ -333,7 +321,7 @@ impl Snapshots {
                     continue;
                 };
                 let bun_ast::ExprData::EString(name_string) = &mut name.data else {
-                    log.add_error(
+                    temp_log.add_error(
                         Some(source),
                         name.loc,
                         "The snapshot name must be a template literal without substitutions",
@@ -341,7 +329,7 @@ impl Snapshots {
                     continue;
                 };
                 let bun_ast::ExprData::EString(value_string) = &mut value.data else {
-                    log.add_error(
+                    temp_log.add_error(
                         Some(source),
                         value.loc,
                         "The snapshot value must be a template literal without substitutions",
@@ -353,6 +341,9 @@ impl Snapshots {
             }
         }
 
+        if temp_log.errors > 0 {
+            return Err(crate::Error::ParseError);
+        }
         Ok(())
     }
 
@@ -383,22 +374,19 @@ impl Snapshots {
         Some((&mut e_index.index, &mut e_binary.right))
     }
 
-    /// Empties the per-file state: the next `.snap` file is read into the same buffer.
-    fn take_file_buf(&mut self) -> Vec<u8> {
-        self.values.clear();
-        self.counts.clear();
-        core::mem::take(&mut self.file_buf)
-    }
-
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
-        let Some(file) = self._current_file.take() else {
-            return Ok(());
-        };
-        let contents = self.take_file_buf();
-        file.file
-            .write_all(&contents)
-            .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
-        let _ = file.file.close();
+        if let Some(file) = self._current_file.take() {
+            file.file
+                .write_all(&self.file_buf)
+                .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
+            let _ = file.file.close();
+            self.file_buf.clear();
+            self.file_buf.shrink_to_fit();
+
+            self.values.clear();
+
+            self.counts.clear();
+        }
         Ok(())
     }
 
@@ -960,7 +948,9 @@ impl Snapshots {
             }
 
             if let Err(err) = self.parse_file(&file) {
-                drop(self.take_file_buf());
+                // Or the next `.snap` file is appended to this one and parsed with it.
+                self.file_buf = Vec::new();
+                self.values.clear();
                 return Err(err);
             }
             self._current_file = Some(file);

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -383,19 +383,22 @@ impl Snapshots {
         Some((&mut e_index.index, &mut e_binary.right))
     }
 
+    /// Empties the per-file state: the next `.snap` file is read into the same buffer.
+    fn take_file_buf(&mut self) -> Vec<u8> {
+        self.values.clear();
+        self.counts.clear();
+        core::mem::take(&mut self.file_buf)
+    }
+
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
-        if let Some(file) = self._current_file.take() {
-            file.file
-                .write_all(&self.file_buf)
-                .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
-            let _ = file.file.close();
-            self.file_buf.clear();
-            self.file_buf.shrink_to_fit();
-
-            self.values.clear();
-
-            self.counts.clear();
-        }
+        let Some(file) = self._current_file.take() else {
+            return Ok(());
+        };
+        let contents = self.take_file_buf();
+        file.file
+            .write_all(&contents)
+            .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
+        let _ = file.file.close();
         Ok(())
     }
 
@@ -957,9 +960,7 @@ impl Snapshots {
             }
 
             if let Err(err) = self.parse_file(&file) {
-                // Otherwise the next `.snap` file is appended to this one and parsed with it.
-                self.file_buf = Vec::new();
-                self.values.clear();
+                drop(self.take_file_buf());
                 return Err(err);
             }
             self._current_file = Some(file);

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -41,8 +41,7 @@ pub struct Snapshots {
     snapshot_dir_path: Option<&'static [u8]>,
     inline_snapshots_to_write: IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
     pub(crate) last_error_snapshot_name: Option<Box<[u8]>>,
-    /// Why `parse_file` rejected the `.snap` file of the last `get_or_put` that returned
-    /// `Error::ParseError`: the file's path and the rejected lines of it.
+    /// Set by `parse_file` with `Error::ParseError`, thrown by `Expect::snapshot`.
     pub(crate) parse_error_message: Option<String>,
 }
 
@@ -262,8 +261,7 @@ impl Snapshots {
         // SAFETY: buf[pos] == 0 written above
         let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
 
-        // `source` borrows `file_buf`, which nothing touches until `load_entries` returns:
-        // it writes to `values` only.
+        // `source` aliases `file_buf` (lifetime erased); `load_entries` writes to `values` only.
         let source = bun_ast::Source::init_path_string(
             snapshot_file_path.as_bytes(),
             self.file_buf.as_slice(),
@@ -275,8 +273,7 @@ impl Snapshots {
             return Ok(());
         }
 
-        // The matcher throws this as a plain error, so the message itself carries the rendered
-        // messages (the `.snap` line, `error: ...`, `at path:line:col`, as the bundler prints them).
+        // `Expect::snapshot` throws a plain error, so the rendered messages go into its text.
         let mut message = format!(
             "Failed to parse snapshot file: {}\n\n",
             bstr::BStr::new(snapshot_file_path.as_bytes())
@@ -291,10 +288,7 @@ impl Snapshots {
     }
 
     /// Loads the `exports[`name`] = `value`;` statements of a `.snap` file into `values`.
-    ///
-    /// Every other statement goes to `log` as an error. An entry this reader cannot read (a
-    /// `${}` substitution in the name or the value, for example) must not pass for a missing
-    /// snapshot: `get_or_put` would then append a second entry with the same name under it.
+    /// Any other statement is an error: skipped, it would count as a missing snapshot.
     fn load_entries(
         values: &mut HashMap<u64, Box<[u8]>>,
         source: &bun_ast::Source,
@@ -374,8 +368,7 @@ impl Snapshots {
         let bun_ast::ExprData::EBinary(e_binary) = &mut s_expr.value.data else {
             return None;
         };
-        // deref the `StoreRef`s to plain `&mut` structs so the borrow checker sees
-        // `.left`/`.right` and `.target`/`.index` as disjoint fields.
+        // Plain `&mut` structs, so `.left`/`.right` and `.target`/`.index` split-borrow.
         let e_binary = &mut **e_binary;
         if e_binary.op != bun_ast::Op::Code::BinAssign {
             return None;
@@ -965,8 +958,7 @@ impl Snapshots {
             }
 
             if let Err(err) = self.parse_file(&file) {
-                // Nothing is written back for a rejected file. Drop its contents here, or the
-                // next file's contents are appended to them and parsed along with them.
+                // Otherwise the next `.snap` file is appended to this one and parsed with it.
                 self.file_buf = Vec::new();
                 self.values.clear();
                 return Err(err);

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -41,6 +41,9 @@ pub struct Snapshots {
     snapshot_dir_path: Option<&'static [u8]>,
     inline_snapshots_to_write: IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
     pub(crate) last_error_snapshot_name: Option<Box<[u8]>>,
+    /// Why `parse_file` rejected the `.snap` file of the last `get_or_put` that returned
+    /// `Error::ParseError`: the file's path and the rejected lines of it.
+    pub(crate) parse_error_message: Option<String>,
 }
 
 // Re-export the TSV-mandated container name so the field type matches verbatim.
@@ -68,6 +71,7 @@ impl Snapshots {
             snapshot_dir_path: None,
             inline_snapshots_to_write: IndexMap::new(),
             last_error_snapshot_name: None,
+            parse_error_message: None,
         }
     }
 }
@@ -223,20 +227,10 @@ impl Snapshots {
     }
 
     pub(crate) fn parse_file(&mut self, file: &File) -> Result<(), Error> {
+        self.parse_error_message = None;
         if self.file_buf.is_empty() {
             return Ok(());
         }
-
-        // SAFETY: VM is thread-local singleton installed before any test runs; lives for the
-        // duration of the runner. Per `VirtualMachine::get` doc, callers form a short-lived borrow.
-        let vm = VirtualMachine::get().as_mut();
-        let opts = js_parser::ParserOptions::init(
-            vm.transpiler.options.jsx.clone(),
-            bun_ast::Loader::Js,
-        );
-        // Thread a per-call arena — js_parser is bump-allocated.
-        let arena = bun_alloc::Arena::new();
-        let mut temp_log = bun_ast::Log::init();
 
         // do NOT call `Jest::runner()` here — it hands out an exclusive ref to the global TestRunner,
         // and `self: &mut Snapshots` is a live borrow of that same TestRunner's `.snapshots`
@@ -268,81 +262,133 @@ impl Snapshots {
         // SAFETY: buf[pos] == 0 written above
         let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
 
+        // `source` borrows `file_buf`, which nothing touches until `load_entries` returns:
+        // it writes to `values` only.
         let source = bun_ast::Source::init_path_string(
             snapshot_file_path.as_bytes(),
             self.file_buf.as_slice(),
         );
 
-        let parser = js_parser::Parser::init(
-            opts,
-            &mut temp_log,
-            &source,
-            &vm.transpiler.options.define,
-            &arena,
-        )?;
+        let mut log = bun_ast::Log::init();
+        let result = Self::load_entries(&mut self.values, &source, &mut log);
+        if result.is_ok() && log.errors == 0 {
+            return Ok(());
+        }
 
-        let parse_result = parser.parse()?;
-        let mut ast = match parse_result {
+        // The matcher throws this as a plain error, so the message itself carries the rendered
+        // messages (the `.snap` line, `error: ...`, `at path:line:col`, as the bundler prints them).
+        let mut message = format!(
+            "Failed to parse snapshot file: {}\n\n",
+            bstr::BStr::new(snapshot_file_path.as_bytes())
+        );
+        log.print(&mut message).expect("infallible: in-memory write");
+        if !log.msgs.is_empty() {
+            message.push('\n');
+        }
+        message.push_str("Fix the file, or run \"bun test --update-snapshots\" to rewrite it.");
+        self.parse_error_message = Some(message);
+        Err(crate::Error::ParseError)
+    }
+
+    /// Loads the `exports[`name`] = `value`;` statements of a `.snap` file into `values`.
+    ///
+    /// Every other statement goes to `log` as an error. An entry this reader cannot read (a
+    /// `${}` substitution in the name or the value, for example) must not pass for a missing
+    /// snapshot: `get_or_put` would then append a second entry with the same name under it.
+    fn load_entries(
+        values: &mut HashMap<u64, Box<[u8]>>,
+        source: &bun_ast::Source,
+        log: &mut bun_ast::Log,
+    ) -> Result<(), Error> {
+        // SAFETY: VM is thread-local singleton installed before any test runs; lives for the
+        // duration of the runner. Per `VirtualMachine::get` doc, callers form a short-lived borrow.
+        let vm = VirtualMachine::get().as_mut();
+        let opts = js_parser::ParserOptions::init(
+            vm.transpiler.options.jsx.clone(),
+            bun_ast::Loader::Js,
+        );
+        // Thread a per-call arena — js_parser is bump-allocated.
+        let arena = bun_alloc::Arena::new();
+
+        let parser =
+            js_parser::Parser::init(opts, log, source, &vm.transpiler.options.define, &arena)?;
+        let mut ast = match parser.parse()? {
             bun_js_parser::Result::Ast(ast) => ast,
             _ => return Err(crate::Error::ParseError),
         };
-
-        if ast.exports_ref.is_empty() {
-            return Ok(());
-        }
         let exports_ref = ast.exports_ref;
-
-        // TODO: when common js transform changes, keep this updated or add flag to support this version
 
         for part in ast.parts.as_mut_slice() {
             // `part.stmts` is an arena-owned `StoreSlice<Stmt>`; arena outlives this
             // loop and `ast` is owned here, so unique access is upheld.
             for stmt in part.stmts.slice_mut() {
-                match &mut stmt.data {
-                    bun_ast::StmtData::SExpr(expr) => {
-                        if let bun_ast::ExprData::EBinary(e_binary) = &mut expr.value.data {
-                            // deref `StoreRef` once to a plain `&mut E::Binary`
-                            // so the borrow checker can see `.left`/`.right` as disjoint
-                            // field projections (custom `DerefMut` blocks split-borrows
-                            // otherwise).
-                            let e_binary = &mut **e_binary;
-                            if e_binary.op == bun_ast::Op::Code::BinAssign {
-                                let (left, right) = (&mut e_binary.left, &mut e_binary.right);
-                                if let bun_ast::ExprData::EIndex(e_index) = &mut left.data {
-                                    // split-borrow `index`/`target` so we can take
-                                    // `&mut` on `index` (EString::slice needs &mut) while reading
-                                    // `target` immutably.
-                                    let target_is_exports = matches!(
-                                        &e_index.target.data,
-                                        bun_ast::ExprData::EIdentifier(target) if target.ref_.eql(exports_ref)
-                                    );
-                                    if target_is_exports {
-                                        if let bun_ast::ExprData::EString(index) =
-                                            &mut e_index.index.data
-                                        {
-                                            if let bun_ast::ExprData::EString(value_string) =
-                                                &mut right.data
-                                            {
-                                                let key = index.slice(&arena);
-                                                let value = value_string.slice(&arena);
-                                                let value_clone: Box<[u8]> =
-                                                    Box::<[u8]>::from(value);
-                                                let name_hash: u64 = hash(key);
-                                                self.values.insert(name_hash, value_clone);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
+                if matches!(
+                    stmt.data,
+                    bun_ast::StmtData::SComment(_)
+                        | bun_ast::StmtData::SDirective(_)
+                        | bun_ast::StmtData::SEmpty(_)
+                ) {
+                    continue;
                 }
+                let Some((name, value)) = Self::exports_assignment(&mut stmt.data, exports_ref)
+                else {
+                    log.add_error(
+                        Some(source),
+                        stmt.loc,
+                        "Expected a snapshot entry: exports[`name`] = `value`;",
+                    );
+                    continue;
+                };
+                let bun_ast::ExprData::EString(name_string) = &mut name.data else {
+                    log.add_error(
+                        Some(source),
+                        name.loc,
+                        "The snapshot name must be a template literal without substitutions",
+                    );
+                    continue;
+                };
+                let bun_ast::ExprData::EString(value_string) = &mut value.data else {
+                    log.add_error(
+                        Some(source),
+                        value.loc,
+                        "The snapshot value must be a template literal without substitutions",
+                    );
+                    continue;
+                };
+                let name_hash: u64 = hash(name_string.slice(&arena));
+                values.insert(name_hash, Box::<[u8]>::from(value_string.slice(&arena)));
             }
         }
 
-        let _ = &mut ast;
         Ok(())
+    }
+
+    /// The `name` and `value` expressions of a `exports[name] = value;` statement.
+    fn exports_assignment(
+        stmt: &mut bun_ast::StmtData,
+        exports_ref: bun_ast::Ref,
+    ) -> Option<(&mut bun_ast::Expr, &mut bun_ast::Expr)> {
+        let bun_ast::StmtData::SExpr(s_expr) = stmt else {
+            return None;
+        };
+        let bun_ast::ExprData::EBinary(e_binary) = &mut s_expr.value.data else {
+            return None;
+        };
+        // deref the `StoreRef`s to plain `&mut` structs so the borrow checker sees
+        // `.left`/`.right` and `.target`/`.index` as disjoint fields.
+        let e_binary = &mut **e_binary;
+        if e_binary.op != bun_ast::Op::Code::BinAssign {
+            return None;
+        }
+        let bun_ast::ExprData::EIndex(e_index) = &mut e_binary.left.data else {
+            return None;
+        };
+        let e_index = &mut **e_index;
+        match &e_index.target.data {
+            bun_ast::ExprData::EIdentifier(target) if target.ref_.eql(exports_ref) => {}
+            _ => return None,
+        }
+        Some((&mut e_index.index, &mut e_binary.right))
     }
 
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
@@ -918,7 +964,13 @@ impl Snapshots {
                 }
             }
 
-            self.parse_file(&file)?;
+            if let Err(err) = self.parse_file(&file) {
+                // Nothing is written back for a rejected file. Drop its contents here, or the
+                // next file's contents are appended to them and parsed along with them.
+                self.file_buf = Vec::new();
+                self.values.clear();
+                return Err(err);
+            }
             self._current_file = Some(file);
         }
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -287,8 +287,7 @@ impl Snapshots {
         Err(crate::Error::ParseError)
     }
 
-    /// Loads the `exports[`name`] = `value`;` statements of a `.snap` file into `values`.
-    /// Any other statement is an error: skipped, it would count as a missing snapshot.
+    /// Loads the entries of a `.snap` file into `values`. Any other statement is an error.
     fn load_entries(
         values: &mut HashMap<u64, Box<[u8]>>,
         source: &bun_ast::Source,

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -374,19 +374,22 @@ impl Snapshots {
         Some((&mut e_index.index, &mut e_binary.right))
     }
 
+    /// Empties the per-file state: the next `.snap` file is read into the same buffer.
+    fn take_file_buf(&mut self) -> Vec<u8> {
+        self.values.clear();
+        self.counts.clear();
+        core::mem::take(&mut self.file_buf)
+    }
+
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
-        if let Some(file) = self._current_file.take() {
-            file.file
-                .write_all(&self.file_buf)
-                .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
-            let _ = file.file.close();
-            self.file_buf.clear();
-            self.file_buf.shrink_to_fit();
-
-            self.values.clear();
-
-            self.counts.clear();
-        }
+        let Some(file) = self._current_file.take() else {
+            return Ok(());
+        };
+        let contents = self.take_file_buf();
+        file.file
+            .write_all(&contents)
+            .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
+        let _ = file.file.close();
         Ok(())
     }
 
@@ -948,9 +951,7 @@ impl Snapshots {
             }
 
             if let Err(err) = self.parse_file(&file) {
-                // Or the next `.snap` file is appended to this one and parsed with it.
-                self.file_buf = Vec::new();
-                self.values.clear();
+                drop(self.take_file_buf());
                 return Err(err);
             }
             self._current_file = Some(file);

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
@@ -77,25 +77,23 @@ describe("a .snap entry bun test cannot read", () => {
     const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
 
     const { stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr).toContain(`error: Failed to parse snapshot file: ${snapPath}\n`);
-    expect(stderr).toContain(`error: ${message}\n`);
-    expect(stderr).toContain(`${snapPath}:${position}\n`);
-    expect(stderr).toContain('run "bun test --update-snapshots"');
+    expect(stderr).toContain(`error: ${message}\n    at ${snapPath}:${position}\n`);
+    expect(stderr).toContain("Failed to parse snapshot file");
     expect(stderr).toContain(" 1 fail");
     expect(stderr).not.toContain("added");
     expect(exitCode).toBe(1);
     expect(fs.readFileSync(snapPath, "utf8")).toBe(snap);
   });
 
-  test.concurrent("every bad entry of the file is listed in one failure", async () => {
+  test.concurrent("every bad entry of the file is reported at once", async () => {
     const snap = `${HEADER}\nexports[\`a 1\`] = \`\${x}\`;\n\nexports[\`a \${2}\`] = \`"hello"\`;\n\nexports[\`b 1\`] = \`"ok"\`;\n`;
     using dir = tempDir("snap-bad-entries", { "a.test.ts": A_TEST, "__snapshots__/a.test.ts.snap": snap });
     const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
 
     const { stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr.match(/^error: Failed to parse snapshot file: /gm)).toHaveLength(1);
     expect(stderr).toContain(`error: ${VALUE_ERROR}\n    at ${snapPath}:3:18\n`);
     expect(stderr).toContain(`error: ${NAME_ERROR}\n    at ${snapPath}:5:9\n`);
+    expect(stderr.split(`    at ${snapPath}:`)).toHaveLength(3);
     expect(exitCode).toBe(1);
     expect(fs.readFileSync(snapPath, "utf8")).toBe(snap);
   });
@@ -112,8 +110,8 @@ describe("a .snap entry bun test cannot read", () => {
     const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
 
     const { stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr).toContain(`error: Failed to parse snapshot file: ${snapPath}\n`);
-    expect(stderr).toContain(`${snapPath}:3:18\n`);
+    expect(stderr).toContain(`\n    at ${snapPath}:3:18\n`);
+    expect(stderr).toContain("Failed to parse snapshot file");
     expect(stderr).not.toContain("Failed to snapshot value");
     // a.test.ts must run first. The bytes of its unreadable .snap file used to stay in the buffer
     // that b.test.ts.snap was then read into, so b's valid snapshot failed to parse as well.
@@ -161,31 +159,3 @@ describe("a .snap entry bun test cannot read", () => {
     expect(fs.readFileSync(snapPath, "utf8")).toBe(edited);
   });
 });
-
-// /dev/full reads as empty and refuses every write with ENOSPC.
-test.skipIf(!isLinux || !fs.existsSync("/dev/full"))(
-  "a .snap file that cannot be written does not leak into the next test file",
-  async () => {
-    using dir = tempDir("snap-unwritable", {
-      "a.test.ts": A_TEST,
-      "b.test.ts": `
-        import { test, expect } from "bun:test";
-        test("b1", () => expect(1).toMatchSnapshot());
-        test("b2", () => expect(2).toMatchSnapshot());
-      `,
-    });
-    fs.mkdirSync(join(String(dir), "__snapshots__"));
-    fs.symlinkSync("/dev/full", join(String(dir), "__snapshots__", "a.test.ts.snap"));
-
-    // a's entry is written, and fails to be written, when b1 opens b's own .snap file.
-    const { stderr, exitCode } = await runBunTest(String(dir));
-    expect(stderr.match(/^\w+\.test\.ts:$/gm)).toEqual(["a.test.ts:", "b.test.ts:"]);
-    expect(stderr).toContain("Failed write to snapshot file");
-    expect(stderr).toContain(" 2 pass\n 1 fail\n");
-    expect(exitCode).toBe(1);
-    // b's file used to start with a's unwritten entry, followed by a second header.
-    expect(fs.readFileSync(join(String(dir), "__snapshots__", "b.test.ts.snap"), "utf8")).toBe(
-      `${HEADER}\nexports[\`b2 1\`] = \`2\`;\n`,
-    );
-  },
-);

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
@@ -161,3 +161,31 @@ describe("a .snap entry bun test cannot read", () => {
     expect(fs.readFileSync(snapPath, "utf8")).toBe(edited);
   });
 });
+
+// /dev/full reads as empty and refuses every write with ENOSPC.
+test.skipIf(!isLinux || !fs.existsSync("/dev/full"))(
+  "a .snap file that cannot be written does not leak into the next test file",
+  async () => {
+    using dir = tempDir("snap-unwritable", {
+      "a.test.ts": A_TEST,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        test("b1", () => expect(1).toMatchSnapshot());
+        test("b2", () => expect(2).toMatchSnapshot());
+      `,
+    });
+    fs.mkdirSync(join(String(dir), "__snapshots__"));
+    fs.symlinkSync("/dev/full", join(String(dir), "__snapshots__", "a.test.ts.snap"));
+
+    // a's entry is written, and fails to be written, when b1 opens b's own .snap file.
+    const { stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr.match(/^\w+\.test\.ts:$/gm)).toEqual(["a.test.ts:", "b.test.ts:"]);
+    expect(stderr).toContain("Failed write to snapshot file");
+    expect(stderr).toContain(" 2 pass\n 1 fail\n");
+    expect(exitCode).toBe(1);
+    // b's file used to start with a's unwritten entry, followed by a second header.
+    expect(fs.readFileSync(join(String(dir), "__snapshots__", "b.test.ts.snap"), "utf8")).toBe(
+      `${HEADER}\nexports[\`b2 1\`] = \`2\`;\n`,
+    );
+  },
+);

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
   const tempDir = tmpdirSync();
@@ -27,4 +28,136 @@ test("it will create a snapshot file and directory if they don't exist", () => {
 
   expect(exitCode2).toBe(0);
   expect(fs.existsSync(tempDir + "/__snapshots__/new-snapshot.test.ts.snap")).toBe(true);
+});
+
+const HEADER = "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n";
+const A_TEST = `
+  import { test, expect } from "bun:test";
+  test("a", () => expect("hello").toMatchSnapshot());
+`;
+const B_TEST = `
+  import { test, expect } from "bun:test";
+  test("b", () => expect("world").toMatchSnapshot());
+`;
+const VALUE_ERROR = "The snapshot value must be a template literal without substitutions";
+const NAME_ERROR = "The snapshot name must be a template literal without substitutions";
+
+// CI=false: only a run that may add snapshots can append to the file.
+async function runBunTest(dir: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args],
+    cwd: dir,
+    env: { ...bunEnv, CI: "false" },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("a .snap entry bun test cannot read", () => {
+  // Each entry below is line 3 of its .snap file. The reader used to skip it, so the snapshot
+  // counted as new: the test passed, and a second `a 1` entry was appended under the bad one.
+  test.concurrent.each([
+    ["a substitution in the value", "exports[`a 1`] = `${x}`;", "3:18", VALUE_ERROR],
+    ["a substitution in the name", 'exports[`a ${1}`] = `"hello"`;', "3:9", NAME_ERROR],
+    ["a regular expression as the value", "exports[`a 1`] = /hello/;", "3:18", VALUE_ERROR],
+    ["a number as the value", "exports[`a 1`] = 1;", "3:18", VALUE_ERROR],
+    ["a concatenation as the value", 'exports[`a 1`] = `"hel"` + `"lo"`;', "3:18", VALUE_ERROR],
+    [
+      "a statement that is not an exports[...] assignment",
+      'module.exports[`a 1`] = `"hello"`;',
+      "3:1",
+      "Expected a snapshot entry: exports[`name`] = `value`;",
+    ],
+  ])("%s fails the test and leaves the file alone", async (_, entry, position, message) => {
+    const snap = `${HEADER}\n${entry}\n`;
+    using dir = tempDir("snap-bad-entry", { "a.test.ts": A_TEST, "__snapshots__/a.test.ts.snap": snap });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+
+    const { stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr).toContain(`error: Failed to parse snapshot file: ${snapPath}\n`);
+    expect(stderr).toContain(`error: ${message}\n`);
+    expect(stderr).toContain(`${snapPath}:${position}\n`);
+    expect(stderr).toContain('run "bun test --update-snapshots"');
+    expect(stderr).toContain(" 1 fail");
+    expect(stderr).not.toContain("added");
+    expect(exitCode).toBe(1);
+    expect(fs.readFileSync(snapPath, "utf8")).toBe(snap);
+  });
+
+  test.concurrent("every bad entry of the file is listed in one failure", async () => {
+    const snap = `${HEADER}\nexports[\`a 1\`] = \`\${x}\`;\n\nexports[\`a \${2}\`] = \`"hello"\`;\n\nexports[\`b 1\`] = \`"ok"\`;\n`;
+    using dir = tempDir("snap-bad-entries", { "a.test.ts": A_TEST, "__snapshots__/a.test.ts.snap": snap });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+
+    const { stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr.match(/^error: Failed to parse snapshot file: /gm)).toHaveLength(1);
+    expect(stderr).toContain(`error: ${VALUE_ERROR}\n    at ${snapPath}:3:18\n`);
+    expect(stderr).toContain(`error: ${NAME_ERROR}\n    at ${snapPath}:5:9\n`);
+    expect(exitCode).toBe(1);
+    expect(fs.readFileSync(snapPath, "utf8")).toBe(snap);
+  });
+
+  test.concurrent("a file that does not parse names the line and does not break the next test file", async () => {
+    const torn = `${HEADER}\nexports[\`a 1\`] = \`"hello;\n`;
+    const intact = `${HEADER}\nexports[\`b 1\`] = \`"world"\`;\n`;
+    using dir = tempDir("snap-torn", {
+      "a.test.ts": A_TEST,
+      "b.test.ts": B_TEST,
+      "__snapshots__/a.test.ts.snap": torn,
+      "__snapshots__/b.test.ts.snap": intact,
+    });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+
+    const { stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr).toContain(`error: Failed to parse snapshot file: ${snapPath}\n`);
+    expect(stderr).toContain(`${snapPath}:3:18\n`);
+    expect(stderr).not.toContain("Failed to snapshot value");
+    // a.test.ts runs first. The bytes of its unreadable .snap file used to stay in the buffer
+    // that b.test.ts.snap was then read into, so b's valid snapshot failed to parse as well.
+    expect(stderr.indexOf("a.test.ts:")).toBeLessThan(stderr.indexOf("b.test.ts:"));
+    expect(stderr).toContain("(pass) b");
+    expect(stderr).toContain(" 1 pass\n 1 fail\n");
+    expect(exitCode).toBe(1);
+    expect(fs.readFileSync(snapPath, "utf8")).toBe(torn);
+    expect(fs.readFileSync(join(String(dir), "__snapshots__", "b.test.ts.snap"), "utf8")).toBe(intact);
+  });
+
+  test.concurrent("--update-snapshots rewrites the file", async () => {
+    using dir = tempDir("snap-bad-entry-update", {
+      "a.test.ts": A_TEST,
+      "__snapshots__/a.test.ts.snap": `${HEADER}\nexports[\`a 1\`] = \`\${x}\`;\n`,
+    });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+
+    const { stderr, exitCode } = await runBunTest(String(dir), "--update-snapshots");
+    expect(stderr).not.toContain("Failed to parse snapshot file");
+    expect(stderr).toContain("snapshots: +1 added");
+    expect(exitCode).toBe(0);
+    expect(fs.readFileSync(snapPath, "utf8")).toBe(`${HEADER}\nexports[\`a 1\`] = \`"hello"\`;\n`);
+  });
+
+  test.concurrent("comments, directives, empty statements and escaped ${} are still read", async () => {
+    using dir = tempDir("snap-trivia", {
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        test("a", () => expect("\${x} and \`ticks\`").toMatchSnapshot());
+      `,
+    });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+    expect((await runBunTest(String(dir))).exitCode).toBe(0);
+
+    const written = fs.readFileSync(snapPath, "utf8");
+    expect(written).toContain("\\${x} and \\`ticks\\`");
+    const edited = written.replace(HEADER, `${HEADER}"use strict";\n/*! kept */\n;\n`);
+    fs.writeFileSync(snapPath, edited);
+
+    const { stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(stderr).toContain(" 1 snapshots, ");
+    expect(exitCode).toBe(0);
+    expect(fs.readFileSync(snapPath, "utf8")).toBe(edited);
+  });
 });

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -115,9 +115,9 @@ describe("a .snap entry bun test cannot read", () => {
     expect(stderr).toContain(`error: Failed to parse snapshot file: ${snapPath}\n`);
     expect(stderr).toContain(`${snapPath}:3:18\n`);
     expect(stderr).not.toContain("Failed to snapshot value");
-    // a.test.ts runs first. The bytes of its unreadable .snap file used to stay in the buffer
+    // a.test.ts must run first. The bytes of its unreadable .snap file used to stay in the buffer
     // that b.test.ts.snap was then read into, so b's valid snapshot failed to parse as well.
-    expect(stderr.indexOf("a.test.ts:")).toBeLessThan(stderr.indexOf("b.test.ts:"));
+    expect(stderr.match(/^\w+\.test\.ts:$/gm)).toEqual(["a.test.ts:", "b.test.ts:"]);
     expect(stderr).toContain("(pass) b");
     expect(stderr).toContain(" 1 pass\n 1 fail\n");
     expect(exitCode).toBe(1);

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
@@ -159,3 +159,31 @@ describe("a .snap entry bun test cannot read", () => {
     expect(fs.readFileSync(snapPath, "utf8")).toBe(edited);
   });
 });
+
+// /dev/full reads as empty and refuses every write with ENOSPC.
+test.skipIf(!isLinux || !fs.existsSync("/dev/full"))(
+  "a .snap file that cannot be written does not leak into the next test file",
+  async () => {
+    using dir = tempDir("snap-unwritable", {
+      "a.test.ts": A_TEST,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        test("b1", () => expect(1).toMatchSnapshot());
+        test("b2", () => expect(2).toMatchSnapshot());
+      `,
+    });
+    fs.mkdirSync(join(String(dir), "__snapshots__"));
+    fs.symlinkSync("/dev/full", join(String(dir), "__snapshots__", "a.test.ts.snap"));
+
+    // a's entry is written, and fails to be written, when b1 opens b's own .snap file.
+    const { stderr, exitCode } = await runBunTest(String(dir));
+    expect(stderr.match(/^\w+\.test\.ts:$/gm)).toEqual(["a.test.ts:", "b.test.ts:"]);
+    expect(stderr).toContain("Failed write to snapshot file");
+    expect(stderr).toContain(" 2 pass\n 1 fail\n");
+    expect(exitCode).toBe(1);
+    // b's file used to start with a's unwritten entry, followed by a second header.
+    expect(fs.readFileSync(join(String(dir), "__snapshots__", "b.test.ts.snap"), "utf8")).toBe(
+      `${HEADER}\nexports[\`b2 1\`] = \`2\`;\n`,
+    );
+  },
+);


### PR DESCRIPTION
### Problem
- A `.snap` entry that `bun test` cannot read, for example `` exports[`a 1`] = `${x}`; ``, counts as a missing snapshot. The test passes with `+1 added`, and a second `a 1` entry is appended under the bad one. Users saw this symptom in #4722, #10868 and #14029, when the writer escaped a value badly.
- Cause: `Snapshots::parse_file` (`src/runtime/test_runner/snapshot.rs`) records statements of the shape `exports[<string>] = <string>;` and skips the rest.
- A `.snap` with a syntax error fails with `Failed to snapshot value`, and its bytes stay in `file_buf`. So do the bytes of a `.snap` whose write fails. The next test file's `.snap` is appended to them: it fails to parse, or it is written back with the first file's entries in front of its own.

### Fix
- `load_entries` reports every statement that is not an entry and fails the parse when it reported one. `parse_file` prints the log, as the inline snapshot writer prints its log: `error: <reason>` and `at <path>.snap:<line>:<col>` per line. A syntax error takes the same path. The matcher then throws the existing `Failed to parse snapshot file for:` error. The file is not written.
- `take_file_buf` empties the per-file state in one place. `write_snapshot_file` calls it before the write, and `get_snapshot_file` calls it for a rejected file.
- Correct because Bun, Jest and Vitest escape backticks, `\` and `${` in the entries they write. Such an entry comes from an edit or a corrupt file and must not pass for an absent one. `-u` still rewrites it: `-u` does not parse the old contents. All 61 `.snap` files in `test/` pass the new rule.
- Verified: `test/js/bun/test/snapshot-tests/new-snapshot.test.ts`, 11 new tests, 9 fail on 1.4.0. Also `snapshot-tests/`, `ci-restrictions.test.ts`, `expect.test.js`.

### Background
- A `.snap` file is a header comment and `` exports[`name N`] = `value`; `` lines. Bun does not evaluate it. It parses it as JS and walks the statements. A template literal without substitutions parses as `EString`.
- `Snapshots` buffers one `.snap` at a time: `get_snapshot_file` reads it into `file_buf`, `parse_file` fills `values`, and `write_snapshot_file` writes `file_buf` back when the next file opens. Only that step cleared `file_buf`, and only after a successful write.
- #39689 (open) reworks the handling of a rejected `.snap` (one parse, one print, a thrown message with the `.snap` path) and writes the file through a rename. The statement walk here is in code #39689 does not touch. The conflicts (the `parse_file` wrapper, the clear in `get_snapshot_file`, `write_snapshot_file`) resolve to #39689's side, and its rename needs another fixture than `/dev/full` for the write test.

<details><summary>Notes</summary>

Found by an automated sweep of `bun test`, not by a GitHub issue. Other shapes that took the same silent path on 1.4.0: a `${}` in the name, `/re/` or `1` as the value, `` `a` + `b` `` as the value, `` module.exports[`a 1`] = ... ``. A syntax error in the file (`` exports[`a 1`] = `"hello; ``) reported `Failed to snapshot value: hello` for every snapshot of the file, and a second test file with a valid `.snap` then failed the same way in the same run (new test "does not break the next test file").

Still skipped: comments, directives and empty statements, the statements the parser itself treats as trivial. The test "comments, directives, empty statements and escaped ${} are still read" pins that, and pins that an entry Bun wrote for a value containing `${x}` and backticks still loads. The `--update-snapshots` test passes before and after. It pins the way out of a rejected file, which #34042 (it parses the old file under `-u`) has to keep working.

The 61 committed `.snap` files were checked by copying each one into a temporary project with a test file of the matching name and one `toMatchSnapshot()` of a new name under `CI=true`: every file reported the CI error for the new name, none reported a parse error. The set includes the Jest-written `existing-snapshots.test.ts.snap`.

The failed write is tested with a `.snap` that is a symlink to `/dev/full` (Linux only): it reads as empty, and every write to it fails with ENOSPC. On 1.4.0 the second file's `.snap` ends up as header, first file's entry, header, own entry. A review comment found this path. The write change was taken out in b73351d in favor of #39689's rewrite of the same function, and put back in c25f3be at a maintainer's request.

Earlier shape of this PR (a99dc63 to 601711c): the diagnostics were rendered into the thrown error's text through a new `Snapshots` field and an `expect.rs` arm. b73351d prints them from `parse_file` instead, the way the inline snapshot writer prints its log, so that `src/` changes stay in `snapshot.rs` and the error plumbing merges with #39689 in either order. What is different standalone is small: the `.snap` position is printed above the failure instead of inside it, and the diagnostics print once per snapshot assertion of the file until #39689 makes the parse happen once.

Left as they are: the header line is still not checked (Jest's header is accepted on purpose), and `get_snapshot_file` still opens the path without a regular-file check. `snapshot.test.ts` "error snapshots" fails on this machine with and without this change (it expects colors).

Suites run with the debug build: `test/js/bun/test/snapshot-tests/` (all files), `test/js/bun/test/ci-restrictions.test.ts`, `test/js/bun/test/expect.test.js`, `test/internal/source-lints/`, `cargo clippy -p bun_runtime`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/test/snapshot-tests/new-snapshot.test.ts

<!-- robobun:evidence:end -->
