### PR TITLE
Read user-defined accessors of builtin ES modules at load time, not while an importer links

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -1160,7 +1160,7 @@ JSC::JSObject* generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobal
     object->getOwnNonIndexPropertyNames(globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    return exportObjectProperties(vm, object, propertyNames, exportNames, exportValues);
+    RELEASE_AND_RETURN(scope, exportObjectProperties(globalObject, object, propertyNames, exportNames, exportValues));
 }
 
 } // namespace Zig

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -123,8 +123,9 @@ static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateIntern
             PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty);
             bool hasOwn = object->methodTable()->getOwnPropertySlot(object, globalObject, entry, slot);
             RETURN_IF_EXCEPTION(throwScope, nullptr);
-            if (hasOwn && !slot.isValue()) {
-                // Accessors are how builtins defer loading (fs.ReadStream pulls in node:stream); JSC reads them off `object` on first binding.
+            // Accessors are how builtins defer loading (fs.ReadStream pulls in node:stream); JSC reads them off `object` on
+            // first binding. An accessor user code defined on the exports object is read now instead (see isBunDefinedGetter).
+            if (hasOwn && (slot.isCustom() || (slot.isAccessor() && Zig::isBunDefinedGetter(slot.getterSetter()->getter())))) {
                 exportValues.append(JSValue());
                 hasLazyExports = true;
                 continue;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1227,7 +1227,7 @@ JSC::JSObject* generateNativeModule_NodeModule(JSC::JSGlobalObject* lexicalGloba
         properties.add(Identifier::fromString(vm, entry.m_key));
     }
 
-    return exportObjectProperties(vm, constructor, properties, exportNames, exportValues);
+    return exportObjectProperties(globalObject, constructor, properties, exportNames, exportValues);
 }
 
 } // namespace Zig

--- a/src/jsc/modules/NodeProcessModule.h
+++ b/src/jsc/modules/NodeProcessModule.h
@@ -18,7 +18,7 @@ DEFINE_LAZY_NATIVE_MODULE(NodeProcess)
     process->getPropertyNames(globalObject, properties, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    return exportObjectProperties(vm, process, properties, exportNames, exportValues);
+    RELEASE_AND_RETURN(scope, exportObjectProperties(globalObject, process, properties, exportNames, exportValues));
 }
 
 } // namespace Zig

--- a/src/jsc/modules/_NativeModule.h
+++ b/src/jsc/modules/_NativeModule.h
@@ -1,6 +1,8 @@
 // clang-format off
 #pragma once
 #include "JSBuffer.h"
+#include <JavaScriptCore/GetterSetter.h>
+#include <JavaScriptCore/JSFunctionInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/PropertyNameArray.h>
@@ -142,17 +144,34 @@ JSC::JSObject* generateNativeModule_##enumName( \
   JSC::MarkedArgumentBuffer &exportValues);
 BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(FORWARD_DECL_LAZY_GENERATOR)
 
+// An export declared without a value is read off its object by JSC while a module that imports it is
+// being linked (SyntheticModuleRecord::materializeLazyExport, called from
+// CyclicModuleRecord::initializeEnvironment). Linking cannot run user code: a getter that require()s
+// an ES module starts a second link() inside the one in progress, and once either of them fails, the
+// records they leave behind crash the next import() that evaluates them. So only a getter that is
+// Bun's own (native, or compiled from src/js) may be deferred; an accessor user code defined is read
+// while the module loads, as every export was before exports became lazy.
+inline bool isBunDefinedGetter(JSC::JSObject *getter) {
+  auto *function = dynamicDowncast<JSC::JSFunction>(getter);
+  return function && (function->isNonBoundHostFunction() || function->isBuiltinFunction());
+}
+
 // The lazy modules each mirror an object that already exists (the Bun object, process, the Module
-// constructor): `default` is the object and each of propertyNames is an export. A value that is
-// already stored on the object is exported as is. Anything else, i.e. a static table entry nothing
-// has read yet, an accessor, or an inherited property, is declared without a value, and JSC reads
-// object[name] when something first binds to it, so loading the module does not construct the
-// object's lazy properties. Returns the object, as the LazySyntheticSourceGenerator contract wants.
+// constructor): `default` is the object and each of propertyNames is an export. An export is
+// declared without a value, so that JSC reads object[name] when something first binds to it, only
+// when Bun's own code produces the value: a static table entry nothing has constructed yet or a
+// native accessor (see isBunDefinedGetter). Loading the module therefore does not construct the
+// object's lazy properties. A value already stored on the object, an accessor user code defined and
+// a property inherited from the prototype chain are read now. Returns the object, as the
+// LazySyntheticSourceGenerator contract wants, or nullptr if reading a property threw.
 inline JSC::JSObject *exportObjectProperties(
-    JSC::VM &vm, JSC::JSObject *object,
+    JSC::JSGlobalObject *globalObject, JSC::JSObject *object,
     const JSC::PropertyNameArrayBuilder &propertyNames,
     Vector<JSC::Identifier, 4> &exportNames,
     JSC::MarkedArgumentBuffer &exportValues) {
+  auto &vm = JSC::getVM(globalObject);
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
   exportNames.reserveCapacity(propertyNames.size() + 1);
   exportValues.ensureCapacity(propertyNames.size() + 1);
 
@@ -162,11 +181,25 @@ inline JSC::JSObject *exportObjectProperties(
   for (const auto &propertyName : propertyNames) {
     if (propertyName == vm.propertyNames->defaultKeyword) [[unlikely]]
       continue;
-    JSC::JSValue stored = object->getDirect(vm, propertyName);
-    if (stored && (stored.isGetterSetter() || stored.isCustomGetterSetter()))
-      stored = JSC::JSValue();
+    JSC::JSValue value = object->getDirect(vm, propertyName);
+    bool deferred;
+    if (value) {
+      deferred = value.isCustomGetterSetter() ||
+                 (value.isGetterSetter() &&
+                  isBunDefinedGetter(uncheckedDowncast<JSC::GetterSetter>(value)->getter()));
+    } else {
+      deferred = object->hasNonReifiedStaticProperties() &&
+                 object->findPropertyHashEntry(propertyName).has_value();
+    }
+    if (deferred) {
+      value = JSC::JSValue();
+    } else if (!value || value.isGetterSetter()) {
+      // Inherited, or an accessor user code defined: read it here, outside of any link().
+      value = object->get(globalObject, propertyName);
+      RETURN_IF_EXCEPTION(scope, nullptr);
+    }
     exportNames.append(propertyName);
-    exportValues.append(stored);
+    exportValues.append(value);
   }
 
   return object;

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -513,3 +513,163 @@ test.concurrent("node:module: linking constructs the linked bindings, not the re
     resolveFilename: true,
   });
 });
+
+// Only exports whose value comes from Bun's own code (a static table entry, a native accessor, a getter compiled from
+// src/js) are declared lazily. A lazy export is materialized by JSC while the module importing it is being linked, and
+// linking must not run user code (see the re-entrancy tests below), so an accessor that user code defined on the
+// object is read when the builtin loads instead, the way every export used to be.
+
+test.concurrent("node:process: a user-defined accessor is read when the module loads, builtins stay lazy", async () => {
+  const result = await runEntry(`
+    import { constructedOnProcess, print } from "./native-helper.mjs";
+    let reads = 0;
+    Object.defineProperty(process, "userDefined", { enumerable: true, configurable: true, get: () => ++reads });
+    // Nothing binds to userDefined here: a lazy export would not be read at all.
+    const ns = await import("node:process");
+    print({
+      readsAfterLoad: reads,
+      afterLoad: constructedOnProcess(),
+      value: ns.userDefined,
+      readsAfterRead: reads,
+      on: ns.on === process.on,
+    });
+  `);
+  expect(result).toEqual({ readsAfterLoad: 1, afterLoad: [], value: 1, readsAfterRead: 1, on: true });
+});
+
+test.concurrent("node:fs: a user-defined accessor is read when the module loads, fs's own stay lazy", async () => {
+  const result = await runEntry(`
+    const fs = require("node:fs");
+    let reads = 0;
+    Object.defineProperty(fs, "userDefined", { enumerable: true, configurable: true, get: () => ++reads });
+    const ns = await import("node:fs");
+    console.log(JSON.stringify({
+      readsAfterLoad: reads,
+      readStreamStillAnAccessor: typeof Object.getOwnPropertyDescriptor(fs, "ReadStream").get === "function",
+      value: ns.userDefined,
+      readsAfterRead: reads,
+    }));
+  `);
+  expect(result).toEqual({ readsAfterLoad: 1, readStreamStillAnAccessor: true, value: 1, readsAfterRead: 1 });
+});
+
+test.concurrent("a user-defined getter can itself load the modules that import the export it backs", async () => {
+  // Read while E.mjs linked, the require() evaluated E.mjs inside that link, before the binding it imports had a
+  // value: "Cannot access 'userDefined' before initialization". Read while node:process loads, the require() loads
+  // E.mjs and X.mjs against the finished binding, and the import() of E.mjs that is under way picks them up.
+  const result = await runEntry(
+    `
+      import { print } from "./native-helper.mjs";
+      const log = (globalThis.log = []);
+      Object.defineProperty(process, "userDefined", {
+        enumerable: true,
+        configurable: true,
+        get() {
+          if (!log.includes("getter")) {
+            log.push("getter");
+            log.push("require(X) -> " + require("./X.mjs").x);
+          }
+          return "value";
+        },
+      });
+      const { e } = await import("./E.mjs");
+      const { x } = await import("./X.mjs");
+      print({ log, e, x });
+    `,
+    {
+      "E.mjs": `import { userDefined } from "node:process";\nglobalThis.log.push("E: " + userDefined);\nexport const e = 1;`,
+      "X.mjs": `import "./E.mjs";\nglobalThis.log.push("X");\nexport const x = 2;`,
+    },
+  );
+  expect(result).toEqual({ log: ["getter", "E: value", "X", "require(X) -> 2"], e: 1, x: 2 });
+});
+
+// The getter of a user-defined accessor that is exported by a builtin. It require()s Q.mjs and then throws.
+//
+// When the accessor was read while E.mjs was being linked, the require() linked Q.mjs, Y.mjs and X.mjs inside that
+// link. X.mjs imports E.mjs, which was still linking, so X.mjs was marked linked on its own; Y.mjs then threw while
+// Q.mjs evaluated, so X.mjs did not evaluate. The getter's throw failed E.mjs's link, which reset E.mjs to unlinked.
+// import("./X.mjs") afterwards had nothing left to link, evaluated X.mjs and with it the unlinked E.mjs, and
+// segfaulted in JSModuleRecord::evaluate. Read while the builtin loads, the getter runs before anything links against
+// the builtin, and its throw fails the builtin's load: every import that depends on it rejects with the getter's error.
+const throwingGetter = `{
+  enumerable: true,
+  configurable: true,
+  get() {
+    try {
+      require("./Q.mjs");
+    } catch {}
+    throw new Error("getter throws");
+  },
+}`;
+
+const linkReentrancyCases: {
+  name: string;
+  install: string;
+  exportName: string;
+  importFrom: string;
+  files?: Record<string, string>;
+}[] = [
+  {
+    name: "node:process, an accessor on process",
+    install: `Object.defineProperty(process, "userDefined", ${throwingGetter});`,
+    exportName: "userDefined",
+    importFrom: "node:process",
+  },
+  {
+    name: "node:process, an accessor process inherits from EventEmitter.prototype",
+    install: `Object.defineProperty(require("node:events").prototype, "userDefined", ${throwingGetter});`,
+    exportName: "userDefined",
+    importFrom: "node:process",
+  },
+  {
+    name: "node:module, a static table entry redefined as an accessor",
+    install: `Object.defineProperty(require("node:module"), "globalPaths", ${throwingGetter});`,
+    exportName: "globalPaths",
+    importFrom: "node:module",
+  },
+  {
+    name: '"bun", an accessor on the Bun object, bound through export *',
+    install: `Object.defineProperty(Bun, "userDefined", ${throwingGetter});`,
+    exportName: "userDefined",
+    importFrom: "./reexport.mjs",
+    files: { "reexport.mjs": bunReexport },
+  },
+  {
+    name: "node:fs, an accessor on the exports object of a src/js builtin",
+    install: `Object.defineProperty(require("node:fs"), "userDefined", ${throwingGetter});`,
+    exportName: "userDefined",
+    importFrom: "node:fs",
+  },
+];
+
+for (const { name, install, exportName, importFrom, files } of linkReentrancyCases) {
+  test.concurrent(`a user-defined getter does not run while a module links: ${name}`, async () => {
+    const result = await runEntry(
+      `
+        ${install}
+        const result = {};
+        try {
+          await import("./E.mjs");
+          result.E = "evaluated";
+        } catch (error) {
+          result.E = error.message;
+        }
+        try {
+          result.X = (await import("./X.mjs")).x;
+        } catch (error) {
+          result.X = error.message;
+        }
+        console.log(JSON.stringify(result));
+      `,
+      {
+        ...files,
+        "E.mjs": `import { ${exportName} } from ${JSON.stringify(importFrom)};\nexport const e = 1;`,
+        "X.mjs": `import "./E.mjs";\nexport const x = "evaluated";`,
+        "Q.mjs": `import "./Y.mjs";\nimport "./X.mjs";`,
+        "Y.mjs": `throw new Error("Y.mjs throws while evaluating");`,
+      },
+    );
+    expect(result).toEqual({ E: "getter throws", X: "getter throws" });
+  });
+}


### PR DESCRIPTION
### Problem
- A user-defined accessor on `process`, `Bun`, `Module` or a `src/js` builtin's exports is exported lazily. Its getter runs while the importing module links. If it `require()`s an ES module and throws, the next `import()` crashes: `panic(main thread): Segmentation fault at address 0x0` in `Interpreter::executeModuleProgram`, from `JSModuleRecord::evaluate` with a null environment. Sentry BUN-4MT4, new in 1.4.0.
- Cause: `exportObjectProperties` (`src/jsc/modules/_NativeModule.h:165`) and `generateInternalModuleSourceCode` (`src/jsc/bindings/ModuleLoader.cpp:126`) defer every accessor. The `require()` nests a second `link()` in the first. It skips the outer module and marks its importer `Linked`. The outer link then fails and leaves that importer pointing at an `Unlinked` record.

### Fix
- Both generators defer an export only when Bun's own code produces the value: an unconstructed static table entry, a native accessor, or a getter that is a host function or compiled from `src/js` (`isBunDefinedGetter`). User-defined accessors and inherited properties are read while the builtin loads, as in 1.3. No `link()` runs there.
- Bun's own getters do not load ES modules, so a `link()` can no longer nest another one. A user getter that throws now fails the builtin's load.
- Verified: 8 new tests in `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` fail on 1.4.0 (5 segfault), the 15 laziness tests still pass. Other suites are in the notes.

### Background
- The builtins are `SyntheticModuleRecord`s. Since #37525, #37714 and #37726 (1.4.0) a generator may leave an export empty. JSC then reads `object[name]` when a module first binds to it, so importing `node:process` does not construct `process.stdout`.
- That read is in `CyclicModuleRecord::initializeEnvironment`, inside `link()`. The spec runs no user code while linking, so JSC only asserts what a nested link breaks.
- `JSFunction::isBuiltinFunction()` is true for functions compiled from the bundled `src/js` sources. `isNonBoundHostFunction()` excludes a bound user function.

<details><summary>Notes</summary>

Repro shape (the five segfault tests): `E.mjs` imports the user accessor from the builtin. The getter `require()`s `Q.mjs`, which imports `Y.mjs` (throws while evaluating) and `X.mjs` (imports `E.mjs`), then throws. `import("./E.mjs")` rejects with the getter's error, and `import("./X.mjs")` segfaulted. The five variants: an own accessor on `process`, an accessor `process` inherits from `EventEmitter.prototype`, a `Module` static table entry redefined as an accessor, an accessor on `Bun` bound through `export * from "bun"`, and an accessor on `require("node:fs")`. With the fix, both imports reject with `getter throws`.

The nested link in detail: the inner `innerModuleLinking` reaches `E.mjs`, which is `Linking` on the outer stack, and treats it as done (the spec allows that only for a cycle on the same stack), so `X.mjs` becomes `Linked` on its own. The getter's throw fails `E.mjs`'s `initializeEnvironment` after step 5 created its executable, so `link()` resets `E.mjs` to `Unlinked` and the environment is cleared. `import("./X.mjs")` has nothing to link and evaluates `E.mjs` through `X.mjs`. `innerModuleEvaluation` only checks for `Evaluating` and `Evaluated` in release builds, and `JSModuleRecord::evaluate` passes the null environment on.

A second symptom of the same cause, without a throw: a getter that `require()`s a module which imports the export the getter backs got `Cannot access 'userDefined' before initialization`, because the nested link evaluated the importer before the binding had a value. Covered by the "can itself load the modules" test. The other two new tests count getter calls: a namespace import of the builtin reads a user accessor once at load, while `process` constructs nothing and `fs.ReadStream` stays an accessor.

A user getter that throws during the load: 1.3 exported `undefined` for `node:process` and `node:module`, and failed the load for `"bun"` and the `src/js` builtins. This change fails the load everywhere. Only user getters are read here, so the error is the user's own.

`src/js` getters are builtin functions because `InternalModuleRegistry.cpp` compiles each module with `createBuiltinExecutable`. A survey of the builtins importable as ESM found 36 accessor exports: 23 `src/js` getters and 13 native accessors (`process`, `Module`, `Bun.main`, `buffer.INSPECT_MAX_BYTES`). All of them stay lazy. Inherited properties of `process` are the EventEmitter methods, all data properties, so reading them at load costs 16 lookups.

Pre-existing observation: when the getter's `require()` leads back to the builtin whose generator is running (the "can itself load" test), the synchronous loader runs the generator a second time. The generators are idempotent (cached default objects, `requireId`), both test modules evaluate once, and the value the test reads does not depend on it.

The JSC side is not changed here. `innerModuleEvaluation` could reject a record that is not `Linked` in release builds, and `JSModuleRecord::evaluate` could check for a null environment, so that this class of bug throws instead of crashing. That is a change in oven-sh/WebKit plus a version bump, separate from this fix.

Also run on this build: `test/js/bun/resolve/`, `test/js/node/module/`, `test/js/node/process/`, `test/js/node/events/event-emitter.test.ts`, `test/js/bun/util/BunObject.test.ts`, `test/js/bun/test/mock/mock-module.test.ts`, and `BUN_JSC_validateExceptionChecks=1` over all four generators with user accessors installed, including one that throws. Environmental failures, identical without the change: `process.test.js` "process" (`$USER` unset), `process-args.test.js` "args exclude run" (100 debug spawns in 5 s), `stdin/stdin-fixtures.test.ts` (it kills the child after 1 s, and a debug start takes 1.1 s here), and `load the same empty JS file 2000 times` in `test/js/bun/resolve/`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
bun test v1.4.0 (4199361ed)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [818.43ms]
(pass) a named import materializes exactly the binding it links [1061.02ms]
(pass) a namespace export materializes when it is read, not on import or `in` [1072.09ms]
(pass) a deferred namespace (import defer) materializes on read as well [1084.02ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [1169.43ms]
(pass) "bun": re-exports construct the properties that get bound, not the rest of the object [662.57ms]
(pass) re-exports bind through to the builtin's own binding [1130.69ms]
(pass) "bun": import() namespace has the same export list, and every export is the Bun.* value [737.49ms]
(pass) "bun": a property whose getter throws only fails the binding that reads it [336.78ms]
(pass) spyOn and mock.module on an imported builtin [1120.22ms]
(pass) node:process: a value already stored on the obj
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (0a4e3b1e1)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [32.87ms]
(pass) a namespace export materializes when it is read, not on import or `in` [29.49ms]
(pass) a named import materializes exactly the binding it links [34.34ms]
(pass) re-exports bind through to the builtin's own binding [30.79ms]
(pass) a deferred namespace (import defer) materializes on read as well [31.90ms]
(pass) "bun": a property whose getter throws only fails the binding that reads it [24.19ms]
(pass) "bun": re-exports construct the properties that get bound, not the rest of the object [25.93ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [31.42ms]
(pass) "bun": mock.module replaces a binding without constructing the property it shadows [21.43ms]
532 |       value: ns.userDefined,
533 |       readsAfterRead: reads,
534 |       on: ns.on === process.on,
535 |     });
536 |   `);
537 |   expect(result).toEqual({ readsAfterLoad: 1, afterLoad: [], value: 1, readsAfterRead: 1, on: true });
                       ^
error: expect(received).toEqual(expected)

  {
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
bun test v1.4.0 (4199361ed)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [835.77ms]
(pass) a named import materializes exactly the binding it links [1064.32ms]
(pass) a namespace export materializes when it is read, not on import or `in` [1071.29ms]
(pass) a deferred namespace (import defer) materializes on read as well [1091.55ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [1182.08ms]
(pass) "bun": re-exports construct the properties that get bound, not the rest of the object [651.35ms]
(pass) re-exports bind through to the builtin's own binding [1105.02ms]
(pass) "bun": import() namespace has the same export list, and every export is the Bun.* value [740.68ms]
(pass) "bun": a property whose getter throws only fails the binding that reads it [333.97ms]
(pass) spyOn and mock.module on an imported builtin [1087.35ms]
(pass) node:process: a value already stored on the obj
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e726305a97
  features     baseline

23 deps, 120 codegen, 1172 objects in 788ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1235] install /workspace/bun
bun install v1.4.0-canary.1 (0a4e3b1e1)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[2/1235] gen bindgenv2
[3/1235] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (0a4e3b1e1)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1235] gen ErrorCode+*.h
[5/1235] fetch tinycc
[tinycc] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (0a4e3b1e1)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1207] fetch zlib
[zlib] up to date
[9/1207] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1207] gen .bind.ts → GeneratedBindings.cpp
[11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunObject.cpp                     |   2 +-
 src/jsc/bindings/ModuleLoader.cpp                  |   5 +-
 src/jsc/modules/NodeModuleModule.cpp               |   2 +-
 src/jsc/modules/NodeProcessModule.h                |   2 +-
 src/jsc/modules/_NativeModule.h                    |  53 +++++--
 .../bun/resolve/builtin-esm-lazy-exports.test.ts   | 160 +++++++++++++++++++++
 6 files changed, 209 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/BunObject.cpp                            1      1      0
src/jsc/bindings/ModuleLoader.cpp                         3      1      0
src/jsc/modules/NodeModuleModule.cpp                      1      1      0
src/jsc/modules/NodeProcessModule.h                       1      1      0
src/jsc/modules/_NativeModule.h                           2      5      0
test/js/bun/resolve/builtin-esm-lazy-exports.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->