### PR TITLE
node:net: keep the process alive while an early-unref'd/paused socket is still connecting

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1926,14 +1926,12 @@ Socket.prototype.connect = function connect(...args) {
       this.pause();
     } else {
       process.nextTick(() => {
-        // Honor pause()/resume() calls made while connecting — only start
-        // reading if the user hasn't explicitly paused the stream. Matches
-        // Node's afterConnect, which calls socket.read(0) only when not paused:
+        // An already-open handle (fd, wrapped duplex) starts reading here unless
+        // the user paused; read(0) does that without switching to flowing mode.
+        // A pending connect gets this from afterConnect instead, so a pause()
+        // that lands before then is still honored:
         // https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/net.js#L1649
-        // read(0) starts the handle reading without switching the stream into
-        // flowing mode, so data that arrives before a 'data' listener is
-        // attached stays buffered instead of being emitted to nobody.
-        if (!this.isPaused()) this.read(0);
+        if (!this.connecting && !this.isPaused()) this.read(0);
       });
       if (fd == null) this.connecting = true;
     }
@@ -2134,8 +2132,8 @@ Socket.prototype.connect = function connect(...args) {
 
   if (!this._handle) {
     this._handle = newDetachedSocket(typeof this[bunTlsSymbol] === "function");
-    initSocketHandle(this);
   }
+  initSocketHandle(this);
 
   if (!pipe) {
     lookupAndConnect(this, options);
@@ -4272,8 +4270,10 @@ function initSocketHandle(self) {
   const handle = self._handle;
   if (handle) {
     handle[owner_symbol] = self;
-    // A fresh handle (e.g. an autoSelectFamily retry) inherits a prior unref()/pause().
+    // The new connection (fresh handle, autoSelectFamily retry, or reconnect through a
+    // live handle) inherits a prior unref()/pause(), not the previous connection's hold.
     if (self[kUserUnrefed] || self[kPausedUnref]) handle.unref?.();
+    else handle.ref?.();
   }
 }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2132,8 +2132,8 @@ Socket.prototype.connect = function connect(...args) {
 
   if (!this._handle) {
     this._handle = newDetachedSocket(typeof this[bunTlsSymbol] === "function");
+    initSocketHandle(this);
   }
-  initSocketHandle(this);
 
   if (!pipe) {
     lookupAndConnect(this, options);
@@ -4270,10 +4270,8 @@ function initSocketHandle(self) {
   const handle = self._handle;
   if (handle) {
     handle[owner_symbol] = self;
-    // The new connection (fresh handle, autoSelectFamily retry, or reconnect through a
-    // live handle) inherits a prior unref()/pause(), not the previous connection's hold.
+    // A fresh handle (e.g. an autoSelectFamily retry) inherits a prior unref()/pause().
     if (self[kUserUnrefed] || self[kPausedUnref]) handle.unref?.();
-    else handle.ref?.();
   }
 }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4272,8 +4272,8 @@ function initSocketHandle(self) {
   const handle = self._handle;
   if (handle) {
     handle[owner_symbol] = self;
-    // A fresh handle (e.g. an autoSelectFamily retry) inherits a prior unref().
-    if (self[kUserUnrefed]) handle.unref?.();
+    // A fresh handle (e.g. an autoSelectFamily retry) inherits a prior unref()/pause().
+    if (self[kUserUnrefed] || self[kPausedUnref]) handle.unref?.();
   }
 }
 

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -147,7 +147,7 @@ pub(crate) fn new_detached_socket(global: &JSGlobalObject, frame: &CallFrame) ->
             flags: Cell::new(SocketFlags::default() | SocketFlags::DEFERS_SERVER_IDENTITY),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(true),
+            ref_pollref_on_connect: Cell::new(true),
             connection: JsCell::new(None),
             server_name: JsCell::new(None),
             buffered_data_for_node_net: Default::default(),

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -147,7 +147,7 @@ pub(crate) fn new_detached_socket(global: &JSGlobalObject, frame: &CallFrame) ->
             flags: Cell::new(SocketFlags::default() | SocketFlags::DEFERS_SERVER_IDENTITY),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
+            user_wants_ref: Cell::new(true),
             connection: JsCell::new(None),
             server_name: JsCell::new(None),
             buffered_data_for_node_net: Default::default(),

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1619,9 +1619,7 @@ fn connect_finish<const IS_SSL: bool>(
         f.set(SocketFlags::ALLOW_HALF_OPEN, allow_half_open);
         socket_ref.flags.set(f);
     }
-    // The connect attempt holds the loop whatever `.ref()`/`.unref()` said so
-    // far (node:net hands out the handle before connecting); `on_open` applies
-    // `user_wants_ref`, and every failure path releases `poll_ref` itself.
+    // Held for the connect attempt regardless of `user_wants_ref`; `on_open` applies that.
     socket_ref
         .poll_ref
         .with_mut(|p| p.ref_(bun_io::js_vm_ctx()));

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -626,7 +626,7 @@ impl Listener {
             owned_ssl_ctx: Cell::new(None),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(true),
+            ref_pollref_on_connect: Cell::new(true),
             connection: JsCell::new(None),
             local_binding: JsCell::new(None),
             server_name: JsCell::new(None),
@@ -672,7 +672,7 @@ impl Listener {
             owned_ssl_ctx: Cell::new(None),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(true),
+            ref_pollref_on_connect: Cell::new(true),
             connection: JsCell::new(None),
             local_binding: JsCell::new(None),
             server_name: JsCell::new(None),
@@ -1256,7 +1256,7 @@ impl Listener {
                             flags: Cell::new(SocketFlags::default()),
                             this_value: JsCell::new(jsc::JsRef::empty()),
                             poll_ref: JsCell::new(KeepAlive::init()),
-                            user_wants_ref: Cell::new(true),
+                            ref_pollref_on_connect: Cell::new(true),
                             buffered_data_for_node_net: Default::default(),
                             bytes_written: Cell::new(0),
                             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
@@ -1342,7 +1342,7 @@ impl Listener {
                             flags: Cell::new(SocketFlags::default()),
                             this_value: JsCell::new(jsc::JsRef::empty()),
                             poll_ref: JsCell::new(KeepAlive::init()),
-                            user_wants_ref: Cell::new(true),
+                            ref_pollref_on_connect: Cell::new(true),
                             buffered_data_for_node_net: Default::default(),
                             bytes_written: Cell::new(0),
                             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
@@ -1584,7 +1584,7 @@ fn connect_finish<const IS_SSL: bool>(
             flags: Cell::new(SocketFlags::default()),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(true),
+            ref_pollref_on_connect: Cell::new(true),
             buffered_data_for_node_net: Default::default(),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
@@ -1619,7 +1619,7 @@ fn connect_finish<const IS_SSL: bool>(
         f.set(SocketFlags::ALLOW_HALF_OPEN, allow_half_open);
         socket_ref.flags.set(f);
     }
-    // Held for the connect attempt regardless of `user_wants_ref`; `on_open` applies that.
+    // Held for the connect attempt regardless of `ref_pollref_on_connect`; `on_open` applies that.
     socket_ref
         .poll_ref
         .with_mut(|p| p.ref_(bun_io::js_vm_ctx()));

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -626,7 +626,7 @@ impl Listener {
             owned_ssl_ctx: Cell::new(None),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
+            user_wants_ref: Cell::new(true),
             connection: JsCell::new(None),
             local_binding: JsCell::new(None),
             server_name: JsCell::new(None),
@@ -672,7 +672,7 @@ impl Listener {
             owned_ssl_ctx: Cell::new(None),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
+            user_wants_ref: Cell::new(true),
             connection: JsCell::new(None),
             local_binding: JsCell::new(None),
             server_name: JsCell::new(None),
@@ -1256,7 +1256,7 @@ impl Listener {
                             flags: Cell::new(SocketFlags::default()),
                             this_value: JsCell::new(jsc::JsRef::empty()),
                             poll_ref: JsCell::new(KeepAlive::init()),
-                            ref_pollref_on_connect: Cell::new(true),
+                            user_wants_ref: Cell::new(true),
                             buffered_data_for_node_net: Default::default(),
                             bytes_written: Cell::new(0),
                             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
@@ -1342,7 +1342,7 @@ impl Listener {
                             flags: Cell::new(SocketFlags::default()),
                             this_value: JsCell::new(jsc::JsRef::empty()),
                             poll_ref: JsCell::new(KeepAlive::init()),
-                            ref_pollref_on_connect: Cell::new(true),
+                            user_wants_ref: Cell::new(true),
                             buffered_data_for_node_net: Default::default(),
                             bytes_written: Cell::new(0),
                             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
@@ -1584,7 +1584,7 @@ fn connect_finish<const IS_SSL: bool>(
             flags: Cell::new(SocketFlags::default()),
             this_value: JsCell::new(jsc::JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
+            user_wants_ref: Cell::new(true),
             buffered_data_for_node_net: Default::default(),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
@@ -1619,6 +1619,12 @@ fn connect_finish<const IS_SSL: bool>(
         f.set(SocketFlags::ALLOW_HALF_OPEN, allow_half_open);
         socket_ref.flags.set(f);
     }
+    // The connect attempt holds the loop whatever `.ref()`/`.unref()` said so
+    // far (node:net hands out the handle before connecting); `on_open` applies
+    // `user_wants_ref`, and every failure path releases `poll_ref` itself.
+    socket_ref
+        .poll_ref
+        .with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
     // Note: `do_connect` reads `self.connection` directly so no second
     // borrow is needed here.
     // An already-open fd socket runs `on_open` synchronously; what settling
@@ -1686,14 +1692,6 @@ fn connect_finish<const IS_SSL: bool>(
             }
         }
     };
-
-    // if this is from node:net there's surface where the user can .ref() and .deref()
-    // before the connection starts. make sure we honor that here.
-    if socket_ref.ref_pollref_on_connect.get() && !socket_ref.socket.get().is_closed() {
-        socket_ref
-            .poll_ref
-            .with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
-    }
 
     // What settling the connect promise in `on_open` left pending (allocation
     // failure, a terminating VM).

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -308,7 +308,7 @@ pub struct NewSocket<const SSL: bool> {
     /// downgraded to weak once the socket is closed/inactive so GC can reclaim it.
     pub this_value: JsCell<JsRef>,
     pub poll_ref: JsCell<KeepAlive>,
-    pub(crate) user_wants_ref: Cell<bool>,
+    pub(crate) ref_pollref_on_connect: Cell<bool>,
     pub(crate) connection: JsCell<Option<super::listener::UnixOrHost>>,
     /// `localAddress`/`localPort` from the connect options: the socket is
     /// bound to this address before connecting. Always a literal IP.
@@ -1423,7 +1423,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         // update the internal socket instance to the one that was just connected
         // This socket must be replaced because the previous one is a connecting socket not a uSockets socket
         this.socket.set(socket);
-        if !this.user_wants_ref.get() {
+        // Stale if node:net reconnected through this wrapper while it was paused.
+        this.update_flags(|f| f.remove(Flags::IS_PAUSED));
+        if !this.ref_pollref_on_connect.replace(true) {
             this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
         }
         jsc::mark_binding!();
@@ -3227,10 +3229,11 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        this.user_wants_ref.set(true);
-        // Not yet established: `connect_finish` holds the loop and `on_open` applies this.
         if this.socket.get().is_established() {
             this.poll_ref.with_mut(|p| p.ref_(js_loop_ctx()));
+        } else {
+            // `connect_finish` holds the loop until then; `on_open` applies this.
+            this.ref_pollref_on_connect.set(true);
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -3242,9 +3245,10 @@ impl<const SSL: bool> NewSocket<SSL> {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        this.user_wants_ref.set(false);
         if this.socket.get().is_established() {
             this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
+        } else {
+            this.ref_pollref_on_connect.set(false);
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -3586,7 +3590,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             flags: Cell::new(initial_flags),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(this.user_wants_ref.get()),
+            ref_pollref_on_connect: Cell::new(true),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
@@ -3693,7 +3697,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             flags: Cell::new(Flags::BYPASS_TLS | Flags::IS_ACTIVE | Flags::OWNED_PROTOS),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(true),
+            ref_pollref_on_connect: Cell::new(true),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
@@ -4813,7 +4817,7 @@ pub fn js_upgrade_duplex_to_tls(
         flags: Cell::new(initial_flags),
         this_value: JsCell::new(JsRef::empty()),
         poll_ref: JsCell::new(KeepAlive::init()),
-        user_wants_ref: Cell::new(true),
+        ref_pollref_on_connect: Cell::new(true),
         buffered_data_for_node_net: JsCell::new(Vec::new()),
         bytes_written: Cell::new(0),
         native_callback: JsCell::new(NativeCallbacks::None),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3586,7 +3586,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             flags: Cell::new(initial_flags),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            user_wants_ref: Cell::new(true),
+            user_wants_ref: Cell::new(this.user_wants_ref.get()),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -308,7 +308,7 @@ pub struct NewSocket<const SSL: bool> {
     /// downgraded to weak once the socket is closed/inactive so GC can reclaim it.
     pub this_value: JsCell<JsRef>,
     pub poll_ref: JsCell<KeepAlive>,
-    pub(crate) ref_pollref_on_connect: Cell<bool>,
+    pub(crate) user_wants_ref: Cell<bool>,
     pub(crate) connection: JsCell<Option<super::listener::UnixOrHost>>,
     /// `localAddress`/`localPort` from the connect options: the socket is
     /// bound to this address before connecting. Always a literal IP.
@@ -1423,6 +1423,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         // update the internal socket instance to the one that was just connected
         // This socket must be replaced because the previous one is a connecting socket not a uSockets socket
         this.socket.set(socket);
+        if !this.user_wants_ref.get() {
+            this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
+        }
         jsc::mark_binding!();
 
         // Add SNI support for TLS (mongodb and others requires this)
@@ -3220,41 +3223,29 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(method)]
     pub(crate) fn js_ref(
         this: &Self,
-        global: &JSGlobalObject,
+        _global: &JSGlobalObject,
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        if this.socket.get().is_detached() {
-            this.ref_pollref_on_connect.set(true);
+        this.user_wants_ref.set(true);
+        // Not yet established: `connect_finish` holds the loop and `on_open` applies this.
+        if this.socket.get().is_established() {
+            this.poll_ref.with_mut(|p| p.ref_(js_loop_ctx()));
         }
-        if this.socket.get().is_detached() {
-            return Ok(JSValue::UNDEFINED);
-        }
-        let _ = global;
-        this.poll_ref.with_mut(|p| {
-            p.ref_(bun_io::posix_event_loop::get_vm_ctx(
-                bun_io::AllocatorType::Js,
-            ))
-        });
         Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn js_unref(
         this: &Self,
-        global: &JSGlobalObject,
+        _global: &JSGlobalObject,
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        if this.socket.get().is_detached() {
-            this.ref_pollref_on_connect.set(false);
+        this.user_wants_ref.set(false);
+        if this.socket.get().is_established() {
+            this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
         }
-        let _ = global;
-        this.poll_ref.with_mut(|p| {
-            p.unref(bun_io::posix_event_loop::get_vm_ctx(
-                bun_io::AllocatorType::Js,
-            ))
-        });
         Ok(JSValue::UNDEFINED)
     }
 
@@ -3595,7 +3586,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             flags: Cell::new(initial_flags),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
+            user_wants_ref: Cell::new(true),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
@@ -3702,7 +3693,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             flags: Cell::new(Flags::BYPASS_TLS | Flags::IS_ACTIVE | Flags::OWNED_PROTOS),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
-            ref_pollref_on_connect: Cell::new(true),
+            user_wants_ref: Cell::new(true),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
@@ -4822,7 +4813,7 @@ pub fn js_upgrade_duplex_to_tls(
         flags: Cell::new(initial_flags),
         this_value: JsCell::new(JsRef::empty()),
         poll_ref: JsCell::new(KeepAlive::init()),
-        ref_pollref_on_connect: Cell::new(true),
+        user_wants_ref: Cell::new(true),
         buffered_data_for_node_net: JsCell::new(Vec::new()),
         bytes_written: Cell::new(0),
         native_callback: JsCell::new(NativeCallbacks::None),

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -504,9 +504,12 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
 
     // ── flow control / sockopts ─────────────────────────────────────────────
 
+    /// A connect that has not completed yet is left alone (like the
+    /// `connecting` arm): the open re-arms reads, so latching a pause here
+    /// would only make the next real `pause()` a no-op.
     pub fn pause_stream(&self) -> bool {
         on_socket!(self.socket;
-            connected s => { s.pause(); true },
+            connected s => if s.is_established() { s.pause(); true } else { false },
             connecting _c => false,
             detached => true,
             duplex _d => false, // TODO: pause/resume upgraded duplex
@@ -516,7 +519,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
 
     pub fn resume_stream(&self) -> bool {
         on_socket!(self.socket;
-            connected s => { s.resume(); true },
+            connected s => if s.is_established() { s.resume(); true } else { false },
             connecting _c => false,
             detached => true,
             duplex _d => false, // TODO: pause/resume upgraded duplex

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -787,6 +787,46 @@ describe.concurrent("unref()/pause() around connect()", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  // A pause() that reached the native socket mid-connect used to latch its paused bit while the
+  // open re-armed reads, so backpressure could never pause it again and the buffer grew unbounded.
+  it("pause() while the connect is in flight still lets backpressure stop reads", async () => {
+    const chunk = Buffer.alloc(64 * 1024, "x");
+    await using server = createServer(c => {
+      const pump = () => {
+        while (!c.destroyed && c.write(chunk)) {}
+      };
+      c.on("drain", pump);
+      c.on("error", () => {});
+      pump();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const s = new Socket();
+    try {
+      s.connect((server.address() as any).port, "127.0.0.1");
+      await new Promise<void>(resolve =>
+        process.nextTick(() =>
+          process.nextTick(() => {
+            s.pause();
+            resolve();
+          }),
+        ),
+      );
+      await once(s, "connect");
+      // Once the buffer passes the high-water mark reads must stop. Unpatched, every loop turn
+      // delivered another recv; allow at most a couple that were already in flight.
+      const deadline = performance.now() + 5000;
+      while (performance.now() < deadline && s.readableLength < s.readableHighWaterMark)
+        await new Promise(r => setTimeout(r, 1));
+      expect(s.readableLength).toBeGreaterThanOrEqual(s.readableHighWaterMark);
+      const settled = s.bytesRead;
+      for (let i = 0; i < 100; i++) await new Promise(r => setTimeout(r, 0));
+      const recvBuffer = 512 * 1024;
+      expect(s.bytesRead - settled).toBeLessThanOrEqual(2 * recvBuffer);
+    } finally {
+      s.destroy();
+    }
+  });
 });
 
 it("socket should keep process alive if unref is not called", async () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -792,9 +792,11 @@ describe.concurrent("unref()/pause() around connect()", () => {
   // open re-armed reads, so backpressure could never pause it again and the buffer grew unbounded.
   it("pause() while the connect is in flight still lets backpressure stop reads", async () => {
     const chunk = Buffer.alloc(64 * 1024, "x");
+    let serverBackedUp = false;
     await using server = createServer(c => {
       const pump = () => {
         while (!c.destroyed && c.write(chunk)) {}
+        serverBackedUp = !c.destroyed;
       };
       c.on("drain", pump);
       c.on("error", () => {});
@@ -813,12 +815,13 @@ describe.concurrent("unref()/pause() around connect()", () => {
         ),
       );
       await once(s, "connect");
-      // Once the buffer passes the high-water mark reads must stop. Unpatched, every loop turn
-      // delivered another recv; allow at most a couple that were already in flight.
+      // Once the client stops reading (buffer past the high-water mark, or never started) the
+      // server backs up; from then on bytesRead must stay put. Unpatched, every loop turn
+      // delivered another recv; allow a couple that were already in flight.
       const deadline = performance.now() + 5000;
-      while (performance.now() < deadline && s.readableLength < s.readableHighWaterMark)
+      while (performance.now() < deadline && !serverBackedUp && s.readableLength < s.readableHighWaterMark)
         await new Promise(r => setTimeout(r, 1));
-      expect(s.readableLength).toBeGreaterThanOrEqual(s.readableHighWaterMark);
+      expect(serverBackedUp || s.readableLength >= s.readableHighWaterMark).toBeTrue();
       const settled = s.bytesRead;
       for (let i = 0; i < 100; i++) await new Promise(r => setTimeout(r, 0));
       const recvBuffer = 512 * 1024;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -699,9 +699,9 @@ it("unref should exit when no more work pending", async () => {
   expect(await process.exited).toBe(0);
 });
 
-// An unref() applied while lookup is pending must survive the autoSelectFamily handle reinit.
-it("unref survives an autoSelectFamily retry", async () => {
-  // IPv4-only server + injected lookup listing ::1 first forces a refused attempt then a retry; unref() runs mid-lookup.
+// IPv4-only server + injected lookup listing ::1 first forces a refused attempt then a retry; the call runs mid-lookup
+// and must carry over to the retry handle. The pending connect holds the loop by itself; once connected it lets go.
+it.concurrent.each(["s.unref()", "s.pause()"])("%s survives an autoSelectFamily retry", async call => {
   const server = createServer(() => {});
   await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
   try {
@@ -714,25 +714,70 @@ it("unref survives an autoSelectFamily retry", async () => {
           const lookup = (host, opts, cb) =>
             setTimeout(() => cb(null, [{ address: "::1", family: 6 }, { address: "127.0.0.1", family: 4 }]), 10);
           const s = net.connect({ host: "localhost", port: ${server.address().port}, autoSelectFamily: true, lookup });
-          s.on("data", () => {});
           s.on("error", e => process.stdout.write("error " + e.code + "\\n"));
           s.on("connect", () => process.stdout.write("connected " + s.remoteAddress + "\\n"));
-          s.unref();
-          // Sentinel keeping the loop alive across the refuse + retry.
-          setTimeout(() => process.stdout.write("timer\\n"), 500);
+          ${call};
         `,
       ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
     });
-    // After the sentinel timer only the unref'd socket remains, so the process must exit.
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout.trim().split("\n").sort()).toEqual(["connected 127.0.0.1", "timer"]);
+    expect(stdout).toBe("connected 127.0.0.1\n");
     expect(exitCode).toBe(0);
   } finally {
     server.close();
   }
+});
+
+// https://github.com/oven-sh/bun/issues/37086 — node's pending uv_connect_t keeps the loop alive even on an
+// unref'd/non-reading handle, so unref()/pause() issued before or while connecting only take effect once connected.
+describe.concurrent("unref()/pause() around connect()", () => {
+  async function run(client: string, onConnection = "c => c.unref()") {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          const server = net.createServer(${onConnection});
+          server.listen(0, "127.0.0.1", () => {
+            const port = server.address().port;
+            const s = new net.Socket();
+            s.on("connect", () => process.stdout.write("connected\\n"));
+            s.on("close", () => { process.stdout.write("closed\\n"); server.close(); });
+            ${client}
+          });
+          server.unref();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    return { stdout, exitCode };
+  }
+
+  it.each([
+    ["unref() before connect()", `s.unref(); s.connect(port, "127.0.0.1");`],
+    ["unref() while connecting", `s.connect(port, "127.0.0.1"); s.unref();`],
+    ["pause() while connecting", `s.connect(port, "127.0.0.1"); s.pause();`],
+  ])("%s waits for the connection, then lets the process exit", async (_, client) => {
+    const { stdout, exitCode } = await run(client);
+    expect(stdout).toBe("connected\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("ref() after unref() while connecting keeps holding the loop", async () => {
+    const { stdout, exitCode } = await run(
+      `s.connect(port, "127.0.0.1"); s.unref(); s.ref(); s.resume();`,
+      "c => { c.unref(); c.end(); }",
+    );
+    expect(stdout).toBe("connected\nclosed\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("socket should keep process alive if unref is not called", async () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -721,10 +721,11 @@ it.concurrent.each(["s.unref()", "s.pause()"])("%s survives an autoSelectFamily 
       ],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "inherit",
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("connected 127.0.0.1\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   } finally {
     server.close();
@@ -754,28 +755,36 @@ describe.concurrent("unref()/pause() around connect()", () => {
       ],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "inherit",
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    return { stdout, exitCode };
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
   }
 
+  // net.ts hands the connect to the native socket on the next tick, so two ticks in the
+  // attempt is in flight (the handle exists but is not yet established).
+  const inFlight = (code: string) => `process.nextTick(() => process.nextTick(() => { ${code} }));`;
   it.each([
     ["unref() before connect()", `s.unref(); s.connect(port, "127.0.0.1");`],
-    ["unref() while connecting", `s.connect(port, "127.0.0.1"); s.unref();`],
-    ["pause() while connecting", `s.connect(port, "127.0.0.1"); s.pause();`],
+    ["unref() right after connect()", `s.connect(port, "127.0.0.1"); s.unref();`],
+    ["unref() while the connect is in flight", `s.connect(port, "127.0.0.1"); ${inFlight("s.unref();")}`],
+    ["pause() before connect()", `s.pause(); s.connect(port, "127.0.0.1");`],
+    ["pause() right after connect()", `s.connect(port, "127.0.0.1"); s.pause();`],
+    ["pause() while the connect is in flight", `s.connect(port, "127.0.0.1"); ${inFlight("s.pause();")}`],
   ])("%s waits for the connection, then lets the process exit", async (_, client) => {
-    const { stdout, exitCode } = await run(client);
+    const { stdout, stderr, exitCode } = await run(client);
     expect(stdout).toBe("connected\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 
-  it("ref() after unref() while connecting keeps holding the loop", async () => {
-    const { stdout, exitCode } = await run(
-      `s.connect(port, "127.0.0.1"); s.unref(); s.ref(); s.resume();`,
-      "c => { c.unref(); c.end(); }",
-    );
+  it.each([
+    ["right after connect()", `s.connect(port, "127.0.0.1"); s.unref(); s.ref(); s.resume();`],
+    ["while the connect is in flight", `s.connect(port, "127.0.0.1"); ${inFlight("s.unref(); s.ref(); s.resume();")}`],
+  ])("ref() after unref() %s keeps holding the loop", async (_, client) => {
+    const { stdout, stderr, exitCode } = await run(client, "c => { c.unref(); c.end(); }");
     expect(stdout).toBe("connected\nclosed\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #37086

### Repro

```js
import net from "node:net";
const server = net.createServer(() => {});
server.listen(0, "127.0.0.1", () => {
  const s = new net.Socket();
  s.unref(); // before connect()
  s.connect(server.address().port, "127.0.0.1", () => {
    console.log("CONNECTED");
    s.destroy();
    server.close();
  });
});
server.unref();
```

Node and Bun 1.3.14 print `CONNECTED`; Bun 1.4.0 exits 0 silently before the connection completes. This is what makes every `testcontainers` program exit during container startup (its Ryuk client calls `socket.unref()` before `.connect()`). The same happens for `s.connect(); s.unref()` and `s.connect(); s.pause()`.

### Cause

In Node a pending `uv_connect_t` keeps the loop alive no matter what the handle's ref state is; `unref()`/`readStop` only matter once the socket is established. Bun's native socket instead had a `ref_pollref_on_connect` flag that made an early `unref()` skip taking the loop hold for the connect attempt altogether, and an `unref()` on a connecting handle dropped it immediately. #36619 started applying node:net's recorded `unref()` to the freshly created (detached) handle, which routed the common "unref before connect" case into that path.

### Fix

Native (`Listener.rs` / `socket_body.rs`): the connect attempt always holds `poll_ref` (taken before `do_connect`, released by every failure path); `ref()`/`unref()` on a not-yet-established socket only record the preference and `on_open` applies it. `pause()`/`resume()` on a half-connected socket are likewise left for after the open (`uws_sys/socket.rs`) — usockets re-arms reads on open without clearing its paused bit, so a pause latched there made every later `pause()` a no-op and a paused stream buffered without bound once connected.

`net.ts`: an autoSelectFamily retry handle inherits a mid-connect `pause()` the same way it inherits `unref()`, and the `read(0)` that `connect()` queued on the next tick is left to `afterConnect` while still connecting, so a `pause()` issued mid-connect is not undone by a read queued before it (Node only issues that read from `afterConnect`).

### Tests

`test/js/node/net/node-net.test.ts`:
- `unref()/pause() around connect()`: unref/pause before `connect()`, right after it, and while the native connect is actually in flight → `connected` then exit; `ref()` after `unref()` (both timings) keeps holding; an in-flight `pause()` still lets backpressure stop reads. The unref/pause cases print nothing (or hang) on 1.4.0; all match Node's output.
- `unref survives an autoSelectFamily retry` no longer needs its 500 ms sentinel timer (the pending connect holds the loop by itself — that sentinel was also why it failed under slow debug/ASAN builds) and gains a `pause()` variant, which hung before this change.

Also ran `node-net-server`, `node-tls-connect`, `node-tls-server`, `node-http`, `socket-reconnect-live`, `double-connect`, `bun/net/socket.test.ts` and the node parallel net pause/connect tests locally with no new failures.
