### PR TITLE
Bun.serve websocket: deliver the Close frame over backpressureLimit and send the FIN right after a close() made inside a handler

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -672,13 +672,14 @@ private:
             AsyncSocket<SSL> *asyncSocket = (AsyncSocket<SSL> *) httpContextData->upgradedWebSocket;
 
             /* Uncork here as well (note: what if we failed to uncork and we then pub/sub before we even upgraded?) */
-            auto [written, failed] = asyncSocket->uncork();
+            asyncSocket->uncork();
 
-            /* If we succeeded in uncorking, check if we have sent WebSocket FIN */
-            if (!failed) {
+            /* An end() in the open handler left the TCP FIN to us. Gate on the buffer like onData / onWritable in
+             * WebSocketContext, not on uncork() succeeding: uncork() also succeeds when a large send in the open
+             * handler already released the cork and left a full buffer behind. onWritable FINs after the drain. */
+            if (!us_socket_is_closed((us_socket_t *) asyncSocket) && asyncSocket->getBufferedAmount() == 0) {
                 WebSocketData *webSocketData = (WebSocketData *) asyncSocket->getAsyncSocketData();
                 if (webSocketData->isShuttingDown) {
-                    /* In that case, also send TCP FIN (this is similar to what we have in ws drain handler) */
                     asyncSocket->shutdown();
                 }
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -671,18 +671,9 @@ private:
             /* This path is only for upgraded websockets */
             AsyncSocket<SSL> *asyncSocket = (AsyncSocket<SSL> *) httpContextData->upgradedWebSocket;
 
-            /* Uncork here as well (note: what if we failed to uncork and we then pub/sub before we even upgraded?) */
+            /* Uncork here as well (note: what if we failed to uncork and we then pub/sub before we even upgraded?).
+             * An end() in the open handler has already uncorked and dealt with the FIN itself. */
             asyncSocket->uncork();
-
-            /* An end() in the open handler left the TCP FIN to us. Gate on the buffer like onData / onWritable in
-             * WebSocketContext, not on uncork() succeeding: uncork() also succeeds when a large send in the open
-             * handler already released the cork and left a full buffer behind. onWritable FINs after the drain. */
-            if (!us_socket_is_closed((us_socket_t *) asyncSocket) && asyncSocket->getBufferedAmount() == 0) {
-                WebSocketData *webSocketData = (WebSocketData *) asyncSocket->getAsyncSocketData();
-                if (webSocketData->isShuttingDown) {
-                    asyncSocket->shutdown();
-                }
-            }
 
             /* Reset upgradedWebSocket before we return */
             httpContextData->upgradedWebSocket = nullptr;

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -234,7 +234,7 @@ private:
     }
 
 public:
-    /* Send websocket close frame, emit close event, send FIN if successful.
+    /* Send websocket close frame, emit close event, send FIN once everything before it is written.
      * Will not append a close reason if code is 0 or 1005. */
     void end(int code = 0, std::string_view message = {}) {
         /* Check if we already called this one */
@@ -243,7 +243,7 @@ public:
             return;
         }
 
-        /* We postpone any FIN sending to either drainage or uncorking */
+        /* Makes onWritable send the FIN if we cannot do it below */
         webSocketData->isShuttingDown = true;
 
         /* Format and send the close frame */
@@ -251,17 +251,14 @@ public:
         size_t length = std::min<size_t>(MAX_CLOSE_PAYLOAD, message.length());
         char closePayload[MAX_CLOSE_PAYLOAD + 2];
         size_t closePayloadLength = protocol::formatClosePayload(closePayload, (uint16_t) code, message.data(), length);
-        SendStatus status = sendFrame(std::string_view(closePayload, closePayloadLength), OpCode::CLOSE, false, true);
+        sendFrame(std::string_view(closePayload, closePayloadLength), OpCode::CLOSE, false, true);
 
-        /* FIN if we are ok and not corked */
-        if (!this->isCorked()) {
-            if (status == SUCCESS) {
-                /* If we are not corked, and we just sent off everything, we need to FIN right here.
-                 * In all other cases whoever uncorks us (onData, the upgrade path in HttpContext) sends the FIN
-                 * if the buffer is empty by then, else onWritable does once it has drained. shutdown() with data
-                 * still buffered would discard it, close frame included. */
-                this->shutdown();
-            }
+        /* The close frame is the last thing we send, so there is nothing left to batch: flush whatever the
+         * handler we may be running in has corked, then FIN right here unless some of it is still buffered.
+         * In that case onWritable FINs once the buffer has drained; shutdown() now would discard it. */
+        Super::uncork();
+        if (getBufferedAmount() == 0) {
+            this->shutdown();
         }
 
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -138,6 +138,17 @@ public:
             return DROPPED;
         }
 
+        return sendFrame(message, opCode, compress, fin);
+    }
+
+private:
+    /* send() without the maxBackpressure check: the frame is always written or buffered.
+     * end() uses this for the close frame, which is at most 127 bytes and the last frame
+     * of the connection, so it queues behind the buffered data no matter how much there is.
+     * Returns BACKPRESSURE or SUCCESS, never DROPPED. */
+    SendStatus sendFrame(std::string_view message, OpCode opCode, bool compress, bool fin) {
+        WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();
+
         /* If we are subscribers and have messages to drain we need to drain them here to stay synced */
         WebSocketData *webSocketData = (WebSocketData *) Super::getAsyncSocketData();
 
@@ -222,6 +233,7 @@ public:
         return SUCCESS;
     }
 
+public:
     /* Send websocket close frame, emit close event, send FIN if successful.
      * Will not append a close reason if code is 0 or 1005. */
     void end(int code = 0, std::string_view message = {}) {
@@ -239,13 +251,14 @@ public:
         size_t length = std::min<size_t>(MAX_CLOSE_PAYLOAD, message.length());
         char closePayload[MAX_CLOSE_PAYLOAD + 2];
         size_t closePayloadLength = protocol::formatClosePayload(closePayload, (uint16_t) code, message.data(), length);
-        bool ok = send(std::string_view(closePayload, closePayloadLength), OpCode::CLOSE);
+        SendStatus status = sendFrame(std::string_view(closePayload, closePayloadLength), OpCode::CLOSE, false, true);
 
         /* FIN if we are ok and not corked */
         if (!this->isCorked()) {
-            if (ok) {
+            if (status == SUCCESS) {
                 /* If we are not corked, and we just sent off everything, we need to FIN right here.
-                 * In all other cases, we need to fin either if uncork was successful, or when drainage is complete. */
+                 * In all other cases, we need to fin either if uncork was successful, or when drainage is complete
+                 * (onWritable). shutdown() with data still buffered would discard it, close frame included. */
                 this->shutdown();
             }
         }

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -257,8 +257,9 @@ public:
         if (!this->isCorked()) {
             if (status == SUCCESS) {
                 /* If we are not corked, and we just sent off everything, we need to FIN right here.
-                 * In all other cases, we need to fin either if uncork was successful, or when drainage is complete
-                 * (onWritable). shutdown() with data still buffered would discard it, close frame included. */
+                 * In all other cases whoever uncorks us (onData, the upgrade path in HttpContext) sends the FIN
+                 * if the buffer is empty by then, else onWritable does once it has drained. shutdown() with data
+                 * still buffered would discard it, close frame included. */
                 this->shutdown();
             }
         }

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -332,17 +332,9 @@ private:
         /* This parser has virtually no overhead */
         WebSocketProtocol<isServer, WebSocketContext<SSL, isServer, USERDATA>>::consume(data, (unsigned int) length, (WebSocketState<isServer> *) webSocketData, s);
 
-        /* Uncorking a closed socekt is fine, in fact it is needed */
+        /* Uncorking a closed socekt is fine, in fact it is needed. If consume() ended the WebSocket, end()
+         * has already uncorked and sent the FIN, or left it to onWritable while data is buffered. */
         asyncSocket->uncork();
-
-        /* If uncorking was successful and we are in shutdown state then send TCP FIN */
-        if (asyncSocket->getBufferedAmount() == 0) {
-            /* We can now be in shutdown state */
-            if (webSocketData->isShuttingDown) {
-                /* Shutting down a closed socket is handled by uSockets and just fine */
-                asyncSocket->shutdown();
-            }
-        }
 
         return s;
     }

--- a/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
+++ b/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
@@ -238,9 +238,8 @@ describe("BackPressure buffer", () => {
 
 // Once a socket is over backpressureLimit, uws drops every further frame. The
 // Close frame must not be one of them: it has to go out behind the buffered
-// data, and the TCP FIN only after that buffer has drained. Skipped on Windows
-// like the tests above: the loopback there never builds up backpressure.
-describe.skipIf(isWindows)("close while over backpressureLimit", () => {
+// data, and the TCP FIN only after that buffer has drained.
+describe("close while over backpressureLimit", () => {
   const FRAME = 1024 * 1024;
   const LIMIT = 2 * FRAME;
   // Server frame: FIN + binary, 64-bit extended length, no mask.
@@ -272,43 +271,35 @@ describe.skipIf(isWindows)("close while over backpressureLimit", () => {
     return { dataFrames, rest: rest.length <= 16 ? rest.toString("hex") : `${rest.length} bytes` };
   }
 
-  // Upgrades a paused client and sends 1 MiB frames to it until uws reports a
-  // drop (0). Frames reported as sent (> 0) or buffered (-1) were accepted and
-  // have to reach the client.
-  async function fillPastLimit(server: { port: number }, opened: Promise<import("bun").ServerWebSocket<unknown>>) {
-    const { sock, initial } = await pausedClient(server.port);
-    const ws = await opened;
+  // Sends 1 MiB frames until uws reports a drop (0) and returns how many it
+  // accepted before that. Frames reported as sent (> 0) or buffered (-1) have
+  // to reach the client.
+  function fillPastLimit(ws: import("bun").ServerWebSocket<unknown>): number {
     const payload = Buffer.alloc(FRAME);
     let accepted = 0;
-    for (;;) {
-      if (accepted === 64) throw new Error("send() never reported a drop");
-      if (ws.sendBinary(payload) === 0) break;
-      accepted++;
+    while (ws.sendBinary(payload) !== 0) {
+      if (++accepted === 64) throw new Error("send() never reported a drop");
     }
-    // The client reads nothing until readToEnd(), so the socket stays over the
-    // limit until the test closes it.
     expect(ws.getBufferedAmount()).toBeGreaterThan(LIMIT);
-    return {
-      ws,
-      sock,
-      accepted,
-      async readToEnd() {
-        const chunks = [initial];
-        const finished = new Promise<void>(resolve => {
-          sock.once("end", resolve);
-          sock.once("close", resolve);
-        });
-        sock.on("data", chunk => chunks.push(chunk));
-        sock.resume();
-        await finished;
-        sock.destroy();
-        return Buffer.concat(chunks);
-      },
-    };
+    return accepted;
   }
 
-  function serveWithLimit() {
-    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
+  // Lets the paused client read and returns everything after the handshake,
+  // up to the server's FIN.
+  async function readToEnd(sock: net.Socket, initial: Buffer): Promise<Buffer> {
+    const chunks = [initial];
+    const finished = new Promise<void>(resolve => {
+      sock.once("end", resolve);
+      sock.once("close", resolve);
+    });
+    sock.on("data", chunk => chunks.push(chunk));
+    sock.resume();
+    await finished;
+    sock.destroy();
+    return Buffer.concat(chunks);
+  }
+
+  function serveWithLimit(open: (ws: import("bun").ServerWebSocket<unknown>) => void) {
     const closed = Promise.withResolvers<{ code: number; reason: string }>();
     const server = Bun.serve({
       port: 0,
@@ -318,27 +309,27 @@ describe.skipIf(isWindows)("close while over backpressureLimit", () => {
       },
       websocket: {
         backpressureLimit: LIMIT,
-        open(ws) {
-          opened.resolve(ws);
-        },
+        open,
         message() {},
         close(_ws, code, reason) {
           closed.resolve({ code, reason });
         },
       },
     });
-    return { server, opened: opened.promise, closed: closed.promise };
+    return { server, closed: closed.promise };
   }
 
   it("ws.close() delivers the buffered frames and then the Close frame", async () => {
-    const { server, opened, closed } = serveWithLimit();
+    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
+    const { server, closed } = serveWithLimit(opened.resolve);
     await using _server = server;
-    const { ws, accepted, readToEnd } = await fillPastLimit(server, opened);
+    const { sock, initial } = await pausedClient(server.port);
+    const ws = await opened.promise;
+    const accepted = fillPastLimit(ws);
 
     ws.close(1000, "bye");
 
-    const bytes = await readToEnd();
-    expect({ ...splitStream(bytes), closeEvent: await closed }).toEqual({
+    expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual({
       dataFrames: accepted,
       rest: closeFrame(1000, "bye").toString("hex"),
       closeEvent: { code: 1000, reason: "bye" },
@@ -346,20 +337,46 @@ describe.skipIf(isWindows)("close while over backpressureLimit", () => {
   });
 
   it("a Close frame from the client is answered behind the buffered frames", async () => {
-    const { server, opened, closed } = serveWithLimit();
+    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
+    const { server, closed } = serveWithLimit(opened.resolve);
     await using _server = server;
-    const { sock, accepted, readToEnd } = await fillPastLimit(server, opened);
+    const { sock, initial } = await pausedClient(server.port);
+    const accepted = fillPastLimit(await opened.promise);
 
     // The client's read side is paused, but it can still write. uws answers
     // the peer's Close frame with end() while the socket is still over the limit.
     sock.write(maskedCloseFrame(4001, "peer"));
     const closeEvent = await closed;
 
-    const bytes = await readToEnd();
-    expect({ ...splitStream(bytes), closeEvent }).toEqual({
+    expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent }).toEqual({
       dataFrames: accepted,
       rest: closeFrame(4001, "peer").toString("hex"),
       closeEvent: { code: 4001, reason: "peer" },
+    });
+  });
+
+  // A synchronous upgrade runs open() inside the HTTP parser, which uncorks the
+  // new socket afterwards and is then the one that has to hold back the FIN
+  // (HttpContext.h). The client cannot read before open() returns, so the
+  // socket is over the limit when close() runs.
+  it("ws.close() inside open() after a synchronous upgrade", async () => {
+    const filled = Promise.withResolvers<number>();
+    const { server, closed } = serveWithLimit(ws => {
+      try {
+        filled.resolve(fillPastLimit(ws));
+      } catch (error) {
+        filled.reject(error);
+      }
+      ws.close(1000, "bye");
+    });
+    await using _server = server;
+    const { sock, initial } = await pausedClient(server.port);
+    const accepted = await filled.promise;
+
+    expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual({
+      dataFrames: accepted,
+      rest: closeFrame(1000, "bye").toString("hex"),
+      closeEvent: { code: 1000, reason: "bye" },
     });
   });
 });

--- a/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
+++ b/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
@@ -236,10 +236,13 @@ describe("BackPressure buffer", () => {
   });
 });
 
-// Once a socket is over backpressureLimit, uws drops every further frame. The
-// Close frame must not be one of them: it has to go out behind the buffered
-// data, and the TCP FIN only after that buffer has drained.
-describe("close while over backpressureLimit", () => {
+// Whatever closes a server socket, the client has to end up with every frame
+// uws accepted, then the Close frame, then the TCP FIN. readToEnd() below only
+// returns once the FIN has arrived, so a missing FIN fails these tests by the
+// test timeout: uws's own fallback is the end() timer, 16 s at the default
+// idleTimeout, which is why these tests do not lower it.
+describe("close()", () => {
+  type ServerWebSocket = import("bun").ServerWebSocket<unknown>;
   const FRAME = 1024 * 1024;
   const LIMIT = 2 * FRAME;
   // Server frame: FIN + binary, 64-bit extended length, no mask.
@@ -271,10 +274,15 @@ describe("close while over backpressureLimit", () => {
     return { dataFrames, rest: rest.length <= 16 ? rest.toString("hex") : `${rest.length} bytes` };
   }
 
+  // The expected shape of { ...splitStream(bytes), closeEvent }.
+  function delivered(dataFrames: number, code: number, reason: string) {
+    return { dataFrames, rest: closeFrame(code, reason).toString("hex"), closeEvent: { code, reason } };
+  }
+
   // Sends 1 MiB frames until uws reports a drop (0) and returns how many it
   // accepted before that. Frames reported as sent (> 0) or buffered (-1) have
   // to reach the client.
-  function fillPastLimit(ws: import("bun").ServerWebSocket<unknown>): number {
+  function fillPastLimit(ws: ServerWebSocket): number {
     const payload = Buffer.alloc(FRAME);
     let accepted = 0;
     while (ws.sendBinary(payload) !== 0) {
@@ -299,17 +307,26 @@ describe("close while over backpressureLimit", () => {
     return Buffer.concat(chunks);
   }
 
-  function serveWithLimit(open: (ws: import("bun").ServerWebSocket<unknown>) => void) {
+  function serve(options: {
+    open?: (ws: ServerWebSocket) => void;
+    drain?: (ws: ServerWebSocket) => void;
+    // Upgrade from a later task. open() then runs from uws's own cork()
+    // instead of inside the HTTP parser, which holds the cork of a
+    // synchronous upgrade and uncorks the socket itself afterwards.
+    asyncUpgrade?: boolean;
+  }) {
     const closed = Promise.withResolvers<{ code: number; reason: string }>();
     const server = Bun.serve({
       port: 0,
-      fetch(req, s) {
+      async fetch(req, s) {
+        if (options.asyncUpgrade) await new Promise(resolve => setTimeout(resolve, 0));
         if (s.upgrade(req)) return;
         return new Response("no", { status: 500 });
       },
       websocket: {
         backpressureLimit: LIMIT,
-        open,
+        open: options.open ?? (() => {}),
+        drain: options.drain,
         message() {},
         close(_ws, code, reason) {
           closed.resolve({ code, reason });
@@ -319,64 +336,132 @@ describe("close while over backpressureLimit", () => {
     return { server, closed: closed.promise };
   }
 
-  it("ws.close() delivers the buffered frames and then the Close frame", async () => {
-    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
-    const { server, closed } = serveWithLimit(opened.resolve);
-    await using _server = server;
-    const { sock, initial } = await pausedClient(server.port);
-    const ws = await opened.promise;
-    const accepted = fillPastLimit(ws);
+  // Over backpressureLimit uws drops every further frame. The Close frame must
+  // not be one of them: it has to queue behind the buffered data, and the FIN
+  // has to wait until that data has drained.
+  describe("while over backpressureLimit", () => {
+    it("ws.close() delivers the buffered frames and then the Close frame", async () => {
+      const opened = Promise.withResolvers<ServerWebSocket>();
+      const { server, closed } = serve({ open: opened.resolve });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+      const ws = await opened.promise;
+      const accepted = fillPastLimit(ws);
 
-    ws.close(1000, "bye");
-
-    expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual({
-      dataFrames: accepted,
-      rest: closeFrame(1000, "bye").toString("hex"),
-      closeEvent: { code: 1000, reason: "bye" },
-    });
-  });
-
-  it("a Close frame from the client is answered behind the buffered frames", async () => {
-    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
-    const { server, closed } = serveWithLimit(opened.resolve);
-    await using _server = server;
-    const { sock, initial } = await pausedClient(server.port);
-    const accepted = fillPastLimit(await opened.promise);
-
-    // The client's read side is paused, but it can still write. uws answers
-    // the peer's Close frame with end() while the socket is still over the limit.
-    sock.write(maskedCloseFrame(4001, "peer"));
-    const closeEvent = await closed;
-
-    expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent }).toEqual({
-      dataFrames: accepted,
-      rest: closeFrame(4001, "peer").toString("hex"),
-      closeEvent: { code: 4001, reason: "peer" },
-    });
-  });
-
-  // A synchronous upgrade runs open() inside the HTTP parser, which uncorks the
-  // new socket afterwards and is then the one that has to hold back the FIN
-  // (HttpContext.h). The client cannot read before open() returns, so the
-  // socket is over the limit when close() runs.
-  it("ws.close() inside open() after a synchronous upgrade", async () => {
-    const filled = Promise.withResolvers<number>();
-    const { server, closed } = serveWithLimit(ws => {
-      try {
-        filled.resolve(fillPastLimit(ws));
-      } catch (error) {
-        filled.reject(error);
-      }
       ws.close(1000, "bye");
-    });
-    await using _server = server;
-    const { sock, initial } = await pausedClient(server.port);
-    const accepted = await filled.promise;
 
-    expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual({
-      dataFrames: accepted,
-      rest: closeFrame(1000, "bye").toString("hex"),
-      closeEvent: { code: 1000, reason: "bye" },
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(accepted, 1000, "bye"),
+      );
+    });
+
+    it("a Close frame from the client is answered behind the buffered frames", async () => {
+      const opened = Promise.withResolvers<ServerWebSocket>();
+      const { server, closed } = serve({ open: opened.resolve });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+      const accepted = fillPastLimit(await opened.promise);
+
+      // The client's read side is paused, but it can still write. uws answers
+      // the peer's Close frame while the socket is still over the limit.
+      sock.write(maskedCloseFrame(4001, "peer"));
+      const closeEvent = await closed;
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent }).toEqual(delivered(accepted, 4001, "peer"));
+    });
+
+    // The client cannot read anything before open() returns, so the socket is
+    // over the limit when close() runs.
+    it("ws.close() inside open() after a synchronous upgrade", async () => {
+      const filled = Promise.withResolvers<number>();
+      const { server, closed } = serve({
+        open(ws) {
+          try {
+            filled.resolve(fillPastLimit(ws));
+          } catch (error) {
+            filled.reject(error);
+          }
+          ws.close(1000, "bye");
+        },
+      });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+      const accepted = await filled.promise;
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(accepted, 1000, "bye"),
+      );
+    });
+  });
+
+  // Bun runs every handler corked, so the Close frame only leaves the cork
+  // buffer when the handler returns. end() has to flush it and send the FIN
+  // itself: none of the places that uncork afterwards know about the close.
+  describe("from a corked handler", () => {
+    it("ws.close() inside open() after a synchronous upgrade", async () => {
+      const { server, closed } = serve({ open: ws => ws.close(1000, "bye") });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(0, 1000, "bye"),
+      );
+    });
+
+    it("ws.close() inside open() after an asynchronous upgrade", async () => {
+      const { server, closed } = serve({ asyncUpgrade: true, open: ws => ws.close(1000, "bye") });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(0, 1000, "bye"),
+      );
+    });
+
+    it("ws.close() inside ws.cork()", async () => {
+      const opened = Promise.withResolvers<ServerWebSocket>();
+      const { server, closed } = serve({ open: opened.resolve });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+      const ws = await opened.promise;
+
+      ws.cork(() => ws.close(1000, "bye"));
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(0, 1000, "bye"),
+      );
+    });
+
+    it("ws.close() inside drain() once the buffer is empty", async () => {
+      const opened = Promise.withResolvers<ServerWebSocket>();
+      const { server, closed } = serve({
+        open: opened.resolve,
+        drain(ws) {
+          if (ws.getBufferedAmount() === 0) ws.close(1000, "bye");
+        },
+      });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+      const accepted = fillPastLimit(await opened.promise);
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(accepted, 1000, "bye"),
+      );
+    });
+
+    // uws answers a Close frame from inside its corked data handler.
+    it("a Close frame from the client is answered and followed by the FIN", async () => {
+      const opened = Promise.withResolvers<ServerWebSocket>();
+      const { server, closed } = serve({ open: opened.resolve });
+      await using _server = server;
+      const { sock, initial } = await pausedClient(server.port);
+      await opened.promise;
+
+      sock.write(maskedCloseFrame(4001, "peer"));
+
+      expect({ ...splitStream(await readToEnd(sock, initial)), closeEvent: await closed }).toEqual(
+        delivered(0, 4001, "peer"),
+      );
     });
   });
 });

--- a/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
+++ b/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
@@ -235,3 +235,131 @@ describe("BackPressure buffer", () => {
     expect(hash.digest("hex")).toBe(expectedHash);
   });
 });
+
+// Once a socket is over backpressureLimit, uws drops every further frame. The
+// Close frame must not be one of them: it has to go out behind the buffered
+// data, and the TCP FIN only after that buffer has drained. Skipped on Windows
+// like the tests above: the loopback there never builds up backpressure.
+describe.skipIf(isWindows)("close while over backpressureLimit", () => {
+  const FRAME = 1024 * 1024;
+  const LIMIT = 2 * FRAME;
+  // Server frame: FIN + binary, 64-bit extended length, no mask.
+  const frameHeader = Buffer.from([0x82, 0x7f, 0, 0, 0, 0, 0, 0x10, 0, 0]);
+
+  function closeFrame(code: number, reason: string): Buffer {
+    return Buffer.concat([Buffer.from([0x88, 2 + reason.length, code >> 8, code & 0xff]), Buffer.from(reason)]);
+  }
+
+  // The client side of a Close frame must be masked.
+  function maskedCloseFrame(code: number, reason: string): Buffer {
+    const payload = closeFrame(code, reason).subarray(2);
+    const mask = [0x12, 0x34, 0x56, 0x78];
+    return Buffer.from([0x88, 0x80 | payload.length, ...mask, ...Array.from(payload, (byte, i) => byte ^ mask[i & 3])]);
+  }
+
+  // Counts the intact 1 MiB frames at the front of what the client read and
+  // returns whatever follows them, so a failure shows where the stream ends.
+  function splitStream(bytes: Buffer) {
+    const perFrame = frameHeader.length + FRAME;
+    let dataFrames = 0;
+    while (
+      bytes.length - dataFrames * perFrame >= perFrame &&
+      bytes.subarray(dataFrames * perFrame, dataFrames * perFrame + frameHeader.length).equals(frameHeader)
+    ) {
+      dataFrames++;
+    }
+    const rest = bytes.subarray(dataFrames * perFrame);
+    return { dataFrames, rest: rest.length <= 16 ? rest.toString("hex") : `${rest.length} bytes` };
+  }
+
+  // Upgrades a paused client and sends 1 MiB frames to it until uws reports a
+  // drop (0). Frames reported as sent (> 0) or buffered (-1) were accepted and
+  // have to reach the client.
+  async function fillPastLimit(server: { port: number }, opened: Promise<import("bun").ServerWebSocket<unknown>>) {
+    const { sock, initial } = await pausedClient(server.port);
+    const ws = await opened;
+    const payload = Buffer.alloc(FRAME);
+    let accepted = 0;
+    for (;;) {
+      if (accepted === 64) throw new Error("send() never reported a drop");
+      if (ws.sendBinary(payload) === 0) break;
+      accepted++;
+    }
+    // The client reads nothing until readToEnd(), so the socket stays over the
+    // limit until the test closes it.
+    expect(ws.getBufferedAmount()).toBeGreaterThan(LIMIT);
+    return {
+      ws,
+      sock,
+      accepted,
+      async readToEnd() {
+        const chunks = [initial];
+        const finished = new Promise<void>(resolve => {
+          sock.once("end", resolve);
+          sock.once("close", resolve);
+        });
+        sock.on("data", chunk => chunks.push(chunk));
+        sock.resume();
+        await finished;
+        sock.destroy();
+        return Buffer.concat(chunks);
+      },
+    };
+  }
+
+  function serveWithLimit() {
+    const opened = Promise.withResolvers<import("bun").ServerWebSocket<unknown>>();
+    const closed = Promise.withResolvers<{ code: number; reason: string }>();
+    const server = Bun.serve({
+      port: 0,
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("no", { status: 500 });
+      },
+      websocket: {
+        backpressureLimit: LIMIT,
+        open(ws) {
+          opened.resolve(ws);
+        },
+        message() {},
+        close(_ws, code, reason) {
+          closed.resolve({ code, reason });
+        },
+      },
+    });
+    return { server, opened: opened.promise, closed: closed.promise };
+  }
+
+  it("ws.close() delivers the buffered frames and then the Close frame", async () => {
+    const { server, opened, closed } = serveWithLimit();
+    await using _server = server;
+    const { ws, accepted, readToEnd } = await fillPastLimit(server, opened);
+
+    ws.close(1000, "bye");
+
+    const bytes = await readToEnd();
+    expect({ ...splitStream(bytes), closeEvent: await closed }).toEqual({
+      dataFrames: accepted,
+      rest: closeFrame(1000, "bye").toString("hex"),
+      closeEvent: { code: 1000, reason: "bye" },
+    });
+  });
+
+  it("a Close frame from the client is answered behind the buffered frames", async () => {
+    const { server, opened, closed } = serveWithLimit();
+    await using _server = server;
+    const { sock, accepted, readToEnd } = await fillPastLimit(server, opened);
+
+    // The client's read side is paused, but it can still write. uws answers
+    // the peer's Close frame with end() while the socket is still over the limit.
+    sock.write(maskedCloseFrame(4001, "peer"));
+    const closeEvent = await closed;
+
+    const bytes = await readToEnd();
+    expect({ ...splitStream(bytes), closeEvent }).toEqual({
+      dataFrames: accepted,
+      rest: closeFrame(4001, "peer").toString("hex"),
+      closeEvent: { code: 4001, reason: "peer" },
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `ws.close()` over `backpressureLimit` delivers neither the buffered frames nor the Close frame, only a FIN. Same for the echo of a peer's Close frame. `end()` does `bool ok = send(closePayload, CLOSE)` (`packages/bun-uws/src/WebSocket.h:242`), and `DROPPED` is 2, so it shuts down on the full buffer.
- `close()` inside a handler sends the Close frame but no FIN until the `end()` timer fires, 16 s at the default `idleTimeout`. `end()` left the FIN to whoever uncorks the socket. Only `onData` and the synchronous upgrade path did that, not `WebSocket::cork()`, which runs the open handler of an asynchronous upgrade, the drain handler and `ws.cork()`.

### Fix
- `send()` keeps the `maxBackpressure` check and delegates to a new private `sendFrame()`, which `end()` uses for the Close frame. That frame is at most 127 bytes, so the limit protects nothing there. It can only go behind the buffer: the buffer usually starts mid-frame, so a Close frame sent instead would land inside that frame.
- `end()` now uncorks (the Close frame is the last frame, nothing is left to batch) and sends the FIN itself when nothing is buffered. Otherwise `onWritable` (`WebSocketContext.h:379`) sends it after the drain, as before. The copies of this check in `onData` and `HttpContext.h` are dead now and removed.
- Verified: `test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts`, block `close()`. 6 of 8 tests fail on the released build, the other 2 guard the removed checks. Other suites: notes.

### Background
- uws buffers unsent bytes per socket in user space. Above `maxBackpressure` (`backpressureLimit` in `Bun.serve`) `send()` drops the message. `SendStatus` is `BACKPRESSURE = 0, SUCCESS = 1, DROPPED = 2`, so only `BACKPRESSURE` is false.
- Corking: while a handler runs, writes go to a cork buffer that `uncork()` writes out when the handler returns. A synchronous upgrade hands the cork of the 101 response to the new socket, and the HTTP parser uncorks it.
- `shutdown()` is `shutdown(fd, SHUT_WR)`. The kernel sends what it holds, then the FIN. uws also drops the writable poll, so its own buffer is never flushed.

<details><summary>Notes</summary>

Measured on the released build with a raw client that reads nothing until the server is done, `backpressureLimit: 2 MiB`, 1 MiB frames until `sendBinary()` returns 0 (5 accepted on Linux, 3 on Windows). `ws.close(1000, "bye")`: 2 frames plus 524268 bytes of the third, then FIN. Peer Close frame: all frames, then FIN, no Close frame (`end()` ran corked inside `onData`, so the FIN waited, but the frame was dropped). `close()` in `open()` after a synchronous upgrade: 2 frames plus part of the third. The three corked cases with an empty buffer (asynchronous upgrade, `drain`, `ws.cork()`) deliver the Close frame within 100 ms and the FIN at 16 s. With this change all of them end with the accepted frames, the Close frame (`880503e8627965` or `88060fa170656572`) and an immediate FIN. A debug build with the headers stashed fails like the released build.

History of this PR: the first revision fixed only the over-limit case, the second added a buffer check to the synchronous upgrade path in `HttpContext.h` (the old check keyed on `uncork()` not failing, which is also true for a socket that a large send left uncorked with a full buffer). The self-review pointed out that this was one more copy of the same check while `WebSocket::cork()` had none, so the third revision moves the FIN into `end()` and deletes the copies. #39802 adds the same check after the drain handler and waits for `getBufferedAmount() === 0` in the `ws` shim before closing. With this change neither is needed, noted there.

`end()` uncorking inside a handler: the cork buffer holds this socket's frames from the same handler plus the Close frame, which are written out in one `write()` either way. Nothing writes to the socket after `end()`: Bun marks the `ServerWebSocket` closed before calling it, `end()` frees the pub/sub subscriber, and `onData` ignores further input. The outer `uncork()` of the handler finds no cork and is a no-op. `uncork()` on a closed socket is also a no-op, and both the raw and the TLS `shutdown()` check the closed and already shut down states themselves.

The timeout after `end()` is `idleTimeoutComponents.second`, 16 s at the default `idleTimeout`. It already bounded a close under the limit with a non-empty buffer. An over-limit close now gets the same bound instead of an immediate FIN. `ws.terminate()` remains the immediate path. The three FIN tests rely on that timer being longer than the test timeout, so they do not lower `idleTimeout`.

Where the partial frame comes from: a frame of 16 KiB or more goes to `us_socket_write2()` and the unwritten tail is appended to the buffer (`WebSocket.h:161-169`); smaller frames take `AsyncSocket::write()`, which does the same (`AsyncSocket.h:368`). `closeOnBackpressureLimit`: `end()` no longer passes the branch in `send()` that calls `us_socket_shutdown_read()`. A dropped user send has already done that when it applies, and `end()` is itself the close. Queued publishes still go through the public `send()` and are still dropped over the limit. Upstream uWebSockets has the old code.

Windows: the tests run there. The released build fails them the same way on a Windows x64 machine, and the second revision's tests passed on the Windows x64 and aarch64 lanes.

Suites on the debug build after the third revision: 26 websocket files (`test/js/bun/websocket/` except the big file, `test/js/first_party/ws/` except the proxy file, `node-http-with-ws`, the close, upgrade, deflate, fault and unix tests in `test/js/web/websocket/`, regression tests 012040, 26358, 29684, 32734, 3613), 216 pass. `websocket-server.test.ts`: the same 8 load timeouts next to the send() benchmark as on main (#39370), 80 close, publish, upgrade and stop tests pass with a filter. `test/bake/dev/hot.test.ts` and `deinitialization.test.ts` pass. `test/cli/inspect/inspect.test.ts` fails in this container with the released build and without my changes as well.
</details>
