### PR TITLE
fs.watch: report the watched directory's removal once on Windows, and start a new watch when the path is watched again

### DIFF
--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -970,10 +970,13 @@ impl Linux {
 
                 // Kernel retired this wd: `remove_watch` issued an explicit
                 // `inotify_rm_watch` (it deletes the `wd_map` entry first, so no
-                // owners remain to notify) or the watched inode is gone. libuv
-                // turns the latter into one more "rename" after IN_DELETE_SELF,
-                // so a deleted watch root reports two. Recursive sub-wds stay
-                // silent; their parent directory's IN_DELETE already reported it.
+                // owners remain to notify) or the watched inode is gone. A watch
+                // whose root is gone leaves the dedup map, so that a watch() of the
+                // path (recreated, say) starts a new one; its handlers keep it
+                // alive until they close. libuv turns the retirement into one
+                // more "rename" after IN_DELETE_SELF, so a deleted watch root
+                // reports two. Recursive sub-wds stay silent; their parent
+                // directory's IN_DELETE already reported it.
                 if ev.mask & IN::IGNORED != 0 {
                     // SAFETY: holding manager.mutex; exclusive access to `wd_map`.
                     let wd_map = unsafe { &mut (*plat).wd_map };
@@ -982,13 +985,16 @@ impl Linux {
                             // SAFETY: o.watcher live under manager.mutex; shared
                             // access only — `emit_unsuppressed` takes `&self`.
                             let w = unsafe { &*o.watcher };
-                            if o.subpath.as_bytes().is_empty() && (w.is_file || !w.recursive) {
-                                w.emit_unsuppressed(
-                                    WatchEventKind::Rename,
-                                    path::basename(w.path.as_bytes()),
-                                    w.is_file,
-                                );
-                                let _ = handle_oom(touched.get_or_put(o.watcher));
+                            if o.subpath.as_bytes().is_empty() {
+                                manager.unlink_watcher_locked(o.watcher);
+                                if w.is_file || !w.recursive {
+                                    w.emit_unsuppressed(
+                                        WatchEventKind::Rename,
+                                        path::basename(w.path.as_bytes()),
+                                        w.is_file,
+                                    );
+                                    let _ = handle_oom(touched.get_or_put(o.watcher));
+                                }
                             }
                             // SAFETY: exclusive scoped access to this watcher's wd
                             // list under manager.mutex; the shared borrow above is
@@ -1101,6 +1107,13 @@ impl Linux {
                         )
                         .as_bytes()
                     };
+
+                    // Leave the dedup map (see IN_IGNORED above) before the event is
+                    // queued, so a listener that recreates and re-watches the path
+                    // cannot join this watch; IN_IGNORED may land a read() later.
+                    if owner_subpath.is_empty() && ev.mask & IN::DELETE_SELF != 0 {
+                        manager.unlink_watcher_locked(owner_watcher);
+                    }
 
                     // SAFETY: owner_watcher live under manager.mutex; `emit` takes `&self`.
                     unsafe {
@@ -1617,6 +1630,12 @@ impl Kqueue {
                 } else {
                     entry.subpath.as_bytes()
                 };
+
+                // The watched path itself is gone: leave the dedup map, as the inotify
+                // backend does, so that a watch() of the path starts a new one.
+                if entry.subpath.is_empty() && kev.fflags & (NOTE::DELETE | NOTE::REVOKE) != 0 {
+                    manager.unlink_watcher_locked(entry.watcher);
+                }
 
                 watcher.emit(event_type, rel, entry.is_file);
                 let _ = handle_oom(touched.get_or_put(entry.watcher));

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -970,13 +970,12 @@ impl Linux {
 
                 // Kernel retired this wd: `remove_watch` issued an explicit
                 // `inotify_rm_watch` (it deletes the `wd_map` entry first, so no
-                // owners remain to notify) or the watched inode is gone. A watch
-                // whose root is gone leaves the dedup map, so that a watch() of the
-                // path (recreated, say) starts a new one; its handlers keep it
-                // alive until they close. libuv turns the retirement into one
-                // more "rename" after IN_DELETE_SELF, so a deleted watch root
-                // reports two. Recursive sub-wds stay silent; their parent
-                // directory's IN_DELETE already reported it.
+                // owners remain to notify) or the watched inode is gone. A dead
+                // root also leaves the dedup map: a watch() of the path must start
+                // a new watch. libuv turns the retirement into one more "rename"
+                // after IN_DELETE_SELF, so a deleted watch root reports two.
+                // Recursive sub-wds stay silent; their parent directory's
+                // IN_DELETE already reported it.
                 if ev.mask & IN::IGNORED != 0 {
                     // SAFETY: holding manager.mutex; exclusive access to `wd_map`.
                     let wd_map = unsafe { &mut (*plat).wd_map };
@@ -1108,9 +1107,8 @@ impl Linux {
                         .as_bytes()
                     };
 
-                    // Leave the dedup map (see IN_IGNORED above) before the event is
-                    // queued, so a listener that recreates and re-watches the path
-                    // cannot join this watch; IN_IGNORED may land a read() later.
+                    // Leave the dedup map before the listener can re-watch the path:
+                    // the IN_IGNORED that also does it (above) may land a read() later.
                     if owner_subpath.is_empty() && ev.mask & IN::DELETE_SELF != 0 {
                         manager.unlink_watcher_locked(owner_watcher);
                     }
@@ -1631,8 +1629,7 @@ impl Kqueue {
                     entry.subpath.as_bytes()
                 };
 
-                // The watched path itself is gone: leave the dedup map, as the inotify
-                // backend does, so that a watch() of the path starts a new one.
+                // A dead root leaves the dedup map, as in the inotify backend above.
                 if entry.subpath.is_empty() && kev.fflags & (NOTE::DELETE | NOTE::REVOKE) != 0 {
                     manager.unlink_watcher_locked(entry.watcher);
                 }

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -1107,9 +1107,11 @@ impl Linux {
                         .as_bytes()
                     };
 
-                    // Leave the dedup map before the listener can re-watch the path:
-                    // the IN_IGNORED that also does it (above) may land a read() later.
-                    if owner_subpath.is_empty() && ev.mask & IN::DELETE_SELF != 0 {
+                    // The path no longer leads to this watch: leave the dedup map before
+                    // the listener can re-watch the path (a removal's IN_IGNORED, above,
+                    // may land a read() later, and a move has none).
+                    if owner_subpath.is_empty() && ev.mask & (IN::DELETE_SELF | IN::MOVE_SELF) != 0
+                    {
                         manager.unlink_watcher_locked(owner_watcher);
                     }
 
@@ -1629,8 +1631,10 @@ impl Kqueue {
                     entry.subpath.as_bytes()
                 };
 
-                // A dead root leaves the dedup map, as in the inotify backend above.
-                if entry.subpath.is_empty() && kev.fflags & (NOTE::DELETE | NOTE::REVOKE) != 0 {
+                // A removed or moved root leaves the dedup map, as in the inotify backend.
+                if entry.subpath.is_empty()
+                    && kev.fflags & (NOTE::DELETE | NOTE::RENAME | NOTE::REVOKE) != 0
+                {
                     manager.unlink_watcher_locked(entry.watcher);
                 }
 

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -283,8 +283,7 @@ impl PathWatcher {
             return;
         }
 
-        // A watched path that ends in a separator (a drive root, or given that way)
-        // makes libuv report its entries as `\name`.
+        // libuv reports the entries of a watch path that ends in a separator as `\name`.
         let name = name.strip_prefix(b"\\").unwrap_or(name);
         // Intentional wrap to bun_watcher::HashType
         let hash = me.handle.hash(name, events, status) as bun_watcher::HashType;

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -266,26 +266,29 @@ impl PathWatcher {
             return;
         }
         // SAFETY: libuv passes a valid NUL-terminated string when non-null.
-        let path = ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(filename) });
+        let name = unsafe { core::ffi::CStr::from_ptr(filename) }.to_bytes();
         let is_file = !me.handle.is_dir();
 
         // The watched directory itself was removed: libuv names that report with
-        // the path it was given (no child name is absolute) and repeats it on
-        // every loop iteration until the handle is stopped (nodejs/node#61398).
+        // the path it was given, volume included, and repeats it on every loop
+        // iteration until the handle is stopped (nodejs/node#61398).
         if !is_file
             && event_type == WatchEventKind::Rename
-            && bun_paths::is_absolute(path.as_bytes())
+            && bun_paths::resolve_path::windows_volume_name_len(name).0 != 0
         {
             Self::retire(this);
-            // `path` is libuv's own copy of the name; stopping the handle does not free it.
-            Self::emit_unsuppressed(this, bun_paths::basename(path.as_bytes()), event_type);
+            // `name` is libuv's own copy; stopping the handle does not free it.
+            Self::emit_unsuppressed(this, bun_paths::basename(name), event_type);
             Self::maybe_deinit(this);
             return;
         }
 
+        // A watched path that ends in a separator (a drive root, or given that way)
+        // makes libuv report its entries as `\name`.
+        let name = name.strip_prefix(b"\\").unwrap_or(name);
         // Intentional wrap to bun_watcher::HashType
-        let hash = me.handle.hash(path.as_bytes(), events, status) as bun_watcher::HashType;
-        Self::emit(this, path.as_bytes(), hash, timestamp, is_file, event_type);
+        let hash = me.handle.hash(name, events, status) as bun_watcher::HashType;
+        Self::emit(this, name, hash, timestamp, is_file, event_type);
     }
 
     fn emit(

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -269,13 +269,9 @@ impl PathWatcher {
         let path = ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(filename) });
         let is_file = !me.handle.is_dir();
 
-        // libuv reports the removal of the watched directory itself as a rename
-        // whose filename is the directory's own path (src/win/fs-event.c, the
-        // DeletePending branch): the one report that is not relative to the
-        // watched directory. It then re-arms ReadDirectoryChangesW, which fails
-        // the same way on every loop iteration for as long as the handle is
-        // active (nodejs/node#61398). Report it once, named the way the inotify
-        // backend names a deleted watch root, and retire the handle.
+        // The watched directory itself was removed: libuv names that report with
+        // the directory's own path (its only absolute filename) and repeats it on
+        // every loop iteration until the handle is stopped (nodejs/node#61398).
         if !is_file
             && event_type == WatchEventKind::Rename
             && bun_paths::is_absolute(path.as_bytes())
@@ -340,14 +336,11 @@ impl PathWatcher {
         Self::maybe_deinit(this);
     }
 
-    /// Like [`emit`](Self::emit), but without per-handler duplicate suppression
-    /// (the posix backend's `emit_unsuppressed`). Used for the removal of the
-    /// watched directory, which is named after the directory: a child entry of
-    /// the same name removed in the same millisecond would otherwise swallow
-    /// it. The caller `maybe_deinit`s once it is done with `this`.
+    /// [`emit`](Self::emit) without the duplicate suppression: the watched
+    /// directory's removal is named after it, so a same-named child removed in
+    /// the same millisecond would otherwise swallow it.
     fn emit_unsuppressed(this: *mut PathWatcher, path: &[u8], event_type: WatchEventKind) {
-        // SAFETY: `this` is the live heap pointer from `init`; delivering only
-        // enqueues tasks, so nothing here can free it.
+        // SAFETY: `this` is the live heap pointer from `init`; nothing here frees it.
         let me = unsafe { &*this };
         me.emit_in_progress.set(true);
 
@@ -369,8 +362,7 @@ impl PathWatcher {
         me.emit_in_progress.set(false);
     }
 
-    /// Hands one event to one handler. The payload is built per handler because
-    /// its shape depends on the handler's encoding.
+    /// Hands one event to one handler, in the payload shape of its encoding.
     fn deliver(handler: *mut c_void, path: &[u8], is_file: bool, event_type: WatchEventKind) {
         let ctx: *mut FSWatcher = handler.cast::<FSWatcher>();
         // SAFETY: handlers keys are `*mut FSWatcher` erased to `*mut c_void` in `watch()`.
@@ -386,18 +378,13 @@ impl PathWatcher {
         on_update_end_fn(Some(ctx.cast()));
     }
 
-    /// Takes the watcher out of service once libuv has nothing more to report
-    /// for it: drops it out of the manager's map, so that a later `fs.watch()`
-    /// of the same path (the directory may be recreated) starts a new handle
-    /// instead of joining this one, and stops the handle, so that libuv does not
-    /// re-arm it. The attached `FSWatcher`s stay open until they are closed, as
-    /// they do on Linux once inotify has retired a deleted watch root; the last
-    /// `detach` then frees this. Idempotent: `deinit` runs it as well.
+    /// Stops the handle and leaves the manager's map, so a later `fs.watch()` of
+    /// the path gets a new handle. The handlers stay attached until their
+    /// `FSWatcher`s close, as on Linux; the last `detach` frees this. Idempotent.
     fn retire(this: *mut PathWatcher) {
         {
-            // SAFETY: `this` is the live heap pointer from `init`. Unregistering
-            // may free the manager, never `this`; the borrow ends before the stop
-            // below frees `handle.path`.
+            // SAFETY: `this` is the live heap pointer from `init`; unregistering may
+            // free the manager, never `this`. The borrow ends before the stop below.
             let me = unsafe { &*this };
             if let Some(manager) = me.manager.take() {
                 let path: &ZStr = if !me.handle.path.is_null() {

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -270,7 +270,7 @@ impl PathWatcher {
         let is_file = !me.handle.is_dir();
 
         // The watched directory itself was removed: libuv names that report with
-        // the directory's own path (its only absolute filename) and repeats it on
+        // the path it was given (no child name is absolute) and repeats it on
         // every loop iteration until the handle is stopped (nodejs/node#61398).
         if !is_file
             && event_type == WatchEventKind::Rename

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -276,8 +276,9 @@ impl PathWatcher {
             && event_type == WatchEventKind::Rename
             && bun_paths::is_absolute(path.as_bytes())
         {
-            Self::emit_unsuppressed(this, bun_paths::basename(path.as_bytes()), event_type);
             Self::retire(this);
+            // `path` is libuv's own copy of the name; stopping the handle does not free it.
+            Self::emit_unsuppressed(this, bun_paths::basename(path.as_bytes()), event_type);
             Self::maybe_deinit(this);
             return;
         }

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -219,6 +219,11 @@ impl PathWatcher {
         let timestamp = unsafe { (*me.handle.loop_).time };
 
         if let Some(err) = status.to_error(sys::Tag::watch) {
+            // The handlers close on the error, so the watch is over: retire it before
+            // one of them can re-watch the path.
+            Self::retire(this);
+            // SAFETY: as above; borrowed again because `retire` wrote to the handle.
+            let me = unsafe { &*this };
             me.emit_in_progress.set(true);
 
             let keys: Vec<_> = me.handlers.get().keys().iter().copied().collect();
@@ -271,7 +276,8 @@ impl PathWatcher {
 
         // The watched directory itself was removed: libuv names that report with
         // the path it was given, volume included, and repeats it on every loop
-        // iteration until the handle is stopped (nodejs/node#61398).
+        // iteration until the handle is stopped (nodejs/node#61398). Reported
+        // once, by name, as the other backends report it.
         if !is_file
             && event_type == WatchEventKind::Rename
             && bun_paths::resolve_path::windows_volume_name_len(name).0 != 0

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -267,10 +267,27 @@ impl PathWatcher {
         }
         // SAFETY: libuv passes a valid NUL-terminated string when non-null.
         let path = ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(filename) });
+        let is_file = !me.handle.is_dir();
+
+        // libuv reports the removal of the watched directory itself as a rename
+        // whose filename is the directory's own path (src/win/fs-event.c, the
+        // DeletePending branch): the one report that is not relative to the
+        // watched directory. It then re-arms ReadDirectoryChangesW, which fails
+        // the same way on every loop iteration for as long as the handle is
+        // active (nodejs/node#61398). Report it once, named the way the inotify
+        // backend names a deleted watch root, and retire the handle.
+        if !is_file
+            && event_type == WatchEventKind::Rename
+            && bun_paths::is_absolute(path.as_bytes())
+        {
+            Self::emit_unsuppressed(this, bun_paths::basename(path.as_bytes()), event_type);
+            Self::retire(this);
+            Self::maybe_deinit(this);
+            return;
+        }
 
         // Intentional wrap to bun_watcher::HashType
         let hash = me.handle.hash(path.as_bytes(), events, status) as bun_watcher::HashType;
-        let is_file = !me.handle.is_dir();
         Self::emit(this, path.as_bytes(), hash, timestamp, is_file, event_type);
     }
 
@@ -299,22 +316,11 @@ impl PathWatcher {
                     continue;
                 };
                 if fire {
-                    let ctx: *mut FSWatcher = key.cast::<FSWatcher>();
-                    // SAFETY: handlers keys are `*mut FSWatcher` erased to `*mut c_void` in `watch()`.
-                    let encoding = unsafe { (*ctx).encoding };
-                    // `EventPathString` on Windows is `StringOrBytesToDecode`.
-                    let payload = match encoding {
-                        crate::node::Encoding::Utf8 => {
-                            StringOrBytesToDecode::String(BunString::clone_utf8(path))
-                        }
-                        _ => StringOrBytesToDecode::BytesToFree(Box::<[u8]>::from(path)),
-                    };
-                    on_path_update_fn(Some(ctx.cast()), event_type.to_event(payload), is_file);
+                    Self::deliver(key, path, is_file, event_type);
                     #[cfg(debug_assertions)]
                     {
                         debug_count += 1;
                     }
-                    on_update_end_fn(Some(ctx.cast()));
                 }
             }
 
@@ -332,6 +338,83 @@ impl PathWatcher {
             me.emit_in_progress.set(false);
         }
         Self::maybe_deinit(this);
+    }
+
+    /// Like [`emit`](Self::emit), but without per-handler duplicate suppression
+    /// (the posix backend's `emit_unsuppressed`). Used for the removal of the
+    /// watched directory, which is named after the directory: a child entry of
+    /// the same name removed in the same millisecond would otherwise swallow
+    /// it. The caller `maybe_deinit`s once it is done with `this`.
+    fn emit_unsuppressed(this: *mut PathWatcher, path: &[u8], event_type: WatchEventKind) {
+        // SAFETY: `this` is the live heap pointer from `init`; delivering only
+        // enqueues tasks, so nothing here can free it.
+        let me = unsafe { &*this };
+        me.emit_in_progress.set(true);
+
+        let keys: Vec<_> = me.handlers.get().keys().iter().copied().collect();
+        for key in keys {
+            if !me.handlers.get().contains_key(&key) {
+                continue;
+            }
+            Self::deliver(key, path, false, event_type);
+        }
+
+        bun_output::scoped_log!(
+            fs_watch,
+            "emit_unsuppressed({}, dir, {})",
+            bstr::BStr::new(path),
+            <&'static str>::from(event_type),
+        );
+
+        me.emit_in_progress.set(false);
+    }
+
+    /// Hands one event to one handler. The payload is built per handler because
+    /// its shape depends on the handler's encoding.
+    fn deliver(handler: *mut c_void, path: &[u8], is_file: bool, event_type: WatchEventKind) {
+        let ctx: *mut FSWatcher = handler.cast::<FSWatcher>();
+        // SAFETY: handlers keys are `*mut FSWatcher` erased to `*mut c_void` in `watch()`.
+        let encoding = unsafe { (*ctx).encoding };
+        // `EventPathString` on Windows is `StringOrBytesToDecode`.
+        let payload = match encoding {
+            crate::node::Encoding::Utf8 => {
+                StringOrBytesToDecode::String(BunString::clone_utf8(path))
+            }
+            _ => StringOrBytesToDecode::BytesToFree(Box::<[u8]>::from(path)),
+        };
+        on_path_update_fn(Some(ctx.cast()), event_type.to_event(payload), is_file);
+        on_update_end_fn(Some(ctx.cast()));
+    }
+
+    /// Takes the watcher out of service once libuv has nothing more to report
+    /// for it: drops it out of the manager's map, so that a later `fs.watch()`
+    /// of the same path (the directory may be recreated) starts a new handle
+    /// instead of joining this one, and stops the handle, so that libuv does not
+    /// re-arm it. The attached `FSWatcher`s stay open until they are closed, as
+    /// they do on Linux once inotify has retired a deleted watch root; the last
+    /// `detach` then frees this. Idempotent: `deinit` runs it as well.
+    fn retire(this: *mut PathWatcher) {
+        {
+            // SAFETY: `this` is the live heap pointer from `init`. Unregistering
+            // may free the manager, never `this`; the borrow ends before the stop
+            // below frees `handle.path`.
+            let me = unsafe { &*this };
+            if let Some(manager) = me.manager.take() {
+                let path: &ZStr = if !me.handle.path.is_null() {
+                    // SAFETY: handle.path is a NUL-terminated C string owned by libuv
+                    // until `uv_fs_event_stop` frees it.
+                    ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(me.handle.path) })
+                } else {
+                    ZStr::EMPTY
+                };
+                PathWatcherManager::unregister_watcher(manager, this, path);
+            }
+        }
+        // SAFETY: the handle was initialized in `init`; stopping a handle that is
+        // not active is a no-op.
+        unsafe {
+            uv::uv_fs_event_stop(ptr::addr_of_mut!((*this).handle));
+        }
     }
 
     fn init(
@@ -470,22 +553,10 @@ impl PathWatcher {
     /// frees the box, so this type is always managed via raw `*mut PathWatcher`.
     unsafe fn deinit(this: *mut PathWatcher) {
         bun_output::scoped_log!(fs_watch, "deinit");
-        {
-            // SAFETY: caller guarantees `this` is a live heap-allocated pointer (see `init`);
-            // the borrow ends before the free below.
-            let me = unsafe { &*this };
-            me.handlers.with_mut(|h| h.clear());
-
-            if let Some(manager) = me.manager.take() {
-                let path: &ZStr = if !me.handle.path.is_null() {
-                    // SAFETY: handle.path is a NUL-terminated C string owned by libuv.
-                    ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(me.handle.path) })
-                } else {
-                    ZStr::EMPTY
-                };
-                PathWatcherManager::unregister_watcher(manager, this, path);
-            }
-        }
+        // SAFETY: caller guarantees `this` is a live heap-allocated pointer (see `init`);
+        // the borrow ends before the free below.
+        unsafe { &*this }.handlers.with_mut(|h| h.clear());
+        Self::retire(this);
 
         // `UvHandle::is_closed` reads `flags & UV_HANDLE_CLOSED` via the handle prefix.
         // SAFETY: `this` is still the live heap allocation from `init`.
@@ -493,9 +564,9 @@ impl PathWatcher {
             // SAFETY: `this` was heap-allocated in `init`.
             drop(unsafe { bun_core::heap::take(this) });
         } else {
-            // SAFETY: handle is open and not yet closing; stop/close are valid in that state.
+            // SAFETY: the handle is initialized (`retire` stopped it) and not yet
+            // closing; close is valid in that state.
             unsafe {
-                uv::uv_fs_event_stop(ptr::addr_of_mut!((*this).handle));
                 uv::uv_close(
                     ptr::addr_of_mut!((*this).handle).cast(),
                     Some(PathWatcher::uv_closed_callback),

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -611,33 +611,46 @@ describe("fs.watch", () => {
     ]);
   });
 
-  // Removing the watched directory ends its OS watch. The FSWatcher stays open
-  // until it is closed, and a watch() of the same path from then on (here: of
-  // the directory recreated inside the removal callback) must start a new OS
-  // watch instead of joining the dead one. The new watch's first event also
-  // bounds what the first watcher reports.
+  // Once the watched directory is removed or moved away, its path no longer
+  // leads to its OS watch. The FSWatcher stays open until it is closed (a moved
+  // directory keeps reporting), but a watch() of the path from then on (here:
+  // of the directory recreated inside the callback) must start a new OS watch
+  // instead of joining the old one. The new watch's first event also bounds
+  // what the first watcher reports.
   //
   // Windows: libuv reports the removal as a rename named with the directory's
   // own absolute path and re-arms the watch, which fails the same way on every
   // tick of the event loop (nodejs/node#61398); bun reports it once, by
-  // basename, and stops the watch. Linux: inotify queues IN_DELETE_SELF and
-  // IN_IGNORED, reported like libuv reports them (a recursive root keeps the
-  // root-relative name, which is empty). macOS: FSEvents watches the path, so
-  // the old watch sees the recreated directory and nothing ends; not covered.
+  // basename, and stops the watch. A move is not reported on Windows at all,
+  // so that axis is Linux only. Linux: inotify reports IN_DELETE_SELF and the
+  // IN_IGNORED that retires the wd, or IN_MOVE_SELF, like libuv reports them
+  // (a recursive root keeps the root-relative name, which is empty). macOS:
+  // FSEvents watches the path, so the old watch sees the recreated directory
+  // and nothing ends; not covered.
   describe.each([false, true])("recursive: %p", recursive => {
-    const removalEvents = isWindows
-      ? [["rename", "watched-dir"]]
-      : recursive
-        ? [["rename", undefined]]
-        : [
-            ["rename", "watched-dir"],
-            ["rename", "watched-dir"],
-          ];
+    const selfEvent = isWindows || !recursive ? ["rename", "watched-dir"] : ["rename", undefined];
+    const cases = [
+      {
+        op: "removed",
+        runsHere: isWindows || isLinux,
+        disturb: (target: string) => fs.rmdirSync(target),
+        // A removed root also gets inotify's IN_IGNORED rename, except in recursive mode.
+        firstWatcherEvents: isLinux && !recursive ? [selfEvent, selfEvent] : [selfEvent],
+        afterRewatch: (_root: string) => {},
+      },
+      {
+        op: "moved away",
+        runsHere: isLinux,
+        disturb: (target: string) => fs.renameSync(target, target + "-moved"),
+        // The old watch follows the moved directory: it alone reports the entry created there.
+        firstWatcherEvents: [selfEvent, ["rename", "in-moved"]],
+        afterRewatch: (target: string) => fs.mkdirSync(path.join(target + "-moved", "in-moved")),
+      },
+    ];
 
-    test.skipIf(!isWindows && !isLinux)(
-      "removing the watched directory ends the watch and a new watch of the path starts fresh",
-      async () => {
-        using dir = tempDir("fs-watch-rmdir-self", { "watched-dir": {} });
+    for (const { op, runsHere, disturb, firstWatcherEvents, afterRewatch } of cases) {
+      test.skipIf(!runsHere)(`after the watched directory is ${op}, a new watch of the path starts fresh`, async () => {
+        using dir = tempDir("fs-watch-self", { "watched-dir": {} });
         const target = path.join(String(dir), "watched-dir");
         // Everything the first watcher reports, in order.
         const events: unknown[][] = [];
@@ -650,6 +663,7 @@ describe("fs.watch", () => {
             fs.mkdirSync(target);
             again = fs.watch(target, { recursive }, (...event) => seenByNewWatch.resolve(event));
             again.once("error", seenByNewWatch.reject);
+            afterRewatch(target);
             fs.writeFileSync(path.join(target, "created-after.txt"), "x");
           } catch (err) {
             seenByNewWatch.reject(err);
@@ -661,16 +675,16 @@ describe("fs.watch", () => {
         });
         watcher.on("close", () => events.push(["close"]));
         try {
-          fs.rmdirSync(target);
+          disturb(target);
           const [, filename] = await seenByNewWatch.promise;
           expect(filename).toBe("created-after.txt");
-          expect(events).toEqual(removalEvents);
+          expect(events).toEqual(firstWatcherEvents);
         } finally {
           again?.close();
           watcher.close();
         }
-      },
-    );
+      });
+    }
 
     // A watch path that ends in a separator (a drive root, or given that way)
     // reaches libuv as such, and libuv then reports new entries as "\name".
@@ -712,6 +726,45 @@ describe("fs.watch", () => {
       },
     );
   });
+
+  // On Windows a watched file's directory being removed reaches libuv as a
+  // failed ReadDirectoryChangesW: the watcher gets one 'error' and closes, as
+  // in node. The OS watch is over at that point too, so a watch() of the path
+  // from inside the 'error' listener must start a new one.
+  test.skipIf(!isWindows)(
+    "after a watched file's directory is removed, a new watch of the path starts fresh (windows)",
+    async () => {
+      using dir = tempDir("fs-watch-file-parent-removed", { "parent": { "watched.txt": "1" } });
+      const parent = path.join(String(dir), "parent");
+      const target = path.join(parent, "watched.txt");
+      const events: unknown[][] = [];
+      const seenByNewWatch = Promise.withResolvers<[string, string | null]>();
+      let again: FSWatcher | undefined;
+      const watcher = fs.watch(target, (eventType, filename) => events.push([eventType, filename]));
+      watcher.on("error", (err: NodeJS.ErrnoException) => {
+        events.push(["error", err.code]);
+        try {
+          fs.mkdirSync(parent);
+          fs.writeFileSync(target, "2");
+          again = fs.watch(target, (...event) => seenByNewWatch.resolve(event));
+          again.once("error", seenByNewWatch.reject);
+          fs.appendFileSync(target, "3");
+        } catch (err) {
+          seenByNewWatch.reject(err);
+        }
+      });
+      watcher.on("close", () => events.push(["close"]));
+      try {
+        fs.rmSync(parent, { recursive: true });
+        expect(await seenByNewWatch.promise).toEqual(["change", "watched.txt"]);
+        // The file's own removal is reported first; what follows it is fixed.
+        expect(events.slice(-2)).toEqual([["error", "EPERM"], ["close"]]);
+      } finally {
+        again?.close();
+        watcher.close();
+      }
+    },
+  );
 
   // Past fs.inotify.max_queued_events the kernel drops events and queues one
   // IN_Q_OVERFLOW; Bun reports it as ('change', null) on every watcher sharing

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -624,39 +624,42 @@ describe("fs.watch", () => {
   // whose filename is the directory's own absolute path, and keeps re-arming
   // the watch, which fails the same way on every tick of the event loop
   // (nodejs/node#61398). Bun reports it once, as basename(watched path) like
-  // the Linux backend, and stops the watch. The second watcher proves that no
-  // further event arrives from the first one (the re-armed watch reported
-  // again on every tick) and that a new watch of the same path watches the
-  // recreated directory instead of joining the dead watch.
+  // the Linux backend, and stops the watch; the FSWatcher stays open until it is
+  // closed. The removal callback recreates the directory and watches it again:
+  // that must start a new watch instead of joining the stopped one, and its
+  // first event bounds the first watcher's list (the re-armed watch used to
+  // report again on every tick before it).
   for (const recursive of [false, true]) {
     test.skipIf(!isWindows)(
       `removing the watched directory is reported once, by basename (windows, recursive: ${recursive})`,
       async () => {
         using dir = tempDir("fs-watch-rmdir-self-win", { "watched-dir": {} });
         const target = path.join(String(dir), "watched-dir");
-        const events: [string, string | null][] = [];
-        // The first watcher must not report an error at any point: it stays
-        // open, silent, until it is closed. Both waits race against this.
-        const failure = Promise.withResolvers<never>();
-        const removed = Promise.withResolvers<void>();
+        // Everything the first watcher reports, in order.
+        const events: unknown[][] = [];
+        const seenByNewWatch = Promise.withResolvers<[string, string | null]>();
+        let again: FSWatcher | undefined;
         const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
           events.push([eventType, filename]);
-          removed.resolve();
+          if (again) return;
+          try {
+            fs.mkdirSync(target);
+            again = fs.watch(target, { recursive }, (...event) => seenByNewWatch.resolve(event));
+            again.once("error", seenByNewWatch.reject);
+            fs.writeFileSync(path.join(target, "created-after.txt"), "x");
+          } catch (err) {
+            seenByNewWatch.reject(err);
+          }
         });
-        watcher.once("error", failure.reject);
-        let again: FSWatcher | undefined;
+        watcher.on("error", (err: NodeJS.ErrnoException) => {
+          events.push(["error", err.code]);
+          seenByNewWatch.reject(err);
+        });
+        watcher.on("close", () => events.push(["close"]));
         try {
           fs.rmdirSync(target);
-          await Promise.race([removed.promise, failure.promise]);
-
-          fs.mkdirSync(target);
-          const seen = Promise.withResolvers<[string, string | null]>();
-          again = fs.watch(target, { recursive }, (eventType, filename) => seen.resolve([eventType, filename]));
-          again.once("error", failure.reject);
-          fs.writeFileSync(path.join(target, "created-after.txt"), "x");
-          const [, filename] = await Promise.race([seen.promise, failure.promise]);
+          const [, filename] = await seenByNewWatch.promise;
           expect(filename).toBe("created-after.txt");
-
           expect(events).toEqual([["rename", "watched-dir"]]);
         } finally {
           again?.close();

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -620,6 +620,49 @@ describe("fs.watch", () => {
     ]);
   });
 
+  // On Windows, libuv reports the removal of the watched directory as a rename
+  // whose filename is the directory's own absolute path, and keeps re-arming
+  // the watch, which fails the same way on every tick of the event loop
+  // (nodejs/node#61398). Bun reports it once, as basename(watched path) like
+  // the Linux backend, and stops the watch. The second watcher proves that no
+  // further event arrives from the first one (the re-armed watch reported
+  // again on every tick) and that a new watch of the same path watches the
+  // recreated directory instead of joining the dead watch.
+  for (const recursive of [false, true]) {
+    test.skipIf(!isWindows)(
+      `removing the watched directory is reported once, by basename (windows, recursive: ${recursive})`,
+      async () => {
+        using dir = tempDir("fs-watch-rmdir-self-win", { "watched-dir": {} });
+        const target = path.join(String(dir), "watched-dir");
+        const events: [string, string | null][] = [];
+        const removed = Promise.withResolvers<void>();
+        const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
+          events.push([eventType, filename]);
+          removed.resolve();
+        });
+        watcher.once("error", removed.reject);
+        let again: FSWatcher | undefined;
+        try {
+          fs.rmdirSync(target);
+          await removed.promise;
+
+          fs.mkdirSync(target);
+          const seen = Promise.withResolvers<[string, string | null]>();
+          again = fs.watch(target, { recursive }, (eventType, filename) => seen.resolve([eventType, filename]));
+          again.once("error", seen.reject);
+          fs.writeFileSync(path.join(target, "created-after.txt"), "x");
+          const [, filename] = await seen.promise;
+          expect(filename).toBe("created-after.txt");
+
+          expect(events).toEqual([["rename", "watched-dir"]]);
+        } finally {
+          again?.close();
+          watcher.close();
+        }
+      },
+    );
+  }
+
   // Past fs.inotify.max_queued_events the kernel drops events and queues one
   // IN_Q_OVERFLOW; Bun reports it as ('change', null) on every watcher sharing
   // the inotify fd, the same shape node uses for overflow on Windows.

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -629,45 +629,42 @@ describe("fs.watch", () => {
   // that must start a new watch instead of joining the stopped one, and its
   // first event bounds the first watcher's list (the re-armed watch used to
   // report again on every tick before it).
-  for (const recursive of [false, true]) {
-    test.skipIf(!isWindows)(
-      `removing the watched directory is reported once, by basename (windows, recursive: ${recursive})`,
-      async () => {
-        using dir = tempDir("fs-watch-rmdir-self-win", { "watched-dir": {} });
-        const target = path.join(String(dir), "watched-dir");
-        // Everything the first watcher reports, in order.
-        const events: unknown[][] = [];
-        const seenByNewWatch = Promise.withResolvers<[string, string | null]>();
-        let again: FSWatcher | undefined;
-        const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
-          events.push([eventType, filename]);
-          if (again) return;
-          try {
-            fs.mkdirSync(target);
-            again = fs.watch(target, { recursive }, (...event) => seenByNewWatch.resolve(event));
-            again.once("error", seenByNewWatch.reject);
-            fs.writeFileSync(path.join(target, "created-after.txt"), "x");
-          } catch (err) {
-            seenByNewWatch.reject(err);
-          }
-        });
-        watcher.on("error", (err: NodeJS.ErrnoException) => {
-          events.push(["error", err.code]);
-          seenByNewWatch.reject(err);
-        });
-        watcher.on("close", () => events.push(["close"]));
+  describe.each([false, true])("recursive: %p", recursive => {
+    test.skipIf(!isWindows)("removing the watched directory is reported once, by basename (windows)", async () => {
+      using dir = tempDir("fs-watch-rmdir-self-win", { "watched-dir": {} });
+      const target = path.join(String(dir), "watched-dir");
+      // Everything the first watcher reports, in order.
+      const events: unknown[][] = [];
+      const seenByNewWatch = Promise.withResolvers<[string, string | null]>();
+      let again: FSWatcher | undefined;
+      const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
+        events.push([eventType, filename]);
+        if (again) return;
         try {
-          fs.rmdirSync(target);
-          const [, filename] = await seenByNewWatch.promise;
-          expect(filename).toBe("created-after.txt");
-          expect(events).toEqual([["rename", "watched-dir"]]);
-        } finally {
-          again?.close();
-          watcher.close();
+          fs.mkdirSync(target);
+          again = fs.watch(target, { recursive }, (...event) => seenByNewWatch.resolve(event));
+          again.once("error", seenByNewWatch.reject);
+          fs.writeFileSync(path.join(target, "created-after.txt"), "x");
+        } catch (err) {
+          seenByNewWatch.reject(err);
         }
-      },
-    );
-  }
+      });
+      watcher.on("error", (err: NodeJS.ErrnoException) => {
+        events.push(["error", err.code]);
+        seenByNewWatch.reject(err);
+      });
+      watcher.on("close", () => events.push(["close"]));
+      try {
+        fs.rmdirSync(target);
+        const [, filename] = await seenByNewWatch.promise;
+        expect(filename).toBe("created-after.txt");
+        expect(events).toEqual([["rename", "watched-dir"]]);
+      } finally {
+        again?.close();
+        watcher.close();
+      }
+    });
+  });
 
   // Past fs.inotify.max_queued_events the kernel drops events and queues one
   // IN_Q_OVERFLOW; Bun reports it as ('change', null) on every watcher sharing

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -603,15 +603,6 @@ describe("fs.watch", () => {
     ]);
   });
 
-  test.skipIf(!isLinux)("removing the watched directory delivers both rename self-events named after it", async () => {
-    using dir = tempDir("fs-watch-rmdir-self", { "sub": {} });
-    const target = path.join(String(dir), "sub");
-    expect(await collectWatchEvents(target, 2, () => fs.rmdirSync(target))).toEqual([
-      ["rename", "sub"],
-      ["rename", "sub"],
-    ]);
-  });
-
   test.skipIf(!isLinux)("renaming the watched directory away reports its basename", async () => {
     using dir = tempDir("fs-watch-mv-self", { "sub": {} });
     const target = path.join(String(dir), "sub");
@@ -620,50 +611,106 @@ describe("fs.watch", () => {
     ]);
   });
 
-  // On Windows, libuv reports the removal of the watched directory as a rename
-  // whose filename is the directory's own absolute path, and keeps re-arming
-  // the watch, which fails the same way on every tick of the event loop
-  // (nodejs/node#61398). Bun reports it once, as basename(watched path) like
-  // the Linux backend, and stops the watch; the FSWatcher stays open until it is
-  // closed. The removal callback recreates the directory and watches it again:
-  // that must start a new watch instead of joining the stopped one, and its
-  // first event bounds the first watcher's list (the re-armed watch used to
-  // report again on every tick before it).
+  // Removing the watched directory ends its OS watch. The FSWatcher stays open
+  // until it is closed, and a watch() of the same path from then on (here: of
+  // the directory recreated inside the removal callback) must start a new OS
+  // watch instead of joining the dead one. The new watch's first event also
+  // bounds what the first watcher reports.
+  //
+  // Windows: libuv reports the removal as a rename named with the directory's
+  // own absolute path and re-arms the watch, which fails the same way on every
+  // tick of the event loop (nodejs/node#61398); bun reports it once, by
+  // basename, and stops the watch. Linux: inotify queues IN_DELETE_SELF and
+  // IN_IGNORED, reported like libuv reports them (a recursive root keeps the
+  // root-relative name, which is empty). macOS: FSEvents watches the path, so
+  // the old watch sees the recreated directory and nothing ends; not covered.
   describe.each([false, true])("recursive: %p", recursive => {
-    test.skipIf(!isWindows)("removing the watched directory is reported once, by basename (windows)", async () => {
-      using dir = tempDir("fs-watch-rmdir-self-win", { "watched-dir": {} });
-      const target = path.join(String(dir), "watched-dir");
-      // Everything the first watcher reports, in order.
-      const events: unknown[][] = [];
-      const seenByNewWatch = Promise.withResolvers<[string, string | null]>();
-      let again: FSWatcher | undefined;
-      const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
-        events.push([eventType, filename]);
-        if (again) return;
-        try {
-          fs.mkdirSync(target);
-          again = fs.watch(target, { recursive }, (...event) => seenByNewWatch.resolve(event));
-          again.once("error", seenByNewWatch.reject);
-          fs.writeFileSync(path.join(target, "created-after.txt"), "x");
-        } catch (err) {
+    const removalEvents = isWindows
+      ? [["rename", "watched-dir"]]
+      : recursive
+        ? [["rename", undefined]]
+        : [
+            ["rename", "watched-dir"],
+            ["rename", "watched-dir"],
+          ];
+
+    test.skipIf(!isWindows && !isLinux)(
+      "removing the watched directory ends the watch and a new watch of the path starts fresh",
+      async () => {
+        using dir = tempDir("fs-watch-rmdir-self", { "watched-dir": {} });
+        const target = path.join(String(dir), "watched-dir");
+        // Everything the first watcher reports, in order.
+        const events: unknown[][] = [];
+        const seenByNewWatch = Promise.withResolvers<[string, string | null]>();
+        let again: FSWatcher | undefined;
+        const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
+          events.push([eventType, filename]);
+          if (again) return;
+          try {
+            fs.mkdirSync(target);
+            again = fs.watch(target, { recursive }, (...event) => seenByNewWatch.resolve(event));
+            again.once("error", seenByNewWatch.reject);
+            fs.writeFileSync(path.join(target, "created-after.txt"), "x");
+          } catch (err) {
+            seenByNewWatch.reject(err);
+          }
+        });
+        watcher.on("error", (err: NodeJS.ErrnoException) => {
+          events.push(["error", err.code]);
           seenByNewWatch.reject(err);
+        });
+        watcher.on("close", () => events.push(["close"]));
+        try {
+          fs.rmdirSync(target);
+          const [, filename] = await seenByNewWatch.promise;
+          expect(filename).toBe("created-after.txt");
+          expect(events).toEqual(removalEvents);
+        } finally {
+          again?.close();
+          watcher.close();
         }
-      });
-      watcher.on("error", (err: NodeJS.ErrnoException) => {
-        events.push(["error", err.code]);
-        seenByNewWatch.reject(err);
-      });
-      watcher.on("close", () => events.push(["close"]));
-      try {
-        fs.rmdirSync(target);
-        const [, filename] = await seenByNewWatch.promise;
-        expect(filename).toBe("created-after.txt");
-        expect(events).toEqual([["rename", "watched-dir"]]);
-      } finally {
-        again?.close();
-        watcher.close();
-      }
-    });
+      },
+    );
+
+    // A watch path that ends in a separator (a drive root, or given that way)
+    // reaches libuv as such, and libuv then reports new entries as "\name".
+    // They are delivered by name, like node delivers them, and must not be
+    // mistaken for the removal of the directory itself, which ends the watch:
+    // every step below runs only once the previous one was reported, and only
+    // the last one, the removal, may end the watch.
+    test.skipIf(!isWindows)(
+      "a watch path with a trailing separator reports its entries by name (windows)",
+      async () => {
+        using dir = tempDir("fs-watch-trailing-sep", { "watched-dir": {} });
+        const target = path.join(String(dir), "watched-dir");
+        const renames: (string | null)[] = [];
+        const done = Promise.withResolvers<void>();
+        const steps = [
+          () => fs.writeFileSync(path.join(target, "second.txt"), "2"),
+          () => fs.unlinkSync(path.join(target, "first.txt")),
+          () => fs.unlinkSync(path.join(target, "second.txt")),
+          () => fs.rmdirSync(target),
+          () => done.resolve(),
+        ];
+        const watcher = fs.watch(target + path.sep, { recursive }, (eventType, filename) => {
+          if (eventType !== "rename") return;
+          renames.push(filename);
+          try {
+            steps[renames.length - 1]?.();
+          } catch (err) {
+            done.reject(err);
+          }
+        });
+        watcher.once("error", done.reject);
+        try {
+          fs.writeFileSync(path.join(target, "first.txt"), "1");
+          await done.promise;
+          expect(renames).toEqual(["first.txt", "second.txt", "first.txt", "second.txt", "watched-dir"]);
+        } finally {
+          watcher.close();
+        }
+      },
+    );
   });
 
   // Past fs.inotify.max_queued_events the kernel drops events and queues one

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -635,23 +635,26 @@ describe("fs.watch", () => {
         using dir = tempDir("fs-watch-rmdir-self-win", { "watched-dir": {} });
         const target = path.join(String(dir), "watched-dir");
         const events: [string, string | null][] = [];
+        // The first watcher must not report an error at any point: it stays
+        // open, silent, until it is closed. Both waits race against this.
+        const failure = Promise.withResolvers<never>();
         const removed = Promise.withResolvers<void>();
         const watcher = fs.watch(target, { recursive }, (eventType, filename) => {
           events.push([eventType, filename]);
           removed.resolve();
         });
-        watcher.once("error", removed.reject);
+        watcher.once("error", failure.reject);
         let again: FSWatcher | undefined;
         try {
           fs.rmdirSync(target);
-          await removed.promise;
+          await Promise.race([removed.promise, failure.promise]);
 
           fs.mkdirSync(target);
           const seen = Promise.withResolvers<[string, string | null]>();
           again = fs.watch(target, { recursive }, (eventType, filename) => seen.resolve([eventType, filename]));
-          again.once("error", seen.reject);
+          again.once("error", failure.reject);
           fs.writeFileSync(path.join(target, "created-after.txt"), "x");
-          const [, filename] = await seen.promise;
+          const [, filename] = await Promise.race([seen.promise, failure.promise]);
           expect(filename).toBe("created-after.txt");
 
           expect(events).toEqual([["rename", "watched-dir"]]);


### PR DESCRIPTION
### Problem
- Windows: after the watched directory is removed, the listener gets `('rename', 'C:\\...\\dir')` about 500 times per second until the watcher is closed. libuv reports the removal under the directory's own path and re-arms the watch, which fails again on every loop iteration (nodejs/node#61398).
- All backends: the watches of one path share one OS watch, keyed by path. A watch whose directory was removed or moved away stayed in that map, so a later `fs.watch()` of the path joined it: nothing, or the moved directory's events. Node delivers the new directory's events.
- Windows reported the entries of a watch path that ends in a separator (a drive root, say) as `\name`. Node reports `name`.

### Fix
- `win_watcher.rs`: a rename whose name carries a volume is the removal report. No entry name does, `\name` included. The watch is stopped and taken out of the map, then one `('rename', basename)` is delivered. Entry names lose the `\`.
- `path_watcher.rs`: inotify takes a watch out of the map on `IN_DELETE_SELF` or `IN_MOVE_SELF` of its root (before the event is queued) and on `IN_IGNORED`, kqueue on `NOTE_DELETE | NOTE_RENAME | NOTE_REVOKE`. A failed Windows request (a watched file's directory removed) retires the watch before the `'error'` too. Handlers keep the old watch alive until they close, and its events are unchanged.
- libuv's own test consumes the report this way (it stops the handle in the callback). Node, where each watcher has its own OS watch, behaves this way in both cases.
- Verified: `fs.watch.test.ts` re-watches after a removal (Windows, Linux), a move (Linux) and a file watch's `'error'` (Windows), and checks the trailing separator (Windows). All fail on the canary and, on Linux, without `src/`. `test/js/node/watch/` and the node `test-fs-watch*` tests pass on both platforms.

### Background
- A `PathWatcher` owns one OS watch and is found through `PathWatcherManager.watchers`, keyed by path. Each `FSWatcher` on the path is one of its handlers.
- On Windows the OS watch is a `ReadDirectoryChangesW` request on a handle of the directory, which libuv renews after each callback unless the handle was stopped. A removed directory fails every request.
- inotify reports a removed watched inode as `IN_DELETE_SELF`, then retires the wd with `IN_IGNORED`. Both are reported as `rename`, as libuv does.

<details><summary>Notes</summary>

- Windows repro on the 1.4.0 canary (01c4e2f), Server 2019 x64 and Windows 11 arm64: an empty directory removed with `rmdirSync` gives 251 calls in 500 ms. Node 26.3.0 (libuv 1.52.1) gives 146k calls in 800 ms on the issue's repro.
- Linux repro, debug build of main: watch a directory, `rmdirSync` it (the watcher reports `rename` twice), `mkdirSync` it again, `fs.watch()` it again and write a file: the second watcher gets nothing, in both recursive modes and for a watched file that is unlinked and recreated. Node 26 reports `['rename', 'created-after.txt']`. With this branch the second watcher reports it too and the first watcher's events are unchanged.
- Why the volume: for a `dirw` that ends in `\`, libuv builds `dir\\name`, and `uv__relative_path` then yields `\name` for added and renamed-to entries (removed entries use the raw name). The first revision of this PR tested `is_absolute()`, which `\name` passes, so `fs.watch(dir + "\\")` ended the watch on the first new file (probe: canary delivers 4 events as `\first.txt`, `\second.txt`, that revision delivered 1, this one delivers 4 as `first.txt`, `second.txt`, like node). A drive letter or UNC prefix never occurs in an entry name. Removed entries never carried the `\`, which is why the trailing-separator test unlinks the files between the creations and the removal.
- Excluded: a directory symlink whose stored target is relative. `PathWatcher::init` hands libuv the `readlink()` result as stored, so the removal report carries no volume and this branch does not fire (it cannot misfire either). Probed: it can only be watched with the cwd set to the link's directory (ENOENT elsewhere), and removing the target then gives about 150 `rename:real` in 300 ms on the canary and on this branch alike. #39474 replaces the `readlink()` with `realpath()`, after which it is covered. Junctions store absolute targets and are covered now.
- Upstream libuv fixed the loop in libuv/libuv#5013 (not in a release as of 1.52.1): after the rename it reports `UV_ENOENT` when the handle points into `$Extend\$Deleted`, and node then emits `'error'` and closes. Not needed here: Bun stops the handle in the first callback, on any file system, and the result matches Linux instead of adding a Windows-only `'error'`. After a libuv bump the retired handle skips that check. libuv 1.52 reports the path with a `\\?\` prefix, which `windows_volume_name_len` accepts.
- The map is cleaned up when the OS reports that the root is gone, not checked when a watch joins. A join-time check would have to compare file identities, and `(st_dev, st_ino)` is not one across a removal: on this box's file system the recreated directory or file got the same inode number in 50 of 50 tries, so such a check would join the dead watch in exactly the case being fixed. Holding an fd per watch to compare live inodes would cost one fd per watched path.
- Not covered as a result: a `watch()` of the path issued before the OS report is processed. On Linux that is the straight-line `rmdirSync(); mkdirSync(); watch()` racing the reader thread, on Windows the same sequence within one tick always joins, since libuv delivers the report on the next loop iteration (before this PR it joined too, and got the loop's events). A directory replaced with `rename()` while an fd keeps the old one open is in the same position. Windows reports nothing for a watched directory that is moved away, so that case stays as it is there. macOS is unchanged: FSEvents watches the path, so the old watch sees the recreated directory and nothing is dead.
- The review's 4-cell probe (directory or file, removed or moved away, then recreated and watched again) reports the recreated path in every cell on this branch's Linux build, as node 26 does. On main, none of the four did.
- The `IN_DELETE_SELF | IN_MOVE_SELF` call exists next to the `IN_IGNORED` one because the kernel queues the two in one go but a `read()` can split them, and the listener of the first event may re-watch the path right away. `unlink_watcher_locked` is the call `detach` already makes, so the later `detach` is a no-op for the map.
- Recursive roots: Windows reports the basename, the inotify backend keeps reporting the empty root-relative name (`undefined`; node reports `""`), unchanged here.
- Child events queued but not yet delivered when the directory is removed are dropped by the OS. The issue's repro (a tree removed with `rmSync`) prints `change:d`, `rename:d` on this branch, where `rename:d` is this report (debug log `emit_unsuppressed(d, dir, rename)`).
- Other probes on the Windows x64 debug build: two watchers on one directory each get exactly one report and nothing more over 20 further loop turns, `encoding: "buffer"` gets the basename as a Buffer, a watch on a file whose file is unlinked still gets `('rename', 'file.txt')` through the ordinary path, a Worker that watches, removes, recreates and watches again gets one report each time, and a persistent watcher keeps the process alive after the removal until `close()`.
- Test runs: Linux debug build, `test/js/node/watch/` 65 pass, 13 platform skips, and the 42 `test-fs-watch*` / `test-fs-promises-watch*` files exit 0. Windows x64 debug build: 66 pass, 12 skips, and the same 42 files exit 0. `cargo check -p bun_runtime --target x86_64-unknown-freebsd` passes. The Windows `'error'` test fails on the canary because the watcher created in the listener gets the dead watch's next `EPERM`.
- Earlier revisions: the first one recognized the report with `is_absolute()` (see above) and only fixed Windows. The second retired removed roots only; moved roots and the Windows error path came out of the review of that revision. The Linux-only test "removing the watched directory delivers both rename self-events named after it" is folded into the new test, whose Linux expectation is the same two events.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/watch/fs.watch.test.ts

<!-- robobun:evidence:end -->