### PR TITLE
ws: close server sockets through the drain path and keep them CLOSING until 'close' is emitted

### DIFF
--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -387,8 +387,13 @@ private:
             auto *webSocketContextData = getExtS(s);
             if (webSocketContextData->drainHandler) {
                 webSocketContextData->drainHandler((WebSocket<SSL, isServer, USERDATA> *) s);
+
+                /* Bun runs the handler corked, so an end() in there wrote the close frame on uncork
+                 * and left the FIN to us, the same way onData handles an end() during consume() */
+                if (!us_socket_is_closed(s) && webSocketData->isShuttingDown && asyncSocket->getBufferedAmount() == 0) {
+                    asyncSocket->shutdown();
+                }
             }
-            /* No need to check for closed here as we leave the handler immediately*/
         }
 
         return s;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1084,8 +1084,7 @@ class BunWebSocketMocked extends EventEmitter {
     this.#drain(ws);
   }
 
-  // uws calls this from inside ws.close() and ws.terminate() too. Like npm ws,
-  // stay CLOSING until the 'close' event, which goes out on the next tick.
+  // Runs synchronously inside ws.close() and ws.terminate() as well, hence the deferred 'close'.
   #close(ws, code, reason) {
     this.#state = ReadyState_CLOSING;
     this.#ws = null;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -145,8 +145,10 @@ function controlPayload(binaryType, data) {
 
 function payloadByteLength(data) {
   if (typeof data === "string") return Buffer.byteLength(data);
-  const byteLength = data?.byteLength ?? data?.size;
-  return typeof byteLength === "number" ? byteLength : 0;
+  if (data == null) return 0;
+  const byteLength = data.byteLength ?? data.size;
+  // anything else goes out as the text frame of its string form
+  return typeof byteLength === "number" ? byteLength : Buffer.byteLength(String(data));
 }
 
 // ServerWebSocket.send() returns the bytes written (-1 once buffered), so 0 is a drop unless the frame was empty.
@@ -1093,8 +1095,10 @@ class BunWebSocketMocked extends EventEmitter {
     const undelivered = this.#enquedMessages;
     if (undelivered.length) {
       this.#enquedMessages = [];
-      this.#bufferedAmount = 0;
-      for (const [, , cb] of undelivered) sendAfterClose(ReadyState_CLOSING, cb);
+      for (const [, , cb, byteLength] of undelivered) {
+        this.#bufferedAmount -= byteLength;
+        sendAfterClose(ReadyState_CLOSING, cb);
+      }
     }
 
     process.nextTick(() => {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -143,6 +143,17 @@ function controlPayload(binaryType, data) {
   return binaryType === "arraybuffer" ? Buffer.from(data) : data;
 }
 
+function payloadByteLength(data) {
+  if (typeof data === "string") return Buffer.byteLength(data);
+  const byteLength = data?.byteLength ?? data?.size;
+  return typeof byteLength === "number" ? byteLength : 0;
+}
+
+// ServerWebSocket.send() returns the bytes written (-1 once buffered), so 0 is a drop unless the frame was empty.
+function wasDropped(bytesWritten, data) {
+  return bytesWritten === 0 && payloadByteLength(data) !== 0;
+}
+
 // https://github.com/oven-sh/bun/issues/11866
 let WebSocket;
 
@@ -994,6 +1005,8 @@ class BunWebSocketMocked extends EventEmitter {
   #ws;
   #state;
   #enquedMessages = [];
+  // [code, reason] of a close() that waits for the queued messages to go out first.
+  #pendingClose = null;
   #url;
   #protocol;
   #extensions;
@@ -1071,27 +1084,49 @@ class BunWebSocketMocked extends EventEmitter {
     this.#drain(ws);
   }
 
+  // uws calls this from inside ws.close() and ws.terminate() too. Like npm ws,
+  // stay CLOSING until the 'close' event, which goes out on the next tick.
   #close(ws, code, reason) {
-    this.#state = ReadyState_CLOSED;
+    this.#state = ReadyState_CLOSING;
     this.#ws = null;
+    this.#pendingClose = null;
 
-    this.emit("close", code, reason);
+    const undelivered = this.#enquedMessages;
+    if (undelivered.length) {
+      this.#enquedMessages = [];
+      this.#bufferedAmount = 0;
+      for (const [, , cb] of undelivered) sendAfterClose(ReadyState_CLOSING, cb);
+    }
+
+    process.nextTick(() => {
+      this.#state = ReadyState_CLOSED;
+      this.emit("close", code, Buffer.from(reason));
+    });
+  }
+
+  #enqueue(data, compress, cb) {
+    const byteLength = payloadByteLength(data);
+    this.#bufferedAmount += byteLength;
+    this.#enquedMessages.push([data, compress, cb, byteLength]);
   }
 
   #drain(ws) {
-    let chunk;
-    while ((chunk = this.#enquedMessages[0]) && this.#state === 1) {
-      const [data, compress, cb] = chunk;
-      const written = ws.send(data, compress);
-      if (written < 1) {
-        // backpressure wait until next drain event
-        return;
-      }
+    const queue = this.#enquedMessages;
+    while (queue.length) {
+      const [data, compress, cb, byteLength] = queue[0];
+      // still over the backpressure limit, wait for the next drain event
+      if (wasDropped(ws.send(data, compress), data)) return;
 
-      this.#bufferedAmount -= chunk.length;
-      this.#enquedMessages.shift();
+      queue.shift();
+      this.#bufferedAmount -= byteLength;
+      if (typeof cb === "function") process.nextTick(cb);
+    }
 
-      if (typeof cb === "function") queueMicrotask(cb);
+    // Over the backpressure limit uws drops the Close frame and cuts the connection: close once all data is out.
+    const pendingClose = this.#pendingClose;
+    if (pendingClose !== null && ws.getBufferedAmount() === 0) {
+      this.#pendingClose = null;
+      ws.close(pendingClose[0], pendingClose[1]);
     }
   }
 
@@ -1149,35 +1184,34 @@ class BunWebSocketMocked extends EventEmitter {
       opts = undefined;
     }
 
-    if (this.#state === ReadyState_OPEN) {
+    const state = this.#state;
+    data = normalizeData(data, opts);
+
+    if (state === ReadyState_OPEN) {
       const compress = opts?.compress;
-      data = normalizeData(data, opts);
-      // send returns:
-      // 1+ - The number of bytes sent is always the byte length of the data never less
-      // 0 - dropped due to backpressure (not sent)
-      // -1 - enqueue the data internaly
-      // we dont need to do anything with the return value here
-      const written = this.#ws.send(data, compress);
-      if (written === 0) {
-        // dropped
-        this.#enquedMessages.push([data, compress, cb]);
-        this.#bufferedAmount += data.length;
+      if (wasDropped(this.#ws.send(data, compress), data)) {
+        // goes out from #drain
+        this.#enqueue(data, compress, cb);
         return;
       }
 
       if (typeof cb === "function") process.nextTick(cb);
-    } else if (this.#state === ReadyState_CONNECTING) {
+    } else if (state === ReadyState_CONNECTING) {
       // not connected yet
-      this.#enquedMessages.push([data, opts?.compress, cb]);
-      this.#bufferedAmount += data.length;
+      this.#enqueue(data, opts?.compress, cb);
+    } else {
+      // npm ws, like the WHATWG API, still counts these bytes in bufferedAmount.
+      this.#bufferedAmount += payloadByteLength(data);
+      sendAfterClose(state, cb);
     }
   }
 
   close(code, reason) {
-    if (this.#state === ReadyState_OPEN) {
-      this.#state = ReadyState_CLOSING;
-      this.#ws.close(code, reason);
-    }
+    if (this.#state !== ReadyState_OPEN) return;
+    this.#state = ReadyState_CLOSING;
+    this.#pendingClose = [code, reason];
+    // Sends the Close frame right away unless messages are still on their way out.
+    this.#drain(this.#ws);
   }
 
   terminate() {
@@ -1234,7 +1268,8 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   get bufferedAmount() {
-    return this.#bufferedAmount ?? 0;
+    const ws = this.#ws;
+    return (ws ? ws.getBufferedAmount() : 0) + this.#bufferedAmount;
   }
   /**
    * Set up the socket and the internal resources.

--- a/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
+++ b/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
@@ -234,4 +234,52 @@ describe("BackPressure buffer", () => {
     expect(received).toBe(target);
     expect(hash.digest("hex")).toBe(expectedHash);
   });
+
+  // The drain handler runs corked, so a close() inside it writes the Close
+  // frame on uncork; the TCP FIN has to follow once that is written out.
+  // Without that, uws only closes the socket from its end() timer, which is
+  // 16s at the default idleTimeout, so this test times out instead.
+  it.skipIf(isWindows)("close() from inside the drain handler sends the Close frame and then the FIN", async () => {
+    const payload = patternBuffer(1024 * 1024, 7);
+    const closeFrame = Buffer.concat([Buffer.from([0x88, 0x05, 0x03, 0xe8]), Buffer.from("bye")]);
+
+    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
+    let closeCalls = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("no", { status: 500 });
+      },
+      websocket: {
+        open(ws) {
+          opened.resolve(ws);
+        },
+        drain(ws) {
+          if (ws.getBufferedAmount() !== 0) return;
+          closeCalls++;
+          ws.close(1000, "bye");
+        },
+        message() {},
+      },
+    });
+
+    const { sock, initial } = await pausedClient(server.port);
+    const ws = await opened.promise;
+    // Fill until uws has to buffer, so that drain events follow once the client reads.
+    let status = 0;
+    for (let i = 0; i < 16 && (status = ws.sendBinary(payload)) > 0; i++) {}
+    expect(status).toBe(-1);
+
+    const chunks = [initial];
+    sock.on("data", chunk => chunks.push(chunk));
+    const ended = new Promise<void>(resolve => sock.once("end", resolve));
+    sock.resume();
+    await ended;
+    sock.destroy();
+
+    const bytes = Buffer.concat(chunks);
+    expect(closeCalls).toBe(1);
+    expect(bytes.subarray(bytes.length - closeFrame.length)).toEqual(closeFrame);
+  });
 });

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1532,6 +1532,38 @@ describe("server socket close lifecycle", () => {
     }
   });
 
+  // 'connection' is emitted from inside the HTTP upgrade handler. Rejecting a
+  // client right there is the common case for a listener added after close().
+  it("close() inside the 'connection' handler emits 'close' to a listener added after it", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Record<string, unknown>>();
+      wss.on("connection", async ws => {
+        try {
+          ws.close(4001, "unauthorized");
+          expect(ws.readyState).toBe(WebSocket.CLOSING);
+          resolve(await closeEvent(ws));
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      using client = await rawClient(wss);
+      const wire = wireBytes(client);
+      const seen = await promise;
+      const bytes = await wire;
+      expect({ ...seen, closeFrameHeader: [...bytes.subarray(0, 2)] }).toEqual({
+        code: 4001,
+        reason: Buffer.from("unauthorized"),
+        readyState: WebSocket.CLOSED,
+        // a Close frame with the 2 byte code and the 12 byte reason
+        closeFrameHeader: [0x88, 14],
+      });
+    } finally {
+      wss.close();
+    }
+  });
+
   it("terminate() leaves the socket CLOSING, then emits 'close' with 1006", async () => {
     const wss = new WebSocketServer({ port: 0 });
     try {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1635,6 +1635,51 @@ describe("server socket close lifecycle", () => {
     }
   });
 
+  it.skipIf(isWindows)("terminate() with messages still queued fails their callbacks", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const connected = Promise.withResolvers<WebSocket>();
+      wss.on("connection", ws => connected.resolve(ws));
+
+      const client = await rawClient(wss);
+      client.socket.pause();
+      const ws = await connected.promise;
+
+      const payload = Buffer.alloc(1024 * 1024, "a");
+      const frames = 26;
+      const sends: string[] = [];
+      for (let i = 0; i < frames; i++) ws.send(payload, err => sends.push(err ? err.message : "ok"));
+
+      const closed = closeEvent(ws);
+      ws.close(4000, "never sent");
+      // waits for the queue, so the socket is still there to terminate
+      expect(ws.readyState).toBe(WebSocket.CLOSING);
+      const lateSend = sendResult(ws, "late");
+      ws.terminate();
+
+      const notOpen = "WebSocket is not open: readyState 2 (CLOSING)";
+      expect({
+        closed: await closed,
+        lateSend: await lateSend,
+        callbacks: sends.length,
+        failed: sends.filter(result => result === notOpen).length > 0,
+        other: sends.filter(result => result !== "ok" && result !== notOpen),
+        // only the late send() still counts, the queued messages are gone
+        bufferedAmount: ws.bufferedAmount,
+      }).toEqual({
+        closed: { code: 1006, reason: Buffer.alloc(0), readyState: WebSocket.CLOSED },
+        lateSend: notOpen,
+        callbacks: frames,
+        failed: true,
+        other: [],
+        bufferedAmount: 4,
+      });
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
+  });
+
   it.skipIf(isWindows)("bufferedAmount includes what the native socket has buffered", async () => {
     const wss = new WebSocketServer({ port: 0 });
     try {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1449,8 +1449,11 @@ describe("server socket close lifecycle", () => {
 
   // Connects a raw TCP client and completes the handshake, so the server side
   // sees exactly the bytes each test writes. `rest` holds any frame bytes that
-  // arrived in the same chunk as the handshake response.
-  async function rawClient(wss: WebSocketServer): Promise<{ socket: ReturnType<typeof connect>; rest: Buffer }> {
+  // arrived in the same chunk as the handshake response. Disposing it destroys
+  // the connection, which also takes the server side socket down.
+  async function rawClient(
+    wss: WebSocketServer,
+  ): Promise<{ socket: ReturnType<typeof connect>; rest: Buffer } & Disposable> {
     const { port } = wss.address() as AddressInfo;
     const socket = connect({ port, host: "127.0.0.1" });
     socket.on("error", () => {});
@@ -1475,7 +1478,7 @@ describe("server socket close lifecycle", () => {
         "Sec-WebSocket-Version: 13\r\n\r\n",
     );
     const rest = await promise;
-    return { socket, rest };
+    return { socket, rest, [Symbol.dispose]: () => socket.destroy() };
   }
 
   // Everything the server writes after the handshake, once it has closed the connection.
@@ -1514,7 +1517,7 @@ describe("server socket close lifecycle", () => {
         });
       });
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       client.socket.write(textFrame);
       expect(await promise).toEqual({
         code: 4000,
@@ -1524,7 +1527,6 @@ describe("server socket close lifecycle", () => {
         bufferedAmount: 4,
         clients: 0,
       });
-      client.socket.destroy();
     } finally {
       wss.close();
     }
@@ -1546,10 +1548,9 @@ describe("server socket close lifecycle", () => {
         });
       });
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       client.socket.write(textFrame);
       expect(await promise).toEqual({ code: 1006, reason: Buffer.alloc(0), readyState: WebSocket.CLOSED });
-      client.socket.destroy();
     } finally {
       wss.close();
     }
@@ -1574,10 +1575,9 @@ describe("server socket close lifecycle", () => {
         });
       });
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       client.socket.write(closeFrame4444);
       expect(await promise).toEqual({ lateSend: "WebSocket is not open: readyState 3 (CLOSED)" });
-      client.socket.destroy();
     } finally {
       wss.close();
     }
@@ -1593,7 +1593,7 @@ describe("server socket close lifecycle", () => {
       const connected = Promise.withResolvers<WebSocket>();
       wss.on("connection", ws => connected.resolve(ws));
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       client.socket.pause();
       const ws = await connected.promise;
 
@@ -1629,7 +1629,6 @@ describe("server socket close lifecycle", () => {
         closed: { code: 4000, reason: Buffer.from("done"), readyState: WebSocket.CLOSED },
         bufferedAmount: 0,
       });
-      client.socket.destroy();
     } finally {
       wss.close();
     }
@@ -1641,7 +1640,7 @@ describe("server socket close lifecycle", () => {
       const connected = Promise.withResolvers<WebSocket>();
       wss.on("connection", ws => connected.resolve(ws));
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       client.socket.pause();
       const ws = await connected.promise;
 
@@ -1674,7 +1673,6 @@ describe("server socket close lifecycle", () => {
         other: [],
         bufferedAmount: 4,
       });
-      client.socket.destroy();
     } finally {
       wss.close();
     }
@@ -1686,7 +1684,7 @@ describe("server socket close lifecycle", () => {
       const connected = Promise.withResolvers<WebSocket>();
       wss.on("connection", ws => connected.resolve(ws));
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       client.socket.pause();
       const ws = await connected.promise;
       expect(ws.bufferedAmount).toBe(0);
@@ -1712,8 +1710,6 @@ describe("server socket close lifecycle", () => {
       await delivered;
 
       expect({ received, bufferedAmount: ws.bufferedAmount }).toEqual({ received: expectedBytes, bufferedAmount: 0 });
-      ws.close();
-      client.socket.destroy();
     } finally {
       wss.close();
     }
@@ -1731,7 +1727,7 @@ describe("server socket close lifecycle", () => {
         ws.close();
       });
 
-      const client = await rawClient(wss);
+      using client = await rawClient(wss);
       const bytes = await wireBytes(client);
       expect({ sends, dataFrames: bytes.subarray(0, 4).toString("hex"), then: bytes[4] }).toEqual({
         sends: ["text ok", "binary ok"],
@@ -1739,7 +1735,6 @@ describe("server socket close lifecycle", () => {
         dataFrames: "81008200",
         then: 0x88,
       });
-      client.socket.destroy();
     } finally {
       wss.close();
     }

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "bun";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import crypto from "crypto";
 import { EventEmitter, once } from "events";
-import { bunEnv, bunExe, isDebug } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows } from "harness";
 import { createServer } from "http";
 import { AddressInfo, connect } from "net";
 import path from "node:path";
@@ -1429,5 +1429,274 @@ describe("module loading", () => {
     // HTTPParser structures at load time, this test needs a new marker.
     expect(JSON.parse(stdout)).toEqual({ afterWs: 0, httpMarkerWorks: true });
     expect(exitCode).toBe(0);
+  });
+});
+
+// The server side socket sits on top of the Bun.serve websocket callbacks, and
+// uws runs the close callback from inside ws.close()/ws.terminate(). These
+// tests pin the npm ws lifecycle on top of that: CLOSING right after close(),
+// 'close' emitted later with a Buffer reason, send() after close still calling
+// back, and queued messages going out before the Close frame.
+describe("server socket close lifecycle", () => {
+  // A masked client frame (RFC 6455 5.3); an all-zero key leaves the payload as is.
+  function clientFrame(opcode: number, payload: Buffer | string): Buffer {
+    const data = Buffer.from(payload);
+    return Buffer.concat([Buffer.from([0x80 | opcode, 0x80 | data.length, 0, 0, 0, 0]), data]);
+  }
+
+  const textFrame = clientFrame(0x1, "x");
+  const closeFrame4444 = clientFrame(0x8, Buffer.concat([Buffer.from([0x11, 0x5c]), Buffer.from("other")]));
+
+  // Connects a raw TCP client and completes the handshake, so the server side
+  // sees exactly the bytes each test writes. `rest` holds any frame bytes that
+  // arrived in the same chunk as the handshake response.
+  async function rawClient(wss: WebSocketServer): Promise<{ socket: ReturnType<typeof connect>; rest: Buffer }> {
+    const { port } = wss.address() as AddressInfo;
+    const socket = connect({ port, host: "127.0.0.1" });
+    socket.on("error", () => {});
+    const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+    let response = "";
+    const onData = (data: Buffer) => {
+      response += data.toString("latin1");
+      const end = response.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      socket.off("data", onData);
+      if (response.startsWith("HTTP/1.1 101 ")) resolve(Buffer.from(response.slice(end + 4), "latin1"));
+      else reject(new Error(`upgrade failed: ${response}`));
+    };
+    socket.on("data", onData);
+    socket.once("close", () => reject(new Error("socket closed before the upgrade completed")));
+    socket.write(
+      "GET / HTTP/1.1\r\n" +
+        `Host: 127.0.0.1:${port}\r\n` +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    );
+    const rest = await promise;
+    return { socket, rest };
+  }
+
+  // Everything the server writes after the handshake, once it has closed the connection.
+  function wireBytes({ socket, rest }: Awaited<ReturnType<typeof rawClient>>): Promise<Buffer> {
+    const chunks = [rest];
+    socket.on("data", chunk => chunks.push(chunk));
+    return new Promise(resolve => socket.once("end", () => resolve(Buffer.concat(chunks))));
+  }
+
+  function closeEvent(ws: WebSocket): Promise<{ code: number; reason: Buffer; readyState: number }> {
+    return new Promise(resolve =>
+      ws.once("close", (code, reason) => resolve({ code, reason, readyState: ws.readyState })),
+    );
+  }
+
+  function sendResult(ws: WebSocket, data: string | Buffer): Promise<string> {
+    return new Promise(resolve => ws.send(data, err => resolve(err ? err.message : "ok")));
+  }
+
+  it("close() leaves the socket CLOSING, then emits 'close' to a listener added after it", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Record<string, unknown>>();
+      wss.on("connection", ws => {
+        ws.on("message", async () => {
+          try {
+            ws.close(4000, "bye");
+            expect(ws.readyState).toBe(WebSocket.CLOSING);
+            const closed = closeEvent(ws);
+            const lateSend = sendResult(ws, "late");
+            const bufferedAmount = ws.bufferedAmount;
+            resolve({ ...(await closed), lateSend: await lateSend, bufferedAmount, clients: wss.clients.size });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      const client = await rawClient(wss);
+      client.socket.write(textFrame);
+      expect(await promise).toEqual({
+        code: 4000,
+        reason: Buffer.from("bye"),
+        readyState: WebSocket.CLOSED,
+        lateSend: "WebSocket is not open: readyState 2 (CLOSING)",
+        bufferedAmount: 4,
+        clients: 0,
+      });
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
+  });
+
+  it("terminate() leaves the socket CLOSING, then emits 'close' with 1006", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Record<string, unknown>>();
+      wss.on("connection", ws => {
+        ws.on("message", async () => {
+          try {
+            ws.terminate();
+            expect(ws.readyState).toBe(WebSocket.CLOSING);
+            resolve(await closeEvent(ws));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      const client = await rawClient(wss);
+      client.socket.write(textFrame);
+      expect(await promise).toEqual({ code: 1006, reason: Buffer.alloc(0), readyState: WebSocket.CLOSED });
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
+  });
+
+  it("a Close frame from the peer emits 'close' with its code and a Buffer reason", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Record<string, unknown>>();
+      wss.on("connection", ws => {
+        ws.on("close", async (code, reason) => {
+          try {
+            expect({ code, reason, readyState: ws.readyState }).toEqual({
+              code: 4444,
+              reason: Buffer.from("other"),
+              readyState: WebSocket.CLOSED,
+            });
+            resolve({ lateSend: await sendResult(ws, "late") });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      const client = await rawClient(wss);
+      client.socket.write(closeFrame4444);
+      expect(await promise).toEqual({ lateSend: "WebSocket is not open: readyState 3 (CLOSED)" });
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
+  });
+
+  // Bun.serve drops a message once 16 MiB is buffered; the shim queues it for
+  // the drain callback. Skipped on Windows like the backpressure tests in
+  // test/js/bun/websocket: Winsock's loopback takes the whole payload into the
+  // kernel, so nothing ever builds up in user space.
+  it.skipIf(isWindows)("close() sends the queued messages from drain before the Close frame", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const connected = Promise.withResolvers<WebSocket>();
+      wss.on("connection", ws => connected.resolve(ws));
+
+      const client = await rawClient(wss);
+      client.socket.pause();
+      const ws = await connected.promise;
+
+      const payload = Buffer.alloc(1024 * 1024, "a");
+      const frameLength = payload.length + 10;
+      // 16 MiB limit plus whatever the loopback kernel buffers take (under 8 MiB).
+      const frames = 26;
+      const sends: string[] = [];
+      for (let i = 0; i < frames; i++) ws.send(payload, err => sends.push(err ? err.message : "ok"));
+
+      ws.close(4000, "done");
+      const readyStateAfterClose = ws.readyState;
+      let closed: unknown = "not emitted";
+      ws.on("close", (code, reason) => (closed = { code, reason, readyState: ws.readyState }));
+
+      const wire = wireBytes(client);
+      client.socket.resume();
+      const bytes = await wire;
+
+      const closeFrame = Buffer.concat([Buffer.from([0x88, 6, 0x0f, 0xa0]), Buffer.from("done")]);
+      expect({
+        readyStateAfterClose,
+        sends,
+        closeFrameAt: bytes.indexOf(closeFrame),
+        totalBytes: bytes.length,
+        closed,
+        bufferedAmount: ws.bufferedAmount,
+      }).toEqual({
+        readyStateAfterClose: WebSocket.CLOSING,
+        sends: Array(frames).fill("ok"),
+        closeFrameAt: frames * frameLength,
+        totalBytes: frames * frameLength + closeFrame.length,
+        closed: { code: 4000, reason: Buffer.from("done"), readyState: WebSocket.CLOSED },
+        bufferedAmount: 0,
+      });
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
+  });
+
+  it.skipIf(isWindows)("bufferedAmount includes what the native socket has buffered", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const connected = Promise.withResolvers<WebSocket>();
+      wss.on("connection", ws => connected.resolve(ws));
+
+      const client = await rawClient(wss);
+      client.socket.pause();
+      const ws = await connected.promise;
+      expect(ws.bufferedAmount).toBe(0);
+
+      const payload = Buffer.alloc(1024 * 1024, "a");
+      let frames = 0;
+      while (ws.bufferedAmount === 0 && frames < 8) {
+        ws.send(payload);
+        frames++;
+      }
+      const buffered = ws.bufferedAmount;
+      expect(buffered).toBeGreaterThan(0);
+      expect(buffered).toBeLessThanOrEqual(frames * (payload.length + 10));
+
+      const expectedBytes = frames * (payload.length + 10);
+      let received = client.rest.length;
+      const { promise: delivered, resolve } = Promise.withResolvers<void>();
+      client.socket.on("data", chunk => {
+        received += chunk.length;
+        if (received >= expectedBytes) resolve();
+      });
+      client.socket.resume();
+      await delivered;
+
+      expect({ received, bufferedAmount: ws.bufferedAmount }).toEqual({ received: expectedBytes, bufferedAmount: 0 });
+      ws.close();
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
+  });
+
+  // The native send() reports the bytes written, so a delivered empty frame
+  // returns 0 just like a message dropped at the backpressure limit.
+  it("send() of an empty payload calls back without an error and goes out once", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const sends: string[] = [];
+      wss.on("connection", ws => {
+        ws.send("", err => sends.push(err ? err.message : "text ok"));
+        ws.send(Buffer.alloc(0), err => sends.push(err ? err.message : "binary ok"));
+        ws.close();
+      });
+
+      const client = await rawClient(wss);
+      const bytes = await wireBytes(client);
+      expect({ sends, dataFrames: bytes.subarray(0, 4).toString("hex"), then: bytes[4] }).toEqual({
+        sends: ["text ok", "binary ok"],
+        // an empty text frame, an empty binary frame, then the Close frame
+        dataFrames: "81008200",
+        then: 0x88,
+      });
+      client.socket.destroy();
+    } finally {
+      wss.close();
+    }
   });
 });


### PR DESCRIPTION
Rewritten after the first review: no immediates, the close goes through the drain path.

### Problem
- A server socket of the built-in `ws` shim is CLOSED when `close()` returns, and a `'close'` listener added after it never fires. npm ws is CLOSING and emits `'close'` later, with a `Buffer` reason. Cause: uws runs the close callback inside `ServerWebSocket.close()` (`packages/bun-uws/src/WebSocket.h:270`) and `#close` (`ws.js:1056` on main) emitted right there.
- `close()` with messages still queued for `drain` lost them. `send()` after close dropped its callback, `bufferedAmount` ignored `getBufferedAmount()`, and `#drain` resent messages uws had accepted.
- uws never sent the FIN for a `close()` issued inside the `drain` handler. The connection only went away through the `end()` timer, 16 s by default. Plain `Bun.serve` reproduces it.

### Fix
- `close()` records the pending close and runs the drain step: queued messages go out first, the native close follows once `getBufferedAmount()` is 0. The close callback stays in CLOSING, fails the callbacks of undelivered messages, and emits `'close'` on the next tick with a `Buffer` reason.
- `send()` on a closing or closed socket calls back with the "not open" error and counts the bytes. `bufferedAmount` adds what uws has buffered. A native `0` is a drop only for a non-empty payload.
- `onWritable` shuts the socket down after the drain handler when `end()` was called in it, as `onData` already does (`WebSocketContext.h:339`). Bun runs the handler corked, so `end()` leaves the FIN to the caller.
- Verified: `test/js/first_party/ws/ws.test.ts` (block "server socket close lifecycle") and `test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts`. All 9 new tests fail on the released build. More in the notes.

### Background
- `"ws"` always resolves to the shim. Its server socket is a JS state machine over the `Bun.serve` websocket callbacks installed by `node:http` (`_http_server.ts:648`).
- Native `send()` returns the byte count, `-1` if uws buffered the message, `0` if it dropped it (after 16 MiB). The shim queues dropped messages and retries them from `drain`.
- After sending a Close frame uws ignores incoming data, so the peer's reply code is not observable. `'close'` carries the code passed to `close()`, which a compliant peer echoes anyway.

<details><summary>Notes</summary>

Reference behavior was taken from node v26 with ws 8.18.3 (`test/node_modules/ws`) using a raw RFC 6455 client, so both implementations saw identical bytes. The shim now matches on: readyState after `close()` and `terminate()`, the send and ping callbacks after close, `'close'` args `(4000, Buffer("bye"))` for a local close with an echoing peer, `(1006, Buffer(0))` after `terminate()`, `(4444, Buffer("other"))` for a peer close, `bufferedAmount === 4` after a late `send("late")`, and `send("", cb)` calling back with one empty frame on the wire.

Known remaining differences: the close code after a local `close()` is the local one (native limitation above). The binary frame shape for `binaryType = "arraybuffer"` was fixed on main by #39808 (now in the base of this branch), the text frame shape is #36061. The deferred `'close'` relies on request handlers running with the event loop entered (#39826, in the base of this branch): before that, a `nextTick` queued inside `close()` ran before `close()` returned when called from the `'connection'` handler. The test "close() inside the 'connection' handler" pins that case.

Why the close waits for `getBufferedAmount() === 0` and not only for the shim queue: uws `end()` sends the Close frame with `send()`, and when the socket is over its backpressure limit that returns DROPPED, which `end()` treats as sent and shuts the socket down at once. The released build delivers 2.5 MiB of 26 MiB in the new drain test for that reason. That is a separate uws issue, reported separately. Waiting for an empty buffer also matches when npm ws emits `'close'`.

Probe for the FIN bug with plain `Bun.serve`: pause a raw client, `ws.send()` 1 MiB until it returns `-1`, in `drain` call `ws.close()` once `getBufferedAmount()` is 0, resume the client. Released build: the client gets the Close frame and no FIN for 4 to 16 s (the `end()` timer). This branch: FIN right after the Close frame. The new test relies on that timer being 16 s at the default idleTimeout, so it times out on the released build instead of passing late.

The backpressure tests are skipped on Windows like the ones already in that file: Winsock's loopback takes the whole payload into the kernel. On Linux and macOS the kernel takes under 8 MiB from a paused reader (the existing 8 MiB test depends on the same), so the queue test sends 26 x 1 MiB to get past the 16 MiB limit. The two blocks take about 1.5 s on a debug ASAN build and were stable over 6 runs.

`#drain` callbacks moved from `queueMicrotask` to `process.nextTick`, which is what `send()` uses for the direct path.

From the second review round (1607583): `payloadByteLength` sizes a payload that is neither a string nor buffer-like as the text frame of its string form, which is what the native `send()` sends, so a drop of such a message is not mistaken for a delivered empty frame. The close callback subtracts the entries it discards instead of zeroing the counter, so bytes counted by a `send()` during CLOSING stay in `bufferedAmount` as in npm ws. The test "terminate() with messages still queued fails their callbacks" pins that and the error callbacks of undelivered messages.

Suites run on the debug build: `test/js/first_party/ws/` (4 files), `node-http-with-ws.test.ts`, the ws regression tests (`012040`, `03844`, `26358`, `29684`, `32734`, `3613`), `test/js/bun/websocket/` (the 8 failures in `websocket-server.test.ts` are the debug-build fixture timeouts that #39370 addresses, the file passes on the released build here too), `test/js/web/websocket/` (2 failures need the public internet). `ws-proxy.test.ts` needs `HTTP_PROXY` unset in this container, on the released build as well.
Overlap with #39843: that PR fixes both uws findings from this one in `end()` itself (Close frame past the backpressure limit, FIN sent by `end()` after uncork), which covers the drain handler case too. The `onWritable` hunk here then becomes redundant and can be dropped when #39843 lands first, or #39843 can remove it on rebase. Both can coexist at runtime: `shutdown()` on an already shut down socket is a no-op in usockets (raw and SSL). The two PRs also both add tests to `websocket-server-backpressure-buffer.test.ts`, so whichever lands second needs a small rebase.

Rebased onto main after #39642 and #39808 landed in `ws.js`. The only conflicts were adjacent additions (the `controlPayload` helper next to `payloadByteLength`/`wasDropped`, and the `EventEmitter`/`isWindows` imports in the test file), kept both sides.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/first_party/ws/ws.test.ts, test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts

<!-- robobun:evidence:end -->



