### PR TITLE
crash_handler: name the image of a foreign frame in the trace string on macOS and Linux

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2404,20 +2404,16 @@ mod draft {
     };
 
     struct StackLine {
-        /// Offset from the start of the image the address belongs to.
+        /// Offset inside the image.
         address: i32,
-        /// `None` -> from bun's own executable. Otherwise the basename of the
-        /// image (a `.node` addon, a system library) the address belongs to;
-        /// bun.report shows it as the frame's package, which is what tells a
-        /// native addon's crash apart from bun's own.
+        /// None -> bun's own executable; otherwise the image's basename, which bun.report shows as the frame's package.
         object: Option<Box<[u8]>>,
         // Box<[u8]> rather than a borrowed slice into caller's `name_bytes`,
         // since the only caller writes into a stack buffer and the value is consumed immediately.
     }
 
     impl StackLine {
-        /// A frame in an image other than bun's executable. `None` when the
-        /// loader has no name for the image.
+        /// `None` when the loader has no name for the image.
         #[cfg(not(windows))]
         fn in_foreign_image(image_path: &[u8], image_relative_address: usize) -> Option<StackLine> {
             let basename = bun_paths::basename_posix(image_path);
@@ -2509,42 +2505,41 @@ mod draft {
                                     continue;
                                 }
 
-                                // Subtract ASLR value for stable address
-                                let stable_address = address - vmaddr_slide;
+                                let original_address = address - vmaddr_slide;
                                 let seg_start = segment_cmd.vmaddr as usize;
                                 let seg_end = seg_start + segment_cmd.vmsize as usize;
-                                if stable_address >= seg_start && stable_address < seg_end {
-                                    let image_relative_address = stable_address - seg_start;
+                                if original_address >= seg_start && original_address < seg_end {
+                                    // Subtract ASLR value for stable address
+                                    let stable_address: usize = address - vmaddr_slide;
 
-                                    // Image 0 is always the main executable.
-                                    if i != 0 {
+                                    // Image 0 is the main executable.
+                                    if i == 0 {
+                                        let image_relative_address = stable_address - seg_start;
+                                        if image_relative_address > i32::MAX as usize {
+                                            return None;
+                                        }
+
+                                        // To remap this, you have to add the offset (which is going to be 0x100000000),
+                                        // and then you can run it through `llvm-symbolizer --obj bun-with-symbols 0x123456`
+                                        // The reason we are subtracting this known offset is mostly just so that we can
+                                        // fit it within a signed 32-bit integer. The VLQs will be shorter too.
+                                        return Some(StackLine {
+                                            object: None,
+                                            address: i32::try_from(image_relative_address)
+                                                .expect("int cast"),
+                                        });
+                                    } else {
                                         let name = bun_sys::c::_dyld_get_image_name(i);
                                         if name.is_null() {
                                             return None;
                                         }
-                                        // SAFETY: dyld returns a NUL-terminated path that
-                                        // stays valid while the image is loaded, and the
-                                        // image is loaded: we just found `address` in it.
+                                        // SAFETY: dyld owns the NUL-terminated path and keeps it while the image is loaded; `address` is inside that image.
                                         let name = unsafe { bun_core::ffi::cstr(name) }.to_bytes();
                                         return StackLine::in_foreign_image(
                                             name,
-                                            image_relative_address,
+                                            stable_address - seg_start,
                                         );
                                     }
-
-                                    if image_relative_address > i32::MAX as usize {
-                                        return None;
-                                    }
-
-                                    // To remap this, you have to add the offset (which is going to be 0x100000000),
-                                    // and then you can run it through `llvm-symbolizer --obj bun-with-symbols 0x123456`
-                                    // The reason we are subtracting this known offset is mostly just so that we can
-                                    // fit it within a signed 32-bit integer. The VLQs will be shorter too.
-                                    return Some(StackLine {
-                                        object: None,
-                                        address: i32::try_from(image_relative_address)
-                                            .expect("int cast"),
-                                    });
                                 }
                             }
                             _ => {}
@@ -2582,9 +2577,7 @@ mod draft {
                 writer.write_all(
                     VLQ::encode(i32::try_from(object.len()).expect("int cast")).slice(),
                 )?;
-                // The name goes into the URL verbatim and the decoder reads it
-                // by length, so every byte must be one character that needs
-                // no URL escaping.
+                // Goes into the URL verbatim and is decoded by length: one URL-safe byte per byte.
                 for &byte in object.iter() {
                     writer.write_byte(match byte {
                         b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' => byte,
@@ -2598,10 +2591,7 @@ mod draft {
         }
     }
 
-    /// Load base of bun's own executable, found through an address that is
-    /// known to be inside it. `dl_iterate_phdr` does not flag the main program,
-    /// and its name for it differs between libcs (glibc reports "", musl the
-    /// program path), so the base address is what identifies it.
+    /// Load base of bun's executable. It is what identifies the main program: glibc names it "", musl names it by path.
     #[cfg(not(any(windows, target_os = "macos")))]
     fn own_image_base() -> usize {
         static BASE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2559,7 +2559,7 @@ mod draft {
                     return StackLine::in_foreign_image(&m.name, address - m.base_address);
                 }
                 return Some(StackLine {
-                    address: i32::try_from(address - m.base_address).expect("int cast"),
+                    address: i32::try_from(address - m.base_address).ok()?,
                     object: None,
                 });
             }

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2404,14 +2404,32 @@ mod draft {
     };
 
     struct StackLine {
+        /// Offset from the start of the image the address belongs to.
         address: i32,
-        // None -> from bun.exe
+        /// `None` -> from bun's own executable. Otherwise the basename of the
+        /// image (a `.node` addon, a system library) the address belongs to;
+        /// bun.report shows it as the frame's package, which is what tells a
+        /// native addon's crash apart from bun's own.
         object: Option<Box<[u8]>>,
         // Box<[u8]> rather than a borrowed slice into caller's `name_bytes`,
         // since the only caller writes into a stack buffer and the value is consumed immediately.
     }
 
     impl StackLine {
+        /// A frame in an image other than bun's executable. `None` when the
+        /// loader has no name for the image.
+        #[cfg(not(windows))]
+        fn in_foreign_image(image_path: &[u8], image_relative_address: usize) -> Option<StackLine> {
+            let basename = bun_paths::basename_posix(image_path);
+            if basename.is_empty() {
+                return None;
+            }
+            Some(StackLine {
+                address: i32::try_from(image_relative_address).ok()?,
+                object: Some(Box::<[u8]>::from(basename)),
+            })
+        }
+
         /// `None` implies the trace is not known.
         fn from_address(addr: usize, name_bytes: &mut [u8]) -> Option<StackLine> {
             #[cfg(windows)]
@@ -2491,32 +2509,42 @@ mod draft {
                                     continue;
                                 }
 
-                                let original_address = address - vmaddr_slide;
+                                // Subtract ASLR value for stable address
+                                let stable_address = address - vmaddr_slide;
                                 let seg_start = segment_cmd.vmaddr as usize;
                                 let seg_end = seg_start + segment_cmd.vmsize as usize;
-                                if original_address >= seg_start && original_address < seg_end {
-                                    // Subtract ASLR value for stable address
-                                    let stable_address: usize = address - vmaddr_slide;
+                                if stable_address >= seg_start && stable_address < seg_end {
+                                    let image_relative_address = stable_address - seg_start;
 
-                                    if i == 0 {
-                                        let image_relative_address = stable_address - seg_start;
-                                        if image_relative_address > i32::MAX as usize {
+                                    // Image 0 is always the main executable.
+                                    if i != 0 {
+                                        let name = bun_sys::c::_dyld_get_image_name(i);
+                                        if name.is_null() {
                                             return None;
                                         }
+                                        // SAFETY: dyld returns a NUL-terminated path that
+                                        // stays valid while the image is loaded, and the
+                                        // image is loaded: we just found `address` in it.
+                                        let name = unsafe { bun_core::ffi::cstr(name) }.to_bytes();
+                                        return StackLine::in_foreign_image(
+                                            name,
+                                            image_relative_address,
+                                        );
+                                    }
 
-                                        // To remap this, you have to add the offset (which is going to be 0x100000000),
-                                        // and then you can run it through `llvm-symbolizer --obj bun-with-symbols 0x123456`
-                                        // The reason we are subtracting this known offset is mostly just so that we can
-                                        // fit it within a signed 32-bit integer. The VLQs will be shorter too.
-                                        return Some(StackLine {
-                                            object: None,
-                                            address: i32::try_from(image_relative_address)
-                                                .expect("int cast"),
-                                        });
-                                    } else {
-                                        // these libraries are not interesting, mark as unknown
+                                    if image_relative_address > i32::MAX as usize {
                                         return None;
                                     }
+
+                                    // To remap this, you have to add the offset (which is going to be 0x100000000),
+                                    // and then you can run it through `llvm-symbolizer --obj bun-with-symbols 0x123456`
+                                    // The reason we are subtracting this known offset is mostly just so that we can
+                                    // fit it within a signed 32-bit integer. The VLQs will be shorter too.
+                                    return Some(StackLine {
+                                        object: None,
+                                        address: i32::try_from(image_relative_address)
+                                            .expect("int cast"),
+                                    });
                                 }
                             }
                             _ => {}
@@ -2533,6 +2561,9 @@ mod draft {
                 let _ = name_bytes;
                 let address = addr.saturating_sub(1);
                 let m = bun_sys::elf::find_loaded_module(address)?;
+                if m.base_address != own_image_base() {
+                    return StackLine::in_foreign_image(&m.name, address - m.base_address);
+                }
                 return Some(StackLine {
                     address: i32::try_from(address - m.base_address).expect("int cast"),
                     object: None,
@@ -2551,12 +2582,33 @@ mod draft {
                 writer.write_all(
                     VLQ::encode(i32::try_from(object.len()).expect("int cast")).slice(),
                 )?;
-                writer.write_all(object)?;
+                // The name goes into the URL verbatim and the decoder reads it
+                // by length, so every byte must be one character that needs
+                // no URL escaping.
+                for &byte in object.iter() {
+                    writer.write_byte(match byte {
+                        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' => byte,
+                        _ => b'_',
+                    })?;
+                }
             }
 
             writer.write_all(VLQ::encode(known.address).slice())?;
             Ok(())
         }
+    }
+
+    /// Load base of bun's own executable, found through an address that is
+    /// known to be inside it. `dl_iterate_phdr` does not flag the main program,
+    /// and its name for it differs between libcs (glibc reports "", musl the
+    /// program path), so the base address is what identifies it.
+    #[cfg(not(any(windows, target_os = "macos")))]
+    fn own_image_base() -> usize {
+        static BASE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        *BASE.get_or_init(|| {
+            bun_sys::elf::find_loaded_module(own_image_base as *const () as usize)
+                .map_or(usize::MAX, |m| m.base_address)
+        })
     }
 
     struct TraceString<'a> {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2406,7 +2406,7 @@ mod draft {
     struct StackLine {
         /// Offset inside the image.
         address: i32,
-        /// None -> bun's own executable; otherwise the image's basename, which bun.report shows as the frame's package.
+        /// None -> bun's own executable; otherwise the image as the loader names it (a path on POSIX, a basename on Windows).
         object: Option<Box<[u8]>>,
         // Box<[u8]> rather than a borrowed slice into caller's `name_bytes`,
         // since the only caller writes into a stack buffer and the value is consumed immediately.
@@ -2416,13 +2416,12 @@ mod draft {
         /// `None` when the loader has no name for the image.
         #[cfg(not(windows))]
         fn in_foreign_image(image_path: &[u8], image_relative_address: usize) -> Option<StackLine> {
-            let basename = bun_paths::basename_posix(image_path);
-            if basename.is_empty() {
+            if bun_paths::basename_posix(image_path).is_empty() {
                 return None;
             }
             Some(StackLine {
                 address: i32::try_from(image_relative_address).ok()?,
-                object: Some(Box::<[u8]>::from(basename)),
+                object: Some(Box::<[u8]>::from(image_path)),
             })
         }
 
@@ -2573,12 +2572,13 @@ mod draft {
             };
 
             if let Some(object) = &known.object {
+                // The report carries the basename only, which bun.report shows as the frame's package.
+                let name = bun_paths::basename_posix(object);
                 writer.write_all(VLQ::encode(1).slice())?;
-                writer.write_all(
-                    VLQ::encode(i32::try_from(object.len()).expect("int cast")).slice(),
-                )?;
+                writer
+                    .write_all(VLQ::encode(i32::try_from(name.len()).expect("int cast")).slice())?;
                 // Goes into the URL verbatim and is decoded by length: one URL-safe byte per byte.
-                for &byte in object.iter() {
+                for &byte in name.iter() {
                     writer.write_byte(match byte {
                         b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' => byte,
                         _ => b'_',
@@ -3180,28 +3180,39 @@ mod draft {
     fn spawn_symbolizer(program: &bun_core::ZStr, trace: &StackTrace) -> crate::Result<()> {
         let mut argv: Vec<Vec<u8>> = Vec::new();
         argv.push(program.as_bytes().to_vec());
-        argv.push(b"--exe".to_vec());
-        argv.push({
-            #[cfg(windows)]
-            {
-                // `to_utf8_alloc` is infallible (Vec<u8>); OOM aborts.
-                let image_path = strings::to_utf8_alloc(bun_sys::windows::exe_path_w());
-                let mut s = image_path[0..image_path.len() - 3].to_vec();
-                s.extend_from_slice(b"pdb");
-                s
-            }
-            #[cfg(not(windows))]
-            {
-                bun_core::self_exe_path()?.as_bytes().to_vec()
-            }
-        });
+        #[cfg(windows)]
+        {
+            argv.push(b"--exe".to_vec());
+            // `to_utf8_alloc` is infallible (Vec<u8>); OOM aborts.
+            let image_path = strings::to_utf8_alloc(bun_sys::windows::exe_path_w());
+            let mut pdb_path = image_path[0..image_path.len() - 3].to_vec();
+            pdb_path.extend_from_slice(b"pdb");
+            argv.push(pdb_path);
+        }
+        #[cfg(not(windows))]
+        let exe_path = bun_core::self_exe_path()?;
 
         let mut name_bytes: [u8; 1024] = [0; 1024];
         for &addr in &trace.instruction_addresses[0..trace.index] {
             let Some(line) = StackLine::from_address(addr, &mut name_bytes) else {
                 continue;
             };
-            argv.push(format!("0x{:X}", line.address).into_bytes());
+            #[cfg(windows)]
+            {
+                // pdb-addr2line reads bun's PDB only; a frame of another DLL has nothing to be resolved against.
+                if line.object.is_some() {
+                    continue;
+                }
+                argv.push(format!("0x{:X}", line.address).into_bytes());
+            }
+            #[cfg(not(windows))]
+            {
+                // One `"<file>" <offset>` argument per frame resolves each frame against the image it is in.
+                let mut arg = b"\"".to_vec();
+                arg.extend_from_slice(line.object.as_deref().unwrap_or(exe_path.as_bytes()));
+                arg.extend_from_slice(format!("\" 0x{:X}", line.address).as_bytes());
+                argv.push(arg);
+            }
         }
 
         // PORTING.md: no std::process — routed through bun_core::spawn_sync_inherit (posix_spawn).

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -790,7 +790,7 @@ mod draft {
             Output::disable_scoped_debug_writer();
         }
 
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
+        let mut trace_str_buf = TraceStringBuf::default();
 
         match PANIC_STAGE.with(|s| s.get()) {
             0 => {
@@ -1020,7 +1020,7 @@ mod draft {
                         }
                     }
 
-                    let mut addr_buf: [usize; 20] = [0; 20];
+                    let mut addr_buf: [usize; MAX_FRAMES] = [0; MAX_FRAMES];
                     let trace_buf: StackTrace;
 
                     let trace: &StackTrace = {
@@ -1753,7 +1753,7 @@ mod draft {
         let reason =
             CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg_buf.const_slice()) });
 
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
+        let mut trace_str_buf = TraceStringBuf::default();
         {
             let _panic_guard = PANIC_MUTEX.lock();
             let writer = &mut stderr_writer();
@@ -1789,7 +1789,7 @@ mod draft {
                 let _ = writeln!(writer, "Crashed while {}", action);
             }
 
-            let mut addr_buf: [usize; 20] = [0; 20];
+            let mut addr_buf: [usize; MAX_FRAMES] = [0; MAX_FRAMES];
             let idx = debug::capture_stack_trace(debug::return_address(), &mut addr_buf);
             let trace = StackTrace {
                 index: idx,
@@ -2565,6 +2565,11 @@ mod draft {
             }
         }
 
+        /// A longer basename is cut; its start still identifies the image.
+        const MAX_NAME_LEN: usize = 64;
+        /// Marker VLQ, length VLQ, name, and an address VLQ of up to 7 digits.
+        const MAX_ENCODED_LEN: usize = 1 + 2 + Self::MAX_NAME_LEN + 7;
+
         fn write_encoded(self_: Option<&StackLine>, writer: &mut impl Write) -> crate::Result<()> {
             let Some(known) = self_ else {
                 writer.write_all(b"_")?;
@@ -2574,6 +2579,7 @@ mod draft {
             if let Some(object) = &known.object {
                 // The report carries the basename only, which bun.report shows as the frame's package.
                 let name = bun_paths::basename_posix(object);
+                let name = &name[..name.len().min(Self::MAX_NAME_LEN)];
                 writer.write_all(VLQ::encode(1).slice())?;
                 writer
                     .write_all(VLQ::encode(i32::try_from(name.len()).expect("int cast")).slice())?;
@@ -2600,6 +2606,14 @@ mod draft {
                 .map_or(usize::MAX, |m| m.base_address)
         })
     }
+
+    /// Frames a crash captures. An abort inside an addon routinely has more than 20 frames of its own before the first bun one.
+    const MAX_FRAMES: usize = 64;
+    /// The trace string is built in a buffer of this size; `report()` copies it into 4 KB command lines.
+    const TRACE_STRING_CAPACITY: usize = 2048;
+    /// Bytes of the trace string the frames may take; the rest holds the header and the reason, which for a panic is the compressed message.
+    const FRAMES_CAPACITY: usize = TRACE_STRING_CAPACITY / 2;
+    type TraceStringBuf = BoundedArray<u8, TRACE_STRING_CAPACITY>;
 
     struct TraceString<'a> {
         trace: &'a StackTrace<'a>,
@@ -2638,11 +2652,17 @@ mod draft {
         write_u64_as_two_vlqs(writer, packed_features as usize)?;
 
         let mut name_bytes: [u8; 1024] = [0; 1024];
-
+        let mut frames = BoundedArray::<u8, FRAMES_CAPACITY>::default();
         for &addr in &opts.trace.instruction_addresses[0..opts.trace.index] {
             let line = StackLine::from_address(addr, &mut name_bytes);
-            StackLine::write_encoded(line.as_ref(), writer)?;
+            let mut frame = BoundedArray::<u8, { StackLine::MAX_ENCODED_LEN }>::default();
+            StackLine::write_encoded(line.as_ref(), frame.writer())?;
+            // Frames past the budget are the outermost ones; dropping them keeps the string decodable.
+            if frames.append_slice(frame.const_slice()).is_err() {
+                break;
+            }
         }
+        writer.write_all(frames.const_slice())?;
 
         writer.write_all(VLQ::ZERO.slice())?;
 

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -97,14 +97,17 @@ pub(crate) mod js_bindings {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// Triggers a segfault with the fault PC inside a system DLL rather than
-    /// inside bun.exe. Exercises the Windows fault-context unwinder: the walk
-    /// must recover the bun frames that called into the DLL.
+    /// Triggers a segfault with the fault PC inside a system library (ntdll.dll,
+    /// libc) rather than inside bun's own executable. Windows: exercises the
+    /// fault-context unwinder, which must recover the bun frames that called
+    /// into the DLL. Everywhere: frame 0 of the trace string must name the
+    /// image it is in, the way a crash inside a `.node` addon names the addon.
     #[bun_jsc::host_fn]
-    fn js_segfault_in_dll(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    fn js_segfault_in_dll(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         #[cfg(windows)]
         {
+            let _ = global;
             // `RtlFillMemory` is exported by ntdll.dll, so the faulting
             // instruction is outside bun.exe's image.
             #[link(name = "ntdll")]
@@ -117,10 +120,33 @@ pub(crate) mod js_bindings {
         }
         #[cfg(not(windows))]
         {
-            // No equivalent on POSIX (the fault-context walk is fp-based and
-            // doesn't care which image the fault is in); fall through to the
-            // in-bun segfault so the test hook is defined everywhere.
-            return js_segfault(_global, _frame);
+            const BAD_ADDRESS: usize = 0xDEADBEEF;
+            // libc's own `strlen`, not this executable's PLT stub for it (which
+            // is what `libc::strlen as usize` is in a non-PIE executable): the
+            // faulting pc has to be inside libc's image.
+            // SAFETY: RTLD_NEXT is a valid pseudo-handle and the name is NUL-terminated.
+            let strlen = unsafe { libc::dlsym(libc::RTLD_NEXT, c"strlen".as_ptr()) };
+            if strlen.is_null() {
+                return Err(global.throw(format_args!("dlsym(RTLD_NEXT, \"strlen\") failed")));
+            }
+            // Under ASAN bun's SIGSEGV handler is not installed (see `js_segfault`),
+            // so hand the handler the context the fault below would have given it.
+            if Environment::ENABLE_ASAN {
+                crash_handler::crash_handler(
+                    crash_handler::CrashReason::SegmentationFault(BAD_ADDRESS),
+                    crash_handler::TraceSeed::Fault {
+                        pc: strlen as usize,
+                        fp: bun_core::debug::frame_address(),
+                    },
+                );
+            }
+            // SAFETY: the symbol is libc's `strlen`, which has this signature.
+            let strlen: unsafe extern "C" fn(*const core::ffi::c_char) -> usize =
+                unsafe { core::mem::transmute(strlen) };
+            // SAFETY: intentionally reading from an invalid address so the
+            // fault happens inside libc for testing.
+            let len = unsafe { strlen(core::hint::black_box(BAD_ADDRESS as *const _)) };
+            core::hint::black_box(len);
         }
         #[allow(unreachable_code)]
         Ok(JSValue::UNDEFINED)

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -97,11 +97,7 @@ pub(crate) mod js_bindings {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// Triggers a segfault with the fault PC inside a system library (ntdll.dll,
-    /// libc) rather than inside bun's own executable. Windows: exercises the
-    /// fault-context unwinder, which must recover the bun frames that called
-    /// into the DLL. Everywhere: frame 0 of the trace string must name the
-    /// image it is in, the way a crash inside a `.node` addon names the addon.
+    /// Triggers a segfault with the fault PC inside a system library (ntdll.dll, libc) rather than inside bun's own image.
     #[bun_jsc::host_fn]
     fn js_segfault_in_dll(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
@@ -121,16 +117,13 @@ pub(crate) mod js_bindings {
         #[cfg(not(windows))]
         {
             const BAD_ADDRESS: usize = 0xDEADBEEF;
-            // libc's own `strlen`, not this executable's PLT stub for it (which
-            // is what `libc::strlen as usize` is in a non-PIE executable): the
-            // faulting pc has to be inside libc's image.
+            // Not `libc::strlen as usize`: in a non-PIE executable that is the PLT stub in bun's own image.
             // SAFETY: RTLD_NEXT is a valid pseudo-handle and the name is NUL-terminated.
             let strlen = unsafe { bun_sys::c::dlsym(bun_sys::c::RTLD_NEXT, c"strlen".as_ptr()) };
             if strlen.is_null() {
                 return Err(global.throw(format_args!("dlsym(RTLD_NEXT, \"strlen\") failed")));
             }
-            // Under ASAN bun's SIGSEGV handler is not installed (see `js_segfault`),
-            // so hand the handler the context the fault below would have given it.
+            // ASAN owns SIGSEGV (see `js_segfault`): hand the handler the context the fault below would produce.
             if Environment::ENABLE_ASAN {
                 crash_handler::crash_handler(
                     crash_handler::CrashReason::SegmentationFault(BAD_ADDRESS),
@@ -143,8 +136,7 @@ pub(crate) mod js_bindings {
             // SAFETY: the symbol is libc's `strlen`, which has this signature.
             let strlen: unsafe extern "C" fn(*const core::ffi::c_char) -> usize =
                 unsafe { core::mem::transmute(strlen) };
-            // SAFETY: intentionally reading from an invalid address so the
-            // fault happens inside libc for testing.
+            // SAFETY: intentionally reading from an invalid address so the fault happens inside libc.
             let len = unsafe { strlen(core::hint::black_box(BAD_ADDRESS as *const _)) };
             core::hint::black_box(len);
         }

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -125,7 +125,7 @@ pub(crate) mod js_bindings {
             // is what `libc::strlen as usize` is in a non-PIE executable): the
             // faulting pc has to be inside libc's image.
             // SAFETY: RTLD_NEXT is a valid pseudo-handle and the name is NUL-terminated.
-            let strlen = unsafe { libc::dlsym(libc::RTLD_NEXT, c"strlen".as_ptr()) };
+            let strlen = unsafe { bun_sys::c::dlsym(bun_sys::c::RTLD_NEXT, c"strlen".as_ptr()) };
             if strlen.is_null() {
                 return Err(global.throw(format_args!("dlsym(RTLD_NEXT, \"strlen\") failed")));
             }

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -121,7 +121,10 @@ pub(crate) mod js_bindings {
             // SAFETY: RTLD_NEXT is a valid pseudo-handle and the name is NUL-terminated.
             let strlen = unsafe { bun_sys::c::dlsym(bun_sys::c::RTLD_NEXT, c"strlen".as_ptr()) };
             if strlen.is_null() {
-                return Err(global.throw(format_args!("dlsym(RTLD_NEXT, \"strlen\") failed")));
+                return Err(global.throw(format_args!(
+                    "dlsym(RTLD_NEXT, \"strlen\") failed: {}",
+                    bstr::BStr::new(&crate::ffi::get_dl_error())
+                )));
             }
             // ASAN owns SIGSEGV (see `js_segfault`): hand the handler the context the fault below would produce.
             if Environment::ENABLE_ASAN {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5116,6 +5116,10 @@ pub mod c {
         /// index; out-of-range returns null (no precondition).
         #[link_name = "_dyld_get_image_header"]
         safe fn dyld_get_image_header_raw(image_index: u32) -> *const core::ffi::c_void;
+        /// `const char* _dyld_get_image_name(uint32_t image_index)` — the path
+        /// the image was loaded from, owned by dyld and valid while the image
+        /// stays loaded; null for an out-of-range index (no precondition).
+        pub safe fn _dyld_get_image_name(image_index: u32) -> *const core::ffi::c_char;
     }
     /// `mach_task_self()` — C macro `#define mach_task_self() mach_task_self_`.
     #[cfg(target_os = "macos")]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4969,12 +4969,10 @@ pub mod c {
     ))]
     pub use libc::{getloadavg, sockaddr_dl, sysctlbyname};
 
-    /// `dlsym` pseudo-handle: search the objects loaded after the one that
-    /// contains the caller.
+    /// `dlsym` pseudo-handle: the objects loaded after the caller's.
     #[cfg(all(unix, not(target_os = "android")))]
     pub use libc::RTLD_NEXT;
-    /// Bionic's `<dlfcn.h>` value for 64-bit targets; the `libc` crate has no
-    /// binding for it on Android.
+    /// Bionic's 64-bit `<dlfcn.h>` value; the `libc` crate does not bind it for Android.
     #[cfg(all(target_os = "android", target_pointer_width = "64"))]
     pub const RTLD_NEXT: *mut c_void = -1isize as *mut c_void;
 
@@ -5125,9 +5123,7 @@ pub mod c {
         /// index; out-of-range returns null (no precondition).
         #[link_name = "_dyld_get_image_header"]
         safe fn dyld_get_image_header_raw(image_index: u32) -> *const core::ffi::c_void;
-        /// `const char* _dyld_get_image_name(uint32_t image_index)` — the path
-        /// the image was loaded from, owned by dyld and valid while the image
-        /// stays loaded; null for an out-of-range index (no precondition).
+        /// `const char* _dyld_get_image_name(uint32_t)`: dyld-owned path, live while the image is; null when out of range.
         pub safe fn _dyld_get_image_name(image_index: u32) -> *const core::ffi::c_char;
     }
     /// `mach_task_self()` — C macro `#define mach_task_self() mach_task_self_`.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4969,6 +4969,15 @@ pub mod c {
     ))]
     pub use libc::{getloadavg, sockaddr_dl, sysctlbyname};
 
+    /// `dlsym` pseudo-handle: search the objects loaded after the one that
+    /// contains the caller.
+    #[cfg(all(unix, not(target_os = "android")))]
+    pub use libc::RTLD_NEXT;
+    /// Bionic's `<dlfcn.h>` value for 64-bit targets; the `libc` crate has no
+    /// binding for it on Android.
+    #[cfg(all(target_os = "android", target_pointer_width = "64"))]
+    pub const RTLD_NEXT: *mut c_void = -1isize as *mut c_void;
+
     /// libc `dlsym` (RTLD_DEFAULT when `handle` is null).
     #[cfg(unix)]
     pub unsafe fn dlsym(handle: *mut c_void, name: *const c_char) -> *mut c_void {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -246,14 +246,9 @@ function decodeTraceFrames(payload: string): { object: string; address: number }
   throw new Error(`unterminated frame list in ${payload}`);
 }
 
-// A frame outside bun's own executable is encoded with the basename of the
-// image it is in, which bun.report shows as the frame's package: that is what
-// attributes a crash inside a native addon to the addon's `.node` file.
-// Windows has always encoded DLL names this way. macOS encoded every such
-// frame as unknown, and Linux encoded them as bun offsets, which symbolized to
-// unrelated bun functions. The fault here is inside libc, so frame 0 is libc's.
 // Crashes bun with `args`, receives the report it uploads, and returns the
-// crash's stderr together with the decoded frames of the uploaded trace string.
+// crash's stderr and exit code together with the decoded frames of the
+// uploaded trace string.
 async function uploadedCrashFrames(args: string[]) {
   const uploaded = Promise.withResolvers<string>();
   using server = Bun.serve({
@@ -276,17 +271,31 @@ async function uploadedCrashFrames(args: string[]) {
     stdio: ["ignore", "ignore", "pipe"],
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(exitCode).not.toBe(0);
 
-  const pathname = await uploaded.promise;
+  // The upload comes from a curl the crashed process started, so it can arrive
+  // shortly after the exit. A process that died without reporting (for example
+  // with a JS error out of the test hook) never uploads: fail with its stderr
+  // instead of waiting for the test timeout.
+  const pathname = await Promise.race([
+    uploaded.promise,
+    Bun.sleep(2000).then(() => {
+      throw new Error(`no crash report was uploaded; exit code ${exitCode}, stderr:\n${stderr}`);
+    }),
+  ]);
   // `/` is also a VLQ digit, so the payload cannot be split out on it.
   const payload = pathname.match(/^\/[^/]+\/(.*)\/ack$/)?.[1];
   expect(payload, pathname).toBeDefined();
-  return { stderr, frames: decodeTraceFrames(payload!) };
+  return { stderr, exitCode, frames: decodeTraceFrames(payload!) };
 }
 
+// A frame outside bun's own executable is encoded with the basename of the
+// image it is in, which bun.report shows as the frame's package: that is what
+// attributes a crash inside a native addon to the addon's `.node` file.
+// Windows has always encoded DLL names this way. macOS encoded every such
+// frame as unknown, and Linux encoded them as bun offsets, which symbolized to
+// unrelated bun functions. The fault here is inside libc, so frame 0 is libc's.
 test.if(isPosix)("the uploaded trace string names the image of a frame outside bun", async () => {
-  const { stderr, frames } = await uploadedCrashFrames([
+  const { stderr, exitCode, frames } = await uploadedCrashFrames([
     path.join(import.meta.dir, "fixture-crash.js"),
     "segfaultInDll",
   ]);
@@ -302,6 +311,7 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
   // executable must not be mistaken for a foreign image, under any name.
   expect(frames.some(frame => frame.object === "bun")).toBe(true);
   expect(frames.map(frame => frame.object)).not.toContain(path.basename(bunExe()));
+  expect(exitCode).not.toBe(0);
 });
 
 // A crash used to upload at most 20 frames. An addon that aborts on the JS
@@ -312,7 +322,7 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
 // 60 levels of JS recursion under the crash give the walk more than 20 frames
 // to find.
 test.if(isPosix)("the uploaded trace string holds more than 20 frames", async () => {
-  const { stderr, frames } = await uploadedCrashFrames([
+  const { stderr, exitCode, frames } = await uploadedCrashFrames([
     "-e",
     `const { crash_handler } = require("bun:internal-for-testing");
      function recurse(depth) { return depth === 0 ? crash_handler.segfault() : recurse(depth - 1) + 1; }
@@ -322,6 +332,7 @@ test.if(isPosix)("the uploaded trace string holds more than 20 frames", async ()
   expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
   expect(frames.length).toBeGreaterThan(20);
   expect(frames.length).toBeLessThanOrEqual(64);
+  expect(exitCode).not.toBe(0);
 });
 
 // The Windows crash handler is a Vectored Exception Handler, which sees every

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -271,7 +271,7 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
       GITHUB_ACTIONS: undefined,
       CI: undefined,
     },
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "ignore", "pipe"],
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -206,6 +206,95 @@ test.if(isWindows && isDebug)("Windows: segfault inside a system DLL captures th
   expect(span).toBeLessThan(2n ** 31n);
 });
 
+// The frames of a trace string `{base}/{version}/{payload}`, decoded the way
+// bun.report's parser decodes them. The payload is the platform, command and
+// format characters, 7 characters of commit, two VLQs of feature bits, then
+// one frame per VLQ (an offset in bun; a leading 1 introduces a name length,
+// the name, and an offset in that image; `_` is unknown; `=` is JS) until a
+// VLQ of 0 ends the list.
+function decodeTraceFrames(payload: string): { object: string; address: number }[] {
+  const digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let i = 3 + 7;
+  function vlq(): number {
+    let value = 0;
+    for (let shift = 0; ; shift += 5) {
+      const digit = digits.indexOf(payload[i++]);
+      if (digit < 0) throw new Error(`bad VLQ digit at ${i - 1} of ${payload}`);
+      value += (digit & 31) * 2 ** shift;
+      if (!(digit & 32)) return value % 2 ? -Math.floor(value / 2) : value / 2;
+    }
+  }
+  vlq();
+  vlq();
+  const frames = [];
+  while (i < payload.length) {
+    if (payload[i] === "_" || payload[i] === "=") {
+      frames.push({ object: payload[i++] === "_" ? "?" : "js", address: 0 });
+      continue;
+    }
+    let address = vlq();
+    if (address === 0) return frames;
+    let object = "bun";
+    if (address === 1) {
+      const length = vlq();
+      object = payload.slice(i, i + length);
+      i += length;
+      address = vlq();
+    }
+    frames.push({ object, address });
+  }
+  throw new Error(`unterminated frame list in ${payload}`);
+}
+
+// A frame outside bun's own executable is encoded with the basename of the
+// image it is in, which bun.report shows as the frame's package: that is what
+// attributes a crash inside a native addon to the addon's `.node` file.
+// Windows has always encoded DLL names this way. macOS encoded every such
+// frame as unknown, and Linux encoded them as bun offsets, which symbolized to
+// unrelated bun functions. The fault here is inside libc, so frame 0 is libc's.
+test.if(isPosix)("the uploaded trace string names the image of a frame outside bun", async () => {
+  const uploaded = Promise.withResolvers<string>();
+  using server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      uploaded.resolve(new URL(request.url).pathname);
+      return new Response("OK");
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "segfaultInDll"],
+    env: {
+      ...bunEnv,
+      BUN_CRASH_REPORT_URL: server.url.origin,
+      BUN_ENABLE_CRASH_REPORTING: "1",
+      GITHUB_ACTIONS: undefined,
+      CI: undefined,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // strlen() read from the bad pointer, possibly rounded down to its alignment.
+  expect(stderr).toContain("Segmentation fault at address 0xDEADBEE");
+  expect(exitCode).not.toBe(0);
+
+  const pathname = await uploaded.promise;
+  // `/` is also a VLQ digit, so the payload cannot be split out on it.
+  const payload = pathname.match(/^\/[^/]+\/(.*)\/ack$/)?.[1];
+  expect(payload, pathname).toBeDefined();
+  const frames = decodeTraceFrames(payload!);
+
+  // Frame 0 is the faulting strlen, in libc (or, under ASAN, its interceptor
+  // in the sanitizer runtime); either way in a shared library that is not bun.
+  expect(frames[0].object).toMatch(/\.(so\b|dylib$)/);
+  expect(frames[0].address).toBeGreaterThan(0);
+  // The callers of strlen are still bun's own frames, encoded as such: the
+  // executable must not be mistaken for a foreign image, under any name.
+  expect(frames.some(frame => frame.object === "bun")).toBe(true);
+  expect(frames.map(frame => frame.object)).not.toContain(path.basename(bunExe()));
+});
+
 // The Windows crash handler is a Vectored Exception Handler, which sees every
 // first-chance exception process-wide before frame-based SEH does. Third-party
 // DLLs injected into the process (AV/EDR agents such as BeyondTrust's

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -252,7 +252,9 @@ function decodeTraceFrames(payload: string): { object: string; address: number }
 // Windows has always encoded DLL names this way. macOS encoded every such
 // frame as unknown, and Linux encoded them as bun offsets, which symbolized to
 // unrelated bun functions. The fault here is inside libc, so frame 0 is libc's.
-test.if(isPosix)("the uploaded trace string names the image of a frame outside bun", async () => {
+// Crashes bun with `args`, receives the report it uploads, and returns the
+// crash's stderr together with the decoded frames of the uploaded trace string.
+async function uploadedCrashFrames(args: string[]) {
   const uploaded = Promise.withResolvers<string>();
   using server = Bun.serve({
     port: 0,
@@ -263,7 +265,7 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
   });
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "segfaultInDll"],
+    cmd: [bunExe(), ...args],
     env: {
       ...bunEnv,
       BUN_CRASH_REPORT_URL: server.url.origin,
@@ -274,16 +276,23 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
     stdio: ["ignore", "ignore", "pipe"],
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-
-  // strlen() read from the bad pointer, possibly rounded down to its alignment.
-  expect(stderr).toContain("Segmentation fault at address 0xDEADBEE");
   expect(exitCode).not.toBe(0);
 
   const pathname = await uploaded.promise;
   // `/` is also a VLQ digit, so the payload cannot be split out on it.
   const payload = pathname.match(/^\/[^/]+\/(.*)\/ack$/)?.[1];
   expect(payload, pathname).toBeDefined();
-  const frames = decodeTraceFrames(payload!);
+  return { stderr, frames: decodeTraceFrames(payload!) };
+}
+
+test.if(isPosix)("the uploaded trace string names the image of a frame outside bun", async () => {
+  const { stderr, frames } = await uploadedCrashFrames([
+    path.join(import.meta.dir, "fixture-crash.js"),
+    "segfaultInDll",
+  ]);
+
+  // strlen() read from the bad pointer, possibly rounded down to its alignment.
+  expect(stderr).toContain("Segmentation fault at address 0xDEADBEE");
 
   // Frame 0 is the faulting strlen, in libc (or, under ASAN, its interceptor
   // in the sanitizer runtime); either way in a shared library that is not bun.
@@ -293,6 +302,26 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
   // executable must not be mistaken for a foreign image, under any name.
   expect(frames.some(frame => frame.object === "bun")).toBe(true);
   expect(frames.map(frame => frame.object)).not.toContain(path.basename(bunExe()));
+});
+
+// A crash used to upload at most 20 frames. An addon that aborts on the JS
+// thread has that many frames of its own and libc's before the first bun one,
+// so such reports showed no bun frame at all (Sentry BUN-4MN5), and an addon
+// thread's report (BUN-2PFR) could not be told apart from those. The capture
+// now holds 64 frames and the encoder keeps as many as fit the trace string.
+// 60 levels of JS recursion under the crash give the walk more than 20 frames
+// to find.
+test.if(isPosix)("the uploaded trace string holds more than 20 frames", async () => {
+  const { stderr, frames } = await uploadedCrashFrames([
+    "-e",
+    `const { crash_handler } = require("bun:internal-for-testing");
+     function recurse(depth) { return depth === 0 ? crash_handler.segfault() : recurse(depth - 1) + 1; }
+     recurse(60);`,
+  ]);
+
+  expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
+  expect(frames.length).toBeGreaterThan(20);
+  expect(frames.length).toBeLessThanOrEqual(64);
 });
 
 // The Windows crash handler is a Vectored Exception Handler, which sees every

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -211,7 +211,9 @@ test.if(isWindows && isDebug)("Windows: segfault inside a system DLL captures th
 // format characters, 7 characters of commit, two VLQs of feature bits, then
 // one frame per VLQ (an offset in bun; a leading 1 introduces a name length,
 // the name, and an offset in that image; `_` is unknown; `=` is JS) until a
-// VLQ of 0 ends the list.
+// VLQ of 0 ends the list. A frame in bun's own image decodes with the object
+// `<bun>`: the encoder writes names from `[A-Za-z0-9._-]` only, so no image
+// (not even an executable named `bun`) can decode to that.
 function decodeTraceFrames(payload: string): { object: string; address: number }[] {
   const digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   let i = 3 + 7;
@@ -234,7 +236,7 @@ function decodeTraceFrames(payload: string): { object: string; address: number }
     }
     let address = vlq();
     if (address === 0) return frames;
-    let object = "bun";
+    let object = "<bun>";
     if (address === 1) {
       const length = vlq();
       object = payload.slice(i, i + length);
@@ -309,7 +311,7 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
   expect(frames[0].address).toBeGreaterThan(0);
   // The callers of strlen are still bun's own frames, encoded as such: the
   // executable must not be mistaken for a foreign image, under any name.
-  expect(frames.some(frame => frame.object === "bun")).toBe(true);
+  expect(frames.some(frame => frame.object === "<bun>")).toBe(true);
   expect(frames.map(frame => frame.object)).not.toContain(path.basename(bunExe()));
   expect(exitCode).not.toBe(0);
 });


### PR DESCRIPTION
### Problem
- A crash inside a native addon uploads nothing that names the addon. On macOS, `StackLine::from_address` (`src/crash_handler/lib.rs`) encodes every frame outside bun's image as unknown: Sentry shows `<anonymous>` for BUN-4MMY, BUN-4KFP, BUN-2V1T and BUN-2V2Y. On Linux it encodes such a frame as an offset into bun, so bun.report names an unrelated bun function.
- A report holds at most 20 frames (`addr_buf: [usize; 20]`). An addon that aborts has more frames than that before the first bun frame, so the report shows no bun frame at all (BUN-4MN5, BUN-2PFR).
- The trace string format has a named frame (`1`, length, name, offset). Only the Windows encoder uses it. bun.report decodes it on every platform.

### Fix
- macOS: a frame in dyld image `i != 0` gets the name of `_dyld_get_image_name(i)` and its offset in that image. ELF: the module name from `dl_iterate_phdr`, unless the load base is bun's own. The base identifies the main program, because glibc names it `""` and musl names it by path.
- `write_encoded` writes the basename, cut at 64 bytes. Each byte outside `[A-Za-z0-9._-]` becomes `_`. bun.report reads the name back by length, so the byte count must not change.
- The capture holds 64 frames. The buffer grows to 2 KB and the frames get half of it. The frames that do not fit are the outermost ones. They are dropped, so the string stays decodable.
- Verified: `test/cli/run/run-crash-handler.test.ts`. The two new tests decode the uploaded string. Without the fix, frame 0 decodes as `bun`, and a crash under 60 JS frames uploads 20 frames. Also the rest of the file, `crash-report-command-char.test.ts`, and `cargo check` for darwin, windows, musl, freebsd and android.

### Background
- A trace string is the `bun.report/...` URL a crash prints and uploads. It holds one VLQ offset per frame. bun.report remaps the offsets against bun's debug symbols. A frame that starts with VLQ `1` names an image instead. bun.report shows the name as the frame's package, as it does for DLL frames today.
- `segfaultInDll` in `bun:internal-for-testing` now faults inside libc's `strlen` on POSIX. `dlsym(RTLD_NEXT)` finds libc's address, not the PLT stub in the executable. Under ASAN bun installs no fault handler, so the hook calls the handler with the fault context itself, as `segfault` does.

<details><summary>Notes</summary>

- #39815 (opened later, from another run) contains this same encoder change and adds a classifier, a banner and a feature bit on top. This PR is the small piece on its own. One of the two lands. Differences: this one identifies the main program by load base and not by `dl_iterate_phdr` order, and it fixes the debug symbolizer.
- Debug symbolizer: `spawn_symbolizer` passed every offset to llvm-symbolizer together with bun's executable. It now passes each frame as its own `"<file>" <offset>` argument, so a foreign frame resolves against its own image. pdb-addr2line reads one PDB, so Windows leaves foreign frames out.
- bun.report's current `lib/parser.ts` decodes a trace from the new hook as `{address: 0x175aff, object: "libc.so.6"}` followed by bun frames. `llvm-symbolizer "libc.so.6 0x175b00"` gives `__strlen_evex`.
- Grouping per addon is a bun.report change: `buildFingerprint` uses remapped bun frames only. The name now arrives in every event.
- Event counts at the time of writing: BUN-2V1T 826, BUN-2V2Y 542, BUN-2PFR about 22k. BUN-2PFR is a crash on an addon's own thread, so all of its frames are foreign.
- Sizes: 64 bun frames take about 380 bytes of trace string (20 frames: about 140). The 1 KB frame budget holds 64 bun frames or about 40 named ones. `report()` copies the string into 4 KB command lines on both platforms. Before the budget, a long trace could fail the buffer write in the middle of a frame and leave an undecodable string.
- Panic messages: on main the buffer is 1 KB, the frames have no budget, and a message that does not fit is dropped as a whole. Here the message always has at least 1 KB minus the header, which is more than on main. #38950 fits the message into the room that is left after the frames. The two compose. Whichever lands second needs a small rebase in `encode_trace_string`.
- `own_image_base()` is one extra `dl_iterate_phdr` call per process. The encoder already makes one per frame.
- The LR seeding that would recover the null-calling function in BUN-4MMY is #32871 (needs a rebase). #39817 reports the exception type for BUN-4KFP.
- Rebased onto main at 3c8d5d6. Two conflicts, both in `src/crash_handler/lib.rs` against #37181's dead code removal: it deleted the `Display` impl for `StackLine`, which this branch had extended with the image name. The impl stays deleted. `own_image_base()` and the frame constants were kept from this branch. Main's new platform characters for musl and android (#39801) are still one byte, so the test decoder is unchanged.
- CI on d1b017a (build 104029): 180 of 181 jobs pass, including the size check against main's head. The one failed job is a darwin aarch64 test shard that died before it ran a test: the runner's `git clone` of `vendor/elysia` timed out on that host (GitHub was slow to reach from it, the other Macs were fine). Retriggered once as 654b4e9.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 13 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->



