### PR TITLE
ws: pass the not-open error to the client send() callback after close(), throw while CONNECTING

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -494,18 +494,28 @@ class BunWebSocket extends EventEmitter {
   }
 
   send(data, opts, cb) {
+    const state = this.#ws.readyState;
+    if (state === ReadyState_CONNECTING) {
+      throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
+    }
+
     if ($isCallable(opts)) {
       cb = opts;
       opts = undefined;
     }
 
     try {
+      // Once CLOSING or CLOSED, the native send() discards the frame and only
+      // adds its size to bufferedAmount, which npm ws's sendAfterClose() does too.
       this.#ws.send(normalizeData(data, opts), opts?.compress);
     } catch (error) {
       // Node.js APIs expect callback arguments to be called after the current stack pops
       if (typeof cb === "function") process.nextTick(cb, error);
       return;
     }
+
+    if (state !== ReadyState_OPEN) return sendAfterClose(state, cb);
+
     // deviation: this should be called once the data is written, not immediately
     // Node.js APIs expect callback arguments to be called after the current stack pops
     if (typeof cb === "function") process.nextTick(cb, null);

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -257,6 +257,114 @@ describe("WebSocket", () => {
   });
 });
 
+// npm ws: send() throws while CONNECTING and, once CLOSING or CLOSED, passes an
+// Error to the callback (sendAfterClose) because the frame is never written.
+describe("WebSocket.send() when the socket is not OPEN", () => {
+  const readyStates = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
+  const notOpen = (state: number) => `WebSocket is not open: readyState ${state} (${readyStates[state]})`;
+
+  // Resolves with the value send() passes to its callback.
+  function sendCb(ws: WebSocket, data: string | Buffer, opts?: { binary: boolean }) {
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    let inSend = true;
+    const cb = (err: unknown) => resolve(inSend ? new Error("send() called its callback synchronously") : err);
+    if (opts) ws.send(data, opts, cb);
+    else ws.send(data, cb);
+    inSend = false;
+    return promise;
+  }
+
+  function messageOf(err: unknown) {
+    expect(err).toBeInstanceOf(Error);
+    return (err as Error).message;
+  }
+
+  async function connectedPair() {
+    const wss = new WebSocketServer({ port: 0 });
+    const received: string[] = [];
+    const { promise: serverSawClose, resolve: onServerClose } = Promise.withResolvers<void>();
+    wss.on("connection", serverWs => {
+      serverWs.on("message", data => received.push(data.toString()));
+      serverWs.on("close", () => onServerClose());
+    });
+    const ws = new WebSocket(`ws://127.0.0.1:${(wss.address() as AddressInfo).port}/`);
+    await once(ws, "open");
+    return { wss, ws, received, serverSawClose };
+  }
+
+  it("throws synchronously while CONNECTING and never calls the callback", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const ws = new WebSocket(`ws://127.0.0.1:${(wss.address() as AddressInfo).port}/`);
+    try {
+      const callbackArgs: unknown[] = [];
+      expect(ws.readyState).toBe(WebSocket.CONNECTING);
+      expect(() => ws.send("data", err => callbackArgs.push(err))).toThrow(notOpen(WebSocket.CONNECTING));
+      expect(() => ws.send("data")).toThrow(notOpen(WebSocket.CONNECTING));
+
+      await once(ws, "open");
+      const clientClosed = once(ws, "close");
+      ws.close();
+      await clientClosed;
+      expect(callbackArgs).toEqual([]);
+    } finally {
+      ws.terminate();
+      wss.close();
+    }
+  });
+
+  it("passes the CLOSING or CLOSED error to the callback after close() and sends nothing", async () => {
+    const { wss, ws, received, serverSawClose } = await connectedPair();
+    try {
+      expect(await sendCb(ws, "while open")).toBeNull();
+
+      const clientClosed = once(ws, "close");
+      ws.close();
+      expect(ws.readyState).toBe(WebSocket.CLOSING);
+      const closingResults = Promise.all([
+        sendCb(ws, "after close"),
+        sendCb(ws, Buffer.from("after close"), { binary: true }),
+        sendCb(ws, "after close", { binary: false }),
+      ]);
+      // Without a callback it must not throw, like npm ws.
+      ws.send("after close");
+      // npm ws and the WHATWG API both keep counting discarded payloads in bufferedAmount.
+      expect(ws.bufferedAmount).toBeGreaterThanOrEqual(4 * "after close".length);
+
+      expect((await closingResults).map(messageOf)).toEqual([
+        notOpen(WebSocket.CLOSING),
+        notOpen(WebSocket.CLOSING),
+        notOpen(WebSocket.CLOSING),
+      ]);
+
+      await clientClosed;
+      expect(ws.readyState).toBe(WebSocket.CLOSED);
+      expect(messageOf(await sendCb(ws, "after closed"))).toBe(notOpen(WebSocket.CLOSED));
+
+      await serverSawClose;
+      expect(received).toEqual(["while open"]);
+    } finally {
+      ws.terminate();
+      wss.close();
+    }
+  });
+
+  it("passes the error to the callback after terminate()", async () => {
+    const { wss, ws } = await connectedPair();
+    try {
+      const clientClosed = once(ws, "close");
+      ws.terminate();
+      // The error names the state send() saw, whether or not the close has completed yet.
+      const state = ws.readyState;
+      expect(state).toBeOneOf([WebSocket.CLOSING, WebSocket.CLOSED]);
+      expect(messageOf(await sendCb(ws, "after terminate"))).toBe(notOpen(state));
+      await clientClosed;
+      expect(messageOf(await sendCb(ws, "after closed"))).toBe(notOpen(WebSocket.CLOSED));
+    } finally {
+      wss.close();
+    }
+  });
+});
+
 describe("WebSocketServer", () => {
   it("sets websocket prototype properties correctly", async () => {
     const wss = new WebSocketServer({ port: 0 });


### PR DESCRIPTION
### Problem
- The `ws` module's client `send(data, cb)` calls `cb(null)` after `close()`. The native socket discards the frame once it is CLOSING or CLOSED, so the message is acked and lost. `ping()` passes `Error: WebSocket is not open: readyState 2 (CLOSING)` to its callback.
- While CONNECTING, `send()` swallows the native `InvalidStateError` or passes it to the callback. npm ws throws `readyState 0 (CONNECTING)`.
- Cause: `BunWebSocket.send()` (`src/js/thirdparty/ws.js:496`) has no readyState check. It always queues `cb(null)`.

### Fix
- `send()` reads `readyState` first, as `ping()` and `pong()` do. CONNECTING throws the npm ws error. CLOSING and CLOSED use the existing `sendAfterClose()`, which passes the error to the callback on the next tick.
- The native `send()` is still called when not open. There it only adds the payload to `bufferedAmount`, as npm ws does. The OPEN path is unchanged.
- Matches npm ws 8.18.3 under Node (Notes). #39802 does the same for the server class. Open #35459 edits the same lines with a weaker guard (Notes).
- Verified: `test/js/first_party/ws/ws.test.ts`, block `WebSocket.send() when the socket is not OPEN` (3 tests, all fail without the fix). Other suites: Notes.

### Background
- `require("ws")` resolves to `src/js/thirdparty/ws.js`. Its `BunWebSocket` class wraps the native WHATWG `WebSocket` in the npm ws EventEmitter API.
- The WHATWG `send()` throws `InvalidStateError` while CONNECTING. Once CLOSING or CLOSED it returns normally and only counts the payload in `bufferedAmount` (`WebSocket.cpp:670`).
- npm ws `send()` throws while CONNECTING. In every other state but OPEN it calls `sendAfterClose()`: count the payload, then `process.nextTick(cb, err)`. `ws.js` already has this helper for `ping()` and `pong()`.

<details><summary>Notes</summary>

Repro: an in-process `WebSocketServer({ port: 0 })`, a `ws` client, and in `open`: `send("while-open", cb)`, `close(1000)`, then `send(..., cb)`, `send(..., { binary: true }, cb)`, `ping("p", undefined, cb)`, and one more `send` after the `close` event.

Before (bun 1.4.0, same on main):

```
CONNECTING send(data, cb): did not throw       (cb later gets InvalidStateError)
CONNECTING send(data): did not throw
CLOSING send cb arg: null
CLOSING send(data, opts, cb) cb arg: null
CLOSING ping cb arg: WebSocket is not open: readyState 2 (CLOSING)
CLOSED send cb arg: null
server received messages: ["while-open"]
```

After (debug build), identical to Node 26 with npm ws 8.18.3 except for `bufferedAmount` (57 here, 46 in npm ws: the native count includes framing overhead, unchanged by this PR):

```
CONNECTING send(data, cb): threw Error "WebSocket is not open: readyState 0 (CONNECTING)"
CONNECTING send(data): threw Error "WebSocket is not open: readyState 0 (CONNECTING)"
CLOSING send cb arg: WebSocket is not open: readyState 2 (CLOSING) | sync: false
CLOSING send(data, opts, cb) cb arg: WebSocket is not open: readyState 2 (CLOSING)
CLOSING ping cb arg: WebSocket is not open: readyState 2 (CLOSING)
CLOSED send cb arg: WebSocket is not open: readyState 3 (CLOSED)
server received messages: ["while-open"]
```

The OPEN path keeps its try/catch: a payload conversion error still reaches the callback, which #39082 relies on.

The new tests check: the CONNECTING throw for both call shapes, and that the callback is never called. After `close()`: `cb(null)` while open, the CLOSING error for the 2-argument form, for the options form with a Buffer, and for the options form with a string, no throw without a callback, `bufferedAmount` at least the discarded payload bytes, the CLOSED error after the `close` event, and that the server received only the message sent while open. After `terminate()`: the error names the state `send()` saw, then CLOSED after the `close` event. All callbacks are checked to run asynchronously.

Callers that `send()` before `open` now get the npm ws throw. `test/cli/inspect/inspect.test.ts` looks like such a caller, but its un-awaited `expect(...).resolves` runs the event loop until `open`, so `send()` runs on an OPEN socket there. Checked with a copy of that block against the debug build. The other callers in the tree (`websocket-client-echo.mjs`, `websocket-server-echo.mjs`, `node-http-with-ws.test.ts`, the regression tests) send from `open` or `message` handlers.

Suites run against the debug build: `test/js/first_party/ws/` (83 pass; 3 tests in `ws-proxy.test.ts` fail the same way on the release binary in this container, which sets `HTTP_PROXY`, and do not call `send()`), `test/js/web/websocket/websocket-client.test.ts`, `websocket-accept-header-validation.test.ts`, `websocket-client-short-read.test.ts`, `test/js/node/http/node-http-with-ws.test.ts`, and regression tests 012040, 03844, 26358, 29684, 32734, 3613 (67 pass). `test/cli/inspect/inspect.test.ts` fails identically with and without this change in this container (the `ws://localhost:...` connection to the inspector fails here).

Related open PRs. #39802 fixes the same bug in the server class and does not touch the client `send()`. #35459 (`createWebSocketStream`) includes its own guard in client `send()` on the same lines: it returns `sendAfterClose()` for CLOSING and CLOSED, but lets CONNECTING fall through to the native `InvalidStateError` and skips the `bufferedAmount` count. Its stream test only needs the CLOSING and CLOSED error, which this PR provides, so whichever of the two lands second has to take this version of the hunk. I left a note on #35459.

Self-review. I ran the public readyState cases from upstream ws 8.18.3 `test/websocket.test.js` against the shim. The two cases that change with this PR are `#send` throws while CONNECTING, and the send callback error for readyState 2 or 3. The ping/pong half of this matrix is tested by hand in `test/js/web/websocket/websocket-client.test.ts:500` (#35030), the send half here, and #39802 adds the server half. A vendored copy of the upstream cases would replace all three and also shows 14 unrelated gaps (for example the static `CONNECTING`..`CLOSED` fields are writable). That is a separate change. This PR keeps the 10-line fix and its 3 tests.
</details>
