### PR TITLE
Update the jsc class skill for BUN_SUBSPACE_SLOTS and lint IsoSubspace construction

### DIFF
--- a/.claude/skills/implementing-jsc-classes-cpp/SKILL.md
+++ b/.claude/skills/implementing-jsc-classes-cpp/SKILL.md
@@ -28,13 +28,11 @@ static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm) {
     if constexpr (mode == JSC::SubspaceAccess::Concurrently)
         return nullptr;
     return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
-        vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMyClassT.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMyClassT = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMyClassT.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMyClassT = std::forward<decltype(space)>(space); });
+        vm, BUN_SUBSPACE_SLOTS(m_clientSubspaceForMyClassT, m_subspaceForMyClassT));
 }
 ```
+
+`subspaceForImpl` only reads the slots inline. The subspaces themselves are created by `subspaceForImplSlow` in `src/jsc/bindings/BunClientData.cpp`, which is the only place that constructs an `IsoSubspace` (`test/internal/source-lints/iso-subspace-creation.test.ts` checks this).
 
 ## Property Definitions
 

--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -13,8 +13,10 @@ on:
     branches: [main]
     paths:
       - "src/**/*.rs"
+      - "src/**/*.h"
+      - "src/**/*.cpp"
       - "src/**/*.classes.ts"
-      - "src/codegen/class-definitions.ts"
+      - "src/codegen/**"
       - "src/js/builtins.d.ts"
       - "src/jsc/bindings/**"
       - "packages/bun-types/redis.d.ts"
@@ -34,8 +36,10 @@ on:
   pull_request:
     paths:
       - "src/**/*.rs"
+      - "src/**/*.h"
+      - "src/**/*.cpp"
       - "src/**/*.classes.ts"
-      - "src/codegen/class-definitions.ts"
+      - "src/codegen/**"
       - "src/js/builtins.d.ts"
       - "src/jsc/bindings/**"
       - "packages/bun-types/redis.d.ts"

--- a/test/internal/source-lints/iso-subspace-creation.test.ts
+++ b/test/internal/source-lints/iso-subspace-creation.test.ts
@@ -1,0 +1,67 @@
+import { Glob } from "bun";
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Every JS class with C++ fields has a subspaceFor<T>() that JSC calls on each
+// allocation of T. Creating the IsoSubspace behind it (lock the heap, build it,
+// register it, build the per-VM GCClient::IsoSubspace, fill both slots) is about
+// 640 bytes of code that runs once per type. Until #39770 that creation path
+// lived in the ALWAYS_INLINE WebCore::subspaceForImpl template, so the binary
+// carried one copy of it per class; taking them out of line saved about 160 KB
+// of the stripped linux-x64 binary.
+//
+// It now lives in exactly one out-of-line function, subspaceForImplSlow in
+// BunClientData.cpp (the file that also constructs the two subspaces JSHeapData
+// owns eagerly). subspaceForImpl<T> passes it a per-type constant table and the
+// two slot offsets from BUN_SUBSPACE_SLOTS. A new class needs a slot in
+// DOMIsoSubspaces.h and DOMClientIsoSubspaces.h and a subspaceFor that calls
+// WebCore::subspaceForImpl; it never constructs an IsoSubspace itself.
+const creationSite = "src/jsc/bindings/BunClientData.cpp";
+
+const constructsIsoSubspace =
+  /\bISO_SUBSPACE_INIT(?:_WITH_NAME)?\b|\b(?:makeUnique|makeUniqueWithoutFastMallocCheck|make_unique)\s*<\s*(?:JSC::)?(?:GCClient::)?IsoSubspace\s*>|\bnew\s+(?:JSC::)?(?:GCClient::)?IsoSubspace\b/;
+
+function linesConstructingIsoSubspace(source: string): number[] {
+  if (!constructsIsoSubspace.test(source)) return [];
+  const lines: number[] = [];
+  source.split("\n").forEach((line, index) => {
+    const commentStart = line.indexOf("//");
+    const code = commentStart === -1 ? line : line.slice(0, commentStart);
+    if (constructsIsoSubspace.test(code)) lines.push(index + 1);
+  });
+  return lines;
+}
+
+test("IsoSubspaces are only constructed in BunClientData.cpp", async () => {
+  const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+  const src = path.join(repoRoot, "src");
+
+  // The codegen templates are included because anything they emit is repeated
+  // once per generated class.
+  const globs = [new Glob("**/*.{h,cpp}"), new Glob("codegen/**/*.ts")];
+  const violations: string[] = [];
+  let scanned = 0;
+  let linesInCreationSite = 0;
+
+  for (const glob of globs) {
+    for await (const rel of glob.scan({ cwd: src })) {
+      scanned++;
+      const relFromRepo = path.join("src", rel).replaceAll("\\", "/");
+      const lines = linesConstructingIsoSubspace(readFileSync(path.join(src, rel), "utf8"));
+      if (relFromRepo === creationSite) {
+        linesInCreationSite = lines.length;
+        continue;
+      }
+      for (const line of lines) violations.push(`${relFromRepo}:${line}`);
+    }
+  }
+
+  // Guards against the scan passing vacuously: the globs must have found the
+  // tree, and the one permitted file must still be where the creation lives.
+  expect(scanned).toBeGreaterThan(1000);
+  expect(linesInCreationSite).toBeGreaterThan(0);
+
+  violations.sort();
+  expect(violations).toEqual([]);
+});


### PR DESCRIPTION
Follow-up to #39770, which moved the IsoSubspace creation path out of `WebCore::subspaceForImpl` into one out-of-line `subspaceForImplSlow`. #39503 did the same thing and is closed as superseded. These are the two pieces of it that still apply.

### Problem
- `.claude/skills/implementing-jsc-classes-cpp/SKILL.md:30-35` still shows the four-lambda `subspaceForImpl` call. That signature no longer exists, so the snippet does not compile when copied.
- Nothing stops a new class, or a codegen template, from constructing its own `IsoSubspace` again. The compiler does not enforce that invariant, and a template that does it pays for it once per generated class.

### Fix
- The skill snippet now shows the `BUN_SUBSPACE_SLOTS` form that every caller on main uses (for example `src/jsc/bindings/AsyncContextFrame.h:39`), and says where the subspaces are created.
- `test/internal/source-lints/iso-subspace-creation.test.ts` scans `src/**/*.{h,cpp}` and `src/codegen/**/*.ts` for `ISO_SUBSPACE_INIT`, `makeUnique<IsoSubspace>` or `new IsoSubspace` outside `src/jsc/bindings/BunClientData.cpp`. It also asserts that file still constructs one, so the lint cannot pass on an empty scan.
- `source-lints.yml` now also triggers on `src/**/*.h`, `src/**/*.cpp` and `src/codegen/**`, the files this lint reads (the README in that directory asks for this). `src/codegen/**` replaces the narrower `src/codegen/class-definitions.ts` entry.
- Verified: the lint passes on main (`bun bd test` and the released bun). It fails on the tree before #39770, listing the four constructions in `BunClientData.h`, and it fails when a construction is added to a header or to `generate-jssink.ts`, naming the file and line.

### Background
- Every JS class with C++ fields has a `subspaceFor<T>` hook that JSC calls on each allocation of `T`. The creation of the subspace behind it (lock, construct, register, fill the two slots) is about 640 bytes of code and runs once per type. Inlined per class it cost about 160 KB of the linux-x64 binary, which is what #39770 removed.
- `test/internal/source-lints/` holds grep-style lints over `src/`. They run on GitHub Actions against a released bun and are excluded from the Buildkite shards, so they only run on PRs that touch the paths listed in the workflow.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/source-lints/iso-subspace-creation.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/source-lints/iso-subspace-creation.test.ts
bun test v1.4.0 (6e906e468)

test/internal/source-lints/iso-subspace-creation.test.ts:
(pass) IsoSubspaces are only constructed in BunClientData.cpp [1035.72ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [4.46s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../skills/implementing-jsc-classes-cpp/SKILL.md   |  8 +--
 .github/workflows/source-lints.yml                 |  8 ++-
 .../source-lints/iso-subspace-creation.test.ts     | 67 ++++++++++++++++++++++
 3 files changed, 76 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
.claude/skills/implementing-jsc-classes-cpp/SKILL.md          2      2      0
.github/workflows/source-lints.yml                            1      1      0
test/internal/source-lints/iso-subspace-creation.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->