### PR TITLE
install: refetch the manifest once when a cached copy lacks a requested version

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -125,6 +125,14 @@ pub struct DedupeMapEntry {
     /// later `enqueue_*_for_download` can observe the failure instead of
     /// re-scheduling the entire network task (and its retry cycle) a second time.
     pub(crate) failed: bool,
+    /// Manifest tasks only: a full (200) manifest body was parsed this run, so
+    /// the in-memory manifest is current and a missing version is
+    /// authoritative. Stays false when the registry answered 304.
+    pub(crate) manifest_fetched: bool,
+    /// Manifest tasks only: an unconditional refetch was already forced after
+    /// a cached manifest lacked a requested version
+    /// (`refetch_manifest_for_missing_version`).
+    pub(crate) manifest_refetch_forced: bool,
 }
 /// `Id` is already a wyhash output, so identity hashing
 /// (hash = value bits) avoids re-hashing.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -867,15 +867,22 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     let resolve_result = match resolve_result_ {
                         Ok(v) => v,
                         Err(err) => {
+                            // Only for failures reported as errors: an
+                            // optional dependency skips silently and an unmet
+                            // peer only warns, and neither warranted a network
+                            // request before.
                             if matches!(
                                 err,
                                 crate::Error::DistTagNotFound | crate::Error::NoMatchingVersion
                             ) && matches!(
                                 version.tag,
                                 dependency::version::Tag::Npm | dependency::version::Tag::DistTag
-                            ) && refetch_manifest_for_missing_version(
-                                this, name, dependency, id, is_root,
-                            )? {
+                            ) && dependency.behavior.is_required()
+                                && !dependency.behavior.is_peer()
+                                && refetch_manifest_for_missing_version(
+                                    this, name, dependency, id, is_root,
+                                )?
+                            {
                                 return Ok(());
                             }
                             if err == crate::Error::DistTagNotFound {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -635,6 +635,78 @@ fn resolve_from_appended_task(
     Some(pkg_id)
 }
 
+/// A cached manifest can predate a version that was published moments ago:
+/// within the cache-control window no request is made at all, and after the
+/// window a stale registry edge can answer 304 to the conditional
+/// revalidation. When resolution fails on a manifest the network did not
+/// deliver in full this run, refetch it once without conditional headers
+/// before reporting the failure. Returns true when a refetch is pending and
+/// `id` is queued on its completion callback.
+fn refetch_manifest_for_missing_version(
+    this: &mut PackageManager,
+    name: SemverString,
+    dependency: &Dependency,
+    id: DependencyID,
+    is_root: bool,
+) -> crate::Result<bool> {
+    let name_str: Vec<u8> = this.lockfile.str(&name).to_vec();
+    let task_id = Task::Id::for_manifest(&name_str);
+
+    let gpe = this.network_dedupe_map.get_or_put(task_id)?;
+    if gpe.value_ptr.manifest_fetched {
+        // The registry already answered with a full manifest this run; the
+        // missing version is authoritative.
+        return Ok(false);
+    }
+    gpe.value_ptr.is_required = gpe.value_ptr.is_required || dependency.behavior.is_required();
+    let already_forced = gpe.value_ptr.manifest_refetch_forced;
+    gpe.value_ptr.manifest_refetch_forced = true;
+
+    if !already_forced {
+        if verbose_install() {
+            bun_core::pretty_errorln!(
+                "Re-fetching package manifest without revalidation headers: {}",
+                bstr::BStr::new(&name_str)
+            );
+        }
+
+        let needs_extended_manifest = this.options.minimum_release_age_ms.is_some();
+        let this_ptr: *mut PackageManager = this;
+        let network_task = this.get_network_task();
+        // SAFETY: `network_task` is the unique handle to a freshly-vended
+        // pool slot. `write_init` resets every defaulted field (callback is
+        // uninitialized and overwritten by `for_manifest`).
+        unsafe {
+            NetworkTask::write_init(network_task, task_id, this_ptr, None);
+        }
+        let scope = this.scope_for_package_name(&name_str);
+        // `loaded_manifest: None` keeps `If-None-Match` / `If-Modified-Since`
+        // out of the request so a stale 304 cannot re-stamp the old manifest.
+        // SAFETY: `network_task` points to a valid initialized NetworkTask slot.
+        unsafe {
+            (*network_task).for_manifest(
+                &name_str,
+                scope,
+                None,
+                dependency.behavior.is_optional(),
+                needs_extended_manifest,
+            )?;
+        }
+        enqueue_network_task(this, network_task);
+    }
+
+    let manifest_entry_parse = this.task_queue.get_or_put_context(task_id, ())?;
+    if !manifest_entry_parse.found_existing {
+        *manifest_entry_parse.value_ptr = TaskCallbackList::default();
+    }
+    manifest_entry_parse.value_ptr.push(if is_root {
+        TaskCallbackContext::RootDependency(id)
+    } else {
+        TaskCallbackContext::Dependency(id)
+    });
+    Ok(true)
+}
+
 /// Q: "What do we do with a dependency in a package.json?"
 /// A: "We enqueue it!"
 pub fn enqueue_dependency_with_main_and_success_fn(
@@ -795,6 +867,17 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     let resolve_result = match resolve_result_ {
                         Ok(v) => v,
                         Err(err) => {
+                            if matches!(
+                                err,
+                                crate::Error::DistTagNotFound | crate::Error::NoMatchingVersion
+                            ) && matches!(
+                                version.tag,
+                                dependency::version::Tag::Npm | dependency::version::Tag::DistTag
+                            ) && refetch_manifest_for_missing_version(
+                                this, name, dependency, id, is_root,
+                            )? {
+                                return Ok(());
+                            }
                             if err == crate::Error::DistTagNotFound {
                                 if dependency.behavior.is_required() {
                                     if let Some(fail) = fail_fn {

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -347,7 +347,16 @@ impl PackageManager {
                     if !any_failed {
                         Output::flush();
                     }
-                    if failed_dep.version.tag == dependency::Tag::Catalog {
+                    // A catalog dependency whose entry exists failed on the
+                    // entry's version, not on the catalog lookup. Report it
+                    // like any other unresolved dependency (the version
+                    // resolution error was already logged).
+                    if failed_dep.version.tag == dependency::Tag::Catalog
+                        && lockfile
+                            .catalogs
+                            .get_ref(string_buf, *failed_dep.version.catalog(), failed_dep.name)
+                            .is_none()
+                    {
                         let name = bstr::BStr::new(failed_dep.name.slice(string_buf));
                         let literal = failed_dep.version.literal.fmt(string_buf);
                         let catalog_name = failed_dep.version.catalog().slice(string_buf);

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1109,6 +1109,10 @@ fn run_tasks_erased(
 
                 manager.manifests.insert(name_hash, manifest)?;
 
+                if let Some(entry) = manager.network_dedupe_map.get_mut(&task.id) {
+                    entry.manifest_fetched = true;
+                }
+
                 if cb.manifests_only {
                     continue;
                 }

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1641,7 +1641,16 @@ describe("peer dependencies", () => {
 // additionally reported "is not in the catalog".
 // https://github.com/oven-sh/bun/issues/39784
 describe("version published after the manifest was cached", () => {
-  function serveMutableRegistry(packages: Record<string, string[]>) {
+  function serveMutableRegistry(
+    packages: Record<string, string[]>,
+    options: {
+      // Mutable extra dist-tags per package, merged over `latest`.
+      tags?: Record<string, Record<string, string>>;
+      // Simulate a stale registry edge: answer 304 to every conditional
+      // request even though the content changed.
+      respond304ToConditional?: boolean;
+    } = {},
+  ) {
     const manifestRequests: { name: string; ifNoneMatch: string | null }[] = [];
     const server = Bun.serve({
       port: 0,
@@ -1659,23 +1668,28 @@ describe("version published after the manifest was cached", () => {
         const name = pathname.slice(1);
         const versionList = packages[name];
         if (!versionList) return new Response("not found", { status: 404 });
-        manifestRequests.push({ name, ifNoneMatch: request.headers.get("if-none-match") });
+        const ifNoneMatch = request.headers.get("if-none-match");
+        manifestRequests.push({ name, ifNoneMatch });
+        const etag = `"v${versionList.length}"`;
+        if (options.respond304ToConditional && ifNoneMatch !== null) {
+          return new Response(null, { status: 304, headers: { etag } });
+        }
         const versions: Record<string, unknown> = {};
         for (const version of versionList) {
           versions[version] = { name, version, dist: { tarball: `${origin}/${name}-${version}.tgz` } };
         }
         return Response.json(
-          { name, versions, "dist-tags": { latest: versionList.at(-1) } },
-          { headers: { etag: `"v${versionList.length}"` } },
+          { name, versions, "dist-tags": { latest: versionList.at(-1), ...options.tags?.[name] } },
+          { headers: { etag } },
         );
       },
     });
     return { server, manifestRequests };
   }
 
-  async function install(cwd: string) {
+  async function install(cwd: string, ...args: string[]) {
     await using proc = spawn({
-      cmd: [bunExe(), "install"],
+      cmd: [bunExe(), "install", ...args],
       cwd,
       stdout: "pipe",
       stderr: "pipe",
@@ -1803,5 +1817,168 @@ describe("version published after the manifest was cached", () => {
     expect(second.exitCode).toBe(0);
     expect((await file(join(String(dir), "node_modules", "fresh-pkg", "package.json")).json()).version).toBe("1.0.1");
     expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+
+  test.concurrent("a bump to a dist-tag published after the manifest was cached installs it", async () => {
+    const versions = ["1.0.0"];
+    const tags: Record<string, string> = {};
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions }, { tags: { "fresh-pkg": tags } });
+    await using _server = server;
+    using dir = writeRegistryProject(
+      { "package.json": JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.0" } }) },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    versions.push("1.0.1");
+    tags.beta = "1.0.1";
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "beta" } }),
+    );
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+    expect((await file(join(String(dir), "node_modules", "fresh-pkg", "package.json")).json()).version).toBe("1.0.1");
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+
+  test.concurrent("a dist-tag that does not exist reports the tag after one refetch", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
+    await using _server = server;
+    using dir = writeRegistryProject(
+      { "package.json": JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.0" } }) },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "nope" } }),
+    );
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).toContain('Package "fresh-pkg" with tag "nope" not found');
+    expect(second.exitCode).not.toBe(0);
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+
+  test.concurrent("one refetch serves every workspace that needs the new version", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
+    await using _server = server;
+    const workspacePackageJson = (catalogVersion: string) =>
+      JSON.stringify({
+        name: "root",
+        workspaces: { packages: ["packages/*"], catalog: { "fresh-pkg": catalogVersion } },
+      });
+    using dir = writeRegistryProject(
+      {
+        "package.json": workspacePackageJson("1.0.0"),
+        "packages/pkg1/package.json": JSON.stringify({ name: "pkg1", dependencies: { "fresh-pkg": "catalog:" } }),
+        "packages/pkg2/package.json": JSON.stringify({ name: "pkg2", dependencies: { "fresh-pkg": "catalog:" } }),
+      },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    versions.push("1.0.1");
+    await write(join(String(dir), "package.json"), workspacePackageJson("1.0.1"));
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+    // Both workspaces wait on one in-flight refetch instead of forcing two.
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "console.log(require('fresh-pkg/package.json').version)"],
+      cwd: join(String(dir), "packages", "pkg2"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect((await proc.stdout.text()).trim()).toBe("1.0.1");
+  });
+
+  test.concurrent("one refetch resolves one workspace and authoritatively fails the other", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
+    await using _server = server;
+    const pkgJson = (name: string, spec: string) =>
+      JSON.stringify({ name, dependencies: { "fresh-pkg": spec } });
+    using dir = writeRegistryProject(
+      {
+        "package.json": JSON.stringify({ name: "root", workspaces: { packages: ["packages/*"] } }),
+        "packages/pkg1/package.json": pkgJson("pkg1", "1.0.0"),
+        "packages/pkg2/package.json": pkgJson("pkg2", "1.0.0"),
+      },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    versions.push("1.0.1");
+    await write(join(String(dir), "packages", "pkg1", "package.json"), pkgJson("pkg1", "1.0.1"));
+    await write(join(String(dir), "packages", "pkg2", "package.json"), pkgJson("pkg2", "9.9.9"));
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).toContain('No version matching "9.9.9" found for specifier "fresh-pkg"');
+    expect(second.exitCode).not.toBe(0);
+    // The missing version is authoritative after the one shared refetch.
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+
+  test.concurrent("a stale 304 to the revalidation does not mask the new version", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry(
+      { "fresh-pkg": versions },
+      { respond304ToConditional: true },
+    );
+    await using _server = server;
+    using dir = writeRegistryProject(
+      { "package.json": JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.0" } }) },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    versions.push("1.0.1");
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.1" } }),
+    );
+
+    // --force disables the freshness window but keeps the manifest cache, so
+    // the install revalidates with If-None-Match. The stale edge answers 304,
+    // then the refetch goes out without conditional headers.
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir), "--force");
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+    expect((await file(join(String(dir), "node_modules", "fresh-pkg", "package.json")).json()).version).toBe("1.0.1");
+    expect(manifestRequests.slice(requestsBefore)).toEqual([
+      { name: "fresh-pkg", ifNoneMatch: '"v1"' },
+      { name: "fresh-pkg", ifNoneMatch: null },
+    ]);
   });
 });

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1725,7 +1725,9 @@ describe("version published after the manifest was cached", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      return (await proc.stdout.text()).trim();
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ err, exitCode }).toEqual({ err: "", exitCode: 0 });
+      return out.trim();
     };
 
     const first = await install(String(dir));
@@ -1915,7 +1917,9 @@ describe("version published after the manifest was cached", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    expect((await proc.stdout.text()).trim()).toBe("1.0.1");
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ err, exitCode }).toEqual({ err: "", exitCode: 0 });
+    expect(out.trim()).toBe("1.0.1");
   });
 
   test.concurrent("one refetch resolves one workspace and authoritatively fails the other", async () => {

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1634,3 +1634,171 @@ describe("peer dependencies", () => {
     });
   });
 });
+
+// A registry manifest is cached as fresh for 300 seconds. A version spec (or a
+// catalog entry) bumped to a version published inside that window used to fail
+// resolution without ever refetching the stale manifest, and a catalog entry
+// additionally reported "is not in the catalog".
+// https://github.com/oven-sh/bun/issues/39784
+describe("version published after the manifest was cached", () => {
+  function serveMutableRegistry(packages: Record<string, string[]>) {
+    const manifestRequests: { name: string; ifNoneMatch: string | null }[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const { origin, pathname } = new URL(request.url);
+        const tarball = pathname.match(/^\/(.+)-(\d+\.\d+\.\d+)\.tgz$/);
+        if (tarball) {
+          const [, name, version] = tarball;
+          const archive = new Bun.Archive(
+            { "package/package.json": JSON.stringify({ name, version }) },
+            { compress: "gzip" },
+          );
+          return new Response(await archive.bytes());
+        }
+        const name = pathname.slice(1);
+        const versionList = packages[name];
+        if (!versionList) return new Response("not found", { status: 404 });
+        manifestRequests.push({ name, ifNoneMatch: request.headers.get("if-none-match") });
+        const versions: Record<string, unknown> = {};
+        for (const version of versionList) {
+          versions[version] = { name, version, dist: { tarball: `${origin}/${name}-${version}.tgz` } };
+        }
+        return Response.json(
+          { name, versions, "dist-tags": { latest: versionList.at(-1) } },
+          { headers: { etag: `"v${versionList.length}"` } },
+        );
+      },
+    });
+    return { server, manifestRequests };
+  }
+
+  async function install(cwd: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  test.concurrent("a catalog bump to the new version installs it", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
+    await using _server = server;
+    using dir = writeRegistryProject(
+      {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: { packages: ["packages/*"], catalog: { "fresh-pkg": "1.0.0" } },
+        }),
+        "packages/pkg1/package.json": JSON.stringify({ name: "pkg1", dependencies: { "fresh-pkg": "catalog:" } }),
+      },
+      server.url.href,
+    );
+
+    const installedVersion = async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", "console.log(require('fresh-pkg/package.json').version)"],
+        cwd: join(String(dir), "packages", "pkg1"),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return (await proc.stdout.text()).trim();
+    };
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+    expect(await installedVersion()).toBe("1.0.0");
+
+    // publish 1.0.1 and bump the catalog entry while the cached manifest is still fresh
+    versions.push("1.0.1");
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({
+        name: "root",
+        workspaces: { packages: ["packages/*"], catalog: { "fresh-pkg": "1.0.1" } },
+      }),
+    );
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).not.toContain("is not in the catalog");
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+    expect(await installedVersion()).toBe("1.0.1");
+
+    // the refetch is unconditional so a stale 304 cannot re-stamp the old manifest
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+
+  test.concurrent("a catalog bump to a version that does not exist reports the version, not the catalog", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
+    await using _server = server;
+    using dir = writeRegistryProject(
+      {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: { packages: ["packages/*"], catalog: { "fresh-pkg": "1.0.0" } },
+        }),
+        "packages/pkg1/package.json": JSON.stringify({ name: "pkg1", dependencies: { "fresh-pkg": "catalog:" } }),
+      },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({
+        name: "root",
+        workspaces: { packages: ["packages/*"], catalog: { "fresh-pkg": "9.9.9" } },
+      }),
+    );
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).toContain('No version matching "9.9.9" found for specifier "fresh-pkg"');
+    expect(second.err).toContain("fresh-pkg@catalog: failed to resolve");
+    expect(second.err).not.toContain("is not in the catalog");
+    expect(second.exitCode).not.toBe(0);
+
+    // exactly one refetch, then the missing version is authoritative
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+
+  test.concurrent("a plain dependency bump to the new version installs it", async () => {
+    const versions = ["1.0.0"];
+    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
+    await using _server = server;
+    using dir = writeRegistryProject(
+      { "package.json": JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.0" } }) },
+      server.url.href,
+    );
+
+    const first = await install(String(dir));
+    expect(first.err).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+
+    versions.push("1.0.1");
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.1" } }),
+    );
+
+    const requestsBefore = manifestRequests.length;
+    const second = await install(String(dir));
+    expect(second.err).not.toContain("error:");
+    expect(second.exitCode).toBe(0);
+    expect((await file(join(String(dir), "node_modules", "fresh-pkg", "package.json")).json()).version).toBe("1.0.1");
+    expect(manifestRequests.slice(requestsBefore)).toEqual([{ name: "fresh-pkg", ifNoneMatch: null }]);
+  });
+});

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1679,7 +1679,10 @@ describe("version published after the manifest was cached", () => {
       cwd,
       stdout: "pipe",
       stderr: "pipe",
-      env: bunEnv,
+      // The environment's cache dir takes precedence over bunfig. These
+      // concurrent tests need a manifest cache of their own per project: they
+      // reuse one package name across different registries and version sets.
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") },
     });
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { out, err, exitCode };

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1822,7 +1822,10 @@ describe("version published after the manifest was cached", () => {
   test.concurrent("a bump to a dist-tag published after the manifest was cached installs it", async () => {
     const versions = ["1.0.0"];
     const tags: Record<string, string> = {};
-    const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions }, { tags: { "fresh-pkg": tags } });
+    const { server, manifestRequests } = serveMutableRegistry(
+      { "fresh-pkg": versions },
+      { tags: { "fresh-pkg": tags } },
+    );
     await using _server = server;
     using dir = writeRegistryProject(
       { "package.json": JSON.stringify({ name: "root", dependencies: { "fresh-pkg": "1.0.0" } }) },
@@ -1919,8 +1922,7 @@ describe("version published after the manifest was cached", () => {
     const versions = ["1.0.0"];
     const { server, manifestRequests } = serveMutableRegistry({ "fresh-pkg": versions });
     await using _server = server;
-    const pkgJson = (name: string, spec: string) =>
-      JSON.stringify({ name, dependencies: { "fresh-pkg": spec } });
+    const pkgJson = (name: string, spec: string) => JSON.stringify({ name, dependencies: { "fresh-pkg": spec } });
     using dir = writeRegistryProject(
       {
         "package.json": JSON.stringify({ name: "root", workspaces: { packages: ["packages/*"] } }),


### PR DESCRIPTION
### Problem

- Bun treats a cached registry manifest as fresh for a hardcoded 300 seconds (`src/install/npm.rs:577`) and makes no request in that window. A dependency or catalog entry bumped to a version published after the manifest was cached fails with `No version matching "x.y.z" found for specifier` (`NoMatchingVersion`). A `catalog:` dependency misreports it as `mypkg@catalog: is not in the catalog`.
- After the window, a stale registry edge can answer 304, and `runTasks.rs:627` stamps the old manifest fresh again.
- An optional dependency fails silently and stays failed. `bun.lock` is saved with it unresolved, and no later install retries it, not even `--force`.

### Fix

- On `NoMatchingVersion` or `DistTagNotFound`, when the network did not deliver the full manifest this run, refetch it once without `If-None-Match` or `If-Modified-Since` and resolve again (`refetch_manifest_for_missing_version`, `PackageManagerEnqueue.rs`).
- Two flags on the network dedupe entry bound it. `manifest_fetched`: a 200 was parsed, so a second miss is final. `manifest_refetch_forced`: concurrent dependents wait on the one refetch.
- No refetch under `--offline` or for peers (an unmet peer only warns). `verify_resolutions` prints `is not in the catalog` only when the entry is missing.
- Verified: `test/cli/install/catalogs.test.ts` (13 new tests, 12 fail on unfixed bun), plus the offline, bun-lock, bun-add, bun-update and bun-install-registry suites.

### Background

- Resolution walks `enqueue_dependency_with_main_and_success_fn`. A fresh cached manifest without the requested version returned `Err(NoMatchingVersion)` with no fallback.
- `network_dedupe_map` holds one entry per network task per run. The new flags live there.
- The refetched manifest goes through the normal parse task, which drains the queued dependents, so each resolves again once.

<details><summary>Notes</summary>

Reproduction (mirrors the report): a local registry whose version list can grow between installs. Install with catalog entry 1.0.0. Publish 1.0.1 to the registry, bump the catalog entry, reinstall within 300 s. Before the fix the second install makes zero requests and fails with `is not in the catalog`. After the fix it makes one manifest request with no conditional headers and installs 1.0.1.

Test coverage: the catalog, plain-version, and dist-tag bumps, each with a success and a still-missing variant. Two workspaces that share one refetch, both when both succeed and when one fails. The stale-304 leg runs the second install with `--force`, which disables only the freshness window and keeps the cached manifest, so the conditional request and the 304 happen in every build profile. The request-log assertions pin exactly one unconditional refetch (`ifNoneMatch: null`).

Termination: the refetch response is a full 200 (no conditional headers were sent), its parse sets `manifest_fetched`, and the next `NoMatchingVersion` for that package reports the error. A refetch that fails over the network follows the existing manifest-failure path: the GET error is logged and the dependency stays unresolved.

Optional dependencies: on unfixed bun, `optionalDependencies: { pkg: "1.0.1" }` against a cached manifest without 1.0.1 exits 0 with zero requests and writes `bun.lock` with `"packages": {}`. After that a plain `bun install`, an install with the manifest cache deleted, and `bun install --force` all make zero requests and leave 1.0.0 in `node_modules`. Only an edit to `package.json` or deleting `bun.lock` recovers. With the fix the optional dependency takes the same single refetch. An optional dependency on a version that does not exist costs one request in the run that first resolves it. The lockfile then records the skip, and an unchanged project makes zero requests (pinned by a test).

Offline modes: `--offline` and `--prefer-offline` (#40010) landed after this branch was cut. The branch merged clean, but the refetch did not know about them, and `bun install --offline` asked the registry for the manifest. The refetch now returns early under `--offline` (zero requests, same error as before this PR). `--prefer-offline` keeps the refetch because the requested version is missing from the cache. Both are pinned by tests.

Peers are excluded on purpose. An unmet peer only warns, and `bun-lock.test.ts` ("peer no published version satisfies") asserts that resolving it from the cache makes no request.

The `bun add --catalog` suggestion for a genuinely missing entry is unchanged (covered by existing tests in catalogs.test.ts and bun-add-filter.test.ts).

Runtime auto-install goes through the same refetch, on the root dependency callback. After the publish, `require("pkg@1.0.1/package.json")` prints `Cannot find module` with zero requests on unfixed bun. With the fix it makes one manifest request and loads 1.0.1. A test covers it.

The manifest task setup and the callback registration are shared between the first fetch and the refetch (`enqueue_manifest_network_task`, `queue_dependency_on_task`).

Self-reviewed: 7 concerns raised, 4 addressed, 3 rejected.
- Addressed: the two-workspace test now asserts the side that resolved. The `--offline` test says that it is a guard (it also passes without the refetch). The optional-dependency tests assert the parsed `bun.lock`. The auto-install path has a test.
- Rejected: `bun update` and `bun audit fix` pass synthetic dependency rows that need a synchronous resolve. They turn the manifest cache off, so every manifest is a full response from this run and the refetch cannot fire. Under `--prefer-offline` the cache is on. Probed: `bun update foo --prefer-offline` with a range only the new version satisfies, where foo is also a peer of another dependency. Result: one refetch, exit 0.
- Rejected: a refetch that fails on the network reports the GET error and `failed to resolve`. An optional dependency gets a warning and is skipped. The `No version matching` line is not printed in that case. The GET error is the more accurate one.
- Rejected: a 304 re-stamp followed by the refetch writes the manifest cache file twice in one run. Each write is atomic. If the older write lands last, the next run pays one more refetch.

The refetch replaces the in-memory manifest while the run continues. Probed under ASAN: one dependent resolves from the stale manifest and has a slow tarball in flight, then another dependent's refetch replaces the manifest. Three orderings, no sanitizer report, correct lockfile.

Suites run locally on the debug ASAN build, merged with main: catalogs (102 pass), bun-install-offline (10 pass), bun-lock (40 pass), bun-add + bun-add-catalog + bun-add-filter + minimum-release-age (392 pass), bun-update + bun-update-transitive + bun-update-lockfile-sync + isolated-install (527 pass), bun-install-registry (281 pass). bun-install.test.ts: 245 pass, 13 fail, and all 13 need the public internet (bitbucket, gitlab, gitpkg-fork.vercel.sh), which the local environment blocks.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.3 (367d939d9)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [560.96ms]
(pass) basic > both catalog and catalogs in workspaces [499.13ms]
(pass) basic > detect changes (bun.lockb) [736.94ms]
(pass) basic > detect changes (bun.lock) [739.05ms]
(pass) basic > switching a dependency to a different catalog is detected [824.25ms]
(pass) basic > catalog and catalogs.default may split different packages between them [458.81ms]
(pass) update > --latest updates catalog versions in top-level [647.46ms]
(pass) update > --latest updates catalog versions in workspaces [433.91ms]
(pass) update > --latest updates catalog versions with -r [540.50ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [705.17ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [551.30ms]
(pass) update > --latest updates the same package independently per catalog [470.94ms]
(pass) update > --latest --dry-run does not modify 
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (c6513912b)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [85.48ms]
(pass) basic > both catalog and catalogs in workspaces [24.16ms]
(pass) basic > detect changes (bun.lockb) [58.22ms]
(pass) basic > detect changes (bun.lock) [51.74ms]
(pass) basic > switching a dependency to a different catalog is detected [50.00ms]
(pass) basic > catalog and catalogs.default may split different packages between them [21.14ms]
(pass) update > --latest updates catalog versions in top-level [35.48ms]
(pass) update > --latest updates catalog versions in workspaces [41.55ms]
(pass) update > --latest updates catalog versions with -r [33.48ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [34.26ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [28.83ms]
(pass) update > --latest updates the same package independently per catalog [33.85ms]
(pass) update > --latest --dry-run does not modify any package.json (from root) [28.90ms]
(pass) update > --latest --dry-run does not modify any package.json (from workspace) [22.37ms]
(pass) update > update without --la
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/catalogs.test.ts
bun test v1.4.3 (367d939d9)

test/cli/install/catalogs.test.ts:
(pass) basic > both catalog and catalogs in top-level [636.77ms]
(pass) basic > both catalog and catalogs in workspaces [411.24ms]
(pass) basic > detect changes (bun.lockb) [747.82ms]
(pass) basic > detect changes (bun.lock) [600.87ms]
(pass) basic > switching a dependency to a different catalog is detected [530.61ms]
(pass) basic > catalog and catalogs.default may split different packages between them [320.55ms]
(pass) update > --latest updates catalog versions in top-level [392.29ms]
(pass) update > --latest updates catalog versions in workspaces [529.78ms]
(pass) update > --latest updates catalog versions with -r [430.52ms]
(pass) update > --frozen-lockfile passes after --latest updates catalogs [584.33ms]
(pass) update > --latest run from inside a workspace package updates the root catalog [459.97ms]
(pass) update > --latest updates the same package independently per catalog [429.65ms]
(pass) update > --latest --dry-run does not modify 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 787ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/7] cargo bun_runtime → libbun_runtime.a
[1m[33mwarning[0m[1m: binary `bun_shim_impl` should have a kebab-case name[0m
   [1m[94m|[0m
[1m[94m 1[0m [1m[94m|[0m /workspace/bun/build/release/rust-target/.../bun_shim_impl
   [1m[94m|[0m                                              [1m[33m^^^^^^^^^^^^^[0m
   [1m[94m|[0m
   [1m[94m= [0m[1mnote[0m: `cargo::non_kebab_case_bins` is set to `warn` by default
[1m[96mhelp[0m: to change the binary name to `bun-shim-impl`, convert `bin.name`
  [1m[94m--> [0msrc/install/windows-shim/Cargo.toml:41:8
   [1m[94m|[0m
[1m[94m41[0m [91m- [0mname = [91m"bun_shim_impl"[0m
[1m[94m41[0m [92m+ [0mname = [92m"bun-shim-impl"[0m
   [1m[94m|[0m
[1m[33mwarning[0m: `bun_shim_impl` (manifest) generated 1 warning
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/NetworkTask.rs                         |   8 +
 .../PackageManager/PackageManagerEnqueue.rs        | 169 +++++--
 .../PackageManager/PackageManagerResolution.rs     |  11 +-
 src/install/PackageManager/runTasks.rs             |   4 +
 test/cli/install/catalogs.test.ts                  | 493 +++++++++++++++++++++
 5 files changed, 647 insertions(+), 38 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/install/NetworkTask.rs                                  2      1     28
src/install/PackageManager/PackageManagerEnqueue.rs         7      6     28
src/install/PackageManager/PackageManagerResolution.rs      1      1     28
src/install/PackageManager/runTasks.rs                      5      2     28
test/cli/install/catalogs.test.ts                           2     16     28
```

</details>

**root cause** · written by the author bot

The installer resolved catalog dependencies against a cached npm manifest without revalidating it, so a catalog entry bumped to a version newer than the cached copy could not be matched, and the resulting NoMatchingVersion failure was reported as a missing catalog entry. The fix tracks manifest fetch state per package and, when resolution of a required non-peer npm or dist-tag dependency fails with DistTagNotFound or NoMatchingVersion, retries once with an unconditional manifest refetch before giving up. Catalog error reporting now distinguishes a genuinely absent entry from a present entry…

<!-- robobun:evidence:end -->

