### PR TITLE
ws: one binaryType rule for both shim sockets, add binaryType "blob" to ServerWebSocket

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -416,6 +416,8 @@ declare module "bun" {
      * - if `uint8array`, then the message is a `Uint8Array`.
      * - if `blob`, then the message is a `Blob`.
      *
+     * The declared type of `message` is the one of the default `binaryType`.
+     *
      * @param ws The websocket that sent the message
      * @param message The message received
      */
@@ -448,6 +450,9 @@ declare module "bun" {
     /**
      * Called when a ping is received.
      *
+     * Like a binary message, `data` has the type that `binaryType` selects.
+     * The declared type is the one of the default `binaryType`.
+     *
      * @param ws The websocket that received the ping
      * @param data The data sent with the ping
      */
@@ -455,6 +460,9 @@ declare module "bun" {
 
     /**
      * Called when a pong is received.
+     *
+     * Like a binary message, `data` has the type that `binaryType` selects.
+     * The declared type is the one of the default `binaryType`.
      *
      * @param ws The websocket that received the pong
      * @param data The data sent with the pong

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -285,6 +285,9 @@ declare module "bun" {
      * - if `nodebuffer`, binary data is returned as `Buffer` objects. **(default)**
      * - if `arraybuffer`, binary data is returned as `ArrayBuffer` objects.
      * - if `uint8array`, binary data is returned as `Uint8Array` objects.
+     * - if `blob`, binary data is returned as `Blob` objects.
+     *
+     * This applies to binary messages and to the payloads of pings and pongs.
      *
      * @example
      * ```ts
@@ -295,7 +298,7 @@ declare module "bun" {
      * });
      * ```
      */
-    binaryType?: "nodebuffer" | "arraybuffer" | "uint8array";
+    binaryType?: "nodebuffer" | "arraybuffer" | "uint8array" | "blob";
 
     /**
      * Custom data you can assign to a client. It can be read and written at any time.
@@ -411,6 +414,7 @@ declare module "bun" {
      * - if `nodebuffer`, then the message is a `Buffer`.
      * - if `arraybuffer`, then the message is an `ArrayBuffer`.
      * - if `uint8array`, then the message is a `Uint8Array`.
+     * - if `blob`, then the message is a `Blob`.
      *
      * @param ws The websocket that sent the message
      * @param message The message received

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -138,8 +138,7 @@ function normalizeData(data, opts) {
   return data;
 }
 
-// The native sockets apply binaryType to ping and pong payloads, npm ws emits them as a Buffer.
-// Only an ArrayBuffer can be wrapped synchronously, a Blob is emitted as is.
+// npm ws emits ping and pong payloads as a Buffer. Only an ArrayBuffer can be wrapped synchronously.
 function controlPayload(binaryType, data) {
   return binaryType === "arraybuffer" ? Buffer.from(data) : data;
 }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -138,6 +138,12 @@ function normalizeData(data, opts) {
   return data;
 }
 
+// The native sockets apply binaryType to ping and pong payloads, npm ws emits them as a Buffer.
+// Only an ArrayBuffer can be wrapped synchronously, a Blob is emitted as is.
+function controlPayload(binaryType, data) {
+  return binaryType === "arraybuffer" ? Buffer.from(data) : data;
+}
+
 // https://github.com/oven-sh/bun/issues/11866
 let WebSocket;
 
@@ -441,7 +447,7 @@ class BunWebSocket extends EventEmitter {
         this.#ws.addEventListener(
           "ping",
           ({ data }) => {
-            this.emit("ping", data);
+            this.emit("ping", controlPayload(this.#binaryType, data));
           },
           once,
         );
@@ -449,7 +455,7 @@ class BunWebSocket extends EventEmitter {
         this.#ws.addEventListener(
           "pong",
           ({ data }) => {
-            this.emit("pong", data);
+            this.emit("pong", controlPayload(this.#binaryType, data));
           },
           once,
         );
@@ -538,7 +544,7 @@ class BunWebSocket extends EventEmitter {
   }
 
   set binaryType(value) {
-    if (value === "nodebuffer" || value === "arraybuffer") {
+    if (value === "nodebuffer" || value === "arraybuffer" || value === "blob") {
       this.#ws.binaryType = this.#binaryType = value;
       this.#fragments = false;
     } else if (value === "fragments") {
@@ -1003,19 +1009,14 @@ class BunWebSocketMocked extends EventEmitter {
     };
   }
 
-  // npm ws emits ping and pong payloads as a Buffer. Only an ArrayBuffer can be wrapped synchronously.
-  #controlPayload(data) {
-    return this.#binaryType === "arraybuffer" ? Buffer.from(data) : data;
-  }
-
   #ping(ws, data) {
     this.#ws = ws;
-    this.emit("ping", this.#controlPayload(data));
+    this.emit("ping", controlPayload(this.#binaryType, data));
   }
 
   #pong(ws, data) {
     this.#ws = ws;
-    this.emit("pong", this.#controlPayload(data));
+    this.emit("pong", controlPayload(this.#binaryType, data));
   }
 
   #message(ws, message) {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -969,24 +969,20 @@ class BunWebSocketMocked extends EventEmitter {
   #protocol;
   #extensions;
   #bufferedAmount = 0;
-  #binaryType = "arraybuffer";
+  // The default of the ServerWebSocket. The setter keeps both sides in sync.
+  #binaryType = "nodebuffer";
 
   #onclose;
   #onerror;
   #onmessage;
   #onopen;
 
-  constructor(url, protocol, extensions, binaryType) {
+  constructor(url, protocol, extensions) {
     super();
     this.#ws = null;
     this.#state = ReadyState_CONNECTING;
     this.#url = url;
     this.#bufferedAmount = 0;
-    binaryType = binaryType || "arraybuffer";
-    if (binaryType !== "nodebuffer" && binaryType !== "blob" && binaryType !== "arraybuffer") {
-      throw new TypeError("binaryType must be either 'blob', 'arraybuffer' or 'nodebuffer'");
-    }
-    this.#binaryType = binaryType;
     this.#protocol = protocol;
     this.#extensions = extensions;
 
@@ -1532,7 +1528,7 @@ class WebSocketServer extends EventEmitter {
         ? this.options.handleProtocols(protocols, request)
         : protocols.values().next().value;
     }
-    const ws = new BunWebSocketMocked(request.url, protocol, extensions, "nodebuffer");
+    const ws = new BunWebSocketMocked(request.url, protocol, extensions);
 
     const headers = ["HTTP/1.1 101 Switching Protocols", "Upgrade: websocket", "Connection: Upgrade"];
     this.emit("headers", headers, request);

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1007,14 +1007,19 @@ class BunWebSocketMocked extends EventEmitter {
     };
   }
 
+  // ServerWebSocket applies binaryType to ping and pong payloads too. npm ws always emits a Buffer for them.
+  #controlPayload(data) {
+    return this.#binaryType === "arraybuffer" ? Buffer.from(data) : data;
+  }
+
   #ping(ws, data) {
     this.#ws = ws;
-    this.emit("ping", data);
+    this.emit("ping", this.#controlPayload(data));
   }
 
   #pong(ws, data) {
     this.#ws = ws;
-    this.emit("pong", data);
+    this.emit("pong", this.#controlPayload(data));
   }
 
   #message(ws, message) {
@@ -1031,15 +1036,10 @@ class BunWebSocketMocked extends EventEmitter {
         message = Buffer.from(message);
       }
     } else {
-      //Buffer
+      // Buffer, or ArrayBuffer when binaryType is "arraybuffer" (the setter forwards it to the ServerWebSocket)
       isBinary = true;
-      if (this.#binaryType !== "nodebuffer") {
-        if (this.#binaryType === "arraybuffer") {
-          // ServerWebSocket creates this Buffer over its own ArrayBuffer, so .buffer holds exactly the message.
-          message = message.buffer;
-        } else if (this.#binaryType === "blob") {
-          message = new Blob([message]);
-        }
+      if (this.#binaryType === "blob") {
+        message = new Blob([message]);
       }
     }
 
@@ -1196,6 +1196,9 @@ class BunWebSocketMocked extends EventEmitter {
       throw new TypeError("binaryType must be either 'blob', 'arraybuffer' or 'nodebuffer'");
     }
     this.#binaryType = type;
+    // The ServerWebSocket builds the ArrayBuffer itself. "blob" is wrapped in #message from a Buffer.
+    const ws = this.#ws;
+    if (ws) ws.binaryType = type === "arraybuffer" ? "arraybuffer" : "nodebuffer";
   }
 
   get readyState() {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1007,7 +1007,8 @@ class BunWebSocketMocked extends EventEmitter {
     };
   }
 
-  // ServerWebSocket applies binaryType to ping and pong payloads too. npm ws always emits a Buffer for them.
+  // ServerWebSocket applies binaryType to ping and pong payloads too, while npm ws always emits a Buffer
+  // for them. An ArrayBuffer can be wrapped synchronously, a Blob cannot, so "blob" passes through.
   #controlPayload(data) {
     return this.#binaryType === "arraybuffer" ? Buffer.from(data) : data;
   }
@@ -1036,11 +1037,8 @@ class BunWebSocketMocked extends EventEmitter {
         message = Buffer.from(message);
       }
     } else {
-      // Buffer, or ArrayBuffer when binaryType is "arraybuffer" (the setter forwards it to the ServerWebSocket)
+      // The ServerWebSocket already built the Buffer, ArrayBuffer or Blob that binaryType selects.
       isBinary = true;
-      if (this.#binaryType === "blob") {
-        message = new Blob([message]);
-      }
     }
 
     this.emit("message", message, isBinary);
@@ -1196,9 +1194,9 @@ class BunWebSocketMocked extends EventEmitter {
       throw new TypeError("binaryType must be either 'blob', 'arraybuffer' or 'nodebuffer'");
     }
     this.#binaryType = type;
-    // The ServerWebSocket builds the ArrayBuffer itself. "blob" is wrapped in #message from a Buffer.
+    // #ws is null before open and after close. The ServerWebSocket builds the selected type itself.
     const ws = this.#ws;
-    if (ws) ws.binaryType = type === "arraybuffer" ? "arraybuffer" : "nodebuffer";
+    if (ws) ws.binaryType = type;
   }
 
   get readyState() {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1007,8 +1007,7 @@ class BunWebSocketMocked extends EventEmitter {
     };
   }
 
-  // ServerWebSocket applies binaryType to ping and pong payloads too, while npm ws always emits a Buffer
-  // for them. An ArrayBuffer can be wrapped synchronously, a Blob cannot, so "blob" passes through.
+  // npm ws emits ping and pong payloads as a Buffer. Only an ArrayBuffer can be wrapped synchronously.
   #controlPayload(data) {
     return this.#binaryType === "arraybuffer" ? Buffer.from(data) : data;
   }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1035,7 +1035,8 @@ class BunWebSocketMocked extends EventEmitter {
       isBinary = true;
       if (this.#binaryType !== "nodebuffer") {
         if (this.#binaryType === "arraybuffer") {
-          message = new Uint8Array(message);
+          // ServerWebSocket creates this Buffer over its own ArrayBuffer, so .buffer holds exactly the message.
+          message = message.buffer;
         } else if (this.#binaryType === "blob") {
           message = new Blob([message]);
         }

--- a/src/jsc/CommonStrings.rs
+++ b/src/jsc/CommonStrings.rs
@@ -24,6 +24,7 @@ enum CommonStringsForZig {
     BinaryTypeArrayBuffer = 10,
     BinaryTypeNodeBuffer = 11,
     BinaryTypeUint8Array = 12,
+    BinaryTypeBlob = 13,
 }
 
 unsafe extern "C" {
@@ -95,5 +96,9 @@ impl<'a> CommonStrings<'a> {
     #[inline]
     pub fn uint8array(self) -> JSValue {
         CommonStringsForZig::BinaryTypeUint8Array.to_js(self.global_object)
+    }
+    #[inline]
+    pub fn blob(self) -> JSValue {
+        CommonStringsForZig::BinaryTypeBlob.to_js(self.global_object)
     }
 }

--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -177,6 +177,7 @@ enum class CommonStringsForZig : uint8_t {
     binaryTypeArrayBuffer = 10,
     binaryTypeNodeBuffer = 11,
     binaryTypeUint8Array = 12,
+    binaryTypeBlob = 13,
 };
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForZig commonString)
@@ -209,6 +210,8 @@ static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForZig co
         return commonStrings.binaryTypeNodeBufferString(globalObject);
     case CommonStringsForZig::binaryTypeUint8Array:
         return commonStrings.binaryTypeUint8ArrayString(globalObject);
+    case CommonStringsForZig::binaryTypeBlob:
+        return commonStrings.binaryTypeBlobString(globalObject);
     default: {
         ASSERT_NOT_REACHED();
         return jsUndefined();

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -60,6 +60,7 @@
     macro(base64, "base64") \
     macro(base64url, "base64url") \
     macro(binaryTypeArrayBuffer, "arraybuffer") \
+    macro(binaryTypeBlob, "blob") \
     macro(binaryTypeNodeBuffer, "nodebuffer") \
     macro(binaryTypeUint8Array, "uint8array") \
     macro(buffer, "buffer") \

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -112,15 +112,12 @@ impl Flags {
     }
     #[inline]
     pub(crate) fn binary_type(self) -> BinaryType {
-        // Stored value was written via `set_binary_type` from a valid
-        // `BinaryType` discriminant.
         match ((self.0 & Self::BINARY_TYPE_MASK) >> Self::BINARY_TYPE_SHIFT) as u8 {
             0 => BinaryType::Buffer,
             1 => BinaryType::ArrayBuffer,
             2 => BinaryType::Uint8Array,
             3 => BinaryType::Blob,
-            // 4-bit field; only `set_binary_type` writes it, so anything else
-            // indicates memory corruption — trap.
+            // Only `set_binary_type` writes this field, so any other value is memory corruption.
             n => unreachable!("invalid BinaryType {n}"),
         }
     }
@@ -626,8 +623,6 @@ impl ServerWebSocket {
             }
             BinaryType::Blob => {
                 let blob = Blob::init(data.to_vec(), global_this);
-                // UFCS: the consuming `JsClass::to_js` heap-promotes the blob. The inherent
-                // `Blob::to_js` expects a receiver that is already on the heap.
                 Ok(<Blob as bun_jsc::JsClass>::to_js(blob, global_this))
             }
         }

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -14,7 +14,7 @@ use crate::server::jsc::{
     JsError, JsRef, JsResult, ZigStringSlice,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
-use crate::webcore::Blob;
+use crate::webcore::{Blob, BlobExt};
 
 bun_output::declare_scope!(WebSocketServer, visible);
 
@@ -622,8 +622,10 @@ impl ServerWebSocket {
                 ArrayBuffer::create::<{ JSType::ArrayBuffer }>(global_this, data)
             }
             BinaryType::Blob => {
-                let blob = Blob::init(data.to_vec(), global_this);
-                Ok(<Blob as bun_jsc::JsClass>::to_js(blob, global_this))
+                let blob = Blob::new(Blob::init(data.to_vec(), global_this));
+                // SAFETY: `blob` is the live allocation `Blob::new` just made. `BlobExt::to_js`
+                // reports the payload size to the GC, which the by-value `JsClass::to_js` skips.
+                Ok(unsafe { BlobExt::to_js(&*blob, global_this) })
             }
         }
     }

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -3,20 +3,44 @@ use core::ffi::c_void;
 use core::mem;
 use core::ptr::NonNull;
 
-use bun_jsc::JsCell;
+use bun_jsc::{ComptimeStringMapExt as _, JsCell};
 use bun_uws::{self as uws, AnyWebSocket, WebSocketBehavior};
 use bun_uws_sys::web_socket::{WebSocketHandler, WebSocketUpgradeServer, Wrap};
 use bun_uws_sys::{Opcode, SendStatus};
 
 use crate::server::WebSocketServerHandler;
 use crate::server::jsc::{
-    self, AbortSignal, ArrayBuffer, BinaryType, CallFrame, CommonAbortReason, JSGlobalObject,
-    JSType, JSValue, JsError, JsRef, JsResult, ZigStringSlice,
+    self, AbortSignal, ArrayBuffer, CallFrame, CommonAbortReason, JSGlobalObject, JSType, JSValue,
+    JsError, JsRef, JsResult, ZigStringSlice,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
 use crate::webcore::Blob;
 
 bun_output::declare_scope!(WebSocketServer, visible);
+
+/// The JS type that `ws.binaryType` selects for binary messages, pings and pongs.
+#[repr(u8)]
+#[derive(Copy, Clone)]
+pub(crate) enum BinaryType {
+    Buffer = 0,
+    ArrayBuffer = 1,
+    Uint8Array = 2,
+    Blob = 3,
+}
+
+bun_core::comptime_string_map! {
+    /// The spellings `bun_jsc::BinaryType` accepted for the first three types, plus "blob".
+    static BINARY_TYPE_MAP: BinaryType = {
+        b"ArrayBuffer" => BinaryType::ArrayBuffer,
+        b"Buffer" => BinaryType::Buffer,
+        b"Uint8Array" => BinaryType::Uint8Array,
+        b"arraybuffer" => BinaryType::ArrayBuffer,
+        b"blob" => BinaryType::Blob,
+        b"buffer" => BinaryType::Buffer,
+        b"nodebuffer" => BinaryType::Buffer,
+        b"uint8array" => BinaryType::Uint8Array,
+    };
+}
 
 // No `'a` on a `.classes.ts` m_ctx payload — the JS wrapper outlives any
 // stack frame. The handler lives in `ServerConfig.websocket` for the server's
@@ -89,24 +113,14 @@ impl Flags {
     #[inline]
     pub(crate) fn binary_type(self) -> BinaryType {
         // Stored value was written via `set_binary_type` from a valid
-        // `BinaryType` discriminant (4-bit field, 14 variants).
+        // `BinaryType` discriminant.
         match ((self.0 & Self::BINARY_TYPE_MASK) >> Self::BINARY_TYPE_SHIFT) as u8 {
             0 => BinaryType::Buffer,
             1 => BinaryType::ArrayBuffer,
             2 => BinaryType::Uint8Array,
-            3 => BinaryType::Uint8ClampedArray,
-            4 => BinaryType::Uint16Array,
-            5 => BinaryType::Uint32Array,
-            6 => BinaryType::Int8Array,
-            7 => BinaryType::Int16Array,
-            8 => BinaryType::Int32Array,
-            9 => BinaryType::Float16Array,
-            10 => BinaryType::Float32Array,
-            11 => BinaryType::Float64Array,
-            12 => BinaryType::BigInt64Array,
-            13 => BinaryType::BigUint64Array,
-            // 4-bit field; only `set_binary_type` writes it, so 14/15 indicate
-            // memory corruption — trap.
+            3 => BinaryType::Blob,
+            // 4-bit field; only `set_binary_type` writes it, so anything else
+            // indicates memory corruption — trap.
             n => unreachable!("invalid BinaryType {n}"),
         }
     }
@@ -607,7 +621,15 @@ impl ServerWebSocket {
             BinaryType::Uint8Array => {
                 ArrayBuffer::create::<{ JSType::Uint8Array }>(global_this, data)
             }
-            _ => ArrayBuffer::create::<{ JSType::ArrayBuffer }>(global_this, data),
+            BinaryType::ArrayBuffer => {
+                ArrayBuffer::create::<{ JSType::ArrayBuffer }>(global_this, data)
+            }
+            BinaryType::Blob => {
+                let blob = Blob::init(data.to_vec(), global_this);
+                // UFCS: the consuming `JsClass::to_js` heap-promotes the blob. The inherent
+                // `Blob::to_js` expects a receiver that is already on the heap.
+                Ok(<Blob as bun_jsc::JsClass>::to_js(blob, global_this))
+            }
         }
     }
 
@@ -1420,7 +1442,7 @@ impl ServerWebSocket {
             BinaryType::Uint8Array => global_this.common_strings().uint8array(),
             BinaryType::Buffer => global_this.common_strings().nodebuffer(),
             BinaryType::ArrayBuffer => global_this.common_strings().arraybuffer(),
-            _ => panic!("Invalid binary type"),
+            BinaryType::Blob => global_this.common_strings().blob(),
         })
     }
 
@@ -1432,14 +1454,18 @@ impl ServerWebSocket {
     ) -> JsResult<bool> {
         bun_output::scoped_log!(WebSocketServer, "setBinaryType()");
 
-        match BinaryType::from_js_value(global_this, value)? {
-            Some(val @ (BinaryType::ArrayBuffer | BinaryType::Buffer | BinaryType::Uint8Array)) => {
+        let binary_type = if value.is_string() {
+            BINARY_TYPE_MAP.from_js(global_this, value)?
+        } else {
+            None
+        };
+        match binary_type {
+            Some(val) => {
                 self.update_flags(|f| f.set_binary_type(val));
                 Ok(true)
             }
-            // some other value which we don't support
-            _ => Err(global_this.throw(format_args!(
-                "binaryType must be either \"uint8array\" or \"arraybuffer\" or \"nodebuffer\"",
+            None => Err(global_this.throw(format_args!(
+                "binaryType must be either \"uint8array\", \"arraybuffer\", \"nodebuffer\" or \"blob\"",
             ))),
         }
     }

--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -128,6 +128,7 @@ test("basic + websocket + upgrade", {
       expectType<typeof ws>().is<Bun.ServerWebSocket<undefined>>();
       ws.send(message);
       expectType(message).is<string | Buffer<ArrayBuffer>>();
+      expectType(ws.binaryType).is<"nodebuffer" | "arraybuffer" | "uint8array" | "blob" | undefined>();
     },
   },
 

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -57,6 +57,10 @@ const binaryTypes = [
     label: "uint8array",
     type: Uint8Array,
   },
+  {
+    label: "blob",
+    type: Blob,
+  },
 ] as const;
 
 let servers: Server[] = [];
@@ -736,6 +740,71 @@ describe("ServerWebSocket", () => {
         },
       }));
     }
+    test("keeps accepting the capitalized and 'buffer' spellings", done => ({
+      open(ws) {
+        try {
+          const seen: string[] = [];
+          for (const spelling of ["Buffer", "buffer", "ArrayBuffer", "Uint8Array", "nodebuffer"]) {
+            ws.binaryType = spelling as typeof ws.binaryType;
+            seen.push(ws.binaryType!);
+          }
+          expect(seen).toEqual(["nodebuffer", "nodebuffer", "arraybuffer", "uint8array", "nodebuffer"]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+    }));
+    test("blob payloads carry the frame bytes", done => {
+      const received: { event: string; size: number; type: string; bytes: number[] }[] = [];
+      async function record(event: string, data: unknown) {
+        const blob = data as Blob;
+        received.push({ event, size: blob.size, type: blob.type, bytes: Array.from(await blob.bytes()) });
+      }
+      // The echo client answers a message with the same message, a pong with the same pong
+      // and a ping with the same ping. The client's WebSocket also answers a ping with an
+      // automatic pong, so the server pong is sent first and only the first pong is recorded.
+      return {
+        open(ws) {
+          try {
+            ws.binaryType = "blob";
+            ws.send(new Uint8Array([1, 2, 3]));
+          } catch (err) {
+            done(err);
+          }
+        },
+        async message(ws, data) {
+          try {
+            await record("message", data);
+            ws.pong(new Uint8Array([5]));
+          } catch (err) {
+            done(err);
+          }
+        },
+        async pong(ws, data) {
+          if (received.some(({ event }) => event === "pong")) return;
+          try {
+            await record("pong", data);
+            ws.ping(new Uint8Array([4]));
+          } catch (err) {
+            done(err);
+          }
+        },
+        async ping(_, data) {
+          try {
+            await record("ping", data);
+            expect(received).toEqual([
+              { event: "message", size: 3, type: "", bytes: [1, 2, 3] },
+              { event: "pong", size: 1, type: "", bytes: [5] },
+              { event: "ping", size: 1, type: "", bytes: [4] },
+            ]);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        },
+      };
+    });
   });
   describe("send()", () => {
     for (const { label, message, bytes } of messages) {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,5 +1,6 @@
 import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
+import { heapStats } from "bun:jsc";
 import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
@@ -804,6 +805,50 @@ describe("ServerWebSocket", () => {
           }
         },
       };
+    });
+    it("blob frames report their bytes to the garbage collector", async () => {
+      const { promise, resolve, reject } = Promise.withResolvers<Blob>();
+      using server = serve({
+        port: 0,
+        fetch(req, server) {
+          if (server.upgrade(req)) return;
+          return new Response(null, { status: 400 });
+        },
+        websocket: {
+          open(ws) {
+            try {
+              ws.binaryType = "blob";
+            } catch (err) {
+              reject(err);
+            }
+          },
+          message(_, data) {
+            resolve(data as unknown as Blob);
+          },
+        },
+      });
+      // Stays alive until the end, so it is part of both measurements.
+      const payload = new Uint8Array(2 * 1024 * 1024);
+      let before = 0;
+      const client = new WebSocket(`ws://${server.hostname}:${server.port}`);
+      client.onerror = () => reject(new Error("client error"));
+      client.onopen = () => {
+        // Both sockets exist at this point, so only the transfer separates the two measurements.
+        Bun.gc(true);
+        before = heapStats().extraMemorySize;
+        client.send(payload);
+      };
+      try {
+        const blob = await promise;
+        Bun.gc(true);
+        const reported = heapStats().extraMemorySize - before;
+        expect(blob.size).toBe(payload.byteLength);
+        // Without the report this is close to 0. Memory that earlier tests release in the
+        // meantime lowers the number a little, so half the payload is the bound.
+        expect(reported).toBeGreaterThanOrEqual(payload.byteLength / 2);
+      } finally {
+        client.close();
+      }
     });
   });
   describe("send()", () => {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -352,36 +352,40 @@ describe("WebSocketServer", () => {
       }
     }
 
-    // Like npm ws, binaryType applies to binary data frames only: ping and pong
-    // payloads are always a Buffer.
+    // npm ws emits ping and pong payloads as a Buffer in every mode. The shim keeps that
+    // where it can wrap the payload synchronously. A Blob cannot be wrapped, so "blob"
+    // applies to ping and pong payloads too, as it does on a Bun.serve socket.
     const serverBinaryTypes = [
-      { binaryType: "nodebuffer", shape: "Buffer" },
-      { binaryType: "arraybuffer", shape: "ArrayBuffer" },
-      { binaryType: "blob", shape: "Blob" },
+      { binaryType: "nodebuffer", shape: "Buffer", controlShape: "Buffer" },
+      { binaryType: "arraybuffer", shape: "ArrayBuffer", controlShape: "Buffer" },
+      { binaryType: "blob", shape: "Blob", controlShape: "Blob" },
     ] as const;
 
-    it.each(serverBinaryTypes)("$binaryType: binary frames arrive as $shape", async ({ binaryType, shape }) => {
-      const received = await receiveOnServer(
-        ws => {
-          // @types/ws 8.5 does not list "blob", ws 8.18 accepts it
-          ws.binaryType = binaryType as WebSocket["binaryType"];
-        },
-        client => {
-          client.ping(Buffer.from([4]));
-          client.pong(Buffer.from([5]));
-          client.send(Buffer.from([1, 2, 3]));
-          client.send(Buffer.alloc(0));
-        },
-        2,
-      );
+    it.each(serverBinaryTypes)(
+      "$binaryType: binary frames arrive as $shape, ping and pong payloads as $controlShape",
+      async ({ binaryType, shape, controlShape }) => {
+        const received = await receiveOnServer(
+          ws => {
+            // @types/ws 8.5 does not list "blob", ws 8.18 accepts it
+            ws.binaryType = binaryType as WebSocket["binaryType"];
+          },
+          client => {
+            client.ping(Buffer.from([4]));
+            client.pong(Buffer.from([5]));
+            client.send(Buffer.from([1, 2, 3]));
+            client.send(Buffer.alloc(0));
+          },
+          2,
+        );
 
-      expect(received).toEqual([
-        { event: "ping", shape: "Buffer", bytes: [4] },
-        { event: "pong", shape: "Buffer", bytes: [5] },
-        { event: "message", shape, bytes: [1, 2, 3], isBinary: true },
-        { event: "message", shape, bytes: [], isBinary: true },
-      ]);
-    });
+        expect(received).toEqual([
+          { event: "ping", shape: controlShape, bytes: [4] },
+          { event: "pong", shape: controlShape, bytes: [5] },
+          { event: "message", shape, bytes: [1, 2, 3], isBinary: true },
+          { event: "message", shape, bytes: [], isBinary: true },
+        ]);
+      },
+    );
 
     it("defaults to nodebuffer and applies a new value to the next frame", async () => {
       const binaryTypesSeen: string[] = [];
@@ -408,7 +412,7 @@ describe("WebSocketServer", () => {
       expect(received).toEqual([
         { event: "message", shape: "ArrayBuffer", bytes: [1], isBinary: true },
         // the ping arrives after the change to "blob"
-        { event: "ping", shape: "Buffer", bytes: [2] },
+        { event: "ping", shape: "Blob", bytes: [2] },
         { event: "message", shape: "Blob", bytes: [3], isBinary: true },
         { event: "message", shape: "Buffer", bytes: [4], isBinary: true },
       ]);

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -299,6 +299,115 @@ describe("WebSocketServer", () => {
     new WebSocket("ws://localhost:" + wss.address().port);
     await promise;
   });
+
+  describe("binaryType", () => {
+    type Received = { event: string; shape: string; bytes: number[]; isBinary?: boolean };
+
+    function shapeOf(data: unknown): string {
+      if (Buffer.isBuffer(data)) return "Buffer";
+      if (data instanceof ArrayBuffer) return "ArrayBuffer";
+      if (data instanceof Blob) return "Blob";
+      return Object.prototype.toString.call(data);
+    }
+
+    async function describeReceived(event: string, data: unknown, isBinary?: boolean): Promise<Received> {
+      const bytes = Array.from(new Uint8Array(data instanceof Blob ? await data.bytes() : (data as Uint8Array)));
+      const received: Received = { event, shape: shapeOf(data), bytes };
+      if (isBinary !== undefined) received.isBinary = isBinary;
+      return received;
+    }
+
+    // Collects what the server socket emits for the frames `sendFrames` puts on the wire.
+    // Resolves once `messageCount` 'message' events arrived. The frames arrive in order,
+    // so every ping/pong sent before the last message has been emitted by then.
+    async function receiveOnServer(
+      onConnection: (ws: WebSocket) => void,
+      sendFrames: (client: WebSocket) => void,
+      messageCount: number,
+    ): Promise<Received[]> {
+      const wss = new WebSocketServer({ port: 0 });
+      const { promise, resolve, reject } = Promise.withResolvers<Promise<Received>[]>();
+      const received: Promise<Received>[] = [];
+      let messages = 0;
+
+      wss.on("connection", ws => {
+        ws.on("error", reject);
+        onConnection(ws);
+        ws.on("ping", data => received.push(describeReceived("ping", data)));
+        ws.on("pong", data => received.push(describeReceived("pong", data)));
+        ws.on("message", (data, isBinary) => {
+          received.push(describeReceived("message", data, isBinary));
+          if (++messages === messageCount) resolve(received);
+        });
+      });
+
+      const client = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+      client.on("error", reject);
+      client.on("open", () => sendFrames(client));
+      try {
+        return await Promise.all(await promise);
+      } finally {
+        client.terminate();
+        wss.close();
+      }
+    }
+
+    // Like npm ws, binaryType applies to binary data frames only: ping and pong
+    // payloads are always a Buffer.
+    const serverBinaryTypes = [
+      { binaryType: "nodebuffer", shape: "Buffer" },
+      { binaryType: "arraybuffer", shape: "ArrayBuffer" },
+      { binaryType: "blob", shape: "Blob" },
+    ] as const;
+
+    it.each(serverBinaryTypes)("$binaryType: binary frames arrive as $shape", async ({ binaryType, shape }) => {
+      const received = await receiveOnServer(
+        ws => {
+          // @types/ws 8.5 does not list "blob", ws 8.18 accepts it
+          ws.binaryType = binaryType as WebSocket["binaryType"];
+        },
+        client => {
+          client.ping(Buffer.from([4]));
+          client.pong(Buffer.from([5]));
+          client.send(Buffer.from([1, 2, 3]));
+          client.send(Buffer.alloc(0));
+        },
+        2,
+      );
+
+      expect(received).toEqual([
+        { event: "ping", shape: "Buffer", bytes: [4] },
+        { event: "pong", shape: "Buffer", bytes: [5] },
+        { event: "message", shape, bytes: [1, 2, 3], isBinary: true },
+        { event: "message", shape, bytes: [], isBinary: true },
+      ]);
+    });
+
+    it("defaults to nodebuffer and applies a new value to the next message", async () => {
+      const binaryTypesSeen: string[] = [];
+      const received = await receiveOnServer(
+        ws => {
+          binaryTypesSeen.push(ws.binaryType);
+          ws.binaryType = "arraybuffer";
+          binaryTypesSeen.push(ws.binaryType);
+          ws.once("message", () => {
+            ws.binaryType = "nodebuffer";
+          });
+        },
+        client => {
+          client.send(Buffer.from([1]));
+          client.send(Buffer.from([2]));
+        },
+        2,
+      );
+
+      expect(binaryTypesSeen).toEqual(["nodebuffer", "arraybuffer"]);
+      expect(received).toEqual([
+        { event: "message", shape: "ArrayBuffer", bytes: [1], isBinary: true },
+        { event: "message", shape: "Buffer", bytes: [2], isBinary: true },
+      ]);
+    });
+  });
 });
 
 describe("Server", () => {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -383,29 +383,60 @@ describe("WebSocketServer", () => {
       ]);
     });
 
-    it("defaults to nodebuffer and applies a new value to the next message", async () => {
+    it("defaults to nodebuffer and applies a new value to the next frame", async () => {
       const binaryTypesSeen: string[] = [];
       const received = await receiveOnServer(
         ws => {
           binaryTypesSeen.push(ws.binaryType);
           ws.binaryType = "arraybuffer";
           binaryTypesSeen.push(ws.binaryType);
-          ws.once("message", () => {
-            ws.binaryType = "nodebuffer";
+          const next = ["blob", "nodebuffer"];
+          ws.on("message", () => {
+            if (next.length) ws.binaryType = next.shift() as WebSocket["binaryType"];
           });
         },
         client => {
           client.send(Buffer.from([1]));
-          client.send(Buffer.from([2]));
+          client.ping(Buffer.from([2]));
+          client.send(Buffer.from([3]));
+          client.send(Buffer.from([4]));
         },
-        2,
+        3,
       );
 
       expect(binaryTypesSeen).toEqual(["nodebuffer", "arraybuffer"]);
       expect(received).toEqual([
         { event: "message", shape: "ArrayBuffer", bytes: [1], isBinary: true },
-        { event: "message", shape: "Buffer", bytes: [2], isBinary: true },
+        // the ping arrives after the change to "blob"
+        { event: "ping", shape: "Buffer", bytes: [2] },
+        { event: "message", shape: "Blob", bytes: [3], isBinary: true },
+        { event: "message", shape: "Buffer", bytes: [4], isBinary: true },
       ]);
+    });
+
+    it("can be set after the socket closed", async () => {
+      const wss = new WebSocketServer({ port: 0 });
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      wss.on("connection", ws => {
+        ws.on("error", reject);
+        ws.on("close", () => {
+          try {
+            ws.binaryType = "arraybuffer";
+            resolve(ws.binaryType);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      const client = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+      client.on("error", reject);
+      client.on("open", () => client.close());
+      try {
+        expect(await promise).toBe("arraybuffer");
+      } finally {
+        wss.close();
+      }
     });
   });
 });

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -47,16 +47,36 @@ const buffers = [
 
 const messages = [...strings, ...buffers] as const;
 
+// One rule for the client and the server socket of the shim. `type` is the shape of a binary
+// message. npm ws emits ping and pong payloads as a Buffer in every mode. The shim keeps that
+// where it can wrap the payload synchronously. A Blob cannot be wrapped, so "blob" applies to
+// ping and pong payloads too, as it does on the native sockets.
 const binaryTypes = [
   {
     label: "nodebuffer",
     type: Buffer,
+    controlType: Buffer,
   },
   {
     label: "arraybuffer",
     type: ArrayBuffer,
+    controlType: Buffer,
+  },
+  {
+    label: "blob",
+    type: Blob,
+    controlType: Blob,
   },
 ] as const;
+
+// Names match `type.name` and `controlType.name` above. A plain Uint8Array, which is what
+// the server socket used to emit in "arraybuffer" mode, shows up as "[object Uint8Array]".
+function shapeOf(data: unknown): string {
+  if (Buffer.isBuffer(data)) return "Buffer";
+  if (data instanceof ArrayBuffer) return "ArrayBuffer";
+  if (data instanceof Blob) return "Blob";
+  return Object.prototype.toString.call(data);
+}
 
 let servers: Subprocess[] = [];
 let clients: WebSocket[] = [];
@@ -103,26 +123,41 @@ describe("WebSocket", () => {
         done();
       }
     });
-    for (const { label, type } of binaryTypes) {
+    for (const { label, type, controlType } of binaryTypes) {
       test(label, (ws, done) => {
-        ws.binaryType = label;
+        // @types/ws 8.5 does not list "blob", ws 8.18 accepts it
+        ws.binaryType = label as WebSocket["binaryType"];
+        const seen: Record<string, string> = {};
+        // The echo server answers the message, pings back when pinged and pongs back when
+        // ponged. The native client also pongs the echoed ping by itself, so the first pong
+        // is the one that gets recorded. Every one of them has the shape binaryType selects.
+        function record(event: string, data: unknown) {
+          seen[event] ??= shapeOf(data);
+          if (!(seen.message && seen.ping && seen.pong)) return;
+          try {
+            expect(seen).toEqual({
+              binaryType: label,
+              message: type.name,
+              ping: controlType.name,
+              pong: controlType.name,
+            });
+            done();
+          } catch (err) {
+            done(err);
+          }
+        }
         ws.on("open", () => {
-          expect(ws.binaryType).toBe(label);
+          seen.binaryType = ws.binaryType;
           ws.send(new Uint8Array(1));
-        });
-        ws.on("message", (data, isBinary) => {
-          expect(data).toBeInstanceOf(type);
-          expect(isBinary).toBeTrue();
           ws.ping();
-        });
-        ws.on("ping", data => {
-          expect(data).toBeInstanceOf(type);
           ws.pong();
         });
-        ws.on("pong", data => {
-          expect(data).toBeInstanceOf(type);
-          done();
+        ws.on("message", (data, isBinary) => {
+          if (isBinary) record("message", data);
+          else done(new Error(`expected a binary echo, got ${shapeOf(data)}`));
         });
+        ws.on("ping", data => record("ping", data));
+        ws.on("pong", data => record("pong", data));
       });
     }
   });
@@ -303,13 +338,6 @@ describe("WebSocketServer", () => {
   describe("binaryType", () => {
     type Received = { event: string; shape: string; bytes: number[]; isBinary?: boolean };
 
-    function shapeOf(data: unknown): string {
-      if (Buffer.isBuffer(data)) return "Buffer";
-      if (data instanceof ArrayBuffer) return "ArrayBuffer";
-      if (data instanceof Blob) return "Blob";
-      return Object.prototype.toString.call(data);
-    }
-
     async function describeReceived(event: string, data: unknown, isBinary?: boolean): Promise<Received> {
       const bytes = Array.from(new Uint8Array(data instanceof Blob ? await data.bytes() : (data as Uint8Array)));
       const received: Received = { event, shape: shapeOf(data), bytes };
@@ -352,22 +380,13 @@ describe("WebSocketServer", () => {
       }
     }
 
-    // npm ws emits ping and pong payloads as a Buffer in every mode. The shim keeps that
-    // where it can wrap the payload synchronously. A Blob cannot be wrapped, so "blob"
-    // applies to ping and pong payloads too, as it does on a Bun.serve socket.
-    const serverBinaryTypes = [
-      { binaryType: "nodebuffer", shape: "Buffer", controlShape: "Buffer" },
-      { binaryType: "arraybuffer", shape: "ArrayBuffer", controlShape: "Buffer" },
-      { binaryType: "blob", shape: "Blob", controlShape: "Blob" },
-    ] as const;
-
-    it.each(serverBinaryTypes)(
-      "$binaryType: binary frames arrive as $shape, ping and pong payloads as $controlShape",
-      async ({ binaryType, shape, controlShape }) => {
+    it.each(binaryTypes)(
+      "$label: binary frames arrive as $type.name, ping and pong payloads as $controlType.name",
+      async ({ label, type, controlType }) => {
         const received = await receiveOnServer(
           ws => {
             // @types/ws 8.5 does not list "blob", ws 8.18 accepts it
-            ws.binaryType = binaryType as WebSocket["binaryType"];
+            ws.binaryType = label as WebSocket["binaryType"];
           },
           client => {
             client.ping(Buffer.from([4]));
@@ -379,10 +398,10 @@ describe("WebSocketServer", () => {
         );
 
         expect(received).toEqual([
-          { event: "ping", shape: controlShape, bytes: [4] },
-          { event: "pong", shape: controlShape, bytes: [5] },
-          { event: "message", shape, bytes: [1, 2, 3], isBinary: true },
-          { event: "message", shape, bytes: [], isBinary: true },
+          { event: "ping", shape: controlType.name, bytes: [4] },
+          { event: "pong", shape: controlType.name, bytes: [5] },
+          { event: "message", shape: type.name, bytes: [1, 2, 3], isBinary: true },
+          { event: "message", shape: type.name, bytes: [], isBinary: true },
         ]);
       },
     );


### PR DESCRIPTION
### Problem
- The built-in `ws` package differs from npm ws 8.18.3. A server socket with `binaryType = "arraybuffer"` emits a plain `Uint8Array`, not an `ArrayBuffer`. Ping and pong payloads follow `binaryType`, npm ws emits a `Buffer`. The client socket rejects `"blob"` (#8721, #26669), which the native `WebSocket` supports.
- The server socket converted binary frames in JS (`#message`, `src/js/thirdparty/ws.js`).

### Fix
- `ServerWebSocket.binaryType` accepts `"blob"`. `binary_to_js` (`src/runtime/server/ServerWebSocket.rs`) builds the `Blob` like the other three types, so it applies to messages, pings and pongs, as on the client `WebSocket`. The stored type is a socket local enum of the four values. The old spellings still work.
- Both shim sockets forward `binaryType` to their native socket as is. The server socket no longer converts binary frames, the client socket accepts `"blob"`.
- The shared `controlPayload` wraps ping and pong payloads in a `Buffer` in `"arraybuffer"` mode, as npm ws emits one. A `Blob` cannot be unwrapped synchronously, so `"blob"` mode emits it as is.
- Verified: `test/js/first_party/ws/ws.test.ts` (one table of shapes for both sockets), `test/js/bun/websocket/websocket-server.test.ts`, `test/integration/bun-types`. Stock bun fails the `arraybuffer` and `blob` cases.

### Background
- Bun replaces npm `ws` with `src/js/thirdparty/ws.js`. `BunWebSocket` wraps the native client `WebSocket`. A server connection is a `BunWebSocketMocked` over a `Bun.serve` `ServerWebSocket`, which calls its `#message`, `#ping` and `#pong`.
- `ServerWebSocket` keeps its binary type in a 4 bit field of its packed `Flags` word. `binary_to_js` reads it for every binary frame, ping and pong.
- In npm ws, `binaryType` only changes binary data frames. Pings and pongs are a `Buffer`.

<details><summary>Notes</summary>

Repro (raw client, so the bytes are exact). It prints `Uint8Array` on Bun 1.4.0 and on main, and `ArrayBuffer` on node with ws@8.18.3 (installed in `test/node_modules`):

```js
import { WebSocketServer } from "ws";
import net from "node:net";
const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
wss.on("connection", ws => {
  ws.binaryType = "arraybuffer";
  ws.on("message", (data, isBinary) => {
    console.log(isBinary, data instanceof ArrayBuffer ? "ArrayBuffer" : data.constructor.name);
    process.exit(0);
  });
});
wss.on("listening", () => {
  const c = net.connect(wss.address().port, "127.0.0.1", () => c.write(
    "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"));
  c.once("data", () => c.write(Buffer.from([0x82, 0x83, 0, 0, 0, 0, 1, 2, 3])));
});
```

With ping, pong, binary and text frames in `arraybuffer` mode, main prints `ping: Buffer, pong: Buffer, binary: Uint8Array, text: ArrayBuffer`. node prints `Buffer, Buffer, ArrayBuffer, Buffer`. This PR fixes the binary column and keeps the ping and pong columns. The text column is the text branch of the same method. #36061 changes that branch (it also removes the remaining `new Blob` there), so this PR leaves it alone and the new tests do not assert the shape of text frames.

History of this PR:
1. a3da3e3 emitted `message.buffer` in the shim. Review asked for the `ArrayBuffer` to be created natively.
2. 5a54f28 forwarded `"arraybuffer"` to the native socket and kept wrapping `"blob"` in JS. Review asked for native blob support instead of `new Blob`.
3. 355c538 made the native socket build every type. Follow up commits: e4da89b (no constructor argument), bcc9f9f (GC size report), 18a6e57 (client socket).
4. 18a6e57 applies the same rule to the client socket. The self review of 355c538 found that the client class in the same file had the same divergences (ping and pong payloads emitted in the shape of `binaryType`, `"blob"` rejected), and that `ws.test.ts` would otherwise pin opposite rules for the two classes. The client change is the shared helper, one accepted value in the setter, and the two emit lines. #18845 is an older attempt at the client `"blob"` value from before the native client supported it, it wraps in JS and makes `send()` asynchronous. This PR makes it unnecessary.

355c538 is the current native design. The ping and pong behavior in `blob` mode is the one open question, noted in the comments below. Making `"blob"` apply to messages only would be a small change in `on_ping` and `on_pong`.

Why a socket local enum: the shared `bun_jsc::BinaryType` is also used by UDP sockets and the HTTP/2 frame parser, and it cannot build a `Blob`. Before this PR the socket stored that enum but only ever three of its values. The local enum has exactly the storable values, so the 14 arm decode, the wildcard arm in `binary_to_js` and the `panic!` arm in the getter go away. The accepted spellings are copied from the shared map for the three old values.

The shim socket no longer takes a `binaryType` constructor argument (e4da89b). Its field starts as `"nodebuffer"`, the default of the native socket, so only the setter can change the mode and the two sides cannot start out of sync. The ping and pong JSDoc in `serve.d.ts` says that the payload follows `binaryType` and that the declared `Buffer` type is the one of the default mode.

The blob arm wraps through `BlobExt::to_js` (bcc9f9f), like the slice path in `Blob.rs`. The by-value `JsClass::to_js` skips `calculate_estimated_byte_size`, so the GC would see a few bytes per frame. The test "blob frames report their bytes to the garbage collector" holds a 2 MiB blob frame and checks that `heapStats().extraMemorySize` grows by at least half of it after `Bun.gc(true)` (about 2 MiB with the fix, 663 bytes without). The bound is half the payload because memory that earlier tests release in the meantime lowers the number a little.

Behavior change for shim client users in `arraybuffer` mode: ping and pong payloads were an `ArrayBuffer` and are now a `Buffer` view of it, as in npm ws. The client test at the top of `ws.test.ts` asserted the old shape and now asserts the new one. Messages are unchanged.

Behavior change for shim users in `blob` mode: ping and pong payloads were a `Buffer` on main (the native socket stayed in `nodebuffer` mode) and are now a `Blob`. `arraybuffer` mode is unchanged for pings and pongs. `nodebuffer` mode is unchanged everywhere.

Tests:
- `ws.test.ts`: one `binaryTypes` table at the top holds the message shape and the ping/pong shape per mode. The client block (echo server subprocess) records the shapes of the echoed message, ping and pong into one object per mode. The server block runs `it.each` over the same table. The client sends a ping, a pong, a 3 byte binary frame and an empty binary frame. One `toEqual` checks the shape and the bytes of every event, plus `isBinary`, including the per mode shape of ping and pong. A second test covers the default, the getter, and a change of mode between frames (`arraybuffer`, then `blob` with a ping in between, then `nodebuffer`). A third test sets the value in the `close` listener, when the native handle is gone.
- `websocket-server.test.ts`: `blob` joins the binaryType matrix (message, ping and pong are a `Blob`, the getter returns `"blob"`). A second test checks `size`, `type` and the bytes of the three blobs. A third test pins the old spellings. A fourth test checks the GC size report described above.
- `test/integration/bun-types/fixture/serve-types.test.ts` asserts the `binaryType` union. Removing `"blob"` from the assertion fails the types test.

Without the `#ping`/`#pong` wrapping, the `arraybuffer` row of the shim matrix fails. With a setter that forwards only `"arraybuffer"`, the mode change test fails. Both were checked by mutating the source.

Suites run with the debug build: all of `ws.test.ts` (53 pass), the `binaryType` block and the `send` related tests of `websocket-server.test.ts`, the bun-types integration test, `cargo clippy -p bun_runtime -p bun_jsc`. When the whole of `websocket-server.test.ts` runs at once in this container, the 28 s `send() (benchmark)` test starves 8 concurrent siblings past their 10 s timeout. They pass when the benchmark is not in the filter, and they do not touch this change. `ws-proxy.test.ts` has 3 failures that depend on the ambient `HTTP_PROXY` variables of this container, see #37439.

Other open PRs that edit these files: #36061 (text branch of `#message`), #39802 (`#close`, `#drain`, `send()`), #39642, #36650, #39093, #39370 (`websocket-server.test.ts` fixture). None of them touches `#ping`, `#pong`, the binary branch, the `binaryType` setter or `binary_to_js`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/integration/bun-types/fixture/serve-types.test.ts test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->