### PR TITLE
Drain microtasks after a Windows Bun.file() read completes

### DIFF
--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -932,9 +932,7 @@ impl ReadFile {
 #[cfg(windows)]
 pub struct ReadFileUV {
     pub(crate) loop_: *mut libuv::uv_loop_t,
-    /// Raw, not `&EventLoop`: `finalize` passes it to `EventLoop::enter_scope`,
-    /// which writes through it. A `&`-derived pointer would carry
-    /// `SharedReadOnly` provenance (same as `WriteFileWindows.event_loop`).
+    /// Raw, not `&EventLoop`: `finalize`'s `enter_scope` writes through it.
     pub(crate) event_loop: *mut EventLoop,
     pub(crate) file_store: FileStore,
     pub(crate) byte_store: ByteStore,

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -1126,8 +1126,7 @@ impl<'a> ReadFileUV<'a> {
         // continuation still queued.
         // SAFETY: VM-owned event loop is valid for the process lifetime;
         // `enter_scope` calls enter() now and exit() on drop.
-        let _guard =
-            unsafe { EventLoop::enter_scope(core::ptr::from_ref(event_loop).cast_mut()) };
+        let _guard = unsafe { EventLoop::enter_scope(core::ptr::from_ref(event_loop).cast_mut()) };
 
         // The completion must run BEFORE the cleanup below (store deref / req.deinit /
         // box drop / event_loop.unref) — it may inspect store. A libuv callback returns void: an

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -1119,6 +1119,16 @@ impl<'a> ReadFileUV<'a> {
             })
         };
 
+        // Settling the promise enters JS from a libuv callback, so bracket it
+        // with enter/exit: the guard's drop (after the unref below) is the
+        // microtask checkpoint that runs the await continuation. Without it, a
+        // read that leaves nothing else pending lets the loop exit with the
+        // continuation still queued.
+        // SAFETY: VM-owned event loop is valid for the process lifetime;
+        // `enter_scope` calls enter() now and exit() on drop.
+        let _guard =
+            unsafe { EventLoop::enter_scope(core::ptr::from_ref(event_loop).cast_mut()) };
+
         // The completion must run BEFORE the cleanup below (store deref / req.deinit /
         // box drop / event_loop.unref) — it may inspect store. A libuv callback returns void: an
         // exception the JS side left pending is reported here (a termination just stands down).

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -930,9 +930,12 @@ impl ReadFile {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[cfg(windows)]
-pub struct ReadFileUV<'a> {
+pub struct ReadFileUV {
     pub(crate) loop_: *mut libuv::uv_loop_t,
-    pub(crate) event_loop: &'a EventLoop,
+    /// Raw, not `&EventLoop`: `finalize` passes it to `EventLoop::enter_scope`,
+    /// which writes through it. A `&`-derived pointer would carry
+    /// `SharedReadOnly` provenance (same as `WriteFileWindows.event_loop`).
+    pub(crate) event_loop: *mut EventLoop,
     pub(crate) file_store: FileStore,
     pub(crate) byte_store: ByteStore,
     pub(crate) store: StoreRef,
@@ -957,7 +960,7 @@ pub struct ReadFileUV<'a> {
 }
 
 #[cfg(windows)]
-impl<'a> FileOpener for ReadFileUV<'a> {
+impl FileOpener for ReadFileUV {
     fn opened_fd(&self) -> Fd {
         self.opened_fd
     }
@@ -988,7 +991,7 @@ impl<'a> FileOpener for ReadFileUV<'a> {
 }
 
 #[cfg(windows)]
-impl<'a> FileCloser for ReadFileUV<'a> {
+impl FileCloser for ReadFileUV {
     const IO_TAG: bun_io::Tag = bun_io::Tag::ReadFile;
     fn opened_fd(&self) -> Fd {
         self.opened_fd
@@ -1028,7 +1031,7 @@ impl<'a> FileCloser for ReadFileUV<'a> {
 }
 
 #[cfg(windows)]
-impl<'a> ReadFileUV<'a> {
+impl ReadFileUV {
     /// Typed entry: `C` supplies run/cancel for the erased completion.
     pub(crate) fn start<C: ReadFileCompletion>(
         event_loop: *mut EventLoop,
@@ -1056,15 +1059,14 @@ impl<'a> ReadFileUV<'a> {
         completion: ReadFileCompletionFns,
     ) {
         log!("ReadFileUV.start");
+        let file_store = store.data.as_file().clone();
         // SAFETY: `event_loop` is the per-thread `EventLoop` singleton owned by
         // the VM (`global.bun_vm().event_loop()`); it strictly outlives this
         // async op, which additionally holds a keep-alive on it below.
-        let event_loop: &'a EventLoop = unsafe { &*event_loop };
-        let file_store = store.data.as_file().clone();
         let this = Box::new(ReadFileUV {
             // Projected through the helper to avoid materializing a
             // `&VirtualMachine`.
-            loop_: event_loop.uv_loop().cast(),
+            loop_: unsafe { (*event_loop).uv_loop().cast() },
             event_loop,
             file_store,
             byte_store: ByteStore::default(),
@@ -1085,8 +1087,9 @@ impl<'a> ReadFileUV<'a> {
             req: bun_core::ffi::zeroed(),
             open_callback: Self::on_file_open,
         });
-        // Keep the event loop alive while the async operation is pending
-        event_loop.ref_keep_alive();
+        // Keep the event loop alive while the async operation is pending.
+        // SAFETY: `event_loop` is the live per-thread singleton (see above).
+        unsafe { (*event_loop).ref_keep_alive() };
         let this_ptr: *mut ReadFileUV = bun_core::heap::into_raw(this);
         // SAFETY: this_ptr is freshly boxed and uniquely owned by the async op.
         unsafe { (*this_ptr).get_fd(Self::on_file_open) };
@@ -1124,9 +1127,10 @@ impl<'a> ReadFileUV<'a> {
         // microtask checkpoint that runs the await continuation. Without it, a
         // read that leaves nothing else pending lets the loop exit with the
         // continuation still queued.
-        // SAFETY: VM-owned event loop is valid for the process lifetime;
-        // `enter_scope` calls enter() now and exit() on drop.
-        let _guard = unsafe { EventLoop::enter_scope(core::ptr::from_ref(event_loop).cast_mut()) };
+        // SAFETY: `event_loop` is the raw VM-owned pointer stored at start()
+        // (valid for the process lifetime); `enter_scope` calls enter() now and
+        // exit() on drop.
+        let _guard = unsafe { EventLoop::enter_scope(event_loop) };
 
         // The completion must run BEFORE the cleanup below (store deref / req.deinit /
         // box drop / event_loop.unref) — it may inspect store. A libuv callback returns void: an
@@ -1136,8 +1140,9 @@ impl<'a> ReadFileUV<'a> {
         // store.deref runs via StoreRef's Drop when the Box drops.
         this_box.req.deinit();
         drop(this_box);
-        // Release the event loop reference now that we're done
-        event_loop.unref_keep_alive();
+        // Release the event loop reference now that we're done.
+        // SAFETY: same pointer as the enter_scope above.
+        unsafe { (*event_loop).unref_keep_alive() };
         log!("ReadFileUV.finalize destroy");
     }
 

--- a/test/regression/issue/39787.test.ts
+++ b/test/regression/issue/39787.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/39787
+// On Windows, a rejecting Bun.file() read settled its promise inside a libuv
+// callback with no microtask checkpoint. If the read was the only pending
+// work, the process exited 0 before the await continuation ran.
+test("a rejecting Bun.file() read runs its continuation before the process exits", async () => {
+  using dir = tempDir("issue-39787", {});
+  const missing = join(String(dir), "definitely-missing-file.txt");
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `async function main() {
+        try {
+          await Bun.file(${JSON.stringify(missing)}).text();
+          console.log("UNEXPECTED RESOLVE");
+        } catch (e) {
+          console.log("CAUGHT " + e.code);
+        }
+        console.log("DONE");
+      }
+      main();`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("CAUGHT ENOENT\nDONE\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- On Windows, a rejecting `Bun.file()` read (for example a missing file) does not run its `await` continuation when the read is the only pending work. The process exits 0 with no output. Fixes #39787, a 1.3.14 to 1.4.0 regression. All read methods are affected: `.text()`, `.json()`, `.bytes()`, `.arrayBuffer()`.
- `ReadFileUV::finalize` (src/runtime/webcore/blob/read_file.rs:1097) settles the promise directly from a libuv callback, with no event loop enter/exit bracket. No microtask checkpoint follows, the keep-alive is released, and the run loop sees a dead loop and exits with the continuation still queued.

### Fix
- Bracket the completion in `ReadFileUV::finalize` with `EventLoop::enter_scope`. The guard's drop is the outermost `exit()`, which drains microtasks after the keep-alive is released.
- This is the existing convention for Windows uv completions: `write_file.rs:1060` and `copy_file.rs:1643` already do it. The read path lost it in the Rust rewrite (#30412).
- The success path only worked by accident: the async `uv_fs_close` kept the loop alive one more iteration, so the next tick drained the microtasks. The error path has no fd to close, so nothing drained them.
- Verified on windows-x64: test/regression/issue/39787.test.ts fails with stock 1.4.0 (empty stdout, exit 0) and passes with this fix. The changed code is `#[cfg(windows)]`, so on Linux the test passes with and without the change. A Linux-only check cannot show the failure.

### Background
- On Windows the JS thread polls libuv (`us_loop_run`). Filesystem callbacks like `uv_fs_open` completions run inside that poll, outside `EventLoop::tick`, so nothing drains microtasks for them unless the callback brackets its JS entry with `enter()`/`exit()`.
- `is_event_loop_alive()` counts loop handles, tasks, and refs. It does not see JSC's microtask queue. A queued microtask alone cannot keep the process alive.
- On Linux this path is unaffected: `ReadFile` completions arrive as tasks from the work pool, and `tick()` drains microtasks after running tasks.

<details><summary>Notes</summary>

Fail-before on windows-x64 with the released 1.4.0 binary (`USE_SYSTEM_BUN=1 bun test test/regression/issue/39787.test.ts`):

```
- "CAUGHT ENOENT
- DONE
- "
+ ""
(fail) a rejecting Bun.file() read runs its continuation before the process exits
 0 pass
 1 fail
```

Pass-after on windows-x64 with the debug build of this branch: 1 pass. The issue's other repro shapes were also checked against the fixed build: 10/10 runs of the plain repro print `DONE`, the `beforeExit` variant prints `CAUGHT ENOENT`, `DONE`, then `BEFOREEXIT 0`, `EXIT 0`, and the no-await `.json().catch().then()` chain completes. The success path (file exists) still prints and exits 0.

Debug-log evidence for the accidental success path: with `BUN_DEBUG_ReadFile=1`, the resolve case shows `finalize` running inside the poll, then `DONE`, then the `uv_fs_close` completion. That pending close is the only thing that kept the loop alive long enough for the next tick to drain microtasks. The reject case has no fd to close, so before this change the log showed `finalize destroy` followed directly by `beforeExit`/`exit` with the continuation never run.

Suites run on windows-x64 with the fix: test/js/bun/io/bun-write.test.js (41 pass), test/js/web/fetch/blob.test.ts (102 pass), test/js/bun/util/bun-file*.test (15 pass, 3 skip). The new regression test also passes on linux-x64 (debug build).

</details>
