### PR TITLE
gitattributes: pin eol=lf for cjs, cts, sh, snap, snapshot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,15 @@
 *.mdx text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mjs text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mts text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.cjs text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.cts text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+
+# CRLF shell scripts fail to run on Linux.
+*.sh text eol=lf
+
+# Snapshot tests compare exact bytes.
+*.snap text eol=lf
+*.snapshot text eol=lf
 
 # Patch files are line-ending-sensitive — `git apply` rejects CRLF as corrupt.
 *.patch text eol=lf


### PR DESCRIPTION
Fixes #39676

Adds the clearly-missed extensions to `.gitattributes` so a default Windows clone (`core.autocrlf=true`) stops rewriting them to CRLF:

- `*.cjs`, `*.cts` — sit beside the already-covered `*.js`/`*.mjs`/`*.ts`/`*.mts`; looks like an oversight (98 + 15 files affected)
- `*.sh` — CRLF shell scripts fail to run on Linux (44 files)
- `*.snap`, `*.snapshot` — snapshot tests compare exact bytes (107 files)

This is the narrower "extend the extension list" alternative from the issue rather than the `* text=auto eol=lf` catch-all, since a catch-all needs full-CI verification against byte-exact fixtures. Same whitespace policy as the neighbouring entries.
