### PR TITLE
node:http: emit ServerResponse 'close' asynchronously after destroy()

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3580,11 +3580,17 @@ ServerResponse.prototype.destroy = function (err?: Error) {
   if (handle && this[kPipelinedQueuedState] === undefined) {
     handle.abort();
   }
-  this?.socket?.destroy(err);
-  if (!this._closed) {
-    // res.closed must already be true inside the 'close' listeners.
-    this._closed = true;
-    this.emit("close");
+  // Like Node.js's OutgoingMessage#destroy, 'close' is never emitted from
+  // inside destroy(): the assigned socket's close path emits it (#onClose, or
+  // onServerResponseClose for an assignSocket()ed one), after the 'finish' an
+  // end()ed response has already scheduled. Without a socket (standalone,
+  // queued behind a pipelined response, or already detached) it is deferred
+  // a tick, exactly like Node.js.
+  const socket = this[kSocket];
+  if (socket) {
+    socket.destroy(err);
+  } else {
+    process.nextTick(emitCloseNT, this);
   }
   return this;
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3580,8 +3580,6 @@ ServerResponse.prototype.destroy = function (err?: Error) {
   if (handle && this[kPipelinedQueuedState] === undefined) {
     handle.abort();
   }
-  // Like Node.js's OutgoingMessage#destroy: the socket's close path (#onClose /
-  // onServerResponseClose) emits 'close'; without a socket it is deferred a tick.
   const socket = this[kSocket];
   if (socket) {
     socket.destroy(err);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3580,12 +3580,8 @@ ServerResponse.prototype.destroy = function (err?: Error) {
   if (handle && this[kPipelinedQueuedState] === undefined) {
     handle.abort();
   }
-  // Like Node.js's OutgoingMessage#destroy, 'close' is never emitted from
-  // inside destroy(): the assigned socket's close path emits it (#onClose, or
-  // onServerResponseClose for an assignSocket()ed one), after the 'finish' an
-  // end()ed response has already scheduled. Without a socket (standalone,
-  // queued behind a pipelined response, or already detached) it is deferred
-  // a tick, exactly like Node.js.
+  // Like Node.js's OutgoingMessage#destroy: the socket's close path (#onClose /
+  // onServerResponseClose) emits 'close'; without a socket it is deferred a tick.
   const socket = this[kSocket];
   if (socket) {
     socket.destroy(err);

--- a/test/js/node/http/node-http-server-abort-events.test.ts
+++ b/test/js/node/http/node-http-server-abort-events.test.ts
@@ -221,34 +221,37 @@ describe("res.destroy() defers 'close'", () => {
 
   // server.emit("connection", duplex) serves the connection with the JS
   // HTTP/1 parser: here 'close' comes from the assigned socket's own 'close'.
-  test.concurrent.each([false, true])("on a response served over server.emit('connection') (ended first: %p)", async endFirst => {
-    const events: string[] = [];
-    const resClosed = Promise.withResolvers<void>();
-    const server = createServer((req, res) => {
-      recordResponse(res, events, resClosed.resolve);
-      if (endFirst) res.end("hello");
-      destroyRecording(res, events);
-      events.push("listener returned");
-    });
-    const [clientSide, serverSide] = duplexPair();
-    try {
-      serverSide.on("close", () => events.push("socket.close"));
-      server.emit("connection", serverSide);
-      clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
-      await resClosed.promise;
-      expect(events).toEqual([
-        "destroy()",
-        "destroy() returned (closed: false)",
-        "listener returned",
-        ...(endFirst ? ["res.finish"] : []),
-        "socket.close",
-        "res.close (closed: true)",
-      ]);
-    } finally {
-      clientSide.destroy();
-      serverSide.destroy();
-    }
-  });
+  test.concurrent.each([false, true])(
+    "on a response served over server.emit('connection') (ended first: %p)",
+    async endFirst => {
+      const events: string[] = [];
+      const resClosed = Promise.withResolvers<void>();
+      const server = createServer((req, res) => {
+        recordResponse(res, events, resClosed.resolve);
+        if (endFirst) res.end("hello");
+        destroyRecording(res, events);
+        events.push("listener returned");
+      });
+      const [clientSide, serverSide] = duplexPair();
+      try {
+        serverSide.on("close", () => events.push("socket.close"));
+        server.emit("connection", serverSide);
+        clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+        await resClosed.promise;
+        expect(events).toEqual([
+          "destroy()",
+          "destroy() returned (closed: false)",
+          "listener returned",
+          ...(endFirst ? ["res.finish"] : []),
+          "socket.close",
+          "res.close (closed: true)",
+        ]);
+      } finally {
+        clientSide.destroy();
+        serverSide.destroy();
+      }
+    },
+  );
 
   // A response queued behind an unfinished pipelined response has no socket
   // yet (res.socket === null), so this takes the same deferred path as a

--- a/test/js/node/http/node-http-server-abort-events.test.ts
+++ b/test/js/node/http/node-http-server-abort-events.test.ts
@@ -1,11 +1,12 @@
 /**
  * This test must also pass in Node.js.
  */
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
-import { createServer } from "node:http";
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { connect } from "node:net";
+import { duplexPair } from "node:stream";
 
 test("aborted request body emits 'error' ECONNRESET and res 'close' before req 'close'", async () => {
   // Like Node.js's socketOnClose → abortIncoming: the aborted request is
@@ -46,4 +47,252 @@ test("aborted request body emits 'error' ECONNRESET and res 'close' before req '
   } finally {
     server.close();
   }
+});
+
+// Like Node.js's OutgoingMessage#destroy, res.destroy() does not emit 'close'
+// itself. A response that still has its socket gets 'close' from the socket
+// teardown (so an ended response still emits 'finish' first); a response
+// without one (already finished, still queued, standalone) gets it a tick
+// later. Either way 'close' is observed after destroy() has returned, with
+// res.closed false in between.
+describe("res.destroy() defers 'close'", () => {
+  function destroyRecording(res: ServerResponse, events: string[], err?: Error) {
+    events.push("destroy()");
+    res.destroy(err);
+    events.push(`destroy() returned (closed: ${res.closed})`);
+  }
+
+  function recordResponse(res: ServerResponse, events: string[], onClose: () => void) {
+    res.on("finish", () => events.push("res.finish"));
+    res.on("close", () => {
+      events.push(`res.close (closed: ${res.closed})`);
+      onClose();
+    });
+  }
+
+  // Serves one GET over a real connection and returns the recorded events once
+  // both the request and the response have emitted 'close'. With
+  // connectionClosedByServer it also waits for the server to close the
+  // connection, which destroy() does whenever the response still has its socket.
+  async function serveAndRecord(
+    listener: (req: IncomingMessage, res: ServerResponse, events: string[]) => void,
+    { connectionClosedByServer = true } = {},
+  ) {
+    const events: string[] = [];
+    const reqClosed = Promise.withResolvers<void>();
+    const resClosed = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      req.on("aborted", () => events.push("req.aborted"));
+      req.on("close", () => {
+        events.push("req.close");
+        reqClosed.resolve();
+      });
+      recordResponse(res, events, resClosed.resolve);
+      listener(req, res, events);
+      events.push("listener returned");
+    });
+    let client: ReturnType<typeof connect> | undefined;
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      client = connect(port, "127.0.0.1");
+      client.on("error", () => {});
+      const clientClosed = Promise.withResolvers<void>();
+      client.on("close", () => clientClosed.resolve());
+      let received = "";
+      client.on("data", chunk => (received += chunk.toString("latin1")));
+      client.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      await Promise.all([reqClosed.promise, resClosed.promise]);
+      if (connectionClosedByServer) await clientClosed.promise;
+      return { events, received };
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  }
+
+  test.concurrent("after end(): 'close' follows 'finish' and the response still reaches the client", async () => {
+    const { events, received } = await serveAndRecord((req, res, events) => {
+      res.end("hello");
+      destroyRecording(res, events);
+    });
+    expect(events).toEqual([
+      "destroy()",
+      "destroy() returned (closed: false)",
+      "listener returned",
+      "res.finish",
+      "res.close (closed: true)",
+      "req.close",
+    ]);
+    expect(received).toStartWith("HTTP/1.1 200 ");
+    expect(received).toEndWith("\r\n\r\nhello");
+  });
+
+  // Once the response has finished it no longer has a socket, so (like Node)
+  // destroy() leaves the kept-alive connection alone and only defers 'close'.
+  test.concurrent("inside a 'finish' listener", async () => {
+    const { events } = await serveAndRecord(
+      (req, res, events) => {
+        res.on("finish", () => destroyRecording(res, events));
+        res.end("hello");
+      },
+      { connectionClosedByServer: false },
+    );
+    expect(events).toEqual([
+      "listener returned",
+      "res.finish",
+      "destroy()",
+      "destroy() returned (closed: false)",
+      "res.close (closed: true)",
+      "req.close",
+    ]);
+  });
+
+  test.concurrent("inside the end() callback", async () => {
+    const { events } = await serveAndRecord(
+      (req, res, events) => {
+        res.end("hello", () => {
+          events.push("end callback");
+          destroyRecording(res, events);
+        });
+      },
+      { connectionClosedByServer: false },
+    );
+    expect(events).toEqual([
+      "listener returned",
+      "res.finish",
+      "end callback",
+      "destroy()",
+      "destroy() returned (closed: false)",
+      "res.close (closed: true)",
+      "req.close",
+    ]);
+  });
+
+  const destroyedBeforeFinishing = [
+    "destroy()",
+    "destroy() returned (closed: false)",
+    "listener returned",
+    "req.aborted",
+    "res.close (closed: true)",
+    "req.close",
+  ];
+
+  test.concurrent("before anything was written: 'close' comes from the connection teardown", async () => {
+    const { events } = await serveAndRecord((req, res, events) => {
+      destroyRecording(res, events);
+    });
+    expect(events).toEqual(destroyedBeforeFinishing);
+  });
+
+  test.concurrent("after a partial body", async () => {
+    const { events } = await serveAndRecord((req, res, events) => {
+      res.write("partial");
+      destroyRecording(res, events);
+    });
+    expect(events).toEqual(destroyedBeforeFinishing);
+  });
+
+  test.concurrent("destroy(err) reports the error as res.errored inside 'close'", async () => {
+    const err = new Error("boom");
+    let erroredInClose: unknown;
+    const { events } = await serveAndRecord((req, res, events) => {
+      res.on("close", () => (erroredInClose = res.errored));
+      destroyRecording(res, events, err);
+    });
+    expect(events).toEqual(destroyedBeforeFinishing);
+    expect(erroredInClose).toBe(err);
+  });
+
+  test.concurrent("after the request listener has returned", async () => {
+    const { events } = await serveAndRecord((req, res, events) => {
+      setImmediate(() => destroyRecording(res, events));
+    });
+    expect(events).toEqual([
+      "listener returned",
+      "destroy()",
+      "destroy() returned (closed: false)",
+      "req.aborted",
+      "res.close (closed: true)",
+      "req.close",
+    ]);
+  });
+
+  // server.emit("connection", duplex) serves the connection with the JS
+  // HTTP/1 parser: here 'close' comes from the assigned socket's own 'close'.
+  test.concurrent.each([false, true])("on a response served over server.emit('connection') (ended first: %p)", async endFirst => {
+    const events: string[] = [];
+    const resClosed = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      recordResponse(res, events, resClosed.resolve);
+      if (endFirst) res.end("hello");
+      destroyRecording(res, events);
+      events.push("listener returned");
+    });
+    const [clientSide, serverSide] = duplexPair();
+    try {
+      serverSide.on("close", () => events.push("socket.close"));
+      server.emit("connection", serverSide);
+      clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      await resClosed.promise;
+      expect(events).toEqual([
+        "destroy()",
+        "destroy() returned (closed: false)",
+        "listener returned",
+        ...(endFirst ? ["res.finish"] : []),
+        "socket.close",
+        "res.close (closed: true)",
+      ]);
+    } finally {
+      clientSide.destroy();
+      serverSide.destroy();
+    }
+  });
+
+  // A response queued behind an unfinished pipelined response has no socket
+  // yet (res.socket === null), so this takes the same deferred path as a
+  // standalone response.
+  test.concurrent("on a response still queued behind a pipelined response", async () => {
+    const events: string[] = [];
+    const secondClosed = Promise.withResolvers<void>();
+    const responses: ServerResponse[] = [];
+    const server = createServer((req, res) => {
+      responses.push(res);
+      if (req.url === "/first") return;
+      events.push(`second dispatched (socket: ${res.socket})`);
+      recordResponse(res, events, secondClosed.resolve);
+      destroyRecording(res, events);
+    });
+    let client: ReturnType<typeof connect> | undefined;
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      client = connect(port, "127.0.0.1");
+      client.on("error", () => {});
+      client.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\nGET /second HTTP/1.1\r\nHost: x\r\n\r\n");
+      await secondClosed.promise;
+      expect(events).toEqual([
+        "second dispatched (socket: null)",
+        "destroy()",
+        "destroy() returned (closed: false)",
+        "res.close (closed: true)",
+      ]);
+    } finally {
+      for (const res of responses) res.destroy();
+      client?.destroy();
+      server.close();
+    }
+  });
+
+  test("on a standalone response that was never given a socket", async () => {
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    const res = new ServerResponse(new IncomingMessage(null as any));
+    recordResponse(res, events, closed.resolve);
+    destroyRecording(res, events);
+    await closed.promise;
+    expect(events).toEqual(["destroy()", "destroy() returned (closed: false)", "res.close (closed: true)"]);
+  });
 });


### PR DESCRIPTION
### Problem
- `res.end(); res.destroy()` on a `node:http` server emits the response's `'close'` synchronously inside `destroy()`, before `'finish'`. Node 26 emits it after `destroy()` returns and after `'finish'`. on-finished style `'close'` listeners count every such response as aborted.
- Cause: `ServerResponse.prototype.destroy` (`src/js/node/_http_server.ts:3584`) sets `_closed` and emits `'close'` itself.

### Fix
- `destroy()` no longer emits `'close'`. With a socket assigned (`this[kSocket]`) it only destroys the socket, and the socket teardown emits `'close'`. An ended response gets the `'finish'` then `'close'` that `end()` already scheduled. Without a socket (standalone, queued behind a pipelined response, detached) it schedules `process.nextTick(emitCloseNT, this)`.
- This is Node's `OutgoingMessage.prototype.destroy`, which `ServerResponse` inherits there. Bun's own `OutgoingMessage.prototype.destroy` already has this shape. `kSocket` is null exactly when no socket is assigned. The `socket` getter is not: it returns a `FakeSocket` for a detached response.
- `'close'` still fires once (`emitCloseNT` checks `_closed`) and still resolves the dispatch.
- Verified: `test/js/node/http/node-http-server-abort-events.test.ts`, 11 new cases, all fail on main. They assert the event arrays Node v26.3.0 produces (Notes). No new failures in `test/js/node/http/`, the vendored `test-http*` scripts, http2, express, body-parser.

### Background
- `ServerResponse` wraps a native handle (`kHandle`). `destroy()` calls `handle.abort()` to release it, then tears the connection down through the JS socket.
- `#onClose` runs once the native connection has closed. It aborts the attached request and schedules `emitCloseNT` for the attached or destroyed response. `emitCloseNT` (`src/js/internal/http.ts`) sets `_closed`, resolves the dispatch, emits `'close'`.
- `kSocket` is the `OutgoingMessage` slot for the assigned socket: null for a standalone response, for a response queued behind a pipelined one (`res.socket` is null in Node too), and after `detachSocket()`.

<details><summary>Notes</summary>

Event order for the shapes the test covers, recorded with the same listeners. Node v26.3.0 and this branch produce identical arrays for all of them. Bun 1.4.0 and main differ in every one: `res.close` appears between `destroy()` and `destroy() returned`, with `closed: true`.

```
end() then destroy()     destroy() -> destroy() returned (closed: false) -> listener returned -> res.finish -> res.close -> req.close
destroy() in 'finish'    listener returned -> res.finish -> destroy() -> destroy() returned -> res.close -> req.close
destroy() in end() cb    listener returned -> res.finish -> end callback -> destroy() -> destroy() returned -> res.close -> req.close
nothing written          destroy() -> destroy() returned -> listener returned -> req.aborted -> res.close -> req.close
partial body / err arg   same as above, res.errored === err inside 'close'
setImmediate destroy     listener returned -> destroy() -> destroy() returned -> req.aborted -> res.close -> req.close
emit('connection')       destroy() -> destroy() returned -> listener returned -> [res.finish] -> socket.close -> res.close
queued pipelined res     second dispatched (socket: null) -> destroy() -> destroy() returned -> res.close
standalone res           destroy() -> destroy() returned -> res.close
```

Who emits the deferred `'close'`:
- Native path, `destroy()` inside the listener: the socket is destroyed while the response is still attached, so `#closeHandle` captures it in `#pendingAbortMessage`, and `#onClose` (#35025) schedules `emitCloseNT` for it even though the dispatcher detached the response in the meantime.
- Native path, `destroy()` later: the response stays attached until `#onClose` runs.
- Ended response: the `'finish'` then `emitCloseNT` chain that `end()` scheduled, before `#onClose` even runs.
- `server.emit('connection', duplex)` and `assignSocket()`: the socket's own `'close'` event, through `onServerResponseClose`, which is also Node's path.
- Every other close site in `_http_server.ts` already used `emitCloseNT`.

Things checked that do not change:
- The client still receives the complete response for `end(); destroy()` (asserted by the first test). `handle.abort()` is a no-op on an ended handle.
- `destroy()` inside a `'finish'` listener leaves the kept-alive connection open. Node does the same (`res.socket` is null there), and so did main, because the getter returned a detached `FakeSocket` whose `destroy()` does nothing.
- `advanceResponsePipeline` still destroys the connection when it reaches a destroyed queued response. In `#onClose`'s queued-response loop, `queuedRes.destroy()` now schedules the `'close'` itself, and the `else if (!_closed)` branch stays a guarded no-op.
- `Server[captureRejectionSymbol]` and `advanceResponsePipeline` are the only internal callers of `res.destroy()`. Neither reads `res.closed` afterwards.
- A separate, pre-existing difference is visible in the not-ended shapes: `req.complete` is `false` inside `req 'close'` on Bun and `true` on Node. Not touched here.

Suites run on this branch and on a main build of the same tree (debug, ASAN):
- `test/js/node/http/`: the same 4 failures on both (`node-http-syscall-fault` two 5 s timeouts, `node-http-connect` "tests should run on bun" 5 s timeout, `issue#4295` proxy ECONNREFUSED).
- 449 vendored `test/js/node/test/parallel/test-http*.js`, `test-https*.js` and the 4 http2 `allowHTTP1` scripts: only `test-http-agent-keepalive.js` fails, identically on the main build (1 ms timer, passes on release).
- `test/js/node/http2/node-http2.test.js`: 362 pass, 0 fail.
- `test/js/third_party/express/` and `body-parser/`: the same 4 failures on both builds (500 ms fetch timeout, two 20 s leak checks, `--compile` timeout).

Supersedes the closed #33818. Its request-side half landed in #35025. This is the remaining response-side half, built on the `#pendingAbortMessage` mechanism from #35025 instead of that PR's dispatcher change.
</details>
