### PR TITLE
compile: fix invalid ad-hoc code signature on darwin-arm64

### DIFF
--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -511,18 +511,19 @@ impl MachoFile {
         Ok(())
     }
 
-    pub fn build_and_sign(&self, writer: &mut impl std::io::Write) -> crate::Result<()> {
+    // Returns the byte count written; callers writing over an existing file must truncate to it.
+    pub fn build_and_sign(&self, writer: &mut impl std::io::Write) -> crate::Result<usize> {
         if self.header.cputype == macho::CPU_TYPE_ARM64
             && feature_flag::BUN_NO_CODESIGN_MACHO_BINARY.get() != Some(true)
         {
             let mut data: Vec<u8> = Vec::new();
             self.build(&mut data)?;
             let mut signer = MachoSigner::init(&data)?;
-            signer.sign(writer)?;
+            signer.sign(writer)
         } else {
             self.build(writer)?;
+            Ok(self.data.len())
         }
-        Ok(())
     }
 }
 
@@ -674,7 +675,7 @@ impl MachoSigner {
         super_blob_header_size + blob_index_size + code_dir_length
     }
 
-    fn sign(&mut self, writer: &mut impl std::io::Write) -> crate::Result<()> {
+    fn sign(&mut self, writer: &mut impl std::io::Write) -> crate::Result<usize> {
         const PAGE_SIZE: usize = MachoSigner::SIGNATURE_PAGE_SIZE;
         const HASH_SIZE: usize = MachoSigner::SIGNATURE_HASH_SIZE;
 
@@ -774,17 +775,12 @@ impl MachoSigner {
 
         if end - off > 0 {
             let remaining_len = end - off;
-            let mut last_page = [0u8; PAGE_SIZE];
-            // SAFETY: range [off..end] is within the original len.
-            unsafe {
-                core::ptr::copy_nonoverlapping(
-                    self.data.as_ptr().add(off),
-                    last_page.as_mut_ptr(),
-                    remaining_len,
-                );
-            }
+            // The last partial page is hashed unpadded, as codesign does.
             let mut digest = [0u8; HASH_SIZE];
-            sha256_hash(&last_page, &mut digest);
+            // SAFETY: range [off..end] is within the original len (sig_off).
+            let page =
+                unsafe { core::slice::from_raw_parts(self.data.as_ptr().add(off), remaining_len) };
+            sha256_hash(page, &mut digest);
             self.data.extend_from_slice(&digest);
         }
 
@@ -805,7 +801,7 @@ impl MachoSigner {
 
         // Write final binary
         writer.write_all(&self.data)?;
-        Ok(())
+        Ok(self.data.len())
     }
 }
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1472,16 +1472,28 @@ pub(crate) fn inject<'a>(
                 512 * 1024,
                 bun_sys::FileWriter(cloned_executable_fd),
             );
-            if let Err(e) = macho_file.build_and_sign(&mut buffered_writer) {
-                bun_core::pretty_errorln!(
-                    "Error writing standalone module graph: {}",
-                    bstr::BStr::new(e.name())
-                );
+            let written = match macho_file.build_and_sign(&mut buffered_writer) {
+                Ok(n) => n,
+                Err(e) => {
+                    bun_core::pretty_errorln!(
+                        "Error writing standalone module graph: {}",
+                        bstr::BStr::new(e.name())
+                    );
+                    cleanup(zname, cloned_executable_fd);
+                    return None;
+                }
+            };
+            if let Err(e) = std::io::Write::flush(&mut buffered_writer) {
+                bun_core::pretty_errorln!("Error flushing standalone module graph: {}", e);
                 cleanup(zname, cloned_executable_fd);
                 return None;
             }
-            if let Err(e) = std::io::Write::flush(&mut buffered_writer) {
-                bun_core::pretty_errorln!("Error flushing standalone module graph: {}", e);
+            // The template copy may be longer than the signed output; codesign rejects bytes past the signature.
+            if let Err(err) = Syscall::ftruncate(
+                cloned_executable_fd,
+                i64::try_from(written).expect("int cast"),
+            ) {
+                bun_core::pretty_errorln!("Error truncating temporary file: {}", err);
                 cleanup(zname, cloned_executable_fd);
                 return None;
             }

--- a/test/bundler/compile-macho-codesign.test.ts
+++ b/test/bundler/compile-macho-codesign.test.ts
@@ -250,35 +250,39 @@ test.each(Object.entries(bundles))(
   },
 );
 
-test.skipIf(!isMacOS || !isArm64)("codesign verifies a natively compiled executable", async () => {
-  using dir = tempDir("compile-macho-codesign-native", {
-    "entry.ts": `console.log("hi");`,
-  });
-  const cwd = String(dir);
-  const out = join(cwd, "out-native");
+test.skipIf(!isMacOS || !isArm64)(
+  "codesign verifies a natively compiled executable",
+  async () => {
+    using dir = tempDir("compile-macho-codesign-native", {
+      "entry.ts": `console.log("hi");`,
+    });
+    const cwd = String(dir);
+    const out = join(cwd, "out-native");
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "--compile", join(cwd, "entry.ts"), "--outfile", out],
-    env: bunEnv,
-    cwd,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [, buildStderr, buildExitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(buildStderr).not.toContain("error:");
-  expect(buildExitCode).toBe(0);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", join(cwd, "entry.ts"), "--outfile", out],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(buildStderr).not.toContain("error:");
+    expect(buildExitCode).toBe(0);
 
-  await using codesign = Bun.spawn({
-    cmd: ["codesign", "--verify", out],
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    codesign.stdout.text(),
-    codesign.stderr.text(),
-    codesign.exited,
-  ]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
-}, 60_000);
+    await using codesign = Bun.spawn({
+      cmd: ["codesign", "--verify", out],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      codesign.stdout.text(),
+      codesign.stderr.text(),
+      codesign.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);

--- a/test/bundler/compile-macho-codesign.test.ts
+++ b/test/bundler/compile-macho-codesign.test.ts
@@ -1,0 +1,284 @@
+// https://github.com/oven-sh/bun/issues/32159 — the ad-hoc signer must hash the last partial page unpadded and end the file at the signature.
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, isArm64, isMacOS, tempDir } from "harness";
+import { createHash } from "node:crypto";
+import { join } from "path";
+
+const MH_MAGIC_64 = 0xfeedfacf;
+const CPU_TYPE_ARM64 = 0x0100000c;
+const MH_EXECUTE = 2;
+const LC_SEGMENT_64 = 0x19;
+const LC_CODE_SIGNATURE = 0x1d;
+const CSMAGIC_EMBEDDED_SIGNATURE = 0xfade0cc0;
+const CSMAGIC_CODEDIRECTORY = 0xfade0c02;
+const CSSLOT_CODEDIRECTORY = 0;
+const PAGE_SIZE = 0x1000;
+
+// Not page-aligned on purpose, so the last hashed page is partial.
+const TEMPLATE_SIG_OFF = 0x8100;
+
+// Larger than the ad-hoc signature, so a missing truncate leaves a stale tail.
+const TEMPLATE_SIG_SIZE = 0x2000;
+
+// Minimal arm64 Mach-O: __TEXT, __BUN with one __bun section, __LINKEDIT ending in LC_CODE_SIGNATURE.
+function machoTemplate(): Buffer {
+  const fileSize = TEMPLATE_SIG_OFF + TEMPLATE_SIG_SIZE;
+  const segCmdSize = 72; // sizeof(segment_command_64)
+  const sectSize = 80; // sizeof(section_64)
+  const sigCmdSize = 16; // sizeof(linkedit_data_command)
+  const sizeofcmds = segCmdSize + (segCmdSize + sectSize) + segCmdSize + sigCmdSize;
+
+  // Non-zero fill so pages (especially the partial last one) hash real content.
+  const buf = Buffer.alloc(fileSize, 0xc3);
+  const writeName = (off: number, name: string) => {
+    buf.fill(0, off, off + 16);
+    buf.write(name, off, 16, "latin1");
+  };
+
+  // mach_header_64
+  buf.writeUInt32LE(MH_MAGIC_64, 0);
+  buf.writeInt32LE(CPU_TYPE_ARM64, 4);
+  buf.writeInt32LE(0, 8); // cpusubtype
+  buf.writeUInt32LE(MH_EXECUTE, 12);
+  buf.writeUInt32LE(4, 16); // ncmds
+  buf.writeUInt32LE(sizeofcmds, 20);
+  buf.writeUInt32LE(0, 24); // flags
+  buf.writeUInt32LE(0, 28); // reserved
+
+  // LC_SEGMENT_64 __TEXT [0, 0x4000)
+  let o = 32;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize, o + 4);
+  writeName(o + 8, "__TEXT");
+  buf.writeBigUInt64LE(0x1_0000_0000n, o + 24); // vmaddr
+  buf.writeBigUInt64LE(0x4000n, o + 32); // vmsize
+  buf.writeBigUInt64LE(0n, o + 40); // fileoff
+  buf.writeBigUInt64LE(0x4000n, o + 48); // filesize
+  buf.writeInt32LE(5, o + 56); // maxprot r-x
+  buf.writeInt32LE(5, o + 60); // initprot
+  buf.writeUInt32LE(0, o + 64); // nsects
+
+  // LC_SEGMENT_64 __BUN [0x4000, 0x8000) with one __bun section
+  o += segCmdSize;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize + sectSize, o + 4);
+  writeName(o + 8, "__BUN");
+  buf.writeBigUInt64LE(0x1_0000_4000n, o + 24); // vmaddr
+  buf.writeBigUInt64LE(0x4000n, o + 32); // vmsize
+  buf.writeBigUInt64LE(0x4000n, o + 40); // fileoff
+  buf.writeBigUInt64LE(0x4000n, o + 48); // filesize
+  buf.writeInt32LE(3, o + 56); // maxprot rw-
+  buf.writeInt32LE(3, o + 60); // initprot
+  buf.writeUInt32LE(1, o + 64); // nsects
+
+  // section_64 __bun
+  o += segCmdSize;
+  writeName(o, "__bun");
+  writeName(o + 16, "__BUN");
+  buf.writeBigUInt64LE(0x1_0000_4000n, o + 32); // addr
+  buf.writeBigUInt64LE(0x4000n, o + 40); // size
+  buf.writeUInt32LE(0x4000, o + 48); // offset
+  buf.writeUInt32LE(14, o + 52); // align = 2^14
+
+  // LC_SEGMENT_64 __LINKEDIT [0x8000, fileSize)
+  o += sectSize;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize, o + 4);
+  writeName(o + 8, "__LINKEDIT");
+  buf.writeBigUInt64LE(0x1_0000_8000n, o + 24); // vmaddr
+  buf.writeBigUInt64LE(0x3000n, o + 32); // vmsize
+  buf.writeBigUInt64LE(0x8000n, o + 40); // fileoff
+  buf.writeBigUInt64LE(BigInt(fileSize - 0x8000), o + 48); // filesize
+  buf.writeInt32LE(1, o + 56); // maxprot r--
+  buf.writeInt32LE(1, o + 60); // initprot
+  buf.writeUInt32LE(0, o + 64); // nsects
+
+  // LC_CODE_SIGNATURE (linkedit_data_command)
+  o += segCmdSize;
+  buf.writeUInt32LE(LC_CODE_SIGNATURE, o);
+  buf.writeUInt32LE(sigCmdSize, o + 4);
+  buf.writeUInt32LE(TEMPLATE_SIG_OFF, o + 8); // dataoff
+  buf.writeUInt32LE(TEMPLATE_SIG_SIZE, o + 12); // datasize
+
+  return buf;
+}
+
+type Mismatch = { slot: number; stored: string; expected: string };
+
+type ParsedSignature = {
+  dataoff: number;
+  datasize: number;
+  superBlobMagic: number;
+  cdMagic: number;
+  codeLimit: number;
+  nCodeSlots: number;
+  hashSize: number;
+  hashType: number;
+  pageSizeLog2: number;
+  mismatches: Mismatch[];
+};
+
+// Recompute every CodeDirectory slot hash the way Apple's verifier does (last page unpadded).
+function parseAndVerifySignature(buf: Buffer): ParsedSignature {
+  expect(buf.length).toBeGreaterThan(32);
+  expect(buf.readUInt32LE(0)).toBe(MH_MAGIC_64);
+  const ncmds = buf.readUInt32LE(16);
+
+  let dataoff = 0;
+  let datasize = 0;
+  let p = 32;
+  for (let i = 0; i < ncmds; i++) {
+    const cmd = buf.readUInt32LE(p);
+    const cmdsize = buf.readUInt32LE(p + 4);
+    expect(cmdsize).toBeGreaterThanOrEqual(8);
+    if (cmd === LC_CODE_SIGNATURE) {
+      dataoff = buf.readUInt32LE(p + 8);
+      datasize = buf.readUInt32LE(p + 12);
+    }
+    p += cmdsize;
+  }
+  expect(dataoff).toBeGreaterThan(0);
+  // The advertised signature region must physically exist in the file.
+  expect(dataoff + datasize).toBeLessThanOrEqual(buf.length);
+
+  // SuperBlob and everything inside it is big-endian.
+  const superBlobMagic = buf.readUInt32BE(dataoff);
+  const blobCount = buf.readUInt32BE(dataoff + 8);
+  let cd = 0;
+  for (let i = 0; i < blobCount; i++) {
+    const type = buf.readUInt32BE(dataoff + 12 + i * 8);
+    const offset = buf.readUInt32BE(dataoff + 16 + i * 8);
+    if (type === CSSLOT_CODEDIRECTORY) cd = dataoff + offset;
+  }
+  expect(cd).toBeGreaterThan(0);
+
+  const cdMagic = buf.readUInt32BE(cd);
+  const hashOffset = buf.readUInt32BE(cd + 16);
+  const nSpecialSlots = buf.readUInt32BE(cd + 24);
+  const nCodeSlots = buf.readUInt32BE(cd + 28);
+  const codeLimit = buf.readUInt32BE(cd + 32);
+  const hashSize = buf.readUInt8(cd + 36);
+  const hashType = buf.readUInt8(cd + 37);
+  const pageSizeLog2 = buf.readUInt8(cd + 39);
+  expect(nSpecialSlots).toBe(0);
+  expect(cd + hashOffset + nCodeSlots * hashSize).toBeLessThanOrEqual(buf.length);
+
+  const pageSize = 1 << pageSizeLog2;
+  const mismatches: Mismatch[] = [];
+  for (let slot = 0; slot < nCodeSlots; slot++) {
+    const stored = buf
+      .subarray(cd + hashOffset + slot * hashSize, cd + hashOffset + (slot + 1) * hashSize)
+      .toString("hex");
+    const pageStart = slot * pageSize;
+    const pageEnd = Math.min(pageStart + pageSize, codeLimit);
+    const expected = createHash("sha256").update(buf.subarray(pageStart, pageEnd)).digest("hex");
+    if (stored !== expected) mismatches.push({ slot, stored, expected });
+  }
+
+  return {
+    dataoff,
+    datasize,
+    superBlobMagic,
+    cdMagic,
+    codeLimit,
+    nCodeSlots,
+    hashSize,
+    hashType,
+    pageSizeLog2,
+    mismatches,
+  };
+}
+
+// tiny fits the template's __BUN slot (size_diff == 0); large shifts __LINKEDIT forward.
+const bundles = {
+  tiny: `console.log("hi");`,
+  large: `console.log("${Buffer.alloc(32 * 1024, "a").toString()}");`,
+};
+
+test.each(Object.entries(bundles))(
+  "--compile --target=bun-darwin-arm64 stores Apple-style page hashes, including the final partial page (%s bundle)",
+  async (label, source) => {
+    using dir = tempDir(`compile-macho-codesign-${label}`, {
+      "entry.ts": source,
+    });
+    const cwd = String(dir);
+    const template = join(cwd, "template");
+    await Bun.write(template, machoTemplate());
+    const out = join(cwd, `out-${label}`);
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "--target=bun-darwin-arm64",
+        "--compile-executable-path",
+        template,
+        join(cwd, "entry.ts"),
+        "--outfile",
+        out,
+      ],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const outBytes = readFileSync(out);
+    const sig = parseAndVerifySignature(outBytes);
+    expect(sig.superBlobMagic).toBe(CSMAGIC_EMBEDDED_SIGNATURE);
+    expect(sig.cdMagic).toBe(CSMAGIC_CODEDIRECTORY);
+    expect(sig.hashType).toBe(2); // SHA-256
+    expect(sig.hashSize).toBe(32);
+    expect(1 << sig.pageSizeLog2).toBe(PAGE_SIZE);
+
+    // codeLimit covers everything before the signature blob.
+    expect(sig.codeLimit).toBe(sig.dataoff);
+    expect(sig.nCodeSlots).toBe(Math.ceil(sig.codeLimit / PAGE_SIZE));
+    // The layout must end in a partial page or the test is vacuous.
+    expect(sig.codeLimit % PAGE_SIZE).not.toBe(0);
+
+    // codesign strict validation requires the signature to end at EOF.
+    expect(outBytes.length).toBe(sig.dataoff + sig.datasize);
+
+    expect(sig.mismatches).toStrictEqual([]);
+  },
+);
+
+test.skipIf(!isMacOS || !isArm64)("codesign verifies a natively compiled executable", async () => {
+  using dir = tempDir("compile-macho-codesign-native", {
+    "entry.ts": `console.log("hi");`,
+  });
+  const cwd = String(dir);
+  const out = join(cwd, "out-native");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", join(cwd, "entry.ts"), "--outfile", out],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, buildStderr, buildExitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(buildStderr).not.toContain("error:");
+  expect(buildExitCode).toBe(0);
+
+  await using codesign = Bun.spawn({
+    cmd: ["codesign", "--verify", out],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    codesign.stdout.text(),
+    codesign.stderr.text(),
+    codesign.exited,
+  ]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
### What does this PR do?

`bun build --compile` output for darwin-arm64 failed `codesign -v` with "invalid signature (code or signature have been modified)". macOS up to 26 still ran the binary; macOS 27 SIGKILLs it at launch.

Two bugs in the in-process signer, both inherited from the Zig version:

- The last partial page was hashed zero-padded to 4096 bytes. Apple's verifier hashes it at its real length. Every signed output had one wrong hash in the last CodeDirectory slot.
- The signed output was written over a copy of the template without `ftruncate`. The template's signature is larger than the ad-hoc one, so stale bytes stayed past the new signature. codesign strict validation rejects that.

Fix: hash the trailing bytes unpadded, return the written byte count from `build_and_sign`, and truncate the file to it (the ELF path already does this).

Ported from #32162, which no longer merges cleanly.

Fixes #32159
Fixes #39764

### How did you verify your code works?

- New `test/bundler/compile-macho-codesign.test.ts`: builds a synthetic arm64 Mach-O template, compiles with `--target=bun-darwin-arm64`, recomputes every page hash the way Apple does, and asserts the signature ends at EOF. Fails on 1.4.0, passes with this change. On darwin-arm64 it also runs `codesign --verify` on a native compile.
- `test/regression/issue/29120.test.ts` passes.
- Manual: `codesign -v` accepts a binary compiled by the debug build; on 1.4.0 it reports the invalid signature.