### PR TITLE
Fix the Windows watcher panic when a change burst with a delete spans an event batch

### DIFF
--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -414,11 +414,6 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
         // NOTE: using a 1ms timeout would be ideal, but that actually makes the thread wait for at least 10ms more than it should
         // Instead we use a 0ms timeout, which may not do as much coalescing but is more responsive.
         timeout = Timeout::None;
-        bun_core::scoped_log!(
-            watcher,
-            "number of watched items: {}",
-            this.watchlist.items_file_path().len()
-        );
         while let Some(event) = iter.next() {
             // `event.filename` is a `RawSlice<u16>` into `this.platform.watcher.buf`,
             // live for the duration of this iteration (no `prepare()` until the
@@ -443,54 +438,35 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             //   to implement and maintain.
             // - others that i'm not thinking of
 
-            let n_items = this.watchlist.items_file_path().len();
-            for item_idx in 0..n_items {
-                // reshaped for borrowck — `rel` is computed in a scoped
-                // block so the borrows of `this.watchlist` / `this.platform.buf`
-                // are released before we touch `this.watch_events` or hand the
-                // whole `&mut Watcher` to `process_watch_event_batch`.
-                let rel = {
-                    let eventpath = &this.platform.buf[..eventpath_len];
-                    let path = &this.watchlist.items_file_path()[item_idx];
-                    let rel = is_parent_or_equal(path.as_ref(), eventpath);
-                    bun_core::scoped_log!(
-                        watcher,
-                        "checking path: {} = .{}",
-                        bstr::BStr::new(path.as_ref()),
-                        match rel {
-                            ParentEqual::Parent => "parent",
-                            ParentEqual::Equal => "equal",
-                            ParentEqual::Unrelated => "unrelated",
-                        }
-                    );
-                    rel
-                };
-                // skip unrelated items
-                if rel == ParentEqual::Unrelated {
-                    continue;
-                }
-                // if the event is for a parent dir of the item, only emit it if it's a delete or rename
-
-                // Check if we're about to exceed the watch_events array capacity
-                if event_id >= this.watch_events.len() {
-                    // Process current batch of events
-                    process_watch_event_batch(this, event_id)?;
-                    // passing `this: &mut Watcher` above materialises a fresh Unique
-                    // borrow over the whole `Watcher`, which under Stacked Borrows pops the
-                    // SharedReadOnly tag that `iter.watcher` (a `*const DirWatcher` derived from
-                    // an earlier `&this.platform.watcher`) carries. The next `iter.next()` would
-                    // then dereference a pointer with invalidated provenance — UB that MIRI flags.
-                    // The callee never touches `platform.watcher`, so re-deriving the pointer
-                    // here from the now-current `&mut Watcher` restores valid provenance.
-                    iter.watcher = BackRef::new(&this.platform.watcher);
-                    // Reset event_id to start a new batch
-                    event_id = 0;
-                }
-
-                this.watch_events[event_id] =
-                    create_watch_event(&event, item_idx as WatchItemIndex);
-                event_id += 1;
+            let mut matched = match_record(this, &event, eventpath_len, event_id);
+            if matched.is_none() && event_id > 0 {
+                // The batch is full. Dispatch the records already in it, then match this
+                // record again from scratch: `on_file_update` evicts the entries of deleted
+                // files (`flush_evictions` swap-removes them), so the dispatch both shrinks
+                // the watchlist and moves entries to other indices. Indices matched before
+                // the dispatch cannot be carried over into the next batch.
+                process_watch_event_batch(this, event_id)?;
+                event_id = 0;
+                matched = match_record(this, &event, eventpath_len, 0);
             }
+            event_id += match matched {
+                Some(count) => count,
+                None => {
+                    // This one record matched more entries than a batch holds (the path has
+                    // more than `MAX_COUNT` watched ancestors). `watch_events` is full of its
+                    // matches; the rest are dropped.
+                    debug_assert_eq!(event_id, 0);
+                    this.watch_events.len()
+                }
+            };
+            // Passing `this: &mut Watcher` to the calls above materialises a fresh Unique
+            // borrow over the whole `Watcher`, which under Stacked Borrows pops the
+            // SharedReadOnly tag that `iter.watcher` (a `*const DirWatcher` derived from
+            // an earlier `&this.platform.watcher`) carries. The next `iter.next()` would
+            // then dereference a pointer with invalidated provenance, which MIRI flags as
+            // UB. The callees never touch `platform.watcher`, so re-deriving the pointer
+            // here from the now-current `&mut Watcher` restores valid provenance.
+            iter.watcher = BackRef::new(&this.platform.watcher);
         }
     }
 
@@ -500,6 +476,51 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     }
 
     Ok(())
+}
+
+/// Records a `WatchEvent` in `this.watch_events[start..]` for every watchlist entry that
+/// the record's path (`this.platform.buf[..eventpath_len]`) is equal to or nested under.
+///
+/// Returns how many events it recorded, or `None` when the batch ran out of room. The
+/// events recorded before that point are left in place: when `start == 0` they are a
+/// complete batch of this record's first `MAX_COUNT` matches, otherwise the caller
+/// dispatches the batch and matches the record again.
+///
+/// The scan holds `this.mutex`. The transpiler and bundler threads append to the
+/// watchlist under the same mutex, and an append that grows the list frees the columns
+/// read here. The guard is dropped before the caller dispatches the batch, because
+/// `dispatch_file_updates` takes the same (non-recursive) mutex.
+fn match_record(
+    this: &mut Watcher,
+    event: &FileEvent,
+    eventpath_len: usize,
+    start: usize,
+) -> Option<usize> {
+    let _guard = this.mutex.lock_guard();
+    let eventpath = &this.platform.buf[..eventpath_len];
+    let paths = this.watchlist.items_file_path();
+    bun_core::scoped_log!(watcher, "number of watched items: {}", paths.len());
+    let mut event_id = start;
+    for (item_idx, path) in paths.iter().enumerate() {
+        let rel = is_parent_or_equal(path.as_ref(), eventpath);
+        bun_core::scoped_log!(
+            watcher,
+            "checking path: {} = .{}",
+            bstr::BStr::new(path.as_ref()),
+            match rel {
+                ParentEqual::Parent => "parent",
+                ParentEqual::Equal => "equal",
+                ParentEqual::Unrelated => "unrelated",
+            }
+        );
+        if rel == ParentEqual::Unrelated {
+            continue;
+        }
+        *this.watch_events.get_mut(event_id)? =
+            create_watch_event(event, item_idx as WatchItemIndex);
+        event_id += 1;
+    }
+    Some(event_id - start)
 }
 
 fn process_watch_event_batch(this: &mut Watcher, event_count: usize) -> bun_sys::Result<()> {

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -20,6 +20,11 @@ pub(crate) type Platform = WindowsWatcher;
 pub struct WindowsWatcher {
     pub(crate) iocp: HANDLE,
     pub(crate) watcher: DirWatcher,
+    /// A `ReadDirectoryChangesW` request issued by [`DirWatcher::prepare`] has not
+    /// completed yet. The requests share `watcher.buf` and `watcher.overlapped`, so
+    /// only one may be in flight: a second one would be completed into the buffer
+    /// while the records of the first one are still being read.
+    pub(crate) request_pending: bool,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
 }
@@ -33,6 +38,7 @@ impl Default for WindowsWatcher {
                 buf: [0u8; 64 * 1024],
                 dir_handle: w::INVALID_HANDLE_VALUE,
             },
+            request_pending: false,
             buf: PathBuffer::uninit(),
             base_idx: 0,
         }
@@ -301,9 +307,15 @@ impl WindowsWatcher {
 
     /// wait until new events are available
     fn next(&mut self, timeout: Timeout) -> bun_sys::Result<Option<EventIterator>> {
-        if let Err(err) = self.watcher.prepare() {
-            bun_core::scoped_log!(watcher, "prepare() returned error");
-            return Err(err);
+        // A wait that timed out returns with its request still pending, and that request
+        // is the one a later call waits for. Issuing another one per call queued an
+        // additional request on the directory for every cycle that ended in a timeout.
+        if !self.request_pending {
+            if let Err(err) = self.watcher.prepare() {
+                bun_core::scoped_log!(watcher, "prepare() returned error");
+                return Err(err);
+            }
+            self.request_pending = true;
         }
 
         let mut nbytes: w::DWORD = 0;
@@ -342,6 +354,7 @@ impl WindowsWatcher {
                 if overlapped != &mut self.watcher.overlapped as *mut w::OVERLAPPED {
                     continue;
                 }
+                self.request_pending = false;
                 if nbytes == 0 {
                     // ReadDirectoryChangesW internal change-buffer overflow — too many
                     // events arrived between drain and re-arm. This is NOT a shutdown
@@ -359,6 +372,7 @@ impl WindowsWatcher {
                     if let Err(err) = self.watcher.prepare() {
                         return Err(err);
                     }
+                    self.request_pending = true;
                     continue;
                 }
                 return Ok(Some(EventIterator {

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isASAN, isCI, isLinux, tempDir } from "harness";
-import { mkdirSync, readdirSync, readlinkSync, realpathSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, forEachLine, isASAN, isCI, isLinux, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkdirSync, readdirSync, readlinkSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("--hot with many directories", () => {
@@ -244,5 +244,64 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     const leaks = stderr.split(/\n\s*\n/).filter(block => /^(?:Direct|Indirect) leak of /.test(block));
     expect(leaks).toEqual([]);
     expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  });
+
+  // The Windows watcher gets one record per deleted path and matches it against
+  // the deleted file and every watched ancestor directory. The modules below
+  // sit under up to 80 watched directories, so two records of the delete burst
+  // already overflow the 128-event batch, and a batch is dispatched while the
+  // burst is still being matched. Dispatching evicts the deleted files from the
+  // watchlist. The matching loop used to keep going with the old length, and
+  // the watcher thread died with `panic: index out of bounds`, taking the
+  // process with it.
+  test.skipIf(!isWindows)("survives a delete burst that spans more than one event batch", async () => {
+    const depth = 80;
+    const files: Record<string, string> = {};
+    const imports: string[] = [];
+    for (let level = 1; level <= depth; level++) {
+      const subdir = Array(level).fill("d").join("/");
+      files[`${subdir}/m.js`] = `export const level = ${level};`;
+      imports.push(`import "./${subdir}/m.js";`);
+    }
+    files["entry.js"] = `${imports.join("\n")}\nconsole.log("LOADED");`;
+    // Removed at the end instead of with `using`: if the child crashes, its
+    // crash reporter keeps the directory busy for a moment, and the removal
+    // error would hide the panic output inside a SuppressedError.
+    const dir = tempDirWithFiles("hot-delete-burst", files);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--hot", "entry.js"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Drained from the start: the reload that the burst itself queues reports
+    // the deleted imports on stderr.
+    const stderr = proc.stderr.text();
+
+    const iter = forEachLine(proc.stdout);
+    const waitForLine = async (expected: string) => {
+      while (true) {
+        const { value: line, done } = await iter.next();
+        if (done) {
+          throw new Error(`--hot exited (code ${await proc.exited}) before printing "${expected}"\n${await stderr}`);
+        }
+        if (line === expected) return;
+      }
+    };
+
+    await waitForLine("LOADED");
+    rmSync(join(dir, "d"), { recursive: true });
+    // Only events raised after the burst prove that the watcher thread is still
+    // running.
+    for (let i = 1; i <= 2; i++) {
+      writeFileSync(join(dir, "entry.js"), `console.log("RELOAD ${i}");`);
+      await waitForLine(`RELOAD ${i}`);
+    }
+
+    proc.kill();
+    await proc.exited;
+    rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
### Problem
- Windows: a change burst with a delete in it kills `--hot`, `--watch` and the dev server with `panic: index out of bounds: the len is 1358 but the index is 1358` in `windows_watcher::watch_loop_cycle` (`src/watcher/WindowsWatcher.rs:454`, Sentry BUN-4MQD and BUN-4S6N, new in 1.4.0).
- The cycle dispatched a full batch from inside its loop over the entries. The dispatch evicts deleted files with `swap_remove`, and the loop kept its old length. The scan also ran without the mutex that `add_file` takes.
- `next` issued a `ReadDirectoryChangesW` request on every call, although a timed out wait leaves the old one pending. They share one buffer.

### Fix
- `match_record` matches one record under the mutex. When the batch is full, the cycle dispatches the complete records and matches the record again against the compacted list. No entry is skipped or reported twice.
- `next` issues a request only when none is pending.
- Verified: new Windows-only case in `test/cli/hot/watch-many-dirs.test.ts`, the canary fails it 10 of 10 runs with the panic above, this branch passes 10 of 10.

### Background
- One recursive `ReadDirectoryChangesW` request covers the project root. A record names one changed path and matches that entry plus every watched ancestor directory, so one record gives several events.
- Events fill a batch of 128 that goes to `on_file_update` under `Watcher.mutex`. That callback evicts deleted files, so a dispatch shrinks the watchlist and moves entries.
- Linux matches against a locked snapshot, macOS gets the index from kqueue `udata`. Neither is affected.

<details><summary>Notes</summary>

- Suites run on the Windows debug build: `test/cli/hot/hot.test.ts` (12), `watch.test.ts` (2), `watch-many-dirs.test.ts` (2, 2 skipped as Linux-only), `test/cli/watch/watcher-trace.test.ts` (4), `test/bake/dev/hot.test.ts` (10, 1 todo), `stress.test.ts`, `incremental-graph-edge-deletion.test.ts`. `cargo check -p bun_watcher --target x86_64-pc-windows-msvc` is clean. Clippy for that target reports only the 14 findings that main already has in unchanged code.
- The test imports one module from each of 80 nested directories. A record for a deep module matches the module and up to 81 directories, so two records of the delete burst overflow the batch whatever the timing of the burst. A shape with 20 levels and 8 files per level panicked in only 3 of 6 runs on the canary, 40 levels and deeper in every run.
- The panic needs 129 or more (record, entry) pairs inside one watcher cycle with a file delete or rename among the first 128. Typical triggers: `git checkout`, deleting or moving a source folder, a formatter rewriting many files with rename-save, on a project with more than 128 watched entries.
- Dispatch contents were checked with `BUN_WATCHER_TRACE` on the debug build: no `(unknown)` index in any batch and no module deleted more than once. Deep bursts also lose a tail of records on the debug build, with the old and the new code alike. That is the kernel notification buffer overflowing while the slow debug build is still matching (the existing `nbytes == 0` path). Flat bursts of 300 files arrive complete. The test therefore checks that the process still reloads after the burst instead of counting events.
- `.get(item_idx)` with a break, or re-reading the length each iteration, stops the panic but goes on scanning from the old position after a `swap_remove`, so entries moved below the cursor are not matched for the current record. #31695 takes the mutex for this scan as one of its four fixes and documents that skip as a trade-off. This PR supersedes its Windows part.
- Restoring the slice captured before the loop, as the original implementation did, would read freed memory: since #39197 `flush_evictions` frees the path of every evicted entry.
- Pending requests: each cycle that ends in a zero-timeout wait left one more request queued on the handle, and a later change completes an older request into the buffer while the current records are still being read. Measured with `Get-Process`, `NonpagedSystemMemorySize64` over 200 saves of one file under `--hot`: canary 6 KiB to 109 KiB, this branch 11 KiB to 13 KiB. The old `next` had the same shape before the port, so this is not a port regression.
- The test removes its directory at the end instead of with `using`. When the child crashes, the crash reporter keeps the directory busy for a moment, and the removal error hid the panic output inside a `SuppressedError`.
- Sentry groups this panic by the length in the message, so each watchlist size is its own issue: BUN-4MQD (`len is 1358`) and BUN-4S6N (`len is 1072`, a public 1.4.0 `bun run` with the dev server and http server tags). Both have the same `watch_loop_cycle` frame at `WindowsWatcher.rs:454`.
- Unrelated bugs found on the way were handed off separately: `--hot` leaks one handle per save on Windows (`flush_evictions` does not close handles there), `--hot` watches nothing when the cwd is an 8.3 short path, and `fs.watch` on a directory that gets deleted fires hundreds of `rename` events.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/watch-many-dirs.test.ts

<!-- robobun:evidence:end -->
