### PR TITLE
child_process: expose the parent-end pipe fd through stream._handle

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -44,6 +44,30 @@ var Uint8ArrayPrototypeIncludes = Uint8Array.prototype.includes;
 const MAX_BUFFER = 1024 * 1024;
 const kFromNode = Symbol("kFromNode");
 
+const setStdioBlocking = $newRustFunction("subprocess.rs", "setStdioBlocking", 2);
+
+// Minimal stand-in for Node's `Pipe` handle on piped child stdio streams.
+// It exposes the raw parent-end fd for synchronous fd-based IPC
+// (`fs.readSync`/`fs.writeSync` on `stream._handle.fd`, the pattern used by
+// TypeScript 7's sync API) plus `setBlocking`, which such consumers call
+// before a blocking read. The fd stays owned by the native stream; closing
+// it here would double-close.
+class StdioPipeHandle {
+  #getFd;
+  constructor(getFd) {
+    this.#getFd = getFd;
+  }
+  get fd() {
+    const fd = this.#getFd();
+    return typeof fd === "number" ? fd : -1;
+  }
+  setBlocking(blocking) {
+    const fd = this.fd;
+    if (fd < 0) return false;
+    return setStdioBlocking(fd, !!blocking);
+  }
+}
+
 // Pass DEBUG_CHILD_PROCESS=1 to enable debug output
 if ($debug) {
   $debug("child_process: debug mode on");
@@ -1214,6 +1238,17 @@ class ChildProcess extends EventEmitter {
             }
             const result = require("internal/fs/streams").writableFromFileSink(stdin);
             result.readable = false;
+            result._handle = new StdioPipeHandle(() => stdin._getFd());
+            // Node's child.stdin is a net.Socket, which has ref/unref.
+            // Forward them to the FileSink (fs.WriteStream has neither).
+            result.ref = function ref() {
+              stdin.ref();
+              return this;
+            };
+            result.unref = function unref() {
+              stdin.unref();
+              return this;
+            };
             return result;
           }
           case "inherit":
@@ -1252,6 +1287,10 @@ class ChildProcess extends EventEmitter {
             }
 
             const pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
+            const ptr = pipe.$bunNativePtr;
+            if (ptr) {
+              pipe._handle = new StdioPipeHandle(() => ptr.getFd());
+            }
             this.#closesNeeded++;
             pipe.once("close", () => this.#maybeClose());
             if (autoResume) pipe.resume();

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -46,12 +46,9 @@ const kFromNode = Symbol("kFromNode");
 
 const setStdioBlocking = $newRustFunction("subprocess.rs", "setStdioBlocking", 2);
 
-// Minimal stand-in for Node's `Pipe` handle on piped child stdio streams.
-// It exposes the raw parent-end fd for synchronous fd-based IPC
-// (`fs.readSync`/`fs.writeSync` on `stream._handle.fd`, the pattern used by
-// TypeScript 7's sync API) plus `setBlocking`, which such consumers call
-// before a blocking read. The fd stays owned by the native stream; closing
-// it here would double-close.
+// Stand-in for Node's `Pipe` handle on piped child stdio: consumers read
+// `stream._handle.fd` and call `setBlocking` for synchronous fd-based IPC
+// with readSync/writeSync. The native stream owns the fd.
 class StdioPipeHandle {
   #getFd;
   constructor(getFd) {
@@ -1239,8 +1236,7 @@ class ChildProcess extends EventEmitter {
             const result = require("internal/fs/streams").writableFromFileSink(stdin);
             result.readable = false;
             result._handle = new StdioPipeHandle(() => stdin._getFd());
-            // Node's child.stdin is a net.Socket, which has ref/unref.
-            // Forward them to the FileSink (fs.WriteStream has neither).
+            // Node's child.stdin is a net.Socket: forward ref/unref to the FileSink.
             result.ref = function ref() {
               stdin.ref();
               return this;

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1236,13 +1236,23 @@ class ChildProcess extends EventEmitter {
             const result = require("internal/fs/streams").writableFromFileSink(stdin);
             result.readable = false;
             result._handle = new StdioPipeHandle(() => stdin._getFd());
-            // Node's child.stdin is a net.Socket: forward ref/unref to the FileSink.
+            // Node's child.stdin is a net.Socket: forward ref/unref to the
+            // FileSink, edge-triggered like a Socket. The sink starts ref'd
+            // and #spawn's eager-load loop calls ref() on every slot, so a
+            // bare counter would need two unref() calls to take effect.
+            let refed = true;
             result.ref = function ref() {
-              stdin.ref();
+              if (!refed) {
+                refed = true;
+                stdin.ref();
+              }
               return this;
             };
             result.unref = function unref() {
-              stdin.unref();
+              if (refed) {
+                refed = false;
+                stdin.unref();
+              }
               return this;
             };
             return result;
@@ -1283,9 +1293,11 @@ class ChildProcess extends EventEmitter {
             }
 
             const pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
+            // A pipe that already drained to a buffer has a Blob source with
+            // no getFd; the handle getter maps the undefined to -1.
             const ptr = pipe.$bunNativePtr;
             if (ptr) {
-              pipe._handle = new StdioPipeHandle(() => ptr.getFd());
+              pipe._handle = new StdioPipeHandle(() => ptr.getFd?.());
             }
             this.#closesNeeded++;
             pipe.once("close", () => this.#maybeClose());
@@ -1731,7 +1743,7 @@ function streamFdOf(item): number | undefined {
 
   const handle = item._handle;
   const handleFd = handle ? handle.fd : undefined;
-  if (typeof handleFd === "number") return handleFd;
+  if (typeof handleFd === "number" && handleFd >= 0) return handleFd;
 
   if (item.destroyed) return undefined;
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1584,6 +1584,37 @@ pub(crate) extern "C" fn on_pipe_close(this: *mut bun_sys::windows::libuv::Pipe)
     drop(unsafe { bun_core::heap::take(this) });
 }
 
+/// `node:child_process` exposes the parent-end fd of a piped stdio stream
+/// through a Node-style `stream._handle`. Spawn sets that fd nonblocking, so
+/// `_handle.setBlocking(true)` must clear `O_NONBLOCK` for callers that block
+/// in `fs.readSync` / `fs.writeSync` for synchronous fd-based IPC. Returns
+/// whether the flag was applied. No-op `false` on Windows: pipes there have
+/// no CRT fd, like Node.
+#[bun_jsc::host_fn]
+pub(crate) fn set_stdio_blocking(
+    _global_this: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    let [fd_value, blocking_value] = callframe.arguments_as_array::<2>();
+    let fd = fd_value.to_int32();
+    #[cfg(windows)]
+    {
+        let _ = (fd, blocking_value);
+        Ok(JSValue::FALSE)
+    }
+    #[cfg(not(windows))]
+    {
+        if fd < 0 {
+            return Ok(JSValue::FALSE);
+        }
+        let nonblocking = blocking_value != JSValue::TRUE;
+        match bun_sys::update_nonblocking(bun_sys::Fd::from_native(fd), nonblocking) {
+            Ok(()) => Ok(JSValue::TRUE),
+            Err(_) => Ok(JSValue::FALSE),
+        }
+    }
+}
+
 pub mod testing_apis {
     use super::*;
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1584,12 +1584,10 @@ pub(crate) extern "C" fn on_pipe_close(this: *mut bun_sys::windows::libuv::Pipe)
     drop(unsafe { bun_core::heap::take(this) });
 }
 
-/// `node:child_process` exposes the parent-end fd of a piped stdio stream
-/// through a Node-style `stream._handle`. Spawn sets that fd nonblocking, so
-/// `_handle.setBlocking(true)` must clear `O_NONBLOCK` for callers that block
-/// in `fs.readSync` / `fs.writeSync` for synchronous fd-based IPC. Returns
-/// whether the flag was applied. No-op `false` on Windows: pipes there have
-/// no CRT fd, like Node.
+/// `child_process` `stream._handle.setBlocking(fd, blocking)`: spawn sets the
+/// parent-end pipe fd nonblocking, so blocking `fs.readSync` IPC needs
+/// `O_NONBLOCK` cleared. Returns whether the flag was applied (`false` on
+/// Windows: no CRT fd, like Node).
 #[bun_jsc::host_fn]
 pub(crate) fn set_stdio_blocking(
     _global_this: &JSGlobalObject,

--- a/src/runtime/api/streams.classes.ts
+++ b/src/runtime/api/streams.classes.ts
@@ -88,6 +88,10 @@ function source(name) {
               fn: "setFlowingFromJS",
               length: 1,
             },
+            getFd: {
+              fn: "getFdFromJS",
+              length: 0,
+            },
           }
         : {}),
     },

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1020,10 +1020,9 @@ impl FileReader {
         self.reader().memory_cost() + self.buffered.get().capacity()
     }
 
-    /// Raw fd as a JS-visible number, `-1` when closed or not fd-backed.
-    /// Before `start` (a lazy subprocess pipe) the fd lives in the
-    /// `BufferedReader`, not in `self.fd`. Windows pipes have no CRT fd, so
-    /// return `-1` there like Node's `StreamBase::GetFD`.
+    /// Raw fd as a JS-visible number, `-1` when closed or not fd-backed (all
+    /// Windows pipes, like Node's `StreamBase::GetFD`). Before `start` the fd
+    /// lives in the `BufferedReader`, not `self.fd`.
     pub(crate) fn get_fd(&self) -> i32 {
         #[cfg(windows)]
         {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1030,6 +1030,11 @@ impl FileReader {
         }
         #[cfg(not(windows))]
         {
+            // `self.fd` is a cache that `on_start` fills and nothing clears,
+            // so gate on reader liveness or a closed fd leaks a stale number.
+            if self.done.get() || self.reader().is_done() {
+                return -1;
+            }
             let mut fd = self.fd.get();
             if fd == Fd::INVALID {
                 fd = self.reader().get_fd();

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1019,6 +1019,25 @@ impl FileReader {
         // ReadableStreamSource covers @sizeOf(FileReader)
         self.reader().memory_cost() + self.buffered.get().capacity()
     }
+
+    /// Raw fd as a JS-visible number, `-1` when closed or not fd-backed.
+    /// Before `start` (a lazy subprocess pipe) the fd lives in the
+    /// `BufferedReader`, not in `self.fd`. Windows pipes have no CRT fd, so
+    /// return `-1` there like Node's `StreamBase::GetFD`.
+    pub(crate) fn get_fd(&self) -> i32 {
+        #[cfg(windows)]
+        {
+            -1
+        }
+        #[cfg(not(windows))]
+        {
+            let mut fd = self.fd.get();
+            if fd == Fd::INVALID {
+                fd = self.reader().get_fd();
+            }
+            if fd == Fd::INVALID { -1 } else { fd.native() }
+        }
+    }
 }
 
 pub type Source = readable_stream::NewSource<FileReader>;
@@ -1071,6 +1090,9 @@ impl readable_stream::SourceContext for FileReader {
     }
     fn set_flowing(&mut self, flag: bool) {
         Self::set_flowing(self, flag)
+    }
+    fn get_fd(&mut self) -> i32 {
+        Self::get_fd(self)
     }
     // toBufferedValue: null
 }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1337,9 +1337,14 @@ impl crate::webcore::sink::JsSinkType for FileSink {
 
 impl FileSink {
     fn get_fd(&self) -> i32 {
-        // `self.fd` is never cleared when the writer closes, so gate on
-        // `done` or a closed fd leaks a stale number.
-        if self.done.get() {
+        // `self.fd` is never cleared when the writer closes, and `end()`
+        // closes the fd without setting `done`, so gate on both or a closed
+        // fd leaks a stale number.
+        #[cfg(windows)]
+        let writer_done = self.writer.get().is_done();
+        #[cfg(not(windows))]
+        let writer_done = self.writer.get().is_done;
+        if self.done.get() || writer_done {
             return -1;
         }
         #[cfg(windows)]

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1337,6 +1337,11 @@ impl crate::webcore::sink::JsSinkType for FileSink {
 
 impl FileSink {
     fn get_fd(&self) -> i32 {
+        // `self.fd` is never cleared when the writer closes, so gate on
+        // `done` or a closed fd leaks a stale number.
+        if self.done.get() {
+            return -1;
+        }
         #[cfg(windows)]
         {
             match self.fd.get().decode_windows() {

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -816,6 +816,12 @@ pub trait SourceContext: Sized {
 
     /// Default no-op.
     fn set_flowing(&mut self, _flag: bool) {}
+
+    /// Raw OS fd behind this source as a JS-visible number. `-1` when the
+    /// source is closed or not fd-backed.
+    fn get_fd(&mut self) -> i32 {
+        -1
+    }
 }
 
 // Hand-wired JSC class (the `#[bun_jsc::JsClass]` derive cannot be used on a
@@ -1276,6 +1282,14 @@ impl<C: SourceContext> NewSource<C> {
         debug_assert!(flag.is_boolean());
         this.context.set_flowing(flag == JSValue::TRUE);
         Ok(JSValue::UNDEFINED)
+    }
+
+    pub fn get_fd_from_js(
+        this: &mut Self,
+        _global: &JSGlobalObject,
+        _call_frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        Ok(JSValue::js_number_from_int32(this.context.get_fd()))
     }
 
     pub fn memory_cost(&self) -> usize {

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { execSync, spawn } from "node:child_process";
 import { once } from "node:events";
+import { readSync, writeSync } from "node:fs";
 
 const CHILD_PROCESS_FILE = import.meta.dir + "/spawned-child.js";
 const OUT_FILE = import.meta.dir + "/stdio-test-out.txt";
@@ -164,5 +165,62 @@ describe("child.stdin", () => {
       ret: false,
       cbCode: "ERR_STREAM_DESTROYED",
     });
+  });
+});
+
+describe("stdio _handle", () => {
+  it("piped stdio streams carry a _handle with a numeric fd", async () => {
+    const child = spawn(bunExe(), ["-e", "setTimeout(() => {}, 100_000)"], {
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    try {
+      expect(typeof child.stdin._handle.fd).toBe("number");
+      expect(typeof child.stdout._handle.fd).toBe("number");
+      expect(typeof child.stderr._handle.fd).toBe("number");
+      if (!isWindows) {
+        // Windows pipes have no CRT fd: Node reports -1 there too.
+        expect(child.stdin._handle.fd).toBeGreaterThanOrEqual(0);
+        expect(child.stdout._handle.fd).toBeGreaterThanOrEqual(0);
+        expect(child.stderr._handle.fd).toBeGreaterThanOrEqual(0);
+      }
+    } finally {
+      child.kill();
+    }
+    await once(child, "exit");
+  });
+
+  // The synchronous fd-based IPC pattern used by TypeScript 7's sync API:
+  // grab the raw fds from _handle, make them blocking, keep the streams
+  // paused, and drive a request/response cycle with writeSync/readSync.
+  it.skipIf(isWindows)("_handle.fd supports blocking readSync/writeSync IPC", async () => {
+    const child = spawn(
+      bunExe(),
+      ["-e", `process.stdin.once("data", d => process.stdout.write("pong:" + d.toString().trim()))`],
+      { env: bunEnv, stdio: ["pipe", "pipe", "inherit"] },
+    );
+    try {
+      const readFd = child.stdout._handle.fd;
+      const writeFd = child.stdin._handle.fd;
+      expect(child.stdout._handle.setBlocking(true)).toBe(true);
+      expect(child.stdin._handle.setBlocking(true)).toBe(true);
+      child.stdout.pause();
+      child.stdout.unref();
+      child.stdin.unref();
+      child.unref();
+
+      writeSync(writeFd, "ping\n");
+      const buf = Buffer.alloc(64);
+      let out = "";
+      while (!out.includes("pong:ping")) {
+        const n = readSync(readFd, buf, 0, buf.length, null);
+        expect(n).toBeGreaterThan(0);
+        out += buf.toString("utf8", 0, n);
+      }
+      expect(out).toBe("pong:ping");
+    } finally {
+      child.kill();
+    }
+    await once(child, "exit");
   });
 });

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -190,6 +190,32 @@ describe("stdio _handle", () => {
     await once(child, "exit");
   });
 
+  it("child.stdin.unref releases the stdin writer keep-alive", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { spawn } = require("node:child_process");
+        const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30_000)"], {
+          stdio: ["pipe", "ignore", "ignore"],
+        });
+        process.on("exit", () => child.kill());
+        // Fill the pipe so the sink's writable poll stays armed, then unref
+        // everything: the process must exit on its own.
+        child.stdin.write(Buffer.alloc(1 << 20, 10));
+        child.stdin.unref();
+        child.unref();
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   // The synchronous fd-based IPC pattern used by TypeScript 7's sync API:
   // grab the raw fds from _handle, make them blocking, keep the streams
   // paused, and drive a request/response cycle with writeSync/readSync.

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -188,6 +188,9 @@ describe("stdio _handle", () => {
       child.kill();
     }
     await once(child, "exit");
+    // The parent-end write fd is closed once the child is gone: the handle
+    // must not leak the stale number.
+    expect(child.stdin._handle.fd).toBe(-1);
   });
 
   it("child.stdin.unref releases the stdin writer keep-alive", async () => {

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -193,6 +193,22 @@ describe("stdio _handle", () => {
     expect(child.stdin._handle.fd).toBe(-1);
   });
 
+  it.skipIf(isWindows)("stdin _handle.fd is -1 after end()", async () => {
+    const child = spawn(bunExe(), ["-e", "process.stdin.resume(); setTimeout(() => {}, 30_000)"], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    try {
+      expect(child.stdin._handle.fd).toBeGreaterThanOrEqual(0);
+      child.stdin.end();
+      await once(child.stdin, "finish");
+      expect(child.stdin._handle.fd).toBe(-1);
+    } finally {
+      child.kill();
+    }
+    await once(child, "exit");
+  });
+
   it("child.stdin.unref releases the stdin writer keep-alive", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Problem

- `child.stdout._handle` is `undefined` for `stdio: "pipe"`, so `stdout._handle.fd` throws `TypeError: undefined is not an object (evaluating 'stdout._handle.fd')`. In Node `_handle` is the `Pipe` wrap and `.fd` is the raw parent-end fd of the pipe.
- TypeScript 7's sync API (`typescript/dist/api/syncChannel.js`) reads `stdout._handle.fd` and `stdin._handle.fd` to build a blocking RPC channel with `fs.readSync`/`fs.writeSync`. It also calls `stdin.unref()`, which the `fs.WriteStream` wrapper did not have.

### Fix

- Piped `child.stdin`/`stdout`/`stderr` now get a minimal `_handle` (`src/js/node/child_process.ts`) with a live `fd` getter and `setBlocking(bool)`. The fd stays owned by the native stream.
- stdout/stderr fds come from a new `getFd` host fn on the File stream source (`streams.classes.ts`, `ReadableStream.rs`, `FileReader.rs`). It reads the fd the `BufferedReader` already holds. stdin uses the existing FileSink `_getFd`. On Windows it returns -1, like Node's `StreamBase::GetFD` for pipes.
- `setBlocking(true)` clears `O_NONBLOCK` (spawn sets it) through a new `setStdioBlocking` host fn in `subprocess.rs`, so `fs.readSync` can block. `child.stdin` also forwards `ref`/`unref` to the FileSink.
- This is safe against the async reader: `child_process` spawns with `lazy: true`, so the native side reads the pipe only once the stream is resumed. A paused stream leaves the fd untouched, which is the state the sync pattern uses.
- Verified: `test/js/node/child_process/child-process-stdio.test.js` (two new tests, both fail on stock bun). Also ran `child_process.test.ts`, `child_process-node.test.js`, `child-process-exec.test.ts`, `child_process_ipc.test.js`.

### Background

- `handle.stdout` from `Bun.spawn` is a web `ReadableStream` whose native source is a `NewSource<FileReader>`. `child_process` converts it to a Node `Readable` that keeps the source as `$bunNativePtr`. `getFd` is a method on that source.
- `on_process_exit` still drains stdout/stderr after the child is reaped. That only races a raw-fd reader after child exit, at which point the sync channel is done (it reads while the child serves requests).

<details><summary>Notes</summary>

The exact consumer sequence (from `typescript@7.0.2` `dist/api/syncChannel.js`, POSIX path):

```js
this.child = spawn(exe, args, { stdio: ["pipe", "pipe", "inherit"] });
this.readFd = stdout._handle.fd;
this.writeFd = stdin._handle.fd;
stdout._handle.setBlocking?.(true);
stdin._handle.setBlocking?.(true);
stdout.pause();
stdout.unref();
stdin.unref();
this.child.unref();
```

All requests then go through `writeSync(this.writeFd, ...)` and `readSync(this.readFd, ...)` with an EAGAIN retry loop. On Windows it does not use `_handle.fd` at all (named pipes instead), so a -1 fd there matches both Node and the consumer.

Node's `uv_stream_set_blocking` on unix only flags blocking writes. Bun's `setBlocking(true)` actually clears `O_NONBLOCK` on the fd, so the consumer's blocking reads work without the 1 ms `Atomics.wait` retry loop it falls back to.

Two unrelated local failures while running the suites: "spawn in the default shell" fails with stock bun in this container too, and "extra stdio pipes are not double-closed on GC" exceeds its 5 s timeout under debug ASAN on a loaded machine (the loop itself completes with OK in 7.3 s, the assert does not fire).

Related: #36316 makes these streams `net.Socket` instances. It does not expose `_handle`, and this change does not depend on it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child-process-stdio.test.js

<!-- robobun:evidence:end -->