### PR TITLE
bundler: reject a builtin entry point on every target, and resolve --external matches on entry points normally

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -125,6 +125,11 @@ impl ImportKind {
         matches!(self, Self::Require | Self::RequireResolve)
     }
 
+    #[inline]
+    pub fn is_entry_point(self) -> bool {
+        matches!(self, Self::EntryPointRun | Self::EntryPointBuild)
+    }
+
     pub fn is_from_css(self) -> bool {
         self == Self::AtConditional
             || self == Self::At

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -421,42 +421,50 @@ impl<'a> Transpiler<'a> {
 
     fn _resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         let top_level_dir = self.fs().top_level_dir;
-        match self.resolver.resolve_with_framework(
+        let first = match self.resolver.resolve_with_framework(
             top_level_dir,
             entry_point,
             bun_ast::ImportKind::EntryPointBuild,
         ) {
-            Ok(r) => Ok(r),
-            Err(err) => {
-                // Relative entry points that were not resolved to a node_modules package are
-                // interpreted as relative to the current working directory.
-                if !bun_paths::is_absolute(entry_point)
-                    && !(entry_point.starts_with(b"./") || entry_point.starts_with(b".\\"))
-                {
-                    let mut prefixed = Vec::with_capacity(2 + entry_point.len());
-                    prefixed.extend_from_slice(b"./");
-                    prefixed.extend_from_slice(entry_point);
-                    // `Resolver::resolve` interns the path internally,
-                    // so the heap buffer can drop after the call.
-                    if let Ok(r) = self.resolver.resolve(
-                        top_level_dir,
-                        &prefixed,
-                        bun_ast::ImportKind::EntryPointBuild,
-                    ) {
-                        return Ok(r);
-                    }
-                    // return the original error
-                }
-                Err(err.into())
+            Ok(r) if !r.flags.is_external() => return Ok(r),
+            // A data: URL whose MIME type is not code; there is no module in it.
+            Ok(r) if r.path_pair.primary.is_data_url() => {
+                Err(resolver::Error::ModuleNotFound.into())
             }
+            // A builtin. `reject_unbundleable_entry_point` reports it unless the name is also a file.
+            Ok(builtin) => Ok(builtin),
+            Err(err) => Err(err.into()),
+        };
+
+        // Relative entry points that were not resolved to a node_modules package are
+        // interpreted as relative to the current working directory.
+        if !bun_paths::is_absolute(entry_point)
+            && !(entry_point.starts_with(b"./") || entry_point.starts_with(b".\\"))
+        {
+            let mut prefixed = Vec::with_capacity(2 + entry_point.len());
+            prefixed.extend_from_slice(b"./");
+            prefixed.extend_from_slice(entry_point);
+            // `Resolver::resolve` interns the path internally,
+            // so the heap buffer can drop after the call.
+            if let Ok(r) = self.resolver.resolve(
+                top_level_dir,
+                &prefixed,
+                bun_ast::ImportKind::EntryPointBuild,
+            ) {
+                if !r.flags.is_external() {
+                    return Ok(r);
+                }
+            }
+            // return the original result
         }
+        first
     }
 
     /// Resolve an entry-point specifier, busting the directory cache and
     /// retrying once on failure before reporting the error to the log.
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
-            Ok(r) => self.reject_disabled_entry_point(r, entry_point),
+            Ok(r) => self.reject_unbundleable_entry_point(r, entry_point),
             Err(err) => {
                 let mut cache_bust_buf = bun_paths::PathBuffer::uninit();
 
@@ -511,7 +519,7 @@ impl<'a> Transpiler<'a> {
                 // Only re-query if we previously had something cached.
                 if busted {
                     if let Ok(result) = self._resolve_entry_point(entry_point) {
-                        return self.reject_disabled_entry_point(result, entry_point);
+                        return self.reject_unbundleable_entry_point(result, entry_point);
                     }
                     // ignore this error, we will print the original error
                 }
@@ -530,23 +538,28 @@ impl<'a> Transpiler<'a> {
         }
     }
 
-    /// A disabled module (no usable path) imports as `{}`, but an entry point has nothing to emit.
-    fn reject_disabled_entry_point(
+    /// A disabled module imports as `{}` and an external one stays an import. An entry point has
+    /// nothing to emit in either case. `--external` skips entry points, so external means builtin.
+    fn reject_unbundleable_entry_point(
         &self,
         resolved: resolver::Result,
         entry_point: &[u8],
     ) -> crate::Result<resolver::Result> {
-        if resolved.path_const().is_some() {
+        let is_builtin = if resolved.flags.is_external() {
+            true
+        } else if resolved.path_const().is_some() {
             return Ok(resolved);
-        }
+        } else {
+            // Stubbed builtins carry the "node" namespace; anything else came from a "browser" map.
+            resolved.path_pair.primary.namespace == b"node"
+        };
 
-        // Stubbed builtins carry the "node" namespace; anything else came from a "browser" map.
-        if resolved.path_pair.primary.namespace == b"node" {
+        if is_builtin {
             self.log_mut().add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,
                 format_args!(
-                    "Cannot use Node.js builtin \"{}\" as an entry point",
+                    "Cannot use \"{}\" as an entry point: it resolves to a builtin module",
                     bstr::BStr::new(entry_point)
                 ),
             );

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1172,8 +1172,7 @@ impl<'a> Resolver<'a> {
         // the alias first, but only follow it when it actually resolves to
         // a file on disk — a catch-all `"*": ["./types/*"]` for ambient
         // .d.ts stubs must still let real bare imports stay external.
-        if kind != ast::ImportKind::EntryPointBuild
-            && kind != ast::ImportKind::EntryPointRun
+        if !kind.is_entry_point()
             && self.opts.packages == options::Packages::External
             && is_package_path(import_path)
             && !self.matches_user_external_pattern(import_path)
@@ -1205,8 +1204,7 @@ impl<'a> Resolver<'a> {
 
         // Certain types of URLs default to being external for convenience,
         // while these rules should not be applied to the entrypoint as it is never external (#12734)
-        if kind != ast::ImportKind::EntryPointBuild
-            && kind != ast::ImportKind::EntryPointRun
+        if !kind.is_entry_point()
             && (self.is_external_pattern(import_path)
             // "fill: url(#filter);"
             || (kind.is_from_css() && import_path.starts_with(b"#"))
@@ -1804,7 +1802,8 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            if self.opts.external.abs_paths.count() > 0
+            if !kind.is_entry_point()
+                && self.opts.external.abs_paths.count() > 0
                 && self.opts.external.abs_paths.contains(import_path)
             {
                 // If the string literal in the source text is an absolute path and has
@@ -1969,9 +1968,10 @@ impl<'a> Resolver<'a> {
             }
 
             // Check for external packages first
-            if self.opts.external.node_modules.count() > 0
-            // Imports like "process/" need to resolve to the filesystem, not a builtin
-            && !import_path.ends_with(b"/")
+            if !kind.is_entry_point()
+                && self.opts.external.node_modules.count() > 0
+                // Imports like "process/" need to resolve to the filesystem, not a builtin
+                && !import_path.ends_with(b"/")
             {
                 let mut query = import_path;
                 loop {
@@ -2063,7 +2063,8 @@ impl<'a> Resolver<'a> {
             return ResultUnion::NotFound;
         };
 
-        if self.opts.external.abs_paths.count() > 0
+        if !kind.is_entry_point()
+            && self.opts.external.abs_paths.count() > 0
             && self.opts.external.abs_paths.contains(abs_path)
         {
             // If the string literal in the source text is an absolute path and has

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -302,6 +302,42 @@ describe("Bun.build", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("an entry point that resolves to a builtin or to a non-code data: URL is a build error", async () => {
+    // Runs in a child: unfixed, "bun:wrap" was dropped (the bundler registers its runtime under that
+    // name) and the others were scheduled as files. The data: URL is an image, which resolves as
+    // external like a builtin does, and was emitted as a module exporting "". It is listed next to a
+    // file because a lone data: entry point fails earlier, when the build opens its directory.
+    using dir = tempDir("build-api-builtin-entrypoint", { "valid.js": "console.log(1);" });
+    const image = "data:image/png;base64,iVBORw0KGgo=";
+    const fixture = /* ts */ `
+      const report = async (entrypoints: string[]) => {
+        const { success, outputs, logs } = await Bun.build({ entrypoints, target: "bun", throw: false });
+        return { success, outputs: outputs.length, logs: logs.map(log => [log.name, log.message]) };
+      };
+      console.log(JSON.stringify([
+        await report(["bun:wrap"]),
+        await report(["node:fs"]),
+        await report(["./valid.js", ${JSON.stringify(image)}]),
+      ]));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const failedWith = (message: string) => ({ success: false, outputs: 0, logs: [["BuildMessage", message]] });
+    expect(JSON.parse(stdout)).toEqual([
+      failedWith('Cannot use "bun:wrap" as an entry point: it resolves to a builtin module'),
+      failedWith('Cannot use "node:fs" as an entry point: it resolves to a builtin module'),
+      failedWith(`ModuleNotFound resolving "${image}" (entry point)`),
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   test("returns output files", async () => {
     Bun.gc(true);
     const build = await Bun.build({

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -449,8 +449,8 @@ describe("bundler", () => {
     target: "browser",
     bundleErrors: {
       "<bun>": [
-        `Cannot use Node.js builtin "fs" as an entry point`,
-        `Cannot use Node.js builtin "node:fs" as an entry point`,
+        `Cannot use "fs" as an entry point: it resolves to a builtin module`,
+        `Cannot use "node:fs" as an entry point: it resolves to a builtin module`,
       ],
     },
   });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1636,6 +1636,103 @@ describe("bundler", () => {
       `,
     },
   });
+  // Under --target bun/node the resolver returns a builtin as an external result. An entry point
+  // has to be bundled, so that used to be scheduled as a file named after the specifier ("File not
+  // found"). "bun:wrap" is the name the bundler registers its runtime under, so that one was dropped
+  // instead and the build failed with no entry point named.
+  itBundled("edgecase/EntryPointIsNodeBuiltinWithTargetBun", {
+    files: {
+      "/entry.ts": `console.log("never built");`,
+    },
+    entryPointsRaw: ["node:fs"],
+    target: "bun",
+    bundleErrors: {
+      "<bun>": ['Cannot use "node:fs" as an entry point: it resolves to a builtin module'],
+    },
+  });
+  itBundled("edgecase/EntryPointIsBareNodeBuiltinWithTargetNode", {
+    files: {
+      "/entry.ts": `console.log("never built");`,
+    },
+    entryPointsRaw: ["fs"],
+    target: "node",
+    bundleErrors: {
+      "<bun>": ['Cannot use "fs" as an entry point: it resolves to a builtin module'],
+    },
+  });
+  itBundled("edgecase/EntryPointIsBunWrap", {
+    files: {
+      "/entry.ts": `console.log("never built");`,
+    },
+    entryPointsRaw: ["bun:wrap"],
+    target: "bun",
+    bundleErrors: {
+      "<bun>": ['Cannot use "bun:wrap" as an entry point: it resolves to a builtin module'],
+    },
+  });
+  itBundled("edgecase/EntryPointIsBunBuiltinNextToRealEntryPoint", {
+    files: {
+      "/entry.ts": `console.log("built");`,
+    },
+    entryPoints: ["/entry.ts"],
+    entryPointsRaw: ["bun"],
+    outdir: "/out",
+    target: "bun",
+    bundleErrors: {
+      "<bun>": ['Cannot use "bun" as an entry point: it resolves to a builtin module'],
+    },
+  });
+  // A package.json "imports" entry that maps to a builtin resolves to the same external result.
+  itBundled("edgecase/EntryPointIsImportsAliasOfBuiltin", {
+    files: {
+      "/package.json": `{ "name": "app", "imports": { "#fs": "node:fs" } }`,
+      "/entry.ts": `console.log("never built");`,
+    },
+    entryPointsRaw: ["#fs"],
+    target: "bun",
+    bundleErrors: {
+      "<bun>": ['Cannot use "#fs" as an entry point: it resolves to a builtin module'],
+    },
+  });
+  // A bare entry point is retried as "./<name>" when it does not resolve to a package. A name that
+  // is also a builtin takes the same retry instead of failing.
+  itBundled("edgecase/EntryPointNamedLikeBuiltinIsALocalFile", {
+    files: {
+      "/util.ts": `console.log("local util");`,
+    },
+    entryPointsRaw: ["util"],
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out/util.js").toContain("local util");
+    },
+  });
+  // --external applies to imports, not to entry points (#12734 did this for the patterns). An exact
+  // match on the entry point's package name used to come back as the same unbundleable external result.
+  itBundled("edgecase/EntryPointIsExternalPackage", {
+    files: {
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "main": "index.js" }`,
+      "/node_modules/pkg/index.js": `console.log("bundled pkg");`,
+    },
+    entryPointsRaw: ["pkg"],
+    external: ["pkg"],
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out/node_modules/pkg/index.js").toContain("bundled pkg");
+    },
+  });
+  // An exact match on the entry point's own file resolved to an external result too. That one was
+  // bundled, but without the package.json and tsconfig the normal resolution attaches.
+  itBundled("edgecase/EntryPointIsExternalFile", {
+    files: {
+      "/entry.tsx": `console.log(<div />);`,
+      "/tsconfig.json": `{ "compilerOptions": { "jsx": "react", "jsxFactory": "h" } }`,
+    },
+    external: ["./entry.tsx"],
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("h(");
+    },
+  });
   itBundled("edgecase/IntegerUnderflow#12547", {
     files: {
       "/entry.js": `

--- a/test/js/web/workers/worker-entry-point.test.ts
+++ b/test/js/web/workers/worker-entry-point.test.ts
@@ -47,4 +47,22 @@ describe.concurrent("package.json imports alias as the entry point", () => {
     expect(stdout).toBe("message: hi\nclosed\n");
     expect(exitCode).toBe(0);
   });
+
+  test("an alias of a builtin fires the error event", async () => {
+    // `new Worker("node:fs")` fails to resolve. An alias of a builtin resolves to the builtin marked
+    // external, and that used to start a worker running node:fs as its entry point.
+    const { stdout, stderr, exitCode } = await runWorkerFixture({
+      "package.json": JSON.stringify({ name: "app", imports: { "#fs": "node:fs" } }),
+      "main.js": `
+        const worker = new Worker("#fs");
+        worker.addEventListener("error", event => console.log("error:", event.message));
+        worker.addEventListener("close", () => console.log("closed"));
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      'error: BuildMessage: Cannot use "#fs" as an entry point: it resolves to a builtin module\nclosed\n',
+    );
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun build --target=bun node:fs` (also `--target=node fs`, and `Bun.build()`) schedules the specifier as a file. A debug build aborts with `panic: assertion failed: crate::is_absolute(self.text)` in `Path::assert_file_path_is_absolute`, from `BundleV2::enqueue_entry_item`. A release build prints `File not found "node:fs"`. Still the case on main after #39799.
- `bun build --target=bun bun:wrap` is dropped instead (the runtime is registered under that name). Main fails it with the backstop from #39799, which does not name the entry point.
- Cause: under `--target bun`/`node` the resolver returns a builtin as an external result with the bare specifier as its path (`src/resolver/resolver.rs:1141`). An exact `--external` match on an entry point came back the same way (`:1971`, `:1805`, `:2066`). `resolve_entry_point` accepted both.

### Fix
- The resolver skips the exact `--external` matches for an entry point, as it already skips the patterns (#12734, `resolver.rs:1207`). `--external pkg pkg` now bundles `pkg`. `--external ./a.tsx ./a.tsx` was bundled from the external result, which ignored its tsconfig. It now resolves normally.
- A builtin is now the only external result an entry point can get. `_resolve_entry_point` tries a bare name as `./name` first, as it does for a name that is not a package, so `bun build util` builds a local `util.ts`. Otherwise the helper from #39799 that rejects a disabled entry point rejects it too.
- One message for both: `Cannot use "fs" as an entry point: it resolves to a builtin module`. The browser wording from #39799 said `Node.js builtin`, which does not fit `bun:sqlite`, so it changes to this one (`bundler_browser.test.ts` updated). A `data:` URL that is not code is the one other external result and is reported as `ModuleNotFound`.
- Correct because an entry point has to be parsed, and an external result is the one thing the bundler leaves unparsed. Every caller shares this function: `new Worker("#fs")`, with an `imports` alias of `node:fs`, now fires an error event like `new Worker("node:fs")`.
- Verified: `test/bundler/bundler_edgecase.test.ts` (8 cases), `bun-build-api.test.ts`, `workers/worker-entry-point.test.ts`, all red with this PR's `src/` stashed on main. Other suites: see the notes.

### Background
- Under `--target bun`/`node` a builtin stays an import in the output. The resolver returns it with the `IS_EXTERNAL` flag. The import code checks the flag. The entry point code did not.
- `--external` is two exact match sets (package names, absolute files) plus wildcard patterns. Only the patterns had the entry point exemption.
- The worker case exposed a resolver leak on the ASAN lanes. #39947 (merged) fixed it, and this PR's worker case sits next to that one in `worker-entry-point.test.ts`.

<details><summary>Notes</summary>

Behaviour per input on main (4448a2e, debug build unless noted) and on this branch:

```sh
bun build --target=bun node:fs          # assert (release: File not found "node:fs")    -> Cannot use "node:fs" as an entry point: it resolves to a builtin module
bun build --target=node fs              # same                                          -> same error
bun build --target=bun bun:wrap         # assert (release: None of the entry points could be bundled) -> error naming "bun:wrap"
bun build --target=bun '#fs'            # same as node:fs, with "imports": {"#fs": "node:fs"} -> error naming "#fs"
bun build --target=bun util             # util.ts present: assert / File not found        -> bundles util.ts
bun build --external pkg pkg            # assert / File not found "pkg"                   -> bundles node_modules/pkg (not installed: ModuleNotFound resolving "pkg" (entry point))
bun build --external ./a.tsx ./a.tsx    # bundled, tsconfig jsxFactory ignored            -> bundled with it
bun build --external a.ts a.ts          # assert (release: read "a.ts" relative to the cwd) -> resolved as ./a.ts
bun build ./valid.js 'data:image/png;base64,...'   # emitted a module exporting "" into a directory named data:image -> ModuleNotFound resolving "data:image/..." (entry point)
bun build --target=browser fs           # Cannot use Node.js builtin "fs" as an entry point (#39799) -> the unified message
```

A lone `data:` entry point fails before resolution, when the build opens its root directory. It only reaches this code next to another entry point.

Shape: an earlier revision of this PR added its own check and error variant next to #39799's helper and moved the length guard, which #39799 then landed. Both are gone. The transpiler delta is now the `./name` retry for a builtin result, the data: URL arm, and the `is_external()` arm in the helper. The disabled result keeps #39799's flow (no retry, reported at once). A builtin result takes the retry first because, unlike a disabled file, a bare builtin name is routinely also a local file name.

`--no-bundle` resolves entry points on its own (`Transpiler::enqueue_entry_points`) without `mark_builtins_as_external`, so it reports `node:fs` as `ModuleNotFound` today. #38752 moves it onto `resolve_entry_point`. The plugin path that marks an entry point external (`on_resolve`) is covered by #39799.

Worker preloads resolve through the same function. A preload given as an `imports` alias of a builtin now fails to resolve, as a bare `fs` or `bun:sqlite` preload already does. Only `node:` prefixed preloads skip the resolver.

Suites run on the debug build of this branch: `bundler_edgecase`, `bun-build-api`, `bundler_browser` (each in full), `bundler_plugin`, `esbuild/packagejson`, `cli`, `worker-entry-point`. The worker case is in the file #39947 added instead of `worker.test.ts`: three stress cases there go over their budget on a debug build on a slow machine, which hides whether a new case flips. The earlier revision also ran `esbuild/default`, `bundler_npm`, `bundler_regressions`, `bundler_naming`, `bundler_html`, `test/js/bun/resolve/`, `bake/dev/bundle`, `bake/dev-and-prod` with the same resolver change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts, test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
