### PR TITLE
install: read patchedDependencies from the root package.json only

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1311,11 +1311,11 @@ impl<'a> PackageInstaller<'a> {
             )
         };
 
-        let (patch_patch, patch_contents_hash, patch_name_and_version_hash, remove_patch) = 'brk: {
+        let (patch_contents_hash, patch_name_and_version_hash, remove_patch) = 'brk: {
             if self.manager().lockfile.patched_dependencies.count() == 0
                 && self.manager().patched_dependencies_to_remove.count() == 0
             {
-                break 'brk (None, None, None, false);
+                break 'brk (None, None, false);
             }
             let mut name_and_version: Vec<u8> = Vec::new();
             use std::io::Write;
@@ -1339,17 +1339,28 @@ impl<'a> PackageInstaller<'a> {
                     .patched_dependencies_to_remove
                     .contains(&name_and_version_hash);
                 if to_remove {
-                    break 'brk (None, None, Some(name_and_version_hash), true);
+                    break 'brk (None, Some(name_and_version_hash), true);
                 }
-                break 'brk (None, None, None, false);
+                break 'brk (None, None, false);
             };
-            debug_assert!(!patchdep.patchfile_hash_is_null);
-            // if (!patchdep.patchfile_hash_is_null) {
-            //     this.manager.enqueuePatchTask(PatchTask.newCalcPatchHash(this, package_id, name_and_version_hash, dependency_id, url: string))
-            // }
+            let Some(patch_contents_hash) = patchdep.patchfile_hash() else {
+                if log_level != Options::LogLevel::Silent {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: failed to patch package <b>{}<r>: the hash of patch file {} was not calculated before install, this is a bug in Bun",
+                        bstr::BStr::new(&name_and_version),
+                        bun_core::fmt::quote(patchdep.path.slice(string_buf!())),
+                    );
+                }
+                self.summary.fail += 1;
+                self.increment_tree_install_count(
+                    !IS_PENDING_PACKAGE_INSTALL,
+                    self.current_tree_id,
+                    log_level,
+                );
+                return;
+            };
             break 'brk (
-                Some(patchdep.path.slice(string_buf!())),
-                Some(patchdep.patchfile_hash().unwrap()),
+                Some(patch_contents_hash),
                 Some(name_and_version_hash),
                 false,
             );
@@ -1375,9 +1386,8 @@ impl<'a> PackageInstaller<'a> {
             // same raw pointer, so this `&mut` does not invalidate it under stacked-borrows.
             destination_dir_subpath_buf: unsafe { (*subpath_buf_ptr).as_mut_slice() },
             package_name: pkg_name,
-            patch: patch_patch.map(|_| package_install::Patch {
-                contents_hash: patch_contents_hash.unwrap(),
-            }),
+            patch: patch_contents_hash
+                .map(|contents_hash| package_install::Patch { contents_hash }),
             package_version,
             node_modules: node_modules_ref.get(),
             // BACKREF accessor — `self.lockfile` is `*mut Lockfile` (never null,

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -266,8 +266,13 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     installer
                         .on_task_complete(task.entry_id, store_installer::CompleteState::Success);
                 }
-                store_installer::Result::Err(err) => {
-                    let err = err.clone();
+                store_installer::Result::Err(_) => {
+                    // Move the error out: `on_task_fail` takes `&mut installer`, which owns `task`.
+                    let store_installer::Result::Err(err) =
+                        core::mem::replace(&mut task.result, store_installer::Result::None)
+                    else {
+                        unreachable!()
+                    };
                     installer.on_task_fail(task.entry_id, &err);
                 }
                 store_installer::Result::Blocked => {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2213,7 +2213,16 @@ pub(crate) fn install_isolated_packages(
                     let pkg_res_tag = pkg_res.tag;
 
                     let patch_info =
-                        installer.package_patch_info(pkg_name, pkg_name_hash, &pkg_res)?;
+                        match installer.package_patch_info(pkg_name, pkg_name_hash, &pkg_res) {
+                            Ok(patch_info) => patch_info,
+                            Err(err) => {
+                                // .monotonic is okay because the task isn't running on another thread.
+                                entry_steps[entry_id.get() as usize]
+                                    .store(installer::Step::Done as u32, Ordering::Relaxed);
+                                installer.on_task_fail(entry_id, &err);
+                                continue;
+                            }
+                        };
 
                     let uses_global_store = installer.entry_uses_global_store(entry_id);
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -224,8 +224,7 @@ impl<'a> Installer<'a> {
                     });
 
                 if let Err(err) = patched {
-                    // monotonic is okay because we haven't started the task yet (it isn't running
-                    // on another thread)
+                    // .monotonic is okay because the task isn't running on another thread.
                     entry_steps[entry_id.get() as usize]
                         .store(Step::Done as u32, Ordering::Relaxed);
                     self.on_task_fail(entry_id, &err);
@@ -2047,8 +2046,7 @@ impl PatchInfo {
 }
 
 impl<'a> Installer<'a> {
-    /// A patched package whose patch file was never hashed is an error, not
-    /// `PatchInfo::None`: the entry fails instead of installing unpatched.
+    /// A patch entry without a hash is an error, not `PatchInfo::None`.
     pub(crate) fn package_patch_info(
         &self,
         pkg_name: SemverString,

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -209,20 +209,27 @@ impl<'a> Installer<'a> {
                 let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
                 let pkg_res = &pkg_resolutions[pkg_id as usize];
 
-                let patch_info =
-                    bun_core::handle_oom(self.package_patch_info(pkg_name, pkg_name_hash, pkg_res));
+                let patched = self
+                    .package_patch_info(pkg_name, pkg_name_hash, pkg_res)
+                    .and_then(|patch_info| {
+                        let PatchInfo::Patch(patch) = patch_info else {
+                            return Ok(());
+                        };
+                        let mut log = Log::init();
+                        self.apply_package_patch(entry_id, &patch, &mut log);
+                        if log.has_errors() {
+                            return Err(TaskError::Patching(log));
+                        }
+                        Ok(())
+                    });
 
-                if let PatchInfo::Patch(patch) = &patch_info {
-                    let mut log = Log::init();
-                    self.apply_package_patch(entry_id, patch, &mut log);
-                    if log.has_errors() {
-                        // monotonic is okay because we haven't started the task yet (it isn't running
-                        // on another thread)
-                        entry_steps[entry_id.get() as usize]
-                            .store(Step::Done as u32, Ordering::Relaxed);
-                        self.on_task_fail(entry_id, &TaskError::Patching(log));
-                        continue;
-                    }
+                if let Err(err) = patched {
+                    // monotonic is okay because we haven't started the task yet (it isn't running
+                    // on another thread)
+                    entry_steps[entry_id.get() as usize]
+                        .store(Step::Done as u32, Ordering::Relaxed);
+                    self.on_task_fail(entry_id, &err);
+                    continue;
                 }
 
                 self.start_task(entry_id);
@@ -693,34 +700,6 @@ pub enum TaskError {
     Download(DownloadError),
 }
 
-impl TaskError {
-    pub(crate) fn clone(&self) -> TaskError {
-        match self {
-            TaskError::LinkPackage(err) => TaskError::LinkPackage(err.clone()),
-            TaskError::SymlinkDependencies(err) => TaskError::SymlinkDependencies(err.clone()),
-            TaskError::Binaries(err) => TaskError::Binaries(*err),
-            TaskError::RunScripts(err) => TaskError::RunScripts(*err),
-            TaskError::Patching(_log) => {
-                // `bun_ast::Log` is non-Clone; the only caller of
-                // `TaskError::clone()` is the `Result::Err(err) => err.clone()`
-                // task-batch drain in PackageManager/runTasks.rs, and
-                // `Task::result` is only set to `Result::Err` from the
-                // `Yield::Fail` arm in `Task::run`. No `Yield::Fail` /
-                // `Yield::failure` site ever constructs `TaskError::Patching` —
-                // it is built only for direct `on_task_fail` calls (Installer.rs
-                // and isolated_install.rs patch paths), so this arm is
-                // unreachable in practice. Preserve a fresh Log so we don't UAF
-                // a borrowed one.
-                TaskError::Patching(Log::init())
-            }
-            TaskError::Download(dl) => TaskError::Download(DownloadError {
-                err: dl.err,
-                url: dl.url.clone(),
-            }),
-        }
-    }
-}
-
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Step {
@@ -1108,8 +1087,14 @@ impl Task {
                         }
 
                         tag => {
-                            let patch_info =
-                                installer.package_patch_info(pkg_name, pkg_name_hash, &pkg_res)?;
+                            let patch_info = match installer.package_patch_info(
+                                pkg_name,
+                                pkg_name_hash,
+                                &pkg_res,
+                            ) {
+                                Ok(patch_info) => patch_info,
+                                Err(err) => return Ok(Yield::failure(err)),
+                            };
 
                             let manager = manager_ref.get();
                             // SAFETY: `tag` discriminates the active `Resolution.value` variant
@@ -2062,12 +2047,14 @@ impl PatchInfo {
 }
 
 impl<'a> Installer<'a> {
+    /// A patched package whose patch file was never hashed is an error, not
+    /// `PatchInfo::None`: the entry fails instead of installing unpatched.
     pub(crate) fn package_patch_info(
         &self,
         pkg_name: SemverString,
         pkg_name_hash: PackageNameHash,
         pkg_res: &Resolution,
-    ) -> core::result::Result<PatchInfo, bun_alloc::AllocError> {
+    ) -> core::result::Result<PatchInfo, TaskError> {
         if self.lockfile().patched_dependencies.len() == 0
             && self.manager().patched_dependencies_to_remove.len() == 0
         {
@@ -2083,7 +2070,7 @@ impl<'a> Installer<'a> {
             "{}@",
             bstr::BStr::new(pkg_name.slice(string_buf))
         )
-        .map_err(|_| bun_alloc::AllocError)?;
+        .expect("unreachable");
 
         match pkg_res.tag {
             ResolutionTag::Workspace => {
@@ -2091,7 +2078,7 @@ impl<'a> Installer<'a> {
                     self.lockfile().workspace_versions.get(&pkg_name_hash)
                 {
                     write!(&mut version_buf, "{}", workspace_version.fmt(string_buf))
-                        .map_err(|_| bun_alloc::AllocError)?;
+                        .expect("unreachable");
                 }
             }
             _ => {
@@ -2100,7 +2087,7 @@ impl<'a> Installer<'a> {
                     "{}",
                     pkg_res.fmt(string_buf, bun_core::fmt::PathSep::Posix),
                 )
-                .map_err(|_| bun_alloc::AllocError)?;
+                .expect("unreachable");
             }
         }
 
@@ -2111,9 +2098,20 @@ impl<'a> Installer<'a> {
             .patched_dependencies
             .get(&name_and_version_hash)
         {
+            let Some(contents_hash) = patch.patchfile_hash() else {
+                let mut log = Log::init();
+                log.add_error_fmt_opts(
+                    format_args!(
+                        "the hash of patch file {} was not calculated before install, this is a bug in Bun",
+                        bun_core::fmt::quote(patch.path.slice(string_buf)),
+                    ),
+                    Default::default(),
+                );
+                return Err(TaskError::Patching(log));
+            };
             return Ok(PatchInfo::Patch(PatchInfoPatch {
                 name_and_version_hash,
-                contents_hash: patch.patchfile_hash().unwrap(),
+                contents_hash,
             }));
         }
 

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2215,11 +2215,13 @@ impl Package<u64> {
             }
         }
 
-        if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
-            if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
-                for (_, value, _) in rows {
-                    if let Some(value) = value {
-                        string_builder.count(value);
+        if FEATURES.patched_dependencies {
+            if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
+                if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
+                    for (_, value, _) in rows {
+                        if let Some(value) = value {
+                            string_builder.count(value);
+                        }
                     }
                 }
             }
@@ -2578,28 +2580,30 @@ impl Package<u64> {
             self.resolution = Resolution::<u64>::init(TaggedValue::Root);
         }
 
-        if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
-            if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
-                lockfile
-                    .patched_dependencies
-                    .ensure_total_capacity(rows.len())
-                    .expect("unreachable");
-                for (key, value, _) in rows {
-                    let Some(value) = value else {
-                        continue;
-                    };
-                    let keyhash = semver::string::Builder::string_hash(key);
-                    let patch_path = string_builder.append::<String>(value);
+        if FEATURES.patched_dependencies {
+            if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
+                if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
                     lockfile
                         .patched_dependencies
-                        .put(
-                            keyhash,
-                            PatchedDep {
-                                path: patch_path,
-                                ..Default::default()
-                            },
-                        )
+                        .ensure_total_capacity(rows.len())
                         .expect("unreachable");
+                    for (key, value, _) in rows {
+                        let Some(value) = value else {
+                            continue;
+                        };
+                        let keyhash = semver::string::Builder::string_hash(key);
+                        let patch_path = string_builder.append::<String>(value);
+                        lockfile
+                            .patched_dependencies
+                            .put(
+                                keyhash,
+                                PatchedDep {
+                                    path: patch_path,
+                                    ..Default::default()
+                                },
+                            )
+                            .expect("unreachable");
+                    }
                 }
             }
         }

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1,7 +1,14 @@
 import { $ } from "bun";
-import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  normalizeBunSnapshot as normalizeBunSnapshot_,
+  runBunInstall,
+  tempDir,
+  VerdaccioRegistry,
+} from "harness";
 import { join } from "path";
 
 const normalizeBunSnapshot = (str: string) => {
@@ -1117,5 +1124,133 @@ describe("patchedDependencies contents_hash", () => {
     const mB = await installedMjs(String(projB));
     // Compare just the tail so a failure doesn't dump the 80 KiB padding.
     expect({ hasB: mB.includes("TAIL_BBBB"), hasA: mB.includes("TAIL_AAAA") }).toEqual({ hasB: true, hasA: false });
+  });
+});
+
+// `patchedDependencies` is only read from the root package.json. The entries a
+// dependency's own package.json declared (a `file:` folder, a tarball, a
+// workspace member) used to be merged into the consumer's lockfile without a
+// patch hash. If the patched package was already resolved, the installer
+// panicked with `called Option::unwrap() on a None value`. Otherwise the
+// install failed with "Couldn't find patch file" because the dependency's patch
+// path was resolved against the consumer's root (#13531).
+describe("patchedDependencies declared by a dependency", () => {
+  const registry = new VerdaccioRegistry();
+
+  beforeAll(async () => {
+    await registry.start();
+  });
+
+  afterAll(() => {
+    registry.stop();
+  });
+
+  // Adds a file, so it applies to any version of the package.
+  const noDepsPatch = `diff --git a/patched.txt b/patched.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e728b8dad
+--- /dev/null
++++ b/patched.txt
+@@ -0,0 +1 @@
++hello world
+`;
+
+  // A package that patches its own `no-deps` dependency.
+  const patchingDep = {
+    "package.json": JSON.stringify({
+      name: "patching-dep",
+      version: "1.0.0",
+      dependencies: { "no-deps": "1.0.0" },
+      patchedDependencies: { "no-deps@1.0.0": "patches/no-deps@1.0.0.patch" },
+    }),
+    patches: { "no-deps@1.0.0.patch": noDepsPatch },
+  };
+
+  // A consumer that installs the same `no-deps` that `patching-dep` patches.
+  const consumerPackageJson = (dependencies: Record<string, string>, rest: Record<string, unknown> = {}) =>
+    JSON.stringify({ name: "consumer", dependencies: { "no-deps": "1.0.0", ...dependencies }, ...rest });
+
+  const lockfileHasPatches = async (packageDir: string) =>
+    (await Bun.file(join(packageDir, "bun.lock")).text()).includes("patchedDependencies");
+
+  const noDepsFile = (packageDir: string, name: string) => Bun.file(join(packageDir, "node_modules", "no-deps", name));
+
+  async function installUnpatched(packageDir: string) {
+    await runBunInstall(bunEnv, packageDir);
+    expect({
+      noDeps: await noDepsFile(packageDir, "package.json").json(),
+      patched: await noDepsFile(packageDir, "patched.txt").exists(),
+      lockfileHasPatches: await lockfileHasPatches(packageDir),
+    }).toEqual({
+      noDeps: { name: "no-deps", version: "1.0.0" },
+      patched: false,
+      lockfileHasPatches: false,
+    });
+  }
+
+  test.concurrent("apply when the declaring package is the install root", async () => {
+    const { packageDir } = await registry.createTestDir({ files: patchingDep });
+    await runBunInstall(bunEnv, packageDir);
+    expect({
+      patched: await noDepsFile(packageDir, "patched.txt").text(),
+      lockfileHasPatches: await lockfileHasPatches(packageDir),
+    }).toEqual({ patched: "hello world\n", lockfileHasPatches: true });
+  });
+
+  describe.each(["hoisted", "isolated"] as const)("are ignored by the consumer (%s linker)", linker => {
+    test.concurrent("file: dependency added to an existing install", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({
+        bunfigOpts: { linker },
+        files: { "package.json": consumerPackageJson({}), dep: patchingDep },
+      });
+      await runBunInstall(bunEnv, packageDir);
+
+      await Bun.write(packageJson, consumerPackageJson({ "patching-dep": "file:./dep" }));
+      await installUnpatched(packageDir);
+    });
+
+    // The tarball is extracted after `no-deps` was taken from the lockfile, so
+    // the entry it used to add reached the installer without a patch hash. This
+    // is the install that panicked.
+    test.concurrent("tarball dependency added to an existing install", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({
+        bunfigOpts: { linker },
+        files: { "package.json": consumerPackageJson({}), dep: patchingDep },
+      });
+      await runBunInstall(bunEnv, packageDir);
+
+      await using pack = Bun.spawn({
+        cmd: [bunExe(), "pm", "pack", "--quiet"],
+        cwd: join(packageDir, "dep"),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([pack.stdout.text(), pack.stderr.text(), pack.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "patching-dep-1.0.0.tgz\n", stderr: "", exitCode: 0 });
+
+      await Bun.write(packageJson, consumerPackageJson({ "patching-dep": "./dep/patching-dep-1.0.0.tgz" }));
+      await installUnpatched(packageDir);
+    });
+
+    // https://github.com/oven-sh/bun/issues/13531
+    test.concurrent("file: dependency on a fresh install", async () => {
+      const { packageDir } = await registry.createTestDir({
+        bunfigOpts: { linker },
+        files: { "package.json": consumerPackageJson({ "patching-dep": "file:./dep" }), dep: patchingDep },
+      });
+      await installUnpatched(packageDir);
+    });
+
+    test.concurrent("workspace member", async () => {
+      const { packageDir } = await registry.createTestDir({
+        bunfigOpts: { linker },
+        files: {
+          "package.json": consumerPackageJson({}, { workspaces: ["packages/*"] }),
+          packages: { dep: patchingDep },
+        },
+      });
+      await installUnpatched(packageDir);
+    });
   });
 });

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1182,13 +1182,19 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
     GIT_COMMITTER_EMAIL: "test@example.com",
   };
 
+  // CI exports BUN_INSTALL_CACHE_DIR, which overrides the per-directory cache
+  // in bunfig.toml. The tests below run concurrently, and two cold installs of
+  // the same package into one cache replace each other's cache directory.
+  const install = (packageDir: string, env = bunEnv) =>
+    runBunInstall({ ...env, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") }, packageDir);
+
   const lockfileHasPatches = async (packageDir: string) =>
     (await Bun.file(join(packageDir, "bun.lock")).text()).includes("patchedDependencies");
 
   const noDepsFile = (packageDir: string, name: string) => Bun.file(join(packageDir, "node_modules", "no-deps", name));
 
   async function installUnpatched(packageDir: string, env = bunEnv) {
-    await runBunInstall(env, packageDir);
+    await install(packageDir, env);
     expect({
       noDeps: await noDepsFile(packageDir, "package.json").json(),
       patched: await noDepsFile(packageDir, "patched.txt").exists(),
@@ -1202,7 +1208,7 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
 
   test.concurrent("apply when the declaring package is the install root", async () => {
     const { packageDir } = await registry.createTestDir({ files: patchingDep });
-    await runBunInstall(bunEnv, packageDir);
+    await install(packageDir);
     expect({
       patched: await noDepsFile(packageDir, "patched.txt").text(),
       lockfileHasPatches: await lockfileHasPatches(packageDir),
@@ -1216,7 +1222,7 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
         bunfigOpts: { linker },
         files: { "package.json": consumerPackageJson({}), dep: patchingDep },
       });
-      await runBunInstall(bunEnv, dir.packageDir);
+      await install(dir.packageDir);
       return dir;
     }
 

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -10,6 +10,7 @@ import {
   VerdaccioRegistry,
 } from "harness";
 import { join } from "path";
+import { pathToFileURL } from "url";
 
 const normalizeBunSnapshot = (str: string) => {
   str = normalizeBunSnapshot_(str);
@@ -1170,13 +1171,24 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
   const consumerPackageJson = (dependencies: Record<string, string>, rest: Record<string, unknown> = {}) =>
     JSON.stringify({ name: "consumer", dependencies: { "no-deps": "1.0.0", ...dependencies }, ...rest });
 
+  const gitEnv = {
+    ...bunEnv,
+    // Set on the asan lanes, where it makes `bun install` kill its own git clones (#33982).
+    BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+
   const lockfileHasPatches = async (packageDir: string) =>
     (await Bun.file(join(packageDir, "bun.lock")).text()).includes("patchedDependencies");
 
   const noDepsFile = (packageDir: string, name: string) => Bun.file(join(packageDir, "node_modules", "no-deps", name));
 
-  async function installUnpatched(packageDir: string) {
-    await runBunInstall(bunEnv, packageDir);
+  async function installUnpatched(packageDir: string, env = bunEnv) {
+    await runBunInstall(env, packageDir);
     expect({
       noDeps: await noDepsFile(packageDir, "package.json").json(),
       patched: await noDepsFile(packageDir, "patched.txt").exists(),
@@ -1198,26 +1210,28 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
   });
 
   describe.each(["hoisted", "isolated"] as const)("are ignored by the consumer (%s linker)", linker => {
-    test.concurrent("file: dependency added to an existing install", async () => {
-      const { packageDir, packageJson } = await registry.createTestDir({
+    // A consumer with `no-deps` installed, plus `dep/` that is not a dependency yet.
+    async function installedConsumer() {
+      const dir = await registry.createTestDir({
         bunfigOpts: { linker },
         files: { "package.json": consumerPackageJson({}), dep: patchingDep },
       });
-      await runBunInstall(bunEnv, packageDir);
+      await runBunInstall(bunEnv, dir.packageDir);
+      return dir;
+    }
+
+    test.concurrent("file: dependency added to an existing install", async () => {
+      const { packageDir, packageJson } = await installedConsumer();
 
       await Bun.write(packageJson, consumerPackageJson({ "patching-dep": "file:./dep" }));
       await installUnpatched(packageDir);
     });
 
-    // The tarball is extracted after `no-deps` was taken from the lockfile, so
-    // the entry it used to add reached the installer without a patch hash. This
-    // is the install that panicked.
+    // A tarball or a git checkout is extracted after `no-deps` was taken from
+    // the lockfile, so the entry it used to add reached the installer without a
+    // patch hash. These are the installs that panicked.
     test.concurrent("tarball dependency added to an existing install", async () => {
-      const { packageDir, packageJson } = await registry.createTestDir({
-        bunfigOpts: { linker },
-        files: { "package.json": consumerPackageJson({}), dep: patchingDep },
-      });
-      await runBunInstall(bunEnv, packageDir);
+      const { packageDir, packageJson } = await installedConsumer();
 
       await using pack = Bun.spawn({
         cmd: [bunExe(), "pm", "pack", "--quiet"],
@@ -1231,6 +1245,16 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
 
       await Bun.write(packageJson, consumerPackageJson({ "patching-dep": "./dep/patching-dep-1.0.0.tgz" }));
       await installUnpatched(packageDir);
+    });
+
+    test.concurrent("git dependency added to an existing install", async () => {
+      const { packageDir, packageJson } = await installedConsumer();
+
+      const repo = join(packageDir, "dep");
+      await $`git init -q && git add -A && git commit -q -m init --no-gpg-sign`.cwd(repo).env(gitEnv).quiet();
+
+      await Bun.write(packageJson, consumerPackageJson({ "patching-dep": `git+${pathToFileURL(repo)}` }));
+      await installUnpatched(packageDir, gitEnv);
     });
 
     // https://github.com/oven-sh/bun/issues/13531


### PR DESCRIPTION
### Problem
- `bun install` panics with `called Option::unwrap() on a None value` in `Installer::package_patch_info` (the hoisted installer has the same unwrap) when a dependency's package.json declares `patchedDependencies` for a package in the tree. Sentry BUN-4MV1, new in 1.4.0.
- `Package::parse_with_json` (`src/install/lockfile/Package.rs:2583`) merges `patchedDependencies` from every manifest it parses. Hashes are only computed for the entries that exist before resolution, so these have none. If the patched package resolves later, the install fails with `Couldn't find patch file` instead (#13531).

### Fix
- Both parse blocks check `Features::patched_dependencies`, which only the root manifest sets. The flag existed for this but was never read. Same gate as #29594, which this supersedes.
- An entry with no hash now fails that package's install instead of panicking. `package_patch_info` returns `TaskError::Patching`. The hoisted installer prints an error and counts a failure.
- The `run_tasks` drain moves the error out instead of cloning it, so `TaskError::clone`, which dropped a `Patching` log, is deleted.
- Verified: `test/cli/install/bun-install-patch.test.ts`, new describe block. On 1.4.0 the tarball and git cases panic and the folder and workspace cases fail with `Couldn't find patch file`. The other patch suites pass.

### Background
- `lockfile.patched_dependencies` maps a `name@version` label to a patch path and the hash of the patch file. That hash names the patched copy in the cache.
- Before resolution, `install_with_manager` enqueues a `PatchTask` per entry to compute that hash and waits. Nothing hashes an entry added later.
- Patch paths are relative to the project root. `bun patch --commit` in a workspace member writes to the root package.json. npm and pnpm also apply only the root's patches.
- `Features` is the per-manifest parse configuration. `trustedDependencies` is gated the same way.

Fixes #13531

<details><summary>Notes</summary>

Repro on 1.4.0, offline once `is-number@7.0.0` is cached. The tarball variant panics on the second install. A `file:` folder variant panics on the first install. Both also panic with `--linker=hoisted`. Zig had the same `.?` at both sites, so 1.3 failed with `failed to read patchfile` instead.

```
mkdir package
printf '{"name":"dep","version":"1.0.0","dependencies":{"is-number":"7.0.0"},"patchedDependencies":{"is-number@7.0.0":"patches/is-number@7.0.0.patch"}}' > package/package.json
tar czf dep-1.0.0.tgz package
printf '{"name":"root","dependencies":{"is-number":"7.0.0"}}' > package.json && bun install --linker=isolated
printf '{"name":"root","dependencies":{"is-number":"7.0.0","dep":"./dep-1.0.0.tgz"}}' > package.json && bun install --linker=isolated
```

The hashes are computed at `install_with_manager.rs:626` (existing lockfile) and `:1947` (new lockfile), before the root dependencies are enqueued. Which failure a scenario hit depends on whether the patched package was resolved before or after the dependency's manifest was parsed. Already in the lockfile, or resolved from a tarball: the entry reaches the installer and the unwrap panics. Resolved from the registry afterwards: `determine_preinstall_state` sees the entry, schedules a hash task, and the task fails on the missing root-relative file. The new tests cover both orders on both linkers, plus a control that installs the declaring package as the root and gets the patch applied. The manifests parsed this way are `file:` folders, workspace members, extracted tarballs and git checkouts, and each kind has a case. Registry packages have none on purpose: `process_extracted_tarball_package` only reads `scripts` from their package.json, so they never contributed an entry, and such a test passes with and without this change.

The error paths. `package_patch_info` has three callers: the start loop in `install_isolated_packages`, `on_package_extracted`, and the `LinkPackage` step of `Task::run` on a pool thread. Each one fails the store entry. The drain change matters for the last one: `TaskError::clone` documented that no pool-thread failure was ever a `Patching` error, and now one can be. After the gate, every entry comes from the root manifest or a lockfile load, and all of them are hashed before `clean_with_logger` runs, so nothing reaches these paths today. A hand-edited bun.lock does not either: its entries are hashed at line 626, and a missing file fails there with the existing message. The `debug_assert` in `clean_migrate_patched_dependencies_cold` (`lockfile.rs:1170`) stays as the debug-build check of that invariant. The installer paths are what a release build does if it is violated again. The hash is not computed at those sites because the pool thread cannot write to the lockfile. The `debug_assert!(value.patchfile_hash_is_null)` in `install_with_manager.rs:425` checks the opposite fact, that a freshly parsed root entry has no hash yet, and is unchanged.

`package_patch_info` returned `Result<_, AllocError>` only because of `write!` into a `Vec`, which cannot fail. The `?` on it was also the last non-allocation early return in the `install_isolated_packages` start loop. The pool-thread failure path through the changed drain was exercised by hand with the debug build: an isolated install as an unprivileged user into a read-only `node_modules/.bun` prints `failed to link package: baz@./baz-0.0.3.tgz (link)` and exits 1. Each test pins `BUN_INSTALL_CACHE_DIR` to its own directory: the CI runner sets one cache per test file, and the first CI run showed concurrent cold installs of `no-deps@1.0.0` replacing each other's cache directory on Windows (`extract_tarball.rs` renames an existing destination away before moving the new one in).

Suites run with the debug build: bun-install-patch (whole file), isolated-install, isolated-relink, bun-patch, bun-lock, bun-lockb, bun-workspaces, bun-dedupe, bun-update-transitive, frozen-lockfile-pruned, bun-link, bun-install-git-deps, migration/pnpm-comprehensive, pnpm-migration-complete, pnpm-lock-v9, js/bun/patch. One failure, `bun-link.test.ts` "should link dependency without crashing", is independent of this change: with a plain debug build `PackageInstaller.rs` dumps a `cfg(bun_debug)` stack trace into stdout on any install failure. CI test lanes build release and asan.

</details>
