### PR TITLE
bun test: stop the coverage report from panicking on modules that are not files

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -25,7 +25,7 @@ bun_output::declare_scope!(bun_test, hidden);
 
 mod coverage {
     pub(super) use bun_sourcemap_jsc::code_coverage::{
-        ByteRangeMapping, Fraction, Report as CodeCoverageReport, lcov, text,
+        ByteRangeMapping, Fraction, Report as CodeCoverageReport, file_name, lcov, text,
     };
 
     /// Less-than predicate adapted to the `Ordering` shape `sort_by` wants.
@@ -45,7 +45,7 @@ mod coverage {
         if opts.ignore_patterns.is_empty() {
             return false;
         }
-        let relative_path = bun_paths::resolve_path::relative(relative_dir, source_url);
+        let relative_path = file_name(source_url, relative_dir);
         opts.ignore_patterns
             .iter()
             .any(|pattern| bun_glob::r#match(pattern, relative_path).matches())
@@ -1554,7 +1554,7 @@ fn print_coverage_table<const COLORS: bool>(
     let thresholds = *thresholds;
     let max_filepath_length = reports
         .iter()
-        .map(|r| resolve_path::relative(relative_dir, &r.source_url).len())
+        .map(|r| coverage::file_name(&r.source_url, relative_dir).len())
         .fold(b"All files".len(), usize::max);
 
     let zero = Fraction {
@@ -1691,6 +1691,11 @@ extern "C" fn BunTest__shouldGenerateCodeCoverage(test_name_str: &bun_core::Stri
     // In this particular case, we don't actually care about non-ascii latin1 characters.
     // so we skip the ascii check
     let slice: &[u8] = zig_slice.slice();
+
+    // The report would name these rows by the source text itself or by a per-run UUID.
+    if slice.starts_with(b"data:") || slice.starts_with(b"blob:") {
+        return false;
+    }
 
     // always ignore node_modules.
     if strings::contains(slice, b"/node_modules/") || strings::contains(slice, b"\\node_modules\\")

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -350,6 +350,23 @@ impl MergedReport {
     }
 }
 
+/// The name a module is reported under: its path relative to `base_path`, or its id as it is.
+pub fn file_name<'a>(source_url: &'a [u8], base_path: &[u8]) -> &'a [u8] {
+    if base_path.is_empty() || !bun_paths::is_absolute(source_url) {
+        return source_url;
+    }
+    // `relative` answers with up to one `/..` per component of `base_path`, then the name.
+    let mut separators = bun_core::strings::count_char(base_path, b'/');
+    if cfg!(windows) {
+        separators += bun_core::strings::count_char(base_path, b'\\');
+    }
+    let fits = source_url.len() + 3 * separators + 2 <= bun_paths::MAX_PATH_BYTES;
+    if !fits {
+        return source_url;
+    }
+    bun_paths::resolve_path::relative(base_path, source_url)
+}
+
 pub mod text {
     use super::*;
     // The `pretty_fmt!` macro only accepts literal `true`/`false` today,
@@ -428,10 +445,7 @@ pub mod text {
         base_path: &[u8],
         writer: &mut impl bun_io::Write,
     ) -> bun_io::Result<()> {
-        let mut filename: &[u8] = &report.source_url;
-        if !base_path.is_empty() {
-            filename = bun_paths::resolve_path::relative(base_path, filename);
-        }
+        let filename = file_name(&report.source_url, base_path);
 
         write_format_with_values::<ENABLE_COLORS>(
             filename,
@@ -501,10 +515,7 @@ pub mod lcov {
         base_path: &[u8],
         writer: &mut impl bun_io::Write,
     ) -> bun_io::Result<()> {
-        let mut filename: &[u8] = &report.source_url;
-        if !base_path.is_empty() {
-            filename = bun_paths::resolve_path::relative(base_path, filename);
-        }
+        let filename = file_name(&report.source_url, base_path);
 
         // TN: test name
         // Empty value appears fine. For example, `TN:`.

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
 
@@ -697,3 +697,141 @@ test("calls second", () => {
   expect(record).toMatch(/FNF:2\nFNH:2\n/);
   expect(exitCode).toBe(0);
 });
+
+// MAX_PATH_BYTES in src/bun_core/util.rs: the size of the buffers the report relativizes paths in.
+const pathBufferSize = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
+const longerThanAPathBuffer = 128 * 1024;
+
+// `virtualId` and `dataUrl` are JavaScript expressions. The virtual module is a
+// Bun.plugin `build.module()` module, which the report lists under its id.
+function virtualModuleFixture(virtualId: string, dataUrl: string) {
+  return {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = false
+`,
+    "helper.ts": `
+export function helper() {
+  return "helper";
+}
+`,
+    "virtual.test.ts": `
+import { test, expect } from "bun:test";
+import { helper } from "./helper";
+
+const virtualId = ${virtualId};
+const dataUrl = ${dataUrl};
+
+Bun.plugin({
+  name: "virtual",
+  setup(build) {
+    build.module(virtualId, () => ({
+      contents: "export function used() { return 'virtual'; }\\nexport function unused() { return 0; }\\n",
+      loader: "js",
+    }));
+  },
+});
+
+test("imports modules that are not files", async () => {
+  expect((await import(virtualId)).used()).toBe("virtual");
+  expect((await import(dataUrl)).default).toBe("data");
+  expect(helper()).toBe("helper");
+});
+`,
+  };
+}
+
+async function runCoverage(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter", "text", "--coverage-reporter", "lcov"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  return { stderr, exitCode };
+}
+
+function lcovSourceFiles(dir: string) {
+  return readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8")
+    .split("\n")
+    .filter(line => line.startsWith("SF:"));
+}
+
+test.concurrent("virtual modules are reported under their id and data: URL modules are left out", async () => {
+  using dir = tempDir(
+    "cov",
+    virtualModuleFixture(
+      `"virtual-module"`,
+      `"data:text/javascript," + encodeURIComponent("export default 'data'; //" + Buffer.alloc(${longerThanAPathBuffer}, "x"))`,
+    ),
+  );
+
+  const { stderr, exitCode } = await runCoverage(String(dir));
+
+  expect(normalizeBunSnapshot(stderr, dir)).toMatchInlineSnapshot(`
+    "virtual.test.ts:
+    (pass) imports modules that are not files
+    -----------------|---------|---------|-------------------
+    File             | % Funcs | % Lines | Uncovered Line #s
+    -----------------|---------|---------|-------------------
+    All files        |   83.33 |  100.00 |
+     helper.ts       |  100.00 |  100.00 | 
+     virtual.test.ts |  100.00 |  100.00 | 
+     virtual-module  |   50.00 |  100.00 | 
+    -----------------|---------|---------|-------------------
+
+     1 pass
+     0 fail
+     3 expect() calls
+    Ran 1 test across 1 file."
+  `);
+  expect(lcovSourceFiles(String(dir))).toEqual(["SF:helper.ts", "SF:virtual.test.ts", "SF:virtual-module"]);
+  expect(exitCode).toBe(0);
+});
+
+// Ids that do not fit the path buffers: a plain id, an id that looks like an absolute path, and
+// one that fits by itself but not once the report puts a `../` per directory of the cwd before it.
+const longIds = [
+  { shape: "a plain id", prefix: "virtual-", length: longerThanAPathBuffer },
+  { shape: "an absolute path", prefix: "/virtual/", length: longerThanAPathBuffer },
+  { shape: "an absolute path that almost fills the buffer", prefix: "/virtual/", length: pathBufferSize - 4 },
+];
+for (const { shape, prefix, length } of longIds) {
+  test.concurrent(`a virtual module id too long to relativize is reported as it is (${shape})`, async () => {
+    const virtualId = prefix + Buffer.alloc(length - prefix.length, "x").toString();
+    using dir = tempDir(
+      "cov",
+      virtualModuleFixture(
+        `${JSON.stringify(prefix)} + Buffer.alloc(${length - prefix.length}, "x").toString()`,
+        `"data:text/javascript,export default 'data';"`,
+      ),
+    );
+
+    const { stderr, exitCode } = await runCoverage(String(dir));
+
+    // Every table line is padded to the width of the id, so compare the lines with the id and
+    // the padding taken out. The entries are sorted by their full name, which is platform specific.
+    const rows = stderr
+      .split("\n")
+      .filter(line => line.includes(" | "))
+      .map(line => line.replace(virtualId, "<id>").replace(/ {2,}/g, " "))
+      .sort();
+    expect(rows).toEqual(
+      [
+        "File | % Funcs | % Lines | Uncovered Line #s",
+        "All files | 83.33 | 100.00 |",
+        " helper.ts | 100.00 | 100.00 | ",
+        " virtual.test.ts | 100.00 | 100.00 | ",
+        " <id> | 50.00 | 100.00 | ",
+      ].sort(),
+    );
+    expect(
+      lcovSourceFiles(String(dir))
+        .map(line => line.replace(virtualId, "<id>"))
+        .sort(),
+    ).toEqual(["SF:<id>", "SF:helper.ts", "SF:virtual.test.ts"].sort());
+    expect(exitCode).toBe(0);
+  });
+}


### PR DESCRIPTION
### Problem
- `bun test --coverage` runs every test, then aborts while it writes the report: `panic: range end index 6048 out of range for slice of length 4096` (1024 on macOS). Top frame `normalize_string_generic_tz` (`src/paths/resolve_path.rs:1076`) under `print_code_coverage` (`src/runtime/cli/test_command.rs:1894` at the time). Sentry BUN-4MTY and BUN-4WXY.
- A coverage entry is named by its module's source URL: the whole URL for a `data:` import, the id for a `build.module()` module. The report ran `resolve_path::relative(cwd, name)` on every entry (four sites, see the notes). `relative` copies its input into a fixed path buffer, so a longer name panics.

### Fix
- `code_coverage::file_name` (`src/sourcemap_jsc/CodeCoverage.rs`) replaces the four `relative` calls. It relativizes a name only when it is an absolute path and the result (one `/..` per directory of the cwd, then the name) fits a path buffer. Any other name is returned as it is. A virtual module keeps its row, under its id, whatever the length.
- `BunTest__shouldGenerateCodeCoverage` (`test_command.rs:1689`) no longer records `data:` and `blob:` modules. Their row names would be the module's own source text and a UUID that changes every run. Every other module is recorded as before.
- `resolve_path.rs` is not changed. #39658, #38392 and #38696 each add a length safe `relative` there. A fourth variant would conflict with all three.
- Verified: four new tests in `test/cli/test/coverage.test.ts`: a `virtual-module` row next to a 128 KiB `data:` import, a 128 KiB virtual module id as a plain id and as a `/virtual/...` id, and a `/virtual/...` id 4 bytes short of the buffer. The released build panics on all four. The rest of `coverage.test.ts` and the `--coverage` tests in `parallel.test.ts` pass.

### Background
- `Zig::SourceProvider::create` (`src/jsc/bindings/ZigSourceProvider.cpp:81`) asks `BunTest__shouldGenerateCodeCoverage` whether to record a module in the `ByteRangeMapping` table, keyed by source URL. The report iterates that table.
- A test file can import a module that a `Bun.plugin` defines with `build.module()`. Its code, and any tests in it, run like a file's, and the report lists it under its id today.
- `resolve_path::relative` writes into `PathBuffer`s (4096 bytes on Linux, 1024 on macOS, 98302 on Windows) with no length check. It joins a non absolute `to` onto the cwd first, so a long id overflows even without separators.

<details><summary>Notes</summary>

- The `relative` sites on current main, after #40678 moved the `--parallel` merge onto the serial writers: `test_command.rs` `coverage::is_ignored` (`coveragePathIgnorePatterns`, the Sentry frame) and `print_coverage_table` (text column width), and `CodeCoverage.rs` `text::write_format` and `lcov::write_format` (the row writers). Before #40678 there were five: the ignore check in both `render_lcov` and `print_code_coverage`, the column width, and the two writers. `coveragePathIgnorePatterns` now matches a virtual module against its id, which is what `relative` returned for a short id as well.
- Repro on the released 1.4.0 build (Linux): a test that does `await import("data:text/javascript," + encodeURIComponent("export default 1;" + "//".padEnd(6000, "x")))`, run with `bun test --coverage`, exits 134 with `range end index 6048`. `Bun.plugin` with `build.module("<5000 char id>")` exits with `range end index 5008`. The 1.5 x `MAX_PATH_BYTES` cap on specifiers in `VirtualMachine::resolve` does not apply to `build.module()` ids: a 110000 byte id loads and panics the same way. With `coverageReporter = ["lcov"]` and `coveragePathIgnorePatterns` set, the stack matches the Sentry event frame for frame. The default text reporter dies at `:1705`.
- Sentry BUN-4WXY is a second grouping of the same panic: 2 events on 2026-09-03, `bun@1.4.0`, macOS arm64, `range end index 1071 out of range for slice of length 1024`. Its stack is `normalize_string_generic_tz` (`resolve_path.rs:1076`) under `relative_platform_buf::<Posix, false>` (`:724`, the branch for a `to` that is not an absolute path), `relative` (`:644`) and `print_code_coverage<true, true, false>` (`test_command.rs:1705`, the column width pass of the text reporter). So the name was not a path: a `data:` URL or a virtual module id of about 1 KB. On main that pass is `print_coverage_table`, which calls `file_name` with this change. The events carry the feature tags WebSocket, fetch, http_server, process_dlopen and define.
- 1.3.14 has the same logic and wrote past the thread local buffer without a check. The Rust port checks the bounds, which is why the signature is new.
- Rows that disappear: a `data:` module (today a row and an `SF:data:text/javascript,...` record whose name is the source, which also sets the width of the whole table) and an in-memory `blob:` module. A `blob:` URL made from `Bun.file(path)` loads under the file's path and keeps its row. No test depended on either.
- `bun test` cannot select a virtual module as a test file itself. The first version of this PR dropped every name that is not an absolute path. Review pointed out that this also dropped virtual modules, which is real information (a `virtual-lib` row shows which of its functions ran), so the second version changed the approach to the one above. Review then found that a `build.module()` id may start with a separator, and such an id longer than a path buffer still reached `relative` (`range end index 5008 out of range for slice of length 4095`, confirmed). Review also found the second buffer: `relative` writes one `/..` per directory of the cwd and then the name into its result buffer, so a `/virtual/...` id a few bytes below the limit still overflowed there (`range end index 4097 out of range for slice of length 4096` from a two-level cwd, confirmed). That is why `file_name` counts the separators of the cwd and requires `name + 3 * separators + 2` bytes to fit `MAX_PATH_BYTES`. The length of the cwd is not a bound for the prefix (a cwd of one-letter directories produces 3 bytes of `/..` per 2 bytes of cwd), the separator count is. The same overflow exists on main for a real file that close to the limit outside the cwd (the bundler case in #38696); the report now prints such a file under its absolute path instead of aborting. A file at any normal length is printed exactly as before.
- The branch was rebased onto main after the first CI run: the binary size check compared the old base against a main that had shrunk by about 2 MB in the meantime (the dead code removals in #39582 and #39732 are in between), which this diff of a few lines cannot explain. Later rebases picked up #39934 and #40586 (tests appended to the same file), #40238 and #40374 (`Report.source_url` became a `&[u8]`, now a `Cow<[u8]>`), and #40678, which rewrote the report path: the three `relative` calls in `print_code_coverage` and `render_lcov` became the two in `is_ignored` and `print_coverage_table`, and `file_name` replaces those. The six commits were squashed into one at that point because each of them conflicted with the rewrite.
- The new tests set `coverageSkipTestFiles = false` because that default differs between debug and release builds. A function on one line leaves no uncovered line, so the `virtual-module` row reads `50.00 | 100.00`.
- The same unchecked `relative` call on a stack frame's source URL exists in the JUnit reporter (`test_command.rs:386`) and in the `GITHUB_ACTIONS` annotation (`src/jsc/VirtualMachine.rs:6606`, `:6668`). Both panic on the released build when a frame comes from a long `data:` URL module. Reported separately, not part of this change.
- Checked: `cargo fmt --all -- --check`, `cargo clippy -p bun_sourcemap_jsc -p bun_runtime --no-deps`, `bun bd test test/cli/test/coverage.test.ts` (18 pass, the four new tests fail on the released build), `bun bd test test/cli/test/parallel.test.ts -t coverage` (6 pass).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/coverage.test.ts

<!-- robobun:evidence:end -->


