### PR TITLE
crash_handler: give the musl and android builds their own trace string platform characters

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2337,11 +2337,18 @@ mod draft {
 
     /// Each platform is encoded as a single character. It is placed right after the
     /// slash after the version, so someone just reading the trace string can tell
-    /// what platform it came from. L, M, and W are for Linux, macOS, and Windows,
-    /// with capital letters indicating aarch64, lowercase indicating x86_64.
+    /// what platform it came from. L, M, W and F are for Linux (glibc), macOS,
+    /// Windows and FreeBSD, U is Linux built against musl and A is Android, with
+    /// capital letters indicating aarch64, lowercase indicating x86_64.
     ///
     /// eg: 'https://bun.report/1.1.3/we04c...
     ///                               ^ this tells you it is windows x86_64
+    ///
+    /// bun.report picks the debug file by this character, so every build of a
+    /// commit that is a different binary needs its own: `bun-linux-<arch>`,
+    /// `bun-linux-<arch>-musl` and `bun-linux-<arch>-android` are three links of
+    /// the same commit. Older musl and android builds emitted 'l'/'L', which the
+    /// backend keeps decoding as the glibc build.
     ///
     /// x64 ships one nehalem build; the old baseline codes ('B','b','e','g')
     /// are no longer emitted but the backend still accepts them from old bins.
@@ -2350,21 +2357,29 @@ mod draft {
     impl Platform {
         // Rust cannot concat ident names at const time without a proc-macro; spell out the cfg matrix.
         const CURRENT: u8 = {
-            // Android folds into the Linux variants. bun.report decodes the same
-            // single-char codes; introducing new ones would break older decoders.
-            #[cfg(all(
-                any(target_os = "linux", target_os = "android"),
-                target_arch = "x86_64"
-            ))]
+            #[cfg(all(target_os = "linux", not(target_env = "musl"), target_arch = "x86_64"))]
             {
                 b'l'
             }
-            #[cfg(all(
-                any(target_os = "linux", target_os = "android"),
-                target_arch = "aarch64"
-            ))]
+            #[cfg(all(target_os = "linux", not(target_env = "musl"), target_arch = "aarch64"))]
             {
                 b'L'
+            }
+            #[cfg(all(target_os = "linux", target_env = "musl", target_arch = "x86_64"))]
+            {
+                b'u'
+            }
+            #[cfg(all(target_os = "linux", target_env = "musl", target_arch = "aarch64"))]
+            {
+                b'U'
+            }
+            #[cfg(all(target_os = "android", target_arch = "x86_64"))]
+            {
+                b'a'
+            }
+            #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+            {
+                b'A'
             }
             #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
             {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2337,18 +2337,13 @@ mod draft {
 
     /// Each platform is encoded as a single character. It is placed right after the
     /// slash after the version, so someone just reading the trace string can tell
-    /// what platform it came from. L, M, W and F are for Linux (glibc), macOS,
-    /// Windows and FreeBSD, U is Linux built against musl and A is Android, with
-    /// capital letters indicating aarch64, lowercase indicating x86_64.
+    /// what platform it came from. L, M, W and F are Linux (glibc), macOS, Windows
+    /// and FreeBSD, U is Linux (musl) and A is Android, with capital letters
+    /// indicating aarch64, lowercase indicating x86_64. bun.report picks the debug
+    /// file by this character, so each separately linked binary needs its own.
     ///
     /// eg: 'https://bun.report/1.1.3/we04c...
     ///                               ^ this tells you it is windows x86_64
-    ///
-    /// bun.report picks the debug file by this character, so every build of a
-    /// commit that is a different binary needs its own: `bun-linux-<arch>`,
-    /// `bun-linux-<arch>-musl` and `bun-linux-<arch>-android` are three links of
-    /// the same commit. Older musl and android builds emitted 'l'/'L', which the
-    /// backend keeps decoding as the glibc build.
     ///
     /// x64 ships one nehalem build; the old baseline codes ('B','b','e','g')
     /// are no longer emitted but the backend still accepts them from old bins.

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -1,45 +1,76 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, mergeWindowEnvs, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isAndroid,
+  isArm64,
+  isFreeBSD,
+  isMacOS,
+  isMusl,
+  isWindows,
+  mergeWindowEnvs,
+  tempDir,
+} from "harness";
 import path from "path";
 
-// NOTE: kept separate from run-crash-handler.test.ts on purpose — that file
-// is skip-listed in test/expectations.txt (its segfault-reporter test is
-// broken), so anything added there never runs in CI.
+// The fixed-position header of the trace string. bun.report's decoder reads it
+// positionally, so these characters are part of the wire format.
+
+// Crash while running the given arguments and return the payload of the trace
+// string printed to stderr:
+//   {base}/{version}/{platform char}{command char}{remainder}
+async function traceStringPayloadFromCrash(args: string[]): Promise<string> {
+  using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
+  const base = new URL(server.url).origin;
+
+  // No cwd override: on Windows the crash reporter spawns a detached child
+  // that inherits the crashing process's cwd, which would keep a tempDir
+  // cwd alive past the test and make its cleanup fail with EBUSY.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: mergeWindowEnvs([
+      bunEnv,
+      {
+        BUN_CRASH_REPORT_URL: base,
+        BUN_ENABLE_CRASH_REPORTING: "1",
+      },
+    ]),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(exitCode).not.toBe(0);
+
+  const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
+  expect(trace).not.toBeNull();
+  const payload = new URL(trace![0]).pathname.split("/")[2];
+  expect(payload.length).toBeGreaterThan(2);
+  return payload;
+}
+
+const fixture = path.join(import.meta.dir, "fixture-crash.js");
+
+describe.concurrent("crash report platform character", () => {
+  // Must stay in sync with `Platform::CURRENT` (src/crash_handler/lib.rs) and
+  // bun.report's `platform_map`. bun.report downloads the debug file of the
+  // build this character names, so the glibc, musl and android builds of one
+  // commit (three different binaries) each need their own character. Through
+  // 1.4.0 the musl and android builds reported the glibc character, and every
+  // crash report from them was symbolicated against the glibc binary.
+  const expectedLowercase = isWindows ? "w" : isMacOS ? "m" : isFreeBSD ? "f" : isAndroid ? "a" : isMusl ? "u" : "l";
+  const expected = isArm64 ? expectedLowercase.toUpperCase() : expectedLowercase;
+
+  test(`encodes this build as '${expected}'`, async () => {
+    const payload = await traceStringPayloadFromCrash([fixture, "panic"]);
+    expect(payload[0]).toBe(expected);
+  });
+});
+
 describe.concurrent("crash report command character", () => {
-  // Crash while a given subcommand is running and return the command
-  // character from the trace string printed to stderr:
-  //   {base}/{version}/{platform char}{command char}{remainder}
   // Expected characters must stay in sync with `Command.Tag.char()`
   // (src/options_types/command_tag.rs) and bun.report's decoder.
   async function commandCharFromCrash(args: string[]): Promise<string> {
-    using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
-    const base = new URL(server.url).origin;
-
-    // No cwd override: on Windows the crash reporter spawns a detached child
-    // that inherits the crashing process's cwd, which would keep a tempDir
-    // cwd alive past the test and make its cleanup fail with EBUSY.
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), ...args],
-      env: mergeWindowEnvs([
-        bunEnv,
-        {
-          BUN_CRASH_REPORT_URL: base,
-          BUN_ENABLE_CRASH_REPORTING: "1",
-        },
-      ]),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(exitCode).not.toBe(0);
-
-    const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
-    expect(trace).not.toBeNull();
-    const payload = new URL(trace![0]).pathname.split("/")[2];
-    expect(payload.length).toBeGreaterThan(2);
-    return payload[1];
+    return (await traceStringPayloadFromCrash(args))[1];
   }
-
-  const fixture = path.join(import.meta.dir, "fixture-crash.js");
 
   test("bun <script> encodes AutoCommand", async () => {
     expect(await commandCharFromCrash([fixture, "panic"])).toBe("a");

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -1,76 +1,45 @@
 import { describe, expect, test } from "bun:test";
-import {
-  bunEnv,
-  bunExe,
-  isAndroid,
-  isArm64,
-  isFreeBSD,
-  isMacOS,
-  isMusl,
-  isWindows,
-  mergeWindowEnvs,
-  tempDir,
-} from "harness";
+import { bunEnv, bunExe, mergeWindowEnvs, tempDir } from "harness";
 import path from "path";
 
-// The fixed-position header of the trace string. bun.report's decoder reads it
-// positionally, so these characters are part of the wire format.
-
-// Crash while running the given arguments and return the payload of the trace
-// string printed to stderr:
-//   {base}/{version}/{platform char}{command char}{remainder}
-async function traceStringPayloadFromCrash(args: string[]): Promise<string> {
-  using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
-  const base = new URL(server.url).origin;
-
-  // No cwd override: on Windows the crash reporter spawns a detached child
-  // that inherits the crashing process's cwd, which would keep a tempDir
-  // cwd alive past the test and make its cleanup fail with EBUSY.
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), ...args],
-    env: mergeWindowEnvs([
-      bunEnv,
-      {
-        BUN_CRASH_REPORT_URL: base,
-        BUN_ENABLE_CRASH_REPORTING: "1",
-      },
-    ]),
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(exitCode).not.toBe(0);
-
-  const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
-  expect(trace).not.toBeNull();
-  const payload = new URL(trace![0]).pathname.split("/")[2];
-  expect(payload.length).toBeGreaterThan(2);
-  return payload;
-}
-
-const fixture = path.join(import.meta.dir, "fixture-crash.js");
-
-describe.concurrent("crash report platform character", () => {
-  // Must stay in sync with `Platform::CURRENT` (src/crash_handler/lib.rs) and
-  // bun.report's `platform_map`. bun.report downloads the debug file of the
-  // build this character names, so the glibc, musl and android builds of one
-  // commit (three different binaries) each need their own character. Through
-  // 1.4.0 the musl and android builds reported the glibc character, and every
-  // crash report from them was symbolicated against the glibc binary.
-  const expectedLowercase = isWindows ? "w" : isMacOS ? "m" : isFreeBSD ? "f" : isAndroid ? "a" : isMusl ? "u" : "l";
-  const expected = isArm64 ? expectedLowercase.toUpperCase() : expectedLowercase;
-
-  test(`encodes this build as '${expected}'`, async () => {
-    const payload = await traceStringPayloadFromCrash([fixture, "panic"]);
-    expect(payload[0]).toBe(expected);
-  });
-});
-
+// NOTE: kept separate from run-crash-handler.test.ts on purpose — that file
+// is skip-listed in test/expectations.txt (its segfault-reporter test is
+// broken), so anything added there never runs in CI.
 describe.concurrent("crash report command character", () => {
+  // Crash while a given subcommand is running and return the command
+  // character from the trace string printed to stderr:
+  //   {base}/{version}/{platform char}{command char}{remainder}
   // Expected characters must stay in sync with `Command.Tag.char()`
   // (src/options_types/command_tag.rs) and bun.report's decoder.
   async function commandCharFromCrash(args: string[]): Promise<string> {
-    return (await traceStringPayloadFromCrash(args))[1];
+    using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
+    const base = new URL(server.url).origin;
+
+    // No cwd override: on Windows the crash reporter spawns a detached child
+    // that inherits the crashing process's cwd, which would keep a tempDir
+    // cwd alive past the test and make its cleanup fail with EBUSY.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: base,
+          BUN_ENABLE_CRASH_REPORTING: "1",
+        },
+      ]),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+
+    const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
+    expect(trace).not.toBeNull();
+    const payload = new URL(trace![0]).pathname.split("/")[2];
+    expect(payload.length).toBeGreaterThan(2);
+    return payload[1];
   }
+
+  const fixture = path.join(import.meta.dir, "fixture-crash.js");
 
   test("bun <script> encodes AutoCommand", async () => {
     expect(await commandCharFromCrash([fixture, "panic"])).toBe("a");


### PR DESCRIPTION
Merge after oven-sh/bun.report#32 is deployed. bun.report rejects the new characters until then.

### Problem
- `Platform::CURRENT` (src/crash_handler/lib.rs) emits `'l'`/`'L'` for every Linux build. The glibc, musl and android builds of a commit are three binaries with three profile zips, and bun.report picks one by this character. Every musl or android crash report is symbolicated against the glibc binary and shows plausible but wrong frames.
- BUN-4MRJ is one: reported as a segfault in `NestedRuleParser::parse_block` (`css_parser.rs:1738`), it is a `VariableEnvironment` lookup on a bad `UniquedStringImpl*` against the musl profile (notes).

### Fix
- musl builds emit `'u'`/`'U'`, android builds `'a'`/`'A'`, and `'l'`/`'L'` mean glibc. Lowercase is x86_64, uppercase aarch64. bun.report#32 decodes them.
- Shipped binaries keep emitting `'l'`/`'L'`, which bun.report keeps decoding as glibc.
- The format is unchanged. #38838 (a debug id in a new format) verifies the downloaded file instead. The two compose: here the first download is right, and the URL says which build crashed.
- Verified: CI build 101799 ran an assertion on the Alpine x64 and aarch64 lanes that the build emits `'u'`/`'U'`. It passed and was then removed at review, since it only mirrored the table. Also `cargo check -p bun_crash_handler` for gnu, musl and android, and clippy.

### Background
- Trace string: the `https://bun.report/<version>/<payload>` URL in a crash report. The payload starts with the platform character, then command character, format version and sha. bun.report maps the character to an artifact name.
- The baseline characters (`'B'`, `'b'`, `'e'`) did the same for the old baseline binaries until #34782 made x64 one binary.

<details><summary>Notes</summary>

The human-readable report header already says `musl` or `Android ... bionic`; only the trace string lacked the distinction.

BUN-4MRJ, trace `1.4.0/L_134cbb9aEggggC+98pvDA2Dhggw6jC` (commit `34cbb9a40`), one address `0x37a79df`, fault address `0xFFFFFFFFBC2C0000`. `llvm-symbolizer --inlines --relative-address` against the 1.4.0 release profiles:

- `bun-linux-aarch64-profile.zip` (what bun.report used): `<NestedRuleParser<BundlerAtRuleParser> as AtRuleParser>::parse_block`, `src/css/css_parser.rs:1738`.
- `bun-linux-aarch64-musl-profile.zip`, fault pc `0x37a79e0`: `WTF::InlineMap<PackedRefPtr<UniquedStringImpl>, JSC::VariableEnvironmentEntry, 9>::findKeyOrEmpty<const UniquedStringImpl*>` (`InlineMap.h:725`) > `findKeyOrEmptyInStorage` (`InlineMap.h:703`) > `JSC::IdentifierRepHash::hash` (`Identifier.h:235`) > `SymbolImpl::existingSymbolAwareHash` > `StringImpl::isSymbol` (`StringImpl.h:334`). That is the load of `m_hashAndFlags` (offset 0x10) through the lookup key, so the key the caller passed was `0xFFFFFFFFBC2BFFF0`: a user-space pointer truncated to 32 bits and sign-extended. The scope had more than 9 variables (out-of-line storage). The trace has no caller frame, so the report says nothing more about the crash. It is not a CSS crash. It is almost certainly a musl build: the musl reading accounts for the fault address exactly (key + 0x10), the glibc reading needs a frame pointer that changed between two adjacent loads, and in the android build the address is data (`.text` ends at 0x32ea060).

BUN-4NQQ is a second 1.4.0 aarch64 report in the same state, and a clearer one: `abort() called` during `bun run`, 18 frames, trace `1.4.0/Lr134cbb9aAggggCmrtU2vjI2w/ktB2m42rD+/32rD+s32rD++22rD+r61oEm842oE2k2g1B2vlz3C+l6voCm5i1pCururuCusssuCunjpuCux0zsB2kgI_Aa`. Against the glibc profile the frames are unrelated functions (`llint_op_instanceof_wide16`, `bun_md::HtmlRenderer`, `WTF::PrintStream`). Against the musl profile every frame lines up: two frames in the statically linked libc (`abort`), then `WTF::RandomDevice::RandomDevice()` (`RandomDevice.cpp:95`, the `crashUnableToOpenURandom()` call, and `CRASH()` is `std::abort()` on Linux release builds) < `cryptographicallyRandomValuesFromOS` < `ARC4RandomNumberGenerator::stirIfNeeded` < `cryptographicallyRandomNumber` < `JSC::VM::VM` (`VM.cpp:258`) < `VM::tryCreate` < `Zig__GlobalObject__create` (`ZigGlobalObject.cpp:476`) < `VirtualMachine::init` (`VirtualMachine.rs:2567`) < `RunCommand::boot` (`run_command.rs:954`) < `boot_and_handle_error` < `exec_auto_or_run` < `cli::start` < `main`. So that process could not open `/dev/urandom` while creating the VM. The platform character was the only thing in the way of reading that.

Which byte values: `'u'`/`'U'` and `'a'`/`'A'` are unused in bun.report's table (`w e W m b M l B L f F`). The reason and command characters are separate positions, so they do not constrain the choice.

`scripts/ci-remap-server` pins `bun-tracestrings` at bun.report 912ca63, which does not decode these characters (nor the `'a'`/`'b'` reasons or FreeBSD from #29 and bun.report#29). A crash on the Alpine CI lanes prints the raw trace string in the annotation instead of a remap until the pin is bumped, as SIGABRT and SIGTRAP crashes do on every lane today. #38838 bumps the pin as part of its landing.

</details>

