### PR TITLE
crash_handler: attribute a crash inside a native module to that module

### DIFF
--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -299,11 +299,9 @@ pub mod features {
         58 => (xml_parse, "xml_parse", core = XML_PARSE),
         /// A standalone executable whose embedded bytecode was produced on a different os/arch/libc than the one running it.
         59 => (cross_compiled_bytecode, "cross_compiled_bytecode"),
-        /// `bun:ffi` `dlopen()` loaded a library. Together with `process_dlopen`
-        /// this tells a crash report how third-party native code got in.
+        /// `bun:ffi` `dlopen()` loaded a library (`process_dlopen` is the Node-API counterpart).
         60 => (ffi_dlopen, "ffi_dlopen"),
-        /// Set by the crash handler when the crash happened inside a native
-        /// module rather than in Bun (see `native_module_of_crash`).
+        /// Set while crashing when the crash is inside a native module, not in Bun.
         61 => (native_module_crash, "native_module_crash"),
     }
 

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -299,6 +299,12 @@ pub mod features {
         58 => (xml_parse, "xml_parse", core = XML_PARSE),
         /// A standalone executable whose embedded bytecode was produced on a different os/arch/libc than the one running it.
         59 => (cross_compiled_bytecode, "cross_compiled_bytecode"),
+        /// `bun:ffi` `dlopen()` loaded a library. Together with `process_dlopen`
+        /// this tells a crash report how third-party native code got in.
+        60 => (ffi_dlopen, "ffi_dlopen"),
+        /// Set by the crash handler when the crash happened inside a native
+        /// module rather than in Bun (see `native_module_of_crash`).
+        61 => (native_module_crash, "native_module_crash"),
     }
 
     // C++ declares these as `extern "C" size_t Bun__...;` and

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -303,6 +303,9 @@ pub mod features {
         60 => (ffi_dlopen, "ffi_dlopen"),
         /// Set while crashing when the crash is inside a native module, not in Bun.
         61 => (native_module_crash, "native_module_crash"),
+        /// `bun:ffi` `cc()` compiled C into the process. It runs from anonymous memory,
+        /// so a crash in it has no image to be attributed to.
+        62 => (ffi_cc, "ffi_cc"),
     }
 
     // C++ declares these as `extern "C" size_t Bun__...;` and

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -303,8 +303,7 @@ pub mod features {
         60 => (ffi_dlopen, "ffi_dlopen"),
         /// Set while crashing when the crash is inside a native module, not in Bun.
         61 => (native_module_crash, "native_module_crash"),
-        /// `bun:ffi` `cc()` compiled C into the process. It runs from anonymous memory,
-        /// so a crash in it has no image to be attributed to.
+        /// `bun:ffi` `cc()` compiled C into the process (it has no image a crash could be attributed to).
         62 => (ffi_cc, "ffi_cc"),
     }
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2519,11 +2519,6 @@ mod draft {
                     });
                 }
 
-                let mut windows_directory = [0u16; bun_sys::windows::MAX_PATH];
-                let is_system =
-                    bun_sys::windows::system_windows_directory_w(&mut windows_directory)
-                        .is_some_and(|directory| is_inside_directory_w(name, directory));
-
                 // Only the basename is converted: `name_bytes` is sized for a
                 // path component, not for a whole path of non-ASCII characters.
                 let basename = bun_paths::basename_windows(name);
@@ -2531,7 +2526,7 @@ mod draft {
                     address,
                     object: Object::named(
                         strings::convert_utf16_to_utf8_in_buffer(name_bytes, basename),
-                        is_system,
+                        is_system_image_windows(name),
                     )?,
                 });
             }
@@ -2690,14 +2685,26 @@ mod draft {
         if !strings::contains_char(path, b'/') {
             return true;
         }
-        // Also matches /lib64, /usr/lib64, /usr/lib/x86_64-linux-gnu and
-        // FreeBSD's /libexec/ld-elf.so.1. /usr/local/lib is deliberately not
-        // here: that is where user-installed libraries go.
-        if path.starts_with(b"/lib") || path.starts_with(b"/usr/lib") {
-            return true;
-        }
-        #[cfg(target_os = "android")]
-        if path.starts_with(b"/system/") || path.starts_with(b"/apex/") {
+        // /usr/local/lib is deliberately not here: that is where
+        // user-installed libraries go.
+        const SYSTEM_LIBRARY_DIRS: &[&[u8]] = &[
+            b"/lib/",
+            b"/lib32/",
+            b"/lib64/",
+            b"/libx32/",
+            // FreeBSD's ld-elf.so.1
+            b"/libexec/",
+            b"/usr/lib/",
+            b"/usr/lib32/",
+            b"/usr/lib64/",
+            b"/usr/libx32/",
+            b"/usr/libexec/",
+            #[cfg(target_os = "android")]
+            b"/system/",
+            #[cfg(target_os = "android")]
+            b"/apex/",
+        ];
+        if SYSTEM_LIBRARY_DIRS.iter().any(|dir| path.starts_with(dir)) {
             return true;
         }
         // Nix and Guix keep libc in a store path instead, so also recognize
@@ -2718,6 +2725,31 @@ mod draft {
         LIBC_FAMILY
             .iter()
             .any(|prefix| basename.starts_with(prefix))
+    }
+
+    /// DLLs that ship with Windows load from the system directory
+    /// (`C:\Windows\System32`, which also holds `DriverStore` and the api-set
+    /// DLLs) or from `WinSxS`. The rest of the Windows directory does not
+    /// count: `C:\Windows\Temp` is the temp directory of a service, which is
+    /// where a standalone executable extracts its embedded addons to.
+    #[cfg(windows)]
+    fn is_system_image_windows(path: &[u16]) -> bool {
+        let mut directory = [0u16; bun_sys::windows::MAX_PATH];
+        if bun_sys::windows::system_directory_w(&mut directory)
+            .is_some_and(|system32| is_inside_directory_w(path, system32))
+        {
+            return true;
+        }
+        let Some(windows) = bun_sys::windows::system_windows_directory_w(&mut directory) else {
+            return false;
+        };
+        let windows_len = windows.len();
+        let winsxs = bun_core::w!("\\WinSxS");
+        let Some(tail) = directory.get_mut(windows_len..windows_len + winsxs.len()) else {
+            return false;
+        };
+        tail.copy_from_slice(winsxs);
+        is_inside_directory_w(path, &directory[..windows_len + winsxs.len()])
     }
 
     /// `path` names something inside `directory` (which has no trailing

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -790,7 +790,7 @@ mod draft {
             Output::disable_scoped_debug_writer();
         }
 
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
+        let mut trace_str_buf = BoundedArray::<u8, TRACE_STRING_CAPACITY>::default();
 
         match PANIC_STAGE.with(|s| s.get()) {
             0 => {
@@ -1049,9 +1049,30 @@ mod draft {
                         &trace_buf
                     };
 
+                    // Decided before the trace string is encoded so that the
+                    // feature bit ends up in it, which is what lets bun.report
+                    // and Sentry tell these crashes apart from Bun's own.
+                    let native_module = native_module_of_crash(trace);
+                    if native_module.is_some() {
+                        bun_analytics::features::native_module_crash
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+
                     if debug_trace {
                         // SAFETY: single-threaded mutation under panic_mutex
                         HAS_PRINTED_MESSAGE.store(true, Ordering::Relaxed);
+
+                        if let Some(module) = &native_module {
+                            if writeln!(
+                                writer,
+                                "Crashed inside native module: {}",
+                                bstr::BStr::new(module.const_slice())
+                            )
+                            .is_err()
+                            {
+                                abort();
+                            }
+                        }
 
                         dump_stack_trace(trace, WriteStackTraceLimits::default());
 
@@ -1120,6 +1141,19 @@ mod draft {
                                 if writer.write_all(
                                 b"Bun has run out of memory.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
                             ).is_err() { abort(); }
+                            } else if let Some(module) = &native_module {
+                                let colors = enable_ansi_colors_stderr();
+                                if write!(
+                                    writer,
+                                    "Bun has crashed inside the native module {}\"{}\"{}.\n\nThis is most likely a bug in that module, not in Bun.\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
+                                    Output::pretty_fmt_rt("<red><d>", colors),
+                                    bstr::BStr::new(module.const_slice()),
+                                    Output::pretty_fmt_rt("<r>", colors),
+                                )
+                                .is_err()
+                                {
+                                    abort();
+                                }
                             } else {
                                 if writer.write_all(
                                 b"Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
@@ -1753,7 +1787,7 @@ mod draft {
         let reason =
             CrashReason::Panic(unsafe { bun_collections::detach_lifetime(msg_buf.const_slice()) });
 
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
+        let mut trace_str_buf = BoundedArray::<u8, TRACE_STRING_CAPACITY>::default();
         {
             let _panic_guard = PANIC_MUTEX.lock();
             let writer = &mut stderr_writer();
@@ -2403,12 +2437,60 @@ mod draft {
         }
     };
 
+    /// Longest image name a [`StackLine`] keeps. Every non-bun frame carries its
+    /// name in the trace string.
+    const MAX_OBJECT_NAME_LEN: usize = 64;
+
+    /// Holds the trace string of a crash whose 20 captured frames all carry a
+    /// `MAX_OBJECT_NAME_LEN` name (about 1.5 KB), plus the header and a fault
+    /// address. `report()` copies it into 4 KB command-line buffers.
+    const TRACE_STRING_CAPACITY: usize = 2048;
+
+    type ObjectName = BoundedArray<u8, MAX_OBJECT_NAME_LEN>;
+
+    /// The image a captured address belongs to. This decides both how the
+    /// frame is encoded (bun frames carry no name so that bun.report can remap
+    /// them) and who a crash at that address is attributed to.
+    enum Object {
+        Bun,
+        /// Part of the operating system, or linked by Bun itself: libc,
+        /// ntdll.dll, the dyld shared cache. A fault in here was caused by
+        /// whatever called into it.
+        System(ObjectName),
+        /// Loaded by something other than Bun: a Node-API addon, a `bun:ffi`
+        /// library, or a library one of those depends on.
+        ThirdParty(ObjectName),
+    }
+
+    impl Object {
+        /// `None` when the loader has no name for the image.
+        fn named(image_path: &[u8], is_system: bool) -> Option<Object> {
+            let basename = bun_paths::basename(image_path);
+            if basename.is_empty() {
+                return None;
+            }
+            let mut name = ObjectName::default();
+            let _ = name.append_slice(&basename[..basename.len().min(MAX_OBJECT_NAME_LEN)]);
+            Some(if is_system {
+                Object::System(name)
+            } else {
+                Object::ThirdParty(name)
+            })
+        }
+
+        /// `None` for bun itself.
+        fn name(&self) -> Option<&[u8]> {
+            match self {
+                Object::Bun => None,
+                Object::System(name) | Object::ThirdParty(name) => Some(name.const_slice()),
+            }
+        }
+    }
+
     struct StackLine {
+        /// Offset inside `object`. For bun this is what bun.report remaps.
         address: i32,
-        // None -> from bun.exe
-        object: Option<Box<[u8]>>,
-        // Box<[u8]> rather than a borrowed slice into caller's `name_bytes`,
-        // since the only caller writes into a stack buffer and the value is consumed immediately.
+        object: Object,
     }
 
     impl StackLine {
@@ -2423,27 +2505,34 @@ mod draft {
                 let mut temp: [u16; 512] = [0; 512];
                 let name = bun_sys::windows::get_module_name_w(module, &mut temp)?;
 
-                let image_path = bun_sys::windows::exe_path_w();
+                // To remap this, `pdb-addr2line --exe bun.pdb 0x123456`
+                // Use a wrapping cast so an oversize/underflowed module offset
+                // produces a junk frame instead of panicking *inside* the crash
+                // handler (which would escalate to a double-panic and lose the
+                // entire report).
+                let address = addr.wrapping_sub(base_address) as i32;
 
+                if name == bun_sys::windows::exe_path_w().as_slice() {
+                    return Some(StackLine {
+                        address,
+                        object: Object::Bun,
+                    });
+                }
+
+                let mut windows_directory = [0u16; bun_sys::windows::MAX_PATH];
+                let is_system =
+                    bun_sys::windows::system_windows_directory_w(&mut windows_directory)
+                        .is_some_and(|directory| is_inside_directory_w(name, directory));
+
+                // Only the basename is converted: `name_bytes` is sized for a
+                // path component, not for a whole path of non-ASCII characters.
+                let basename = bun_paths::basename_windows(name);
                 return Some(StackLine {
-                    // To remap this, `pdb-addr2line --exe bun.pdb 0x123456`
-                    // Use a wrapping cast so an oversize/underflowed module offset
-                    // produces a junk frame instead of panicking *inside* the crash
-                    // handler (which would escalate to a double-panic and lose the
-                    // entire report).
-                    address: addr.wrapping_sub(base_address) as i32,
-
-                    object: if name != image_path.as_slice() {
-                        // GetModuleFileNameW output never has a trailing separator
-                        // or bare drive prefix, so `basename_windows`'s
-                        // stripping is a no-op on this domain.
-                        let basename = bun_paths::basename_windows(name);
-                        Some(Box::<[u8]>::from(
-                            &*strings::convert_utf16_to_utf8_in_buffer(name_bytes, basename),
-                        ))
-                    } else {
-                        None
-                    },
+                    address,
+                    object: Object::named(
+                        strings::convert_utf16_to_utf8_in_buffer(name_bytes, basename),
+                        is_system,
+                    )?,
                 });
             }
             #[cfg(target_os = "macos")]
@@ -2509,14 +2598,31 @@ mod draft {
                                         // The reason we are subtracting this known offset is mostly just so that we can
                                         // fit it within a signed 32-bit integer. The VLQs will be shorter too.
                                         return Some(StackLine {
-                                            object: None,
+                                            object: Object::Bun,
                                             address: i32::try_from(image_relative_address)
                                                 .expect("int cast"),
                                         });
-                                    } else {
-                                        // these libraries are not interesting, mark as unknown
+                                    }
+
+                                    let image_name = bun_sys::c::_dyld_get_image_name(i);
+                                    if image_name.is_null() {
                                         return None;
                                     }
+                                    // SAFETY: dyld returns a NUL-terminated path that stays
+                                    // valid while the image is loaded, and the image is
+                                    // loaded: we just found `address` inside it.
+                                    let image_path =
+                                        unsafe { bun_core::ffi::cstr(image_name) }.to_bytes();
+                                    // Everything Apple ships, including the dyld shared
+                                    // cache, lives under one of these two prefixes.
+                                    let is_system = image_path.starts_with(b"/usr/lib/")
+                                        || image_path.starts_with(b"/System/");
+                                    return Some(StackLine {
+                                        object: Object::named(image_path, is_system)?,
+                                        // Same wrapping cast as Windows: the offset is only
+                                        // informational for a library that is not bun.
+                                        address: address.wrapping_sub(base_address) as i32,
+                                    });
                                 }
                             }
                             _ => {}
@@ -2533,9 +2639,17 @@ mod draft {
                 let _ = name_bytes;
                 let address = addr.saturating_sub(1);
                 let m = bun_sys::elf::find_loaded_module(address)?;
+                if m.is_main_program {
+                    return Some(StackLine {
+                        address: i32::try_from(address - m.base_address).expect("int cast"),
+                        object: Object::Bun,
+                    });
+                }
                 return Some(StackLine {
-                    address: i32::try_from(address - m.base_address).expect("int cast"),
-                    object: None,
+                    // Same wrapping cast as Windows: the offset is only
+                    // informational for a library that is not bun.
+                    address: address.wrapping_sub(m.base_address) as i32,
+                    object: Object::named(&m.name, is_system_library_elf(&m.name))?,
                 });
             }
         }
@@ -2546,17 +2660,108 @@ mod draft {
                 return Ok(());
             };
 
-            if let Some(object) = &known.object {
+            if let Some(object) = known.object.name() {
+                // The name goes into the URL verbatim, and bun.report reads it
+                // back as `len` characters, so it has to stay ASCII and free of
+                // URL syntax.
+                let mut encodable = ObjectName::default();
+                for &byte in object {
+                    let _ = encodable.append(match byte {
+                        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' | b'+' => byte,
+                        _ => b'_',
+                    });
+                }
                 writer.write_all(VLQ::encode(1).slice())?;
-                writer.write_all(
-                    VLQ::encode(i32::try_from(object.len()).expect("int cast")).slice(),
-                )?;
-                writer.write_all(object)?;
+                writer.write_all(VLQ::encode(encodable.len() as i32).slice())?;
+                writer.write_all(encodable.const_slice())?;
             }
 
             writer.write_all(VLQ::encode(known.address).slice())?;
             Ok(())
         }
+    }
+
+    /// Whether a shared object came with the operating system, judged by where
+    /// it lives. A library that user code loads from a system directory is
+    /// treated as system too, which errs towards reporting a Bun crash.
+    #[cfg(not(any(windows, target_os = "macos")))]
+    fn is_system_library_elf(path: &[u8]) -> bool {
+        // The vDSO is reported with a bare name ("linux-vdso.so.1").
+        if !strings::contains_char(path, b'/') {
+            return true;
+        }
+        // Also matches /lib64, /usr/lib64, /usr/lib/x86_64-linux-gnu and
+        // FreeBSD's /libexec/ld-elf.so.1. /usr/local/lib is deliberately not
+        // here: that is where user-installed libraries go.
+        if path.starts_with(b"/lib") || path.starts_with(b"/usr/lib") {
+            return true;
+        }
+        #[cfg(target_os = "android")]
+        if path.starts_with(b"/system/") || path.starts_with(b"/apex/") {
+            return true;
+        }
+        // Nix and Guix keep libc in a store path instead, so also recognize
+        // the libraries Bun itself links against (and the ones glibc loads
+        // lazily) by name.
+        const LIBC_FAMILY: &[&[u8]] = &[
+            b"libc.",
+            b"libm.",
+            b"libdl.",
+            b"libpthread.",
+            b"librt.",
+            b"libresolv.",
+            b"libgcc_s.",
+            b"libnss_",
+            b"ld-",
+        ];
+        let basename = bun_paths::basename(path);
+        LIBC_FAMILY
+            .iter()
+            .any(|prefix| basename.starts_with(prefix))
+    }
+
+    /// `path` names something inside `directory` (which has no trailing
+    /// separator). Windows paths compare case-insensitively, and
+    /// `GetModuleFileNameW` reports whatever casing the image was loaded with.
+    #[cfg(windows)]
+    fn is_inside_directory_w(path: &[u16], directory: &[u16]) -> bool {
+        fn is_separator(unit: u16) -> bool {
+            unit == u16::from(b'\\') || unit == u16::from(b'/')
+        }
+        fn fold(unit: u16) -> u16 {
+            match u8::try_from(unit) {
+                Ok(byte) => u16::from(byte.to_ascii_lowercase()),
+                Err(_) => unit,
+            }
+        }
+        !directory.is_empty()
+            && path.len() > directory.len()
+            && is_separator(path[directory.len()])
+            && path[..directory.len()]
+                .iter()
+                .zip(directory)
+                .all(|(&a, &b)| fold(a) == fold(b) || (is_separator(a) && is_separator(b)))
+    }
+
+    /// Names the third-party image the crash happened in, if any. The
+    /// innermost frame that belongs to an image at all decides: if that is
+    /// Bun's own code, this is a Bun crash, whatever native code is further
+    /// up the stack. System libraries do not decide anything because a fault
+    /// inside `memcpy` belongs to whoever passed it the pointer, and neither
+    /// do frames outside every image (JIT code, `bun:ffi` trampolines).
+    fn native_module_of_crash(trace: &StackTrace) -> Option<ObjectName> {
+        let mut name_bytes: [u8; 1024] = [0; 1024];
+        for &addr in &trace.instruction_addresses[0..trace.index] {
+            let Some(line) = StackLine::from_address(addr, &mut name_bytes) else {
+                continue;
+            };
+            match line.object {
+                Object::Bun => return None,
+                Object::System(_) => continue,
+                Object::ThirdParty(name) => return Some(name),
+            }
+        }
+        None
     }
 
     struct TraceString<'a> {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1049,9 +1049,7 @@ mod draft {
                         &trace_buf
                     };
 
-                    // Decided before the trace string is encoded so that the
-                    // feature bit ends up in it, which is what lets bun.report
-                    // and Sentry tell these crashes apart from Bun's own.
+                    // Before the trace string is encoded, so that it carries the bit.
                     let native_module = native_module_of_crash(trace);
                     if native_module.is_some() {
                         bun_analytics::features::native_module_crash
@@ -2437,28 +2435,21 @@ mod draft {
         }
     };
 
-    /// Longest image name a [`StackLine`] keeps. Every non-bun frame carries its
-    /// name in the trace string.
     const MAX_OBJECT_NAME_LEN: usize = 64;
 
-    /// Holds the trace string of a crash whose 20 captured frames all carry a
-    /// `MAX_OBJECT_NAME_LEN` name (about 1.5 KB), plus the header and a fault
-    /// address. `report()` copies it into 4 KB command-line buffers.
+    /// Fits the 20 captured frames with a `MAX_OBJECT_NAME_LEN` name each.
+    /// `report()` copies the result into 4 KB buffers.
     const TRACE_STRING_CAPACITY: usize = 2048;
 
     type ObjectName = BoundedArray<u8, MAX_OBJECT_NAME_LEN>;
 
-    /// The image a captured address belongs to. This decides both how the
-    /// frame is encoded (bun frames carry no name so that bun.report can remap
-    /// them) and who a crash at that address is attributed to.
+    /// The image a captured address belongs to.
     enum Object {
+        /// Encoded without a name so that bun.report remaps the address.
         Bun,
-        /// Part of the operating system, or linked by Bun itself: libc,
-        /// ntdll.dll, the dyld shared cache. A fault in here was caused by
-        /// whatever called into it.
+        /// libc, ntdll.dll, the dyld shared cache: a fault in here is blamed on the caller.
         System(ObjectName),
-        /// Loaded by something other than Bun: a Node-API addon, a `bun:ffi`
-        /// library, or a library one of those depends on.
+        /// A Node-API addon, a `bun:ffi` library, or something one of them loaded.
         ThirdParty(ObjectName),
     }
 
@@ -2519,8 +2510,7 @@ mod draft {
                     });
                 }
 
-                // Only the basename is converted: `name_bytes` is sized for a
-                // path component, not for a whole path of non-ASCII characters.
+                // A whole path can overflow `name_bytes`; one component cannot.
                 let basename = bun_paths::basename_windows(name);
                 return Some(StackLine {
                     address,
@@ -2603,19 +2593,15 @@ mod draft {
                                     if image_name.is_null() {
                                         return None;
                                     }
-                                    // SAFETY: dyld returns a NUL-terminated path that stays
-                                    // valid while the image is loaded, and the image is
-                                    // loaded: we just found `address` inside it.
+                                    // SAFETY: dyld owns the NUL-terminated path and keeps it
+                                    // while the image is loaded, and `address` is inside it.
                                     let image_path =
                                         unsafe { bun_core::ffi::cstr(image_name) }.to_bytes();
-                                    // Everything Apple ships, including the dyld shared
-                                    // cache, lives under one of these two prefixes.
+                                    // The dyld shared cache included.
                                     let is_system = image_path.starts_with(b"/usr/lib/")
                                         || image_path.starts_with(b"/System/");
                                     return Some(StackLine {
                                         object: Object::named(image_path, is_system)?,
-                                        // Same wrapping cast as Windows: the offset is only
-                                        // informational for a library that is not bun.
                                         address: address.wrapping_sub(base_address) as i32,
                                     });
                                 }
@@ -2641,8 +2627,6 @@ mod draft {
                     });
                 }
                 return Some(StackLine {
-                    // Same wrapping cast as Windows: the offset is only
-                    // informational for a library that is not bun.
                     address: address.wrapping_sub(m.base_address) as i32,
                     object: Object::named(&m.name, is_system_library_elf(&m.name))?,
                 });
@@ -2656,9 +2640,7 @@ mod draft {
             };
 
             if let Some(object) = known.object.name() {
-                // The name goes into the URL verbatim, and bun.report reads it
-                // back as `len` characters, so it has to stay ASCII and free of
-                // URL syntax.
+                // Goes into the URL as is, and bun.report reads it back by character count.
                 let mut encodable = ObjectName::default();
                 for &byte in object {
                     let _ = encodable.append(match byte {
@@ -2676,17 +2658,15 @@ mod draft {
         }
     }
 
-    /// Whether a shared object came with the operating system, judged by where
-    /// it lives. A library that user code loads from a system directory is
-    /// treated as system too, which errs towards reporting a Bun crash.
+    /// Judged by where the object lives, so a user library installed into a
+    /// system directory counts as system too (and is reported as a Bun crash).
     #[cfg(not(any(windows, target_os = "macos")))]
     fn is_system_library_elf(path: &[u8]) -> bool {
-        // The vDSO is reported with a bare name ("linux-vdso.so.1").
+        // The vDSO ("linux-vdso.so.1") has no path.
         if !strings::contains_char(path, b'/') {
             return true;
         }
-        // /usr/local/lib is deliberately not here: that is where
-        // user-installed libraries go.
+        // Not /usr/local/lib: that is where users install libraries.
         const SYSTEM_LIBRARY_DIRS: &[&[u8]] = &[
             b"/lib/",
             b"/lib32/",
@@ -2707,9 +2687,7 @@ mod draft {
         if SYSTEM_LIBRARY_DIRS.iter().any(|dir| path.starts_with(dir)) {
             return true;
         }
-        // Nix and Guix keep libc in a store path instead, so also recognize
-        // the libraries Bun itself links against (and the ones glibc loads
-        // lazily) by name.
+        // Nix and Guix keep these in store paths.
         const LIBC_FAMILY: &[&[u8]] = &[
             b"libc.",
             b"libm.",
@@ -2727,11 +2705,9 @@ mod draft {
             .any(|prefix| basename.starts_with(prefix))
     }
 
-    /// DLLs that ship with Windows load from the system directory
-    /// (`C:\Windows\System32`, which also holds `DriverStore` and the api-set
-    /// DLLs) or from `WinSxS`. The rest of the Windows directory does not
-    /// count: `C:\Windows\Temp` is the temp directory of a service, which is
-    /// where a standalone executable extracts its embedded addons to.
+    /// System32 (drivers included) or WinSxS. Not the whole Windows directory:
+    /// a service's temp directory is `C:\Windows\Temp`, and embedded addons
+    /// are extracted into the temp directory.
     #[cfg(windows)]
     fn is_system_image_windows(path: &[u16]) -> bool {
         let mut directory = [0u16; bun_sys::windows::MAX_PATH];
@@ -2752,9 +2728,7 @@ mod draft {
         is_inside_directory_w(path, &directory[..windows_len + winsxs.len()])
     }
 
-    /// `path` names something inside `directory` (which has no trailing
-    /// separator). Windows paths compare case-insensitively, and
-    /// `GetModuleFileNameW` reports whatever casing the image was loaded with.
+    /// `directory` has no trailing separator. Case-insensitive, like the file system.
     #[cfg(windows)]
     fn is_inside_directory_w(path: &[u16], directory: &[u16]) -> bool {
         fn is_separator(unit: u16) -> bool {
@@ -2775,12 +2749,9 @@ mod draft {
                 .all(|(&a, &b)| fold(a) == fold(b) || (is_separator(a) && is_separator(b)))
     }
 
-    /// Names the third-party image the crash happened in, if any. The
-    /// innermost frame that belongs to an image at all decides: if that is
-    /// Bun's own code, this is a Bun crash, whatever native code is further
-    /// up the stack. System libraries do not decide anything because a fault
-    /// inside `memcpy` belongs to whoever passed it the pointer, and neither
-    /// do frames outside every image (JIT code, `bun:ffi` trampolines).
+    /// The innermost frame inside an image decides. System frames are skipped
+    /// (a fault in `memcpy` belongs to the caller), and so are frames outside
+    /// every image (JIT code, FFI trampolines).
     fn native_module_of_crash(trace: &StackTrace) -> Option<ObjectName> {
         let mut name_bytes: [u8; 1024] = [0; 1024];
         for &addr in &trace.instruction_addresses[0..trace.index] {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1141,17 +1141,34 @@ mod draft {
                             ).is_err() { abort(); }
                             } else if let Some(module) = &native_module {
                                 let colors = enable_ansi_colors_stderr();
-                                if write!(
-                                    writer,
-                                    "Bun has crashed inside the native module {}\"{}\"{}.\n\nThis is most likely a bug in that module, not in Bun.\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
-                                    Output::pretty_fmt_rt("<red><d>", colors),
-                                    bstr::BStr::new(module.const_slice()),
-                                    Output::pretty_fmt_rt("<r>", colors),
-                                )
-                                .is_err()
+                                if writer
+                                    .write_all(b"Bun has crashed inside the native module ")
+                                    .is_err()
                                 {
                                     abort();
                                 }
+                                if colors
+                                    && writer
+                                        .write_all(&Output::pretty_fmt::<true>("<red><d>"))
+                                        .is_err()
+                                {
+                                    abort();
+                                }
+                                if write!(writer, "\"{}\"", bstr::BStr::new(module.const_slice()))
+                                    .is_err()
+                                {
+                                    abort();
+                                }
+                                if colors
+                                    && writer
+                                        .write_all(&Output::pretty_fmt::<true>("<r>"))
+                                        .is_err()
+                                {
+                                    abort();
+                                }
+                                if writer.write_all(
+                                b".\n\nThis is most likely a bug in that module, not in Bun.\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
+                            ).is_err() { abort(); }
                             } else {
                                 if writer.write_all(
                                 b"Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
@@ -2622,7 +2639,7 @@ mod draft {
                 let m = bun_sys::elf::find_loaded_module(address)?;
                 if m.is_main_program {
                     return Some(StackLine {
-                        address: i32::try_from(address - m.base_address).expect("int cast"),
+                        address: i32::try_from(address - m.base_address).ok()?,
                         object: Object::Bun,
                     });
                 }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -120,7 +120,17 @@ export const cssInternals = {
 
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
+  getFeatureData: () => {
+    features: string[];
+    version: string;
+    is_canary: boolean;
+    revision: string;
+    generated_at: number;
+  };
   segfault: () => void;
+  segfaultInDll: () => void;
+  /** Reports a segfault whose frame 0 is `pc`, a code address such as a `bun:ffi` function's `.ptr`. */
+  segfaultAtPc: (pc: number) => void;
   panic: () => void;
   rootError: () => void;
   outOfMemory: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -127,13 +127,9 @@ pub(crate) mod js_bindings {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// Reports a segmentation fault as if the faulting instruction were at the
-    /// code address passed in (a number, e.g. a `bun:ffi` function's `.ptr`),
-    /// which is how the signal and exception handlers seed the trace from a
-    /// real fault. Lets a test choose which image frame 0 falls into without
-    /// a real fault, which ASAN builds would not route to the crash handler.
-    /// On POSIX the rest of the trace is this function's callers; on Windows
-    /// the walk needs a fault `CONTEXT`, so the trace is frame 0 alone.
+    /// Reports a segfault whose frame 0 is the code address passed in, so a test
+    /// can put the fault inside any image without a real fault (which ASAN
+    /// builds do not route here). Windows has no fault `CONTEXT` to walk from.
     #[bun_jsc::host_fn]
     fn js_segfault_at_pc(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let pc = frame.argument(0).to_number(global)?;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -23,6 +23,7 @@ pub(crate) mod js_bindings {
             ("getFeatureData", __jsc_host_js_get_feature_data),
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
+            ("segfaultAtPc", __jsc_host_js_segfault_at_pc),
             ("panic", __jsc_host_js_panic),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
@@ -124,6 +125,28 @@ pub(crate) mod js_bindings {
         }
         #[allow(unreachable_code)]
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// Reports a segmentation fault as if the faulting instruction were at the
+    /// code address passed in (a number, e.g. a `bun:ffi` function's `.ptr`),
+    /// which is how the signal and exception handlers seed the trace from a
+    /// real fault. Lets a test choose which image frame 0 falls into without
+    /// a real fault, which ASAN builds would not route to the crash handler.
+    /// On POSIX the rest of the trace is this function's callers; on Windows
+    /// the walk needs a fault `CONTEXT`, so the trace is frame 0 alone.
+    #[bun_jsc::host_fn]
+    fn js_segfault_at_pc(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let pc = frame.argument(0).to_number(global)? as usize;
+        crash_handler::suppress_core_dumps_if_necessary();
+        let fp = if cfg!(windows) {
+            0
+        } else {
+            bun_core::debug::frame_address()
+        };
+        crash_handler::crash_handler(
+            crash_handler::CrashReason::SegmentationFault(0),
+            crash_handler::TraceSeed::Fault { pc, fp },
+        );
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -136,7 +136,13 @@ pub(crate) mod js_bindings {
     /// the walk needs a fault `CONTEXT`, so the trace is frame 0 alone.
     #[bun_jsc::host_fn]
     fn js_segfault_at_pc(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        let pc = frame.argument(0).to_number(global)? as usize;
+        let pc = frame.argument(0).to_number(global)?;
+        if !(pc >= 0.0 && pc <= usize::MAX as f64 && pc.fract() == 0.0) {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "segfaultAtPc: expected a code address, got {pc}"
+            )));
+        }
+        let pc = pc as usize;
         crash_handler::suppress_core_dumps_if_necessary();
         let fp = if cfg!(windows) {
             0

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -133,7 +133,8 @@ pub(crate) mod js_bindings {
     #[bun_jsc::host_fn]
     fn js_segfault_at_pc(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let pc = frame.argument(0).to_number(global)?;
-        if !(pc >= 0.0 && pc <= usize::MAX as f64 && pc.fract() == 0.0) {
+        // `usize::MAX as f64` rounds up to 2^64, hence `<`.
+        if !(pc >= 0.0 && pc < usize::MAX as f64 && pc.fract() == 0.0) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "segfaultAtPc: expected a code address, got {pc}"
             )));

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1488,6 +1488,7 @@ impl FFI {
                 }
             }
         };
+        bun_analytics::features::ffi_dlopen.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
         let mut size = symbols.values().len();
         if size >= 63 {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1167,6 +1167,7 @@ impl FFI {
                 }
             },
         };
+        bun_analytics::features::ffi_cc.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         let _tcc_guard = scopeguard::guard(&mut tcc_state, |s| {
             if let Some(state) = s {
                 // SAFETY: state is a valid TCC::State pointer from compile()

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5112,6 +5112,10 @@ pub mod c {
         pub safe fn _dyld_image_count() -> u32;
         /// `intptr_t _dyld_get_image_vmaddr_slide(uint32_t image_index)`
         pub safe fn _dyld_get_image_vmaddr_slide(image_index: u32) -> isize;
+        /// `const char* _dyld_get_image_name(uint32_t image_index)` — the
+        /// image's install path, owned by dyld and valid while the image stays
+        /// loaded; null for an out-of-range index.
+        pub safe fn _dyld_get_image_name(image_index: u32) -> *const core::ffi::c_char;
         /// `const struct mach_header* _dyld_get_image_header(uint32_t)` — by-value
         /// index; out-of-range returns null (no precondition).
         #[link_name = "_dyld_get_image_header"]
@@ -8428,21 +8432,26 @@ pub mod elf {
         /// `dlpi_name` copied to an owned buffer (empty when libc reports `NULL`,
         /// as Android does for the main program).
         pub name: Box<[u8]>,
+        /// The object is the executable itself, not a shared object. glibc,
+        /// musl and bionic all report the main program first; what they put in
+        /// its `dlpi_name` differs, so the position is what identifies it.
+        pub is_main_program: bool,
     }
 
     /// Walk loaded ELF objects via `dl_iterate_phdr`, returning the one whose
-    /// `PT_LOAD` segment contains `address` (matched by address, so it does not
-    /// depend on how a libc names or orders the main program).
+    /// `PT_LOAD` segment contains `address`.
     #[cfg(not(any(windows, target_os = "macos")))]
     pub fn find_loaded_module(address: usize) -> Option<LoadedModule> {
         use core::ffi::{c_int, c_void};
 
         struct Ctx {
             address: usize,
+            visited: usize,
             result: Option<LoadedModule>,
         }
         let mut ctx = Ctx {
             address,
+            visited: 0,
             result: None,
         };
 
@@ -8458,6 +8467,8 @@ pub mod elf {
             let context = unsafe { bun_core::callback_ctx::<Ctx>(data) };
             // SAFETY: dl_iterate_phdr passes a valid info pointer.
             let info = unsafe { &*info };
+            let is_main_program = context.visited == 0;
+            context.visited += 1;
             // The base address is too high
             if context.address < info.dlpi_addr as usize {
                 return 0;
@@ -8488,6 +8499,7 @@ pub mod elf {
                     context.result = Some(LoadedModule {
                         base_address: info.dlpi_addr as usize,
                         name,
+                        is_main_program,
                     });
                     return 1; // error.Found → stop iteration
                 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5112,9 +5112,8 @@ pub mod c {
         pub safe fn _dyld_image_count() -> u32;
         /// `intptr_t _dyld_get_image_vmaddr_slide(uint32_t image_index)`
         pub safe fn _dyld_get_image_vmaddr_slide(image_index: u32) -> isize;
-        /// `const char* _dyld_get_image_name(uint32_t image_index)` — the
-        /// image's install path, owned by dyld and valid while the image stays
-        /// loaded; null for an out-of-range index.
+        /// `const char* _dyld_get_image_name(uint32_t image_index)` — dyld-owned,
+        /// valid while the image is loaded; null when out of range.
         pub safe fn _dyld_get_image_name(image_index: u32) -> *const core::ffi::c_char;
         /// `const struct mach_header* _dyld_get_image_header(uint32_t)` — by-value
         /// index; out-of-range returns null (no precondition).
@@ -8432,9 +8431,8 @@ pub mod elf {
         /// `dlpi_name` copied to an owned buffer (empty when libc reports `NULL`,
         /// as Android does for the main program).
         pub name: Box<[u8]>,
-        /// The object is the executable itself, not a shared object. glibc,
-        /// musl and bionic all report the main program first; what they put in
-        /// its `dlpi_name` differs, so the position is what identifies it.
+        /// The first object reported, which glibc, musl and bionic all define
+        /// as the executable (its `dlpi_name` differs between them).
         pub is_main_program: bool,
     }
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -90,15 +90,12 @@ pub mod kernel32 {
         /// No preconditions; reads the calling thread's ID.
         pub safe fn GetCurrentThreadId() -> DWORD;
 
-        /// `GetSystemWindowsDirectoryW` (`sysinfoapi.h`): the shared Windows
-        /// directory (`C:\Windows`), unlike `GetWindowsDirectoryW`, which can
-        /// be a per-user directory under Terminal Services.
+        /// Unlike `GetWindowsDirectoryW`, never a per-user (Terminal Services) directory.
         pub fn GetSystemWindowsDirectoryW(lpBuffer: LPWSTR, uSize: UINT) -> UINT;
     }
 }
 
-/// The Windows directory (`C:\Windows`) without a trailing separator, written
-/// into `buf`. `None` if the call fails or `buf` is too small.
+/// `C:\Windows`, without a trailing separator.
 pub fn system_windows_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
     // SAFETY: `buf` is valid for `capacity` u16 writes.
     well_known_directory_w(buf, |ptr, capacity| unsafe {
@@ -106,8 +103,7 @@ pub fn system_windows_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
     })
 }
 
-/// The system directory (`C:\Windows\System32`) without a trailing separator,
-/// written into `buf`. `None` if the call fails or `buf` is too small.
+/// `C:\Windows\System32`, without a trailing separator.
 pub fn system_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
     // SAFETY: `buf` is valid for `capacity` u16 writes.
     well_known_directory_w(buf, |ptr, capacity| unsafe {
@@ -115,12 +111,10 @@ pub fn system_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
     })
 }
 
-/// Shared shape of `GetSystemDirectoryW` and friends: they return the length
-/// written without the NUL, or the size needed including the NUL when the
-/// buffer is too small.
 fn well_known_directory_w(buf: &mut [u16], get: impl FnOnce(LPWSTR, u32) -> u32) -> Option<&[u16]> {
     let capacity = u32::try_from(buf.len()).ok()?;
     let len = get(buf.as_mut_ptr(), capacity) as usize;
+    // `len >= buf.len()` is the "buffer too small, this is the size needed" return.
     if len == 0 || len >= buf.len() {
         return None;
     }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -29,7 +29,7 @@ pub use bun_windows_sys::ws2_32;
 pub mod kernel32 {
     use super::{
         BOOL, CONDITION_VARIABLE, DWORD, FileNotifyChangeFilter, HANDLE, LPCWSTR, LPOVERLAPPED,
-        LPOVERLAPPED_COMPLETION_ROUTINE, OVERLAPPED, SRWLOCK, ULONG, ULONG_PTR,
+        LPOVERLAPPED_COMPLETION_ROUTINE, LPWSTR, OVERLAPPED, SRWLOCK, UINT, ULONG, ULONG_PTR,
     };
     pub use bun_windows_sys::externs::SetEndOfFile;
     pub use bun_windows_sys::externs::{GetConsoleMode, GetExitCodeProcess, SetConsoleMode};
@@ -89,7 +89,32 @@ pub mod kernel32 {
 
         /// No preconditions; reads the calling thread's ID.
         pub safe fn GetCurrentThreadId() -> DWORD;
+
+        /// `GetSystemWindowsDirectoryW` (`sysinfoapi.h`): the shared Windows
+        /// directory (`C:\Windows`), unlike `GetWindowsDirectoryW`, which can
+        /// be a per-user directory under Terminal Services.
+        pub fn GetSystemWindowsDirectoryW(lpBuffer: LPWSTR, uSize: UINT) -> UINT;
     }
+}
+
+/// The Windows directory without a trailing separator, written into `buf`.
+/// `None` if the call fails or `buf` is too small.
+pub fn system_windows_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
+    let Ok(capacity) = u32::try_from(buf.len()) else {
+        return None;
+    };
+    // SAFETY: `buf` is valid for `capacity` u16 writes.
+    let len = unsafe { kernel32::GetSystemWindowsDirectoryW(buf.as_mut_ptr(), capacity) } as usize;
+    // Returns the required size (including the NUL) when the buffer is too
+    // small, and the length written (excluding the NUL) otherwise.
+    if len == 0 || len >= buf.len() {
+        return None;
+    }
+    let mut end = len;
+    while end > 0 && (buf[end - 1] == u16::from(b'\\') || buf[end - 1] == u16::from(b'/')) {
+        end -= 1;
+    }
+    Some(&buf[..end])
 }
 
 pub use bun_windows_sys::BOOL;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -97,16 +97,30 @@ pub mod kernel32 {
     }
 }
 
-/// The Windows directory without a trailing separator, written into `buf`.
-/// `None` if the call fails or `buf` is too small.
+/// The Windows directory (`C:\Windows`) without a trailing separator, written
+/// into `buf`. `None` if the call fails or `buf` is too small.
 pub fn system_windows_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
-    let Ok(capacity) = u32::try_from(buf.len()) else {
-        return None;
-    };
     // SAFETY: `buf` is valid for `capacity` u16 writes.
-    let len = unsafe { kernel32::GetSystemWindowsDirectoryW(buf.as_mut_ptr(), capacity) } as usize;
-    // Returns the required size (including the NUL) when the buffer is too
-    // small, and the length written (excluding the NUL) otherwise.
+    well_known_directory_w(buf, |ptr, capacity| unsafe {
+        kernel32::GetSystemWindowsDirectoryW(ptr, capacity)
+    })
+}
+
+/// The system directory (`C:\Windows\System32`) without a trailing separator,
+/// written into `buf`. `None` if the call fails or `buf` is too small.
+pub fn system_directory_w(buf: &mut [u16]) -> Option<&[u16]> {
+    // SAFETY: `buf` is valid for `capacity` u16 writes.
+    well_known_directory_w(buf, |ptr, capacity| unsafe {
+        kernel32::GetSystemDirectoryW(ptr, capacity)
+    })
+}
+
+/// Shared shape of `GetSystemDirectoryW` and friends: they return the length
+/// written without the NUL, or the size needed including the NUL when the
+/// buffer is too small.
+fn well_known_directory_w(buf: &mut [u16], get: impl FnOnce(LPWSTR, u32) -> u32) -> Option<&[u16]> {
+    let capacity = u32::try_from(buf.len()).ok()?;
+    let len = get(buf.as_mut_ptr(), capacity) as usize;
     if len == 0 || len >= buf.len() {
         return None;
     }

--- a/test/cli/run/crash-in-native-module-fixture.c
+++ b/test/cli/run/crash-in-native-module-fixture.c
@@ -1,0 +1,26 @@
+// Built with compileFixture() by run-crash-handler.test.ts. Stands in for a
+// Node-API addon or bun:ffi library that has a bug of its own.
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#define EXPORT __declspec(dllexport)
+#else
+#include <stdlib.h>
+#define EXPORT __attribute__((visibility("default")))
+#endif
+
+EXPORT void crash_in_native_module(void) {
+  *(volatile int*)0 = 1;
+}
+
+// A code address inside a library the operating system ships. `Sleep` lives in
+// kernel32.dll; `labs` lives in libc (bun itself does not import it, so the
+// address cannot resolve to a PLT stub inside the bun executable).
+EXPORT uintptr_t address_in_system_library(void) {
+#ifdef _WIN32
+  return (uintptr_t)&Sleep;
+#else
+  return (uintptr_t)&labs;
+#endif
+}

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -783,7 +783,7 @@ describe("crash inside a native module", () => {
       "--debug-crash-handler-use-trace-string",
     ];
     await using proc = Bun.spawn({
-      cmd: realFault && isPosix ? ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...bun] : bun,
+      cmd: realFault && isPosix ? noCoreCmd(bun) : bun,
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -7,6 +7,7 @@ import {
   isASAN,
   isDebug,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   mergeWindowEnvs,
@@ -820,7 +821,8 @@ describe("crash inside a native module", () => {
 
     expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
     expect(stderr).not.toContain("inside the native module");
-    expect(objects[0]).not.toBeOneOf(["bun", "?", "js", ""]);
+    // labs() is in libc (ld-musl-*.so.1 on musl), Sleep() in kernel32.
+    expect(objects[0]).toMatch(isWindows ? /^kernel32\.dll$/i : isMacOS ? /^libsystem_/ : /^(libc\.|ld-musl-)/);
     expectBunCallers(objects);
     expect(features).not.toContain("native_module_crash");
   });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -759,23 +759,28 @@ describe("crash inside a native module", () => {
     if (isPosix) expect(objects.slice(1)).toContain("bun");
   }
 
-  async function crashWith(script: string) {
+  // `realFault`: the process dies from the re-raised signal like any crashed
+  // process, so on the --coredump-upload lanes it would leave a core file
+  // behind, which the runner reports as a failure. The test hooks suppress
+  // core dumps themselves.
+  async function crashWith(script: string, { realFault = false } = {}) {
+    const bun = [
+      bunExe(),
+      "-e",
+      `const { dlopen } = require("bun:ffi");
+       const { crash_handler } = require("bun:internal-for-testing");
+       const lib = dlopen(${JSON.stringify(fixture)}, {
+         crash_in_native_module: { args: [], returns: "void" },
+         address_in_system_library: { args: [], returns: "ptr" },
+       });
+       ${script}
+       console.log("SHOULD NOT REACH");`,
+      // Debug builds otherwise symbolize the trace instead of printing the
+      // report a release build prints.
+      "--debug-crash-handler-use-trace-string",
+    ];
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const { dlopen } = require("bun:ffi");
-         const { crash_handler } = require("bun:internal-for-testing");
-         const lib = dlopen(${JSON.stringify(fixture)}, {
-           crash_in_native_module: { args: [], returns: "void" },
-           address_in_system_library: { args: [], returns: "ptr" },
-         });
-         ${script}
-         console.log("SHOULD NOT REACH");`,
-        // Debug builds otherwise symbolize the trace instead of printing the
-        // report a release build prints.
-        "--debug-crash-handler-use-trace-string",
-      ],
+      cmd: realFault && isPosix ? ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...bun] : bun,
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -822,7 +827,9 @@ describe("crash inside a native module", () => {
   // and the fault pc it records is inside the library. ASAN builds do not
   // install Bun's fault handlers, so there the fault never reaches the report.
   test.skipIf(!fixture || isASAN).concurrent("a real fault inside the module is attributed to it", async () => {
-    const { stderr, features, objects } = await crashWith("lib.symbols.crash_in_native_module();");
+    const { stderr, features, objects } = await crashWith("lib.symbols.crash_in_native_module();", {
+      realFault: true,
+    });
 
     expect(stderr).toContain(`oh no: Bun has crashed inside the native module "${fixtureName}".`);
     expect(objects[0]).toBe(fixtureName);

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,17 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  compileFixture,
+  isASAN,
+  isDebug,
+  isLinux,
+  isPosix,
+  isWindows,
+  mergeWindowEnvs,
+  tempDir,
+} from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -661,3 +672,161 @@ test.if(isWindows)(
     }
   },
 );
+
+// A crash whose innermost frame is inside a third-party native library (a
+// Node-API addon, a bun:ffi library, or something one of them loaded) is a bug
+// in that library. The report has to say so instead of "a bug in Bun", set the
+// `native_module_crash` feature bit in the trace string so bun.report and
+// Sentry can separate these from Bun's own crashes, and encode the library's
+// name into the frame. Before, Linux encoded such a frame as a bun address (so
+// bun.report symbolized it against the bun binary) and macOS dropped it.
+describe("crash inside a native module", () => {
+  let fixture: string | null = null;
+  try {
+    fixture = compileFixture(path.join(import.meta.dir, "crash-in-native-module-fixture.c"));
+  } catch (e) {
+    if (!String((e as Error)?.message ?? e).includes("no C compiler")) throw e;
+  }
+  const fixtureName = fixture ? path.basename(fixture) : "";
+
+  const VLQ_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  // Mirrors bun.report's decoder for the parts of the trace string this test
+  // cares about: the two feature VLQs after the commit hash, then the frames.
+  // A frame is a VLQ offset in bun, except that a VLQ of 1 introduces a name
+  // length, the name and an offset in that image, `_` is a frame outside every
+  // image, `=` is JS, and a VLQ of 0 ends the list. See `encode_trace_string`
+  // and `StackLine::write_encoded` in src/crash_handler/lib.rs.
+  function readVlq(payload: string, i: number): [value: number, next: number] {
+    let value = 0;
+    let shift = 0;
+    for (;;) {
+      const digit = VLQ_ALPHABET.indexOf(payload[i++]);
+      if (digit < 0) throw new Error(`invalid VLQ at offset ${i - 1} of ${JSON.stringify(payload)}`);
+      value += (digit & 31) * 2 ** shift;
+      shift += 5;
+      if (!(digit & 32)) break;
+    }
+    const magnitude = Math.floor(value / 2);
+    return [value % 2 ? -magnitude : magnitude, i];
+  }
+
+  function decodeTraceString(stderr: string) {
+    const banner = stderr.slice(stderr.indexOf("link below:"));
+    const url = banner.match(/\/\d+\.\d+\.\d+\/(\S+)/);
+    if (!url) throw new Error(`no trace string in:\n${stderr}`);
+    const payload = url[1];
+    // platform char, command char, trace string version, 7 chars of commit.
+    expect(payload[2]).toMatch(/^[12]$/);
+    let i = 10;
+    let high: number, low: number;
+    [high, i] = readVlq(payload, i);
+    [low, i] = readVlq(payload, i);
+    const featureNames = crash_handler.getFeatureData().features;
+    const features = featureNames.filter((_, bit) =>
+      bit < 32 ? ((low >>> 0) >>> bit) & 1 : ((high >>> 0) >>> (bit - 32)) & 1,
+    );
+
+    const frames: { object: string; address: number }[] = [];
+    for (;;) {
+      if (i >= payload.length) throw new Error(`unterminated frame list in ${JSON.stringify(payload)}`);
+      if (payload[i] === "_" || payload[i] === "=") {
+        frames.push({ object: payload[i++] === "_" ? "?" : "js", address: 0 });
+        continue;
+      }
+      let address: number;
+      [address, i] = readVlq(payload, i);
+      if (address === 0) break;
+      let object = "bun";
+      if (address === 1) {
+        let length: number;
+        [length, i] = readVlq(payload, i);
+        object = payload.slice(i, i + length);
+        i += length;
+        [address, i] = readVlq(payload, i);
+      }
+      frames.push({ object, address });
+    }
+    return { features, frames, objects: frames.map(frame => frame.object) };
+  }
+
+  // Everything above the fault is Bun's own code, and it must still be encoded
+  // as bun (not under the executable's file name) for bun.report to remap it.
+  // The Windows version of `segfaultAtPc` has no fault CONTEXT to walk from, so
+  // there the trace is the fault alone.
+  function expectBunCallers(objects: string[]) {
+    expect(objects).not.toContain(path.basename(bunExe()));
+    if (isPosix) expect(objects.slice(1)).toContain("bun");
+  }
+
+  async function crashWith(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { dlopen } = require("bun:ffi");
+         const { crash_handler } = require("bun:internal-for-testing");
+         const lib = dlopen(${JSON.stringify(fixture)}, {
+           crash_in_native_module: { args: [], returns: "void" },
+           address_in_system_library: { args: [], returns: "ptr" },
+         });
+         ${script}
+         console.log("SHOULD NOT REACH");`,
+        // Debug builds otherwise symbolize the trace instead of printing the
+        // report a release build prints.
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).not.toContain("SHOULD NOT REACH");
+    expect(stderr).toContain("Segmentation fault at address");
+    expect(exitCode).not.toBe(0);
+    return { stderr, ...decodeTraceString(stderr) };
+  }
+
+  // `segfaultAtPc` hands the crash handler a fault whose frame 0 is the given
+  // code address, the way the signal/exception handlers do for a real fault.
+  // That keeps this runnable under ASAN, which owns the fault signals.
+  test.skipIf(!fixture).concurrent("is attributed to the module, not to Bun", async () => {
+    const { stderr, features, objects } = await crashWith(
+      "crash_handler.segfaultAtPc(lib.symbols.crash_in_native_module.ptr);",
+    );
+
+    expect(stderr).toContain(`oh no: Bun has crashed inside the native module "${fixtureName}".`);
+    expect(stderr).toContain("This is most likely a bug in that module, not in Bun.");
+    expect(stderr).not.toContain("This indicates a bug in Bun");
+    expect(objects[0]).toBe(fixtureName);
+    expectBunCallers(objects);
+    expect(features).toContain("native_module_crash");
+    expect(features).toContain("ffi_dlopen");
+  });
+
+  // libc / kernel32 are not to blame for what their callers pass them, so a
+  // fault inside one of them is reported the usual way. The frame still names
+  // the library so the report shows where the fault was.
+  test.skipIf(!fixture).concurrent("a fault inside a system library is still reported as a Bun crash", async () => {
+    const { stderr, features, objects } = await crashWith(
+      "crash_handler.segfaultAtPc(Number(lib.symbols.address_in_system_library()));",
+    );
+
+    expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
+    expect(stderr).not.toContain("inside the native module");
+    expect(objects[0]).not.toBeOneOf(["bun", "?", "js", ""]);
+    expectBunCallers(objects);
+    expect(features).not.toContain("native_module_crash");
+  });
+
+  // The real thing: the library faults, the OS delivers it to Bun's handler,
+  // and the fault pc it records is inside the library. ASAN builds do not
+  // install Bun's fault handlers, so there the fault never reaches the report.
+  test.skipIf(!fixture || isASAN).concurrent("a real fault inside the module is attributed to it", async () => {
+    const { stderr, features, objects } = await crashWith("lib.symbols.crash_in_native_module();");
+
+    expect(stderr).toContain(`oh no: Bun has crashed inside the native module "${fixtureName}".`);
+    expect(objects[0]).toBe(fixtureName);
+    expect(objects).not.toContain(path.basename(bunExe()));
+    expect(features).toContain("native_module_crash");
+  });
+});

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -738,7 +738,9 @@ describe("crash inside a native module", () => {
       let address: number;
       [address, i] = readVlq(payload, i);
       if (address === 0) break;
-      let object = "bun";
+      // The encoder only writes `[A-Za-z0-9._+-]` names, so a frame it wrongly
+      // names after an executable called `bun` cannot look like this.
+      let object = "<bun>";
       if (address === 1) {
         let length: number;
         [length, i] = readVlq(payload, i);
@@ -757,7 +759,7 @@ describe("crash inside a native module", () => {
   // there the trace is the fault alone.
   function expectBunCallers(objects: string[]) {
     expect(objects).not.toContain(path.basename(bunExe()));
-    if (isPosix) expect(objects.slice(1)).toContain("bun");
+    if (isPosix) expect(objects.slice(1)).toContain("<bun>");
   }
 
   const loadFixture = () => `const lib = dlopen(${JSON.stringify(fixture)}, {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -759,20 +759,22 @@ describe("crash inside a native module", () => {
     if (isPosix) expect(objects.slice(1)).toContain("bun");
   }
 
+  const loadFixture = () => `const lib = dlopen(${JSON.stringify(fixture)}, {
+    crash_in_native_module: { args: [], returns: "void" },
+    address_in_system_library: { args: [], returns: "ptr" },
+  });`;
+
   // `realFault`: the process dies from the re-raised signal like any crashed
   // process, so on the --coredump-upload lanes it would leave a core file
   // behind, which the runner reports as a failure. The test hooks suppress
   // core dumps themselves.
-  async function crashWith(script: string, { realFault = false } = {}) {
+  async function crashWith(script: string, { realFault = false, load = loadFixture() } = {}) {
     const bun = [
       bunExe(),
       "-e",
-      `const { dlopen } = require("bun:ffi");
+      `const { cc, dlopen } = require("bun:ffi");
        const { crash_handler } = require("bun:internal-for-testing");
-       const lib = dlopen(${JSON.stringify(fixture)}, {
-         crash_in_native_module: { args: [], returns: "void" },
-         address_in_system_library: { args: [], returns: "ptr" },
-       });
+       ${load}
        ${script}
        console.log("SHOULD NOT REACH");`,
       // Debug builds otherwise symbolize the trace instead of printing the
@@ -835,5 +837,22 @@ describe("crash inside a native module", () => {
     expect(objects[0]).toBe(fixtureName);
     expect(objects).not.toContain(path.basename(bunExe()));
     expect(features).toContain("native_module_crash");
+  });
+
+  // C compiled by bun:ffi's cc() runs from anonymous memory: there is no image
+  // to attribute the crash to, so it is reported like a Bun crash. The ffi_cc
+  // bit is the only trace of it in the report.
+  test.concurrent("a fault inside cc() code is reported as a Bun crash with the ffi_cc bit", async () => {
+    // The function hands out its own address: `.ptr` of a cc() function is
+    // not usable for this (it is the pointer's bits read as a double).
+    using dir = tempDir("crash-in-cc", { "f.c": "void* f(void) { return (void*)&f; }" });
+    const { stderr, features, objects } = await crashWith("crash_handler.segfaultAtPc(Number(lib.symbols.f()));", {
+      load: `const lib = cc({ source: ${JSON.stringify(path.join(String(dir), "f.c"))}, symbols: { f: { args: [], returns: "ptr" } } });`,
+    });
+
+    expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code.");
+    expect(objects[0]).toBe("?");
+    expect(features).toContain("ffi_cc");
+    expect(features).not.toContain("native_module_crash");
   });
 });


### PR DESCRIPTION
### Problem
- A fault inside a third-party native library is reported as a Bun crash: `This indicates a bug in Bun, not your code.` The trace string does not mark it, so bun.report groups it with Bun's own crashes.
- `StackLine::from_address` (`src/crash_handler/lib.rs`) named the image only on Windows. macOS encoded such a frame as unknown. Linux encoded it as an offset into bun, so bun.report symbolized it wrongly.

### Fix
- `from_address` returns `Bun`, `System` or `ThirdParty` on every platform. Non-bun frames carry their name, as on Windows.
- `native_module_of_crash` takes the innermost frame that is inside an image. Bun code means a Bun crash. A third-party image is named. System frames and frames outside every image (JIT) are skipped: a fault inside `memcpy` belongs to its caller.
- A named module changes the banner (wording is open) and sets a new `native_module_crash` feature bit. `bun:ffi` `dlopen()` counts a new `ffi_dlopen` bit, next to `process_dlopen`, and `cc()` counts `ffi_cc`.
- Verified: `test/cli/run/run-crash-handler.test.ts`, three new tests with a C fixture. Other suites are in the notes.

### Background
- A trace string is the `bun.report/...` URL a crash prints and uploads. A frame is a VLQ offset that bun.report remaps. A frame that starts with VLQ `1` carries an image name instead. bun.report decodes that already.
- Feature bits are two VLQs in the trace string. `features.json` names them per build, and bun.report makes each one a Sentry tag.
- `crash_handler.segfaultAtPc(pc)` reports a fault with frame 0 at `pc`. ASAN builds install no fault handlers, so the tests need it.
- #39806 adds only the macOS and Linux names. This PR includes that change, so one of the two should land.

<details><summary>Notes</summary>

Sentry examples: BUN-2PYE has 7 frames of Intel's `igvk64.dll` under 13 frames of `metis-native.win32-x64-msvc.node`. `igvk64.dll` lives under `System32\DriverStore`, so it is skipped and the `.node` is named. BUN-4BBC has 13 frames of `godot.windows.template_release.x86_64.llvm.dll` under `NapiClass_ConstructorFunction`: named. BUN-2MPD has `opentui.dll` reached through `bun:ffi`: named, and `ffi_dlopen` is set.

Repro, before:

```
cc -shared -fPIC -o crash.so -xc - <<<'void f(){*(volatile int*)0=1;}'
bun -e 'import {dlopen} from "bun:ffi"; dlopen("./crash.so",{f:{args:[],returns:"void"}}).symbols.f()'
```

prints the generic banner, and bun.report's `lib/parser.ts` decodes frame 0 of the uploaded trace as `{address: 0x10ff, object: "bun"}`. After this PR, the same parser decodes the two hook tests on this container as:

```
["fixture.so", "bun", "bun", "bun", "bun", "bun", "?", "bun", ...]   bits 60 (ffi_dlopen) and 61 (native_module_crash), module banner
["libc.so.6",  "bun", "bun", "bun", "bun", "bun", "?", "bun", ...]   bit 60 only, generic banner
```

Feature bit numbers: #40270 took bit 59 for `cross_compiled_bytecode` while this PR was open, so after the rebase `ffi_dlopen` is 60, `native_module_crash` 61 and `ffi_cc` 62. bun.report names a bit through `features.json`, so the numbers do not matter to it, and the tests read them from `getFeatureData()`.

Grouping itself is a bun.report change: its `buildFingerprint` (`backend/sentry.ts`) uses remapped bun frames only. With this PR it can add the first named frame to the fingerprint when the `native_module_crash` tag is present. No bun.report deploy is needed for this PR: named frames are already decoded on every platform (Windows has sent them for a long time), and new feature names arrive through `features.json`. `unsupported_uv_function` is the existing precedent for a feature bit set while crashing.

Banner, release builds:

```
oh no: Bun has crashed inside the native module "crash.so".

This is most likely a bug in that module, not in Bun.
To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:
```

Debug builds print `Crashed inside native module: <name>` above the symbolized trace instead. The bundler native plugin and unsupported libuv function banners keep priority. `Action::Dlopen` (`Crashed while loading native module: ...`) is unchanged. A Rust `panic!` goes through `rust_panic_hook`, whose frame 0 is always bun code, and keeps the old banner.

Classification details:
- System on Windows: the module path is under the system directory (`GetSystemDirectoryW`, which holds `DriverStore` too) or under `<Windows directory>\WinSxS`, compared case-insensitively, because `GetModuleFileNameW` returns `C:\WINDOWS\SYSTEM32\ntdll.dll` next to `C:\Windows\System32\KERNELBASE.dll`. The first version of this PR counted the whole Windows directory. The Windows CI agents run as a service, so their temp directory is `C:\Windows\Temp`, the fixture DLL was built there, and it was classified as system. That is also where a standalone executable that runs as a service extracts its embedded addons to, so the rule was wrong, not only the test. Bun itself is still the module whose path equals the executable path.
- System on macOS: `/usr/lib/` or `/System/`, which includes the dyld shared cache. Bun itself is still dyld image 0. The image name comes from `_dyld_get_image_name`.
- System on ELF targets: the directories `/lib`, `/lib32`, `/lib64`, `/libx32`, `/libexec` and the same five under `/usr` (this covers `/usr/lib/x86_64-linux-gnu` and Alpine's `/lib/ld-musl-*`), the vDSO (no path), Android's `/system/` and `/apex/`, and the libc family by basename for Nix and Guix, where libc lives in a store path. `/usr/local/lib` is not a system directory. Bun itself is the first object `dl_iterate_phdr` reports (`LoadedModule::is_main_program`); glibc, musl and bionic all report the main program first, and what they put in its name differs.
- A library that user code loads from a system directory (`/usr/lib/libpython3.so` through `bun:ffi`) stays system. That errs towards reporting a Bun crash. Its frames are named either way.
- Names are capped at 64 bytes and reduced to `[A-Za-z0-9._+-]` on every platform, Windows included. bun.report reads a name back by character count, and the Windows reporter puts the URL inside a single-quoted PowerShell string. The trace string buffer grows from 1 KB to 2 KB so that 20 named frames fit; `report()` copies it into 4 KB buffers.
- The classifier does one image lookup per frame and stops at the first decision. The encoder already does the same lookup for every frame.

`ffi_cc` (BUN-4NF4 is a fault under `JSC::ffiCall` with three image-less frames above it): code from `cc()` lives in anonymous memory, so its frames encode as `_` and the crash is reported as a Bun crash. The bit is what tells such a report apart from a crash in `bun:ffi` itself. The fourth test pins that: frame 0 decodes as `?`, `ffi_cc` is set, `native_module_crash` is not. It gets the code address from the C function itself because `.ptr` of a `cc()` function is the pointer bit-cast to a double (`JSFFIFunction.cpp:81`, pre-existing, reported separately).

Tests:
- The three module tests share `crash-in-native-module-fixture.c`, built with `compileFixture` like `ffi.test.js`, and skip when there is no C compiler. The two hook tests run everywhere; the real-fault test skips under ASAN, where Bun installs no fault handlers, and runs on the release lanes. It runs bun under `ulimit -c 0` because the process dies from the re-raised SIGSEGV, and the core-dump-upload lanes report the core file it would otherwise leave. All three also pass on a Windows x64 debug build, both with the fixture in the user's temp directory and with `TEMP=C:\Windows\Temp` like CI.
- The system-library case takes the address of libc's `labs` (kernel32's `Sleep` on Windows) from inside the fixture. bun does not import `labs`, so in bun's non-PIE executable that address cannot be a PLT stub inside bun.
- On POSIX the hook seeds the walk from its own frame pointer, so the tests also check that the callers still encode as `bun` and never under the executable's file name. On Windows the walk needs a fault `CONTEXT`, so the hook's trace is frame 0 alone.
- On the released 1.4.0, the real-fault test fails on the banner and the hook tests fail because the hook does not exist.
- Also run here: the rest of `run-crash-handler.test.ts`, `crash-report-command-char.test.ts`, `test/internal/macos-cross-config.test.ts` (pins the `features.json` parser against the new list), all of `test/internal/source-lints/`, and `cargo check -p bun_crash_handler` for the darwin, windows (x64 and arm64), android, freebsd and musl targets. `test/js/bun/ffi/ffi.test.js` passes except `integer identities ... int64_t`, a 32k-iteration loop that exceeds its 5 s timeout under this ASAN debug build and does not touch the one-line change in `FFI::open`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->


