### PR TITLE
install: resolve a bare npm: alias to the latest dist-tag

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1379,9 +1379,14 @@ pub(crate) fn edit(
                     let installed = request.version.literal.slice(request.version_buf());
                     let resolved = resolutions[request.package_id as usize].npm().version;
                     let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+                    // `foo@npm:bar` (no version part) parses as a dist-tag but
+                    // spells no tag, so it is not kept verbatim below.
+                    let bare_alias =
+                        split_npm_alias(installed).is_some_and(|(_, version)| version.is_empty());
                     // `bun update <name>` keeps a dist-tag literal as written unless --latest, like the bare path.
                     if manager.subcommand == Subcommand::Update
                         && request.version.tag == dependency::Tag::DistTag
+                        && !bare_alias
                         && !update_to_latest
                     {
                         break 'npm arena_dup(arena, installed);
@@ -1425,8 +1430,6 @@ pub(crate) fn edit(
                         }
                     }
                     // `foo@npm:bar` (no version part) is saved like `foo` would be: `npm:bar@^<resolved>`.
-                    let bare_alias =
-                        split_npm_alias(installed).is_some_and(|(_, version)| version.is_empty());
                     if request.version.tag == dependency::Tag::DistTag
                         || bare_alias
                         || (manager.subcommand == Subcommand::Update

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1379,8 +1379,7 @@ pub(crate) fn edit(
                     let installed = request.version.literal.slice(request.version_buf());
                     let resolved = resolutions[request.package_id as usize].npm().version;
                     let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                    // `foo@npm:bar` (no version part) parses as a dist-tag but
-                    // spells no tag, so it is not kept verbatim below.
+                    // `foo@npm:bar` parses as a dist-tag but spells no tag to keep verbatim
                     let bare_alias =
                         split_npm_alias(installed).is_some_and(|(_, version)| version.is_empty());
                     // `bun update <name>` keeps a dist-tag literal as written unless --latest, like the bare path.

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -945,8 +945,7 @@ impl TagExt for Tag {
                         }
                     }
 
-                    // no version after the alias means `latest`, like the
-                    // empty string above
+                    // no version after the alias means `latest`
                     return Tag::DistTag;
                 }
             }
@@ -1197,7 +1196,6 @@ pub(crate) fn parse_with_tag(
                         }
 
                         // npm:foo without a version resolves to `latest`
-                        // (the empty tag defaults below)
                         tag_to_use = if i < dependency.len() {
                             sliced.sub(&dependency[i + 1..]).value()
                         } else {

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -945,7 +945,9 @@ impl TagExt for Tag {
                         }
                     }
 
-                    return Tag::Npm;
+                    // no version after the alias means `latest`, like the
+                    // empty string above
+                    return Tag::DistTag;
                 }
             }
             // v1.2.3
@@ -1194,7 +1196,13 @@ pub(crate) fn parse_with_tag(
                             i += 1;
                         }
 
-                        tag_to_use = sliced.sub(&dependency[i + 1..]).value();
+                        // npm:foo without a version resolves to `latest`
+                        // (the empty tag defaults below)
+                        tag_to_use = if i < dependency.len() {
+                            sliced.sub(&dependency[i + 1..]).value()
+                        } else {
+                            String::EMPTY
+                        };
                         break 'brk &dependency[b"npm:".len()..i];
                     })
                     .value()

--- a/test/cli/install/bun-add-catalog.test.ts
+++ b/test/cli/install/bun-add-catalog.test.ts
@@ -826,14 +826,14 @@ describe.concurrent("bun add --catalog", () => {
   });
 
   describe("literals other than a bare name", () => {
-    test("alias@npm:pkg is written verbatim, like plain add", async () => {
+    test("alias@npm:pkg gets the resolved range, like plain add", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
       expectOk(await dir.add(dir.pkg1Dir, "foo@npm:no-deps", "--catalog"));
 
       expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: "npm:no-deps" });
-      expect((await dir.lock()).catalog).toStrictEqual({ foo: "npm:no-deps" });
+      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: "npm:no-deps@^2.0.0" });
+      expect((await dir.lock()).catalog).toStrictEqual({ foo: "npm:no-deps@^2.0.0" });
       expect(await dir.installed("foo")).toMatchObject({ name: "no-deps", version: "2.0.0" });
 
       const { err } = await dir.install({ savesLockfile: false });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3080,6 +3080,59 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/39771
+  it("should resolve a bare npm: alias to the latest dist-tag even when it is a prerelease", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "0.0.1": { as: "0.0.3" },
+          "4.6.0-nightly.1": {
+            as: "0.0.3",
+            bin: {
+              "baz-run": "index.js",
+            },
+          },
+          latest: "4.6.0-nightly.1",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "Foo",
+          version: "0.0.1",
+          dependencies: {
+            Bar: "npm:baz",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("Saved lockfile");
+      const out = await stdout.text();
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        expect.stringContaining("bun install v1."),
+        "",
+        "+ Bar@4.6.0-nightly.1",
+        "",
+        "1 package installed",
+      ]);
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}baz`, `${ctx.registry_url}baz-0.0.3.tgz`]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "Bar", "index.js"));
+      await access(join(ctx.package_dir, "bun.lockb"));
+    });
+  });
+
   it("should handle dependency aliasing (versioned)", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];


### PR DESCRIPTION
### Problem

- `bun install` with `"nuxt": "npm:nuxt-nightly"` installs `nuxt-nightly@0.0.1`, a placeholder with no `bin` field, so `node_modules/.bin/nuxt` is missing (#39771). npm installs the `latest` dist-tag, `4.6.0-29784541.x`, a prerelease with the bins.
- `Tag::infer` (`src/install/dependency.rs:948`) classifies `npm:name` with no version as an npm range. The empty version parses as the match-anything range, which resolves to the highest stable version and skips prereleases.

### Fix

- Classify `npm:name` with no version as a dist-tag dependency. `infer` already does this for an empty version string ("empty string means latest"), and `npm:name@latest` already takes this path. The dist-tag parse branch now tolerates a missing `@version` and defaults to `latest`.
- Correct because npm-package-arg gives a bare registry spec the `latest` tag, so npm and bun now pick the same version.
- Keep the `bun update` write-back behavior: the keep-dist-tags-verbatim rule in `PackageJSONEditor.rs` now excludes bare aliases, so `bun update aliased@npm:other` still retargets to `npm:other@~<resolved>` with the declared pin style.
- Verified: new test in `test/cli/install/bun-install.test.ts` (stock bun installs 0.0.1 with no bin, fixed bun installs the prerelease and links the bin). Also ran `bun-add.test.ts`, `bun-add-catalog.test.ts`, `bun-update.test.ts`, `bun-update-transitive.test.ts`, `bun-update-lockfile-sync.test.ts`, and `bun-lock.test.ts`.

### Background

- An npm alias (`"x": "npm:real-name@spec"`) installs package `real-name` under the name `x`. With no `@spec`, npm treats it like a bare `bun add real-name`: the `latest` dist-tag.
- Bun classifies each dependency literal into a `Tag` (npm range, dist-tag, git, tarball, ...) in `Tag::infer` before parsing it. Ranges resolve against the version list, dist-tags resolve against the packument's `dist-tags` map.
- Nightly-only packages like `nuxt-nightly` publish every real version as a prerelease, so `latest` points at a prerelease and range resolution never finds it.

<details><summary>Notes</summary>

- Reproduced on Linux against a local mock registry: one stable `0.0.1` plus prerelease `4.6.0-nightly.1` with `latest` pointing at the prerelease. Bare alias installed `0.0.1`, `npm:pkg@latest` installed the prerelease with its bin.
- One behavior change in `bun add foo@npm:pkg --catalog`: the catalog entry was written verbatim (`npm:pkg`) and now gets the resolved range (`npm:pkg@^2.0.0`). This matches plain `bun add foo@npm:pkg` and `--catalog` with `npm:pkg@latest`, which already wrote the resolved range. The catalog test expectation is updated.
- The related range bugs (`"nuxt-nightly": "*"` also resolves to `0.0.1`) are a different code path (`find_best_version` in `src/install/npm.rs`) and are covered by the open #32843. This PR has no file overlap with it.
- The 14 failures in the full `bun-install.test.ts` run are network tests (bitbucket, gitlab, external tarball URLs) that fail identically with unmodified bun in this environment.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->