### PR TITLE
crash_handler: name the native module being loaded or run, locally and in the uploaded panic message

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -649,14 +649,19 @@ mod draft {
             ))
         }
 
-        /// What goes into the uploaded report: the part after the last `node_modules`, else the basename. Never the user's directories.
+        /// What goes into the uploaded report: the part after the last `node_modules` directory, else the basename. Never the user's directories.
         fn report_name(name: &[u8]) -> &[u8] {
             const NODE_MODULES: &[u8] = b"node_modules";
-            if let Some(index) = strings::last_index_of(name, NODE_MODULES) {
+            let is_separator = |byte: &u8| matches!(byte, b'/' | b'\\');
+            let mut end = name.len();
+            while let Some(index) = strings::last_index_of(&name[..end], NODE_MODULES) {
                 let rest = &name[index + NODE_MODULES.len()..];
-                if matches!(rest.first(), Some(b'/' | b'\\')) && rest.len() > 1 {
+                let whole_component = (index == 0 || is_separator(&name[index - 1]))
+                    && rest.first().is_some_and(is_separator);
+                if whole_component && rest.len() > 1 {
                     return &rest[1..];
                 }
+                end = index;
             }
             bun_paths::basename(name)
         }

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -607,6 +607,121 @@ mod draft {
         /// attach the affected files to crash report. Others, which may have low crash
         /// rate or only crash due to assertion failures, are debug-only. See `Action`.
         static CURRENT_ACTION: Cell<Option<Action>> = const { Cell::new(None) };
+
+        /// The native module (a `.node` addon) whose code this thread is inside of, if any.
+        static NATIVE_MODULE: Cell<NativeModule> = const { Cell::new(NativeModule::NONE) };
+    }
+
+    /// What bun is doing with which native module. `repr(C)` because C++ holds the previous value between enter and leave.
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct NativeModule {
+        kind: NativeModuleKind,
+        /// A NUL-terminated path, file URL or module-declared name. Read only by a crash on this thread, so it is stored as is.
+        name: *const c_char,
+    }
+
+    #[repr(u8)]
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub enum NativeModuleKind {
+        None = 0,
+        /// `process.dlopen`: from `dlopen` until the module's register function has returned.
+        Loading = 1,
+        /// A callback, finalizer, cleanup hook or async work function of the module.
+        Running = 2,
+    }
+
+    impl NativeModule {
+        pub const NONE: NativeModule = NativeModule {
+            kind: NativeModuleKind::None,
+            name: core::ptr::null(),
+        };
+
+        fn current() -> Option<(NativeModuleKind, &'static [u8])> {
+            let this = NATIVE_MODULE.with(|c| c.get());
+            if this.kind == NativeModuleKind::None || this.name.is_null() {
+                return None;
+            }
+            // SAFETY: whoever entered the module keeps `name` alive until it leaves, and the thread is still inside it.
+            Some((
+                this.kind,
+                unsafe { bun_core::ffi::cstr(this.name) }.to_bytes(),
+            ))
+        }
+
+        /// What goes into the uploaded report: the part after the last `node_modules`, else the basename. Never the user's directories.
+        fn report_name(name: &[u8]) -> &[u8] {
+            const NODE_MODULES: &[u8] = b"node_modules";
+            if let Some(index) = strings::last_index_of(name, NODE_MODULES) {
+                let rest = &name[index + NODE_MODULES.len()..];
+                if matches!(rest.first(), Some(b'/' | b'\\')) && rest.len() > 1 {
+                    return &rest[1..];
+                }
+            }
+            bun_paths::basename(name)
+        }
+    }
+
+    /// Restores what the thread was inside of before, so modules that call into each other nest.
+    pub struct NativeModuleGuard(NativeModule);
+
+    impl Drop for NativeModuleGuard {
+        #[inline]
+        fn drop(&mut self) {
+            NATIVE_MODULE.with(|c| c.set(self.0));
+        }
+    }
+
+    /// `name` must stay valid until the guard is dropped. A null `name` records nothing, so callers need no check.
+    #[inline]
+    #[must_use]
+    pub fn enter_native_module(kind: NativeModuleKind, name: *const c_char) -> NativeModuleGuard {
+        NativeModuleGuard(NATIVE_MODULE.with(|c| c.replace(NativeModule { kind, name })))
+    }
+
+    impl NativeModuleKind {
+        fn verb(self) -> &'static str {
+            match self {
+                NativeModuleKind::Loading => "loading",
+                NativeModuleKind::Running | NativeModuleKind::None => "running",
+            }
+        }
+    }
+
+    /// The line under the panic message, next to the `Crashed while <action>` one; prints nothing outside a native module.
+    fn write_native_module_line(writer: &mut impl Write) -> crate::Result<()> {
+        if let Some((kind, name)) = NativeModule::current() {
+            writeln!(
+                writer,
+                "Crashed while {} native module: {}",
+                kind.verb(),
+                bstr::BStr::new(name)
+            )?;
+        }
+        Ok(())
+    }
+
+    /// `message` with the module being loaded or run appended, when there is one, so that bun.report groups the panic by module.
+    fn attribute_panic_message<'a>(
+        message: &'a [u8],
+        buf: &'a mut BoundedArray<u8, 1280>,
+    ) -> &'a [u8] {
+        let Some((kind, name)) = NativeModule::current() else {
+            return message;
+        };
+        let attributed = buf.append_slice(message).is_ok()
+            && write!(
+                buf.writer(),
+                " ({} native module {})",
+                kind.verb(),
+                bstr::BStr::new(NativeModule::report_name(name))
+            )
+            .is_ok();
+        if attributed {
+            buf.const_slice()
+        } else {
+            message
+        }
     }
 
     /// Prevents crash reports from being uploaded to any server. Reports will still be printed and
@@ -710,7 +825,6 @@ mod draft {
         Visit(&'static [u8]),
         Print(&'static [u8]),
         Resolver,
-        Dlopen(&'static [u8]),
     }
 
     impl fmt::Display for Action {
@@ -720,9 +834,6 @@ mod draft {
                 Action::Visit(path) => write!(writer, "visiting {}", bstr::BStr::new(path)),
                 Action::Print(path) => write!(writer, "printing {}", bstr::BStr::new(path)),
                 Action::Resolver => writer.write_str("resolving a module"),
-                Action::Dlopen(path) => {
-                    write!(writer, "loading native module: {}", bstr::BStr::new(path))
-                }
             }
         }
     }
@@ -1021,6 +1132,9 @@ mod draft {
                         if writeln!(writer, "Crashed while {}", action).is_err() {
                             abort();
                         }
+                    }
+                    if write_native_module_line(writer).is_err() {
+                        abort();
                     }
 
                     let mut addr_buf: [usize; 20] = [0; 20];
@@ -1813,6 +1927,7 @@ mod draft {
             if let Some(action) = CURRENT_ACTION.with(|c| c.get()) {
                 let _ = writeln!(writer, "Crashed while {}", action);
             }
+            let _ = write_native_module_line(writer);
 
             let mut addr_buf: [usize; 20] = [0; 20];
             let idx = debug::capture_stack_trace(debug::return_address(), &mut addr_buf);
@@ -2653,6 +2768,9 @@ mod draft {
         match opts.reason {
             CrashReason::Panic(message) => {
                 writer.write_byte(b'0')?;
+
+                let mut attributed = BoundedArray::<u8, 1280>::default();
+                let message = attribute_panic_message(message, &mut attributed);
 
                 let mut compressed_bytes: [u8; 2048] = [0; 2048];
                 let mut len: bun_zlib::uLong = compressed_bytes.len() as bun_zlib::uLong;
@@ -3774,24 +3892,20 @@ mod draft {
         );
     }
 
-    /// # Safety
-    /// `action` must be null or a valid NUL-terminated C string that outlives the dlopen call.
+    /// C++ side of [`enter_native_module`] (`Bun::NativeModuleCrashScope`); the result goes back to `CrashHandler__leaveNativeModule`.
     #[unsafe(no_mangle)]
-    unsafe extern "C" fn CrashHandler__setDlOpenAction(action: *const c_char) {
-        if !action.is_null() {
-            debug_assert!(CURRENT_ACTION.with(|c| c.get()).is_none());
-            // SAFETY: action is a valid NUL-terminated C string for the duration of the dlopen call
-            let s = unsafe { bun_core::ffi::cstr(action) }.to_bytes();
-            // SAFETY: noreturn-on-crash usage; the C string outlives the action via caller contract
-            let s: &'static [u8] = unsafe { bun_collections::detach_lifetime(s) };
-            CURRENT_ACTION.with(|c| c.set(Some(Action::Dlopen(s))));
-        } else {
-            debug_assert!(matches!(
-                CURRENT_ACTION.with(|c| c.get()),
-                Some(Action::Dlopen(_))
-            ));
-            CURRENT_ACTION.with(|c| c.set(None));
-        }
+    extern "C" fn CrashHandler__enterNativeModule(kind: u8, name: *const c_char) -> NativeModule {
+        let kind = match kind {
+            1 => NativeModuleKind::Loading,
+            2 => NativeModuleKind::Running,
+            _ => NativeModuleKind::None,
+        };
+        NATIVE_MODULE.with(|c| c.replace(NativeModule { kind, name }))
+    }
+
+    #[unsafe(no_mangle)]
+    extern "C" fn CrashHandler__leaveNativeModule(previous: NativeModule) {
+        NATIVE_MODULE.with(|c| c.set(previous));
     }
 
     pub fn fix_dead_code_elimination() {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -122,6 +122,7 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
   panic: () => void;
+  panicInsideNativeModule: (name: string) => void;
   rootError: () => void;
   outOfMemory: () => void;
   abort: () => void;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -401,7 +401,6 @@ static char* toFileURI(std::span<const char> span)
 
 extern "C" size_t Bun__process_dlopen_count;
 
-extern "C" void CrashHandler__setDlOpenAction(const char* action);
 extern "C" bool Bun__VM__allowAddons(void* vm);
 extern "C" int32_t Bun__addonNeedsGlibcOnMusl(const char* path, size_t len, char* soname_out, size_t soname_cap);
 
@@ -509,6 +508,9 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
 
     Bun__process_dlopen_count++;
 
+    // Covers the module's static constructors and, below, its register function; `utf8` outlives it.
+    Bun::NativeModuleCrashScope crashScope(Bun::NativeModuleCrashScope::Loading, utf8.data());
+
 #if OS(WINDOWS)
     BunString filename_str = Bun::toString(filename);
     HMODULE handle = Bun__LoadLibraryBunString(&filename_str);
@@ -531,9 +533,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
         }
     }
 #endif
-    CrashHandler__setDlOpenAction(utf8.data());
     void* handle = dlopen(utf8.data(), RTLD_LAZY);
-    CrashHandler__setDlOpenAction(nullptr);
 #endif
 
     globalObject->m_pendingNapiModuleDlopenHandle = handle;

--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -65,7 +65,11 @@ JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::
     NAPICallFrame frame(globalObject, callFrame, napi->dataPtr(), newTarget);
     Bun::NapiHandleScope handleScope(uncheckedDowncast<Zig::GlobalObject>(globalObject));
 
-    JSValue ret = toJS(napi->constructor()(napi->env(), frame.toNapi()));
+    JSValue ret;
+    {
+        Bun::NativeModuleCrashScope crashScope(Bun::NativeModuleCrashScope::Running, napi->env()->moduleNameForCrashReport());
+        ret = toJS(napi->constructor()(napi->env(), frame.toNapi()));
+    }
     napi_set_last_error(napi->env(), napi_ok);
     if (napi->env()->throwPendingException()) {
         return {};

--- a/src/jsc/bindings/NativeModuleCrashScope.h
+++ b/src/jsc/bindings/NativeModuleCrashScope.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <wtf/Noncopyable.h>
+
+// Layout of `NativeModule` in src/crash_handler/lib.rs.
+struct CrashHandlerNativeModule {
+    uint8_t kind;
+    const char* name;
+};
+
+extern "C" CrashHandlerNativeModule CrashHandler__enterNativeModule(uint8_t kind, const char* name);
+extern "C" void CrashHandler__leaveNativeModule(CrashHandlerNativeModule previous);
+
+namespace Bun {
+
+// Names the native module whose code this thread runs until the scope ends, for the crash report; `name` has to outlive the scope.
+class NativeModuleCrashScope {
+    WTF_MAKE_NONCOPYABLE(NativeModuleCrashScope);
+
+public:
+    enum Kind : uint8_t {
+        Loading = 1,
+        Running = 2,
+    };
+
+    NativeModuleCrashScope(Kind kind, const char* name)
+        : m_previous(CrashHandler__enterNativeModule(kind, name))
+    {
+    }
+
+    ~NativeModuleCrashScope()
+    {
+        CrashHandler__leaveNativeModule(m_previous);
+    }
+
+private:
+    CrashHandlerNativeModule m_previous;
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3441,6 +3441,11 @@ extern "C" const ::BunVmHandleRef* NapiEnv__vmHandle(napi_env env)
     return env->vmHandle();
 }
 
+extern "C" const char* NapiEnv__moduleNameForCrashReport(napi_env env)
+{
+    return env->moduleNameForCrashReport();
+}
+
 extern "C" void NapiEnv__ref(napi_env env)
 {
     env->ref();

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -14,6 +14,7 @@
 #include "ZigGlobalObject.h"
 #include "napi_handle_scope.h"
 #include "napi_finalizer.h"
+#include "NativeModuleCrashScope.h"
 #include "wtf/Assertions.h"
 #include "napi_macros.h"
 
@@ -412,9 +413,18 @@ public:
         if (mustDeferFinalizers() && inGC()) {
             napi_internal_enqueue_finalizer(this, finalize_cb, data, finalize_hint);
         } else {
-            finalize_cb(this, data, finalize_hint);
+            {
+                Bun::NativeModuleCrashScope crashScope(Bun::NativeModuleCrashScope::Running, moduleNameForCrashReport());
+                finalize_cb(this, data, finalize_hint);
+            }
             throwPendingException();
         }
+    }
+
+    // The addon's file as a URL when it was loaded through process.dlopen, otherwise whatever name the module registered itself with.
+    const char* moduleNameForCrashReport() const
+    {
+        return filename ? filename : m_napiModule.nm_filename;
     }
 
     void scheduleException(JSC::JSValue exception)
@@ -538,6 +548,7 @@ public:
         void call(napi_env env) const
         {
             if (callback && active) {
+                Bun::NativeModuleCrashScope crashScope(Bun::NativeModuleCrashScope::Running, env->moduleNameForCrashReport());
                 callback(env, data, hint);
             }
         }
@@ -615,6 +626,7 @@ private:
                 continue;
             }
 
+            Bun::NativeModuleCrashScope crashScope(Bun::NativeModuleCrashScope::Running, moduleNameForCrashReport());
             if (auto* sync = std::get_if<Napi::SyncCleanupHook>(&hook)) {
                 ASSERT(sync->function != nullptr);
                 sync->function(sync->data);

--- a/src/jsc/bindings/napi_finalizer.cpp
+++ b/src/jsc/bindings/napi_finalizer.cpp
@@ -10,6 +10,7 @@ void NapiFinalizer::call(WTF::RefPtr<NapiEnv> env, void* data, bool immediate)
     if (m_callback) {
         NAPI_LOG_CURRENT_FUNCTION;
         if (immediate) {
+            NativeModuleCrashScope crashScope(NativeModuleCrashScope::Running, env->moduleNameForCrashReport());
             m_callback(env.get(), data, m_hint);
         } else {
             napi_internal_enqueue_finalizer(env.get(), m_callback, data, m_hint);

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -24,6 +24,10 @@ pub(crate) mod js_bindings {
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
             ("panic", __jsc_host_js_panic),
+            (
+                "panicInsideNativeModule",
+                __jsc_host_js_panic_inside_native_module,
+            ),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
             ("abort", __jsc_host_js_abort),
@@ -129,6 +133,26 @@ pub(crate) mod js_bindings {
     #[bun_jsc::host_fn]
     fn js_panic(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
+        crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
+    }
+
+    /// `panicInsideNativeModule(name)`: panics as if inside a callback of the native module `name`.
+    #[bun_jsc::host_fn]
+    fn js_panic_inside_native_module(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let name = BunString::from_js(frame.argument(0), global)?.to_utf8();
+        let mut name_z = BoundedArray::<u8, 1024>::default();
+        if name_z.append_slice(name.slice()).is_err() || name_z.append(0).is_err() {
+            return Err(global.throw(format_args!("name is too long")));
+        }
+        crash_handler::suppress_core_dumps_if_necessary();
+        // The panic never returns, so `name_z` outlives the guard.
+        let _in_module = crash_handler::enter_native_module(
+            crash_handler::NativeModuleKind::Running,
+            name_z.const_slice().as_ptr().cast(),
+        );
         crash_handler::panic_impl(b"invoked crashByPanic() handler", None, None);
     }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2747,7 +2747,9 @@ impl ThreadSafeFunction {
                 // thread reference is gone.
                 let leftovers = self.take_queue();
                 drop(_g);
-                self.hand_back(leftovers);
+                // SAFETY: `self.env` holds the env alive for as long as the function exists.
+                let env = self.env.as_ref().map(|env| unsafe { &*env.get() });
+                self.hand_back(env, leftovers);
                 let _g = self.lock.lock_guard();
                 if self.thread_count.load(Ordering::SeqCst) == 0 {
                     self.maybe_queue_finalizer();
@@ -2866,8 +2868,9 @@ impl ThreadSafeFunction {
     /// back to the addon's call_js_cb with a null env and js_callback, which is
     /// the signal napi_threadsafe_function_call_js documents for "free this,
     /// JS is no longer reachable" (Node's ThreadSafeFunction::EmptyQueue). A
-    /// function created without a call_js_cb has nothing to give back.
-    fn hand_back(&self, items: Vec<*mut c_void>) {
+    /// function created without a call_js_cb has nothing to give back. `env` is
+    /// this function's own, for the crash report only; the addon gets null.
+    fn hand_back(&self, env: Option<&NapiEnv>, items: Vec<*mut c_void>) {
         let TsfnCallback::C {
             napi_threadsafe_function_call_js,
             ..
@@ -2876,6 +2879,7 @@ impl ThreadSafeFunction {
             return;
         };
         let call_js = *napi_threadsafe_function_call_js;
+        let _in_module = env.map(NapiEnv::enter_for_crash_report);
         for item in items {
             call_js(ptr::null_mut(), napi_value(0), self.ctx, item);
         }
@@ -3062,7 +3066,7 @@ impl ThreadSafeFunction {
             && env.to_js().bun_vm().worker_ref().is_some()
         {
             if was_closing {
-                self.hand_back(queued);
+                self.hand_back(Some(env), queued);
             } else if matches!(self.callback, TsfnCallback::C { .. }) {
                 for item in queued {
                     // The env's cleanup hook is each delivery's landing frame,

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -96,6 +96,8 @@ unsafe extern "C" {
     fn NapiEnv__ref(env: *mut NapiEnv);
     /// The reference to its VM's handle the env holds (`BunVmHandleRef`).
     fn NapiEnv__vmHandle(env: *mut NapiEnv) -> *const bun_jsc::vm_handle::Shared;
+    /// Lives as long as the env does.
+    fn NapiEnv__moduleNameForCrashReport(env: *mut NapiEnv) -> *const c_char;
     fn napi_set_last_error(env: napi_env, status: NapiStatus) -> napi_status;
     fn NapiUngatedScope__construct(storage: *mut c_void, env: *mut NapiEnv);
     fn NapiUngatedScope__destruct(storage: *mut c_void);
@@ -111,6 +113,16 @@ impl NapiEnv {
     pub(crate) fn vm_handle(&self) -> bun_jsc::vm_handle::BorrowedRef {
         // SAFETY: the env holds a reference for its whole lifetime.
         unsafe { bun_jsc::VmHandle::borrow_ref(NapiEnv__vmHandle(self.as_mut_ptr())) }
+    }
+
+    /// Names this env's module in a crash report on the current thread while the guard lives (any thread).
+    #[must_use]
+    pub(crate) fn enter_for_crash_report(&self) -> bun_crash_handler::NativeModuleGuard {
+        bun_crash_handler::enter_native_module(
+            bun_crash_handler::NativeModuleKind::Running,
+            // SAFETY: env is non-null; the name it returns lives as long as the env, which outlives every guard.
+            unsafe { NapiEnv__moduleNameForCrashReport(self.as_mut_ptr()) },
+        )
     }
 
     /// Convert err to an extern napi_status, and store the error code in env so that it can be
@@ -1916,7 +1928,11 @@ impl napi_async_work {
                 Err(state) => state != AsyncWorkStatus::Cancelled as u32,
             };
         if started {
-            (self.execute)(self.env.get(), self.data);
+            {
+                // SAFETY: the work holds a NapiEnvRef, so the env is alive for this call.
+                let _in_module = unsafe { &*self.env.get() }.enter_for_crash_report();
+                (self.execute)(self.env.get(), self.data);
+            }
             self.status
                 .store(AsyncWorkStatus::Completed as u32, Ordering::SeqCst);
         } else {
@@ -1975,7 +1991,10 @@ impl napi_async_work {
                 NapiStatus::ok
             };
 
-        complete(env, status as napi_status, self.data);
+        {
+            let _in_module = env_ref.enter_for_crash_report();
+            complete(env, status as napi_status, self.data);
+        }
 
         // SAFETY: env is valid for the duration of this call.
         unsafe { &*env }.surface_exception(global)
@@ -2400,7 +2419,10 @@ impl Finalizer {
         let env_ref = unsafe { &*env };
         let _hs = NapiHandleScope::open_scoped(env_ref);
 
-        (self.fun)(env, self.data, self.hint);
+        {
+            let _in_module = env_ref.enter_for_crash_report();
+            (self.fun)(env, self.data, self.hint);
+        }
         // SAFETY: env is valid; passes the C finalizer back for bookkeeping.
         unsafe { napi_internal_remove_finalizer(env, Some(self.fun), self.hint, self.data) };
 
@@ -2820,7 +2842,10 @@ impl ThreadSafeFunction {
                     Some(v) => napi_value::create(env, v),
                     None => napi_value(0),
                 };
-                napi_threadsafe_function_call_js(env.as_mut_ptr(), js, self.ctx, task);
+                {
+                    let _in_module = env.enter_for_crash_report();
+                    napi_threadsafe_function_call_js(env.as_mut_ptr(), js, self.ctx, task);
+                }
                 env.surface_exception(global_object)
             }
         }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
+import { inflateSync } from "node:zlib";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -608,6 +609,91 @@ describe("automatic crash reporter", () => {
       expect(sent).toBe(true);
     });
   }
+});
+
+// The panic message of an uploaded trace string `{base}/{version}/{payload}`,
+// decoded the way bun.report does: after the platform, command and format
+// characters, 7 characters of commit and two VLQs of feature bits come the
+// frames (one VLQ each, `_` or `=` for a frame without an offset, a leading 1
+// introducing a name of the following length) up to a VLQ of 0, then the
+// reason: `0` and the zlib-compressed message in base64.
+function decodeUploadedPanicMessage(payload: string): string {
+  const digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let i = 3 + 7;
+  function vlq(): number {
+    let value = 0;
+    for (let shift = 0; ; shift += 5) {
+      const digit = digits.indexOf(payload[i++]);
+      if (digit < 0) throw new Error(`bad VLQ digit at ${i - 1} of ${payload}`);
+      value += (digit & 31) * 2 ** shift;
+      if (!(digit & 32)) return value % 2 ? -Math.floor(value / 2) : value / 2;
+    }
+  }
+  vlq();
+  vlq();
+  for (;;) {
+    if (payload[i] === "_" || payload[i] === "=") {
+      i++;
+      continue;
+    }
+    const frame = vlq();
+    if (frame === 0) break;
+    if (frame === 1) {
+      i += vlq();
+      vlq();
+    }
+  }
+  expect(payload[i]).toBe("0");
+  return inflateSync(Buffer.from(payload.slice(i + 1), "base64")).toString();
+}
+
+// A panic (a Rust panic!, a napi_fatal_error) raised while bun is inside a
+// native module's code has bun frames only, so the report has to say which
+// module it was: a line under the panic locally, and a suffix on the uploaded
+// message. bun.report's fingerprint for a panic includes the message, so Sentry
+// groups these per module. The suffix carries the path from the last
+// node_modules on, never the user's directories. The hook stands in for a
+// callback of a module at the given path.
+test("a panic inside a native module names the module locally and in the uploaded message", async () => {
+  const uploaded = Promise.withResolvers<string>();
+  using server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      uploaded.resolve(new URL(request.url).pathname);
+      return new Response("OK");
+    },
+  });
+  const modulePath = "/home/someone/app/node_modules/@scope/pkg/build/Release/pkg.node";
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `require("bun:internal-for-testing").crash_handler.panicInsideNativeModule(${JSON.stringify(modulePath)})`,
+    ],
+    env: mergeWindowEnvs([
+      bunEnv,
+      {
+        BUN_CRASH_REPORT_URL: server.url.origin,
+        BUN_ENABLE_CRASH_REPORTING: "1",
+        GITHUB_ACTIONS: undefined,
+        CI: undefined,
+      },
+    ]),
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain(`Crashed while running native module: ${modulePath}\n`);
+  expect(exitCode).not.toBe(0);
+
+  const pathname = await uploaded.promise;
+  // `/` is also a VLQ and base64 digit, so the payload cannot be split out on it.
+  const payload = pathname.match(/^\/[^/]+\/(.*)\/ack$/)?.[1];
+  expect(payload, pathname).toBeDefined();
+  expect(decodeUploadedPanicMessage(payload!)).toBe(
+    "invoked crashByPanic() handler (running native module @scope/pkg/build/Release/pkg.node)",
+  );
 });
 
 test.if(isWindows)(

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -652,8 +652,8 @@ function decodeUploadedPanicMessage(payload: string): string {
 // module it was: a line under the panic locally, and a suffix on the uploaded
 // message. bun.report's fingerprint for a panic includes the message, so Sentry
 // groups these per module. The suffix carries the path from the last
-// node_modules on, never the user's directories. The hook stands in for a
-// callback of a module at the given path.
+// node_modules directory on, never the user's directories. The hook stands in
+// for a callback of a module at the given path.
 test("a panic inside a native module names the module locally and in the uploaded message", async () => {
   const uploaded = Promise.withResolvers<string>();
   using server = Bun.serve({
@@ -663,7 +663,9 @@ test("a panic inside a native module names the module locally and in the uploade
       return new Response("OK");
     },
   });
-  const modulePath = "/home/someone/app/node_modules/@scope/pkg/build/Release/pkg.node";
+  // `old_node_modules` is a user directory that merely ends in the word; the
+  // real `node_modules` before it is the one the uploaded name starts after.
+  const modulePath = "/home/someone/app/node_modules/@scope/pkg/old_node_modules/pkg.node";
 
   await using proc = Bun.spawn({
     cmd: [
@@ -692,7 +694,7 @@ test("a panic inside a native module names the module locally and in the uploade
   const payload = pathname.match(/^\/[^/]+\/(.*)\/ack$/)?.[1];
   expect(payload, pathname).toBeDefined();
   expect(decodeUploadedPanicMessage(payload!)).toBe(
-    "invoked crashByPanic() handler (running native module @scope/pkg/build/Release/pkg.node)",
+    "invoked crashByPanic() handler (running native module @scope/pkg/old_node_modules/pkg.node)",
   );
 });
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -698,6 +698,53 @@ test("a panic inside a native module names the module locally and in the uploade
   );
 });
 
+// process.dlopen can run inside another crash handler action: with
+// --install=fallback, resolving a package that is not installed holds the
+// resolver action while bun waits for the registry, and that wait runs the
+// event loop, microtasks included. The module being loaded used to go into the
+// same slot as that action, asserting it was empty on the way in and clearing
+// it on the way out. It is a slot of its own now, restored to what it replaced,
+// so a dlopen in that position neither asserts nor costs a later crash its
+// `Crashed while resolving a module` line.
+test("process.dlopen inside the resolver action leaves that action in place", async () => {
+  using dir = tempDir("crash-handler-dlopen-inside-resolver", {
+    "package.json": JSON.stringify({ name: "box", version: "0.0.0" }),
+    "index.ts": `
+      import { crash_handler } from "bun:internal-for-testing";
+      Promise.resolve().then(() => {
+        try {
+          process.dlopen({ exports: {} }, "/nonexistent-addon.node");
+        } catch {}
+        crash_handler.panic();
+      });
+      try {
+        import.meta.resolve("some-package-that-is-not-installed-xyz", import.meta.url);
+      } catch {}
+      console.log("the microtask did not run inside the resolver");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=fallback", "--debug-crash-handler-use-trace-string", "index.ts"],
+    cwd: String(dir),
+    // Nothing listens there: auto-install queues the request, runs the event
+    // loop while it waits (which is when the microtask runs), then gives up.
+    env: { ...noReportEnv, BUN_CONFIG_REGISTRY: "http://127.0.0.1:1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The microtask's own panic is the crash, so dlopen itself did not assert,
+  // and the script never got past the resolve, so the microtask ran inside it.
+  expect(stderr).toContain("invoked crashByPanic() handler");
+  expect(stdout).toBe("");
+  // The resolver action is only recorded by builds with assertions on.
+  if (isDebug || isASAN) {
+    expect(stderr).toContain("Crashed while resolving a module\n");
+  }
+  expect(exitCode).not.toBe(0);
+});
+
 test.if(isWindows)(
   "Windows: crash report upload runs the system PowerShell, not a powershell.exe in the working directory",
   async () => {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import { inflateSync } from "node:zlib";

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -319,5 +319,21 @@
                 "NAPI_VERSION=8",
             ],
         },
+        {
+            "target_name": "crash_report_addon",
+            "sources": ["crash_report_addon.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
+        },
+        {
+            "target_name": "crash_report_on_load_addon",
+            "sources": ["crash_report_addon.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS", "CRASH_ON_LOAD=1"],
+        },
     ]
 }

--- a/test/napi/napi-app/crash_report_addon.c
+++ b/test/napi/napi-app/crash_report_addon.c
@@ -1,0 +1,55 @@
+// Built twice (see binding.gyp): as crash_report_addon, whose exports crash on
+// request from a method or from a finalizer, and with CRASH_ON_LOAD as
+// crash_report_on_load_addon, which crashes inside its own register function.
+// The crash is napi_fatal_error, which goes through bun's crash reporter like
+// any other panic, so the tests can check which native module the report names.
+#include <node_api.h>
+#include <stddef.h>
+
+static void fatal(const char *where) {
+  napi_fatal_error(where, NAPI_AUTO_LENGTH, "crash_report_addon", NAPI_AUTO_LENGTH);
+}
+
+#ifdef CRASH_ON_LOAD
+
+NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
+  fatal("register");
+  return exports;
+}
+
+#else
+
+static napi_value crash_in_method(napi_env env, napi_callback_info info) {
+  (void)env;
+  (void)info;
+  fatal("method");
+  return NULL;
+}
+
+static void crashing_finalizer(napi_env env, void *data, void *hint) {
+  (void)env;
+  (void)data;
+  (void)hint;
+  fatal("finalizer");
+}
+
+// Returns an object whose finalizer crashes. It runs when the object is
+// collected or, at the latest, when the environment is torn down at exit.
+static napi_value crash_in_finalizer(napi_env env, napi_callback_info info) {
+  (void)info;
+  napi_value object;
+  napi_create_object(env, &object);
+  napi_wrap(env, object, NULL, crashing_finalizer, NULL, NULL);
+  return object;
+}
+
+NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
+  napi_property_descriptor props[] = {
+      {"crashInMethod", NULL, crash_in_method, NULL, NULL, NULL, napi_default, NULL},
+      {"crashInFinalizer", NULL, crash_in_finalizer, NULL, NULL, NULL, napi_default, NULL},
+  };
+  napi_define_properties(env, exports, sizeof(props) / sizeof(props[0]), props);
+  return exports;
+}
+
+#endif

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1541,6 +1541,45 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     expect(stderr).toBe("");
   });
 
+  // A crash report produced while bun is inside an addon's code (here a
+  // napi_fatal_error, which is reported like any panic) says which addon, so
+  // that a report is attributable even when nothing in the stack names it.
+  describe("the crash report names the native module", () => {
+    async function crashReport(code: string, where: string): Promise<string> {
+      await using proc = spawn({
+        // The trailing flag keeps debug builds from symbolizing the trace with
+        // llvm-symbolizer, which is slow; the attribution line is printed before it.
+        cmd: [bunExe(), "-e", code, "--debug-crash-handler-use-trace-string"],
+        env: { ...bunEnv, BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1" },
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(`NAPI FATAL ERROR: ${where} crash_report_addon`);
+      expect(exitCode).not.toBe(0);
+      return stderr;
+    }
+    const addon = JSON.stringify(join(__dirname, "napi-app/build/Debug/crash_report_addon.node"));
+
+    it("while loading it", async () => {
+      const onLoadAddon = join(__dirname, "napi-app/build/Debug/crash_report_on_load_addon.node");
+      const stderr = await crashReport(`require(${JSON.stringify(onLoadAddon)})`, "register");
+      expect(stderr).toContain(`Crashed while loading native module: ${onLoadAddon}\n`);
+    });
+
+    it("in one of its methods", async () => {
+      const stderr = await crashReport(`require(${addon}).crashInMethod()`, "method");
+      expect(stderr).toMatch(/Crashed while running native module: file:\/\/.*\/crash_report_addon\.node\n/);
+    });
+
+    it("in one of its finalizers", async () => {
+      // The finalizer runs when the object is collected, or else when the
+      // environment is torn down at exit; both paths are attributed.
+      const stderr = await crashReport(`require(${addon}).crashInFinalizer()`, "finalizer");
+      expect(stderr).toMatch(/Crashed while running native module: file:\/\/.*\/crash_report_addon\.node\n/);
+    });
+  });
+
   it("napi_reference_unref can be called from finalizers in regular modules", async () => {
     // This test ensures that napi_reference_unref can be called during GC
     // without triggering the NAPI_CHECK_ENV_NOT_IN_GC assertion for regular modules.

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -13,7 +13,7 @@ import {
   nodeExeMatchingAbi,
   tempDir,
 } from "harness";
-import { join } from "path";
+import { join, resolve } from "path";
 
 // The napi-app addons don't link against bun, so existing binaries stay valid
 // across bun builds. `bun install` runs a full `node-gyp rebuild` (clean + build
@@ -1564,7 +1564,9 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("while loading it", async () => {
       const onLoadAddon = join(__dirname, "napi-app/build/Debug/crash_report_on_load_addon.node");
       const stderr = await crashReport(`require(${JSON.stringify(onLoadAddon)})`, "register");
-      expect(stderr).toContain(`Crashed while loading native module: ${onLoadAddon}\n`);
+      // The line carries the path as require() handed it to dlopen; resolve() evens out the separators.
+      const named = stderr.match(/Crashed while loading native module: (.*)\n/)?.[1];
+      expect(named && resolve(named)).toBe(resolve(onLoadAddon));
     });
 
     it("in one of its methods", async () => {


### PR DESCRIPTION
### Problem
- A panic raised while bun runs an addon's code has only bun frames, so nothing in its report names the addon. `Panic: NAPI FATAL ERROR: Error::New napi_get_last_error_info` (BUN-41DM, 818 events, and four sibling groups) and `Panic: napi_reference_unref` (BUN-39FR, 520) are panics raised inside addon callbacks and finalizers; every addon lands in the same groups. Frame classification (#39815) cannot attribute these: frame 0 is bun.
- `Action::Dlopen` (`src/crash_handler/lib.rs`) named the module only during `dlopen` itself, not during the register function that runs after it, not on Windows, and only on stderr. BUN-4MMY's upload has no module name for that reason.

### Fix
- The crash handler keeps, per thread, the native module whose code the thread is inside of and what it is doing with it: `Loading` (`Process_functionDlopen`, from `dlopen` or `LoadLibrary` until the register function returns) or `Running` (callbacks, the three finalizer paths, cleanup hooks, async work, threadsafe function calls; entry points `Bun::NativeModuleCrashScope` and `NapiEnv::enter_for_crash_report()`). Entering swaps the value in and leaving restores the old one, so modules that call each other nest.
- A crash prints `Crashed while running native module: file:///.../foo.node` under the panic line. A panic's uploaded message gets ` (running native module <name>)` appended, where `<name>` is the path from the last `node_modules` on, else the basename, never the user's directories. bun.report's panic fingerprint includes the message, so Sentry groups these per module with no change on its side. Faults are unchanged: their uploaded reason has no text, and #39806 or #39815 name the addon in their frames.
- Cost on the Node-API call path: a thread-local swap on entry and a store on exit. Linux x64 release build, small method from the napi test addon: 85.6 ns/call before, 84.8 after (best of 8 runs each), under the noise of about 5 ns. The `NapiClass.cpp` scope is one line if that is still too much for the call path.
- Verified: `test/cli/run/run-crash-handler.test.ts` (hook test, decodes the uploaded message; fails before) and `test/napi/napi.test.ts` (a C addon crashing while loading, in a method, in a finalizer; all fail before with no line at all). Both files pass; `cargo check` of the touched crates for darwin and windows.

### Background
- A trace string is the URL a crash prints and uploads. For a panic it carries the message, compressed; for a fault only the address. Both `rust_panic_hook` (a Rust `panic!`, which is what `napi_fatal_error` raises) and `crash_handler()` print the new line.
- `NapiEnv::filename` is the addon's file as a URL for modules loaded through `process.dlopen`. A module that registered itself through `napi_module_register` only has the name it declared, and that is what its reports show.
- `CrashHandler__enterNativeModule` returns the previous value as a `repr(C)` struct and `CrashHandler__leaveNativeModule` takes it back: no stack, and an unbalanced caller cannot disturb its callers' state.

<details><summary>Notes</summary>

- Sample from the new test addon (debug build): `panic: NAPI FATAL ERROR: method crash_report_addon`, then `Crashed while running native module: file:///.../build/Debug/crash_report_addon.node`. The hook test's upload decodes, with bun.report's own steps, to `invoked crashByPanic() handler (running native module @scope/pkg/build/Release/pkg.node)`.
- Benchmark details: `second_addon.try_unwrap` (three Node-API calls), best of 7 rounds of 2M calls per process, 8 alternating runs per binary. Baseline runs 85.6 to 98.1 ns (median 93.1), this branch 84.8 to 105.7 ns (median 93.3). Each scope is two calls into Rust around a thread-local; macOS thread-locals go through `tlv_get_addr`, so expect a few ns there rather than none.
- The name pointer is stored as is and read only by a crash on the same thread; `NapiEnv` owns it for its lifetime and every scope is shorter. The attributed message is built in a 1280-byte buffer on the crash handler's stack; a message that does not fit uploads unattributed.
- Rebased over #39810, which reshaped the threadsafe function code: the scope sits in `deliver()`, and `hand_back()` (the items a closing function returns to the addon with a null env) opens one from the function's own env, so a call_js_cb that cannot take the null env is attributed as well.
- #35305 (a `process.dlopen` inside the resolver action tripped the old marker's empty-slot assert) is closed in favor of this PR: the slot is separate now and the scope restores what it replaced. Its case is the `process.dlopen inside the resolver action` test in `run-crash-handler.test.ts`, which fails before with that assert. #39815 attributes faults from their frames and changes the banner; this PR leaves the banner alone and the two compose. The bundler's native plugin marker (`INSIDE_NATIVE_PLUGIN`) has the same shape and could be folded in later.
- `panicInsideNativeModule` exists so the report format is tested on every platform without building an addon; the addon tests cover the real entry points where node-gyp runs.
- Rebased onto main at 0e14172 (an import conflict in the test file; the rebase also dropped `isASAN` from the import that the resolver action test reads on release builds, fixed in the last commit). CI on this head fails only in `test/cli/install/bun-audit.test.ts`, a snapshot that breaks on main since the version bump to 1.4.1, unrelated to this diff. `run-crash-handler.test.ts` and the napi tests pass.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/napi.test.ts, test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->

