### PR TITLE
bun-types: add http3 and h3 to the fetch protocol option

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -2014,15 +2014,17 @@ interface BunFetchRequestInit extends RequestInit {
   /**
    * Force the underlying HTTP version. `"http2"` advertises only `h2` in
    * the TLS ALPN list and the request fails with `HTTP2Unsupported` if the
-   * server doesn't select it. `"http1.1"` pins the request to HTTP/1.1,
-   * overriding `--experimental-http2-fetch` /
+   * server doesn't select it. `"http3"` sends the request over HTTP/3
+   * (QUIC). `"http1.1"` pins the request to HTTP/1.1, overriding
+   * `--experimental-http2-fetch` /
    * `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT` if set. Omit to use the
-   * default (h2 is offered iff the flag is on).
+   * default (h2 is offered iff the flag is on). `"h2"`, `"h3"` and `"h1"`
+   * are aliases.
    *
    * Requires `https`. Not part of the Fetch API specification.
    * @experimental
    */
-  protocol?: "http2" | "http1.1" | "h2" | "h1";
+  protocol?: "http2" | "http1.1" | "http3" | "h2" | "h1" | "h3";
 
   /**
    * Control automatic decompression of the response body. When `false`, the

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -824,7 +824,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // protocol: "http2" | "h2" | "http3" | "h3" | "http1.1" | "h1" | undefined.
+    // protocol: "http2" | "h2" | "http1.1" | "h1" | undefined.
     'extract_protocol: {
         let objects_to_try = [
             options_object.unwrap_or_default(),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -824,7 +824,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // protocol: "http2" | "h2" | "http1.1" | "h1" | undefined.
+    // protocol: "http2" | "h2" | "http3" | "h3" | "http1.1" | "h1" | undefined.
     'extract_protocol: {
         let objects_to_try = [
             options_object.unwrap_or_default(),

--- a/test/integration/bun-types/fixture/fetch.ts
+++ b/test/integration/bun-types/fixture/fetch.ts
@@ -332,3 +332,19 @@ if (typeof process !== "undefined") {
   // @ts-expect-error - Proxy must be string or object, not array
   fetch("https://example.com", { proxy: ["http://proxy.example.com"] });
 }
+
+// Protocol option types
+{
+  // All six values the runtime accepts are valid
+  fetch("https://example.com", { protocol: "http1.1" });
+  fetch("https://example.com", { protocol: "h1" });
+  fetch("https://example.com", { protocol: "http2" });
+  fetch("https://example.com", { protocol: "h2" });
+  fetch("https://example.com", { protocol: "http3" });
+  fetch("https://example.com", { protocol: "h3" });
+}
+
+{
+  // @ts-expect-error - Not a protocol the runtime accepts
+  fetch("https://example.com", { protocol: "spdy" });
+}


### PR DESCRIPTION
Fixes #39773

### Problem
- The runtime accepts six values for the fetch `protocol` option: the validation error says `fetch: 'protocol' must be "http2", "h2", "http3", "h3", "http1.1", or "h1"` (src/runtime/webcore/fetch.rs:847).
- bun-types declares only four: `"http2" | "http1.1" | "h2" | "h1"` (packages/bun-types/globals.d.ts:2025). TypeScript rejects `fetch(url, { protocol: "h3" })` even though the runtime supports it.

### Fix
- Add `"http3"` and `"h3"` to the union and mention HTTP/3 in the JSDoc.
- Cover all six values in test/integration/bun-types/fixture/fetch.ts, plus a `@ts-expect-error` case for a value the runtime rejects.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` passes (15/15). Without the globals.d.ts change, the new fixture lines fail with `Type '"h3"' is not assignable to type '"http2" | "http1.1" | "h2" | "h1" | undefined'`.

### Background
- The `protocol` option is a Bun extension to `fetch` that forces the HTTP version. The parser maps `"http2"`/`"h2"`, `"http3"`/`"h3"`, and `"http1.1"`/`"h1"` to the matching `http::Protocol` variant.
- The bun-types test packs the `.d.ts` files and runs `tsc` against the fixtures, so the fixture change is the type-level test for this union.
