### PR TITLE
js_parser: fold `using x = null` into const instead of let

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8807,9 +8807,7 @@ impl LowerUsingDeclarationsContext {
                     ));
                 }
             }
-            // The binding stays immutable. select_local_kind() turns it into
-            // "var" at the top level of a module that is wrapped in try/catch,
-            // where the declaration must be visible outside the try block.
+            // "var" at the top level of a wrapped module, "const" everywhere else.
             local.kind = p.select_local_kind(js_ast::s::Kind::KConst);
         }
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8807,7 +8807,6 @@ impl LowerUsingDeclarationsContext {
                     ));
                 }
             }
-            // "var" at the top level of a wrapped module, "const" everywhere else.
             local.kind = p.select_local_kind(js_ast::s::Kind::KConst);
         }
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8807,14 +8807,10 @@ impl LowerUsingDeclarationsContext {
                     ));
                 }
             }
-            // SAFETY: arena-owned Scope pointer valid for parser 'a lifetime; no aliasing &mut outstanding
-            if p.will_wrap_module_in_try_catch_for_using
-                && p.current_scope().kind == js_ast::scope::Kind::Entry
-            {
-                local.kind = js_ast::s::Kind::KVar;
-            } else {
-                local.kind = js_ast::s::Kind::KConst;
-            }
+            // The binding stays immutable. select_local_kind() turns it into
+            // "var" at the top level of a module that is wrapped in try/catch,
+            // where the declaration must be visible outside the try block.
+            local.kind = p.select_local_kind(js_ast::s::Kind::KConst);
         }
     }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1176,8 +1176,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Optimization: Avoid unnecessary "using" machinery by changing ones
         // initialized to "null" or "undefined" into a normal variable. Note that
         // "await using" still needs the "await", so we can't do it for those.
+        //
+        // The binding stays immutable, so this must be "const" and not "let".
+        // select_local_kind() below still shortens it to "let" when bundling.
         if p.options.features.minify_syntax && data.kind == S::Kind::KUsing {
-            data.kind = S::Kind::KLet;
+            data.kind = S::Kind::KConst;
             for d in data.decls.slice() {
                 if let Some(val) = d.value {
                     if !matches!(val.data, js_ast::ExprData::ENull(_))

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1174,11 +1174,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Optimization: Avoid unnecessary "using" machinery by changing ones
-        // initialized to "null" or "undefined" into a normal variable. Note that
+        // initialized to "null" or "undefined" into a normal constant. Note that
         // "await using" still needs the "await", so we can't do it for those.
-        //
-        // The binding stays immutable, so this must be "const" and not "let".
-        // select_local_kind() below still shortens it to "let" when bundling.
         if p.options.features.minify_syntax && data.kind == S::Kind::KUsing {
             data.kind = S::Kind::KConst;
             for d in data.decls.slice() {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1472,6 +1472,37 @@ describe("bundler", () => {
       expect(code.match(/let keep = /g)).toHaveLength(10);
     },
   });
+
+  // A `using` binding is a constant. When bundling with minify-syntax, every
+  // `const` is printed as `let`, so both the `using x = null` fold and the
+  // lowered `using` must end up as `let`, like esbuild prints them.
+  itBundled("minify/LoweredUsingIsPrintedLikeConst", {
+    files: {
+      "/entry.js": /* js */ `
+        function open() {
+          return { [Symbol.dispose]() { console.log("disposed"); } };
+        }
+        function f() {
+          using a = null;
+          using b = open();
+          console.log("body", a, typeof b);
+        }
+        f();
+      `,
+    },
+    target: "browser",
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toMatch(/\blet a = null\b/);
+      expect(code).toMatch(/\blet b = __using\(/);
+      expect(code).not.toMatch(/\b(const|var) [ab]\b/);
+    },
+    run: {
+      stdout: "body null object\ndisposed\n",
+    },
+  });
 });
 
 // The runtime transpiler (`bun run`/`bun test`) implicitly enables

--- a/test/js/bun/resolve/lower-using-bun-target.test.ts
+++ b/test/js/bun/resolve/lower-using-bun-target.test.ts
@@ -347,3 +347,22 @@ console.log(JSON.stringify({
     expect(exitCode).toBe(0);
   });
 });
+
+describe("lowered using declarations", () => {
+  test("a using inside a namespace stays const when the module also has a top-level using", () => {
+    // Lowering a top-level `using` wraps the whole module in try/catch, so the
+    // top-level declarations become `var` to stay visible outside the try
+    // block. A namespace body is not the module top level: its `using` has to
+    // stay immutable.
+    const t = new Bun.Transpiler({ target: "node", loader: "ts" });
+    const out = t.transformSync(`using top = r();
+namespace N {
+  using x = s();
+  export const y = x.v;
+}
+`);
+    expect(out).toMatch(/\bvar top = __using\w*\(/);
+    expect(out).toMatch(/\bconst x = __using\w*\(/);
+    expect(out).not.toMatch(/\bvar x\b/);
+  });
+});

--- a/test/js/bun/resolve/lower-using-bun-target.test.ts
+++ b/test/js/bun/resolve/lower-using-bun-target.test.ts
@@ -261,3 +261,89 @@ export const result = handle.val;
     expect(exitCode).toBe(0);
   });
 });
+
+describe("using initialized to null or undefined", () => {
+  // minify_syntax turns `using x = null` into a plain declaration, since there
+  // is nothing to dispose. The binding is still immutable, so the plain
+  // declaration has to be `const`, like esbuild emits.
+  test.each(["bun", "browser", "node"] as const)("becomes const, not let, for target=%s", target => {
+    const t = new Bun.Transpiler({ target, minify: { syntax: true } });
+    const out = t.transformSync(
+      `function f() {
+  using a = null;
+  using b = undefined;
+  console.log(a, b);
+  return [a, b];
+}
+`,
+      "js",
+    );
+    expect(out).toBe(`function f() {
+  const a = null, b = void 0;
+  console.log(a, b);
+  return [a, b];
+}
+`);
+  });
+
+  test("only the statements initialized to null or undefined are folded", () => {
+    const t = new Bun.Transpiler({ target: "bun", minify: { syntax: true } });
+    const out = t.transformSync(
+      `function f() {
+  using a = null;
+  using b = open();
+  console.log(a, b);
+  return [a, b];
+}
+`,
+      "js",
+    );
+    expect(out).toBe(`function f() {
+  const a = null;
+  using b = open();
+  console.log(a, b);
+  return [a, b];
+}
+`);
+  });
+
+  test("assigning to the binding at runtime throws like it does for const", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `function tryAssign(fn) {
+  try {
+    return "assigned " + fn();
+  } catch (e) {
+    return e.constructor.name;
+  }
+}
+using top = null;
+console.log(JSON.stringify({
+  constNull: tryAssign(() => { const x = null; eval("x = 1"); return x; }),
+  usingNull: tryAssign(() => { using x = null; eval("x = 1"); return x; }),
+  usingUndefined: tryAssign(() => { using x = undefined; eval("x = 1"); return x; }),
+  usingNullInBlock: tryAssign(() => { { using x = null; eval("x = 1"); return x; } }),
+  usingNullTopLevel: tryAssign(() => { eval("top = 1"); return top; }),
+  usingObject: tryAssign(() => { using x = { [Symbol.dispose]() {} }; eval("x = 1"); return typeof x; }),
+}));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      constNull: "TypeError",
+      usingNull: "TypeError",
+      usingUndefined: "TypeError",
+      usingNullInBlock: "TypeError",
+      usingNullTopLevel: "TypeError",
+      usingObject: "TypeError",
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- Two sites turn a `using` declaration into a plain one, and both can drop its immutability. The `minify_syntax` fold for `null` and `undefined` initializers picks `let` (`src/js_parser/visit/visit_stmt.rs:1180`). `bun run` always has `minify_syntax` on, so `using p = null; eval("p = 1")` assigns. Native `using` and `const` throw a TypeError.
- The lowering (`scan_stmts`, `src/js_parser/p.rs:8839`) picks `var` when the module is wrapped in try/catch and the scope has the `Entry` kind. A namespace body has that kind too, so its `using` becomes a mutable `var` when the module also has a top-level `using`.

### Fix
- Both sites now start from `const` and pass it through `select_local_kind()`, like every `let` and `const` declaration. The top level of a wrapped module still gets `var`.
- Correct because a `using` binding is immutable, and its symbol is already a constant (`src/js_parser/parse/mod.rs:837`). The `let` that bundling prints is as safe as it is for `const`: the bundler rejects a direct assignment at build time.
- Matches esbuild 0.25.1 in every one of these modes.
- Verified: 6 new cases in `test/js/bun/resolve/lower-using-bun-target.test.ts` and 1 in `test/bundler/bundler_minify.test.ts`. All 7 fail on the released bun.

### Background
- `using x = v` declares an immutable binding and disposes `v` when the scope exits. The spec skips `null` and `undefined`, so such a declaration behaves like `const x = v`.
- For targets without native `using`, the parser lowers `using x = v` to `x = __using(stack, v)` plus a try/finally that disposes the stack. A top-level `using` wraps the whole module in it, so top-level declarations become `var` to stay visible outside the try block.
- `select_local_kind()` (`src/js_parser/p.rs:5746`) picks the keyword a declaration is printed with: `var` at the top level of a bundled or wrapped module, `let` for a `const` when bundling with `minify_syntax` (an assignment to a constant is a build error there), otherwise the keyword itself.

<details><summary>Notes</summary>

Repro for the fold, `ev.js`:

```js
function a() { using p = null; try { eval("p = 1"); return "assigned p=" + p; } catch (e) { return "THREW " + e.message; } }
console.log(a());
console.log((function z() { using p = null; using q = undefined; using r = 0; }).toString());
```

Released bun 1.4.0 (the report also reproduced it on 1.3.14, so this is not a regression):

```
assigned p=1
function z() {
  let p = null, q = void 0;
  using r = 0;
}
```

With this change:

```
THREW Attempted to assign to readonly property.
function z() {
  const p = null, q = void 0;
  using r = 0;
}
```

That is the same TypeError message that JavaScriptCore throws for an assignment to a native `using` binding.

Repro for the lowering, `ns.ts` with `bun build --no-bundle --target=node ns.ts`:

```ts
using top = r();
namespace N {
  using x = s();
  export const y = x.v;
}
```

Released bun prints `var x = __using(...)` inside the namespace closure. Without the `using top` line it prints `const x`. With this change it prints `const x` in both cases. The top-level `top` stays `var` in both versions. The self-review of the first commit found this second site.

Keyword matrix after this change, identical to esbuild 0.25.1 with the same flags:

| input | transform (`bun run`, `Bun.Transpiler`, `--no-bundle`) | bundle + `--minify-syntax` |
| --- | --- | --- |
| `using a = null` in a function | `const a = null` | `let a = null` (unchanged) |
| lowered `using b = open()` in a function, for-of body, or switch case | `const b = __using(...)` (unchanged) | `let b = __using(...)` (was `const`) |
| lowered `using` inside a namespace, module has a top-level `using` | `const` (was `var`) | `let` (was `var`) |
| lowered top-level `using` | `var` (unchanged) | `var` (unchanged) |
| `using` without minify, target bun | kept as `using` (unchanged) | kept as `using` (unchanged) |

The bundler's build error for a direct assignment is `Cannot assign to "u" because it is a constant`. It fires for `using` bindings today, with or without this change.

`scan_stmts` runs for function and block bodies (`visit/mod.rs:1552`), for-of bodies (`visit_stmt.rs:2003`) and switch cases (`visit_stmt.rs:2123`). In the last two the block scope is still pushed, so `select_local_kind()` never sees the module scope there and never produces a `var` inside a loop body.

Only a fold statement whose initializers are all `null` or `undefined` is affected. A statement with any other initializer stays `using`. `await using` is never folded. The `const_values` inlining and the unused constant removal in `visit_stmts` key off the kind the statement had before it was visited (`was_const` in `s_local`), so the fold does not enable them.

Intentionally excluded: a module whose only top-level `using` declarations all fold away, transformed for a target that lowers `using` with `minify_syntax` on (for example `bun build --no-bundle --minify-syntax --target=node`). `will_wrap_module_in_try_catch_for_using` is computed before the visit pass, so it stays set, and every top-level declaration of that module is printed as `var`, the folded one included. That is the stale flag, not one of the two sites above, it affects plain `const` declarations in the same module the same way, and esbuild 0.25.1 prints the same output. Output there is identical before and after this PR. `bun run` never lowers `using`, so the runtime is not affected (covered by the `usingNullTopLevel` case).

Suites run with the debug build: `test/js/bun/resolve/lower-using-bun-target.test.ts`, `test/bundler/bundler_minify.test.ts`, `test/bundler/transpiler/transpiler.test.js` (has the lowering snapshots), `test/bundler/bundler_edgecase.test.ts`, `test/bundler/bundler_browser.test.ts -t Using`, `test/bundler/metafile.test.ts -t runtime-helper`, `test/js/web/explicit-resource-management.test.ts`, `test/regression/issue/11100.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts test/js/bun/resolve/lower-using-bun-target.test.ts
bun test v1.4.0 (6e906e468)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [609.93ms]
(pass) bundler > minify/StringAdditionFolding [142.76ms]
(pass) bundler > minify/FunctionExpressionRemoveName [189.35ms]
(pass) bundler > minify/KeepNamesPreservesNames [128.37ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [114.06ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1246.94ms]
(pass) bundler > minify/MergeAdjacentVars [401.70ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [521.45ms]
(pass) bundler > minify/Infinity [114.24ms]
(pass) bundler > minify+whitespace/Infinity [117.60ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [408.76ms]
(pass) bundler > minify/InlineArraySpread [98.91ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [397.46ms]
(pass) bundler > minify/MissingExpressionBlocks [496.61ms]
(pass) bundler > minify/BunRequireStatement [1134.41ms]
(pas
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [23.55ms]
(pass) bundler > minify/StringAdditionFolding [5.93ms]
(pass) bundler > minify/FunctionExpressionRemoveName [4.86ms]
(pass) bundler > minify/KeepNamesPreservesNames [5.79ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [5.35ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [18.61ms]
(pass) bundler > minify/MergeAdjacentVars [11.12ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [10.70ms]
(pass) bundler > minify/Infinity [3.77ms]
(pass) bundler > minify+whitespace/Infinity [4.40ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [9.69ms]
(pass) bundler > minify/InlineArraySpread [4.44ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [10.59ms]
(pass) bundler > minify/MissingExpressionBlocks [12.65ms]
(pass) bundler > minify/BunRequireStatement [20.45ms]
(pass) bundler > minify/SwitchUndefined [11.85ms]
(pass) bundler > minify/RequireInDeadBranch [4.69ms]
(pass) bundler > minify/TypeOfRequire [4.37ms]
(pass) bundler > minify/RequireMainToImportMetaMain [3.61ms]
(pass) bundler > minify/Cons
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts test/js/bun/resolve/lower-using-bun-target.test.ts
bun test v1.4.0 (6e906e468)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [664.88ms]
(pass) bundler > minify/StringAdditionFolding [121.36ms]
(pass) bundler > minify/FunctionExpressionRemoveName [193.34ms]
(pass) bundler > minify/KeepNamesPreservesNames [137.95ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [99.90ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1160.43ms]
(pass) bundler > minify/MergeAdjacentVars [452.99ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [486.09ms]
(pass) bundler > minify/Infinity [108.56ms]
(pass) bundler > minify+whitespace/Infinity [114.41ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [425.82ms]
(pass) bundler > minify/InlineArraySpread [121.30ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [470.69ms]
(pass) bundler > minify/MissingExpressionBlocks [509.32ms]
(pass) bundler > minify/BunRequireStatement [1117.72ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 924ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
^[[1m^[[92m   Compiling^[[0m bun_outpu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                                 |   9 +-
 src/js_parser/visit/visit_stmt.rs                  |   4 +-
 test/bundler/bundler_minify.test.ts                |  31 ++++++
 test/js/bun/resolve/lower-using-bun-target.test.ts | 105 +++++++++++++++++++++
 4 files changed, 139 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js_parser/p.rs                                      6      3      0
src/js_parser/visit/visit_stmt.rs                       6      3      0
test/bundler/bundler_minify.test.ts                     1      2      0
test/js/bun/resolve/lower-using-bun-target.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->
