### PR TITLE
install: accept --recursive with --global as a no-op again

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1719,21 +1719,19 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         }
 
         if cli.global
-            && (!cli.filters.is_empty() || cli.recursive)
             && matches!(
                 subcommand,
                 Subcommand::Install | Subcommand::Add | Subcommand::Remove | Subcommand::Update
             )
         {
-            Output::err_generic(
-                if cli.filters.is_empty() {
-                    "--recursive cannot be used with --global\n"
-                } else {
-                    "--filter cannot be used with --global\n"
-                },
-                (),
-            );
-            Global::crash();
+            if !cli.filters.is_empty() {
+                Output::err_generic("--filter cannot be used with --global\n", ());
+                Global::crash();
+            }
+            // The global dir has no workspaces, so --recursive selects nothing
+            // extra. Pre-1.4 accepted the combination, so treat it as a no-op
+            // instead of an error.
+            cli.recursive = false;
         }
 
         if cli.global && subcommand == Subcommand::Prune {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -2820,18 +2820,34 @@ describe("bun update <name> semantics", () => {
       await expectProjectUntouched(project, projectBefore);
     });
 
-    it.concurrent.each([
-      [["-r"], "--recursive"],
-      [["--filter", "*"], "--filter"],
-    ])("bun update <name> %p -g is an error that writes nothing", async (flags, flag) => {
+    it.concurrent("bun update <name> --filter -g is an error that writes nothing", async () => {
       const { project, globalDir, runGlobal, projectBefore } = await globalRepo();
       const globalBefore = await snapshotFiles(globalDir);
-      const { stderr, exitCode } = await runGlobal("update", "no-deps", ...flags);
-      expect(stderr).toContain(`error: ${flag} cannot be used with --global`);
+      const { stderr, exitCode } = await runGlobal("update", "no-deps", "--filter", "*");
+      expect(stderr).toContain("error: --filter cannot be used with --global");
       await expectUnchanged(globalDir, globalBefore);
       expect(await installedVersion(globalDir, "no-deps")).toBe("1.0.0");
       await expectProjectUntouched(project, projectBefore);
       expect(exitCode).toBe(1);
+    });
+
+    // The global dir has no workspaces, so --recursive is a no-op there.
+    // Pre-1.4 accepted `bun update -g -r`; it must not error (#39823).
+    it.concurrent.each([
+      [[], { "no-deps": "^1.1.0", "a-dep": "^1.0.10" }, "1.1.0", "1.0.10"],
+      [["no-deps"], { "no-deps": "^1.1.0", "a-dep": "^1.0.1" }, "1.1.0", "1.0.1"],
+      [["--latest"], { "no-deps": "^2.0.0", "a-dep": "^1.0.10" }, "2.0.0", "1.0.10"],
+    ])("bun update -g --recursive %p behaves like bun update -g", async (args, expected, noDeps, aDep) => {
+      const { project, globalDir, runGlobal, projectBefore } = await globalRepo();
+      const { stderr, exitCode } = await runGlobal("update", "--recursive", ...args);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      await expectGlobalInSync(globalDir, expected);
+      expect(await lockedVersions(globalDir, "no-deps")).toStrictEqual([noDeps]);
+      expect(await lockedVersions(globalDir, "a-dep")).toStrictEqual([aDep]);
+      expect(await installedVersion(globalDir, "no-deps")).toBe(noDeps);
+      expect(await installedVersion(globalDir, "a-dep")).toBe(aDep);
+      await expectProjectUntouched(project, projectBefore);
     });
   });
 });


### PR DESCRIPTION
### Problem
- `bun update --latest --recursive --global` fails on 1.4 with `error: --recursive cannot be used with --global`. Bun 1.3 accepted the combination, so scripts and aliases that pass both flags broke (#39823).
- The rejection comes from the 1.4 workspace changes in #38333 (`src/install/PackageManager/CommandLineArguments.rs:1721`). It groups `--recursive` with `--filter`, but the two differ: `--filter <pattern>` names a workspace to select, while bare `--recursive` selects nothing extra in a global dir, which has no workspaces.

### Fix
- Accept `--recursive` with `--global` again and clear the flag in global mode, so the command behaves exactly like `bun update --global`. This matches the 1.3 behavior, where the flag was accepted and had no effect.
- `--filter` with `--global` still errors, for install, add, remove, and update.
- Verified: `test/cli/install/bun-update.test.ts` adds three cases (`-g --recursive` bare, with a name, and with `--latest`). All three fail on stock 1.4 with the old error. The full `bun-update.test.ts` (158 tests) and `bun-add-filter.test.ts` (123 tests) pass with the fix.

### Background
- The global install dir (`$BUN_INSTALL/install/global`) is a normal project: a `package.json` whose dependencies are the globally installed packages, plus a `bun.lock`. It never contains workspaces.
- `--recursive` on `bun update` means "update in every workspace". #38333 added it together with `--filter` and made both error with `--global`.
- The issue also reports that bare `bun update --global` now re-resolves transitive packages. That is the documented 1.4 update model from #38333 (every edge moves to the newest version its range allows) and this PR does not change it. `bun update -g <name>` updates only the named package.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update.test.ts
bun test v1.4.0 (6e906e468)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [493.57ms]
(pass) should update to latest versions of dependencies (~) [425.60ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [1203.25ms]
(pass) --recursive updates dependencies and peerDependencies in workspace members [386.02ms]
(pass) --recursive --latest updates workspace members to the latest version [391.65ms]
(pass) --filter updates only matching workspaces, leaving siblings and root untouched [386.34ms]
(pass) --filter pkg-a removes the nested copy whose row it collapsed [587.46ms]
(pass) --filter excluding a workspace leaves that workspace's node_modules alone [693.94ms]
(pass) --filter with multiple patterns selects the union of matching workspaces [402.26ms]
(pass) named update -r --latest rewrites every workspace that declares the name, keeping each file's style [449.76ms]
(pass) named update --filter rewrites only the selected
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [16.62ms]
(pass) should update to latest versions of dependencies (~) [11.76ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [26.71ms]
(pass) --recursive updates dependencies and peerDependencies in workspace members [9.65ms]
(pass) --recursive --latest updates workspace members to the latest version [10.75ms]
(pass) --filter updates only matching workspaces, leaving siblings and root untouched [11.23ms]
(pass) --filter pkg-a removes the nested copy whose row it collapsed [15.57ms]
(pass) --filter excluding a workspace leaves that workspace's node_modules alone [14.37ms]
(pass) --filter with multiple patterns selects the union of matching workspaces [10.35ms]
(pass) named update -r --latest rewrites every workspace that declares the name, keeping each file's style [14.20ms]
(pass) named update --filter rewrites only the selected workspace [10.62ms]
(pass) named update accepts -F as the short form of --filter [10.84ms]
(pass) named update --filter of a workspace that does not depend on the name is 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update.test.ts
bun test v1.4.0 (6e906e468)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [563.26ms]
(pass) should update to latest versions of dependencies (~) [437.42ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [1220.02ms]
(pass) --recursive updates dependencies and peerDependencies in workspace members [382.08ms]
(pass) --recursive --latest updates workspace members to the latest version [393.67ms]
(pass) --filter updates only matching workspaces, leaving siblings and root untouched [394.51ms]
(pass) --filter pkg-a removes the nested copy whose row it collapsed [645.59ms]
(pass) --filter excluding a workspace leaves that workspace's node_modules alone [668.48ms]
(pass) --filter with multiple patterns selects the union of matching workspaces [374.36ms]
(pass) named update -r --latest rewrites every workspace that declares the name, keeping each file's style [434.63ms]
(pass) named update --filter rewrites only the selected
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 612ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcema
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager/CommandLineArguments.rs | 18 +++++++-------
 test/cli/install/bun-update.test.ts                | 28 +++++++++++++++++-----
 2 files changed, 30 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/install/PackageManager/CommandLineArguments.rs      2      1      0
test/cli/install/bun-update.test.ts                     1      1      0
```

</details>

**root cause** · written by the author bot

A validation guard added in #38333 made `bun update` reject `--recursive` whenever `--global` was passed, breaking a combination that worked in 1.3 where the flag was simply ignored because the global install directory has no workspaces to recurse into. The fix narrows the guard so that only `--filter` with `--global` remains an error, while `--recursive` is silently cleared under `--global`, making `bun update -g --recursive` behave identically to `bun update -g`. Since `cli.recursive` is only ever set for the update and outdated subcommands and outdated is outside the guard, clearing it t…

<!-- robobun:evidence:end -->