### PR TITLE
module loader: find the mid-TLA awaiter through caller frames for the dynamic-import deadlock skip

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3697,6 +3697,43 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         sourceOriginStringHolder = sourceURL.path().toString();
     }
 
+    if (referrerAsyncOrder == -1 && vm.topCallFrame) {
+        // The lexical referrer of this import() has no asyncEvaluationOrder,
+        // but the call can still run synchronously inside the body of a module
+        // that is mid top-level-await (a helper module's function invoked from
+        // that body). Waiting on that module at innerModuleEvaluation 12.b.v
+        // is the same guaranteed deadlock the referrerAsyncOrder skip exists
+        // for, so take the order from the nearest caller frame whose module
+        // has one. #39831.
+        auto* moduleLoader = globalObject->moduleLoader();
+        JSC::StackVisitor::visit(vm.topCallFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
+            // Only module body frames matter: a module's asyncEvaluationOrder
+            // is live exactly while its body runs (pre-first-await) on this
+            // stack. This also keeps the walk cheap for the common case of an
+            // import() with no module body on the stack at all.
+            if (visitor->codeType() != JSC::StackVisitor::Frame::Module)
+                return WTF::IterationStatus::Continue;
+            auto* codeBlock = visitor->codeBlock();
+            if (!codeBlock)
+                return WTF::IterationStatus::Continue;
+            const auto& frameURL = codeBlock->ownerExecutable()->sourceOrigin().url();
+            if (!frameURL.protocolIsFile())
+                return WTF::IterationStatus::Continue;
+            if (frameURL == sourceURL)
+                return WTF::IterationStatus::Continue;
+            auto path = frameURL.fileSystemPath();
+            auto query = frameURL.queryWithLeadingQuestionMark();
+            auto frameKey = query.isEmpty()
+                ? JSC::Identifier::fromString(vm, path)
+                : JSC::Identifier::fromString(vm, makeString(path, query));
+            int64_t order = moduleLoader->asyncEvaluationOrderForKey(frameKey);
+            if (order == -1)
+                return WTF::IterationStatus::Continue;
+            referrerAsyncOrder = order;
+            return WTF::IterationStatus::Done;
+        });
+    }
+
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3698,13 +3698,15 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     }
 
     if (referrerAsyncOrder == -1 && vm.topCallFrame) {
-        // A mid-TLA module body can reach import() through a helper module's
-        // function, so the lexical referrer has no order. Waiting on that
-        // module at innerModuleEvaluation 12.b.v deadlocks when it awaits the
-        // import() result (#39831), and awaitedness is not observable here,
-        // so assume it: use the order of the nearest module body frame on the
-        // stack. A fire-and-forget import() whose target cycles back then
-        // sees partial bindings, the same as with import() in the caller.
+        // A mid-TLA module body can reach import() synchronously through a
+        // helper module's function, leaving the lexical referrer with no
+        // order. Waiting on that module at innerModuleEvaluation 12.b.v
+        // deadlocks when it awaits the result (#39831), and awaitedness is
+        // not observable here, so assume it: use the order of the nearest
+        // module body frame on the stack. Fire-and-forget targets that cycle
+        // back see partial bindings (same as import() in the caller), and a
+        // helper that suspends before importing is not covered: the walk
+        // sees only the synchronous stack, so such a graph still deadlocks.
         auto* moduleLoader = globalObject->moduleLoader();
         JSC::StackVisitor::visit(vm.topCallFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
             // Only a module body frame carries a live asyncEvaluationOrder.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3701,10 +3701,14 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         // The lexical referrer of this import() has no asyncEvaluationOrder,
         // but the call can still run synchronously inside the body of a module
         // that is mid top-level-await (a helper module's function invoked from
-        // that body). Waiting on that module at innerModuleEvaluation 12.b.v
-        // is the same guaranteed deadlock the referrerAsyncOrder skip exists
-        // for, so take the order from the nearest caller frame whose module
-        // has one. #39831.
+        // that body). If that module awaits the import() result, even
+        // transitively, waiting on it at innerModuleEvaluation 12.b.v is the
+        // same deadlock the referrerAsyncOrder skip exists for, so take the
+        // order from the nearest caller frame whose module has one. #39831.
+        // Whether the caller will await the result is not observable here, so
+        // the skip also fires for a fire-and-forget import() whose target
+        // cycles back: that target then sees the caller's partial bindings,
+        // the same as when the import() is written in the caller directly.
         auto* moduleLoader = globalObject->moduleLoader();
         JSC::StackVisitor::visit(vm.topCallFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
             // Only module body frames matter: a module's asyncEvaluationOrder

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3698,23 +3698,16 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     }
 
     if (referrerAsyncOrder == -1 && vm.topCallFrame) {
-        // The lexical referrer of this import() has no asyncEvaluationOrder,
-        // but the call can still run synchronously inside the body of a module
-        // that is mid top-level-await (a helper module's function invoked from
-        // that body). If that module awaits the import() result, even
-        // transitively, waiting on it at innerModuleEvaluation 12.b.v is the
-        // same deadlock the referrerAsyncOrder skip exists for, so take the
-        // order from the nearest caller frame whose module has one. #39831.
-        // Whether the caller will await the result is not observable here, so
-        // the skip also fires for a fire-and-forget import() whose target
-        // cycles back: that target then sees the caller's partial bindings,
-        // the same as when the import() is written in the caller directly.
+        // A mid-TLA module body can reach import() through a helper module's
+        // function, so the lexical referrer has no order. Waiting on that
+        // module at innerModuleEvaluation 12.b.v deadlocks when it awaits the
+        // import() result (#39831), and awaitedness is not observable here,
+        // so assume it: use the order of the nearest module body frame on the
+        // stack. A fire-and-forget import() whose target cycles back then
+        // sees partial bindings, the same as with import() in the caller.
         auto* moduleLoader = globalObject->moduleLoader();
         JSC::StackVisitor::visit(vm.topCallFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
-            // Only module body frames matter: a module's asyncEvaluationOrder
-            // is live exactly while its body runs (pre-first-await) on this
-            // stack. This also keeps the walk cheap for the common case of an
-            // import() with no module body on the stack at all.
+            // Only a module body frame carries a live asyncEvaluationOrder.
             if (visitor->codeType() != JSC::StackVisitor::Frame::Module)
                 return WTF::IterationStatus::Continue;
             auto* codeBlock = visitor->codeBlock();

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -240,6 +240,55 @@ test("dynamic import through a helper module whose target imports the TLA awaite
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/39831
+// The import() is not awaited directly: the entry awaits a separate promise
+// that the import's settlement resolves. Awaitedness is not observable at the
+// import() call, so the stack-walk fallback must treat this the same as a
+// direct await. Without the skip this graph deadlocks (chunk waits on the
+// entry at 12.b.v, the entry waits on `settled`, `settled` waits on chunk).
+// The chunk runs against the entry's partial bindings, so reading the
+// post-await binding throws. Node deadlocks here by design (exit 13).
+test("dynamic import through a helper awaited transitively via separate promise plumbing does not deadlock", async () => {
+  using dir = tempDir("dyn-tla-cycle-transitive", {
+    "entry.mjs": `
+      import { preload, settled } from "./helper.mjs";
+      export const early = 1;
+      preload();
+      await settled;
+      export const late = 2;
+      console.log("entry done");
+    `,
+    "helper.mjs": `
+      const w = Promise.withResolvers();
+      export const settled = w.promise;
+      export function preload() {
+        import("./chunk.mjs").then(
+          m => { console.log("chunk:", m.result); w.resolve(); },
+          e => { console.log("chunk error:", e.constructor.name); w.resolve(); },
+        );
+      }
+    `,
+    "chunk.mjs": `
+      import { early, late } from "./entry.mjs";
+      export const result = early + late;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("chunk error: ReferenceError\nentry done");
+  expect(exitCode).toBe(0);
+});
+
 // https://github.com/oven-sh/bun/issues/30634
 test("sibling dynamic imports sharing a TLA wrapper wait for its post-await exports", async () => {
   using dir = tempDir("dyn-tla-shared-wrapper", {

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -200,6 +200,46 @@ test("static sibling import waits for an indirectly-shared TLA dep in the same E
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/39831
+// Same self-deadlock as the first test, but the import() call site lives in a
+// sync helper module, invoked from the entry's TLA body. The lexical referrer
+// (utils.mjs) has no asyncEvaluationOrder, so the skip must fall back to the
+// caller frames on the stack to find the mid-TLA module (the entry).
+test("dynamic import through a helper module whose target imports the TLA awaiter back does not deadlock", async () => {
+  using dir = tempDir("dyn-tla-cycle-helper", {
+    "index.mjs": `
+      import { load } from "./utils.mjs";
+      export const x = 1;
+      const mod = await load();
+      console.log("mod:", mod.value);
+      console.log("done");
+    `,
+    "utils.mjs": `
+      export function load() {
+        return import("./mod.mjs");
+      }
+    `,
+    "mod.mjs": `
+      import { x } from "./index.mjs";
+      export const value = x + 1;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("mod: 2\ndone");
+  expect(exitCode).toBe(0);
+});
+
 // https://github.com/oven-sh/bun/issues/30634
 test("sibling dynamic imports sharing a TLA wrapper wait for its post-await exports", async () => {
   using dir = tempDir("dyn-tla-shared-wrapper", {


### PR DESCRIPTION
### Problem
- A top-level `await` on a dynamic import hangs at 100% CPU forever when the `import()` call site lives in a helper module and the imported module statically imports the awaiting module back. Worked in 1.3.14, broke in 1.4.0.
- The cause is the TLA self-deadlock skip at `innerModuleEvaluation` 12.b.v (added in #32437). It compares the dependency's `asyncEvaluationOrder` to the order of the `import()` call's lexical referrer (`ZigGlobalObject.cpp:3746`). With a helper module the lexical referrer is the helper, which has no order, so the skip never fires and the graph deadlocks.

### Fix
- In `moduleLoaderImportModule`, when the lexical referrer has no order, walk the machine stack (`JSC::StackVisitor`) and take the order from the nearest module body frame that has one. The helper's function runs synchronously inside the entry's TLA body, so that frame is on the stack at `import()` time.
- Only module body frames are inspected. A module's order is live exactly while its body runs before its first await. Other frames are skipped with a cheap `codeType()` check, so an `import()` with no module body on the stack pays almost nothing.
- The skip still requires exact order equality at 12.b.v, so async siblings (#30259, #30634) still wait. The walk only widens how the awaiter is found, from "lexical referrer" to "caller chain".
- Trade-off: whether the caller awaits the result is not observable at the `import()` call, so a fire-and-forget helper import whose target cycles back now sees partial bindings (a ReferenceError) instead of waiting. That matches what the direct `import()` form already does on main. The notes have the measurements.
- Exclusion: a helper that suspends before it calls `import()` (an async helper past its first await, or a `.then` callback) leaves no module body frame on the machine stack, so the walk finds nothing and that graph still deadlocks, as it does on main. The notes explain why.
- Verified: `test/js/bun/resolve/dynamic-import-tla-cycle.test.ts` (two new tests, both hang on unfixed bun). The other 6 tests in that file, `test/js/bun/resolve/` (one pre-existing local timeout in `load-same-js-file-a-lot.test.ts`, fails identically without this diff), and the require-esm TLA suites all pass.

### Background
- A module with top-level await gets an `asyncEvaluationOrder` when its evaluation starts. Per spec, a module that imports an async-evaluating module must wait for it to finish (12.b.v).
- When the async-evaluating module is itself awaiting the `import()` result, that wait is a guaranteed deadlock. Node deadlocks by design and exits 13. Bun 1.3.14 evaluated the imported module against the awaiter's already-initialized bindings, and #32437 restored that for the case where the `import()` is written directly in the awaiting module.
- This PR extends that shipped behavior to the helper-module shape from #39831. Note the open #36052 takes the opposite policy (remove the skip, match Node's exit 13). That is a semantics decision for a maintainer. This PR keeps the current shipped semantics and fixes the hole in them.

<details><summary>Notes</summary>

Reproduction (3 files): entry exports `x`, then `await load()` where `load()` lives in `utils.js` and returns `import("./m.js")`, and `m.js` does `import { x } from "./index.js"`. On 1.4.0 and main this spins forever at 100% CPU and prints nothing. All three of these make it work: inlining the `import()` into the entry, removing the cycle, or running on 1.3.14.

The 100% CPU (rather than an idle deadlock) is a separate event-loop issue: the run loop stays hot while the pending module load keeps it alive. #36052 addresses that path (`wait_for_module_promise`, exit 13 on unsettled TLA). With this fix the reported graph completes, so it no longer reaches that state.

Fire-and-forget measurements (entry exports `early`, calls a helper's `preload()` that does `import("./chunk.mjs").then(log)`, awaits a 50ms timer, exports `late`; chunk reads both):
- main, direct `import()` in the entry: `ReferenceError` on `late` (skip fires per #32437).
- main, through the helper: waits, prints `3` (skip misses). This only completes because the timer happens to outlast chunk evaluation.
- this PR, through the helper: `ReferenceError`, same as the direct form.
- If the entry's await is connected to the import settlement through any promise plumbing (`Promise.withResolvers`, resolved in the import's `.then`), main deadlocks at 100% CPU. That shape is the second new test. Awaitedness is not knowable at the call, so the walk assumes the mid-TLA caller awaits.

The walk builds an `Identifier` and does one registry lookup per distinct module body frame, and only runs when the lexical referrer had no order. Frames whose URL equals the lexical referrer are skipped since that key already returned -1.

The async-helper exclusion: `StackVisitor` walks the synchronous machine stack only. Once the mid-TLA module suspends, its body frame is gone, so an `import()` issued from a later microtask (async helper past an await, `.then` callback, `queueMicrotask`) cannot be attributed to it. Reaching it would need JSC's async stack tracking, which is debugger machinery and is not always captured. The shipped 1.3.14-style skip never covered that shape either, and #36052 may remove the skip entirely, so it stays out of scope here.

Suites run: `test/js/bun/resolve/dynamic-import-tla-cycle.test.ts`, `test/js/bun/resolve/` (full directory), `concurrent-dynamic-import`, `import-defer`, `import-query`, `require-esm-transitive-tla`, `require-esm-microtask-order`. The `load-same-js-file-a-lot.test.ts` timeouts reproduce on unmodified main in this environment (debug+ASAN, capped cores) and are unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/resolve/dynamic-import-tla-cycle.test.ts:
(pass) dynamic import inside TLA whose target imports the awaiter back does not deadlock [1492.54ms]
(pass) dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock [444.07ms]
(pass) static sibling import waits for an async-pending SCC from the same Evaluate() [571.09ms]
(pass) static sibling import waits for a TLA dep that suspended earlier in the same Evaluate() [432.01ms]
(pass) static sibling import waits for an indirectly-shared TLA dep in the same Evaluate() [449.81ms]
killed 1 dangling process
(fail) dynamic import through a helper module whose target imports the TLA awaiter back does not deadlock [5003.26ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
234 |   });
235 | 
236 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
237 | 
238 |  
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8bc52efd5)

test/js/bun/resolve/dynamic-import-tla-cycle.test.ts:
(pass) dynamic import inside TLA whose target imports the awaiter back does not deadlock [15.11ms]
(pass) dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock [7.77ms]
(pass) static sibling import waits for an async-pending SCC from the same Evaluate() [8.60ms]
(pass) static sibling import waits for a TLA dep that suspended earlier in the same Evaluate() [8.55ms]
(pass) static sibling import waits for an indirectly-shared TLA dep in the same Evaluate() [11.61ms]
(pass) dynamic import through a helper module whose target imports the TLA awaiter back does not deadlock [8.89ms]
(pass) dynamic import through a helper awaited transitively via separate promise plumbing does not deadlock [7.65ms]
(pass) sibling dynamic imports sharing a TLA wrapper wait for its post-await exports [8.18ms]

 8 pass
 0 fail
 24 expect() calls
Ran 8 tests across 1 file. [269.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/resolve/dynamic-import-tla-cycle.test.ts:
(pass) dynamic import inside TLA whose target imports the awaiter back does not deadlock [811.94ms]
(pass) dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock [405.76ms]
(pass) static sibling import waits for an async-pending SCC from the same Evaluate() [330.05ms]
(pass) static sibling import waits for a TLA dep that suspended earlier in the same Evaluate() [316.79ms]
(pass) static sibling import waits for an indirectly-shared TLA dep in the same Evaluate() [318.76ms]
(pass) dynamic import through a helper module whose target imports the TLA awaiter back does not deadlock [305.83ms]
(pass) dynamic import through a helper awaited transitively via separate promise plumbing does not deadlock [300.91ms]
(pass) sibling dynamic imports sharing a TLA wrapper wait for its post-await exports [324.52ms]

 8 pass
 0 fail
 24 expect() calls
Ran 8 tests across 1 file. [5.60s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 23s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+031fb4a68
[build] done
bun test v1.4.0-canary.1 (031fb4a68)

test/js/bun/resolve/dynamic-import-tla-cycle.test.ts:
(pass) dynamic import inside TLA whose target imports the awaiter back does not deadlock [27.08ms]
(pass) dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock [11.44ms]
(pass) static sibling import waits for an async-pending SCC from the same Evaluate() [9.75ms]
(pass) static sibling import waits for a TLA dep that suspended earlier in the same Evaluate() [15.68m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp               | 36 +++++++++
 .../bun/resolve/dynamic-import-tla-cycle.test.ts   | 89 ++++++++++++++++++++++
 2 files changed, 125 insertions(+)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp                      3      7      0
test/js/bun/resolve/dynamic-import-tla-cycle.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->