### PR TITLE
install: report ENAMETOOLONG when the bin linker's directories do not fit the path buffer

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1519,18 +1519,23 @@ impl<'a> Linker<'a> {
         resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target])
     }
 
-    /// uses `self.abs_target_buf`
-    pub(crate) fn build_target_package_dir(&mut self) -> &[u8] {
+    /// Length of `<node_modules>/<package>/` in `abs_target_buf`, `None` if a NUL no longer fits.
+    pub(crate) fn build_target_package_dir(&mut self) -> Option<usize> {
         // SAFETY: `target_node_modules_path` is set at construction to either
         // a caller-owned `AbsPath` or the same buffer as `node_modules_path`;
         // both outlive `self` and are not mutated for the duration of this
         // read.
         let dest_dir_without_trailing_slash =
             strings::without_trailing_slash(unsafe { (*self.target_node_modules_path).slice() });
+        let package_name = self.target_package_name.slice();
+
+        let buf = &mut *self.abs_target_buf;
+        if dest_dir_without_trailing_slash.len() + 1 + package_name.len() + 1 >= buf.len() {
+            return None;
+        }
 
         // reshaped for borrowck — track offset instead of remain.ptr arithmetic
         let mut off: usize = 0;
-        let buf = &mut *self.abs_target_buf;
 
         buf[off..off + dest_dir_without_trailing_slash.len()]
             .copy_from_slice(dest_dir_without_trailing_slash);
@@ -1538,52 +1543,54 @@ impl<'a> Linker<'a> {
         buf[off] = SEP;
         off += 1;
 
-        let package_name = self.target_package_name.slice();
         buf[off..off + package_name.len()].copy_from_slice(package_name);
         off += package_name.len();
         buf[off] = SEP;
         off += 1;
 
-        &self.abs_target_buf[0..off]
+        Some(off)
     }
 
-    /// Returns the offset into `self.abs_dest_buf` where the destination dir ends
-    /// (i.e. where the bin name should be written).
-    // Returning an offset (rather than a slice into abs_dest_buf) avoids
-    // overlapping &mut borrows of self.
-    pub(crate) fn build_destination_dir(&mut self, global: bool) -> usize {
-        let dest_dir_without_trailing_slash =
-            strings::without_trailing_slash(self.node_modules_path.slice());
+    /// Length of the `.bin/` (or global bin) dir in `abs_dest_buf`, `None` if a NUL no longer fits.
+    pub(crate) fn build_destination_dir(&mut self, global: bool) -> Option<usize> {
+        let dest_dir_without_trailing_slash = if global {
+            strings::without_trailing_slash(self.global_bin_path.as_bytes())
+        } else {
+            strings::without_trailing_slash(self.node_modules_path.slice())
+        };
+        let suffix_len = if global { b"/".len() } else { b"/.bin/".len() };
 
         let buf = &mut *self.abs_dest_buf;
-        let mut off: usize = 0;
-        if global {
-            let global_bin_path_without_trailing_slash =
-                strings::without_trailing_slash(self.global_bin_path.as_bytes());
-            buf[off..off + global_bin_path_without_trailing_slash.len()]
-                .copy_from_slice(global_bin_path_without_trailing_slash);
-            off += global_bin_path_without_trailing_slash.len();
-            buf[off] = SEP;
-            off += 1;
-        } else {
-            buf[off..off + dest_dir_without_trailing_slash.len()]
-                .copy_from_slice(dest_dir_without_trailing_slash);
-            off += dest_dir_without_trailing_slash.len();
-            // sep_str ++ ".bin" ++ sep_str
-            buf[off] = SEP;
-            buf[off + 1..off + 1 + b".bin".len()].copy_from_slice(b".bin");
-            buf[off + 1 + b".bin".len()] = SEP;
-            off += b"/.bin/".len();
+        if dest_dir_without_trailing_slash.len() + suffix_len >= buf.len() {
+            return None;
         }
 
-        off
+        let mut off: usize = 0;
+        buf[off..off + dest_dir_without_trailing_slash.len()]
+            .copy_from_slice(dest_dir_without_trailing_slash);
+        off += dest_dir_without_trailing_slash.len();
+        buf[off] = SEP;
+        off += 1;
+        if !global {
+            buf[off..off + b".bin".len()].copy_from_slice(b".bin");
+            off += b".bin".len();
+            buf[off] = SEP;
+            off += 1;
+        }
+
+        Some(off)
     }
 
     // target: what the symlink points to
     // destination: where the symlink exists on disk
     pub fn link(&mut self, global: bool) {
-        let package_dir_len = self.build_target_package_dir().len();
-        let mut dest_off = self.build_destination_dir(global);
+        let (Some(package_dir_len), Some(mut dest_off)) = (
+            self.build_target_package_dir(),
+            self.build_destination_dir(global),
+        ) else {
+            self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+            return;
+        };
         let is_redirect = self.is_native_binlink_redirect();
 
         debug_assert!(self.bin.tag != Tag::None);
@@ -1842,8 +1849,13 @@ impl<'a> Linker<'a> {
     }
 
     pub fn unlink(&mut self, global: bool) {
-        let package_dir_len = self.build_target_package_dir().len();
-        let mut dest_off = self.build_destination_dir(global);
+        let (Some(package_dir_len), Some(mut dest_off)) = (
+            self.build_target_package_dir(),
+            self.build_destination_dir(global),
+        ) else {
+            self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+            return;
+        };
 
         debug_assert!(self.bin.tag != Tag::None);
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -2,12 +2,13 @@ import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { copyFileSync, mkdirSync } from "fs";
-import { cp, exists, lstat, mkdir, readlink, rm, writeFile } from "fs/promises";
+import { cp, exists, lstat, mkdir, readlink, rename, rm, writeFile } from "fs/promises";
 import {
   assertManifestsPopulated,
   bunExe,
   bunEnv as env,
   isFlaky,
+  isLinux,
   isMacOS,
   isWindows,
   mergeWindowEnvs,
@@ -3255,6 +3256,112 @@ describe("binaries", () => {
     expect(err).toBeEmpty();
     expect(await result.exited).toBe(0);
   }
+
+  // Before it appends a bin name, the bin linker writes `<node_modules>/<package>/` and
+  // `<node_modules>/.bin/` into two path buffers of MAX_PATH_BYTES (4096 bytes on Linux, 1024 on
+  // macOS). A project deep enough for one of them not to fit has to fail like a bin name that does
+  // not fit. Windows is left out: its buffer holds more than any path the OS accepts.
+  describe.skipIf(isWindows)("directories longer than the path buffer", () => {
+    const maxPathBytes = isLinux ? 4096 : 1024;
+
+    // Writes `<dir>/<name>`, a package whose bin is named after it.
+    const writeBinPackage = (dir: string, name: string) =>
+      Promise.all([
+        write(
+          join(dir, name, "package.json"),
+          JSON.stringify({ name, version: "1.0.0", bin: { [name]: `${name}.js` } }),
+        ),
+        write(join(dir, name, `${name}.js`), `#!/usr/bin/env node\nconsole.log("${name}")`),
+      ]);
+
+    // Directory names of at most 200 bytes which bring `base` to exactly `length` bytes.
+    function componentsUpTo(base: string, length: number) {
+      const components: string[] = [];
+      let remaining = length - Buffer.byteLength(base);
+      while (remaining > 0) {
+        let len = Math.min(200, remaining - "/".length);
+        // Never leave exactly one byte: it would have to be a separator with no name after it.
+        if (remaining - "/".length - len === 1) len -= 1;
+        components.push(Buffer.alloc(len, "d").toString());
+        remaining -= "/".length + len;
+      }
+      return components;
+    }
+
+    // Creates, under `base`, a directory whose `<dir>/<subpath>` is exactly maxPathBytes long. The
+    // directory itself fits, so it can be created. Whatever bun creates below `<dir>/<subpath>` does
+    // not, so `shorten()` renames the first directory name to one byte before those paths are used.
+    function directoryFilledBy(base: string, subpath: string) {
+      const components = componentsUpTo(base, maxPathBytes - Buffer.byteLength("/" + subpath));
+      const dir = join(base, ...components);
+      expect(Buffer.byteLength(join(dir, subpath))).toBe(maxPathBytes);
+      mkdirSync(dir, { recursive: true });
+      const shorten = async () => {
+        await rename(join(base, components[0]), join(base, "x"));
+        return join(base, "x", ...components.slice(1));
+      };
+      return { dir, shorten };
+    }
+
+    async function run(args: string[], cwd: string, runEnv: NodeJS.Dict<string>) {
+      await using proc = spawn({
+        cmd: [bunExe(), ...args],
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: runEnv,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { out, err, exitCode };
+    }
+
+    // With `has-bin`, `<project>/node_modules/has-bin/` is one byte too long for the buffer. With
+    // `a`, the package directory fits and `<project>/node_modules/.bin/` is one byte too long.
+    test.each([
+      ["package directory", "has-bin", join("node_modules", "has-bin")],
+      [".bin directory", "a", join("node_modules", ".bin")],
+    ])("install reports a %s that does not fit as ENAMETOOLONG", async (_, name, subpath) => {
+      await writeBinPackage(packageDir, name);
+      const { dir: project, shorten } = directoryFilledBy(packageDir, subpath);
+      await write(
+        join(project, "package.json"),
+        JSON.stringify({ name: "foo", dependencies: { [name]: `file:${join(packageDir, name)}` } }),
+      );
+
+      const { out, err, exitCode } = await run(["install"], project, env);
+      const shortened = await shorten();
+
+      expect(err).toContain(`error: Failed to link ${name}: ENAMETOOLONG`);
+      expect(out).not.toContain("installed");
+      // The package itself was installed. Only its bin is missing.
+      expect(await exists(join(shortened, "node_modules", name, "package.json"))).toBeTrue();
+      expect(await exists(join(shortened, "node_modules", ".bin", name))).toBeFalse();
+      expect(exitCode).toBe(1);
+    });
+
+    // `bun link` symlinks the package into the global directory's node_modules and links its bins
+    // from there, into the global bin directory.
+    test("bun link reports a global package directory that does not fit as ENAMETOOLONG", async () => {
+      await writeBinPackage(packageDir, "has-bin");
+      const { dir: globalDir, shorten } = directoryFilledBy(packageDir, join("node_modules", "has-bin"));
+      const globalBinDir = join(packageDir, "global-bin-dir");
+
+      const { out, err, exitCode } = await run(["link"], join(packageDir, "has-bin"), {
+        ...env,
+        BUN_INSTALL: join(packageDir, "global-install-dir"),
+        BUN_INSTALL_GLOBAL_DIR: globalDir,
+        BUN_INSTALL_BIN: globalBinDir,
+      });
+      const shortened = await shorten();
+
+      expect(err).toContain("error: failed to link bin due to error ENAMETOOLONG");
+      expect(out).not.toContain("Success!");
+      // The package itself was registered. Only its bin is missing.
+      expect(await exists(join(shortened, "node_modules", "has-bin", "package.json"))).toBeTrue();
+      expect(await exists(join(globalBinDir, "has-bin"))).toBeFalse();
+      expect(exitCode).toBe(1);
+    });
+  });
 
   test("it will skip (without errors) if a folder from `directories.bin` does not exist", async () => {
     await Promise.all([


### PR DESCRIPTION
### Problem
- `bun install` from a project directory close to PATH_MAX aborts once a dependency declares a bin: `panic: index out of bounds: the len is 4096 but the index is 4096`. `bun link` with a global directory that deep aborts too. Found by an audit of this file. There is no user report.
- `Linker::build_target_package_dir` (`src/install/bin.rs:1523`) and `build_destination_dir` (`bin.rs:1554`) copy `<node_modules>/<package>/` and `<node_modules>/.bin/` into their buffers with no length check. `link()` and `unlink()` call both before the bin name checks. The Zig version had the same copy (notes).

### Fix
- Both builders return `None` when the directory is `MAX_PATH_BYTES` or longer, so no NUL fits after it. `link()` and `unlink()` then set `Error::Sys(ENAMETOOLONG)` and return.
- The bin name checks in `link()` use this bound and this error. The OS refuses such a path with `ENAMETOOLONG`, so this is the OS error, one step earlier. A directory that does not fit never got a bin linked, so `unlink()` gets the same bound.
- The callers already print `Linker::err` and exit 1. `bun install` prints `error: Failed to link has-bin: ENAMETOOLONG` and keeps the package installed.
- Verified: `test/cli/install/bun-install-registry.test.ts`, block `directories longer than the path buffer`. Its three tests abort without the fix. Also the rest of its `binaries` block and the `isolated-install`, `native-binlink`, `bun-link` and `shebang-normalize` suites.

### Background
- `bin::Linker` links the bins of one package. Per bin it builds two NUL terminated absolute paths in buffers of the caller: `<node_modules>/<package>/<file>` and `<node_modules>/.bin/<name>` (`<global bin dir>/<name>` for `-g` and `bun link`).
- `MAX_PATH_BYTES` is the size of these buffers: 4096 on Linux, 1024 on macOS, about 96 KiB on Windows. PATH_MAX counts the NUL, so a usable path has at most `MAX_PATH_BYTES - 1` bytes.
- One site of the path buffer sweep that #39403 folds. Written to be folded (notes).

<details><summary>Notes</summary>

Relation to the fold (#39403, branch `claude/install-mega`). The fold converts every other raw path write in `bin.rs` (#38954) but leaves these two builders as they are, so this is the rest of that file. The diff touches the two builders and their two call sites only. Checked with a cherry-pick onto the fold head `65bd4dd91d`: `bin.rs` merges without a conflict. The test block lands inside the fold's `binaries` block. It needs two things there: the import conflict of two adjacent lines, and `const { packageDir, env } = await setupTest();` as the first line of its two test bodies, because the fold creates the project directory per test. The helpers take the directory and the env as arguments for that reason. `componentsUpTo` has the shape of the helper #38954 adds, so one of the two can go.

Sibling sites, each with its own open PR. They are independent of the two builders, so each lands on its own:
- `<package>/<bin file>` under a package directory that still fits: `resolve_bin_target` joins it in a thread local buffer and aborts on main. #38954 checks those joins in this file, #39658 makes the thread local joins spill to the heap. A 4065 byte cwd with `typescript` is in that range. From the point where the directory itself no longer fits, this PR is the one that applies.
- The second `bun install` in the same project aborts in `PackageInstall::uninstall_before_install` (`src/install/PackageInstall.rs:1967`), a thread local `join_abs_string` of `<node_modules>/.old-<random>`. #39658 covers it with no change at that caller.
- `bun unlink` with such a global directory aborts in `unlink_command.rs:115` before it reaches `unlink()`, in its own thread local `join_abs_string_z` of `<global node_modules>/<name>`. #39658 covers that one too.
- The isolated linker aborts while it builds the store path (`isolated_install/Installer.rs:2784`), before it links bins. That is the area of #37400 and #37424, so there is no isolated test here.

Why `unlink()` has no test of its own. Its new early return has no observable effect: one byte below the bound, `bun unlink` prints `success: unlinked package` and exits 0 with and without this change, because `bun link` never created a bin for such a directory, and `unlink_command` does not read `Linker::err` (`unlink_command.rs:216`, as before). At the bound it aborts earlier, see above.

Callers of `link()`: the hoisted installer (`PackageInstaller::link_tree_bins`, prints `Failed to link <alias>: <error>`), the isolated installer (`Step::Binaries` and `link_dependency_bins`, print `failed to link binaries for package`), and `link_command` (prints `failed to link bin due to error ENAMETOOLONG`).

Test shapes. Each test builds a directory under the test's tmp directory out of names of at most 200 bytes, so that one path is exactly `MAX_PATH_BYTES` long:
- `<project>/node_modules/has-bin`: the `has-bin/` prefix is one byte too long (`build_target_package_dir`, through `bun install`).
- `<project>/node_modules/.bin` with a package named `a`: the package directory fits and `.bin/` is one byte too long (`build_destination_dir`, through `bun install`).
- `<global dir>/node_modules/has-bin` through `BUN_INSTALL_GLOBAL_DIR`: `build_target_package_dir` through `bun link`, which also runs the global branch of `build_destination_dir`.

After the command, the test renames the first long directory name so that it can inspect and delete the paths below the limit. Windows is skipped: its buffer is larger than any path the OS accepts.

History. The Zig builders (`bin.zig`, `buildTargetPackageDir` and `buildDestinationDir`) had the same unchecked copies. A release build of Bun 1.3 wrote past the buffer and went on, which is why 1.3.14 exits 0 here. That was not correct behavior, so this is not a regression test case.

`bun-link.test.ts` has one failure with a debug build on main as well: `should link dependency without crashing` expects exact stdout, and a debug build prints the failure trace. It is unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->