### PR TITLE
Report the type and what() of an uncaught C++ exception instead of "A C++ exception occurred"

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -127,6 +127,7 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   abort: () => void;
   fastfail: () => void;
   trap: () => void;
+  uncaughtCxxException: () => void;
   raiseIgnoringPanicHandler: () => void;
 };
 

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1467,30 +1467,32 @@ unsafe extern "C" fn Zig__GlobalObject__onCrash(
     exception_type: *const c_char,
     what: *const c_char,
 ) -> ! {
-    use core::fmt::Write as _;
+    const NO_EXCEPTION: &[u8] = b"std::terminate() was called with no C++ exception in flight";
+    const PREFIX: &[u8] = b"uncaught C++ exception ";
+    const SEPARATOR: &[u8] = b": ";
+    // The message has to leave the trace string room for the frames; a longer type name or what() is cut.
+    const TYPE_LIMIT: usize = 512;
+    const WHAT_LIMIT: usize = 256;
+    const CAPACITY: usize = PREFIX.len() + TYPE_LIMIT + SEPARATOR.len() + WHAT_LIMIT;
+    const _: () = assert!(NO_EXCEPTION.len() <= CAPACITY);
+
     crate::mark_binding();
     Output::flush();
 
-    let as_bytes = |ptr: *const c_char| {
+    let as_bytes = |ptr: *const c_char, limit: usize| {
         // SAFETY: the C++ side passes null or a NUL-terminated string that outlives this call, which never returns.
-        (!ptr.is_null()).then(|| unsafe { bun_core::ffi::cstr(ptr) }.to_bytes())
+        let bytes = (!ptr.is_null()).then(|| unsafe { bun_core::ffi::cstr(ptr) }.to_bytes())?;
+        Some(&bytes[..bytes.len().min(limit)])
     };
-    let mut message = bun_core::BoundedArray::<u8, 1024>::default();
-    match (as_bytes(exception_type), as_bytes(what)) {
-        (None, _) => {
-            let _ = message
-                .append_slice(b"std::terminate() was called with no C++ exception in flight");
-        }
-        (Some(exception_type), what) => {
-            let _ = write!(
-                message,
-                "uncaught C++ exception {}",
-                bstr::BStr::new(exception_type)
-            );
-            if let Some(what) = what {
-                // Bounded so the message fits the trace string together with the frames.
-                let what = &what[..what.len().min(256)];
-                let _ = write!(message, ": {}", bstr::BStr::new(what));
+    let mut message = bun_core::BoundedArray::<u8, CAPACITY>::default();
+    match as_bytes(exception_type, TYPE_LIMIT) {
+        None => message.append_slice_assume_capacity(NO_EXCEPTION),
+        Some(exception_type) => {
+            message.append_slice_assume_capacity(PREFIX);
+            message.append_slice_assume_capacity(exception_type);
+            if let Some(what) = as_bytes(what, WHAT_LIMIT) {
+                message.append_slice_assume_capacity(SEPARATOR);
+                message.append_slice_assume_capacity(what);
             }
         }
     }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1461,11 +1461,40 @@ unsafe extern "C" fn Zig__GlobalObject__reportUncaughtException(
     unsafe { VirtualMachine::report_uncaught_exception(&*global, &*exception) }
 }
 
+/// Called by the C++ terminate handler (CxxTerminateHandler.cpp); either string is null when it has nothing to say.
 #[unsafe(no_mangle)]
-extern "C" fn Zig__GlobalObject__onCrash() {
+unsafe extern "C" fn Zig__GlobalObject__onCrash(
+    exception_type: *const c_char,
+    what: *const c_char,
+) -> ! {
+    use core::fmt::Write as _;
     crate::mark_binding();
     Output::flush();
-    panic!("A C++ exception occurred");
+
+    let as_bytes = |ptr: *const c_char| {
+        // SAFETY: the C++ side passes null or a NUL-terminated string that outlives this call, which never returns.
+        (!ptr.is_null()).then(|| unsafe { bun_core::ffi::cstr(ptr) }.to_bytes())
+    };
+    let mut message = bun_core::BoundedArray::<u8, 1024>::default();
+    match (as_bytes(exception_type), as_bytes(what)) {
+        (None, _) => {
+            let _ = message
+                .append_slice(b"std::terminate() was called with no C++ exception in flight");
+        }
+        (Some(exception_type), what) => {
+            let _ = write!(
+                message,
+                "uncaught C++ exception {}",
+                bstr::BStr::new(exception_type)
+            );
+            if let Some(what) = what {
+                // Bounded so the message fits the trace string together with the frames.
+                let what = &what[..what.len().min(256)];
+                let _ = write!(message, ": {}", bstr::BStr::new(what));
+            }
+        }
+    }
+    bun_crash_handler::panic_impl(message.const_slice(), None, None)
 }
 
 // LAYERING: `getBodyStreamOrBytesForWasmStreaming` deals entirely

--- a/src/jsc/bindings/CxxTerminateHandler.cpp
+++ b/src/jsc/bindings/CxxTerminateHandler.cpp
@@ -1,0 +1,138 @@
+#include "root.h"
+
+#include <exception>
+
+#if !OS(WINDOWS)
+#include <cstring>
+#include <cxxabi.h>
+#include <new>
+#include <stdexcept>
+#include <typeinfo>
+#endif
+
+extern "C" [[noreturn]] void Zig__GlobalObject__onCrash(const char* exceptionType, const char* what);
+
+#if !OS(WINDOWS)
+
+// Every runtime for the Itanium C++ ABI describes a class with one non-virtual base at offset 0 with a type_info using the first vtable, and a class with any other bases with one using the second.
+extern "C" void* _ZTVN10__cxxabiv120__si_class_type_infoE[];
+extern "C" void* _ZTVN10__cxxabiv121__vmi_class_type_infoE[];
+extern "C" std::type_info _ZTISt13runtime_error;
+
+namespace {
+
+// Itanium C++ ABI 2.9.5, __si_class_type_info.
+struct SingleBaseClassTypeInfo {
+    const void* vtable;
+    const char* name;
+    const std::type_info* base;
+};
+
+// Itanium C++ ABI 2.9.5, __base_class_type_info: bit 0 marks a virtual base, the bits above the low 8 hold a non-virtual base's byte offset.
+struct BaseClassEntry {
+    const std::type_info* type;
+    long offsetFlags;
+};
+
+// Itanium C++ ABI 2.9.5, __vmi_class_type_info.
+struct MultipleBaseClassTypeInfo {
+    const void* vtable;
+    const char* name;
+    unsigned flags;
+    unsigned baseCount;
+    BaseClassEntry bases[1];
+};
+
+bool hasVTable(const std::type_info* type, void** vtableSymbol)
+{
+    // An object's vtable pointer points past the offset-to-top and type_info words at the start of the vtable.
+    return *reinterpret_cast<const void* const*>(type) == static_cast<const void*>(vtableSymbol + 2);
+}
+
+// Byte offset of the std::exception subobject inside an object of this type, or -1 when the type does not derive from it non-virtually.
+ptrdiff_t offsetOfStdException(const std::type_info* type)
+{
+    if (strcmp(type->name(), "St9exception") == 0)
+        return 0;
+    if (hasVTable(type, _ZTVN10__cxxabiv120__si_class_type_infoE))
+        return offsetOfStdException(reinterpret_cast<const SingleBaseClassTypeInfo*>(type)->base);
+    if (!hasVTable(type, _ZTVN10__cxxabiv121__vmi_class_type_infoE))
+        return -1;
+    const auto* info = reinterpret_cast<const MultipleBaseClassTypeInfo*>(type);
+    for (unsigned i = 0; i < info->baseCount; i++) {
+        const BaseClassEntry& base = info->bases[i];
+        if (base.offsetFlags & 1)
+            continue;
+        ptrdiff_t offset = offsetOfStdException(base.type);
+        if (offset >= 0)
+            return (base.offsetFlags >> 8) + offset;
+    }
+    return -1;
+}
+
+// libc++ and libstdc++ both implement exception_ptr as the address of the thrown object and nothing else.
+const char* currentExceptionObject()
+{
+    std::exception_ptr current = std::current_exception();
+    static_assert(sizeof(current) == sizeof(void*));
+    const char* object;
+    memcpy(&object, &current, sizeof(object));
+    return object;
+}
+
+// Replaces the runtime's default handler, which would have printed the same type name and what() itself before aborting.
+void terminateHandler()
+{
+    const std::type_info* type = abi::__cxa_current_exception_type();
+    if (!type)
+        Zig__GlobalObject__onCrash(nullptr, nullptr);
+
+    int status = 0;
+    const char* demangled = abi::__cxa_demangle(type->name(), nullptr, nullptr, &status);
+    const char* what = nullptr;
+    ptrdiff_t offset = offsetOfStdException(type);
+    if (offset >= 0) {
+        if (const char* object = currentExceptionObject())
+            what = reinterpret_cast<const std::exception*>(object + offset)->what();
+    }
+    Zig__GlobalObject__onCrash(demangled ? demangled : type->name(), what);
+}
+
+void destroyRuntimeError(void* object)
+{
+    static_cast<std::runtime_error*>(object)->~runtime_error();
+}
+
+} // namespace
+
+// bun is built without exception support, so nothing in it catches this: the unwinder gives up and the handler above runs, as when an addon's exception escapes into bun.
+extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
+{
+    void* memory = abi::__cxa_allocate_exception(sizeof(std::runtime_error));
+    new (memory) std::runtime_error("thrown by the crash handler test");
+    abi::__cxa_throw(memory, &_ZTISt13runtime_error, destroyRuntimeError);
+}
+
+#else
+
+namespace {
+
+// MSVC's exception machinery has none of the entry points used above.
+void terminateHandler()
+{
+    Zig__GlobalObject__onCrash(nullptr, nullptr);
+}
+
+} // namespace
+
+extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
+{
+    std::terminate();
+}
+
+#endif
+
+extern "C" void Bun__installCxxTerminateHandler()
+{
+    std::set_terminate(terminateHandler);
+}

--- a/src/jsc/bindings/CxxTerminateHandler.cpp
+++ b/src/jsc/bindings/CxxTerminateHandler.cpp
@@ -18,6 +18,8 @@ extern "C" [[noreturn]] void Zig__GlobalObject__onCrash(const char* exceptionTyp
 extern "C" void* _ZTVN10__cxxabiv120__si_class_type_infoE[];
 extern "C" void* _ZTVN10__cxxabiv121__vmi_class_type_infoE[];
 extern "C" std::type_info _ZTISt13runtime_error;
+// libcxxrt (FreeBSD) does not declare this one in <cxxabi.h>; a C-linkage declaration outside the namespace names the same function in every runtime.
+extern "C" void __cxa_throw(void* thrownObject, std::type_info* type, void (*destructor)(void*));
 
 namespace {
 
@@ -110,7 +112,7 @@ extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
 {
     void* memory = abi::__cxa_allocate_exception(sizeof(std::runtime_error));
     new (memory) std::runtime_error("thrown by the crash handler test");
-    abi::__cxa_throw(memory, &_ZTISt13runtime_error, destroyRuntimeError);
+    __cxa_throw(memory, &_ZTISt13runtime_error, destroyRuntimeError);
 }
 
 #else

--- a/src/jsc/bindings/CxxTerminateHandler.cpp
+++ b/src/jsc/bindings/CxxTerminateHandler.cpp
@@ -17,9 +17,6 @@ extern "C" [[noreturn]] void Zig__GlobalObject__onCrash(const char* exceptionTyp
 // Every runtime for the Itanium C++ ABI describes a class with one non-virtual base at offset 0 with a type_info using the first vtable, and a class with any other bases with one using the second.
 extern "C" void* _ZTVN10__cxxabiv120__si_class_type_infoE[];
 extern "C" void* _ZTVN10__cxxabiv121__vmi_class_type_infoE[];
-extern "C" std::type_info _ZTISt13runtime_error;
-// libcxxrt (FreeBSD) does not declare this one in <cxxabi.h>; a C-linkage declaration outside the namespace names the same function in every runtime.
-extern "C" void __cxa_throw(void* thrownObject, std::type_info* type, void (*destructor)(void*));
 
 namespace {
 
@@ -100,20 +97,7 @@ void terminateHandler()
     Zig__GlobalObject__onCrash(demangled ? demangled : type->name(), what);
 }
 
-void destroyRuntimeError(void* object)
-{
-    static_cast<std::runtime_error*>(object)->~runtime_error();
-}
-
 } // namespace
-
-// bun is built without exception support, so nothing in it catches this: the unwinder gives up and the handler above runs, as when an addon's exception escapes into bun.
-extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
-{
-    void* memory = abi::__cxa_allocate_exception(sizeof(std::runtime_error));
-    new (memory) std::runtime_error("thrown by the crash handler test");
-    __cxa_throw(memory, &_ZTISt13runtime_error, destroyRuntimeError);
-}
 
 #else
 
@@ -127,14 +111,42 @@ void terminateHandler()
 
 } // namespace
 
-extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
-{
-    std::terminate();
-}
-
 #endif
 
 extern "C" void Bun__installCxxTerminateHandler()
 {
     std::set_terminate(terminateHandler);
 }
+
+#if OS(DARWIN)
+
+extern "C" std::type_info _ZTISt13runtime_error;
+// Declared here rather than taken from <cxxabi.h>, which not every runtime declares it in; C linkage makes this the same function.
+extern "C" void __cxa_throw(void* thrownObject, std::type_info* type, void (*destructor)(void*));
+
+namespace {
+
+void destroyRuntimeError(void* object)
+{
+    static_cast<std::runtime_error*>(object)->~runtime_error();
+}
+
+} // namespace
+
+// What `throw std::runtime_error(...)` compiles to. Nothing in bun can catch it, so the unwinder gives up and the handler runs, as when an addon's exception escapes into bun.
+extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
+{
+    void* memory = abi::__cxa_allocate_exception(sizeof(std::runtime_error));
+    new (memory) std::runtime_error("thrown by the crash handler test");
+    __cxa_throw(memory, &_ZTISt13runtime_error, destroyRuntimeError);
+}
+
+#else
+
+// glibc release builds strip the unwind tables, so a throw from inside bun aborts in the unwinder before any handler runs; macOS, where an addon shares bun's libc++abi, is also the one platform where an addon's throw reaches this handler.
+extern "C" void Bun__throwUncaughtCxxExceptionForTesting()
+{
+    std::terminate();
+}
+
+#endif

--- a/src/jsc/bindings/CxxTerminateHandler.cpp
+++ b/src/jsc/bindings/CxxTerminateHandler.cpp
@@ -103,7 +103,7 @@ void terminateHandler()
 
 namespace {
 
-// MSVC's exception machinery has none of the entry points used above.
+// MSVC's runtime has none of the entry points used above, and with _HAS_EXCEPTIONS=0 its std::terminate() aborts without calling this handler at all (bun's own CRT is static, so an addon's terminate never arrives here either).
 void terminateHandler()
 {
     Zig__GlobalObject__onCrash(nullptr, nullptr);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -279,6 +279,8 @@ extern "C" long Bun__crashHandlerFromJSCFrame(void*, void*, void*, void*);
 
 // bun_icu_default_locale.cpp
 extern "C" void Bun__ensureICUDefaultLocale();
+// CxxTerminateHandler.cpp
+extern "C" void Bun__installCxxTerminateHandler();
 
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup, bool shortLivedGlobals)
 {
@@ -290,7 +292,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         // JSC options come from BUN_JSC_* (applied in the callback below), not JSC_*.
         JSC::Config::disableEnvironmentOptions();
 
-        std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
+        Bun__installCxxTerminateHandler();
         WTF::initializeMainThread();
 
         // Use JSC::initialize with a callback to set Options during initialization.

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -429,7 +429,6 @@ CPP_DECL JSC::JSGlobalObject* Zig__GlobalObject__create(void* arg0, int32_t arg1
 #ifdef __cplusplus
 
 ZIG_DECL void Zig__GlobalObject__fetch(ErrorableResolvedSource* arg0, JSC::JSGlobalObject* arg1, BunString* arg2, BunString* arg3);
-ZIG_DECL void Zig__GlobalObject__onCrash();
 ZIG_DECL JSC::EncodedJSValue Zig__GlobalObject__promiseRejectionTracker(JSC::JSGlobalObject* arg0, JSC::JSPromise* arg1, uint32_t JSPromiseRejectionOperation2);
 ZIG_DECL JSC::EncodedJSValue Zig__GlobalObject__reportUncaughtException(JSC::JSGlobalObject* arg0, JSC::Exception* arg1);
 ZIG_DECL void Zig__GlobalObject__resolve(ErrorableString* arg0, JSC::JSGlobalObject* arg1, BunString* arg2, BunString* arg3, BunString* arg4);

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -198,7 +198,7 @@ pub(crate) mod js_bindings {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// Ends in the C++ terminate handler: with a `std::runtime_error` in flight on POSIX, with nothing in flight on Windows.
+    /// Ends in the C++ terminate handler: with a `std::runtime_error` in flight on macOS, with nothing in flight elsewhere.
     #[bun_jsc::host_fn]
     fn js_uncaught_cxx_exception(
         _global: &JSGlobalObject,

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -29,6 +29,7 @@ pub(crate) mod js_bindings {
             ("abort", __jsc_host_js_abort),
             ("fastfail", __jsc_host_js_fastfail),
             ("trap", __jsc_host_js_trap),
+            ("uncaughtCxxException", __jsc_host_js_uncaught_cxx_exception),
             (
                 "raiseIgnoringPanicHandler",
                 __jsc_host_js_raise_ignoring_panic_handler,
@@ -194,6 +195,20 @@ pub(crate) mod js_bindings {
             crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
         );
         #[allow(unreachable_code)]
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// Ends in the C++ terminate handler: with a `std::runtime_error` in flight on POSIX, with nothing in flight on Windows.
+    #[bun_jsc::host_fn]
+    fn js_uncaught_cxx_exception(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        unsafe extern "C" {
+            safe fn Bun__throwUncaughtCxxExceptionForTesting();
+        }
+        crash_handler::suppress_core_dumps_if_necessary();
+        Bun__throwUncaughtCxxExceptionForTesting();
         Ok(JSValue::UNDEFINED)
     }
 

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,6 +12,6 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error(
-    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
+    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|uncaughtCxxException|raiseIgnoringPanicHandler>",
   );
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -89,6 +89,34 @@ test.if(isPosix)(
   20_000,
 );
 
+// bun installs a std::terminate handler. A C++ exception that escapes from a
+// native addon's code into bun ends up there (bun is built without unwind
+// tables, so the unwinder gives up at the first bun frame), and the report used
+// to say only "A C++ exception occurred". It has to name the exception's type
+// and, for a std::exception, carry its what(). The fixture throws a
+// std::runtime_error through the C++ ABI; on Windows, whose runtime has none of
+// those entry points, it calls std::terminate() with no exception in flight.
+test("an uncaught C++ exception is reported with its type and message", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      path.join(import.meta.dir, "fixture-crash.js"),
+      "uncaughtCxxException",
+      "--debug-crash-handler-use-trace-string",
+    ],
+    env: noReportEnv,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain(
+    isWindows
+      ? "panic(main thread): std::terminate() was called with no C++ exception in flight"
+      : "panic(main thread): uncaught C++ exception std::runtime_error: thrown by the crash handler test",
+  );
+  expect(exitCode).not.toBe(0);
+});
+
 // After printing the crash report the handler must terminate with a signal
 // that reflects the crash cause: panics abort (SIGABRT), a caught fault is
 // re-raised as the original signal. Previously the handler ended in a trap

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -94,10 +94,13 @@ test.if(isPosix)(
 // has no unwind tables) ends up in that handler, and the report used to say only
 // "A C++ exception occurred". It has to name the exception's type and, for a
 // std::exception, carry its what(). The fixture throws a std::runtime_error
-// there. Everywhere else it calls std::terminate() with nothing in flight: a
-// Linux addon has its own runtime, and a throw from inside a glibc release build
-// of bun aborts in the unwinder (its tables are stripped) before any handler.
-test("an uncaught C++ exception is reported with its type and message", async () => {
+// there. Elsewhere it calls std::terminate() with nothing in flight: a Linux
+// addon has its own runtime, and a throw from inside a glibc release build of
+// bun aborts in the unwinder (its tables are stripped) before any handler. Not
+// on Windows: bun builds with _HAS_EXCEPTIONS=0, and the MSVC STL's
+// std::terminate() then aborts (exit status 3, nothing printed) without calling
+// the handler std::set_terminate installed, so there is nothing to observe.
+test.if(isPosix)("an uncaught C++ exception is reported with its type and message", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isMacOS, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -89,13 +89,14 @@ test.if(isPosix)(
   20_000,
 );
 
-// bun installs a std::terminate handler. A C++ exception that escapes from a
-// native addon's code into bun ends up there (bun is built without unwind
-// tables, so the unwinder gives up at the first bun frame), and the report used
-// to say only "A C++ exception occurred". It has to name the exception's type
-// and, for a std::exception, carry its what(). The fixture throws a
-// std::runtime_error through the C++ ABI; on Windows, whose runtime has none of
-// those entry points, it calls std::terminate() with no exception in flight.
+// bun installs a std::terminate handler. On macOS an addon shares bun's C++
+// runtime, so an exception that escapes from the addon's code into bun (which
+// has no unwind tables) ends up in that handler, and the report used to say only
+// "A C++ exception occurred". It has to name the exception's type and, for a
+// std::exception, carry its what(). The fixture throws a std::runtime_error
+// there. Everywhere else it calls std::terminate() with nothing in flight: a
+// Linux addon has its own runtime, and a throw from inside a glibc release build
+// of bun aborts in the unwinder (its tables are stripped) before any handler.
 test("an uncaught C++ exception is reported with its type and message", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -110,9 +111,9 @@ test("an uncaught C++ exception is reported with its type and message", async ()
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain(
-    isWindows
-      ? "panic(main thread): std::terminate() was called with no C++ exception in flight"
-      : "panic(main thread): uncaught C++ exception std::runtime_error: thrown by the crash handler test",
+    isMacOS
+      ? "panic(main thread): uncaught C++ exception std::runtime_error: thrown by the crash handler test"
+      : "panic(main thread): std::terminate() was called with no C++ exception in flight",
   );
   expect(exitCode).not.toBe(0);
 });


### PR DESCRIPTION
### Problem
- Sentry BUN-4KFP is `Panic: A C++ exception occurred` (macOS arm64, raised from a Node-API finalizer, `Finalizer::run` in `napi_body.rs`). That message is all bun uploads about it. Every uncaught C++ exception from every addon produces the same one, so the events cannot be told apart and the exception is unknown.
- Cause: the `std::set_terminate` handler in `JSCInitialize` (`src/jsc/bindings/ZigGlobalObject.cpp:298`) called `Zig__GlobalObject__onCrash`, which did `panic!("A C++ exception occurred")` (`src/jsc/JSGlobalObject.rs:1468`). It replaced the runtime's default handler, which prints the type and `what()`.

### Fix
- `src/jsc/bindings/CxxTerminateHandler.cpp` installs the handler. It takes the type from `__cxa_current_exception_type()`, demangles it, and reads `what()` when the type derives from `std::exception`. Bun's C++ has no `catch` and no `dynamic_cast` (`-fno-exceptions -fno-rtti`), so the handler walks the Itanium C++ ABI `type_info` records (section 2.9.5) to find the `std::exception` subobject, and reads the object's address out of `std::current_exception()`. It touches the object only after that walk proves the type.
- `Zig__GlobalObject__onCrash(type, what)` builds the panic: `uncaught C++ exception Napi::Error: <what>` (type cut at 512 bytes, what() at 256), or `std::terminate() was called with no C++ exception in flight`. bun.report's panic fingerprint includes the message, so these events now group by exception.
- Windows: with `_HAS_EXCEPTIONS=0` the MSVC STL's `std::terminate()` aborts without calling any installed handler (verified, see notes), so the handler was never reachable there. The Windows branch only keeps the symbols defined.
- Verified: `test/cli/run/run-crash-handler.test.ts`, new test (fails before: no hook). macOS CI gets `uncaught C++ exception std::runtime_error: thrown by the crash handler test`; Linux gets the no-exception message. Rest of the file passes; `cargo check` of `bun_jsc` and `bun_runtime` for darwin and windows.

### Background
- `std::terminate` runs when an exception finds no handler. Bun has no unwind tables, so an exception that leaves an addon's frames terminates at the first bun frame. On macOS the addon and bun share the system libc++abi, so bun's handler runs. On Linux an addon has its own libstdc++, whose default handler prints and aborts, and bun reports `abort() called`.
- Inside the handler the exception counts as caught (the runtime calls `__cxa_begin_catch` before terminating), which is what lets `__cxa_current_exception_type()` and `std::current_exception()` see it.
- The `uncaughtCxxException` hook throws a `std::runtime_error` through `__cxa_allocate_exception` and `__cxa_throw` on macOS, and calls `std::terminate()` elsewhere.

<details><summary>Notes</summary>

- Why the hook throws on macOS only: a glibc release build strips `.eh_frame`, so `__cxa_throw` aborts inside libgcc's unwinder before `std::terminate` is reached. The first CI run showed `abort() called` on every glibc lane and nothing at all on the ASAN lane (no signal handlers there). The Linux debug build keeps the tables and reported the runtime_error message through the same code, which is how the type_info walk was exercised against libstdc++; the musl lanes passed with the throw as well.
- Windows verification: a debug build of this branch exits with status 3 and prints nothing for the hook; a standalone program built with `/EHs-c- /D_HAS_EXCEPTIONS=0` shows the same, and with `/EHsc` the handler runs. Bun also links the CRT statically, so an addon's terminate would not arrive in bun's runtime anyway.
- `__cxa_throw` is declared in this file because FreeBSD's libcxxrt leaves it out of `<cxxabi.h>` (the first CI run failed there).
- `what()` is an addon string. Node-API fatal error messages (`NAPI FATAL ERROR: ...`, BUN-41DM and friends) are addon strings bun already uploads in the same position. Dropping it from the upload is a one-line change in `onCrash`.
- type_info kinds are told apart by their vtables (`__si_class_type_info`, `__vmi_class_type_info`), exported by every runtime for this ABI. Virtual bases are skipped. A type_info from another runtime fails the vtable test and the report carries the type name only. `std::exception_ptr` is one pointer in libc++ and libstdc++; a `static_assert` guards that.
- On Linux x86_64 the captured stack stops after `terminateHandler`, as before: the toolchain's libstdc++ has no frame pointers. macOS keeps them, which is why BUN-4KFP has a full stack.
- #32569 changes the same handler so that an addon destructor that throws during `exit()` does not crash (BUN-390H). It needs a rebase; its check belongs at the top of `terminateHandler()`.
- #39806 names the addon in the frames. Naming the module being loaded or run in the panic message is a separate PR.
- Rebased onto main at 552c375 (one import line conflicted in the test file). CI on this head: every Linux lane and Windows fail in `test/cli/install/bun-audit.test.ts`, a snapshot that breaks on main since the version bump to 1.4.1 (`normalizeBunSnapshot` now rewrites the advisory range `<1.4.1`). Not related to this diff. `run-crash-handler.test.ts` passes on every lane; its one Windows retry was the PowerShell upload race that #36550 fixes.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->
