### PR TITLE
install: fix the variable name that broke the Rust build on main

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1356,7 +1356,7 @@ impl<'a> PackageInstaller<'a> {
                 }
                 self.summary.fail += 1;
                 self.increment_tree_install_count(
-                    !IS_PENDING_PACKAGE_INSTALL,
+                    !is_pending_package_install,
                     self.current_tree_id,
                     log_level,
                 );


### PR DESCRIPTION
### What does this PR do?

Fixes the Rust build on main. `cargo check -p bun_install` fails with:

```
error[E0425]: cannot find value `IS_PENDING_PACKAGE_INSTALL` in this scope
  --> src/install/PackageInstaller.rs:1359
```

The cause is a merge race with no textual conflict. #39816 (56c4e3d51a) added a call that uses the const generic `IS_PENDING_PACKAGE_INSTALL`. #39585 (c6a05c1014) had already replaced that const generic with the `is_pending_package_install` runtime parameter. Each PR compiled on its own branch. The combination does not.

The fix renames the one reference to the parameter name. The semantics match the other call sites in the same function (lines 1262 and 1478 use `!is_pending_package_install`).

### How did you verify your code works?

- `cargo check -p bun_install` fails on main and passes with this change.
- A full debug build (`bun bd`) passes with this change applied on top of main.

This PR adds no test files. The defect is that main does not compile, so no test file can express it: every test fails before the fix because nothing builds. #39816 already added behavior coverage for this code path (test/cli/install/bun-install-patch.test.ts, the "patchedDependencies declared by a dependency" block), and it runs again once this compiles.
