### PR TITLE
Bun.serve, node:http: run request handlers with the event loop entered

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -974,6 +974,17 @@ impl VirtualMachine {
         unsafe { EventLoop::enter_scope(self.event_loop) }
     }
 
+    /// `event_loop().enter()` now, `.exit_without_checkpoint()` on drop, for a
+    /// dispatcher that drains microtasks itself: see
+    /// [`EventLoop::enter_scope_without_checkpoint`].
+    #[inline]
+    pub fn enter_event_loop_scope_without_checkpoint(
+        &self,
+    ) -> crate::event_loop::EventLoopEnterNoCheckpointGuard {
+        // SAFETY: as `enter_event_loop_scope`.
+        unsafe { EventLoop::enter_scope_without_checkpoint(self.event_loop) }
+    }
+
     /// Safe shared-reference accessor for the process-lifetime dotenv loader
     /// (`vm.transpiler.env`). The loader is allocated once during VM init and
     /// never freed; callers previously open-coded `unsafe { &*vm.transpiler.env }`.

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -271,6 +271,25 @@ impl Drop for EventLoopEnterGuard {
     }
 }
 
+/// RAII pairing for [`EventLoop::enter`] / [`EventLoop::exit_without_checkpoint`].
+///
+/// Holds the raw pointer for the same reason as [`EventLoopEnterGuard`].
+/// Construct via [`EventLoop::enter_scope_without_checkpoint`].
+#[must_use = "dropping immediately exits the event loop scope"]
+pub struct EventLoopEnterNoCheckpointGuard {
+    loop_: *mut EventLoop,
+}
+
+impl Drop for EventLoopEnterNoCheckpointGuard {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: as `EventLoopEnterGuard`: `loop_` was live at
+        // `enter_scope_without_checkpoint` and the VM owns it for the process
+        // lifetime; short-lived `&mut` only.
+        unsafe { (*self.loop_).exit_without_checkpoint() };
+    }
+}
+
 impl EventLoop {
     /// Before your code enters JavaScript at the top of the event loop, call
     /// `loop.enter()`. If running a single callback, prefer `runCallback` instead.
@@ -313,6 +332,48 @@ impl EventLoop {
         // SAFETY: caller contract — `loop_` is live; short-lived `&mut` only.
         unsafe { (*loop_).enter() };
         EventLoopEnterGuard { loop_ }
+    }
+
+    /// Balance an [`enter`](Self::enter) without the checkpoint [`exit`](Self::exit)
+    /// runs at the outermost level. See [`Self::enter_scope_without_checkpoint`].
+    #[inline]
+    pub fn exit_without_checkpoint(&mut self) {
+        bun_core::scoped_log!(
+            EventLoop,
+            "exit_without_checkpoint() = {}",
+            self.entered_event_loop_count - 1
+        );
+        self.entered_event_loop_count -= 1;
+    }
+
+    /// `enter()` now, [`exit_without_checkpoint`](Self::exit_without_checkpoint)
+    /// on drop.
+    ///
+    /// For a dispatcher that runs the checkpoint itself once the callback has
+    /// returned, at points of its own choosing: the HTTP request paths drain
+    /// explicitly so that they can look at a returned promise that the drain
+    /// settled (`RequestContext::on_response`, the node:http dispatch), and a
+    /// checkpoint on exit would add an empty one per request.
+    ///
+    /// What the scope is for is the count. Only while it is above zero is the
+    /// callback's frame safe from a checkpoint in the middle of it: a native
+    /// call made from inside the callback that dispatches another callback
+    /// through `enter()`/`exit()` (`server.upgrade()` running `open()`,
+    /// `ws.close()` running `close()`) is then a nested pair, not the outermost
+    /// one, so its exit does not run the nextTicks and promise reactions the
+    /// callback queued before its next statement. The dispatcher's explicit
+    /// drains are unconditional, so the held count does not skip them, and the
+    /// continuations they run are covered by it as well.
+    ///
+    /// # Safety
+    /// As [`Self::enter_scope`].
+    #[inline]
+    pub unsafe fn enter_scope_without_checkpoint(
+        loop_: *mut EventLoop,
+    ) -> EventLoopEnterNoCheckpointGuard {
+        // SAFETY: caller contract — `loop_` is live; short-lived `&mut` only.
+        unsafe { (*loop_).enter() };
+        EventLoopEnterNoCheckpointGuard { loop_ }
     }
 
     pub fn exit_maybe_drain_microtasks(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1352,6 +1352,9 @@ where
         let server = this.server();
         let vm = server.vm();
         let global_this = server.global_this();
+        // Entered for the abort listeners below, and (dropped last) for the
+        // drains below and in the release of `_ref`.
+        let _entered = vm.enter_event_loop_scope_without_checkpoint();
         let _ref = RequestContextRef::adopt(this.as_ctx_ptr());
         // This is a task in the event loop.
         // If we called into JavaScript, we must drain the microtask queue.
@@ -2576,6 +2579,12 @@ where
     //
     // - If you return a Promise, we drain the microtask queue once
     // - If you return a streaming Response, we drain the microtask queue (possibly the 2nd time this task!)
+    //
+    // Like a task, the handler and these drains run with the event loop entered
+    // (the dispatchers hold `enter_event_loop_scope_without_checkpoint`), so a
+    // callback the handler dispatches synchronously through `enter()`/`exit()`
+    // (`server.upgrade()` -> `open()`, `ws.close()` -> `close()`) does not
+    // drain in the middle of the handler.
     pub(crate) fn on_response(
         &self,
         this: &ThisServer,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -997,6 +997,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // SAFETY: `this` is the live server backref for this request.
         let server = unsafe { &*this };
+        let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
         let global = server.global_this();
         let response_value = match callback.call(global, server_js, &args) {
             Ok(v) => v,
@@ -1143,6 +1144,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // SAFETY: `this` is the live server backref for this request.
         let server = unsafe { &*this };
+        let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
         let on_request = server.config.on_request;
         debug_assert!(!on_request.is_empty());
 
@@ -1194,6 +1196,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // SAFETY: `server` is the live backref stored in `user_route`.
         let server_ref = unsafe { &*server };
+        let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
         let global = server_ref.global_this();
         let server_request_list =
             Self::js_route_list_get_cached(server_js).expect("routeList cached value missing");
@@ -1275,6 +1278,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             core::ptr::NonNull::new(this).expect("on_node_http_request: this non-null"),
         );
         let vm = this_ref.vm_mut();
+        let _entered = this_ref.vm().enter_event_loop_scope_without_checkpoint();
         req.set_yield(false);
         resp.timeout(this_ref.config.idle_timeout);
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2947,6 +2947,7 @@ where
             return;
         };
 
+        let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
         let call_route = if Ctx::IS_H3 {
             Bun__ServerRouteList__callRouteH3
@@ -3045,6 +3046,7 @@ where
         // SAFETY: `self_ptr` is `self`, live for this frame. Shared — the
         // handler call below re-enters JS, so no `&mut` may span it.
         let server = unsafe { &*self_ptr };
+        let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
         let on_request_fn = server.config.on_request;
         debug_assert!(!on_request_fn.is_empty());
 
@@ -3359,6 +3361,7 @@ where
                 .upgrade_context
                 .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)))
         };
+        let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
         // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe deref.
         let global = bun_opaque::opaque_deref(server_ref.global_this);
@@ -3441,6 +3444,7 @@ where
             resp.end_without_body(true);
             return;
         }
+        let _entered = this.vm().enter_event_loop_scope_without_checkpoint();
         this.on_pending_request();
         req.set_yield(false);
         // SAFETY: `request_pool` is non-null while the server is alive; `claim()`

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,3 +1,4 @@
+import type { ServerWebSocket } from "bun";
 import { describe, expect, test } from "bun:test";
 import { createHash, createPrivateKey, randomBytes } from "crypto";
 import { readFileSync } from "fs";
@@ -1447,5 +1448,70 @@ describe("Bun.serve HTTP/3 request validation", () => {
     const chained = await h3Exchange(server.port, requestHeaders("/"), clientIdentity("agent1"));
 
     expect({ selfSigned, chained }).toEqual({ selfSigned: "closed", chained: "200 1" });
+  });
+});
+
+// The HTTP/3 twin of the HTTP/1 cases in websocket-server.test.ts: ws.close()
+// runs close() before it returns, and a request handler that calls it must still
+// run to completion before the nextTick and promise callbacks it queued. The
+// socket being closed lives on a plain HTTP/1 server, since HTTP/3 carries no
+// WebSockets; any handler can close it.
+describe("Bun.serve HTTP/3 request handlers run to completion before the callbacks they queued", () => {
+  async function openHeldSocket() {
+    const order: string[] = [];
+    const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+    const closed = Promise.withResolvers<void>();
+    const wsServer = Bun.serve({
+      port: 0,
+      fetch: (req, srv) => (srv.upgrade(req) ? undefined : new Response("upgrade() failed", { status: 500 })),
+      websocket: {
+        open: ws => opened.resolve(ws),
+        message() {},
+        close() {
+          order.push("close()");
+        },
+      },
+    });
+    const client = new WebSocket(wsServer.url.href.replace(/^http/, "ws"));
+    client.onerror = () => closed.resolve();
+    client.onclose = () => closed.resolve();
+    const held = await opened.promise;
+    return {
+      order,
+      closed: closed.promise,
+      handler() {
+        process.nextTick(() => order.push("nextTick"));
+        Promise.resolve().then(() => order.push("microtask"));
+        held.close();
+        order.push("rest of handler");
+        return new Response("ok");
+      },
+      [Symbol.dispose]: () => wsServer.stop(true),
+    };
+  }
+
+  test("fetch() and a route handler closing an open ServerWebSocket", async () => {
+    using viaFetch = await openHeldSocket();
+    using viaRoute = await openHeldSocket();
+    await using server = Bun.serve({
+      port: 0,
+      tls,
+      http3: true,
+      routes: { "/route": viaRoute.handler },
+      fetch: viaFetch.handler,
+    });
+
+    const responses = {
+      fetch: await h3Exchange(server.port, requestHeaders("/")),
+      route: await h3Exchange(server.port, requestHeaders("/route")),
+    };
+    await Promise.all([viaFetch.closed, viaRoute.closed]);
+
+    const expectedOrder = ["close()", "rest of handler", "nextTick", "microtask"];
+    expect({ responses, fetch: viaFetch.order, route: viaRoute.order }).toEqual({
+      responses: { fetch: "200 ok", route: "200 ok" },
+      fetch: expectedOrder,
+      route: expectedOrder,
+    });
   });
 });

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1998,3 +1998,192 @@ describe("server.upgrade() validates the opening handshake", () => {
     expect(upgradeResult).toBe(false);
   });
 });
+
+// server.upgrade() runs open() before it returns, and ws.close() runs close()
+// before it returns. A request handler (or a request's abort listener) that
+// calls one of them must still run to completion first: the nextTick and
+// promise callbacks it queued run once it has returned, as they do for a timer
+// or socket callback that does the same thing. They used to run inside the
+// upgrade()/close() call.
+describe.concurrent("request handlers run to completion before the callbacks they queued", () => {
+  function queueThen(order: string[], nativeCall: () => void) {
+    process.nextTick(() => order.push("nextTick"));
+    Promise.resolve().then(() => order.push("microtask"));
+    nativeCall();
+    order.push("rest of handler");
+  }
+
+  function wsUrl(server: Server, pathname: string) {
+    return new URL(pathname, server.url.href.replace(/^http/, "ws"));
+  }
+
+  // Resolves once the server has closed the socket (or the handshake failed).
+  function connectUntilClosed(server: Server, pathname: string) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const ws = new WebSocket(wsUrl(server, pathname));
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    return promise;
+  }
+
+  const upgradeHandler = (order: string[]) => (req: Request, srv: Server) => {
+    queueThen(order, () => {
+      if (!srv.upgrade(req)) order.push("upgrade() failed");
+    });
+  };
+
+  const websocket = (order: string[], onOpen: (ws: ServerWebSocket<unknown>) => void) =>
+    ({
+      open(ws) {
+        onOpen(ws);
+      },
+      message() {},
+      close() {
+        order.push("close()");
+      },
+    }) satisfies WebSocketHandler<unknown>;
+
+  it("fetch() calling server.upgrade()", async () => {
+    const order: string[] = [];
+    using server = serve({
+      port: 0,
+      fetch: upgradeHandler(order),
+      websocket: websocket(order, ws => {
+        order.push("open()");
+        ws.close();
+      }),
+    });
+
+    await connectUntilClosed(server, "/");
+    expect(order).toEqual(["open()", "close()", "rest of handler", "nextTick", "microtask"]);
+  });
+
+  it("a route handler calling server.upgrade()", async () => {
+    const order: string[] = [];
+    using server = serve({
+      port: 0,
+      routes: { "/ws": upgradeHandler(order) },
+      websocket: websocket(order, ws => {
+        order.push("open()");
+        ws.close();
+      }),
+    });
+
+    await connectUntilClosed(server, "/ws");
+    expect(order).toEqual(["open()", "close()", "rest of handler", "nextTick", "microtask"]);
+  });
+
+  // Opens a websocket on `/ws` and hands back the server side of it.
+  async function openHeldSocket(server: Server, opened: Promise<ServerWebSocket<unknown>>) {
+    const closed = connectUntilClosed(server, "/ws");
+    const held = await opened;
+    return { held, closed };
+  }
+
+  it("fetch() closing an open ServerWebSocket", async () => {
+    const order: string[] = [];
+    const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+    let held: ServerWebSocket<unknown>;
+    using server = serve({
+      port: 0,
+      fetch(req, srv) {
+        if (new URL(req.url).pathname === "/ws") {
+          return srv.upgrade(req) ? undefined : new Response("upgrade() failed", { status: 500 });
+        }
+        queueThen(order, () => held.close());
+        return new Response("ok");
+      },
+      websocket: websocket(order, opened.resolve),
+    });
+
+    const sockets = await openHeldSocket(server, opened.promise);
+    held = sockets.held;
+    expect(await fetch(new URL("/close-it", server.url)).then(res => res.text())).toBe("ok");
+    await sockets.closed;
+    expect(order).toEqual(["close()", "rest of handler", "nextTick", "microtask"]);
+  });
+
+  it("a route handler closing an open ServerWebSocket", async () => {
+    const order: string[] = [];
+    const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+    let held: ServerWebSocket<unknown>;
+    using server = serve({
+      port: 0,
+      routes: {
+        "/ws": (req, srv) => (srv.upgrade(req) ? undefined : new Response("upgrade() failed", { status: 500 })),
+        "/close-it": () => {
+          queueThen(order, () => held.close());
+          return new Response("ok");
+        },
+      },
+      websocket: websocket(order, opened.resolve),
+    });
+
+    const sockets = await openHeldSocket(server, opened.promise);
+    held = sockets.held;
+    expect(await fetch(new URL("/close-it", server.url)).then(res => res.text())).toBe("ok");
+    await sockets.closed;
+    expect(order).toEqual(["close()", "rest of handler", "nextTick", "microtask"]);
+  });
+
+  it("a request's abort listener closing an open ServerWebSocket", async () => {
+    const order: string[] = [];
+    const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+    const reachedHandler = Promise.withResolvers<void>();
+    let held: ServerWebSocket<unknown>;
+    using server = serve({
+      port: 0,
+      fetch(req, srv) {
+        if (new URL(req.url).pathname === "/ws") {
+          return srv.upgrade(req) ? undefined : new Response("upgrade() failed", { status: 500 });
+        }
+        req.signal.addEventListener("abort", () => queueThen(order, () => held.close()));
+        reachedHandler.resolve();
+        // Never responds: the client aborts the request instead.
+        return new Promise<Response>(() => {});
+      },
+      websocket: websocket(order, opened.resolve),
+    });
+
+    const sockets = await openHeldSocket(server, opened.promise);
+    held = sockets.held;
+    const controller = new AbortController();
+    const aborted = fetch(new URL("/abort-me", server.url), { signal: controller.signal });
+    await reachedHandler.promise;
+    controller.abort();
+    await expect(aborted).rejects.toThrow();
+    await sockets.closed;
+    expect(order).toEqual(["close()", "rest of handler", "nextTick", "microtask"]);
+  });
+
+  // After an await, the rest of an async handler runs from the microtask
+  // checkpoint the server performs as soon as the handler returns its promise.
+  // Only a promise callback is queued here: a nextTick queued from inside a
+  // microtask is ordered differently from one queued by synchronous code, and
+  // that ordering is not what this test is about.
+  it("the continuation of an async fetch() closing an open ServerWebSocket", async () => {
+    const order: string[] = [];
+    const opened = Promise.withResolvers<ServerWebSocket<unknown>>();
+    let held: ServerWebSocket<unknown>;
+    using server = serve({
+      port: 0,
+      async fetch(req, srv) {
+        if (new URL(req.url).pathname === "/ws") {
+          return srv.upgrade(req) ? undefined : new Response("upgrade() failed", { status: 500 });
+        }
+        await Promise.resolve();
+        Promise.resolve().then(() => order.push("microtask"));
+        held.close();
+        order.push("rest of handler");
+        return new Response("ok");
+      },
+      websocket: websocket(order, opened.resolve),
+    });
+
+    const sockets = await openHeldSocket(server, opened.promise);
+    held = sockets.held;
+    expect(await fetch(new URL("/close-it", server.url)).then(res => res.text())).toBe("ok");
+    await sockets.closed;
+    expect(order).toEqual(["close()", "rest of handler", "microtask"]);
+  });
+});

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -1,9 +1,11 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as options } from "harness";
+import http from "http";
 import https from "https";
+import { once } from "node:events";
 import type { AddressInfo } from "node:net";
 import tls from "tls";
-import { WebSocketServer } from "ws";
+import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 
 test.concurrent("WebSocket upgrade should unref poll_ref from response", async () => {
   // Regression test for bug where poll_ref was not unref'd on WebSocket upgrade
@@ -102,4 +104,61 @@ test.concurrent("should not crash when closing sockets after upgrade", async () 
 
   await promise;
   expect().pass();
+});
+
+// ws.close() on a server-side socket runs the native close callback before it
+// returns. A node:http 'request' or 'upgrade' handler that calls it must still
+// run to completion first: the nextTick and promise callbacks the handler
+// queued run once it has returned, as in Node.js. They used to run inside the
+// close() call.
+describe.concurrent("request handlers run to completion before the callbacks they queued", () => {
+  function queueThen(order: string[], nativeCall: () => void) {
+    process.nextTick(() => order.push("nextTick"));
+    Promise.resolve().then(() => order.push("microtask"));
+    nativeCall();
+    order.push("rest of handler");
+  }
+
+  async function listen(server: http.Server) {
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return (server.address() as AddressInfo).port;
+  }
+
+  // Resolves once the server has closed the socket (or the handshake failed).
+  function connectUntilClosed(port: number) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    return promise;
+  }
+
+  test("the 'connection' handler of a WebSocketServer, run from the upgrade request", async () => {
+    const order: string[] = [];
+    await using server = http.createServer();
+    const wss = new WebSocketServer({ server });
+    wss.on("connection", ws => queueThen(order, () => ws.close()));
+
+    await connectUntilClosed(await listen(server));
+    expect(order).toEqual(["rest of handler", "nextTick", "microtask"]);
+  });
+
+  test("a 'request' handler closing an open WebSocketServer socket", async () => {
+    const order: string[] = [];
+    const connected = Promise.withResolvers<WsWebSocket>();
+    let held: WsWebSocket;
+    await using server = http.createServer((req, res) => {
+      queueThen(order, () => held.close());
+      res.end("ok");
+    });
+    const wss = new WebSocketServer({ server });
+    wss.on("connection", connected.resolve);
+
+    const port = await listen(server);
+    const closed = connectUntilClosed(port);
+    held = await connected.promise;
+    expect(await fetch(`http://127.0.0.1:${port}/`).then(res => res.text())).toBe("ok");
+    await closed;
+    expect(order).toEqual(["rest of handler", "nextTick", "microtask"]);
+  });
 });


### PR DESCRIPTION
### Problem
- In a `fetch()`, route, or `node:http` request handler, `server.upgrade()` (which runs `open()` before it returns) or `ws.close()` (which runs `close()`) drains the microtask queue in the middle of the handler: `then(f); ws.close(); g()` runs `f` before `g`. Node runs `f` after the handler returns. Async continuations and `abort` listeners are affected too.
- Cause: the dispatch paths under `src/runtime/server/` (list in Notes) call into JS with `entered_event_loop_count` at 0 and drain explicitly afterwards. The `enter()`/`exit()` pair around `open()` or `close()` (`ServerWebSocket.rs`) is then the outermost one, so `EventLoop::exit()` drains. The explicit drains ran at 0 too.

### Fix
- Adds `EventLoop::enter_scope_without_checkpoint()`: an `enter()` whose exit only balances the count. Each dispatch path holds it across the handler call and its explicit drains.
- Every other dispatcher runs callbacks with the count above 0 (`tick()`, timers, sockets). Under the scope the nested pair is not the outermost one and does not drain. The queued callbacks run at the drain the dispatcher performs anyway, so the checkpoints per request are unchanged. Matches Node.
- Verified: 9 new cases in `websocket-server.test.ts`, `node-http-with-ws.test.ts` and `serve-http3.test.ts`, all failing on current bun. Also ran the websocket, http, node/http, ws and bake suites.

### Background
- `entered_event_loop_count` (`src/jsc/event_loop.rs`) is the depth of native entries into JS. `exit()` runs the microtask checkpoint (nextTick callbacks, then promise jobs) only for the outermost exit. This gives each callback run-to-completion.
- The request paths drain explicitly: `RequestContext::on_response` drains before it looks at the returned value, so a promise the drain settled is unwrapped without a tick. Hence a scope that exits without a checkpoint.

<details><summary>Notes</summary>

Dispatch paths changed: `mod.rs` `on_request`, `on_user_route_request`, `on_node_http_request_with_upgrade_ctx`, `on_saved_request` (bake); `server_body.rs` `on_web_socket_upgrade`, `upgrade_web_socket_user_route`, `on_request_for` and `on_user_route_request_for` (HTTP/3); `RequestContext::on_abort`.

Cost: on a release build, the difference in the disassembly of `NewServer::on_request` is two loads, an `inc` of `entered_event_loop_count` before the handler call and a `dec` after it, plus a push/pop of the register that holds the pointer. The node:http dispatch gets the same and still contains its two calls to `drain_microtasks_with_global`. No drain call is added or removed on any path. Details in the comments below.

Tests: 6 cases in `test/js/bun/websocket/websocket-server.test.ts` (fetch and route, each calling `upgrade()` and closing a socket; an abort listener; an async continuation), 2 in `test/js/node/http/node-http-with-ws.test.ts` (a `ws` `connection` handler run from the upgrade request, and a request handler closing a socket), 1 in `test/js/bun/http/serve-http3.test.ts` (fetch and a route over HTTP/3).

Repro on bun 1.4.0 (prints `["microtask","after"]`, expected `["after"]`):

```js
const server = Bun.serve({
  port: 0,
  fetch(req, server) {
    const order = [];
    Promise.resolve().then(() => order.push("microtask"));
    server.upgrade(req);
    order.push("after");
    console.log(JSON.stringify(order));
  },
  websocket: { open() {}, message() {} },
});
new WebSocket(`ws://127.0.0.1:${server.port}`).onopen = () => server.stop(true);
```

The same code in a `setTimeout` callback prints the expected order, because timers run under `enter()`/`exit()`. The async variant (`await null` first, then the same statements) also printed the wrong order: the continuation ran from the explicit drain in `on_response`, with the count at 0. The two node:http cases print `["rest of handler","nextTick","microtask"]` on Node 26 and printed `["nextTick","microtask","rest of handler"]` on bun.

Out of scope, unchanged:
- The explicit drains are unconditional. `server.stop(true)` called from inside a handler still runs `on_abort`, and its drain, inside the handler. Making every explicit drain observe the count would be a change to `drain_microtasks_with_global`, the hottest function of the request path, and would affect every subsystem that drains explicitly.
- Evaluation of the main module also runs with the count at 0.
- The bake `on_saved_request` path gets the same one-line change but has no test here, since it needs a framework app. The bake framework suites (`react-response`, `request-cookies`, `response-to-bake-response`) pass.

Suites run with the debug build: `test/js/bun/websocket/`, `test/js/bun/http/serve.test.ts`, `bun-serve-routes.test.ts`, `bun-server.test.ts`, `serve-http3.test.ts`, the abort and stream related `serve-*.test.ts` files, `test/js/node/http/`, `test/js/first_party/ws/`, the `ws` regression tests, and the three bake files above. The failures seen were the same with and without this change: the `send() (benchmark)` test in `websocket-server.test.ts` starves its concurrent neighbours on a debug build in this container, and a few tests depend on `localhost` resolution, on not running as root, or on an empty proxy environment. They fail on stock bun here too.

</details>
