### PR TITLE
node:inspector: drop zero-width ranges from Profiler.takePreciseCoverage

### DIFF
--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -302,11 +302,14 @@ function buildScriptCoverageList(
     }
 
     // Outer functions before nested ones, so a stack-based sweep below sees
-    // enclosing ranges first.
+    // enclosing ranges first. Zero-width entries (JSC emits them, e.g. for an
+    // `export function` declaration) are dropped: V8 never produces
+    // startOffset === endOffset, and @bcoe/v8-coverage's range-tree merge
+    // recurses forever on one.
     const functions = script.functions
-      .filter(([start, end]) => start >= 0 && end >= start)
+      .filter(([start, end]) => start >= 0 && end > start)
       .sort((a, b) => a[0] - b[0] || b[1] - a[1]);
-    const blocks = script.blocks.filter(([start, end]) => start >= 0 && end >= start).sort((a, b) => a[0] - b[0]);
+    const blocks = script.blocks.filter(([start, end]) => start >= 0 && end > start).sort((a, b) => a[0] - b[0]);
 
     // Assign each basic block to the innermost function range containing it.
     const blocksPerFunction: Array<Array<[number, number, number]>> = functions.map(() => []);

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -293,8 +293,7 @@ function buildScriptCoverageList(
 
   for (const script of rawScripts) {
     const { scriptId, sourceLength } = script;
-    // V8 does not report empty scripts. Emitting one would make the
-    // whole-script range below zero-width.
+    // V8 does not report empty scripts (the whole-script range would be zero-width).
     if (sourceLength === 0) continue;
     let { url } = script;
     // V8 coverage reports file-backed scripts with file:// URLs even when the
@@ -305,10 +304,8 @@ function buildScriptCoverageList(
     }
 
     // Outer functions before nested ones, so a stack-based sweep below sees
-    // enclosing ranges first. Zero-width entries (JSC emits them, e.g. for an
-    // `export function` declaration) are dropped: V8 never produces
-    // startOffset === endOffset, and @bcoe/v8-coverage's range-tree merge
-    // recurses forever on one.
+    // enclosing ranges first. Zero-width entries are dropped: V8 never emits
+    // startOffset === endOffset, and @bcoe/v8-coverage recurses forever on one.
     const functions = script.functions
       .filter(([start, end]) => start >= 0 && end > start)
       .sort((a, b) => a[0] - b[0] || b[1] - a[1]);

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -293,6 +293,9 @@ function buildScriptCoverageList(
 
   for (const script of rawScripts) {
     const { scriptId, sourceLength } = script;
+    // V8 does not report empty scripts. Emitting one would make the
+    // whole-script range below zero-width.
+    if (sourceLength === 0) continue;
     let { url } = script;
     // V8 coverage reports file-backed scripts with file:// URLs even when the
     // script name is a plain filesystem path (e.g. a vm script filename or a

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -97,6 +97,39 @@ export function neverCalled(x) {
 }
 `;
 
+// The exported-declaration form makes JSC emit a zero-width basic block past
+// the end of the function (issue #39821).
+const zeroWidthRangeFixture = `
+import { Session } from "node:inspector/promises";
+
+const session = new Session();
+session.connect();
+await session.post("Profiler.enable");
+await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed: true });
+
+const { f } = await import("./exported-fn.mjs");
+f(1);
+
+const coverage = await session.post("Profiler.takePreciseCoverage");
+await session.post("Profiler.stopPreciseCoverage");
+session.disconnect();
+
+const zeroWidth = [];
+let rangeCount = 0;
+for (const script of coverage.result) {
+  for (const fn of script.functions) {
+    for (const range of fn.ranges) {
+      rangeCount++;
+      if (range.startOffset >= range.endOffset) {
+        zeroWidth.push({ url: script.url, ...range });
+      }
+    }
+  }
+}
+const entry = coverage.result.find(script => script.url.endsWith("exported-fn.mjs"));
+console.log(JSON.stringify({ rangeCount, zeroWidth, fixtureRanges: entry?.functions.length ?? 0 }));
+`;
+
 // Picks the entry whose primary range most tightly encloses the offset, the
 // same way a coverage consumer attributes an AST node to a function.
 function entryCoveringOffset(functions: any[], offset: number) {
@@ -651,6 +684,32 @@ console.log(JSON.stringify({ count: fn?.ranges[0].count }));
       // double() ran twice, neverCalled() never ran.
       expect(functionCounts).toContain(2);
       expect(functionCounts).toContain(0);
+    });
+
+    // V8 never emits startOffset === endOffset; @bcoe/v8-coverage (vitest/c8
+    // --coverage) recurses forever on a zero-width range (issue #39821).
+    test.concurrent("never emits zero-width ranges", async () => {
+      using dir = tempDir("inspector-coverage-zero-width", {
+        "fixture.mjs": zeroWidthRangeFixture,
+        "exported-fn.mjs": "export function f(x){return x}\n",
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+      const { rangeCount, zeroWidth, fixtureRanges } = JSON.parse(stdout);
+
+      // The fixture module was reported and coverage was non-trivial.
+      expect(fixtureRanges).toBeGreaterThan(0);
+      expect(rangeCount).toBeGreaterThan(0);
+      // Every range across every script satisfies startOffset < endOffset.
+      expect(zeroWidth).toEqual([]);
     });
   });
 

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -98,9 +98,11 @@ export function neverCalled(x) {
 `;
 
 // The exported-declaration form makes JSC emit a zero-width basic block past
-// the end of the function (issue #39821).
+// the end of the function, and an empty vm script would get a zero-width
+// whole-script range (issue #39821).
 const zeroWidthRangeFixture = `
 import { Session } from "node:inspector/promises";
+import vm from "node:vm";
 
 const session = new Session();
 session.connect();
@@ -109,6 +111,7 @@ await session.post("Profiler.startPreciseCoverage", { callCount: true, detailed:
 
 const { f } = await import("./exported-fn.mjs");
 f(1);
+vm.runInThisContext("", { filename: "file:///empty-script.js" });
 
 const coverage = await session.post("Profiler.takePreciseCoverage");
 await session.post("Profiler.stopPreciseCoverage");


### PR DESCRIPTION
### Problem
- `Profiler.takePreciseCoverage` emits zero-width ranges (`startOffset === endOffset`). A one-line `export function f(x){return x}` module produces `{"startOffset":36,"endOffset":36,"count":1}`. V8 never emits a zero-width range.
- `@bcoe/v8-coverage`, the merge library behind `vitest --coverage` and `c8`, recurses forever on a zero-width range and dies with `RangeError: Maximum call stack size exceeded` in `mergeRangeTrees`. That makes the v8 coverage provider unusable on suites large enough to merge such a range.
- The cause: JSC's control flow profiler emits a zero-width basic block for the exported-declaration form, and the filters in `buildScriptCoverageList` (`src/js/node/inspector.ts`) use `end >= start`, which keeps it.

### Fix
- Tighten both filters to `end > start`, for basic blocks and for function ranges.
- Skip scripts with an empty source. An empty `vm.runInThisContext("")` script produced a zero-width whole-script range `[0,0]`. Node v26 does not report the empty script at all, verified with the same probe.
- Correct because a zero-width block spans no source byte, so it carries no coverage information. Every protocol consumer treats a range as a half-open interval, where a zero-width entry is not a valid node. Every emitted range now satisfies `startOffset < endOffset`.
- Verified: `test/js/node/inspector/inspector-profiler.test.ts`, new test `never emits zero-width ranges`. Without the fix it fails with the exact `[36,36]` and `[0,0]` ranges. The whole file (46 tests) and `inspector.test.ts` (24 tests) pass with the fix.

### Background
- `Profiler.takePreciseCoverage` data comes from JSC's control flow profiler, not V8. The native side (`src/jsc/bindings/JSInspectorProfiler.cpp`) serializes raw basic-block ranges. `buildScriptCoverageList` in `src/js/node/inspector.ts` reshapes them into the V8 `ScriptCoverage` format.
- The new test asserts the invariant over every range in every reported script, not only the fixture module.

<details><summary>Notes</summary>

- The zero-width block also lies past EOF (offset 36 in a 31-byte file) because offsets index the transpiled source. That offset mapping is tracked separately in #35727. The invariant fixed here holds regardless of the mapping.
- The dropped block does not change call counts: the count approximation uses the block with the smallest start offset inside a function, and the zero-width block sits at the function end.
- The empty-script case also emitted a garbage function range `[0, 4294967295]` (JSC reports UINT32_MAX for the program-level range of an empty source). Skipping empty scripts removes that too.
- Related open PRs #35727 (real functionName and original offsets), #35755 (JSC-internal synthetics), #35719 (pre-start call counts) touch the same file but none drops zero-width ranges.
- Also verified the reporter's self-contained repro from the issue exits 0 with the fix and 1 without it.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (6e906e468)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [21.88ms]
(pass) node:inspector > Session > Session extends EventEmitter [3.68ms]
(pass) node:inspector > Session > connect() establishes connection [9.50ms]
(pass) node:inspector > Session > connect() throws if already connected [7.65ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [7.62ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [4.28ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [3.83ms]
(pass) node:inspector > Session > post() throws if not connected [13.32ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [14.70ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [29.11ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [4.23ms]
(pass) node:inspec
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (27d0d212f)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [0.17ms]
(pass) node:inspector > Session > Session extends EventEmitter [0.03ms]
(pass) node:inspector > Session > connect() establishes connection [0.09ms]
(pass) node:inspector > Session > connect() throws if already connected [0.06ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [0.07ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [0.04ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [0.02ms]
(pass) node:inspector > Session > post() throws if not connected [0.13ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [0.18ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [0.36ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [0.04ms]
(pass) node:inspector > Profiler > Profiler.start without enable throws [0.04ms]
(pass) node:inspector > Profiler > Profiler.start after enable succeeds [0.30ms]
(pass) node:inspector > Profiler >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
bun test v1.4.0 (6e906e468)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [12.98ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.31ms]
(pass) node:inspector > Session > connect() establishes connection [5.87ms]
(pass) node:inspector > Session > connect() throws if already connected [4.38ms]
(pass) node:inspector > Session > connectToMainThread() throws ERR_INSPECTOR_NOT_WORKER on the main thread [4.80ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [2.61ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.42ms]
(pass) node:inspector > Session > post() throws if not connected [8.04ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [8.72ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [17.59ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [2.51ms]
(pass) node:inspecto
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 697ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9370ms)
Bundle modules (58ms)
Postprocesss modules (26ms)
Bundle Functions (644ms)
Generate Code (23ms)

[10.14s] Bundled "src/js" for production
  2628 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/inspector.ts                          |  9 ++--
 test/js/node/inspector/inspector-profiler.test.ts | 62 +++++++++++++++++++++++
 2 files changed, 68 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/js/node/inspector.ts                               3      5      0
test/js/node/inspector/inspector-profiler.test.ts      2      3      0
```

</details>

**root cause** · written by the author bot

The bug was in the translation of JavaScriptCore coverage data into V8 protocol output, where buildScriptCoverageList could emit zero-width ranges with startOffset equal to endOffset, such as for an export function declaration or an empty script, and sometimes with offsets past end of file. V8 never produces such ranges, and consumers like @bcoe/v8-coverage treat ranges as half-open intervals, so a zero-width entry causes infinite recursion in their range-tree merge. The fix enforces a strict endOffset greater than startOffset invariant by dropping zero-width range entries during constructi…

<!-- robobun:evidence:end -->