### PR TITLE
fetch: give 204, 205, 304 and HEAD responses a null body

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -280,6 +280,15 @@ impl<'a> AsyncHTTP<'a> {
         &MAX_SIMULTANEOUS_REQUESTS
     }
 
+    /// The method the request was made with. A redirect can only rewrite the
+    /// method to GET, and only on the HTTP thread's copy (restored from this
+    /// field in `on_async_http_callback`), so a HEAD request reads as HEAD here
+    /// for its whole lifetime.
+    #[inline]
+    pub fn method(&self) -> Method {
+        self.method
+    }
+
     /// A store into the shared signal `Store`, not into `self`.
     pub fn enable_response_body_streaming(&self) {
         self.signals.store(

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -280,10 +280,8 @@ impl<'a> AsyncHTTP<'a> {
         &MAX_SIMULTANEOUS_REQUESTS
     }
 
-    /// The method the request was made with. A redirect can only rewrite the
-    /// method to GET, and only on the HTTP thread's copy (restored from this
-    /// field in `on_async_http_callback`), so a HEAD request reads as HEAD here
-    /// for its whole lifetime.
+    /// The method the request was made with. A redirect only ever rewrites the
+    /// HTTP thread's copy (`client.method`), and only to GET.
     #[inline]
     pub fn method(&self) -> Method {
         self.method

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -33,11 +33,21 @@ class Headers extends WebHeaders {
 
 const kHeaders = Symbol("kHeaders");
 const kBody = Symbol("kBody");
+// Set on the responses fetch() returns. node-fetch pipes every network
+// response into a stream, so `body` is a stream even when the response has no
+// body (204, 304, a HEAD request), while `new Response(null).body` is null:
+// https://github.com/node-fetch/node-fetch/blob/8b3320d2a7c07bce4afc6b2bf6c3bbddda85b01f/src/index.js#L253-L286
+const kFetched = Symbol("kFetched");
 const HeadersPrototype = Headers.prototype;
+
+function closeEmptyBody(controller) {
+  controller.close();
+}
 
 class Response extends WebResponse {
   [kBody]: any;
   [kHeaders];
+  [kFetched]: boolean | undefined;
 
   constructor(body, init) {
     const { Readable, Stream } = require("node:stream");
@@ -52,7 +62,10 @@ class Response extends WebResponse {
     let body = this[kBody];
     if (!body) {
       var web = super.body;
-      if (!web) return null;
+      if (!web) {
+        if (!this[kFetched]) return null;
+        web = new ReadableStream({ start: closeEmptyBody });
+      }
       body = this[kBody] = new (require("internal/webstreams_adapters")._ReadableFromWeb)({}, web);
     }
 
@@ -64,7 +77,9 @@ class Response extends WebResponse {
   }
 
   clone() {
-    return Object.setPrototypeOf(super.clone(this), ResponsePrototype);
+    const cloned = Object.setPrototypeOf(super.clone(this), ResponsePrototype);
+    if (this[kFetched]) cloned[kFetched] = true;
+    return cloned;
   }
 
   async arrayBuffer() {
@@ -172,6 +187,7 @@ async function fetch(
   }
   const response = await nativeFetch.$call(undefined, url, init);
   Object.setPrototypeOf(response, ResponsePrototype);
+  response[kFetched] = true;
   return response;
 }
 

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -33,9 +33,7 @@ class Headers extends WebHeaders {
 
 const kHeaders = Symbol("kHeaders");
 const kBody = Symbol("kBody");
-// Set on the responses fetch() returns. node-fetch pipes every network
-// response into a stream, so `body` is a stream even when the response has no
-// body (204, 304, a HEAD request), while `new Response(null).body` is null:
+// A fetched response has a body stream even when it has no body (204, HEAD):
 // https://github.com/node-fetch/node-fetch/blob/8b3320d2a7c07bce4afc6b2bf6c3bbddda85b01f/src/index.js#L253-L286
 const kFetched = Symbol("kFetched");
 const HeadersPrototype = Headers.prototype;

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -54,14 +54,19 @@ function notImplemented() {
  * @typedef {import('events').EventEmitter} EventEmitter
  */
 
+function closeEmptyBody(controller) {
+  controller.close();
+}
+
 class BodyReadable extends ReadableFromWeb {
   #response;
   #bodyUsed;
 
   constructor(response, options = {}) {
-    var { body } = response;
-    if (!body) throw new Error("Response body is null");
-    super(options, body);
+    // undici's request() returns a body for every response, so one that has none
+    // (204, 304, a HEAD request) reads as an empty body here:
+    // https://github.com/nodejs/undici/blob/v6.21.3/lib/api/api-request.js#L118-L126
+    super(options, response.body ?? new ReadableStream({ start: closeEmptyBody }));
 
     this.#response = response;
     this.#bodyUsed = response.bodyUsed;
@@ -232,7 +237,7 @@ async function request(
     throw new Error(`Request failed with status code ${statusCode}`);
   }
 
-  const body = resp.body ? new BodyReadable(resp) : null;
+  const body = new BodyReadable(resp);
 
   return { statusCode, headers: headers.toJSON(), body, trailers, opaque: kEmptyObject, context: kEmptyObject };
 }

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -63,8 +63,7 @@ class BodyReadable extends ReadableFromWeb {
   #bodyUsed;
 
   constructor(response, options = {}) {
-    // undici's request() returns a body for every response, so one that has none
-    // (204, 304, a HEAD request) reads as an empty body here:
+    // A response with no body (204, HEAD) still gets a body, as in undici:
     // https://github.com/nodejs/undici/blob/v6.21.3/lib/api/api-request.js#L118-L126
     super(options, response.body ?? new ReadableStream({ start: closeEmptyBody }));
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1869,13 +1869,43 @@ impl FetchTasklet {
         response
     }
 
+    /// WHATWG fetch gives a response to a HEAD request, or one with a null body
+    /// status, a null body whatever the server frames after the head
+    /// (<https://fetch.spec.whatwg.org/#main-fetch>, "set internalResponse's body
+    /// to null"). 101 is the exception: the HTTP client only accepts one for a
+    /// request that asked to upgrade, and the upgraded connection is then the
+    /// body (`fetch.upgrade.test.ts`). The other 1xx statuses are interim
+    /// responses that the HTTP client never reports as the response.
+    fn response_body_is_null(&self, status_code: u16) -> bool {
+        (crate::server::http_status_text::is_null_body(status_code) && status_code != 101)
+            || self
+                .http
+                .as_deref()
+                .is_some_and(|http_| http_.method() == Method::HEAD)
+    }
+
+    /// The body for `response_body_is_null`. Bytes the server frames anyway (a
+    /// 205 with content, say) are dropped: the ones already here now, the rest
+    /// by the HTTP thread, which drains them as it does the body of a Response
+    /// that was collected unread, so the connection can still be pooled. No
+    /// Response is attached to the tasklet yet, so `ignore_remaining_response_body`
+    /// only switches the transport over and releases the event loop.
+    /// `is_waiting_body` stays false: neither those bytes nor a transport
+    /// failure during the drain may reach the body.
+    fn null_body_value(&mut self) -> BodyValue {
+        self.scheduled_response_buffer = MutableString::default();
+        if self.result.has_more {
+            self.ignore_remaining_response_body();
+        }
+        BodyValue::Null
+    }
+
     fn to_response(&mut self) -> Response {
         bun_output::scoped_log!(FetchTasklet, "toResponse");
         debug_assert!(self.metadata.is_some());
         // at this point we always should have metadata
         let metadata = self.metadata.as_ref().unwrap();
         let http_response = &metadata.response;
-        self.is_waiting_body = self.result.has_more;
         // reshaped for borrowck — capture metadata fields before to_body_value() takes &mut self
         let headers = FetchHeaders::create_from_pico_headers(http_response.headers.list);
         let status_code = http_response.status_code as u16;
@@ -1896,6 +1926,12 @@ impl FetchTasklet {
         };
         let url = BunString::clone_utf8(metadata.url.slice());
         let redirected = self.result.redirected;
+        let body = if self.response_body_is_null(status_code) {
+            self.null_body_value()
+        } else {
+            self.is_waiting_body = self.result.has_more;
+            self.to_body_value()
+        };
         Response::init(
             crate::webcore::response::Init {
                 // SAFETY: create_from_pico_headers returns a fresh refcount=1 FetchHeaders*.
@@ -1904,7 +1940,7 @@ impl FetchTasklet {
                 status_text: status_text.into(),
                 ..Default::default()
             },
-            Body::new(self.to_body_value()),
+            Body::new(body),
             url,
             redirected,
         )

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1869,13 +1869,9 @@ impl FetchTasklet {
         response
     }
 
-    /// WHATWG fetch gives a response to a HEAD request, or one with a null body
-    /// status, a null body whatever the server frames after the head
-    /// (<https://fetch.spec.whatwg.org/#main-fetch>, "set internalResponse's body
-    /// to null"). 101 is the exception: the HTTP client only accepts one for a
-    /// request that asked to upgrade, and the upgraded connection is then the
-    /// body (`fetch.upgrade.test.ts`). The other 1xx statuses are interim
-    /// responses that the HTTP client never reports as the response.
+    /// <https://fetch.spec.whatwg.org/#main-fetch>: HEAD responses and null body
+    /// statuses have no body. Not 101: the HTTP client only accepts it for a
+    /// requested upgrade, and the upgraded connection is then the body.
     fn response_body_is_null(&self, status_code: u16) -> bool {
         (crate::server::http_status_text::is_null_body(status_code) && status_code != 101)
             || self
@@ -1884,14 +1880,10 @@ impl FetchTasklet {
                 .is_some_and(|http_| http_.method() == Method::HEAD)
     }
 
-    /// The body for `response_body_is_null`. Bytes the server frames anyway (a
-    /// 205 with content, say) are dropped: the ones already here now, the rest
-    /// by the HTTP thread, which drains them as it does the body of a Response
-    /// that was collected unread, so the connection can still be pooled. No
-    /// Response is attached to the tasklet yet, so `ignore_remaining_response_body`
-    /// only switches the transport over and releases the event loop.
-    /// `is_waiting_body` stays false: neither those bytes nor a transport
-    /// failure during the drain may reach the body.
+    /// Content the server frames anyway (a 205 with content) is dropped, and the
+    /// rest of it drained as for a Response collected unread, which keeps the
+    /// connection poolable. No Response is attached yet, so that is all the
+    /// ignore does. `is_waiting_body` stays false: nothing may reach this body.
     fn null_body_value(&mut self) -> BodyValue {
         self.scheduled_response_buffer = MutableString::default();
         if self.result.has_more {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -2530,6 +2530,34 @@ describe("HEAD requests #15355", () => {
       expect(response.headers.get("strict-transport-security")).toBe("max-age=31536000");
     });
   });
+
+  test("a proxied upstream HEAD response keeps the upstream Content-Length", async () => {
+    using upstream = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("Hello World");
+      },
+    });
+    // The upstream's response to HEAD has a null body, so the handler-supplied
+    // Content-Length (the upstream's) is what gets sent, as for any bodiless
+    // Response above.
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return fetch(upstream.url, { method: req.method });
+      },
+    });
+    const head = await fetch(server.url, { method: "HEAD" });
+    expect({ status: head.status, contentLength: head.headers.get("content-length"), text: await head.text() }).toEqual(
+      { status: 200, contentLength: "11", text: "" },
+    );
+    const get = await fetch(server.url);
+    expect({ status: get.status, contentLength: get.headers.get("content-length"), text: await get.text() }).toEqual({
+      status: 200,
+      contentLength: "11",
+      text: "Hello World",
+    });
+  });
 });
 
 describe("websocket and routes test", () => {

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { request } from "undici";
+import { request, fetch as undiciFetch } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -85,6 +85,27 @@ describe("undici", () => {
       } catch (e) {
         expect((e as Error).message).toBe("Body not allowed for GET or HEAD requests");
       }
+    });
+
+    // undici's fetch() gives these responses a null body, as the Fetch spec
+    // says. undici's request() hands out a body object for every response,
+    // and this one is empty.
+    it.each([
+      ["a 204", "/status/204", 204, {}],
+      ["the response to a HEAD request", "/head", 200, { method: "HEAD" }],
+    ])("%s has no body", async (_, path, expectedStatus, init) => {
+      const response = await undiciFetch(`${hostUrl}${path}`, init);
+      expect({ status: response.status, body: response.body }).toEqual({ status: expectedStatus, body: null });
+
+      const { statusCode, body } = await request(`${hostUrl}${path}`, init);
+      expect(statusCode).toBe(expectedStatus);
+      expect(body.bodyUsed).toBe(false);
+      expect(await body.text()).toBe("");
+      expect(body.bodyUsed).toBe(true);
+
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of (await request(`${hostUrl}${path}`, init)).body) chunks.push(chunk);
+      expect(chunks).toEqual([]);
     });
 
     it("should allow a query string to be passed", async () => {

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -91,6 +91,41 @@ test("node-fetch uses node streams instead of web streams", async () => {
   }
 });
 
+// node-fetch pipes every network response into a stream, so a response without
+// a body (204, HEAD) still has a stream body that ends at once, while a Response
+// constructed with a null body has `body === null`.
+test("node-fetch gives a fetched response without a body an empty stream", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (new URL(req.url).pathname === "/204") return new Response(null, { status: 204 });
+      return new Response("hello world");
+    },
+  });
+  const webBody = Object.getOwnPropertyDescriptor(originalResponse.prototype, "body").get;
+
+  for (const [path, init, status] of [
+    ["/204", {}, 204],
+    ["/", { method: "HEAD" }, 200],
+  ]) {
+    const result = await fetch2(new URL(path, server.url), init);
+    expect(result.status).toBe(status);
+    expect(webBody.call(result)).toBeNull();
+    expect(result.body).toBeInstanceOf(stream.Readable);
+    expect(result.body === result.body).toBe(true); // cached lazy getter
+    expect(result.clone().body).toBeInstanceOf(stream.Readable);
+    const chunks = [];
+    for await (const chunk of result.body) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([]);
+    expect(await result.text()).toBe("");
+  }
+
+  expect(new Response(null, { status: 204 }).body).toBeNull();
+  expect(new Response(null, { status: 204 }).clone().body).toBeNull();
+});
+
 test("node-fetch request body streams properly", async () => {
   let responseResolve;
   const responsePromise = new Promise(resolve => {

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -111,11 +111,12 @@ test("node-fetch gives a fetched response without a body an empty stream", async
     const result = await fetch2(new URL(path, server.url), init);
     expect(result.status).toBe(status);
     expect(webBody.call(result)).toBeNull();
-    expect(result.body).toBeInstanceOf(stream.Readable);
-    expect(result.body === result.body).toBe(true); // cached lazy getter
+    const body = result.body;
+    expect(body).toBeInstanceOf(stream.Readable);
+    expect(result.body).toBe(body); // cached lazy getter
     expect(result.clone().body).toBeInstanceOf(stream.Readable);
     const chunks = [];
-    for await (const chunk of result.body) {
+    for await (const chunk of body) {
       chunks.push(chunk);
     }
     expect(chunks).toEqual([]);

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1335,21 +1335,22 @@ test("a fetch() Response still reports the Content-Length after .body created th
 // hand out an empty stream instead, so reading it used the body up and clone()
 // threw afterwards.
 describe.concurrent("a fetch() Response that cannot have a body", () => {
-  // Every response closes its connection, so each fetch() below gets its own
-  // socket and the server answers exactly one request per socket. The HEAD
-  // answer carries the Content-Length of the GET body, as RFC 9110 section 9.3.2
-  // wants. RFC 9110 section 15.3.6 forbids content on a 205, but HTTP/1.1 framing
-  // can still carry it, and the bytes must then be received and dropped.
-  const wire: Record<string, string> = {
-    "/204": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n",
-    "/205": "HTTP/1.1 205 Reset Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-    "/205-with-content": "HTTP/1.1 205 Reset Content\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
-    "/304": 'HTTP/1.1 304 Not Modified\r\nETag: "x"\r\nConnection: close\r\n\r\n',
-    "/head": "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
-    "/empty": "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+  // The HEAD answer carries the Content-Length of the GET body, as RFC 9110
+  // section 9.3.2 wants. RFC 9110 section 15.3.6 forbids content on a 205, but
+  // HTTP/1.1 framing can still carry it, and the bytes must then be received and
+  // dropped. Every answer closes its connection, so each fetch() below gets its
+  // own socket.
+  const wire = {
+    noContent: "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n",
+    resetContent: "HTTP/1.1 205 Reset Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    resetContentWithContent: "HTTP/1.1 205 Reset Content\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+    notModified: 'HTTP/1.1 304 Not Modified\r\nETag: "x"\r\nConnection: close\r\n\r\n',
+    toHead: "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
+    emptyContent: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
   };
 
-  function listen() {
+  // Answers the one request it gets with `answer`, once the request head is in.
+  function listen(answer: string) {
     return Bun.listen<{ request: string }>({
       hostname: "127.0.0.1",
       port: 0,
@@ -1359,23 +1360,21 @@ describe.concurrent("a fetch() Response that cannot have a body", () => {
         },
         data(socket, data) {
           socket.data.request += data.toString("latin1");
-          if (!socket.data.request.includes("\r\n\r\n")) return;
-          const target = socket.data.request.split(" ")[1];
-          socket.end(wire[target]);
+          if (socket.data.request.includes("\r\n\r\n")) socket.end(answer);
         },
       },
     });
   }
 
   test.each([
-    ["204", "/204", undefined, 204, null],
-    ["205", "/205", undefined, 205, "0"],
-    ["205 whose server sent content anyway", "/205-with-content", undefined, 205, "5"],
-    ["304", "/304", undefined, 304, null],
-    ["200 to a HEAD request", "/head", { method: "HEAD" }, 200, "5"],
-  ])("%s: the body is null and reading it does not use it up", async (_, path, init, status, contentLength) => {
-    using listener = listen();
-    const response = await fetch(`http://127.0.0.1:${listener.port}${path}`, init);
+    ["204", wire.noContent, undefined, 204, null],
+    ["205", wire.resetContent, undefined, 205, "0"],
+    ["205 whose server sent content anyway", wire.resetContentWithContent, undefined, 205, "5"],
+    ["304", wire.notModified, undefined, 304, null],
+    ["200 to a HEAD request", wire.toHead, { method: "HEAD" }, 200, "5"],
+  ])("%s: the body is null and reading it does not use it up", async (_, answer, init, status, contentLength) => {
+    using listener = listen(answer);
+    const response = await fetch(`http://127.0.0.1:${listener.port}/`, init);
     await expect(response.json()).rejects.toThrow(SyntaxError);
     expect({
       status: response.status,
@@ -1397,20 +1396,20 @@ describe.concurrent("a fetch() Response that cannot have a body", () => {
   });
 
   test("a 200 with empty content still has a body", async () => {
-    using listener = listen();
-    const response = await fetch(`http://127.0.0.1:${listener.port}/empty`);
+    using listener = listen(wire.emptyContent);
+    const response = await fetch(`http://127.0.0.1:${listener.port}/`);
     expect(response.body).toBeInstanceOf(ReadableStream);
     expect(await response.text()).toBe("");
     expect(response.bodyUsed).toBe(true);
   });
 
   test.each([
-    ["204", "/204", undefined],
-    ["200 to a HEAD request", "/head", { method: "HEAD" }],
-  ])("%s: an abort after the response arrived has no body to error", async (_, path, init) => {
-    using listener = listen();
+    ["204", wire.noContent, undefined],
+    ["200 to a HEAD request", wire.toHead, { method: "HEAD" }],
+  ])("%s: an abort after the response arrived has no body to error", async (_, answer, init) => {
+    using listener = listen(answer);
     const controller = new AbortController();
-    const response = await fetch(`http://127.0.0.1:${listener.port}${path}`, { ...init, signal: controller.signal });
+    const response = await fetch(`http://127.0.0.1:${listener.port}/`, { ...init, signal: controller.signal });
     controller.abort();
     expect(response.body).toBeNull();
     expect(await response.text()).toBe("");

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1328,3 +1328,128 @@ test("a fetch() Response still reports the Content-Length after .body created th
   (await upstream).end(payload);
   expect(await stream.text()).toBe(payload);
 });
+
+// WHATWG fetch (main fetch, "set internalResponse's body to null"): a response to
+// a HEAD request, or with a null body status (204, 205, 304), has a null body,
+// whatever the server frames after the head. Node and browsers agree. Bun used to
+// hand out an empty stream instead, so reading it used the body up and clone()
+// threw afterwards.
+describe.concurrent("a fetch() Response that cannot have a body", () => {
+  // Every response closes its connection, so each fetch() below gets its own
+  // socket and the server answers exactly one request per socket. The HEAD
+  // answer carries the Content-Length of the GET body, as RFC 9110 section 9.3.2
+  // wants. RFC 9110 section 15.3.6 forbids content on a 205, but HTTP/1.1 framing
+  // can still carry it, and the bytes must then be received and dropped.
+  const wire: Record<string, string> = {
+    "/204": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n",
+    "/205": "HTTP/1.1 205 Reset Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    "/205-with-content": "HTTP/1.1 205 Reset Content\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+    "/304": 'HTTP/1.1 304 Not Modified\r\nETag: "x"\r\nConnection: close\r\n\r\n',
+    "/head": "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
+    "/empty": "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+  };
+
+  function listen() {
+    return Bun.listen<{ request: string }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { request: "" };
+        },
+        data(socket, data) {
+          socket.data.request += data.toString("latin1");
+          if (!socket.data.request.includes("\r\n\r\n")) return;
+          const target = socket.data.request.split(" ")[1];
+          socket.end(wire[target]);
+        },
+      },
+    });
+  }
+
+  test.each([
+    ["204", "/204", undefined, 204, null],
+    ["205", "/205", undefined, 205, "0"],
+    ["205 whose server sent content anyway", "/205-with-content", undefined, 205, "5"],
+    ["304", "/304", undefined, 304, null],
+    ["200 to a HEAD request", "/head", { method: "HEAD" }, 200, "5"],
+  ])("%s: the body is null and reading it does not use it up", async (_, path, init, status, contentLength) => {
+    using listener = listen();
+    const response = await fetch(`http://127.0.0.1:${listener.port}${path}`, init);
+    await expect(response.json()).rejects.toThrow(SyntaxError);
+    expect({
+      status: response.status,
+      contentLength: response.headers.get("content-length"),
+      body: response.body,
+      text: await response.text(),
+      bytes: await response.bytes(),
+      bodyUsed: response.bodyUsed,
+      cloneBody: response.clone().body,
+    }).toEqual({
+      status,
+      contentLength,
+      body: null,
+      text: "",
+      bytes: new Uint8Array(0),
+      bodyUsed: false,
+      cloneBody: null,
+    });
+  });
+
+  test("a 200 with empty content still has a body", async () => {
+    using listener = listen();
+    const response = await fetch(`http://127.0.0.1:${listener.port}/empty`);
+    expect(response.body).toBeInstanceOf(ReadableStream);
+    expect(await response.text()).toBe("");
+    expect(response.bodyUsed).toBe(true);
+  });
+
+  test.each([
+    ["204", "/204", undefined],
+    ["200 to a HEAD request", "/head", { method: "HEAD" }],
+  ])("%s: an abort after the response arrived has no body to error", async (_, path, init) => {
+    using listener = listen();
+    const controller = new AbortController();
+    const response = await fetch(`http://127.0.0.1:${listener.port}${path}`, { ...init, signal: controller.signal });
+    controller.abort();
+    expect(response.body).toBeNull();
+    expect(await response.text()).toBe("");
+  });
+
+  test("content that arrives after a 205 resolved is drained, so the process can exit", async () => {
+    // The server sends 3 of the 5 declared bytes with the head and the other 2
+    // only once fetch() has resolved. Nothing but the fetch refs the event loop,
+    // so the process only exits if the fetch takes those 2 bytes off the socket
+    // instead of keeping them for a body reader that cannot exist.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import net from "node:net";
+          let upstream;
+          const server = net.createServer(socket => {
+            upstream = socket;
+            socket.unref();
+            socket.once("data", () => {
+              socket.write("HTTP/1.1 205 Reset Content\\r\\nContent-Length: 5\\r\\n\\r\\nhel");
+            });
+          });
+          server.unref();
+          await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+          const response = await fetch("http://127.0.0.1:" + server.address().port + "/");
+          const body = response.body;
+          upstream.write("lo");
+          console.log(JSON.stringify({ status: response.status, body, text: await response.text() }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ status: 205, body: null, text: "" });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -818,6 +818,53 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
+  test("a 204, a 205 and the response to a HEAD request have a null body", async () => {
+    const server = makeH2Server();
+    server.on("stream", (stream, headers) => {
+      stream.on("error", () => {});
+      if (headers[":method"] === "HEAD") {
+        stream.respond({ ":status": 200, "content-length": "5" }, { endStream: true });
+      } else if (headers[":path"] === "/204") {
+        stream.respond({ ":status": 204 }, { endStream: true });
+      } else {
+        // RFC 9110 section 15.3.6 forbids content on a 205. A server that sends
+        // some anyway must not get it into the body.
+        stream.respond({ ":status": 205 });
+        stream.end("hello");
+      }
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = await spawnFetch(`
+        const results = [];
+        for (const [path, init] of [["/204", {}], ["/205", {}], ["/head", { method: "HEAD" }]]) {
+          const r = await fetch("https://localhost:${port}" + path, { ...init, tls: { rejectUnauthorized: false } });
+          results.push({
+            status: r.status,
+            contentLength: r.headers.get("content-length"),
+            body: r.body,
+            text: await r.text(),
+            bodyUsed: r.bodyUsed,
+            cloneBody: r.clone().body,
+          });
+        }
+        console.log(JSON.stringify(results));
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        { status: 204, contentLength: null, body: null, text: "", bodyUsed: false, cloneBody: null },
+        { status: 205, contentLength: null, body: null, text: "", bodyUsed: false, cloneBody: null },
+        { status: 200, contentLength: "5", body: null, text: "", bodyUsed: false, cloneBody: null },
+      ]);
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
   describe("raw frame server", () => {
     test("REFUSED_STREAM is transparently retried on the same connection", async () => {
       let attempts = 0;

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -269,6 +269,20 @@ describe("fetch protocol: http3", () => {
     expect(await res.text()).toBe("");
   });
 
+  test.each([
+    ["a 204", "/status?code=204&body=", {}],
+    ["a 304", "/status?code=304&body=", {}],
+    ["a HEAD request", "/head", { method: "HEAD" }],
+  ])("the response to %s has a null body", async (_, path, init) => {
+    const res = await fetch(`${base}${path}`, { ...h3, ...init });
+    expect({
+      body: res.body,
+      text: await res.text(),
+      bodyUsed: res.bodyUsed,
+      cloneBody: res.clone().body,
+    }).toEqual({ body: null, text: "", bodyUsed: false, cloneBody: null });
+  });
+
   test("gzip response is decompressed", async () => {
     const res = await fetch(`${base}/gzip`, h3);
     expect(await res.text()).toBe("compressed body over h3");


### PR DESCRIPTION
### Problem
- `fetch()` gives a 204, 205 or 304 response, and any response to a HEAD request, a non-null `body`. `res.text()` sets `bodyUsed`, and since 1.4.0 `res.clone()` then throws `TypeError: Body is disturbed or locked` (`ERR_BODY_ALREADY_USED`). Node gives `body === null`.
- Cause: `FetchTasklet::to_response` (`src/runtime/webcore/fetch/FetchTasklet.rs`) only builds `InternalBlob` or `Locked` bodies, never `BodyValue::Null`.

### Fix
- `to_response` builds `BodyValue::Null` for a null body status (shared `is_null_body`, minus 101) and for a HEAD request (new `AsyncHTTP::method()`). `null_body_value` is the fix.
- Content a server frames anyway (a 205) is dropped. Content still on the wire is drained like the body of an unread, collected Response. The connection stays poolable and the process can exit.
- Matches the Fetch spec (main fetch) and Node. `new Response(null, { status: 204 })` already works this way. 101 keeps its body: it only arrives for a requested upgrade, whose connection is the body. The `undici` and `node-fetch` shims keep their upstream shape.
- Verified: `test/js/web/fetch/body.test.ts` (new block, 8 of 9 tests fail on current bun), plus new h2, h3, undici, node-fetch and Bun.serve proxy cases.

### Background
- `FetchTasklet` is the JS-thread side of one `fetch()`. `to_response` turns the response head into the `Response` the promise resolves with.
- `BodyValue` (`src/runtime/webcore/Body.rs`) is a Response's body state. `Null` is what `new Response(null)` has: `.body` is null, `text()` resolves `""` and changes nothing, so `bodyUsed` stays false.
- RFC 9112 ends a 204, a 304 and a HEAD response at the header block, so the HTTP client already reads no body for them. A 205 is framed normally, so content can arrive. `BodyReceiveMode::Ignore` (`src/http/Signals.rs`) makes the HTTP thread discard it.

<details><summary>Notes</summary>

Repro, one script against a `node:http` server. Bun 1.4.0 prints the first column, Node 26 the second. The fixed build prints the Node column.

```
GET /204   body=stream  bodyUsed(after text)=true  clone=ERR_BODY_ALREADY_USED  json()=null        | body=null  bodyUsed=false  clone=ok  json()=SyntaxError
GET /205   same                                                                                    | same
GET /304   same                                                                                    | same
HEAD /x    same                                                                                    | same
GET /x     body=stream  bodyUsed=true  clone throws  (a real body, unchanged)                      | same as Bun
```

Consequences of the null body. All of them are shared with `new Response(null)` and with Node:

- `res.json()` on these responses now rejects with a `SyntaxError`. It resolved `null` before.
- `text()`, `arrayBuffer()` and `bytes()` resolve empty and can be called more than once.
- An abort after the response arrived no longer errors the body (`BodyAbortListener` skips `Null`). Before, `text()` rejected with an `AbortError`. The new block has tests for this.
- `Bun.serve` that answers a HEAD request with a proxied upstream HEAD response now sends the upstream `Content-Length` (the bodiless branch of the HEAD renderer) instead of `content-length: 0`. `bun-server.test.ts` gets a test for it.

Drain path. The test "content that arrives after a 205 resolved is drained" sends 3 of 5 declared bytes with the head and the other 2 after `fetch()` resolved. With the `ignore_remaining_response_body()` call removed, the body is still null, but the transport stays paused and the child never exits, so the test fails by timeout. With the call, the child exits at once.

Why the original method is enough for the HEAD check: a redirect only ever rewrites a method to GET, and only on the HTTP thread's copy, so a request ends as HEAD exactly when it started as HEAD. A 101 cannot reach `to_response` without a requested upgrade (`UnrequestedUpgrade` in `src/http/lib.rs`). h1, h2 and h3 all skip the other 1xx responses as interim responses. `fetch.upgrade.test.ts` reads the body of a 101 and still passes.

Shims, checked against the real packages under Node 26 (`undici@5.20.0` and `node-fetch@2.6.7` from `test/node_modules`): `undici.request()` returns a `BodyReadable` whose `text()` is `""` for a 204 and for HEAD. `node-fetch` returns a `PassThrough` body for both, and `new Response(null).body` is `null`. The shim tests assert that shape. They also assert, through the native `body` getter, that the body underneath is now null, so they fail on current bun too.

Suites run with the debug build: `fetch.test.ts`, `body.test.ts`, `body-clone`, `body-mixin-errors`, `body-stream`, `body-async-iterator`, `body-stream-excess`, `response.test.ts`, `fetch.upgrade`, `fetch-redirect`, `fetch-backpressure`, `fetch.stream`, `fetch-keepalive`, `fetch-http2-client`, `fetch-http3-client`, `regression/issue/29181`, the undici and node-fetch files, `serve-if-none-match`, and the HEAD, 204 and status tests of `serve.test.ts` and `bun-server.test.ts`.

In this container, tests that listen on `hostname: "localhost"` fail with `ConnectionRefused` on current bun as well, because the listener binds `::1`. I re-ran the 304, `http/1.1 response body length` and keep-alive tests from `fetch.test.ts` on a copy that binds `127.0.0.1`. All of them pass with this change. `response.test.ts` "handle stack overflow" and a few streaming tests sit at the 5 s limit under the debug build when several files run at once. They pass when run alone and do not touch this code.

No in-tree test relied on the old shape. The two shims are the only consumers of a fetched response's `.body` in `src/js`.
</details>
