### PR TITLE
Bun.serve: do not crash when the bundle of an html route has no html page

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1059,6 +1059,10 @@ pub mod bv2_impl {
                 pub(crate) import_record_index: u32,
                 pub(crate) range: bun_ast::Range,
                 pub(crate) original_target: Target,
+                /// Set for the html file of a dev server route: the loader the
+                /// file gets when the plugins leave it to the bundler, see
+                /// `BundleV2::requested_file_loader`.
+                pub(crate) loader: Option<Loader>,
             }
 
             /// Mirrors `JSBundler.Resolve.Value.success` payload.
@@ -2544,10 +2548,12 @@ pub mod bv2_impl {
             }
         }
 
+        /// `loader`: see `requested_file_loader`.
         pub fn enqueue_file_from_dev_server_incremental_graph_invalidation(
             &mut self,
             path_slice: &[u8],
             target: options::Target,
+            loader: Option<Loader>,
         ) -> Result<(), Error> {
             // TODO: plugins with non-file namespaces
             // borrowck: get-then-put (instead of a single get-or-put) so the map
@@ -2569,9 +2575,7 @@ pub mod bv2_impl {
             let mut path = result.path_pair.primary;
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
-            let loader = path
-                .loader(&self.transpiler.options.loaders)
-                .unwrap_or(Loader::File);
+            let loader = self.requested_file_loader(&path, loader);
 
             path = self.path_with_pretty_initialized(&path, target)?;
             path.assert_pretty_is_valid();
@@ -2626,10 +2630,19 @@ pub mod bv2_impl {
             Ok(())
         }
 
-        /// `loader` overrides the loader the file's extension selects. The dev
+        /// The loader of a file the dev server or the build asks for by path.
+        /// `loader` overrides the one the file's extension selects: the dev
         /// server passes `Loader::Html` for the html file of a route, which the
         /// runtime may have loaded as html through an import attribute or a
         /// bunfig `[loader]` entry that the bundler's loader table does not have.
+        fn requested_file_loader(&self, path: &Fs::Path<'_>, loader: Option<Loader>) -> Loader {
+            loader.unwrap_or_else(|| {
+                path.loader(&self.transpiler.options.loaders)
+                    .unwrap_or(Loader::File)
+            })
+        }
+
+        /// `loader`: see `requested_file_loader`.
         pub(crate) fn enqueue_entry_item(
             &mut self,
             resolve: &mut _resolver::Result,
@@ -2657,10 +2670,7 @@ pub mod bv2_impl {
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
 
-            let loader = loader.unwrap_or_else(|| {
-                path.loader(&self.transpiler.options.loaders)
-                    .unwrap_or(Loader::File)
-            });
+            let loader = self.requested_file_loader(&path, loader);
 
             // SAFETY: `path_with_pretty_initialized` allocates into `self.graph.heap`, which
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
@@ -3002,6 +3012,7 @@ pub mod bv2_impl {
                 if self.enqueue_entry_point_on_resolve_plugin_if_needed(
                     entry_point,
                     self.transpiler.options.target,
+                    None,
                 ) {
                     continue;
                 }
@@ -3072,23 +3083,28 @@ pub mod bv2_impl {
                         &raw mut *self.transpiler
                     };
                 let server_target = self.transpiler.options.target;
+                let client_loader = flags.html().then_some(Loader::Html);
 
                 struct TargetCheck {
                     should_dispatch: bool,
                     target: options::Target,
+                    loader: Option<Loader>,
                 }
                 let targets_to_check = [
                     TargetCheck {
                         should_dispatch: flags.client(),
                         target: Target::Browser,
+                        loader: client_loader,
                     },
                     TargetCheck {
                         should_dispatch: flags.server(),
                         target: server_target,
+                        loader: None,
                     },
                     TargetCheck {
                         should_dispatch: flags.ssr(),
                         target: Target::ServerComponentsSsr,
+                        loader: None,
                     },
                 ];
 
@@ -3098,6 +3114,7 @@ pub mod bv2_impl {
                         if self.enqueue_entry_point_on_resolve_plugin_if_needed(
                             abs_path,
                             target_info.target,
+                            target_info.loader,
                         ) {
                             any_plugin_matched = true;
                         }
@@ -3135,9 +3152,12 @@ pub mod bv2_impl {
 
                 if flags.client() {
                     'brk: {
-                        let loader = flags.html().then_some(Loader::Html);
-                        let Some(source_index) =
-                            self.enqueue_entry_item(&mut resolved, true, Target::Browser, loader)?
+                        let Some(source_index) = self.enqueue_entry_item(
+                            &mut resolved,
+                            true,
+                            Target::Browser,
+                            client_loader,
+                        )?
                         else {
                             break 'brk;
                         };
@@ -3191,7 +3211,7 @@ pub mod bv2_impl {
                     bake::Side::Server => self.transpiler.options.target,
                 };
 
-                if self.enqueue_entry_point_on_resolve_plugin_if_needed(abs_path, target) {
+                if self.enqueue_entry_point_on_resolve_plugin_if_needed(abs_path, target, None) {
                     continue;
                 }
 
@@ -4612,9 +4632,12 @@ pub mod bv2_impl {
                                 return;
                             };
                             let mut resolved = resolved;
-                            let Ok(source_index) =
-                                this.enqueue_entry_item(&mut resolved, true, target, None)
-                            else {
+                            let Ok(source_index) = this.enqueue_entry_item(
+                                &mut resolved,
+                                true,
+                                target,
+                                resolve.import_record.loader,
+                            ) else {
                                 return;
                             };
 
@@ -4733,9 +4756,16 @@ pub mod bv2_impl {
                             unsafe { *value_ptr = source_index.get() };
                             out_source_index = Some(source_index);
                             let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
-                            let loader = path
-                                .loader(&this.transpiler.options.loaders)
-                                .unwrap_or(Loader::File);
+                            // The record's loader is for the record's own file.
+                            // A plugin that resolves it to another file gets
+                            // that file's loader.
+                            let loader = this.requested_file_loader(
+                                &path,
+                                resolve
+                                    .import_record
+                                    .loader
+                                    .filter(|_| path.text == &*resolve.import_record.specifier),
+                            );
 
                             this.graph
                                 .input_files
@@ -5592,6 +5622,7 @@ pub mod bv2_impl {
                             import_record_index,
                             range: import_record.range,
                             original_target,
+                            loader: None,
                         },
                     );
 
@@ -5603,10 +5634,12 @@ pub mod bv2_impl {
             false
         }
 
+        /// `loader`: see `requested_file_loader`.
         pub(crate) fn enqueue_entry_point_on_resolve_plugin_if_needed(
             &mut self,
             entry_point: &[u8],
             target: options::Target,
+            loader: Option<Loader>,
         ) -> bool {
             if let Some(plugins) = self.plugins_ref() {
                 let mut temp_path = Fs::Path::init(entry_point);
@@ -5635,6 +5668,7 @@ pub mod bv2_impl {
                             import_record_index: 0,
                             range: bun_ast::Range::NONE,
                             original_target: target,
+                            loader,
                         },
                     );
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -416,6 +416,8 @@ pub mod bv2_impl {
             pub(crate) const SSR: u8 = 1 << 2;
             /// When set, `.CLIENT` is also set.
             pub(crate) const CSS: u8 = 1 << 3;
+            /// The html file of a route. When set, `.CLIENT` is also set.
+            pub(crate) const HTML: u8 = 1 << 4;
             #[inline]
             pub(crate) fn client(self) -> bool {
                 self.0 & Self::CLIENT != 0
@@ -431,6 +433,10 @@ pub mod bv2_impl {
             #[inline]
             pub(crate) fn css(self) -> bool {
                 self.0 & Self::CSS != 0
+            }
+            #[inline]
+            pub(crate) fn html(self) -> bool {
+                self.0 & Self::HTML != 0
             }
         }
 
@@ -2620,11 +2626,16 @@ pub mod bv2_impl {
             Ok(())
         }
 
+        /// `loader` overrides the loader the file's extension selects. The dev
+        /// server passes `Loader::Html` for the html file of a route, which the
+        /// runtime may have loaded as html through an import attribute or a
+        /// bunfig `[loader]` entry that the bundler's loader table does not have.
         pub(crate) fn enqueue_entry_item(
             &mut self,
             resolve: &mut _resolver::Result,
             is_entry_point: bool,
             target: options::Target,
+            loader: Option<Loader>,
         ) -> Result<Option<IndexInt>, Error> {
             let result = &mut *resolve;
             // borrowck: clone the active path out so we don't hold a `&mut`
@@ -2646,9 +2657,10 @@ pub mod bv2_impl {
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
 
-            let loader = path
-                .loader(&self.transpiler.options.loaders)
-                .unwrap_or(Loader::File);
+            let loader = loader.unwrap_or_else(|| {
+                path.loader(&self.transpiler.options.loaders)
+                    .unwrap_or(Loader::File)
+            });
 
             // SAFETY: `path_with_pretty_initialized` allocates into `self.graph.heap`, which
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
@@ -3002,6 +3014,7 @@ pub mod bv2_impl {
                             &mut { file_map_result },
                             true,
                             self.transpiler.options.target,
+                            None,
                         )?;
                         continue;
                     }
@@ -3027,7 +3040,7 @@ pub mod bv2_impl {
                     }
                     break 'brk main_target;
                 };
-                let _ = self.enqueue_entry_item(&mut resolved, true, target)?;
+                let _ = self.enqueue_entry_item(&mut resolved, true, target, None)?;
             }
             Ok(())
         }
@@ -3122,8 +3135,9 @@ pub mod bv2_impl {
 
                 if flags.client() {
                     'brk: {
+                        let loader = flags.html().then_some(Loader::Html);
                         let Some(source_index) =
-                            self.enqueue_entry_item(&mut resolved, true, Target::Browser)?
+                            self.enqueue_entry_item(&mut resolved, true, Target::Browser, loader)?
                         else {
                             break 'brk;
                         };
@@ -3142,11 +3156,16 @@ pub mod bv2_impl {
                         &mut resolved,
                         true,
                         self.transpiler.options.target,
+                        None,
                     )?;
                 }
                 if flags.ssr() {
-                    let _ =
-                        self.enqueue_entry_item(&mut resolved, true, Target::ServerComponentsSsr)?;
+                    let _ = self.enqueue_entry_item(
+                        &mut resolved,
+                        true,
+                        Target::ServerComponentsSsr,
+                        None,
+                    )?;
                 }
             }
             Ok(())
@@ -3183,7 +3202,7 @@ pub mod bv2_impl {
                 };
 
                 // TODO: wrap client files so the exports arent preserved.
-                let Some(_) = self.enqueue_entry_item(&mut resolved, true, target)? else {
+                let Some(_) = self.enqueue_entry_item(&mut resolved, true, target, None)? else {
                     continue;
                 };
             }
@@ -4594,7 +4613,7 @@ pub mod bv2_impl {
                             };
                             let mut resolved = resolved;
                             let Ok(source_index) =
-                                this.enqueue_entry_item(&mut resolved, true, target)
+                                this.enqueue_entry_item(&mut resolved, true, target, None)
                             else {
                                 return;
                             };

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1059,9 +1059,7 @@ pub mod bv2_impl {
                 pub(crate) import_record_index: u32,
                 pub(crate) range: bun_ast::Range,
                 pub(crate) original_target: Target,
-                /// Set for the html file of a dev server route: the loader the
-                /// file gets when the plugins leave it to the bundler, see
-                /// `BundleV2::requested_file_loader`.
+                /// Set for the html file of a dev server route, see `BundleV2::requested_file_loader`.
                 pub(crate) loader: Option<Loader>,
             }
 
@@ -2630,11 +2628,7 @@ pub mod bv2_impl {
             Ok(())
         }
 
-        /// The loader of a file the dev server or the build asks for by path.
-        /// `loader` overrides the one the file's extension selects: the dev
-        /// server passes `Loader::Html` for the html file of a route, which the
-        /// runtime may have loaded as html through an import attribute or a
-        /// bunfig `[loader]` entry that the bundler's loader table does not have.
+        /// The dev server passes `Loader::Html` for the html file of a route: its extension need not be `.html`.
         fn requested_file_loader(&self, path: &Fs::Path<'_>, loader: Option<Loader>) -> Loader {
             loader.unwrap_or_else(|| {
                 path.loader(&self.transpiler.options.loaders)
@@ -4756,9 +4750,7 @@ pub mod bv2_impl {
                             unsafe { *value_ptr = source_index.get() };
                             out_source_index = Some(source_index);
                             let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
-                            // The record's loader is for the record's own file.
-                            // A plugin that resolves it to another file gets
-                            // that file's loader.
+                            // A file that a plugin resolved the record to instead keeps its own loader.
                             let loader = this.requested_file_loader(
                                 &path,
                                 resolve

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2356,10 +2356,7 @@ impl DevServer {
                 }
             }
             route_bundle::Data::Html(html) => {
-                entry_points.append(
-                    &html.html_bundle.bundle.path,
-                    entry_point_list::Flags::CLIENT,
-                )?;
+                entry_points.append_html(&html.html_bundle.bundle.path)?;
             }
         }
 
@@ -2767,8 +2764,16 @@ impl DevServer {
         debug_assert!(route_bundle.server_state == route_bundle::State::Loaded);
         debug_assert!(html.html_bundle.dev_server_id.get() == Some(route_bundle_index));
         debug_assert!(html.cached_response.is_none());
-        let script_injection_offset = html.script_injection_offset.unwrap().get_usize();
-        let bundled_html = html.bundled_html_text.as_ref().unwrap();
+        // `report_html_routes_without_html` keeps a route without these out of
+        // the loaded state.
+        let script_injection_offset = html
+            .script_injection_offset
+            .expect("loaded html route has no script injection offset")
+            .get_usize();
+        let bundled_html = html
+            .bundled_html_text
+            .as_ref()
+            .expect("loaded html route has no bundled html");
 
         // The bundler records an offsets in development mode, splitting the HTML
         // file into two chunks. DevServer is able to insert style/script tags
@@ -3328,6 +3333,59 @@ impl DevServer {
                 bun_core::debug_warn!("dev.log should not be written into when using DevServer");
             }
             let _ = self.log.print(std::ptr::from_mut(Output::error_writer()));
+        }
+        Ok(())
+    }
+
+    /// An html route is rendered from the html chunk `finalize_bundle` stores
+    /// on its route bundle. A bundle can finish without one and without an
+    /// error for the file, for example when a plugin resolves the html file to
+    /// a different file. Such a route must not reach the loaded state: record
+    /// a failure on its html file so the requests get the build failure page.
+    fn report_html_routes_without_html(&mut self) -> crate::Result<()> {
+        for route_bundle in &self.route_bundles {
+            let route_bundle::Data::Html(html) = &route_bundle.data else {
+                continue;
+            };
+            if html.bundled_html_text.is_some() {
+                continue;
+            }
+            let file_index = html.bundled_file;
+            let failed_in_this_bundle = |failure: &SerializedFailure| {
+                matches!(
+                    failure.get_owner(),
+                    serialized_failure::Owner::Client(owner) if owner == file_index
+                )
+            };
+            let has_failure = match route_bundle.server_state {
+                route_bundle::State::Unqueued | route_bundle::State::DeferredToNextBundle => {
+                    continue;
+                }
+                // This bundle was for the route. `finalize_bundle` answers its
+                // requests with the failures this bundle added, so a failure
+                // left over from an earlier bundle has to be added again.
+                route_bundle::State::Bundling => self
+                    .incremental_result
+                    .failures_added
+                    .iter()
+                    .any(failed_in_this_bundle),
+                // The route is not served until its earlier failure is gone.
+                // That failure is only a problem if this bundle cleared it by
+                // delivering something other than html for the file.
+                route_bundle::State::PossibleBundlingFailures | route_bundle::State::Loaded => {
+                    self.client_graph.bundled_files.values()[file_index.get() as usize].failed
+                }
+            };
+            if has_failure {
+                continue;
+            }
+
+            let log = html.html_bundle.bundle.no_html_page_log();
+            self.client_graph.insert_failure(
+                incremental_graph::InsertFailureKey::Index(file_index.get()),
+                &log,
+                false,
+            )?;
         }
         Ok(())
     }
@@ -4153,6 +4211,7 @@ pub(super) fn finalize_bundle(
     dev.incremental_result.had_adjusted_edges = false;
 
     dev.prepare_and_log_resolution_failures()?;
+    dev.report_html_routes_without_html()?;
 
     // Pass 2, update the graph's edges by performing import diffing on each
     // changed file, removing dependencies. This pass also flags what routes
@@ -5238,6 +5297,25 @@ impl DevServer {
 
         let _g = self.graph_safety_lock.guard();
 
+        // `server.reload()` registers a new `HTMLBundleRoute` for an html file
+        // the dev server may already have a route bundle for. The graph file
+        // delivers bundled html to one route bundle only, so a second one for
+        // the same file would never receive any.
+        if let route_bundle::UnresolvedIndex::Html(html) = route {
+            // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
+            // allocation; single-threaded (uws JS-thread callback).
+            let html_ref = unsafe { &*html };
+            if let Some(existing) = self
+                .client_graph
+                .bundled_files
+                .get(&html_ref.bundle.path)
+                .and_then(|file| file.html_route_bundle_index)
+            {
+                html_ref.dev_server_id.set(Some(existing));
+                return Ok(existing);
+            }
+        }
+
         let bundle_index =
             route_bundle::Index::init(u32::try_from(self.route_bundles.len()).expect("int cast"));
 
@@ -6064,6 +6142,8 @@ pub mod entry_point_list {
             const SSR = 1 << 2;
             /// When this is set, also set CLIENT
             const CSS = 1 << 3;
+            /// The html file of a route. When this is set, also set CLIENT
+            const HTML = 1 << 4;
         }
     }
 }
@@ -6088,6 +6168,16 @@ impl EntryPointList {
         self.append(
             abs_path,
             entry_point_list::Flags::CLIENT | entry_point_list::Flags::CSS,
+        )
+    }
+
+    /// The html file of a route is bundled as html whatever its extension is.
+    /// The runtime made it an `HTMLBundle`, so its loader may have come from an
+    /// import attribute or a bunfig `[loader]` entry the bundler does not see.
+    pub(crate) fn append_html(&mut self, abs_path: &[u8]) -> crate::Result<()> {
+        self.append(
+            abs_path,
+            entry_point_list::Flags::CLIENT | entry_point_list::Flags::HTML,
         )
     }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2764,8 +2764,7 @@ impl DevServer {
         debug_assert!(route_bundle.server_state == route_bundle::State::Loaded);
         debug_assert!(html.html_bundle.dev_server_id.get() == Some(route_bundle_index));
         debug_assert!(html.cached_response.is_none());
-        // `report_html_routes_without_html` keeps a route without these out of
-        // the loaded state.
+        // `report_html_routes_without_html` keeps a route without these out of the loaded state.
         let script_injection_offset = html
             .script_injection_offset
             .expect("loaded html route has no script injection offset")
@@ -3337,11 +3336,7 @@ impl DevServer {
         Ok(())
     }
 
-    /// An html route is rendered from the html chunk `finalize_bundle` stores
-    /// on its route bundle. A bundle can finish without one and without an
-    /// error for the file, for example when a plugin resolves the html file to
-    /// a different file. Such a route must not reach the loaded state: record
-    /// a failure on its html file so the requests get the build failure page.
+    /// A route that a bundle left without html must not reach the loaded state: fail its file instead.
     fn report_html_routes_without_html(&mut self) -> crate::Result<()> {
         for route_bundle in &self.route_bundles {
             let route_bundle::Data::Html(html) = &route_bundle.data else {
@@ -3361,17 +3356,13 @@ impl DevServer {
                 route_bundle::State::Unqueued | route_bundle::State::DeferredToNextBundle => {
                     continue;
                 }
-                // This bundle was for the route. `finalize_bundle` answers its
-                // requests with the failures this bundle added, so a failure
-                // left over from an earlier bundle has to be added again.
+                // `finalize_bundle` answers this bundle's requests from the failures it added: re-add an older one.
                 route_bundle::State::Bundling => self
                     .incremental_result
                     .failures_added
                     .iter()
                     .any(failed_in_this_bundle),
-                // The route is not served until its earlier failure is gone.
-                // That failure is only a problem if this bundle cleared it by
-                // delivering something other than html for the file.
+                // An earlier failure still gates the route, unless this bundle cleared it without delivering html.
                 route_bundle::State::PossibleBundlingFailures | route_bundle::State::Loaded => {
                     self.client_graph.bundled_files.values()[file_index.get() as usize].failed
                 }
@@ -5297,10 +5288,7 @@ impl DevServer {
 
         let _g = self.graph_safety_lock.guard();
 
-        // `server.reload()` registers a new `HTMLBundleRoute` for an html file
-        // the dev server may already have a route bundle for. The graph file
-        // delivers bundled html to one route bundle only, so a second one for
-        // the same file would never receive any.
+        // A file delivers its html to one route bundle only: a route `server.reload()` re-registers reuses it.
         if let route_bundle::UnresolvedIndex::Html(html) = route {
             // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
             // allocation; single-threaded (uws JS-thread callback).
@@ -6171,9 +6159,7 @@ impl EntryPointList {
         )
     }
 
-    /// The html file of a route is bundled as html whatever its extension is.
-    /// The runtime made it an `HTMLBundle`, so its loader may have come from an
-    /// import attribute or a bunfig `[loader]` entry the bundler does not see.
+    /// The html file of a route: an import attribute or a bunfig `[loader]` entry may have made it html.
     pub(crate) fn append_html(&mut self, abs_path: &[u8]) -> crate::Result<()> {
         self.append(
             abs_path,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4159,7 +4159,11 @@ pub(super) fn finalize_bundle(
             .get_cached_index(bake::Side::Client, index)
             .unwrap::<{ bake::Side::Client }>()
             .expect("unresolved index");
-        let route_bundle_index = dev.client_graph.html_route_bundle_index(client_index);
+        // Not the file of a route: a plugin resolved a route's file to it, or loaded it as html.
+        let Some(route_bundle_index) = dev.client_graph.html_route_bundle_index(client_index)
+        else {
+            continue;
+        };
         let route_bundle = dev.route_bundle_ptr(route_bundle_index);
         debug_assert!(route_bundle.data.html().bundled_file == client_index);
         // Note: split borrow — `invalidate_client_bundle` needs `&mut RouteBundle`

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -1586,8 +1586,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         Ok(())
     }
 
-    /// The html file of a route is bundled as html whatever its extension is.
-    /// Every other client file is bundled with the loader of its extension.
+    /// See `EntryPointList::append_html`.
     fn append_client_entry_point(
         &self,
         entry_points: &mut EntryPointList,

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -1580,6 +1580,25 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         Ok(())
     }
 
+    /// The html file of a route is bundled as html whatever its extension is.
+    /// Every other client file is bundled with the loader of its extension.
+    fn append_client_entry_point(
+        &self,
+        entry_points: &mut EntryPointList,
+        index: usize,
+    ) -> Result<(), crate::Error> {
+        debug_assert!(matches!(SIDE, Side::Client));
+        let abs_path = &self.bundled_files.keys()[index];
+        if self.bundled_files.values()[index]
+            .html_route_bundle_index
+            .is_some()
+        {
+            entry_points.append_html(abs_path)
+        } else {
+            entry_points.append_js(abs_path, bake::Graph::Client)
+        }
+    }
+
     /// `IncrementalGraph(side).invalidate` (spec :1589). Given a set of paths,
     /// mark the relevant files as stale and append them into `entry_points`.
     pub(crate) fn invalidate(
@@ -1640,16 +1659,16 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             ) {
                                 entry_points.append_css(k)?;
                             } else {
-                                entry_points.append_js(k, bake::Graph::Client)?;
+                                self.append_client_entry_point(entry_points, dep.get() as usize)?;
                             }
                             it = entry.next_dependency;
                         }
-                        entry_points.append_js(owned_path, bake::Graph::Client)?;
+                        self.append_client_entry_point(entry_points, index)?;
                     }
                     // When re-bundling SCBs, only bundle the server.
                     Content::Js(_) | Content::Unknown => {
                         if !self.bundled_files.values()[index].is_hmr_root {
-                            entry_points.append_js(owned_path, bake::Graph::Client)?;
+                            self.append_client_entry_point(entry_points, index)?;
                         }
                     }
                 },

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -364,11 +364,12 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             .map(|i| FileIndex::init(i as u32))
     }
 
-    /// `IncrementalGraph(.client).htmlRouteBundleIndex`.
-    pub(crate) fn html_route_bundle_index(&self, index: FileIndex<SIDE>) -> route_bundle::Index {
-        self.bundled_files.values()[index.get() as usize]
-            .html_route_bundle_index
-            .expect("html_route_bundle_index on non-HTML file")
+    /// `None` for an html file that is not the file of a route.
+    pub(crate) fn html_route_bundle_index(
+        &self,
+        index: FileIndex<SIDE>,
+    ) -> Option<route_bundle::Index> {
+        self.bundled_files.values()[index.get() as usize].html_route_bundle_index
     }
 
     // ── per-bundle scratch accessors (kept for existing call sites) ────────

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -1564,8 +1564,14 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             it = dep.next_dependency;
             debug_assert_eq!(dep.imported.get(), index.get());
             let key = &self.bundled_files.keys()[dep.dependency.get() as usize];
+            let loader = self.bundled_files.values()[dep.dependency.get() as usize]
+                .html_route_bundle_index
+                .is_some()
+                .then_some(bun_ast::Loader::Html);
             bun_core::handle_oom(
-                bv2.enqueue_file_from_dev_server_incremental_graph_invalidation(key, target),
+                bv2.enqueue_file_from_dev_server_incremental_graph_invalidation(
+                    key, target, loader,
+                ),
             );
         }
 

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -131,10 +131,7 @@ impl HTMLBundle {
         bun_jsc::bun_string_jsc::create_utf8_for_js(global, &this.path)
     }
 
-    /// The error a route reports when a build of its file finishes without an
-    /// html page in its output. `Route::on_complete` and the dev server's
-    /// `finalize_bundle` both reach this state, for example when a plugin
-    /// resolves or loads the file as something other than html.
+    /// For `Route::on_complete` and the dev server's `finalize_bundle`, when a build has no page for the file.
     pub(crate) fn no_html_page_log(&self) -> Log {
         let mut log = Log::init();
         log.add_error_fmt(
@@ -443,14 +440,10 @@ impl Route {
         self.server.get().expect("server set").on_request_complete();
     }
 
-    /// Production says nothing about why a route failed to build, see
-    /// `resume_pending_responses`.
+    /// Production keeps the reason to itself, see `resume_pending_responses`.
     fn set_build_error(&self, server: AnyServer, log: Log) {
         if server.config().is_development() {
-            // `Output.errorWriterBuffered()` → process-global writer;
-            // `Log::print` accepts it via the `*mut io::Writer`
-            // `IntoLogWrite` adapter and dispatches on
-            // `enable_ansi_colors_stderr` internally.
+            // `Log::print` takes the process-global writer as a `*mut io::Writer` through `IntoLogWrite`.
             let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
             let _ = log.print(writer);
             bun_output::flush();
@@ -474,10 +467,7 @@ impl Route {
         // `Config` owns its fields and
         // drops on early-return.
         config.entry_points.insert(&self.bundle.path)?;
-        // The runtime made this file an HTMLBundle, possibly through an import
-        // attribute or a bunfig `[loader]` entry. The build picks loaders by
-        // extension, so map the file's extension (the same key `Path::loader`
-        // looks up, `""` for no extension) to html for this build.
+        // An import attribute or a bunfig `[loader]` entry may have made this html. `ext` is `""` without one.
         config.loaders = Some(bun_options_types::schema::api::LoaderMap {
             extensions: vec![Box::from(
                 bun_paths::fs::PathName::init(&self.bundle.path).ext,
@@ -645,8 +635,7 @@ impl Route {
                     bun_output::flush();
                 }
 
-                // The build succeeds without an html page when a plugin resolves
-                // or loads the entry point as something else.
+                // A plugin can resolve or load the entry point as something other than html.
                 let Some(html_index) = output_files.iter().position(|output_file| {
                     output_file.output_kind == bundler_options::OutputKind::EntryPoint
                         && output_file.loader == Loader::Html

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -138,7 +138,7 @@ impl HTMLBundle {
             None,
             bun_ast::Loc::EMPTY,
             format_args!(
-                "Bundling {} did not produce an html page. A plugin may have resolved or loaded the file as something other than html.",
+                "Bundling {} did not produce an html page for it. A plugin may have resolved it to another file or loaded it as something other than html.",
                 bun_core::fmt::quote(&self.path)
             ),
         );

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -130,6 +130,23 @@ impl HTMLBundle {
     pub(crate) fn get_index(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         bun_jsc::bun_string_jsc::create_utf8_for_js(global, &this.path)
     }
+
+    /// The error a route reports when a build of its file finishes without an
+    /// html page in its output. `Route::on_complete` and the dev server's
+    /// `finalize_bundle` both reach this state, for example when a plugin
+    /// resolves or loads the file as something other than html.
+    pub(crate) fn no_html_page_log(&self) -> Log {
+        let mut log = Log::init();
+        log.add_error_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "Bundling {} did not produce an html page. A plugin may have resolved or loaded the file as something other than html.",
+                bun_core::fmt::quote(&self.path)
+            ),
+        );
+        log
+    }
 }
 
 /// Deprecated: use Route instead.
@@ -426,6 +443,21 @@ impl Route {
         self.server.get().expect("server set").on_request_complete();
     }
 
+    /// Production says nothing about why a route failed to build, see
+    /// `resume_pending_responses`.
+    fn set_build_error(&self, server: AnyServer, log: Log) {
+        if server.config().is_development() {
+            // `Output.errorWriterBuffered()` → process-global writer;
+            // `Log::print` accepts it via the `*mut io::Writer`
+            // `IntoLogWrite` adapter and dispatches on
+            // `enable_ansi_colors_stderr` internally.
+            let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
+            let _ = log.print(writer);
+            bun_output::flush();
+        }
+        self.state.set(State::Err(log));
+    }
+
     pub(crate) fn on_plugins_resolved(
         &self,
         plugins: Option<NonNull<JSBundler::Plugin>>,
@@ -442,6 +474,16 @@ impl Route {
         // `Config` owns its fields and
         // drops on early-return.
         config.entry_points.insert(&self.bundle.path)?;
+        // The runtime made this file an HTMLBundle, possibly through an import
+        // attribute or a bunfig `[loader]` entry. The build picks loaders by
+        // extension, so map the file's extension (the same key `Path::loader`
+        // looks up, `""` for no extension) to html for this build.
+        config.loaders = Some(bun_options_types::schema::api::LoaderMap {
+            extensions: vec![Box::from(
+                bun_paths::fs::PathName::init(&self.bundle.path).ext,
+            )],
+            loaders: vec![bun_options_types::schema::api::Loader::html],
+        });
         let xform = &vm.transpiler.options.transform_options;
         if let Some(public_path) = xform.serve_public_path.as_deref() {
             if !public_path.is_empty() {
@@ -573,18 +615,9 @@ impl Route {
                 }
                 let mut log = Log::init();
                 completion_task.log.clone_to_with_recycled(&mut log, true);
-                if server.config().is_development() {
-                    // `Output.errorWriterBuffered()` → process-global writer;
-                    // `Log::print` accepts it via the `*mut io::Writer`
-                    // `IntoLogWrite` adapter and dispatches on
-                    // `enable_ansi_colors_stderr` internally.
-                    let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
-                    let _ = log.print(writer);
-                    bun_output::flush();
-                }
-                self.state.set(State::Err(log));
+                self.set_build_error(server, log);
             }
-            BundleV2Result::Value(bundle) => {
+            BundleV2Result::Value(bundle) => 'bundle: {
                 if bun_core::Environment::ENABLE_LOGS {
                     bun_output::scoped_log!(debug, "onComplete: success");
                 }
@@ -611,6 +644,16 @@ impl Route {
                     );
                     bun_output::flush();
                 }
+
+                // The build succeeds without an html page when a plugin resolves
+                // or loads the entry point as something else.
+                let Some(html_index) = output_files.iter().position(|output_file| {
+                    output_file.output_kind == bundler_options::OutputKind::EntryPoint
+                        && output_file.loader == Loader::Html
+                }) else {
+                    self.set_build_error(server, self.bundle.no_html_page_log());
+                    break 'bundle;
+                };
 
                 // `AnyRoute::Static` carries
                 // an intrusive `*mut StaticRoute` here; defer appending the HTML
@@ -695,10 +738,7 @@ impl Route {
                         route_path = &route_path[1..];
                     }
 
-                    if this_html_route.is_none()
-                        && output_files[i].output_kind == bundler_options::OutputKind::EntryPoint
-                        && output_files[i].loader == Loader::Html
-                    {
+                    if i == html_index {
                         // Defer registration so we retain unique ownership for `clone()`.
                         this_html_route = Some((static_route, Box::<[u8]>::from(route_path)));
                         continue;
@@ -711,9 +751,8 @@ impl Route {
                     ));
                 }
 
-                let (html_route, html_route_path) = this_html_route.unwrap_or_else(|| {
-                    panic!("Internal assertion failure: HTML entry point not found in HTMLBundle.")
-                });
+                let (html_route, html_route_path) =
+                    this_html_route.expect("the loop above visited html_index");
                 // SAFETY: html_route is a fresh heap::alloc with ref_count=1;
                 // sole owner before registration.
                 let html_route_clone =

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -937,26 +937,44 @@ describe("html route whose file is not named .html", () => {
 });
 
 // A plugin can resolve the route's html file to a different file. The bundle
-// then finishes without an html page and without an error for the file. Both
-// the dev server and the production build used to crash on that: the dev
-// server when it rendered the page, the production build when it registered
-// the outputs. Now the route reports a build failure.
+// then finishes without an html page for the route's file. Both the dev server
+// and the production build used to crash on that: the dev server when it
+// rendered the page, or when it stored the page of the other html file, the
+// production build when it registered the outputs without an html page.
+//
+// The dev server now reports a build failure for the route. The production
+// build does too when the other file is not html. When it is, the production
+// build serves that file, as it does for any entry point a plugin resolves.
 describe("html route whose file a plugin resolves to a different file", () => {
+  const otherPage = { status: 200, title: "other page" };
+  const failurePage = { status: 500, title: "Bun - Build Failed" };
+  const emptyFailure = { status: 500, title: null };
+  const builtWithout: Record<string, object> = {
+    "app.ts": { devWithoutHmr: [emptyFailure, emptyFailure], production: [emptyFailure] },
+    "other.html": { devWithoutHmr: [otherPage, otherPage], production: [otherPage] },
+  };
+
   // With BUN_ASSUME_PERFECT_INCREMENTAL=0, the default of release builds, the
   // dev server bundles a failed route again for the next request, and that
   // bundle has to report the failure again. With 1, the default of debug
   // builds, the next request is answered from the recorded failure.
-  test.concurrent.each(["0", "1"])("BUN_ASSUME_PERFECT_INCREMENTAL=%s", async assumePerfectIncremental => {
+  test.concurrent.each([
+    ["app.ts", "0"],
+    ["app.ts", "1"],
+    ["other.html", "0"],
+    ["other.html", "1"],
+  ])("resolved to %s, BUN_ASSUME_PERFECT_INCREMENTAL=%s", async (target, assumePerfectIncremental) => {
     using dir = tempDir("bun-serve-html-route-resolved-elsewhere", {
       "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
       "index.html": `<!DOCTYPE html><html><head><title>never served</title></head><body></body></html>`,
+      "other.html": `<!DOCTYPE html><html><head><title>other page</title></head><body></body></html>`,
       "app.ts": `console.log("app");`,
       "plugin.ts": /*ts*/ `
         import { join } from "node:path";
         export default {
           name: "resolve-html-elsewhere",
           setup(build) {
-            build.onResolve({ filter: /index\\.html$/ }, () => ({ path: join(import.meta.dir, "app.ts") }));
+            build.onResolve({ filter: /index\\.html$/ }, () => ({ path: join(import.meta.dir, ${JSON.stringify(target)}) }));
           },
         };
       `,
@@ -980,7 +998,7 @@ describe("html route whose file a plugin resolves to a different file", () => {
             devServer: await serve(true, 2),
             // Every request builds the route again.
             devWithoutHmr: await serve({ hmr: false }, 2),
-            // Requests after the failed build are the subject of #37916.
+            // Requests after a failed build are the subject of #37916.
             production: await serve(false, 1),
           }),
         );
@@ -989,19 +1007,13 @@ describe("html route whose file a plugin resolves to a different file", () => {
     const { stdout, stderr, exitCode } = await runServeFixture(dir, {
       BUN_ASSUME_PERFECT_INCREMENTAL: assumePerfectIncremental,
     });
-    const failurePage = { status: 500, title: "Bun - Build Failed" };
-    const emptyFailure = { status: 500, title: null };
     expect({ stdout, exitCode }, stderr).toEqual({
-      stdout: JSON.stringify({
-        devServer: [failurePage, failurePage],
-        devWithoutHmr: [emptyFailure, emptyFailure],
-        production: [emptyFailure],
-      }),
+      stdout: JSON.stringify({ devServer: [failurePage, failurePage], ...builtWithout[target] }),
       exitCode: 0,
     });
-    // Printed by the dev server and by the development build. Production says nothing.
+    // Printed by the dev server (and by the development build when it fails too). Production says nothing.
     expect(stderr).toMatch(
-      /error: Bundling "[^"]*index\.html" did not produce an html page\. A plugin may have resolved or loaded the file as something other than html\./,
+      /error: Bundling "[^"]*index\.html" did not produce an html page for it\. A plugin may have resolved it to another file or loaded it as something other than html\./,
     );
   });
 });

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -736,6 +736,269 @@ test("serve html whose file is deleted before its first bundle", async () => {
   });
 });
 
+/** Runs the `serve.ts` of a fixture directory to completion. */
+async function runServeFixture(dir: { toString(): string }, env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "serve.ts"],
+    env: { ...bunEnv, ...env },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+}
+
+// The runtime turns a module into an HTMLBundle when its loader is html, and
+// the loader can come from an import attribute or from a bunfig [loader] entry
+// as well as from the .html extension. The dev server and the production build
+// picked the loader of the route's file by its extension only, so a route whose
+// file is not named .html was bundled as an asset. The bundle then finished
+// without an html page for the route, and the process crashed: the dev server
+// while it rendered the page, the production build while it registered the
+// outputs.
+describe("html route whose file is not named .html", () => {
+  const htmPage = (title: string) =>
+    `<!DOCTYPE html><html><head><title>${title}</title></head><body><script type="module" src="./app.ts"></script></body></html>`;
+
+  // Serves the route with the dev server and then with a production build,
+  // and fetches the page and the script the page was given in each mode.
+  const serveInBothModes = (importStatement: string) => /*ts*/ `
+    ${importStatement}
+
+    async function serveOnce(development) {
+      using server = Bun.serve({ port: 0, development, routes: { "/": page } });
+      const response = await fetch(server.url);
+      const text = await response.text();
+      const scriptSrc = text.match(/<script[^>]*\\ssrc="([^"]+)"/)?.[1] ?? null;
+      const scriptStatus = scriptSrc === null ? null : (await fetch(new URL(scriptSrc, server.url))).status;
+      return { status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] ?? null, scriptSrc, scriptStatus };
+    }
+
+    console.log(JSON.stringify({ dev: await serveOnce(true), prod: await serveOnce(false) }));
+  `;
+
+  const served = {
+    status: 200,
+    title: "htm page",
+    // The route's own script, not the "./app.ts" of the source file.
+    scriptSrc: expect.stringMatching(/^\/.+\.js$/),
+    scriptStatus: 200,
+  };
+
+  test.concurrent("import attribute", async () => {
+    using dir = tempDir("bun-serve-html-htm-import-attribute", {
+      "index.htm": htmPage("htm page"),
+      "app.ts": `console.log("app");`,
+      "serve.ts": serveInBothModes(`import page from "./index.htm" with { type: "html" };`),
+    });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    expect({ result: stdout === "" ? null : JSON.parse(stdout), exitCode }, stderr).toEqual({
+      result: { dev: served, prod: served },
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bunfig [loader]", async () => {
+    using dir = tempDir("bun-serve-html-htm-bunfig-loader", {
+      "bunfig.toml": `[loader]\n".htm" = "html"\n`,
+      "index.htm": htmPage("htm page"),
+      "app.ts": `console.log("app");`,
+      "serve.ts": serveInBothModes(`import page from "./index.htm";`),
+    });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    expect({ result: stdout === "" ? null : JSON.parse(stdout), exitCode }, stderr).toEqual({
+      result: { dev: served, prod: served },
+      exitCode: 0,
+    });
+  });
+
+  // A changed route file is bundled again through the incremental graph, which
+  // has to mark it as the html file of a route too.
+  test.concurrent("dev server bundles the edited file as html again", async () => {
+    using dir = tempDir("bun-serve-html-htm-edit", {
+      "index.htm": htmPage("htm page"),
+      "app.ts": `console.log("app");`,
+      "serve.ts": /*ts*/ `
+        import { writeFileSync } from "node:fs";
+        import page from "./index.htm" with { type: "html" };
+
+        using server = Bun.serve({ port: 0, development: true, routes: { "/": page } });
+        async function fetchPage() {
+          const response = await fetch(server.url);
+          const text = await response.text();
+          return { status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] ?? null };
+        }
+
+        const first = await fetchPage();
+        writeFileSync("index.htm", ${JSON.stringify(htmPage("edited htm page"))});
+        let edited = await fetchPage();
+        const deadline = Date.now() + 30_000;
+        while (edited.title !== "edited htm page" && Date.now() < deadline) {
+          await Bun.sleep(10);
+          edited = await fetchPage();
+        }
+        console.log(JSON.stringify({ first, edited }));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: JSON.stringify({
+        first: { status: 200, title: "htm page" },
+        edited: { status: 200, title: "edited htm page" },
+      }),
+      exitCode: 0,
+    });
+  });
+});
+
+// A plugin can resolve the route's html file to a different file. The bundle
+// then finishes without an html page and without an error for the file. Both
+// the dev server and the production build used to crash on that: the dev
+// server when it rendered the page, the production build when it registered
+// the outputs. Now the route reports a build failure.
+describe("html route whose file a plugin resolves to a different file", () => {
+  // With BUN_ASSUME_PERFECT_INCREMENTAL=0, the default of release builds, the
+  // dev server bundles a failed route again for the next request, and that
+  // bundle has to report the failure again. With 1, the default of debug
+  // builds, the next request is answered from the recorded failure.
+  test.concurrent.each(["0", "1"])("BUN_ASSUME_PERFECT_INCREMENTAL=%s", async assumePerfectIncremental => {
+    using dir = tempDir("bun-serve-html-route-resolved-elsewhere", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "index.html": `<!DOCTYPE html><html><head><title>never served</title></head><body></body></html>`,
+      "app.ts": `console.log("app");`,
+      "plugin.ts": /*ts*/ `
+        import { join } from "node:path";
+        export default {
+          name: "resolve-html-elsewhere",
+          setup(build) {
+            build.onResolve({ filter: /index\\.html$/ }, () => ({ path: join(import.meta.dir, "app.ts") }));
+          },
+        };
+      `,
+      "serve.ts": /*ts*/ `
+        import page from "./index.html";
+
+        async function serve(development, requestCount) {
+          using server = Bun.serve({ port: 0, development, routes: { "/": page } });
+          const responses = [];
+          for (let i = 0; i < requestCount; i++) {
+            const response = await fetch(server.url);
+            const text = await response.text();
+            responses.push({ status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] ?? null });
+          }
+          return responses;
+        }
+
+        console.log(
+          JSON.stringify({
+            // The second request reaches the route after its bundle has failed.
+            devServer: await serve(true, 2),
+            // Every request builds the route again.
+            devWithoutHmr: await serve({ hmr: false }, 2),
+            // Requests after the failed build are the subject of #37916.
+            production: await serve(false, 1),
+          }),
+        );
+      `,
+    });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir, {
+      BUN_ASSUME_PERFECT_INCREMENTAL: assumePerfectIncremental,
+    });
+    const failurePage = { status: 500, title: "Bun - Build Failed" };
+    const emptyFailure = { status: 500, title: null };
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: JSON.stringify({
+        devServer: [failurePage, failurePage],
+        devWithoutHmr: [emptyFailure, emptyFailure],
+        production: [emptyFailure],
+      }),
+      exitCode: 0,
+    });
+    // Printed by the dev server and by the development build. Production says nothing.
+    expect(stderr).toMatch(
+      /error: Bundling "[^"]*index\.html" did not produce an html page\. A plugin may have resolved or loaded the file as something other than html\./,
+    );
+  });
+});
+
+// server.reload() hands the dev server a new route object for the same html
+// file. The dev server used to give it a second route bundle and deliver the
+// bundled html there, so a request that was deferred on the original bundle
+// while it was still building crashed the process once the bundle finished.
+test.concurrent("server.reload() while an html route's first bundle is still in flight", async () => {
+  using dir = tempDir("bun-serve-html-reload-during-bundle", {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body><script type="module" src="./app.ts"></script></body></html>`,
+    "app.ts": `console.log("app");`,
+    // Holds the first bundle open until serve.ts has reloaded the server, so
+    // the request that started the bundle stays deferred on it meanwhile.
+    "plugin.ts": /*ts*/ `
+      export default {
+        name: "hold-bundle",
+        setup(build) {
+          build.onLoad({ filter: /app\\.ts$/ }, async () => {
+            globalThis.bundleStarted.resolve();
+            await globalThis.releaseBundle.promise;
+            return { loader: "ts", contents: "console.log('app');" };
+          });
+        },
+      };
+    `,
+    "serve.ts": /*ts*/ `
+      import html from "./index.html";
+
+      globalThis.bundleStarted = Promise.withResolvers();
+      globalThis.releaseBundle = Promise.withResolvers();
+
+      const options = { port: 0, development: true, routes: { "/": html } };
+      const server = Bun.serve(options);
+
+      // Asks the dev server over its HMR socket which route bundle currently
+      // backs "/": the client's "set url" message ('n' + route pattern) is
+      // answered with 'n' + the route bundle index as a u32.
+      async function routeBundleIndex() {
+        const url = new URL("/_bun/hmr", server.url);
+        url.protocol = "ws:";
+        const ws = new WebSocket(url);
+        ws.binaryType = "arraybuffer";
+        const { promise, resolve, reject } = Promise.withResolvers();
+        ws.onerror = reject;
+        ws.onclose = () => reject(new Error("hmr socket closed before answering"));
+        ws.onmessage = ({ data }) => {
+          const view = new DataView(data);
+          if (view.getUint8(0) === "n".charCodeAt(0)) resolve(view.getUint32(1, true));
+        };
+        ws.onopen = () => ws.send(new TextEncoder().encode("n/"));
+        try {
+          return await promise;
+        } finally {
+          ws.onclose = null;
+          ws.close();
+        }
+      }
+
+      const first = fetch(server.url).then(res => res.status);
+      await globalThis.bundleStarted.promise;
+      const before = await routeBundleIndex();
+
+      server.reload(options);
+      const after = await routeBundleIndex();
+
+      globalThis.releaseBundle.resolve();
+      const second = fetch(server.url).then(res => res.status);
+
+      console.log(JSON.stringify({ first: await first, second: await second, sameRouteBundle: before === after }));
+      server.stop(true);
+    `,
+  });
+  const { stdout, stderr, exitCode } = await runServeFixture(dir);
+  expect({ stdout, exitCode }, stderr).toEqual({
+    stdout: JSON.stringify({ first: 200, second: 200, sameRouteBundle: true }),
+    exitCode: 0,
+  });
+});
+
 test("wildcard static routes", async () => {
   await using dir = tempDir("bun-serve-html-error-handling", {
     "index.html": /*html*/ `

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -850,6 +850,90 @@ describe("html route whose file is not named .html", () => {
       exitCode: 0,
     });
   });
+
+  // When a file is deleted, the files that import it are bundled again so that
+  // they report the missing import. This goes through the bundler directly, not
+  // through the entry point list, and has to bundle the route file as html too.
+  test.concurrent("dev server reports a deleted file that the page references", async () => {
+    using dir = tempDir("bun-serve-html-htm-deleted-import", {
+      "index.htm": htmPage("htm page"),
+      "app.ts": `console.log("app");`,
+      "serve.ts": /*ts*/ `
+        import { unlinkSync } from "node:fs";
+        import page from "./index.htm" with { type: "html" };
+
+        using server = Bun.serve({ port: 0, development: true, routes: { "/": page } });
+        async function fetchPage() {
+          const response = await fetch(server.url);
+          const text = await response.text();
+          return { status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] ?? null };
+        }
+
+        const first = await fetchPage();
+        unlinkSync("app.ts");
+        let deleted = await fetchPage();
+        const deadline = Date.now() + 30_000;
+        while (deleted.status === 200 && Date.now() < deadline) {
+          await Bun.sleep(10);
+          deleted = await fetchPage();
+        }
+        console.log(JSON.stringify({ first, deleted }));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: JSON.stringify({
+        first: { status: 200, title: "htm page" },
+        deleted: { status: 500, title: "Bun - Build Failed" },
+      }),
+      exitCode: 0,
+    });
+  });
+
+  // An onResolve plugin whose filter matches the route file takes the entry
+  // point through the plugin path of the bundler. The file is still bundled as
+  // html when the plugin declines, and when it resolves the file to itself.
+  test.concurrent("onResolve plugin that declines or returns the file", async () => {
+    using dir = tempDir("bun-serve-html-htm-resolve-plugin", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "index.htm": htmPage("htm page"),
+      "app.ts": `console.log("app");`,
+      "plugin.ts": /*ts*/ `
+        export default {
+          name: "resolve-htm",
+          setup(build) {
+            build.onResolve({ filter: /\\.htm$/ }, args => (globalThis.returnTheFile ? { path: args.path } : undefined));
+          },
+        };
+      `,
+      "serve.ts": /*ts*/ `
+        import page from "./index.htm" with { type: "html" };
+
+        async function serveOnce(development) {
+          using server = Bun.serve({ port: 0, development, routes: { "/": page } });
+          const response = await fetch(server.url);
+          const text = await response.text();
+          return { status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] ?? null };
+        }
+
+        const results = {};
+        for (const returnTheFile of [false, true]) {
+          globalThis.returnTheFile = returnTheFile;
+          results[returnTheFile ? "returned" : "declined"] = { dev: await serveOnce(true), prod: await serveOnce(false) };
+        }
+        console.log(JSON.stringify(results));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    const page = { status: 200, title: "htm page" };
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: JSON.stringify({
+        declined: { dev: page, prod: page },
+        returned: { dev: page, prod: page },
+      }),
+      exitCode: 0,
+    });
+  });
 });
 
 // A plugin can resolve the route's html file to a different file. The bundle


### PR DESCRIPTION
### Problem
- `Bun.serve` aborts with `panic: called Option::unwrap() on a None value` in `DevServer::generate_html_payload` (`src/runtime/bake/DevServer.rs:2770`) when a bundle ends without html for an html route. Production aborts with `Internal assertion failure: HTML entry point not found in HTMLBundle` (`HTMLBundle.rs:715`). Crash group BUN-3E93.
- Three inputs: (A) a route file not named `.html` (import attribute or bunfig `[loader]`), which both bundlers load by extension; (B) `server.reload()` during the first bundle, which adds a second route bundle for the file (#37929, folded into the open #39488); (C) a `[serve.static]` plugin that resolves the html file to another file.

### Fix
- (A) The dev server asks for `Loader::Html` on every path that bundles the file of a route: the entry point list, the re-bundles after a change or a deleted import, and the onResolve plugin path. The production build maps the file's extension to the html loader.
- (B) A new route for a known file reuses its route bundle. (C) `finalize_bundle` skips an html chunk that belongs to no route and records a build failure for each route it bundled for and left without html, so the requests get the 500 page. `Route::on_complete` sets `State::Err` when no output is an html entry point.
- Verified: 10 fixtures in `test/js/bun/http/bun-serve-html.test.ts`, all abort on the current canary. The related suites stay green (notes).

### Background
- An html route is a `RouteBundle`. `finalize_bundle` stores the html chunk on the route bundle that the file's graph entry points at, then renders the deferred requests from it.
- `EntryPointList` is the file list of one dev bundle, with flags per file. The bundler reads the bits as `EntryPointFlags`.
- A build failure is recorded on a graph file. `finalize_bundle` takes the failure path when the current bundle added one. Release builds bundle a failed route again per request, so the failure is added on every bundle. Outside the dev server, `Route` in `HTMLBundle.rs` builds the route and `State::Err` answers with an empty 500.

<details><summary>Notes</summary>

Reproductions (all abort on the current canary, which already has #39567):

```js
// A: index.htm next to this file. Same with a bunfig [loader] ".htm" = "html" entry.
import page from "./index.htm" with { type: "html" };
const s = Bun.serve({ port: 0, development: true, routes: { "/": page } });
console.log((await fetch(s.url)).status); // now 200, also with development: false
```

```js
// B: app.js imports a few hundred modules so the first bundle takes a while
import page from "./index.html";
const s = Bun.serve({ port: 0, development: true, routes: { "/": page } });
const p1 = fetch(s.url); await Bun.sleep(5);
s.reload({ development: true, routes: { "/": page } });
const p2 = fetch(s.url);
console.log((await p1).status, (await p2).status); // now 200 200
```

Cause of (A): the runtime makes the `HTMLBundle` from the module's loader. The dev bundler (`enqueue_entry_item` in `bundle_v2.rs`) and the production build (`Bun.build` config without a loader entry) pick the loader of the entry point from its extension, so the file is bundled as an asset, `html_files` is empty, no failure is recorded, and `finalize_bundle` sets the route to loaded without html. Cause of (B): `get_or_put_route_bundle` pushed a second `RouteBundle` and `insert_stale_extra` pointed the file at it, so the html chunk went to the new bundle while the deferred request was on the old one.

C is the test fixture: a `[serve.static]` plugin with `onResolve({ filter: /index\.html$/ }, () => ({ path: "app.ts" }))`. Now 500 in all three modes, and the development modes print `error: Bundling "/.../index.html" did not produce an html page for it. A plugin may have resolved it to another file or loaded it as something other than html.` The fixture also runs with `other.html` as the target. That variant panicked the dev server at a different place: the bundle has an html chunk for `other.html`, which has no route bundle, and the html chunk loop in `finalize_bundle` hit `expect("html_route_bundle_index on non-HTML file")` before the new check ran. The loop now receives such a chunk into the graph and skips the route part, and the route gets the same failure. The production build serves `other.html` for the route in that variant (it serves whatever a plugin resolves an entry point to), and the fixture asserts that.

A symlinked route file is not a door: the runtime stores the real path, with and without `--preserve-symlinks` (checked on this branch). A missing html file is #39567. A client abort while bundling, `.HTML` and a `?query` were ruled out before this change was written.

Why `finalize_bundle` does not use the `failed` flag of the file alone: with `BUN_ASSUME_PERFECT_INCREMENTAL=0` (the release default, `check_route_failures` returns `Rebuild`) the second request bundles the route again, the file is still flagged from the first bundle, nothing adds a failure in the second bundle, and the route was set to loaded without html. A version of this change that used the flag alone failed the `=0` case of the plugin test that way. The check now looks at the failures the current bundle added for routes in the `Bundling` state, and at the flag only for routes this bundle was not for (a re-bundle of the file through the watcher that clears the flag without delivering html).

The dev server bundles the file of a route on four paths, and `requested_file_loader` in `bundle_v2.rs` is where all of them pick the loader. `EntryPointList` (first request, and a change of the file or of an asset it uses) carries the `HTML` flag. `on_file_deleted` re-bundles the importers of a deleted file directly through `enqueue_file_from_dev_server_incremental_graph_invalidation` and now passes the loader. Without that, a `.htm` route whose script was deleted tripped a debug assertion in `receive_chunk` and, in release builds, kept serving the old page without an error ("dev server reports a deleted file that the page references"). An onResolve plugin whose filter matches the file takes the entry point through `MiniImportRecord`, which now carries the loader. It applies when the plugins decline and when a plugin returns the file itself. A file that a plugin resolves to instead keeps the loader of its extension, so the (C) fixture still gets its error instead of a page made from the other file's text ("onResolve plugin that declines or returns the file" covers both, in development and production).

The production build keys the loader on the extension because that is the only knob the `Bun.build` path has, and it covers its plugin path as well. It is wider than the dev server's per-file loader: a page whose file is named, say, `page.txt` makes every `.txt` file that the page references html too. Such a file already crashed the process before this change. The bunfig `[loader]` variant means exactly that anyway.

Removing the incremental graph part of (A) makes "dev server bundles the edited file as html again" fail: the edited `.htm` is bundled as an asset and trips `debug_assert!(html_route_bundle_index.is_none())` in `receive_chunk`.

`server.reload()` with an unchanged file now serves the existing bundle instead of building a new route bundle. The file watcher still bundles changed files. #39488 has the same hunk plus a retry of a cached failure on reload, which needs state that main does not have.

A request that arrives after a production build failed still gets an empty 200 from the `State::Err` arm of `on_any_request`. #37916 fixes that, so the production case of the plugin test makes one request.

The two `unwrap()` calls in `generate_html_payload` are now `expect()` with distinct messages, so a future door gets its own crash title instead of the `Option::unwrap` group.

Suites run on the debug build: the rest of `bun-serve-html.test.ts`, `bun-serve-html-{405,build-holds-server,hot-reload-drop,manifest}.test.ts`, `test/bake/dev/{html,plugins,bundle,hot,css,incremental-graph-edge-deletion,production}.test.ts`, `test/bake/{serve-plugins-dev-server,deinitialization,dev-and-prod}.test.ts`, `test/bundler/{bundler_html,bundler_html_server,bundler_plugin,html-import-manifest}.test.ts`. Each new test was run repeatedly, the related ones also with `BUN_ASSUME_PERFECT_INCREMENTAL=0`. `bun-serve-html-entry.test.ts` fails in this container with and without the change (`localhost` connection refused). Two React tests in `test/bake/dev/production.test.ts` hit the 5s default timeout on this debug build and pass with a longer one, with and without the change. `cargo clippy` is clean for `bun_bundler` and `bun_runtime`.

</details>
