### PR TITLE
watcher: accept the real path spelling of the project root on Windows

### DIFF
--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -774,9 +774,6 @@ impl Watcher {
         self.is_in_top_level_dir(dir) && !strings::contains(dir, b"node_modules")
     }
 
-    /// Windows watches one directory tree, so this is also the eligibility
-    /// check for every path added; see `WindowsWatcher::real_root` for why the
-    /// root has two spellings there.
     #[cfg(windows)]
     fn is_in_top_level_dir(&self, path: &[u8]) -> bool {
         use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -523,8 +523,7 @@ impl Watcher {
         #[cfg(windows)]
         {
             // on windows we can only watch items that are in the directory tree of the top level dir
-            let rel = bun_paths::resolve_path::is_parent_or_equal(self.top_level_dir(), file_path);
-            if rel == bun_paths::resolve_path::ParentEqual::Unrelated {
+            if !self.is_in_top_level_dir(file_path) {
                 bun_core::warn!(
                     "File {} is not in the project directory and will not be watched\n",
                     bstr::BStr::new(file_path)
@@ -592,8 +591,7 @@ impl Watcher {
     ) -> sys::Result<WatchItemIndex> {
         #[cfg(windows)]
         {
-            let rel = bun_paths::resolve_path::is_parent_or_equal(self.top_level_dir(), file_path);
-            if rel == bun_paths::resolve_path::ParentEqual::Unrelated {
+            if !self.is_in_top_level_dir(file_path) {
                 bun_core::warn!(
                     "Directory {} is not in the project directory and will not be watched\n",
                     bstr::BStr::new(file_path)
@@ -773,12 +771,23 @@ impl Watcher {
 
     #[inline]
     fn is_eligible_directory(&self, dir: &[u8]) -> bool {
-        strings::contains(dir, self.top_level_dir()) && !strings::contains(dir, b"node_modules")
+        self.is_in_top_level_dir(dir) && !strings::contains(dir, b"node_modules")
     }
 
+    /// Windows watches one directory tree, so this is also the eligibility
+    /// check for every path added; see `WindowsWatcher::real_root` for why the
+    /// root has two spellings there.
+    #[cfg(windows)]
+    fn is_in_top_level_dir(&self, path: &[u8]) -> bool {
+        use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
+        let is_inside = |root: &[u8]| is_parent_or_equal(root, path) != ParentEqual::Unrelated;
+        is_inside(self.cwd) || self.platform.real_root.as_deref().is_some_and(is_inside)
+    }
+
+    #[cfg(not(windows))]
     #[inline]
-    fn top_level_dir(&self) -> &[u8] {
-        self.cwd
+    fn is_in_top_level_dir(&self, path: &[u8]) -> bool {
+        strings::contains(path, self.cwd)
     }
 
     pub fn add_directory<const CLONE_FILE_PATH: bool>(
@@ -959,9 +968,7 @@ impl Watcher {
         // We don't want to watch:
         // - Directories outside the root directory
         // - Directories inside node_modules
-        if !strings::contains(file_path, b"node_modules")
-            && strings::contains(file_path, self.top_level_dir())
-        {
+        if self.is_eligible_directory(file_path) {
             let _ = self.add_directory::<false>(dir_fd, file_path, Self::get_hash(file_path));
         }
     }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -20,8 +20,19 @@ pub(crate) type Platform = WindowsWatcher;
 pub struct WindowsWatcher {
     pub(crate) iocp: HANDLE,
     pub(crate) watcher: DirWatcher,
+    /// The root as given plus a trailing separator (`base_idx` bytes); each
+    /// event's root-relative name is appended after it to form the event path.
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
+    /// `realpath(root)` plus a trailing separator, when it spells the root
+    /// differently than `buf` does. `GetCurrentDirectoryW` returns the cwd in
+    /// whatever spelling the process was started with (8.3 short names, a
+    /// junction), while the entry point and every module resolved from it carry
+    /// the `GetFinalPathNameByHandle` spelling. Paths built from the cwd
+    /// (`bun build --watch` entries, the dev server) keep the given spelling, so
+    /// both spellings count as inside the root and both are matched against
+    /// events.
+    pub(crate) real_root: Option<Box<[u8]>>,
 }
 
 impl Default for WindowsWatcher {
@@ -35,6 +46,7 @@ impl Default for WindowsWatcher {
             },
             buf: PathBuffer::uninit(),
             base_idx: 0,
+            real_root: None,
         }
     }
 }
@@ -292,6 +304,15 @@ impl WindowsWatcher {
         } else {
             root.len()
         };
+        self.real_root = real_root_prefix(root, &self.buf[..self.base_idx]);
+        if let Some(real_root) = self.real_root.as_deref() {
+            bun_core::scoped_log!(
+                watcher,
+                "root {} also watched as {}",
+                bstr::BStr::new(&self.buf[..self.base_idx]),
+                bstr::BStr::new(real_root)
+            );
+        }
 
         // disarm the cleanup scopeguards on success
         scopeguard::ScopeGuard::into_inner(iocp_guard);
@@ -389,6 +410,29 @@ impl WindowsWatcher {
     }
 }
 
+/// See [`WindowsWatcher::real_root`]. `given_prefix` is `root` plus its
+/// trailing separator; `None` when `realpath` fails or spells the root the same
+/// way (differences in case only are already covered by the case-insensitive
+/// path comparisons).
+fn real_root_prefix(root: &[u8], given_prefix: &[u8]) -> Option<Box<[u8]>> {
+    let mut root_buf = bun_paths::path_buffer_pool::get();
+    let mut real_buf = bun_paths::path_buffer_pool::get();
+    let root_z = bun_paths::resolve_path::z(root, &mut root_buf);
+    let real = bun_sys::realpath(root_z, &mut real_buf).ok()?;
+    let mut prefix = Vec::with_capacity(real.len() + 1);
+    prefix.extend_from_slice(real);
+    if !real
+        .last()
+        .is_some_and(|&c| bun_paths::string_paths::char_is_any_slash(c))
+    {
+        prefix.push(b'\\');
+    }
+    if strings::eql_case_insensitive_ascii(&prefix, given_prefix, true) {
+        return None;
+    }
+    Some(prefix.into_boxed_slice())
+}
+
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum Timeout {
@@ -400,6 +444,8 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     // We re-borrow buf inside the inner loop instead of holding `&this.platform.buf`
     // across calls to `this.platform.next()`.
     let base_idx = this.platform.base_idx;
+    // The current event's path spelled under `real_root`; empty while there is none.
+    let mut real_eventpath: Vec<u8> = Vec::new();
 
     let mut event_id: usize = 0;
 
@@ -427,6 +473,11 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             let convert_res =
                 strings::copy_utf16_into_utf8(&mut this.platform.buf[base_idx..], filename);
             let eventpath_len = base_idx + convert_res.written as usize;
+            if let Some(real_root) = this.platform.real_root.as_deref() {
+                real_eventpath.clear();
+                real_eventpath.extend_from_slice(real_root);
+                real_eventpath.extend_from_slice(&this.platform.buf[base_idx..eventpath_len]);
+            }
 
             bun_core::scoped_log!(
                 watcher,
@@ -452,7 +503,10 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 let rel = {
                     let eventpath = &this.platform.buf[..eventpath_len];
                     let path = &this.watchlist.items_file_path()[item_idx];
-                    let rel = is_parent_or_equal(path.as_ref(), eventpath);
+                    let mut rel = is_parent_or_equal(path.as_ref(), eventpath);
+                    if rel == ParentEqual::Unrelated && !real_eventpath.is_empty() {
+                        rel = is_parent_or_equal(path.as_ref(), &real_eventpath);
+                    }
                     bun_core::scoped_log!(
                         watcher,
                         "checking path: {} = .{}",

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -22,9 +22,7 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
-    /// `realpath(root)` plus a separator, if it differs from the root in `buf`.
-    /// The cwd keeps the spelling it was started with (8.3 names, junctions) and
-    /// watched paths come in both spellings, so both are roots.
+    /// Paths come in the cwd's spelling (8.3 names, junctions) or the real one, so both are roots.
     pub(crate) real_root: Option<Box<[u8]>>,
 }
 

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -20,18 +20,11 @@ pub(crate) type Platform = WindowsWatcher;
 pub struct WindowsWatcher {
     pub(crate) iocp: HANDLE,
     pub(crate) watcher: DirWatcher,
-    /// The root as given plus a trailing separator (`base_idx` bytes); each
-    /// event's root-relative name is appended after it to form the event path.
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
-    /// `realpath(root)` plus a trailing separator, when it spells the root
-    /// differently than `buf` does. `GetCurrentDirectoryW` returns the cwd in
-    /// whatever spelling the process was started with (8.3 short names, a
-    /// junction), while the entry point and every module resolved from it carry
-    /// the `GetFinalPathNameByHandle` spelling. Paths built from the cwd
-    /// (`bun build --watch` entries, the dev server) keep the given spelling, so
-    /// both spellings count as inside the root and both are matched against
-    /// events.
+    /// `realpath(root)` plus a separator, if it differs from the root in `buf`.
+    /// The cwd keeps the spelling it was started with (8.3 names, junctions) and
+    /// watched paths come in both spellings, so both are roots.
     pub(crate) real_root: Option<Box<[u8]>>,
 }
 
@@ -410,10 +403,7 @@ impl WindowsWatcher {
     }
 }
 
-/// See [`WindowsWatcher::real_root`]. `given_prefix` is `root` plus its
-/// trailing separator; `None` when `realpath` fails or spells the root the same
-/// way (differences in case only are already covered by the case-insensitive
-/// path comparisons).
+/// See [`WindowsWatcher::real_root`]. `given_prefix` is `root` plus a separator.
 fn real_root_prefix(root: &[u8], given_prefix: &[u8]) -> Option<Box<[u8]>> {
     let mut root_buf = bun_paths::path_buffer_pool::get();
     let mut real_buf = bun_paths::path_buffer_pool::get();
@@ -427,6 +417,7 @@ fn real_root_prefix(root: &[u8], given_prefix: &[u8]) -> Option<Box<[u8]>> {
     {
         prefix.push(b'\\');
     }
+    // Case-insensitive like the path matching, so a case difference needs no second root.
     if strings::eql_case_insensitive_ascii(&prefix, given_prefix, true) {
         return None;
     }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -401,12 +401,18 @@ impl WindowsWatcher {
     }
 }
 
-/// See [`WindowsWatcher::real_root`]. `given_prefix` is `root` plus a separator.
+/// See [`WindowsWatcher::real_root`]. A root that cannot be resolved is watched as given, as before.
 fn real_root_prefix(root: &[u8], given_prefix: &[u8]) -> Option<Box<[u8]>> {
     let mut root_buf = bun_paths::path_buffer_pool::get();
     let mut real_buf = bun_paths::path_buffer_pool::get();
     let root_z = bun_paths::resolve_path::z(root, &mut root_buf);
-    let real = bun_sys::realpath(root_z, &mut real_buf).ok()?;
+    let real = match bun_sys::realpath(root_z, &mut real_buf) {
+        Ok(real) => real,
+        Err(err) => {
+            bun_core::scoped_log!(watcher, "realpath of the watched root failed: {}", err);
+            return None;
+        }
+    };
     let mut prefix = Vec::with_capacity(real.len() + 1);
     prefix.extend_from_slice(real);
     if !real

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -781,8 +781,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
 // names, a junction), while the entrypoint and the modules imported from it get
 // their real path. The watcher is rooted at the cwd and compared the two as
 // strings, so every module was reported as outside the project and nothing
-// reloaded. A module resolved against the cwd (here the preload) keeps the
-// cwd's spelling, so both spellings have to be watched at the same time.
+// reloaded. With an 8.3 cwd, a module resolved against the cwd (here the
+// preload) keeps the cwd's spelling, so both spellings have to be watched at
+// the same time.
 describe.concurrent.skipIf(!isWindows)("--hot when the cwd is spelled differently from the project's real path", () => {
   const warning = "is not in the project directory";
   const projectFiles = {
@@ -836,8 +837,9 @@ describe.concurrent.skipIf(!isWindows)("--hot when the cwd is spelled differentl
 
   // The entrypoint is passed by its real path so that the test does not depend
   // on how a relative entrypoint is resolved; the preload is resolved against
-  // the cwd. Editing either file has to reload.
-  async function expectReloadsFrom(cwd: string, project: string, preload: string | ReturnType<typeof expect.any>) {
+  // the cwd. `preload` is the path the preload ends up with. Editing either
+  // file has to reload.
+  async function expectReloadsFrom(cwd: string, project: string, preload: string) {
     await using runner = spawn({
       cmd: [bunExe(), "--hot", "--preload", "./preload.js", join(project, "entry.js")],
       cwd,
@@ -850,20 +852,20 @@ describe.concurrent.skipIf(!isWindows)("--hot when the cwd is spelled differentl
     // Without the fix the watcher prints this for every module and never
     // reloads; failing on the warning is faster and clearer than a timeout.
     let stderr = "";
-    const { promise: warned, reject: failOnWarning } = Promise.withResolvers<never>();
-    warned.catch(() => {});
+    const { promise: failed, reject: fail } = Promise.withResolvers<never>();
+    failed.catch(() => {});
     (async () => {
       const decoder = new TextDecoder();
       for await (const chunk of runner.stderr) {
         stderr += decoder.decode(chunk, { stream: true });
-        if (stderr.includes(warning)) failOnWarning(new Error(`--hot refused to watch the project:\n${stderr}`));
+        if (stderr.includes(warning)) fail(new Error(`--hot refused to watch the project:\n${stderr}`));
       }
-    })();
+    })().catch(fail);
 
     const lines = forEachLine(runner.stdout);
     async function nextLoad(matches: (load: Load) => boolean): Promise<Load> {
       while (true) {
-        const { value, done } = await Promise.race([lines.next(), warned]);
+        const { value, done } = await Promise.race([lines.next(), failed]);
         if (done) throw new Error(`--hot exited with ${runner.exitCode} before reloading. stderr:\n${stderr}`);
         const load: Load = JSON.parse(value);
         if (matches(load)) return load;
@@ -883,20 +885,30 @@ describe.concurrent.skipIf(!isWindows)("--hot when the cwd is spelled differentl
     expect(afterDepEdit.loads).toBeGreaterThan(afterPreloadEdit.loads);
   }
 
-  it.skipIf(!hasShortNames)("reloads when the cwd uses 8.3 short names", async () => {
-    using project = tempDir("hot-short-cwd", projectFiles);
-    const cwd = shortPath(String(project));
-    expect(cwd.toLowerCase()).not.toBe(String(project).toLowerCase());
+  it.skipIf(!hasShortNames)(
+    "reloads when the cwd uses 8.3 short names",
+    async () => {
+      using project = tempDir("hot-short-cwd", projectFiles);
+      const cwd = shortPath(String(project));
+      expect(cwd.toLowerCase()).not.toBe(String(project).toLowerCase());
 
-    await expectReloadsFrom(cwd, String(project), join(cwd, "preload.js"));
-  });
+      await expectReloadsFrom(cwd, String(project), join(cwd, "preload.js"));
+    },
+    timeout,
+  );
 
-  it("reloads when the cwd is a junction to the project", async () => {
-    using project = tempDir("hot-junction-target", projectFiles);
-    using linkParent = tempDir("hot-junction-cwd", {});
-    const cwd = join(String(linkParent), "project");
-    symlinkSync(String(project), cwd, "junction");
+  it(
+    "reloads when the cwd is a junction to the project",
+    async () => {
+      using project = tempDir("hot-junction-target", projectFiles);
+      using linkParent = tempDir("hot-junction-cwd", {});
+      const cwd = join(String(linkParent), "project");
+      symlinkSync(String(project), cwd, "junction");
 
-    await expectReloadsFrom(cwd, String(project), expect.any(String));
-  });
+      // The resolver follows the junction, so here even the preload gets its real
+      // path and nothing is spelled like the cwd.
+      await expectReloadsFrom(cwd, String(project), join(String(project), "preload.js"));
+    },
+    timeout,
+  );
 });

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, forEachLine, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -776,3 +776,127 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+// On Windows the cwd keeps the spelling the process was started with (8.3 short
+// names, a junction), while the entrypoint and the modules imported from it get
+// their real path. The watcher is rooted at the cwd and compared the two as
+// strings, so every module was reported as outside the project and nothing
+// reloaded. A module resolved against the cwd (here the preload) keeps the
+// cwd's spelling, so both spellings have to be watched at the same time.
+describe.concurrent.skipIf(!isWindows)("--hot when the cwd is spelled differently from the project's real path", () => {
+  const warning = "is not in the project directory";
+  const projectFiles = {
+    "entry.js": `
+      import { dep } from "./dep.js";
+      globalThis.loads = (globalThis.loads ?? 0) + 1;
+      console.log(
+        JSON.stringify({
+          loads: globalThis.loads,
+          dep,
+          cwd: process.cwd(),
+          entryDir: import.meta.dir,
+          preload: globalThis.preloadPath,
+        }),
+      );
+    `,
+    "dep.js": `export const dep = 0;`,
+    "preload.js": `globalThis.preloadPath = import.meta.path;`,
+  };
+  interface Load {
+    loads: number;
+    dep: number;
+    cwd: string;
+    entryDir: string;
+    preload: string;
+  }
+
+  /** The 8.3 spelling of `path` (`C:\\Users\\AZUREU~1\\...`), as far as the volume has short names for it. */
+  function shortPath(path: string): string {
+    using dir = tempDir("hot-short-path", {
+      "short.cmd": `@echo off\r\nfor %%I in ("${path}") do echo %%~sI\r\n`,
+    });
+    const { stdout, exitCode } = Bun.spawnSync({
+      cmd: ["cmd.exe", "/d", "/c", join(String(dir), "short.cmd")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    if (exitCode !== 0) throw new Error(`cmd.exe exited with ${exitCode}`);
+    return stdout.toString().trim();
+  }
+
+  // 8.3 name generation can be turned off per volume (fsutil 8dot3name), in
+  // which case there is no second spelling of the directory to start from.
+  const hasShortNames =
+    isWindows &&
+    (() => {
+      using dir = tempDir("hot-short-names-probe", {});
+      return shortPath(String(dir)).toLowerCase() !== String(dir).toLowerCase();
+    })();
+
+  // The entrypoint is passed by its real path so that the test does not depend
+  // on how a relative entrypoint is resolved; the preload is resolved against
+  // the cwd. Editing either file has to reload.
+  async function expectReloadsFrom(cwd: string, project: string, preload: string | ReturnType<typeof expect.any>) {
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "--preload", "./preload.js", join(project, "entry.js")],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    // Without the fix the watcher prints this for every module and never
+    // reloads; failing on the warning is faster and clearer than a timeout.
+    let stderr = "";
+    const { promise: warned, reject: failOnWarning } = Promise.withResolvers<never>();
+    warned.catch(() => {});
+    (async () => {
+      const decoder = new TextDecoder();
+      for await (const chunk of runner.stderr) {
+        stderr += decoder.decode(chunk, { stream: true });
+        if (stderr.includes(warning)) failOnWarning(new Error(`--hot refused to watch the project:\n${stderr}`));
+      }
+    })();
+
+    const lines = forEachLine(runner.stdout);
+    async function nextLoad(matches: (load: Load) => boolean): Promise<Load> {
+      while (true) {
+        const { value, done } = await Promise.race([lines.next(), warned]);
+        if (done) throw new Error(`--hot exited with ${runner.exitCode} before reloading. stderr:\n${stderr}`);
+        const load: Load = JSON.parse(value);
+        if (matches(load)) return load;
+      }
+    }
+
+    const initial = await nextLoad(() => true);
+    expect(initial).toEqual({ loads: 1, dep: 0, cwd, entryDir: project, preload });
+
+    writeFileSync(join(project, "preload.js"), projectFiles["preload.js"] + "\n");
+    const afterPreloadEdit = await nextLoad(load => load.loads > initial.loads);
+    expect(afterPreloadEdit).toEqual({ ...initial, loads: afterPreloadEdit.loads });
+
+    writeFileSync(join(project, "dep.js"), `export const dep = 1;`);
+    const afterDepEdit = await nextLoad(load => load.dep === 1);
+    expect(afterDepEdit).toEqual({ ...initial, loads: afterDepEdit.loads, dep: 1 });
+    expect(afterDepEdit.loads).toBeGreaterThan(afterPreloadEdit.loads);
+  }
+
+  it.skipIf(!hasShortNames)("reloads when the cwd uses 8.3 short names", async () => {
+    using project = tempDir("hot-short-cwd", projectFiles);
+    const cwd = shortPath(String(project));
+    expect(cwd.toLowerCase()).not.toBe(String(project).toLowerCase());
+
+    await expectReloadsFrom(cwd, String(project), join(cwd, "preload.js"));
+  });
+
+  it("reloads when the cwd is a junction to the project", async () => {
+    using project = tempDir("hot-junction-target", projectFiles);
+    using linkParent = tempDir("hot-junction-cwd", {});
+    const cwd = join(String(linkParent), "project");
+    symlinkSync(String(project), cwd, "junction");
+
+    await expectReloadsFrom(cwd, String(project), expect.any(String));
+  });
+});


### PR DESCRIPTION
**Sequencing note.** #35596 (one watch root per package, reviewed as ready on 2026-08-13) replaces the code this PR changes and makes these files reload too, by opening a second root on the project directory. This PR is the small fix for as long as #35596 has not landed. Once it lands, this PR becomes a root dedupe plus the two tests on top of it. The two findings for #35596 are posted there.

### Problem
- On Windows, `bun --hot` (also `--watch` and the dev server) watches nothing when the cwd is spelled with an 8.3 short name (`C:\Users\AZUREU~1\...`, a common `%TEMP%`) or through a junction. Every module prints `warn: File <path> is not in the project directory and will not be watched`. Nothing reloads.
- The cwd keeps the spelling the parent passed. The entry point and its imports get the real spelling (`run_command.rs:2769`). The watcher compares the two as strings (`Watcher.rs:526`) and builds event paths from the cwd spelling (`WindowsWatcher.rs:455`).

### Fix
- `WindowsWatcher::init` also stores `realpath(root)` when it differs. A path is inside the root when it is under either spelling. Events are matched under both.
- The real path cannot replace the root. A module resolved against the cwd (a preload, `bun build --watch` entries) keeps the cwd spelling. With an 8.3 cwd both spellings exist in one process (Notes).
- A canonical cwd gives `real_root == None`, and the old code runs. POSIX is unchanged.
- Verified: `test/cli/hot/hot.test.ts`, two Windows-only tests (8.3 cwd, junction cwd). The canary fails both with the warning above. The debug build passes 10 of 10 runs. Other suites: Notes.

### Background
- The Windows watcher is one recursive `ReadDirectoryChangesW` on the project root. Records name paths relative to the root. The watcher prefixes them with the root and matches watchlist entries by prefix, so a file outside the root is rejected on insert with the warning.
- An NTFS directory has several spellings: the long name, the 8.3 name, and every junction or symlink to it. `realpath` returns the canonical one.
- A watchlist entry has to keep the module graph's spelling. The hot reloader finds the module by path hash. So the watcher accepts both spellings instead of normalizing entries.

<details><summary>Notes</summary>

Repro on Windows x64 with `bun 1.4.0-canary.1+01c4e2fd6`: `entry.js` imports `dep.js`, started as `bun --hot --preload ./preload.js entry.js` from the 8.3 spelling of the project directory. The entry reports both spellings in one process:

```
cwd=C:\Users\AZUREU~1\AppData\Local\Temp\HOT-CW~2
entry_dir=C:\Users\azureuser\AppData\Local\Temp\hot-cwd-repro-short-2348-long-directory-name
preload=C:\Users\AZUREU~1\AppData\Local\Temp\HOT-CW~2\preload.js
```

Editing `preload.js` (cwd spelling) reloads. Editing `dep.js` (real spelling) prints `warn: File ...\dep.js is not in the project directory and will not be watched` and never reloads. Started through a junction instead, the resolver follows the reparse point, so every module has the real spelling and nothing reloads. The warning also repeats on every event loop turn, because `add_main_to_watcher_if_needed` retries the entry point. With this branch both edits reload in both setups and no warning is printed.

The cwd spelling comes from `GetCurrentDirectoryW`. POSIX has no equivalent problem: `getcwd` returns the physical path. The real spelling comes from `GetFinalPathNameByHandle` (`get_fd_path` on the entry point, the resolver for reparse points). The comparison is `is_parent_or_equal`, a case-insensitive prefix compare, so a difference in case only needs no second spelling and `real_root` stays `None` then. `Watcher::is_in_top_level_dir` holds the rule. On Windows it also replaces the `contains` check of the two directory filters, so directories follow the same rule as files. On POSIX it is the old `contains` check. The root is canonicalized with `bun_sys::realpath` by path rather than through the directory handle, so it does not rely on `get_fd_path`. The extra cost is one `realpath` when a watcher starts.

Each test edits the cwd-resolved preload and the entry-resolved module. The tests pass the entry point by its real path, so they do not depend on how a relative entry point is resolved (#38365 changes that). The 8.3 test skips itself on volumes with 8.3 name generation turned off.

Suites run with the debug build: on Windows `test/cli/hot/*.test.ts`, `test/cli/watch/*.test.ts`, `test/regression/issue/29524.test.ts`, `test/js/bun/resolve/bun-main-entry-point.test.ts`, `test/bake/dev/hot.test.ts`. On Linux `test/cli/hot/*.test.ts`, `test/cli/watch/watch.test.ts`, `test/regression/issue/29524.test.ts`. `cargo fmt --check`, prettier and `test/internal/source-lints` pass. Clippy on the Windows target reports the same pre-existing stack-size warnings for `WindowsWatcher::default` and `Watcher::init` before and after this change.

Related, not the same bug: #35596 adds extra `ReadDirectoryChangesW` roots for files that really are outside the project. For this bug it would open a second root on the project directory itself. #39820 restructures the matching loop in `watch_loop_cycle` for a different bug. Whichever of the two lands second needs a small rebase.

Demand: there is no issue for this exact case. Users hit the same warning text as #9547, so reports would land there. Aliased cwds of this kind show up in #39357 (junction onto another drive) and #20568 (`subst`) for `bun install`. This case came up while a `--hot` test was started from `os.tmpdir()`, which is the 8.3 spelling on many machines.

Self-review outcome: the fix is correct and the tests are durable, but the ~45 non-test lines live in the single-root structure that #35596 removes and that #39820 also rewrites. Hence the sequencing note above.
</details>
