### PR TITLE
watcher: close the handle of an evicted watchlist entry on Windows

### DIFF
--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -420,13 +420,13 @@ impl Watcher {
                 continue;
             }
 
-            #[cfg(not(windows))]
-            {
-                // on mac and linux we can just close the file descriptor
-                // we don't need to call inotify_rm_watch on linux because it gets removed when the file descriptor is closed
-                if fds[item as usize].is_valid() {
-                    let _ = bun_sys::close(fds[item as usize]);
-                }
+            // The watchlist owns the stored descriptor on every platform
+            // (`FdOwnership::Watcher`); shutdown closes the same column. Closing
+            // it is also what drops the kqueue registration. inotify and
+            // ReadDirectoryChangesW watch by path, so there is nothing else to
+            // unregister here.
+            if fds[item as usize].is_valid() {
+                let _ = bun_sys::close(fds[item as usize]);
             }
             last_item = item;
         }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -420,11 +420,7 @@ impl Watcher {
                 continue;
             }
 
-            // The watchlist owns the stored descriptor on every platform
-            // (`FdOwnership::Watcher`); shutdown closes the same column. Closing
-            // it is also what drops the kqueue registration. inotify and
-            // ReadDirectoryChangesW watch by path, so there is nothing else to
-            // unregister here.
+            // The watchlist owns the stored descriptor (`FdOwnership::Watcher`).
             if fds[item as usize].is_valid() {
                 let _ = bun_sys::close(fds[item as usize]);
             }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -420,7 +420,7 @@ impl Watcher {
                 continue;
             }
 
-            // The watchlist owns the stored descriptor (`FdOwnership::Watcher`).
+            // Same rule as the shutdown sweep: a stored descriptor goes with its entry.
             if fds[item as usize].is_valid() {
                 let _ = bun_sys::close(fds[item as usize]);
             }

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -256,22 +256,32 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
   // directory event busts the resolver's directory cache, which abandons the
   // directory handle the busted entry holds. So both phases below run the same
   // reloads and directory events per cycle and differ only in whether the
-  // deleted file is watched. The eviction phase's extra growth is what the
-  // evictions leak.
+  // deleted files are watched, and each cycle evicts `files` entries, so the
+  // leak is `files` handles per cycle while anything else a cycle can differ
+  // by (an extra reload) is one or two.
   test.skipIf(!isWindows)("evicting watchlist entries closes their handles", async () => {
-    const cycles = 16;
+    const files = 16;
+    const cycles = 6;
+    const indexes = Array.from({ length: files }, (_, i) => i);
     await using dir = tempDir("hot-evict-handles", {
       "entry.js": `
         import { existsSync } from "node:fs";
-        import { loadDep, seq } from "./trigger.js";
+        import { loadDeps, seq } from "./trigger.js";
         // GC helper threads are handles too. Create them before the first sample.
         Bun.gc(true);
-        const dep = loadDep ? require("./dep.js").value : existsSync("dep.js") ? "skipped" : "deleted";
-        console.log("RELOAD", seq, dep);
+        let deps = "skipped";
+        if (loadDeps) {
+          let sum = 0;
+          for (let i = 0; i < ${files}; i++) sum += require("./dep" + i + ".js").value;
+          deps = sum;
+        } else if (!existsSync("dep0.js")) {
+          deps = "deleted";
+        }
+        console.log("RELOAD", seq, deps);
       `,
-      "trigger.js": `export const seq = 0; export const loadDep = true;`,
-      "dep.js": `export const value = 0;`,
-      "other.js": `export const value = 0;`,
+      "trigger.js": `export const seq = 0; export const loadDeps = true;`,
+      ...Object.fromEntries(indexes.map(i => [`dep${i}.js`, `export const value = 0;`])),
+      ...Object.fromEntries(indexes.map(i => [`other${i}.js`, `export const value = 0;`])),
     });
     const root = String(dir);
 
@@ -312,47 +322,46 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
       }
     };
     let seq = 0;
-    const reloadWith = async (loadDep: boolean, expectedDep: string) => {
+    const reloadWith = async (loadDeps: boolean, expectedDeps: string) => {
       seq++;
-      writeFileSync(join(root, "trigger.js"), `export const seq = ${seq}; export const loadDep = ${loadDep};`);
-      await waitForLine(`RELOAD ${seq} ${expectedDep}`);
+      writeFileSync(join(root, "trigger.js"), `export const seq = ${seq}; export const loadDeps = ${loadDeps};`);
+      await waitForLine(`RELOAD ${seq} ${expectedDeps}`);
     };
-    // Deletes and recreates `victim` between reloads that do not load dep.js,
-    // then reloads once more with dep.js loaded. When the victim is dep.js, the
-    // delete event evicts its entry and enqueues the "deleted" reload, and the
-    // last reload watches the recreated file again. Deleting the never-imported
-    // other.js instead raises the same directory events and the same number of
-    // reloads without touching the watchlist.
-    const cycle = async (victim: "dep.js" | "other.js", value: number) => {
+    // Deletes and recreates the `victim` files between reloads that do not load
+    // the deps, then reloads once more with the deps loaded. Deleting the deps
+    // evicts their entries (the same delete events enqueue the "deleted"
+    // reload), and the last reload watches the recreated files again. Deleting
+    // the never-imported other* files instead raises the same directory events
+    // and the same number of reloads without touching the watchlist.
+    const cycle = async (victim: "dep" | "other", value: number) => {
       await reloadWith(false, "skipped");
-      rmSync(join(root, victim));
-      if (victim === "dep.js") {
+      for (const i of indexes) rmSync(join(root, `${victim}${i}.js`));
+      if (victim === "dep") {
         await waitForLine(`RELOAD ${seq} deleted`);
       } else {
         await reloadWith(false, "skipped");
       }
-      writeFileSync(join(root, victim), `export const value = ${value};`);
-      await reloadWith(true, String(victim === "dep.js" ? value : 0));
+      for (const i of indexes) writeFileSync(join(root, `${victim}${i}.js`), `export const value = ${value};`);
+      await reloadWith(true, String(victim === "dep" ? files * value : 0));
     };
 
     await waitForLine("RELOAD 0 0");
-    for (let i = 1; i <= 3; i++) await cycle("other.js", i);
+    for (let i = 1; i <= 2; i++) await cycle("other", i);
     const start = handleCount(proc.pid);
-    for (let i = 1; i <= cycles; i++) await cycle("other.js", i);
+    for (let i = 1; i <= cycles; i++) await cycle("other", i);
     const afterBaseline = handleCount(proc.pid);
-    for (let i = 1; i <= cycles; i++) await cycle("dep.js", i);
+    for (let i = 1; i <= cycles; i++) await cycle("dep", i);
     const afterEvictions = handleCount(proc.pid);
 
     const baselineGrowth = afterBaseline - start;
     const evictionGrowth = afterEvictions - afterBaseline;
-    // Unfixed, every eviction cycle leaks one more handle than a baseline
-    // cycle, so this is `cycles`. Fixed, it is within a couple of handles of
-    // zero (the process still creates the odd handle on its own over time).
+    // Unfixed, every eviction cycle leaks `files` handles more than a baseline
+    // cycle. Fixed, the two phases grow by about the same amount.
     const leakedByEvictions = evictionGrowth - baselineGrowth;
     expect({ baselineGrowth, evictionGrowth, leakedByEvictions }).toEqual({
       baselineGrowth,
       evictionGrowth,
-      leakedByEvictions: Math.min(leakedByEvictions, cycles / 2),
+      leakedByEvictions: Math.min(leakedByEvictions, (files * cycles) / 2),
     });
   });
 });

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -256,16 +256,18 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
   // directory event busts the resolver's directory cache, which abandons the
   // directory handle the busted entry holds. So both phases below run the same
   // reloads and directory events per cycle and differ only in whether the
-  // deleted files are watched, and each cycle evicts `files` entries, so the
-  // leak is `files` handles per cycle while anything else a cycle can differ
-  // by (an extra reload) is one or two.
+  // deleted files are watched. The entry blocks on stdin after every reload, so
+  // the file changes of a step all land while no reload can run and then
+  // coalesce into one reload per step in both phases. Each cycle evicts `files`
+  // entries, so the leak is `files` handles per cycle, far more than the one
+  // handle an occasional extra reload would cost.
   test.skipIf(!isWindows)("evicting watchlist entries closes their handles", async () => {
     const files = 16;
     const cycles = 6;
     const indexes = Array.from({ length: files }, (_, i) => i);
     await using dir = tempDir("hot-evict-handles", {
       "entry.js": `
-        import { existsSync } from "node:fs";
+        import { existsSync, readSync } from "node:fs";
         import { loadDeps, seq } from "./trigger.js";
         // GC helper threads are handles too. Create them before the first sample.
         Bun.gc(true);
@@ -278,6 +280,8 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
           deps = "deleted";
         }
         console.log("RELOAD", seq, deps);
+        // Block until the test has made the next step's file changes.
+        readSync(0, new Uint8Array(1));
       `,
       "trigger.js": `export const seq = 0; export const loadDeps = true;`,
       ...Object.fromEntries(indexes.map(i => [`dep${i}.js`, `export const value = 0;`])),
@@ -309,6 +313,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
       cmd: [bunExe(), "--hot", "entry.js"],
       cwd: root,
       env: bunEnv,
+      stdin: "pipe",
       stdout: "pipe",
       stderr: "inherit",
     });
@@ -321,28 +326,40 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
         if (line === expected) return;
       }
     };
+    // The entry is blocked on stdin between steps. Unblock it so the reload the
+    // step's file changes enqueued runs, then wait for that reload's line.
+    const releaseAndWaitFor = async (expected: string) => {
+      proc.stdin.write("\n");
+      await proc.stdin.flush();
+      await waitForLine(expected);
+    };
     let seq = 0;
-    const reloadWith = async (loadDeps: boolean, expectedDeps: string) => {
+    const writeTrigger = (loadDeps: boolean) => {
       seq++;
       writeFileSync(join(root, "trigger.js"), `export const seq = ${seq}; export const loadDeps = ${loadDeps};`);
-      await waitForLine(`RELOAD ${seq} ${expectedDeps}`);
     };
     // Deletes and recreates the `victim` files between reloads that do not load
     // the deps, then reloads once more with the deps loaded. Deleting the deps
     // evicts their entries (the same delete events enqueue the "deleted"
     // reload), and the last reload watches the recreated files again. Deleting
     // the never-imported other* files instead raises the same directory events
-    // and the same number of reloads without touching the watchlist.
+    // without touching the watchlist, so that step gets its reload from the
+    // trigger. Every step is one reload in both phases.
     const cycle = async (victim: "dep" | "other", value: number) => {
-      await reloadWith(false, "skipped");
+      writeTrigger(false);
+      await releaseAndWaitFor(`RELOAD ${seq} skipped`);
+
       for (const i of indexes) rmSync(join(root, `${victim}${i}.js`));
       if (victim === "dep") {
-        await waitForLine(`RELOAD ${seq} deleted`);
+        await releaseAndWaitFor(`RELOAD ${seq} deleted`);
       } else {
-        await reloadWith(false, "skipped");
+        writeTrigger(false);
+        await releaseAndWaitFor(`RELOAD ${seq} skipped`);
       }
+
       for (const i of indexes) writeFileSync(join(root, `${victim}${i}.js`), `export const value = ${value};`);
-      await reloadWith(true, String(victim === "dep" ? files * value : 0));
+      writeTrigger(true);
+      await releaseAndWaitFor(`RELOAD ${seq} ${victim === "dep" ? files * value : 0}`);
     };
 
     await waitForLine("RELOAD 0 0");

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -259,7 +259,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
   // deleted file is watched. The eviction phase's extra growth is what the
   // evictions leak.
   test.skipIf(!isWindows)("evicting watchlist entries closes their handles", async () => {
-    const cycles = 20;
+    const cycles = 16;
     await using dir = tempDir("hot-evict-handles", {
       "entry.js": `
         import { existsSync } from "node:fs";
@@ -282,16 +282,16 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     });
     const handleCount = (pid: number) => {
       const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
-      const process = kernel32.symbols.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
-      if (!process) throw new Error(`OpenProcess(${pid}) failed`);
+      const handle = kernel32.symbols.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+      if (!handle) throw new Error(`OpenProcess(${pid}) failed`);
       try {
         const count = new Uint32Array(1);
-        if (kernel32.symbols.GetProcessHandleCount(process, count) === 0) {
+        if (kernel32.symbols.GetProcessHandleCount(handle, count) === 0) {
           throw new Error("GetProcessHandleCount failed");
         }
         return count[0];
       } finally {
-        kernel32.symbols.CloseHandle(process);
+        kernel32.symbols.CloseHandle(handle);
       }
     };
 
@@ -317,12 +317,12 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
       writeFileSync(join(root, "trigger.js"), `export const seq = ${seq}; export const loadDep = ${loadDep};`);
       await waitForLine(`RELOAD ${seq} ${expectedDep}`);
     };
-    // Deletes and recreates `victim` between two reloads that do not load
-    // dep.js, then reloads once more with dep.js loaded. When the victim is
-    // dep.js, the deletion evicts its entry (that eviction is what enqueues the
-    // "deleted" reload) and the last reload watches the recreated file again.
-    // Deleting the never-imported other.js instead raises the same directory
-    // events and reloads without touching the watchlist.
+    // Deletes and recreates `victim` between reloads that do not load dep.js,
+    // then reloads once more with dep.js loaded. When the victim is dep.js, the
+    // delete event evicts its entry and enqueues the "deleted" reload, and the
+    // last reload watches the recreated file again. Deleting the never-imported
+    // other.js instead raises the same directory events and the same number of
+    // reloads without touching the watchlist.
     const cycle = async (victim: "dep.js" | "other.js", value: number) => {
       await reloadWith(false, "skipped");
       rmSync(join(root, victim));
@@ -346,12 +346,13 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     const baselineGrowth = afterBaseline - start;
     const evictionGrowth = afterEvictions - afterBaseline;
     // Unfixed, every eviction cycle leaks one more handle than a baseline
-    // cycle, so the difference is `cycles`. Fixed, it is about zero.
+    // cycle, so this is `cycles`. Fixed, it is within a couple of handles of
+    // zero (the process still creates the odd handle on its own over time).
     const leakedByEvictions = evictionGrowth - baselineGrowth;
-    expect({ baselineGrowth, evictionGrowth, leakedByEvictions: Math.min(leakedByEvictions, cycles / 2) }).toEqual({
+    expect({ baselineGrowth, evictionGrowth, leakedByEvictions }).toEqual({
       baselineGrowth,
       evictionGrowth,
-      leakedByEvictions,
+      leakedByEvictions: Math.min(leakedByEvictions, cycles / 2),
     });
   });
 });

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -1,7 +1,8 @@
 import { spawn } from "bun";
+import { dlopen } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isASAN, isCI, isLinux, tempDir } from "harness";
-import { mkdirSync, readdirSync, readlinkSync, realpathSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, forEachLine, isASAN, isCI, isLinux, isWindows, tempDir } from "harness";
+import { mkdirSync, readdirSync, readlinkSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("--hot with many directories", () => {
@@ -244,5 +245,113 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     const leaks = stderr.split(/\n\s*\n/).filter(block => /^(?:Direct|Indirect) leak of /.test(block));
     expect(leaks).toEqual([]);
     expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  });
+
+  // Deleting a watched file evicts its watchlist entry, which owns the handle
+  // the file was transpiled through. Eviction used to close that handle on
+  // POSIX only, so on Windows every evicted entry leaked it, and the reload
+  // that watched the file again opened a new one.
+  //
+  // A raw handle count is not flat under --hot even without that leak: every
+  // directory event busts the resolver's directory cache, which abandons the
+  // directory handle the busted entry holds. So both phases below run the same
+  // reloads and directory events per cycle and differ only in whether the
+  // deleted file is watched. The eviction phase's extra growth is what the
+  // evictions leak.
+  test.skipIf(!isWindows)("evicting watchlist entries closes their handles", async () => {
+    const cycles = 20;
+    await using dir = tempDir("hot-evict-handles", {
+      "entry.js": `
+        import { existsSync } from "node:fs";
+        import { loadDep, seq } from "./trigger.js";
+        // GC helper threads are handles too. Create them before the first sample.
+        Bun.gc(true);
+        const dep = loadDep ? require("./dep.js").value : existsSync("dep.js") ? "skipped" : "deleted";
+        console.log("RELOAD", seq, dep);
+      `,
+      "trigger.js": `export const seq = 0; export const loadDep = true;`,
+      "dep.js": `export const value = 0;`,
+      "other.js": `export const value = 0;`,
+    });
+    const root = String(dir);
+
+    const kernel32 = dlopen("kernel32.dll", {
+      OpenProcess: { args: ["u32", "i32", "u32"], returns: "ptr" },
+      GetProcessHandleCount: { args: ["ptr", "ptr"], returns: "i32" },
+      CloseHandle: { args: ["ptr"], returns: "i32" },
+    });
+    const handleCount = (pid: number) => {
+      const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+      const process = kernel32.symbols.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+      if (!process) throw new Error(`OpenProcess(${pid}) failed`);
+      try {
+        const count = new Uint32Array(1);
+        if (kernel32.symbols.GetProcessHandleCount(process, count) === 0) {
+          throw new Error("GetProcessHandleCount failed");
+        }
+        return count[0];
+      } finally {
+        kernel32.symbols.CloseHandle(process);
+      }
+    };
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--hot", "entry.js"],
+      cwd: root,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    const iter = forEachLine(proc.stdout);
+    const waitForLine = async (expected: string) => {
+      while (true) {
+        const { value: line, done } = await iter.next();
+        if (done) throw new Error(`--hot exited before printing "${expected}" (exit ${proc.exitCode})`);
+        if (line === expected) return;
+      }
+    };
+    let seq = 0;
+    const reloadWith = async (loadDep: boolean, expectedDep: string) => {
+      seq++;
+      writeFileSync(join(root, "trigger.js"), `export const seq = ${seq}; export const loadDep = ${loadDep};`);
+      await waitForLine(`RELOAD ${seq} ${expectedDep}`);
+    };
+    // Deletes and recreates `victim` between two reloads that do not load
+    // dep.js, then reloads once more with dep.js loaded. When the victim is
+    // dep.js, the deletion evicts its entry (that eviction is what enqueues the
+    // "deleted" reload) and the last reload watches the recreated file again.
+    // Deleting the never-imported other.js instead raises the same directory
+    // events and reloads without touching the watchlist.
+    const cycle = async (victim: "dep.js" | "other.js", value: number) => {
+      await reloadWith(false, "skipped");
+      rmSync(join(root, victim));
+      if (victim === "dep.js") {
+        await waitForLine(`RELOAD ${seq} deleted`);
+      } else {
+        await reloadWith(false, "skipped");
+      }
+      writeFileSync(join(root, victim), `export const value = ${value};`);
+      await reloadWith(true, String(victim === "dep.js" ? value : 0));
+    };
+
+    await waitForLine("RELOAD 0 0");
+    for (let i = 1; i <= 3; i++) await cycle("other.js", i);
+    const start = handleCount(proc.pid);
+    for (let i = 1; i <= cycles; i++) await cycle("other.js", i);
+    const afterBaseline = handleCount(proc.pid);
+    for (let i = 1; i <= cycles; i++) await cycle("dep.js", i);
+    const afterEvictions = handleCount(proc.pid);
+
+    const baselineGrowth = afterBaseline - start;
+    const evictionGrowth = afterEvictions - afterBaseline;
+    // Unfixed, every eviction cycle leaks one more handle than a baseline
+    // cycle, so the difference is `cycles`. Fixed, it is about zero.
+    const leakedByEvictions = evictionGrowth - baselineGrowth;
+    expect({ baselineGrowth, evictionGrowth, leakedByEvictions: Math.min(leakedByEvictions, cycles / 2) }).toEqual({
+      baselineGrowth,
+      evictionGrowth,
+      leakedByEvictions,
+    });
   });
 });

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -247,10 +247,10 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
   });
 
-  // Deleting a watched file evicts its watchlist entry, which owns the handle
-  // the file was transpiled through. Eviction used to close that handle on
-  // POSIX only, so on Windows every evicted entry leaked it, and the reload
-  // that watched the file again opened a new one.
+  // Evicting a watchlist entry used to close the handle stored in it on POSIX
+  // only. On Windows every evicted entry leaked its handle: under --hot a
+  // deleted import (the reload then watched it again through a new handle),
+  // in the dev server a freed directory watch. This drives the --hot case.
   //
   // A raw handle count is not flat under --hot even without that leak: every
   // directory event busts the resolver's directory cache, which abandons the
@@ -261,6 +261,11 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
   // coalesce into one reload per step in both phases. Each cycle evicts `files`
   // entries, so the leak is `files` handles per cycle, far more than the one
   // handle an occasional extra reload would cost.
+  //
+  // The first assertion guards against a vacuous pass: watching the files again
+  // must show up as `files` handles. Once file entries stop holding a handle
+  // outside kqueue, re-anchor this on the dev server's directory watches
+  // (`DirectoryWatchStore::free_entry`), the evicted entries that still hold one.
   test.skipIf(!isWindows)("evicting watchlist entries closes their handles", async () => {
     const files = 16;
     const cycles = 6;
@@ -344,7 +349,9 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     // reload), and the last reload watches the recreated files again. Deleting
     // the never-imported other* files instead raises the same directory events
     // without touching the watchlist, so that step gets its reload from the
-    // trigger. Every step is one reload in both phases.
+    // trigger. Every step is one reload in both phases. Returns how many handles
+    // the last reload added: the deps it watches again, plus the same directory
+    // handle in both phases.
     const cycle = async (victim: "dep" | "other", value: number) => {
       writeTrigger(false);
       await releaseAndWaitFor(`RELOAD ${seq} skipped`);
@@ -356,29 +363,39 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
         writeTrigger(false);
         await releaseAndWaitFor(`RELOAD ${seq} skipped`);
       }
+      const beforeLoad = handleCount(proc.pid);
 
       for (const i of indexes) writeFileSync(join(root, `${victim}${i}.js`), `export const value = ${value};`);
       writeTrigger(true);
       await releaseAndWaitFor(`RELOAD ${seq} ${victim === "dep" ? files * value : 0}`);
+      return handleCount(proc.pid) - beforeLoad;
+    };
+    const phase = async (victim: "dep" | "other") => {
+      const start = handleCount(proc.pid);
+      let addedByLoads = 0;
+      for (let i = 1; i <= cycles; i++) addedByLoads += await cycle(victim, i);
+      return { growth: handleCount(proc.pid) - start, addedByLoads };
     };
 
     await waitForLine("RELOAD 0 0");
     for (let i = 1; i <= 2; i++) await cycle("other", i);
-    const start = handleCount(proc.pid);
-    for (let i = 1; i <= cycles; i++) await cycle("other", i);
-    const afterBaseline = handleCount(proc.pid);
-    for (let i = 1; i <= cycles; i++) await cycle("dep", i);
-    const afterEvictions = handleCount(proc.pid);
+    const baseline = await phase("other");
+    const evictions = await phase("dep");
 
-    const baselineGrowth = afterBaseline - start;
-    const evictionGrowth = afterEvictions - afterBaseline;
-    // Unfixed, every eviction cycle leaks `files` handles more than a baseline
-    // cycle. Fixed, the two phases grow by about the same amount.
-    const leakedByEvictions = evictionGrowth - baselineGrowth;
-    expect({ baselineGrowth, evictionGrowth, leakedByEvictions }).toEqual({
-      baselineGrowth,
-      evictionGrowth,
-      leakedByEvictions: Math.min(leakedByEvictions, (files * cycles) / 2),
+    // In the eviction phase the deps are watched again on every cycle, so its
+    // loads add `files` handles per cycle that the baseline's loads (the deps
+    // stayed watched) do not.
+    const rewatched = evictions.addedByLoads - baseline.addedByLoads;
+    // Unfixed, every eviction cycle also keeps the `files` handles it evicted,
+    // so the phase grows by that much more than the baseline. Fixed, the two
+    // phases grow by about the same amount.
+    const leaked = evictions.growth - baseline.growth;
+    const half = (files * cycles) / 2;
+    expect({ baseline, evictions, rewatched, leaked }).toEqual({
+      baseline,
+      evictions,
+      rewatched: Math.max(rewatched, half),
+      leaked: Math.min(leaked, half),
     });
   });
 });


### PR DESCRIPTION
### Problem
- On Windows, an evicted watchlist entry never closes its handle: `Watcher::flush_evictions` (`src/watcher/Watcher.rs:423`) closed the stored descriptor only under `#[cfg(not(windows))]`. Under `--hot` an import that is deleted and written again leaks one handle per save. A directory watch the dev server frees (`DirectoryWatchStore::free_entry`) leaks its handle too.
- 1.4.0-canary (01c4e2fd6), Windows x64: deleting and recreating 16 imports leaks 16 handles per cycle.
- The plain-save growth in the report is a different leak: `bust_dir_cache` orphans the resolver's `DirEntry` with its directory handle, on Linux too. #36675 fixes it. Not touched here.

### Fix
- `flush_evictions` closes the stored descriptor on every platform, the rule the shutdown sweep already applies to this column everywhere.
- Correct because it is the only close of that descriptor on Windows (adopting callers stop closing on `FdOwnership::Watcher`, directory entries are the watcher's own, the entry is swap-removed right after), and nothing on Windows reads it: events are matched by path, #37050 removed the JS thread reader.
- It covers both evicting surfaces: file entries under `--hot` now, and the dev server's directory watches in every end state, also after #39571 (Notes).
- Verified: `test/cli/hot/watch-many-dirs.test.ts` (Windows-only). It first checks that re-watching shows up as 96 handles on both builds, so it cannot pass vacuously, then compares the phases: unfixed canary leaks 95 (limit 48), fixed debug build 0. Also green on Windows: `test/cli/hot/`, `test/bake/dev/{bundle,hot}.test.ts`.

### Background
- The watcher keeps one `WatchItem` per watched file or directory. Its `fd` column is the descriptor the item was registered with. On kqueue it is the watch itself. inotify and `ReadDirectoryChangesW` watch by path, so there it is only held until eviction.
- An eviction has two steps. `remove_at_index` records the index (hot reloader on a delete event, dev server when it frees a directory watch). `flush_evictions` later closes and swap-removes the entries on the watcher thread.

<details><summary>Notes</summary>

Measurements with the canary on Windows x64 (`GetProcessHandleCount` of a `bun --hot entry.js` child that imports `lib/dep.js`, 20 saves after 5 warm-up saves):

| save style | handles per save |
| --- | --- |
| overwrite in place | +3 (directory cache, #36675) |
| delete, then write | +4 (the same +3, plus the evicted entry's handle) |

An overwrite does not evict on Windows (only a delete event does, `hot_reloader.rs` File arm), which is why the report's loop of plain writes shows the directory cache leak and not this one. On Linux the same plain-write loop grows `/proc/<pid>/fd` of the released build by one fd on the project directory per save, which is how the two leaks were told apart. The reload that follows an eviction watches the file again through a new handle, so the leak is one handle per evicted entry per save.

Test design. The test reads `GetProcessHandleCount` of the child through `bun:ffi`, as `spawn.test.ts` does. A raw handle count grows by 3 per cycle on every build because of the directory cache leak, so the test runs two phases with identical reloads and directory events (delete and recreate 16 never-imported files, or the 16 imported ones) and compares their growth. The entry blocks on stdin after each reload, so the 16 delete events of a step all arrive while no reload can run and coalesce into exactly one reload. Without that, the release build spread the deletes over several reloads, and each extra reload added one directory-cache handle to the eviction phase (120 to 133 instead of 96). Numbers are the same on every run: the reload that loads the deps adds 1 handle per baseline cycle and 17 per eviction cycle on both builds (`rewatched` = 96), and the phases grow 18 / 18 on the fixed build and 18 / 114 on the unfixed one (`leaked` = 0 and 95). Both limits are 48. The test takes 0.2 s on a release build and 2.1 s on a debug build.

Self-review. The review did not dispute the close itself. Its concern was shape: #39571 (open, same author) stops storing a descriptor in file entries outside kqueue, so once it lands this test's file entries hold nothing, and the review suggested folding the one-line change into #39571 instead. This PR stays separate because the close is right in every end state (file entries now, the dev server's directory watches always), it is already brought up to date with main, and the two diffs do not overlap textually. The test answers the vacuity concern: its first assertion fails, instead of passing for nothing, once file entries stop holding a handle, and its comment says what to re-anchor it on then (the dev server's directory watches). The review's further suggestion, that directory entries should not open or store a handle outside kqueue either (as `DirectoryWatchStore::insert` already does on its side), would make the whole column inert on Linux and Windows. It conflicts with how #39571 re-anchors the Linux test in this file, so it belongs stacked on #39571 and is noted there.

Other related PRs. #33073 would add one reload per eviction cycle after the files are recreated; the stdin handshake coalesces it into the step's single reload, so the test holds with or without it. While an import is watched on Windows, renaming another file over it fails with `EPERM` because of this same stored handle. That is unchanged here and goes away with #39571.

Other checks: `cargo check` and `cargo clippy -p bun_watcher` on Linux (the non-Windows code is unchanged). On Windows with the fix: `test/cli/hot/hot.test.ts` and `watch.test.ts` (14 pass, including the delete-and-rewrite and rename-into-place cases that go through the changed path), `test/bake/dev/bundle.test.ts` (20 pass, includes the cases that free directory watches), `test/bake/dev/hot.test.ts` (10 pass).
</details>
