### PR TITLE
test: hard-link the upgrade stand-in and run bun-upgrade.test.ts concurrently

### DIFF
--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -13,7 +13,7 @@ import {
   tmpdirSync,
 } from "harness";
 import { readdirSync, statSync } from "node:fs";
-import { copyFile, link, writeFile } from "node:fs/promises";
+import { copyFile, link, realpath, writeFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
 
@@ -39,7 +39,7 @@ const unpackFailure = isWindows ? "error: Failed to verify Bun (code: ENOENT)\n"
 async function installStandIn(dir: string): Promise<string> {
   const execPath = join(dir, basename(bunExe()));
   try {
-    await link(bunExe(), execPath);
+    await link(await realpath(bunExe()), execPath);
   } catch {
     await copyFile(bunExe(), execPath);
   }
@@ -55,11 +55,13 @@ beforeAll(async () => {
   standInExe = await installStandIn(standInDir);
 });
 
-// The first line of every release flow names the version bun decided to
-// install. Canary builds (CI and `bun bd`) word it as a downgrade; release
-// builds announce the new version.
+// Every release flow prints one line naming the version bun decided to install.
+// Canary builds (CI and `bun bd`) word it as a downgrade; release builds
+// announce the new version. It is not necessarily the first line: when the
+// version fetch takes longer than the progress bar's delay (a loaded machine
+// running a debug build), a "Fetching version tags" line precedes it on POSIX.
 function expectTargetsRelease(stderr: string, version: string) {
-  expect(stderr.split("\n")[0]).toBeOneOf([
+  expect(stderr.split("\n")).toContainAnyValues([
     `Downgrading from Bun ${Bun.version}-canary to Bun v${version}`,
     `Bun v${version} is out! You're on v${Bun.version}`,
   ]);
@@ -356,10 +358,10 @@ it.concurrent(
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     closeTempDirHandle();
 
-    if (stderr.startsWith("Congrats!")) {
+    if (stderr.includes("Congrats!")) {
       // A non-canary build is "already on" the version the server advertises
       // (its own) and stops before the download, so nothing may have changed.
-      expect(stderr).toBe(`Congrats! You're already on the latest version of Bun (which is v${version})\n`);
+      expect(stderr).toEndWith(`Congrats! You're already on the latest version of Bun (which is v${version})\n`);
       expect(readdirSync(installDir)).toEqual([exeName]);
     } else {
       expectTargetsRelease(stderr, version);

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -1,11 +1,73 @@
 import { spawn } from "bun";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
-import { describe, expect, it } from "bun:test";
-import { bunExe, bunEnv as env, isMusl, isWindows, tempDir, tls, tmpdirSync } from "harness";
-import { existsSync, statSync } from "node:fs";
-import { copyFile, writeFile } from "node:fs/promises";
+import { beforeAll, describe, expect, it } from "bun:test";
+import {
+  bunExe,
+  bunEnv as env,
+  isDebug,
+  isMusl,
+  isWindows,
+  normalizeBunSnapshot,
+  tempDir,
+  tls,
+  tmpdirSync,
+} from "harness";
+import { readdirSync, statSync } from "node:fs";
+import { copyFile, link, writeFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
+
+// The asset `bun upgrade` picks for the target this test runs on, and the
+// folder inside it.
+const releaseOs = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux";
+const releaseArch = process.arch === "arm64" ? "aarch64" : "x64";
+const releaseFolder = `bun-${releaseOs}-${releaseArch}${isMusl ? "-musl" : ""}`;
+const releaseAsset = `${releaseFolder}.zip`;
+
+// Last line `bun upgrade` prints when the downloaded archive is not a zip. On
+// POSIX `unzip` rejects it; on Windows Expand-Archive's failure is only noticed
+// when the executable it should have produced is missing.
+const unpackFailure = isWindows ? "error: Failed to verify Bun (code: ENOENT)\n" : "Unzip failed (exit code: 9)\n";
+
+// `bun upgrade` swaps out the executable it runs as, so the release flows run a
+// stand-in in a temp dir instead of bunExe() itself. A hard link is enough: the
+// upgrade only renames directory entries (POSIX swaps the staged file in,
+// Windows renames the old image to `<name>.outdated`), so bunExe() is never
+// modified through the link. Unlike a copy, a link is not a new file, so
+// Windows does not re-scan the 80+ MB image on first launch (about 2.4s per
+// copy on the arm64 lane). A temp dir on another volume falls back to a copy.
+async function installStandIn(dir: string): Promise<string> {
+  const execPath = join(dir, basename(bunExe()));
+  try {
+    await link(bunExe(), execPath);
+  } catch {
+    await copyFile(bunExe(), execPath);
+  }
+  return execPath;
+}
+
+// The flows that are expected to fail never reach the swap, so they all share
+// one stand-in.
+let standInDir: string;
+let standInExe: string;
+beforeAll(async () => {
+  standInDir = tmpdirSync();
+  standInExe = await installStandIn(standInDir);
+});
+
+// The first line of every release flow names the version bun decided to
+// install. Canary builds (CI and `bun bd`) word it as a downgrade; release
+// builds announce the new version.
+function expectTargetsRelease(stderr: string, version: string) {
+  expect(stderr.split("\n")[0]).toBeOneOf([
+    `Downgrading from Bun ${Bun.version}-canary to Bun v${version}`,
+    `Bun v${version} is out! You're on v${Bun.version}`,
+  ]);
+}
+
+function fakeReleaseScript(version: string): string {
+  return `#!/bin/sh\nprintf '%s\\n' '${version}'\n`;
+}
 
 // Cover every platform/arch/abi/cpu combination so the asset list matches
 // whichever target this test runs on. Non-matching names are ignored.
@@ -103,16 +165,12 @@ function makeZipStored(entryName: string, data: Buffer, unixMode: number): Buffe
 // enough because `unzip` preserves the mode bits; on Windows the verify step
 // spawns `bun.exe` directly, so the archive has to carry a real PE image.
 async function writeFakeReleaseZip(outPath: string, version: string): Promise<void> {
-  const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux";
-  const arch = process.arch === "arm64" ? "aarch64" : "x64";
-  const abi = isMusl ? "-musl" : "";
-  const folder = `bun-${os}-${arch}${abi}`;
   if (isWindows) {
     const exe = Buffer.from(await Bun.file(bunExe()).arrayBuffer());
-    await writeFile(outPath, makeZipStored(`${folder}/bun.exe`, exe, 0o755));
+    await writeFile(outPath, makeZipStored(`${releaseFolder}/bun.exe`, exe, 0o755));
   } else {
-    const script = Buffer.from(`#!/bin/sh\nprintf '%s\\n' '${version}'\n`);
-    await writeFile(outPath, makeZipStored(`${folder}/bun`, script, 0o755));
+    const script = Buffer.from(fakeReleaseScript(version));
+    await writeFile(outPath, makeZipStored(`${releaseFolder}/bun`, script, 0o755));
   }
 }
 
@@ -169,15 +227,19 @@ describe.concurrent(() => {
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "bun-types", "--dev"],
       cwd,
-      stdout: null,
+      stdout: "pipe",
       stdin: "pipe",
       stderr: "pipe",
       env,
     });
 
-    const err = await proc.stderr.text();
-    expect(err.split(/\r?\n/)).toContain("error: This command updates Bun itself, and does not take package names.");
-    expect(err.split(/\r?\n/)).toContain("note: Use `bun update bun-types --dev` instead.");
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(out).toBe("");
+    expect(normalizeBunSnapshot(err)).toMatchInlineSnapshot(`
+      "error: This command updates Bun itself, and does not take package names.
+      note: Use \`bun update bun-types --dev\` instead."
+    `);
+    expect(exitCode).toBe(1);
   });
 
   it("two invalid arguments flipped, should display error message and suggest command", async () => {
@@ -185,15 +247,19 @@ describe.concurrent(() => {
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "--dev", "bun-types"],
       cwd,
-      stdout: null,
+      stdout: "pipe",
       stdin: "pipe",
       stderr: "pipe",
       env,
     });
 
-    const err = await proc.stderr.text();
-    expect(err.split(/\r?\n/)).toContain("error: This command updates Bun itself, and does not take package names.");
-    expect(err.split(/\r?\n/)).toContain("note: Use `bun update --dev bun-types` instead.");
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(out).toBe("");
+    expect(normalizeBunSnapshot(err)).toMatchInlineSnapshot(`
+      "error: This command updates Bun itself, and does not take package names.
+      note: Use \`bun update --dev bun-types\` instead."
+    `);
+    expect(exitCode).toBe(1);
   });
 
   it("one invalid argument, should display error message and suggest command", async () => {
@@ -201,15 +267,19 @@ describe.concurrent(() => {
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "bun-types"],
       cwd,
-      stdout: null,
+      stdout: "pipe",
       stdin: "pipe",
       stderr: "pipe",
       env,
     });
 
-    const err = await proc.stderr.text();
-    expect(err.split(/\r?\n/)).toContain("error: This command updates Bun itself, and does not take package names.");
-    expect(err.split(/\r?\n/)).toContain("note: Use `bun update bun-types` instead.");
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(out).toBe("");
+    expect(normalizeBunSnapshot(err)).toMatchInlineSnapshot(`
+      "error: This command updates Bun itself, and does not take package names.
+      note: Use \`bun update bun-types\` instead."
+    `);
+    expect(exitCode).toBe(1);
   });
 
   it("one valid argument, should succeed", async () => {
@@ -217,87 +287,102 @@ describe.concurrent(() => {
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "--help"],
       cwd,
-      stdout: null,
+      stdout: "pipe",
       stdin: "pipe",
       stderr: "pipe",
       env,
     });
 
-    const err = await proc.stderr.text();
-    // Should not contain error message
-    expect(err.split(/\r?\n/)).not.toContain(
-      "error: This command updates bun itself, and does not take package names.",
-    );
-    expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --help` instead.");
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(out).toStartWith("Usage: bun upgrade [flags]\n");
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
   });
 
   it("two valid arguments, should succeed", async () => {
     // `--stable --profile` are both recognised flags; argument validation must
-    // let them through. The release server returns a garbage archive so the
-    // upgrade fails later, after argument parsing has already accepted them.
+    // let them through. Only profile assets are served, so reaching the version
+    // announcement also proves `--profile` was honored. The archive is garbage,
+    // so the upgrade fails later, after argument parsing has accepted the flags.
     using server = startReleaseServer({ tagName: "bun-v9.9.9", assetNames: allAssetNames(true) });
-    const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
+    using stagingRoot = tempDir("bun-upgrade-args", {});
     await using proc = spawn({
-      cmd: [execPath, "upgrade", "--stable", "--profile"],
-      cwd,
+      cmd: [standInExe, "upgrade", "--stable", "--profile"],
+      cwd: standInDir,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: { ...server.env, BUN_TMPDIR: String(stagingRoot) },
+    });
+
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("does not take package names");
+    expectTargetsRelease(err, "9.9.9");
+    expect(err).toEndWith(unpackFailure);
+    expect(exitCode).toBe(1);
+  });
+});
+
+it.concurrent(
+  "completes against a locally-served release with the system temp dir held open without FILE_SHARE_DELETE",
+  async () => {
+    // `--stable` routes through the GitHub releases API (overridable via
+    // GITHUB_API_DOMAIN) instead of the compiled-in canary URL, so the whole
+    // download/unpack/verify/swap path runs against the local server. This flow
+    // really swaps the executable, so it gets a stand-in of its own. The staging
+    // directory must stay in the default temp dir: that is the directory held
+    // open below.
+    const version = Bun.version;
+    const exeName = basename(bunExe());
+    const installDir = tmpdirSync();
+    const zipPath = join(tmpdirSync(), "release.zip");
+    const [execPath] = await Promise.all([installStandIn(installDir), writeFakeReleaseZip(zipPath, version)]);
+
+    using server = startReleaseServer({ tagName: `bun-v${version}`, zipPath });
+
+    // On Windows, open the temporary directory without FILE_SHARE_DELETE before spawning
+    // the upgrade process. This is to test for EBUSY errors.
+    openTempDirWithoutSharingDelete();
+
+    await using proc = Bun.spawn({
+      cmd: [execPath, "upgrade", "--stable"],
+      cwd: installDir,
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",
       env: server.env,
     });
 
-    const err = await proc.stderr.text();
-    // Should not contain error message
-    expect(err.split(/\r?\n/)).not.toContain(
-      "error: This command updates Bun itself, and does not take package names.",
-    );
-    expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --stable --profile` instead.");
-    await proc.exited;
-  });
-});
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    closeTempDirHandle();
 
-it("completes against a locally-served release with the system temp dir held open without FILE_SHARE_DELETE", async () => {
-  // `--stable` routes through the GitHub releases API (overridable via
-  // GITHUB_API_DOMAIN) instead of the compiled-in canary URL, so the whole
-  // download/unpack/verify path runs against the local server. On non-canary
-  // builds the current-version check short-circuits before the download,
-  // which still produces no `error:` and is fine: canary covers the temp-dir
-  // path on Windows.
-  const version = Bun.version;
-  const cwd = tmpdirSync();
-  const execPath = join(cwd, basename(bunExe()));
-  const zipPath = join(cwd, "release.zip");
-  await Promise.all([copyFile(bunExe(), execPath), writeFakeReleaseZip(zipPath, version)]);
+    if (stderr.startsWith("Congrats!")) {
+      // A non-canary build is "already on" the version the server advertises
+      // (its own) and stops before the download, so nothing may have changed.
+      expect(stderr).toBe(`Congrats! You're already on the latest version of Bun (which is v${version})\n`);
+      expect(readdirSync(installDir)).toEqual([exeName]);
+    } else {
+      expectTargetsRelease(stderr, version);
+      expect(stderr).toEndWith(
+        ` Upgraded.\n\nWelcome to Bun v${version}!\n\nWhat's new in Bun v${version}:\n\n    https://bun.com/blog/release-notes/bun-v${version}\n\nReport any bugs:\n\n    https://github.com/oven-sh/bun/issues\n\nCommit log:\n\n    https://github.com/oven-sh/bun/compare/bun-v${Bun.version}...bun-v${version}\n`,
+      );
+      if (isWindows) {
+        // A running image cannot be deleted, so the old one is parked as
+        // `.outdated`. The upgrade then ran `completions` with the installed
+        // executable, which recreates the bunx hard link next to itself.
+        expect(readdirSync(installDir).sort()).toEqual(
+          [exeName, `${exeName}.outdated`, isDebug ? "bunx-debug.exe" : "bunx.exe"].sort(),
+        );
+      } else {
+        expect(readdirSync(installDir)).toEqual([exeName]);
+        expect(await Bun.file(execPath).text()).toBe(fakeReleaseScript(version));
+      }
+    }
+    expect(exitCode).toBe(0);
+  },
+);
 
-  using server = startReleaseServer({ tagName: `bun-v${version}`, zipPath });
-
-  // On Windows, open the temporary directory without FILE_SHARE_DELETE before spawning
-  // the upgrade process. This is to test for EBUSY errors.
-  openTempDirWithoutSharingDelete();
-
-  await using proc = Bun.spawn({
-    cmd: [execPath, "upgrade", "--stable"],
-    cwd,
-    stdout: null,
-    stdin: "pipe",
-    stderr: "pipe",
-    env: server.env,
-  });
-
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  closeTempDirHandle();
-
-  expect(stderr).not.toContain("error:");
-  // Canary builds always download (the current-version short-circuit is gated
-  // on !IS_CANARY); a non-canary build whose version matches the served tag
-  // takes the "already on the latest" exit instead.
-  expect(stderr).toMatch(/Upgraded\.|already on the latest/);
-  expect(exitCode).toBe(0);
-});
-
-it("recreates the staging directory in the temp dir instead of reusing a pre-existing one", async () => {
+it.concurrent("recreates the staging directory in the temp dir instead of reusing a pre-existing one", async () => {
   const tagName = "bun-v9.9.9";
   // Simulate a directory that already exists at the predictable staging path
   // ($TMPDIR/<version>) before the upgrade runs, with content planted inside it.
@@ -313,15 +398,11 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
 
   using server = startReleaseServer({ tagName });
 
-  const cwd = tmpdirSync();
-  const execPath = join(cwd, basename(bunExe()));
-  await copyFile(bunExe(), execPath);
-
   await using proc = Bun.spawn({
     // --stable forces the GitHub-release code path (with a predictable
     // version-named staging directory) even on canary/debug builds.
-    cmd: [execPath, "upgrade", "--stable"],
-    cwd,
+    cmd: [standInExe, "upgrade", "--stable"],
+    cwd: standInDir,
     stdout: null,
     stdin: "pipe",
     stderr: "pipe",
@@ -333,16 +414,21 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
 
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  // Sanity check: the upgrade got past the version fetch and targeted v9.9.9.
-  expect(stderr).toContain("9.9.9");
+  // The upgrade targeted v9.9.9 and got as far as unpacking into the staging
+  // directory, where the bogus archive made it fail.
+  expectTargetsRelease(stderr, "9.9.9");
+  expect(stderr).toEndWith(unpackFailure);
 
   // Nothing that existed in the staging directory before the upgrade started
   // may survive into the directory the new binary is unpacked and verified in.
-  expect(existsSync(join(stagingRootPath, "9.9.9", "planted-before-upgrade.txt"))).toBe(false);
-  expect(existsSync(join(stagingRootPath, "9.9.9", "planted-subdir", "bun"))).toBe(false);
+  // The failed unpack leaves nothing behind either: bun removes its own
+  // download (bun.zip) again.
+  expect(readdirSync(join(stagingRootPath, "9.9.9"))).toEqual([]);
 
-  if (process.platform !== "win32" && existsSync(join(stagingRootPath, "9.9.9"))) {
-    // The staging directory must be freshly created with no group/other access.
+  if (!isWindows) {
+    // The staging directory must be freshly created with no group/other
+    // access. The planted one was created with the default mode, so a reused
+    // directory fails here.
     expect(statSync(join(stagingRootPath, "9.9.9")).mode & 0o077).toBe(0);
   }
 
@@ -350,37 +436,53 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
   expect(exitCode).toBe(1);
 });
 
-it("verifies the downloaded release archive against the digest reported by the release asset", async () => {
+it.concurrent("verifies the downloaded release archive against the digest reported by the release asset", async () => {
   const archiveBody = "this is not a real zip archive";
   const correctDigest = `sha256:${new Bun.CryptoHasher("sha256").update(archiveBody).digest("hex")}`;
   const wrongDigest = `sha256:${Buffer.alloc(32, 0xab).toString("hex")}`;
 
   const runUpgrade = async (tagName: string, digest: string) => {
     using server = startReleaseServer({ tagName, digest, zipBody: archiveBody });
-
-    const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
+    using stagingRoot = tempDir("bun-upgrade-digest", {});
 
     await using proc = Bun.spawn({
-      cmd: [execPath, "upgrade", "--stable"],
-      cwd,
+      cmd: [standInExe, "upgrade", "--stable"],
+      cwd: standInDir,
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",
-      env: server.env,
+      env: { ...server.env, BUN_TMPDIR: String(stagingRoot) },
     });
 
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { stderr, exitCode };
+    return {
+      stderr,
+      exitCode,
+      // Whatever the upgrade staged before it gave up.
+      staged: readdirSync(String(stagingRoot)),
+      downloadUrl: `https://${server.hostname}:${server.port}/download/${releaseAsset}`,
+    };
   };
 
-  const mismatched = await runUpgrade("bun-v9.9.7", wrongDigest);
-  expect(mismatched.stderr).toContain("did not match the checksum reported by the GitHub API for this release");
+  const [mismatched, matched] = await Promise.all([
+    runUpgrade("bun-v9.9.7", wrongDigest),
+    runUpgrade("bun-v9.9.8", correctDigest),
+  ]);
+
+  expectTargetsRelease(mismatched.stderr, "9.9.7");
+  expect(mismatched.stderr).toEndWith(
+    `error: The file downloaded from ${mismatched.downloadUrl} did not match the checksum reported by the GitHub API for this release.\n` +
+      "note: run bun upgrade again to retry the download\n",
+  );
+  // Rejected before anything was written to disk.
+  expect(mismatched.staged).toEqual([]);
   expect(mismatched.exitCode).toBe(1);
 
-  const matched = await runUpgrade("bun-v9.9.8", correctDigest);
-  expect(matched.stderr).toContain("9.9.8");
-  expect(matched.stderr).not.toContain("did not match the checksum reported by the GitHub API for this release");
+  expectTargetsRelease(matched.stderr, "9.9.8");
+  // With a matching digest the archive is accepted and staged; this run only
+  // fails afterwards because the body is not a zip.
+  expect(matched.stderr).not.toContain("did not match the checksum");
+  expect(matched.stderr).toEndWith(unpackFailure);
+  expect(matched.staged).toEqual(["9.9.8"]);
   expect(matched.exitCode).toBe(1);
 });


### PR DESCRIPTION
### Problem
- `bun-upgrade.test.ts` takes 20s on Windows 11 arm64 and 13s on Windows 2019 x64 (build 101560), 2s elsewhere.
- Four release flows each copied `bunExe()`. On Windows the first launch of a new copy costs 2.4s (canary build, arm64) or 7s (debug build). A hard link starts in under 20ms.
- The last three flows ran one after another.

### Fix
- The flows that fail before the swap share one stand-in from `beforeAll`. The flow that swaps gets its own. Both are hard links to `bunExe()`, with a copy as the cross-volume fallback. Five copies per run become two links.
- The links are safe because the upgrade only renames directory entries (`src/sys/lib.rs:9060`, cross-device path at `:8982`). It never writes into the file behind `bunExe()`. `test/cli/bun.test.ts:146` already runs a linked stand-in the same way.
- All eight tests run concurrently. Each failing flow stages into its own `BUN_TMPDIR`. The completing flow keeps the default temp dir, the one it holds open.
- Every run now pins its output and its result on disk (notes). No test was removed. Verified: arm64 17.2s to 3.7s, x64 10.2s to 3.1s, Linux debug+ASAN 5.4s to 3.0s, 8 to 13 green runs each.

### Background
- `bun upgrade --stable` unpacks the asset into `<tmpdir>/<version>/`, runs it with `--version`, then moves it over its own executable. The test serves the release locally.
- Only the completing flow needs a real archive. On Windows the verify step needs a real PE image, so the archive holds the test binary, built once per run as before.
- Windows cannot delete a running image. The upgrade parks it as `<name>.outdated` and runs `completions`, which recreates the `bunx` link (`install_completions_command.rs:106`).

<details><summary>Notes</summary>

#### Timings (same machine, same build, old file vs this file)

| Machine | Binary | Old | New |
| --- | --- | --- | --- |
| Windows 11 arm64 | canary build, as CI runs it | 17.2s, 17.2s, 17.3s | 3.6s to 3.7s (13 runs) |
| Windows 11 arm64 | `bun bd test` (debug, 216 MB) | 52.5s, 51.8s, 52.1s | 16.3s, 16.9s, 16.8s |
| Windows Server 2019 x64 | canary build | 11.3s, 10.2s, 10.0s | 3.0s to 3.3s (10 runs) |
| Linux x64 | `bun bd test` (debug+ASAN, 820 MB) | 5.3s, 5.4s, 6.3s | 3.0s to 3.1s (8 runs) |
| Linux x64 | release build | 0.4s to 1.3s | 0.2s |

The old file was run with `--timeout=90000` on Windows, which is what the CI runner passes: on the arm64 machine two of the old tests did not fit into the default 5s per test. The new file was also run 10 times per Windows machine with the default timeout. What remains is the completing flow: the first launch of the extracted image (2.4s on arm64, which is part of what the flow verifies) plus `Expand-Archive` (0.7s on arm64, about 2s on Server 2019). A deflated archive was slower (0.4s to compress, 1.3s to expand), so the archive stays stored.

Per run: executable materializations 5 copies -> 2 hard links, zip builds 1 -> 1, `bun upgrade` processes 9 -> 9, sequential phases 4 -> 1. The zip is not built in `beforeAll` because only one test needs it and it is on that test's own critical path either way.

First-launch probe on the arm64 machine (78 MB canary build): fresh copy 2431ms and 2371ms, the same copy again 7ms, a hard link 18ms, a fresh copy of the small `cmd.exe` 26ms. The cost is per new file and grows with its size. On Server 2019, where the bootstrap removes Defender, a fresh copy costs 273ms and a hard link 6ms. The arm64 image still reports real-time protection on (it is tamper protected), which may be why that lane is the slowest.

Why the links are safe: POSIX installs the new binary with a NOREPLACE rename, then an EXCHANGE, then delete plus rename (`renameat_concurrently_without_fallback`). Windows renames the old image to `.outdated` and moves the new one in. The cross-device fallback unlinks the destination before it writes. `self_exe_path()` (`src/bun_core/util.rs:2745`) is `/proc/self/exe` on Linux, `_NSGetExecutablePath` plus `realpath` on macOS and `GetModuleFileNameW` plus `GetFinalPathNameByHandle` on Windows. All of them return the link that was launched, because a hard link is an ordinary name and not a symlink. Confirmed on Linux (link count of the debug binary was 3 after a run, the swapped-out link sat in the staging dir) and on Windows (`fsutil hardlink list` showed the stand-ins and the parked `.outdated` entries, `bunExe()` unchanged). Renaming and deleting a link to the running test binary works on Windows (probed), so temp dir cleanup is unaffected.

#### Assertion changes
- Three invalid-argument tests: stdout is empty, stderr is an exact inline snapshot, exit code 1. Before: two `toContain` lines, no exit code.
- `--help`: stdout starts with the usage line, stderr is empty, exit code 0. Before: a `not.toContain` of a message spelled differently from the real one (`bun itself`), so it could not fail.
- `--stable --profile`: one line names v9.9.9 (only profile assets are served, so this also proves `--profile` was honored), stderr ends with the exact unpack error, exit code 1. Before: two `not.toContain`, exit code awaited but not checked.
- Completing flow: one line names the version, stderr ends with the complete `Upgraded` banner, exit code 0. On disk: on POSIX the install dir holds exactly the executable and its content is the fake release script. On Windows it holds exactly the executable, `<name>.outdated` and `bunx.exe` (`bunx-debug.exe` for debug builds). The non-canary branch (output ends with the exact `Congrats! ...` line, install dir unchanged) is derived from the source strings. CI and `bun bd` are canary builds and take the other branch, as before.
- Staging test: one line names v9.9.9, stderr ends with the exact unpack error, `readdirSync` of the staging dir is `[]`, the mode check is unconditional on POSIX. Before: `toContain("9.9.9")` and two `existsSync` checks.
- Digest test: both runs in parallel. Mismatch: stderr ends with the exact error, including the exact asset URL for this target, plus the note line, and the staging root is `[]`. Match: one line names v9.9.8, stderr ends with the exact unpack error, the staging root is `["9.9.8"]`. Before: `toContain` on a fragment and `toContain("9.9.8")`.
- stdout of the release flows is still not asserted: debug builds print the asset search on stdout, and on Windows `Expand-Archive` writes to the inherited stdout.

The version line is looked up among the lines (`toContainAnyValues`), not pinned to line 0. On POSIX a piped stderr receives a `Fetching version tags` progress line first when the version fetch takes longer than the progress bar's 500ms delay. The first version of this PR pinned line 0: with the debug build pinned to one CPU (`taskset -c <cpu> bun bd test ...`) three or four tests failed in 3 of 3 runs. With the lookup, 3 of 3 starved runs and 3 normal runs pass. The `toEndWith` assertions are not affected by progress output, because the progress bar ends its line before bun prints anything else.

The exact unpack line differs by platform. POSIX: `Unzip failed (exit code: 9)` (Info-ZIP, which `scripts/bootstrap.sh` installs on every Linux image and which macOS ships). Windows: `error: Failed to verify Bun (code: ENOENT)`, because `upgrade_command.rs` does not check the Expand-Archive exit status and notices the failure at the verify step.

The Windows unpack line pins what `bun upgrade` prints today. The Windows block in `upgrade_command.rs` (around line 957) does not look at the Expand-Archive status, unlike the POSIX block, so a corrupt download is reported as a verify failure. That is a product question outside this test-only change. A fix there changes one constant in this file.

The stand-in is linked from `realpath(bunExe())`, the same idiom as `test/cli/bun.test.ts:146`. A shared harness helper, and the other tests that copy the binary on Windows (`bun-install-registry.test.ts` makes seven copies around line 9073), are candidates for a follow-up and are out of scope here. NTFS allows 1023 links per file. A machine that runs this file hundreds of times without clearing its temp dir hits that limit, and the helper then falls back to a copy.

With a Windows debug build the completing flow takes about 14s, of which about 7s is the first launch of the extracted 216 MB image, so a local `bun bd test` on Windows still needs `--timeout` as the CI runner passes it. Before this change two tests needed it even with the release build.

Open PRs #39379, #37674 and #31743 touch this file. The helpers keep their names and signatures, the argument tests keep their order, and the `startReleaseServer` comment that #37674 edits is untouched. The two flows that #39379 adds can use `standInExe` when either side rebases. `test/expected-durations.json` is left for CI to regenerate.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->