### PR TITLE
test(install): compare stderr exactly and check every package.json and bun.lock row in bun-add-filter.test.ts

### DIFF
--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -137,11 +137,12 @@ function plus(json: { name: string; dependencies?: Record<string, string> }, dep
   return { ...json, dependencies: { ...json.dependencies, [dep]: range } };
 }
 
-/** Every package.json (in WORKSPACES order) is `expected`, and bun.lock mirrors each one. */
+/** Every package.json (in WORKSPACES order) is `expected`, and the `workspaces` section of bun.lock is exactly their rows. */
 async function expectWorkspaces(dir: string, expected: Record<string, unknown>[]) {
   expect(await allPackageJsons(dir)).toStrictEqual(expected);
-  const { workspaces } = await lockfileJson(dir);
-  expect(WORKSPACES.map(w => workspaces[lockKey(w)])).toStrictEqual(expected.map(lockEntryOf));
+  expect((await lockfileJson(dir)).workspaces).toStrictEqual(
+    Object.fromEntries(WORKSPACES.map((workspace, i) => [lockKey(workspace), lockEntryOf(expected[i])])),
+  );
 }
 
 /** The workspaces (in WORKSPACES order) whose package.json declares `dep` in any dependency group. */

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -1,13 +1,54 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
+import { copyFileSync, mkdirSync, readdirSync } from "fs";
 import { chmod, exists, mkdir, rm } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
 
+// The registry packages the cases below add or depend on. One install in beforeAll downloads them, and every test
+// dir starts from a copy of that cache (see `createDir`), so the cases still share no cache but only the few
+// packages outside this list, and the error cases that ask for one, reach the registry. Under ASAN the registry is
+// a single-threaded child of the same build, and that is what the concurrent cases used to queue up behind.
+const WARM = {
+  name: "warm",
+  dependencies: {
+    "no-deps": "2.0.0",
+    "no-deps-1": "npm:no-deps@1.0.0",
+    "a-dep": "1.0.1",
+    "a-dep-10": "npm:a-dep@1.0.10",
+    "is-number": "1.0.0",
+  },
+};
+
+// The manifests (`*.npm`) and extracted packages of the warm cache, as paths relative to it. The per-name index
+// entries bun also leaves in a cache are links; installing does not read them, so a copy is plain files and
+// directories on every platform.
+const warmCache = { root: "", dirs: [] as string[], files: [] as string[] };
+
+function listWarmCache(rel: string) {
+  for (const entry of readdirSync(join(warmCache.root, rel), { withFileTypes: true })) {
+    const path = join(rel, entry.name);
+    if (entry.isDirectory()) {
+      warmCache.dirs.push(path);
+      listWarmCache(path);
+    } else if (entry.isFile()) {
+      warmCache.files.push(path);
+    }
+  }
+}
+
 beforeAll(async () => {
   await registry.start();
+  const { packageDir } = await registry.createTestDir({
+    files: { "package.json": JSON.stringify(WARM) },
+    bunfigOpts: { linker: "hoisted" },
+  });
+  await installOk(packageDir, "hoisted");
+  warmCache.root = join(packageDir, ".bun-cache");
+  listWarmCache("");
+  expect(warmCache.files).not.toBeEmpty();
 });
 
 afterAll(() => {
@@ -30,26 +71,38 @@ type Workspace = "root" | "api" | "web" | "pkg-a" | "pkg-b";
 
 type Linker = "hoisted" | "isolated";
 
+/** A test dir with `files` and its own copy of the warm cache at the path `envFor` points bun at. */
+async function createDir(files: Record<string, string> = {}, linker: Linker = "hoisted") {
+  const { packageDir } = await registry.createTestDir({ files, bunfigOpts: { linker } });
+  const cache = join(packageDir, ".bun-cache");
+  for (const dir of ["", ...warmCache.dirs]) mkdirSync(join(cache, dir));
+  for (const path of warmCache.files) copyFileSync(join(warmCache.root, path), join(cache, path));
+  return packageDir;
+}
+
 // A string value is written verbatim, so a test can detect a rewrite that would otherwise be byte-identical.
-async function makeMonorepo(extra: Partial<Record<Workspace, object | string>> = {}, linker: Linker = "hoisted") {
+function makeMonorepo(extra: Partial<Record<Workspace, object | string>> = {}, linker: Linker = "hoisted") {
   const text = (value: object | string) => (typeof value === "string" ? value : JSON.stringify(value, null, 2));
-  const { packageDir } = await registry.createTestDir({
-    files: {
+  return createDir(
+    {
       "package.json": text(extra.root ?? ROOT),
       "packages/api/package.json": text(extra.api ?? API),
       "packages/web/package.json": text(extra.web ?? WEB),
       "packages/pkg-a/package.json": text(extra["pkg-a"] ?? PKG_A),
       "packages/pkg-b/package.json": text(extra["pkg-b"] ?? PKG_B),
     },
-    bunfigOpts: { linker },
-  });
-  return packageDir;
+    linker,
+  );
 }
 
 // CI exports BUN_INSTALL_CACHE_DIR (one per test file), which overrides the per-test-dir bunfig `cache`; concurrent cases racing on one cache fail on Windows.
 function envFor(dir: string) {
   return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") };
 }
+
+// Whether these two lines show up depends on what the cache already holds, so stderr comes back without them and
+// callers compare the rest exactly: `Saved lockfile` when bun.lock was written, nothing when it was not.
+const PROGRESS_LINES = /^(?:Resolving dependencies|Resolved, downloaded and extracted \[\d+\])\n/gm;
 
 // `--linker` is passed explicitly: an `install-strategy` in the user's ~/.npmrc overrides the bunfig linker.
 async function run(args: string[], dir: string, opts: { linker?: Linker; cwd?: string } = {}) {
@@ -61,7 +114,7 @@ async function run(args: string[], dir: string, opts: { linker?: Linker; cwd?: s
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  return { stdout, stderr: stderr.replace(PROGRESS_LINES, ""), exitCode };
 }
 
 const HEADER = (command: string) => `bun ${command} <version> (<revision>)`;
@@ -101,8 +154,43 @@ function lockfileJson(dir: string) {
 
 async function installOk(dir: string, linker?: Linker) {
   const { stderr, exitCode } = await run(["install"], dir, { linker });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
+}
+
+/** A plain `bun install` afterwards (which also links whatever the filtered command left out) has nothing to save. */
+async function installUnchanged(dir: string, linker?: Linker) {
+  const { stderr, exitCode } = await run(["install"], dir, { linker });
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}
+
+const LOCK_ENTRY_KEYS = [
+  "name",
+  "version",
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+] as const;
+
+/** The `workspaces` row bun.lock keeps for a workspace: its name, version and dependency groups, nothing else. */
+function lockEntryOf(json: Record<string, unknown>) {
+  return Object.fromEntries(LOCK_ENTRY_KEYS.filter(key => key in json).map(key => [key, json[key]]));
+}
+
+const lockKey = (workspace: Workspace) => (workspace === "root" ? "" : `packages/${workspace}`);
+
+/** `json` with `dep: range` added to (or replaced in) its dependencies. */
+function plus(json: { dependencies?: Record<string, string> }, dep = "no-deps", range = "^2.0.0") {
+  return { ...json, dependencies: { ...json.dependencies, [dep]: range } };
+}
+
+/** Every package.json (in WORKSPACES order) is `expected`, and bun.lock mirrors each one. */
+async function expectWorkspaces(dir: string, expected: Record<string, unknown>[]) {
+  expect(await allPackageJsons(dir)).toStrictEqual(expected);
+  const { workspaces } = await lockfileJson(dir);
+  expect(WORKSPACES.map(w => workspaces[lockKey(w)])).toStrictEqual(expected.map(lockEntryOf));
 }
 
 /** The workspaces (in WORKSPACES order) whose package.json declares `dep` in any dependency group. */
@@ -115,7 +203,10 @@ async function declaring(dir: string, dep: string) {
   );
 }
 
-/** `edited` gained `dep: range` in dependencies; every other workspace's package.json is byte-identical to `before`. */
+/**
+ * `edited` gained `dep: range` in dependencies, every other workspace's package.json is byte-identical to `before`,
+ * and bun.lock mirrors all of them.
+ */
 async function expectAddedOnlyTo(
   dir: string,
   before: string[],
@@ -131,6 +222,8 @@ async function expectAddedOnlyTo(
       expect(await pkgText(dir, workspace)).toBe(before[i]);
     }
   }
+  const { workspaces } = await lockfileJson(dir);
+  expect(WORKSPACES.map(w => workspaces[lockKey(w)])).toStrictEqual((await allPackageJsons(dir)).map(lockEntryOf));
 }
 
 test.concurrent(
@@ -139,16 +232,10 @@ test.concurrent(
     const dir = await makeMonorepo();
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir, { linker: "hoisted" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await allPackageJsons(dir)).toStrictEqual([
-      ROOT,
-      { name: "api", dependencies: { "no-deps": "^2.0.0" } },
-      WEB,
-      PKG_A,
-      PKG_B,
-    ]);
+    await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
 
     expect(await file(join(dir, "node_modules", "no-deps", "package.json")).json()).toStrictEqual({
       name: "no-deps",
@@ -195,28 +282,20 @@ test.concurrent("bun install <pkg> --filter carries the filter through", async (
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["install", "no-deps", "--filter", "api"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "root")).toStrictEqual(ROOT);
-  expect(await pkg(dir, "web")).toStrictEqual(WEB);
+  await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
 });
 
 test.concurrent("glob filter edits every match", async () => {
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "pkg-*"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await allPackageJsons(dir)).toStrictEqual([
-    ROOT,
-    API,
-    WEB,
-    { name: "pkg-a", dependencies: { "no-deps": "^2.0.0" } },
-    { name: "pkg-b", dependencies: { "no-deps": "^2.0.0" } },
-  ]);
+  await expectWorkspaces(dir, [ROOT, API, WEB, plus(PKG_A), plus(PKG_B)]);
 });
 
 test.concurrent("'*' edits every workspace except the root; '!' excludes", async () => {
@@ -224,18 +303,11 @@ test.concurrent("'*' edits every workspace except the root; '!' excludes", async
   const rootBefore = await pkgText(dir, "root");
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*", "--filter", "!api"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await allPackageJsons(dir)).toStrictEqual([
-    ROOT,
-    API,
-    { name: "web", dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } },
-    { name: "pkg-a", dependencies: { "no-deps": "^2.0.0" } },
-    { name: "pkg-b", dependencies: { "no-deps": "^2.0.0" } },
-  ]);
+  await expectWorkspaces(dir, [ROOT, API, plus(WEB), plus(PKG_A), plus(PKG_B)]);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
-  expect((await lockfileJson(dir)).workspaces[""]).toStrictEqual({ name: "root" });
 });
 
 test.concurrent("a negation-only filter set skips the root", async () => {
@@ -243,14 +315,12 @@ test.concurrent("a negation-only filter set skips the root", async () => {
   const [rootBefore, apiBefore] = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "!api"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
+  await expectWorkspaces(dir, [ROOT, API, plus(WEB), plus(PKG_A), plus(PKG_B)]);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
   expect(await pkgText(dir, "api")).toBe(apiBefore);
-  expect(await pkg(dir, "web")).toStrictEqual({ name: "web", dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "pkg-a", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "pkg-b", dependencies: { "no-deps": "^2.0.0" } });
 });
 
 test.concurrent("every member negated: zero targets is an error, the root is not silently edited", async () => {
@@ -264,13 +334,13 @@ test.concurrent("every member negated: zero targets is an error, the root is not
       ["add", "a-dep", "--filter", "!api", "--filter", "!web", "--filter", "!pkg-*"],
       dir,
     );
-    expect(stderr).toContain("error: No workspace packages matched the filter");
+    expect(stderr).toBe('error: No workspace packages matched the filters "!api", "!web", "!pkg-*"\n');
     expect(exitCode).toBe(1);
   }
 
   {
     const { stderr, exitCode } = await run(["remove", "no-deps", "--filter", "!./packages/*"], dir);
-    expect(stderr).toContain("error: No workspace packages matched the filter");
+    expect(stderr).toBe('error: No workspace packages matched the filter "!./packages/*"\n');
     expect(exitCode).toBe(1);
   }
 
@@ -285,20 +355,22 @@ test.concurrent("the root is included by naming it next to '*'", async () => {
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
+    await expectWorkspaces(dir, [ROOT, ...[API, WEB, PKG_A, PKG_B].map(json => plus(json, "a-dep", "^1.0.10"))]);
     expect(await pkgText(dir, "root")).toBe(rootBefore);
-    expect(await declaring(dir, "a-dep")).toStrictEqual(["api", "web", "pkg-a", "pkg-b"]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*", "--filter", "root"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await declaring(dir, "no-deps")).toStrictEqual(WORKSPACES);
-    expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [
+      plus(ROOT),
+      ...[API, WEB, PKG_A, PKG_B].map(json => plus(plus(json, "a-dep", "^1.0.10"))),
+    ]);
   }
 });
 
@@ -306,11 +378,10 @@ test.concurrent("'{.}' from the root selects the root and every workspace", asyn
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "{.}"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await declaring(dir, "no-deps")).toStrictEqual(WORKSPACES);
-  expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [plus(ROOT), plus(API), plus(WEB), plus(PKG_A), plus(PKG_B)]);
 });
 
 test.concurrent("'{dir}' selects every workspace under the directory", async () => {
@@ -319,10 +390,10 @@ test.concurrent("'{dir}' selects every workspace under the directory", async () 
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "{packages}"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await declaring(dir, "no-deps")).toStrictEqual(["api", "web", "pkg-a", "pkg-b"]);
+    await expectWorkspaces(dir, [ROOT, plus(API), plus(WEB), plus(PKG_A), plus(PKG_B)]);
     expect(await pkgText(dir, "root")).toBe(rootBefore);
   }
 
@@ -331,13 +402,10 @@ test.concurrent("'{dir}' selects every workspace under the directory", async () 
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "{..}"], dir, {
       cwd: join(dir, "packages", "web"),
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    const [, api, web, pkgA, pkgB] = await allPackageJsons(dir);
-    for (const json of [api, web, pkgA, pkgB]) {
-      expect(json.dependencies["a-dep"]).toBe("^1.0.10");
-    }
+    await expectWorkspaces(dir, [ROOT, ...[API, WEB, PKG_A, PKG_B].map(json => plus(plus(json), "a-dep", "^1.0.10"))]);
     expect(await pkgText(dir, "root")).toBe(rootBefore);
   }
 });
@@ -348,17 +416,19 @@ test.concurrent("'{dir}' naming one workspace directory selects just it; '!{dir}
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "{./packages/pkg-a}"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
     await expectAddedOnlyTo(dir, before, ["pkg-a"]);
   }
 
   {
     const after = await allPackageJsonTexts(dir);
+    const lockAfter = await file(join(dir, "bun.lock")).text();
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "*", "--filter", "!{./packages}"], dir);
-    expect(stderr).toContain('error: No workspace packages matched the filters "*", "!{./packages}"');
+    expect(stderr).toBe('error: No workspace packages matched the filters "*", "!{./packages}"\n');
     expect(exitCode).toBe(1);
     expect(await allPackageJsonTexts(dir)).toStrictEqual(after);
+    expect(await file(join(dir, "bun.lock")).text()).toBe(lockAfter);
   }
 });
 
@@ -367,10 +437,11 @@ test.concurrent("a '{dir}' matching nothing is the usual no-match error", async 
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "{./tools}"], dir);
-  expect(stderr).toContain('error: No workspace packages matched the filter "{./tools}"');
+  expect(stderr).toBe('error: No workspace packages matched the filter "{./tools}"\n');
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+  expect(await exists(join(dir, "bun.lock"))).toBeFalse();
 });
 
 test.concurrent.each<[string, Workspace[]]>([
@@ -386,8 +457,7 @@ test.concurrent.each<[string, Workspace[]]>([
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", pattern], dir);
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, edited);
@@ -400,7 +470,7 @@ test.concurrent("a negated relation subtracts the whole closure", async () => {
     const before = await allPackageJsonTexts(dir);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*", "--filter", "!...api"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     await expectAddedOnlyTo(dir, before, ["pkg-a", "pkg-b"]);
@@ -413,7 +483,7 @@ test.concurrent("a negated relation subtracts the whole closure", async () => {
     const before = await allPackageJsonTexts(dir);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "!...api"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     await expectAddedOnlyTo(dir, before, ["pkg-a", "pkg-b"]);
@@ -426,7 +496,7 @@ test.concurrent("two relation selectors union", async () => {
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api...", "--filter", "...api"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api", "web", "pkg-a"]);
@@ -444,7 +514,7 @@ test.concurrent(
     const before = await allPackageJsonTexts(dir);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...api"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     await expectAddedOnlyTo(dir, before, ["api", "web"]);
@@ -468,7 +538,7 @@ test.concurrent("relation selectors terminate on a workspace dependency cycle", 
     const [rootBefore, zBefore] = await Promise.all([read(dir, "root").text(), read(dir, "z").text()]);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "x..."], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect((await read(dir, "x").json()).dependencies).toStrictEqual({ y: "workspace:*", "no-deps": "^2.0.0" });
@@ -488,7 +558,7 @@ test.concurrent("relation selectors terminate on a workspace dependency cycle", 
     ]);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...^x"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect((await read(dir, "y").json()).dependencies).toStrictEqual({ x: "workspace:*", "no-deps": "^2.0.0" });
@@ -510,13 +580,18 @@ test.concurrent("remove with a relation", async () => {
   const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api..."], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   // web still depends on no-deps, so nothing leaves bun.lock: the rows describe the package.json edits.
   expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", " done"]);
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "pkg-a": "workspace:*" } });
-  expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "pkg-a" });
+  await expectWorkspaces(dir, [
+    ROOT,
+    { name: "api", dependencies: { "pkg-a": "workspace:*" } },
+    { name: "web", dependencies: { api: "workspace:*", "no-deps": "^2.0.0" } },
+    PKG_A,
+    PKG_B,
+  ]);
   expect(await pkgText(dir, "web")).toBe(webBefore);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
   expect(await pkgText(dir, "pkg-b")).toBe(pkgBBefore);
@@ -530,18 +605,19 @@ test.concurrent("a relation that reaches nothing warns like any other pattern", 
   {
     const before = await allPackageJsonTexts(dir);
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--filter", "...^web"], dir);
-    expect(stderr).toContain('warn: No workspace packages matched the filter "...^web"');
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe('warn: No workspace packages matched the filter "...^web"\nSaved lockfile\n');
     expect(exitCode).toBe(0);
     await expectAddedOnlyTo(dir, before, ["api"]);
   }
 
   {
     const before = await allPackageJsonTexts(dir);
+    const lockBefore = await file(join(dir, "bun.lock")).text();
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "nope..."], dir);
-    expect(stderr).toContain('error: No workspace packages matched the filter "nope..."');
+    expect(stderr).toBe('error: No workspace packages matched the filter "nope..."\n');
     expect(exitCode).toBe(1);
     expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+    expect(await file(join(dir, "bun.lock")).text()).toBe(lockBefore);
   }
 });
 
@@ -550,8 +626,7 @@ test.concurrent("a relation works before the first install", async () => {
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api..."], dir);
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api", "pkg-a"]);
@@ -584,7 +659,7 @@ test.concurrent.each<[string, Workspace, object, string, Workspace[]]>([
     const before = await allPackageJsonTexts(dir);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", pattern], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     await expectAddedOnlyTo(dir, before, edited);
@@ -606,7 +681,7 @@ test.concurrent("a workspace created since the last install takes part in relati
     const before = await allPackageJsonTexts(dir);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "pkg-c..."], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     await expectAddedOnlyTo(dir, before, ["api", "pkg-a"]);
@@ -618,7 +693,7 @@ test.concurrent("a workspace created since the last install takes part in relati
     const before = await allPackageJsonTexts(dir);
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...^api"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     await expectAddedOnlyTo(dir, before, ["web"]);
@@ -638,7 +713,7 @@ test.concurrent(
       const before = await allPackageJsonTexts(dir);
 
       const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...^api"], dir);
-      expect(stderr).toContain('error: No workspace packages matched the filter "...^api"');
+      expect(stderr).toBe('error: No workspace packages matched the filter "...^api"\n');
       expect(exitCode).toBe(1);
 
       expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -653,7 +728,7 @@ test.concurrent(
       const before = await allPackageJsonTexts(dir);
 
       const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...^api"], dir);
-      expect(stderr).not.toContain("error:");
+      expect(stderr).toBe("Saved lockfile\n");
       expect(exitCode).toBe(0);
 
       await expectAddedOnlyTo(dir, before, ["web"]);
@@ -667,7 +742,9 @@ test.concurrent(
       const before = await allPackageJsonTexts(dir);
 
       const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...api"], dir);
-      expect(stderr).toContain('No matching version for workspace dependency "api"');
+      expect(stderr).toStartWith(
+        'error: No matching version for workspace dependency "api". Version: "workspace:^2.0.0"\n',
+      );
       expect(exitCode).toBe(1);
 
       expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -680,7 +757,7 @@ test.concurrent(
       const before = await allPackageJsonTexts(dir);
 
       const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...^api"], dir);
-      expect(stderr).not.toContain("error:");
+      expect(stderr).toBe("Saved lockfile\n");
       expect(exitCode).toBe(0);
 
       await expectAddedOnlyTo(dir, before, ["web"]);
@@ -695,7 +772,7 @@ test.concurrent(
       const before = await allPackageJsonTexts(dir);
 
       const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "...^api"], dir);
-      expect(stderr).not.toContain("error:");
+      expect(stderr).toBe("Saved lockfile\n");
       expect(exitCode).toBe(0);
 
       await expectAddedOnlyTo(dir, before, ["web"]);
@@ -710,7 +787,7 @@ test.concurrent("a bare '...' is rejected", async () => {
   const lockBefore = await file(join(dir, "bun.lock")).text();
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "..."], dir);
-  expect(stderr).toContain('error: --filter "..." is missing a workspace name or path');
+  expect(stderr).toBe('error: --filter "..." is missing a workspace name or path\n');
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -721,16 +798,17 @@ test.concurrent("a bare '...' is rejected", async () => {
 test.concurrent(
   "install --filter with a positive and a negated pattern installs only the positive matches",
   async () => {
-    const dir = await makeMonorepo({
+    const fixture = {
       root: { ...ROOT, dependencies: { "a-dep": "1.0.1" } },
       api: { name: "api", dependencies: { "no-deps": "2.0.0" } },
       "pkg-a": { name: "pkg-a", dependencies: { "is-number": "1.0.0" } },
-    });
+    };
+    const dir = await makeMonorepo(fixture);
 
     const { stderr, exitCode } = await run(["install", "--filter", "api", "--filter", "!web"], dir, {
       linker: "hoisted",
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect(
@@ -740,32 +818,37 @@ test.concurrent(
         exists(join(dir, "node_modules", "is-number")),
       ]),
     ).toStrictEqual([true, false, false]);
+    // The whole monorepo is still resolved into bun.lock; the filter only decides what gets linked.
+    await expectWorkspaces(dir, [fixture.root, fixture.api, WEB, fixture["pkg-a"], PKG_B]);
   },
 );
 
 test.concurrent("install --filter with relations installs the closure only", async () => {
-  const dir = await makeMonorepo({
+  const fixture = {
     root: { ...ROOT, dependencies: { "basic-1": "1.0.0" } },
     api: { name: "api", dependencies: { "pkg-a": "workspace:*", "no-deps": "2.0.0" } },
     web: { name: "web", dependencies: { api: "workspace:*", "a-dep": "1.0.1" } },
     "pkg-a": { name: "pkg-a", dependencies: { "is-number": "1.0.0" } },
     "pkg-b": { name: "pkg-b", dependencies: { "left-pad": "1.0.0" } },
-  });
+  };
+  const dir = await makeMonorepo(fixture);
   const installed = (name: string) => exists(join(dir, "node_modules", name));
 
   {
     const { stderr, exitCode } = await run(["install", "--filter", "api..."], dir, { linker: "hoisted" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect(
       await Promise.all(["no-deps", "is-number", "api", "pkg-a", "a-dep", "left-pad", "basic-1"].map(installed)),
     ).toStrictEqual([true, true, true, true, false, false, false]);
+    await expectWorkspaces(dir, [fixture.root, fixture.api, fixture.web, fixture["pkg-a"], fixture["pkg-b"]]);
   }
 
+  // The first filtered install already resolved the whole monorepo, so the second one only links.
   {
     const { stderr, exitCode } = await run(["install", "--filter", "...^pkg-a"], dir, { linker: "hoisted" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
     expect(await Promise.all(["a-dep", "left-pad", "basic-1"].map(installed))).toStrictEqual([true, false, false]);
@@ -777,8 +860,7 @@ test.concurrent("install --filter with a pattern that matches nothing warns and 
   const dir = await makeMonorepo();
 
   const { stdout, stderr, exitCode } = await run(["install", "--filter", "nope"], dir, { linker: "hoisted" });
-  expect(stderr).toContain('warn: No workspace packages matched the filter "nope"');
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe('warn: No workspace packages matched the filter "nope"\nSaved lockfile\n');
   expect(stdoutLines(stdout)).toStrictEqual([
     HEADER("install"),
     "",
@@ -786,6 +868,7 @@ test.concurrent("install --filter with a pattern that matches nothing warns and 
   ]);
   expect(exitCode).toBe(0);
 
+  await expectWorkspaces(dir, [ROOT, API, WEB, PKG_A, PKG_B]);
   expect(await exists(join(dir, "node_modules", "a-dep"))).toBeFalse();
 });
 
@@ -800,19 +883,31 @@ test.concurrent("outdated --filter with relations", async () => {
 
   {
     const { stdout, stderr, exitCode } = await run(["outdated", "--filter", "api..."], dir);
-    expect(stderr).not.toContain("error:");
-    expect(stdout).toContain("no-deps");
-    expect(stdout).toContain("a-dep");
-    expect(stdout).not.toContain("is-number");
+    expect(stderr).toBe("");
+    expect(stdoutLines(stdout)).toStrictEqual([
+      HEADER("outdated"),
+      "|--------------------------------------------------|",
+      "| Package  | Current | Update | Latest | Workspace |",
+      "|----------|---------|--------|--------|-----------|",
+      "| no-deps  | 1.0.0   | 1.0.0  | 2.0.0  | api       |",
+      "|----------|---------|--------|--------|-----------|",
+      "| a-dep    | 1.0.1   | 1.0.1  | 1.0.10 | pkg-a     |",
+      "|--------------------------------------------------|",
+    ]);
     expect(exitCode).toBe(0);
   }
 
   {
     const { stdout, stderr, exitCode } = await run(["outdated", "--filter", "...^api"], dir);
-    expect(stderr).not.toContain("error:");
-    expect(stdout).toContain("is-number");
-    expect(stdout).not.toContain("no-deps");
-    expect(stdout).not.toContain("a-dep");
+    expect(stderr).toBe("");
+    expect(stdoutLines(stdout)).toStrictEqual([
+      HEADER("outdated"),
+      "|---------------------------------------------------|",
+      "| Package   | Current | Update | Latest | Workspace |",
+      "|-----------|---------|--------|--------|-----------|",
+      "| is-number | 1.0.0   | 1.0.0  | 2.0.0  | web       |",
+      "|---------------------------------------------------|",
+    ]);
     expect(exitCode).toBe(0);
   }
 });
@@ -822,27 +917,20 @@ test.concurrent("path filter, run from inside another workspace", async () => {
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "./packages/api"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-    expect(await pkg(dir, "root")).toStrictEqual(ROOT);
-    expect(await pkg(dir, "web")).toStrictEqual(WEB);
+    await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "../api"], dir, {
       cwd: join(dir, "packages", "web"),
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "api")).toStrictEqual({
-      name: "api",
-      dependencies: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" },
-    });
-    expect(await pkg(dir, "root")).toStrictEqual(ROOT);
-    expect(await pkg(dir, "web")).toStrictEqual(WEB);
+    await expectWorkspaces(dir, [ROOT, plus(plus(API), "a-dep", "^1.0.10"), WEB, PKG_A, PKG_B]);
   }
 });
 
@@ -851,7 +939,7 @@ test.concurrent("no match is an error and nothing is written", async () => {
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "does-not-exist"], dir);
-  expect(stderr).toContain("error: No workspace packages matched the filter");
+  expect(stderr).toBe('error: No workspace packages matched the filter "does-not-exist"\n');
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -872,12 +960,11 @@ test.concurrent("remove --filter removes from the matched workspace only", async
     const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api"], dir, {
       linker: "hoisted",
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", " done"]);
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "api")).toStrictEqual({ name: "api" });
-    expect(await pkg(dir, "web")).toStrictEqual({ name: "web", dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [ROOT, API, { name: "web", dependencies: { "no-deps": "^2.0.0" } }, PKG_A, PKG_B]);
     expect(await exists(join(dir, "node_modules", "no-deps", "package.json"))).toBeTrue();
   }
 
@@ -885,11 +972,12 @@ test.concurrent("remove --filter removes from the matched workspace only", async
     const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "web"], dir, {
       linker: "hoisted",
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", "1 package removed"]);
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "web")).toStrictEqual({ name: "web" });
+    await expectWorkspaces(dir, [ROOT, API, { name: "web" }, PKG_A, PKG_B]);
+    expect((await lockfileJson(dir)).packages["no-deps"]).toBeUndefined();
     expect(await exists(join(dir, "node_modules", "no-deps"))).toBeFalse();
   }
 });
@@ -908,12 +996,17 @@ test.concurrent("remove --filter prints the same removed summary as --filter roo
     const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "a-dep", "--filter", "pkg-*"], dir, {
       linker: "hoisted",
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", "- a-dep", "2 packages removed"]);
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "pkg-a")).toStrictEqual(PKG_A);
-    expect(await pkg(dir, "pkg-b")).toStrictEqual(PKG_B);
+    await expectWorkspaces(dir, [
+      { ...ROOT, dependencies: { "is-number": "1.0.0" } },
+      API,
+      { name: "web" },
+      PKG_A,
+      PKG_B,
+    ]);
     const { packages } = await lockfileJson(dir);
     expect([packages["no-deps"], packages["a-dep"], packages["is-number"]]).toStrictEqual([
       undefined,
@@ -933,11 +1026,12 @@ test.concurrent("remove --filter prints the same removed summary as --filter roo
     const { stdout, stderr, exitCode } = await run(["remove", "is-number", "--filter", "root"], dir, {
       linker: "hoisted",
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- is-number", "1 package removed"]);
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "root")).toStrictEqual(ROOT);
+    await expectWorkspaces(dir, [ROOT, API, { name: "web" }, PKG_A, PKG_B]);
+    expect((await lockfileJson(dir)).packages["is-number"]).toBeUndefined();
     expect(await exists(join(dir, "node_modules", "is-number"))).toBeFalse();
   }
 });
@@ -955,17 +1049,11 @@ test.concurrent("remove --filter '*' leaves the root's entries alone", async () 
   const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "a-dep", "--filter", "*"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", "- a-dep", " done"]);
   expect(exitCode).toBe(0);
 
-  expect(await allPackageJsons(dir)).toStrictEqual([
-    { ...ROOT, dependencies: deps },
-    API,
-    { name: "web" },
-    PKG_A,
-    PKG_B,
-  ]);
+  await expectWorkspaces(dir, [{ ...ROOT, dependencies: deps }, API, { name: "web" }, PKG_A, PKG_B]);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
   expect(
     await Promise.all([
@@ -973,7 +1061,6 @@ test.concurrent("remove --filter '*' leaves the root's entries alone", async () 
       exists(join(dir, "node_modules", "a-dep", "package.json")),
     ]),
   ).toStrictEqual([true, true]);
-  expect((await lockfileJson(dir)).workspaces[""].dependencies).toStrictEqual(deps);
 });
 
 test.concurrent("add --filter with an existing lockfile re-resolves only the added dep", async () => {
@@ -981,13 +1068,10 @@ test.concurrent("add --filter with an existing lockfile re-resolves only the add
   await installOk(dir, "hoisted");
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "web"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "web")).toStrictEqual({
-    name: "web",
-    dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" },
-  });
+  await expectWorkspaces(dir, [ROOT, API, plus(WEB), PKG_A, PKG_B]);
   expect(await file(join(dir, "node_modules", "a-dep", "package.json")).json()).toStrictEqual({
     name: "a-dep",
     version: "1.0.1",
@@ -1000,14 +1084,28 @@ test.concurrent("add --filter with an existing lockfile re-resolves only the add
 
 test.concurrent("--dry-run writes nothing", async () => {
   const dir = await makeMonorepo();
-  const before = await pkgText(dir, "api");
+  const before = await allPackageJsonTexts(dir);
 
-  const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--dry-run"], dir);
-  expect(stderr).not.toContain("error:");
+  const { stdout, stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--dry-run"], dir);
+  expect(stderr).toBe("");
+  // A dry run lists everything it resolved (the whole monorepo, not just api) and what it would have added.
+  expect(stdoutLines(stdout)).toStrictEqual([
+    HEADER("add"),
+    "",
+    " api@workspace:packages/api",
+    " pkg-a@workspace:packages/pkg-a",
+    " pkg-b@workspace:packages/pkg-b",
+    " web@workspace:packages/web",
+    " a-dep@1.0.1",
+    "installed no-deps@2.0.0",
+    "",
+    " done",
+  ]);
   expect(exitCode).toBe(0);
 
-  expect(await pkgText(dir, "api")).toBe(before);
-  expect(await pkg(dir, "root")).toStrictEqual(ROOT);
+  expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+  expect(await exists(join(dir, "bun.lock"))).toBeFalse();
+  expect(await exists(join(dir, "node_modules"))).toBeFalse();
 });
 
 // Ported from pnpm's filtered add/remove suites and pacquet's install_filters.rs.
@@ -1019,11 +1117,11 @@ test.concurrent(
     const apiBefore = await pkgText(dir, "api");
 
     const { stderr, exitCode } = await run(["add", "no-deps", "--only-missing", "--filter", "*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect(await pkgText(dir, "api")).toBe(apiBefore);
-    expect(await allPackageJsons(dir)).toStrictEqual([
+    await expectWorkspaces(dir, [
       ROOT,
       { name: "api", dependencies: { "no-deps": "1.0.0" } },
       { name: "web", dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } },
@@ -1042,11 +1140,11 @@ test.concurrent("add --only-missing --filter resolves from a target that receive
     ["add", "no-deps", "--only-missing", "--filter", "root", "--filter", "web"],
     dir,
   );
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   expect(await pkgText(dir, "root")).toBe(rootBefore);
-  expect(await pkg(dir, "web")).toStrictEqual({ name: "web", dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [{ ...ROOT, dependencies: { "no-deps": "1.0.0" } }, API, plus(WEB), PKG_A, PKG_B]);
 });
 
 test.concurrent("add --only-missing --filter where every target already has it writes nothing", async () => {
@@ -1063,7 +1161,7 @@ test.concurrent("add --only-missing --filter where every target already has it w
     dir,
     { linker: "hoisted" },
   );
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("");
   // The same no-op line a satisfied `bun install --filter api --filter web` prints: api, web and no-deps checked.
   expect(stdoutLines(stdout)).toStrictEqual([HEADER("add"), "", "Checked 3 installs across 6 packages (no changes)"]);
   expect(exitCode).toBe(0);
@@ -1077,7 +1175,7 @@ test.concurrent("add --only-missing --filter where every target already has it w
     cwd: join(dir, "packages", "api"),
     linker: "hoisted",
   });
-  expect(inside.stderr).not.toContain("error:");
+  expect(inside.stderr).toBe("");
   expect(stdoutLines(inside.stdout)).toStrictEqual([
     HEADER("add"),
     "",
@@ -1101,11 +1199,11 @@ test.concurrent("remove --filter leaves targets that did not contain the depende
   const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api", "--filter", "web"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", "1 package removed"]);
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api" });
+  await expectWorkspaces(dir, [ROOT, API, WEB, PKG_A, PKG_B]);
   expect(await pkgText(dir, "web")).toBe(webBefore);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
   expect(await pkgText(dir, "pkg-a")).toBe(pkgABefore);
@@ -1121,16 +1219,14 @@ test.concurrent("remove --filter where no target contains the dependency writes 
 
   {
     const { stdout, stderr, exitCode } = await run(["remove", "foo", "--filter", "api"], dir);
-    expect(stderr).not.toContain("Saved lockfile");
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("");
     expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "foo is not a dependency of api"]);
     expect(exitCode).toBe(0);
   }
 
   {
     const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "*"], dir);
-    expect(stderr).not.toContain("Saved lockfile");
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("");
     const [header, blank, summary, ...rest] = stdoutLines(stdout);
     expect([header, blank, rest]).toStrictEqual([HEADER("remove"), "", []]);
     const prefix = "no-deps is not a dependency of ";
@@ -1150,10 +1246,10 @@ test.concurrent("add/remove --filter with the isolated linker links only the tar
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir, { linker: "isolated" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
     expect(await file(join(dir, "packages", "api", "node_modules", "no-deps", "package.json")).json()).toStrictEqual({
       name: "no-deps",
       version: "2.0.0",
@@ -1169,17 +1265,16 @@ test.concurrent("add/remove --filter with the isolated linker links only the tar
     const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api"], dir, {
       linker: "isolated",
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "- no-deps", "1 package removed"]);
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "api")).toStrictEqual({ name: "api" });
-    expect(await pkg(dir, "web")).toStrictEqual(WEB);
+    await expectWorkspaces(dir, [ROOT, API, WEB, PKG_A, PKG_B]);
     // The isolated installer does not yet prune packages/api/node_modules/no-deps (same as unfiltered `bun remove`).
     expect(await file(join(dir, "bun.lock")).text()).not.toContain("no-deps");
   }
 
-  await installOk(dir, "isolated");
+  await installUnchanged(dir, "isolated");
   expect(await exists(join(dir, "packages", "web", "node_modules", "a-dep", "package.json"))).toBeTrue();
 });
 
@@ -1198,15 +1293,16 @@ test.concurrent("add --filter links only the selected workspace (hoisted)", asyn
     ]);
 
   const { stdout, stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
-  expect(stdout).toContain("installed no-deps@2.0.0");
-  expect(stdout).toMatch(/\b2 packages installed\b/);
+  expect(stderr).toBe("Saved lockfile\n");
+  // api itself and no-deps: web, its a-dep and the other workspaces are resolved into bun.lock but not linked.
+  expect(stdoutLines(stdout)).toStrictEqual([HEADER("add"), "", "installed no-deps@2.0.0", "", "2 packages installed"]);
   expect(exitCode).toBe(0);
 
   expect(await installed()).toStrictEqual([true, true, false, false, false, true]);
-  expect(await file(join(dir, "bun.lock")).text()).toContain('"a-dep@1.0.1"');
+  await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
+  expect((await lockfileJson(dir)).packages["a-dep"][0]).toBe("a-dep@1.0.1");
 
-  await installOk(dir, "hoisted");
+  await installUnchanged(dir, "hoisted");
   expect(await installed()).toStrictEqual([true, true, true, true, true, true]);
 });
 
@@ -1216,20 +1312,34 @@ test.concurrent("add --filter leaves the root's own dependencies alone unless th
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*"], dir, { linker: "hoisted" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect(
       await Promise.all(["is-number", "api", "web", "pkg-a", "pkg-b", "a-dep", "no-deps"].map(installed)),
     ).toStrictEqual([false, true, true, true, true, true, true]);
+    await expectWorkspaces(dir, [
+      { ...ROOT, dependencies: { "is-number": "1.0.0" } },
+      plus(API),
+      plus(WEB),
+      plus(PKG_A),
+      plus(PKG_B),
+    ]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "root"], dir, { linker: "hoisted" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect(await installed("is-number")).toBeTrue();
+    await expectWorkspaces(dir, [
+      { ...ROOT, dependencies: { "is-number": "1.0.0", "a-dep": "^1.0.10" } },
+      plus(API),
+      plus(WEB),
+      plus(PKG_A),
+      plus(PKG_B),
+    ]);
   }
 });
 
@@ -1244,18 +1354,19 @@ test.concurrent("remove --filter re-links only the selected workspace", async ()
   const installed = () =>
     Promise.all(["api", "web", "no-deps", "a-dep"].map(name => exists(join(dir, "node_modules", name))));
 
-  const { stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
+  const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api"], dir, { linker: "hoisted" });
+  expect(stderr).toBe("Saved lockfile\n");
+  // As with an unfiltered remove, the summary is the install count once something had to be linked: here api alone.
+  expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove"), "", "1 package installed"]);
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api" });
+  await expectWorkspaces(dir, [ROOT, API, plus(WEB), PKG_A, PKG_B]);
   expect(await pkgText(dir, "web")).toBe(webBefore);
   expect(await installed()).toStrictEqual([true, false, false, false]);
-  expect((await lockfileJson(dir)).packages["no-deps"]).toBeDefined();
+  expect((await lockfileJson(dir)).packages["no-deps"][0]).toBe("no-deps@2.0.0");
 
-  await installOk(dir, "hoisted");
-  expect(await exists(join(dir, "node_modules", "no-deps", "package.json"))).toBeTrue();
-  expect(await exists(join(dir, "node_modules", "a-dep"))).toBeTrue();
+  await installUnchanged(dir, "hoisted");
+  expect(await installed()).toStrictEqual([true, true, true, true]);
 });
 
 test.concurrent("add --filter with a relation links the whole closure and nothing else", async () => {
@@ -1269,7 +1380,7 @@ test.concurrent("add --filter with a relation links the whole closure and nothin
   await rm(join(dir, "node_modules"), { recursive: true });
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api..."], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api", "pkg-a"]);
@@ -1284,18 +1395,26 @@ test.concurrent("outdated --filter warns about a positive pattern that matched n
   const dir = await makeMonorepo({ api: { name: "api", dependencies: { "no-deps": "1.0.0" } } });
   await installOk(dir);
 
+  const table = [
+    HEADER("outdated"),
+    "|--------------------------------------------------|",
+    "| Package  | Current | Update | Latest | Workspace |",
+    "|----------|---------|--------|--------|-----------|",
+    "| no-deps  | 1.0.0   | 1.0.0  | 2.0.0  | api       |",
+    "|--------------------------------------------------|",
+  ];
+
   {
     const { stdout, stderr, exitCode } = await run(["outdated", "--filter", "api", "--filter", "typo"], dir);
-    expect(stderr).toContain('warn: No workspace packages matched the filter "typo"');
-    expect(stderr).not.toContain("error:");
-    expect(stdout).toContain("no-deps");
+    expect(stderr).toBe('warn: No workspace packages matched the filter "typo"\n');
+    expect(stdoutLines(stdout)).toStrictEqual(table);
     expect(exitCode).toBe(0);
   }
 
   {
     const { stdout, stderr, exitCode } = await run(["outdated", "--filter", "api", "--filter", "!typo"], dir);
-    expect(stderr).not.toContain("warn:");
-    expect(stdout).toContain("no-deps");
+    expect(stderr).toBe("");
+    expect(stdoutLines(stdout)).toStrictEqual(table);
     expect(exitCode).toBe(0);
   }
 });
@@ -1305,7 +1424,7 @@ test.concurrent("--filter=<pattern> is accepted before the subcommand", async ()
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["--filter=api", "add", "no-deps"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api"]);
@@ -1319,11 +1438,10 @@ test.concurrent("two name filters are unioned and unselected workspaces are byte
   const [rootBefore, , , pkgABefore, pkgBBefore] = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--filter", "web"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "web")).toStrictEqual({ name: "web", dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [ROOT, plus(API), plus(WEB), PKG_A, PKG_B]);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
   expect(await pkgText(dir, "pkg-a")).toBe(pkgABefore);
   expect(await pkgText(dir, "pkg-b")).toBe(pkgBBefore);
@@ -1335,8 +1453,9 @@ test.concurrent("remove --filter with no match names the pattern and touches not
   const before = await allPackageJsonTexts(dir);
   const lockBefore = await file(join(dir, "bun.lock")).text();
 
-  const { stderr, exitCode } = await run(["remove", "no-deps", "--filter", "nope"], dir, { linker: "hoisted" });
-  expect(stderr).toContain('error: No workspace packages matched the filter "nope"');
+  const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "nope"], dir, { linker: "hoisted" });
+  expect(stderr).toBe('error: No workspace packages matched the filter "nope"\n');
+  expect(stdoutLines(stdout)).toStrictEqual([HEADER("remove")]);
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -1349,11 +1468,10 @@ test.concurrent("a filter that matches nothing warns when another filter matched
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--filter", "typo"], dir);
-    expect(stderr).toContain('warn: No workspace packages matched the filter "typo"');
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe('warn: No workspace packages matched the filter "typo"\nSaved lockfile\n');
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
   }
 
   {
@@ -1361,11 +1479,10 @@ test.concurrent("a filter that matches nothing warns when another filter matched
       ["add", "a-dep", "--filter", "web", "--filter", "typo", "--filter", "typo2"],
       dir,
     );
-    expect(stderr).toContain('warn: No workspace packages matched the filters "typo", "typo2"');
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe('warn: No workspace packages matched the filters "typo", "typo2"\nSaved lockfile\n');
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "web")).toStrictEqual({ name: "web", dependencies: { "a-dep": "^1.0.10" } });
+    await expectWorkspaces(dir, [ROOT, plus(API), { name: "web", dependencies: { "a-dep": "^1.0.10" } }, PKG_A, PKG_B]);
   }
 });
 
@@ -1373,11 +1490,10 @@ test.concurrent("negated filters that match nothing do not warn", async () => {
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--filter", "!nothing"], dir);
-  expect(stderr).not.toContain("warn:");
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
 });
 
 test.concurrent("an explicit version is written verbatim to every target", async () => {
@@ -1385,22 +1501,24 @@ test.concurrent("an explicit version is written verbatim to every target", async
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep@1.0.1", "--filter", "pkg-*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "pkg-a", dependencies: { "a-dep": "1.0.1" } });
-    expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "pkg-b", dependencies: { "a-dep": "1.0.1" } });
+    await expectWorkspaces(dir, [ROOT, API, WEB, plus(PKG_A, "a-dep", "1.0.1"), plus(PKG_B, "a-dep", "1.0.1")]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps@^1.0.0", "--filter", "web"], dir, { linker: "hoisted" });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "web")).toStrictEqual({
-      name: "web",
-      dependencies: { "a-dep": "1.0.1", "no-deps": "^1.0.0" },
-    });
+    await expectWorkspaces(dir, [
+      ROOT,
+      API,
+      plus(WEB, "no-deps", "^1.0.0"),
+      plus(PKG_A, "a-dep", "1.0.1"),
+      plus(PKG_B, "a-dep", "1.0.1"),
+    ]);
     expect(await file(join(dir, "node_modules", "no-deps", "package.json")).json()).toStrictEqual({
       name: "no-deps",
       version: "1.1.0",
@@ -1413,24 +1531,30 @@ test.concurrent("--peer and --optional target the right list in every selected w
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--peer", "--filter", "pkg-*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "pkg-a", peerDependencies: { "no-deps": "^2.0.0" } });
-    expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "pkg-b", peerDependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [
+      ROOT,
+      API,
+      WEB,
+      { name: "pkg-a", peerDependencies: { "no-deps": "^2.0.0" } },
+      { name: "pkg-b", peerDependencies: { "no-deps": "^2.0.0" } },
+    ]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep", "--optional", "--filter", "pkg-a"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "pkg-a")).toStrictEqual({
-      name: "pkg-a",
-      optionalDependencies: { "a-dep": "^1.0.10" },
-      peerDependencies: { "no-deps": "^2.0.0" },
-    });
-    expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "pkg-b", peerDependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [
+      ROOT,
+      API,
+      WEB,
+      { name: "pkg-a", optionalDependencies: { "a-dep": "^1.0.10" }, peerDependencies: { "no-deps": "^2.0.0" } },
+      { name: "pkg-b", peerDependencies: { "no-deps": "^2.0.0" } },
+    ]);
   }
 });
 
@@ -1439,10 +1563,10 @@ test.concurrent("the root can be selected by name", async () => {
   const [, ...membersBefore] = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "root"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [plus(ROOT), API, WEB, PKG_A, PKG_B]);
   const [, ...membersAfter] = await allPackageJsonTexts(dir);
   expect(membersAfter).toStrictEqual(membersBefore);
 });
@@ -1453,10 +1577,10 @@ test.concurrent("'.' selects the workspace of the invoking directory", async () 
   {
     const [, ...membersBefore] = await allPackageJsonTexts(dir);
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "."], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { "a-dep": "^1.0.10" } });
+    await expectWorkspaces(dir, [plus(ROOT, "a-dep", "^1.0.10"), API, WEB, PKG_A, PKG_B]);
     const [, ...membersAfter] = await allPackageJsonTexts(dir);
     expect(membersAfter).toStrictEqual(membersBefore);
   }
@@ -1466,15 +1590,11 @@ test.concurrent("'.' selects the workspace of the invoking directory", async () 
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "."], dir, {
       cwd: join(dir, "packages", "web"),
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "web")).toStrictEqual({
-      name: "web",
-      dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" },
-    });
+    await expectWorkspaces(dir, [plus(ROOT, "a-dep", "^1.0.10"), API, plus(WEB), PKG_A, PKG_B]);
     expect(await pkgText(dir, "root")).toBe(rootBefore);
-    expect(await pkg(dir, "api")).toStrictEqual(API);
   }
 });
 
@@ -1484,22 +1604,28 @@ test.concurrent("a directory excluded by a '!' entry in workspaces is never a ta
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
     expect(await allPackageJsons(dir)).toStrictEqual([
       { name: "root", workspaces: ["packages/*", "!packages/web"] },
-      { name: "api", dependencies: { "no-deps": "^2.0.0" } },
+      plus(API),
       WEB,
-      { name: "pkg-a", dependencies: { "no-deps": "^2.0.0" } },
-      { name: "pkg-b", dependencies: { "no-deps": "^2.0.0" } },
+      plus(PKG_A),
+      plus(PKG_B),
     ]);
     expect(await pkgText(dir, "web")).toBe(webBefore);
+    expect(Object.keys((await lockfileJson(dir)).workspaces).sort()).toStrictEqual([
+      "",
+      "packages/api",
+      "packages/pkg-a",
+      "packages/pkg-b",
+    ]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "web"], dir);
-    expect(stderr).toContain("error: No workspace packages matched the filter");
+    expect(stderr).toBe('error: No workspace packages matched the filter "web"\n');
     expect(exitCode).toBe(1);
     expect(await pkgText(dir, "web")).toBe(webBefore);
   }
@@ -1509,11 +1635,16 @@ test.concurrent("workspaces: { packages: [...] } object form is honoured", async
   const dir = await makeMonorepo({ root: { name: "root", workspaces: { packages: ["packages/*"] } } });
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "root")).toStrictEqual({ name: "root", workspaces: { packages: ["packages/*"] } });
+  await expectWorkspaces(dir, [
+    { name: "root", workspaces: { packages: ["packages/*"] } },
+    plus(API),
+    WEB,
+    PKG_A,
+    PKG_B,
+  ]);
 });
 
 test.concurrent("scoped workspace names match a scope glob", async () => {
@@ -1521,25 +1652,18 @@ test.concurrent("scoped workspace names match a scope glob", async () => {
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "@acme/*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await allPackageJsons(dir)).toStrictEqual([
-      ROOT,
-      API,
-      WEB,
-      { name: "@acme/a", dependencies: { "no-deps": "^2.0.0" } },
-      { name: "@acme/b", dependencies: { "no-deps": "^2.0.0" } },
-    ]);
+    await expectWorkspaces(dir, [ROOT, API, WEB, plus({ name: "@acme/a" }), plus({ name: "@acme/b" })]);
   }
 
   {
     const { stderr, exitCode } = await run(["remove", "no-deps", "--filter", "@acme/a"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
 
-    expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "@acme/a" });
-    expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "@acme/b", dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [ROOT, API, WEB, { name: "@acme/a" }, plus({ name: "@acme/b" })]);
   }
 });
 
@@ -1547,11 +1671,11 @@ test.concurrent("add --filter --lockfile-only edits package.json and bun.lock bu
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api", "--lockfile-only"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await file(join(dir, "bun.lock")).text()).toContain('"no-deps@2.0.0"');
+  await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
+  expect((await lockfileJson(dir)).packages["no-deps"][0]).toBe("no-deps@2.0.0");
   expect(await exists(join(dir, "node_modules"))).toBeFalse();
 });
 
@@ -1566,7 +1690,7 @@ test.concurrent("running from a non-package subdirectory selects by filter and s
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "web"], dir, {
       cwd: join(dir, "packages", "api", "src"),
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
     expect(await exists(join(dir, "packages", "api", "src", "package.json"))).toBeFalse();
   }
@@ -1575,17 +1699,12 @@ test.concurrent("running from a non-package subdirectory selects by filter and s
     const { stderr, exitCode } = await run(["install", "a-dep", "--filter", "web"], dir, {
       cwd: join(dir, "tools", "scratch"),
     });
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
     expect(await exists(join(dir, "tools", "scratch", "package.json"))).toBeFalse();
   }
 
-  expect(await pkg(dir, "web")).toStrictEqual({
-    name: "web",
-    dependencies: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" },
-  });
-  expect(await pkg(dir, "api")).toStrictEqual(API);
-  expect(await pkg(dir, "root")).toStrictEqual(ROOT);
+  await expectWorkspaces(dir, [ROOT, API, plus(plus(WEB), "a-dep", "^1.0.10"), PKG_A, PKG_B]);
 });
 
 test.concurrent.each(["add", "install"])(
@@ -1594,7 +1713,9 @@ test.concurrent.each(["add", "install"])(
     const { packageDir } = await registry.createTestDir();
 
     const { stderr, exitCode } = await run([cmd, "no-deps", "--filter", "web"], packageDir);
-    expect(stderr).toContain("error: Bun could not find a package.json file to install from");
+    expect(stderr).toBe(
+      'error: Bun could not find a package.json file to install from\nnote: Run "bun init" to initialize a project\n',
+    );
     expect(exitCode).toBe(1);
 
     expect(await exists(join(packageDir, "package.json"))).toBeFalse();
@@ -1609,16 +1730,17 @@ test.concurrent("filtered remove keeps the unselected workspace's lockfile entri
   await installOk(dir, "hoisted");
 
   const { stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  const lockfile = await lockfileJson(dir);
-  expect(lockfile.workspaces["packages/api"]).toStrictEqual({ name: "api" });
-  expect(lockfile.workspaces["packages/web"]).toStrictEqual({
-    name: "web",
-    dependencies: { api: "workspace:*", "no-deps": "^2.0.0" },
-  });
-  expect(lockfile.packages["no-deps"]).toBeDefined();
+  await expectWorkspaces(dir, [
+    ROOT,
+    API,
+    { name: "web", dependencies: { api: "workspace:*", "no-deps": "^2.0.0" } },
+    PKG_A,
+    PKG_B,
+  ]);
+  expect((await lockfileJson(dir)).packages["no-deps"][0]).toBe("no-deps@2.0.0");
   expect(await exists(join(dir, "node_modules", "no-deps", "package.json"))).toBeTrue();
 });
 
@@ -1626,20 +1748,19 @@ test.concurrent("bun install <pkg> -F targets the workspace", async () => {
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["install", "no-deps", "-F", "api"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "root")).toStrictEqual(ROOT);
+  await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
 });
 
 // The root is only skipped by '*' when there are workspaces to select instead.
 test.concurrent("--filter outside a workspace: the lone package is the only candidate", async () => {
-  const { packageDir } = await registry.createTestDir({ files: { "package.json": JSON.stringify({ name: "solo" }) } });
+  const packageDir = await createDir({ "package.json": JSON.stringify({ name: "solo" }) });
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*"], packageDir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
     expect(await file(join(packageDir, "package.json")).json()).toStrictEqual({
       name: "solo",
@@ -1650,7 +1771,7 @@ test.concurrent("--filter outside a workspace: the lone package is the only cand
   {
     const before = await file(join(packageDir, "package.json")).text();
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "other"], packageDir);
-    expect(stderr).toContain("error: No workspace packages matched the filter");
+    expect(stderr).toBe('error: No workspace packages matched the filter "other"\n');
     expect(exitCode).toBe(1);
     expect(await file(join(packageDir, "package.json")).text()).toBe(before);
   }
@@ -1671,7 +1792,7 @@ test.concurrent.each(["add", "remove", "update"])("%s --filter with --global is 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("");
-  expect(stderr).toContain("error: --filter cannot be used with --global");
+  expect(stderr).toBe("error: --filter cannot be used with --global\n");
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -1703,14 +1824,16 @@ test.concurrent("package.json is written even when a root postinstall fails (pnp
   const dir = await makeMonorepo({ root: { ...ROOT, scripts: { postinstall: "exit 1" } } });
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "root", "--filter", "api"], dir);
-  expect(stderr).toContain('postinstall script from "root" exited with 1');
+  expect(stderr).toBe('Saved lockfile\n\n$ exit 1\nerror: postinstall script from "root" exited with 1\n');
   expect(exitCode).toBe(1);
 
-  expect((await pkg(dir, "root")).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  const { workspaces } = await lockfileJson(dir);
-  expect(workspaces[""].dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
-  expect(workspaces["packages/api"]).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [
+    { ...ROOT, scripts: { postinstall: "exit 1" }, dependencies: { "no-deps": "^2.0.0" } },
+    plus(API),
+    WEB,
+    PKG_A,
+    PKG_B,
+  ]);
 });
 
 test.concurrent("the root's lifecycle scripts do not run when --filter leaves the root out", async () => {
@@ -1718,8 +1841,7 @@ test.concurrent("the root's lifecycle scripts do not run when --filter leaves th
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir);
-  expect(stderr).not.toContain("postinstall");
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api"]);
@@ -1730,26 +1852,22 @@ test.concurrent("a failed resolution leaves every target untouched", async () =>
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "does-not-exist-anywhere", "--filter", "pkg-*"], dir);
-  expect(stderr).toContain(`error: GET ${registry.registryUrl()}does-not-exist-anywhere - 404`);
+  expect(stderr).toBe(`error: GET ${registry.registryUrl()}does-not-exist-anywhere - 404\n`);
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+  expect(await exists(join(dir, "bun.lock"))).toBeFalse();
 });
 
 test.concurrent("bun.lock records the resolved range for every target, not just the first", async () => {
   const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "pkg-*"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  const { workspaces } = await lockfileJson(dir);
-  expect(workspaces["packages/pkg-a"]).toStrictEqual({ name: "pkg-a", dependencies: { "no-deps": "^2.0.0" } });
-  expect(workspaces["packages/pkg-b"]).toStrictEqual({ name: "pkg-b", dependencies: { "no-deps": "^2.0.0" } });
-
-  const second = await run(["install"], dir);
-  expect(second.stderr).not.toContain("Saved lockfile");
-  expect(second.exitCode).toBe(0);
+  await expectWorkspaces(dir, [ROOT, API, WEB, plus(PKG_A), plus(PKG_B)]);
+  await installUnchanged(dir);
 });
 
 test.concurrent("--only-missing resolves each request from a target that received it", async () => {
@@ -1762,14 +1880,16 @@ test.concurrent("--only-missing resolves each request from a target that receive
     ["add", "no-deps", "a-dep", "--only-missing", "--filter", "root", "--filter", "web"],
     dir,
   );
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "web")).toStrictEqual({
-    name: "web",
-    dependencies: { "a-dep": "^1.0.10", "no-deps": "1.0.0" },
-  });
+  await expectWorkspaces(dir, [
+    { ...ROOT, dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } },
+    API,
+    { name: "web", dependencies: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } },
+    PKG_A,
+    PKG_B,
+  ]);
 });
 
 test.concurrent("a local path is relative to the cwd and re-spelled for each target (pnpm#9368)", async () => {
@@ -1779,19 +1899,20 @@ test.concurrent("a local path is relative to the cwd and re-spelled for each tar
   const { stderr, exitCode } = await run(["add", "./vendor/foo", "--filter", "root", "--filter", "api"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { foo: "./vendor/foo" } });
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { foo: "../../vendor/foo" } });
-  expect(await pkg(dir, "web")).toStrictEqual(WEB);
-  const { workspaces } = await lockfileJson(dir);
-  expect(workspaces[""].dependencies).toStrictEqual({ foo: "./vendor/foo" });
-  expect(workspaces["packages/api"].dependencies).toStrictEqual({ foo: "../../vendor/foo" });
+  await expectWorkspaces(dir, [
+    { ...ROOT, dependencies: { foo: "./vendor/foo" } },
+    { name: "api", dependencies: { foo: "../../vendor/foo" } },
+    WEB,
+    PKG_A,
+    PKG_B,
+  ]);
   expect(await file(join(dir, "node_modules", "foo", "package.json")).json()).toStrictEqual(VENDOR_FOO);
 
   const frozen = await run(["install", "--frozen-lockfile"], dir, { linker: "hoisted" });
-  expect(frozen.stderr).not.toContain("error:");
+  expect(frozen.stderr).toBe("");
   expect(frozen.exitCode).toBe(0);
 });
 
@@ -1802,11 +1923,16 @@ test.concurrent("a file: path keeps its prefix and resolves from a nested cwd", 
   const { stderr, exitCode } = await run(["add", "file:../../vendor/foo", "--filter", "api"], dir, {
     cwd: join(dir, "packages", "web"),
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { foo: "file:../../vendor/foo" } });
-  expect(await pkg(dir, "web")).toStrictEqual(WEB);
+  await expectWorkspaces(dir, [
+    ROOT,
+    { name: "api", dependencies: { foo: "file:../../vendor/foo" } },
+    WEB,
+    PKG_A,
+    PKG_B,
+  ]);
 });
 
 test.concurrent("a local path that does not exist relative to the cwd fails and writes nothing", async () => {
@@ -1816,10 +1942,13 @@ test.concurrent("a local path that does not exist relative to the cwd fails and 
 
   // Relative to packages/api this would exist; paths are relative to the cwd (the root) instead.
   const { stderr, exitCode } = await run(["add", "../../vendor/foo", "--filter", "api"], dir);
-  expect(stderr).toContain('error: Could not find package.json for "file:');
+  expect(stderr).toStartWith(
+    'error: Could not find package.json for "file:../../vendor/foo" dependency "../../../../vendor/foo"\n',
+  );
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+  expect(await exists(join(dir, "bun.lock"))).toBeFalse();
 });
 
 test.concurrent("--filter writes the same entry as running bun add inside the workspace (pnpm#7194)", async () => {
@@ -1828,17 +1957,16 @@ test.concurrent("--filter writes the same entry as running bun add inside the wo
   for (const flags of [[], ["-E"]]) {
     const dep = flags.length ? "no-deps" : "a-dep";
     const filtered = await run(["add", dep, ...flags, "--filter", "pkg-a"], dir);
-    expect(filtered.stderr).not.toContain("error:");
+    expect(filtered.stderr).toBe("Saved lockfile\n");
     expect(filtered.exitCode).toBe(0);
 
     const inside = await run(["add", dep, ...flags], dir, { cwd: join(dir, "packages", "api") });
-    expect(inside.stderr).not.toContain("error:");
+    expect(inside.stderr).toBe("Saved lockfile\n");
     expect(inside.exitCode).toBe(0);
   }
 
-  const [pkgA, api] = await Promise.all([pkg(dir, "pkg-a"), pkg(dir, "api")]);
-  expect(pkgA.dependencies).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "2.0.0" });
-  expect(api.dependencies).toStrictEqual(pkgA.dependencies);
+  const dependencies = { "a-dep": "^1.0.10", "no-deps": "2.0.0" };
+  await expectWorkspaces(dir, [ROOT, { name: "api", dependencies }, WEB, { name: "pkg-a", dependencies }, PKG_B]);
 });
 
 test.concurrent("a directory name is not a package name for a scoped workspace (pnpm#5601)", async () => {
@@ -1847,17 +1975,21 @@ test.concurrent("a directory name is not a package name for a scoped workspace (
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "pkg-a"], dir);
-    expect(stderr).toContain('error: No workspace packages matched the filter "pkg-a"');
+    expect(stderr).toBe('error: No workspace packages matched the filter "pkg-a"\n');
     expect(exitCode).toBe(1);
     expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
   }
 
-  for (const pattern of ["*/pkg-a", "./packages/pkg-a"]) {
+  // The second pattern finds the entry the first one wrote, so it has nothing to save: it selected the same workspace.
+  for (const [pattern, saved] of [
+    ["*/pkg-a", "Saved lockfile\n"],
+    ["./packages/pkg-a", ""],
+  ]) {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", pattern], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe(saved);
     expect(exitCode).toBe(0);
   }
-  expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "@org/pkg-a", dependencies: { "no-deps": "^2.0.0" } });
+  await expectWorkspaces(dir, [ROOT, API, WEB, plus({ name: "@org/pkg-a" }), PKG_B]);
 });
 
 test.concurrent("a name glob does not cross the scope separator (pnpm#3452)", async () => {
@@ -1865,18 +1997,22 @@ test.concurrent("a name glob does not cross the scope separator (pnpm#3452)", as
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*-utils"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
-    expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "@org/date-utils" });
-    expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "string-utils", dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [ROOT, API, WEB, { name: "@org/date-utils" }, plus({ name: "string-utils" })]);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep", "--filter", "*/*-utils"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
-    expect(await pkg(dir, "pkg-a")).toStrictEqual({ name: "@org/date-utils", dependencies: { "a-dep": "^1.0.10" } });
-    expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "string-utils", dependencies: { "no-deps": "^2.0.0" } });
+    await expectWorkspaces(dir, [
+      ROOT,
+      API,
+      WEB,
+      plus({ name: "@org/date-utils" }, "a-dep", "^1.0.10"),
+      plus({ name: "string-utils" }),
+    ]);
   }
 });
 
@@ -1885,7 +2021,7 @@ test.concurrent("a negated pattern wins regardless of flag order (pnpm#9354)", a
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "!./packages/*", "--filter", "api"], dir);
-  expect(stderr).toContain("error: No workspace packages matched the filter");
+  expect(stderr).toBe('error: No workspace packages matched the filters "!./packages/*", "api"\n');
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -1898,22 +2034,17 @@ test.concurrent("a path pattern naming the parent directory selects nothing (pnp
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "./packages"], dir);
-    expect(stderr).toContain("error: No workspace packages matched the filter");
+    expect(stderr).toBe('error: No workspace packages matched the filter "./packages"\n');
     expect(exitCode).toBe(1);
     expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+    expect(await exists(join(dir, "bun.lock"))).toBeFalse();
   }
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "./packages/*"], dir);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("Saved lockfile\n");
     expect(exitCode).toBe(0);
-    expect(await allPackageJsons(dir)).toStrictEqual([
-      ROOT,
-      { name: "api", dependencies: { "no-deps": "^2.0.0" } },
-      { name: "web", dependencies: { "a-dep": "1.0.1", "no-deps": "^2.0.0" } },
-      { name: "pkg-a", dependencies: { "no-deps": "^2.0.0" } },
-      { name: "pkg-b", dependencies: { "no-deps": "^2.0.0" } },
-    ]);
+    await expectWorkspaces(dir, [ROOT, plus(API), plus(WEB), plus(PKG_A), plus(PKG_B)]);
   }
 });
 
@@ -1922,7 +2053,7 @@ test.concurrent("an empty --filter value is a no-match error, not a crash (pnpm#
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", ""], dir);
-  expect(stderr).toContain('error: No workspace packages matched the filter ""');
+  expect(stderr).toBe('error: No workspace packages matched the filter ""\n');
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -1936,12 +2067,12 @@ test.concurrent("path filters resolve against --cwd (pnpm#5270)", async () => {
   const { stderr, exitCode } = await run(["add", "no-deps", "--cwd", dir, "--filter", "./packages/api"], dir, {
     cwd: elsewhere,
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "api")).toStrictEqual({ name: "api", dependencies: { "no-deps": "^2.0.0" } });
-  expect(await pkg(dir, "root")).toStrictEqual(ROOT);
+  await expectWorkspaces(dir, [ROOT, plus(API), WEB, PKG_A, PKG_B]);
   expect(await exists(join(elsewhere, "package.json"))).toBeFalse();
+  expect(await exists(join(elsewhere, "bun.lock"))).toBeFalse();
 });
 
 // Coverage pass: request assignment, local-path spellings, write-back and selector edge cases.
@@ -1958,24 +2089,17 @@ test.concurrent.each([
   const { stderr, exitCode } = await run(["add", first, second, "--filter", "root", "--filter", "api"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await allPackageJsons(dir)).toStrictEqual([
+  await expectWorkspaces(dir, [
     { ...ROOT, dependencies: NO_DEPS_AND_FOO("./vendor/foo") },
     { name: "api", dependencies: NO_DEPS_AND_FOO("../../vendor/foo") },
     WEB,
     PKG_A,
     PKG_B,
   ]);
-  const { workspaces } = await lockfileJson(dir);
-  expect(workspaces[""].dependencies).toStrictEqual(NO_DEPS_AND_FOO("./vendor/foo"));
-  expect(workspaces["packages/api"].dependencies).toStrictEqual(NO_DEPS_AND_FOO("../../vendor/foo"));
-
-  const reinstall = await run(["install"], dir, { linker: "hoisted" });
-  expect(reinstall.stderr).not.toContain("Saved lockfile");
-  expect(reinstall.stderr).not.toContain("error:");
-  expect(reinstall.exitCode).toBe(0);
+  await installUnchanged(dir, "hoisted");
 });
 
 // `link:` resolves against the global link dir (same failure without --filter); the error shows the per-target spelling.
@@ -2006,7 +2130,7 @@ test.concurrent.each([
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", positional, "--filter", "api"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api"], "foo", written);
@@ -2022,7 +2146,7 @@ test.concurrent("an aliased local path keeps the alias as the key and re-spells 
   const { stderr, exitCode } = await run(["add", "myfoo@file:./vendor/foo", "--filter", "api"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api"], "myfoo", "file:../../vendor/foo");
@@ -2045,7 +2169,7 @@ test.concurrent("an aliased local path is shared by targets at the same depth", 
     dir,
     { linker: "hoisted" },
   );
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api", "web"], "myfoo", "file:../../vendor/foo");
@@ -2062,8 +2186,8 @@ test.concurrent(
       ["add", "myfoo@file:./vendor/foo", "--filter", "root", "--filter", "api"],
       dir,
     );
-    expect(stderr).toContain(
-      'error: "myfoo@file:../../vendor/foo" is spelled differently relative to each selected workspace; add it to one workspace at a time',
+    expect(stderr).toBe(
+      'error: "myfoo@file:../../vendor/foo" is spelled differently relative to each selected workspace; add it to one workspace at a time\n',
     );
     expect(exitCode).toBe(1);
 
@@ -2081,20 +2205,11 @@ test.concurrent("an absolute local path is written verbatim into every target", 
   const { stderr, exitCode } = await run(["add", abs, "--filter", "root", "--filter", "api"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   const literal = abs.replaceAll("\\", "/");
-  expect(await allPackageJsons(dir)).toStrictEqual([
-    { ...ROOT, dependencies: { foo: literal } },
-    { name: "api", dependencies: { foo: literal } },
-    WEB,
-    PKG_A,
-    PKG_B,
-  ]);
-  const { workspaces } = await lockfileJson(dir);
-  expect(workspaces[""].dependencies).toStrictEqual({ foo: literal });
-  expect(workspaces["packages/api"].dependencies).toStrictEqual({ foo: literal });
+  await expectWorkspaces(dir, [plus(ROOT, "foo", literal), plus(API, "foo", literal), WEB, PKG_A, PKG_B]);
 });
 
 test.concurrent("a workspaces entry naming a missing directory is an error and nothing is written", async () => {
@@ -2102,7 +2217,7 @@ test.concurrent("a workspaces entry naming a missing directory is an error and n
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir);
-  expect(stderr).toContain('Workspace not found "missing/dir"');
+  expect(stderr).toContain('\nerror: Workspace not found "missing/dir"\n');
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -2115,8 +2230,7 @@ test.concurrent("an unparsable root package.json is an error and nothing is writ
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api"], dir);
-  expect(stderr).toContain("error:");
-  expect(stderr).toContain("package.json");
+  expect(stderr).toMatch(/^error: failed to parse package\.json ".*package\.json": ParserError$/m);
   expect(exitCode).toBe(1);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -2130,10 +2244,21 @@ test.concurrent("remove --filter --dry-run touches nothing", async () => {
   const before = await allPackageJsonTexts(dir);
   const lockBefore = await file(join(dir, "bun.lock")).text();
 
-  const { stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api", "--dry-run"], dir, {
+  const { stdout, stderr, exitCode } = await run(["remove", "no-deps", "--filter", "api", "--dry-run"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("");
+  expect(stdoutLines(stdout)).toStrictEqual([
+    HEADER("remove"),
+    "",
+    " api@workspace:packages/api",
+    " pkg-a@workspace:packages/pkg-a",
+    " pkg-b@workspace:packages/pkg-b",
+    " web@workspace:packages/web",
+    " a-dep@1.0.1",
+    "- no-deps",
+    "1 package removed",
+  ]);
   expect(exitCode).toBe(0);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
@@ -2176,10 +2301,10 @@ test.concurrent("--trust --filter writes trustedDependencies into every target, 
   const { stderr, exitCode } = await run(["add", "uses-what-bin@1.0.0", "--trust", "--filter", "pkg-*"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
-  expect(await allPackageJsons(dir)).toStrictEqual([
+  await expectWorkspaces(dir, [
     ROOT,
     API,
     WEB,
@@ -2187,6 +2312,7 @@ test.concurrent("--trust --filter writes trustedDependencies into every target, 
     { name: "pkg-b", dependencies: { "uses-what-bin": "1.0.0" }, trustedDependencies: ["uses-what-bin"] },
   ]);
   expect(await pkgText(dir, "root")).toBe(rootBefore);
+  expect((await lockfileJson(dir)).trustedDependencies).toStrictEqual(["uses-what-bin"]);
   expect(await exists(join(dir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
 });
 
@@ -2201,7 +2327,7 @@ test.concurrent("each target keeps its own indentation and trailing-newline styl
   const rootBefore = await pkgText(dir, "root");
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*"], dir);
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual([
@@ -2227,8 +2353,7 @@ test.concurrent.each<[string, Workspace[]]>([
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", pattern], dir);
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, edited);
@@ -2240,7 +2365,7 @@ test.concurrent("workspace: and npm: positionals write the same entry as an unfi
 
   for (const positional of ["pkg-a@workspace:*", "alias@npm:no-deps"]) {
     const filtered = await run(["add", positional, "--filter", "api"], dir, { linker: "hoisted" });
-    expect(filtered.stderr).not.toContain("error:");
+    expect(filtered.stderr).toBe("Saved lockfile\n");
     expect(filtered.exitCode).toBe(0);
   }
   expect(await allPackageJsonTexts(dir)).toStrictEqual([
@@ -2255,7 +2380,7 @@ test.concurrent("workspace: and npm: positionals write the same entry as an unfi
 
   for (const positional of ["pkg-a@workspace:*", "alias@npm:no-deps"]) {
     const inside = await run(["add", positional], dir, { cwd: join(dir, "packages", "web"), linker: "hoisted" });
-    expect(inside.stderr).not.toContain("error:");
+    expect(inside.stderr).toBe("Saved lockfile\n");
     expect(inside.exitCode).toBe(0);
   }
   const [api, web] = await Promise.all([pkg(dir, "api"), pkg(dir, "web")]);
@@ -2269,7 +2394,7 @@ test.concurrent("a relation with an unreadable bun.lock warns and regenerates it
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "api..."], dir);
-  expect(stderr).toContain("Ignoring lockfile");
+  expect(stderr).toEndWith("\nwarn: Ignoring lockfile\nSaved lockfile\n");
   expect(stderr).not.toContain("needed by --filter");
   expect(exitCode).toBe(0);
 
@@ -2289,16 +2414,24 @@ test.concurrent("the install summary comes from a target that received every req
     dir,
     { linker: "hoisted" },
   );
-  expect(stderr).not.toContain("error:");
-  expect(stdout).toContain("installed no-deps@2.0.0");
-  expect(stdout).toContain("installed a-dep@1.0.10");
+  expect(stderr).toBe("Saved lockfile\n");
+  expect(stdoutLines(stdout)).toStrictEqual([
+    HEADER("add"),
+    "",
+    "installed a-dep@1.0.10",
+    "installed no-deps@2.0.0",
+    "",
+    "4 packages installed",
+  ]);
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "root")).toStrictEqual({ ...ROOT, dependencies: { "no-deps": "1.0.0", "a-dep": "^1.0.10" } });
-  expect(await pkg(dir, "web")).toStrictEqual({
-    name: "web",
-    dependencies: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" },
-  });
+  await expectWorkspaces(dir, [
+    { ...ROOT, dependencies: { "no-deps": "1.0.0", "a-dep": "^1.0.10" } },
+    API,
+    { name: "web", dependencies: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } },
+    PKG_A,
+    PKG_B,
+  ]);
 });
 
 test.concurrent("'!!name' is a positive selector", async () => {
@@ -2306,8 +2439,7 @@ test.concurrent("'!!name' is a positive selector", async () => {
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "!!api"], dir);
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api"]);
@@ -2318,8 +2450,7 @@ test.concurrent("'**' selects every workspace except the root, like '*'", async 
   const before = await allPackageJsonTexts(dir);
 
   const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "**"], dir);
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("warn:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   await expectAddedOnlyTo(dir, before, ["api", "web", "pkg-a", "pkg-b"]);
@@ -2375,13 +2506,13 @@ test.concurrent.each([
     const [filtered, unfiltered] = await Promise.all([makeMonorepo({ root }), makeMonorepo({ root })]);
 
     const a = await run(["add", "no-deps", "--catalog", "--filter", "pkg-b"], filtered, { linker: "hoisted" });
-    expect(a.stderr).not.toContain("error:");
+    expect(a.stderr).toBe("Saved lockfile\n");
     expect(a.exitCode).toBe(0);
     const b = await run(["add", "no-deps", "--catalog"], unfiltered, {
       cwd: join(unfiltered, "packages", "pkg-b"),
       linker: "hoisted",
     });
-    expect(b.stderr).not.toContain("error:");
+    expect(b.stderr).toBe("Saved lockfile\n");
     expect(b.exitCode).toBe(0);
 
     const rootText = await pkgText(filtered, "root");
@@ -2411,11 +2542,18 @@ test.concurrent("add --catalog --filter leaves a root whose entry is reused byte
   const { stderr, exitCode } = await run(["add", "no-deps", "--catalog", "--filter", "pkg-b"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe("Saved lockfile\n");
   expect(exitCode).toBe(0);
 
   expect(await pkgText(dir, "root")).toBe(rootBefore);
-  expect(await pkg(dir, "pkg-b")).toStrictEqual({ name: "pkg-b", dependencies: { "no-deps": "catalog:" } });
+  await expectWorkspaces(dir, [
+    CATALOG_ROOT({ "no-deps": "1.0.0" }),
+    API,
+    WEB,
+    PKG_A,
+    plus(PKG_B, "no-deps", "catalog:"),
+  ]);
+  expect((await lockfileJson(dir)).catalog).toStrictEqual({ "no-deps": "1.0.0" });
 });
 
 test.concurrent.each([
@@ -2440,13 +2578,13 @@ test.concurrent.each([
     const { stderr, exitCode } = await run(["add", url, "--catalog", "--filter", "pkg-b"], dir, {
       linker: "hoisted",
     });
-    expect(stderr).toContain(
+    expect(stderr).toBe(
       `error: --catalog cannot add "${url}": pkg-b already declares no-deps\n  bun add no-deps@${url} --catalog\n`,
     );
-    expect(stderr).not.toContain("returned error");
     expect(exitCode).toBe(1);
 
     expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+    expect(await exists(join(dir, "bun.lock"))).toBeFalse();
   },
 );
 
@@ -2462,7 +2600,7 @@ test.concurrent("add <tarball> --catalog --filter with an existing entry is refu
   const lockBefore = await file(join(dir, "bun.lock")).text();
 
   const { stderr, exitCode } = await run(["add", url, "--catalog", "--filter", "pkg-b"], dir, { linker: "hoisted" });
-  expect(stderr).toContain(
+  expect(stderr).toBe(
     `error: --catalog cannot add "${url}": pkg-b already declares no-deps\n  bun add no-deps@${url} --catalog\n`,
   );
   expect(exitCode).toBe(1);
@@ -2484,17 +2622,29 @@ test.concurrent("add --catalog --filter notes a replaced entry and who else foll
   const { stderr, exitCode } = await run(["add", "no-deps@1.0.0", "--catalog", "--filter", "api"], dir, {
     linker: "hoisted",
   });
-  expect(stderr).toContain('note: catalog entry no-deps changed from "^2.0.0" to "1.0.0" (also used by pkg-a, pkg-b)');
-  expect(stderr).not.toContain("error:");
+  expect(stderr).toBe(
+    'note: catalog entry no-deps changed from "^2.0.0" to "1.0.0" (also used by pkg-a, pkg-b)\nSaved lockfile\n',
+  );
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "root")).toStrictEqual(CATALOG_ROOT({ "no-deps": "1.0.0" }));
-  expect(await declaring(dir, "no-deps")).toStrictEqual(["api", "pkg-a", "pkg-b"]);
+  await expectFollowersCatalog(dir, "1.0.0");
   expect(await file(join(dir, "node_modules", "no-deps", "package.json")).json()).toStrictEqual({
     name: "no-deps",
     version: "1.0.0",
   });
 });
+
+/** Only the root's catalog entry (and its copy in bun.lock) moved to `range`; the three `catalog:` users are as written. */
+async function expectFollowersCatalog(dir: string, range: string) {
+  await expectWorkspaces(dir, [
+    CATALOG_ROOT({ "no-deps": range }),
+    FOLLOWERS.api,
+    WEB,
+    FOLLOWERS["pkg-a"],
+    FOLLOWERS["pkg-b"],
+  ]);
+  expect((await lockfileJson(dir)).catalog).toStrictEqual({ "no-deps": range });
+}
 
 test.concurrent("add --catalog --filter --silent prints nothing, note included", async () => {
   const dir = await makeMonorepo(FOLLOWERS);
@@ -2508,7 +2658,7 @@ test.concurrent("add --catalog --filter --silent prints nothing, note included",
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 
-  expect(await pkg(dir, "root")).toStrictEqual(CATALOG_ROOT({ "no-deps": "1.0.0" }));
+  await expectFollowersCatalog(dir, "1.0.0");
 });
 
 test.concurrent("a catalog: range that resolves to nothing names the missing catalog or entry", async () => {
@@ -2517,25 +2667,24 @@ test.concurrent("a catalog: range that resolves to nothing names the missing cat
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps@catalog:missing", "--filter", "api"], dir);
-    expect(stderr).toContain(
-      'error: no-deps@catalog:missing: there is no catalog named "missing" in the root package.json',
+    expect(stderr).toBe(
+      'error: no-deps@catalog:missing: there is no catalog named "missing" in the root package.json\n',
     );
-    expect(stderr).not.toContain("failed to resolve");
     expect(exitCode).toBe(1);
   }
 
   {
     const { stderr, exitCode } = await run(["add", "a-dep@catalog:", "--filter", "api"], dir);
-    expect(stderr).toContain("error: a-dep@catalog: is not in the catalog\n  bun add --catalog a-dep\n");
-    expect(stderr).not.toContain("failed to resolve");
+    expect(stderr).toBe("error: a-dep@catalog: is not in the catalog\n  bun add --catalog a-dep\n");
     expect(exitCode).toBe(1);
   }
 
   expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+  expect(await exists(join(dir, "bun.lock"))).toBeFalse();
 
   // The same package.json state reached by hand fails the same way under bun install.
   await write(pkgPath(dir, "api"), JSON.stringify({ name: "api", dependencies: { "a-dep": "catalog:" } }));
   const { stderr, exitCode } = await run(["install"], dir);
-  expect(stderr).toContain("error: a-dep@catalog: is not in the catalog\n  bun add --catalog a-dep\n");
+  expect(stderr).toBe("error: a-dep@catalog: is not in the catalog\n  bun add --catalog a-dep\n");
   expect(exitCode).toBe(1);
 });

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -178,7 +178,7 @@ function lockEntryOf(json: Record<string, unknown>) {
 const lockKey = (workspace: Workspace) => (workspace === "root" ? "" : `packages/${workspace}`);
 
 /** `json` with `dep: range` added to (or replaced in) its dependencies. */
-function plus(json: { dependencies?: Record<string, string> }, dep = "no-deps", range = "^2.0.0") {
+function plus(json: { name: string; dependencies?: Record<string, string> }, dep = "no-deps", range = "^2.0.0") {
   return { ...json, dependencies: { ...json.dependencies, [dep]: range } };
 }
 

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -1,50 +1,13 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { readdirSync } from "fs";
-import { chmod, copyFile, exists, mkdir, rm } from "fs/promises";
+import { chmod, exists, mkdir, rm } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
-import { dirname, join } from "path";
+import { join } from "path";
 
 const registry = new VerdaccioRegistry();
 
-// The registry packages the cases below add or depend on. One install in beforeAll downloads them, and every test
-// dir starts from a copy of that cache (see `createDir`), so the cases still share no cache but only the few
-// packages outside this list, and the error cases that ask for one, reach the registry. Under ASAN the registry is
-// a single-threaded child of the same build, and that is what the concurrent cases used to queue up behind.
-const WARM = {
-  name: "warm",
-  dependencies: {
-    "no-deps": "2.0.0",
-    "no-deps-1": "npm:no-deps@1.0.0",
-    "a-dep": "1.0.1",
-    "a-dep-10": "npm:a-dep@1.0.10",
-    "is-number": "1.0.0",
-  },
-};
-
-// The files of the warm cache (the manifests and the extracted packages) and their directories, relative to its
-// root. The per-name index entries bun also leaves in a cache are links; installing does not read them, so they are
-// skipped and a copy is plain files and directories on every platform.
-let warmCache: { root: string; dirs: string[]; files: string[] };
-
-function listFiles(root: string, rel = "."): string[] {
-  return readdirSync(join(root, rel), { withFileTypes: true }).flatMap(entry => {
-    const path = join(rel, entry.name);
-    return entry.isDirectory() ? listFiles(root, path) : entry.isFile() ? [path] : [];
-  });
-}
-
 beforeAll(async () => {
   await registry.start();
-  const { packageDir } = await registry.createTestDir({
-    files: { "package.json": JSON.stringify(WARM) },
-    bunfigOpts: { linker: "hoisted" },
-  });
-  await installOk(packageDir, "hoisted");
-  const root = join(packageDir, ".bun-cache");
-  const files = listFiles(root);
-  expect(files).not.toBeEmpty();
-  warmCache = { root, files, dirs: [...new Set(files.map(path => dirname(path)))] };
 });
 
 afterAll(() => {
@@ -67,28 +30,20 @@ type Workspace = "root" | "api" | "web" | "pkg-a" | "pkg-b";
 
 type Linker = "hoisted" | "isolated";
 
-/** A test dir with `files` and its own copy of the warm cache at the path `envFor` points bun at. */
-async function createDir(files: Record<string, string> = {}, linker: Linker = "hoisted") {
-  const { packageDir } = await registry.createTestDir({ files, bunfigOpts: { linker } });
-  const cache = join(packageDir, ".bun-cache");
-  await Promise.all(warmCache.dirs.map(dir => mkdir(join(cache, dir), { recursive: true })));
-  await Promise.all(warmCache.files.map(path => copyFile(join(warmCache.root, path), join(cache, path))));
-  return packageDir;
-}
-
 // A string value is written verbatim, so a test can detect a rewrite that would otherwise be byte-identical.
-function makeMonorepo(extra: Partial<Record<Workspace, object | string>> = {}, linker: Linker = "hoisted") {
+async function makeMonorepo(extra: Partial<Record<Workspace, object | string>> = {}, linker: Linker = "hoisted") {
   const text = (value: object | string) => (typeof value === "string" ? value : JSON.stringify(value, null, 2));
-  return createDir(
-    {
+  const { packageDir } = await registry.createTestDir({
+    files: {
       "package.json": text(extra.root ?? ROOT),
       "packages/api/package.json": text(extra.api ?? API),
       "packages/web/package.json": text(extra.web ?? WEB),
       "packages/pkg-a/package.json": text(extra["pkg-a"] ?? PKG_A),
       "packages/pkg-b/package.json": text(extra["pkg-b"] ?? PKG_B),
     },
-    linker,
-  );
+    bunfigOpts: { linker },
+  });
+  return packageDir;
 }
 
 // CI exports BUN_INSTALL_CACHE_DIR (one per test file), which overrides the per-test-dir bunfig `cache`; concurrent cases racing on one cache fail on Windows.
@@ -96,8 +51,8 @@ function envFor(dir: string) {
   return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") };
 }
 
-// Whether these two lines show up depends on what the cache already holds, so stderr comes back without them and
-// callers compare the rest exactly: `Saved lockfile` when bun.lock was written, nothing when it was not.
+// These two lines, and the count in the second one, only say what a run had to download, so stderr comes back without
+// them and callers compare the rest exactly: `Saved lockfile` when bun.lock was written, nothing when it was not.
 const PROGRESS_LINES = /^(?:Resolving dependencies|Resolved, downloaded and extracted \[\d+\])\n/gm;
 
 // `--linker` is passed explicitly: an `install-strategy` in the user's ~/.npmrc overrides the bunfig linker.
@@ -1752,7 +1707,7 @@ test.concurrent("bun install <pkg> -F targets the workspace", async () => {
 
 // The root is only skipped by '*' when there are workspaces to select instead.
 test.concurrent("--filter outside a workspace: the lone package is the only candidate", async () => {
-  const packageDir = await createDir({ "package.json": JSON.stringify({ name: "solo" }) });
+  const { packageDir } = await registry.createTestDir({ files: { "package.json": JSON.stringify({ name: "solo" }) } });
 
   {
     const { stderr, exitCode } = await run(["add", "no-deps", "--filter", "*"], packageDir);

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -1,9 +1,9 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { copyFileSync, mkdirSync, readdirSync } from "fs";
-import { chmod, exists, mkdir, rm } from "fs/promises";
+import { readdirSync } from "fs";
+import { chmod, copyFile, exists, mkdir, rm } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
-import { join } from "path";
+import { dirname, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -22,21 +22,16 @@ const WARM = {
   },
 };
 
-// The manifests (`*.npm`) and extracted packages of the warm cache, as paths relative to it. The per-name index
-// entries bun also leaves in a cache are links; installing does not read them, so a copy is plain files and
-// directories on every platform.
-const warmCache = { root: "", dirs: [] as string[], files: [] as string[] };
+// The files of the warm cache (the manifests and the extracted packages) and their directories, relative to its
+// root. The per-name index entries bun also leaves in a cache are links; installing does not read them, so they are
+// skipped and a copy is plain files and directories on every platform.
+let warmCache: { root: string; dirs: string[]; files: string[] };
 
-function listWarmCache(rel: string) {
-  for (const entry of readdirSync(join(warmCache.root, rel), { withFileTypes: true })) {
+function listFiles(root: string, rel = "."): string[] {
+  return readdirSync(join(root, rel), { withFileTypes: true }).flatMap(entry => {
     const path = join(rel, entry.name);
-    if (entry.isDirectory()) {
-      warmCache.dirs.push(path);
-      listWarmCache(path);
-    } else if (entry.isFile()) {
-      warmCache.files.push(path);
-    }
-  }
+    return entry.isDirectory() ? listFiles(root, path) : entry.isFile() ? [path] : [];
+  });
 }
 
 beforeAll(async () => {
@@ -46,9 +41,10 @@ beforeAll(async () => {
     bunfigOpts: { linker: "hoisted" },
   });
   await installOk(packageDir, "hoisted");
-  warmCache.root = join(packageDir, ".bun-cache");
-  listWarmCache("");
-  expect(warmCache.files).not.toBeEmpty();
+  const root = join(packageDir, ".bun-cache");
+  const files = listFiles(root);
+  expect(files).not.toBeEmpty();
+  warmCache = { root, files, dirs: [...new Set(files.map(path => dirname(path)))] };
 });
 
 afterAll(() => {
@@ -75,8 +71,8 @@ type Linker = "hoisted" | "isolated";
 async function createDir(files: Record<string, string> = {}, linker: Linker = "hoisted") {
   const { packageDir } = await registry.createTestDir({ files, bunfigOpts: { linker } });
   const cache = join(packageDir, ".bun-cache");
-  for (const dir of ["", ...warmCache.dirs]) mkdirSync(join(cache, dir));
-  for (const path of warmCache.files) copyFileSync(join(warmCache.root, path), join(cache, path));
+  await Promise.all(warmCache.dirs.map(dir => mkdir(join(cache, dir), { recursive: true })));
+  await Promise.all(warmCache.files.map(path => copyFile(join(warmCache.root, path), join(cache, path))));
   return packageDir;
 }
 


### PR DESCRIPTION
### Problem
- Most of the 124 cases in `test/cli/install/bun-add-filter.test.ts` check stderr with `not.toContain("error:")` and read 1 to 3 of the 5 package.json files. A stray warning, an unwritten lockfile, an edit to an unselected workspace or a bun.lock that does not match the files all pass.
- The file was handed over as slow (20s to 22s on x64-asan). The CI logs say that time is not the cases (see the notes), so this PR claims no speedup. An earlier revision seeded each case's install cache. It measured within noise in CI and is gone.

### Fix
- `run` strips the two progress lines from stderr. The cases compare the rest exactly: `Saved lockfile`, nothing, or the exact warn, note or error text.
- `expectWorkspaces` checks all 5 package.json files and the rows bun.lock keeps for them. `expectAddedOnlyTo`, used by the relation and selector cases, checks the same rows. `installUnchanged` pins that a plain install afterwards has nothing to save.
- The outdated tables, the dry-run listings and three install summaries are pinned line by line. The "writes nothing" cases also check that bun.lock is absent or byte-identical.
- Verified: `bun bd test test/cli/install/bun-add-filter.test.ts`, 123 pass, 1039 assertions against 997 before, in the same 216 processes. The previous revision passed every lane of build 101612 and 12 release runs on Windows x64. This one only removes setup.

### Background
- bun.lock repeats each workspace's name, version and dependency groups under `workspaces`, keyed by path. `""` is the root. A filtered add or remove has to keep those rows in step with the files it edits.
- `bun install` prints `Resolving dependencies` and `Resolved, downloaded and extracted [N]` to stderr when it downloads something, and `Saved lockfile` when it writes bun.lock. Only `N` varies between runs.
- Three open PRs touch this file (#36284, #35461, #39232). The four places they rewrite are left byte-identical.

<details><summary>Notes</summary>

**Where the 22s goes.** The dots reporter flushes about once a second with a timestamp. On x64-asan the file prints its header at +0.1s, its first dots at +15.1s and its summary at +22.2s (build 101560, position 4 of 289 in its shard), or +13.9s and +20.6s (build 101586). With the cache seeding of the previous revision: +15.6s and +22.1s (build 101612). So the 124 cases take 6.5s to 7.1s, and the 14s in front of them is the first verdaccio start of the shard, under the ASAN build, while the job is still starting its containers (the `coordinator: ... ready` lines land in the middle of this file in all three builds). The next verdaccio file in the same shard, `isolated-relink.test.ts`, starts its registry and runs 7 cases in 3.3s. On darwin, where the file runs 16th, it takes 1.3s to 1.7s in total; at position 3 (build 101612, a PR build puts the touched file first) it takes 6.9s. The expected duration of this file is mostly the cost of being the first registry user in its shard. The levers for that are in test/harness.ts: the verdaccio child runs under `bunExe()` in CI (harness.ts:1905), `stop()` does not stop it (#36352), `start()` (#38891), or no verdaccio at all (#33115). The 6.5s to 7s that is this file's own is 216 ASAN process starts 5 at a time (`src/options_types/context.rs:506`).

**The cache seeding that was removed.** One install in `beforeAll`, its manifests and package directories copied into every test dir. With verdaccio under the debug ASAN build locally it looked large (the file went from 55s to 45s), but that registry is far slower than the release ASAN one CI runs: in CI the cases went from 6.7s and 7.1s to 6.5s, within the flush granularity, and with the registry under a release bun the debug build measured 12.3s to 12.7s before and after. Release runs measured 1.2s against 1.0s to 1.1s on Linux and 1.78s against 1.79s to 1.89s on Windows. The self-review also pointed out that #39741 is solving the same question differently for another file, so if seeding is wanted it belongs in `VerdaccioRegistry`, not in one file. Sharing one pre-installed tree for the 17 setup installs of `GRAPH` and `ROOT_GRAPH` would save about 0.5s of the 7s and is not done either.

**Assertion changes.**
- 101 success sites go from `not.toContain("error:")` to `toBe("Saved lockfile\n")`. The sites where nothing may be written pin `""`: both `--dry-run` cases, the two `--only-missing` runs that find everything present, the two removes of an undeclared name, the second filtered install, `--frozen-lockfile`, and the four `outdated` runs. The sites with a warning or note pin the whole text and its order, including the postinstall case (`Saved lockfile`, then `$ exit 1`, then the error), which shows the files are written before the script runs.
- About 20 error sites pin the whole stderr. They now check which patterns a no-match error lists, the `note:` line outside a project, the 404 line, the catalog refusals and the spelled-differently error. Errors with a code frame pin their own line instead of `error:`: unparsable root (`failed to parse package.json ... ParserError`), missing workspace dir, unsatisfied `workspace:` range with its `Version:` suffix, missing local path with the re-spelled name.
- `expectWorkspaces` replaces partial checks at about 45 sites. It compares the whole `workspaces` section of bun.lock, so an extra or stale row fails too (a review comment asked for the key set). `expectAddedOnlyTo` covers the roughly 30 relation and selector cases; it compares the five known rows, because one of those cases adds a sixth workspace. The remove, `--lockfile-only`, catalog and `--trust` cases also check the `packages`, `catalog` and `trustedDependencies` sections of bun.lock. The `!packages/web` case checks the key set by hand instead, because web has no row there.
- stdout pinned line by line: both `outdated` cases, both `--dry-run` cases (the listing shows the whole monorepo is resolved, not just the target), `links only the selected workspace` (`2 packages installed`), `re-links only the selected workspace` (`1 package installed`, which is also what an unfiltered remove prints when it has to link something), the `--only-missing` summary (`4 packages installed`), and the no-match remove banner.
- `installUnchanged` replaces `installOk` and `not.toContain("Saved lockfile")` at 6 post-check sites. Six "writes nothing" cases also check that bun.lock is absent or byte-identical. In the pnpm#5601 case the second pattern is pinned as a no-op (`""`), which is what shows it selected the same workspace as the first one.
- Left byte-identical: the `-F ... -d -E` case and the two-groups `--peer` case (#36284 rewrites both), the `link:` case (#35461), the `skipIf` line of the unwritable case (#39232), and the body of that case, which is skipped as root here. The imports, `beforeAll`, `makeMonorepo` and `envFor` are unchanged too. A new case only needs `expect(stderr).toBe("Saved lockfile\n")` and, where it applies, `expectWorkspaces`.
- `PROGRESS_LINES` is the same constant #39646 adds to bun-update.test.ts. Moving it into harness.ts is a follow-up once both are in.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->