### PR TITLE
Fix invalid ad-hoc code signature on `bun build --compile` darwin-arm64 output

### DIFF
--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -511,18 +511,20 @@ impl MachoFile {
         Ok(())
     }
 
-    pub fn build_and_sign(&self, writer: &mut impl std::io::Write) -> crate::Result<()> {
+    /// Returns the number of bytes written so the caller can truncate an output
+    /// file that started as a copy of a larger template.
+    pub fn build_and_sign(&self, writer: &mut impl std::io::Write) -> crate::Result<usize> {
         if self.header.cputype == macho::CPU_TYPE_ARM64
             && feature_flag::BUN_NO_CODESIGN_MACHO_BINARY.get() != Some(true)
         {
             let mut data: Vec<u8> = Vec::new();
             self.build(&mut data)?;
             let mut signer = MachoSigner::init(&data)?;
-            signer.sign(writer)?;
+            signer.sign(writer)
         } else {
             self.build(writer)?;
+            Ok(self.data.len())
         }
-        Ok(())
     }
 }
 
@@ -674,7 +676,7 @@ impl MachoSigner {
         super_blob_header_size + blob_index_size + code_dir_length
     }
 
-    fn sign(&mut self, writer: &mut impl std::io::Write) -> crate::Result<()> {
+    fn sign(&mut self, writer: &mut impl std::io::Write) -> crate::Result<usize> {
         const PAGE_SIZE: usize = MachoSigner::SIGNATURE_PAGE_SIZE;
         const HASH_SIZE: usize = MachoSigner::SIGNATURE_HASH_SIZE;
 
@@ -772,19 +774,13 @@ impl MachoSigner {
             off += PAGE_SIZE;
         }
 
+        // The final partial page is hashed truncated to `code_limit % PAGE_SIZE` bytes,
+        // not zero-padded — that is what the kernel and codesign(1) compute.
         if end - off > 0 {
-            let remaining_len = end - off;
-            let mut last_page = [0u8; PAGE_SIZE];
-            // SAFETY: range [off..end] is within the original len.
-            unsafe {
-                core::ptr::copy_nonoverlapping(
-                    self.data.as_ptr().add(off),
-                    last_page.as_mut_ptr(),
-                    remaining_len,
-                );
-            }
             let mut digest = [0u8; HASH_SIZE];
-            sha256_hash(&last_page, &mut digest);
+            // SAFETY: range [off..end] is within the original len (sig_off).
+            let page = unsafe { core::slice::from_raw_parts(self.data.as_ptr().add(off), end - off) };
+            sha256_hash(page, &mut digest);
             self.data.extend_from_slice(&digest);
         }
 
@@ -805,7 +801,7 @@ impl MachoSigner {
 
         // Write final binary
         writer.write_all(&self.data)?;
-        Ok(())
+        Ok(final_len)
     }
 }
 

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -779,7 +779,8 @@ impl MachoSigner {
         if end - off > 0 {
             let mut digest = [0u8; HASH_SIZE];
             // SAFETY: range [off..end] is within the original len (sig_off).
-            let page = unsafe { core::slice::from_raw_parts(self.data.as_ptr().add(off), end - off) };
+            let page =
+                unsafe { core::slice::from_raw_parts(self.data.as_ptr().add(off), end - off) };
             sha256_hash(page, &mut digest);
             self.data.extend_from_slice(&digest);
         }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1472,16 +1472,29 @@ pub(crate) fn inject<'a>(
                 512 * 1024,
                 bun_sys::FileWriter(cloned_executable_fd),
             );
-            if let Err(e) = macho_file.build_and_sign(&mut buffered_writer) {
-                bun_core::pretty_errorln!(
-                    "Error writing standalone module graph: {}",
-                    bstr::BStr::new(e.name())
-                );
+            let written = match macho_file.build_and_sign(&mut buffered_writer) {
+                Ok(written) => written,
+                Err(e) => {
+                    bun_core::pretty_errorln!(
+                        "Error writing standalone module graph: {}",
+                        bstr::BStr::new(e.name())
+                    );
+                    cleanup(zname, cloned_executable_fd);
+                    return None;
+                }
+            };
+            if let Err(e) = std::io::Write::flush(&mut buffered_writer) {
+                bun_core::pretty_errorln!("Error flushing standalone module graph: {}", e);
                 cleanup(zname, cloned_executable_fd);
                 return None;
             }
-            if let Err(e) = std::io::Write::flush(&mut buffered_writer) {
-                bun_core::pretty_errorln!("Error flushing standalone module graph: {}", e);
+            // The temp file started as a copy of the template, whose original signature
+            // (CMS blob, requirements) is larger than the ad-hoc one written here.
+            if let Err(err) = Syscall::ftruncate(
+                cloned_executable_fd,
+                i64::try_from(written).expect("int cast"),
+            ) {
+                bun_core::pretty_errorln!("Error truncating Mach-O file: {}", err);
                 cleanup(zname, cloned_executable_fd);
                 return None;
             }

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isArm64, isMacOS, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
@@ -1392,7 +1392,7 @@ test("compile --compile-executable-path rejects a template shorter than the exec
   }
 }, 60_000);
 
-test.skipIf(!isMacOS || process.arch !== "arm64")(
+test.skipIf(!isMacOS || !isArm64)(
   "compile on darwin-arm64 produces a signature the kernel accepts",
   async () => {
     // The in-process ad-hoc signer must hash the final partial page truncated to
@@ -1415,7 +1415,9 @@ test.skipIf(!isMacOS || process.arch !== "arm64")(
         stderr: "pipe",
       });
       const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("error:");
+      if (exitCode !== 0) {
+        expect(stderr).toBe("");
+      }
       expect(exitCode).toBe(0);
     }
 
@@ -1436,6 +1438,9 @@ test.skipIf(!isMacOS || process.arch !== "arm64")(
 
     const result = await Bun.$`${outfile}`.cwd(cwd).env(bunEnv).nothrow();
     expect(result.stdout.toString()).toBe("signed\n");
+    if (result.exitCode !== 0) {
+      expect(result.stderr.toString()).toBe("");
+    }
     expect(result.exitCode).toBe(0);
   },
   60_000,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
@@ -1391,3 +1391,52 @@ test("compile --compile-executable-path rejects a template shorter than the exec
     expect(exitCode).toBe(1);
   }
 }, 60_000);
+
+test.skipIf(!isMacOS || process.arch !== "arm64")(
+  "compile on darwin-arm64 produces a signature the kernel accepts",
+  async () => {
+    // The in-process ad-hoc signer must hash the final partial page truncated to
+    // `codeLimit % 4096` bytes (as the kernel and codesign(1) do), and the output must end
+    // exactly at the end of the signature. A wrong last-page hash is not caught by merely
+    // running the binary — the kernel only validates a page when it is faulted in, which
+    // is why the same defect was fatal on some macOS/layout combinations and invisible
+    // on others (#39764).
+    using dir = tempDir("compile-macho-codesign", {
+      "entry.js": `console.log("signed");`,
+    });
+    const cwd = String(dir);
+    const outfile = join(cwd, "app");
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", join(cwd, "entry.js"), "--outfile", outfile],
+        env: bunEnv,
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    await using verify = Bun.spawn({
+      cmd: ["codesign", "--verify", "--strict", "--verbose=2", outfile],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [verifyOut, verifyErr, verifyCode] = await Promise.all([
+      verify.stdout.text(),
+      verify.stderr.text(),
+      verify.exited,
+    ]);
+    expect(verifyOut + verifyErr).toBe(`${outfile}: valid on disk\n${outfile}: satisfies its Designated Requirement\n`);
+    expect(verifyCode).toBe(0);
+
+    const result = await Bun.$`${outfile}`.cwd(cwd).env(bunEnv).nothrow();
+    expect(result.stdout.toString()).toBe("signed\n");
+    expect(result.exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
Fixes #39764

### Problem

`bun build --compile` binaries on darwin-arm64 fail `codesign -v` with `invalid signature (code or signature have been modified)`, and on macOS 27 the process is SIGKILLed at launch.

### Cause

`MachoSigner::sign()` in `src/exe_format/macho.rs` hashes the code region in 4096-byte pages. For the final partial page it copied the remaining bytes into a zeroed 4096-byte buffer and hashed the whole buffer. The kernel and `codesign(1)` hash the last page truncated to `codeLimit % 4096` bytes, so the last CodeDirectory slot never matched.

Separately, `inject()` in `src/standalone_graph/StandaloneModuleGraph.rs` never truncated the Mach-O output. The temp file starts as a copy of the template, whose original signature can be larger than the ad-hoc one written here, leaving a stale tail past the signature that `codesign --strict` rejects. The ELF and PE branches already `ftruncate`.

### Fix

- Hash the trailing `codeLimit % 4096` bytes directly.
- `build_and_sign()` returns the bytes written; `inject()` truncates the output to it.

### Verification

Compiled with the debug build on macOS arm64:

```
$ codesign --verify --strict --verbose=2 ./app
./app: valid on disk
./app: satisfies its Designated Requirement
```

All CodeDirectory page hashes recomputed externally match, and the file ends exactly at the signature end.

New test in `test/bundler/bundler_compile.test.ts` (darwin-arm64 only) compiles, runs `codesign --verify --strict`, and runs the binary. It fails on bun 1.4.0 with the `invalid signature` error above.