### PR TITLE
docs: Vercel no longer labels the Bun runtime as beta

### DIFF
--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -7,8 +7,8 @@ mode: center
 [Vercel](https://vercel.com/) is a cloud platform for building, deploying, and scaling apps. Vercel Functions can run on the Bun runtime, either behind a framework that Vercel supports or as a [`Bun.serve()`](/runtime/http/server) server.
 
 <Warning>
-  The Bun runtime on Vercel is in Beta. Automatic source maps, bytecode caching, and request metrics for `node:http` and
-  `node:https` are not supported yet (request metrics for `fetch` are). See [feature
+  Automatic source maps, bytecode caching, and request metrics for `node:http` and `node:https` are not supported on the
+  Bun runtime (request metrics for `fetch` are). See [feature
   support](https://vercel.com/docs/functions/runtimes/bun#feature-support) in the Vercel documentation.
 </Warning>
 


### PR DESCRIPTION
Vercel's docs for the Bun runtime no longer say "beta". Drops the word from the warning in the deploy guide and keeps the list of unsupported features.

Follow-up to #39753.