### PR TITLE
Remove dead code: 92 trait impls nothing calls, across 29 crates

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -138,15 +138,6 @@ pub struct CommonJSNamedExport {
     pub needs_decl: bool,
 }
 
-impl Default for CommonJSNamedExport {
-    fn default() -> Self {
-        Self {
-            loc_ref: LocRef::default(),
-            needs_decl: true,
-        }
-    }
-}
-
 // `Ast` is held in arena-allocated structures whose `Drop` never runs (the
 // `BabyList` pattern — bulk-freed on `ASTMemoryAllocator` / `store_ast_alloc_heap`
 // reset). Any `Vec`/`Box` field that defaults to the global allocator therefore

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1334,14 +1334,6 @@ pub enum SetError {
 }
 bun_core::impl_tag_error!(SetError);
 bun_core::oom_from_alloc!(SetError);
-impl From<SetError> for crate::Error {
-    fn from(e: SetError) -> Self {
-        match e {
-            SetError::OutOfMemory => crate::Error::Alloc(bun_alloc::AllocError),
-            SetError::Clobber => crate::Error::Clobber,
-        }
-    }
-}
 
 // ── live Object accessor surface ───────────────────────────────────────────
 // Adapted to the current `Vec` API (`append(v)`, `slice()`, `slice_mut()`).

--- a/src/ast/error.rs
+++ b/src/ast/error.rs
@@ -1,7 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("Clobber")]
-    Clobber,
     #[error("SyntaxError")]
     SyntaxError,
     #[error("ModuleNotFound")]
@@ -14,7 +12,6 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
-            Self::Clobber => "Clobber",
             Self::SyntaxError => "SyntaxError",
             Self::ModuleNotFound => "ModuleNotFound",
             Self::Alloc(_) => "OutOfMemory",

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -136,16 +136,6 @@ pub struct Query {
     pub i: u32,
 }
 
-impl Default for Query {
-    fn default() -> Self {
-        Self {
-            expr: Expr::EMPTY,
-            loc: Loc::EMPTY,
-            i: 0,
-        }
-    }
-}
-
 // ───────────────────────────────────────────────────────────────────────────
 // ── live Expr accessor surface ─────────────────────────────────────────────
 // Subset of the gated impl below; bodies adapted to the live `E::Object` /

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -130,15 +130,6 @@ pub struct ClassStaticBlock {
     pub loc: crate::Loc,
 }
 
-impl Default for ClassStaticBlock {
-    fn default() -> Self {
-        Self {
-            stmts: bun_alloc::AstAlloc::vec(),
-            loc: crate::Loc::default(),
-        }
-    }
-}
-
 pub struct Property {
     /// This is used when parsing a pattern that uses default values:
     ///

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1217,16 +1217,6 @@ pub struct MetadataResolve {
     pub err: crate::Error,
 }
 
-impl Default for MetadataResolve {
-    fn default() -> Self {
-        MetadataResolve {
-            specifier: BabyString::new(0, 0),
-            import_kind: ImportKind::default(),
-            err: crate::Error::ModuleNotFound,
-        }
-    }
-}
-
 // ───────────────────────────────────────────────────────────────────────────
 // Range
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1021,15 +1021,6 @@ pub struct Dependency {
     pub part_index: u32, // Index.Int
 }
 
-impl Default for Dependency {
-    fn default() -> Self {
-        Self {
-            source_index: Index::INVALID,
-            part_index: 0,
-        }
-    }
-}
-
 pub type DependencyList = bun_alloc::AstVec<Dependency>;
 
 // PERF: these may be arena-backed in callers; revisit with
@@ -1185,20 +1176,6 @@ pub struct NamedImport {
     /// It's useful to flag exported imports because if they are in a TypeScript
     /// file, we can't tell if they are a type or a value.
     pub is_exported: bool,
-}
-
-impl Default for NamedImport {
-    fn default() -> Self {
-        Self {
-            local_parts_with_uses: bun_alloc::AstAlloc::vec(),
-            alias: None,
-            alias_loc: crate::Loc::EMPTY,
-            namespace_ref: Ref::NONE,
-            import_record_index: 0,
-            alias_is_star: false,
-            is_exported: false,
-        }
-    }
 }
 
 #[derive(Copy, Clone)]

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -344,52 +344,6 @@ const _: () = assert!(
 );
 const _: () = assert!(core::mem::size_of::<StoreRef<S::SExpr>>() == core::mem::size_of::<usize>());
 
-/// Tag compare, then payload compare. Payloads here are arena pointers
-/// (`StoreRef<T>`) or ZSTs, so this is tag + pointer-identity, never a deep
-/// structural compare.
-impl PartialEq for Data {
-    fn eq(&self, other: &Self) -> bool {
-        use Data::*;
-        match (*self, *other) {
-            (SBlock(a), SBlock(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SBreak(a), SBreak(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SClass(a), SClass(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SComment(a), SComment(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SContinue(a), SContinue(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SDirective(a), SDirective(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SDoWhile(a), SDoWhile(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SEnum(a), SEnum(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SExportClause(a), SExportClause(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SExportDefault(a), SExportDefault(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SExportEquals(a), SExportEquals(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SExportFrom(a), SExportFrom(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SExportStar(a), SExportStar(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SExpr(a), SExpr(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SForIn(a), SForIn(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SForOf(a), SForOf(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SFor(a), SFor(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SFunction(a), SFunction(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SIf(a), SIf(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SImport(a), SImport(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SLabel(a), SLabel(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SLocal(a), SLocal(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SNamespace(a), SNamespace(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SReturn(a), SReturn(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SSwitch(a), SSwitch(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SThrow(a), SThrow(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (STry(a), STry(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SWhile(a), SWhile(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SWith(a), SWith(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (SLazyExport(a), SLazyExport(b)) => core::ptr::eq(a.as_ptr(), b.as_ptr()),
-            (STypeScript(_), STypeScript(_)) => true,
-            (SEmpty(_), SEmpty(_)) => true,
-            (SDebugger(_), SDebugger(_)) => true,
-            _ => false,
-        }
-    }
-}
-impl Eq for Data {}
-
 // Field-style union accessors (`data.s_function()`, `data.s_local()`, …).
 // Callers `.unwrap()` (or pattern-match) — the `Option` is the cheapest
 // sound encoding of a tag mismatch.

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -218,15 +218,6 @@ pub mod vlq {
         pub len: u8,
     }
 
-    impl Default for VLQ {
-        fn default() -> Self {
-            Self {
-                bytes: [0; VLQ_MAX_IN_BYTES],
-                len: 0,
-            }
-        }
-    }
-
     const VLQ_MAX_IN_BYTES: usize = 7;
 
     impl VLQ {

--- a/src/bun_alloc/MaxHeapAllocator.rs
+++ b/src/bun_alloc/MaxHeapAllocator.rs
@@ -44,12 +44,6 @@ impl MaxHeapAllocator {
     }
 }
 
-impl Default for MaxHeapAllocator {
-    fn default() -> Self {
-        Self::init()
-    }
-}
-
 /// RAII guard returned by [`MaxHeapAllocator::scope`]. Derefs to the underlying
 /// allocator so callers can hand out `&mut MaxHeapAllocator` (or a derived
 /// `&dyn Allocator`) for the duration of the scope, and resets it on drop.

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -585,11 +585,6 @@ impl Mutex {
 pub(crate) struct MutexGuard {
     _guard: std::sync::MutexGuard<'static, ()>,
 }
-impl Default for Mutex {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 // Per PORTING.md type map: `OOM!T` / `error{OutOfMemory}!T` → `Result<T, bun_alloc::AllocError>`.
 // This is the crate root, so define it here. Re-exported as `bun_core::OOM`.

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -489,11 +489,6 @@ pub(crate) mod kind {
                 deser: DeserOpts::DEFAULT,
             };
         }
-        impl Default for CtorOptions {
-            fn default() -> Self {
-                Self::DEFAULT
-            }
-        }
 
         /// Control how deserializing and deserialization errors are handled.
         ///
@@ -534,11 +529,6 @@ pub(crate) mod kind {
                 error_handling: ErrorHandling::DebugWarn,
                 empty_string_as: EmptyStringAs::Erroneous,
             };
-        }
-        impl Default for DeserOpts {
-            fn default() -> Self {
-                Self::DEFAULT
-            }
         }
 
         // `ip` (var_name + opts) lives on the struct so handle_error can read it; it is

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -997,14 +997,6 @@ pub enum JsError {
 
 bun_alloc::oom_from_alloc!(JsError);
 
-impl From<crate::Error> for JsError {
-    fn from(_: crate::Error) -> Self {
-        // Mapping to `Thrown` here lets `?` propagate while the actual throw
-        // is handled by the host-fn wrapper.
-        JsError::Thrown
-    }
-}
-
 /// Write `parts` consecutively
 /// into `dest` and return the written prefix as a mutable slice. Panics if
 /// `sum(parts.len()) > dest.len()`.

--- a/src/bun_core/string/SmolStr.rs
+++ b/src/bun_core/string/SmolStr.rs
@@ -16,19 +16,6 @@ const _: () = assert!(mem::size_of::<usize>() == 8);
 #[repr(transparent)]
 pub struct SmolStr(u128);
 
-impl Clone for SmolStr {
-    /// Port of `SmolStr.clone` (allocator-free): inlined strings copy by value;
-    /// heap-backed strings duplicate the buffer.
-    fn clone(&self) -> Self {
-        if self.is_inlined() {
-            return SmolStr(self.0);
-        }
-        // Heap-backed: dupe the bytes into a fresh Vec allocation.
-        // Panic on OOM.
-        SmolStr::from_slice(self.slice()).expect("OOM")
-    }
-}
-
 const TAG: usize = 0x8000_0000_0000_0000; // bit 63 of the ptr word == bit 127 of the u128
 const NEGATED_TAG: usize = !TAG;
 

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -607,6 +607,17 @@ pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'
     Some((&self_[..i], &self_[i + delimiter.len()..]))
 }
 
+/// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
+/// delimiter never matches.
+#[inline]
+pub fn rsplit_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    if delimiter.is_empty() {
+        return None;
+    }
+    let i = last_index_of(self_, delimiter)?;
+    Some((&self_[..i], &self_[i + delimiter.len()..]))
+}
+
 pub struct SplitIterator<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) index: Option<usize>,

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -607,17 +607,6 @@ pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'
     Some((&self_[..i], &self_[i + delimiter.len()..]))
 }
 
-/// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
-/// delimiter never matches.
-#[inline]
-pub fn rsplit_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-    if delimiter.is_empty() {
-        return None;
-    }
-    let i = last_index_of(self_, delimiter)?;
-    Some((&self_[..i], &self_[i + delimiter.len()..]))
-}
-
 pub struct SplitIterator<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) index: Option<usize>,

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -63,45 +63,6 @@ impl OutputFile {
     }
 }
 
-impl Clone for OutputFile {
-    fn clone(&self) -> Self {
-        let owned_src_path_text = self.owned_src_path_text.clone();
-        // SAFETY: `owned_src_path_text` is a sibling field that outlives `src_path`; the boxed buffer never moves.
-        let text: &'static [u8] =
-            unsafe { core::mem::transmute::<&[u8], &'static [u8]>(&owned_src_path_text) };
-        let src_path = if !self.owned_src_path_text.is_empty() {
-            fs::Path {
-                is_disabled: self.src_path.is_disabled,
-                is_symlink: self.src_path.is_symlink,
-                ..fs::Path::init(text)
-            }
-        } else {
-            self.src_path
-        };
-        OutputFile {
-            loader: self.loader,
-            input_loader: self.input_loader,
-            src_path,
-            owned_src_path_text,
-            value: self.value.clone(),
-            size: self.size,
-            size_without_sourcemap: self.size_without_sourcemap,
-            hash: self.hash,
-            is_executable: self.is_executable,
-            source_map_index: self.source_map_index,
-            bytecode_index: self.bytecode_index,
-            module_info_index: self.module_info_index,
-            output_kind: self.output_kind,
-            dest_path: self.dest_path.clone(),
-            side: self.side,
-            entry_point_index: self.entry_point_index,
-            referenced_css_chunks: self.referenced_css_chunks.clone(),
-            source_index: self.source_index,
-            bake_extra: self.bake_extra,
-        }
-    }
-}
-
 #[derive(Default, Clone, Copy)]
 pub struct BakeExtra {
     pub route: BakeRouteKind,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1686,25 +1686,6 @@ pub mod parse_worker {
         pub(crate) column_end: i32,
     }
 
-    impl Default for BunLogOptions {
-        fn default() -> Self {
-            Self {
-                struct_size: core::mem::size_of::<BunLogOptions>(),
-                message_ptr: core::ptr::null(),
-                message_len: 0,
-                path_ptr: core::ptr::null(),
-                path_len: 0,
-                source_line_text_ptr: core::ptr::null(),
-                source_line_text_len: 0,
-                level: bun_ast::Level::Err,
-                line: 0,
-                line_end: 0,
-                column: 0,
-                column_end: 0,
-            }
-        }
-    }
-
     // These structs are passed by-pointer to **third-party** native plugins via
     // `packages/bun-native-bundler-plugin-api/bundler_plugin.h`, so layout drift
     // is a silent ABI break for every plugin in the wild. Literals are the 64-bit

--- a/src/collections/string_map.rs
+++ b/src/collections/string_map.rs
@@ -10,12 +10,6 @@ pub struct StringMap {
     pub dupe_keys: bool,
 }
 
-impl Default for StringMap {
-    fn default() -> Self {
-        Self::init(false)
-    }
-}
-
 impl StringMap {
     pub fn init(dupe_keys: bool) -> Self {
         Self {

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -1562,16 +1562,6 @@ pub enum CustomPropertyName {
     Unknown(Ident),
 }
 
-// `DashedIdent`/`Ident` carry `*const [u8]` arena slices and
-// intentionally don't derive `PartialEq` (pointer-eq would be wrong).
-// `PropertyId` derives `PartialEq`, so compare the underlying bytes here.
-impl PartialEq for CustomPropertyName {
-    fn eq(&self, other: &Self) -> bool {
-        // SAFETY: arena-owned slices live for the parse session.
-        unsafe { (&*self.as_ptr()).eq(&*other.as_ptr()) }
-    }
-}
-
 impl CustomPropertyName {
     pub fn to_css(&self, dest: &mut Printer) -> PrintResult<()> {
         match self {

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -1,5 +1,3 @@
-use core::hash::{Hash, Hasher};
-
 use crate as css;
 use crate::css_rules::Location;
 use crate::css_values::ident::{CustomIdent, is_reserved_custom_ident};
@@ -24,29 +22,6 @@ pub enum KeyframesName {
 }
 
 // A generic type alias keyed by `KeyframesName` with the custom hash/eq below.
-
-impl Hash for KeyframesName {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash only the underlying string bytes; the variant tag does NOT participate.
-        match self {
-            KeyframesName::Ident(ident) => state.write(ident.v()),
-            KeyframesName::Custom(s) => state.write(s),
-        }
-    }
-}
-
-impl PartialEq for KeyframesName {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (KeyframesName::Ident(a), KeyframesName::Ident(b)) => {
-                bun_core::strings::eql(a.v(), b.v())
-            }
-            (KeyframesName::Custom(a), KeyframesName::Custom(b)) => bun_core::strings::eql(a, b),
-            _ => false,
-        }
-    }
-}
-impl Eq for KeyframesName {}
 
 impl KeyframesName {
     pub fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -21,8 +21,6 @@ pub enum KeyframesName {
     Custom(&'static [u8]),
 }
 
-// A generic type alias keyed by `KeyframesName` with the custom hash/eq below.
-
 impl KeyframesName {
     pub fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
         use bun_core::strings;

--- a/src/css/rules/layer.rs
+++ b/src/css/rules/layer.rs
@@ -18,26 +18,6 @@ pub struct LayerName {
     pub v: SmallList<&'static [u8], 1>,
 }
 
-// The inline hash/eql context is replaced by `Hash`/`PartialEq` impls on `LayerName` below.
-// Iteration order is insertion order (collections/array_hash_map.rs)
-// regardless of hash function.
-
-impl core::hash::Hash for LayerName {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        // Hash each part's bytes.
-        for part in self.v.slice() {
-            state.write(part);
-        }
-    }
-}
-
-impl PartialEq for LayerName {
-    fn eq(&self, other: &Self) -> bool {
-        self.eql(other)
-    }
-}
-impl Eq for LayerName {}
-
 // Trait `Clone` (not just inherent `deep_clone`) so the bundler's
 // `Chunk::Layers::to_owned` can `deep_clone_with(|l| l.clone())`. Segments are
 // arena-borrowed `&'static [u8]` (Copy), so this is the same shallow

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -289,12 +289,6 @@ impl Backend {
     }
 }
 
-impl Default for Backend {
-    fn default() -> Self {
-        Backend::default()
-    }
-}
-
 pub type Address = bun_sys::net::Address;
 
 pub struct GetAddrInfoResult {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1289,12 +1289,6 @@ pub struct Map {
     pub map: HashTable,
 }
 
-impl Default for Map {
-    fn default() -> Self {
-        Self::init()
-    }
-}
-
 impl Map {
     /// Builds a NULL-terminated `K=V\0` envp array. Returns an owning struct so
     /// dropping it frees the joined buffers (PORTING.md §Forbidden: no Box::leak).

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -452,11 +452,6 @@ impl From<ForManifestError> for crate::Error {
         }
     }
 }
-impl PartialEq<crate::Error> for ForManifestError {
-    fn eq(&self, other: &crate::Error) -> bool {
-        <&'static str>::from(self) == other.name()
-    }
-}
 impl bun_core::output::ErrName for ForManifestError {
     fn name(&self) -> &[u8] {
         <&'static str>::from(self).as_bytes()

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -977,15 +977,6 @@ struct MoreInstructions<'a> {
     folder: &'a [u8],
 }
 
-impl Default for MoreInstructions<'_> {
-    fn default() -> Self {
-        Self {
-            shell: ShellCompletions::Shell::Unknown,
-            folder: b"",
-        }
-    }
-}
-
 impl fmt::Display for MoreInstructions<'_> {
     fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
         let path = ShellPathFormatter {

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -320,22 +320,6 @@ pub mod entry {
         }
     }
 
-    impl Default for Entry {
-        fn default() -> Self {
-            Self {
-                node_id: super::node::Id::INVALID,
-                dependencies: Dependencies::EMPTY,
-                parents: Vec::new(),
-                // `Step::LinkPackage as u32 == 0`.
-                step: core::sync::atomic::AtomicU32::new(0),
-                hoisted: false,
-                peer_hash: PeerHash::NONE,
-                entry_hash: 0,
-                scripts: core::cell::Cell::new(None),
-            }
-        }
-    }
-
     #[repr(transparent)]
     #[derive(Copy, Clone, PartialEq, Eq, Hash)]
     pub struct PeerHash(u64);

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2377,12 +2377,6 @@ impl Scratch {
     }
 }
 
-impl Default for Scratch {
-    fn default() -> Self {
-        Self::init()
-    }
-}
-
 // ────────────────────────────────────────────────────────────────────────────
 // LockfileFields — disjoint split borrow alongside StringBuilder
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -155,15 +155,6 @@ bun_core::impl_tag_error!(FromExprError);
 
 bun_core::oom_from_alloc!(FromExprError);
 
-impl From<CreateMatcherError> for FromExprError {
-    fn from(e: CreateMatcherError) -> Self {
-        match e {
-            CreateMatcherError::OutOfMemory => Self::OutOfMemory,
-            CreateMatcherError::InvalidRegExp => Self::InvalidRegExp,
-        }
-    }
-}
-
 impl PnpmMatcher {
     // `bun_ast::ExprData` exposes the real value-shaped enum
     // (`EString`/`EArray` via `StoreRef<E::*>`). The arena-taking

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -384,15 +384,6 @@ pub struct TarballInfo {
     pub package_name: SemverString,
 }
 
-impl Default for TarballInfo {
-    fn default() -> Self {
-        TarballInfo {
-            uri: URI::Local(SemverString::default()),
-            package_name: SemverString::default(),
-        }
-    }
-}
-
 impl TarballInfo {
     pub fn eql(&self, that: &TarballInfo, this_buf: &[u8], that_buf: &[u8]) -> bool {
         URI::eql(self.uri, that.uri, this_buf, that_buf)

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -302,20 +302,6 @@ pub struct FilePoll {
 }
 
 #[cfg(not(windows))]
-impl Default for FilePoll {
-    fn default() -> Self {
-        Self {
-            fd: INVALID_FD,
-            flags: FlagsSet::empty(),
-            owner: Owner::NULL,
-            generation_number: 0,
-            next_to_free: ptr::null_mut(),
-            allocator_type: AllocatorType::Js,
-        }
-    }
-}
-
-#[cfg(not(windows))]
 impl FilePoll {
     fn update_flags(&mut self, updated: FlagsSet) {
         let mut flags = self.flags;

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -146,13 +146,6 @@ pub mod options {
     pub struct ReactFastRefresh {
         pub import_source: Cow<'static, [u8]>,
     }
-    impl Default for ReactFastRefresh {
-        fn default() -> Self {
-            Self {
-                import_source: Cow::Borrowed(b"react-refresh/runtime"),
-            }
-        }
-    }
 }
 pub use crate::parse::parse_entry::{Options as ParserOptions, Parser};
 pub use crate::renamer;
@@ -1048,15 +1041,6 @@ pub struct ThenCatchChain {
     pub(crate) next_target: js_ast::ExprData,
     pub(crate) has_multiple_args: bool,
     pub(crate) has_catch: bool,
-}
-impl Default for ThenCatchChain {
-    fn default() -> Self {
-        Self {
-            next_target: js_ast::ExprData::EMissing(E::Missing {}),
-            has_multiple_args: false,
-            has_catch: false,
-        }
-    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -16,15 +16,6 @@ pub struct BuildMessage {
     pub(crate) logged: Cell<bool>,
 }
 
-impl Default for BuildMessage {
-    fn default() -> Self {
-        Self {
-            msg: bun_ast::Msg::default(),
-            logged: Cell::new(false),
-        }
-    }
-}
-
 impl BuildMessage {
     // `#[JsClass]` emits `BuildMessageClass__construct` calling this.
     pub fn constructor(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<*mut BuildMessage> {

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -26,18 +26,6 @@ pub struct CPUProfilerConfig {
     pub interval: u32,
 }
 
-impl Default for CPUProfilerConfig {
-    fn default() -> Self {
-        Self {
-            name: b"",
-            dir: b"",
-            md_format: false,
-            json_format: false,
-            interval: 1000,
-        }
-    }
-}
-
 // C++ function declarations
 unsafe extern "C" {
     /// `VM` is an opaque `UnsafeCell`-backed ZST handle; `&mut VM` is

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -587,15 +587,6 @@ struct Column {
     width: u32,
 }
 
-impl Default for Column {
-    fn default() -> Self {
-        Self {
-            name: BunString::empty(),
-            width: 1,
-        }
-    }
-}
-
 enum RowKey {
     /// Property-name UTF-8 slice + visible width (plain-object tabular data).
     /// `to_utf8` refs the WTF impl (or owns a transcoded copy) and Drop

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -25,16 +25,6 @@ pub struct ResolveMessage {
     pub(crate) logged: Cell<bool>,
 }
 
-impl Default for ResolveMessage {
-    fn default() -> Self {
-        Self {
-            msg: bun_ast::Msg::default(),
-            referrer: None,
-            logged: Cell::new(false),
-        }
-    }
-}
-
 /// `ImportKind.label()` — the canonical table lives in
 /// `bun_ast::ImportKind::label`, but
 /// `bun_ast::MetadataResolve.import_kind` is the type-only `bun_ast::ImportKind`.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -597,18 +597,6 @@ pub struct RuntimeTranspilerCache {
     // arena scratch is needed at all.
 }
 
-impl Default for RuntimeTranspilerCache {
-    fn default() -> Self {
-        Self {
-            input_hash: None,
-            input_byte_length: None,
-            features_hash: None,
-            exports_kind: ExportsKind::None,
-            entry: None,
-        }
-    }
-}
-
 pub(crate) fn hash(bytes: &[u8]) -> u64 {
     Wyhash::hash(SEED, bytes)
 }

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -540,17 +540,6 @@ pub mod store {
         pub is_all_ascii: Option<bool>,
     }
 
-    impl Default for Store {
-        fn default() -> Self {
-            Self {
-                data: Data::Bytes(Bytes::default()),
-                mime_type: bun_http_types::MimeType::NONE,
-                ref_count: bun_ptr::ThreadSafeRefCount::init(),
-                is_all_ascii: None,
-            }
-        }
-    }
-
     /// Backing data for a `Store`.
     #[derive(bun_core::EnumTag)]
     #[enum_tag(existing = DataTag)]

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -47,20 +47,6 @@ pub struct Theme<'a> {
     pub image_base_dir: Option<&'a [u8]>,
 }
 
-impl<'a> Default for Theme<'a> {
-    fn default() -> Self {
-        Self {
-            light: false,
-            columns: 80,
-            colors: true,
-            hyperlinks: false,
-            kitty_graphics: false,
-            remote_image_paths: None,
-            image_base_dir: None,
-        }
-    }
-}
-
 /// Renderer that only collects image URLs — no output. Used by the CLI
 /// pre-scan pass to decide which remote images to download.
 #[derive(Default)]

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -105,18 +105,6 @@ pub struct BlockHeader {
     pub(crate) n_lines: u32,
 }
 
-impl Default for BlockHeader {
-    fn default() -> Self {
-        Self {
-            block_type: BlockType::Doc,
-            _pad: [0, 0, 0],
-            flags: 0,
-            data: 0,
-            n_lines: 0,
-        }
-    }
-}
-
 /// `Parser`'s error type: the union of `{ OutOfMemory, JSError }`
 /// with the parser-specific `{ StackOverflow, InputTooLarge, TooManyBlocks }`.
 // (`bun_jsc::JsError` covers the first two, but the md crate sits below

--- a/src/md/types.rs
+++ b/src/md/types.rs
@@ -236,32 +236,6 @@ pub struct Flags {
     pub(crate) wiki_links: bool,
 }
 
-impl Flags {
-    // Private base of field defaults so the named presets below
-    // can use struct-update syntax in const context.
-    const DEFAULTS: Flags = Flags {
-        collapse_whitespace: false,
-        permissive_atx_headers: false,
-        permissive_url_autolinks: false,
-        permissive_www_autolinks: false,
-        permissive_email_autolinks: false,
-        no_indented_code_blocks: false,
-        no_html_blocks: false,
-        no_html_spans: false,
-        tables: true,
-        strikethrough: true,
-        tasklists: true,
-        latex_math: false,
-        wiki_links: false,
-    };
-}
-
-impl Default for Flags {
-    fn default() -> Self {
-        Self::DEFAULTS
-    }
-}
-
 pub(crate) const TABLE_MAXCOLCOUNT: u32 = 128;
 
 // ========================================

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -35,12 +35,6 @@ impl JSONOptions {
     };
 }
 
-impl Default for JSONOptions {
-    fn default() -> Self {
-        Self::DEFAULT
-    }
-}
-
 const JSON_OPTS: JSONOptions = JSONOptions::DEFAULT;
 
 const DOTENV_JSON_OPTS: JSONOptions = JSONOptions {

--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -132,15 +132,6 @@ pub enum AddToLogError {
 }
 bun_core::impl_tag_error!(AddToLogError);
 
-impl From<AddToLogError> for crate::Error {
-    fn from(e: AddToLogError) -> Self {
-        match e {
-            AddToLogError::OutOfMemory => crate::Error::Alloc(bun_alloc::AllocError),
-            AddToLogError::StackOverflow => crate::Error::StackOverflow,
-        }
-    }
-}
-
 impl Error {
     pub(crate) fn add_to_log(&self, source: &Source, log: &mut Log) -> Result<(), AddToLogError> {
         let loc: Loc = match *self {

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -128,7 +128,6 @@ impl XML {
         match result {
             Ok(root) => Ok(root),
             Err(PErr::Syntax) => Err(crate::Error::SyntaxError),
-            Err(PErr::Oom) => Err(crate::Error::Alloc(bun_alloc::AllocError)),
             Err(PErr::StackOverflow) => Err(crate::Error::StackOverflow),
             Err(PErr::NeedsWiderEncoding) => Err(crate::Error::NeedsWiderEncoding),
         }
@@ -139,16 +138,9 @@ impl XML {
 enum PErr {
     /// Already logged.
     Syntax,
-    Oom,
     StackOverflow,
     /// See `InputEncoding::Latin1`.
     NeedsWiderEncoding,
-}
-
-impl From<bun_alloc::AllocError> for PErr {
-    fn from(_: bun_alloc::AllocError) -> Self {
-        PErr::Oom
-    }
 }
 
 type PResult<T> = Result<T, PErr>;

--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -115,12 +115,6 @@ pub mod options {
         MaxPathExceeded,
     }
 
-    impl From<Error> for crate::Error {
-        fn from(_e: Error) -> Self {
-            crate::Error::MaxPathExceeded
-        }
-    }
-
     // Rust cannot vary a fn's return type on a const-generic value, so all
     // `Result(T)` call sites below return `Result<T, Error>` unconditionally;
     // callers configured with `AssumeAlwaysLessThanMaxPath` should treat the

--- a/src/paths/error.rs
+++ b/src/paths/error.rs
@@ -1,7 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("MaxPathExceeded")]
-    MaxPathExceeded,
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
     #[error(transparent)]
@@ -14,7 +12,6 @@ impl Error {
         match self {
             Self::Sys(e) => <&'static str>::from(e),
             Self::Core(e) => e.name(),
-            Self::MaxPathExceeded => "MaxPathExceeded",
         }
     }
 }

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -438,18 +438,6 @@ pub struct Response<'a> {
     pub bytes_read: usize,
 }
 
-impl<'a> Default for Response<'a> {
-    fn default() -> Self {
-        Response {
-            minor_version: 0,
-            status_code: 0,
-            status: b"",
-            headers: HeaderList::default(),
-            bytes_read: 0,
-        }
-    }
-}
-
 impl<'a> Response<'a> {
     pub fn count(&self, builder: &mut StringBuilder) {
         builder.count(self.status);

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -45,12 +45,6 @@ impl WeakPtrData {
     }
 }
 
-impl Default for WeakPtrData {
-    fn default() -> Self {
-        Self::EMPTY
-    }
-}
-
 /// Implemented by types that embed a `WeakPtrData` field and can be weakly
 /// referenced via `WeakPtr<T>`.
 ///

--- a/src/react_compiler/diagnostics/js_string.rs
+++ b/src/react_compiler/diagnostics/js_string.rs
@@ -90,18 +90,6 @@ impl JsString {
     }
 }
 
-impl From<&str> for JsString {
-    fn from(s: &str) -> Self {
-        Self::from_wtf8_bytes(s.as_bytes())
-    }
-}
-
-impl From<String> for JsString {
-    fn from(s: String) -> Self {
-        Self::from_wtf8_bytes(s.as_bytes())
-    }
-}
-
 impl PartialEq for JsString {
     fn eq(&self, other: &Self) -> bool {
         self.0.get().eql_string(other.0.get())
@@ -112,18 +100,6 @@ impl Eq for JsString {}
 impl Hash for JsString {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.0.get().hash().hash(h);
-    }
-}
-
-impl PartialEq<str> for JsString {
-    fn eq(&self, other: &str) -> bool {
-        self.0.get().eql_bytes(other.as_bytes())
-    }
-}
-
-impl PartialEq<&str> for JsString {
-    fn eq(&self, other: &&str) -> bool {
-        self.0.get().eql_bytes(other.as_bytes())
     }
 }
 

--- a/src/react_compiler/hir/environment.rs
+++ b/src/react_compiler/hir/environment.rs
@@ -860,12 +860,6 @@ impl Environment {
     }
 }
 
-impl Default for Environment {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cold]
 #[inline(never)]
 fn shape_not_found(shape_id: &str) -> CompilerDiagnostic {

--- a/src/react_compiler/hir/environment_config.rs
+++ b/src/react_compiler/hir/environment_config.rs
@@ -46,12 +46,6 @@ pub enum ExhaustiveEffectDepsMode {
     ExtraOnly,
 }
 
-impl Default for ExhaustiveEffectDepsMode {
-    fn default() -> Self {
-        Self::Off
-    }
-}
-
 /// Compiler environment configuration. Contains feature flags and settings.
 ///
 /// Fields that would require passing JS functions across the JS/Rust boundary

--- a/src/react_compiler/hir/globals.rs
+++ b/src/react_compiler/hir/globals.rs
@@ -177,15 +177,6 @@ impl GlobalRegistry {
     }
 }
 
-impl Clone for GlobalRegistry {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base,
-            entries: self.entries.clone(),
-        }
-    }
-}
-
 // =============================================================================
 // Static base registries (initialized once, shared across all Environments)
 // =============================================================================

--- a/src/react_compiler/hir/globals.rs
+++ b/src/react_compiler/hir/globals.rs
@@ -109,7 +109,7 @@ bun_core::comptime_string_map! {
 ///   `build_default_globals` to construct the static base.
 /// - **Overlay mode** (`base=true`): lookups check the extras HashMap first,
 ///   then fall back to the static `BASE_GLOBAL_INDEX` / `BASE.globals` table.
-///   Inserts go into extras. Cloning only copies the extras map.
+///   Inserts go into extras.
 pub struct GlobalRegistry {
     base: bool,
     entries: HashMap<Cow<'static, str>, Global>,

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -156,12 +156,6 @@ impl FloatValue {
     }
 }
 
-impl From<f64> for FloatValue {
-    fn from(value: f64) -> Self {
-        FloatValue::new(value)
-    }
-}
-
 impl From<FloatValue> for f64 {
     fn from(value: FloatValue) -> Self {
         value.value()

--- a/src/react_compiler/hir/object_shape.rs
+++ b/src/react_compiler/hir/object_shape.rs
@@ -132,7 +132,6 @@ pub struct ObjectShape {
 ///   `build_builtin_shapes` / `build_default_globals` to construct the static base.
 /// - **Overlay mode** (`base=Some`): holds a `&'static HashMap` base plus a small
 ///   extras HashMap. Lookups check extras first, then base. Inserts go into extras.
-///   Cloning only copies the extras map (the base pointer is shared).
 pub struct ShapeRegistry {
     base: Option<&'static HashMap<&'static str, ObjectShape>>,
     entries: HashMap<&'static str, ObjectShape>,

--- a/src/react_compiler/hir/object_shape.rs
+++ b/src/react_compiler/hir/object_shape.rs
@@ -211,16 +211,6 @@ impl ShapeRegistry {
     }
 }
 
-impl Clone for ShapeRegistry {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base,
-            entries: self.entries.clone(),
-            next_anon: self.next_anon,
-        }
-    }
-}
-
 // =============================================================================
 // Builder functions (matching TS addFunction, addHook, addObject)
 // =============================================================================

--- a/src/react_compiler/hir/visitors.rs
+++ b/src/react_compiler/hir/visitors.rs
@@ -1004,12 +1004,6 @@ impl ScopeBlockTraversal {
     }
 }
 
-impl Default for ScopeBlockTraversal {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 // =============================================================================
 // Convenience wrappers: extract IdentifierIds from Places
 // =============================================================================

--- a/src/resolve_builtins/HardcodedModule.rs
+++ b/src/resolve_builtins/HardcodedModule.rs
@@ -327,17 +327,6 @@ pub struct Alias {
     pub node_only_prefix: bool,
 }
 
-impl Default for Alias {
-    fn default() -> Self {
-        Self {
-            path: zstr!(""),
-            tag: import_record::Tag::Builtin,
-            node_builtin: false,
-            node_only_prefix: false,
-        }
-    }
-}
-
 /// Prepend `"node:"` to a literal at compile time iff it isn't already prefixed.
 macro_rules! ensure_node_prefix {
     ($path:literal) => {{

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -123,16 +123,6 @@ pub struct EntryCache {
     pub(crate) kind: EntryKind,
 }
 
-impl Default for EntryCache {
-    fn default() -> Self {
-        Self {
-            symlink: Interned::EMPTY,
-            fd: Fd::INVALID,
-            kind: EntryKind::File,
-        }
-    }
-}
-
 // `cache` / `need_stat` are lazily populated by `Entry::kind` /
 // `Entry::symlink` while callers hold a shared
 // `&Entry`. `EntryCache` is `Copy`, so `Cell` gives us safe

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -215,4 +215,3 @@ impl BundleOptions {
         }
     }
 }
-

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -96,28 +96,6 @@ pub struct ExtensionOrderGroup {
     pub default: Box<[Box<[u8]>]>,
     pub esm: Box<[Box<[u8]>]>,
 }
-impl Default for ExtensionOrderGroup {
-    fn default() -> Self {
-        ExtensionOrderGroup {
-            default: owned_string_list(bundle_options::defaults::EXTENSION_ORDER),
-            esm: owned_string_list(bundle_options::defaults::MODULE_EXTENSION_ORDER),
-        }
-    }
-}
-impl Default for ExtensionOrder {
-    fn default() -> Self {
-        ExtensionOrder {
-            default: ExtensionOrderGroup::default(),
-            node_modules: ExtensionOrderGroup {
-                default: owned_string_list(bundle_options::defaults::node_modules::EXTENSION_ORDER),
-                esm: owned_string_list(
-                    bundle_options::defaults::node_modules::MODULE_EXTENSION_ORDER,
-                ),
-            },
-            css: owned_string_list(bundle_options::defaults::CSS_EXTENSION_ORDER),
-        }
-    }
-}
 impl ExtensionOrder {
     /// Returns the
     /// [`ExtOrder`] tag; resolve to a slice via
@@ -165,24 +143,6 @@ impl BundleOptions {
 pub mod bundle_options {
     pub mod defaults {
         pub const CSS_EXTENSION_ORDER: &[&[u8]] = &[b".css"];
-        // Mirrors `bun_bundler::options::bundle_options_defaults::EXTENSION_ORDER`
-        // / `MODULE_EXTENSION_ORDER` — duplicated so `Default for BundleOptions`
-        // below is self-contained (resolver sits below bundler in the dep graph).
-        pub(crate) const EXTENSION_ORDER: &[&[u8]] = &[
-            b".tsx", b".ts", b".jsx", b".cts", b".cjs", b".js", b".mjs", b".mts", b".json",
-        ];
-        pub(crate) const MODULE_EXTENSION_ORDER: &[&[u8]] = &[
-            b".tsx", b".jsx", b".mts", b".ts", b".mjs", b".js", b".cts", b".cjs", b".json",
-        ];
-        /// Mirrors `bun_bundler::options::bundle_options_defaults::node_modules`.
-        pub(crate) mod node_modules {
-            pub(crate) const EXTENSION_ORDER: &[&[u8]] = &[
-                b".jsx", b".cjs", b".js", b".mjs", b".mts", b".tsx", b".ts", b".cts", b".json",
-            ];
-            pub(crate) const MODULE_EXTENSION_ORDER: &[&[u8]] = &[
-                b".mjs", b".jsx", b".js", b".mts", b".tsx", b".ts", b".cjs", b".cts", b".json",
-            ];
-        }
     }
 }
 
@@ -247,49 +207,6 @@ pub struct BundleOptions {
     pub allow_runtime: bool,
 }
 
-impl Default for BundleOptions {
-    /// Only the fields the resolver
-    /// reads — `bun_bundler::Transpiler::init` overlays the per-field
-    /// projections it can map (target/packages/jsx/bools/global_cache/…)
-    /// before handing this to `Resolver::init1`.
-    fn default() -> Self {
-        BundleOptions {
-            target: Target::default(),
-            packages: Packages::default(),
-            jsx: jsx::Pragma::default(),
-            extension_order: ExtensionOrder::default(),
-            conditions: Conditions::default(),
-            external: ExternalModules::default(),
-            extra_cjs_extensions: Box::default(),
-            framework: None,
-            global_cache: Default::default(),
-            install: None,
-            load_package_json: true,
-            load_tsconfig_json: true,
-            main_field_extension_order: owned_string_list(
-                bundle_options::defaults::EXTENSION_ORDER,
-            ),
-            main_fields: owned_string_list(DEFAULT_MAIN_FIELDS.get(Target::default())),
-            main_fields_is_default: true,
-            mark_builtins_as_external: false,
-            polyfill_node_globals: false,
-            install_preference: Default::default(),
-            preserve_symlinks: false,
-            rewrite_jest_for_tests: false,
-            tsconfig_override: None,
-            output_dir: Box::default(),
-            root_dir: Box::default(),
-            public_path: Box::default(),
-            compile: false,
-            supports_multiple_outputs: true,
-            tree_shaking: false,
-            allow_runtime: true,
-            production: false,
-            force_node_env: ForceNodeEnv::default(),
-        }
-    }
-}
-
 impl BundleOptions {
     pub fn set_production(&mut self, value: bool) {
         if self.force_node_env == ForceNodeEnv::Unspecified {
@@ -299,46 +216,3 @@ impl BundleOptions {
     }
 }
 
-// These are the per-target default `--main-fields` orderings. `BundleOptions.main_fields`
-// is initialised to alias one of these slices, and the
-// resolver's `auto_main` heuristic at `load_as_main_field` compares the *pointer* of
-// `opts.main_fields` against `DEFAULT_MAIN_FIELDS.get(opts.target)` to detect whether the
-// user explicitly set a main-fields list. The previous `&[]` stub made that check always
-// false, silently disabling the module-vs-main dual-resolution path.
-struct TargetMainFields;
-
-// Note that this means if a package specifies "module" and "main", the ES6
-// module will not be selected. This means tree shaking will not work when
-// targeting node environments.
-//
-// Some packages incorrectly treat the "module" field as "code for the browser". It
-// actually means "code for ES6 environments" which includes both node and the browser.
-//
-// For example, the package "@firebase/app" prints a warning on startup about
-// the bundler incorrectly using code meant for the browser if the bundler
-// selects the "module" field instead of the "main" field.
-//
-// This is unfortunate but it's a problem on the side of those packages.
-// They won't work correctly with other popular bundlers (with node as a target) anyway.
-static DEFAULT_MAIN_FIELDS_NODE: &[&[u8]] = &[b"main", b"module"];
-
-// Note that this means if a package specifies "main", "module", and
-// "browser" then "browser" will win out over "module". This is the
-// same behavior as webpack: https://github.com/webpack/webpack/issues/4674.
-//
-// This is deliberate because the presence of the "browser" field is a
-// good signal that this should be preferred. Some older packages might only use CJS in their "browser"
-// but in such a case they probably don't have any ESM files anyway.
-static DEFAULT_MAIN_FIELDS_BROWSER: &[&[u8]] = &[b"browser", b"module", b"jsnext:main", b"main"];
-static DEFAULT_MAIN_FIELDS_BUN: &[&[u8]] = &[b"module", b"main", b"jsnext:main"];
-
-impl TargetMainFields {
-    fn get(&self, t: Target) -> &'static [&'static [u8]] {
-        match t {
-            Target::Node => DEFAULT_MAIN_FIELDS_NODE,
-            Target::Browser => DEFAULT_MAIN_FIELDS_BROWSER,
-            Target::Bun | Target::BunMacro | Target::ServerComponentsSsr => DEFAULT_MAIN_FIELDS_BUN,
-        }
-    }
-}
-const DEFAULT_MAIN_FIELDS: TargetMainFields = TargetMainFields;

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -54,17 +54,6 @@ pub struct DependencyMap {
     pub source_buf: &'static [u8],
 }
 
-impl Clone for DependencyMap {
-    /// Deep-clones the small key/value vecs; `SemverString`/`Dependency` are
-    /// POD over `source_buf`.
-    fn clone(&self) -> Self {
-        Self {
-            map: self.map.clone().expect("OOM"),
-            source_buf: self.source_buf,
-        }
-    }
-}
-
 // Inherent impls cannot carry associated type aliases (stable), so use a free alias.
 type DependencyHashMap =
     ArrayHashMap<SemverString, Dependency /* , SemverString::ArrayHashContext */>;
@@ -1338,16 +1327,6 @@ pub struct Package<'a> {
     pub(crate) version: &'a [u8],
     /// Borrows from the `subpath_buf` argument to `Package::parse`.
     pub(crate) subpath: &'a [u8],
-}
-
-impl Default for Package<'_> {
-    fn default() -> Self {
-        Package {
-            name: b"",
-            version: b"",
-            subpath: b"",
-        }
-    }
 }
 
 #[derive(Clone, Copy, Default)]

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -33,12 +33,6 @@ pub(crate) struct GzipOptions {
     pub level: u8,
 }
 
-impl Default for GzipOptions {
-    fn default() -> Self {
-        Self { level: 6 }
-    }
-}
-
 // Hand-written JS class glue (not the `#[bun_jsc::JsClass]` derive): Archive
 // needs a custom `finalize` and no constructor, which the proc-macro does not
 // expose.

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -345,12 +345,6 @@ impl From<CreatePtyError> for InitError {
     }
 }
 
-impl From<InitError> for crate::Error {
-    fn from(e: InitError) -> Self {
-        crate::Error::TerminalInit(e)
-    }
-}
-
 impl Terminal {
     #[inline]
     fn global(&self) -> &JSGlobalObject {
@@ -831,12 +825,6 @@ pub enum CreatePtyError {
     DupFailed,
     #[error("NotSupported")]
     NotSupported,
-}
-
-impl From<CreatePtyError> for crate::Error {
-    fn from(e: CreatePtyError) -> Self {
-        crate::Error::TerminalInit(e.into())
-    }
 }
 
 fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -337,16 +337,6 @@ pub struct FrameHeader {
     flags: u8,
     stream_identifier: u32,
 }
-impl Default for FrameHeader {
-    fn default() -> Self {
-        Self {
-            length: 0,
-            type_: FrameType::HTTP_FRAME_SETTINGS as u8,
-            flags: 0,
-            stream_identifier: 0,
-        }
-    }
-}
 impl FrameHeader {
     pub const BYTE_SIZE: usize = 9;
     #[inline]

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -89,13 +89,6 @@ pub struct ServerComponents {
 pub struct ReactFastRefresh {
     pub(crate) import_source: Cow<'static, [u8]>,
 }
-impl Default for ReactFastRefresh {
-    fn default() -> Self {
-        Self {
-            import_source: Cow::Borrowed(b"react-refresh/runtime"),
-        }
-    }
-}
 
 /// `bake.Framework.FileSystemRouterType`. Full body (with `Style` enum and
 /// `from_js`) lives in the gated `bake_body.rs` draft; only the field set
@@ -128,17 +121,6 @@ pub struct Framework {
     pub(crate) server_components: Option<ServerComponents>,
     pub(crate) react_fast_refresh: Option<ReactFastRefresh>,
     pub(crate) built_in_modules: bun_collections::StringArrayHashMap<BuiltInModule>,
-}
-impl Default for Framework {
-    fn default() -> Self {
-        Self {
-            is_built_in_react: false,
-            file_system_router_types: Vec::new(),
-            server_components: None,
-            react_fast_refresh: None,
-            built_in_modules: bun_collections::StringArrayHashMap::new(),
-        }
-    }
 }
 
 impl Framework {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -80,16 +80,6 @@ pub struct ExecCfg {
     pub(crate) allow_fast_run_for_extensions: bool,
 }
 
-impl Default for ExecCfg {
-    fn default() -> Self {
-        Self {
-            bin_dirs_only: false,
-            log_errors: true,
-            allow_fast_run_for_extensions: true,
-        }
-    }
-}
-
 /// Per-caller knobs for [`RunCommand::configure_env_for_run`] and
 /// [`RunCommand::configure_env_for_run_without_linker`].
 #[derive(Clone, Copy)]

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -459,8 +459,6 @@ pub enum Error {
     Sourcemap(#[from] bun_sourcemap::Error),
     #[error(transparent)]
     StandaloneGraph(#[from] bun_standalone_graph::Error),
-    #[error(transparent)]
-    TerminalInit(crate::api::bun_terminal_body::InitError),
     #[error("JSError")]
     Js(bun_jsc::JsError),
 }
@@ -801,7 +799,6 @@ impl Error {
             Self::JsPrinter(e) => e.name(),
             Self::Sourcemap(e) => e.name(),
             Self::StandaloneGraph(e) => e.name(),
-            Self::TerminalInit(e) => <&'static str>::from(e),
             Self::Js(bun_jsc::JsError::OutOfMemory) => "OutOfMemory",
             Self::Js(_) => "JSError",
         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2901,14 +2901,6 @@ pub mod args {
         pub path: PathLike,
         pub(crate) mode: Mode,
     }
-    impl Default for Chmod {
-        fn default() -> Self {
-            Self {
-                path: PathLike::default(),
-                mode: 0x777,
-            }
-        }
-    }
     fs_args_path_forwarders!(Chmod; path);
     impl Chmod {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Chmod> {
@@ -2935,14 +2927,6 @@ pub mod args {
     pub struct FChmod {
         pub(crate) fd: FD,
         pub(crate) mode: Mode,
-    }
-    impl Default for FChmod {
-        fn default() -> Self {
-            Self {
-                fd: FD::INVALID,
-                mode: 0x777,
-            }
-        }
     }
     impl FChmod {
         pub(crate) fn to_thread_safe(&self) {}
@@ -2996,15 +2980,6 @@ pub mod args {
         pub path: PathLike,
         pub(crate) big_int: bool,
         pub(crate) throw_if_no_entry: bool,
-    }
-    impl Default for Stat {
-        fn default() -> Self {
-            Self {
-                path: PathLike::default(),
-                big_int: false,
-                throw_if_no_entry: true,
-            }
-        }
     }
     fs_args_path_forwarders!(Stat; path);
     impl Stat {
@@ -3263,17 +3238,6 @@ pub mod args {
         pub(crate) recursive: bool,
         pub(crate) retry_delay: c_uint,
     }
-    impl Default for RmDir {
-        fn default() -> Self {
-            Self {
-                path: PathLike::default(),
-                force: false,
-                max_retries: 0,
-                recursive: false,
-                retry_delay: 100,
-            }
-        }
-    }
     fs_args_path_forwarders!(RmDir; path);
     impl RmDir {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<RmDir> {
@@ -3418,18 +3382,6 @@ pub mod args {
         pub(crate) prefix: PathLike,
         pub(crate) encoding: Encoding,
     }
-    impl Default for MkdirTemp {
-        fn default() -> Self {
-            Self {
-                prefix: PathLike::Buffer(Buffer {
-                    buffer: bun_jsc::ArrayBuffer::EMPTY,
-                    owns_buffer: false,
-                    pinned: false,
-                }),
-                encoding: Encoding::Utf8,
-            }
-        }
-    }
     fs_args_path_forwarders!(MkdirTemp; prefix);
     impl MkdirTemp {
         pub fn from_js(
@@ -3518,15 +3470,6 @@ pub mod args {
         pub path: PathLike,
         pub(crate) flags: FileSystemFlags,
         pub(crate) mode: Mode,
-    }
-    impl Default for Open {
-        fn default() -> Self {
-            Self {
-                path: PathLike::default(),
-                flags: FileSystemFlags::R,
-                mode: DEFAULT_PERMISSION,
-            }
-        }
     }
     fs_args_path_forwarders!(Open; path);
     impl Open {

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -52,16 +52,6 @@ pub struct InitOptions<'a> {
     pub(crate) headers: Option<&'a FetchHeaders>,
 }
 
-impl<'a> Default for InitOptions<'a> {
-    fn default() -> Self {
-        Self {
-            server: None,
-            status_code: 200,
-            headers: None,
-        }
-    }
-}
-
 use crate::webcore::headers_ref::blob_content_type;
 
 #[inline]

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1672,17 +1672,6 @@ pub struct FromJSOptions {
     pub(crate) previous_routes: bool,
 }
 
-impl Default for FromJSOptions {
-    fn default() -> Self {
-        Self {
-            allow_bake_config: true,
-            is_fetch_required: true,
-            previous_fetch: false,
-            previous_routes: false,
-        }
-    }
-}
-
 pub struct UserRouteBuilder {
     pub(crate) route: RouteDeclaration,
     pub callback: Strong, // jsc.Strong.Optional

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1357,14 +1357,6 @@ pub(crate) struct ID {
     pub id: i32,
     pub kind: KindBig,
 }
-impl Default for ID {
-    fn default() -> Self {
-        Self {
-            id: 0,
-            kind: KindBig::SetTimeout,
-        }
-    }
-}
 impl ID {
     #[inline]
     fn async_id(self) -> u64 {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2770,41 +2770,6 @@ pub struct FetchOptions {
     pub(crate) compress: Option<http::compress_body::CompressOption>,
 }
 
-impl Default for FetchOptions {
-    fn default() -> Self {
-        // Zero-values for the required fields
-        // (method/headers/body/url/bools/unix_socket_path) so
-        // callers can use `..Default::default()` struct-update syntax while
-        // still overriding the required fields explicitly.
-        Self {
-            method: Method::GET,
-            headers: Headers::default(),
-            body: HTTPRequestBody::default(),
-            disable_timeout: false,
-            idle_timeout_seconds: None,
-            disable_keepalive: false,
-            disable_decompression: false,
-            max_redirects: None,
-            reject_unauthorized: true,
-            url: ZigURL::default(),
-            verbose: http::HTTPVerboseLevel::None,
-            redirect_type: FetchRedirect::Follow,
-            proxy: None,
-            proxy_headers: None,
-            url_proxy_buffer: Box::default(),
-            signal: None,
-            hostname: None,
-            check_server_identity: StrongOptional::empty(),
-            unix_socket_path: ZigStringSlice::EMPTY,
-            ssl_config: None,
-            upgraded_connection: false,
-            forced_protocol: None,
-            is_node_http_client: false,
-            compress: None,
-        }
-    }
-}
-
 pub(crate) struct FetchTaskletPromiseSettle {
     held: StrongOptional,
     promise: jsc::JSPromiseStrong,

--- a/src/runtime/webcore/s3/error_jsc.rs
+++ b/src/runtime/webcore/s3/error_jsc.rs
@@ -123,16 +123,6 @@ struct JSS3Error {
     path: BunString,
 }
 
-impl Default for JSS3Error {
-    fn default() -> Self {
-        Self {
-            code: BunString::empty(),
-            message: BunString::empty(),
-            path: BunString::empty(),
-        }
-    }
-}
-
 impl JSS3Error {
     fn init(code: &[u8], message: &[u8], path: Option<&[u8]>) -> Self {
         Self {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -531,15 +531,6 @@ pub struct IntoArray {
     pub(crate) len: BlobSizeType,
 }
 
-impl Default for IntoArray {
-    fn default() -> Self {
-        Self {
-            value: JSValue::default(),
-            len: BlobSizeType::MAX,
-        }
-    }
-}
-
 // ─── Result.Pending ──────────────────────────────────────────────────────
 
 pub struct Pending {

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1061,12 +1061,6 @@ pub struct SignQueryOptions {
     pub expires: usize,
 }
 
-impl Default for SignQueryOptions {
-    fn default() -> Self {
-        Self { expires: 86400 }
-    }
-}
-
 // transient param-pack struct; lifetime added because every field is a caller-owned
 // borrow. PORTING.md discourages struct lifetimes, but raw pointers here would be strictly worse.
 #[derive(Clone, Copy)]

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -25,12 +25,6 @@ pub struct Chunk {
     pub should_ignore: bool,
 }
 
-impl Default for Chunk {
-    fn default() -> Self {
-        Self::init_empty()
-    }
-}
-
 impl Chunk {
     pub fn init_empty() -> Chunk {
         Chunk {

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -49,17 +49,6 @@ pub struct Mapping {
     pub name_index: i32, // = -1
 }
 
-impl Default for Mapping {
-    fn default() -> Self {
-        Self {
-            generated: LineColumnOffset::default(),
-            original: LineColumnOffset::default(),
-            source_index: 0,
-            name_index: -1,
-        }
-    }
-}
-
 /// Optimization: if we don't care about the "names" column, then don't store the names.
 #[derive(Clone, Copy, Default)]
 pub struct MappingWithoutName {

--- a/src/sql_jsc/error.rs
+++ b/src/sql_jsc/error.rs
@@ -22,8 +22,6 @@ pub enum Error {
     UnsupportedArrayType,
     #[error("JSError")]
     JSError,
-    #[error("AuthenticationFailed")]
-    AuthenticationFailed,
     #[error("InvalidBinaryValue")]
     InvalidBinaryValue,
     #[error("Thrown")]
@@ -53,7 +51,6 @@ impl Error {
             Self::InvalidServerSignature => "InvalidServerSignature",
             Self::UnsupportedArrayType => "UnsupportedArrayType",
             Self::JSError => "JSError",
-            Self::AuthenticationFailed => "AuthenticationFailed",
             Self::InvalidBinaryValue => "InvalidBinaryValue",
             Self::Thrown => "Thrown",
             Self::Alloc(_) => "OutOfMemory",

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1635,11 +1635,6 @@ impl MySQLConnection {
 pub enum FlushQueueError {
     AuthenticationFailed,
 }
-impl From<FlushQueueError> for crate::Error {
-    fn from(_: FlushQueueError) -> Self {
-        crate::Error::AuthenticationFailed
-    }
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Writer / Reader — protocol-layer adapters wrapping the connection's

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8370,15 +8370,6 @@ pub mod net {
             }
         }
     }
-    impl Default for Address {
-        // SAFETY: POD, zero-valid — sockaddr union of integer fields.
-        fn default() -> Self {
-            Self {
-                // SAFETY: `sockaddr_storage` is POD; all-zeros is a valid value.
-                any: unsafe { bun_core::ffi::zeroed_unchecked() },
-            }
-        }
-    }
     impl fmt::Debug for Address {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             fmt::Display::fmt(self, f)

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -292,14 +292,6 @@ impl ThreadPool {
     }
 }
 
-impl Default for ThreadPool {
-    /// Default-initialised pool with zero `max_threads` (`init()` clamps to
-    /// ≥1 when actually started).
-    fn default() -> Self {
-        Self::init(Config::default())
-    }
-}
-
 /// Shut down the thread pool and stop the worker threads.
 impl Drop for ThreadPool {
     fn drop(&mut self) {

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -81,12 +81,6 @@ impl Default for SocketGroup {
     }
 }
 
-impl Default for VTable {
-    fn default() -> Self {
-        bun_core::ffi::zeroed()
-    }
-}
-
 pub enum ConnectResult {
     Socket(*mut us_socket_t),
     Connecting(*mut ConnectingSocket),

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -518,16 +518,6 @@ pub struct ListenConfig {
     pub options: i32,
 }
 
-impl Default for ListenConfig {
-    fn default() -> Self {
-        Self {
-            port: 0,
-            host: ptr::null(),
-            options: 0,
-        }
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // extern "C"
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -613,18 +613,6 @@ pub struct us_socket_stream_buffer_t {
     pub(crate) cursor: usize,
 }
 
-impl Default for us_socket_stream_buffer_t {
-    fn default() -> Self {
-        Self {
-            list_ptr: ptr::null_mut(),
-            list_cap: 0,
-            list_len: 0,
-            total_bytes_written: 0,
-            cursor: 0,
-        }
-    }
-}
-
 /// Minimal structural mirror of `bun_io::StreamBuffer` for tier-0 interop.
 /// The higher-tier `bun_io::StreamBuffer` is field-identical and converts via
 /// `From`/`Into` (added in the move-in pass).


### PR DESCRIPTION
### Problem
- 92 hand-written trait impls (`Default`, `From`, `Clone`, `PartialEq`) across 29 crates have no caller. rustc's `dead_code` lint exempts trait impls, so the workspace lints never report them.
- A few items existed only for those impls: two tables in `src/resolver/options.rs`, `Flags::DEFAULTS` in `src/md/types.rs`, and five error variants that only a removed `From` impl constructed.

### Fix
- Delete the impls and the items that became unused. 80 files, 1064 lines removed. The one added line is a doc comment with its last sentence cut.
- The candidates come from the linker: a relink of the debug build with `--gc-sections --print-gc-sections` lists the trait methods dropped from every codegen unit. Impls that a bound or a supertrait still needs (`Deref` under `DerefMut`, `PartialEq` under `Ord`, `From<RGBA> for SRGB`) do not compile without the impl, so they stay.
- Verified: `bun run rust:check-all` (11 targets), `bun run rust:clippy`, `cargo build --tests` for the 21 touched crates with unit tests, `cargo miri test` for the touched miri crates, `bun bd`, and 2112 tests across css, md, shell, env, resolve, node:fs, console.table, archive, http2, build errors, install, and compile sourcemaps.

### Background
- To rustc a trait impl is always reachable: generic code could call it through the trait. Only a whole-program view shows which impls nothing calls.
- The debug build uses `-ffunction-sections` at opt-level 0, so a function that nothing references is its own section and is not inlined away. `--gc-sections` drops exactly those sections. A method that survives in any codegen unit (an `#[inline]` copy, for example) counts as live.
- The removed impls are listed below.

<details><summary>Removed impls by crate</summary>

- `src/runtime` (19): `Default for Chmod`; `Default for ExecCfg`; `Default for FChmod`; `Default for FetchOptions`; `Default for FrameHeader`; `Default for Framework`; `Default for FromJSOptions`; `Default for GzipOptions`; `Default for ID`; `Default for InitOptions<'a>`; `Default for IntoArray`; `Default for JSS3Error`; `Default for MkdirTemp`; `Default for Open`; `Default for ReactFastRefresh`; `Default for RmDir`; `Default for Stat`; `From<CreatePtyError> for crate::Error`; `From<InitError> for crate::Error`
- `src/react_compiler` (10): `Clone for GlobalRegistry`; `Clone for ShapeRegistry`; `Default for Environment`; `Default for ExhaustiveEffectDepsMode`; `Default for ScopeBlockTraversal`; `From<&str> for JsString`; `From<String> for JsString`; `From<f64> for FloatValue`; `PartialEq<&str> for JsString`; `PartialEq<str> for JsString`
- `src/ast` (8): `Default for ClassStaticBlock`; `Default for CommonJSNamedExport`; `Default for Dependency`; `Default for MetadataResolve`; `Default for NamedImport`; `Default for Query`; `From<SetError> for crate::Error`; `PartialEq for Data`
- `src/jsc` (6): `Default for BuildMessage`; `Default for CPUProfilerConfig`; `Default for Column`; `Default for ResolveMessage`; `Default for RuntimeTranspilerCache`; `Default for Store`
- `src/resolver` (6): `Clone for DependencyMap`; `Default for BundleOptions`; `Default for EntryCache`; `Default for ExtensionOrder`; `Default for ExtensionOrderGroup`; `Default for Package<'_>`
- `src/bun_core` (4): `Clone for SmolStr`; `Default for CtorOptions`; `Default for DeserOpts`; `From<crate::Error> for JsError`
- `src/install` (4): `Default for Entry`; `Default for MoreInstructions<'_>`; `Default for Scratch`; `PartialEq<crate::Error> for ForManifestError`
- `src/css` (3): `PartialEq for CustomPropertyName`; `PartialEq for KeyframesName`; `PartialEq for LayerName`
- `src/md` (3): `Default for BlockHeader`; `Default for Flags`; `Default for Theme<'a>`
- `src/parsers` (3): `Default for JSONOptions`; `From<AddToLogError> for crate::Error`; `From<bun_alloc::AllocError> for PErr`
- `src/uws_sys` (3): `Default for ListenConfig`; `Default for VTable`; `Default for us_socket_stream_buffer_t`
- `src/bun_alloc` (2): `Default for MaxHeapAllocator`; `Default for Mutex`
- `src/bundler` (2): `Clone for OutputFile`; `Default for BunLogOptions`
- `src/install_types` (2): `Default for TarballInfo`; `From<CreateMatcherError> for FromExprError`
- `src/js_parser` (2): `Default for ReactFastRefresh`; `Default for ThenCatchChain`
- `src/sourcemap` (2): `Default for Chunk`; `Default for Mapping`
- `src/base64` (1): `Default for VLQ`
- `src/collections` (1): `Default for StringMap`
- `src/dns` (1): `Default for Backend`
- `src/dotenv` (1): `Default for Map`
- `src/io` (1): `Default for FilePoll`
- `src/paths` (1): `From<Error> for crate::Error`
- `src/picohttp` (1): `Default for Response<'a>`
- `src/ptr` (1): `Default for WeakPtrData`
- `src/resolve_builtins` (1): `Default for Alias`
- `src/s3_signing` (1): `Default for SignQueryOptions`
- `src/sql_jsc` (1): `From<FlushQueueError> for crate::Error`
- `src/sys` (1): `Default for Address`
- `src/threading` (1): `Default for ThreadPool`

Follow-up removals that became unused with them:

- `src/resolver/options.rs`: the `EXTENSION_ORDER` / `MODULE_EXTENSION_ORDER` copies and the `TargetMainFields` / `DEFAULT_MAIN_FIELDS_*` tables (only `Default for BundleOptions` read them; the bundler projects these options itself).
- `src/md/types.rs`: `Flags::DEFAULTS` (only `Default for Flags` read it; `root.rs` builds `Flags` field by field).
- `src/parsers/xml.rs`: the `PErr::Oom` variant and its match arm (only the removed `From<AllocError>` produced it).
- `src/css/rules/keyframes.rs`, `src/css/rules/layer.rs`: the `Hash` and `Eq` impls that went with the removed `PartialEq` impls, and the two comments that described them. The `ShapeRegistry` and `GlobalRegistry` docs in `src/react_compiler/hir/` lose the sentence about cloning for the same reason. Neither type is used as a map key; `LayerName` comparisons go through the inherent `eql`.
- `src/ast/stmt.rs`: `impl Eq for Data`.
- Error variants whose only constructor was a removed `From` impl, with their `name()` arms: `bun_runtime::Error::TerminalInit`, `bun_ast::Error::Clobber`, `bun_paths::Error::MaxPathExceeded`, `bun_sql_jsc::Error::AuthenticationFailed`. The inner error types (`InitError`, `SetError`, `path_options::Error`, `FlushQueueError`) are still live on their own.
</details>

<details><summary>Notes</summary>

- `bun_core::strings::rsplit_once` has no caller, but `clippy.toml` names it as the replacement for `str::rsplit_once`, `str::rsplitn` and `bstr::ByteSlice::rsplit_once_str`, so it stays. Policy files are one kind of reference the linker does not see. No other removed item is named in `clippy.toml`, `hawk.toml`, or the docs.
- Three impls came back during verification and are not in the diff: `Semaphore: Default` (used by the macOS `fs_events.rs`, found by `rust:check-all`), `clap::Help: Default` and `braces::Token: PartialEq` (used only by unit tests, found by `cargo build --tests`). The cross-target and test builds are needed for this kind of sweep: the linux binary alone does not see them.
Scope of this sweep and what came back clean, so the next run can skip it:

- Seven dead-code PRs are open right now (#37181, #37659, #39581, #39582, #39618, #39697, #39732). This PR deletes no line that any of them deletes (checked by diffing the removed lines). `src/jsc/headergen/sizegen.cpp` is dead too, but #39618 already removes it.
- Flipping every `pub` to `pub(crate)` in `bun_runtime` (349k lines) and letting rustc report leaves 53 items, nearly all Windows-only or FFI enum tags. The same two-round flip over the other 95 crates found only macro-generated tables and items that are used from other platforms or from macro bodies.
- The gc-sections list for C++ is almost entirely covered by the open PRs. What is left is small: 15 `JSFoo::toWrapped` stubs, a few `ncrypto` helpers, a handful of unused overloads.
- `src/js/internal/**` (111 files) and the remaining `src/js/node`, `builtins`, `bun`, `thirdparty` files (86 files) were scanned export by export: nothing dead beyond a few single lines (`WASI.prototype.getState/setState`, three unused WASI constants).
- No orphan files: every `.rs` is mounted, every `.cpp` is compiled, every `.h` is included. No stale `cfg` names (the build emits no `unexpected_cfgs` warnings).
- Left alone on purpose: `src/runtime/api/bun/h2/` (in-progress rewrite, `#![allow(dead_code)]` by design), `src/react_compiler/compile_result.rs` (marked as not yet wired), the MySQL `CharacterSet` collation table (222 unused constants, a code table like the ones `hawk.toml` keeps), `Sys`/`Alloc` error variants that follow the crate `Error` convention, and the `JsPoster` clone vtable slot.
- Possible larger follow-up for a maintainer decision: `PerformanceResourceTiming::create` and the `ResourceTiming` / `NetworkLoadMetrics` / `PerformanceServerTiming` constructors are unreferenced, so no such entry can ever exist. The JS classes stay reachable as globals, which is why about 1.8k lines of `src/jsc/bindings/webcore/*Timing*` survive. Removing them changes the global surface, so it is not in this PR.
</details>
