### PR TITLE
Turn seccomp SIGSYS traps into ENOSYS so the syscall fallbacks run on Android

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1501,8 +1501,17 @@ __attribute__((noinline)) static void forwardSignal(int signalNumber)
 static int watchModeStickySignal = 0;
 
 #if !OS(WINDOWS)
+#if OS(LINUX)
+// c-bindings.cpp: the seccomp SIGSYS handler forwards kill(2)-sent SIGSYS itself.
+extern "C" bool Bun__forwardSIGSYSToJS(bool enabled);
+#endif
+
 static void installForwardSignalHandler(int signalNumber)
 {
+#if OS(LINUX)
+    if (signalNumber == SIGSYS && Bun__forwardSIGSYSToJS(true))
+        return;
+#endif
     struct sigaction action;
     memset(&action, 0, sizeof(struct sigaction));
     action.sa_handler = forwardSignal;
@@ -1510,6 +1519,18 @@ static void installForwardSignalHandler(int signalNumber)
     sigaddset(&action.sa_mask, signalNumber);
     action.sa_flags = SA_RESTART;
     sigaction(signalNumber, &action, nullptr);
+}
+
+static void uninstallForwardSignalHandler(int signalNumber)
+{
+#if OS(LINUX)
+    if (signalNumber == SIGSYS && Bun__forwardSIGSYSToJS(false))
+        return;
+#endif
+    if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
+        // Don't uninstall the old handler if it's not the one we installed.
+        signal(signalNumber, oldHandler);
+    }
 }
 
 extern "C" void Bun__installWatchModeSignalHandler(int signalNumber)
@@ -1618,10 +1639,7 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                         // "has JS listeners" source of truth that e.g. self-kill flush consults.
                         if (signalNumber != watchModeStickySignal) {
 #if !OS(WINDOWS)
-                            if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
-                                // Don't uninstall the old handler if it's not the one we installed.
-                                signal(signalNumber, oldHandler);
-                            }
+                            uninstallForwardSignalHandler(signalNumber);
 #else
                             SignalHandleValue signal_handle = signalToContextIdsMap->get(signalNumber);
                             Bun__UVSignalHandle__close(signal_handle.handle);

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -247,6 +247,13 @@ extern "C" ssize_t posix_spawn_bun(
 #endif
 
     sigfillset(&blockall);
+#if OS(LINUX)
+    // A seccomp trap (SIGSYS) kills the process when the signal is blocked
+    // instead of reaching the handler from bun_initialize_process, which turns
+    // it into ENOSYS. Keep it deliverable so clone3 below and the child's setup
+    // syscalls fail with ENOSYS like they do under an errno-returning policy.
+    sigdelset(&blockall, SIGSYS);
+#endif
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);
 #if !OS(ANDROID)
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
@@ -296,6 +303,13 @@ extern "C" ssize_t posix_spawn_bun(
         struct sigaction sa = { 0 };
         sa.sa_handler = SIG_DFL;
         for (int i = 0; i < NSIG; i++) {
+#if OS(LINUX)
+            // Keep the seccomp trap handler until right before execve so a
+            // blocked close_range() below falls back to the loop instead of
+            // killing the child.
+            if (i == SIGSYS)
+                continue;
+#endif
             sigaction(i, &sa, 0);
         }
 
@@ -451,6 +465,9 @@ extern "C" ssize_t posix_spawn_bun(
         // Close all fds > current_max_fd, preferring cloexec if available
         closeRangeOrLoop(current_max_fd + 1, INT_MAX, true);
 
+#if OS(LINUX)
+        sigaction(SIGSYS, &sa, 0);
+#endif
         if (execve(path, argv, envp) == -1) {
             return childFailed();
         }

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -458,13 +458,15 @@ extern "C" ssize_t posix_spawn_bun(
         }
 #endif
 
-        sigprocmask(SIG_SETMASK, &childmask, 0);
         if (!envp)
             envp = environ;
 
         // Close all fds > current_max_fd, preferring cloexec if available
         closeRangeOrLoop(current_max_fd + 1, INT_MAX, true);
 
+        // The caller's mask goes back last (execve keeps it): a caller that
+        // blocks SIGSYS must not make a trapped close_range() above fatal.
+        sigprocmask(SIG_SETMASK, &childmask, 0);
 #if OS(LINUX)
         sigaction(SIGSYS, &sa, 0);
 #endif

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -248,8 +248,7 @@ extern "C" ssize_t posix_spawn_bun(
 
     sigfillset(&blockall);
 #if OS(LINUX)
-    // A seccomp trap on a blocked SIGSYS kills the process instead of reaching
-    // the ENOSYS handler (installSIGSYSHandler in c-bindings.cpp).
+    // A seccomp trap on a blocked SIGSYS is fatal; see installSIGSYSHandler (c-bindings.cpp).
     sigdelset(&blockall, SIGSYS);
 #endif
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -248,10 +248,8 @@ extern "C" ssize_t posix_spawn_bun(
 
     sigfillset(&blockall);
 #if OS(LINUX)
-    // A seccomp trap (SIGSYS) kills the process when the signal is blocked
-    // instead of reaching the handler from bun_initialize_process, which turns
-    // it into ENOSYS. Keep it deliverable so clone3 below and the child's setup
-    // syscalls fail with ENOSYS like they do under an errno-returning policy.
+    // A seccomp trap on a blocked SIGSYS kills the process instead of reaching
+    // the ENOSYS handler (installSIGSYSHandler in c-bindings.cpp).
     sigdelset(&blockall, SIGSYS);
 #endif
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);
@@ -304,9 +302,7 @@ extern "C" ssize_t posix_spawn_bun(
         sa.sa_handler = SIG_DFL;
         for (int i = 0; i < NSIG; i++) {
 #if OS(LINUX)
-            // Keep the seccomp trap handler until right before execve so a
-            // blocked close_range() below falls back to the loop instead of
-            // killing the child.
+            // close_range() below still needs the ENOSYS handler; reset before execve.
             if (i == SIGSYS)
                 continue;
 #endif
@@ -464,8 +460,7 @@ extern "C" ssize_t posix_spawn_bun(
         // Close all fds > current_max_fd, preferring cloexec if available
         closeRangeOrLoop(current_max_fd + 1, INT_MAX, true);
 
-        // The caller's mask goes back last (execve keeps it): a caller that
-        // blocks SIGSYS must not make a trapped close_range() above fatal.
+        // After close_range(): the caller's mask may block SIGSYS. execve keeps the mask.
         sigprocmask(SIG_SETMASK, &childmask, 0);
 #if OS(LINUX)
         sigaction(SIGSYS, &sa, 0);

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -310,6 +310,13 @@ static void onSeccompTrap(int sig, siginfo_t* info, void* context)
 
 static void installSeccompTrapHandler()
 {
+    // A second install would save this handler as the previous action and make
+    // the kill(2) path above re-enter itself forever.
+    static bool installed = false;
+    if (installed)
+        return;
+    installed = true;
+
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_sigaction = onSeccompTrap;

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -274,6 +274,54 @@ extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigne
 {
     return syscall(__NR_close_range, start, end, flags);
 }
+
+#if CPU(X86_64) || CPU(ARM64)
+#include <ucontext.h>
+
+#ifndef SYS_SECCOMP
+#define SYS_SECCOMP 1
+#endif
+
+static struct sigaction sigsys_action_before_seccomp_shim;
+
+// A seccomp policy answers a blocked syscall either with an errno
+// (SECCOMP_RET_ERRNO, what Docker's default profile does) or with SIGSYS
+// (SECCOMP_RET_TRAP, what Android's per-app policy does). Every newer syscall
+// Bun issues (close_range, pidfd_open, openat2, copy_file_range, clone3, ...)
+// has a fallback for the errno form, so turn the signal form into it: make the
+// blocked syscall return -ENOSYS and resume. This is the documented use of
+// SECCOMP_RET_TRAP (seccomp(2)).
+static void onSeccompTrap(int sig, siginfo_t* info, void* context)
+{
+    if (info->si_code == SYS_SECCOMP && context) {
+        ucontext_t* uc = static_cast<ucontext_t*>(context);
+#if CPU(X86_64)
+        uc->uc_mcontext.gregs[REG_RAX] = -ENOSYS;
+#else
+        uc->uc_mcontext.regs[0] = static_cast<unsigned long long>(-ENOSYS);
+#endif
+        return;
+    }
+
+    // Sent with kill(2): behave as if this handler was never installed.
+    sigaction(SIGSYS, &sigsys_action_before_seccomp_shim, nullptr);
+    raise(sig);
+}
+
+static void installSeccompTrapHandler()
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = onSeccompTrap;
+    sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGSYS, &sa, &sigsys_action_before_seccomp_shim);
+}
+#else
+static void installSeccompTrapHandler()
+{
+}
+#endif // CPU(X86_64) || CPU(ARM64)
 #else // OS(FREEBSD)
 // FreeBSD 12.2+ libc has close_range; 14.0+ supports CLOSE_RANGE_CLOEXEC
 // (same value 1<<2 as Linux). Passing flags through means execveZ-failure
@@ -620,6 +668,10 @@ extern "C" void bun_initialize_process()
     setvbuf(stderr, nullptr, _IONBF, 0);
 
 #if OS(LINUX)
+    // Must come before bun_close_range: close_range(2) is the first syscall a
+    // seccomp policy is likely to block.
+    installSeccompTrapHandler();
+
     // Prevent leaking inherited file descriptors on Linux
     // This is less of an issue for macOS due to posix_spawn
     // This is best effort, not all linux kernels support close_range or CLOSE_RANGE_CLOEXEC
@@ -943,7 +995,9 @@ extern "C" int64_t Bun__currentSyncPID = 0;
 static int Bun__pendingSignalToSend = 0;
 static struct sigaction previous_actions[NSIG];
 
-// npm's signal list minus SIGIOT/SIGPOLL (aliases of SIGABRT/SIGIO; listing both would overwrite previous_actions[N]).
+// npm's signal list minus SIGIOT/SIGPOLL (aliases of SIGABRT/SIGIO; listing both would overwrite previous_actions[N])
+// and minus SIGSYS: the kernel raises it for a syscall of this process, so there is nothing to forward, and on Linux
+// the handler installed by bun_initialize_process must stay in place while the child runs.
 // https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/workspaces/arborist/lib/signals.js#L26-L57
 #define FOR_EACH_POSIX_SIGNAL(M) \
     M(SIGABRT);                  \
@@ -956,7 +1010,6 @@ static struct sigaction previous_actions[NSIG];
     M(SIGXFSZ);                  \
     M(SIGUSR2);                  \
     M(SIGTRAP);                  \
-    M(SIGSYS);                   \
     M(SIGQUIT);                  \
     M(SIGIO);
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -315,7 +315,8 @@ static void installSIGSYSHandler()
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_sigaction = onSIGSYS;
-    sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    // SA_RESTART matches installForwardSignalHandler for the kill(2) path; a trap skips the syscall.
+    sa.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_RESTART;
     sigemptyset(&sa.sa_mask);
     sigaction(SIGSYS, &sa, nullptr);
 }

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -285,12 +285,10 @@ extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigne
 
 extern "C" void Bun__onPosixSignal(int signalNumber);
 
-// Set while JS has a process.on("SIGSYS") listener (BunProcess.cpp).
 static std::atomic<bool> forwardSIGSYSToJS { false };
 
-// A SECCOMP_RET_TRAP policy (Android's per-app policy) answers a blocked
-// syscall with SIGSYS instead of an errno. Make the call return ENOSYS, which
-// the callers of close_range, pidfd_open, openat2, fchmodat2, ... handle.
+// A SECCOMP_RET_TRAP policy (Android) reports a blocked syscall with SIGSYS instead of an
+// errno. Turn it into the ENOSYS return that the callers (close_range, pidfd_open, ...) handle.
 static void onSIGSYS(int sig, siginfo_t* info, void* context)
 {
     if (info->si_code == SYS_SECCOMP && context) {
@@ -322,9 +320,8 @@ static void installSIGSYSHandler()
     sigaction(SIGSYS, &sa, nullptr);
 }
 
-// process.on("SIGSYS") must not replace the handler above, so it registers
-// here instead. Returns false where the handler does not exist and the caller
-// has to install its own.
+// BunProcess.cpp routes process.on("SIGSYS") through onSIGSYS instead of replacing it.
+// Returns false on targets without onSIGSYS; the caller then installs its own handler.
 extern "C" bool Bun__forwardSIGSYSToJS(bool enabled)
 {
     forwardSIGSYSToJS.store(enabled, std::memory_order_relaxed);
@@ -390,9 +387,8 @@ extern "C" void on_before_reload_process_posix()
     }
 
     // Reset caught dispositions so a SIGTERM arriving between here and execve isn't queued-then-
-    // lost. Inherited SIG_IGN is left alone. SIGSEGV/SIGBUS/RT/sigThreadSuspendResume/SIGSYS are left
-    // for execve to reset atomically — resetting them here races JSC's sampler/GC threads (and, for
-    // SIGSYS, any thread whose syscall a seccomp policy traps) fatally.
+    // lost. Inherited SIG_IGN is left alone. SIGSEGV/SIGBUS/SIGSYS/RT/sigThreadSuspendResume are left
+    // for execve to reset atomically — resetting them here races JSC's sampler/GC threads fatally.
     struct sigaction sa {};
     sa.sa_handler = SIG_DFL;
     sigemptyset(&sa.sa_mask);
@@ -1016,7 +1012,7 @@ static int Bun__pendingSignalToSend = 0;
 static struct sigaction previous_actions[NSIG];
 
 // npm's signal list minus SIGIOT/SIGPOLL (aliases of SIGABRT/SIGIO; listing both would overwrite previous_actions[N])
-// and minus SIGSYS (raised for this process's own syscall; owned by installSIGSYSHandler on Linux).
+// and minus SIGSYS (synchronous; on Linux owned by installSIGSYSHandler).
 // https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/workspaces/arborist/lib/signals.js#L26-L57
 #define FOR_EACH_POSIX_SIGNAL(M) \
     M(SIGABRT);                  \

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -276,22 +276,22 @@ extern "C" ssize_t bun_close_range(unsigned int start, unsigned int end, unsigne
 }
 
 #if CPU(X86_64) || CPU(ARM64)
+#include <atomic>
 #include <ucontext.h>
 
 #ifndef SYS_SECCOMP
 #define SYS_SECCOMP 1
 #endif
 
-static struct sigaction sigsys_action_before_seccomp_shim;
+extern "C" void Bun__onPosixSignal(int signalNumber);
 
-// A seccomp policy answers a blocked syscall either with an errno
-// (SECCOMP_RET_ERRNO, what Docker's default profile does) or with SIGSYS
-// (SECCOMP_RET_TRAP, what Android's per-app policy does). Every newer syscall
-// Bun issues (close_range, pidfd_open, openat2, copy_file_range, clone3, ...)
-// has a fallback for the errno form, so turn the signal form into it: make the
-// blocked syscall return -ENOSYS and resume. This is the documented use of
-// SECCOMP_RET_TRAP (seccomp(2)).
-static void onSeccompTrap(int sig, siginfo_t* info, void* context)
+// Set while JS has a process.on("SIGSYS") listener (BunProcess.cpp).
+static std::atomic<bool> forwardSIGSYSToJS { false };
+
+// A SECCOMP_RET_TRAP policy (Android's per-app policy) answers a blocked
+// syscall with SIGSYS instead of an errno. Make the call return ENOSYS, which
+// the callers of close_range, pidfd_open, openat2, fchmodat2, ... handle.
+static void onSIGSYS(int sig, siginfo_t* info, void* context)
 {
     if (info->si_code == SYS_SECCOMP && context) {
         ucontext_t* uc = static_cast<ucontext_t*>(context);
@@ -303,30 +303,43 @@ static void onSeccompTrap(int sig, siginfo_t* info, void* context)
         return;
     }
 
-    // Sent with kill(2): behave as if this handler was never installed.
-    sigaction(SIGSYS, &sigsys_action_before_seccomp_shim, nullptr);
+    // Sent with kill(2).
+    if (forwardSIGSYSToJS.load(std::memory_order_relaxed)) {
+        Bun__onPosixSignal(sig);
+        return;
+    }
+    signal(sig, SIG_DFL);
     raise(sig);
 }
 
-static void installSeccompTrapHandler()
+static void installSIGSYSHandler()
 {
-    // A second install would save this handler as the previous action and make
-    // the kill(2) path above re-enter itself forever.
-    static bool installed = false;
-    if (installed)
-        return;
-    installed = true;
-
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
-    sa.sa_sigaction = onSeccompTrap;
+    sa.sa_sigaction = onSIGSYS;
     sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
     sigemptyset(&sa.sa_mask);
-    sigaction(SIGSYS, &sa, &sigsys_action_before_seccomp_shim);
+    sigaction(SIGSYS, &sa, nullptr);
+}
+
+// process.on("SIGSYS") must not replace the handler above, so it registers
+// here instead. Returns false where the handler does not exist and the caller
+// has to install its own.
+extern "C" bool Bun__forwardSIGSYSToJS(bool enabled)
+{
+    forwardSIGSYSToJS.store(enabled, std::memory_order_relaxed);
+    if (enabled)
+        installSIGSYSHandler();
+    return true;
 }
 #else
-static void installSeccompTrapHandler()
+static void installSIGSYSHandler()
 {
+}
+
+extern "C" bool Bun__forwardSIGSYSToJS(bool)
+{
+    return false;
 }
 #endif // CPU(X86_64) || CPU(ARM64)
 #else // OS(FREEBSD)
@@ -377,8 +390,9 @@ extern "C" void on_before_reload_process_posix()
     }
 
     // Reset caught dispositions so a SIGTERM arriving between here and execve isn't queued-then-
-    // lost. Inherited SIG_IGN is left alone. SIGSEGV/SIGBUS/RT/sigThreadSuspendResume are left
-    // for execve to reset atomically — resetting them here races JSC's sampler/GC threads fatally.
+    // lost. Inherited SIG_IGN is left alone. SIGSEGV/SIGBUS/RT/sigThreadSuspendResume/SIGSYS are left
+    // for execve to reset atomically — resetting them here races JSC's sampler/GC threads (and, for
+    // SIGSYS, any thread whose syscall a seccomp policy traps) fatally.
     struct sigaction sa {};
     sa.sa_handler = SIG_DFL;
     sigemptyset(&sa.sa_mask);
@@ -386,7 +400,7 @@ extern "C" void on_before_reload_process_posix()
         if (s == SIGKILL || s == SIGSTOP || s == SIGSEGV || s == SIGBUS)
             continue;
 #if OS(LINUX)
-        if (s == g_wtfConfig.sigThreadSuspendResume)
+        if (s == g_wtfConfig.sigThreadSuspendResume || s == SIGSYS)
             continue;
 #endif
 #ifdef SIGRTMIN
@@ -675,9 +689,8 @@ extern "C" void bun_initialize_process()
     setvbuf(stderr, nullptr, _IONBF, 0);
 
 #if OS(LINUX)
-    // Must come before bun_close_range: close_range(2) is the first syscall a
-    // seccomp policy is likely to block.
-    installSeccompTrapHandler();
+    // Before bun_close_range: a seccomp policy may trap it.
+    installSIGSYSHandler();
 
     // Prevent leaking inherited file descriptors on Linux
     // This is less of an issue for macOS due to posix_spawn
@@ -1003,8 +1016,7 @@ static int Bun__pendingSignalToSend = 0;
 static struct sigaction previous_actions[NSIG];
 
 // npm's signal list minus SIGIOT/SIGPOLL (aliases of SIGABRT/SIGIO; listing both would overwrite previous_actions[N])
-// and minus SIGSYS: the kernel raises it for a syscall of this process, so there is nothing to forward, and on Linux
-// the handler installed by bun_initialize_process must stay in place while the child runs.
+// and minus SIGSYS (raised for this process's own syscall; owned by installSIGSYSHandler on Linux).
 // https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/workspaces/arborist/lib/signals.js#L26-L57
 #define FOR_EACH_POSIX_SIGNAL(M) \
     M(SIGABRT);                  \

--- a/test/cli/run/seccomp-trap.c
+++ b/test/cli/run/seccomp-trap.c
@@ -1,0 +1,118 @@
+// Test helper: seccomp-trap <nr>[,<nr>...]|none <program> [args...]
+//
+// Installs a seccomp filter that answers the listed syscall numbers with
+// SECCOMP_RET_TRAP (the process gets SIGSYS, which is what Android's per-app
+// policy does for syscalls it does not allow), then execs the program. The
+// filter is inherited by every process the program spawns.
+//
+// Exit codes: 77 when the filter cannot be installed, 2 on bad usage.
+//
+// The kernel ABI constants are spelled out so this builds with only libc
+// headers (no linux-headers package needed).
+#define _GNU_SOURCE
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#if defined(__x86_64__)
+#define MY_AUDIT_ARCH 0xC000003EU
+#elif defined(__aarch64__)
+#define MY_AUDIT_ARCH 0xC00000B7U
+#else
+#define MY_AUDIT_ARCH 0U
+#endif
+
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+#ifndef PR_SET_SECCOMP
+#define PR_SET_SECCOMP 22
+#endif
+#define SECCOMP_MODE_FILTER 2
+#define SECCOMP_RET_TRAP 0x00030000U
+#define SECCOMP_RET_ALLOW 0x7fff0000U
+
+#define BPF_LD_W_ABS 0x20
+#define BPF_JMP_JEQ_K 0x15
+#define BPF_RET_K 0x06
+#define SECCOMP_DATA_NR 0
+#define SECCOMP_DATA_ARCH 4
+
+#define MAX_TRAPPED 32
+
+struct bpf_insn {
+    uint16_t code;
+    uint8_t jt;
+    uint8_t jf;
+    uint32_t k;
+};
+
+struct bpf_prog {
+    unsigned short len;
+    struct bpf_insn* filter;
+};
+
+static struct bpf_insn stmt(uint16_t code, uint32_t k)
+{
+    struct bpf_insn insn = { code, 0, 0, k };
+    return insn;
+}
+
+static struct bpf_insn jeq(uint32_t k, uint8_t jt)
+{
+    struct bpf_insn insn = { BPF_JMP_JEQ_K, jt, 0, k };
+    return insn;
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 3) return 2;
+    if (MY_AUDIT_ARCH == 0) return 77;
+
+    // Some runs below die from SIGSYS on purpose. Do not write core files.
+    struct rlimit no_core = { 0, 0 };
+    setrlimit(RLIMIT_CORE, &no_core);
+
+    uint32_t trapped[MAX_TRAPPED];
+    unsigned count = 0;
+    if (strcmp(argv[1], "none") != 0) {
+        for (char* tok = strtok(argv[1], ","); tok != NULL; tok = strtok(NULL, ",")) {
+            if (count == MAX_TRAPPED) return 2;
+            trapped[count++] = (uint32_t)strtoul(tok, NULL, 10);
+        }
+    }
+
+    // Layout: arch check (3), load nr (1), one compare per trapped syscall,
+    // ALLOW, TRAP. Each compare jumps over the remaining compares and the
+    // ALLOW straight to the TRAP.
+    struct bpf_insn insns[3 + 1 + MAX_TRAPPED + 2];
+    unsigned n = 0;
+    insns[n++] = stmt(BPF_LD_W_ABS, SECCOMP_DATA_ARCH);
+    insns[n++] = jeq(MY_AUDIT_ARCH, 1);
+    insns[n++] = stmt(BPF_RET_K, SECCOMP_RET_ALLOW);
+    insns[n++] = stmt(BPF_LD_W_ABS, SECCOMP_DATA_NR);
+    for (unsigned i = 0; i < count; i++) {
+        insns[n++] = jeq(trapped[i], (uint8_t)(count - i));
+    }
+    insns[n++] = stmt(BPF_RET_K, SECCOMP_RET_ALLOW);
+    insns[n++] = stmt(BPF_RET_K, SECCOMP_RET_TRAP);
+
+    struct bpf_prog prog = { (unsigned short)n, insns };
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+        perror("prctl(PR_SET_NO_NEW_PRIVS)");
+        return 77;
+    }
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog) != 0) {
+        perror("prctl(PR_SET_SECCOMP)");
+        return 77;
+    }
+
+    execvp(argv[2], &argv[2]);
+    perror("execvp");
+    return 127;
+}

--- a/test/cli/run/seccomp-trap.c
+++ b/test/cli/run/seccomp-trap.c
@@ -83,7 +83,14 @@ int main(int argc, char** argv)
     if (strcmp(argv[1], "none") != 0) {
         for (char* tok = strtok(argv[1], ","); tok != NULL; tok = strtok(NULL, ",")) {
             if (count == MAX_TRAPPED) return 2;
-            trapped[count++] = (uint32_t)strtoul(tok, NULL, 10);
+            // A token that does not parse must not silently become syscall 0 (read).
+            char* end = NULL;
+            unsigned long nr = strtoul(tok, &end, 10);
+            if (end == tok || *end != '\0' || nr > UINT32_MAX) {
+                fprintf(stderr, "seccomp-trap: bad syscall number '%s'\n", tok);
+                return 2;
+            }
+            trapped[count++] = (uint32_t)nr;
         }
     }
 

--- a/test/cli/run/seccomp-trap.test.ts
+++ b/test/cli/run/seccomp-trap.test.ts
@@ -172,6 +172,34 @@ describe.skipIf(!isLinux)("seccomp SECCOMP_RET_TRAP policies", () => {
       signalCode: "SIGSYS",
     });
   });
+
+  test.concurrent.skipIf(!helper)("process.on('SIGSYS') keeps the trap handler and still sees kill", async () => {
+    // signal-exit and similar libraries listen for SIGSYS. The listener must
+    // not replace the trap handler (spawning still works while it is installed
+    // and after it is removed), and a SIGSYS sent with kill still reaches JS.
+    const result = await runTrapped(
+      [SYS_pidfd_open],
+      [
+        bunExe(),
+        "-e",
+        `const { promise, resolve } = Promise.withResolvers();
+         process.on("SIGSYS", resolve);
+         const first = Bun.spawnSync(["echo", "hi"]).stdout.toString();
+         process.kill(process.pid, "SIGSYS");
+         await promise;
+         process.removeAllListeners("SIGSYS");
+         const second = Bun.spawnSync(["echo", "hi"]).stdout.toString();
+         console.log(JSON.stringify({ first, listenerRan: true, second }));
+         process.kill(process.pid, "SIGSYS");`,
+      ],
+    );
+    expect(result).toEqual({
+      stdout: JSON.stringify({ first: "hi\n", listenerRan: true, second: "hi\n" }) + "\n",
+      stderr: "",
+      exitCode: null,
+      signalCode: "SIGSYS",
+    });
+  });
 });
 
 // Compiles seccomp-trap.c and checks that this environment lets us install a

--- a/test/cli/run/seccomp-trap.test.ts
+++ b/test/cli/run/seccomp-trap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isLinux, libcPathForDlopen, tempDir, tempDirWithFiles } from "harness";
 import { readlinkSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -21,11 +21,15 @@ const SYS_fchmodat2 = 452;
 describe.skipIf(!isLinux)("seccomp SECCOMP_RET_TRAP policies", () => {
   const helper = isLinux ? buildHelper() : null;
 
-  async function runTrapped(trapped: number[] | "none", cmd: string[], cwd?: string) {
+  async function runTrapped(
+    trapped: number[] | "none",
+    cmd: string[],
+    options: { cwd?: string; env?: Record<string, string> } = {},
+  ) {
     await using proc = Bun.spawn({
       cmd: [helper!, trapped === "none" ? "none" : trapped.join(","), ...cmd],
-      env: bunEnv,
-      cwd,
+      env: { ...bunEnv, ...options.env },
+      cwd: options.cwd,
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",
@@ -58,6 +62,45 @@ describe.skipIf(!isLinux)("seccomp SECCOMP_RET_TRAP policies", () => {
       signalCode: null,
     });
   });
+
+  test.concurrent.skipIf(!helper)(
+    "spawned children exec when close_range is trapped and the caller blocks SIGSYS",
+    async () => {
+      // The child takes over the caller's signal mask only after close_range(2):
+      // a trap on a blocked SIGSYS kills the process instead of reaching the
+      // handler. The fixture blocks SIGSYS on the spawning thread first.
+      using dir = tempDir("seccomp-trap-blocked", {
+        "fixture.js": `
+          import { dlopen, FFIType, ptr } from "bun:ffi";
+          const libc = dlopen(process.env.LIBC_PATH, {
+            sigprocmask: { args: [FFIType.i32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
+          });
+          // Large enough for every libc's sigset_t; SIGSYS (31) is bit 30 of the first word.
+          const set = new BigUint64Array(16);
+          set[0] = 1n << 30n;
+          const SIG_BLOCK = 0;
+          if (libc.symbols.sigprocmask(SIG_BLOCK, ptr(set), null) !== 0) throw new Error("sigprocmask failed");
+          const r = Bun.spawnSync(["echo", "hi"]);
+          console.log(JSON.stringify({ stdout: r.stdout.toString(), exitCode: r.exitCode, signalCode: r.signalCode ?? null }));
+        `,
+      });
+      const result = await runTrapped([SYS_close_range], [bunExe(), "fixture.js"], {
+        cwd: String(dir),
+        env: { LIBC_PATH: libcPathForDlopen() },
+      });
+      // bun:ffi under ASAN may print a warning about dlopen; nothing else is allowed on stderr.
+      result.stderr = result.stderr
+        .split("\n")
+        .filter(line => line && !line.startsWith("WARNING: ASAN interferes"))
+        .join("\n");
+      expect(result).toEqual({
+        stdout: JSON.stringify({ stdout: "hi\n", exitCode: 0, signalCode: null }) + "\n",
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    },
+  );
 
   test.concurrent.skipIf(!helper)("Bun.spawn falls back to the waiter thread when pidfd_open is trapped", async () => {
     const result = await runTrapped(
@@ -98,8 +141,13 @@ describe.skipIf(!isLinux)("seccomp SECCOMP_RET_TRAP policies", () => {
     const target = join(String(dir), "dep/bin/cli.js");
     expect(statSync(target).mode & 0o111).toBe(0);
 
-    const result = await runTrapped([SYS_openat2, SYS_fchmodat2], [bunExe(), "install"], String(dir));
-    expect({ exitCode: result.exitCode, signalCode: result.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+    const result = await runTrapped([SYS_openat2, SYS_fchmodat2], [bunExe(), "install"], { cwd: String(dir) });
+    expect(result).toEqual({
+      stdout: expect.stringContaining(" installed"),
+      stderr: expect.not.stringContaining("error"),
+      exitCode: 0,
+      signalCode: null,
+    });
     expect(readlinkSync(join(String(dir), "node_modules/.bin/depbin"))).toBe("../dep/bin/cli.js");
     expect(statSync(target).mode & 0o100).toBe(0o100);
   });
@@ -111,11 +159,9 @@ describe.skipIf(!isLinux)("seccomp SECCOMP_RET_TRAP policies", () => {
     using dir = tempDir("seccomp-trap-run", {
       "package.json": JSON.stringify({ name: "app", scripts: { hello: "echo hello-from-script" } }),
     });
-    const result = await runTrapped(
-      [SYS_pidfd_open],
-      [bunExe(), "run", "--no-orphans", "--silent", "hello"],
-      String(dir),
-    );
+    const result = await runTrapped([SYS_pidfd_open], [bunExe(), "run", "--no-orphans", "--silent", "hello"], {
+      cwd: String(dir),
+    });
     expect(result).toEqual({ stdout: "hello-from-script\n", stderr: "", exitCode: 0, signalCode: null });
   });
 

--- a/test/cli/run/seccomp-trap.test.ts
+++ b/test/cli/run/seccomp-trap.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir, tempDirWithFiles } from "harness";
+import { readlinkSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// Android's per-app seccomp policy (and any other policy built on
+// SECCOMP_RET_TRAP) answers a syscall it does not allow with SIGSYS instead of
+// an errno. Bun installs a SIGSYS handler at startup that makes the blocked
+// syscall return ENOSYS, so the ENOSYS fallbacks that already exist for these
+// syscalls take over. Without it the process dies with "Bad system call".
+//
+// seccomp-trap.c installs such a policy for the given syscall numbers and
+// execs Bun under it. The numbers below are the same on x86_64 and aarch64.
+// close_range, openat2 and fchmodat2 are the ones Android is known to trap
+// (#30766, #39060).
+const SYS_pidfd_open = 434;
+const SYS_close_range = 436;
+const SYS_openat2 = 437;
+const SYS_fchmodat2 = 452;
+
+describe.skipIf(!isLinux)("seccomp SECCOMP_RET_TRAP policies", () => {
+  const helper = isLinux ? buildHelper() : null;
+
+  async function runTrapped(trapped: number[] | "none", cmd: string[], cwd?: string) {
+    await using proc = Bun.spawn({
+      cmd: [helper!, trapped === "none" ? "none" : trapped.join(","), ...cmd],
+      env: bunEnv,
+      cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode: proc.exitCode, signalCode: proc.signalCode };
+  }
+
+  test.concurrent.skipIf(!helper)("bun starts when close_range is trapped", async () => {
+    // bun_initialize_process calls close_range(2) before anything else runs.
+    const result = await runTrapped([SYS_close_range], [bunExe(), "-e", `console.log("ok")`]);
+    expect(result).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test.concurrent.skipIf(!helper)("spawned children exec when close_range is trapped", async () => {
+    // The vfork child calls close_range(2) right before execve(2).
+    const result = await runTrapped(
+      [SYS_close_range],
+      [
+        bunExe(),
+        "-e",
+        `const r = Bun.spawnSync(["echo", "hi"]);
+         console.log(JSON.stringify({ stdout: r.stdout.toString(), exitCode: r.exitCode, signalCode: r.signalCode ?? null }));`,
+      ],
+    );
+    expect(result).toEqual({
+      stdout: JSON.stringify({ stdout: "hi\n", exitCode: 0, signalCode: null }) + "\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent.skipIf(!helper)("Bun.spawn falls back to the waiter thread when pidfd_open is trapped", async () => {
+    const result = await runTrapped(
+      [SYS_pidfd_open],
+      [
+        bunExe(),
+        "-e",
+        `const results = [];
+         for (let i = 0; i < 3; i++) {
+           const proc = Bun.spawn(["echo", "hi" + i], { stdout: "pipe" });
+           results.push([await proc.stdout.text(), await proc.exited]);
+         }
+         console.log(JSON.stringify(results));`,
+      ],
+    );
+    expect(result).toEqual({
+      stdout:
+        JSON.stringify([
+          ["hi0\n", 0],
+          ["hi1\n", 0],
+          ["hi2\n", 0],
+        ]) + "\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent.skipIf(!helper)("bun install links a nested bin when openat2 and fchmodat2 are trapped", async () => {
+    // Bin linking checks a nested link target with openat2(RESOLVE_BENEATH),
+    // falling back to realpath on ENOSYS, and then makes the target executable
+    // with fchmodat2, falling back to libc's fchmodat on ENOSYS.
+    using dir = tempDir("seccomp-trap-install", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { dep: "file:./dep" } }),
+      "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0", bin: { depbin: "bin/cli.js" } }),
+      "dep/bin/cli.js": `#!/usr/bin/env node\nconsole.log("depbin");\n`,
+    });
+    const target = join(String(dir), "dep/bin/cli.js");
+    expect(statSync(target).mode & 0o111).toBe(0);
+
+    const result = await runTrapped([SYS_openat2, SYS_fchmodat2], [bunExe(), "install"], String(dir));
+    expect({ exitCode: result.exitCode, signalCode: result.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+    expect(readlinkSync(join(String(dir), "node_modules/.bin/depbin"))).toBe("../dep/bin/cli.js");
+    expect(statSync(target).mode & 0o100).toBe(0o100);
+  });
+
+  test.concurrent.skipIf(!helper)("bun run --no-orphans waits for the script when pidfd_open is trapped", async () => {
+    // spawnSync installs signal forwarding handlers around the script; SIGSYS
+    // must not be one of them, or the pidfd_open(2) in the no-orphans wait loop
+    // is forwarded to the script as a kill instead of returning ENOSYS.
+    using dir = tempDir("seccomp-trap-run", {
+      "package.json": JSON.stringify({ name: "app", scripts: { hello: "echo hello-from-script" } }),
+    });
+    const result = await runTrapped(
+      [SYS_pidfd_open],
+      [bunExe(), "run", "--no-orphans", "--silent", "hello"],
+      String(dir),
+    );
+    expect(result).toEqual({ stdout: "hello-from-script\n", stderr: "", exitCode: 0, signalCode: null });
+  });
+
+  test.concurrent.skipIf(!helper)("a SIGSYS sent with kill still terminates the process", async () => {
+    const result = await runTrapped("none", [bunExe(), "-e", `process.kill(process.pid, "SIGSYS");`]);
+    expect({ exitCode: result.exitCode, signalCode: result.signalCode }).toEqual({
+      exitCode: null,
+      signalCode: "SIGSYS",
+    });
+  });
+});
+
+// Compiles seccomp-trap.c and checks that this environment lets us install a
+// seccomp filter. Returns null (tests are skipped) when there is no C compiler
+// or the filter cannot be installed. A compile error is a test failure.
+function buildHelper(): string | null {
+  const cc = Bun.which("clang") || Bun.which("gcc") || Bun.which("cc");
+  if (!cc) {
+    console.warn("SKIP seccomp-trap: no C compiler on PATH");
+    return null;
+  }
+
+  const dir = tempDirWithFiles("seccomp-trap-helper", {});
+  const bin = join(dir, "seccomp-trap");
+  const compile = Bun.spawnSync({
+    cmd: [cc, "-O0", "-o", bin, join(import.meta.dirname, "seccomp-trap.c")],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (compile.exitCode !== 0) {
+    throw new Error(`failed to compile seccomp-trap.c:\n${compile.stderr.toString()}`);
+  }
+
+  const probe = Bun.spawnSync({ cmd: [bin, "none", Bun.which("true")!], stdout: "pipe", stderr: "pipe" });
+  if (probe.exitCode !== 0) {
+    console.warn(`SKIP seccomp-trap: cannot install a seccomp filter here: ${probe.stderr.toString().trim()}`);
+    return null;
+  }
+  return bin;
+}


### PR DESCRIPTION
### Problem
- On Android (Termux) Bun dies with `Bad system call` (SIGSYS, exit 159): `bun create astro`, `bun install` with bins (#39060), startup of the android build (#30766). Android's seccomp policy traps syscalls outside its allowlist (`SECCOMP_RET_TRAP`). Known trapped calls: `close_range`, `openat2` (`src/install/bin.rs:1416`), `fchmodat2` (`sys::lchmod`).
- Each call has an ENOSYS fallback. It never runs, because the process is killed instead of getting an errno.

### Fix
- `bun_initialize_process` installs a SIGSYS handler before its own `close_range` call. For `si_code == SYS_SECCOMP` it sets the return register (`rax` or `x0`) to `-ENOSYS` and returns. The trapped call fails with ENOSYS and the fallback runs. A SIGSYS sent with `kill(2)` goes to a `process.on("SIGSYS")` listener when one exists, else the handler resets to `SIG_DFL` and re-raises.
- seccomp(2) documents this use of `SECCOMP_RET_TRAP`. One handler covers every call site, including the fallbacks inside glibc, musl and bionic.
- Three places used to remove the handler: the `spawnSync` forwarding list, `process.on("SIGSYS")` (BunProcess.cpp now routes the listener through the handler) and the watch-mode reload reset. The vfork child keeps it until just before `execve` and takes the caller's mask only after `close_range`: a trap on a blocked SIGSYS kills the process.
- Verified: `test/cli/run/seccomp-trap.test.ts` (7 of 8 tests fail before). Also ran the spawn, spawnSync, terminal, process, no-orphans, crash handler and seccomp tests.

### Background
- A seccomp filter can allow a syscall, fail it with an errno (`SECCOMP_RET_ERRNO`, Docker's default) or trap it (`SECCOMP_RET_TRAP`, Android). A trap skips the call, rolls the registers back and sends SIGSYS to the calling thread. By default SIGSYS kills the process. A handler that does not write the return register makes the call return its own syscall number.
- A `SA_SIGINFO` handler gets the thread's registers (`ucontext_t`) and may change them. The thread resumes with those registers. Libc and rustix read a negative return register as an errno.
- Children inherit the filter but not the handler, so each Bun process installs it itself.

Fixes #30766
Fixes #39060

<details><summary>Notes</summary>

- #30769 (one-shot `siglongjmp` probe for `close_range`) and #39084 (runtime Android detection for `openat2` and `fchmodat2`) each fix one call site. This change covers both of them, plus `pidfd_open`, `copy_file_range`, `clone3`, `epoll_pwait2`, `openat2` in directory routes, and the libc-internal fallbacks (glibc and musl implement `fchmodat(AT_SYMLINK_NOFOLLOW)` by trying `fchmodat2` first, then emulating). Related tracking issues: #8685, #5085, #2413.
- Trapped call sites today: `close_range` in `bun_initialize_process` (c-bindings.cpp) and in the spawn child (bun-spawn.cpp), `openat2(RESOLVE_BENEATH)` in bin linking, `fchmodat2` in `sys::lchmod` when the bin target is chmodded. `bun create` runs `bun add`, and `bunx` re-raises the child's signal, which is why the parent appears to die.
- The test compiles `test/cli/run/seccomp-trap.c`, which installs a trap policy for the given syscall numbers and execs Bun. Cases: startup with `close_range` trapped, spawnSync child with `close_range` trapped (once plainly, once with SIGSYS blocked on the spawning thread through `sigprocmask` from `bun:ffi`), `Bun.spawn` with `pidfd_open` trapped, `bun install` of a local package with `bin: bin/cli.js` with `openat2` and `fchmodat2` trapped (asserts the link and the 755 mode, which goes through `lchmod` -> `fchmodat` -> glibc emulation), `bun run --no-orphans` with `pidfd_open` trapped, `kill -SYS` still terminating, and `process.on("SIGSYS")` followed by spawns, a kill that reaches the listener, listener removal and a final kill.
- Each guard was checked in isolation by rebuilding without it. Forwarding list: the `bun run --no-orphans` test dies, the forwarding handler runs for the `pidfd_open` trap in `wait_linux_signalfd` and kills the script. Child reset loop: the spawnSync test reports `signalCode: "SIGSYS"` for the child. Mask order: the blocked-SIGSYS test reports the same. `process.on` (signal-exit registers a SIGSYS listener, so most CLIs hit this): the trapped `pidfd_open` returned 434 (its own syscall number), Bun used it as a pidfd and the debug build aborted on `close(434) = EBADF`.
- The handler is installed with `SA_RESTART`, like the forwarding handlers `process.on` installs for other signals, so a kill(2)-sent SIGSYS with a listener restarts interrupted syscalls as before. A trap skips the syscall, so the flag does not affect that path.
- The explicit SIGSYS reset before `execve` keeps the old guarantee that children start with SIGSYS at `SIG_DFL`, also on targets where the handler is not built.
- Cost: one signal delivery per trapped call. The call sites that cache unavailability (`pidfd_open`, `copy_file_range`, `openat2_in_root`, `epoll_pwait2`) trap once.
- The handler is C++ against the platform headers on purpose. The `libc` crate's `ucontext_t` for `aarch64-linux-android` lacks the 120 bytes of padding bionic puts before `uc_mcontext`, so a Rust version would write to the wrong offset on the android build. `REG_RAX` needs `_GNU_SOURCE`, which clang++ predefines for C++ on every Linux target this builds for (gnu, musl, android).
- `SECCOMP_RET_KILL*` policies (systemd's default `SystemCallFilter=` action) behave as before: kill actions never run a handler.
- Dropping SIGSYS from the forwarding list also applies to macOS and FreeBSD. A SIGSYS sent to `bun run` now terminates it instead of being relayed to the script. The kernel raises SIGSYS only for the receiving process's own syscall, so relaying it had no use. A SIGSYS disposition of `SIG_IGN` inherited from the parent process is no longer honored on Linux either: the handler takes over at startup.
- Unrelated local failures, identical without this change: the `no-orphans.test.ts` uid/gid case (this container has no CAP_KILL), the `spawn_waiter_thread.test.ts` CPU-time bound (debug build) and the `process.test.js` `USER` check.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/seccomp-trap.test.ts

<!-- robobun:evidence:end -->