### PR TITLE
JUnit report and GitHub Actions annotation: print a frame source that is not a file path as-is

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6618,7 +6618,7 @@ impl VirtualMachine {
         if let Some(frame) = top_frame {
             if !frame.position.is_invalid() {
                 let source_url = frame.source_url.to_utf8();
-                let file = bun_paths::resolve_path::relative(dir, source_url.slice());
+                let file = crate::ZigStackFrame::relative_source_url(dir, source_url.slice());
                 let _ = write!(
                     writer,
                     "\n::error file={},line={},col={},title=",
@@ -6680,7 +6680,7 @@ impl VirtualMachine {
             };
             for frame in frames {
                 let source_url = frame.source_url.to_utf8();
-                let file = bun_paths::resolve_path::relative(dir, source_url.slice());
+                let file = crate::ZigStackFrame::relative_source_url(dir, source_url.slice());
                 let func = frame.function_name.to_utf8();
                 if file.is_empty() && func.slice().is_empty() {
                     continue;

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -75,6 +75,23 @@ impl ZigStackFrame {
         jsc_stack_frame_index: -1,
     };
 
+    /// The frame's source as a report that lists files relative to `dir` (the JUnit
+    /// reporter, the GitHub Actions annotation) prints it.
+    ///
+    /// Only an absolute path is made relative. A source URL that is not a path (a
+    /// `data:` or `blob:` URL, `node:fs`, the name from a `//# sourceURL=` comment)
+    /// is printed as-is, like [`SourceURLFormatter`] prints it. `relative` normalizes
+    /// its operands in fixed path buffers, so a source URL that is too long to be a
+    /// path is printed as-is too.
+    ///
+    /// The relative form lives in `relative`'s thread-local buffer until the next call.
+    pub fn relative_source_url<'a>(dir: &[u8], source_url: &'a [u8]) -> &'a [u8] {
+        if !bun_paths::is_absolute(source_url) || source_url.len() >= bun_paths::MAX_PATH_BYTES {
+            return source_url;
+        }
+        bun_paths::resolve_path::relative(dir, source_url)
+    }
+
     pub fn name_formatter(&self, enable_color: bool) -> NameFormatter {
         NameFormatter {
             function_name: self.function_name,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -383,7 +383,7 @@ impl JunitReporter {
         let dir = FileSystem::instance().top_level_dir;
         for frame in exception.stack.frames() {
             let source_url = frame.source_url.to_utf8();
-            let file = resolve_path::relative(dir, source_url.slice());
+            let file = jsc::ZigStackFrame::relative_source_url(dir, source_url.slice());
             let func = frame.function_name.to_utf8();
             if file.is_empty() && func.slice().is_empty() {
                 continue;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 
 describe("bun test", () => {
   test("running a non-existent absolute file path is a 1 exit code", () => {
@@ -718,6 +718,68 @@ describe("bun test", () => {
         },
       });
       expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
+    });
+    test("should annotate an error thrown from a source whose URL is longer than a path buffer", () => {
+      // Longer than a path buffer on every platform (98302 bytes on Windows).
+      const padding = 100_000;
+      const dataUrlModule = 'export default function fromDataUrl() { throw new Error("boom"); }//';
+      const base64 = btoa(dataUrlModule + Buffer.alloc(padding, "x").toString());
+      const longPath = "/" + Buffer.alloc(padding, "y").toString();
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("data url", async () => {
+            const source = ${JSON.stringify(dataUrlModule)} + Buffer.alloc(${padding}, "x").toString();
+            const m = await import("data:text/javascript;base64," + btoa(source));
+            m.default();
+          });
+          test("long sourceURL", () => {
+            const sourceURL = "/" + Buffer.alloc(${padding}, "y").toString();
+            (0, eval)("(function fromLongPath() { throw new Error('boom'); })\\n//# sourceURL=" + sourceURL)();
+          });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+        expectExitCode: 1,
+      });
+      const annotations = stderr.split("\n").filter(line => line.startsWith("::error"));
+      expect(annotations).toHaveLength(2);
+      const [dataUrl, longSourceUrl] = annotations;
+      expect(dataUrl).toStartWith(`::error file=data%3Atext/javascript;base64%2C${base64},line=1,col=`);
+      expect(dataUrl).toContain(`%0A      at fromDataUrl (data:text/javascript;base64,${base64}:1:`);
+      expect(longSourceUrl).toStartWith(`::error file=${longPath},line=1,col=`);
+      expect(longSourceUrl).toContain(`%0A      at fromLongPath (${longPath}:1:`);
+    });
+    test("should make the annotation file relative to GITHUB_WORKSPACE only when it is a path", () => {
+      const cwd = createTest([
+        {
+          filename: "workspace.test.ts",
+          contents: `
+            import { test } from "bun:test";
+            test("in the test file", () => {
+              throw new Error("boom");
+            });
+            test("in a sourceURL that is not a path", () => {
+              (0, eval)("(function fromSourceUrl() { throw new Error('boom'); })\\n//# sourceURL=webpack://app/./src/x.ts")();
+            });
+          `,
+        },
+      ]);
+      const stderr = runTest({
+        cwd,
+        env: {
+          GITHUB_ACTIONS: "true",
+          GITHUB_WORKSPACE: dirname(cwd),
+        },
+        expectExitCode: 1,
+      });
+      const annotations = stderr.split("\n").filter(line => line.startsWith("::error"));
+      expect(annotations).toHaveLength(2);
+      const [testFile, sourceUrl] = annotations;
+      expect(testFile).toStartWith(`::error file=${basename(cwd)}${sep}workspace.test.ts,line=4,col=`);
+      expect(sourceUrl).toStartWith("::error file=webpack%3A//app/./src/x.ts,line=1,col=");
+      expect(sourceUrl).toContain("%0A      at fromSourceUrl (webpack://app/./src/x.ts:1:");
     });
   });
   describe(".each", () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -105,6 +105,32 @@ test("throwing inside an error suppresses the error and prints the stack", async
   expect(exitCode).toBe(1);
 });
 
+test("uncaught error thrown from a data: URL module longer than a path buffer is annotated for GitHub Actions", async () => {
+  // Longer than a path buffer on every platform (98302 bytes on Windows).
+  const padding = 100_000;
+  const dataUrlModule = 'export default function fromDataUrl() { throw new Error("boom"); }//';
+  const base64 = btoa(dataUrlModule + Buffer.alloc(padding, "x").toString());
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const source = ${JSON.stringify(dataUrlModule)} + Buffer.alloc(${padding}, "x").toString();
+       const m = await import("data:text/javascript;base64," + btoa(source));
+       m.default();`,
+    ],
+    env: { ...bunEnv, GITHUB_ACTIONS: "true" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  const annotation = stderr.split("\n").find(line => line.startsWith("::error"));
+  expect(annotation).toStartWith(`::error file=data%3Atext/javascript;base64%2C${base64},line=1,col=`);
+  expect(annotation).toContain(`%0A      at fromDataUrl (data:text/javascript;base64,${base64}:1:`);
+  expect(exitCode).toBe(1);
+});
+
 test("throwing inside an error suppresses the error and continues printing properties on the object", async () => {
   $.throws(false);
   $.env(bunEnv);

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -554,6 +554,60 @@ describe("junit reporter", () => {
     expect(xmlContent).not.toMatch(/\[[\d;]*[A-HJKSTfm]/);
     expect(exitCode).toBe(1);
   });
+
+  it("prints a stack frame whose source is not a file path as-is in <failure>", async () => {
+    // Longer than a path buffer on every platform (98302 bytes on Windows).
+    const padding = 100_000;
+    const dataUrlModule = 'export default function fromDataUrl() { throw new Error("boom"); }//';
+    const dataUrl = "data:text/javascript;base64," + btoa(dataUrlModule + Buffer.alloc(padding, "x").toString());
+    const longPath = "/" + Buffer.alloc(padding, "y").toString();
+
+    await using tmpDir = tempDir("junit-source-url", {
+      "package.json": "{}",
+      "source-url.test.js": `
+        import { test } from "bun:test";
+        const thrower = (name, sourceURL) =>
+          (0, eval)("(function " + name + "() { throw new Error('boom'); })\\n//# sourceURL=" + sourceURL);
+        test("data url", async function dataUrlTest() {
+          const source = ${JSON.stringify(dataUrlModule)} + Buffer.alloc(${padding}, "x").toString();
+          const m = await import("data:text/javascript;base64," + btoa(source));
+          m.default();
+        });
+        test("sourceURL that is not a path", () => {
+          thrower("fromSourceUrl", "webpack://app/./src/x.ts")();
+        });
+        test("sourceURL longer than a path", () => {
+          thrower("fromLongPath", "/" + Buffer.alloc(${padding}, "y").toString())();
+        });
+        test("sourceURL that is a path", () => {
+          thrower("fromPath", import.meta.dir.replaceAll("\\\\", "/") + "/virtual/../generated.js")();
+        });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(1);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const [dataUrlCase, sourceUrlCase, longPathCase, pathCase] = result.testsuites.testsuite[0].testcase;
+
+    expect(dataUrlCase.failure[0]._).toContain(`at fromDataUrl (${dataUrl}:1:`);
+    // The frame in the test file itself is still relative to the cwd.
+    expect(dataUrlCase.failure[0]._).toContain("at dataUrlTest (source-url.test.js:");
+    expect(sourceUrlCase.failure[0]._).toContain("at fromSourceUrl (webpack://app/./src/x.ts:1:");
+    expect(longPathCase.failure[0]._).toContain(`at fromLongPath (${longPath}:1:`);
+    expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
+  });
 });
 
 function filterJunitXmlOutput(xmlContent) {


### PR DESCRIPTION
### Problem
- A frame in a long `data:` URL module aborts the JUnit reporter and the `GITHUB_ACTIONS` annotation: `panic: range end index 6103 out of range for slice of length 4096`. A long `//# sourceURL=` name does the same.
- Cause: `record_failure` (`src/runtime/cli/test_command.rs:386`) and `print_github_annotation` (`src/jsc/VirtualMachine.rs:6621`, `:6683`) call `resolve_path::relative` on the source URL of every frame. `relative` writes into fixed path buffers with no length check. A source URL is not always a path.
- The same call mangles a short URL: `webpack://app/./x.ts` prints as `webpack:/app/x.ts`.

### Fix
- `ZigStackFrame::relative_source_url` calls `relative` only for an absolute path shorter than `MAX_PATH_BYTES`, and returns any other source URL unchanged. The three sites use it.
- Correct because the reports relativize files. A file that bun loaded is an absolute path that fits a path buffer. Any other source URL has no relative form, and the plain error printer already prints it as-is. File paths print as before.
- `resolve_path.rs` is not changed. #39658, #38392 and #38696 each add a length-safe `relative` there.
- Verified: new tests in `test/js/junit-reporter/junit.test.js`, `test/cli/test/bun-test.test.ts` and `test/js/bun/test/stack.test.ts`. They fail on the released build. The three files pass in full.

### Background
- The `source_url` of a frame is what JSC recorded for its code. For a file module it is the absolute path. For a `data:` module it is the whole URL. For eval'd code it is the `//# sourceURL=` name.
- `resolve_path::relative(from, to)` normalizes both arguments into thread-local `PathBuffer`s and builds the `../` form in a third. It first joins a `to` that is not absolute onto the cwd.
- Both reports run from the error printer for every error bun prints, so plain `bun test` in GitHub Actions hits this too.

<details><summary>Notes</summary>

- Repro on the released 1.4.0 build (Linux): `throw.mjs` with `await import("data:text/javascript," + encodeURIComponent("throw new Error('boom');" + "//".padEnd(6000, "x")))`. `GITHUB_ACTIONS=true bun throw.mjs` prints `error: boom`, then panics with `range end index 6055`, exit 134. The same module imported from a test, run with `bun test --reporter=junit --reporter-outfile=out.xml`, panics with `range end index 6103` and writes no report. `GITHUB_ACTIONS=true bun test` on that test panics too. `//# sourceURL=/` followed by 100000 bytes panics with `range end index 100000 out of range for slice of length 4095` (the absolute branch of `relative`).
- The mangling: `relative` normalizes the URL (`//` to `/`, `.` segments dropped), joins it onto the cwd and relativizes it against `dir`. With `GITHUB_WORKSPACE` outside the cwd it also gets a `../` prefix. `test/js/bun/test/err-custom-fixture.js` shows the shape on an error object with an `http:` sourceURL: the released build prints `file=http%3A/example.com/test.js`, this change prints `file=http%3A//example.com/test.js`. A remapped frame whose sourcemap `sources` entry is a `webpack://` URL is the same case.
- The `file=` property for a non-path top frame keeps the content it has today for a short URL (`file=data%3Atext/javascript...`). Which frame the annotation points at is #38335. That PR edits the same header block, so one of the two gets a small textual conflict. The frame list of the annotation already printed the raw URL through `source_url_formatter`. It uses `file` only for the empty check and, on the dev server, as the prefix to strip.
- Not covered, on purpose: an absolute path a few bytes under `MAX_PATH_BYTES` can still overflow inside `relative` when the `../` chain for `dir` does not fit next to it. Every caller of `relative` has that defect (#38696 describes it) and #39658 and #38392 fix it. It needs a path within about `3 * depth(dir)` bytes of the limit. The length check here only turns the unbounded input (a URL or a `sourceURL` name of any length) away, and becomes redundant once one of those PRs lands.
- `print_error_instance_body` runs the JUnit `record_failure` callback and, under `GITHUB_ACTIONS`, `print_github_annotation` for every error bun prints. So `bun test` in GitHub Actions hits this without `--reporter=junit`, and so does `bun run`. The buffers are `MAX_PATH_BYTES` long: 4096 on Linux, 1024 on macOS, 98302 on Windows.
- #39824 is the sibling fix for the coverage report, which makes the same call on coverage entries. It does not touch these sites.
- Tests pad to 100000 bytes so that the crash cases also exceed the Windows buffer. The JUnit test also pins that a frame in the test file and an absolute `sourceURL` are still relativized. The `GITHUB_WORKSPACE` test pins that a test file is reported relative to the workspace and that a `webpack://` URL is not. On the released build the tests fail with exit 134 and with the mangled URL.
- Checked: `cargo fmt --all -- --check`, prettier on the three test files, `test/internal/source-lints`, `bun bd test` on `junit.test.js` (9 pass), `stack.test.ts` (7 pass, 1 todo) and `bun-test.test.ts` (97 pass, 6 todo). Clippy was not run locally.
</details>
