### PR TITLE
Bun.serve: tear down an aborted request's context at abort instead of waiting for GC

### DIFF
--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -157,7 +157,41 @@ pub(crate) fn take<T>(cell: JSValue) -> Option<NonNull<T>> {
 /// defer that work to the event loop.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__NativePromiseContext__destroy(ctx: *mut c_void, tag: u8) {
-    DeferredDerefTask::schedule(ctx, Tag::from_raw(tag));
+    let tag = Tag::from_raw(tag);
+    clear_remembered_cell(ctx, tag);
+    DeferredDerefTask::schedule(ctx, tag);
+}
+
+/// The cell dies with its claim intact, so the context's `promise_cell` field
+/// still points at it and is about to dangle. Clear it before `on_abort` can
+/// read it again. A plain field write, safe during sweep; the unreleased
+/// claim keeps `ctx` alive through this call.
+fn clear_remembered_cell(ctx: *mut c_void, tag: Tag) {
+    // SAFETY: `tag` names the concrete type `ctx` was created with, and the
+    // claim being released is a live ref on it.
+    unsafe {
+        match tag {
+            Tag::HTTPServerRequestContext => {
+                (*ctx.cast::<HTTPServerRequestContext>()).promise_cell_collected()
+            }
+            Tag::HTTPSServerRequestContext => {
+                (*ctx.cast::<HTTPSServerRequestContext>()).promise_cell_collected()
+            }
+            Tag::DebugHTTPServerRequestContext => {
+                (*ctx.cast::<DebugHTTPServerRequestContext>()).promise_cell_collected()
+            }
+            Tag::DebugHTTPSServerRequestContext => {
+                (*ctx.cast::<DebugHTTPSServerRequestContext>()).promise_cell_collected()
+            }
+            Tag::HTTPSServerH3RequestContext => {
+                (*ctx.cast::<HTTPSServerH3RequestContext>()).promise_cell_collected()
+            }
+            Tag::DebugHTTPSServerH3RequestContext => {
+                (*ctx.cast::<DebugHTTPSServerH3RequestContext>()).promise_cell_collected()
+            }
+            Tag::HTMLRewriterSuspension | Tag::HTMLRewriterPipeFree => {}
+        }
+    }
 }
 
 /// Defers the GC-triggered deref to the next event-loop tick so it runs

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -944,6 +944,19 @@ where
         self.promise_cell.set(JSValue::ZERO);
     }
 
+    /// Once the response is detached or ended, the promise this context
+    /// subscribed to can no longer do anything for the request. Reclaim the
+    /// cell's claim so the context is torn down now instead of when GC
+    /// collects the promise; the settle reactions then see a null `take()`
+    /// and no-op. A no-op when no claim is outstanding (the common case on
+    /// paths reached from a settle reaction, which already cleared the field).
+    fn reclaim_promise_cell(&self) {
+        let cell = self.promise_cell.replace(JSValue::ZERO);
+        if !cell.is_empty() && NativePromiseContext::take::<Self>(cell).is_some() {
+            self.deref();
+        }
+    }
+
     pub(crate) fn on_reject(_global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         ctx_log!("onReject");
 
@@ -1166,6 +1179,7 @@ where
         ctx_log!("end");
         if let Some(resp) = self.resp.get() {
             self.detach_response();
+            self.reclaim_promise_cell();
             // SAFETY: FFI handle
             resp.end(data, close_connection);
             // end_request_streaming_and_drain() must run after the last
@@ -1180,6 +1194,7 @@ where
         ctx_log!("endStream");
         if let Some(resp) = self.resp.get() {
             self.detach_response();
+            self.reclaim_promise_cell();
             // This will send a terminating 0\r\n\r\n chunk to the client
             // We only want to do that if they're still expecting a body
             // We cannot call this function if the Content-Length header was previously set
@@ -1221,6 +1236,7 @@ where
             self.flags.set_is_waiting_for_request_body(false);
             self.flags.set_has_abort_handler(false);
             self.request_body_buf.set(Vec::new());
+            self.reclaim_promise_cell();
             self.end_request_streaming_and_drain();
             self.deref();
         }
@@ -1230,6 +1246,10 @@ where
         ctx_log!("endWithoutBody");
         if let Some(resp) = self.resp.get() {
             self.detach_response();
+            // uWS markDone() clears onAborted on end, so on_abort can never
+            // run for this request; this is the last chance to reclaim an
+            // outstanding claim (e.g. a 413 while the handler promise parks).
+            self.reclaim_promise_cell();
             // SAFETY: FFI handle
             resp.end_without_body(close_connection);
             // This end can run uncorked (e.g. render_production_error from a
@@ -1249,6 +1269,7 @@ where
     pub(crate) fn force_close(&self) {
         if let Some(resp) = self.resp.get() {
             self.detach_response();
+            self.reclaim_promise_cell();
             // SAFETY: FFI handle
             resp.force_close();
             // end_request_streaming_and_drain() must run after the last
@@ -1377,16 +1398,6 @@ where
         }
 
         this.detach_response();
-
-        // The response is gone, so the promise this context subscribed to can
-        // no longer do anything for the request. Reclaim the cell's ref so the
-        // context is torn down now instead of when GC collects the promise;
-        // the settle reactions then see a null `take()` and no-op.
-        let cell = this.promise_cell.replace(JSValue::ZERO);
-        if !cell.is_empty() && NativePromiseContext::take::<Self>(cell).is_some() {
-            this.deref();
-        }
-
         let any_js_calls = core::cell::Cell::new(false);
         let server = this.server();
         let vm = server.vm();
@@ -1431,6 +1442,7 @@ where
                         .cast::<ResponseStream<SSL_ENABLED, HTTP3>>(),
                 );
             }
+            this.reclaim_promise_cell();
             return;
         }
 
@@ -1460,6 +1472,12 @@ where
                 }
             }
         }
+
+        // Reclaim only after the block above: the claim's ref must still
+        // count in `is_dead_request`, so a parked request-body read goes
+        // through `end_request_streaming` and rejects instead of being
+        // silently dropped by `finalize_without_deinit`.
+        this.reclaim_promise_cell();
     }
 
     // This function may be called multiple times

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -950,7 +950,7 @@ where
     /// collects the promise; the settle reactions then see a null `take()`
     /// and no-op. A no-op when no claim is outstanding (the common case on
     /// paths reached from a settle reaction, which already cleared the field).
-    fn reclaim_promise_cell(&self) {
+    pub(crate) fn reclaim_promise_cell(&self) {
         let cell = self.promise_cell.replace(JSValue::ZERO);
         if !cell.is_empty() && NativePromiseContext::take::<Self>(cell).is_some() {
             self.deref();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1445,10 +1445,8 @@ where
             // End request streaming here, not in deinit: a `Used` body
             // (textStream) can only be rejected through
             // request_body_readable_stream_ref, and finalize_without_deinit
-            // drops that ref without erroring it.
-            if this.end_request_streaming().unwrap_or(true) {
-                any_js_calls.set(true);
-            }
+            // drops that ref without erroring it. any_js_calls is already set.
+            let _ = this.end_request_streaming();
             this.reclaim_promise_cell();
             return;
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -675,8 +675,8 @@ where
 
         let arguments = callframe.arguments_as_array::<2>();
         let Some(ctx) = NativePromiseContext::take::<Self>(arguments[1]) else {
-            // The cell's destructor already released the ref (the Promise
-            // was collected before a prior microtask turn reached us).
+            // A termination path (abort, end, upgrade) reclaimed the cell's
+            // claim; the context may already be gone.
             return Ok(JSValue::UNDEFINED);
         };
         let ctx = RequestContextRef::adopt(ctx.as_ptr());
@@ -962,8 +962,8 @@ where
 
         let arguments = callframe.arguments_as_array::<2>();
         let Some(ctx) = NativePromiseContext::take::<Self>(arguments[1]) else {
-            // The cell's destructor already released the ref (the Promise
-            // was collected before a prior microtask turn reached us).
+            // A termination path (abort, end, upgrade) reclaimed the cell's
+            // claim; the context may already be gone.
             return Ok(JSValue::UNDEFINED);
         };
         let ctx = RequestContextRef::adopt(ctx.as_ptr());

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1442,6 +1442,13 @@ where
                         .cast::<ResponseStream<SSL_ENABLED, HTTP3>>(),
                 );
             }
+            // End request streaming here, not in deinit: a `Used` body
+            // (textStream) can only be rejected through
+            // request_body_readable_stream_ref, and finalize_without_deinit
+            // drops that ref without erroring it.
+            if this.end_request_streaming().unwrap_or(true) {
+                any_js_calls.set(true);
+            }
             this.reclaim_promise_cell();
             return;
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -179,6 +179,13 @@ pub struct RequestContext<
     pub(crate) defer_deinit_until_callback_completes: Cell<Option<DeferDeinitFlag>>,
 
     pub(crate) additional_on_abort: JsCell<Option<AdditionalOnAbortCallback>>,
+
+    /// The `NativePromiseContext` cell whose claim (one ref on this context)
+    /// is still outstanding, or `ZERO`. Not visited by GC: the promise
+    /// reaction keeps the cell alive, and the cell's destructor clears this
+    /// field before the value can dangle. `on_abort` reclaims the ref through
+    /// it so an aborted request is torn down without waiting for GC.
+    promise_cell: Cell<JSValue>,
     // TODO: support builtin compression
 }
 
@@ -673,6 +680,7 @@ where
             return Ok(JSValue::UNDEFINED);
         };
         let ctx = RequestContextRef::adopt(ctx.as_ptr());
+        ctx.ctx().promise_cell.set(JSValue::ZERO);
 
         let result = arguments[0];
         result.ensure_still_alive();
@@ -917,6 +925,25 @@ where
         self.ref_count.set(ref_count + 1);
     }
 
+    /// Takes one ref as the cell's claim on this context and remembers the
+    /// cell in `promise_cell`. The settle reactions (`take()` + a field
+    /// clear), `on_abort`, or the cell's destructor release the claim.
+    fn create_promise_cell(&self, global: &JSGlobalObject) -> JSValue {
+        debug_assert!(self.promise_cell.get().is_empty());
+        self.ref_();
+        let cell = NativePromiseContext::create(global, self.as_ctx_ptr());
+        self.promise_cell.set(cell);
+        cell
+    }
+
+    /// Called from the cell's destructor (GC sweep) when the claim was never
+    /// taken: the deref is deferred (or skipped at VM teardown), but the field
+    /// must stop pointing at the dying cell now. A plain field write, safe
+    /// during sweep.
+    pub(crate) fn promise_cell_collected(&self) {
+        self.promise_cell.set(JSValue::ZERO);
+    }
+
     pub(crate) fn on_reject(_global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         ctx_log!("onReject");
 
@@ -927,6 +954,7 @@ where
             return Ok(JSValue::UNDEFINED);
         };
         let ctx = RequestContextRef::adopt(ctx.as_ptr());
+        ctx.ctx().promise_cell.set(JSValue::ZERO);
 
         let err = arguments[0];
         // Pass the rejection reason through verbatim (including `null` and
@@ -1314,6 +1342,7 @@ where
                 pathname: Cell::new(BunString::empty()),
                 response_buf_owned: JsCell::new(Vec::new()),
                 additional_on_abort: JsCell::new(None),
+                promise_cell: Cell::new(JSValue::ZERO),
             });
         }
 
@@ -1348,6 +1377,16 @@ where
         }
 
         this.detach_response();
+
+        // The response is gone, so the promise this context subscribed to can
+        // no longer do anything for the request. Reclaim the cell's ref so the
+        // context is torn down now instead of when GC collects the promise;
+        // the settle reactions then see a null `take()` and no-op.
+        let cell = this.promise_cell.replace(JSValue::ZERO);
+        if !cell.is_empty() && NativePromiseContext::take::<Self>(cell).is_some() {
+            this.deref();
+        }
+
         let any_js_calls = core::cell::Cell::new(false);
         let server = this.server();
         let vm = server.vm();
@@ -2111,8 +2150,7 @@ where
                             global: std::ptr::from_ref(global_this),
                             ..Default::default()
                         });
-                        this.ref_();
-                        let cell = NativePromiseContext::create(global_this, this.as_ctx_ptr());
+                        let cell = this.create_promise_cell(global_this);
                         effective_result.then_with_value(
                             global_this,
                             cell,
@@ -2638,8 +2676,7 @@ where
             // If we immediately have the value available, we can skip the extra event loop tick
             match promise.unwrap(vm.global().vm(), jsc::PromiseUnwrapMode::MarkHandled) {
                 jsc::PromiseResult::Pending => {
-                    ctx.ref_();
-                    let cell = NativePromiseContext::create(this.global_this(), ctx.as_ctx_ptr());
+                    let cell = ctx.create_promise_cell(this.global_this());
                     response_value.then_with_value(
                         this.global_this(),
                         cell,
@@ -2726,8 +2763,7 @@ where
                     stream_log!("handleResolveStream: waiting for pending flush");
                     debug_assert!(self.server.get().is_some());
                     let global_this = self.server().global_this();
-                    self.ref_();
-                    let cell = NativePromiseContext::create(global_this, self.as_ctx_ptr());
+                    let cell = self.create_promise_cell(global_this);
                     // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                     jsc::JSPromise::opaque_ref(flush).to_js().then_with_value(
                         global_this,
@@ -2822,6 +2858,7 @@ where
             return Ok(JSValue::UNDEFINED);
         };
         let req = RequestContextRef::adopt(req.as_ptr());
+        req.ctx().promise_cell.set(JSValue::ZERO);
         req.ctx().handle_resolve_stream();
         Ok(JSValue::UNDEFINED)
     }
@@ -2837,6 +2874,7 @@ where
         };
         let err = args[0];
         let req = RequestContextRef::adopt(req.as_ptr());
+        req.ctx().promise_cell.set(JSValue::ZERO);
 
         req.ctx().handle_reject_stream(global_this, err);
         Ok(JSValue::UNDEFINED)
@@ -3587,8 +3625,7 @@ where
         match promise.unwrap(vm.global().vm(), jsc::PromiseUnwrapMode::MarkHandled) {
             jsc::PromiseResult::Pending => {
                 ctx.flags.set_is_error_promise_pending(true);
-                ctx.ref_();
-                let cell = NativePromiseContext::create(server.global_this(), ctx.as_ctx_ptr());
+                let cell = ctx.create_promise_cell(server.global_this());
                 promise_js.then_with_value(
                     server.global_this(),
                     cell,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2192,6 +2192,10 @@ where
         resp.clear_on_writable();
         resp.clear_timeout();
 
+        // The upgrade detaches the response and disarms onAborted, so neither
+        // on_abort nor an end path can reclaim a parked handler promise's
+        // claim later. Reclaim it here.
+        upgrader.reclaim_promise_cell();
         upgrader.deref();
 
         resp.upgrade(

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -263,187 +263,107 @@ test("client abort frees the context even while the resolve function stays reach
   expect(server.pendingRequests).toBe(0);
 });
 
-test("client abort while a direct stream pull() is parked frees the context and rejects the pending body read", async () => {
-  // Holding the pull() promise keeps its NativePromiseContext cell alive, so
-  // only the abort can release the context. Before the fix, on_abort returned
-  // at the sink branch without ending request streaming, so req.text() on the
-  // cut-off upload stayed pending and pendingRequests stayed at 1 until GC.
-  let pumpHold: Promise<never> | undefined;
-  const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
-  const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
-
-  using server = Bun.serve({
-    port: 0,
-    idleTimeout: 0,
-    fetch(req) {
-      req.text().then(
-        () => signalBodyRead("resolved"),
-        err => signalBodyRead(err),
-      );
-      return new Response(
-        new ReadableStream({
-          type: "direct",
-          pull(ctrl) {
-            ctrl.write("hello");
-            ctrl.flush();
-            signalFirstWrite();
-            pumpHold = new Promise<never>(() => {});
-            return pumpHold;
-          },
-        }),
-      );
+// Holding the pull() promise keeps its NativePromiseContext cell alive, so
+// only the abort can release the context. Before the fix, on_abort's sink
+// branch returned without ending request streaming, so a pending body read on
+// the cut-off upload stayed parked (and pendingRequests at 1) until GC.
+// req.text() and for-await(req.body) keep the body Locked. req.textStream()
+// moves it to Used, whose rejection goes through a stream ref that
+// finalize_without_deinit drops without erroring, so the sink branch must end
+// request streaming itself.
+const bodyConsumers: Array<[string, (req: Request, done: (v: unknown) => void) => void]> = [
+  [
+    "req.text()",
+    (req, done) => {
+      req.text().then(() => done("resolved"), done);
     },
-  });
-
-  // Raw socket: send a chunked POST, deliver one partial chunk so req.text()
-  // stays pending, then destroy the socket mid-stream.
-  const socket = connect(Number(server.port), "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    socket.on("connect", resolve);
-    socket.on("error", reject);
-  });
-  socket.removeAllListeners("error");
-  socket.on("error", () => {});
-  socket.write(
-    "POST / HTTP/1.1\r\n" + //
-      `Host: 127.0.0.1:${server.port}\r\n` +
-      "Transfer-Encoding: chunked\r\n" +
-      "\r\n" +
-      "7\r\npartial\r\n",
-  );
-  await firstWrite;
-  socket.destroy();
-
-  // The cut-off upload rejects the pending req.text() at abort time.
-  const err = await bodyRead;
-  expect(err).toBeInstanceOf(Error);
-  expect((err as Error).name).toBe("AbortError");
-  await waitForPendingRequestsWithoutGC(server, 0);
-  pumpHold = undefined;
-});
-
-test("client abort while a direct stream pull() is parked rejects a parked for-await body read", async () => {
-  // Same scenario as above, but the upload is consumed with
-  // for-await(req.body), which keeps the body Locked. The Locked arm of
-  // end_request_streaming rejects the parked read.
-  let pumpHold: Promise<never> | undefined;
-  const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
-  const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
-
-  using server = Bun.serve({
-    port: 0,
-    idleTimeout: 0,
-    fetch(req) {
+  ],
+  [
+    "for await (req.body)",
+    (req, done) => {
       (async () => {
         try {
           for await (const _chunk of req.body!) {
             // keep reading until the upload ends or errors
           }
-          signalBodyRead("completed");
+          done("completed");
         } catch (e) {
-          signalBodyRead(e);
+          done(e);
         }
       })();
-      return new Response(
-        new ReadableStream({
-          type: "direct",
-          pull(ctrl) {
-            ctrl.write("hello");
-            ctrl.flush();
-            signalFirstWrite();
-            pumpHold = new Promise<never>(() => {});
-            return pumpHold;
-          },
-        }),
-      );
     },
-  });
-
-  const socket = connect(Number(server.port), "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    socket.on("connect", resolve);
-    socket.on("error", reject);
-  });
-  socket.removeAllListeners("error");
-  socket.on("error", () => {});
-  socket.write(
-    "POST / HTTP/1.1\r\n" + //
-      `Host: 127.0.0.1:${server.port}\r\n` +
-      "Transfer-Encoding: chunked\r\n" +
-      "\r\n" +
-      "7\r\npartial\r\n",
-  );
-  await firstWrite;
-  socket.destroy();
-
-  const err = await bodyRead;
-  expect(err).toBeInstanceOf(Error);
-  expect((err as Error).name).toBe("AbortError");
-  await waitForPendingRequestsWithoutGC(server, 0);
-  pumpHold = undefined;
-});
-
-test("client abort while a direct stream pull() is parked rejects a parked textStream read", async () => {
-  // textStream() transitions the body to `Used`, so the rejection can only go
-  // through request_body_readable_stream_ref, and finalize_without_deinit
-  // drops that ref without erroring it. on_abort's sink branch must end
-  // request streaming itself while the ref is still set.
-  let pumpHold: Promise<never> | undefined;
-  const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
-  const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
-
-  using server = Bun.serve({
-    port: 0,
-    idleTimeout: 0,
-    fetch(req) {
+  ],
+  [
+    "req.textStream()",
+    (req, done) => {
       (async () => {
         try {
           for await (const _chunk of req.textStream()) {
             // keep reading until the upload ends or errors
           }
-          signalBodyRead("completed");
+          done("completed");
         } catch (e) {
-          signalBodyRead(e);
+          done(e);
         }
       })();
-      return new Response(
-        new ReadableStream({
-          type: "direct",
-          pull(ctrl) {
-            ctrl.write("hello");
-            ctrl.flush();
-            signalFirstWrite();
-            pumpHold = new Promise<never>(() => {});
-            return pumpHold;
-          },
-        }),
-      );
     },
-  });
+  ],
+];
 
-  const socket = connect(Number(server.port), "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    socket.on("connect", resolve);
-    socket.on("error", reject);
-  });
-  socket.removeAllListeners("error");
-  socket.on("error", () => {});
-  socket.write(
-    "POST / HTTP/1.1\r\n" + //
-      `Host: 127.0.0.1:${server.port}\r\n` +
-      "Transfer-Encoding: chunked\r\n" +
-      "\r\n" +
-      "7\r\npartial\r\n",
-  );
-  await firstWrite;
-  socket.destroy();
+test.each(bodyConsumers)(
+  "client abort while a direct stream pull() is parked frees the context and rejects a pending %s read",
+  async (_name, consume) => {
+    let pumpHold: Promise<never> | undefined;
+    const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
+    const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
 
-  const err = await bodyRead;
-  expect(err).toBeInstanceOf(Error);
-  expect((err as Error).name).toBe("AbortError");
-  await waitForPendingRequestsWithoutGC(server, 0);
-  pumpHold = undefined;
-});
+    using server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch(req) {
+        consume(req, signalBodyRead);
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            pull(ctrl) {
+              ctrl.write("hello");
+              ctrl.flush();
+              signalFirstWrite();
+              pumpHold = new Promise<never>(() => {});
+              return pumpHold;
+            },
+          }),
+        );
+      },
+    });
+
+    // Raw socket: send a chunked POST, deliver one partial chunk so the read
+    // stays pending, then destroy the socket mid-stream.
+    const socket = connect(Number(server.port), "127.0.0.1");
+    await new Promise<void>((resolve, reject) => {
+      socket.on("connect", resolve);
+      socket.on("error", reject);
+    });
+    socket.removeAllListeners("error");
+    socket.on("error", () => {});
+    socket.write(
+      "POST / HTTP/1.1\r\n" + //
+        `Host: 127.0.0.1:${server.port}\r\n` +
+        "Transfer-Encoding: chunked\r\n" +
+        "\r\n" +
+        "7\r\npartial\r\n",
+    );
+    await firstWrite;
+    socket.destroy();
+
+    // The cut-off upload rejects the pending read at abort time.
+    const err = await bodyRead;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("AbortError");
+    await waitForPendingRequestsWithoutGC(server, 0);
+    pumpHold = undefined;
+  },
+);
 
 test("async server.upgrade() frees the context while the handler promise stays parked", async () => {
   // The upgrade detaches the response and disarms onAborted, so neither

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -388,20 +388,23 @@ test("async server.upgrade() frees the context while the handler promise stays p
   });
 
   const ws = new WebSocket(`ws://localhost:${server.port}/`);
-  const { promise: opened, resolve: signalOpen, reject: failOpen } = Promise.withResolvers<void>();
-  ws.onopen = () => signalOpen();
-  ws.onerror = () => failOpen(new Error("websocket upgrade failed"));
-  await opened;
+  try {
+    const { promise: opened, resolve: signalOpen, reject: failOpen } = Promise.withResolvers<void>();
+    ws.onopen = () => signalOpen();
+    ws.onerror = () => failOpen(new Error("websocket upgrade failed"));
+    await opened;
 
-  await waitForPendingRequestsWithoutGC(server, 0);
+    await waitForPendingRequestsWithoutGC(server, 0);
 
-  // Resolving after the context is gone is a safe no-op: the reaction's
-  // take() returns null.
-  capturedResolve!(new Response("late"));
-  capturedResolve = undefined;
-  await Bun.sleep(0);
-  expect(server.pendingRequests).toBe(0);
-  ws.close();
+    // Resolving after the context is gone is a safe no-op: the reaction's
+    // take() returns null.
+    capturedResolve!(new Response("late"));
+    capturedResolve = undefined;
+    await Bun.sleep(0);
+    expect(server.pendingRequests).toBe(0);
+  } finally {
+    ws.close();
+  }
 });
 
 test("413 on a chunked upload frees the context while the handler promise stays parked", async () => {
@@ -425,47 +428,50 @@ test("413 on a chunked upload frees the context while the handler promise stays 
   });
 
   const socket = connect(Number(server.port), "127.0.0.1");
-  await new Promise<void>((resolve, reject) => {
-    socket.on("connect", resolve);
-    socket.on("error", reject);
-  });
-  // The server closes the connection after the 413; EPIPE/ECONNRESET while we
-  // are still writing chunks is the expected outcome.
-  socket.removeAllListeners("error");
-  socket.on("error", () => {});
-
-  let received = "";
-  const { promise: gotResponse, resolve: signalResponse } = Promise.withResolvers<void>();
-  socket.on("data", d => {
-    received += d.toString("latin1");
-    if (received.includes("\r\n\r\n")) signalResponse();
-  });
-  socket.on("close", () => signalResponse());
-
-  socket.write(
-    "POST / HTTP/1.1\r\n" + //
-      `Host: 127.0.0.1:${server.port}\r\n` +
-      "Transfer-Encoding: chunked\r\n" +
-      "\r\n",
-  );
-  await handlerEntered;
-
-  const piece = Buffer.alloc(512, "A").toString("latin1");
-  for (let sent = 0; sent < 4096 && !socket.destroyed; sent += piece.length) {
-    await new Promise<void>(resolve => {
-      if (socket.destroyed) return resolve();
-      socket.write(piece.length.toString(16) + "\r\n" + piece + "\r\n", () => resolve());
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.on("connect", resolve);
+      socket.on("error", reject);
     });
+    // The server closes the connection after the 413; EPIPE/ECONNRESET while
+    // we are still writing chunks is the expected outcome.
+    socket.removeAllListeners("error");
+    socket.on("error", () => {});
+
+    let received = "";
+    const { promise: gotResponse, resolve: signalResponse } = Promise.withResolvers<void>();
+    socket.on("data", d => {
+      received += d.toString("latin1");
+      if (received.includes("\r\n\r\n")) signalResponse();
+    });
+    socket.on("close", () => signalResponse());
+
+    socket.write(
+      "POST / HTTP/1.1\r\n" + //
+        `Host: 127.0.0.1:${server.port}\r\n` +
+        "Transfer-Encoding: chunked\r\n" +
+        "\r\n",
+    );
+    await handlerEntered;
+
+    const piece = Buffer.alloc(512, "A").toString("latin1");
+    for (let sent = 0; sent < 4096 && !socket.destroyed; sent += piece.length) {
+      await new Promise<void>(resolve => {
+        if (socket.destroyed) return resolve();
+        socket.write(piece.length.toString(16) + "\r\n" + piece + "\r\n", () => resolve());
+      });
+    }
+
+    await gotResponse;
+    // An early close resolves gotResponse too; fail on the missing response
+    // before the status-line comparison so the cause is visible.
+    expect(received).not.toBe("");
+    expect(received.split("\r\n")[0]).toBe("HTTP/1.1 413 Payload Too Large");
+
+    // The context is torn down by the 413, not by GC collecting the promise.
+    await waitForPendingRequestsWithoutGC(server, 0);
+    capturedResolve = undefined;
+  } finally {
+    socket.destroy();
   }
-
-  await gotResponse;
-  // An early close resolves gotResponse too; fail on the missing response
-  // before the status-line comparison so the cause is visible.
-  expect(received).not.toBe("");
-  expect(received.split("\r\n")[0]).toBe("HTTP/1.1 413 Payload Too Large");
-
-  // The context is torn down by the 413, not by GC collecting the promise.
-  await waitForPendingRequestsWithoutGC(server, 0);
-  capturedResolve = undefined;
-  socket.destroy();
 });

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -365,6 +365,127 @@ test.each(bodyConsumers)(
   },
 );
 
+test("pendingRequests drops when the client aborts a parked direct-stream pull(), and the late pull() settle is a no-op", async () => {
+  // Same parked pull() scenario, driven through fetch() and an AbortController,
+  // with the pull() resolvers stashed in user state. Releasing them afterwards
+  // settles the pump promise of a context that is already gone: the stream
+  // reaction's take() returns null, and pendingRequests must not move.
+  const parked: Array<() => void> = [];
+  const pullEntered: Array<() => void> = [];
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(c) {
+            c.write("x");
+            await c.flush();
+            pullEntered.shift()?.();
+            await new Promise<void>(r => parked.push(r));
+          },
+        }),
+        { headers: { "Content-Length": "100000" } },
+      );
+    },
+  });
+
+  async function abortWhileParked() {
+    const { promise: entered, resolve: markEntered } = Promise.withResolvers<void>();
+    pullEntered.push(markEntered);
+    const ac = new AbortController();
+    const res = await fetch(server.url, { signal: ac.signal });
+    expect(res.status).toBe(200);
+    const reader = res.body!.getReader();
+    await reader.read();
+    await entered;
+    ac.abort();
+    await reader.closed.catch(() => {});
+  }
+
+  async function releaseParkedPulls(expectedCount: number) {
+    const resolvers = parked.splice(0);
+    expect(resolvers.length).toBe(expectedCount);
+    for (const r of resolvers) r();
+    await Bun.sleep(0);
+    Bun.gc(true);
+    await Bun.sleep(0);
+    expect(server.pendingRequests).toBe(0);
+  }
+
+  const iterations = 3;
+  for (let i = 0; i < iterations; i++) {
+    await abortWhileParked();
+  }
+  await waitForPendingRequestsWithoutGC(server, 0);
+  await releaseParkedPulls(iterations);
+
+  // The server still serves after the late settles, and the counter stays balanced.
+  await abortWhileParked();
+  await waitForPendingRequestsWithoutGC(server, 0);
+  await releaseParkedPulls(1);
+});
+
+// Between the abort and the late settle, the server itself goes away: stop()
+// (issued before or after the abort) plus pendingRequests reaching 0 lets the
+// server release its JS wrapper, and dropping the last reference lets GC free
+// it. Releasing the parked pull() after that must still be a no-op.
+for (const stopFirst of [true, false]) {
+  test(`releasing a parked pull() after the abort tore down the context and the server is a no-op (${stopFirst ? "stop-then-abort" : "abort-then-stop"})`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let release;
+        const gate = new Promise(r => (release = r));
+        let server = Bun.serve({
+          port: 0,
+          idleTimeout: 0,
+          fetch() {
+            return new Response(new ReadableStream({
+              type: "direct",
+              async pull(c) {
+                c.write("x");
+                await c.flush();
+                await gate;
+              },
+            }), { headers: { "Content-Length": "100000" } });
+          },
+        });
+        const ac = new AbortController();
+        const reader = (await fetch(server.url, { signal: ac.signal })).body.getReader();
+        await reader.read();
+        ${stopFirst ? "server.stop();" : ""}
+        ac.abort();
+        await reader.closed.catch(() => {});
+        ${stopFirst ? "" : "server.stop();"}
+        // No Bun.gc here: the abort itself has to tear the context down.
+        for (let i = 0; server.pendingRequests !== 0; i++) {
+          if (i === 200) throw new Error("pendingRequests=" + server.pendingRequests);
+          await Bun.sleep(10);
+        }
+        server = undefined;
+        for (let i = 0; i < 5; i++) { Bun.gc(true); await Bun.sleep(0); }
+        release();
+        for (let i = 0; i < 5; i++) { Bun.gc(true); await Bun.sleep(0); }
+        console.log("ok");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+}
+
 test("async server.upgrade() frees the context while the handler promise stays parked", async () => {
   // The upgrade detaches the response and disarms onAborted, so neither
   // on_abort nor an end path can run afterwards. The upgrade itself must

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -320,3 +320,66 @@ test("client abort while a direct stream pull() is parked frees the context and 
   await waitForPendingRequestsWithoutGC(server, 0);
   pumpHold = undefined;
 });
+
+test("413 on a chunked upload frees the context while the handler promise stays parked", async () => {
+  // The 413 path ends the request through end_without_body, and uWS markDone()
+  // clears onAborted, so on_abort can never run for this request. The held
+  // resolve keeps the promise alive forever, so only the end path itself can
+  // release the context.
+  let capturedResolve: ((r: Response) => void) | undefined;
+  const { promise: handlerEntered, resolve: signalHandler } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    maxRequestBodySize: 1024,
+    fetch() {
+      signalHandler();
+      return new Promise<Response>(resolve => {
+        capturedResolve = resolve;
+      });
+    },
+  });
+
+  const socket = connect(Number(server.port), "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    socket.on("connect", resolve);
+    socket.on("error", reject);
+  });
+  // The server closes the connection after the 413; EPIPE/ECONNRESET while we
+  // are still writing chunks is the expected outcome.
+  socket.removeAllListeners("error");
+  socket.on("error", () => {});
+
+  let received = "";
+  const { promise: gotResponse, resolve: signalResponse } = Promise.withResolvers<void>();
+  socket.on("data", d => {
+    received += d.toString("latin1");
+    if (received.includes("\r\n\r\n")) signalResponse();
+  });
+  socket.on("close", () => signalResponse());
+
+  socket.write(
+    "POST / HTTP/1.1\r\n" + //
+      `Host: 127.0.0.1:${server.port}\r\n` +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n",
+  );
+  await handlerEntered;
+
+  const piece = Buffer.alloc(512, "A").toString("latin1");
+  for (let sent = 0; sent < 4096 && !socket.destroyed; sent += piece.length) {
+    await new Promise<void>(resolve => {
+      if (socket.destroyed) return resolve();
+      socket.write(piece.length.toString(16) + "\r\n" + piece + "\r\n", () => resolve());
+    });
+  }
+
+  await gotResponse;
+  expect(received.split("\r\n")[0]).toBe("HTTP/1.1 413 Payload Too Large");
+
+  // The context is torn down by the 413, not by GC collecting the promise.
+  await waitForPendingRequestsWithoutGC(server, 0);
+  capturedResolve = undefined;
+  socket.destroy();
+});

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -395,7 +395,12 @@ test("async server.upgrade() frees the context while the handler promise stays p
 
   await waitForPendingRequestsWithoutGC(server, 0);
 
+  // Resolving after the context is gone is a safe no-op: the reaction's
+  // take() returns null.
+  capturedResolve!(new Response("late"));
   capturedResolve = undefined;
+  await Bun.sleep(0);
+  expect(server.pendingRequests).toBe(0);
   ws.close();
 });
 

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -322,6 +322,128 @@ test("client abort while a direct stream pull() is parked frees the context and 
   pumpHold = undefined;
 });
 
+test("client abort while a direct stream pull() is parked rejects a parked for-await body read", async () => {
+  // Same scenario as above, but the upload is consumed as a stream (body
+  // `Used`, not `Locked`). The rejection can only come through
+  // request_body_readable_stream_ref, which finalize_without_deinit drops
+  // without erroring, so on_abort itself must end request streaming.
+  let pumpHold: Promise<never> | undefined;
+  const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
+  const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      (async () => {
+        try {
+          for await (const _chunk of req.body!) {
+            // keep reading until the upload ends or errors
+          }
+          signalBodyRead("completed");
+        } catch (e) {
+          signalBodyRead(e);
+        }
+      })();
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(ctrl) {
+            ctrl.write("hello");
+            ctrl.flush();
+            signalFirstWrite();
+            pumpHold = new Promise<never>(() => {});
+            return pumpHold;
+          },
+        }),
+      );
+    },
+  });
+
+  const socket = connect(Number(server.port), "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    socket.on("connect", resolve);
+    socket.on("error", reject);
+  });
+  socket.removeAllListeners("error");
+  socket.on("error", () => {});
+  socket.write(
+    "POST / HTTP/1.1\r\n" + //
+      `Host: 127.0.0.1:${server.port}\r\n` +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "7\r\npartial\r\n",
+  );
+  await firstWrite;
+  socket.destroy();
+
+  const err = await bodyRead;
+  expect(err).toBeInstanceOf(Error);
+  await waitForPendingRequestsWithoutGC(server, 0);
+  pumpHold = undefined;
+});
+
+test("client abort while a direct stream pull() is parked rejects a parked textStream read", async () => {
+  // textStream() transitions the body to `Used`, so the rejection can only go
+  // through request_body_readable_stream_ref, and finalize_without_deinit
+  // drops that ref without erroring it. on_abort's sink branch must end
+  // request streaming itself while the ref is still set.
+  let pumpHold: Promise<never> | undefined;
+  const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
+  const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      (async () => {
+        try {
+          for await (const _chunk of req.textStream()) {
+            // keep reading until the upload ends or errors
+          }
+          signalBodyRead("completed");
+        } catch (e) {
+          signalBodyRead(e);
+        }
+      })();
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(ctrl) {
+            ctrl.write("hello");
+            ctrl.flush();
+            signalFirstWrite();
+            pumpHold = new Promise<never>(() => {});
+            return pumpHold;
+          },
+        }),
+      );
+    },
+  });
+
+  const socket = connect(Number(server.port), "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    socket.on("connect", resolve);
+    socket.on("error", reject);
+  });
+  socket.removeAllListeners("error");
+  socket.on("error", () => {});
+  socket.write(
+    "POST / HTTP/1.1\r\n" + //
+      `Host: 127.0.0.1:${server.port}\r\n` +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "7\r\npartial\r\n",
+  );
+  await firstWrite;
+  socket.destroy();
+
+  const err = await bodyRead;
+  expect(err).toBeInstanceOf(Error);
+  await waitForPendingRequestsWithoutGC(server, 0);
+  pumpHold = undefined;
+});
+
 test("413 on a chunked upload frees the context while the handler promise stays parked", async () => {
   // The 413 path ends the request through end_without_body, and uWS markDone()
   // clears onAborted, so on_abort can never run for this request. The held

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -317,6 +317,7 @@ test("client abort while a direct stream pull() is parked frees the context and 
   // The cut-off upload rejects the pending req.text() at abort time.
   const err = await bodyRead;
   expect(err).toBeInstanceOf(Error);
+  expect((err as Error).name).toBe("AbortError");
   await waitForPendingRequestsWithoutGC(server, 0);
   pumpHold = undefined;
 });
@@ -376,6 +377,9 @@ test("413 on a chunked upload frees the context while the handler promise stays 
   }
 
   await gotResponse;
+  // An early close resolves gotResponse too; fail on the missing response
+  // before the status-line comparison so the cause is visible.
+  expect(received).not.toBe("");
   expect(received.split("\r\n")[0]).toBe("HTTP/1.1 413 Payload Too Large");
 
   // The context is torn down by the 413, not by GC collecting the promise.

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -323,10 +323,9 @@ test("client abort while a direct stream pull() is parked frees the context and 
 });
 
 test("client abort while a direct stream pull() is parked rejects a parked for-await body read", async () => {
-  // Same scenario as above, but the upload is consumed as a stream (body
-  // `Used`, not `Locked`). The rejection can only come through
-  // request_body_readable_stream_ref, which finalize_without_deinit drops
-  // without erroring, so on_abort itself must end request streaming.
+  // Same scenario as above, but the upload is consumed with
+  // for-await(req.body), which keeps the body Locked. The Locked arm of
+  // end_request_streaming rejects the parked read.
   let pumpHold: Promise<never> | undefined;
   const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
   const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
@@ -379,6 +378,7 @@ test("client abort while a direct stream pull() is parked rejects a parked for-a
 
   const err = await bodyRead;
   expect(err).toBeInstanceOf(Error);
+  expect((err as Error).name).toBe("AbortError");
   await waitForPendingRequestsWithoutGC(server, 0);
   pumpHold = undefined;
 });
@@ -440,8 +440,43 @@ test("client abort while a direct stream pull() is parked rejects a parked textS
 
   const err = await bodyRead;
   expect(err).toBeInstanceOf(Error);
+  expect((err as Error).name).toBe("AbortError");
   await waitForPendingRequestsWithoutGC(server, 0);
   pumpHold = undefined;
+});
+
+test("async server.upgrade() frees the context while the handler promise stays parked", async () => {
+  // The upgrade detaches the response and disarms onAborted, so neither
+  // on_abort nor an end path can run afterwards. The upgrade itself must
+  // reclaim the cell's ref, or the held resolve parks the context forever.
+  let capturedResolve: ((r: Response) => void) | undefined;
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req, srv) {
+      return new Promise<Response>(resolve => {
+        capturedResolve = resolve;
+        // Upgrade from a macrotask, so on_response parks the promise and
+        // takes the cell ref before the upgrade runs.
+        setImmediate(() => srv.upgrade(req));
+      });
+    },
+    websocket: {
+      message() {},
+    },
+  });
+
+  const ws = new WebSocket(`ws://localhost:${server.port}/`);
+  const { promise: opened, resolve: signalOpen, reject: failOpen } = Promise.withResolvers<void>();
+  ws.onopen = () => signalOpen();
+  ws.onerror = () => failOpen(new Error("websocket upgrade failed"));
+  await opened;
+
+  await waitForPendingRequestsWithoutGC(server, 0);
+
+  capturedResolve = undefined;
+  ws.close();
 });
 
 test("413 on a chunked upload frees the context while the handler promise stays parked", async () => {

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -12,6 +12,16 @@ async function waitForPendingRequests(server: ReturnType<typeof Bun.serve>, expe
   throw new Error(`Timed out waiting for pendingRequests === ${expected}; got ${server.pendingRequests}`);
 }
 
+// Deliberately never calls Bun.gc: these tests assert the context is torn
+// down by the abort itself, not by GC collecting the pending promise.
+async function waitForPendingRequestsWithoutGC(server: ReturnType<typeof Bun.serve>, expected: number) {
+  for (let i = 0; i < 200; i++) {
+    if (server.pendingRequests === expected) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for pendingRequests === ${expected}; got ${server.pendingRequests}`);
+}
+
 test("RequestContext is freed when client aborts before Promise<Response> settles", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "serve-pending-promise-abort-leak-fixture.ts")],
@@ -217,11 +227,10 @@ test("chunked request body consumed as a ReadableStream is capped at maxRequestB
   await waitForPendingRequests(server, 0);
 }, 15_000);
 
-test("resolve() after abort does not crash and cleans up", async () => {
-  // UAF safety: while the resolve function is reachable, the Promise stays
-  // alive, the NativePromiseContext cell stays alive, and the RequestContext
-  // stays alive. Calling resolve() after abort triggers onResolve, which sees
-  // the aborted state, bails safely, and derefs.
+test("client abort frees the context even while the resolve function stays reachable", async () => {
+  // The held resolve function keeps the handler Promise (and so the
+  // NativePromiseContext cell) alive forever, so GC can never release the
+  // cell's ref on the RequestContext. The abort itself must reclaim it.
   let capturedResolve: ((r: Response) => void) | undefined;
   const { promise: abortObserved, resolve: signalAbort } = Promise.withResolvers<void>();
 
@@ -243,18 +252,71 @@ test("resolve() after abort does not crash and cleans up", async () => {
   await p;
   await abortObserved;
 
-  // While capturedResolve is held, the Promise (and its reaction, and the
-  // cell, and the RequestContext) stay alive. This is the safety guarantee:
-  // no UAF because the ctx outlives any possible resolve() call.
-  Bun.gc(true);
-  await Bun.sleep(0);
-  expect(server.pendingRequests).toBe(1);
+  // The context is torn down on abort, not when GC collects the promise.
+  await waitForPendingRequestsWithoutGC(server, 0);
 
-  // Resolving after abort: onResolve takes the ctx, handleResolve sees
-  // isAbortedOrEnded() and bails, then derefs. Context is freed.
+  // Resolving after the context is gone is a safe no-op: the reaction's
+  // take() returns null.
   capturedResolve!(new Response("very late"));
   capturedResolve = undefined;
-  await waitForPendingRequests(server, 0);
-
+  await Bun.sleep(0);
   expect(server.pendingRequests).toBe(0);
+});
+
+test("client abort while a direct stream pull() is parked frees the context and rejects the pending body read", async () => {
+  // Holding the pull() promise keeps its NativePromiseContext cell alive, so
+  // only the abort can release the context. Before the fix, on_abort returned
+  // at the sink branch without ending request streaming, so req.text() on the
+  // cut-off upload stayed pending and pendingRequests stayed at 1 until GC.
+  let pumpHold: Promise<never> | undefined;
+  const { promise: bodyRead, resolve: signalBodyRead } = Promise.withResolvers<unknown>();
+  const { promise: firstWrite, resolve: signalFirstWrite } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      req.text().then(
+        () => signalBodyRead("resolved"),
+        err => signalBodyRead(err),
+      );
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(ctrl) {
+            ctrl.write("hello");
+            ctrl.flush();
+            signalFirstWrite();
+            pumpHold = new Promise<never>(() => {});
+            return pumpHold;
+          },
+        }),
+      );
+    },
+  });
+
+  // Raw socket: send a chunked POST, deliver one partial chunk so req.text()
+  // stays pending, then destroy the socket mid-stream.
+  const socket = connect(Number(server.port), "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    socket.on("connect", resolve);
+    socket.on("error", reject);
+  });
+  socket.removeAllListeners("error");
+  socket.on("error", () => {});
+  socket.write(
+    "POST / HTTP/1.1\r\n" + //
+      `Host: 127.0.0.1:${server.port}\r\n` +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "7\r\npartial\r\n",
+  );
+  await firstWrite;
+  socket.destroy();
+
+  // The cut-off upload rejects the pending req.text() at abort time.
+  const err = await bodyRead;
+  expect(err).toBeInstanceOf(Error);
+  await waitForPendingRequestsWithoutGC(server, 0);
+  pumpHold = undefined;
 });

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -3,23 +3,13 @@ import { bunEnv, bunExe } from "harness";
 import { connect } from "node:net";
 import { join } from "node:path";
 
-async function waitForPendingRequests(server: ReturnType<typeof Bun.serve>, expected: number) {
-  for (let i = 0; i < 100; i++) {
-    if (server.pendingRequests === expected) return;
-    Bun.gc(true);
-    await Bun.sleep(10);
-  }
-  throw new Error(`Timed out waiting for pendingRequests === ${expected}; got ${server.pendingRequests}`);
-}
-
-// Deliberately never calls Bun.gc: these tests assert the context is torn
-// down by the abort itself, not by GC collecting the pending promise.
-async function waitForPendingRequestsWithoutGC(server: ReturnType<typeof Bun.serve>, expected: number) {
-  for (let i = 0; i < 200; i++) {
-    if (server.pendingRequests === expected) return;
-    await Bun.sleep(10);
-  }
-  throw new Error(`Timed out waiting for pendingRequests === ${expected}; got ${server.pendingRequests}`);
+// The teardown condition, with no timers and no GC: server.stop() resolves
+// only once pendingRequests reaches 0 and every connection is gone. On an
+// unfixed build a parked context pins the count, so this await never settles
+// and the test times out.
+async function stopAndAssertDrained(server: ReturnType<typeof Bun.serve>) {
+  await server.stop();
+  expect(server.pendingRequests).toBe(0);
 }
 
 test("RequestContext is freed when client aborts before Promise<Response> settles", async () => {
@@ -57,10 +47,12 @@ test("Promise<Response> still works normally when not aborted", async () => {
 
 test("resolve() inside abort handler is handled safely", async () => {
   let aborted = false;
+  const { promise: handlerEntered, resolve: signalHandler } = Promise.withResolvers<void>();
   using server = Bun.serve({
     port: 0,
     idleTimeout: 0,
     fetch(req) {
+      signalHandler();
       return new Promise<Response>(resolve => {
         req.signal.addEventListener(
           "abort",
@@ -78,13 +70,12 @@ test("resolve() inside abort handler is handled safely", async () => {
 
   const ac = new AbortController();
   const p = fetch(server.url, { signal: ac.signal }).catch(() => {});
-  await waitForPendingRequests(server, 1);
+  await handlerEntered;
   ac.abort();
   await p;
-  await waitForPendingRequests(server, 0);
+  await stopAndAssertDrained(server);
 
   expect(aborted).toBe(true);
-  expect(server.pendingRequests).toBe(0);
 });
 
 test("streaming 413 detaches the response so a late resolve/reject is a no-op", async () => {
@@ -224,7 +215,7 @@ test("chunked request body consumed as a ReadableStream is capped at maxRequestB
   expect(streamError).toBe("Request body exceeded maxRequestBodySize");
   expect(streamed).toBeLessThan(overflowTotal);
 
-  await waitForPendingRequests(server, 0);
+  await stopAndAssertDrained(server);
 }, 15_000);
 
 test("client abort frees the context even while the resolve function stays reachable", async () => {
@@ -232,34 +223,39 @@ test("client abort frees the context even while the resolve function stays reach
   // NativePromiseContext cell) alive forever, so GC can never release the
   // cell's ref on the RequestContext. The abort itself must reclaim it.
   let capturedResolve: ((r: Response) => void) | undefined;
+  let capturedPromise: Promise<Response> | undefined;
   const { promise: abortObserved, resolve: signalAbort } = Promise.withResolvers<void>();
+  const { promise: handlerEntered, resolve: signalHandler } = Promise.withResolvers<void>();
 
   using server = Bun.serve({
     port: 0,
     idleTimeout: 0,
     fetch(req) {
-      return new Promise<Response>(resolve => {
+      signalHandler();
+      capturedPromise = new Promise<Response>(resolve => {
         capturedResolve = resolve;
         req.signal.addEventListener("abort", () => signalAbort(), { once: true });
       });
+      return capturedPromise;
     },
   });
 
   const ac = new AbortController();
   const p = fetch(server.url, { signal: ac.signal }).catch(() => {});
-  await waitForPendingRequests(server, 1);
+  await handlerEntered;
   ac.abort();
   await p;
   await abortObserved;
 
   // The context is torn down on abort, not when GC collects the promise.
-  await waitForPendingRequestsWithoutGC(server, 0);
+  await stopAndAssertDrained(server);
 
   // Resolving after the context is gone is a safe no-op: the reaction's
-  // take() returns null.
+  // take() returns null. Awaiting the handler promise orders the assertion
+  // after the native reaction, which was attached first.
   capturedResolve!(new Response("very late"));
+  await capturedPromise;
   capturedResolve = undefined;
-  await Bun.sleep(0);
   expect(server.pendingRequests).toBe(0);
 });
 
@@ -360,7 +356,7 @@ test.each(bodyConsumers)(
     const err = await bodyRead;
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).name).toBe("AbortError");
-    await waitForPendingRequestsWithoutGC(server, 0);
+    await stopAndAssertDrained(server);
     pumpHold = undefined;
   },
 );
@@ -372,6 +368,7 @@ test("pendingRequests drops when the client aborts a parked direct-stream pull()
   // reaction's take() returns null, and pendingRequests must not move.
   const parked: Array<() => void> = [];
   const pullEntered: Array<() => void> = [];
+  const pullSettled: Array<() => void> = [];
 
   using server = Bun.serve({
     port: 0,
@@ -385,6 +382,7 @@ test("pendingRequests drops when the client aborts a parked direct-stream pull()
             await c.flush();
             pullEntered.shift()?.();
             await new Promise<void>(r => parked.push(r));
+            pullSettled.shift()?.();
           },
         }),
         { headers: { "Content-Length": "100000" } },
@@ -405,27 +403,28 @@ test("pendingRequests drops when the client aborts a parked direct-stream pull()
     await reader.closed.catch(() => {});
   }
 
-  async function releaseParkedPulls(expectedCount: number) {
-    const resolvers = parked.splice(0);
-    expect(resolvers.length).toBe(expectedCount);
-    for (const r of resolvers) r();
-    await Bun.sleep(0);
-    Bun.gc(true);
-    await Bun.sleep(0);
-    expect(server.pendingRequests).toBe(0);
-  }
-
-  const iterations = 3;
+  const iterations = 4;
   for (let i = 0; i < iterations; i++) {
     await abortWhileParked();
   }
-  await waitForPendingRequestsWithoutGC(server, 0);
-  await releaseParkedPulls(iterations);
 
-  // The server still serves after the late settles, and the counter stays balanced.
-  await abortWhileParked();
-  await waitForPendingRequestsWithoutGC(server, 0);
-  await releaseParkedPulls(1);
+  // stop() resolves only once every abort tore its context down.
+  await stopAndAssertDrained(server);
+
+  // Release the parked pulls: each settle targets a context that is already
+  // gone. The stream reaction's take() returns null and the counter stays 0.
+  // Awaiting the settle signals orders the assertion after those reactions.
+  const resolvers = parked.splice(0);
+  expect(resolvers.length).toBe(iterations);
+  const settled = resolvers.map(() => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    pullSettled.push(resolve);
+    return promise;
+  });
+  for (const r of resolvers) r();
+  await Promise.all(settled);
+  Bun.gc(true);
+  expect(server.pendingRequests).toBe(0);
 });
 
 // Between the abort and the late settle, the server itself goes away: stop()
@@ -441,6 +440,8 @@ for (const stopFirst of [true, false]) {
         `
         let release;
         const gate = new Promise(r => (release = r));
+        let pullDone;
+        const pullExited = new Promise(r => (pullDone = r));
         let server = Bun.serve({
           port: 0,
           idleTimeout: 0,
@@ -451,6 +452,7 @@ for (const stopFirst of [true, false]) {
                 c.write("x");
                 await c.flush();
                 await gate;
+                pullDone();
               },
             }), { headers: { "Content-Length": "100000" } });
           },
@@ -458,19 +460,18 @@ for (const stopFirst of [true, false]) {
         const ac = new AbortController();
         const reader = (await fetch(server.url, { signal: ac.signal })).body.getReader();
         await reader.read();
-        ${stopFirst ? "server.stop();" : ""}
+        ${stopFirst ? "const stopped = server.stop();" : ""}
         ac.abort();
         await reader.closed.catch(() => {});
-        ${stopFirst ? "" : "server.stop();"}
-        // No Bun.gc here: the abort itself has to tear the context down.
-        for (let i = 0; server.pendingRequests !== 0; i++) {
-          if (i === 200) throw new Error("pendingRequests=" + server.pendingRequests);
-          await Bun.sleep(10);
-        }
+        // The stop() promise resolves only once the abort tears the parked
+        // context down. No Bun.gc before it: the abort itself has to do it.
+        ${stopFirst ? "await stopped;" : "await server.stop();"}
+        if (server.pendingRequests !== 0) throw new Error("pendingRequests=" + server.pendingRequests);
         server = undefined;
-        for (let i = 0; i < 5; i++) { Bun.gc(true); await Bun.sleep(0); }
+        Bun.gc(true);
         release();
-        for (let i = 0; i < 5; i++) { Bun.gc(true); await Bun.sleep(0); }
+        await pullExited;
+        Bun.gc(true);
         console.log("ok");
         `,
       ],
@@ -491,17 +492,19 @@ test("async server.upgrade() frees the context while the handler promise stays p
   // on_abort nor an end path can run afterwards. The upgrade itself must
   // reclaim the cell's ref, or the held resolve parks the context forever.
   let capturedResolve: ((r: Response) => void) | undefined;
+  let capturedPromise: Promise<Response> | undefined;
 
   using server = Bun.serve({
     port: 0,
     idleTimeout: 0,
     fetch(req, srv) {
-      return new Promise<Response>(resolve => {
+      capturedPromise = new Promise<Response>(resolve => {
         capturedResolve = resolve;
         // Upgrade from a macrotask, so on_response parks the promise and
         // takes the cell ref before the upgrade runs.
         setImmediate(() => srv.upgrade(req));
       });
+      return capturedPromise;
     },
     websocket: {
       message() {},
@@ -511,17 +514,24 @@ test("async server.upgrade() frees the context while the handler promise stays p
   const ws = new WebSocket(`ws://localhost:${server.port}/`);
   try {
     const { promise: opened, resolve: signalOpen, reject: failOpen } = Promise.withResolvers<void>();
+    const { promise: closed, resolve: signalClose } = Promise.withResolvers<void>();
     ws.onopen = () => signalOpen();
+    ws.onclose = () => signalClose();
     ws.onerror = () => failOpen(new Error("websocket upgrade failed"));
     await opened;
 
-    await waitForPendingRequestsWithoutGC(server, 0);
+    // Close the socket first: stop() also waits for open WebSockets. After
+    // that, its resolution is exactly the context teardown the upgrade owes.
+    ws.close();
+    await closed;
+    await stopAndAssertDrained(server);
 
     // Resolving after the context is gone is a safe no-op: the reaction's
-    // take() returns null.
+    // take() returns null. Awaiting the handler promise orders the assertion
+    // after the native reaction, which was attached first.
     capturedResolve!(new Response("late"));
+    await capturedPromise;
     capturedResolve = undefined;
-    await Bun.sleep(0);
     expect(server.pendingRequests).toBe(0);
   } finally {
     ws.close();
@@ -590,7 +600,8 @@ test("413 on a chunked upload frees the context while the handler promise stays 
     expect(received.split("\r\n")[0]).toBe("HTTP/1.1 413 Payload Too Large");
 
     // The context is torn down by the 413, not by GC collecting the promise.
-    await waitForPendingRequestsWithoutGC(server, 0);
+    // The 413 closed the connection, so stop() waits only on the teardown.
+    await stopAndAssertDrained(server);
     capturedResolve = undefined;
   } finally {
     socket.destroy();


### PR DESCRIPTION
Fixes #39739.

### Problem
- When a `Bun.serve` handler returns a promise that never settles, or a direct stream parks inside `pull()`, the end of the request does not free its context. The `NativePromiseContext` cell's ref keeps the context parked until GC collects the promise: the pool slot, the body slot, the stream refs, the sink, and `server.pendingRequests` all stay held. At VM teardown the cell's deref is skipped on purpose, so the context is never torn down.
- With a response sink, `on_abort` also returns before `end_request_streaming`, so a pending body read (`request.text()` or `textStream()`) on a cut-off upload stays unrejected.

### Fix
- The context remembers its live cell in a new `promise_cell` field. `reclaim_promise_cell` calls the cell's `take()` and derefs, so the context is torn down when the response ends. A later settle reaction gets null from `take()` and no-ops, which the reactions already tolerate.
- Every termination path reclaims: `on_abort` (both branches), the end family (`end`, `end_stream`, `end_without_body`, `force_close`, `end_already_responded_stream`), and `server.upgrade()`. The 413 path and the upgrade need this because they disarm `onAborted`, so `on_abort` can never run after them.
- `on_abort` orders the reclaim after `end_request_streaming`, and its sink branch now calls `end_request_streaming` itself. A `Used` body (`textStream()`) can only be rejected through a stream ref that `finalize_without_deinit` drops without erroring.
- The settle paths clear the field after `take()`. The cell's destructor clears it during sweep, so the field never dangles.
- Verified: test/js/bun/http/serve-pending-promise-abort-leak.test.ts (nine new tests, all fail on unfixed bun). Three of them are the parked pull() scenarios from #36567. Also body.test.ts, the serve stream, leak, and abort suites, serve.test.ts, bun-server.test.ts, serve-http3.test.ts, websocket-server.test.ts, the worker teardown tests, and the html-rewriter suites.

### Background
- `NativePromiseContext` (src/jsc/bindings/NativePromiseContext.h) is a GC cell that carries one native ref across a promise reaction. A settle reaction `take()`s the pointer and derefs. If the promise is collected unsettled, the cell's destructor releases the ref on the next tick.
- That destructor path was the only release the termination paths had. It needs a GC run, and at VM teardown it is skipped because a `RequestContext` deref is not sweep-safe.
- `server.pendingRequests` counts contexts between creation and `deinit`, so each parked context kept it incremented.

Related: #36567 (closed: its accounting special case is not needed with this change, and its scenarios are pinned here), #39660, #37513.

<details><summary>Notes</summary>

- At most one cell claim is outstanding per context: the handler promise cell is taken before the stream pump cell is created, the pump cell before the flush cell, and the flush or pump cell before the error-handler promise cell. `create_promise_cell` asserts this in debug builds.
- The destructor clear runs inside GC sweep. It is a plain `Cell<JSValue>` write on the context, which the unreleased claim keeps alive (pool slots survive teardown for exactly this case, #37513).
- The H3 early return in `on_abort` (stream destroyed after a successful `end()`) leaves the field alone: the promise settles normally there.
- Repro from the issue: `pendingRequests` is now 0 right after the abort, with no `Bun.gc(true)`.
- An earlier revision reclaimed in `on_abort` before `is_dead_request`. That dropped the claim's ref too early, `finalize_without_deinit` cleared the body stream ref without erroring it, and a parked `textStream()` read hung (body.test.ts "rejects when the client aborts mid-upload server-side"). The reclaim now runs after `end_request_streaming`.
- A body consumed with `for await (req.body)` stays `Locked`, so `deinit` still rejects it through `end_request_streaming`. Only a `Used` body (`textStream()`) needs the sink-branch call. Tests cover both.
- The upgrade case needs an async `server.upgrade()` while the handler promise parks with a reachable resolve. A sync upgrade has no cell, and a settled handler releases the claim through `take()`.
- Pre-existing failures seen while running the suites (IPv6 requestIP, root range port, #6583, /bun:info loopback, bun-server source map on port 3000, abruptly closed upload, URL buffer leak under ASAN, two worker terminate tests, 8 websocket-server send timeouts) all reproduce on a baseline build without this diff.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-pending-promise-abort-leak.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/177] gen ErrorCode+*.h
[2/177] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[3/177] gen JSEvent.lut.h
Generating /workspace/bun/build/debug/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[4/177] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/177] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/177] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/debug/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[7/177] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /wor
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/js/bun/http/serve-pending-promise-abort-leak.test.ts:
(pass) RequestContext is freed when client aborts before Promise<Response> settles [71.60ms]
(pass) Promise<Response> still works normally when not aborted [3.59ms]
(pass) resolve() inside abort handler is handled safely [1.28ms]
(pass) streaming 413 detaches the response so a late resolve/reject is a no-op [77.54ms]
(pass) chunked request body consumed as a ReadableStream is capped at maxRequestBodySize [17.09ms]
(fail) client abort frees the context even while the resolve function stays reachable [5001.80ms]
  ^ this test timed out after 5000ms.
(fail) client abort while a direct stream pull() is parked frees the context and rejects a pending req.text() read [5000.75ms]
  ^ this test timed out after 5000ms.
(fail) client abort while a direct stream pull() is parked frees the context and rejects a pending for await (req.body) read [5001.26ms]
  ^ this test timed out after 5000ms.
(fail) client abort while a direct stream pull() is parked frees the context and rejects a pending req.textStream() read [5000.95ms]
  ^ this test timed out after 5000ms.
(fail) pendingRequests
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-pending-promise-abort-leak.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/http/serve-pending-promise-abort-leak.test.ts:
(pass) RequestContext is freed when client aborts before Promise<Response> settles [3476.82ms]
(pass) Promise<Response> still works normally when not aborted [62.73ms]
(pass) resolve() inside abort handler is handled safely [62.86ms]
(pass) streaming 413 detaches the response so a late resolve/reject is a no-op [10409.91ms]
(pass) chunked request body consumed as a ReadableStream is capped at maxRequestBodySize [950.16ms]
(pass) client abort frees the context even while the resolve function stays reachable [69.65ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.text() read [92.25ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending for await (req.body) read [74.05ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.textStream() read [6
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fa4a83e340
  features     baseline

23 deps, 120 codegen, 1172 objects in 1769ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1235] gen bindgenv2
[2/1235] fetch tinycc
[tinycc] up to date
[3/1234] gen ErrorCode+*.h
[4/1234] fetch zlib
[zlib] up to date
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1207] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [162.00ms]
[7/1207] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1207] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1207] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [7.00ms]
[10/1207] subst deps/zlib/zlib.h
[11/1207] fetch nodejs (prebui
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/NativePromiseContext.rs            |  36 +-
 src/runtime/server/RequestContext.rs               |  84 ++++-
 src/runtime/server/server_body.rs                  |   4 +
 .../http/serve-pending-promise-abort-leak.test.ts  | 403 +++++++++++++++++++--
 4 files changed, 487 insertions(+), 40 deletions(-)
```

</details>

**gate history** · 9 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/api/NativePromiseContext.rs                       1      1      0
src/runtime/server/RequestContext.rs                         12     17      0
src/runtime/server/server_body.rs                             1      2      0
…st/js/bun/http/serve-pending-promise-abort-leak.test.ts      6     17      0
```

</details>

**root cause** · written by the author bot

When a request handler or stream promise never settles, the NativePromiseContext cell created to observe it holds a reference on the request context, so an aborted request's context could only be torn down when GC collected the promise, and never at VM teardown since the deferred dereference is skipped during the sweep. This left aborted requests holding their pool slot, body, streams, sink, and a reference to the server indefinitely. The fix has the request context remember its outstanding promise cell and reclaim it, taking the cell's claim and dereferencing, on abort and every other term…

<!-- robobun:evidence:end -->
