### PR TITLE
darwin-ci: trust a third-party tap before installing from it

### DIFF
--- a/scripts/darwin-ci/lib/host.ts
+++ b/scripts/darwin-ci/lib/host.ts
@@ -35,6 +35,10 @@ export async function setHostname(name: string): Promise<void> {
 export async function brewInstall(formula: string): Promise<void> {
   const name = formula.split("/").pop()!;
   if (await succeeds($`${brew} list ${name}`)) return;
+  // Third-party taps must be trusted as a whole: trusting only the formula
+  // still fails on its dependencies from the same tap.
+  const tap = formula.includes("/") ? formula.split("/").slice(0, 2).join("/") : undefined;
+  if (tap) await $`${brew} trust ${tap}`.quiet();
   await $`${brew} install ${formula}`;
 }
 


### PR DESCRIPTION
Homebrew now refuses formulae from untrusted taps, and trusting only the requested formula is not enough: `brew install cirruslabs/cli/tart` still fails with `Refusing to load formula cirruslabs/cli/softnet from untrusted tap` (hit while bringing up a freshly re-imaged host today). `brewInstall` now runs `brew trust <tap>` for the formula's tap before installing. No-op for core formulae.