### PR TITLE
repl: redraw input that wraps past the terminal width from the prompt's row

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -254,17 +254,6 @@ fn stdio_tty_flag(idx: usize) -> bool {
     bun_stdio_tty[idx].load(Ordering::Relaxed) != 0
 }
 
-// TYPE_ONLY: bun_sys::Winsize → bun_core (move-in pass).
-// `AtomicCell` because the SIGWINCH handler writes this from signal context
-// while any thread may read it. `Winsize` is 4×u16 = 8 bytes, padding-free.
-pub static TERMINAL_SIZE: crate::AtomicCell<crate::Winsize> =
-    crate::AtomicCell::new(crate::Winsize {
-        row: 0,
-        col: 0,
-        xpixel: 0,
-        ypixel: 0,
-    });
-
 // ──────────────────────────────────────────────────────────────────────────
 // Source
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bun_core/tty.rs
+++ b/src/bun_core/tty.rs
@@ -1,8 +1,6 @@
 use core::ffi::{c_int, c_void};
 
-// ─── MOVE-IN: Winsize (TYPE_ONLY from bun_sys → bun_core) ─────────────────
-// Used by output.rs::TERMINAL_SIZE. Field names
-// match the move-out forward-ref in output.rs (row/col, not ws_row/ws_col).
+/// Terminal size as reported by the tty (`struct winsize` on POSIX).
 #[repr(C)]
 #[derive(Clone, Copy, Default, Debug)]
 pub struct Winsize {
@@ -13,8 +11,6 @@ pub struct Winsize {
 }
 // SAFETY: four `u16` fields; all-zero is a valid `Winsize`.
 unsafe impl crate::ffi::Zeroable for Winsize {}
-// SAFETY: `#[repr(C)]` over four `u16` — exactly 8 bytes, no padding.
-crate::unsafe_impl_atom!(Winsize);
 
 #[repr(C)]
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -850,6 +850,66 @@ enum InputMode {
     Editor,
 }
 
+/// A terminal cell, in rows below the row that holds the prompt.
+#[derive(Clone, Copy, Default)]
+struct ScreenPos {
+    row: usize,
+    col: usize,
+}
+
+impl ScreenPos {
+    fn next_row(self) -> ScreenPos {
+        ScreenPos {
+            row: self.row + 1,
+            col: 0,
+        }
+    }
+}
+
+/// Follows where the terminal puts text written after the prompt.
+struct Layout {
+    width: usize,
+    pos: ScreenPos,
+}
+
+impl Layout {
+    /// Lays out `text` and returns the cell its first glyph went to, or `next` for empty text.
+    fn advance(&mut self, mut text: &[u8]) -> ScreenPos {
+        let mut first: Option<ScreenPos> = None;
+        while !text.is_empty() {
+            let room = self.width.saturating_sub(self.pos.col);
+            let mut fits =
+                strings::visible::width::exclude_ansi_colors::utf8_index_at_width(text, room);
+            if fits == 0 {
+                // Like the terminal, a glyph that does not fit (a wide one) starts the next row.
+                if self.pos.col > 0 {
+                    self.pos = self.pos.next_row();
+                    continue;
+                }
+                // Wider than the whole terminal.
+                fits = text.len();
+            }
+            let (chunk, rest) = text.split_at(fits);
+            let columns = strings::visible::width::exclude_ansi_colors::utf8(chunk);
+            if columns > 0 {
+                first.get_or_insert(self.pos);
+            }
+            self.pos.col += columns;
+            text = rest;
+        }
+        first.unwrap_or_else(|| self.next())
+    }
+
+    /// The cell the next glyph goes to. A full row counts as wrapped; `refresh_line` makes that so.
+    fn next(&self) -> ScreenPos {
+        if self.pos.col >= self.width {
+            self.pos.next_row()
+        } else {
+            self.pos
+        }
+    }
+}
+
 pub(super) struct Repl<'a> {
     line_editor: LineEditor,
     history: History,
@@ -865,11 +925,10 @@ pub(super) struct Repl<'a> {
     use_colors: bool,
     /// Last width the terminal reported.
     terminal_width: u16,
-    /// Rows below the prompt's row on which `refresh_line` left the cursor.
-    cursor_row: usize,
-    /// Row (below the prompt's row) and column just past the last drawn character.
-    end_row: usize,
-    end_col: usize,
+    /// Where `refresh_line` left the terminal cursor.
+    drawn_cursor: ScreenPos,
+    /// The cell after the last character of the line (the ghost text is not counted).
+    drawn_end: ScreenPos,
     ctrl_c_pressed: bool,
 
     // Buffered stdin
@@ -909,9 +968,8 @@ impl<'a> Repl<'a> {
             is_tty: false,
             use_colors: false,
             terminal_width: 80,
-            cursor_row: 0,
-            end_row: 0,
-            end_col: 0,
+            drawn_cursor: ScreenPos::default(),
+            drawn_end: ScreenPos::default(),
             ctrl_c_pressed: false,
             stdin_buf: [0u8; 256],
             stdin_buf_start: 0,
@@ -1258,11 +1316,9 @@ impl<'a> Repl<'a> {
         }
     }
 
-    /// Redraws the input, however many rows it wraps onto, and leaves the terminal
-    /// cursor on the edit cursor. Call `leave_input` before printing below the input.
+    /// Call `leave_input` before printing anything below the input this draws.
     fn refresh_line(&mut self) {
-        // Non-TTY mirrors node's terminal:false repl: input is never echoed or redrawn, since
-        // per-key redraws wedge write(2) on a full socketpair after a few hundred keystrokes.
+        // Non-TTY never redraws (like node): per-key redraws wedge write(2) on a full socketpair.
         if !self.is_tty {
             if self.line_editor.buffer.is_empty() && self.input_mode == InputMode::Normal {
                 Output::flush();
@@ -1284,8 +1340,8 @@ impl<'a> Repl<'a> {
         let line = self.line_editor.get_line();
 
         // Erase the previous drawing from the prompt's row down.
-        if self.cursor_row > 0 {
-            self.print(format_args!("{}{}A", CSI, self.cursor_row));
+        if self.drawn_cursor.row > 0 {
+            self.print(format_args!("{}{}A", CSI, self.drawn_cursor.row));
         }
         self.write(b"\r");
         self.write(Cursor::CLEAR_BELOW.as_bytes());
@@ -1300,62 +1356,76 @@ impl<'a> Repl<'a> {
             self.write(line);
         }
 
-        // Positions below are in columns, not bytes.
-        let mut end = prompt_len + strings::visible::width::exclude_ansi_colors::utf8(line);
         let ghost = self.drawn_suggestion();
         if !ghost.is_empty() {
             self.write(Color::DIM.as_bytes());
             self.write(ghost);
             self.write(Color::RESET.as_bytes());
-            end += strings::visible::width::exclude_ansi_colors::utf8(ghost);
         }
 
-        // The terminal defers the wrap after a character in the last column; force it,
-        // or the cursor is one row above where the arithmetic below puts it.
-        if end.is_multiple_of(width) {
+        let (before_cursor, after_cursor) = line.split_at(self.line_editor.cursor);
+        let mut layout = Layout {
+            width,
+            pos: ScreenPos {
+                row: 0,
+                col: prompt_len,
+            },
+        };
+        layout.advance(before_cursor);
+        let mut cursor = layout.advance(after_cursor);
+        let end = layout.next();
+        if !ghost.is_empty() {
+            // Only drawn with the cursor at the end of the line, so the cursor sits on the ghost.
+            cursor = layout.advance(ghost);
+        }
+
+        // Terminals defer the wrap after the last column; force it to match `layout`.
+        if layout.pos.col >= width {
             self.write(b"\n");
+            layout.pos = layout.pos.next_row();
         }
-        let end_row = end / width;
-        let end_col = end % width;
-
-        let cursor = prompt_len
-            + strings::visible::width::exclude_ansi_colors::utf8(&line[..self.line_editor.cursor]);
-        let cursor_row = cursor / width;
-        let cursor_col = cursor % width;
-        if end_row > cursor_row {
-            self.print(format_args!("{}{}A", CSI, end_row - cursor_row));
+        if layout.pos.row > cursor.row {
+            self.print(format_args!("{}{}A", CSI, layout.pos.row - cursor.row));
         }
         self.write(b"\r");
-        if cursor_col > 0 {
-            self.print(format_args!("{}{}C", CSI, cursor_col));
+        if cursor.col > 0 {
+            self.print(format_args!("{}{}C", CSI, cursor.col));
         }
 
-        self.cursor_row = cursor_row;
-        self.end_row = end_row;
-        self.end_col = end_col;
+        self.drawn_cursor = cursor;
+        self.drawn_end = end;
 
         Output::flush();
     }
 
-    /// Erases the ghost text and moves the terminal cursor past the drawn input,
-    /// so that whatever is printed next lands below all of its rows.
-    fn leave_input(&mut self) {
-        if !self.drawn_suggestion().is_empty() {
-            // Nothing but the ghost follows the cursor.
-            self.write(Cursor::CLEAR_BELOW.as_bytes());
-        } else if self.is_tty {
-            if self.end_row > self.cursor_row {
-                self.print(format_args!("{}{}B", CSI, self.end_row - self.cursor_row));
-            }
-            self.write(b"\r");
-            if self.end_col > 0 {
-                self.print(format_args!("{}{}C", CSI, self.end_col));
+    /// Erases the ghost, writes `echo` after the line, and moves to the start of the row below it.
+    fn leave_input(&mut self, echo: &[u8]) {
+        // False once a line that ends exactly at the right edge has left the cursor on a fresh row.
+        let mut on_input_row = true;
+        if self.is_tty {
+            if !self.drawn_suggestion().is_empty() {
+                // Nothing but the ghost follows the cursor.
+                self.write(Cursor::CLEAR_BELOW.as_bytes());
+                on_input_row = self.drawn_cursor.col > 0;
+            } else {
+                let end = self.drawn_end;
+                if end.row > self.drawn_cursor.row {
+                    self.print(format_args!("{}{}B", CSI, end.row - self.drawn_cursor.row));
+                }
+                self.write(b"\r");
+                if end.col > 0 {
+                    self.print(format_args!("{}{}C", CSI, end.col));
+                }
+                on_input_row = end.col > 0;
             }
         }
+        self.write(echo);
+        if on_input_row || !echo.is_empty() {
+            self.write(b"\n");
+        }
         self.suggestion.clear();
-        self.cursor_row = 0;
-        self.end_row = 0;
-        self.end_col = 0;
+        self.drawn_cursor = ScreenPos::default();
+        self.drawn_end = ScreenPos::default();
     }
 
     // ========================================================================
@@ -2256,8 +2326,7 @@ impl<'a> Repl<'a> {
         while self.running {
             let Some(key) = self.read_key() else {
                 // EOF
-                self.leave_input();
-                self.print(format_args!("\n"));
+                self.leave_input(b"");
                 break;
             };
 
@@ -2272,8 +2341,7 @@ impl<'a> Repl<'a> {
                 Key::CtrlD => match self.input_mode {
                     InputMode::Editor => {
                         // Finish editor mode
-                        self.leave_input();
-                        self.print(format_args!("\n"));
+                        self.leave_input(b"");
                         // Note: reshaped for borrowck — clone editor_buffer slice before evaluate
                         if !self.editor_buffer.is_empty() {
                             let code = core::mem::take(&mut self.editor_buffer);
@@ -2298,7 +2366,7 @@ impl<'a> Repl<'a> {
                     self.write(Cursor::CLEAR_SCREEN.as_bytes());
                     self.write(Cursor::HOME.as_bytes());
                     // The input is redrawn from the top of the now empty screen.
-                    self.cursor_row = 0;
+                    self.drawn_cursor = ScreenPos::default();
                     self.refresh_line();
                 }
                 Key::CtrlA => {
@@ -2425,8 +2493,7 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_enter(&mut self) -> Result<(), crate::Error> {
-        self.leave_input();
-        self.print(format_args!("\n"));
+        self.leave_input(b"");
 
         // Note: reshaped for borrowck — copy line out so we can call &mut self methods
         let line: Vec<u8> = self.line_editor.get_line().to_vec();
@@ -2531,11 +2598,13 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_ctrl_c(&mut self) {
-        self.leave_input();
+        let cancels_line =
+            self.input_mode == InputMode::Normal && !self.line_editor.buffer.is_empty();
+        self.leave_input(if cancels_line { b"^C" } else { b"" });
         match self.input_mode {
             InputMode::Editor => {
                 self.print(format_args!(
-                    "\n{}// Editor mode cancelled{}\n",
+                    "{}// Editor mode cancelled{}\n",
                     Color::DIM,
                     Color::RESET
                 ));
@@ -2543,24 +2612,21 @@ impl<'a> Repl<'a> {
                 self.editor_buffer.clear();
             }
             InputMode::Multiline => {
-                self.print(format_args!("\n"));
                 self.input_mode = InputMode::Normal;
                 self.multiline_buffer.clear();
             }
-            InputMode::Normal if !self.line_editor.buffer.is_empty() => {
-                self.print(format_args!("^C\n"));
+            InputMode::Normal if cancels_line => {
                 self.line_editor.clear();
             }
             InputMode::Normal if self.ctrl_c_pressed => {
                 // Second Ctrl+C on empty line - exit
-                self.print(format_args!("\n"));
                 self.running = false;
                 return;
             }
             InputMode::Normal => {
                 self.ctrl_c_pressed = true;
                 self.print(format_args!(
-                    "\n{}(press Ctrl+C again to exit, or Ctrl+D){}\n",
+                    "{}(press Ctrl+C again to exit, or Ctrl+D){}\n",
                     Color::DIM,
                     Color::RESET
                 ));
@@ -2602,8 +2668,7 @@ impl<'a> Repl<'a> {
                 let _ = self.line_editor.insert(b' ');
                 self.refresh_line();
             } else if matches.len() > 1 {
-                self.leave_input();
-                self.print(format_args!("\n"));
+                self.leave_input(b"");
                 for m in &matches {
                     self.print(format_args!(
                         "  {}{}{}\n",
@@ -2708,8 +2773,7 @@ impl<'a> Repl<'a> {
             }
         } else if len <= 50 {
             // Multiple completions - show them
-            self.leave_input();
-            self.print(format_args!("\n"));
+            self.leave_input(b"");
             let mut i: u32 = 0;
             while i < (len as u32) {
                 let item = match completions.get_index(global, i) {
@@ -2740,9 +2804,9 @@ impl<'a> Repl<'a> {
             }
             self.refresh_line();
         } else {
-            self.leave_input();
+            self.leave_input(b"");
             self.print(format_args!(
-                "\n{}{} completions{}\n",
+                "{}{} completions{}\n",
                 Color::DIM,
                 len,
                 Color::RESET

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -910,6 +910,41 @@ impl Layout {
     }
 }
 
+/// What `refresh_line` last drew on the terminal. The REPL has one only when it is on a terminal.
+#[derive(Clone, Copy)]
+struct Drawing {
+    /// Last width the terminal reported.
+    width: u16,
+    /// Where the terminal cursor was left.
+    cursor: ScreenPos,
+    /// The cell after the last character of the line (the ghost text is not counted).
+    end: ScreenPos,
+}
+
+impl Drawing {
+    fn new() -> Drawing {
+        Drawing {
+            width: 80,
+            cursor: ScreenPos::default(),
+            end: ScreenPos::default(),
+        }
+    }
+
+    fn update_width(&mut self) {
+        if let Some(size) = bun_core::output::File::from(Fd::stdout()).winsize() {
+            if size.col > 0 {
+                self.width = size.col;
+            }
+        }
+    }
+
+    /// The input is gone from the screen; the next redraw starts where the cursor is.
+    fn erased(&mut self) {
+        self.cursor = ScreenPos::default();
+        self.end = ScreenPos::default();
+    }
+}
+
 pub(super) struct Repl<'a> {
     line_editor: LineEditor,
     history: History,
@@ -921,14 +956,9 @@ pub(super) struct Repl<'a> {
     // State
     input_mode: InputMode,
     running: bool,
-    is_tty: bool,
     use_colors: bool,
-    /// Last width the terminal reported.
-    terminal_width: u16,
-    /// Where `refresh_line` left the terminal cursor.
-    drawn_cursor: ScreenPos,
-    /// The cell after the last character of the line (the ghost text is not counted).
-    drawn_end: ScreenPos,
+    /// `None` when stdin or stdout is not a terminal; the input is then never redrawn.
+    drawing: Option<Drawing>,
     ctrl_c_pressed: bool,
 
     // Buffered stdin
@@ -965,11 +995,8 @@ impl<'a> Repl<'a> {
             suggestion: Vec::new(),
             input_mode: InputMode::Normal,
             running: false,
-            is_tty: false,
             use_colors: false,
-            terminal_width: 80,
-            drawn_cursor: ScreenPos::default(),
-            drawn_end: ScreenPos::default(),
+            drawing: None,
             ctrl_c_pressed: false,
             stdin_buf: [0u8; 256],
             stdin_buf_start: 0,
@@ -1002,12 +1029,11 @@ impl<'a> Repl<'a> {
     // ========================================================================
 
     fn setup_terminal(&mut self) {
-        self.is_tty = Output::is_stdout_tty() && Output::is_stdin_tty();
-
-        if !self.is_tty {
+        if !(Output::is_stdout_tty() && Output::is_stdin_tty()) {
             self.use_colors = false;
             return;
         }
+        self.drawing = Some(Drawing::new());
 
         // Check for NO_COLOR
         self.use_colors = !env_var::NO_COLOR.get().unwrap_or(false);
@@ -1308,40 +1334,32 @@ impl<'a> Repl<'a> {
         }
     }
 
-    fn update_terminal_width(&mut self) {
-        if let Some(size) = bun_core::output::File::from(Fd::stdout()).winsize() {
-            if size.col > 0 {
-                self.terminal_width = size.col;
-            }
-        }
-    }
-
     /// Call `leave_input` before printing anything below the input this draws.
     fn refresh_line(&mut self) {
         // Non-TTY never redraws (like node): per-key redraws wedge write(2) on a full socketpair.
-        if !self.is_tty {
+        let Some(mut drawing) = self.drawing else {
             if self.line_editor.buffer.is_empty() && self.input_mode == InputMode::Normal {
                 Output::flush();
                 self.write(self.get_prompt());
                 Output::flush();
             }
             return;
-        }
+        };
 
         // Flush any buffered output (e.g., from console.log in JS) before drawing prompt
         Output::flush();
 
         // Every redraw, so that a resize is picked up.
-        self.update_terminal_width();
-        let width = usize::from(self.terminal_width);
+        drawing.update_width();
+        let width = usize::from(drawing.width);
 
         let prompt = self.get_prompt();
         let prompt_len = self.get_prompt_length();
         let line = self.line_editor.get_line();
 
         // Erase the previous drawing from the prompt's row down.
-        if self.drawn_cursor.row > 0 {
-            self.print(format_args!("{}{}A", CSI, self.drawn_cursor.row));
+        if drawing.cursor.row > 0 {
+            self.print(format_args!("{}{}A", CSI, drawing.cursor.row));
         }
         self.write(b"\r");
         self.write(Cursor::CLEAR_BELOW.as_bytes());
@@ -1392,8 +1410,9 @@ impl<'a> Repl<'a> {
             self.print(format_args!("{}{}C", CSI, cursor.col));
         }
 
-        self.drawn_cursor = cursor;
-        self.drawn_end = end;
+        drawing.cursor = cursor;
+        drawing.end = end;
+        self.drawing = Some(drawing);
 
         Output::flush();
     }
@@ -1402,15 +1421,14 @@ impl<'a> Repl<'a> {
     fn leave_input(&mut self, echo: &[u8]) {
         // False once a line that ends exactly at the right edge has left the cursor on a fresh row.
         let mut on_input_row = true;
-        if self.is_tty {
+        if let Some(Drawing { cursor, end, .. }) = self.drawing {
             if !self.drawn_suggestion().is_empty() {
                 // Nothing but the ghost follows the cursor.
                 self.write(Cursor::CLEAR_BELOW.as_bytes());
-                on_input_row = self.drawn_cursor.col > 0;
+                on_input_row = cursor.col > 0;
             } else {
-                let end = self.drawn_end;
-                if end.row > self.drawn_cursor.row {
-                    self.print(format_args!("{}{}B", CSI, end.row - self.drawn_cursor.row));
+                if end.row > cursor.row {
+                    self.print(format_args!("{}{}B", CSI, end.row - cursor.row));
                 }
                 self.write(b"\r");
                 if end.col > 0 {
@@ -1424,8 +1442,9 @@ impl<'a> Repl<'a> {
             self.write(b"\n");
         }
         self.suggestion.clear();
-        self.drawn_cursor = ScreenPos::default();
-        self.drawn_end = ScreenPos::default();
+        if let Some(drawing) = &mut self.drawing {
+            drawing.erased();
+        }
     }
 
     // ========================================================================
@@ -1460,7 +1479,7 @@ impl<'a> Repl<'a> {
     fn update_suggestion(&mut self) {
         self.suggestion.clear();
 
-        if !self.is_tty || !self.use_colors {
+        if self.drawing.is_none() || !self.use_colors {
             return;
         }
         if self.input_mode != InputMode::Normal {
@@ -2365,8 +2384,9 @@ impl<'a> Repl<'a> {
                 Key::CtrlL => {
                     self.write(Cursor::CLEAR_SCREEN.as_bytes());
                     self.write(Cursor::HOME.as_bytes());
-                    // The input is redrawn from the top of the now empty screen.
-                    self.drawn_cursor = ScreenPos::default();
+                    if let Some(drawing) = &mut self.drawing {
+                        drawing.erased();
+                    }
                     self.refresh_line();
                 }
                 Key::CtrlA => {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -863,12 +863,11 @@ pub(super) struct Repl<'a> {
     running: bool,
     is_tty: bool,
     use_colors: bool,
-    /// Last width reported by the terminal; the fallback when it cannot be queried.
+    /// Last width the terminal reported.
     terminal_width: u16,
-    /// Where `refresh_line` last left the terminal cursor, in rows below the
-    /// row that holds the prompt, and the row and column just past the last
-    /// character it drew. `leave_input` resets them once the input is done.
+    /// Rows below the prompt's row on which `refresh_line` left the cursor.
     cursor_row: usize,
+    /// Row (below the prompt's row) and column just past the last drawn character.
     end_row: usize,
     end_col: usize,
     ctrl_c_pressed: bool,
@@ -1259,15 +1258,11 @@ impl<'a> Repl<'a> {
         }
     }
 
-    /// Redraws the prompt, the line and the ghost text. The input may occupy
-    /// several terminal rows, so the redraw starts from the row that holds the
-    /// prompt and ends by moving the terminal cursor to the row and column of
-    /// the edit cursor. Anything printed below the input (results, completion
-    /// lists) has to go through `leave_input` first.
+    /// Redraws the input, however many rows it wraps onto, and leaves the terminal
+    /// cursor on the edit cursor. Call `leave_input` before printing below the input.
     fn refresh_line(&mut self) {
-        // Non-TTY mirrors node's terminal:false repl: input is never echoed/redrawn — per-key
-        // redraws fill a socketpair's send buffer and wedge write(2) after a few hundred
-        // keystrokes. Print the prompt once when a fresh line begins, like node.
+        // Non-TTY mirrors node's terminal:false repl: input is never echoed or redrawn, since
+        // per-key redraws wedge write(2) on a full socketpair after a few hundred keystrokes.
         if !self.is_tty {
             if self.line_editor.buffer.is_empty() && self.input_mode == InputMode::Normal {
                 Output::flush();
@@ -1280,7 +1275,7 @@ impl<'a> Repl<'a> {
         // Flush any buffered output (e.g., from console.log in JS) before drawing prompt
         Output::flush();
 
-        // Queried on every redraw so a resized terminal is picked up by the next keystroke.
+        // Every redraw, so that a resize is picked up.
         self.update_terminal_width();
         let width = usize::from(self.terminal_width);
 
@@ -1288,8 +1283,7 @@ impl<'a> Repl<'a> {
         let prompt_len = self.get_prompt_length();
         let line = self.line_editor.get_line();
 
-        // Back up to the prompt's row and erase the previous drawing, including
-        // any rows it wrapped onto.
+        // Erase the previous drawing from the prompt's row down.
         if self.cursor_row > 0 {
             self.print(format_args!("{}{}A", CSI, self.cursor_row));
         }
@@ -1306,8 +1300,7 @@ impl<'a> Repl<'a> {
             self.write(line);
         }
 
-        // Widths are display columns: multi-byte UTF-8 and wide (e.g. CJK)
-        // characters advance the column by their width, not their byte count.
+        // Positions below are in columns, not bytes.
         let mut end = prompt_len + strings::visible::width::exclude_ansi_colors::utf8(line);
         let ghost = self.drawn_suggestion();
         if !ghost.is_empty() {
@@ -1317,9 +1310,8 @@ impl<'a> Repl<'a> {
             end += strings::visible::width::exclude_ansi_colors::utf8(ghost);
         }
 
-        // A character in the last column leaves the terminal cursor on that
-        // column instead of wrapping, so the row arithmetic below would be off
-        // by one row; force the wrap.
+        // The terminal defers the wrap after a character in the last column; force it,
+        // or the cursor is one row above where the arithmetic below puts it.
         if end.is_multiple_of(width) {
             self.write(b"\n");
         }
@@ -1345,12 +1337,11 @@ impl<'a> Repl<'a> {
         Output::flush();
     }
 
-    /// Erases the ghost text and moves the terminal cursor to the end of the
-    /// drawn input, so that output printed next starts below the whole input
-    /// rather than in the middle of a wrapped line.
+    /// Erases the ghost text and moves the terminal cursor past the drawn input,
+    /// so that whatever is printed next lands below all of its rows.
     fn leave_input(&mut self) {
         if !self.drawn_suggestion().is_empty() {
-            // The cursor is at the end of the line, so the ghost is all that follows it.
+            // Nothing but the ghost follows the cursor.
             self.write(Cursor::CLEAR_BELOW.as_bytes());
         } else if self.is_tty {
             if self.end_row > self.cursor_row {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -14,7 +14,6 @@
 #[cfg(unix)]
 use core::ffi::c_int;
 use core::fmt::Arguments;
-use std::io::Write as _;
 
 use bstr::BStr;
 
@@ -80,8 +79,8 @@ use bun_core::output::ansi as Color;
 struct Cursor;
 impl Cursor {
     const HOME: &'static str = concat!("\x1b", "[", "H");
-    const CLEAR_LINE: &'static str = concat!("\x1b", "[", "2K");
-    const CLEAR_TO_END: &'static str = concat!("\x1b", "[", "0K");
+    /// Erase from the cursor to the end of the screen.
+    const CLEAR_BELOW: &'static str = concat!("\x1b", "[", "J");
     const CLEAR_SCREEN: &'static str = concat!("\x1b", "[", "2J");
     const CLEAR_SCROLLBACK: &'static str = concat!("\x1b", "[", "3J");
 }
@@ -864,7 +863,14 @@ pub(super) struct Repl<'a> {
     running: bool,
     is_tty: bool,
     use_colors: bool,
+    /// Last width reported by the terminal; the fallback when it cannot be queried.
     terminal_width: u16,
+    /// Where `refresh_line` last left the terminal cursor, in rows below the
+    /// row that holds the prompt, and the row and column just past the last
+    /// character it drew. `leave_input` resets them once the input is done.
+    cursor_row: usize,
+    end_row: usize,
+    end_col: usize,
     ctrl_c_pressed: bool,
 
     // Buffered stdin
@@ -904,6 +910,9 @@ impl<'a> Repl<'a> {
             is_tty: false,
             use_colors: false,
             terminal_width: 80,
+            cursor_row: 0,
+            end_row: 0,
+            end_col: 0,
             ctrl_c_pressed: false,
             stdin_buf: [0u8; 256],
             stdin_buf_start: 0,
@@ -945,12 +954,6 @@ impl<'a> Repl<'a> {
 
         // Check for NO_COLOR
         self.use_colors = !env_var::NO_COLOR.get().unwrap_or(false);
-
-        // Get terminal size
-        let ts = Output::TERMINAL_SIZE.load();
-        if ts.col > 0 {
-            self.terminal_width = ts.col;
-        }
 
         // Enable raw mode
         #[cfg(unix)]
@@ -1239,10 +1242,32 @@ impl<'a> Repl<'a> {
         2 // "> " or "\u{276f} "
     }
 
-    fn refresh_line(&self) {
+    /// The ghost text is only drawn while the cursor is at the end of the line.
+    fn drawn_suggestion(&self) -> &[u8] {
+        if self.use_colors && self.line_editor.cursor == self.line_editor.buffer.len() {
+            &self.suggestion
+        } else {
+            b""
+        }
+    }
+
+    fn update_terminal_width(&mut self) {
+        if let Some(size) = bun_core::output::File::from(Fd::stdout()).winsize() {
+            if size.col > 0 {
+                self.terminal_width = size.col;
+            }
+        }
+    }
+
+    /// Redraws the prompt, the line and the ghost text. The input may occupy
+    /// several terminal rows, so the redraw starts from the row that holds the
+    /// prompt and ends by moving the terminal cursor to the row and column of
+    /// the edit cursor. Anything printed below the input (results, completion
+    /// lists) has to go through `leave_input` first.
+    fn refresh_line(&mut self) {
         // Non-TTY mirrors node's terminal:false repl: input is never echoed/redrawn — per-key
-        // CLEAR_LINE rewrites fill a socketpair's send buffer and wedge write(2) after a few
-        // hundred keystrokes. Print the prompt once when a fresh line begins, like node.
+        // redraws fill a socketpair's send buffer and wedge write(2) after a few hundred
+        // keystrokes. Print the prompt once when a fresh line begins, like node.
         if !self.is_tty {
             if self.line_editor.buffer.is_empty() && self.input_mode == InputMode::Normal {
                 Output::flush();
@@ -1255,13 +1280,21 @@ impl<'a> Repl<'a> {
         // Flush any buffered output (e.g., from console.log in JS) before drawing prompt
         Output::flush();
 
+        // Queried on every redraw so a resized terminal is picked up by the next keystroke.
+        self.update_terminal_width();
+        let width = usize::from(self.terminal_width);
+
         let prompt = self.get_prompt();
         let prompt_len = self.get_prompt_length();
         let line = self.line_editor.get_line();
 
-        // Move to beginning of line
+        // Back up to the prompt's row and erase the previous drawing, including
+        // any rows it wrapped onto.
+        if self.cursor_row > 0 {
+            self.print(format_args!("{}{}A", CSI, self.cursor_row));
+        }
         self.write(b"\r");
-        self.write(Cursor::CLEAR_LINE.as_bytes());
+        self.write(Cursor::CLEAR_BELOW.as_bytes());
 
         // Write prompt
         self.write(prompt);
@@ -1273,35 +1306,65 @@ impl<'a> Repl<'a> {
             self.write(line);
         }
 
-        // Ghost text; update_suggestion() already guarantees it fits on this row.
-        if !self.suggestion.is_empty()
-            && self.use_colors
-            && self.line_editor.cursor == self.line_editor.buffer.len()
-        {
+        // Widths are display columns: multi-byte UTF-8 and wide (e.g. CJK)
+        // characters advance the column by their width, not their byte count.
+        let mut end = prompt_len + strings::visible::width::exclude_ansi_colors::utf8(line);
+        let ghost = self.drawn_suggestion();
+        if !ghost.is_empty() {
             self.write(Color::DIM.as_bytes());
-            self.write(&self.suggestion);
+            self.write(ghost);
             self.write(Color::RESET.as_bytes());
+            end += strings::visible::width::exclude_ansi_colors::utf8(ghost);
         }
 
-        // Position cursor. The cursor is a byte offset, but the terminal column
-        // is the display width of the text before it, so multi-byte UTF-8 and
-        // wide (e.g. CJK) characters advance the column correctly.
-        let cursor_col =
-            strings::visible::width::exclude_ansi_colors::utf8(&line[..self.line_editor.cursor]);
-        let cursor_pos = prompt_len + cursor_col;
-        if cursor_pos < self.terminal_width as usize {
-            self.write(b"\r");
-            if cursor_pos > 0 {
-                let mut buf = [0u8; 16];
-                let mut w: &mut [u8] = &mut buf;
-                if write!(w, "{}{}C", CSI, cursor_pos).is_ok() {
-                    let written = 16 - w.len();
-                    self.write(&buf[..written]);
-                }
-            }
+        // A character in the last column leaves the terminal cursor on that
+        // column instead of wrapping, so the row arithmetic below would be off
+        // by one row; force the wrap.
+        if end.is_multiple_of(width) {
+            self.write(b"\n");
         }
+        let end_row = end / width;
+        let end_col = end % width;
+
+        let cursor = prompt_len
+            + strings::visible::width::exclude_ansi_colors::utf8(&line[..self.line_editor.cursor]);
+        let cursor_row = cursor / width;
+        let cursor_col = cursor % width;
+        if end_row > cursor_row {
+            self.print(format_args!("{}{}A", CSI, end_row - cursor_row));
+        }
+        self.write(b"\r");
+        if cursor_col > 0 {
+            self.print(format_args!("{}{}C", CSI, cursor_col));
+        }
+
+        self.cursor_row = cursor_row;
+        self.end_row = end_row;
+        self.end_col = end_col;
 
         Output::flush();
+    }
+
+    /// Erases the ghost text and moves the terminal cursor to the end of the
+    /// drawn input, so that output printed next starts below the whole input
+    /// rather than in the middle of a wrapped line.
+    fn leave_input(&mut self) {
+        if !self.drawn_suggestion().is_empty() {
+            // The cursor is at the end of the line, so the ghost is all that follows it.
+            self.write(Cursor::CLEAR_BELOW.as_bytes());
+        } else if self.is_tty {
+            if self.end_row > self.cursor_row {
+                self.print(format_args!("{}{}B", CSI, self.end_row - self.cursor_row));
+            }
+            self.write(b"\r");
+            if self.end_col > 0 {
+                self.print(format_args!("{}{}C", CSI, self.end_col));
+            }
+        }
+        self.suggestion.clear();
+        self.cursor_row = 0;
+        self.end_row = 0;
+        self.end_col = 0;
     }
 
     // ========================================================================
@@ -1433,18 +1496,6 @@ impl<'a> Repl<'a> {
                 }
             }
         }
-
-        // Dropped here, not at render, so accept can never apply more than was drawn.
-        if !self.suggestion.is_empty() {
-            let line_width = strings::visible::width::exclude_ansi_colors::utf8(&line);
-            let suggestion_width =
-                strings::visible::width::exclude_ansi_colors::utf8(&self.suggestion);
-            if self.get_prompt_length() + line_width + suggestion_width
-                >= self.terminal_width as usize
-            {
-                self.suggestion.clear();
-            }
-        }
     }
 
     fn accept_suggestion(&mut self) -> bool {
@@ -1456,14 +1507,6 @@ impl<'a> Repl<'a> {
         self.suggestion = sugg;
         self.suggestion.clear();
         ok
-    }
-
-    /// Clear the suggestion and wipe any ghost text already drawn past the cursor.
-    fn erase_suggestion(&mut self) {
-        if !self.suggestion.is_empty() {
-            self.write(Cursor::CLEAR_TO_END.as_bytes());
-            self.suggestion.clear();
-        }
     }
 
     fn write_highlighted(&self, text: &[u8]) {
@@ -2222,6 +2265,7 @@ impl<'a> Repl<'a> {
         while self.running {
             let Some(key) = self.read_key() else {
                 // EOF
+                self.leave_input();
                 self.print(format_args!("\n"));
                 break;
             };
@@ -2237,6 +2281,7 @@ impl<'a> Repl<'a> {
                 Key::CtrlD => match self.input_mode {
                     InputMode::Editor => {
                         // Finish editor mode
+                        self.leave_input();
                         self.print(format_args!("\n"));
                         // Note: reshaped for borrowck — clone editor_buffer slice before evaluate
                         if !self.editor_buffer.is_empty() {
@@ -2261,6 +2306,8 @@ impl<'a> Repl<'a> {
                 Key::CtrlL => {
                     self.write(Cursor::CLEAR_SCREEN.as_bytes());
                     self.write(Cursor::HOME.as_bytes());
+                    // The input is redrawn from the top of the now empty screen.
+                    self.cursor_row = 0;
                     self.refresh_line();
                 }
                 Key::CtrlA => {
@@ -2387,7 +2434,7 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_enter(&mut self) -> Result<(), crate::Error> {
-        self.erase_suggestion();
+        self.leave_input();
         self.print(format_args!("\n"));
 
         // Note: reshaped for borrowck — copy line out so we can call &mut self methods
@@ -2493,7 +2540,7 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_ctrl_c(&mut self) {
-        self.erase_suggestion();
+        self.leave_input();
         match self.input_mode {
             InputMode::Editor => {
                 self.print(format_args!(
@@ -2564,6 +2611,7 @@ impl<'a> Repl<'a> {
                 let _ = self.line_editor.insert(b' ');
                 self.refresh_line();
             } else if matches.len() > 1 {
+                self.leave_input();
                 self.print(format_args!("\n"));
                 for m in &matches {
                     self.print(format_args!(
@@ -2669,6 +2717,7 @@ impl<'a> Repl<'a> {
             }
         } else if len <= 50 {
             // Multiple completions - show them
+            self.leave_input();
             self.print(format_args!("\n"));
             let mut i: u32 = 0;
             while i < (len as u32) {
@@ -2700,6 +2749,7 @@ impl<'a> Repl<'a> {
             }
             self.refresh_line();
         } else {
+            self.leave_input();
             self.print(format_args!(
                 "\n{}{} completions{}\n",
                 Color::DIM,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3332,9 +3332,7 @@ impl RunCommand {
         // hyperlinks when colors are on. Light/dark detected from env.
         let colors = Output::enable_ansi_colors_stdout();
         let columns: u16 = 'brk: {
-            // Output.terminal_size is never populated; query stdout
-            // directly. Honor COLUMNS so piped output and tests can
-            // pin a width.
+            // Honor COLUMNS so piped output and tests can pin a width.
             if let Some(env) = bun_core::getenv_z(bun_core::zstr!("COLUMNS")) {
                 if let Ok(n) = bun_core::fmt::parse_int::<u16>(env, 10) {
                     if n > 0 {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9371,9 +9371,27 @@ fn sink_tty_winsize(fd: Fd) -> Option<bun_core::Winsize> {
         ypixel: ws.ws_ypixel,
     })
 }
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn sink_tty_winsize(fd: Fd) -> Option<bun_core::Winsize> {
+    // SAFETY: all-zero is a valid CONSOLE_SCREEN_BUFFER_INFO (#[repr(C)] POD).
+    let mut info: windows::CONSOLE_SCREEN_BUFFER_INFO = bun_core::ffi::zeroed();
+    // SAFETY: `info` is a valid out-pointer for the duration of the call; a
+    // handle that is not a console makes the call fail rather than misbehave.
+    let rc = unsafe { windows::kernel32::GetConsoleScreenBufferInfo(fd.native(), &raw mut info) };
+    if rc == windows::FALSE {
+        return None;
+    }
+    // `srWindow` is the visible part of the (possibly much taller) screen buffer.
+    let window = info.srWindow;
+    Some(bun_core::Winsize {
+        row: u16::try_from(i32::from(window.Bottom) - i32::from(window.Top) + 1).ok()?,
+        col: u16::try_from(i32::from(window.Right) - i32::from(window.Left) + 1).ok()?,
+        xpixel: 0,
+        ypixel: 0,
+    })
+}
+#[cfg(not(any(unix, windows)))]
 fn sink_tty_winsize(_fd: Fd) -> Option<bun_core::Winsize> {
-    // TODO(windows): GetConsoleScreenBufferInfo.
     None
 }
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -23,11 +23,11 @@ async function runRepl(
     stderr: "pipe",
     env: {
       ...bunEnv,
-      HOME: String(home),
-      USERPROFILE: String(home),
       TERM: "dumb",
       NO_COLOR: "1",
       ...env,
+      HOME: String(home),
+      USERPROFILE: String(home),
     },
   });
 
@@ -47,100 +47,134 @@ interface Screen {
   cursor: { row: number; col: number };
 }
 
-// Replays the REPL's output on a model of a `cols` wide terminal: printable
-// characters auto-wrap, and the cursor and erase controls the line editor uses
-// are interpreted. The screen is unbounded in height, so rows never scroll off.
-function renderScreen(output: string, cols: number): Screen {
-  const rows: string[][] = [[]];
-  let row = 0;
-  let col = 0;
-  // A character written in the last column leaves the cursor on that column;
-  // the wrap happens when the next character arrives (as in xterm).
-  let pendingWrap = false;
-  const rowAt = (index: number) => {
-    while (rows.length <= index) rows.push([]);
-    return rows[index];
-  };
+// A model of a `cols` wide terminal fed with the REPL's output: text auto-wraps
+// (a wide glyph that does not fit in the last cell moves to the next row whole),
+// and the cursor and erase controls the line editor uses are interpreted. The
+// screen is unbounded in height, so rows never scroll off.
+class ScreenModel {
+  private readonly rows: string[][] = [[]];
+  private row = 0;
+  private col = 0;
+  // A glyph that fills the row leaves the cursor on the last column; the wrap
+  // happens when the next glyph arrives (as in xterm).
+  private pendingWrap = false;
+  // An escape sequence cut off at the end of the previous chunk.
+  private unfinished = "";
 
-  let i = 0;
-  while (i < output.length) {
-    const ch = output[i];
-    if (ch === "\x1b") {
-      const rest = output.slice(i, i + 24);
-      const seq = /^\x1b\[([\d;]*)([A-Za-z])/.exec(rest);
-      if (seq === null) {
-        // The final byte of this sequence has not arrived yet.
-        if (/^\x1b(\[[\d;]*)?$/.test(rest)) break;
-        throw new Error(`renderScreen: unsupported escape sequence ${JSON.stringify(rest)}`);
-      }
-      i += seq[0].length;
-      const n = seq[1] === "" ? undefined : Number(seq[1]);
-      switch (seq[2]) {
-        case "m": // colors
-          break;
-        case "A":
-          row = Math.max(0, row - (n ?? 1));
-          pendingWrap = false;
-          break;
-        case "B":
-          row += n ?? 1;
-          pendingWrap = false;
-          break;
-        case "C":
-          col = Math.min(cols - 1, col + (n ?? 1));
-          pendingWrap = false;
-          break;
-        case "D":
-          col = Math.max(0, col - (n ?? 1));
-          pendingWrap = false;
-          break;
-        case "J": // erase from the cursor to the end of the screen
-          if ((n ?? 0) !== 0) throw new Error(`renderScreen: unsupported erase ${JSON.stringify(seq[0])}`);
-          rowAt(row).length = Math.min(rowAt(row).length, col);
-          rows.length = row + 1;
-          break;
-        case "K": // erase to the end of the row (0) or the whole row (2)
-          if (n === 2) rowAt(row).length = 0;
-          else if ((n ?? 0) === 0) rowAt(row).length = Math.min(rowAt(row).length, col);
-          else throw new Error(`renderScreen: unsupported erase ${JSON.stringify(seq[0])}`);
-          break;
-        default:
-          throw new Error(`renderScreen: unsupported escape sequence ${JSON.stringify(seq[0])}`);
-      }
-      continue;
-    }
-    i++;
-    if (ch === "\r") {
-      col = 0;
-      pendingWrap = false;
-      continue;
-    }
-    if (ch === "\n") {
-      // The pty translates "\n" to "\r\n", so the column was already reset.
-      row++;
-      pendingWrap = false;
-      continue;
-    }
-    if (pendingWrap) {
-      row++;
-      col = 0;
-      pendingWrap = false;
-    }
-    const cells = rowAt(row);
-    while (cells.length < col) cells.push(" ");
-    cells[col] = ch;
-    if (col === cols - 1) pendingWrap = true;
-    else col++;
+  constructor(private readonly cols: number) {}
+
+  private rowAt(index: number): string[] {
+    while (this.rows.length <= index) this.rows.push([]);
+    return this.rows[index];
   }
-  rowAt(row);
-  return { rows: rows.map(cells => cells.join("")), cursor: { row, col } };
+
+  feed(chunk: string): void {
+    const output = this.unfinished + chunk;
+    this.unfinished = "";
+    let i = 0;
+    while (i < output.length) {
+      const codePoint = output.codePointAt(i)!;
+      if (codePoint === 0x1b) {
+        const rest = output.slice(i, i + 24);
+        const seq = /^\x1b\[([\d;]*)([A-Za-z])/.exec(rest);
+        if (seq === null) {
+          if (/^\x1b(\[[\d;]*)?$/.test(rest)) {
+            this.unfinished = output.slice(i);
+            return;
+          }
+          throw new Error(`ScreenModel: unsupported escape sequence ${JSON.stringify(rest)}`);
+        }
+        i += seq[0].length;
+        this.control(seq[2], seq[1] === "" ? undefined : Number(seq[1]), seq[0]);
+        continue;
+      }
+      const ch = codePoint > 0xffff ? String.fromCodePoint(codePoint) : output[i];
+      i += ch.length;
+      if (ch === "\r") {
+        this.col = 0;
+        this.pendingWrap = false;
+      } else if (ch === "\n") {
+        // The pty translates "\n" to "\r\n", so the column was already reset.
+        this.row++;
+        this.pendingWrap = false;
+      } else {
+        this.put(ch, codePoint < 0x80 ? 1 : Bun.stringWidth(ch));
+      }
+    }
+  }
+
+  private control(command: string, n: number | undefined, sequence: string): void {
+    switch (command) {
+      case "m": // colors
+        return;
+      case "A":
+        this.row = Math.max(0, this.row - (n ?? 1));
+        break;
+      case "B":
+        this.row += n ?? 1;
+        break;
+      case "C":
+        this.col = Math.min(this.cols - 1, this.col + (n ?? 1));
+        break;
+      case "D":
+        this.col = Math.max(0, this.col - (n ?? 1));
+        break;
+      case "J": // erase from the cursor to the end of the screen
+        if ((n ?? 0) !== 0) throw new Error(`ScreenModel: unsupported erase ${JSON.stringify(sequence)}`);
+        this.rowAt(this.row).length = Math.min(this.rowAt(this.row).length, this.col);
+        this.rows.length = this.row + 1;
+        break;
+      case "K": // erase to the end of the row (0) or the whole row (2)
+        if (n === 2) this.rowAt(this.row).length = 0;
+        else if ((n ?? 0) === 0) this.rowAt(this.row).length = Math.min(this.rowAt(this.row).length, this.col);
+        else throw new Error(`ScreenModel: unsupported erase ${JSON.stringify(sequence)}`);
+        break;
+      default:
+        throw new Error(`ScreenModel: unsupported escape sequence ${JSON.stringify(sequence)}`);
+    }
+    this.pendingWrap = false;
+  }
+
+  private put(ch: string, width: number): void {
+    if (width === 0) return;
+    if (this.pendingWrap || this.col + width > this.cols) {
+      this.row++;
+      this.col = 0;
+      this.pendingWrap = false;
+    }
+    const cells = this.rowAt(this.row);
+    while (cells.length < this.col) cells.push(" ");
+    cells[this.col] = ch;
+    // The second cell of a wide glyph holds nothing of its own.
+    for (let extra = 1; extra < width; extra++) cells[this.col + extra] = "";
+    if (this.col + width >= this.cols) {
+      this.col = this.cols - 1;
+      this.pendingWrap = true;
+    } else {
+      this.col += width;
+    }
+  }
+
+  screen(): Screen {
+    this.rowAt(this.row);
+    return { rows: this.rows.map(cells => cells.join("")), cursor: { row: this.row, col: this.col } };
+  }
 }
 
 function formatScreen({ rows, cursor }: Screen): string {
   return rows
-    .map((text, row) =>
-      row === cursor.row ? text.slice(0, cursor.col).padEnd(cursor.col) + "|" + text.slice(cursor.col) : text,
-    )
+    .map((text, row) => {
+      if (row !== cursor.row) return text;
+      // Find the character that starts at the cursor's column.
+      let column = 0;
+      let index = 0;
+      while (index < text.length && column < cursor.col) {
+        const ch = String.fromCodePoint(text.codePointAt(index)!);
+        column += Bun.stringWidth(ch);
+        index += ch.length;
+      }
+      return text.slice(0, index) + " ".repeat(Math.max(0, cursor.col - column)) + "|" + text.slice(index);
+    })
     .join("\n");
 }
 
@@ -161,6 +195,8 @@ async function withTerminalRepl(
   const cols = options.cols ?? 120;
   let cursor = 0;
   let resolveWaiter: (() => void) | null = null;
+  // Streaming, so that a multi-byte character split across two reads stays intact.
+  const decoder = new TextDecoder();
 
   // The REPL loads and saves $HOME/.bun_repl_history (USERPROFILE on Windows).
   using home = tempDir("repl-home", {});
@@ -168,7 +204,7 @@ async function withTerminalRepl(
     cols,
     rows: 40,
     data(_term, data) {
-      const str = Buffer.from(data).toString();
+      const str = decoder.decode(data, { stream: true });
       received.push(str);
       if (resolveWaiter) {
         resolveWaiter();
@@ -182,10 +218,10 @@ async function withTerminalRepl(
     terminal,
     env: {
       ...bunEnv,
-      HOME: String(home),
-      USERPROFILE: String(home),
       TERM: "xterm-256color",
       ...options.env,
+      HOME: String(home),
+      USERPROFILE: String(home),
     },
   });
 
@@ -218,10 +254,13 @@ async function withTerminalRepl(
 
   // The REPL redraws within milliseconds of a keystroke; the deadline is well
   // below the test timeout so that a failure reports the screen it got stuck on.
+  const model = new ScreenModel(cols);
+  let modelled = 0;
   const waitForScreen = async (ready: (screen: Screen) => boolean, timeoutMs = 3000): Promise<Screen> => {
     const deadline = Date.now() + timeoutMs;
     while (true) {
-      const screen = renderScreen(received.join(""), cols);
+      while (modelled < received.length) model.feed(received[modelled++]);
+      const screen = model.screen();
       if (ready(screen)) return screen;
       const remaining = deadline - Date.now();
       if (remaining <= 0) {
@@ -1607,8 +1646,79 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
           send("\n");
           screen = await waitForScreen(s => s.rows.at(-1) === "❯ " && s.rows.at(-2) === "7");
           expect(screen.rows.slice(top)).toEqual([...setup, `❯ ${input}`, "7", "❯ "]);
+          const evaluated = [...setup, `❯ ${input}`, "7"];
+
+          // "❯ " plus 38 characters fills the row, so the whole ghost goes to the
+          // next row, and the cursor with it.
+          const filling = "[1, 2, 3, 4, 5, 6, 7, 888].length + zz";
+          send(filling);
+          screen = await waitForScreen(s => s.rows.at(-1) === "LongSuffixName");
+          expect(screen.rows.slice(top)).toEqual([...evaluated, `❯ ${filling}`, "LongSuffixName"]);
+          await waitForScreen(s => s.cursor.row === screen.rows.length - 1 && s.cursor.col === 0);
+
+          // Enter erases the ghost; the result takes the row the ghost was on.
+          send("\n");
+          screen = await waitForScreen(s => s.rows.at(-1) === "❯ " && s.rows.at(-2) === "9");
+          expect(screen.rows.slice(top)).toEqual([...evaluated, `❯ ${filling}`, "9", "❯ "]);
         },
         { cols, env: { NO_COLOR: undefined, FORCE_COLOR: "1" } },
+      );
+    });
+
+    test("a line that fills the row exactly leaves no blank row behind", async () => {
+      // "> " plus 28 characters is exactly 30 columns.
+      const filling = `"${Buffer.alloc(19, "a")}".length`;
+      await withTerminalRepl(
+        async ({ send, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+
+          send(filling);
+          // The cursor has nowhere to go on the full row, so it waits on an empty one.
+          let screen = await waitForScreen(s => s.cursor.row === top + 1 && s.cursor.col === 0);
+          expect(screen.rows.slice(top)).toEqual([`> ${filling}`, ""]);
+
+          send("\n");
+          screen = await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "19");
+          expect(screen.rows.slice(top)).toEqual([`> ${filling}`, "19", "> "]);
+
+          send(filling);
+          await waitForScreen(s => s.rows.at(-1) === "" && s.rows.at(-2) === `> ${filling}`);
+          send("\x03");
+          screen = await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "^C");
+          expect(screen.rows.slice(top)).toEqual([`> ${filling}`, "19", `> ${filling}`, "^C", "> "]);
+        },
+        { cols },
+      );
+    });
+
+    test("wide characters wrap the way the terminal wraps them", async () => {
+      // 21 columns: a 2 column glyph never fits in the last cell of a row that
+      // starts on an even column, so those rows hold one column less than the
+      // width. `> "` and nine glyphs fill the first row; the second row holds ten
+      // glyphs and a blank cell; the rest goes on the third row.
+      const cols = 21;
+      const glyphs = Array.from({ length: 25 }, () => "日");
+      const input = `"${glyphs.join("")}".length`;
+      await withTerminalRepl(
+        async ({ send, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+
+          send(input);
+          const third = `${glyphs.slice(19).join("")}".length`;
+          let screen = await waitForScreen(s => s.rows.at(-1) === third);
+          expect(screen.rows.slice(top)).toEqual([
+            `> "${glyphs.slice(0, 9).join("")}`,
+            glyphs.slice(9, 19).join(""),
+            third,
+          ]);
+          // Six glyphs and `".length` are 20 columns.
+          await waitForScreen(s => s.cursor.row === top + 2 && s.cursor.col === 20);
+
+          send("\n");
+          screen = await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "25");
+          expect(screen.rows.slice(top + 2)).toEqual([third, "25", "> "]);
+        },
+        { cols },
       );
     });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -37,6 +37,109 @@ async function runRepl(
 
 const stripAnsi = Bun.stripANSI;
 
+interface Screen {
+  /** One string per row, holding exactly the cells that were written to it. */
+  rows: string[];
+  cursor: { row: number; col: number };
+}
+
+// Replays the REPL's output on a model of a `cols` wide terminal: printable
+// characters auto-wrap, and the cursor and erase controls the line editor uses
+// are interpreted. The screen is unbounded in height, so rows never scroll off.
+function renderScreen(output: string, cols: number): Screen {
+  const rows: string[][] = [[]];
+  let row = 0;
+  let col = 0;
+  // A character written in the last column leaves the cursor on that column;
+  // the wrap happens when the next character arrives (as in xterm).
+  let pendingWrap = false;
+  const rowAt = (index: number) => {
+    while (rows.length <= index) rows.push([]);
+    return rows[index];
+  };
+
+  let i = 0;
+  while (i < output.length) {
+    const ch = output[i];
+    if (ch === "\x1b") {
+      const rest = output.slice(i, i + 24);
+      const seq = /^\x1b\[([\d;]*)([A-Za-z])/.exec(rest);
+      if (seq === null) {
+        // The final byte of this sequence has not arrived yet.
+        if (/^\x1b(\[[\d;]*)?$/.test(rest)) break;
+        throw new Error(`renderScreen: unsupported escape sequence ${JSON.stringify(rest)}`);
+      }
+      i += seq[0].length;
+      const n = seq[1] === "" ? undefined : Number(seq[1]);
+      switch (seq[2]) {
+        case "m": // colors
+          break;
+        case "A":
+          row = Math.max(0, row - (n ?? 1));
+          pendingWrap = false;
+          break;
+        case "B":
+          row += n ?? 1;
+          pendingWrap = false;
+          break;
+        case "C":
+          col = Math.min(cols - 1, col + (n ?? 1));
+          pendingWrap = false;
+          break;
+        case "D":
+          col = Math.max(0, col - (n ?? 1));
+          pendingWrap = false;
+          break;
+        case "J": // erase from the cursor to the end of the screen
+          if ((n ?? 0) !== 0) throw new Error(`renderScreen: unsupported erase ${JSON.stringify(seq[0])}`);
+          rowAt(row).length = Math.min(rowAt(row).length, col);
+          rows.length = row + 1;
+          break;
+        case "K": // erase to the end of the row (0) or the whole row (2)
+          if (n === 2) rowAt(row).length = 0;
+          else if ((n ?? 0) === 0) rowAt(row).length = Math.min(rowAt(row).length, col);
+          else throw new Error(`renderScreen: unsupported erase ${JSON.stringify(seq[0])}`);
+          break;
+        default:
+          throw new Error(`renderScreen: unsupported escape sequence ${JSON.stringify(seq[0])}`);
+      }
+      continue;
+    }
+    i++;
+    if (ch === "\r") {
+      col = 0;
+      pendingWrap = false;
+      continue;
+    }
+    if (ch === "\n") {
+      // The pty translates "\n" to "\r\n", so the column was already reset.
+      row++;
+      pendingWrap = false;
+      continue;
+    }
+    if (pendingWrap) {
+      row++;
+      col = 0;
+      pendingWrap = false;
+    }
+    const cells = rowAt(row);
+    while (cells.length < col) cells.push(" ");
+    cells[col] = ch;
+    if (col === cols - 1) pendingWrap = true;
+    else col++;
+  }
+  rowAt(row);
+  return { rows: rows.map(cells => cells.join("")), cursor: { row, col } };
+}
+
+function formatScreen({ rows, cursor }: Screen): string {
+  return rows
+    .map((text, row) =>
+      row === cursor.row ? text.slice(0, cursor.col).padEnd(cursor.col) + "|" + text.slice(cursor.col) : text,
+    )
+    .join("\n");
+}
+
 // Helper to run REPL in a PTY and interact with it
 async function withTerminalRepl(
   fn: (helpers: {
@@ -44,16 +147,19 @@ async function withTerminalRepl(
     proc: Bun.ChildProcess;
     send: (text: string) => void;
     waitFor: (pattern: string | RegExp, timeoutMs?: number) => Promise<string>;
+    /** Resolves with the rendered screen once `ready` accepts it. */
+    waitForScreen: (ready: (screen: Screen) => boolean, timeoutMs?: number) => Promise<Screen>;
     allOutput: () => string;
   }) => Promise<void>,
-  options: { env?: Record<string, string | undefined> } = {},
+  options: { env?: Record<string, string | undefined>; cols?: number } = {},
 ) {
   const received: string[] = [];
+  const cols = options.cols ?? 120;
   let cursor = 0;
   let resolveWaiter: (() => void) | null = null;
 
   await using terminal = new Bun.Terminal({
-    cols: 120,
+    cols,
     rows: 40,
     data(_term, data) {
       const str = Buffer.from(data).toString();
@@ -102,16 +208,40 @@ async function withTerminalRepl(
     }
   };
 
+  // The REPL redraws within milliseconds of a keystroke; the deadline is well
+  // below the test timeout so that a failure reports the screen it got stuck on.
+  const waitForScreen = async (ready: (screen: Screen) => boolean, timeoutMs = 3000): Promise<Screen> => {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const screen = renderScreen(received.join(""), cols);
+      if (ready(screen)) return screen;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(`Timed out waiting for the screen. Last screen (| marks the cursor):\n${formatScreen(screen)}`);
+      }
+      // Wait for the next chunk of terminal data, or for the deadline.
+      await new Promise<void>(resolve => {
+        const timer = setTimeout(resolve, remaining);
+        resolveWaiter = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      });
+      resolveWaiter = null;
+    }
+  };
+
   const allOutput = () => stripAnsi(received.join(""));
 
   await waitFor(/\u276f|> /); // Wait for prompt
 
-  await fn({ terminal, proc, send, waitFor, allOutput });
+  await fn({ terminal, proc, send, waitFor, waitForScreen, allOutput });
 
-  // Clean exit. Ctrl+U first discards whatever the test left on the line, so
-  // `.exit` is not appended to it (which would leave the REPL running until
-  // the kill below).
-  send("\x15.exit\n");
+  // Clean exit. Ctrl+E then Ctrl+U first discards whatever the test left on
+  // the line (Ctrl+U only deletes what is before the cursor), so `.exit` is
+  // not appended to it (which would leave the REPL running until the kill
+  // below).
+  send("\x05\x15.exit\n");
   await Promise.race([proc.exited, Bun.sleep(2000)]);
   if (!proc.killed) proc.kill();
 }
@@ -1365,6 +1495,133 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
           await waitFor(/ReferenceError|not defined/);
         },
         { env: colorEnv },
+      );
+    });
+  });
+
+  describe("input wider than the terminal", () => {
+    // Every keystroke redraws the whole input. When the input spans more than
+    // one terminal row, the redraw has to start on the prompt's row, otherwise
+    // each keystroke leaves another stale copy of the first row behind.
+    const cols = 30;
+    // "> " plus 37 characters: the first 28 characters share the prompt's row.
+    const line = "[111, 222, 333, 444, 555, 666].length";
+    const split = cols - "> ".length;
+
+    test("a wrapped line is redrawn in place and its result is printed below it", async () => {
+      await withTerminalRepl(
+        async ({ send, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+
+          send(line);
+          let screen = await waitForScreen(s => s.rows.at(-1) === line.slice(split));
+          expect(screen.rows.slice(top)).toEqual([`> ${line.slice(0, split)}`, line.slice(split)]);
+          await waitForScreen(s => s.cursor.row === top + 1 && s.cursor.col === line.length - split);
+
+          // Ctrl+A, then insert at the start: the cursor is on the prompt's row
+          // while the line still continues on the next one.
+          send("\x01" + "0;");
+          const edited = `0;${line}`;
+          screen = await waitForScreen(s => s.rows.at(-1) === edited.slice(split));
+          expect(screen.rows.slice(top)).toEqual([`> ${edited.slice(0, split)}`, edited.slice(split)]);
+          await waitForScreen(s => s.cursor.row === top && s.cursor.col === "> 0;".length);
+
+          send("\n");
+          screen = await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "6");
+          expect(screen.rows.slice(top)).toEqual([`> ${edited.slice(0, split)}`, edited.slice(split), "6", "> "]);
+        },
+        { cols },
+      );
+    });
+
+    test("Ctrl+C is echoed after the end of a wrapped line", async () => {
+      await withTerminalRepl(
+        async ({ send, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+
+          send(line);
+          await waitForScreen(s => s.rows.at(-1) === line.slice(split));
+          // Ctrl+A moves the cursor up to the prompt's row, then Ctrl+C.
+          send("\x01\x03");
+          const screen = await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === `${line.slice(split)}^C`);
+          expect(screen.rows.slice(top)).toEqual([`> ${line.slice(0, split)}`, `${line.slice(split)}^C`, "> "]);
+        },
+        { cols },
+      );
+    });
+
+    test("recalling a shorter history entry clears the rows of a longer one", async () => {
+      await withTerminalRepl(
+        async ({ send, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+
+          send(`${line}\n`);
+          await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "6");
+          send("7\n");
+          await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "7");
+
+          send("\x1b[A"); // Up: 7
+          await waitForScreen(s => s.rows.at(-1) === "> 7");
+          send("\x1b[A"); // Up: the wrapped line
+          let screen = await waitForScreen(s => s.rows.at(-1) === line.slice(split));
+          const history = [`> ${line.slice(0, split)}`, line.slice(split), "6", "> 7", "7"];
+          expect(screen.rows.slice(top)).toEqual([...history, `> ${line.slice(0, split)}`, line.slice(split)]);
+
+          send("\x1b[B"); // Down: back to 7, which needs one row less
+          screen = await waitForScreen(s => s.rows.at(-1) === "> 7");
+          expect(screen.rows.slice(top)).toEqual([...history, "> 7"]);
+          await waitForScreen(s => s.cursor.row === screen.rows.length - 1 && s.cursor.col === "> 7".length);
+        },
+        { cols },
+      );
+    });
+
+    test("ghost text that does not fit on the row wraps and is erased on enter", async () => {
+      // Colors enable ghost text; the prompt is then "❯ ".
+      const cols = 40;
+      // "❯ " plus 30 characters leaves room for 8 of the 14 ghost characters.
+      const input = "[1, 2, 3, 4, 5, 6].length + zz";
+      await withTerminalRepl(
+        async ({ send, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "❯ ")).rows.length - 1;
+
+          // `zz` itself is skipped as a suggestion for `zz`, so the ghost is
+          // the remainder of zzLongSuffixName.
+          send("var zz = 1, zzLongSuffixName = 5\n");
+          await waitForScreen(s => s.rows.at(-1) === "❯ " && s.rows.at(-2) === "5");
+          const setup = ["❯ var zz = 1, zzLongSuffixName = 5", "5"];
+
+          send(input);
+          let screen = await waitForScreen(s => s.rows.at(-1) === "ixName");
+          expect(screen.rows.slice(top)).toEqual([...setup, `❯ ${input}LongSuff`, "ixName"]);
+          // The cursor stays in front of the ghost, on the prompt's row.
+          await waitForScreen(s => s.cursor.row === top + setup.length && s.cursor.col === `❯ ${input}`.length);
+
+          send("\n");
+          screen = await waitForScreen(s => s.rows.at(-1) === "❯ " && s.rows.at(-2) === "7");
+          expect(screen.rows.slice(top)).toEqual([...setup, `❯ ${input}`, "7", "❯ "]);
+        },
+        { cols, env: { NO_COLOR: undefined, FORCE_COLOR: "1" } },
+      );
+    });
+
+    test("the cursor is positioned past column 80 on a wide terminal", async () => {
+      const cols = 120;
+      const input = Buffer.alloc(90, "q").toString();
+      await withTerminalRepl(
+        async ({ send, waitFor, waitForScreen }) => {
+          const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+
+          send(input);
+          await waitFor(`> ${input}`);
+          send("\x1b[D"); // Left
+          await waitForScreen(s => s.cursor.row === top && s.cursor.col === `> ${input}`.length - 1);
+
+          send("Z");
+          const edited = `${input.slice(0, -1)}Zq`;
+          await waitForScreen(s => s.rows.at(-1) === `> ${edited}` && s.cursor.col === `> ${edited}`.length - 1);
+        },
+        { cols },
       );
     });
   });

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -105,8 +105,10 @@ class ScreenModel {
 
   private control(command: string, params: string, sequence: string): void {
     if (command === "m") return; // colors
-    // The line editor only ever sends a single parameter.
-    if (!/^\d*$/.test(params)) throw new Error(`ScreenModel: unsupported escape sequence ${JSON.stringify(sequence)}`);
+    // The line editor only ever sends a single parameter, and never one past a terminal's size.
+    if (!/^\d{0,4}$/.test(params)) {
+      throw new Error(`ScreenModel: unsupported escape sequence ${JSON.stringify(sequence)}`);
+    }
     const n = params === "" ? undefined : Number(params);
     switch (command) {
       case "A":

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -61,7 +61,12 @@ class ScreenModel {
   // An escape sequence cut off at the end of the previous chunk.
   private unfinished = "";
 
-  constructor(private readonly cols: number) {}
+  constructor(private cols: number) {}
+
+  /** Rows drawn so far keep their cells, as in a terminal that does not reflow. */
+  resize(cols: number): void {
+    this.cols = cols;
+  }
 
   private rowAt(index: number): string[] {
     while (this.rows.length <= index) this.rows.push([]);
@@ -191,12 +196,15 @@ async function withTerminalRepl(
     waitFor: (pattern: string | RegExp, timeoutMs?: number) => Promise<string>;
     /** Resolves with the rendered screen once `ready` accepts it. */
     waitForScreen: (ready: (screen: Screen) => boolean, timeoutMs?: number) => Promise<Screen>;
+    /** Changes the width of the pty, and of the screen that `waitForScreen` renders. */
+    resize: (cols: number) => void;
     allOutput: () => string;
   }) => Promise<void>,
   options: { env?: Record<string, string | undefined>; cols?: number } = {},
 ) {
   const received: string[] = [];
   const cols = options.cols ?? 120;
+  const rows = 40;
   let cursor = 0;
   let resolveWaiter: (() => void) | null = null;
   // Streaming, so that a multi-byte character split across two reads stays intact.
@@ -206,7 +214,7 @@ async function withTerminalRepl(
   using home = tempDir("repl-home", {});
   await using terminal = new Bun.Terminal({
     cols,
-    rows: 40,
+    rows,
     data(_term, data) {
       const str = decoder.decode(data, { stream: true });
       received.push(str);
@@ -260,10 +268,13 @@ async function withTerminalRepl(
   // below the test timeout so that a failure reports the screen it got stuck on.
   const model = new ScreenModel(cols);
   let modelled = 0;
+  const renderReceived = () => {
+    while (modelled < received.length) model.feed(received[modelled++]);
+  };
   const waitForScreen = async (ready: (screen: Screen) => boolean, timeoutMs = 3000): Promise<Screen> => {
     const deadline = Date.now() + timeoutMs;
     while (true) {
-      while (modelled < received.length) model.feed(received[modelled++]);
+      renderReceived();
       const screen = model.screen();
       if (ready(screen)) return screen;
       const remaining = deadline - Date.now();
@@ -282,11 +293,19 @@ async function withTerminalRepl(
     }
   };
 
+  // Call this while the REPL waits for input: what it wrote before is laid out
+  // at the old width, and what it writes next at the new one.
+  const resize = (newCols: number) => {
+    renderReceived();
+    terminal.resize(newCols, rows);
+    model.resize(newCols);
+  };
+
   const allOutput = () => stripAnsi(received.join(""));
 
   await waitFor(/\u276f|> /); // Wait for prompt
 
-  await fn({ terminal, proc, send, waitFor, waitForScreen, allOutput });
+  await fn({ terminal, proc, send, waitFor, waitForScreen, resize, allOutput });
 
   // Clean exit. Ctrl+A then Ctrl+K first discards whatever the test left on
   // the line, wherever the cursor is, so `.exit` is not appended to it (which
@@ -1744,6 +1763,23 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
         },
         { cols },
       );
+    });
+
+    test("a terminal narrowed after startup wraps the input at its new width", async () => {
+      // The pty starts out 120 columns wide, on which the line fits on one row.
+      await withTerminalRepl(async ({ send, resize, waitForScreen }) => {
+        const top = (await waitForScreen(s => s.rows.at(-1) === "> ")).rows.length - 1;
+        resize(cols);
+
+        send(line);
+        let screen = await waitForScreen(s => s.rows.at(-1) === line.slice(split));
+        expect(screen.rows.slice(top)).toEqual([`> ${line.slice(0, split)}`, line.slice(split)]);
+        await waitForScreen(s => s.cursor.row === top + 1 && s.cursor.col === line.length - split);
+
+        send("\n");
+        screen = await waitForScreen(s => s.rows.at(-1) === "> " && s.rows.at(-2) === "6");
+        expect(screen.rows.slice(top)).toEqual([`> ${line.slice(0, split)}`, line.slice(split), "6", "> "]);
+      });
     });
   });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -85,7 +85,7 @@ class ScreenModel {
           throw new Error(`ScreenModel: unsupported escape sequence ${JSON.stringify(rest)}`);
         }
         i += seq[0].length;
-        this.control(seq[2], seq[1] === "" ? undefined : Number(seq[1]), seq[0]);
+        this.control(seq[2], seq[1], seq[0]);
         continue;
       }
       const ch = codePoint > 0xffff ? String.fromCodePoint(codePoint) : output[i];
@@ -103,10 +103,12 @@ class ScreenModel {
     }
   }
 
-  private control(command: string, n: number | undefined, sequence: string): void {
+  private control(command: string, params: string, sequence: string): void {
+    if (command === "m") return; // colors
+    // The line editor only ever sends a single parameter.
+    if (!/^\d*$/.test(params)) throw new Error(`ScreenModel: unsupported escape sequence ${JSON.stringify(sequence)}`);
+    const n = params === "" ? undefined : Number(params);
     switch (command) {
-      case "m": // colors
-        return;
       case "A":
         this.row = Math.max(0, this.row - (n ?? 1));
         break;

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -14,6 +14,8 @@ async function runRepl(
   const inputStr = Array.isArray(input) ? input.join("\n") + "\n" : input;
   const { env = {} } = options;
 
+  // The REPL loads and saves $HOME/.bun_repl_history (USERPROFILE on Windows).
+  using home = tempDir("repl-home", {});
   await using proc = Bun.spawn({
     cmd: [bunExe(), "repl"],
     stdin: Buffer.from(inputStr),
@@ -21,6 +23,8 @@ async function runRepl(
     stderr: "pipe",
     env: {
       ...bunEnv,
+      HOME: String(home),
+      USERPROFILE: String(home),
       TERM: "dumb",
       NO_COLOR: "1",
       ...env,
@@ -158,6 +162,8 @@ async function withTerminalRepl(
   let cursor = 0;
   let resolveWaiter: (() => void) | null = null;
 
+  // The REPL loads and saves $HOME/.bun_repl_history (USERPROFILE on Windows).
+  using home = tempDir("repl-home", {});
   await using terminal = new Bun.Terminal({
     cols,
     rows: 40,
@@ -176,6 +182,8 @@ async function withTerminalRepl(
     terminal,
     env: {
       ...bunEnv,
+      HOME: String(home),
+      USERPROFILE: String(home),
       TERM: "xterm-256color",
       ...options.env,
     },
@@ -237,11 +245,10 @@ async function withTerminalRepl(
 
   await fn({ terminal, proc, send, waitFor, waitForScreen, allOutput });
 
-  // Clean exit. Ctrl+E then Ctrl+U first discards whatever the test left on
-  // the line (Ctrl+U only deletes what is before the cursor), so `.exit` is
-  // not appended to it (which would leave the REPL running until the kill
-  // below).
-  send("\x05\x15.exit\n");
+  // Clean exit. Ctrl+A then Ctrl+K first discards whatever the test left on
+  // the line, wherever the cursor is, so `.exit` is not appended to it (which
+  // would leave the REPL running until the kill below).
+  send("\x01\x0b.exit\n");
   await Promise.race([proc.exited, Bun.sleep(2000)]);
   if (!proc.killed) proc.kill();
 }


### PR DESCRIPTION
Fixes #31897. Supersedes #31607, which conflicts with main since #30413. Fixes the wrap half of #27461.

### Problem
- `bun repl` redraws the input on each keystroke with `\r` + `ESC[2K`. An input wider than the terminal wraps, so each redraw leaves a stale copy of the first row behind and the cursor lands on the wrong row.
- The width came from `Output::TERMINAL_SIZE` (`repl.rs:950`). Nothing writes it, so it was always 80. The ghost text from #30413 trusts it, so on a terminal narrower than 80 columns short lines break too. That is the 1.4 canary report.

### Fix
- `refresh_line` queries the width on each redraw, moves up to the prompt's row, erases to the end of the screen, redraws, and puts the cursor on the cell of the edit cursor. `Layout` finds that cell the way the terminal wraps: a wide glyph that does not fit in the last column starts the next row. The width and the two cells are kept in a `Drawing`, which the REPL only has on a terminal (it replaces `is_tty`).
- `leave_input` replaces `erase_suggestion` and the `\n` the callers printed (Enter, Ctrl+C, completion lists, EOF, end of `.editor`). It erases the ghost, echoes `^C` if needed, and moves below the input. A line that ends at the right edge already left the cursor on a fresh row, so no blank row is added there.
- Suggestions that do not fit on the first row are drawn, not dropped. `Output::TERMINAL_SIZE` is removed. `File::winsize` now works on Windows.
- Verified: `test/js/bun/repl/repl.test.ts`, block `input wider than the terminal`, 8 tests that fail unfixed (the last one narrows the pty after startup). 177 pass in the file.

### Background
- The terminal wraps a long line onto more rows by itself. To erase the line, the editor has to know how many rows it drew. This is linenoise's multi line mode.
- A glyph in the last column leaves the terminal cursor on that column. When the drawing ends there, `refresh_line` writes `\n` so the cursor is where `Layout` says.
- Ghost text is the dimmed rest of a completion, drawn after the cursor. It is not in the buffer and is erased before the input is submitted.

<details><summary>Notes</summary>

- Compared 1.3.14 and the 1.4 canary byte for byte in a PTY over about 60 inputs (highlighting, results, errors, history, tab, Ctrl+C, `.help`, multi line). At 80 or more columns the only differences are the ghost text and the UTF-8 input support. So the canary report is the ghost text meeting the fixed width of 80. The wrap bug itself is older (#27461, #27670, #31604).
- The six tests that #31607 adds (the paste from #31604, the paste from #27670, typing past the edge, a wide terminal, a resize, Ctrl+C from the start of a wrapped line) pass against this branch. Four of them fail on the unfixed canary. The other two guard against hazards of the approach in #31607 and pass on both. #31607 is closed in favor of this PR.
- On a wide terminal the old code also never moved the cursor past column 80, so editing inside a long line showed the cursor at the end. One of the tests covers this.
- Unfixed build at 30 columns, after recalling a long history entry and typing: ten copies of the first row, cursor inside the text, and Ctrl+C produced `6]^Cength`. A failing test prints the screen it got stuck on.
- The tests replay the output through a small terminal model (`ScreenModel`, with deferred wrap and wide glyphs) and compare rows and cursor, not escape sequences. `withTerminalRepl` and `runRepl` give each REPL its own `HOME`, so the suite no longer reads or appends to the developer's `~/.bun_repl_history`.
- Review rounds: the first version divided the total width by the terminal width, which is off by one column per row on which a wide glyph wrapped, and printed a blank row after a line that filled its last row exactly. Both are covered by tests now (`wide characters wrap the way the terminal wraps them`, `a line that fills the row exactly leaves no blank row behind`). The advisory mordant job then flagged the drawing fields as only valid with `is_tty`, hence `Option<Drawing>`; `bun run rust:mordant` is clean now.
- The flicker that #27461 also reports is the per keystroke redraw. This change keeps that.
- Source lints and clippy pass. `cargo check` of `bun_core` and `bun_sys` for `x86_64-pc-windows-msvc` passes. `sink_tty_winsize` in `src/sys/lib.rs` uses `GetConsoleScreenBufferInfo` and reports the visible window, not the screen buffer.
- `update_interactive_command.rs` and `run_command.rs` keep their own width lookups. Only a stale comment in `run_command.rs` changed.
- A resize between two keystrokes is picked up on the next redraw. If the terminal reflowed the previous drawing, that one redraw can be off. Line editors without a SIGWINCH handler behave the same.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->

