### PR TITLE
pm: confine what bun pm cache rm deletes

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -203,11 +203,12 @@ pub use super::package_installer::PackageInstaller;
 pub use self::package_manager_directories as directories;
 use directories::attempt_to_create_package_json_and_open;
 pub use directories::{
-    attempt_to_create_package_json, cached_git_folder_name, cached_git_folder_name_print,
-    cached_git_folder_name_print_auto, cached_github_folder_name, cached_github_folder_name_print,
-    cached_github_folder_name_print_auto, cached_npm_package_folder_name,
-    cached_npm_package_folder_name_print, cached_npm_package_folder_print_basename,
-    cached_tarball_folder_name, cached_tarball_folder_name_print, compute_cache_dir_and_subpath,
+    ClearCacheDirectoryError, attempt_to_create_package_json, cached_git_folder_name,
+    cached_git_folder_name_print, cached_git_folder_name_print_auto, cached_github_folder_name,
+    cached_github_folder_name_print, cached_github_folder_name_print_auto,
+    cached_npm_package_folder_name, cached_npm_package_folder_name_print,
+    cached_npm_package_folder_print_basename, cached_tarball_folder_name,
+    cached_tarball_folder_name_print, clear_cache_directory, compute_cache_dir_and_subpath,
     fetch_cache_directory_path, get_cache_directory, get_cache_directory_and_abs_path,
     get_temporary_directory, global_link_dir, global_link_dir_path, is_folder_in_cache,
     path_for_cached_npm_path, path_for_resolution, save_lockfile, setup_global_dir,

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -440,9 +440,8 @@ pub enum ClearCacheDirectoryError {
     },
 }
 
-/// `bun pm cache rm`. Empties the directory instead of removing it, so a symlinked or
-/// mounted cache directory keeps working. The setting says where the cache is, not
-/// that the directory holds nothing else, hence `protected_dirs`.
+/// `bun pm cache rm`. Empties the directory rather than removing it, so a symlinked or
+/// mounted cache survives. `protected_dirs`: the setting proves nothing about contents.
 pub fn clear_cache_directory(
     env: &mut DotEnvLoader,
     original_cwd: &[u8],

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -375,8 +375,13 @@ pub struct CacheDir {
     pub path: Vec<u8>,
 }
 
+/// A variable that is set but empty (`ENV BUN_INSTALL_CACHE_DIR=$UNSET_ARG`) counts as
+/// unset. `abs(&[b""])` would be the project directory.
 pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
-    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
+    if let Some(dir) = env
+        .get(b"BUN_INSTALL_CACHE_DIR")
+        .filter(|dir| !dir.is_empty())
+    {
         return CacheDir {
             path: FileSystem::instance().abs(&[dir]).to_vec(),
         };
@@ -390,21 +395,21 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
         }
     }
 
-    if let Some(dir) = env.get(b"BUN_INSTALL") {
+    if let Some(dir) = env.get(b"BUN_INSTALL").filter(|dir| !dir.is_empty()) {
         let parts: [&[u8]; 3] = [dir, b"install/", b"cache/"];
         return CacheDir {
             path: FileSystem::instance().abs(&parts).to_vec(),
         };
     }
 
-    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
+    if let Some(dir) = env_var::XDG_CACHE_HOME.get_not_empty() {
         let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
         return CacheDir {
             path: FileSystem::instance().abs(&parts).to_vec(),
         };
     }
 
-    if let Some(dir) = env_var::HOME.get() {
+    if let Some(dir) = env_var::HOME.get_not_empty() {
         let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
         return CacheDir {
             path: FileSystem::instance().abs(&parts).to_vec(),
@@ -414,6 +419,137 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
     let fallback_parts: [&[u8]; 1] = [b"node_modules/.bun-cache"];
     CacheDir {
         path: FileSystem::instance().abs(&fallback_parts).to_vec(),
+    }
+}
+
+// ───────────────────────────── bun pm cache rm ────────────────────────────────
+
+pub enum ClearCacheDirectoryError {
+    /// The cache directory setting resolves to a filesystem root.
+    FilesystemRoot { cache_dir: Box<[u8]> },
+    /// The cache directory is (`is_same_dir`) or contains a directory that holds
+    /// more than the install cache. `what` names that directory for the user.
+    Protected {
+        cache_dir: Box<[u8]>,
+        what: &'static str,
+        protected: Box<[u8]>,
+        is_same_dir: bool,
+    },
+    Io {
+        cache_dir: Box<[u8]>,
+        err: sys::Error,
+    },
+}
+
+/// `bun pm cache rm`: removes the entries of the cache directory that the process
+/// environment names. The directory itself stays, so a cache directory that is a
+/// symlink or a mount point keeps working.
+///
+/// The setting only says where the cache is, not that the directory holds nothing
+/// else. A directory that is, or contains, something bun knows is not a cache is
+/// left alone: the home directory, the running executable, `$BUN_INSTALL`, the
+/// project, or the directory the command was run from.
+pub fn clear_cache_directory(
+    env: &mut DotEnvLoader,
+    original_cwd: &[u8],
+) -> Result<(), ClearCacheDirectoryError> {
+    let configured = fetch_cache_directory_path(env, None).path;
+    let dir = match Dir::open(&configured) {
+        Ok(dir) => dir,
+        Err(err) if err.get_errno() == sys::E::ENOENT => return Ok(()),
+        Err(err) => {
+            return Err(ClearCacheDirectoryError::Io {
+                cache_dir: configured.into_boxed_slice(),
+                err,
+            });
+        }
+    };
+
+    // Compare the directory that was actually opened, not the setting: a setting
+    // that is a symlink to `$HOME` must be caught as `$HOME`.
+    let mut cache_dir_buf = path::path_buffer_pool::get();
+    let cache_dir: &[u8] = match dir.get_fd_path(&mut cache_dir_buf) {
+        Ok(real) => real,
+        Err(err) => {
+            return Err(ClearCacheDirectoryError::Io {
+                cache_dir: configured.into_boxed_slice(),
+                err,
+            });
+        }
+    };
+
+    if path::basename(cache_dir).is_empty() {
+        return Err(ClearCacheDirectoryError::FilesystemRoot {
+            cache_dir: cache_dir.into(),
+        });
+    }
+
+    let protected_dirs: [(&'static str, Option<&[u8]>); 5] = [
+        ("the home directory", env_var::HOME.get_not_empty()),
+        (
+            "the bun executable",
+            bun_core::self_exe_path().ok().map(ZStr::as_bytes),
+        ),
+        (
+            "$BUN_INSTALL",
+            env.get(b"BUN_INSTALL").filter(|dir| !dir.is_empty()),
+        ),
+        (
+            "the project directory",
+            Some(FileSystem::instance().top_level_dir()),
+        ),
+        ("the current directory", Some(original_cwd)),
+    ];
+    for (what, protected) in protected_dirs {
+        let Some(protected) = protected else {
+            continue;
+        };
+        let mut protected_buf = path::path_buffer_pool::get();
+        let protected = canonical_dir_path(protected, &mut protected_buf);
+        let is_same_dir = match path::resolve_path::is_parent_or_equal(cache_dir, protected) {
+            path::resolve_path::ParentEqual::Unrelated => continue,
+            path::resolve_path::ParentEqual::Equal => true,
+            path::resolve_path::ParentEqual::Parent => false,
+        };
+        return Err(ClearCacheDirectoryError::Protected {
+            cache_dir: cache_dir.into(),
+            what,
+            protected: protected.into(),
+            is_same_dir,
+        });
+    }
+
+    let io = |err: sys::Error| ClearCacheDirectoryError::Io {
+        cache_dir: cache_dir.into(),
+        err,
+    };
+
+    // Read every name before removing anything: readdir may skip entries when the
+    // directory changes under it, and unlike `delete_tree` there is no rmdir here
+    // whose ENOTEMPTY would catch that.
+    let mut entries: Vec<Box<[u8]>> = Vec::new();
+    let mut iter = sys::iterate_dir(dir.fd());
+    while let Some(entry) = iter.next().map_err(io)? {
+        entries.push(Box::from(entry.name.slice_u8()));
+    }
+    for entry in &entries {
+        // `delete_tree` unlinks a symlink instead of following it, so an entry
+        // that points outside the cache only loses the link.
+        dir.delete_tree(entry).map_err(io)?;
+    }
+    Ok(())
+}
+
+/// The path the OS reports for the directory at `path`, so that it compares equal
+/// to a cache directory that reaches it through a symlink. `path` itself when it
+/// is not a directory that can be opened.
+fn canonical_dir_path<'a>(path: &'a [u8], buf: &'a mut PathBuffer) -> &'a [u8] {
+    match Dir::open(path) {
+        Ok(dir) => match dir.get_fd_path(buf) {
+            Ok(real) => real,
+            Err(_) => path,
+        },
+        Err(_) => path,
     }
 }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -375,8 +375,7 @@ pub struct CacheDir {
     pub path: Vec<u8>,
 }
 
-/// A variable that is set but empty (`ENV BUN_INSTALL_CACHE_DIR=$UNSET_ARG`) counts as
-/// unset. `abs(&[b""])` would be the project directory.
+/// An empty variable counts as unset: `abs(&[b""])` is the project directory.
 pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
     if let Some(dir) = env
         .get(b"BUN_INSTALL_CACHE_DIR")
@@ -425,10 +424,10 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
 // ───────────────────────────── bun pm cache rm ────────────────────────────────
 
 pub enum ClearCacheDirectoryError {
-    /// The cache directory setting resolves to a filesystem root.
-    FilesystemRoot { cache_dir: Box<[u8]> },
-    /// The cache directory is (`is_same_dir`) or contains a directory that holds
-    /// more than the install cache. `what` names that directory for the user.
+    FilesystemRoot {
+        cache_dir: Box<[u8]>,
+    },
+    /// `cache_dir` is (`is_same_dir`) or contains `protected`, which `what` names.
     Protected {
         cache_dir: Box<[u8]>,
         what: &'static str,
@@ -441,14 +440,9 @@ pub enum ClearCacheDirectoryError {
     },
 }
 
-/// `bun pm cache rm`: removes the entries of the cache directory that the process
-/// environment names. The directory itself stays, so a cache directory that is a
-/// symlink or a mount point keeps working.
-///
-/// The setting only says where the cache is, not that the directory holds nothing
-/// else. A directory that is, or contains, something bun knows is not a cache is
-/// left alone: the home directory, the running executable, `$BUN_INSTALL`, the
-/// project, or the directory the command was run from.
+/// `bun pm cache rm`. Empties the directory instead of removing it, so a symlinked or
+/// mounted cache directory keeps working. The setting says where the cache is, not
+/// that the directory holds nothing else, hence `protected_dirs`.
 pub fn clear_cache_directory(
     env: &mut DotEnvLoader,
     original_cwd: &[u8],
@@ -465,8 +459,7 @@ pub fn clear_cache_directory(
         }
     };
 
-    // Compare the directory that was actually opened, not the setting: a setting
-    // that is a symlink to `$HOME` must be caught as `$HOME`.
+    // The opened directory, not the setting: a symlink to `$HOME` must compare as `$HOME`.
     let mut cache_dir_buf = path::path_buffer_pool::get();
     let cache_dir: &[u8] = match dir.get_fd_path(&mut cache_dir_buf) {
         Ok(real) => real,
@@ -524,25 +517,19 @@ pub fn clear_cache_directory(
         err,
     };
 
-    // Read every name before removing anything: readdir may skip entries when the
-    // directory changes under it, and unlike `delete_tree` there is no rmdir here
-    // whose ENOTEMPTY would catch that.
+    // Collect first: readdir may skip entries while the directory is being emptied.
     let mut entries: Vec<Box<[u8]>> = Vec::new();
     let mut iter = sys::iterate_dir(dir.fd());
     while let Some(entry) = iter.next().map_err(io)? {
         entries.push(Box::from(entry.name.slice_u8()));
     }
     for entry in &entries {
-        // `delete_tree` unlinks a symlink instead of following it, so an entry
-        // that points outside the cache only loses the link.
         dir.delete_tree(entry).map_err(io)?;
     }
     Ok(())
 }
 
-/// The path the OS reports for the directory at `path`, so that it compares equal
-/// to a cache directory that reaches it through a symlink. `path` itself when it
-/// is not a directory that can be opened.
+/// The real path of the directory at `path`, or `path` itself when it cannot be opened.
 fn canonical_dir_path<'a>(path: &'a [u8], buf: &'a mut PathBuffer) -> &'a [u8] {
     match Dir::open(path) {
         Ok(dir) => match dir.get_fd_path(buf) {

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -440,8 +440,7 @@ pub enum ClearCacheDirectoryError {
     },
 }
 
-/// `bun pm cache rm`. Empties the directory rather than removing it, so a symlinked or
-/// mounted cache survives. `protected_dirs`: the setting proves nothing about contents.
+/// `bun pm cache rm`. Empties rather than removes: a symlinked or mounted cache must survive.
 pub fn clear_cache_directory(
     env: &mut DotEnvLoader,
     original_cwd: &[u8],
@@ -476,6 +475,7 @@ pub fn clear_cache_directory(
         });
     }
 
+    // The setting says where the cache is, not that the directory holds only a cache.
     let protected_dirs: [(&'static str, Option<&[u8]>); 5] = [
         ("the home directory", env_var::HOME.get_not_empty()),
         (

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -9,8 +9,8 @@ use bun_install::dependency::Dependency;
 use bun_install::lockfile::{LoadResult, LoadStep, Lockfile, package::PackageColumns as _, tree};
 use bun_install::npm as Npm;
 use bun_install::package_manager_real::{
-    CommandLineArguments, Subcommand, fetch_cache_directory_path, get_cache_directory,
-    package_manager_options::LogLevel, setup_global_dir,
+    ClearCacheDirectoryError, CommandLineArguments, Subcommand, clear_cache_directory,
+    get_cache_directory, package_manager_options::LogLevel, setup_global_dir,
 };
 use bun_install::{DependencyID, PackageID, PackageManager, migration};
 use bun_paths::{self as Path, PathBuffer};
@@ -139,6 +139,12 @@ impl PackageManagerCommand {
         Output::writer().print(format_args!("{}", pm.lockfile.fmt_meta_hash()))?;
         Output::enable_buffering();
         Global::exit(0);
+    }
+
+    fn note_cache_directory_setting() {
+        bun_core::note!(
+            "the cache directory comes from <b>$BUN_INSTALL_CACHE_DIR<r> or <b>$BUN_INSTALL<r>. Point it at a directory that holds nothing but the bun install cache."
+        );
     }
 
     fn get_subcommand(args_ptr: &mut &'static [&'static [u8]]) -> &'static [u8] {
@@ -437,37 +443,43 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             {
                 let mut had_err = false;
 
+                // Not `pm.env`: a .env, bunfig.toml, or .npmrc committed to the project
+                // must not choose what a destructive command deletes.
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
-                let cache_dir = fetch_cache_directory_path(&mut process_env, None);
-                let mut rm_buf = PathBuffer::uninit();
-                let rm_dir = match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
-                    Ok(d) => d,
-                    Err(err) => {
-                        bun_core::pretty_errorln!(
-                            "{} getting cache directory",
-                            crate::Error::from(err).name(),
+                match clear_cache_directory(&mut process_env, &cwd) {
+                    Ok(()) => bun_core::prettyln!("Cleared 'bun install' cache"),
+                    Err(ClearCacheDirectoryError::FilesystemRoot { cache_dir }) => {
+                        Output::err_generic(
+                            "refusing to clear {}: it is the root of a filesystem",
+                            (bun_fmt::quote(&cache_dir),),
                         );
-                        Global::crash();
+                        Self::note_cache_directory_setting();
+                        had_err = true;
                     }
-                };
-                let rm_path = match rm_dir.get_fd_path(&mut rm_buf) {
-                    Ok(p) => &p[..],
-                    Err(err) => {
-                        bun_core::pretty_errorln!(
-                            "{} getting cache directory",
-                            crate::Error::from(err).name(),
+                    Err(ClearCacheDirectoryError::Protected {
+                        cache_dir,
+                        what,
+                        protected,
+                        is_same_dir,
+                    }) => {
+                        Output::err_generic(
+                            "refusing to clear {}: it {} {} ({})",
+                            (
+                                bun_fmt::quote(&cache_dir),
+                                if is_same_dir { "is" } else { "contains" },
+                                what,
+                                bun_fmt::quote(&protected),
+                            ),
                         );
-                        Global::crash();
+                        Self::note_cache_directory_setting();
+                        had_err = true;
                     }
-                };
-                rm_dir.close();
-
-                if let Err(err) = bun_sys::delete_tree_absolute(rm_path) {
-                    Output::err(err, "Could not delete {s}", (bstr::BStr::new(rm_path),));
-                    had_err = true;
+                    Err(ClearCacheDirectoryError::Io { cache_dir, err }) => {
+                        Output::err(err, "could not clear {}", (bun_fmt::quote(&cache_dir),));
+                        had_err = true;
+                    }
                 }
-                bun_core::prettyln!("Cleared 'bun install' cache");
 
                 'bunx: {
                     let tmp = Fs::RealFS::platform_temp_dir();

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -443,8 +443,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             {
                 let mut had_err = false;
 
-                // Not `pm.env`: a .env, bunfig.toml, or .npmrc committed to the project
-                // must not choose what a destructive command deletes.
+                // Not `pm.env`: a committed .env or .npmrc must not pick what gets deleted.
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
                 match clear_cache_directory(&mut process_env, &cwd) {

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -790,7 +790,8 @@ it("bun install treats an empty BUN_INSTALL_CACHE_DIR as unset instead of cachin
     stderr: "pipe",
     env: cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: "", BUN_INSTALL: undefined, XDG_CACHE_HOME: undefined }),
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("+ bar@0.0.2");
   expect(stderr).not.toContain("error:");
   expect(exitCode).toBe(0);
 

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,9 +1,9 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
-import { exists, lstat, mkdir, symlink, writeFile } from "fs/promises";
+import { chmod, copyFile, exists, link, lstat, mkdir, symlink, writeFile } from "fs/promises";
 import { bunEnv, bunExe, bunEnv as env, normalizeBunSnapshot, readdirSorted, tempDir, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
-import { join } from "path";
+import { basename, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -796,11 +796,12 @@ it("bun install treats an empty BUN_INSTALL_CACHE_DIR as unset instead of cachin
   expect(exitCode).toBe(0);
 
   expect(urls.sort()).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
-  const cacheEntry = (name: string) => name.includes("@@") || name.endsWith(".npm");
-  expect((await readdirSorted(package_dir)).filter(cacheEntry)).toEqual([]);
-  expect((await readdirSorted(join(String(side), "home", ".bun", "install", "cache"))).filter(cacheEntry)).not.toEqual(
-    [],
-  );
+  const isManifest = (name: string) => name.endsWith(".npm");
+  expect((await readdirSorted(package_dir)).filter(name => name.includes("@@") || isManifest(name))).toEqual([]);
+  const homeCache = await readdirSorted(join(String(side), "home", ".bun", "install", "cache"));
+  expect(homeCache).toContain("bar@0.0.2@@localhost@@@1");
+  // The manifest name hashes the registry URL, which includes the port.
+  expect(homeCache.filter(isManifest)).toHaveLength(1);
 });
 
 /**
@@ -831,9 +832,9 @@ function cacheEnv(side: string, overrides: Record<string, string | undefined> = 
   return spawnEnv;
 }
 
-async function pmCache(args: string[], cwd: string, spawnEnv: NodeJS.Dict<string>) {
+async function pmCache(args: string[], cwd: string, spawnEnv: NodeJS.Dict<string>, exe: string = bunExe()) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "pm", "cache", ...args],
+    cmd: [exe, "pm", "cache", ...args],
     cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -890,10 +891,9 @@ describe("bun pm cache with an empty variable", () => {
 
     expect(await pmCache([], proj, spawnEnv)).toEqual({ stdout: envCache, stderr: "", exitCode: 0 });
 
-    const result = await pmCache(["rm"], proj, spawnEnv);
+    expect(await pmCache(["rm"], proj, spawnEnv)).toEqual(cleared);
     expect(await readdirSorted(proj)).toEqual(projectEntries);
     expect(await readdirSorted(envCache)).toEqual([]);
-    expect(result).toEqual(cleared);
   });
 
   test("an empty BUN_INSTALL falls through to the next location", async () => {
@@ -970,6 +970,26 @@ describe("bun pm cache rm refuses a cache directory that holds more than the cac
     expect(result).toEqual(refused(bunInstall, `it is $BUN_INSTALL ("${bunInstall}")`));
   });
 
+  test("the directory that holds the running bun executable", async () => {
+    using side = tempDir("pm-cache-rm-exe", sideFiles);
+    using root = tempDir("pm-cache-rm-exe-project", projectFiles);
+    const proj = join(String(root), "proj");
+    // Run a second name for the binary from inside the temp tree. Without the refusal,
+    // this command deletes the directory that holds the binary, which must not be the
+    // build directory.
+    const bin = join(String(root), "bin");
+    const exe = join(bin, basename(bunExe()));
+    await mkdir(bin);
+    await link(bunExe(), exe).catch(async () => {
+      await copyFile(bunExe(), exe);
+      await chmod(exe, 0o755);
+    });
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: bin }), exe);
+    expect(await exists(exe)).toBeTrue();
+    expect(result).toEqual(refused(bin, `it contains the bun executable ("${exe}")`));
+  });
+
   test("a symlink to the home directory", async () => {
     using side = tempDir("pm-cache-rm-symlink-home", sideFiles);
     using root = tempDir("pm-cache-rm-symlink-home-project", projectFiles);
@@ -994,11 +1014,10 @@ describe("bun pm cache rm clears the entries and keeps the directory", () => {
     await symlink(target, link, "junction");
     expect(await readdirSorted(target)).toEqual(envCacheEntries);
 
-    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: link }));
+    expect(await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: link }))).toEqual(cleared);
     expect(await readdirSorted(target)).toEqual([]);
     expect((await lstat(link)).isSymbolicLink()).toBeTrue();
     expect(await readdirSorted(link)).toEqual([]);
-    expect(result).toEqual(cleared);
   });
 
   test("an entry that is a symlink is unlinked, not followed", async () => {
@@ -1009,10 +1028,9 @@ describe("bun pm cache rm clears the entries and keeps the directory", () => {
     const sibling = join(String(root), "sibling");
     await symlink(sibling, join(envCache, "escape@1.0.0@@@1"), "junction");
 
-    const result = await pmCache(["rm"], proj, cacheEnv(String(side)));
+    expect(await pmCache(["rm"], proj, cacheEnv(String(side)))).toEqual(cleared);
     expect(await readdirSorted(envCache)).toEqual([]);
     expect(await readdirSorted(sibling)).toEqual(["keep.txt"]);
-    expect(result).toEqual(cleared);
   });
 
   test("a cache directory that does not exist is not created", async () => {
@@ -1021,9 +1039,8 @@ describe("bun pm cache rm clears the entries and keeps the directory", () => {
     const proj = join(String(root), "proj");
     const missing = join(String(side), "does-not-exist");
 
-    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: missing }));
+    expect(await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: missing }))).toEqual(cleared);
     expect(await exists(missing)).toBeFalse();
-    expect(result).toEqual(cleared);
   });
 
   test("a cache directory named by the project's .npmrc is not the one cleared", async () => {
@@ -1037,10 +1054,9 @@ describe("bun pm cache rm clears the entries and keeps the directory", () => {
     expect(await pmCache([], proj, spawnEnv)).toEqual({ stdout: proj, stderr: "", exitCode: 0 });
 
     // ...but a file committed to the repository cannot choose what `bun pm cache rm` deletes.
-    const result = await pmCache(["rm"], proj, spawnEnv);
+    expect(await pmCache(["rm"], proj, spawnEnv)).toEqual(cleared);
     expect(await readdirSorted(proj)).toEqual([".git", ".npmrc", "package.json", "src"]);
     expect(await readdirSorted(envCache)).toEqual([]);
-    expect(result).toEqual(cleared);
   });
 });
 

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
-import { exists, mkdir, writeFile } from "fs/promises";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
+import { exists, lstat, mkdir, symlink, writeFile } from "fs/promises";
 import { bunEnv, bunExe, bunEnv as env, normalizeBunSnapshot, readdirSorted, tempDir, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
@@ -761,7 +761,286 @@ it("should remove all cache", async () => {
   expect(await new Response(stderr2).text()).toBe("");
   expect(await new Response(stdout2).text()).toInclude("Cleared 'bun install' cache\n");
   expect(await exited2).toBe(0);
-  expect(await exists(cache_dir)).toBeFalse();
+  // The entries are removed. The directory itself stays, so a cache directory that is a
+  // symlink or a mount point keeps working.
+  expect(await readdirSorted(cache_dir)).toEqual([]);
+});
+
+it("bun install treats an empty BUN_INSTALL_CACHE_DIR as unset instead of caching into the project", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  using side = tempDir("pm-cache-empty-var-install", { "home/.keep": "", "tmp/.keep": "" });
+  // dummyBeforeEach writes a bunfig.toml that disables the cache. This test needs it on.
+  await writeFile(join(package_dir, "bunfig.toml"), `[install]\nregistry = "${root_url}/"\n`);
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "0.0.2",
+      },
+    }),
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: "", BUN_INSTALL: undefined, XDG_CACHE_HOME: undefined }),
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  expect(urls.sort()).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+  const cacheEntry = (name: string) => name.includes("@@") || name.endsWith(".npm");
+  expect((await readdirSorted(package_dir)).filter(cacheEntry)).toEqual([]);
+  expect((await readdirSorted(join(String(side), "home", ".bun", "install", "cache"))).filter(cacheEntry)).not.toEqual(
+    [],
+  );
+});
+
+/**
+ * Environment for the `bun pm cache` tests. Every directory the cache directory
+ * resolution can fall back to, and the temp directory that `bun pm cache rm` sweeps for
+ * bunx entries, is inside `side`, so neither behavior under test can reach anything
+ * outside the test's own temp directories. `BUN_INSTALL_CACHE_DIR` is unset unless the
+ * test sets it. An override of `undefined` unsets the variable.
+ */
+function cacheEnv(side: string, overrides: Record<string, string | undefined> = {}): NodeJS.Dict<string> {
+  const spawnEnv: NodeJS.Dict<string> = {
+    ...env,
+    HOME: join(side, "home"),
+    USERPROFILE: join(side, "home"),
+    XDG_CACHE_HOME: join(side, "xdg-cache"),
+    BUN_INSTALL: join(side, "bun-install"),
+    TMPDIR: join(side, "tmp"),
+    TMP: join(side, "tmp"),
+    TEMP: join(side, "tmp"),
+    ...overrides,
+  };
+  if (!("BUN_INSTALL_CACHE_DIR" in overrides)) {
+    delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+  }
+  for (const key of Object.keys(spawnEnv)) {
+    if (spawnEnv[key] === undefined) delete spawnEnv[key];
+  }
+  return spawnEnv;
+}
+
+async function pmCache(args: string[], cwd: string, spawnEnv: NodeJS.Dict<string>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "cache", ...args],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: spawnEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+const sideFiles = {
+  "home/.ssh/id_canary": "keep",
+  "bun-install/bin/bun-canary": "keep",
+  "bun-install/install/cache/bar@0.0.2@@@1/package.json": "{}",
+  "bun-install/install/cache/0123456789abcdef.npm": "manifest",
+  "xdg-cache/.keep": "",
+  "tmp/.keep": "",
+};
+
+const projectFiles = {
+  "proj/package.json": JSON.stringify({ name: "demo" }),
+  "proj/src/index.ts": "console.log(1);\n",
+  "proj/.git/HEAD": "ref: refs/heads/main\n",
+  "sibling/keep.txt": "keep",
+};
+
+const projectEntries = [".git", "package.json", "src"];
+const envCacheEntries = ["0123456789abcdef.npm", "bar@0.0.2@@@1"];
+
+// The bunx count is always 0: `cacheEnv` points the temp directory at an empty one.
+const cleared = {
+  stdout: "Cleared 'bun install' cache\nCleared 0 cached 'bunx' packages\n",
+  stderr: "",
+  exitCode: 0,
+};
+
+function refused(cacheDir: string, reason: string) {
+  return {
+    stdout: "Cleared 0 cached 'bunx' packages\n",
+    stderr:
+      `error: refusing to clear "${cacheDir}": ${reason}\n` +
+      "note: the cache directory comes from $BUN_INSTALL_CACHE_DIR or $BUN_INSTALL. " +
+      "Point it at a directory that holds nothing but the bun install cache.\n",
+    exitCode: 1,
+  };
+}
+
+describe("bun pm cache with an empty variable", () => {
+  test("an empty BUN_INSTALL_CACHE_DIR falls through to the next location", async () => {
+    using side = tempDir("pm-cache-empty-cache-dir", sideFiles);
+    using root = tempDir("pm-cache-empty-cache-dir-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const spawnEnv = cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: "" });
+    const envCache = join(String(side), "bun-install", "install", "cache");
+
+    expect(await pmCache([], proj, spawnEnv)).toEqual({ stdout: envCache, stderr: "", exitCode: 0 });
+
+    const result = await pmCache(["rm"], proj, spawnEnv);
+    expect(await readdirSorted(proj)).toEqual(projectEntries);
+    expect(await readdirSorted(envCache)).toEqual([]);
+    expect(result).toEqual(cleared);
+  });
+
+  test("an empty BUN_INSTALL falls through to the next location", async () => {
+    using side = tempDir("pm-cache-empty-bun-install", sideFiles);
+    using root = tempDir("pm-cache-empty-bun-install-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const spawnEnv = cacheEnv(String(side), { BUN_INSTALL: "" });
+
+    expect(await pmCache([], proj, spawnEnv)).toEqual({
+      stdout: join(String(side), "xdg-cache", ".bun", "install", "cache"),
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await exists(join(proj, "install"))).toBeFalse();
+  });
+});
+
+describe("bun pm cache rm refuses a cache directory that holds more than the cache", () => {
+  test("the project directory", async () => {
+    using side = tempDir("pm-cache-rm-project", sideFiles);
+    using root = tempDir("pm-cache-rm-project-project", projectFiles);
+    const proj = join(String(root), "proj");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: proj }));
+    expect(await readdirSorted(proj)).toEqual(projectEntries);
+    expect(result).toEqual(refused(proj, `it is the project directory ("${proj}")`));
+  });
+
+  test("a parent of the project directory (relative setting)", async () => {
+    using side = tempDir("pm-cache-rm-parent", sideFiles);
+    using root = tempDir("pm-cache-rm-parent-project", projectFiles);
+    const proj = join(String(root), "proj");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: ".." }));
+    expect(await readdirSorted(String(root))).toEqual(["proj", "sibling"]);
+    expect(await readdirSorted(proj)).toEqual(projectEntries);
+    expect(result).toEqual(refused(String(root), `it contains the project directory ("${proj}")`));
+  });
+
+  test("the directory the command runs from, inside a workspace", async () => {
+    using side = tempDir("pm-cache-rm-cwd", sideFiles);
+    using root = tempDir("pm-cache-rm-cwd-workspace", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      "packages/a/package.json": JSON.stringify({ name: "a" }),
+      "packages/b/package.json": JSON.stringify({ name: "b" }),
+    });
+    const packages = join(String(root), "packages");
+    const cwd = join(packages, "a");
+
+    const result = await pmCache(["rm"], cwd, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: packages }));
+    expect(await readdirSorted(packages)).toEqual(["a", "b"]);
+    expect(result).toEqual(refused(packages, `it contains the current directory ("${cwd}")`));
+  });
+
+  test("the home directory", async () => {
+    using side = tempDir("pm-cache-rm-home", sideFiles);
+    using root = tempDir("pm-cache-rm-home-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const home = join(String(side), "home");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: home }));
+    expect(await exists(join(home, ".ssh", "id_canary"))).toBeTrue();
+    expect(result).toEqual(refused(home, `it is the home directory ("${home}")`));
+  });
+
+  test("$BUN_INSTALL", async () => {
+    using side = tempDir("pm-cache-rm-bun-install", sideFiles);
+    using root = tempDir("pm-cache-rm-bun-install-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const bunInstall = join(String(side), "bun-install");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: bunInstall }));
+    expect(await exists(join(bunInstall, "bin", "bun-canary"))).toBeTrue();
+    expect(result).toEqual(refused(bunInstall, `it is $BUN_INSTALL ("${bunInstall}")`));
+  });
+
+  test("a symlink to the home directory", async () => {
+    using side = tempDir("pm-cache-rm-symlink-home", sideFiles);
+    using root = tempDir("pm-cache-rm-symlink-home-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const home = join(String(side), "home");
+    const link = join(String(root), "cache-link");
+    await symlink(home, link, "junction");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: link }));
+    expect(await exists(join(home, ".ssh", "id_canary"))).toBeTrue();
+    expect(result).toEqual(refused(home, `it is the home directory ("${home}")`));
+  });
+});
+
+describe("bun pm cache rm clears the entries and keeps the directory", () => {
+  test("a cache directory that is a symlink", async () => {
+    using side = tempDir("pm-cache-rm-symlink", sideFiles);
+    using root = tempDir("pm-cache-rm-symlink-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const target = join(String(side), "bun-install", "install", "cache");
+    const link = join(String(root), "cache-link");
+    await symlink(target, link, "junction");
+    expect(await readdirSorted(target)).toEqual(envCacheEntries);
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: link }));
+    expect(await readdirSorted(target)).toEqual([]);
+    expect((await lstat(link)).isSymbolicLink()).toBeTrue();
+    expect(await readdirSorted(link)).toEqual([]);
+    expect(result).toEqual(cleared);
+  });
+
+  test("an entry that is a symlink is unlinked, not followed", async () => {
+    using side = tempDir("pm-cache-rm-entry-symlink", sideFiles);
+    using root = tempDir("pm-cache-rm-entry-symlink-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const envCache = join(String(side), "bun-install", "install", "cache");
+    const sibling = join(String(root), "sibling");
+    await symlink(sibling, join(envCache, "escape@1.0.0@@@1"), "junction");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side)));
+    expect(await readdirSorted(envCache)).toEqual([]);
+    expect(await readdirSorted(sibling)).toEqual(["keep.txt"]);
+    expect(result).toEqual(cleared);
+  });
+
+  test("a cache directory that does not exist is not created", async () => {
+    using side = tempDir("pm-cache-rm-missing", sideFiles);
+    using root = tempDir("pm-cache-rm-missing-project", projectFiles);
+    const proj = join(String(root), "proj");
+    const missing = join(String(side), "does-not-exist");
+
+    const result = await pmCache(["rm"], proj, cacheEnv(String(side), { BUN_INSTALL_CACHE_DIR: missing }));
+    expect(await exists(missing)).toBeFalse();
+    expect(result).toEqual(cleared);
+  });
+
+  test("a cache directory named by the project's .npmrc is not the one cleared", async () => {
+    using side = tempDir("pm-cache-rm-npmrc", sideFiles);
+    using root = tempDir("pm-cache-rm-npmrc-project", { ...projectFiles, "proj/.npmrc": "cache=.\n" });
+    const proj = join(String(root), "proj");
+    const envCache = join(String(side), "bun-install", "install", "cache");
+    const spawnEnv = cacheEnv(String(side));
+
+    // `bun pm cache` (like `bun install`) reads the directory from the .npmrc...
+    expect(await pmCache([], proj, spawnEnv)).toEqual({ stdout: proj, stderr: "", exitCode: 0 });
+
+    // ...but a file committed to the repository cannot choose what `bun pm cache rm` deletes.
+    const result = await pmCache(["rm"], proj, spawnEnv);
+    expect(await readdirSorted(proj)).toEqual([".git", ".npmrc", "package.json", "src"]);
+    expect(await readdirSorted(envCache)).toEqual([]);
+    expect(result).toEqual(cleared);
+  });
 });
 
 it("bun pm migrate", async () => {


### PR DESCRIPTION
### Problem
- `BUN_INSTALL_CACHE_DIR=` (set, empty) makes `bun pm cache rm` delete the project directory and print `Cleared 'bun install' cache`. `bun install` caches into the project root. `BUN_INSTALL=` resolves to `<project>/install/cache`. An unset Docker build argument produces this.
- Cause: `fetch_cache_directory_path` (`PackageManagerDirectories.rs:382`) takes the empty value as a path, and `abs(&[b""])` is the project directory.
- `bun pm cache rm` (`package_manager_command.rs:442`) then runs `delete_tree_absolute` on the real path of the setting, whatever it is. `=$HOME` removes the home directory.

### Fix
- An empty `BUN_INSTALL_CACHE_DIR`, `BUN_INSTALL`, `XDG_CACHE_HOME`, or `HOME` counts as unset. This covers `install`, `pm cache`, and `pm cache rm`.
- New `clear_cache_directory` opens the directory without creating it. It refuses when the real path is a filesystem root, or is or contains the home directory, the bun executable, `$BUN_INSTALL`, the project, or the directory the command ran from. Both sides are real paths, so a symlink to `$HOME` is refused too.
- It removes the entries with the existing `Dir::delete_tree` walker and keeps the directory, so a symlinked or mounted cache keeps working.
- Verified: `test/cli/install/bun-pm.test.ts`, 14 tests fail unfixed, 32 pass fixed. Also `npmrc.test.ts` and `cargo check` for the Windows and macOS targets.

### Background
- Resolution order: `BUN_INSTALL_CACHE_DIR`, project config (`--cache-dir`, bunfig, `.npmrc` `cache=`), then `BUN_INSTALL`, `XDG_CACHE_HOME`, `HOME`.
- Since #31495, `pm cache rm` reads the process environment only, so a committed `.npmrc` or `.env` cannot choose what it deletes. `pm cache` and `install` still read project config. This PR keeps and tests that split.
- `is_parent_or_equal` (`resolve_path.rs:77`) is the containment check `bin.rs` already uses on real paths.

<details><summary>Notes</summary>

Repro on 1.4.0:

```
T=$(mktemp -d); mkdir -p $T/proj/src; cd $T/proj; echo '{"name":"demo"}' > package.json
BUN_INSTALL_CACHE_DIR= bun pm cache      # prints $T/proj
BUN_INSTALL_CACHE_DIR= bun pm cache rm   # Cleared 'bun install' cache, exit 0
ls $T/proj                               # No such file or directory
```

With this change, the second command clears `$HOME/.bun/install/cache` and the project stays. A misconfigured value reports, for example:

```
error: refusing to clear "/home/u": it is the home directory ("/home/u")
note: the cache directory comes from $BUN_INSTALL_CACHE_DIR or $BUN_INSTALL. Point it at a directory that holds nothing but the bun install cache.
```

and exits 1. The bunx sweep of the temp directory still runs, as it does today after a delete error.

The walker underneath is unchanged. `Dir::delete_tree` opens directories with `O_NOFOLLOW` and unlinks symlinks, so an entry that is a symlink only loses the link (tested). The entry names are read before anything is removed, because there is no rmdir here whose `ENOTEMPTY` would catch entries that readdir skipped.

User-visible changes besides the refusals: the cache directory itself is no longer removed (the old test asserted that; it now asserts the directory is empty). A missing cache directory is no longer created and deleted again. `Cleared 'bun install' cache` is printed only when the directory was cleared. A bun executable that lives inside the configured cache directory (possible with the global store, `<cache>/links`) is refused.

Failure modes: when the directory cannot be opened for a reason other than ENOENT, or its real path cannot be read, nothing is deleted and the command exits 1. A protected directory that cannot be opened is compared by its configured path instead, so an unset or missing `$HOME` (common in containers) does not block the command. `self_exe_path` failing is not a gap that can be reached: on Linux it and `get_fd_path` both read `/proc`, so when one fails the other fails first and the command stops, and on macOS and Windows the executable path lookup does not fail.

Not done on purpose:
- A marker file or an allowlist of entry shapes. `bun install` writes into the same misconfigured directory, so a marker would mark `$HOME` too. The entry shapes (`name@ver@@@N`, `@scope/`, `@G@`, `@GH@`, `@T@`, `*.npm`, `*.git`, `.tmp`, `links`) are a long list, and some are generic names.
- Rejecting relative values. `bun install` resolves them against the project, and a value that lands inside the project is the user's setting. The ancestor check covers `.` and `..`.
- The executable test runs a hardlink (or copy) of the binary from inside the temp tree, so the unfixed behavior removes that link and not the build directory.
- A test that points the setting at `/`. On the unfixed build it is a no-op by accident (`delete_tree_absolute` returns early on an empty basename). A test that names the real root is not worth the risk. The `..` test covers the ancestor check.
- `bun_sys::fetch_cache_directory_path` (the `--compile` download cache) has the same empty-value behavior and is being reworked in #34330. `open_global_dir` turns a relative or empty `BUN_INSTALL` into a directory at the filesystem root (`/nstall/global`). That is a separate bug and has been handed off.

#38390 touches the same two functions for a different bug (a setting longer than the path buffer) and needs a small rebase on top of this.

Fail-before (the three `src` files reset to the merge base, then `bun bd test test/cli/install/bun-pm.test.ts`): 14 fail, 18 pass. The failures are the project, `$HOME`, and `$BUN_INSTALL` canaries being deleted, the symlink targets being removed, `bun install` caching into the project, and `bun pm cache` printing the project directory. Every canary lives in a temp directory, so the fail-before run is safe. With the fix: 32 pass.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [380.46ms]
(pass) should list all dependencies [314.20ms]
(pass) should list top-level aliased dependency [324.56ms]
(pass) should list aliased dependencies [320.52ms]
(pass) should list only trusted dependencies with --trusted [433.47ms]
(pass) should list only trusted dependencies with --all --trusted [315.07ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [313.75ms]
(pass) should list nothing with --trusted when no dependencies are trusted [324.35ms]
(pass) should list a workspace the root also depends on once (bun.lock) [372.41ms]
(pass) should list a workspace the root also depends on once (bun.lockb) [293.96ms]
(pass) should list a trusted workspace the root also depends on once with --trusted [305.00ms]
(pass) should list a root optional peer that a dependency provides [324.52ms]
2030 |   hoistPattern?: string | string[];
2031 |   hoist
... (truncated)

release without fix: 17 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [16.29ms]
(pass) should list all dependencies [11.66ms]
(pass) should list top-level aliased dependency [12.16ms]
(pass) should list aliased dependencies [12.10ms]
(pass) should list only trusted dependencies with --trusted [15.55ms]
(pass) should list only trusted dependencies with --all --trusted [12.57ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [12.49ms]
(pass) should list nothing with --trusted when no dependencies are trusted [12.92ms]
597 |   expect(await exists(join(package_dir, lockfile))).toBeTrue();
598 |   urls.length = 0;
599 | 
600 |   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls");
601 |   expect(stderr).toBe("");
602 |   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
                                                          ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "<dir> node_modules (5)
  ├── bar@0.0.2
+ ├── bar@0.0.2
  ├── bar-alias@0.0.2
  ├── ws-once@workspace:packages/ws-once
+
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [371.77ms]
(pass) should list all dependencies [316.81ms]
(pass) should list top-level aliased dependency [311.73ms]
(pass) should list aliased dependencies [313.35ms]
(pass) should list only trusted dependencies with --trusted [432.99ms]
(pass) should list only trusted dependencies with --all --trusted [313.75ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [311.47ms]
(pass) should list nothing with --trusted when no dependencies are trusted [311.60ms]
(pass) should list a workspace the root also depends on once (bun.lock) [339.68ms]
(pass) should list a workspace the root also depends on once (bun.lockb) [307.43ms]
(pass) should list a trusted workspace the root also depends on once with --trusted [324.01ms]
(pass) should list a root optional peer that a dependency provides [316.85ms]
(pass) should remove all cache [455.88ms]
(pass) bun inst
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3d5d8c76e8
  features     baseline

23 deps, 129 codegen, 1172 objects in 725ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 12ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/bui
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |  11 +-
 .../PackageManager/PackageManagerDirectories.rs    | 130 ++++++++-
 src/runtime/cli/package_manager_command.rs         |  63 +++--
 test/cli/install/bun-pm.test.ts                    | 304 ++++++++++++++++++++-
 4 files changed, 469 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/install/PackageManager.rs                                5      2      0
src/install/PackageManager/PackageManagerDirectories.rs      9     19      0
src/runtime/cli/package_manager_command.rs                   7      7      0
test/cli/install/bun-pm.test.ts                             11     23      0
```

</details>

<!-- robobun:evidence:end -->

