### PR TITLE
crash_handler: tag a crash on a thread other than the main thread in the uploaded report

### DIFF
--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -297,6 +297,8 @@ pub mod features {
         #[unsafe(export_name = "Bun__Feature__webview_webkit")]
         57 => (webview_webkit, "webview_webkit"),
         58 => (xml_parse, "xml_parse", core = XML_PARSE),
+        /// Never counted: the crash handler sets this bit in a trace string it encodes on a thread other than the main thread.
+        59 => (crash_off_main_thread, "crash_off_main_thread"),
     }
 
     // C++ declares these as `extern "C" size_t Bun__...;` and

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -543,6 +543,12 @@ mod draft {
             MAIN_THREAD_ID.load(Ordering::Relaxed) == bun_threading::current_thread_id()
         }
 
+        /// False until `set_main_thread_id` runs, so a crash during startup does not count as one on another thread.
+        pub(crate) fn is_off_main_thread() -> bool {
+            let main_thread_id = MAIN_THREAD_ID.load(Ordering::Relaxed);
+            main_thread_id != 0 && main_thread_id != bun_threading::current_thread_id()
+        }
+
         /// Zig: `Cli.cmd = command` (cli.zig `createContextData`). `bun_runtime`
         /// stores `Command.Tag.char()` here at dispatch so crash-report trace
         /// strings encode which subcommand was running instead of `_` (pre-init).
@@ -2648,8 +2654,12 @@ mod draft {
         writer.write_all(VERSION_CHAR.as_bytes())?;
         writer.write_all(GIT_SHA.as_bytes())?;
 
-        let packed_features: u64 = bun_analytics::packed_features().bits();
-        write_u64_as_two_vlqs(writer, packed_features as usize)?;
+        let mut packed_features = bun_analytics::packed_features();
+        // The crash header on stderr says "(main thread)" or not; the uploaded string has only this bit to tell the two apart.
+        if cli_state::is_off_main_thread() {
+            packed_features |= bun_analytics::PackedFeatures::crash_off_main_thread;
+        }
+        write_u64_as_two_vlqs(writer, packed_features.bits() as usize)?;
 
         let mut name_bytes: [u8; 1024] = [0; 1024];
         let mut frames = BoundedArray::<u8, FRAMES_CAPACITY>::default();

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -206,15 +206,17 @@ test.if(isWindows && isDebug)("Windows: segfault inside a system DLL captures th
   expect(span).toBeLessThan(2n ** 31n);
 });
 
-// The frames of a trace string `{base}/{version}/{payload}`, decoded the way
-// bun.report's parser decodes them. The payload is the platform, command and
-// format characters, 7 characters of commit, two VLQs of feature bits, then
-// one frame per VLQ (an offset in bun; a leading 1 introduces a name length,
-// the name, and an offset in that image; `_` is unknown; `=` is JS) until a
-// VLQ of 0 ends the list. A frame in bun's own image decodes with the object
-// `<bun>`: the encoder writes names from `[A-Za-z0-9._-]` only, so no image
-// (not even an executable named `bun`) can decode to that.
-function decodeTraceFrames(payload: string): { object: string; address: number }[] {
+// The feature bits and the frames of a trace string `{base}/{version}/{payload}`,
+// decoded the way bun.report's parser decodes them. The payload is the
+// platform, command and format characters, 7 characters of commit, the feature
+// bits as two VLQs (the high 32 bits, then the low 32 bits; bit i is feature i
+// of `crash_handler.getFeatureData().features`), then one frame per VLQ (an
+// offset in bun; a leading 1 introduces a name length, the name, and an offset
+// in that image; `_` is unknown; `=` is JS) until a VLQ of 0 ends the list. A
+// frame in bun's own image decodes with the object `<bun>`: the encoder writes
+// names from `[A-Za-z0-9._-]` only, so no image (not even an executable named
+// `bun`) can decode to that.
+function decodeTrace(payload: string): { features: bigint; frames: { object: string; address: number }[] } {
   const digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   let i = 3 + 7;
   function vlq(): number {
@@ -226,8 +228,10 @@ function decodeTraceFrames(payload: string): { object: string; address: number }
       if (!(digit & 32)) return value % 2 ? -Math.floor(value / 2) : value / 2;
     }
   }
-  vlq();
-  vlq();
+  // Each half is encoded as the signed 32-bit reinterpretation of its bits.
+  const high = BigInt.asUintN(32, BigInt(vlq()));
+  const low = BigInt.asUintN(32, BigInt(vlq()));
+  const features = (high << 32n) | low;
   const frames = [];
   while (i < payload.length) {
     if (payload[i] === "_" || payload[i] === "=") {
@@ -235,7 +239,7 @@ function decodeTraceFrames(payload: string): { object: string; address: number }
       continue;
     }
     let address = vlq();
-    if (address === 0) return frames;
+    if (address === 0) return { features, frames };
     let object = "<bun>";
     if (address === 1) {
       const length = vlq();
@@ -249,9 +253,8 @@ function decodeTraceFrames(payload: string): { object: string; address: number }
 }
 
 // Crashes bun with `args`, receives the report it uploads, and returns the
-// crash's stderr and exit code together with the decoded frames of the
-// uploaded trace string.
-async function uploadedCrashFrames(args: string[]) {
+// crash's stderr and exit code together with the decoded uploaded trace string.
+async function uploadedCrash(args: string[]) {
   const uploaded = Promise.withResolvers<string>();
   using server = Bun.serve({
     port: 0,
@@ -287,7 +290,7 @@ async function uploadedCrashFrames(args: string[]) {
   // `/` is also a VLQ digit, so the payload cannot be split out on it.
   const payload = pathname.match(/^\/[^/]+\/(.*)\/ack$/)?.[1];
   expect(payload, pathname).toBeDefined();
-  return { stderr, exitCode, frames: decodeTraceFrames(payload!) };
+  return { stderr, exitCode, ...decodeTrace(payload!) };
 }
 
 // A frame outside bun's own executable is encoded with the basename of the
@@ -297,7 +300,7 @@ async function uploadedCrashFrames(args: string[]) {
 // frame as unknown, and Linux encoded them as bun offsets, which symbolized to
 // unrelated bun functions. The fault here is inside libc, so frame 0 is libc's.
 test.if(isPosix)("the uploaded trace string names the image of a frame outside bun", async () => {
-  const { stderr, exitCode, frames } = await uploadedCrashFrames([
+  const { stderr, exitCode, frames } = await uploadedCrash([
     path.join(import.meta.dir, "fixture-crash.js"),
     "segfaultInDll",
   ]);
@@ -324,7 +327,7 @@ test.if(isPosix)("the uploaded trace string names the image of a frame outside b
 // 60 levels of JS recursion under the crash give the walk more than 20 frames
 // to find.
 test.if(isPosix)("the uploaded trace string holds more than 20 frames", async () => {
-  const { stderr, exitCode, frames } = await uploadedCrashFrames([
+  const { stderr, exitCode, frames } = await uploadedCrash([
     "-e",
     `const { crash_handler } = require("bun:internal-for-testing");
      function recurse(depth) { return depth === 0 ? crash_handler.segfault() : recurse(depth - 1) + 1; }
@@ -335,6 +338,34 @@ test.if(isPosix)("the uploaded trace string holds more than 20 frames", async ()
   expect(frames.length).toBeGreaterThan(20);
   expect(frames.length).toBeLessThanOrEqual(64);
   expect(exitCode).not.toBe(0);
+});
+
+// The crash header on stderr says "(main thread)" when the crash is on the
+// main thread, but the upload carried nothing about the thread. The encoder
+// now adds the `crash_off_main_thread` feature bit on any other thread, and
+// bun.report turns every feature bit into a Sentry tag. A report with that tag
+// and no bun frame at all is a crash on a thread an addon started (BUN-2PFR);
+// one without the tag is a crash on the JS thread. A Worker crashes bun on a
+// thread other than the main one without needing an addon.
+test.if(isPosix)("the uploaded trace string tells a crash off the main thread from one on it", async () => {
+  const bit = crash_handler.getFeatureData().features.indexOf("crash_off_main_thread");
+  expect(bit).toBeGreaterThanOrEqual(0);
+  const flag = 1n << BigInt(bit);
+
+  const panic = `require("bun:internal-for-testing").crash_handler.panic()`;
+  const [onMainThread, onWorkerThread] = await Promise.all([
+    uploadedCrash(["-e", panic]),
+    uploadedCrash(["-e", `new (require("node:worker_threads").Worker)(${JSON.stringify(panic)}, { eval: true })`]),
+  ]);
+
+  expect(onMainThread.stderr).toContain("panic(main thread): invoked crashByPanic() handler");
+  expect(onMainThread.features & flag).toBe(0n);
+
+  expect(onWorkerThread.stderr).toContain("panic: invoked crashByPanic() handler");
+  expect(onWorkerThread.features & flag).toBe(flag);
+
+  expect(onMainThread.exitCode).not.toBe(0);
+  expect(onWorkerThread.exitCode).not.toBe(0);
 });
 
 // The Windows crash handler is a Vectored Exception Handler, which sees every


### PR DESCRIPTION
Stacked on #39806: the diff of this PR is the last commit. The test uses the trace string decoder that #39806 adds.

### Problem
- Sentry cannot tell a crash on the JS thread from a crash on another thread. The crash header on stderr says `panic(main thread)` or `panic` (`src/crash_handler/lib.rs`, the `cli_state::is_main_thread()` branch). The uploaded trace string carries nothing about the thread.
- The 22k-event `<anonymous>` group (BUN-2PFR) mixes two kinds of reports: a thread an addon started, which has no bun code on its stack, and the JS thread with a frame pointer chain that broke inside an addon. The first kind is not a bug in bun.

### Fix
- A new feature bit, `crash_off_main_thread` (`src/analytics/lib.rs`, index 59). Nothing counts it. `encode_trace_string` adds it to the feature bits of the trace string when it runs on a thread other than the main thread. The crash handler and the panic hook both encode on the crashing thread.
- bun.report turns every feature bit into a Sentry tag (`tags[feature] = true`), and features.json ships with every build. So the tag appears with no change to bun.report. Read it with the frames of #39806: the tag and no bun frame means a thread an addon started. No tag means the JS thread.
- `is_off_main_thread()` is false until the main thread id is set, so a crash during startup is not marked.
- Verified: the new test in `test/cli/run/run-crash-handler.test.ts`. It panics bun on the main thread and in a Worker, decodes both uploads, and checks the bit. Without the fix the feature does not exist and the index lookup fails. The rest of the file and `test/internal/macos-cross-config.test.ts` (the features.json check) pass.

### Background
- A trace string is the `bun.report/...` URL a crash prints and uploads. After the version and commit it holds the feature bits of the process as two VLQs. Bit i is entry i of `define_features!`, and of the features.json the build ships.
- A feature bit normally means that the process used feature X at least once. This is the first bit the crash handler sets itself. That is why its doc comment says that nothing counts it.
- `MAIN_THREAD_ID` is set by `bun_runtime` at startup. The header code compares the current thread id with it in the same way.

<details><summary>Notes</summary>

- Bun cannot tell a thread it created from a thread an addon created with certainty. A marker at every thread start would need about 20 Rust spawn sites plus JSC's own threads (GC, JIT workers), which bun does not start. A frame-based guess ("no bun frame in the walk") is the same information bun.report already has from the frames of #39806, and a broken frame pointer chain makes it wrong. The main thread check is exact, so that is the bit this PR uploads. The reader combines the two.
- #39815 adds feature bits 59 and 60 for a different purpose. Whichever of the two lands second renumbers its entry.
- The test is POSIX only like its neighbours. The thread id check is the same code on Windows. On Windows the header prints the thread name or id instead of nothing.
- Probe on the debug build: a main thread panic prints `panic(main thread): ...` and uploads bit 59 clear. The same panic in a `node:worker_threads` eval Worker prints `panic: ...` and uploads bit 59 set.
- Re-stacked on #39806 after its rebase onto main (5db346f). CI on this head (build 103991): 178 of 181 jobs pass and `run-crash-handler.test.ts` passes on every lane. The three red jobs fail only in `test/js/bun/s3/s3.test.ts` with an `InternalError` from the R2 service during a large upload, unrelated to this diff.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->


