### PR TITLE
test: assert the id that a duplicate CpuProfiler::Start() reports

### DIFF
--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -2033,10 +2033,15 @@ void test_v8_cpu_profiler_title_api(const FunctionCallbackInfo<Value> &info) {
   LOG_EXPR(profiler->StopProfiling(empty_title) == nullptr);
 
   // Both APIs share one set of sessions: a session started by id carries its
-  // title, blocks a title-keyed start, and can be stopped by title.
+  // title, blocks a second start of that title through either API (which
+  // reports the running session), and can be stopped by title.
   CpuProfilingResult by_id = profiler->Start(
       title_b, kLeafNodeLineNumbers, true, CpuProfilingOptions::kNoSampleLimit);
   LOG_EXPR((int)by_id.status);
+  CpuProfilingResult by_id_again = profiler->Start(
+      title_b, kLeafNodeLineNumbers, true, CpuProfilingOptions::kNoSampleLimit);
+  LOG_EXPR((int)by_id_again.status);
+  LOG_EXPR(by_id_again.id == by_id.id);
   LOG_EXPR((int)profiler->StartProfiling(title_b, false));
   busy();
   CpuProfile *profile_by_id = profiler->StopProfiling(title_b);


### PR DESCRIPTION
### Problem
- #39794 made `CpuProfiler::Start()` return `kAlreadyStarted` together with the id of the running session that has the same title (`src/jsc/bindings/v8/V8CpuProfiler.cpp`, the `sessionWithTitle` branch in `Start()`). No committed test observes that id. Every duplicate-title check in `test_v8_cpu_profiler_title_api` goes through `StartProfiling()`, which returns only the status.
- The id is the field that matters for an id-keyed caller. @datadog/pprof ignores the status and passes the returned id to `Stop()`. A wrong id there makes `Stop()` return null. A change to that branch that returns a wrong id passes the current suite.

### Fix
- Test only. `test_v8_cpu_profiler_title_api` now calls `Start()` a second time with the running title and logs the status and whether the id equals the first one. `checkSameOutput` compares the output with node 26, which prints status 1 and an equal id.
- Verified: `bun bd test test/v8/v8.test.ts -t CpuProfiler` on current main, 3 pass. The same lines were run against the branch of #39794 before it merged, with the same result.

### Background
- `test/v8/v8.test.ts` builds `test/v8/v8-module/main.cpp` as a native addon for node and for bun, runs one exported function per test, and requires byte-identical stdout from both runtimes. So each `LOG_EXPR` line is a V8 parity assertion.
- `CpuProfilingResult` is the `{ id, status }` pair that `Start()` returns. V8 fills `id` with the id of the profile that is already running when it reports `kAlreadyStarted`.

<details><summary>Notes</summary>

This came out of the self-review of #39794. The assertion was written while that PR was open and was not pushed before the merge.

The committed coverage of the `kAlreadyStarted` branch: `main.cpp` lines around 2003 and 2041 call `StartProfiling()`, and `test_v8_cpu_profiler_overlapping_sessions` uses two different titles. `test/integration/pprof` exercises google's pprof, which never sees an id. `test/integration/datadog-pprof` starts one session per run, and @datadog/pprof titles its sessions `pprof-<n>`, so it never takes the branch either.

This change is a test addition for behavior that already exists on main. It has no `src/` change, so there is no before and after difference to show. The value is in the mutation it now catches.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->