### PR TITLE
docs: add bunVersion 1.4.x to the Vercel deploy guide

### DIFF
--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -24,10 +24,7 @@ mode: center
     	}
     	```
 
-    	Vercel accepts two values and manages the patch versions for each:
-
-    	- `"1.4.x"` runs [Bun 1.4](https://bun.com/blog/bun-v1.4), the rewrite of Bun in Rust. It has [behavior changes](https://bun.com/blog/bun-v1.4#behavior-changes); set this once your app runs on 1.4 locally.
-    	- `"1.x"` stays on the previous release line (currently 1.3.14).
+    	Vercel manages the patch version.
 
     	For best results, match your local Bun version with the version Vercel uses.
     </Step>

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -20,11 +20,14 @@ mode: center
 
     	```json vercel.json icon="file-json"
     	{
-    		"bunVersion": "1.x" // [!code ++]
+    		"bunVersion": "1.4.x" // [!code ++]
     	}
     	```
 
-    	The value must be `"1.x"`; Vercel manages the minor and patch versions.
+    	Vercel accepts two values and manages the patch versions for each:
+
+    	- `"1.4.x"` runs [Bun 1.4](https://bun.com/blog/bun-v1.4), the rewrite of Bun in Rust. It has [behavior changes](https://bun.com/blog/bun-v1.4#behavior-changes); set this once your app runs on 1.4 locally.
+    	- `"1.x"` stays on the previous release line (currently 1.3.14).
 
     	For best results, match your local Bun version with the version Vercel uses.
     </Step>
@@ -130,7 +133,7 @@ mode: center
     	console.log("runtime", process.versions.bun);
     	```
     	```txt
-    	runtime 1.3.14
+    	runtime 1.4.0
     	```
 
     	[See the Vercel Bun Runtime documentation for feature support →](https://vercel.com/docs/functions/runtimes/bun#feature-support)


### PR DESCRIPTION
Vercel's Bun runtime now takes `"bunVersion": "1.4.x"`. This updates the deploy guide to use it and bumps the version shown in the verify step.

Source: https://vercel.com/docs/functions/runtimes/bun