### PR TITLE
install: fix use-after-free in pnpm-workspace.yaml migration to package.json

### DIFF
--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2519,7 +2519,9 @@ fn update_package_json_after_migration(
             // `workspace_package_json_cache`. Intern the bytes into the same
             // thread-local `DATA_STORE` that owns the surrounding `Expr`
             // nodes — arena ownership, not a leak (bulk-freed on
-            // `Expr::data_store_reset`).
+            // `Expr::data_store_reset`). This only covers scalars that slice
+            // the source; arena-backed scalars are re-interned after the
+            // parse below.
             let contents: &'static [u8] = js_ast::data_store_dupe_str(&contents);
             let yaml_source = bun_ast::Source::init_path_string(b"pnpm-workspace.yaml", contents);
             let arena = bun_alloc::Arena::new();
@@ -2556,6 +2558,21 @@ fn update_package_json_after_migration(
             workspace_patched_deps_obj = ws_root
                 .get_object(b"patchedDependencies")
                 .filter(is_non_empty_object);
+
+            // These subtrees escape this arm (into `json` and the cached
+            // package.json tree) while `arena` drops with it, so their
+            // arena-backed strings must be re-interned first (#39785).
+            for subtree in [
+                &mut catalog_obj,
+                &mut catalogs_obj,
+                &mut workspace_overrides_obj,
+                &mut workspace_patched_deps_obj,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                data_store_dupe_expr_strings(subtree);
+            }
         }
         Err(_) => {}
     }
@@ -2765,6 +2782,37 @@ fn update_package_json_after_migration(
 
 fn is_non_empty_object(expr: &Expr) -> bool {
     matches!(&expr.data, ExprData::EObject(o) if !o.properties.is_empty())
+}
+
+/// The YAML parser backs quoted, block, and multi-line plain scalars with the
+/// caller's parse arena (`NodeScalar::to_expr`), so a subtree that outlives
+/// that arena dangles. Re-intern every string into the thread-local
+/// `DATA_STORE` that owns the surrounding `Expr` nodes.
+fn data_store_dupe_expr_strings(expr: &mut Expr) {
+    match &mut expr.data {
+        ExprData::EString(s) => {
+            let s = &mut **s;
+            if s.is_utf8() {
+                s.data = E::Str::new(js_ast::data_store_dupe_str(s.data.slice()));
+            }
+        }
+        ExprData::EObject(o) => {
+            for prop in (**o).properties.slice_mut() {
+                if let Some(key) = prop.key.as_mut() {
+                    data_store_dupe_expr_strings(key);
+                }
+                if let Some(value) = prop.value.as_mut() {
+                    data_store_dupe_expr_strings(value);
+                }
+            }
+        }
+        ExprData::EArray(a) => {
+            for item in (**a).items.slice_mut() {
+                data_store_dupe_expr_strings(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn paths_array(paths: &[&'static [u8]]) -> Expr {

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2657,10 +2657,11 @@ importers:
     // backed by a parse arena that dropped before package.json was printed.
     // MIMALLOC_PURGE_DELAY=0 makes the freed pages unreadable right away, so
     // the use-after-free is deterministic even in a tiny repo.
-    test.concurrent("pnpm-workspace.yaml overrides migrate verbatim", async () => {
+    test.concurrent("pnpm-workspace.yaml overrides, catalogs, and patches migrate verbatim", async () => {
       using dir = tempDir("pnpm-v9-workspace-overrides-uaf", {
         "package.json": JSON.stringify({ name: "workspace-overrides-uaf", private: true }),
         "packages/a/package.json": JSON.stringify({ name: "a", private: true }),
+        "patches/pkg-g.patch": "",
         "pnpm-workspace.yaml": `packages:
   - 'packages/*'
 overrides:
@@ -2670,6 +2671,14 @@ overrides:
   pkg-c: '>=1.19.10'
   pkg-d: |-
     7.15.1
+  "pkg\\u002dk": 9.9.9
+catalog:
+  pkg-e: "\\u003e=1.0.0"
+catalogs:
+  group-a:
+    pkg-f: '2.3.4'
+patchedDependencies:
+  pkg-g: "patches/pkg\\u002dg.patch"
 `,
         "pnpm-lock.yaml": `lockfileVersion: '9.0'
 
@@ -2685,7 +2694,7 @@ importers:
         cmd: [bunExe(), "pm", "migrate"],
         cwd: String(dir),
         env: { ...bunEnv, MIMALLOC_PURGE_DELAY: "0" },
-        stdout: "pipe",
+        stdout: "ignore",
         stderr: "pipe",
       });
       const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -2694,13 +2703,19 @@ importers:
       expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
         name: "workspace-overrides-uaf",
         private: true,
-        workspaces: ["packages/*"],
+        workspaces: {
+          packages: ["packages/*"],
+          catalog: { "pkg-e": ">=1.0.0" },
+          catalogs: { "group-a": { "pkg-f": "2.3.4" } },
+        },
         overrides: {
           "pkg-a": "7.28.6",
           "pkg-b": ">=5.5.9",
           "pkg-c": ">=1.19.10",
           "pkg-d": "7.15.1",
+          "pkg-k": "9.9.9",
         },
+        patchedDependencies: { "pkg-g": "patches/pkg-g.patch" },
       });
       expect(exitCode).toBe(0);
     });

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2652,6 +2652,58 @@ importers:
       expect(exitCode).toBe(1);
       expect(existsSync(join(String(dir), "bun.lock"))).toBe(false);
     });
+
+    // #39785: quoted, block, and escaped scalars from pnpm-workspace.yaml were
+    // backed by a parse arena that dropped before package.json was printed.
+    // MIMALLOC_PURGE_DELAY=0 makes the freed pages unreadable right away, so
+    // the use-after-free is deterministic even in a tiny repo.
+    test.concurrent("pnpm-workspace.yaml overrides migrate verbatim", async () => {
+      using dir = tempDir("pnpm-v9-workspace-overrides-uaf", {
+        "package.json": JSON.stringify({ name: "workspace-overrides-uaf", private: true }),
+        "packages/a/package.json": JSON.stringify({ name: "a", private: true }),
+        "pnpm-workspace.yaml": `packages:
+  - 'packages/*'
+overrides:
+  pkg-a: >-
+    7.28.6
+  pkg-b: "\\u003e=5.5.9"
+  pkg-c: '>=1.19.10'
+  pkg-d: |-
+    7.15.1
+`,
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+  packages/a: {}
+`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "pm", "migrate"],
+        cwd: String(dir),
+        env: { ...bunEnv, MIMALLOC_PURGE_DELAY: "0" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+      expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
+        name: "workspace-overrides-uaf",
+        private: true,
+        workspaces: ["packages/*"],
+        overrides: {
+          "pkg-a": "7.28.6",
+          "pkg-b": ">=5.5.9",
+          "pkg-c": ">=1.19.10",
+          "pkg-d": "7.15.1",
+        },
+      });
+      expect(exitCode).toBe(0);
+    });
   });
 
   test.concurrent("link: version with a semver specifier resolves to the workspace (pnpm/pnpm#7712)", async () => {


### PR DESCRIPTION
### Problem
- `bun install` in a pnpm repo can write freed memory into the `overrides`, `catalog`, `catalogs`, and `patchedDependencies` blocks it migrates from `pnpm-workspace.yaml` into `package.json`. Keys and values come out as NUL bytes, pointer fragments, or slices of the JSON printer's own buffer. A corrupted value can even reach `git clone` as a URL. Issue #39785.
- The cause is a use-after-free in `update_package_json_after_migration` (`src/install/pnpm.rs:2525`). The function parses `pnpm-workspace.yaml` with an arena that drops at the end of one match arm. The YAML parser copies quoted, block, and multi-line scalars into that arena (`src/parsers/yaml.rs`, `NodeScalar::to_expr`). The four subtrees above escape the arm and are printed into `package.json` later.

### Fix
- After the parse, walk the four escaping subtrees and copy every string into the thread-local `DATA_STORE`, the allocator that already owns the surrounding `Expr` nodes. The arena can then drop safely.
- This matches how the function already handles the `packages` list and how `rewrite_bare_patch_keys` interns its rewritten keys.
- Verified: new test in `test/cli/install/migration/pnpm-lock-v9.test.ts`. It fails on current bun (the migrated `package.json` is not valid JSON) and passes with the fix. All of `test/cli/install/migration/pnpm-*.test.ts` passes.

### Background
- The migration builds the new `package.json` by mutating the cached `Expr` tree of the old one, then printing it. `EString` nodes do not own their bytes. They hold a pointer and a length into whatever allocator produced them.
- `DATA_STORE` is the thread-local arena behind `Expr` nodes. `data_store_dupe_str` copies bytes into it so a slice lives exactly as long as the nodes that reference it.
- Plain single-line YAML scalars slice the source text, which the function already interns. Only scalars the parser has to rewrite (quotes with escapes, block scalars, folded multi-line values) took the arena-backed path, which is why only some entries corrupted.

<details><summary>Notes</summary>

- The corruption needs the freed arena pages to be reused or purged before the print, so small repros look clean. `MIMALLOC_PURGE_DELAY=0` makes mimalloc decommit freed pages at once, which makes a 2-package repro deterministic: every quoted or block override value comes back as NUL bytes of the original length. The test uses this env var.
- On a debug (ASAN) build the same repro crashes with a SEGV in `write_pre_quoted_string_inner` (`src/js_printer/lib.rs:901`) under `print_json`, reached from `update_package_json_after_migration` (`src/install/pnpm.rs:2723`). ASAN does not flag it directly because the arena is a mimalloc heap, so its drop never reaches the system allocator.
- `migrate_pnpm_lockfile` solved the same lifetime problem for `pnpm-lock.yaml` by deep-cloning the parsed tree into a function-scope arena. That is not enough here because the subtrees outlive the function inside the cached `package.json` tree, so they must move to `DATA_STORE` instead.
- The reporter's symptoms all follow from the one dangling slice: invalid UTF-8 in `package.json`, resolution failures against garbage ranges, a `git clone` spawned on a garbage URL, and silently dropped security pins when a key garbles.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.0 (4199361ed)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [271.82ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [386.97ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [153.67ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [164.16ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [154.97ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [149.77ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [195.62ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [183.15ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [323.99ms]
(pass) pnpm-lock.yaml
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0a4e3b1e1)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [6.96ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [38.24ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [40.85ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [41.78ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [42.61ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [40.20ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [8.50ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [7.83ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [12.87ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at another registry is used for the tarballs [13.69ms]
(pass) pnpm-lock.yaml v9 > named registries > two packages from one unknown
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.0 (4199361ed)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [267.75ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [380.80ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [151.47ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [158.50ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [154.17ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [149.01ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [195.56ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [194.36ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [334.79ms]
(pass) pnpm-lock.yaml
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 653ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/pnpm.rs                             | 50 +++++++++++++++++-
 test/cli/install/migration/pnpm-lock-v9.test.ts | 67 +++++++++++++++++++++++++
 2 files changed, 116 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/install/pnpm.rs                                  6      6      0
test/cli/install/migration/pnpm-lock-v9.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->