### PR TITLE
http: stop dropping TRACE response bodies

### DIFF
--- a/src/http_types/Method.rs
+++ b/src/http_types/Method.rs
@@ -172,8 +172,10 @@ impl Method {
         }
     }
 
+    /// Response side. RFC 9112 §6.3 ends only a HEAD response at the header
+    /// section; a TRACE response echoes the request (RFC 9110 §9.3.8).
     pub fn has_body(self) -> bool {
-        !matches!(self, Method::HEAD | Method::TRACE)
+        !matches!(self, Method::HEAD)
     }
 
     /// RFC 9110: GET/HEAD have no defined body semantics; TRACE "MUST NOT

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test"
 import { bunEnv, bunExe, isASAN, isWindows, rmScope, rss, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
 import { closeSync, openSync, unlinkSync, writeSync } from "node:fs";
+import { connect } from "node:net";
 import { join } from "node:path";
 
 const LARGE_SIZE = 1024 * 1024 * 8;
@@ -1371,4 +1372,36 @@ test("file route serves a burst of concurrent requests after reloads", async () 
 
   const a = await fetch(`${server.url}a`).then(r => r.text());
   expect(a).toBe("a-new");
+});
+
+// RFC 9110 §9.3.8: a TRACE response carries content. Announcing Content-Length
+// and then sending zero bytes desyncs the connection. Read the wire directly so
+// the assertion does not depend on Bun's own HTTP client.
+test("TRACE response backed by Bun.file sends the body", async () => {
+  using dir = tempDir("bun-serve-file-trace", { "hello.txt": "Hello, World!" });
+
+  await using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(Bun.file(join(String(dir), "hello.txt"))),
+  });
+
+  const wire = (method: string) =>
+    new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      const socket = connect(server.port, "127.0.0.1", () => {
+        socket.write(`${method} / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`);
+      });
+      socket.on("data", chunk => chunks.push(chunk));
+      socket.on("error", reject);
+      socket.on("end", () => resolve(Buffer.concat(chunks).toString("latin1")));
+    });
+
+  const [trace, head] = await Promise.all([wire("TRACE"), wire("HEAD")]);
+
+  expect(trace).toMatch(/^content-length: 13\r$/im);
+  expect(trace).toEndWith("\r\n\r\nHello, World!");
+
+  // HEAD is the one method still terminated at the end of the header section.
+  expect(head).toMatch(/^content-length: 13\r$/im);
+  expect(head).toEndWith("\r\n\r\n");
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -801,6 +801,40 @@ describe("fetch", () => {
     }),
   );
 
+  // RFC 9112 §6.3: only a HEAD response is terminated at the end of the header
+  // section. A TRACE response echoes the request as content (RFC 9110 §9.3.8).
+  it.concurrent("reads a TRACE response body", async () => {
+    const echo = "TRACE / HTTP/1.1\r\nhost: bun\r\n";
+    const head = (framing: string) =>
+      `HTTP/1.1 200 OK\r\nContent-Type: message/http\r\n${framing}Connection: close\r\n\r\n`;
+    await using server = net.createServer(socket => {
+      socket.once("data", data => {
+        const [method, path] = String(data).split(" ", 2);
+        if (method === "HEAD") {
+          socket.end(head(`Content-Length: ${echo.length}\r\n`));
+        } else if (path === "/chunked") {
+          socket.end(head("Transfer-Encoding: chunked\r\n") + `${echo.length.toString(16)}\r\n${echo}\r\n0\r\n\r\n`);
+        } else {
+          socket.end(head(`Content-Length: ${echo.length}\r\n`) + echo);
+        }
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const sized = await fetch(`http://127.0.0.1:${port}/`, { method: "TRACE" });
+    expect(sized.headers.get("content-length")).toBe(String(echo.length));
+    expect(await sized.text()).toBe(echo);
+
+    const chunked = await fetch(`http://127.0.0.1:${port}/chunked`, { method: "TRACE" });
+    expect(chunked.headers.get("transfer-encoding")).toBe("chunked");
+    expect(await chunked.text()).toBe(echo);
+
+    const bodiless = await fetch(`http://127.0.0.1:${port}/`, { method: "HEAD" });
+    expect(bodiless.headers.get("content-length")).toBe(String(echo.length));
+    expect(await bodiless.text()).toBe("");
+  });
+
   // WHATWG Fetch only forbids a body for GET and HEAD. OPTIONS with content is
   // legal HTTP (RFC 9110 §9.3.7) and must be sent, not rejected.
   it.concurrent("OPTIONS with body is sent and delivered", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #19615.

`Method::has_body()` in `src/http_types/Method.rs` answers "can a **response** to this method carry content?". It returned `false` for `TRACE` as well as `HEAD`:

```rust
pub fn has_body(self) -> bool {
    !matches!(self, Method::HEAD | Method::TRACE)
}
```

That is the rule for the *request* side, and the sibling predicate right below it already implements that rule correctly:

```rust
pub fn has_request_body(self) -> bool {
    !matches!(self, Method::GET | Method::HEAD | Method::TRACE)
}
```

The response side is drawn differently. [RFC 9112 §6.3](https://www.rfc-editor.org/rfc/rfc9112#section-6.3) says a response to a HEAD request "is always terminated by the first empty line after the header fields ... and thus cannot contain a message body". HEAD is the only method that clause names; the rest are status codes (1xx, 204, 304). [RFC 9110 §9.3.8](https://www.rfc-editor.org/rfc/rfc9110#section-9.3.8) says the recipient of a TRACE "SHOULD reflect the message received ... back to the client as the content of a 200 (OK) response". A TRACE request has no content; a TRACE response does.

Because one predicate served both sides, a single wrong arm produced two separate user-visible bugs.

**1. The `fetch` client dropped TRACE response bodies.**

`src/http/lib.rs:4830` forces `content_length = Some(0)` when `!has_body()`. The comment on that branch (`:4840`) already says "ignore body size for HEAD requests" - it just was not true of the predicate guarding it. `src/http/lib.rs:5278` then short-circuits to `Finished` instead of `ContinueStreaming`, so both the sized and the chunked form were discarded. Bun's own `node:http` delivers the body correctly against the same fixture, so the fixture is not at fault and the defect is confined to the `fetch()` client path.

**2. `Bun.serve` announced a length it never wrote.**

`src/runtime/server/RequestContext.rs:1822` uses the same predicate on the file/sendfile path. A TRACE response backed by `Bun.file()` sent `Content-Length: 13` and then zero bytes. On a keep-alive connection that desyncs the stream: the peer waits for 13 bytes that never arrive and then reads the next response's status line as body.

A string-backed `Bun.serve` response was already correct, which is why the issue looked like a client bug from one angle and a server bug from the other.

The fix is one line:

```rust
pub fn has_body(self) -> bool {
    !matches!(self, Method::HEAD)
}
```

I grepped every `TRACE` mention across `src/` (`.rs`, `.cpp`, `.h`, `.ts`). `has_body` was the only place treating TRACE as bodiless. Everything else is either a method-name table or routing registration and carries no body semantics (`ServerConfig.rs`, `uws_sys/App.rs`, `uws_sys/h3.rs`, `js/internal/http.ts`, the llhttp and BunCommonStrings tables), or is correct as written: `Method::is_idempotent` (retry safety - TRACE is idempotent) and `useChunkedEncodingByDefault` in `src/js/node/_http_client.ts`, which is request-side and matches Node's own list.

One thing worth flagging, since it is the obvious alternative fix. WHATWG Fetch lists TRACE as a [forbidden method](https://fetch.spec.whatwg.org/#forbidden-method), and undici does reject it - Node 24.19.0 throws `TypeError: 'TRACE' HTTP method is unsupported.` for `fetch(url, { method: "TRACE" })`. Bun deliberately allows it (the existing test at `fetch.test.ts:796` asserts only that TRACE *with a request body* throws), and rejecting it would not fix the `Bun.serve` half of this issue anyway. So this PR does not change that policy, it only makes the path Bun already allows behave correctly. Happy to switch to rejecting TRACE in `fetch()` instead if you would rather match undici, but the server-side change is needed either way.

### How did you verify your code works?

Debug build on Linux x64, branch based on `01c4e2fd6d`.

**1. Reproduced first, on a debug build rather than a release.** Raw `node:net` wire capture, because the issue is labelled `bun:serve` but only half of it is server-side:

| surface | method | before |
| --- | --- | --- |
| `fetch()` | TRACE | `content-length: 29` announced, body `""` |
| `fetch()` | GET | body delivered (control) |
| `node:http` | TRACE | body delivered (reference) |
| `Bun.serve` + string `Response` | TRACE | body on the wire, already correct |
| `Bun.serve` + `Bun.file()` | TRACE | `content-length: 13`, then zero bytes |
| `Bun.serve` + `Bun.file()` | HEAD | `content-length: 13`, then zero bytes (correct) |

**2. Two tests, in the existing files for the code they cover.**

`test/js/web/fetch/fetch.test.ts` - `reads a TRACE response body`, right after the existing TRACE request-body block. It drives a raw `net.createServer` rather than `Bun.serve`, matching the idiom already used throughout that file, so the wire framing is exact and the server side is not in the loop. Covers `Content-Length`, `Transfer-Encoding: chunked`, and a HEAD control that must still read `""`.

`test/js/bun/http/bun-serve-file.test.ts` - `TRACE response backed by Bun.file sends the body`. Reads the raw socket so the assertion does not route through Bun's own client, plus the same HEAD control.

I originally wrote the chunked case with `Bun.serve` and a `ReadableStream`, then checked the wire: `Bun.serve` collapses a small single-chunk stream into `Content-Length`, so that variant would never have reached the chunked branch at `src/http/lib.rs:5278`. Hence the raw server.

**3. Validated the fixture independently.** The same raw server against Node 24.19.0 `node:http`:

```
sized   {"cl":"29","te":null,"body":"TRACE / HTTP/1.1\r\nhost: bun\r\n"}
chunked {"cl":null,"te":"chunked","body":"TRACE / HTTP/1.1\r\nhost: bun\r\n"}
head    {"cl":"29","te":null,"body":""}
```

All three match what the tests assert, so the fixture is well-formed HTTP and Bun was the outlier.

**4. Both tests fail without the fix and pass with it.**

Restoring `| Method::TRACE` and rebuilding, the client test fails on the body:

```
error: expect(received).toBe(expected)
- "TRACE / HTTP/1.1
- host: bun
- "
+ ""
0 pass, 1 fail
```

and the server test fails on the wire, which is the desync verbatim:

```
error: expect(received).toEndWith(expected)
Expected to end with: "\r\n\r\nHello, World!"
Received: "HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=utf-8\r\ncontent-length: 13\r\nDate: ...\r\n\r\n"
0 pass, 1 fail
```

With the fix rebuilt: `1 pass, 0 fail, 6 expect() calls` and `1 pass, 0 fail, 4 expect() calls`. The fix is a single clause, so deleting it is the whole revert.

**5. Whole files, for regressions.**

```
$ bun bd test test/js/bun/http/bun-serve-file.test.ts --timeout 120000
 106 pass
 1 skip
 3 todo
 0 fail
 4 snapshots, 1366 expect() calls
Ran 110 tests across 1 file. [47.59s]

$ bun bd test test/js/web/fetch/fetch.test.ts --timeout 120000
(fail) simultaneous HTTPS fetch [149061.51ms]
(fail) fetch should allow duplex > does not wedge on Readable.destroy() when _read pushes synchronously [4149.35ms]
(fail) should allow to follow redirect if connection is closed, abort should work even if the socket was closed before the redirect [943.46ms]
 361 pass
 3 fail
 7501 expect() calls
Ran 364 tests across 1 file. [679.39s]
```

None of the three is from this change, and I re-ran each one on its own rather than assuming. The count is not even stable: an earlier full run of the same binary reported `360 pass, 4 fail`. All three are timing bounds rather than assertions about behaviour, and this box is shared: it sat between load 11 and 15 throughout.

- `simultaneous HTTPS fetch` does 80 TLS handshakes against a local `httpsServer`. It blew the 120 s limit at 149 s. Alone, same binary: `1 pass, 0 fail, 164 expect() calls, 10.59s`.
- `does not wedge on Readable.destroy() when _read pushes synchronously` races `proc.exited` against a hardcoded `sleep(isDebug ? 4000 : 2000)` (`fetch.test.ts:2570`) and lost at 4149 ms. Alone: `1 pass, 0 fail, 1 expect() calls, 11.50s`.
- `should allow to follow redirect if connection is closed, ...` is the one that also fails alone (`0 pass, 1 fail, 11.38s`), and in that filtered run my TRACE test never executes, so this change is not in the picture. It is already diagnosed in #37913: the success path carries a hardcoded `AbortSignal.timeout(150)` (`fetch.test.ts:2900`) that a debug build needs 250 to 650 ms to beat. Left alone since that PR is open.

**6. Lints.** `cargo fmt --check` clean, `cargo clippy -p bun_http_types --no-deps` exit 0, `bun run lint` 0 warnings 0 errors, prettier clean on both test files.
