### PR TITLE
bun test --isolate: stop finished files from pinning their global via mocks and plugins

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5104,6 +5104,10 @@ impl VirtualMachine {
         self.main_resolved_path.deref();
         self.main_resolved_path = bun_core::String::empty();
         self.unhandled_error_counter = 0;
+        // The finished file's plugins are dropped with its global; the next
+        // `Bun.plugin()` call reinstalls the runner against the new global.
+        self.transpiler.linker.plugin_runner = None;
+        self.plugin_runner = None;
 
         let old_global = self.global;
         // `old_global` valid for VM lifetime (safe ZST-handle deref);

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -982,10 +982,6 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
     global->onLoadPlugins.clear();
     global->onResolvePlugins.clear();
 
-    delete global->onLoadPlugins.virtualModules;
-    global->onLoadPlugins.virtualModules = nullptr;
-    global->onLoadPlugins.mustDoExpensiveRelativeLookup = false;
-
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -86,6 +86,14 @@ public:
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 
+        void clear()
+        {
+            Base::clear();
+            delete virtualModules;
+            virtualModules = nullptr;
+            mustDoExpensiveRelativeLookup = false;
+        }
+
         ~OnLoad()
         {
             if (virtualModules) {

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -619,7 +619,7 @@ const ClassInfo JSMockFunctionPrototype::s_info = { "Mock"_s, &Base::s_info, nul
 
 // The sets are weak, so a mock that has been collected is simply not visited.
 template<typename Functor>
-static void forEachMockInSet(JSC::Strong<JSC::Unknown>& mockSet, const Functor& apply)
+static void forEachMockInSet(JSC::WriteBarrier<JSC::Unknown>& mockSet, const Functor& apply)
 {
     if (!mockSet) {
         return;
@@ -783,6 +783,8 @@ template<typename Visitor> void JSMockModule::visit(Visitor& visitor)
     name.visit(visitor);
     FOR_EACH_JSMOCKMODULE_GC_MEMBER(VISIT_JSMOCKMODULE_GC_MEMBER)
 #undef VISIT_JSMOCKMODULE_GC_MEMBER
+    visitor.append(activeSpies);
+    visitor.append(activeMocks);
 }
 
 template void JSMockModule::visit(JSC::AbstractSlotVisitor&);
@@ -1570,7 +1572,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
         {
             if (!globalObject->mockModule.activeSpies) {
                 ActiveSpySet* activeSpies = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
-                globalObject->mockModule.activeSpies.set(vm, activeSpies);
+                globalObject->mockModule.activeSpies.set(vm, globalObject, activeSpies);
             }
             ActiveSpySet* activeSpies = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeSpies.get());
             activeSpies->add(vm, mock, mock);
@@ -1579,7 +1581,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
         {
             if (!globalObject->mockModule.activeMocks) {
                 ActiveSpySet* activeMocks = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
-                globalObject->mockModule.activeMocks.set(vm, activeMocks);
+                globalObject->mockModule.activeMocks.set(vm, globalObject, activeMocks);
             }
             ActiveSpySet* activeMocks = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeMocks.get());
             activeMocks->add(vm, mock, mock);
@@ -1626,7 +1628,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsMockFn, (JSC::JSGlobalObject * lexicalGlobalO
 
     if (!globalObject->mockModule.activeMocks) {
         ActiveSpySet* activeMocks = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
-        globalObject->mockModule.activeMocks.set(vm, activeMocks);
+        globalObject->mockModule.activeMocks.set(vm, globalObject, activeMocks);
     }
 
     ActiveSpySet* activeMocks = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeMocks.get());

--- a/src/jsc/bindings/JSMockFunction.h
+++ b/src/jsc/bindings/JSMockFunction.h
@@ -39,12 +39,12 @@ public:
 
     // These are used by "spyOn"
     // This is useful for iterating through every non-GC'd spyOn
-    JSC::Strong<JSC::Unknown> activeSpies;
+    JSC::WriteBarrier<JSC::Unknown> activeSpies;
 
     // Every JSMockFunction::create appends to this list
     // This is useful for iterating through every non-GC'd mock function
     // This list includes activeSpies
-    JSC::Strong<JSC::Unknown> activeMocks;
+    JSC::WriteBarrier<JSC::Unknown> activeMocks;
 
     // Called by GlobalObject::visitChildren
     template<typename Visitor>

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -702,9 +702,18 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
         globalObject->m_processEnvObject.set(vm, globalObject, Bun::createSharedEnvironmentVariablesMap(globalObject).getObject());
     }
 
-    // Drop the permanent root on the previous global so its module registry,
-    // require.cache, and user objects become collectable. JSC's CodeCache and
-    // Bun's RuntimeTranspilerCache are VM/process scoped and survive.
+    // The plugin registries hold Strong<> roots into the old realm; owned by the global itself,
+    // they would keep it (and everything it loaded) alive for the rest of the run.
+    oldGlobal->onLoadPlugins.clear();
+    oldGlobal->onResolvePlugins.clear();
+    // Drop the finished file's module registry and require.cache now rather than whenever the
+    // old global happens to die. JSC's CodeCache and Bun's RuntimeTranspilerCache are VM/process
+    // scoped and survive.
+    {
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        oldGlobal->clearModuleRegistry();
+        scope.assertNoExceptionExceptTermination();
+    }
     oldGlobal->isThreadLocalDefaultGlobalObject = false;
     JSC::gcUnprotect(oldGlobal);
 
@@ -3579,16 +3588,22 @@ template void GlobalObject::visitOutputConstraints(JSCell*, SlotVisitor&);
 
 // DEFINE_VISIT_CHILDREN(Zig::GlobalObject);
 
-void GlobalObject::reload()
+void GlobalObject::clearModuleRegistry()
 {
-    auto& vm = this->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
     {
         auto* moduleLoader = this->moduleLoader();
+        // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread under cellLock().
         WTF::Locker locker { moduleLoader->cellLock() };
         moduleLoader->clearAll();
     }
     this->requireMap()->clear(this);
+}
+
+void GlobalObject::reload()
+{
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    this->clearModuleRegistry();
     RETURN_IF_EXCEPTION(scope, );
 
     // If we run the GC every time, we will never get the SourceProvider cache hit.
@@ -4301,14 +4316,8 @@ void GlobalObject::forbidExecution()
     // Drop the module registry and require() cache so module-level bindings become unreachable
     // for the final collection (their ExternalStringImpl deallocators must run before ~VM).
     {
-        auto* moduleLoader = this->moduleLoader();
-        // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread under cellLock().
-        WTF::Locker locker { moduleLoader->cellLock() };
-        moduleLoader->clearAll();
-    }
-    {
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        requireMap()->clear(this);
+        this->clearModuleRegistry();
         scope.clearException();
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -769,6 +769,7 @@ public:
     size_t reloadCount = 0;
 
     void reload();
+    void clearModuleRegistry();
 
     JSC::Structure* jsonlParseResultStructure() { return m_jsonlParseResultStructure.get(this); }
     JSC::Structure* pathParsedObjectStructure() { return m_pathParsedObjectStructure.get(this); }

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -844,6 +844,10 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 //   pending timeout signal's wrapper (hence its listener, hence the global)
 //   alive for as long as the signal says so. Same story when the timer sat in
 //   the fake-timer heap of a file that never called useRealTimers().
+// - mock()/spyOn()/mock.module()/Bun.plugin: the global's own mock-tracking
+//   sets and plugin callback lists were held through Strong handles, so any
+//   file that created a mock or registered a plugin formed an uncollectable
+//   root -> realm object -> global cycle (#31771's linear growth in practice).
 //
 // Each fixture runs 8 isolated files that leak one handle apiece, forces a
 // full GC, and counts live GlobalObject cells. Pinned globals accumulate
@@ -936,6 +940,37 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         import { vi } from "bun:test";
         vi.useFakeTimers();
         AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
+
+  test("mock(), spyOn() and mock.module() left registered", async () => {
+    using dir = tempDir(
+      "isolate-leak-mocks",
+      makeLeakFixture(`
+        import { mock, spyOn } from "bun:test";
+        const fn = mock(() => 1);
+        fn();
+        spyOn(console, "warn");
+        mock.module("./mocked-dep", () => ({ default: 1 }));
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
+
+  test("Bun.plugin left registered", async () => {
+    using dir = tempDir(
+      "isolate-leak-plugin",
+      makeLeakFixture(`
+        Bun.plugin({
+          name: "leak",
+          setup(build) {
+            build.onLoad({ filter: /never-matches/ }, () => ({ contents: "", loader: "js" }));
+            build.onResolve({ filter: /never-matches/ }, () => null);
+            build.module("leaked-virtual-module", () => ({ exports: {}, loader: "object" }));
+          },
+        });
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);


### PR DESCRIPTION
### What

Closes #31772. Fixes #31771.

Under `bun test --isolate` each file runs in a fresh `GlobalObject` inside one VM. Two pieces of state that live *on the global itself* were held through `JSC::Strong` handles:

- `JSMockModule::activeSpies` / `activeMocks` — created by the first `mock()` / `jest.fn()` / `spyOn()` in a file
- `onLoadPlugins` / `onResolvePlugins` (+ virtual modules) — populated by `Bun.plugin()` and `mock.module()`

A Strong root → realm object → Structure → global cycle is uncollectable, so any file that created a mock or registered a plugin kept its entire global and everything it imported alive for the rest of the run. That is the linear growth people hit on real suites.

### Changes

- `activeSpies` / `activeMocks` become `WriteBarrier`s visited from `JSMockModule::visit` (already called by `GlobalObject::visitChildren`).
- The isolation swap clears the outgoing global's plugin lists (`OnLoad::clear()` now also drops virtual modules; `Bun.plugin.clearAll()` shares it) and resets the VM's cached `plugin_runner`, which pointed at whichever global first registered a plugin and would dangle once that global is collectable.
- The swap drops the outgoing global's module registry and `require.cache` right after microtasks/handles are drained, instead of whenever the old global happens to be collected. `reload()` and `forbidExecution()` share the same `clearModuleRegistry()` helper.

No forced GC of any kind.

### Numbers

Release builds of `main` vs this branch, same machine, interleaved runs. 1000-module shared graph imported by every file; "mock" files additionally do `const fn = mock(() => 1)`.

| files | `main --isolate` (mock) | this PR `--isolate` (mock) | `main` no isolate |
|---|---|---|---|
| 10 | 227 MB | 152 MB | |
| 20 | 426 MB | 190 MB | |
| 40 | 810 MB | 152 MB | |
| 80 | 1591 MB | 215 MB | 59 MB |

Wall time at N=80: 1.95s → 1.46s.

Live `GlobalObject` count after `Bun.gc(true)` in the Nth file (release): `main` = N, this PR = 1–3.

For the mock-free repro in the issue, current `main` already plateaus (finished globals are collectable there); `main` and this branch measure the same (~140/225/225/310 MB at N=10/20/40/80). What remains above shared-global mode in that case is generational GC pacing — each file's graph is promoted to old space while the file runs and is only reclaimed by the next full collection — which this PR deliberately does not force.

### Tests

Two new cases in `test/cli/test/isolation.test.ts` under "collects globals pinned by leaked handles": 8 isolated files that each create mocks / register a plugin, assert live `GlobalObject` ≤ 4. Both fail on `main` (8) and pass here. Existing isolation, mock, and plugin suites pass on the debug+ASAN build, including with `BUN_JSC_validateExceptionChecks=1`.
