### PR TITLE
bundler: join the work still on the pools before the bundle is torn down

### DIFF
--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -267,7 +267,7 @@ impl ASTMemoryAllocator {
     /// Per-iteration reset for hot reuse paths (`initialize_mini_store`'s
     /// per-workspace-child re-entry). Thin delegate to
     /// [`bun_alloc::Arena::reset_retain_with_limit`]; the cold init paths
-    /// (`bundler::ThreadPool::Worker::init`, `BundleThread::generate_in_new_
+    /// (`bundler::ThreadPool::Worker::create`, `BundleThread::generate_in_new_
     /// thread`) keep calling [`Self::reset`].
     pub fn reset_retain_with_limit(&mut self, limit: usize) {
         if self.arena_dirty {

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -297,9 +297,9 @@ impl<C: CompletionStruct> BundleThread<C> {
 
         // Straight-line teardown: log copy
         // runs on both paths; `completeOnBundleThread` only on success (the error
-        // path's `set_result(Err)` + complete happens in `thread_main`). The
-        // `deinitWithoutFreeingArena` + wait-group drain live inside `init_and_run`
-        // (it owns `this`).
+        // path's `set_result(Err)` + complete happens in `thread_main`).
+        // `deinit_without_freeing_arena` lives inside `init_and_run` (it owns
+        // `this`).
         let mut out_log = bun_ast::Log::init();
         // SAFETY: `transpiler.log` is the arena-allocated `*mut Log` set up by
         // `configure_bundler`; valid for the lifetime of `heap`. Raw deref so the

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -358,7 +358,13 @@ unsafe fn io_task_callback(task: *mut ThreadPoolLib::Task) {
     // provenance covers the full `ParseTask` and the `&mut` is unique per the
     // CONCURRENCY note above.
     let parse_task = unsafe { &mut *bun_core::from_field_ptr!(ParseTask, io_task, task) };
+    // Captured before the run: after it, a worker thread may own `*parse_task`.
+    // SAFETY: teardown waits for the count this callback holds
+    // (`ThreadPool::wait_for_io_tasks`), so the bundle is live until `finish_io_task`.
+    let pool: *const crate::ThreadPool = unsafe { parse_task.ctx() }.graph.pool();
     parse_worker::run_from_thread_pool(parse_task);
+    // SAFETY: `pool` scheduled this task; this is the last access to the bundle.
+    unsafe { crate::ThreadPool::finish_io_task(pool) };
 }
 
 // CONCURRENCY: see `io_task_callback` — same task, different intrusive field.

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -49,13 +49,10 @@ pub struct ThreadPool {
     // `wake_for_idle_events`) take `&self` — so the safe `Deref` projection is
     // sufficient and the per-read `unsafe { p.as_ref() }` disappears.
     pub(crate) io_pool: Option<bun_ptr::ParentRef<ThreadPoolLib::ThreadPool>>,
-    /// One count per parse task handed to `io_pool`, finished when its IO
-    /// callback returns. The IO pool outlives this `ThreadPool`, and the
-    /// callback's last step is to re-schedule the task onto `worker_pool`, so
-    /// teardown joins this ([`Self::wait_for_io_tasks`]) before [`Self::deinit`]
-    /// frees `worker_pool`. `graph.pending_items` cannot stand in for it: it
-    /// reaches zero as soon as the re-scheduled parse completes, which can be
-    /// while the IO callback is still inside `schedule`.
+    /// One count per task on `io_pool`, finished when its callback returns.
+    /// That callback ends by scheduling the task onto `worker_pool`, and the
+    /// parse can complete (`graph.pending_items` reaching zero) before it has
+    /// returned from that, so teardown joins this before it frees `worker_pool`.
     io_tasks_in_flight: WaitGroup,
     // Conditionally owned via `worker_pool_is_owned`; kept raw so callers
     // (bundle_v2.rs) can dereference for `wake_for_idle_events()` without a
@@ -225,20 +222,17 @@ impl ThreadPool {
         }
     }
 
-    /// Blocks until every IO callback of this pool has returned. Call it
-    /// (through `&self`, while IO threads may still read the pool) before
-    /// taking the `&mut self` that [`Self::deinit`] needs.
+    /// Blocks until every IO callback has returned. `&self` on purpose: IO
+    /// threads still read the pool until this returns.
     pub(crate) fn wait_for_io_tasks(&self) {
         self.io_tasks_in_flight.wait();
     }
 
-    /// The IO callback's last step (`io_task_callback`), after the task has been
-    /// handed to the worker pool.
+    /// The last step of `io_task_callback`.
     ///
     /// # Safety
-    /// `this` is the pool the task was scheduled on. The bundle keeps it alive
-    /// until [`Self::wait_for_io_tasks`] returns, which this call permits, so
-    /// nothing may touch the pool after it.
+    /// `this` scheduled the task. It may be freed once [`Self::wait_for_io_tasks`]
+    /// returns, which this call permits, so nothing may touch it afterwards.
     pub(crate) unsafe fn finish_io_task(this: *const Self) {
         // SAFETY: caller contract; `finish_raw` is the matching last access.
         unsafe { WaitGroup::finish_raw(&raw const (*this).io_tasks_in_flight) };
@@ -246,9 +240,8 @@ impl ThreadPool {
 
     /// Explicit teardown (no Drop on
     /// `ThreadPool` because `Graph.pool` is `NonNull<ThreadPool>` and the arena
-    /// owns the storage). The caller drains the parse tasks and calls
-    /// [`Self::wait_for_io_tasks`] first: a task still running would use the
-    /// pool this frees.
+    /// owns the storage). Only valid once no task of this pool is running:
+    /// the caller drains the parse tasks and calls [`Self::wait_for_io_tasks`].
     pub(crate) fn deinit(&mut self) {
         if self.worker_pool_is_owned {
             // SAFETY: worker_pool was heap-allocated in `init()` when owned.
@@ -260,11 +253,9 @@ impl ThreadPool {
         }
     }
 
-    /// Safe accessor for the underlying `bun_threading::ThreadPool`. The
-    /// pointer is set in `init`/`init_with_pool` and nulled by `deinit`. The
-    /// arena keeps `self` readable after `deinit`, so a task that is still
-    /// running at teardown gets here: fail with a message instead of a
-    /// null dereference inside the pool.
+    /// Safe accessor for the underlying `bun_threading::ThreadPool`. Set in
+    /// `init`/`init_with_pool`, nulled by `deinit`. `self` stays readable in the
+    /// arena after `deinit`, so a task that runs too late fails here by name.
     #[inline]
     pub(crate) fn worker_pool(&self) -> &ThreadPoolLib::ThreadPool {
         assert!(
@@ -441,48 +432,31 @@ impl ThreadPool {
         let mut map = self.workers_assignments.lock();
         let worker: *mut Worker = match map.entry(id) {
             MapEntry::Occupied(o) => *o.into_mut(),
-            MapEntry::Vacant(v) => {
-                // Allocate raw uninitialized storage; fully written via
-                // `worker.write(...)` below before any read. Keep it as
-                // `*mut MaybeUninit<Worker>` → `.cast()` instead of
-                // `assume_init()` so we never materialize a `Box<Worker>`
-                // whose payload violates `Worker`'s validity invariants
-                // (niche-optimized `Option<_>` discriminants, the non-null
-                // fn-pointer in `deinit_task.callback`, `bool` fields).
-                let worker = bun_core::heap::into_raw(Box::<Worker>::new_uninit()).cast::<Worker>();
-                // SAFETY: `worker` is freshly heap-allocated and reachable from
-                // nothing until `v.insert` below. It has to be complete by then:
-                // `deinit_without_freeing_arena` takes this lock and tears down
-                // every Worker the map holds.
-                unsafe {
-                    worker.write(Worker {
-                        // Placeholder — overwritten by `init()` immediately below.
-                        ctx: bun_ptr::BackRef::from(NonNull::<BundleV2<'static>>::dangling()),
-                        heap: None,
-                        arena: bun_ptr::BackRef::from(NonNull::<ThreadLocalArena>::dangling()),
-                        thread: NonNull::new(ThreadPoolLib::Thread::current())
-                            .map(bun_ptr::ParentRef::from),
-                        data: None,
-                        ast_memory_store: ManuallyDrop::new(bun_ast::ASTMemoryAllocator::default()),
-                        has_created: false,
-                        deinit_task: ThreadPoolLib::Task {
-                            node: ThreadPoolLib::Node::default(),
-                            callback: Worker::deinit_callback,
-                        },
-                        temporary_arena: None,
-                        stmt_list: None,
-                    });
-                    (*worker).init(&*self.v2);
-                }
-                v.insert(worker);
-                worker
-            }
+            // Complete before it is inserted: `deinit_without_freeing_arena`
+            // takes this lock and tears down every Worker the map holds.
+            MapEntry::Vacant(v) => *v.insert(bun_core::heap::into_raw(Box::new(Worker {
+                // SAFETY: `v2` is the bundle that owns this pool; it outlives every Worker.
+                ctx: unsafe { bun_ptr::BackRef::from_raw(self.v2.cast_mut()) },
+                heap: None,
+                // Points into `heap` once `create()` runs.
+                arena: bun_ptr::BackRef::dangling(),
+                thread: NonNull::new(ThreadPoolLib::Thread::current())
+                    .map(bun_ptr::ParentRef::from),
+                data: None,
+                ast_memory_store: ManuallyDrop::new(bun_ast::ASTMemoryAllocator::default()),
+                has_created: false,
+                deinit_task: ThreadPoolLib::Task {
+                    node: ThreadPoolLib::Node::default(),
+                    callback: Worker::deinit_callback,
+                },
+                temporary_arena: None,
+                stmt_list: None,
+            }))),
         };
         drop(map);
         TLS_WORKER.set((self.generation, worker));
-        // SAFETY: the map only holds Workers that were written before they were
-        // inserted (above); each lives until its `deinit_soon`, and this thread
-        // is the only one that uses the Worker keyed by its own id.
+        // SAFETY: the map only holds complete Workers; each lives until its
+        // `deinit_soon`, and only the thread whose id keys it uses it.
         unsafe { &mut *worker }
     }
 }
@@ -695,12 +669,6 @@ impl Worker {
 
     pub(crate) fn unget(&mut self) {
         self.ast_memory_store.pop();
-    }
-
-    pub(crate) fn init(&mut self, v2: &BundleV2<'_>) {
-        // Lifetime-erase `'_` → `'static` via `NonNull::cast` (BACKREF: the
-        // bundle outlives every worker).
-        self.ctx = bun_ptr::BackRef::from(NonNull::from(v2).cast::<BundleV2<'static>>());
     }
 
     fn create(&mut self, ctx: &BundleV2<'_>) {

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -246,8 +246,9 @@ impl ThreadPool {
         if self.worker_pool_is_owned {
             // SAFETY: worker_pool was heap-allocated in `init()` when owned.
             unsafe { drop(bun_core::heap::take(self.worker_pool)) };
-            self.worker_pool = ptr::null_mut();
         }
+        // Also for a shared pool, so that `worker_pool()` catches a late task on every path.
+        self.worker_pool = ptr::null_mut();
         if Self::uses_io_pool() {
             io_thread_pool::release();
         }
@@ -262,8 +263,9 @@ impl ThreadPool {
             !self.worker_pool.is_null(),
             "bundler worker pool used after ThreadPool::deinit"
         );
-        // SAFETY: non-null means `deinit` has not run, so the pool is live;
-        // all driver methods take `&self`.
+        // SAFETY: non-null means `deinit` has not run. Until then an owned pool is
+        // not freed and a shared one is the process-lifetime `WorkPool`; all
+        // driver methods take `&self`.
         unsafe { &*self.worker_pool }
     }
 

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -15,7 +15,7 @@ use bun_alloc::Arena as ThreadLocalArena;
 use bun_collections::{ArrayHashMap, MapEntry};
 use bun_core::{self, env_var, output as Output};
 use bun_sys::Fd;
-use bun_threading::{Mutex, thread_pool as ThreadPoolLib};
+use bun_threading::{Mutex, WaitGroup, thread_pool as ThreadPoolLib};
 
 use crate::cache::{Contents, Entry as CacheEntry};
 use crate::linker_context_mod::StmtList;
@@ -49,6 +49,14 @@ pub struct ThreadPool {
     // `wake_for_idle_events`) take `&self` — so the safe `Deref` projection is
     // sufficient and the per-read `unsafe { p.as_ref() }` disappears.
     pub(crate) io_pool: Option<bun_ptr::ParentRef<ThreadPoolLib::ThreadPool>>,
+    /// One count per parse task handed to `io_pool`, finished when its IO
+    /// callback returns. The IO pool outlives this `ThreadPool`, and the
+    /// callback's last step is to re-schedule the task onto `worker_pool`, so
+    /// teardown joins this ([`Self::wait_for_io_tasks`]) before [`Self::deinit`]
+    /// frees `worker_pool`. `graph.pending_items` cannot stand in for it: it
+    /// reaches zero as soon as the re-scheduled parse completes, which can be
+    /// while the IO callback is still inside `schedule`.
+    io_tasks_in_flight: WaitGroup,
     // Conditionally owned via `worker_pool_is_owned`; kept raw so callers
     // (bundle_v2.rs) can dereference for `wake_for_idle_events()` without a
     // borrow on `ThreadPool`.
@@ -208,6 +216,7 @@ impl ThreadPool {
             } else {
                 None
             },
+            io_tasks_in_flight: WaitGroup::init(),
             // BACKREF: lifetime erased behind the raw pointer.
             v2: std::ptr::from_ref(v2).cast::<BundleV2<'static>>(),
             worker_pool_is_owned: false,
@@ -216,9 +225,30 @@ impl ThreadPool {
         }
     }
 
+    /// Blocks until every IO callback of this pool has returned. Call it
+    /// (through `&self`, while IO threads may still read the pool) before
+    /// taking the `&mut self` that [`Self::deinit`] needs.
+    pub(crate) fn wait_for_io_tasks(&self) {
+        self.io_tasks_in_flight.wait();
+    }
+
+    /// The IO callback's last step (`io_task_callback`), after the task has been
+    /// handed to the worker pool.
+    ///
+    /// # Safety
+    /// `this` is the pool the task was scheduled on. The bundle keeps it alive
+    /// until [`Self::wait_for_io_tasks`] returns, which this call permits, so
+    /// nothing may touch the pool after it.
+    pub(crate) unsafe fn finish_io_task(this: *const Self) {
+        // SAFETY: caller contract; `finish_raw` is the matching last access.
+        unsafe { WaitGroup::finish_raw(&raw const (*this).io_tasks_in_flight) };
+    }
+
     /// Explicit teardown (no Drop on
     /// `ThreadPool` because `Graph.pool` is `NonNull<ThreadPool>` and the arena
-    /// owns the storage).
+    /// owns the storage). The caller drains the parse tasks and calls
+    /// [`Self::wait_for_io_tasks`] first: a task still running would use the
+    /// pool this frees.
     pub(crate) fn deinit(&mut self) {
         if self.worker_pool_is_owned {
             // SAFETY: worker_pool was heap-allocated in `init()` when owned.
@@ -231,13 +261,18 @@ impl ThreadPool {
     }
 
     /// Safe accessor for the underlying `bun_threading::ThreadPool`. The
-    /// pointer is set in `init`/`init_with_pool` and never null while `self`
-    /// is observable; encapsulating the deref keeps callers out of `unsafe`.
+    /// pointer is set in `init`/`init_with_pool` and nulled by `deinit`. The
+    /// arena keeps `self` readable after `deinit`, so a task that is still
+    /// running at teardown gets here: fail with a message instead of a
+    /// null dereference inside the pool.
     #[inline]
     pub(crate) fn worker_pool(&self) -> &ThreadPoolLib::ThreadPool {
-        debug_assert!(!self.worker_pool.is_null());
-        // SAFETY: `worker_pool` is initialized before any caller can observe
-        // `self` and lives until `deinit`; all driver methods take `&self`.
+        assert!(
+            !self.worker_pool.is_null(),
+            "bundler worker pool used after ThreadPool::deinit"
+        );
+        // SAFETY: non-null means `deinit` has not run, so the pool is live;
+        // all driver methods take `&self`.
         unsafe { &*self.worker_pool }
     }
 
@@ -343,6 +378,8 @@ impl ThreadPool {
                     ParseTaskStage::NeedsSourceCode => {
                         // io_pool is Some when uses_io_pool().
                         let io = self.io_pool_ref().unwrap();
+                        // Finished by `finish_io_task` at the end of `io_task_callback`.
+                        self.io_tasks_in_flight.add_one();
                         schedule_fn(
                             io,
                             ThreadPoolLib::Batch::from(&raw mut (*parse_task).io_task),
@@ -401,56 +438,52 @@ impl ThreadPool {
 
     #[cold]
     fn get_worker_slow(&self, id: ThreadId) -> &'static mut Worker {
-        let worker: *mut Worker;
-        {
-            let mut map = self.workers_assignments.lock();
-            match map.entry(id) {
-                MapEntry::Occupied(o) => {
-                    let w = *o.into_mut();
-                    drop(map);
-                    TLS_WORKER.set((self.generation, w));
-                    // SAFETY: map only stores live heap-allocated Workers (inserted below).
-                    return unsafe { &mut *w };
+        let mut map = self.workers_assignments.lock();
+        let worker: *mut Worker = match map.entry(id) {
+            MapEntry::Occupied(o) => *o.into_mut(),
+            MapEntry::Vacant(v) => {
+                // Allocate raw uninitialized storage; fully written via
+                // `worker.write(...)` below before any read. Keep it as
+                // `*mut MaybeUninit<Worker>` → `.cast()` instead of
+                // `assume_init()` so we never materialize a `Box<Worker>`
+                // whose payload violates `Worker`'s validity invariants
+                // (niche-optimized `Option<_>` discriminants, the non-null
+                // fn-pointer in `deinit_task.callback`, `bool` fields).
+                let worker = bun_core::heap::into_raw(Box::<Worker>::new_uninit()).cast::<Worker>();
+                // SAFETY: `worker` is freshly heap-allocated and reachable from
+                // nothing until `v.insert` below. It has to be complete by then:
+                // `deinit_without_freeing_arena` takes this lock and tears down
+                // every Worker the map holds.
+                unsafe {
+                    worker.write(Worker {
+                        // Placeholder — overwritten by `init()` immediately below.
+                        ctx: bun_ptr::BackRef::from(NonNull::<BundleV2<'static>>::dangling()),
+                        heap: None,
+                        arena: bun_ptr::BackRef::from(NonNull::<ThreadLocalArena>::dangling()),
+                        thread: NonNull::new(ThreadPoolLib::Thread::current())
+                            .map(bun_ptr::ParentRef::from),
+                        data: None,
+                        ast_memory_store: ManuallyDrop::new(bun_ast::ASTMemoryAllocator::default()),
+                        has_created: false,
+                        deinit_task: ThreadPoolLib::Task {
+                            node: ThreadPoolLib::Node::default(),
+                            callback: Worker::deinit_callback,
+                        },
+                        temporary_arena: None,
+                        stmt_list: None,
+                    });
+                    (*worker).init(&*self.v2);
                 }
-                MapEntry::Vacant(v) => {
-                    // Allocate raw uninitialized storage; fully written via
-                    // `worker.write(...)` below before any read. Keep it as
-                    // `*mut MaybeUninit<Worker>` → `.cast()` instead of
-                    // `assume_init()` so we never materialize a `Box<Worker>`
-                    // whose payload violates `Worker`'s validity invariants
-                    // (niche-optimized `Option<_>` discriminants, the non-null
-                    // fn-pointer in `deinit_task.callback`, `bool` fields).
-                    worker = bun_core::heap::into_raw(Box::<Worker>::new_uninit()).cast::<Worker>();
-                    v.insert(worker);
-                }
+                v.insert(worker);
+                worker
             }
-        }
-
-        // SAFETY: `worker` is freshly heap-allocated and exclusive on this
-        // thread until published via the map (already inserted above, but no
-        // other thread looks it up under a different `id`).
-        unsafe {
-            worker.write(Worker {
-                // Placeholder — overwritten by `init()` immediately below.
-                ctx: bun_ptr::BackRef::from(NonNull::<BundleV2<'static>>::dangling()),
-                heap: None,
-                arena: bun_ptr::BackRef::from(NonNull::<ThreadLocalArena>::dangling()),
-                thread: NonNull::new(ThreadPoolLib::Thread::current())
-                    .map(bun_ptr::ParentRef::from),
-                data: None,
-                ast_memory_store: ManuallyDrop::new(bun_ast::ASTMemoryAllocator::default()),
-                has_created: false,
-                deinit_task: ThreadPoolLib::Task {
-                    node: ThreadPoolLib::Node::default(),
-                    callback: Worker::deinit_callback,
-                },
-                temporary_arena: None,
-                stmt_list: None,
-            });
-            (*worker).init(&*self.v2);
-            TLS_WORKER.set((self.generation, worker));
-            &mut *worker
-        }
+        };
+        drop(map);
+        TLS_WORKER.set((self.generation, worker));
+        // SAFETY: the map only holds Workers that were written before they were
+        // inserted (above); each lives until its `deinit_soon`, and this thread
+        // is the only one that uses the Worker keyed by its own id.
+        unsafe { &mut *worker }
     }
 }
 

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -699,7 +699,6 @@ impl Worker {
         *self.ast_memory_store = bun_ast::ASTMemoryAllocator::borrowing(arena_ref);
 
         let log: *mut bun_ast::Log = arena_ref.alloc(bun_ast::Log::init());
-        self.ctx = bun_ptr::BackRef::from(NonNull::from(ctx).cast::<BundleV2<'static>>());
         // Use a fresh Bump (no nested-arena type yet).
         self.temporary_arena = Some(bun_alloc::Arena::new());
         self.stmt_list = Some(StmtList::init());

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4046,10 +4046,13 @@ pub mod bv2_impl {
                 // SAFETY: `transpiler.options.entry_points` is borrowed only for the duration
                 // of `enqueue_entry_points_normal`, which never frees/reallocates it; raw-ptr
                 // sidestep for the `&mut self` overlap.
-                this.enqueue_entry_points_normal(unsafe { &*entry_points })?;
+                let enqueued = this.enqueue_entry_points_normal(unsafe { &*entry_points });
 
-                // Like `run_from_js_in_new_thread`: drain the pool, then report entry point errors.
+                // The runtime and every entry point enqueued so far are already on the
+                // pool, including when enqueueing failed: drain it before any error
+                // returns into the teardown below.
                 this.wait_for_parse();
+                enqueued?;
                 this.dump_pool_stats("parse");
 
                 *minify_duration = (((bun_core::time::nano_timestamp() as i64)
@@ -4180,15 +4183,11 @@ pub mod bv2_impl {
             // enqueueEntryPoints schedules the runtime task before any fallible
             // allocation. If a later allocation fails we must still drain the
             // pool so workers aren't left holding pointers into the caller's
-            // stack-allocated Transpiler.
-            if let Err(err) = this.enqueue_entry_points_normal(entry_points) {
-                this.wait_for_parse();
-                return Err(err);
-            }
-
-            // Even if entry point resolution produced errors we still wait for
-            // all enqueued parse tasks to finish so the graph is consistent.
+            // stack-allocated Transpiler. Entry point resolution errors are
+            // drained the same way so the graph is consistent.
+            let enqueued = this.enqueue_entry_points_normal(entry_points);
             this.wait_for_parse();
+            enqueued?;
 
             Ok(this)
         }
@@ -4218,10 +4217,12 @@ pub mod bv2_impl {
                     return Err(crate::Error::BuildFailed);
                 }
 
-                this.enqueue_entry_points_bake_production(entry_points)?;
+                let enqueued = this.enqueue_entry_points_bake_production(entry_points);
 
-                // Drain the pool, then report entry point errors (as `generate_from_cli` does).
+                // Drain the pool before anything returns into the teardown below (as
+                // `generate_from_cli` does), then report entry point errors.
                 this.wait_for_parse();
+                enqueued?;
 
                 if this.transpiler.log().has_errors() {
                     return Err(crate::Error::BuildFailed);
@@ -5148,6 +5149,22 @@ pub mod bv2_impl {
         }
 
         pub fn deinit_without_freeing_arena(&mut self) {
+            // Parse tasks are the driver's to drain (`wait_for_parse`) on every
+            // exit path: their results need the event loop. Everything else the
+            // bundle put on the pools is joined here, before the graph and the
+            // workers it runs on are freed. `link` schedules the source map
+            // tasks and only `generate_chunks_in_parallel` waits for them, so an
+            // error in between gets here with them still running.
+            debug_assert_eq!(
+                self.graph.pending_items, 0,
+                "BundleV2 torn down with parse tasks in flight"
+            );
+            self.linker.source_maps.line_offset_wait_group.wait();
+            self.linker.source_maps.quoted_contents_wait_group.wait();
+            // A parse task whose IO step finished last is still inside
+            // `schedule` on the worker pool that `pool.deinit()` below frees.
+            self.graph.pool().wait_for_io_tasks();
+
             {
                 // We do this first to make it harder for any dangling pointers to data to be used in there.
                 let on_parse_finalizers = core::mem::take(&mut self.finalizers);
@@ -5272,10 +5289,11 @@ pub mod bv2_impl {
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
 
-            self.enqueue_entry_points_normal(entry_points)?;
+            let enqueued = self.enqueue_entry_points_normal(entry_points);
 
             // We must wait for all the parse tasks to complete, even if there are errors.
             self.wait_for_parse();
+            enqueued?;
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2252,9 +2252,8 @@ pub mod bv2_impl {
         }
 
         /// Runs one of the `enqueue_entry_points_*` variants and drains what it
-        /// scheduled. They put the runtime's parse task on the pool before anything
-        /// in them can fail, and every driver tears the bundle down when this
-        /// returns an error, so the drain comes before the error does.
+        /// scheduled, also when it failed: the runtime's parse task is on the pool
+        /// before anything in them can fail, and an error leads to the teardown.
         fn enqueue_and_wait_for_parse(
             &mut self,
             enqueue: impl FnOnce(&mut Self) -> Result<(), Error>,
@@ -4185,8 +4184,7 @@ pub mod bv2_impl {
             let mut this = BundleV2::init(transpiler, None, alloc, event_loop, false, None, alloc)?;
             this.unique_key = generate_unique_key();
 
-            // `init` started the pools: an error exit tears the bundle down here,
-            // a success leaves that to the caller.
+            // The caller tears down a returned bundle; an error exit has to do it here.
             let scanned = if this.transpiler.log().has_errors() {
                 Err(crate::Error::BuildFailed)
             } else {
@@ -5156,21 +5154,17 @@ pub mod bv2_impl {
         }
 
         pub fn deinit_without_freeing_arena(&mut self) {
-            // Parse tasks are the driver's to drain (`enqueue_and_wait_for_parse`;
-            // the dev server gets here from `is_done()`): their results need the
-            // event loop. A task that is still running would use the graph and the
-            // workers this frees, so fail with a message instead. Everything else
-            // the bundle put on the pools is joined here. `link` schedules the
-            // source map tasks and only `generate_chunks_in_parallel` waits for
-            // them, so an error in between gets here with them still running.
+            // Nothing may still run against the graph and the workers this frees.
+            // Parse results need the event loop, so the drivers drain those
+            // (`enqueue_and_wait_for_parse`; the dev server gets here from `is_done`).
             assert_eq!(
                 self.graph.pending_items, 0,
                 "BundleV2 torn down with parse tasks in flight"
             );
+            // Scheduled by `link`, waited for only by `generate_chunks_in_parallel`.
             self.linker.source_maps.line_offset_wait_group.wait();
             self.linker.source_maps.quoted_contents_wait_group.wait();
-            // A parse task whose IO step finished last is still inside
-            // `schedule` on the worker pool that `pool.deinit()` below frees.
+            // The last IO callback may still be inside the worker pool `pool.deinit()` frees.
             self.graph.pool().wait_for_io_tasks();
 
             {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2224,7 +2224,7 @@ pub mod bv2_impl {
             false
         }
 
-        pub(crate) fn wait_for_parse(&mut self) {
+        fn wait_for_parse(&mut self) {
             // `tick_raw` (not `tick`) — `is_done` reborrows `*ctx` as
             // `&mut BundleV2`, and `BundleV2` (via `linker.r#loop`) owns the
             // `AnyEventLoop` slot, so holding `&mut AnyEventLoop` across the
@@ -2249,6 +2249,19 @@ pub mod bv2_impl {
                 self.graph.input_files.len(),
                 self.graph.ast.len()
             );
+        }
+
+        /// Runs one of the `enqueue_entry_points_*` variants and drains what it
+        /// scheduled. They put the runtime's parse task on the pool before anything
+        /// in them can fail, and every driver tears the bundle down when this
+        /// returns an error, so the drain comes before the error does.
+        fn enqueue_and_wait_for_parse(
+            &mut self,
+            enqueue: impl FnOnce(&mut Self) -> Result<(), Error>,
+        ) -> Result<(), Error> {
+            let enqueued = enqueue(self);
+            self.wait_for_parse();
+            enqueued
         }
 
         /// Callers require an entry point, so none after parsing means one was dropped without an error.
@@ -4043,16 +4056,12 @@ pub mod bv2_impl {
 
                 let entry_points: *const [Box<[u8]>] =
                     &raw const *this.transpiler.options.entry_points;
-                // SAFETY: `transpiler.options.entry_points` is borrowed only for the duration
-                // of `enqueue_entry_points_normal`, which never frees/reallocates it; raw-ptr
-                // sidestep for the `&mut self` overlap.
-                let enqueued = this.enqueue_entry_points_normal(unsafe { &*entry_points });
-
-                // The runtime and every entry point enqueued so far are already on the
-                // pool, including when enqueueing failed: drain it before any error
-                // returns into the teardown below.
-                this.wait_for_parse();
-                enqueued?;
+                this.enqueue_and_wait_for_parse(|bundle| {
+                    // SAFETY: `transpiler.options.entry_points` is borrowed only for the duration
+                    // of `enqueue_entry_points_normal`, which never frees/reallocates it; raw-ptr
+                    // sidestep for the `&mut self` overlap.
+                    bundle.enqueue_entry_points_normal(unsafe { &*entry_points })
+                })?;
                 this.dump_pool_stats("parse");
 
                 *minify_duration = (((bun_core::time::nano_timestamp() as i64)
@@ -4176,18 +4185,19 @@ pub mod bv2_impl {
             let mut this = BundleV2::init(transpiler, None, alloc, event_loop, false, None, alloc)?;
             this.unique_key = generate_unique_key();
 
-            if this.transpiler.log().has_errors() {
-                return Err(crate::Error::BuildFailed);
+            // `init` started the pools: an error exit tears the bundle down here,
+            // a success leaves that to the caller.
+            let scanned = if this.transpiler.log().has_errors() {
+                Err(crate::Error::BuildFailed)
+            } else {
+                this.enqueue_and_wait_for_parse(|bundle| {
+                    bundle.enqueue_entry_points_normal(entry_points)
+                })
+            };
+            if let Err(err) = scanned {
+                this.deinit_without_freeing_arena();
+                return Err(err);
             }
-
-            // enqueueEntryPoints schedules the runtime task before any fallible
-            // allocation. If a later allocation fails we must still drain the
-            // pool so workers aren't left holding pointers into the caller's
-            // stack-allocated Transpiler. Entry point resolution errors are
-            // drained the same way so the graph is consistent.
-            let enqueued = this.enqueue_entry_points_normal(entry_points);
-            this.wait_for_parse();
-            enqueued?;
 
             Ok(this)
         }
@@ -4217,12 +4227,9 @@ pub mod bv2_impl {
                     return Err(crate::Error::BuildFailed);
                 }
 
-                let enqueued = this.enqueue_entry_points_bake_production(entry_points);
-
-                // Drain the pool before anything returns into the teardown below (as
-                // `generate_from_cli` does), then report entry point errors.
-                this.wait_for_parse();
-                enqueued?;
+                this.enqueue_and_wait_for_parse(|bundle| {
+                    bundle.enqueue_entry_points_bake_production(entry_points)
+                })?;
 
                 if this.transpiler.log().has_errors() {
                     return Err(crate::Error::BuildFailed);
@@ -5149,13 +5156,14 @@ pub mod bv2_impl {
         }
 
         pub fn deinit_without_freeing_arena(&mut self) {
-            // Parse tasks are the driver's to drain (`wait_for_parse`) on every
-            // exit path: their results need the event loop. Everything else the
-            // bundle put on the pools is joined here, before the graph and the
-            // workers it runs on are freed. `link` schedules the source map
-            // tasks and only `generate_chunks_in_parallel` waits for them, so an
-            // error in between gets here with them still running.
-            debug_assert_eq!(
+            // Parse tasks are the driver's to drain (`enqueue_and_wait_for_parse`;
+            // the dev server gets here from `is_done()`): their results need the
+            // event loop. A task that is still running would use the graph and the
+            // workers this frees, so fail with a message instead. Everything else
+            // the bundle put on the pools is joined here. `link` schedules the
+            // source map tasks and only `generate_chunks_in_parallel` waits for
+            // them, so an error in between gets here with them still running.
+            assert_eq!(
                 self.graph.pending_items, 0,
                 "BundleV2 torn down with parse tasks in flight"
             );
@@ -5289,11 +5297,9 @@ pub mod bv2_impl {
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
 
-            let enqueued = self.enqueue_entry_points_normal(entry_points);
-
-            // We must wait for all the parse tasks to complete, even if there are errors.
-            self.wait_for_parse();
-            enqueued?;
+            self.enqueue_and_wait_for_parse(|bundle| {
+                bundle.enqueue_entry_points_normal(entry_points)
+            })?;
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
 

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -166,7 +166,7 @@ pub(crate) fn post_process_js_chunk(
         ModuleInfo::create(loader.is_type_script())
     });
 
-    // SAFETY: worker.arena is set in Worker::init() before any task runs.
+    // `worker.arena` is set in `Worker::create()`, which `Worker::get` runs first.
     let worker_arena: &Arena = worker.arena();
 
     // An ESM entry point already ends in an `export { }` clause

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1265,23 +1265,17 @@ impl CompletionStruct for JSBundleCompletionTask {
             .map(|b| &**b)
             .collect();
 
-        let run = bv2.run_from_js_in_new_thread(&entry_points);
-
-        // The AST-allocator pop lives in `generate_in_new_thread`; the
-        // source-map wait-group waits run only on the error path.
-        match run {
+        // The AST-allocator pop lives in `generate_in_new_thread`. Teardown
+        // joins the source map tasks an error can leave on the shared pool.
+        let result = match bv2.run_from_js_in_new_thread(&entry_points) {
             Ok(build) => {
                 self.set_result(BundleV2Result::Value(build));
-                bv2.deinit_without_freeing_arena();
                 Ok(())
             }
-            Err(err) => {
-                bv2.linker.source_maps.line_offset_wait_group.wait();
-                bv2.linker.source_maps.quoted_contents_wait_group.wait();
-                bv2.deinit_without_freeing_arena();
-                Err(err)
-            }
-        }
+            Err(err) => Err(err),
+        };
+        bv2.deinit_without_freeing_arena();
+        result
     }
 }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1265,8 +1265,7 @@ impl CompletionStruct for JSBundleCompletionTask {
             .map(|b| &**b)
             .collect();
 
-        // The AST-allocator pop lives in `generate_in_new_thread`. Teardown
-        // joins the source map tasks an error can leave on the shared pool.
+        // The AST-allocator pop lives in `generate_in_new_thread`.
         let result = match bv2.run_from_js_in_new_thread(&entry_points) {
             Ok(build) => {
                 self.set_result(BundleV2Result::Value(build));

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -466,13 +466,12 @@ test("multi-entry build writes each entry point into the output directory", asyn
   expect(b).toContain('"B"');
 });
 
-// A build that fails while it still has work on the thread pools has to join
-// that work before it tears the pools down. Whether a task is still running at
-// that point is a race, so each build is repeated and every run has to exit
-// with only the build error.
+// https://github.com/oven-sh/bun/pull/39855
+// Whether a task is still on the pool when the build fails is a race, so each
+// build is repeated and every run has to exit with only the build error.
 describe("a failing build exits cleanly while it still has tasks on the pool", () => {
-  // Each run is reported as its exit code followed by its normalized stderr, so
-  // a crash report (ASAN exits with 1 as well) fails the comparison too.
+  // Exit code plus normalized stderr: a crash report fails the comparison even
+  // when the process still exits with 1 (ASAN does).
   async function build(dir: string, args: string[], env: Record<string, string | undefined>): Promise<string> {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", ...args],
@@ -485,11 +484,9 @@ describe("a failing build exits cleanly while it still has tasks on the pool", (
     return `exit ${exitCode}\n${normalizeBunSnapshot(stderr, dir)}`;
   }
 
-  // `link` puts one line offset task and one quoted contents task per file on
-  // the pool and then fails on the import. The pool threads are still creating
-  // their Worker for those tasks, or still running them, while the build tears
-  // the workers down. The runs are sequential: the pool threads have to get
-  // the CPU in time to be busy when the build fails.
+  // The source map tasks `link` scheduled are still starting on the pool
+  // threads when the import fails the build. Sequential: the threads have to
+  // get the CPU before that happens.
   test("link error with --sourcemap", async () => {
     using dir = tempDir("build-sourcemap-link-error", {
       "entry.js": `import { nope } from "./lib.js";\nconsole.log(nope);\n`,
@@ -514,12 +511,9 @@ describe("a failing build exits cleanly while it still has tasks on the pool", (
     );
   });
 
-  // With the IO pool (the default on macOS and Windows, forced here so every
-  // platform runs it) a file is read on an IO thread, which then hands the
-  // parse to the worker pool. 1.4.0 returned on the unresolvable entry point
-  // while the other entry points were still being read and crashed in
-  // `ThreadPool::schedule` or in the worker teardown. The reads only outlast
-  // the teardown on a busy machine, so these runs are concurrent.
+  // The IO pool (the default on macOS and Windows) is still reading the other
+  // entry points when the missing one fails the build. Concurrent: the reads
+  // only outlast the teardown on a busy machine.
   test("unresolvable entry point beside entry points that are still being read", async () => {
     const files: Record<string, string> = {};
     for (let i = 0; i < 200; i++) {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -466,6 +466,75 @@ test("multi-entry build writes each entry point into the output directory", asyn
   expect(b).toContain('"B"');
 });
 
+// A build that fails while it still has work on the thread pools has to join
+// that work before it tears the pools down. Whether a task is still running at
+// that point is a race, so each build is repeated and every run has to exit
+// with only the build error.
+describe("a failing build exits cleanly while it still has tasks on the pool", () => {
+  // Each run is reported as its exit code followed by its normalized stderr, so
+  // a crash report (ASAN exits with 1 as well) fails the comparison too.
+  async function build(dir: string, args: string[], env: Record<string, string | undefined>): Promise<string> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env,
+      cwd: dir,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return `exit ${exitCode}\n${normalizeBunSnapshot(stderr, dir)}`;
+  }
+
+  // `link` puts one line offset task and one quoted contents task per file on
+  // the pool and then fails on the import. The pool threads are still creating
+  // their Worker for those tasks, or still running them, while the build tears
+  // the workers down. The runs are sequential: the pool threads have to get
+  // the CPU in time to be busy when the build fails.
+  test("link error with --sourcemap", async () => {
+    using dir = tempDir("build-sourcemap-link-error", {
+      "entry.js": `import { nope } from "./lib.js";\nconsole.log(nope);\n`,
+      "lib.js": `export const yes = 1;\n`,
+    });
+
+    const runs: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      runs.push(await build(String(dir), ["./entry.js", "--sourcemap", "--outdir", "dist"], bunEnv));
+    }
+
+    expect(runs).toEqual(
+      Array(8).fill(
+        [
+          "exit 1",
+          '1 | import { nope } from "./lib.js";',
+          "             ^",
+          'error: No matching export in "lib.js" for import "nope"',
+          "    at <dir>/entry.js:1:10",
+        ].join("\n"),
+      ),
+    );
+  });
+
+  // With the IO pool (the default on macOS and Windows, forced here so every
+  // platform runs it) a file is read on an IO thread, which then hands the
+  // parse to the worker pool. 1.4.0 returned on the unresolvable entry point
+  // while the other entry points were still being read and crashed in
+  // `ThreadPool::schedule` or in the worker teardown. The reads only outlast
+  // the teardown on a busy machine, so these runs are concurrent.
+  test("unresolvable entry point beside entry points that are still being read", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) {
+      files[`f${i}.ts`] = `export const v${i} = ${i};\n`;
+    }
+    using dir = tempDir("build-missing-entry-io-pool", files);
+    const args = ["./missing.ts", ...Object.keys(files).map(name => `./${name}`), "--outdir", "out"];
+    const env = { ...bunEnv, BUN_FEATURE_FLAG_FORCE_IO_POOL: "1" };
+
+    const runs = await Promise.all(Array.from({ length: 16 }, () => build(String(dir), args, env)));
+
+    expect(runs).toEqual(Array(16).fill('exit 1\nerror: ModuleNotFound resolving "./missing.ts" (entry point)'));
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/9859
 describe.concurrent("--no-bundle with --outdir", () => {
   test("writes a single entry point", async () => {


### PR DESCRIPTION
### Problem
- A failing build tore the bundle down under its running tasks. 1.4.0 crashes with `Segmentation fault at address 0x0` in `ThreadPool::schedule_impl` (Sentry BUN-4MYJ) or `at address 0x8` in `deinit_without_freeing_arena` → `Worker::deinit_soon` → `Worker::deinit` (Sentry BUN-4NX2).
- After #39799 this still happens for a link error under `--sourcemap` (a crash on the main thread, a crash on a pool thread, or a silent hang), for an IO pool callback still inside the worker pool that `ThreadPool::deinit` frees, and for an enqueue error.
- `get_worker_slow` (`src/bundler/ThreadPool.rs`) published the `Worker` before it wrote it. A teardown in that window read garbage: the `0x8` crash.

### Fix
- `deinit_without_freeing_arena` waits for the source map wait groups and for a new IO task count before it frees anything, and asserts `pending_items == 0`.
- The bundler `ThreadPool` counts the tasks it hands to the IO pool in a `WaitGroup`. The drivers drain through `enqueue_and_wait_for_parse`, the only caller of `wait_for_parse()` now, so an enqueue error is drained too. `scan_module_graph_from_cli` tears down on its error exits.
- `get_worker_slow` builds the `Worker` with `Box::new` and inserts it complete. `worker_pool()` asserts in release builds.
- Verified: two new cases in `test/bundler/cli.test.ts`. Unfixed, the `--sourcemap` case crashes 30 of 40 ASAN runs (28 in `Worker::deinit_soon`, 2 on a pool thread in `SourceMapDataTask::run_line_offset`) and hangs 1 of 500 release runs. Fixed: 2,000 ASAN runs and 11,500 release runs, 0 crashes, 0 hangs. Other suites: see notes.

### Background
- A `BundleV2` owns a bundler `ThreadPool`, plus a `Worker` of per-thread state per pool thread. For the CLI the pool also owns its worker pool, which `deinit` drops. The IO pool is a process-wide static.
- On macOS and Windows the IO pool reads each file. Its callback then schedules the same task onto the worker pool.
- `pending_items` counts parse tasks until their results are processed. `wait_for_parse()` ticks the event loop until it is zero. Only `generate_chunks_in_parallel` waited for the source map tasks.

Supersedes #37480 and folds in the `get_worker_slow` reorder noted there.

<details><summary>Notes</summary>

The Zig bundler leaked all of this on the CLI error path. The teardown, and with it every crash here, is new with the port.

Repro for the Sentry shape on release 1.4.0 (Linux needs the IO pool forced): 200 `f$i.ts` files, then `BUN_FEATURE_FLAG_FORCE_IO_POOL=1 bun build ./missing.ts ./f*.ts --outdir out`. 200 runs here gave three banners: `Segmentation fault at address 0x0` on a pool thread, `panic(main thread): Segmentation fault at address 0x8`, and `panic: called Option::unwrap() on a None value`. The last two are the same uninitialized `Worker` being dropped, with different contents in the fresh allocation. BUN-4NX2 (macOS arm64, 1.4.0) is the zero-filled variant: `thread` reads as `None`, so `deinit_soon` drops the `Worker` synchronously, `data` reads as `Some`, and the drop glue follows a null `Box<Define>` into `RawTableInner`, the read at `0x8`. This shape no longer crashes on main (0 of 40 on a debug build) because of #39799. Its test documents the IO pool teardown on every platform and would hang if the new count were unbalanced. Its crash rate on 1.4.0 depends on machine load (5 to 15 percent of single runs on a loaded machine, about 4 percent idle), so that test runs its builds concurrently.

The `--sourcemap` shape is from #37480 and still crashes on main: ASAN reports the uninitialized `Worker` in `deinit_soon` or a use-after-poison in `compute_quoted_source_contents` on a pool thread. `link()` schedules those tasks before `scan_imports_and_exports` fails. The test's builds run sequentially because the pool threads have to get the CPU before the build fails: concurrent runs were detected in 4 of 6 invocations, sequential in 6 of 6, and 5 of 5 with the final test.

The enqueue errors left in the drivers (`generate_from_cli`, `generate_from_bake_production_cli`, `scan_module_graph_from_cli`, `run_from_js_in_new_thread`) are allocation failures. `enqueue_entry_points_common` schedules the runtime parse task before any of them, so they are now drained the way `scan_module_graph_from_cli` already drained them. The four drivers share `enqueue_and_wait_for_parse` for it, and `wait_for_parse()` is private to that helper, so a fifth driver cannot skip the drain.

The IO count is separate from `pending_items` because the hazard is the tail of the IO callback: `schedule_impl` pushes the task and then notifies the pool. A worker can parse the task and the bundle thread can finish `wait_for_parse()` and reach teardown while the IO thread is still inside that notify. The callback finishes the count with `WaitGroup::finish_raw`, the group's contract for an owner that frees it as soon as `wait()` returns. Teardown waits through `&self` before it takes `pool_mut()`, which keeps the `Graph::pool` documentation true. The `Worker` is now built and inserted under the map lock, which teardown also takes, so the map only ever holds complete workers. That also retires the uninitialized allocation, the separate write and `Worker::init`, which only existed to insert the pointer first. The release assert in `worker_pool()` turns a task that still reaches a torn down pool into a panic with a message instead of the `0x0` fault. `deinit` nulls the pointer for a shared pool as well (both shared-pool callers, `Bun.build` and the dev server, pass the process-lifetime `WorkPool`), so the assert covers those paths too and not only the CLI's owned pool.

Teardown does not call `wait_for_parse()` itself, as #37480 did: the dev server reaches teardown from inside its JS event loop, and only with `pending_items == 0` (`on_after_decrement_scan_counter`), which the assert now checks, in release builds too, for the same reason `worker_pool()` does. The wait group and IO waits need no event loop, so they can live in teardown for every caller.

`scan_module_graph_from_cli` dropped the bundle without a teardown on its error exits, which leaked the pools `init` had started while `bun test --changed` went on to run every test. It tears down now. Its early exit has nothing scheduled, so that teardown is the same walk over an empty bundle that `generate_from_cli` already does on its first return.

Suites run on the debug build with `BUN_FEATURE_FLAG_FORCE_IO_POOL=1` exported, so the accounting is exercised on Linux: `test/bundler/cli.test.ts`, `bun-build-api.test.ts`, `bundler_edgecase.test.ts`, `bundler_plugin.test.ts`, `bundler_defer.test.ts`, `bundler_html.test.ts`, `bundler_browser.test.ts`, `test/cli/test/test-changed.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bake/deinitialization.test.ts`, `test/bake/dev/production.test.ts` (several cases take 4 to 7 seconds in this container with or without the change and pass with a longer timeout), and the `counted` group of `test/js/web/workers/worker-terminate-funnels.test.ts`, which cancels a `Bun.build` inside a plugin. The new tests passed 8 of 8 invocations on the fixed build, and 40 runs of the 200 file repro plus 30 runs of a 200 file `--sourcemap` link error had 0 failures. `cargo clippy` on `bun_bundler` and `bun_runtime` is clean. After the review changes: `cli.test.ts`, `test-changed.test.ts`, `bundler_edgecase`, `bundler_plugin`, `bundler_defer`, `dev-and-prod`, `production`, the `counted` group and `bun-build-api` again (four clean runs; one run while the host was loaded had two cases time out, both pass on their own).

Verification after the rebase onto ae7b8f4abb (2026-09-06). The repro is the test's 2 file graph: `entry.js` imports `nope` from `lib.js`, which does not export it, built with `bun build ./entry.js --sourcemap --outdir dist`. Each run has a 60 second timeout. A run counts as clean when it exits 1 and prints only the `No matching export` error.

- Unfixed main, ASAN debug build, 40 sequential runs: 10 clean, 30 crashes, 0 hangs. 28 crashes are `SEGV` in `Queue::push` under `Thread::push_idle_task` under `Worker::deinit_soon` under `deinit_without_freeing_arena` (main thread). 2 are `use-after-poison` READ in `LineOffsetTable::generate_in` under `SourceMapData::compute_line_offsets` under `SourceMapDataTask::run_line_offset` under `Thread::run` (a pool thread). None of the 30 crash logs contains the link error.
- Unfixed release canary 1.4.3-canary.1+f42e98025, 500 sequential runs: 351 clean, 148 crashes (130 `panic(main thread): Segmentation fault`, 18 `panic: Segmentation fault` on a pool thread), 1 hang. The hang run printed nothing and was killed by the timeout.
- Fixed ASAN debug build: 1,000 sequential runs plus 1,000 runs in 4 concurrent lanes, 2,000 clean, 0 crashes, 0 hangs.
- Fixed release build (`bun run build:release` on this branch): 1,500 sequential plus 1,000 in 4 lanes with `--sourcemap`, then 5,000 sequential with `--sourcemap`, 2,000 with `--sourcemap=inline` and 2,000 with `--sourcemap=external`, the last two with `MALLOC_PERTURB_=165`. 11,500 clean, 0 crashes, 0 hangs.

Suites on the rebased debug build: `test/bundler/cli.test.ts` (39 pass), `bundler_plugin.test.ts` (65 pass), `bake/deinitialization.test.ts`, `cli/test/test-changed.test.ts` (20 pass), `bun-build-api.test.ts` (63 pass, 2 bytecode cases time out at 5 seconds in this container on unfixed main as well).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->



