### PR TITLE
install: only replace or remove a package's own bins in the global bin dir

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -838,6 +838,10 @@ pub struct Linker<'a> {
 static UMASK: AtomicU32 = AtomicU32::new(0);
 static HAS_SET_UMASK: AtomicBool = AtomicBool::new(false);
 
+/// The two files a Windows bin shim consists of, appended to the bin name.
+#[cfg(windows)]
+const SHIM_SUFFIXES: [&[u8]; 2] = [b".bunx", b".exe"];
+
 impl<'a> Linker<'a> {
     pub fn ensure_umask() {
         // Single-winner gate: only the thread that flips false->true performs
@@ -853,10 +857,8 @@ impl<'a> Linker<'a> {
         }
     }
 
-    /// Removes the bin at `abs_dest`, but only if it is one this package's
-    /// bins were linked to. The global bin directory also holds `bun` itself
-    /// and whatever else the user keeps on `$PATH`, and a package's `bin` map
-    /// chooses the names, so a name alone never justifies a delete.
+    /// The package's `bin` map chooses the names, so only an entry that was
+    /// linked to this package is removed.
     fn unlink_bin_or_shim(&self, abs_dest: &ZStr) {
         if !self.existing_bin_belongs_to_package(abs_dest) {
             self.log_foreign_bin("removing", abs_dest);
@@ -874,30 +876,17 @@ impl<'a> Linker<'a> {
         }
     }
 
-    /// Removes `<abs_dest>.bunx` and `<abs_dest>.exe` without looking at them.
-    /// Callers must already know that the pair is this package's.
+    /// Callers must know that the pair is this package's.
     #[cfg(windows)]
     fn remove_shim_pair(abs_dest: &ZStr) {
-        let mut dest_buf = WPathBuffer::uninit();
-        let abs_dest_w =
-            strings::convert_utf8_to_utf16_in_buffer(dest_buf.as_mut_slice(), abs_dest.as_bytes());
-        let abs_dest_w_len = abs_dest_w.len();
-        let bunx_suffix = w!(".bunx\x00");
-        dest_buf[abs_dest_w_len..abs_dest_w_len + bunx_suffix.len()].copy_from_slice(bunx_suffix);
-        // SAFETY: dest_buf[abs_dest_w_len + ".bunx".len()] == 0 written above
-        let abs_bunx_file =
-            bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".bunx".len());
-        let _ = sys::unlink_w(abs_bunx_file);
-        let exe_suffix = w!(".exe\x00");
-        dest_buf[abs_dest_w_len..abs_dest_w_len + exe_suffix.len()].copy_from_slice(exe_suffix);
-        // SAFETY: dest_buf[abs_dest_w_len + ".exe".len()] == 0 written above
-        let abs_exe_file = bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".exe".len());
-        let _ = sys::unlink_w(abs_exe_file);
+        let mut path_buf = path::path_buffer_pool::get();
+        for suffix in SHIM_SUFFIXES {
+            if let Some(file) = Self::path_with_suffix(&mut path_buf[..], abs_dest, suffix) {
+                let _ = sys::unlink(file);
+            }
+        }
     }
 
-    /// Something that is not this package's bin occupies a name this package
-    /// wants in the global bin directory. The callers' error messages only name
-    /// the package, so the path goes to the debug log.
     fn fail_on_foreign_global_bin(&mut self, abs_dest: &ZStr) {
         self.log_foreign_bin("replacing", abs_dest);
         self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::EEXIST));
@@ -913,12 +902,8 @@ impl<'a> Linker<'a> {
         );
     }
 
-    /// Whether the bin already at `abs_dest` was linked to this package: on
-    /// POSIX a symlink into the package directory, on Windows a shim whose
-    /// `.bunx` sidecar names a file in the package directory. Anything else
-    /// (a missing entry, a regular file such as the `bun` binary, a directory,
-    /// the user's own symlink, another package's bin) is not ours to replace
-    /// or remove.
+    /// True for a symlink into the package directory (on Windows: a shim whose
+    /// `.bunx` points into it), the only entry the linker may replace or remove.
     #[cfg(not(windows))]
     fn existing_bin_belongs_to_package(&self, abs_dest: &ZStr) -> bool {
         let mut link_buf = path::path_buffer_pool::get();
@@ -931,12 +916,14 @@ impl<'a> Linker<'a> {
     #[cfg(windows)]
     fn existing_bin_belongs_to_package(&self, abs_dest: &ZStr) -> bool {
         let mut bunx_path_buf = path::path_buffer_pool::get();
-        let bunx_path = Self::path_with_suffix(&mut bunx_path_buf[..], abs_dest, b".bunx");
+        let Some(bunx_path) = Self::path_with_suffix(&mut bunx_path_buf[..], abs_dest, b".bunx")
+        else {
+            return false;
+        };
         let Ok(bunx_file) = sys::File::openat(Fd::cwd(), bunx_path, sys::O::RDONLY, 0) else {
             return false;
         };
-        // The sidecar starts with `[WSTR:bin_path][u16:'"']`, see
-        // `windows-shim/BinLinkingShim.rs`.
+        // Layout: `[WSTR:bin_path][u16:'"']...`, see windows-shim/BinLinkingShim.rs.
         let mut shim_buf = path::w_path_buffer_pool::get();
         let Ok(read) = bunx_file.read_all(bytemuck::cast_slice_mut(&mut shim_buf[..])) else {
             return false;
@@ -950,44 +937,43 @@ impl<'a> Linker<'a> {
         self.bin_target_is_inside_package(abs_dest, bin_path.as_bytes())
     }
 
-    /// The counterpart of the EEXIST check in `create_symlink`. A shim is the
-    /// pair `<name>.exe` + `<name>.bunx`, written with truncation, so the
-    /// check has to happen before anything is written: the pair may be
-    /// rewritten only when the sidecar says it is this package's. A `.exe`
-    /// without a sidecar is a real program (`bun.exe` itself lives here).
+    /// Runs before the shim files are written (they are opened with truncation).
+    /// A `.exe` without a `.bunx` is a real program, `bun.exe` for example.
     #[cfg(windows)]
     fn global_shim_conflicts(&self, abs_dest: &ZStr) -> bool {
         if self.existing_bin_belongs_to_package(abs_dest) {
             return false;
         }
         let mut path_buf = path::path_buffer_pool::get();
-        if sys::exists_z(Self::path_with_suffix(
-            &mut path_buf[..],
-            abs_dest,
-            b".bunx",
-        )) {
-            return true;
+        for suffix in SHIM_SUFFIXES {
+            // A name too long to check is also too long to write.
+            let Some(file) = Self::path_with_suffix(&mut path_buf[..], abs_dest, suffix) else {
+                return true;
+            };
+            if sys::exists_z(file) {
+                return true;
+            }
         }
-        sys::exists_z(Self::path_with_suffix(&mut path_buf[..], abs_dest, b".exe"))
+        false
     }
 
-    /// `abs_dest` + `suffix`, NUL-terminated, in `buf`.
+    /// `None` when `abs_dest` + `suffix` does not fit in `buf`.
     #[cfg(windows)]
-    fn path_with_suffix<'b>(buf: &'b mut [u8], abs_dest: &ZStr, suffix: &[u8]) -> &'b ZStr {
+    fn path_with_suffix<'b>(buf: &'b mut [u8], abs_dest: &ZStr, suffix: &[u8]) -> Option<&'b ZStr> {
         let dest = abs_dest.as_bytes();
+        let len = dest.len() + suffix.len();
+        if len >= buf.len() {
+            return None;
+        }
         buf[..dest.len()].copy_from_slice(dest);
-        buf[dest.len()..dest.len() + suffix.len()].copy_from_slice(suffix);
-        buf[dest.len() + suffix.len()] = 0;
-        ZStr::from_buf(buf, dest.len() + suffix.len())
+        buf[dest.len()..len].copy_from_slice(suffix);
+        buf[len] = 0;
+        Some(ZStr::from_buf(buf, len))
     }
 
-    /// Whether `stored_target`, the path recorded in the bin at `abs_dest`
-    /// (the symlink target, or the bin path in a `.bunx` shim), names a file
-    /// inside the package this linker links: `<node_modules>/<package_name>/`
-    /// or, under the native binlink redirect, the platform package's
-    /// directory. Bun records the target relative to the bin directory (POSIX)
-    /// or to its parent (Windows shims), so the relative form of each package
-    /// directory is accepted next to the absolute one.
+    /// `stored_target` is the symlink target or the `.bunx` bin path. Bun writes
+    /// it relative to the bin directory (POSIX) or to that directory's parent
+    /// (Windows), so both the relative and the absolute package directory match.
     fn bin_target_is_inside_package(&self, abs_dest: &ZStr, stored_target: &[u8]) -> bool {
         let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
         // SAFETY: `target_node_modules_path` is set at construction to either
@@ -1041,9 +1027,16 @@ impl<'a> Linker<'a> {
     }
 
     fn is_inside_dir(target: &[u8], dir: &[u8]) -> bool {
+        // Windows paths keep the casing of whatever produced them (an fd, an
+        // environment variable), and the file system does not care.
+        let has_prefix: fn(&[u8], &[u8]) -> bool = if cfg!(windows) {
+            strings::has_prefix_case_insensitive
+        } else {
+            strings::has_prefix
+        };
         !dir.is_empty()
             && target.len() > dir.len()
-            && strings::has_prefix(target, dir)
+            && has_prefix(target, dir)
             && target[dir.len()] == SEP
     }
 
@@ -1280,11 +1273,9 @@ impl<'a> Linker<'a> {
             return;
         }
 
-        // From here on the pair at the destination is this package's: its old
-        // shim, or the one being written. A failure below leaves a truncated
-        // `.bunx` that `unlink_bin_or_shim` could no longer attribute to the
-        // package, so remove the pair here instead. Declared before the file
-        // handles below, so it runs after they are closed.
+        // A failure below leaves a truncated `.bunx` that `unlink_bin_or_shim`
+        // cannot attribute to the package. Declared before the file handles so
+        // it runs after they are closed.
         let remove_pair_on_failure = scopeguard::guard((), |()| Self::remove_shim_pair(abs_dest));
 
         // `encode_into` reinterprets this byte buffer as `[u16]`.
@@ -1495,15 +1486,13 @@ impl<'a> Linker<'a> {
             }
         }
 
-        // A project's `node_modules/.bin` is owned by the installer, so whatever
-        // entry is there is stale. The global bin directory is shared with the
-        // user (and with `bun` itself): only a link to this package may be
-        // replaced there. Either way only the entry itself is removed, never a
-        // directory's contents; a directory makes the retry fail with EEXIST.
+        // Anything in a project's `node_modules/.bin` is stale. The global bin
+        // directory is the user's: only this package's own link may be replaced.
         if global && !self.existing_bin_belongs_to_package(abs_dest) {
             self.fail_on_foreign_global_bin(abs_dest);
             return;
         }
+        // Not delete_tree: a directory stays and makes the retry fail with EEXIST.
         let _ = sys::unlink(abs_dest);
         if let Err(err) = sys::symlink_running_executable(rel_target, abs_dest) {
             self.err = Some(err.into());

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -853,11 +853,19 @@ impl<'a> Linker<'a> {
         }
     }
 
-    fn unlink_bin_or_shim(abs_dest: &ZStr) {
+    /// Removes the bin at `abs_dest`, but only if it is one this package's
+    /// bins were linked to. The global bin directory also holds `bun` itself
+    /// and whatever else the user keeps on `$PATH`, and a package's `bin` map
+    /// chooses the names, so a name alone never justifies a delete.
+    fn unlink_bin_or_shim(&self, abs_dest: &ZStr) {
+        if !self.existing_bin_belongs_to_package(abs_dest) {
+            self.log_foreign_bin("removing", abs_dest);
+            return;
+        }
+
         #[cfg(not(windows))]
         {
             let _ = sys::unlink(abs_dest);
-            return;
         }
 
         #[cfg(windows)]
@@ -882,6 +890,158 @@ impl<'a> Linker<'a> {
                 bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".exe".len());
             let _ = sys::unlink_w(abs_exe_file);
         }
+    }
+
+    /// Something that is not this package's bin occupies a name this package
+    /// wants in the global bin directory. The callers' error messages only name
+    /// the package, so the path goes to the debug log.
+    fn fail_on_foreign_global_bin(&mut self, abs_dest: &ZStr) {
+        self.log_foreign_bin("replacing", abs_dest);
+        self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::EEXIST));
+    }
+
+    fn log_foreign_bin(&self, action: &str, abs_dest: &ZStr) {
+        bun_output::scoped_log!(
+            BinLinker,
+            "Not {} {}: it is not a bin of {}",
+            action,
+            bstr::BStr::new(abs_dest.as_bytes()),
+            bstr::BStr::new(self.package_name.slice())
+        );
+    }
+
+    /// Whether the bin already at `abs_dest` was linked to this package: on
+    /// POSIX a symlink into the package directory, on Windows a shim whose
+    /// `.bunx` sidecar names a file in the package directory. Anything else
+    /// (a missing entry, a regular file such as the `bun` binary, a directory,
+    /// the user's own symlink, another package's bin) is not ours to replace
+    /// or remove.
+    #[cfg(not(windows))]
+    fn existing_bin_belongs_to_package(&self, abs_dest: &ZStr) -> bool {
+        let mut link_buf = path::path_buffer_pool::get();
+        let Ok(len) = sys::readlink(abs_dest, &mut link_buf[..]) else {
+            return false;
+        };
+        self.bin_target_is_inside_package(abs_dest, &link_buf[..len])
+    }
+
+    #[cfg(windows)]
+    fn existing_bin_belongs_to_package(&self, abs_dest: &ZStr) -> bool {
+        let mut bunx_path_buf = path::path_buffer_pool::get();
+        let bunx_path = Self::path_with_suffix(&mut bunx_path_buf[..], abs_dest, b".bunx");
+        let Ok(bunx_file) = sys::File::openat(Fd::cwd(), bunx_path, sys::O::RDONLY, 0) else {
+            return false;
+        };
+        // The sidecar starts with `[WSTR:bin_path][u16:'"']`, see
+        // `windows-shim/BinLinkingShim.rs`.
+        let mut shim_buf = path::w_path_buffer_pool::get();
+        let Ok(read) = bunx_file.read_all(bytemuck::cast_slice_mut(&mut shim_buf[..])) else {
+            return false;
+        };
+        let units = &shim_buf[..read / size_of::<u16>()];
+        let Some(end) = strings::index_of_any16(units, &[b'"' as u16]) else {
+            return false;
+        };
+        let mut bin_path_buf = path::path_buffer_pool::get();
+        let bin_path = strings::from_w_path(&mut bin_path_buf[..], &units[..end]);
+        self.bin_target_is_inside_package(abs_dest, bin_path.as_bytes())
+    }
+
+    /// The counterpart of the EEXIST check in `create_symlink`. A shim is the
+    /// pair `<name>.exe` + `<name>.bunx`, written with truncation, so the
+    /// check has to happen before anything is written: the pair may be
+    /// rewritten only when the sidecar says it is this package's. A `.exe`
+    /// without a sidecar is a real program (`bun.exe` itself lives here).
+    #[cfg(windows)]
+    fn global_shim_conflicts(&self, abs_dest: &ZStr) -> bool {
+        if self.existing_bin_belongs_to_package(abs_dest) {
+            return false;
+        }
+        let mut path_buf = path::path_buffer_pool::get();
+        if sys::exists_z(Self::path_with_suffix(
+            &mut path_buf[..],
+            abs_dest,
+            b".bunx",
+        )) {
+            return true;
+        }
+        sys::exists_z(Self::path_with_suffix(&mut path_buf[..], abs_dest, b".exe"))
+    }
+
+    /// `abs_dest` + `suffix`, NUL-terminated, in `buf`.
+    #[cfg(windows)]
+    fn path_with_suffix<'b>(buf: &'b mut [u8], abs_dest: &ZStr, suffix: &[u8]) -> &'b ZStr {
+        let dest = abs_dest.as_bytes();
+        buf[..dest.len()].copy_from_slice(dest);
+        buf[dest.len()..dest.len() + suffix.len()].copy_from_slice(suffix);
+        buf[dest.len() + suffix.len()] = 0;
+        ZStr::from_buf(buf, dest.len() + suffix.len())
+    }
+
+    /// Whether `stored_target`, the path recorded in the bin at `abs_dest`
+    /// (the symlink target, or the bin path in a `.bunx` shim), names a file
+    /// inside the package this linker links: `<node_modules>/<package_name>/`
+    /// or, under the native binlink redirect, the platform package's
+    /// directory. Bun records the target relative to the bin directory (POSIX)
+    /// or to its parent (Windows shims), so the relative form of each package
+    /// directory is accepted next to the absolute one.
+    fn bin_target_is_inside_package(&self, abs_dest: &ZStr, stored_target: &[u8]) -> bool {
+        let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
+        // SAFETY: `target_node_modules_path` is set at construction to either
+        // a caller-owned `AbsPath` or the same buffer as `node_modules_path`;
+        // both outlive `self` and are not mutated for the duration of this
+        // read.
+        let target_node_modules = unsafe { (*self.target_node_modules_path).slice() };
+        let candidates: [(&[u8], &[u8]); 2] = [
+            (target_node_modules, self.target_package_name.slice()),
+            (self.node_modules_path.slice(), self.package_name.slice()),
+        ];
+        let candidate_count = if self.is_native_binlink_redirect() {
+            2
+        } else {
+            1
+        };
+
+        let mut package_dir_buf = path::path_buffer_pool::get();
+        let mut rel_package_dir_buf = path::path_buffer_pool::get();
+        for &(node_modules, package_name) in &candidates[..candidate_count] {
+            let Some(package_dir) = resolve_path::join_abs_string_buf_checked::<PlatformAuto>(
+                node_modules,
+                &mut package_dir_buf[..],
+                &[package_name],
+            ) else {
+                continue;
+            };
+            let package_dir = strings::without_trailing_slash(package_dir);
+            if Self::is_inside_dir(stored_target, package_dir) {
+                return true;
+            }
+
+            let rel_package_dir: &[u8] = resolve_path::relative_buf_z(
+                &mut rel_package_dir_buf[..],
+                abs_dest_dir,
+                package_dir,
+            )
+            .as_bytes();
+            #[cfg(windows)]
+            let rel_package_dir: &[u8] =
+                match strings::without_prefix_if_possible_comptime(rel_package_dir, b"..\\") {
+                    Some(relative_to_parent) => relative_to_parent,
+                    // Another drive: `relative` returned the absolute path, checked above.
+                    None => continue,
+                };
+            if Self::is_inside_dir(stored_target, rel_package_dir) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn is_inside_dir(target: &[u8], dir: &[u8]) -> bool {
+        !dir.is_empty()
+            && target.len() > dir.len()
+            && strings::has_prefix(target, dir)
+            && target[dir.len()] == SEP
     }
 
     fn link_bin_or_create_shim(
@@ -947,7 +1107,7 @@ impl<'a> Linker<'a> {
 
         if self.err.is_some() {
             // cleanup on error just in case
-            Self::unlink_bin_or_shim(abs_dest);
+            self.unlink_bin_or_shim(abs_dest);
             return;
         }
 
@@ -1112,6 +1272,11 @@ impl<'a> Linker<'a> {
         abs_dest: &ZStr,
         global: bool,
     ) {
+        if global && self.global_shim_conflicts(abs_dest) {
+            self.fail_on_foreign_global_bin(abs_dest);
+            return;
+        }
+
         // `encode_into` reinterprets this byte buffer as `[u16]`.
         // Constructing a `&mut [u16]` from a pointer that is not 2-aligned is
         // *immediate language UB* — the reference validity invariant requires
@@ -1263,8 +1428,14 @@ impl<'a> Linker<'a> {
         // so each return path calls `Self::chmod_on_ok` explicitly instead.
 
         let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
-        let rel_target =
-            resolve_path::relative_buf_z(self.rel_buf, abs_dest_dir, abs_target.as_bytes());
+        let rel_target: &ZStr = {
+            let r = resolve_path::relative_buf_z(self.rel_buf, abs_dest_dir, abs_target.as_bytes());
+            // SAFETY: `r` lives in `self.rel_buf`, which nothing below writes to
+            // (`existing_bin_belongs_to_package` works in pooled buffers).
+            // Detached from the `self` borrow so `self` can be used while it
+            // is alive, like `abs_dest` in `link()`.
+            unsafe { ZStr::from_raw(r.as_bytes().as_ptr(), r.len()) }
+        };
 
         debug_assert!(strings::has_prefix(rel_target.as_bytes(), b".."));
 
@@ -1314,8 +1485,16 @@ impl<'a> Linker<'a> {
             }
         }
 
-        // delete and try again
-        let _ = sys::delete_tree_absolute(abs_dest.as_bytes());
+        // A project's `node_modules/.bin` is owned by the installer, so whatever
+        // entry is there is stale. The global bin directory is shared with the
+        // user (and with `bun` itself): only a link to this package may be
+        // replaced there. Either way only the entry itself is removed, never a
+        // directory's contents; a directory makes the retry fail with EEXIST.
+        if global && !self.existing_bin_belongs_to_package(abs_dest) {
+            self.fail_on_foreign_global_bin(abs_dest);
+            return;
+        }
+        let _ = sys::unlink(abs_dest);
         if let Err(err) = sys::symlink_running_executable(rel_target, abs_dest) {
             self.err = Some(err.into());
         }
@@ -1884,7 +2063,7 @@ impl<'a> Linker<'a> {
                     let abs_dest_len = dest_off;
                     let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
 
-                    Self::unlink_bin_or_shim(abs_dest);
+                    self.unlink_bin_or_shim(abs_dest);
                 }
                 Tag::NamedFile => {
                     let named = self.bin.value.named_file;
@@ -1905,7 +2084,7 @@ impl<'a> Linker<'a> {
                     let abs_dest_len = dest_off;
                     let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
 
-                    Self::unlink_bin_or_shim(abs_dest);
+                    self.unlink_bin_or_shim(abs_dest);
                 }
                 Tag::Map => {
                     let mut i = self.bin.value.map.begin();
@@ -1936,7 +2115,7 @@ impl<'a> Linker<'a> {
                         let abs_dest_len = dest_off;
                         let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
 
-                        Self::unlink_bin_or_shim(abs_dest);
+                        self.unlink_bin_or_shim(abs_dest);
 
                         i += 2;
                     }
@@ -1985,7 +2164,7 @@ impl<'a> Linker<'a> {
                                 let abs_dest_len = dest_off;
                                 let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
 
-                                Self::unlink_bin_or_shim(abs_dest);
+                                self.unlink_bin_or_shim(abs_dest);
                             }
                             _ => {}
                         }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -857,8 +857,7 @@ impl<'a> Linker<'a> {
         }
     }
 
-    /// The package's `bin` map chooses the names, so only an entry that was
-    /// linked to this package is removed.
+    /// The package chose the name, so only an entry linked to the package is removed.
     fn unlink_bin_or_shim(&self, abs_dest: &ZStr) {
         if !self.existing_bin_belongs_to_package(abs_dest) {
             self.log_foreign_bin("removing", abs_dest);
@@ -902,8 +901,7 @@ impl<'a> Linker<'a> {
         );
     }
 
-    /// True for a symlink into the package directory (on Windows: a shim whose
-    /// `.bunx` points into it), the only entry the linker may replace or remove.
+    /// A symlink (on Windows: a shim) that points into the package directory.
     #[cfg(not(windows))]
     fn existing_bin_belongs_to_package(&self, abs_dest: &ZStr) -> bool {
         let mut link_buf = path::path_buffer_pool::get();
@@ -937,7 +935,6 @@ impl<'a> Linker<'a> {
         self.bin_target_is_inside_package(abs_dest, bin_path.as_bytes())
     }
 
-    /// Runs before the shim files are written (they are opened with truncation).
     /// A `.exe` without a `.bunx` is a real program, `bun.exe` for example.
     #[cfg(windows)]
     fn global_shim_conflicts(&self, abs_dest: &ZStr) -> bool {
@@ -971,9 +968,7 @@ impl<'a> Linker<'a> {
         Some(ZStr::from_buf(buf, len))
     }
 
-    /// `stored_target` is the symlink target or the `.bunx` bin path. Bun writes
-    /// it relative to the bin directory (POSIX) or to that directory's parent
-    /// (Windows), so both the relative and the absolute package directory match.
+    /// Links are written relative to the bin dir (Windows shims: to its parent), hence both forms.
     fn bin_target_is_inside_package(&self, abs_dest: &ZStr, stored_target: &[u8]) -> bool {
         let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
         // SAFETY: `target_node_modules_path` is set at construction to either
@@ -1027,8 +1022,7 @@ impl<'a> Linker<'a> {
     }
 
     fn is_inside_dir(target: &[u8], dir: &[u8]) -> bool {
-        // Windows paths keep the casing of whatever produced them (an fd, an
-        // environment variable), and the file system does not care.
+        // On Windows the two paths can come from differently cased sources (an fd, an env var).
         let has_prefix: fn(&[u8], &[u8]) -> bool = if cfg!(windows) {
             strings::has_prefix_case_insensitive
         } else {
@@ -1104,6 +1098,10 @@ impl<'a> Linker<'a> {
         if self.err.is_some() {
             // cleanup on error just in case
             self.unlink_bin_or_shim(abs_dest);
+            // No bin was placed, so the native binlink retry must check and report again.
+            if let Some(seen) = self.seen.as_deref_mut() {
+                seen.remove(abs_dest.as_bytes());
+            }
             return;
         }
 
@@ -1273,9 +1271,7 @@ impl<'a> Linker<'a> {
             return;
         }
 
-        // A failure below leaves a truncated `.bunx` that `unlink_bin_or_shim`
-        // cannot attribute to the package. Declared before the file handles so
-        // it runs after they are closed.
+        // A truncated `.bunx` no longer passes the ownership check. Runs after the handles close.
         let remove_pair_on_failure = scopeguard::guard((), |()| Self::remove_shim_pair(abs_dest));
 
         // `encode_into` reinterprets this byte buffer as `[u16]`.
@@ -1486,8 +1482,7 @@ impl<'a> Linker<'a> {
             }
         }
 
-        // Anything in a project's `node_modules/.bin` is stale. The global bin
-        // directory is the user's: only this package's own link may be replaced.
+        // A project's `.bin` holds only stale entries. The global bin dir holds the user's files.
         if global && !self.existing_bin_belongs_to_package(abs_dest) {
             self.fail_on_foreign_global_bin(abs_dest);
             return;

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -870,26 +870,29 @@ impl<'a> Linker<'a> {
 
         #[cfg(windows)]
         {
-            let mut dest_buf = WPathBuffer::uninit();
-            let abs_dest_w = strings::convert_utf8_to_utf16_in_buffer(
-                dest_buf.as_mut_slice(),
-                abs_dest.as_bytes(),
-            );
-            let abs_dest_w_len = abs_dest_w.len();
-            let bunx_suffix = w!(".bunx\x00");
-            dest_buf[abs_dest_w_len..abs_dest_w_len + bunx_suffix.len()]
-                .copy_from_slice(bunx_suffix);
-            // SAFETY: dest_buf[abs_dest_w_len + ".bunx".len()] == 0 written above
-            let abs_bunx_file =
-                bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".bunx".len());
-            let _ = sys::unlink_w(abs_bunx_file);
-            let exe_suffix = w!(".exe\x00");
-            dest_buf[abs_dest_w_len..abs_dest_w_len + exe_suffix.len()].copy_from_slice(exe_suffix);
-            // SAFETY: dest_buf[abs_dest_w_len + ".exe".len()] == 0 written above
-            let abs_exe_file =
-                bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".exe".len());
-            let _ = sys::unlink_w(abs_exe_file);
+            Self::remove_shim_pair(abs_dest);
         }
+    }
+
+    /// Removes `<abs_dest>.bunx` and `<abs_dest>.exe` without looking at them.
+    /// Callers must already know that the pair is this package's.
+    #[cfg(windows)]
+    fn remove_shim_pair(abs_dest: &ZStr) {
+        let mut dest_buf = WPathBuffer::uninit();
+        let abs_dest_w =
+            strings::convert_utf8_to_utf16_in_buffer(dest_buf.as_mut_slice(), abs_dest.as_bytes());
+        let abs_dest_w_len = abs_dest_w.len();
+        let bunx_suffix = w!(".bunx\x00");
+        dest_buf[abs_dest_w_len..abs_dest_w_len + bunx_suffix.len()].copy_from_slice(bunx_suffix);
+        // SAFETY: dest_buf[abs_dest_w_len + ".bunx".len()] == 0 written above
+        let abs_bunx_file =
+            bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".bunx".len());
+        let _ = sys::unlink_w(abs_bunx_file);
+        let exe_suffix = w!(".exe\x00");
+        dest_buf[abs_dest_w_len..abs_dest_w_len + exe_suffix.len()].copy_from_slice(exe_suffix);
+        // SAFETY: dest_buf[abs_dest_w_len + ".exe".len()] == 0 written above
+        let abs_exe_file = bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".exe".len());
+        let _ = sys::unlink_w(abs_exe_file);
     }
 
     /// Something that is not this package's bin occupies a name this package
@@ -1277,6 +1280,13 @@ impl<'a> Linker<'a> {
             return;
         }
 
+        // From here on the pair at the destination is this package's: its old
+        // shim, or the one being written. A failure below leaves a truncated
+        // `.bunx` that `unlink_bin_or_shim` could no longer attribute to the
+        // package, so remove the pair here instead. Declared before the file
+        // handles below, so it runs after they are closed.
+        let remove_pair_on_failure = scopeguard::guard((), |()| Self::remove_shim_pair(abs_dest));
+
         // `encode_into` reinterprets this byte buffer as `[u16]`.
         // Constructing a `&mut [u16]` from a pointer that is not 2-aligned is
         // *immediate language UB* — the reference validity invariant requires
@@ -1411,14 +1421,14 @@ impl<'a> Linker<'a> {
             crate::windows_shim::embedded_executable_data(),
         ) {
             let err: crate::Error = err.into();
-            if err == crate::Error::Sys(bun_errno::SystemErrno::EBUSY) {
-                // exe is most likely running. bunx file has already been updated, ignore error
+            if err != crate::Error::Sys(bun_errno::SystemErrno::EBUSY) {
+                self.err = Some(err);
                 return;
             }
-
-            self.err = Some(err);
-            return;
+            // exe is most likely running. bunx file has already been updated, ignore error
         }
+
+        scopeguard::ScopeGuard::into_inner(remove_pair_on_failure);
     }
 
     #[cfg(not(windows))]

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { copyFileSync, mkdirSync } from "fs";
-import { cp, exists, lstat, mkdir, readlink, rename, rm, writeFile } from "fs/promises";
+import { cp, exists, lstat, mkdir, readFile, readlink, rename, rm, writeFile } from "fs/promises";
 import {
   assertManifestsPopulated,
   bunExe,
@@ -2547,6 +2547,78 @@ describe("binaries", () => {
       });
     });
   }
+
+  describe("existing destinations in the global bin dir", () => {
+    // What a bin named `name` occupies in a bin dir: the symlink itself on POSIX, the `.exe` half
+    // of the `.exe` + `.bunx` shim pair on Windows.
+    const binEntry = (name: string) => (isWindows ? `${name}.exe` : name);
+    const linkTarget = (pkg: string, file: string) =>
+      join("..", "global-install-dir", "install", "global", "node_modules", pkg, file);
+
+    async function installGlobal(...packages: string[]) {
+      await write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({
+          install: {
+            cache: false,
+            registry: `http://localhost:${port}/`,
+            globalBinDir: join(packageDir, "global-bin-dir"),
+          },
+        }),
+      );
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "install",
+          "--linker=hoisted",
+          "-g",
+          `--config=${join(packageDir, "bunfig.toml")}`,
+          ...packages,
+        ],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...env, BUN_INSTALL: join(packageDir, "global-install-dir") },
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { out, err, exitCode };
+    }
+
+    test("a file or directory that is not the package's bin stays", async () => {
+      const binDir = join(packageDir, "global-bin-dir");
+      await Promise.all([
+        // A regular file, which is what `bun` itself is in this directory.
+        write(join(binDir, binEntry("what-bin")), "not a bin of what-bin"),
+        write(join(binDir, binEntry("map-bin-2"), "inner.txt"), "keep"),
+      ]);
+
+      const { err, exitCode } = await installGlobal("what-bin", "dep-with-map-bins");
+      expect(err).toContain("Failed to link what-bin: EEXIST");
+      expect(err).toContain("Failed to link dep-with-map-bins: EEXIST");
+      expect(exitCode).toBe(1);
+
+      expect(await readFile(join(binDir, binEntry("what-bin")), "utf8")).toBe("not a bin of what-bin");
+      expect(await readFile(join(binDir, binEntry("map-bin-2"), "inner.txt"), "utf8")).toBe("keep");
+      // Linked before the package's other bin ran into the directory.
+      expect(join(binDir, "map-bin-1")).toBeValidBin(linkTarget("dep-with-map-bins", "map-bin-1"));
+    });
+
+    test("the package's own bin from an earlier install is replaced", async () => {
+      const bin = join(packageDir, "global-bin-dir", "what-bin");
+
+      let result = await installGlobal("what-bin@1.0.0");
+      expect(result.err).not.toContain("error:");
+      expect(result.exitCode).toBe(0);
+      expect(bin).toBeValidBin(linkTarget("what-bin", "what-bin.js"));
+
+      result = await installGlobal("what-bin@1.5.0");
+      expect(result.err).not.toContain("error:");
+      expect(result.out).toContain("what-bin@1.5.0");
+      expect(result.exitCode).toBe(0);
+      expect(bin).toBeValidBin(linkTarget("what-bin", "what-bin.js"));
+    });
+  });
+
   test("it should correctly link binaries after deleting node_modules", async () => {
     const json: any = {
       name: "foo",

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -2617,6 +2617,26 @@ describe("binaries", () => {
       expect(result.exitCode).toBe(0);
       expect(bin).toBeValidBin(linkTarget("what-bin", "what-bin.js"));
     });
+
+    test("a foreign entry is reported for a package with a native binlink as well", async () => {
+      const binDir = join(packageDir, "global-bin-dir");
+      await Promise.all([
+        write(join(binDir, binEntry("test-binlink-cmd")), "not a bin of test-native-binlink"),
+        // The installer first links the bin of the platform package, then retries with the
+        // package's own bin. The error has to survive the retry.
+        write(
+          join(packageDir, "global-install-dir", "install", "global", "package.json"),
+          JSON.stringify({ dependencies: {}, nativeDependencies: ["test-native-binlink"] }),
+        ),
+      ]);
+
+      const { err, exitCode } = await installGlobal("test-native-binlink");
+      expect(err).toContain("Failed to link test-native-binlink: EEXIST");
+      expect(exitCode).toBe(1);
+      expect(await readFile(join(binDir, binEntry("test-binlink-cmd")), "utf8")).toBe(
+        "not a bin of test-native-binlink",
+      );
+    });
   });
 
   test("it should correctly link binaries after deleting node_modules", async () => {

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -610,6 +610,7 @@ describe("global bin dir", () => {
     expect(result.exitCode).toBe(0);
 
     expect(await exists(join(binDir, binEntry("own-bin")))).toBeFalse();
+    if (isWindows) expect(await exists(join(binDir, "own-bin.bunx"))).toBeFalse();
     expect(await readFile(join(binDir, binEntry("bun")), "utf8")).toBe("the bun binary");
     expect(await readFile(join(binDir, binEntry("adir"), "inner.txt"), "utf8")).toBe("keep");
     if (!isWindows) expect(await readlink(join(binDir, "foreign"))).toBe(join(String(bunInstall), "elsewhere.txt"));

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -1,12 +1,13 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { access, mkdir, writeFile } from "fs/promises";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { access, exists, mkdir, readFile, readlink, symlink, writeFile } from "fs/promises";
 import {
   bunExe,
   bunEnv as env,
   isWindows,
   readdirSorted,
   runBunInstall,
+  tempDir,
   tmpdirSync,
   toBeValidBin,
   toHaveBins,
@@ -470,4 +471,121 @@ it("should link dependency without crashing", async () => {
 
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
+});
+
+describe("global bin dir", () => {
+  // What a bin named `name` occupies in a bin dir: the symlink itself on POSIX, the `.exe` half
+  // of the `.exe` + `.bunx` shim pair on Windows.
+  const binEntry = (name: string) => (isWindows ? `${name}.exe` : name);
+  const linkTarget = (pkg: string, ...file: string[]) => join("..", "install", "global", "node_modules", pkg, ...file);
+  const pkgFiles = (name: string, bin: Record<string, string>) => ({
+    "package.json": JSON.stringify({ name, version: "1.0.0", bin }),
+    "cli.js": "#!/usr/bin/env node\n",
+    "dist/cli.js": "#!/usr/bin/env node\n",
+  });
+
+  async function run(command: "link" | "unlink", pkg: string, bunInstall: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), command],
+      cwd: pkg,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...env, BUN_INSTALL: bunInstall },
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  it("bun link leaves entries that are not its own bins alone", async () => {
+    using bunInstall = tempDir("link-global", {
+      // A regular file, which is what `bun` itself is in this directory.
+      [`bin/${binEntry("bun")}`]: "the bun binary",
+      [`bin/${binEntry("adir")}/inner.txt`]: "keep",
+      "elsewhere.txt": "",
+    });
+    const binDir = join(String(bunInstall), "bin");
+    if (!isWindows) await symlink(join(String(bunInstall), "elsewhere.txt"), join(binDir, "foreign"));
+    // Bins are linked in map order: the free name first, then the taken ones.
+    using pkg = tempDir(
+      "link-pkg",
+      pkgFiles("taken-names", { "taken-names": "cli.js", bun: "cli.js", adir: "cli.js", foreign: "cli.js" }),
+    );
+
+    const { err, exitCode } = await run("link", String(pkg), String(bunInstall));
+    expect(err).toContain("failed to link bin");
+    expect(exitCode).toBe(1);
+
+    expect(join(binDir, "taken-names")).toBeValidBin(linkTarget("taken-names", "cli.js"));
+    expect(await readFile(join(binDir, binEntry("bun")), "utf8")).toBe("the bun binary");
+    if (isWindows) expect(await exists(join(binDir, "bun.bunx"))).toBeFalse();
+    expect(await readFile(join(binDir, binEntry("adir"), "inner.txt"), "utf8")).toBe("keep");
+    if (!isWindows) expect(await readlink(join(binDir, "foreign"))).toBe(join(String(bunInstall), "elsewhere.txt"));
+  });
+
+  it("bun link does not take a bin name over from another linked package", async () => {
+    using bunInstall = tempDir("link-global", {});
+    using first = tempDir("link-pkg", pkgFiles("first-owner", { shared: "cli.js" }));
+    using second = tempDir("link-pkg", pkgFiles("second-owner", { shared: "cli.js" }));
+    const bin = join(String(bunInstall), "bin", "shared");
+
+    let result = await run("link", String(first), String(bunInstall));
+    expect(result.err).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bin).toBeValidBin(linkTarget("first-owner", "cli.js"));
+
+    result = await run("link", String(second), String(bunInstall));
+    expect(result.err).toContain("failed to link bin");
+    expect(result.exitCode).toBe(1);
+    expect(bin).toBeValidBin(linkTarget("first-owner", "cli.js"));
+  });
+
+  it("bun link again replaces the bin links it made before", async () => {
+    using bunInstall = tempDir("link-global", {});
+    using pkg = tempDir("link-pkg", pkgFiles("moved-bin", { "moved-bin": "cli.js" }));
+    const bin = join(String(bunInstall), "bin", "moved-bin");
+
+    let result = await run("link", String(pkg), String(bunInstall));
+    expect(result.err).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bin).toBeValidBin(linkTarget("moved-bin", "cli.js"));
+
+    await writeFile(
+      join(String(pkg), "package.json"),
+      pkgFiles("moved-bin", { "moved-bin": "dist/cli.js" })["package.json"],
+    );
+    result = await run("link", String(pkg), String(bunInstall));
+    expect(result.err).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bin).toBeValidBin(linkTarget("moved-bin", "dist", "cli.js"));
+  });
+
+  it("bun unlink removes its own bins and nothing else", async () => {
+    using bunInstall = tempDir("link-global", { "elsewhere.txt": "" });
+    using pkg = tempDir("link-pkg", pkgFiles("own-bin", { "own-bin": "cli.js" }));
+    const binDir = join(String(bunInstall), "bin");
+
+    let result = await run("link", String(pkg), String(bunInstall));
+    expect(result.err).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(join(binDir, "own-bin")).toBeValidBin(linkTarget("own-bin", "cli.js"));
+
+    // `bun unlink` removes the names in the bin map as it is now, not as it was when linking.
+    await writeFile(join(binDir, binEntry("bun")), "the bun binary");
+    await mkdir(join(binDir, binEntry("adir")));
+    await writeFile(join(binDir, binEntry("adir"), "inner.txt"), "keep");
+    if (!isWindows) await symlink(join(String(bunInstall), "elsewhere.txt"), join(binDir, "foreign"));
+    await writeFile(
+      join(String(pkg), "package.json"),
+      pkgFiles("own-bin", { "own-bin": "cli.js", bun: "cli.js", adir: "cli.js", foreign: "cli.js" })["package.json"],
+    );
+
+    result = await run("unlink", String(pkg), String(bunInstall));
+    expect(result.out).toContain('success: unlinked package "own-bin"');
+    expect(result.exitCode).toBe(0);
+
+    expect(await exists(join(binDir, binEntry("own-bin")))).toBeFalse();
+    expect(await readFile(join(binDir, binEntry("bun")), "utf8")).toBe("the bun binary");
+    expect(await readFile(join(binDir, binEntry("adir"), "inner.txt"), "utf8")).toBe("keep");
+    if (!isWindows) expect(await readlink(join(binDir, "foreign"))).toBe(join(String(bunInstall), "elsewhere.txt"));
+  });
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -559,6 +559,32 @@ describe("global bin dir", () => {
     expect(bin).toBeValidBin(linkTarget("moved-bin", "dist", "cli.js"));
   });
 
+  it.skipIf(!isWindows)("bun link removes a shim it could not finish writing", async () => {
+    using bunInstall = tempDir("link-global", {});
+    using pkg = tempDir("link-pkg", pkgFiles("half-shim", { "half-shim": "cli.js" }));
+    const binDir = join(String(bunInstall), "bin");
+    // The launcher is not valid UTF-8, so encoding the .bunx sidecar fails after the file was created.
+    await writeFile(
+      join(String(pkg), "cli.js"),
+      Buffer.concat([Buffer.from("#!/usr/bin/env n"), Buffer.from([0x80, 0x80]), Buffer.from("\n")]),
+    );
+
+    let result = await run("link", String(pkg), String(bunInstall));
+    expect(result.err).toContain("InvalidBinContent");
+    expect(result.exitCode).toBe(1);
+    expect(await Promise.all([exists(join(binDir, "half-shim.bunx")), exists(join(binDir, "half-shim.exe"))])).toEqual([
+      false,
+      false,
+    ]);
+
+    // Nothing is left behind that the next link would have to treat as foreign.
+    await writeFile(join(String(pkg), "cli.js"), "#!/usr/bin/env node\n");
+    result = await run("link", String(pkg), String(bunInstall));
+    expect(result.err).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(join(binDir, "half-shim")).toBeValidBin(linkTarget("half-shim", "cli.js"));
+  });
+
   it("bun unlink removes its own bins and nothing else", async () => {
     using bunInstall = tempDir("link-global", { "elsewhere.txt": "" });
     using pkg = tempDir("link-pkg", pkgFiles("own-bin", { "own-bin": "cli.js" }));


### PR DESCRIPTION
### Problem
- The bin linker trusts the names in a package's `bin` map. On EEXIST, `create_symlink` (`src/install/bin.rs:1318` on main) ran `delete_tree_absolute` on the destination. `unlink_bin_or_shim` (`bin.rs:856`) ran a bare `unlink`. The Windows shim writer truncated `<name>.exe`.
- The global bin dir (`~/.bun/bin`) also holds `bun` itself and the user's files. `bun add -g` and `bun link` replaced any of them, directories included. `bun unlink` deleted them by name. All three reported success.

### Fix
- `Linker::existing_bin_belongs_to_package` reads the path stored in the entry (the symlink target, or the `.bunx` sidecar on Windows). The entry is ours when it points into the package being linked.
- In the global bin dir an entry is replaced only when it is ours. Otherwise the link fails with EEXIST (`Failed to link what-bin: EEXIST`, exit 1) and the entry stays, as in npm. `bun unlink` and the cleanup after a failed link use the same check. A failed destination also leaves the `seen` set, so the native binlink retry reports the error instead of skipping it.
- `node_modules/.bin` belongs to the installer. A stale entry there is still replaced, but with `unlink`, never recursively.
- Verified: 5 new tests in `test/cli/install/bun-link.test.ts` and 3 in `test/cli/install/bun-install-registry.test.ts`, on Linux and Windows. 5 of the 8 fail on current bun. More suites in the notes.

### Background
- The linker (`src/install/bin.rs`) writes one entry per `bin` key, into `node_modules/.bin` for a project and into `$BUN_INSTALL/bin` for `bun add -g` and `bun link`.
- On POSIX an entry is a relative symlink, `foo -> ../install/global/node_modules/foo/cli.js`. On Windows it is `foo.exe`, a copy of the shim, plus `foo.bunx`, which starts with the script path.
- The native binlink redirect points a bin at a platform package (esbuild at `@esbuild/linux-x64`). `PackageInstaller` links with the redirect first and retries without it on an error. A link into either directory is ours.
- `bun remove -g` was already safe. It removes dangling symlinks and does not read the bin map.

<details><summary>Notes</summary>

Repro on 1.4.0-canary:

```sh
export BUN_INSTALL=$(mktemp -d); mkdir -p $BUN_INSTALL/bin/adir lib && cd lib
echo real > $BUN_INSTALL/bin/bun; ln -s /usr/bin/true $BUN_INSTALL/bin/foreign; touch $BUN_INSTALL/bin/adir/inner
echo '{"name":"lib6","version":"1.0.0","bin":{"lib6cli":"cli.js","bun":"cli.js","foreign":"cli.js","adir":"cli.js"}}' > package.json
echo '#!/usr/bin/env node' > cli.js
bun link      # before: bun, foreign and adir are symlinks into lib6 now, adir/inner is gone, exit 0
              # after: "error: failed to link bin due to error EEXIST", exit 1, the three entries are untouched, lib6cli is linked
bun unlink    # before: removes every key that exists, including a regular file named bun
              # after: removes lib6cli only
```

On Windows the unfixed build overwrites `bin\bun.exe` with the shim executable, and `bun unlink` deletes it. The new tests fail that way on the current build there and pass with this change.

Why the cleanup needs the check too: `link_bin_or_create_shim` unlinks the destination after any error. The refusal is such an error, so without the check the cleanup would delete the foreign entry the refusal just protected.

Windows details: the collision check runs before the shim files are opened, because they are opened with truncation. A `.exe` with no `.bunx` next to it counts as a real program. When writing the pair fails after the sidecar was truncated, `create_windows_shim` removes the pair itself (test "removes a shim it could not finish writing"); the ownership check could not attribute an empty sidecar, and the leftover would block the name with EEXIST. The suffix helpers report a name that does not fit the path buffer as foreign (or as a conflict) instead of indexing past the buffer. The prefix comparison ignores ASCII case on Windows, since the stored path and the one computed now can come from an fd path and from an environment variable.

What the ownership check accepts: the relative form bun writes (`../install/global/node_modules/<pkg>/...` in a symlink, `install\global\node_modules\<pkg>\...` in a `.bunx`, which is relative to the parent of the bin dir) and an absolute path into the package dir. Under the native binlink redirect it checks the root package dir and the platform package dir. When the redirect is off (the feature flag, or a package dropped from the list in a later release), a link that an earlier redirected install pointed into the platform package is foreign to it and the install fails with EEXIST. That is the same rule npm applies, it fails loudly, and `bun remove -g` followed by `bun add -g` clears it, so it is left as is.

The `seen` fix: `link_bin_or_create_shim` records the destination before it links. Without removing it on failure, the retry without the redirect found it recorded, returned without an error, and `bun add -g` of a native binlink package exited 0 with nothing linked (test "a foreign entry is reported for a package with a native binlink as well", which fails that way without the fix).

Behavior changes beyond the repro:
- A package that claims a bin name held by a different global package is refused as well (test "does not take a bin name over from another linked package"). Before, the last link won silently. npm refuses too.
- The refused path is in the debug log (`BUN_DEBUG_BinLinker=1`). The callers' messages name the package, as for other link errors.
- When one bin of a package is refused, the bins after it in the map are linked and then removed again by the pre-existing cleanup, which does not tell this bin's error from an earlier one. #38972 fixes that on its own. The new tests put the free name first.
- `existing non-symlink` in `bun-install-registry.test.ts` (from #11886) pins the `node_modules/.bin` behavior and still passes.

Related open PRs: #36701 and #38972 change neighboring lines in `create_symlink` and `link_bin_or_create_shim` (#38972 also removes the destination from `seen` on an error) but keep the `delete_tree_absolute` and the bare unlink, as does the install fold #39403. If #36200 lands (shim metadata in an NTFS stream instead of `.bunx`), the Windows read in `existing_bin_belongs_to_package` has to read the stream instead.

Suites run with the debug build on Linux, the bin linking ones also on Windows: `bun-link`, `bun-install-registry -t binaries`, `isolated-install`, `isolated-relink`, `bunx`, `bun-prune`, `bun-remove`, `bun-install-native-binlink`, `shebang-normalize`, `bun-add-catalog -t "with --global"`, `bun-update -t --global`. Two failures in local debug builds are unrelated to this change: bun-link "should link dependency without crashing" (debug stack trace in stdout, Linux only) and bunx "npm_config_user_agent" (debug version string).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts test/cli/install/bun-link.test.ts

<!-- robobun:evidence:end -->