### PR TITLE
MessagePort: a close() made inside a handler completes after the drain loop, not inside close()

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -26,7 +26,6 @@
 
 #include "config.h"
 #include "MessagePort.h"
-#include <wtf/SetForScope.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
 
 #include "BunClientData.h"
@@ -105,7 +104,9 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     }
     RETURN_IF_EXCEPTION(warnScope, {});
 
-    if (!isEntangled())
+    // A port that has called close() discards posts, including the ones made while a
+    // dispatch loop still delivers its inbox (node: IsHandleClosing() after uv_close).
+    if (!isEntangled() || m_isClosing)
         return {};
 
     Vector<TransferredMessagePort> transferredPorts;
@@ -187,9 +188,9 @@ void MessagePort::flushQueuedMessagesBeforeClose()
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != ScriptExecutionStatus::Running)
         return;
 
-    // Cap iterations (whatever was queued, at least 1000) so a 'message' handler
-    // re-injecting into this closing port (via its entangled peer) can't starve the loop.
+    // Same per-call cap as node's OnMessage(): whatever was queued, at least 1000.
     size_t limit = std::max<size_t>(MessagePortPipe::queuedCount(m_pipe->state(m_side)), 1000);
+    DispatchScope dispatchScope { *this };
     for (size_t i = 0; i < limit; ++i) {
         // A handler (or a microtask it queued) may have transferred this port; the
         // remaining inbox now belongs to the new owner. drainAndDispatch()'s
@@ -205,19 +206,38 @@ void MessagePort::flushQueuedMessagesBeforeClose()
     }
 }
 
+MessagePort::DispatchScope::DispatchScope(MessagePort& port)
+    : m_port(port)
+    , m_wasDispatching(port.m_isDispatching)
+{
+    port.m_isDispatching = true;
+}
+
+MessagePort::DispatchScope::~DispatchScope()
+{
+    m_port->m_isDispatching = m_wasDispatching;
+    if (!m_wasDispatching && m_port->m_isClosing)
+        m_port->closeNow();
+}
+
 void MessagePort::close()
 {
     if (m_isDetached || m_isClosing)
         return;
     m_isClosing = true;
 
-    // Only an in-flight drain finishes: node keeps delivering the rest of the batch
-    // when a 'message' handler calls close(), but drops everything still queued when
-    // close() runs outside a dispatch. Reentrant close() is short-circuited by
-    // m_isClosing; later sends are rejected by the pipe's Closed check.
+    // Under a DispatchScope the mark is all close() does; the scope finishes the close
+    // once its loop has delivered the rest of the inbox. Anywhere else the close is
+    // immediate and whatever is still queued is dropped. Node does the same in both cases.
     if (m_isDispatching)
-        flushQueuedMessagesBeforeClose();
+        return;
+    closeNow();
+}
 
+void MessagePort::closeNow()
+{
+    if (m_isDetached)
+        return;
     m_isDetached = true;
 
     // m_pipe is held for the port's whole lifetime (the GC thread reads
@@ -351,8 +371,6 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     if (m_isDetached || !context.globalObject())
         return;
 
-    SetForScope dispatching { m_isDispatching, true };
-
     auto* globalObject = defaultGlobalObject(context.globalObject());
     Ref vm = globalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -400,7 +418,7 @@ void MessagePort::contextDestroyed()
 {
     ASSERT(scriptExecutionContext());
 
-    close();
+    closeNow();
     ActiveDOMObject::contextDestroyed();
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -104,8 +104,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     }
     RETURN_IF_EXCEPTION(warnScope, {});
 
-    // A port that has called close() discards posts, including the ones made while a
-    // dispatch loop still delivers its inbox (node: IsHandleClosing() after uv_close).
+    // m_isClosing: the close is pending under a DispatchScope. Node drops these posts too.
     if (!isEntangled() || m_isClosing)
         return {};
 
@@ -226,9 +225,7 @@ void MessagePort::close()
         return;
     m_isClosing = true;
 
-    // Under a DispatchScope the mark is all close() does; the scope finishes the close
-    // once its loop has delivered the rest of the inbox. Anywhere else the close is
-    // immediate and whatever is still queued is dropped. Node does the same in both cases.
+    // ~DispatchScope closes the port once the loop has delivered the rest of the inbox.
     if (m_isDispatching)
         return;
     closeNow();

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -96,12 +96,9 @@ public:
     // Called by the pipe on this port's context thread with one dequeued message.
     void dispatchOneMessage(ScriptExecutionContext&, MessageWithMessagePorts&&);
 
-    // Brackets a loop that delivers this port's inbox (the pipe's drainAndDispatch(), or
-    // flushQueuedMessagesBeforeClose()). A close() that arrives while one is on the stack,
-    // from a 'message' handler or from a microtask run between two deliveries, only marks
-    // the port closing: the loop keeps delivering what is queued, never nested, and the
-    // close completes when the scope ends. Node has the same shape: close() starts the uv
-    // close, OnMessage() finishes its batch, and the close callback runs after that.
+    // On the stack while a loop delivers this port's inbox. A close() made under it only
+    // marks the port: the loop delivers the rest at depth 1 and the scope closes the port
+    // when it ends, like node, whose close callback runs after OnMessage() returns.
     class DispatchScope {
         WTF_MAKE_NONCOPYABLE(DispatchScope);
 
@@ -142,14 +139,12 @@ private:
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
 
-    // ActiveDOMObject. Both run during teardown, where no dispatch loop resumes
-    // afterwards, so they close at once even if one is still on the stack.
+    // ActiveDOMObject. Teardown closes at once: a DispatchScope on the stack never resumes.
     void contextDestroyed() final;
     void stop() final { closeNow(); }
     bool virtualHasPendingActivity() const final;
 
-    // The second half of close(): detaches from the pipe, drops the loop refs and
-    // queues the 'close' event. Runs no script.
+    // close() without the DispatchScope deferral. Runs no script.
     void closeNow();
 
     // peerClosed(): deliver what the peer sent before it closed, ahead of its 'close'.
@@ -158,8 +153,7 @@ private:
     bool isEntangled() const { return !m_isDetached; }
 
 public:
-    // Checked by the transfer path so a closing-but-not-yet-detached port (close()
-    // called inside a dispatch loop) is rejected the same as a detached one.
+    // The transfer path rejects a port whose close() is pending under a DispatchScope.
     bool isClosing() const { return m_isClosing; }
 
 private:

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -96,6 +96,24 @@ public:
     // Called by the pipe on this port's context thread with one dequeued message.
     void dispatchOneMessage(ScriptExecutionContext&, MessageWithMessagePorts&&);
 
+    // Brackets a loop that delivers this port's inbox (the pipe's drainAndDispatch(), or
+    // flushQueuedMessagesBeforeClose()). A close() that arrives while one is on the stack,
+    // from a 'message' handler or from a microtask run between two deliveries, only marks
+    // the port closing: the loop keeps delivering what is queued, never nested, and the
+    // close completes when the scope ends. Node has the same shape: close() starts the uv
+    // close, OnMessage() finishes its batch, and the close callback runs after that.
+    class DispatchScope {
+        WTF_MAKE_NONCOPYABLE(DispatchScope);
+
+    public:
+        explicit DispatchScope(MessagePort&);
+        ~DispatchScope();
+
+    private:
+        const Ref<MessagePort> m_port;
+        const bool m_wasDispatching;
+    };
+
     // Only here for JSMessagePortCustom's GC optimization; always null.
     MessagePort* locallyEntangledPort() { return nullptr; }
 
@@ -124,19 +142,24 @@ private:
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
 
-    // ActiveDOMObject.
+    // ActiveDOMObject. Both run during teardown, where no dispatch loop resumes
+    // afterwards, so they close at once even if one is still on the stack.
     void contextDestroyed() final;
-    void stop() final { close(); }
+    void stop() final { closeNow(); }
     bool virtualHasPendingActivity() const final;
 
-    // Deliver messages already queued when close() is called, before teardown.
+    // The second half of close(): detaches from the pipe, drops the loop refs and
+    // queues the 'close' event. Runs no script.
+    void closeNow();
+
+    // peerClosed(): deliver what the peer sent before it closed, ahead of its 'close'.
     void flushQueuedMessagesBeforeClose();
 
     bool isEntangled() const { return !m_isDetached; }
 
 public:
-    // Checked by the transfer path so a closing-but-not-yet-detached port
-    // (inside close()'s flush window) is rejected the same as a detached one.
+    // Checked by the transfer path so a closing-but-not-yet-detached port (close()
+    // called inside a dispatch loop) is rejected the same as a detached one.
     bool isClosing() const { return m_isClosing; }
 
 private:
@@ -149,9 +172,7 @@ private:
     bool m_started { false };
     bool m_isDetached { false };
     bool m_isClosing { false };
-    // True while a 'message' handler is on the stack. close() called from inside one
-    // must finish delivering the in-flight drain (node does); a close from anywhere
-    // else drops whatever is still queued.
+    // True while a DispatchScope is on the stack; close() then defers to it.
     bool m_isDispatching { false };
     bool m_closeEventDispatched { false };
     bool m_hasMessageEventListener { false };

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -96,9 +96,7 @@ public:
     // Called by the pipe on this port's context thread with one dequeued message.
     void dispatchOneMessage(ScriptExecutionContext&, MessageWithMessagePorts&&);
 
-    // On the stack while a loop delivers this port's inbox. A close() made under it only
-    // marks the port: the loop delivers the rest at depth 1 and the scope closes the port
-    // when it ends, like node, whose close callback runs after OnMessage() returns.
+    // Held by a loop that delivers this port's inbox. close() under it waits for the loop to end.
     class DispatchScope {
         WTF_MAKE_NONCOPYABLE(DispatchScope);
 
@@ -166,7 +164,7 @@ private:
     bool m_started { false };
     bool m_isDetached { false };
     bool m_isClosing { false };
-    // True while a DispatchScope is on the stack; close() then defers to it.
+    // True while a DispatchScope is on the stack. close() then defers to it.
     bool m_isDispatching { false };
     bool m_closeEventDispatched { false };
     bool m_hasMessageEventListener { false };

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -126,7 +126,6 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
 
     static constexpr size_t takeAtOnce = 64;
     ScriptExecutionContextIdentifier rescheduleCtx = 0;
-    // A close() made by a handler below takes effect when this scope ends, after the loop.
     MessagePort::DispatchScope dispatchScope { *port };
     while (true) {
         std::optional<MessageWithMessagePorts> message;
@@ -184,9 +183,8 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     }
 
     // Budget spent with messages left. We are on `context`'s thread: continue on
-    // its next loop iteration (after I/O and timers), not in this drain. Not for a
-    // port that closed meanwhile: the scope above drops what is left when it ends
-    // (node: TriggerAsync() is a no-op on a closing handle).
+    // its next loop iteration (after I/O and timers), not in this drain. A closing
+    // port is not continued. dispatchScope drops the rest (node: TriggerAsync() no-ops).
     if (rescheduleCtx && !port->isClosing()) {
         context->postTaskAfterYield([pipe = Ref { *this }, side, rescheduleCtx](ScriptExecutionContext&) {
             pipe->drainAndDispatch(side, rescheduleCtx);

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -126,6 +126,8 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
 
     static constexpr size_t takeAtOnce = 64;
     ScriptExecutionContextIdentifier rescheduleCtx = 0;
+    // A close() made by a handler below takes effect when this scope ends, after the loop.
+    MessagePort::DispatchScope dispatchScope { *port };
     while (true) {
         std::optional<MessageWithMessagePorts> message;
         {
@@ -182,8 +184,10 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     }
 
     // Budget spent with messages left. We are on `context`'s thread: continue on
-    // its next loop iteration (after I/O and timers), not in this drain.
-    if (rescheduleCtx) {
+    // its next loop iteration (after I/O and timers), not in this drain. Not for a
+    // port that closed meanwhile: the scope above drops what is left when it ends
+    // (node: TriggerAsync() is a no-op on a closing handle).
+    if (rescheduleCtx && !port->isClosing()) {
         context->postTaskAfterYield([pipe = Ref { *this }, side, rescheduleCtx](ScriptExecutionContext&) {
             pipe->drainAndDispatch(side, rescheduleCtx);
         });

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -183,8 +183,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     }
 
     // Budget spent with messages left. We are on `context`'s thread: continue on
-    // its next loop iteration (after I/O and timers), not in this drain. A closing
-    // port is not continued. dispatchScope drops the rest (node: TriggerAsync() no-ops).
+    // its next loop iteration (after I/O and timers), not in this drain.
     if (rescheduleCtx && !port->isClosing()) {
         context->postTaskAfterYield([pipe = Ref { *this }, side, rescheduleCtx](ScriptExecutionContext&) {
             pipe->drainAndDispatch(side, rescheduleCtx);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1818,11 +1818,11 @@ test("MessageEvent ports validation walks the iterator once and gives a detailed
   port1.close();
 });
 
-test("MessagePort: transferring a port from inside its own close()'s flush window throws DataCloneError", async () => {
-  // Queue two messages. The first handler calls A.close(); close()'s flush
-  // (running because m_inMessageDispatch is true) delivers the second, whose
-  // handler tries to transfer A. A is m_isClosing at that point, so the
-  // transfer path rejects it with DataCloneError.
+test("MessagePort: transferring a port that was close()d earlier in the same batch throws DataCloneError", async () => {
+  // Queue two messages. The first handler calls A.close(), which only marks A closing:
+  // the drain still delivers the second message once that handler returns, and its
+  // handler tries to transfer A. The transfer path rejects a closing port the same as a
+  // detached one.
   const { port1: A, port2: A2 } = new MessageChannel();
   const { port1: B1, port2: B2 } = new MessageChannel();
   let err: any;
@@ -1833,13 +1833,13 @@ test("MessagePort: transferring a port from inside its own close()'s flush windo
     n++;
     if (n === 1) {
       A.close();
-      done();
     } else {
       try {
         B1.postMessage(null, [A]);
       } catch (e) {
         err = e;
       }
+      done();
     }
   });
   A2.postMessage("first");

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -73,6 +73,103 @@ describe("MessagePort pipe", () => {
     port1.close();
   });
 
+  // close() from inside a handler only marks the port. The drain that is already running
+  // delivers the rest of the inbox after the handler returns (depth 1, like node); close()
+  // itself dispatches nothing, and the closing port discards everything posted on it.
+  test("close() inside a handler does not re-enter the handler, and posts after it are discarded", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const seen: string[] = [];
+    const peerGot: string[] = [];
+    let depth = 0;
+    port2.onmessage = e => {
+      depth++;
+      seen.push(`${e.data}@${depth}`);
+      port2.close();
+      port2.postMessage(`after-close-${e.data}`);
+      depth--;
+    };
+    port1.onmessage = e => peerGot.push(e.data);
+    // port1's 'close' (fired because port2 closed) lands after anything port2 sent it.
+    const { promise: peerClosed, resolve } = Promise.withResolvers<void>();
+    port1.addEventListener("close", () => resolve());
+    port1.postMessage(1);
+    port1.postMessage(2);
+    port1.postMessage(3);
+    await peerClosed;
+    expect({ seen, peerGot }).toEqual({ seen: ["1@1", "2@1", "3@1"], peerGot: [] });
+    port1.close();
+  });
+
+  test("the batch a handler closed in keeps going, including what the peer posts meanwhile; 'close' follows it", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const seen: string[] = [];
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    let depth = 0;
+    port2.onmessage = e => {
+      depth++;
+      seen.push(`${e.data}@${depth}`);
+      if (e.data === 1) {
+        port2.close();
+        port1.postMessage("from-peer");
+      }
+      depth--;
+    };
+    port2.addEventListener("close", () => {
+      seen.push("close");
+      resolve();
+    });
+    port1.postMessage(1);
+    port1.postMessage(2);
+    await closed;
+    expect(seen).toEqual(["1@1", "2@1", "from-peer@1", "close"]);
+    port1.close();
+  });
+
+  // Same thing on the other delivery loop: the peer closed first, so this side's
+  // messages are flushed ahead of its 'close' event, and a handler closes during that flush.
+  test("close() inside a handler while the peer's close is being delivered", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const seen: string[] = [];
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    let depth = 0;
+    port1.postMessage("a");
+    port1.postMessage("b");
+    port1.close();
+    port2.addEventListener("close", () => {
+      seen.push("close");
+      resolve();
+    });
+    port2.onmessage = e => {
+      depth++;
+      seen.push(`${e.data}@${depth}`);
+      port2.close();
+      depth--;
+    };
+    await closed;
+    expect(seen).toEqual(["a@1", "b@1", "close"]);
+  });
+
+  // A microtask queued by a handler runs between two deliveries, still inside the drain.
+  test("close() from a microtask between two messages lets the batch finish", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const seen: (number | string)[] = [];
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    port2.onmessage = e => {
+      seen.push(e.data);
+      if (e.data === 1) queueMicrotask(() => port2.close());
+    };
+    port2.addEventListener("close", () => {
+      seen.push("close");
+      resolve();
+    });
+    port1.postMessage(1);
+    port1.postMessage(2);
+    port1.postMessage(3);
+    await closed;
+    expect(seen).toEqual([1, 2, 3, "close"]);
+    port1.close();
+  });
+
   test("messages queued on a port follow it across transfer", async () => {
     const { port1: A, port2: B } = new MessageChannel();
     const { port1: C, port2: D } = new MessageChannel();


### PR DESCRIPTION
### Problem
- `port.close()` inside the port's own `onmessage` handler re-enters that handler with every queued message (`msg 2 depth=2`), and a `postMessage()` on the closing port during that nested drain reaches the peer. Node delivers the rest at depth 1 and drops the posts. New in 1.4.0.
- Cause: `MessagePort::close()` (`MessagePort.cpp:218` on main) runs `flushQueuedMessagesBeforeClose()` inline while `m_isDispatching` is set, with the pipe side still open. #31216 added this so the rest of the batch is delivered, as in node.
- The peer-closed flush nests the same way. A `close()` from a microtask between two messages dropped the rest of the batch, which node delivers.

### Fix
- Under a `DispatchScope`, `close()` only sets `m_isClosing`. The loop already on the stack delivers the rest of the inbox from its own frame, and the scope calls `closeNow()` when it ends. `closeNow()` is the old second half of `close()`.
- `postMessage()` drops once `m_isClosing` is set. A drain that spends its budget on a closing port is not rescheduled.
- `stop()` and `contextDestroyed()` call `closeNow()` directly. No loop resumes after teardown.
- Verified: `test/js/web/workers/message-port-pipe.test.ts` (4 new tests, all fail on 1.4.0). Also `test/js/web/workers/`, `test/js/node/worker_threads/`, 18 ported node port tests.

### Background
- A `MessagePort` is an `EventTarget` over one side of a `MessagePortPipe`, which holds the inbox. The posted task `drainAndDispatch()` pops one message at a time and dispatches it. `peerClosed()` runs a second loop of the same kind before it fires `'close'`. `DispatchScope` brackets both.
- `m_isDispatching` was set per message. It is now set per loop, so a `close()` from a microtask also lets the batch finish.
- Node has the same shape: `close()` starts the uv close, `OnMessage()` finishes its batch, and the close callback runs after that.

<details><summary>Notes</summary>

Output of the ledger repro (three queued messages, the handler calls `close()` and then posts on the closing port):

```
node 26 / this branch      bun 1.4.0, main
msg 1 depth=1              msg 1 depth=1
msg 2 depth=1              msg 2 depth=2
msg 3 depth=1              msg 3 depth=2
peer got []                peer got ["after-close-2","after-close-3"]
```

Other probes, node 26 and this branch agree on every line:

- handler closes, then the peer posts into the closing port: `["1@1","2@1","peer-after-close@1","close","peer close"]`. Main printed `["1@1","2@2","close","peer close"]`.
- peer closed first, the handler closes during the flush: `["a@1","b@1","close"]`. Main printed `["a@1","b@2","close"]`.
- `queueMicrotask(() => port.close())` from the first handler: `[1,2,3,"close"]`. Main printed `[1,"close"]`.
- worker_threads `close(cb)` from a handler: `[1,2,"close","close-cb"]`, unchanged.

Messages the peer posts while the batch runs are delivered, up to the existing budget, as in node (`OnMessage()` keeps going after `uv_close()`; `TriggerAsync()` is a no-op on a closing handle, so what is left past the limit is dropped, which is what the reschedule change does here).

The transfer path already checks `isClosing()`, so a port closed earlier in the batch still fails to transfer with `DataCloneError`. The existing worker_threads test for that relied on the nested delivery for its ordering. It now resolves from the second handler.

Teardown: a worker's `process.exit()` or `terminate()` requests termination and unwinds to the worker loop before `stop()` runs, so `stop()` never sees a live scope there. On the main thread with `BUN_DESTRUCT_VM_ON_EXIT=1`, `stop()` can run with a handler frame still on the stack. `closeNow()` closes the pipe at once in that case, as before.

Re-entrancy storm under the ASAN debug build with `Malloc=1`: 8 modes (peer close, `start()`, transfer of the peer, `onmessage = null`, `Bun.gc(true)`, 50 peer posts into the closing port, double close) x 20 rounds x 20 queued. Max handler depth 1, exactly one `'close'` per port, nothing reached the peer, no sanitizer report.

Suites run on the debug build: `test/js/web/workers/` (448 pass), `test/js/node/worker_threads/` (152 pass), and the 18 ported node tests. Seven tests failed in this container. They fail the same way on a build without this diff (worker startup time and 5 s timeouts under debug in `worker.test.ts`, `worker-terminate-lifetime.test.ts`, `worker_destruction.test.ts`, `worker-late-completion.test.ts`).

Related: #33638 keeps the received queue readable after `close()` for `receiveMessageOnPort`. It touches `close()` too and is independent of this change. Whichever lands second needs a small rebase.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/message-port-pipe.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [47.84ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [15.50ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [138.43ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [19.49ms]
94 |     port1.addEventListener("close", () => resolve());
95 |     port1.postMessage(1);
96 |     port1.postMessage(2);
97 |     port1.postMessage(3);
98 |     await peerClosed;
99 |     expect({ seen, peerGot }).toEqual({ seen: ["1@1", "2@1", "3@1"], peerGot: [] });
                                   ^
error: expect(received).toEqual(expected)

  {
-   "peerGot": [],
+   "peerGot": [
+     "after-close-2",
+     "after-close-3",
+   ],
    "seen": [
      "1@1",
-     "2@1",
-     "3@1",
+     
... (truncated)

release without fix: 4 failed, 3 skipped
bun test v1.4.0-canary.1 (6e906e468)

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [0.27ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [0.14ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [0.77ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [0.20ms]
94 |     port1.addEventListener("close", () => resolve());
95 |     port1.postMessage(1);
96 |     port1.postMessage(2);
97 |     port1.postMessage(3);
98 |     await peerClosed;
99 |     expect({ seen, peerGot }).toEqual({ seen: ["1@1", "2@1", "3@1"], peerGot: [] });
                                   ^
error: expect(received).toEqual(expected)

  {
-   "peerGot": [],
+   "peerGot": [
+     "after-close-2",
+     "after-close-3",
+   ],
    "seen": [
      "1@1",
-     "2@1",
-     "3@1",
+     "2@2",
+     "3@2",
    ],
  }

- Expected  - 3
+ Received  + 6

      at <anonymous> (/workspace/bun/test/js/web/workers/message-port-pipe.test.ts:99:31)
(fail) MessagePort pipe > close() inside a handler does not re-enter th
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/message-port-pipe.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [33.28ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [8.87ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [135.04ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [18.69ms]
(pass) MessagePort pipe > close() inside a handler does not re-enter the handler, and posts after it are discarded [12.25ms]
(pass) MessagePort pipe > the batch a handler closed in keeps going, including what the peer posts meanwhile; 'close' follows it [10.91ms]
(pass) MessagePort pipe > close() inside a handler while the peer's close is being delivered [9.81ms]
(pass) MessagePort pipe > close() from a microtask between two messages lets the batch finish [10.90ms]
(pass) MessagePort pipe > messag
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1a55e83146
  features     baseline

23 deps, 129 codegen, 1172 objects in 876ms

ninja: Entering directory `/workspace/bun/build/release'
[1/163] gen ErrorCode+*.h
[2/163] gen compressed/completions/bun.bash.zst
[3/163] gen compressed/completions/bun.fish.zst
[4/163] gen compressed/completions/bun.zsh.zst
[5/163] gen compressed/src/runtime/bake/bun-framework-react/client.tsx.zst
[6/163] gen compressed/codegen/bun-error/index.js.zst
[7/163] gen compressed/codegen/bake.error.js.zst
[8/163] fetch WebKit (prebuilt)
[WebKit] up to date
[9/163] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[10/163] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[11/163] gen compressed/codegen/bake.client.js.zst
[12/163] gen compressed/codegen/bun-error/bun-error.css.zst
[13/163] gen compre
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/MessagePort.cpp           | 39 ++++++---
 src/jsc/bindings/webcore/MessagePort.h             | 29 +++++--
 src/jsc/bindings/webcore/MessagePortPipe.cpp       |  3 +-
 test/js/node/worker_threads/worker_threads.test.ts | 12 +--
 test/js/web/workers/message-port-pipe.test.ts      | 97 ++++++++++++++++++++++
 5 files changed, 153 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/MessagePort.cpp                6     12      0
src/jsc/bindings/webcore/MessagePort.h                  5     11      0
src/jsc/bindings/webcore/MessagePortPipe.cpp            4      6      0
test/js/node/worker_threads/worker_threads.test.ts      2      1      0
test/js/web/workers/message-port-pipe.test.ts           1      1      0
```

</details>

<!-- robobun:evidence:end -->