### PR TITLE
runner: retry and report a failed vendor checkout instead of failing the shard

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -86,6 +86,10 @@ const spawnTimeout = 5_000;
 const spawnBunTimeout = 20_000; // when running with ASAN/LSAN bun can take a bit longer to exit, not a bug.
 const testTimeout = 3 * 60_000;
 const integrationTimeout = 5 * 60_000;
+// Per git command of a vendor checkout. The whole checkout takes about 3s on
+// the darwin agents; a command that stalls is given up on and retried rather
+// than waited out.
+const vendorGitTimeout = 60_000;
 
 const resolutionGatingFlags = new Set([
   "--expose-internals",
@@ -550,7 +554,8 @@ async function runTests() {
   // owns every `docker compose` invocation for this shard — `compose up` is
   // not concurrency-safe, so exactly one process runs it — and prestarts the
   // services this shard's tests need (mysql/postgres/redis/minio/…) in the
-  // background while getVendorTests below installs vendor deps. Tests reach
+  // background while the tests that don't need them run (getRelevantTests
+  // sorts the docker-backed files last). Tests reach
   // it through the unix socket in BUN_DOCKER_COORDINATOR (inherited by every
   // spawned test process); ensure() waits for the coordinator's ready message
   // instead of shelling out to compose itself. Without the env var, ensure()
@@ -605,19 +610,17 @@ async function runTests() {
     coordinator.stdout?.unref?.();
   }
 
-  /** @type {VendorTest[] | undefined} */
-  let vendorTests;
-  let vendorTotal = 0;
+  /** @type {Vendor[]} */
+  let vendors = [];
   if (/true|1|yes|on/i.test(options["vendor"]) || (isCI && typeof options["vendor"] === "undefined")) {
-    vendorTests = await getVendorTests(cwd);
-    if (vendorTests.length) {
-      vendorTotal = vendorTests.reduce((total, { testPaths }) => total + testPaths.length + 1, 0);
-      !isQuiet && console.log("Running vendor tests:", vendorTotal);
-    }
+    vendors = getVendors(cwd);
+    !isQuiet && console.log("Running vendors:", vendors.length);
   }
 
   let i = 0;
-  let total = vendorTotal + tests.length + 2;
+  // Per vendor: the checkout, install and build steps. Its test files are
+  // added once the checkout exists.
+  let total = tests.length + 2 + vendors.length * 3;
 
   const okResults = [];
   const flakyResults = [];
@@ -1174,51 +1177,66 @@ async function runTests() {
     await Promise.all(parallelSafeTests.map(t => parallelSafeLimit(() => runOneTest(t, parallelSafeWidth > 1))));
   }
 
-  if (vendorTests?.length) {
-    for (const { cwd: vendorPath, packageManager, testRunner, testPaths } of vendorTests) {
-      if (!testPaths.length) {
+  // A vendor's setup steps (checkout, install, build) go through runTest like
+  // its test files: a failure is retried, then reported, and skips only that
+  // vendor. Throwing instead would lose the summary, JUnit upload and exit
+  // code of everything that ran above.
+  for (const vendor of vendors) {
+    const { package: name, packageManager = "bun", testRunner = "bun" } = vendor;
+    const vendorPath = join(cwd, "vendor", name);
+    const vendorTitle = relative(cwd, vendorPath).replace(/\\/g, "/");
+
+    const checkout = await runTest(vendorTitle, () => spawnVendorCheckout(vendor, vendorPath));
+    if (!checkout.ok) {
+      continue;
+    }
+
+    const testPaths = getVendorTestPaths(vendor, vendorPath);
+    !isQuiet && console.log("Running vendor tests:", vendorTitle, testPaths.length);
+    if (!testPaths.length) {
+      continue;
+    }
+    total += testPaths.length;
+
+    if (packageManager === "bun") {
+      const { ok } = await runTest(`${vendorTitle}/package.json`, () => spawnBunInstall(execPath, { cwd: vendorPath }));
+      if (!ok) {
         continue;
       }
+    } else {
+      throw new Error(`Unsupported package manager: ${packageManager}`);
+    }
 
-      const packageJson = join(relative(cwd, vendorPath), "package.json").replace(/\\/g, "/");
-      if (packageManager === "bun") {
-        const { ok } = await runTest(packageJson, () => spawnBunInstall(execPath, { cwd: vendorPath }));
-        if (!ok) {
-          continue;
-        }
+    const buildTitle = `${vendorTitle} (bun run build)`;
+    const build = await runTest(buildTitle, async () =>
+      getStepResult(
+        buildTitle,
+        "bun run build",
+        await spawnBun(execPath, { cwd: vendorPath, args: ["run", "build"], timeout: 60_000 }),
+      ),
+    );
+    if (!build.ok) {
+      continue;
+    }
+
+    for (const testPath of testPaths) {
+      const title = `${vendorTitle}/${testPath.replace(/\\/g, "/")}`;
+
+      if (testRunner === "bun") {
+        await runTest(title, index =>
+          spawnBunTest(execPath, testPath, { cwd: vendorPath, env: { TEST_SERIAL_ID: index } }),
+        );
       } else {
-        throw new Error(`Unsupported package manager: ${packageManager}`);
-      }
-
-      // build
-      const buildResult = await spawnBun(execPath, {
-        cwd: vendorPath,
-        args: ["run", "build"],
-        timeout: 60_000,
-      });
-      if (!buildResult.ok) {
-        throw new Error(`Failed to build vendor: ${buildResult.error}`);
-      }
-
-      for (const testPath of testPaths) {
-        const title = join(relative(cwd, vendorPath), testPath).replace(/\\/g, "/");
-
-        if (testRunner === "bun") {
-          await runTest(title, index =>
-            spawnBunTest(execPath, testPath, { cwd: vendorPath, env: { TEST_SERIAL_ID: index } }),
-          );
-        } else {
-          const testRunnerPath = join(cwd, "test", "runners", `${testRunner}.ts`);
-          if (!existsSync(testRunnerPath)) {
-            throw new Error(`Unsupported test runner: ${testRunner}`);
-          }
-          await runTest(title, () =>
-            spawnBunTest(execPath, testPath, {
-              cwd: vendorPath,
-              args: ["--preload", testRunnerPath],
-            }),
-          );
+        const testRunnerPath = join(cwd, "test", "runners", `${testRunner}.ts`);
+        if (!existsSync(testRunnerPath)) {
+          throw new Error(`Unsupported test runner: ${testRunner}`);
         }
+        await runTest(title, () =>
+          spawnBunTest(execPath, testPath, {
+            cwd: vendorPath,
+            args: ["--preload", testRunnerPath],
+          }),
+        );
       }
     }
   }
@@ -2210,7 +2228,7 @@ async function spawnBunInstall(execPath, options) {
   // image's baked cache when one exists (bootstrap.{sh,ps1} set
   // BUN_INSTALL_CACHE_DIR machine-wide).
   const cacheDir = process.env.BUN_INSTALL_CACHE_DIR;
-  let { ok, error, stdout, duration, crashes } = await spawnBun(execPath, {
+  const result = await spawnBun(execPath, {
     args: ["install"],
     timeout: testTimeout,
     ...options,
@@ -2224,9 +2242,19 @@ async function spawnBunInstall(execPath, options) {
       ...(cacheDir && { BUN_INSTALL_CACHE_DIR: cacheDir }),
     },
   });
+  return getStepResult(join(relative(cwd, options.cwd), "package.json"), "bun install", result);
+}
+
+/**
+ * A setup step (an install, a vendor checkout or build) in the shape of a test
+ * result, so that runTest retries, counts and reports it like a test file.
+ * @param {string} testPath reported in place of a test file
+ * @param {string} step
+ * @param {SpawnBunResult} result
+ * @returns {TestResult}
+ */
+function getStepResult(testPath, step, { ok, error, stdout, duration, crashes }) {
   if (crashes) stdout += crashes;
-  const relativePath = relative(cwd, options.cwd);
-  const testPath = join(relativePath, "package.json");
   const status = ok ? "pass" : "fail";
   return {
     testPath,
@@ -2234,14 +2262,7 @@ async function spawnBunInstall(execPath, options) {
     status,
     error,
     errors: [],
-    tests: [
-      {
-        file: testPath,
-        test: "bun install",
-        status,
-        duration: parseDuration(duration),
-      },
-    ],
+    tests: [{ file: testPath, test: step, status, duration }],
     stdout,
     stdoutPreview: stdout,
   };
@@ -2371,18 +2392,11 @@ function getTests(cwd) {
  */
 
 /**
- * @typedef {object} VendorTest
- * @property {string} cwd
- * @property {string} packageManager
- * @property {string} testRunner
- * @property {string[]} testPaths
- */
-
-/**
+ * The entries of test/vendor.json that this shard runs.
  * @param {string} cwd
- * @returns {Promise<VendorTest[]>}
+ * @returns {Vendor[]}
  */
-async function getVendorTests(cwd) {
+function getVendors(cwd) {
   const vendorPath = join(cwd, "test", "vendor.json");
   if (!existsSync(vendorPath)) {
     throw new Error(`Did not find vendor.json: ${vendorPath}`);
@@ -2395,102 +2409,98 @@ async function getVendorTests(cwd) {
 
   const shardId = parseInt(options["shard"]);
   const maxShards = parseInt(options["max-shards"]);
-
-  /** @type {Vendor[]} */
-  let relevantVendors = [];
   if (maxShards > 1) {
-    for (let i = 0; i < vendors.length; i++) {
-      if (i % maxShards === shardId) {
-        relevantVendors.push(vendors[i]);
-      }
+    return vendors.filter((_, i) => i % maxShards === shardId);
+  }
+  return vendors;
+}
+
+/**
+ * Checks the vendor's pinned tag out into `vendorPath`. A clone from github
+ * stalls now and then, so this is a step runTest retries; a failed attempt
+ * removes whatever it left in `vendorPath` so that the next one clones anew.
+ * @param {Vendor} vendor
+ * @param {string} vendorPath
+ * @returns {Promise<TestResult>}
+ */
+async function spawnVendorCheckout({ repository, tag, testPath }, vendorPath) {
+  const commands = [];
+  if (!existsSync(vendorPath)) {
+    commands.push({ args: ["clone", "--depth", "1", "--single-branch", repository, vendorPath], cwd });
+  }
+  commands.push({ args: ["fetch", "--depth", "1", "origin", "tag", tag], cwd: vendorPath });
+  commands.push({ args: ["checkout", tag], cwd: vendorPath });
+
+  let stdout = "";
+  let duration = 0;
+  let error;
+  for (const { args, cwd: commandCwd } of commands) {
+    const command = `$ git ${args.join(" ")}`;
+    console.log(command);
+    stdout += `${command}\n`;
+    const result = await spawnSafe({ command: "git", args, cwd: commandCwd, timeout: vendorGitTimeout });
+    stdout += result.stdout;
+    duration += result.duration;
+    if (!result.ok) {
+      error = `git ${args[0]}: ${result.error}`;
+      break;
     }
-  } else {
-    relevantVendors = vendors.flat();
   }
 
-  return Promise.all(
-    relevantVendors.map(
-      async ({ package: name, repository, tag, testPath, testExtensions, testRunner, packageManager, skipTests }) => {
-        const vendorPath = join(cwd, "vendor", name);
+  const testDir = testPath || "test";
+  if (!error && !existsSync(join(vendorPath, testDir))) {
+    error = `no test directory '${testDir}' at ${tag}`;
+  }
 
-        if (!existsSync(vendorPath)) {
-          const { ok, error } = await spawnSafe({
-            command: "git",
-            args: ["clone", "--depth", "1", "--single-branch", repository, vendorPath],
-            timeout: testTimeout,
-            cwd,
-          });
-          if (!ok) throw new Error(`failed to git clone vendor '${name}': ${error}`);
+  if (error) {
+    try {
+      rmSync(vendorPath, { recursive: true, force: true });
+    } catch (cause) {
+      console.warn(`Failed to remove ${vendorPath}:`, cause);
+    }
+  }
+
+  const title = relative(cwd, vendorPath).replace(/\\/g, "/");
+  return getStepResult(title, `git checkout ${tag}`, { ok: !error, error, stdout, duration });
+}
+
+/**
+ * The test files to run in a vendor checkout, relative to it.
+ * @param {Vendor} vendor
+ * @param {string} vendorPath
+ * @returns {string[]}
+ */
+function getVendorTestPaths({ testPath, testExtensions, skipTests }, vendorPath) {
+  const testPathPrefix = testPath || "test";
+
+  const isTest = path => {
+    if (!isJavaScriptTest(path)) {
+      return false;
+    }
+
+    if (typeof skipTests === "boolean") {
+      return !skipTests;
+    }
+
+    if (typeof skipTests === "object") {
+      for (const [glob, reason] of Object.entries(skipTests)) {
+        const pattern = new RegExp(`^${glob.replace(/\*/g, ".*")}$`);
+        if (pattern.test(path) && reason) {
+          return false;
         }
+      }
+    }
 
-        let { ok, error } = await spawnSafe({
-          command: "git",
-          args: ["fetch", "--depth", "1", "origin", "tag", tag],
-          timeout: testTimeout,
-          cwd: vendorPath,
-        });
-        if (!ok) throw new Error(`failed to fetch tag ${tag} for vendor '${name}': ${error}`);
+    return true;
+  };
 
-        ({ ok, error } = await spawnSafe({
-          command: "git",
-          args: ["checkout", tag],
-          timeout: testTimeout,
-          cwd: vendorPath,
-        }));
-        if (!ok) throw new Error(`failed to checkout tag ${tag} for vendor '${name}': ${error}`);
-
-        const packageJsonPath = join(vendorPath, "package.json");
-        if (!existsSync(packageJsonPath)) {
-          throw new Error(`Vendor '${name}' does not have a package.json: ${packageJsonPath}`);
-        }
-
-        const testPathPrefix = testPath || "test";
-        const testParentPath = join(vendorPath, testPathPrefix);
-        if (!existsSync(testParentPath)) {
-          throw new Error(`Vendor '${name}' does not have a test directory: ${testParentPath}`);
-        }
-
-        const isTest = path => {
-          if (!isJavaScriptTest(path)) {
-            return false;
-          }
-
-          if (typeof skipTests === "boolean") {
-            return !skipTests;
-          }
-
-          if (typeof skipTests === "object") {
-            for (const [glob, reason] of Object.entries(skipTests)) {
-              const pattern = new RegExp(`^${glob.replace(/\*/g, ".*")}$`);
-              if (pattern.test(path) && reason) {
-                return false;
-              }
-            }
-          }
-
-          return true;
-        };
-
-        const testPaths = readdirSync(testParentPath, { encoding: "utf-8", recursive: true })
-          .filter(filename =>
-            testExtensions ? testExtensions.some(ext => filename.endsWith(`.${ext}`)) : isTest(filename),
-          )
-          .map(filename => join(testPathPrefix, filename))
-          .filter(
-            filename =>
-              !filters?.length ||
-              filters.some(filter => join(vendorPath, filename).replace(/\\/g, "/").includes(filter)),
-          );
-
-        return {
-          cwd: vendorPath,
-          packageManager: packageManager || "bun",
-          testRunner: testRunner || "bun",
-          testPaths,
-        };
-      },
-    ),
-  );
+  return readdirSync(join(vendorPath, testPathPrefix), { encoding: "utf-8", recursive: true })
+    .filter(filename => (testExtensions ? testExtensions.some(ext => filename.endsWith(`.${ext}`)) : isTest(filename)))
+    .map(filename => join(testPathPrefix, filename))
+    .filter(
+      filename =>
+        !filters?.length || filters.some(filter => join(vendorPath, filename).replace(/\\/g, "/").includes(filter)),
+    );
 }
 
 /**

--- a/test/internal/runner-vendor.test.ts
+++ b/test/internal/runner-vendor.test.ts
@@ -1,0 +1,195 @@
+/**
+ * scripts/runner.node.mjs runs the test files of the packages listed in
+ * test/vendor.json after the shard's own test files. It used to throw as soon
+ * as one vendor failed to clone (github stalls now and then), which ended the
+ * shard before its first test. Setting a vendor up (checkout, install, build)
+ * is now a sequence of steps the runner retries and reports like test files,
+ * and a step that keeps failing skips only its vendor.
+ *
+ * The runner takes the repository root from its own location: it reads
+ * test/vendor.json there and clones into vendor/ there. So each case runs a
+ * copy of it from a temporary repository layout that has one test file of its
+ * own and a vendor.json pointing at `upstream`, a local git repository. The
+ * copy runs under node, as in CI, with bunExe() as the bun under test.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+// The runner and the files it imports relative to itself. The `bun test`
+// processes it spawns read leaksan.supp from <cwd>/test/.
+const runnerFiles = [
+  "scripts/runner.node.mjs",
+  "scripts/utils.mjs",
+  "scripts/p-limit.mjs",
+  "scripts/yocto-queue.mjs",
+  "test/docker/prestart-map.mjs",
+  "test/leaksan.supp",
+];
+
+const passingTest = `
+  import { expect, test } from "bun:test";
+  test("passes", () => expect(1).toBe(1));
+`;
+
+const node = nodeExe();
+const git = Bun.which("git");
+
+const env = {
+  ...bunEnv,
+  // The copy has to take the runner's local code paths: no docker
+  // coordinator, no buildkite-agent, and --retries defaults to 0.
+  CI: undefined,
+  BUILDKITE: undefined,
+  GITHUB_ACTIONS: undefined,
+  GIT_AUTHOR_NAME: "runner test",
+  GIT_AUTHOR_EMAIL: "runner@example.com",
+  GIT_COMMITTER_NAME: "runner test",
+  GIT_COMMITTER_EMAIL: "runner@example.com",
+};
+
+/**
+ * The repository the vendors point at. Tag `1.0.0` builds and has a passing
+ * test; tag `bad-build`, which is also the branch head that a clone checks
+ * out, fails to build. So a vendor pinned to `1.0.0` passes only if the runner
+ * checks the tag out.
+ */
+let upstreamDir: ReturnType<typeof tempDir> | undefined;
+let upstream: string;
+
+async function runGit(...args: string[]): Promise<void> {
+  await using proc = Bun.spawn({
+    cmd: [git!, "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", ...args],
+    cwd: upstream,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(`git ${args.join(" ")} exited with ${exitCode}:\n${stdout}${stderr}`);
+}
+
+const packageJson = (build: string) => JSON.stringify({ name: "upstream", scripts: { build } });
+
+beforeAll(async () => {
+  if (!node || !git) return;
+  upstreamDir = tempDir("runner-vendor-upstream", {
+    "package.json": packageJson("echo built"),
+    "test/ok.test.ts": passingTest,
+  });
+  upstream = String(upstreamDir);
+  await runGit("init", "--quiet");
+  await runGit("add", ".");
+  await runGit("commit", "--quiet", "--message", "builds");
+  await runGit("tag", "1.0.0");
+  writeFileSync(join(upstream, "package.json"), packageJson("exit 1"));
+  await runGit("commit", "--quiet", "--all", "--message", "does not build");
+  await runGit("tag", "bad-build");
+});
+
+afterAll(() => upstreamDir?.[Symbol.dispose]());
+
+type Vendor = { package: string; tag: string; repository?: string; testPath?: string };
+
+/** A repository layout holding the runner copy, one test file and the given vendor.json. */
+function makeRepo(vendors: Vendor[], leftovers: Record<string, string> = {}) {
+  return tempDir("runner-vendor", {
+    ...Object.fromEntries(runnerFiles.map(file => [file, readFileSync(join(repoRoot, file))])),
+    "test/smoke.test.ts": passingTest,
+    "test/vendor.json": JSON.stringify(vendors.map(vendor => ({ repository: upstream, ...vendor }))),
+    ...leftovers,
+  });
+}
+
+/** Runs the runner copy in `repo`. Returns the steps it logged, in order, and its exit code. */
+async function runRunner(repo: string) {
+  await using proc = Bun.spawn({
+    cmd: [node!, join(repo, "scripts", "runner.node.mjs"), `--exec-path=${bunExe()}`, "--vendor=true", "--quiet"],
+    cwd: repo,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The runner logs "[n/total] <title>" when it starts a step and
+  // "[n/total] <title> - <error>" when the step fails.
+  const steps = Bun.stripANSI(stdout)
+    .split("\n")
+    .map(line => /^\s*\[\d+\/\d+\] (.*)$/.exec(line)?.[1])
+    .filter((step): step is string => step !== undefined);
+  if (steps.length === 0) throw new Error(`the runner ran no step:\n${stdout}${stderr}`);
+  return { steps, exitCode };
+}
+
+describe.skipIf(!node || !git)("runner.node.mjs vendors", () => {
+  test.concurrent("a vendor that cannot be cloned fails on its own, after the shard's own tests", async () => {
+    using repo = makeRepo([{ package: "gone", tag: "1.0.0", repository: join(upstream, "does-not-exist") }]);
+
+    expect(await runRunner(String(repo))).toEqual({
+      steps: ["test/smoke.test.ts", "vendor/gone", expect.stringMatching(/^vendor\/gone - git clone: code /)],
+      exitCode: 1,
+    });
+  });
+
+  test.concurrent("a failed checkout removes its directory, so that a retry clones anew", async () => {
+    // A vendor directory that an interrupted earlier attempt left behind.
+    using repo = makeRepo([{ package: "torn", tag: "1.0.0" }], { "vendor/torn/.git": "not a repository" });
+
+    expect(await runRunner(String(repo))).toEqual({
+      steps: ["test/smoke.test.ts", "vendor/torn", expect.stringMatching(/^vendor\/torn - git fetch: code /)],
+      exitCode: 1,
+    });
+    expect(existsSync(join(String(repo), "vendor", "torn"))).toBe(false);
+  });
+
+  test.concurrent("a tag without the test directory fails the checkout step", async () => {
+    using repo = makeRepo([{ package: "layout", tag: "1.0.0", testPath: "spec" }]);
+
+    expect(await runRunner(String(repo))).toEqual({
+      steps: ["test/smoke.test.ts", "vendor/layout", "vendor/layout - no test directory 'spec' at 1.0.0"],
+      exitCode: 1,
+    });
+    expect(existsSync(join(String(repo), "vendor", "layout"))).toBe(false);
+  });
+
+  test.concurrent("a vendor that fails to build is reported and the next vendor still runs", async () => {
+    // Vendors run in package name order.
+    using repo = makeRepo([
+      { package: "a-bad-build", tag: "bad-build" },
+      { package: "b-good", tag: "1.0.0" },
+    ]);
+
+    expect(await runRunner(String(repo))).toEqual({
+      steps: [
+        "test/smoke.test.ts",
+        "vendor/a-bad-build",
+        "vendor/a-bad-build/package.json",
+        "vendor/a-bad-build (bun run build)",
+        "vendor/a-bad-build (bun run build) - code 1",
+        "vendor/b-good",
+        "vendor/b-good/package.json",
+        "vendor/b-good (bun run build)",
+        "vendor/b-good/test/ok.test.ts",
+      ],
+      exitCode: 1,
+    });
+  });
+
+  test.concurrent("a vendor is checked out at its tag, installed, built, and its tests run", async () => {
+    using repo = makeRepo([{ package: "good", tag: "1.0.0" }]);
+
+    expect(await runRunner(String(repo))).toEqual({
+      steps: [
+        "test/smoke.test.ts",
+        "vendor/good",
+        "vendor/good/package.json",
+        "vendor/good (bun run build)",
+        "vendor/good/test/ok.test.ts",
+      ],
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- One failed vendor clone fails a whole test shard with zero tests run. Build 101785, darwin aarch64 shard 0: `Error: failed to git clone vendor 'elysia': timeout`. The step exits 1 unreported.
- Cause: `getVendorTests()` (scripts/runner.node.mjs:2411 on main) clones before the first test and throws when git fails. The vendor build (line 1199) throws too, which loses the summary and the JUnit upload.

### Fix
- The checkout and the build go through `runTest()`, as the install step already does: a failed step is retried, then reported like a failing test file, and skips only its vendor.
- A failed checkout attempt removes the vendor directory, so the retry clones anew. Each git command gets 60 s: a checkout takes about 3 s, the clone above was waited out for 3 minutes.
- Correct because `runTest()` is the runner's one path to retry and report a failure. A vendor that keeps failing still fails the step.
- Verified: test/internal/runner-vendor.test.ts. All 5 cases fail on main (`git stash push -- scripts/`) and pass here.

### Background
- `runTest(title, fn)` runs one test file: it retries `fn` up to `--retries` times, annotates a failure on Buildkite, and keeps the result for the exit code.
- test/vendor.json lists upstream packages (today: elysia) whose test suites run after the shard's own files. Setup: `git clone`, fetch and check out the pinned tag, `bun install`, `bun run build`.
- An exception that escapes `runTests()` skips the summary, the JUnit upload and `markBuildkiteStepReported()`, hence `step-failed-outside-runner`. `getRetry()` in .buildkite/ci.mjs retries agent loss only, on purpose.

<details><summary>Notes</summary>

- Timing data. Build 101647, darwin shard 0: `Cloning into` at 14:49:21.2, `HEAD is now at` 14:49:24.4. Build 101785: `Cloning into` at 20:35:04, the throw at 20:38:02, 3 minutes after `Running tests: 2786`. The old timeout was `testTimeout`, 3 minutes per git command.
- Worst case on a dead network is now 4 attempts (`--retries` is 3 in CI) of 60 s plus the 5 to 15 s backoff of `runTest`, about 4.5 minutes. With the old timeout it would be 12 minutes, inside a 45 minute job.
- Size of the clone: the depth 1 pack of elysia is 40 MiB and takes 2.4 s here. 60 s per command therefore gives up below about 0.7 MB/s, and the retry opens a new connection. A wall clock is used rather than `spawnSafe`'s `idleTimeout`, because git prints no progress to a pipe unless it is asked to. Stall detection would need `--progress` on each command and its output in every log and annotation, for a command that normally takes 3 s.
- The removal after a failed attempt only touches `vendor/<package>`, the directory the runner already owned: the old code fetched into it and checked a tag out in it. It also removes nothing that would have been used, because the old code threw on the same failures.
- Titles: the checkout step is titled `vendor/<package>`, the build step `vendor/<package> (bun run build)`, the install step keeps `vendor/<package>/package.json`. The build step does not reuse the install title, so that two consecutive steps do not log and annotate under one name. The annotations of the two new steps have no file to link to. Their body holds the git or build output, with each git command echoed before its output.
- The retry itself was checked by hand. A torn vendor directory with `--retries=1`: attempt 1 fails at `git fetch`, attempt 2 clones, the vendor's tests pass, exit 0. 14 s, 13 of them the backoff. It is not in the test file because the backoff is hardcoded in `runTest` and the case would need a per-test timeout.
- A vendor's setup fails for the same reasons as its test files (network, the bun under test), which is why its steps fit `runTest` and its `--retries`.
- Why the checkout moves behind the shard's own files: nothing used the checkout before the vendor loop, it only ran early. It cannot stay early as a `runTest` step, because the shard's files only run when no step has failed yet (`if (!failedResults.length)`, the guard for a failed root install). A failed vendor checkout before that guard would skip the shard again. The docker prestart that the old comment tied to the clone overlaps with the non-docker files instead, which `getRelevantTests` sorts first.
- `USE_SYSTEM_BUN=1` does not separate before and after here. The test copies the runner from the working tree, so the binary is not what changes. The proof is the stash of scripts/ named above: the first three cases then end with `the runner ran no step` and the old throw messages, the other two with a shorter step list.
- The test copies runner.node.mjs and the four files it imports into a temporary repository layout, because the runner takes the repository root from its own location. It runs the copy under node, as CI does, with `bunExe()` as `--exec-path`. The vendors point at a local git repository with two tags. The branch head is the tag that fails to build, so the passing case also proves that the tag is checked out.
- The git exit codes are asserted as a `code ` prefix only. On a Windows agent with a Windows Kit installed, `spawnSafe` maps exit codes other than 1 to an NTSTATUS name.
- Unchanged on purpose: `Unsupported package manager` and `Unsupported test runner` still throw. They are errors in vendor.json and fail on the PR that adds them. A pinned tag without the test directory used to throw as well. It now fails the checkout step, because the step that lists the files cannot report it.
- `getStepResult()` replaces the result literal of `spawnBunInstall()`. One difference: the single test entry now holds the duration in ms. Before, the ms number went through `parseDuration()`, which parses strings, so the entry always held `undefined`. Nothing reads it: these results are excluded from the JUnit report.
- `total` in the `[n/total]` log prefix counts 3 steps per vendor up front and adds the vendor's test files once the checkout exists.
- Open PR #34569 (skipTestNames) edits the same vendor code. Whichever lands second needs a small rebase.
- Suites run: test/internal/runner-vendor.test.ts with `bun bd test`, the same file through `node scripts/runner.node.mjs`, and `node scripts/runner.node.mjs --vendor=true "test/path/"` against the real elysia entry (checkout, install, build, 3 files, exit 0).
- CI of this PR runs the changed runner itself. In build 101851, darwin shard 0 logs `Running vendors: 1`, the three git commands, `Running vendor tests: vendor/elysia 126`, then the `vendor/elysia/package.json` and `vendor/elysia (bun run build)` steps, and passes. The new test file passes on the darwin and windows shards that ran it (5 pass on each).

</details>



