### PR TITLE
Resolve single-slash file: URLs in import() and import.meta.resolve

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -937,13 +937,20 @@ pub fn starts_with(self_: &[u8], str: &[u8]) -> bool {
 /// Strips the `file:` scheme from an absolute file URL: `file:///p` and
 /// `file:/p` both give `/p` (WHATWG). No percent-decoding.
 pub fn strip_file_url_prefix(self_: &[u8]) -> &[u8] {
-    if let Some(rest) = self_.strip_prefix(b"file://".as_slice()) {
-        return rest;
+    let rest = if let Some(rest) = self_.strip_prefix(b"file://".as_slice()) {
+        rest
+    } else if self_.starts_with(b"file:/") {
+        &self_[b"file:".len()..]
+    } else {
+        return self_;
+    };
+    // A drive-letter URL serializes as `file:///C:/x`. Drop the slash before
+    // the drive letter so the result is a native absolute path.
+    #[cfg(windows)]
+    if rest.len() >= 3 && rest[0] == b'/' && rest[1].is_ascii_alphabetic() && rest[2] == b':' {
+        return &rest[1..];
     }
-    if self_.starts_with(b"file:/") {
-        return &self_[b"file:".len()..];
-    }
-    self_
+    rest
 }
 
 /// Transliterated from:

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -934,6 +934,19 @@ pub fn starts_with(self_: &[u8], str: &[u8]) -> bool {
     eql_long(&self_[0..str.len()], str, false)
 }
 
+/// Strips the `file:` scheme from an absolute file URL, returning the path
+/// bytes: `file:///p` and `file:/p` both denote the path `/p` (WHATWG). Does
+/// not percent-decode. Returns the input unchanged for anything else.
+pub fn strip_file_url_prefix(self_: &[u8]) -> &[u8] {
+    if let Some(rest) = self_.strip_prefix(b"file://".as_slice()) {
+        return rest;
+    }
+    if self_.starts_with(b"file:/") {
+        return &self_[b"file:".len()..];
+    }
+    self_
+}
+
 /// Transliterated from:
 /// https://github.com/rust-lang/rust/blob/91376f416222a238227c84a848d168835ede2cc3/library/core/src/str/mod.rs#L188
 pub fn is_on_char_boundary(self_: &[u8], idx: usize) -> bool {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -934,9 +934,8 @@ pub fn starts_with(self_: &[u8], str: &[u8]) -> bool {
     eql_long(&self_[0..str.len()], str, false)
 }
 
-/// Strips the `file:` scheme from an absolute file URL, returning the path
-/// bytes: `file:///p` and `file:/p` both denote the path `/p` (WHATWG). Does
-/// not percent-decode. Returns the input unchanged for anything else.
+/// Strips the `file:` scheme from an absolute file URL: `file:///p` and
+/// `file:/p` both give `/p` (WHATWG). No percent-decoding.
 pub fn strip_file_url_prefix(self_: &[u8]) -> &[u8] {
     if let Some(rest) = self_.strip_prefix(b"file://".as_slice()) {
         return rest;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3479,13 +3479,6 @@ pub fn collect_macro_vm_garbage() {
     vm_ref.jsc_vm().run_gc(true);
 }
 
-fn normalize_source(source: &[u8]) -> &[u8] {
-    if let Some(rest) = source.strip_prefix(b"file://") {
-        return rest;
-    }
-    source
-}
-
 // Additional FFI used by the formerly-gated impl.
 // C++ side defines `extern "C" SYSV_ABI` (BakeAdditionsToGlobalObject.cpp).
 //
@@ -4754,7 +4747,7 @@ impl VirtualMachine {
         let resolve_result = jsc_vm._resolve(
             &mut result,
             specifier_utf8.slice(),
-            normalize_source(source_utf8.slice()),
+            bun_core::strings::strip_file_url_prefix(source_utf8.slice()),
             mode.is_esm(),
             IS_A_FILE_PATH,
         );

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -457,7 +457,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
         return {};
     }
 
-    if (filename.startsWith("file://"_s)) {
+    if (filename.startsWith("file:"_s)) {
         WTF::URL fileURL = WTF::URL(filename);
         if (!fileURL.isValid() || !fileURL.protocolIsFile()) {
             JSC::throwTypeError(globalObject, scope, "invalid file: URL passed to dlopen"_s);

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -396,9 +396,8 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
     auto fromWTFString = from.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // A `file:` specifier is an absolute URL whatever the slash count: WHATWG
-    // parsing normalizes `file:/path` and `file:path` to `file:///path`. Parse
-    // it standalone (no base), like Node, so all three forms resolve the same.
+    // WHATWG parsing makes any `file:` specifier absolute (`file:/p` and
+    // `file:p` normalize to `file:///p`), so parse it standalone like Node.
     if (specifier.startsWith("file:"_s)) {
         WTF::URL url(specifier);
         if (url.isValid() && !url.isEmpty()) {

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -396,8 +396,7 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
     auto fromWTFString = from.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // WHATWG parsing makes any `file:` specifier absolute (`file:/p` and
-    // `file:p` normalize to `file:///p`), so parse it standalone like Node.
+    // Parse a `file:` specifier standalone (no base), like Node: WHATWG parsing makes it absolute.
     if (specifier.startsWith("file:"_s)) {
         WTF::URL url(specifier);
         if (url.isValid() && !url.isEmpty()) {

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -396,13 +396,23 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
     auto fromWTFString = from.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
+    // A `file:` specifier is an absolute URL whatever the slash count: WHATWG
+    // parsing normalizes `file:/path` and `file:path` to `file:///path`. Parse
+    // it standalone (no base), like Node, so all three forms resolve the same.
+    if (specifier.startsWith("file:"_s)) {
+        WTF::URL url(specifier);
+        if (url.isValid() && !url.isEmpty()) {
+            RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, url.string())));
+        }
+    }
+
     // Try to resolve it to a relative file path. This path is not meant to throw module resolution errors.
-    if (specifier.startsWith("./"_s) || specifier.startsWith("../"_s) || specifier.startsWith("/"_s) || specifier.startsWith("file://"_s)
+    if (specifier.startsWith("./"_s) || specifier.startsWith("../"_s) || specifier.startsWith("/"_s)
 #if OS(WINDOWS)
         || specifier.startsWith(".\\"_s) || specifier.startsWith("..\\"_s) || specifier.startsWith("\\"_s)
 #endif
     ) {
-        auto fromURL = fromWTFString.startsWith("file://"_s) ? WTF::URL(fromWTFString) : WTF::URL::fileURLWithFileSystemPath(fromWTFString);
+        auto fromURL = fromWTFString.startsWith("file:"_s) ? WTF::URL(fromWTFString) : WTF::URL::fileURLWithFileSystemPath(fromWTFString);
         if (!fromURL.isValid()) {
             JSC::throwTypeError(globalObject, scope, "`parent` is not a valid Filepath / URL"_s);
             RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::JSValue {}));

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3438,7 +3438,9 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
                     return Identifier::fromString(vm, Bun::builtinModuleKeys[index]);
             }
         }
-        if (moduleName->startsWith("file://"_s)) {
+        // `file:` with any slash count: WHATWG parsing normalizes
+        // `file:/path` and `file:path` to `file:///path`, like Node.
+        if (moduleName->startsWith("file:"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
                 keyString = url.fileSystemPath();
@@ -3590,7 +3592,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     }
 
     {
-        if (moduleName.startsWith("file://"_s)) {
+        if (moduleName.startsWith("file:"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
                 moduleName = url.fileSystemPath();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3438,8 +3438,7 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
                     return Identifier::fromString(vm, Bun::builtinModuleKeys[index]);
             }
         }
-        // `file:` with any slash count: WHATWG parsing normalizes
-        // `file:/path` and `file:path` to `file:///path`, like Node.
+        // Any slash count: WHATWG parsing normalizes `file:/p` to `file:///p`.
         if (moduleName->startsWith("file:"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -70,7 +70,7 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
     ASSERT(context.isContextThread());
 
     String url = urlInit;
-    if (url.startsWith("file://"_s)) {
+    if (url.startsWith("file:"_s)) {
         WTF::URL urlObject { url };
         if (!urlObject.isValid())
             return Exception { TypeError, makeString("Invalid file URL: \""_s, urlInit, '"') };

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -124,7 +124,7 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
     Vector<BunString> preloadModules;
     preloadModules.reserveInitialCapacity(m_options.preloadModules.size());
     for (auto& str : m_options.preloadModules) {
-        if (str.startsWith("file://"_s)) {
+        if (str.startsWith("file:"_s)) {
             WTF::URL urlObject = WTF::URL(str);
             if (!urlObject.isValid())
                 return Exception { TypeError, makeString("Invalid file URL: \""_s, str, '"') };

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1139,7 +1139,7 @@ fn resolve_with_args<const IS_FILE_PATH: bool>(
     let mut query_string = BunString::EMPTY;
 
     let decoded_specifier;
-    let specifier_for_resolve = if specifier.starts_with_ascii(b"file://") {
+    let specifier_for_resolve = if specifier.starts_with_ascii(b"file:") {
         decoded_specifier = bun_url::path_from_file_url(specifier);
         &decoded_specifier
     } else {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -772,10 +772,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         // SAFETY: `preload` points at a live boxed slice for this iteration
         // (heap-stable `Box<[u8]>` payload; nothing below mutates `vm.preload`).
         let preload_slice: &[u8] = unsafe { &*preload };
-        // Strip "file://".
-        let normalized: &[u8] = preload_slice
-            .strip_prefix(b"file://".as_slice())
-            .unwrap_or(preload_slice);
+        let normalized: &[u8] = bun_core::strings::strip_file_url_prefix(preload_slice);
 
         // node: builtin specifiers bypass the file resolver — JSModuleLoader
         // resolves them internally, so `bun --import node:*` works like Node's.

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -1,7 +1,7 @@
-import { spawnSync } from "bun";
+import { pathToFileURL, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 const preloadModule = `
@@ -210,4 +210,21 @@ plugin({
       expect(exitCode).toBe(1);
     }
   });
+});
+
+test("--preload accepts a single-slash file: URL (#39780)", () => {
+  using dir = tempDir("preload-one-slash", {
+    "preload.js": `console.log("preloaded");`,
+    "main.js": `console.log("main");`,
+  });
+  // WHATWG URL parsing normalizes file:/path to file:///path.
+  const oneSlash = pathToFileURL(join(String(dir), "preload.js")).href.replace("file://", "file:");
+  const { stderr, exitCode, stdout } = spawnSync({
+    cmd: [bunExe(), "--preload", oneSlash, join(String(dir), "main.js")],
+    cwd: String(dir),
+    env: bunEnv,
+  });
+  expect(stderr.toString()).toBe("");
+  expect(stdout.toString()).toBe("preloaded\nmain\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -159,6 +159,9 @@ console.log(staticFoo, foo, resolved === ${JSON.stringify(href)});`,
   expect(stderr.toString("utf8")).toBe("");
   expect(stdout.toString("utf8")).toBe("1 1 true\n");
   expect(exitCode).toBe(0);
+
+  // Pins the Bun.resolveSync / require path, which decodes the URL in Rust.
+  expect(Bun.resolveSync(oneSlash, String(dir))).toBe(join(String(dir), "mod.mjs"));
 });
 
 it("zero-slash file: specifier parses standalone like in Node (#39780)", () => {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -136,6 +136,37 @@ it("file url in await import resolves", async () => {
   expect(stdout.toString("utf8")).toBe("1\n");
 });
 
+it("single-slash file: URL resolves like file:// (#39780)", async () => {
+  await using dir = tempDir("fileurl-one-slash", {
+    "mod.mjs": "export const foo = 1;",
+  });
+  const href = pathToFileURL(join(String(dir), "mod.mjs")).href;
+  // WHATWG URL parsing normalizes file:/path to file:///path.
+  const oneSlash = href.replace("file://", "file:");
+  writeFileSync(
+    `${dir}/test.mjs`,
+    `import { foo as staticFoo } from ${JSON.stringify(oneSlash)};
+const { foo } = await import(${JSON.stringify(oneSlash)});
+const resolved = import.meta.resolve(${JSON.stringify(oneSlash)});
+console.log(staticFoo, foo, resolved === ${JSON.stringify(href)});`,
+  );
+
+  const { exitCode, stdout, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), `${dir}/test.mjs`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+  expect(stderr.toString("utf8")).toBe("");
+  expect(stdout.toString("utf8")).toBe("1 1 true\n");
+  expect(exitCode).toBe(0);
+});
+
+it("zero-slash file: specifier parses standalone like in Node (#39780)", () => {
+  // Node parses a file: specifier with no base URL: file:mod.mjs is
+  // file:///mod.mjs, not a sibling of the importer.
+  expect(import.meta.resolve("file:mod.mjs")).toBe("file:///mod.mjs");
+});
+
 it("file url with special characters in await import resolves", async () => {
   const filename = "🅱️ndex.js";
   await using dir = tempDir("file url", {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1458,6 +1458,14 @@ describe.concurrent(() => {
       expect(e.message).not.toContain("file:");
     }
 
+    // Single-slash form (#39780): the URL is decoded to a path before dlopen.
+    try {
+      process.dlopen(mod, import.meta.url.replace("file://", "file:"));
+      throw "Expected error";
+    } catch (e) {
+      expect(e.message).not.toContain("file:");
+    }
+
     expect(() => process.dlopen(mod, "file://asd[kasd[po@[p1o23]1po!-10923-095-@$@8123=-9123=-0==][pc;!")).toThrow(
       "invalid file: URL passed to dlopen",
     );

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -37,6 +37,16 @@ describe("web worker", () => {
       expect(result).toEqual("hello world");
     });
 
+    test("single-slash file: URL for entry and preload (#39780)", async () => {
+      // WHATWG URL parsing normalizes file:/path to file:///path.
+      const oneSlash = (name: string) => new URL(name, import.meta.url).href.replace("file://", "file:");
+      const worker = new Worker(oneSlash("worker-fixture-preload-entry.js"), {
+        preload: oneSlash("worker-fixture-preload.js"),
+      });
+      const result = await waitForWorkerResult(worker, "hello world");
+      expect(result).toEqual("hello world");
+    });
+
     test("array of 2 strings", async () => {
       const worker = new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
         preload: [


### PR DESCRIPTION
### Problem
- `import("file:/abs/path")` and `import.meta.resolve("file:/abs/path")` fail with `Cannot find package 'file:'`. Node accepts the single-slash form. Per WHATWG URL, `file:/path` normalizes to `file:///path`, and Bun's own `new URL("file:/tmp/x").href` agrees.
- Every file-URL special case matches the literal `file://` prefix: the module loader hooks (`ZigGlobalObject.cpp`), `import.meta.resolve` (`ImportMetaObject.cpp`), the `Bun.resolveSync`/`require` path (`BunObject.rs`), `new Worker`, `process.dlopen`, worker preloads, CLI `--preload`/`--import` (`jsc_hooks.rs`), and the referrer normalization (`VirtualMachine.rs`). Other `file:` forms fall through to bare-specifier resolution, which parses `file:` as a package name.
- This breaks Storybook under `bun --bun vitest`: its preset loader builds a specifier with `path.join("file://...", "package.json")`, and `path.join` collapses `//` to `/`.

### Fix
- Match on the `file:` scheme instead of the `file://` prefix at all nine sites. The C++ sites let the WHATWG URL parser normalize before taking the filesystem path. The two byte-level Rust sites share a new `bun_core::strings::strip_file_url_prefix` helper that keeps their existing no-decode semantics.
- `import.meta.resolve` now parses a `file:` specifier standalone (no base), like Node: `file:mod.mjs` resolves to `file:///mod.mjs`, not to a sibling of the importer.
- Correct because any specifier whose scheme is `file` is an absolute URL after parsing. An unparseable `file:` string still takes the old error path.
- Verified: new tests in `test/js/bun/resolve/resolve.test.ts`, `test/js/web/workers/worker.test.ts`, `test/js/node/process/process.test.js`, and `test/cli/run/preload-test.test.js` (all fail on stock Bun). Also ran all of `test/js/bun/resolve/`, `test/js/node/module/`, `test/js/bun/plugin/`, and the worker suite.

### Background
- Bun converts `file:` URL specifiers to filesystem paths before resolution. The conversion is an inline prefix check at each entry point: static and dynamic import, `import.meta.resolve`, `Bun.resolveSync`, `new Worker`, `process.dlopen`, worker preloads, and CLI preloads.
- Node's ESM resolver accepts any specifier that parses as a URL, so every `file:` form works there regardless of slash count.

<details><summary>Notes</summary>

With the fix, Bun matches Node exactly on the repro matrix, including the zero-slash edge:

```
OK import two-slash
OK resolve two-slash file:///tmp/repro39780/mod.mjs
OK import one-slash
OK resolve one-slash file:///tmp/repro39780/mod.mjs
OK import join
OK resolve join file:///tmp/repro39780/mod.mjs
resolve zero-slash: file:///mod.mjs
ERR import zero-slash Cannot find module '/mod.mjs' imported from /tmp/repro39780/probe.mjs
```

CLI check: `bun --preload file:/abs/pre.js main.js` failed with `preload not found` on stock Bun. Node's `--import` accepts the same form.

Scope notes:

- Mixed-case schemes (`FILE:/path`) still resolve as bare specifiers. That gap predates this PR (the old code did not accept `FILE://` either) and needs a hand-written uppercase scheme to hit, so the match stays case-sensitive.
- `require("file:/...")` also works after this change. Bun already accepted `file://` in `require`, which Node does not, so the widening keeps Bun self-consistent rather than matching Node there.
- The two Rust byte-level sites (CLI preloads, referrer normalization) never percent-decoded. The shared helper preserves that, so percent-encoded paths behave as before at those sites.
- `test/js/bun/resolve/load-same-js-file-a-lot.test.ts` and three worker terminate-race tests fail in my local debug build with and without this diff, so they are unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js, test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->