### PR TITLE
Report a refused HTTP, bundle, IO or process waiter thread as an error instead of a crash

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -369,17 +369,13 @@ pub mod singleton {
     unsafe impl Sync for Instance {}
 
     static INSTANCE: std::sync::OnceLock<Instance> = std::sync::OnceLock::new();
-    /// Serializes [`start`]. A lock rather than `OnceLock::get_or_init`,
-    /// because the spawn can fail (the OS refused the thread) and a later
-    /// `start` has to be able to try again.
+    /// Not `OnceLock::get_or_init`: a failed [`start`] is retried by the next call.
     static START_LOCK: bun_threading::Mutex = bun_threading::Mutex::new();
 
-    /// Starts the bundle thread if it is not running yet, and blocks until it
-    /// is. `Bun.build()` calls this before it allocates anything for a build,
-    /// so a refused thread rejects that build and the next build tries again.
-    ///
-    /// All calls (across the process) must use the same `C`; the static is
-    /// type-erased. `get` and `enqueue` rely on a previous `Ok` from here.
+    /// Starts the bundle thread if it is not running yet and blocks until it
+    /// runs. `Err`: the OS refused the thread; the caller fails its build, and
+    /// the next call tries again. All calls must use the same `C` (the static
+    /// is type-erased), and `get`/`enqueue` require a previous `Ok`.
     pub fn start<C: CompletionStruct>() -> Result<(), SpawnError> {
         if INSTANCE.get().is_some() {
             return Ok(());
@@ -393,16 +389,15 @@ pub mod singleton {
 
         // SAFETY: bundle_thread is a leaked Box, valid for 'static; `spawn` takes the
         // raw pointer directly so no `&mut` is materialized that would alias the
-        // bundle thread's own access. A failed attempt does not touch it, so the
-        // next attempt can pass it again.
+        // bundle thread's own access. A failed attempt leaves it untouched.
         let spawned = bun_threading::spawn_with_retry("bundler", || unsafe {
             BundleThread::spawn(bundle_thread)
         });
         let os_thread = match spawned {
             Ok(os_thread) => os_thread,
             Err(err) => {
-                // SAFETY: no thread started against it, so this is the only
-                // pointer to the allocation `into_raw` produced above.
+                // SAFETY: no thread runs against it; sole pointer to the
+                // allocation from `into_raw` above.
                 drop(unsafe { bun_core::heap::take(bundle_thread) });
                 return Err(err);
             }
@@ -412,8 +407,7 @@ pub mod singleton {
 
         // SAFETY: `into_raw` of a `Box` is never null.
         let instance = Instance(unsafe { NonNull::new_unchecked(bundle_thread.cast::<()>()) });
-        // `INSTANCE` was empty above and this thread holds `START_LOCK`, so
-        // `set` cannot fail.
+        // Cannot fail: `INSTANCE` was empty above, and this thread holds `START_LOCK`.
         let _ = INSTANCE.set(instance);
         Ok(())
     }

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -3,6 +3,7 @@ use core::ptr::NonNull;
 use bun_alloc::Arena; // MimallocArena → bumpalo::Bump (ThreadLocalArena)
 use bun_core::{self, Output, zstr};
 use bun_io as Async;
+use bun_threading::SpawnError;
 use bun_threading::unbounded_queue::{Node, UnboundedQueue};
 
 use crate::bundle_v2::{FileMap, JSBundlerPlugin, dispatch};
@@ -368,23 +369,53 @@ pub mod singleton {
     unsafe impl Sync for Instance {}
 
     static INSTANCE: std::sync::OnceLock<Instance> = std::sync::OnceLock::new();
+    /// Serializes [`start`]. A lock rather than `OnceLock::get_or_init`,
+    /// because the spawn can fail (the OS refused the thread) and a later
+    /// `start` has to be able to try again.
+    static START_LOCK: bun_threading::Mutex = bun_threading::Mutex::new();
 
-    // Blocks the calling thread until the bun build thread is created.
-    // OnceLock also blocks other callers of this function until the first caller is done.
-    fn load_once_impl<C: CompletionStruct>() -> Instance {
+    /// Starts the bundle thread if it is not running yet, and blocks until it
+    /// is. `Bun.build()` calls this before it allocates anything for a build,
+    /// so a refused thread rejects that build and the next build tries again.
+    ///
+    /// All calls (across the process) must use the same `C`; the static is
+    /// type-erased. `get` and `enqueue` rely on a previous `Ok` from here.
+    pub fn start<C: CompletionStruct>() -> Result<(), SpawnError> {
+        if INSTANCE.get().is_some() {
+            return Ok(());
+        }
+        let _guard = START_LOCK.lock_guard();
+        if INSTANCE.get().is_some() {
+            return Ok(());
+        }
+
         let bundle_thread = bun_core::heap::into_raw(Box::new(BundleThread::<C>::uninitialized()));
 
-        // 2. Spawn the bun build thread.
         // SAFETY: bundle_thread is a leaked Box, valid for 'static; `spawn` takes the
         // raw pointer directly so no `&mut` is materialized that would alias the
-        // bundle thread's own access.
-        let os_thread = unsafe { BundleThread::spawn(bundle_thread) }
-            .unwrap_or_else(|_| Output::panic(format_args!("Failed to spawn bun build thread")));
+        // bundle thread's own access. A failed attempt does not touch it, so the
+        // next attempt can pass it again.
+        let spawned = bun_threading::spawn_with_retry("bundler", || unsafe {
+            BundleThread::spawn(bundle_thread)
+        });
+        let os_thread = match spawned {
+            Ok(os_thread) => os_thread,
+            Err(err) => {
+                // SAFETY: no thread started against it, so this is the only
+                // pointer to the allocation `into_raw` produced above.
+                drop(unsafe { bun_core::heap::take(bundle_thread) });
+                return Err(err);
+            }
+        };
         // `std.Thread.detach()` — drop the JoinHandle without joining.
         drop(os_thread);
 
         // SAFETY: `into_raw` of a `Box` is never null.
-        Instance(unsafe { NonNull::new_unchecked(bundle_thread.cast::<()>()) })
+        let instance = Instance(unsafe { NonNull::new_unchecked(bundle_thread.cast::<()>()) });
+        // `INSTANCE` was empty above and this thread holds `START_LOCK`, so
+        // `set` cannot fail.
+        let _ = INSTANCE.set(instance);
+        Ok(())
     }
 
     /// Returns the raw singleton pointer. The bundle thread runs `thread_main`
@@ -394,17 +425,21 @@ pub mod singleton {
     ///
     /// # Safety
     /// All calls (across the process) must use the same `C`; the static is
-    /// type-erased.
+    /// type-erased. [`start`] must have returned `Ok` before.
     pub(crate) fn get<C: CompletionStruct>() -> *mut BundleThread<C> {
         // INSTANCE is a leaked 'static Box of `BundleThread<C>` (same `C` per
         // the safety contract).
         INSTANCE
-            .get_or_init(load_once_impl::<C>)
+            .get()
+            .unwrap_or_else(|| {
+                Output::panic(format_args!("BundleThread used before singleton::start()"))
+            })
             .0
             .as_ptr()
             .cast::<BundleThread<C>>()
     }
 
+    /// The caller has called [`start`] and got `Ok`.
     pub fn enqueue<C: CompletionStruct>(completion: *mut C) {
         // Validate the caller's pointer at the public boundary so the unsafe
         // path below never receives null.

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -304,6 +304,23 @@ pub fn from_errno(errno: i32) -> SystemErrno {
     SystemErrno::init(errno as i64).unwrap_or(SystemErrno::EIO)
 }
 
+impl SystemErrno {
+    /// The OS error behind a `std::io::Error`. `None` when the error did not
+    /// come from the OS, or its code has no `SystemErrno`. On Windows the code
+    /// is a Win32 error, which the `u32` entry point of `init` maps.
+    pub fn from_io_error(err: &std::io::Error) -> Option<SystemErrno> {
+        let code = err.raw_os_error()?;
+        #[cfg(windows)]
+        {
+            SystemErrno::init(code as u32)
+        }
+        #[cfg(not(windows))]
+        {
+            SystemErrno::init(i64::from(code))
+        }
+    }
+}
+
 #[cfg(not(windows))]
 impl SystemErrno {
     // `i64` covers every concrete call site (errno-range values).
@@ -442,6 +459,37 @@ mod errno_name_tests {
             assert_eq!(SystemErrno::init(35), Some(SystemErrno::EAGAIN));
             assert_eq!(SystemErrno::init(54), Some(SystemErrno::ECONNRESET));
         }
+    }
+
+    #[test]
+    fn io_error_to_errno() {
+        #[cfg(not(windows))]
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(libc::ENOMEM)),
+            Some(SystemErrno::ENOMEM)
+        );
+        #[cfg(windows)]
+        {
+            // ERROR_NOT_ENOUGH_MEMORY and ERROR_ACCESS_DENIED are Win32 codes.
+            // Read as errno values, 8 and 5 would be ENOEXEC and EIO.
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(8)),
+                Some(SystemErrno::ENOMEM)
+            );
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(5)),
+                Some(SystemErrno::EPERM)
+            );
+            // ERROR_COMMITMENT_LIMIT has no errno.
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(1455)),
+                None
+            );
+        }
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::other("not from the OS")),
+            None
+        );
     }
 
     /// Exhaustive: every dense slot in the per-platform enum round-trips through

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -463,9 +463,12 @@ mod errno_name_tests {
 
     #[test]
     fn io_error_to_errno() {
+        // On POSIX the discriminant is the errno value.
         #[cfg(not(windows))]
         assert_eq!(
-            SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(libc::ENOMEM)),
+            SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(
+                SystemErrno::ENOMEM as i32
+            )),
             Some(SystemErrno::ENOMEM)
         );
         #[cfg(windows)]

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -354,7 +354,16 @@ impl Preconnect {
 }
 
 pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
-    if !FeatureFlags::IS_FETCH_PRECONNECT_SUPPORTED {
+    // Write-before-read: `Bun__fetchPreconnect` reaches here without going
+    // through any path that calls `HTTPThread::init`, so `schedule()` below
+    // would deref the uninitialized `HTTP_THREAD` static (UB on niche-bearing
+    // fields) if `fetch.preconnect()` is the process's first HTTP operation.
+    // Every other JS-side entry point (`send_sync`, `fetch()`, S3) passes
+    // default opts too. A preconnect is only a hint, so when the thread cannot
+    // start there is nothing to report here: the request that follows reports it.
+    if !FeatureFlags::IS_FETCH_PRECONNECT_SUPPORTED
+        || crate::http_thread::init(&Default::default()).is_err()
+    {
         if is_url_owned {
             // SAFETY: `is_url_owned` is the caller's promise that `url.href` is a
             // global-allocator `Box<[u8]>` we now own.
@@ -362,14 +371,6 @@ pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
         }
         return;
     }
-
-    // Write-before-read: `Bun__fetchPreconnect` reaches here without going
-    // through any path that calls `HTTPThread::init`, so `schedule()` below
-    // would deref the uninitialized `HTTP_THREAD` static (UB on niche-bearing
-    // fields) if `fetch.preconnect()` is the process's first HTTP operation.
-    // `init` is idempotent (`Once`) and every other JS-side entry point
-    // (`send_sync`, `FetchTasklet::start`, S3) passes default opts too.
-    crate::http_thread::init(&Default::default());
 
     let this: *mut Preconnect = bun_core::heap::into_raw(Box::new(Preconnect {
         async_http: None,
@@ -615,7 +616,7 @@ impl<'a> AsyncHTTP<'a> {
         &mut self,
         response_buffer: &mut MutableString,
     ) -> crate::Result<crate::HTTPResponseMetadata> {
-        crate::http_thread::init(&Default::default());
+        crate::http_thread::init(&Default::default())?;
 
         // Note: `Box::leak` is forbidden (PORTING.md §Forbidden);
         // allocate via `heap::alloc` and reclaim once

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -354,13 +354,9 @@ impl Preconnect {
 }
 
 pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
-    // Write-before-read: `Bun__fetchPreconnect` reaches here without going
-    // through any path that calls `HTTPThread::init`, so `schedule()` below
-    // would deref the uninitialized `HTTP_THREAD` static (UB on niche-bearing
-    // fields) if `fetch.preconnect()` is the process's first HTTP operation.
-    // Every other JS-side entry point (`send_sync`, `fetch()`, S3) passes
-    // default opts too. A preconnect is only a hint, so when the thread cannot
-    // start there is nothing to report here: the request that follows reports it.
+    // `schedule()` below needs the thread started (`fetch.preconnect()` may be
+    // the first HTTP operation of the process). A preconnect is only a hint:
+    // a refused thread is reported by the request that follows.
     if !FeatureFlags::IS_FETCH_PRECONNECT_SUPPORTED
         || crate::http_thread::init(&Default::default()).is_err()
     {

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use bun_collections::ArrayHashMap;
 use bun_core::{self, Output};
 use bun_ptr::RefPtr;
-use bun_threading::{Mutex, UnboundedQueue};
+use bun_threading::{Mutex, SpawnError, UnboundedQueue};
 use bun_uws as uws;
 
 use crate::async_http::{ACTIVE_REQUESTS_COUNT, MAX_SIMULTANEOUS_REQUESTS};
@@ -1051,7 +1051,7 @@ impl HttpThread {
         // dereffing `as_mut_ptr()` below on an uninitialized static is UB.
         // The "every caller goes through `init`" invariant was unenforced
         // (e.g. `async_http::preconnect` did not), so check it here. The
-        // `Acquire` load pairs with `init_once`'s `Release` store to publish
+        // `Acquire` load pairs with `start`'s `Release` store to publish
         // the `HTTP_THREAD.write(..)` to this thread.
         assert!(
             crate::HTTP_THREAD_INIT.load(Ordering::Acquire),
@@ -1167,9 +1167,13 @@ use core::cell::Cell;
 
 mod _event_loop_draft {
     use super::*;
-    use std::sync::Once;
 
-    static INIT_ONCE: Once = Once::new();
+    /// Serializes [`start`]. It is a lock and not a `Once` because a start
+    /// can fail (the OS refused the thread) and the next `init` call has to
+    /// try again.
+    static START_LOCK: Mutex = Mutex::new();
+    // Set once the thread runs; `init` is a no-op from then on.
+    //
     // Note: `Builder::spawn` allocates an `Arc<thread::Inner>` (48 B)
     // shared between the `JoinHandle` and the new thread's TLS `current()`.
     // Dropping the handle leaves the only strong ref inside the spawned
@@ -1182,33 +1186,43 @@ mod _event_loop_draft {
     static HTTP_THREAD_HANDLE: std::sync::OnceLock<std::thread::JoinHandle<()>> =
         std::sync::OnceLock::new();
 
-    pub(super) fn init(opts: &InitOpts) {
-        INIT_ONCE.call_once(|| init_once(opts));
+    pub(super) fn init(opts: &InitOpts) -> Result<(), SpawnError> {
+        if HTTP_THREAD_HANDLE.get().is_some() {
+            return Ok(());
+        }
+        let _guard = START_LOCK.lock_guard();
+        if HTTP_THREAD_HANDLE.get().is_some() {
+            return Ok(());
+        }
+        start(opts)
     }
 
-    fn init_once(opts: &InitOpts) {
-        // Initialize the global (with timer
-        // started on the calling thread) BEFORE spawning, so `on_start`'s
-        // `crate::http_thread_mut()` finds `Some(..)` and can fill in
-        // `loop_`/`uws_loop`/contexts.
-        // SAFETY: `init_once` runs under `Once`; no other thread reads
-        // `HTTP_THREAD` until `has_awoken` is set in `on_start`.
-        unsafe {
-            (*crate::HTTP_THREAD.get()).write(HttpThread::new());
-        }
-        crate::HTTP_THREAD_INIT.store(true, core::sync::atomic::Ordering::Release);
-        bun_libdeflate_sys::libdeflate::load();
-        let opts_copy = opts.clone();
-        let thread = std::thread::Builder::new()
-            .stack_size(bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE as usize)
-            .spawn(move || on_start(opts_copy));
-        match thread {
-            // detach — see HTTP_THREAD_HANDLE note above re: LSAN reachability
-            Ok(t) => {
-                let _ = HTTP_THREAD_HANDLE.set(t);
+    /// Caller holds `START_LOCK`.
+    fn start(opts: &InitOpts) -> Result<(), SpawnError> {
+        if !crate::HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire) {
+            // Initialize the global (with timer started on the calling
+            // thread) BEFORE spawning, so `on_start`'s `crate::http_thread_mut()`
+            // finds it and can fill in `loop_`/`uws_loop`/contexts. Written
+            // once: a failed spawn leaves it in place (nothing else touches it
+            // until a thread runs `on_start`) and a later call only retries the
+            // spawn, so no reader can observe it being rewritten.
+            // SAFETY: the caller holds `START_LOCK`, and `HTTP_THREAD_INIT` is
+            // still false, so nothing reads `HTTP_THREAD` yet.
+            unsafe {
+                (*crate::HTTP_THREAD.get()).write(HttpThread::new());
             }
-            Err(err) => Output::panic(format_args!("Failed to start HTTP Client thread: {}", err)),
+            crate::HTTP_THREAD_INIT.store(true, core::sync::atomic::Ordering::Release);
+            bun_libdeflate_sys::libdeflate::load();
         }
+        let thread = bun_threading::spawn_with_retry("HTTP client", || {
+            let opts = opts.clone();
+            std::thread::Builder::new()
+                .stack_size(bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE as usize)
+                .spawn(move || on_start(opts))
+        })?;
+        // detach — see HTTP_THREAD_HANDLE note above re: LSAN reachability
+        let _ = HTTP_THREAD_HANDLE.set(thread);
+        Ok(())
     }
 
     fn on_start(opts: InitOpts) {
@@ -1409,10 +1423,14 @@ pub fn shutdown_for_exit() -> bool {
 // dispatch_deps bridge removed — real impls now live in
 // h3_client/ClientContext.rs (abort_by_http_id / stream_body_by_http_id).
 
-/// Module-level bridge for `HTTPThread::init`. The real body lives in
-/// `_event_loop_draft` below (depends on `bun_event_loop::MiniEventLoop`,
-/// which is outside this crate's dep set). Call sites in AsyncHTTP.rs hit
-/// this until that tier boundary is resolved.
-pub fn init(opts: &InitOpts) {
+/// Starts the HTTP client thread if it is not running yet. Every path that
+/// schedules work on it calls this first. `opts` is used by the call that
+/// starts the thread; later calls return `Ok` at once.
+///
+/// `Err` means the OS refused the thread (see `bun_threading::spawn`). The
+/// caller reports it: `fetch()` rejects, `bun install` exits. The next call
+/// tries again, so a limit that goes away does not disable HTTP for the rest
+/// of the process.
+pub fn init(opts: &InitOpts) -> Result<(), SpawnError> {
     _event_loop_draft::init(opts)
 }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1168,11 +1168,9 @@ use core::cell::Cell;
 mod _event_loop_draft {
     use super::*;
 
-    /// Serializes [`start`]. It is a lock and not a `Once` because a start
-    /// can fail (the OS refused the thread) and the next `init` call has to
-    /// try again.
+    /// Not a `Once`: a failed [`start`] is retried by the next `init` call.
     static START_LOCK: Mutex = Mutex::new();
-    // Set once the thread runs; `init` is a no-op from then on.
+    // Set once the thread runs.
     //
     // Note: `Builder::spawn` allocates an `Arc<thread::Inner>` (48 B)
     // shared between the `JoinHandle` and the new thread's TLS `current()`.
@@ -1200,12 +1198,9 @@ mod _event_loop_draft {
     /// Caller holds `START_LOCK`.
     fn start(opts: &InitOpts) -> Result<(), SpawnError> {
         if !crate::HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire) {
-            // Initialize the global (with timer started on the calling
-            // thread) BEFORE spawning, so `on_start`'s `crate::http_thread_mut()`
-            // finds it and can fill in `loop_`/`uws_loop`/contexts. Written
-            // once: a failed spawn leaves it in place (nothing else touches it
-            // until a thread runs `on_start`) and a later call only retries the
-            // spawn, so no reader can observe it being rewritten.
+            // Written before the spawn, because `on_start` fills it in, and
+            // written only once: a failed spawn leaves it in place for the
+            // next attempt, so no reader ever sees it rewritten.
             // SAFETY: the caller holds `START_LOCK`, and `HTTP_THREAD_INIT` is
             // still false, so nothing reads `HTTP_THREAD` yet.
             unsafe {
@@ -1423,14 +1418,10 @@ pub fn shutdown_for_exit() -> bool {
 // dispatch_deps bridge removed — real impls now live in
 // h3_client/ClientContext.rs (abort_by_http_id / stream_body_by_http_id).
 
-/// Starts the HTTP client thread if it is not running yet. Every path that
-/// schedules work on it calls this first. `opts` is used by the call that
-/// starts the thread; later calls return `Ok` at once.
-///
-/// `Err` means the OS refused the thread (see `bun_threading::spawn`). The
-/// caller reports it: `fetch()` rejects, `bun install` exits. The next call
-/// tries again, so a limit that goes away does not disable HTTP for the rest
-/// of the process.
+/// Starts the HTTP client thread if it is not running yet; every path that
+/// schedules work on it calls this first. `opts` only matters for the call
+/// that starts it. `Err`: the OS refused the thread. The caller reports that,
+/// and the next call tries again.
 pub fn init(opts: &InitOpts) -> Result<(), SpawnError> {
     _event_loop_draft::init(opts)
 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -360,9 +360,8 @@ impl From<bun_uws::ConnectError> for Error {
     }
 }
 
-/// The HTTP client thread could not be started for a request
-/// (`AsyncHTTP::send_sync`). Only the errno fits in this `Copy` enum; the
-/// callers that report the failure to the user take the `SpawnError` itself.
+/// `AsyncHTTP::send_sync` could not start the HTTP client thread. Only the
+/// errno fits in this `Copy` enum.
 impl From<bun_threading::SpawnError> for Error {
     fn from(e: bun_threading::SpawnError) -> Self {
         Error::Sys(e.errno())

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -360,6 +360,15 @@ impl From<bun_uws::ConnectError> for Error {
     }
 }
 
+/// The HTTP client thread could not be started for a request
+/// (`AsyncHTTP::send_sync`). Only the errno fits in this `Copy` enum; the
+/// callers that report the failure to the user take the `SpawnError` itself.
+impl From<bun_threading::SpawnError> for Error {
+    fn from(e: bun_threading::SpawnError) -> Self {
+        Error::Sys(e.errno())
+    }
+}
+
 impl From<bun_picohttp::ParseResponseError> for Error {
     fn from(e: bun_picohttp::ParseResponseError) -> Self {
         match e {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -947,16 +947,16 @@ pub fn http_thread() -> &'static mut HTTPThread {
     // niche-bearing fields (`Box`, `Vec`, `NonNull`, `Option<Arc>` …), so
     // `assume_init_mut()` on the uninitialized static is *immediate* UB — a
     // `debug_assert!` leaves release builds unguarded. The `Acquire` load
-    // pairs with `init_once`'s `Release` store on `HTTP_THREAD_INIT`,
+    // pairs with `http_thread::start`'s `Release` store on `HTTP_THREAD_INIT`,
     // establishing happens-before for cross-thread callers that did not
-    // themselves go through `Once::call_once` (e.g. `schedule_*` paths from
-    // the JS thread). Cost is a single relaxed-on-x86 atomic load.
+    // themselves take `http_thread::init`'s lock (e.g. `schedule_*` paths
+    // from the JS thread). Cost is a single relaxed-on-x86 atomic load.
     assert!(
         HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire),
         "http_thread() called before HTTPThread::init()"
     );
     // SAFETY: `HTTP_THREAD_INIT == true` (checked above) is set only after
-    // `HTTP_THREAD.write(..)` in `init_once`, so the `MaybeUninit` is fully
+    // `HTTP_THREAD.write(..)` in `http_thread::start`, so the `MaybeUninit` is fully
     // written. Thread-affinity is documented (HTTP-thread-only after
     // `on_start`); the `ThreadCell` owner assert covers debug.
     unsafe { (*HTTP_THREAD.get()).assume_init_mut() }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2345,9 +2345,8 @@ pub fn init(
             holder::ABS_CA_FILE_NAME.set(abs_ca_file_name.into_vec_with_nul().into_boxed_slice());
         holder::ABS_CA_FILE_NAME.get().map(|b| &**b).unwrap_or(b"")
     };
-    // Every install subcommand may need the registry, and this is where the
-    // CA options have to be handed over, so a refused thread ends the command
-    // here, the way `http_thread_on_init_error` ends it for a bad CA file.
+    // A refused thread ends the command here, like `http_thread_on_init_error`
+    // does for a bad CA file.
     if let Err(err) = http::http_thread::init(&http::http_thread::InitOpts {
         ca: ca_ptrs,
         abs_ca_file_name: abs_ca_file_name_static,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2345,12 +2345,18 @@ pub fn init(
             holder::ABS_CA_FILE_NAME.set(abs_ca_file_name.into_vec_with_nul().into_boxed_slice());
         holder::ABS_CA_FILE_NAME.get().map(|b| &**b).unwrap_or(b"")
     };
-    http::http_thread::init(&http::http_thread::InitOpts {
+    // Every install subcommand may need the registry, and this is where the
+    // CA options have to be handed over, so a refused thread ends the command
+    // here, the way `http_thread_on_init_error` ends it for a bad CA file.
+    if let Err(err) = http::http_thread::init(&http::http_thread::InitOpts {
         ca: ca_ptrs,
         abs_ca_file_name: abs_ca_file_name_static,
         on_init_error: http_thread_on_init_error,
         ..Default::default()
-    });
+    }) {
+        err.print();
+        Global::exit(1);
+    }
 
     let timestamp_for_manifest_cache_control: u32 = 'brk: {
         if cfg!(debug_assertions) {

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -453,14 +453,16 @@ unsafe fn __bun_resolver_init_package_manager(
     mut log: core::ptr::NonNull<bun_ast::Log>,
     install: Option<core::ptr::NonNull<crate::bun_schema::api::BunInstall>>,
     mut env: core::ptr::NonNull<bun_dotenv::Loader>,
-) -> core::result::Result<core::ptr::NonNull<dyn hooks::AutoInstaller>, bun_errno::SystemErrno> {
-    // ABI: the resolver-side `extern "Rust"` declaration names
-    // `bun_errno::SystemErrno` (both crates depend on bun_errno; carries the
-    // real errno name so resolve.test.ts sees `EACCES` not `Unexpected`). Keep
-    // both sides byte-identical or the `Result` layout diverges.
+) -> core::result::Result<core::ptr::NonNull<dyn hooks::AutoInstaller>, bun_resolver::Error> {
+    // ABI: the resolver-side `extern "Rust"` declaration names this same
+    // `bun_resolver::Error`, so both sides have one `Result` layout by
+    // construction. `Sys` carries the real errno name (resolve.test.ts sees
+    // `EACCES`, not `Unexpected`); `HttpThread` selects the resolver's message.
     //
-    // Idempotent.
-    bun_http::http_thread::init(&Default::default());
+    // Started before the sticky init below: a refused thread leaves the
+    // manager uncreated, and the next resolve tries both again.
+    bun_http::http_thread::init(&Default::default())
+        .map_err(|err| bun_resolver::Error::HttpThread(err.errno()))?;
 
     // SAFETY: when `Some`, `install` points at a live `Api::BunInstall`
     // (see `run_command::wire_transpiler_from_ctx`); read-only borrow.
@@ -478,14 +480,14 @@ unsafe fn __bun_resolver_init_package_manager(
         env_ref,
     )
     .map_err(|e| match e {
-        crate::Error::Sys(errno) => errno,
-        crate::Error::Resolver(bun_resolver::Error::Sys(errno)) => errno,
+        crate::Error::Sys(errno) => bun_resolver::Error::Sys(errno),
+        crate::Error::Resolver(err @ bun_resolver::Error::Sys(_)) => err,
         other => {
             log_ref.add_zig_error_with_note(
                 other.name(),
                 format_args!("while initializing the auto-install package manager"),
             );
-            bun_errno::SystemErrno::EIO
+            bun_resolver::Error::Sys(bun_errno::SystemErrno::EIO)
         }
     })?;
     // On success `init_with_runtime` returns the non-null `holder::RAW_PTR`

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -454,13 +454,11 @@ unsafe fn __bun_resolver_init_package_manager(
     install: Option<core::ptr::NonNull<crate::bun_schema::api::BunInstall>>,
     mut env: core::ptr::NonNull<bun_dotenv::Loader>,
 ) -> core::result::Result<core::ptr::NonNull<dyn hooks::AutoInstaller>, bun_resolver::Error> {
-    // ABI: the resolver-side `extern "Rust"` declaration names this same
-    // `bun_resolver::Error`, so both sides have one `Result` layout by
-    // construction. `Sys` carries the real errno name (resolve.test.ts sees
-    // `EACCES`, not `Unexpected`); `HttpThread` selects the resolver's message.
+    // ABI: the resolver-side `extern "Rust"` declaration names the same
+    // `bun_resolver::Error`. `Sys` keeps the errno name (resolve.test.ts sees
+    // `EACCES`); `HttpThread` selects the resolver's message.
     //
-    // Started before the sticky init below: a refused thread leaves the
-    // manager uncreated, and the next resolve tries both again.
+    // Before the sticky init below, so that the next resolve tries again.
     bun_http::http_thread::init(&Default::default())
         .map_err(|err| bun_resolver::Error::HttpThread(err.errno()))?;
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -882,10 +882,18 @@ impl IoRequestLoop {
         }
 
         // smaller thread, since it's not doing much.
-        std::thread::Builder::new()
-            .stack_size(1024 * 1024 * 2)
-            .spawn(Self::on_spawn_io_thread)
-            .unwrap_or_else(|_| panic!("Failed to spawn IO watcher thread"));
+        let spawned = bun_threading::spawn_with_retry("IO", || {
+            std::thread::Builder::new()
+                .stack_size(1024 * 1024 * 2)
+                .spawn(Self::on_spawn_io_thread)
+        });
+        if let Err(err) = spawned {
+            // The callers of `schedule` are in the middle of a read or write
+            // that cannot be failed from here, so the process reports the
+            // limit and exits, rather than filing a crash report for it.
+            err.print();
+            bun_core::Global::exit(1);
+        }
         // The JoinHandle detaches on drop.
     }
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -888,9 +888,8 @@ impl IoRequestLoop {
                 .spawn(Self::on_spawn_io_thread)
         });
         if let Err(err) = spawned {
-            // The callers of `schedule` are in the middle of a read or write
-            // that cannot be failed from here, so the process reports the
-            // limit and exits, rather than filing a crash report for it.
+            // `schedule` has no way to fail the read or write that needs the
+            // thread, so this exits instead.
             err.print();
             bun_core::Global::exit(1);
         }

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -14,6 +14,11 @@ pub enum Error {
     VersionSpecifierNotAllowedHere,
     #[error("ParseErrorAlreadyLogged")]
     ParseErrorAlreadyLogged,
+    /// The auto-installer could not start the HTTP client thread it downloads
+    /// with: the OS refused the thread with this errno. Kept apart from `Sys`,
+    /// which on that path means the top-level directory could not be read.
+    #[error("{0}")]
+    HttpThread(bun_errno::SystemErrno),
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
     #[error(transparent)]
@@ -35,7 +40,7 @@ impl Error {
             Self::ModuleNotFound => "ModuleNotFound",
             Self::VersionSpecifierNotAllowedHere => "VersionSpecifierNotAllowedHere",
             Self::ParseErrorAlreadyLogged => "ParseErrorAlreadyLogged",
-            Self::Sys(e) => <&'static str>::from(e),
+            Self::HttpThread(e) | Self::Sys(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
             Self::Core(e) => e.name(),
             Self::Overflow(_) => "Overflow",

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -14,9 +14,8 @@ pub enum Error {
     VersionSpecifierNotAllowedHere,
     #[error("ParseErrorAlreadyLogged")]
     ParseErrorAlreadyLogged,
-    /// The auto-installer could not start the HTTP client thread it downloads
-    /// with: the OS refused the thread with this errno. Kept apart from `Sys`,
-    /// which on that path means the top-level directory could not be read.
+    /// The OS refused the auto-installer's HTTP client thread. Not `Sys`, which
+    /// on that path means the top-level directory could not be read.
     #[error("{0}")]
     HttpThread(bun_errno::SystemErrno),
     #[error(transparent)]

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -30,11 +30,9 @@ unsafe extern "Rust" {
     /// reborrows `&mut *log` / `&mut *env` and reads `*install` if non-null.
     /// All three must point at process-lifetime Transpiler-owned storage; the
     /// returned `NonNull` names the `'static` `PackageManager` singleton.
-    /// Errs with `Error::Sys` when the one-time init fails (e.g. the top-level
-    /// directory is unreadable); that failure is sticky across calls. Errs
-    /// with `Error::HttpThread` when the OS refused the HTTP client thread;
-    /// the next call tries again. The definition in `bun_install` names this
-    /// same `crate::Error`, so the two signatures cannot drift apart.
+    /// `Error::Sys`: the one-time init failed (e.g. an unreadable top-level
+    /// directory), sticky across calls. `Error::HttpThread`: the OS refused the
+    /// HTTP client thread, retried by the next call.
     fn __bun_resolver_init_package_manager(
         log: NonNull<bun_ast::Log>,
         install: Option<NonNull<bun_options_types::schema::api::BunInstall>>,
@@ -825,10 +823,8 @@ impl<'a> Resolver<'a> {
     /// `on_wake` and cache the pointer. Reached from
     /// the auto-install path (`load_node_modules` global-cache block) when
     /// [`use_package_manager`] is `true`. Errs (without caching) when the
-    /// factory fails: the one-time init could not read the top-level
-    /// directory (sticky inside the factory), or the OS refused the HTTP
-    /// thread (retried on the next call) — callers surface that as a resolve
-    /// failure rather than panicking.
+    /// factory fails; callers surface that as a resolve failure rather than
+    /// panicking.
     pub fn get_package_manager(&mut self) -> crate::CrateResult<*mut dyn AutoInstaller> {
         if let Some(pm) = self.package_manager {
             return Ok(pm.as_ptr());
@@ -2884,12 +2880,10 @@ impl<'a> Resolver<'a> {
                 let manager_ptr: *mut dyn AutoInstaller = match self.get_package_manager() {
                     Ok(pm) => pm,
                     Err(err) => {
-                        // Report it as a catchable resolve error; the
-                        // `Metadata::Resolve` msg carries the text for
-                        // `import.meta.resolveSync` & co. Apart from the HTTP
-                        // thread, the one-time init fails when it cannot read
-                        // the top-level directory (cwd deleted, EACCES, a
-                        // dropped network drive).
+                        // A catchable resolve error: the `Metadata::Resolve`
+                        // msg carries the text for `import.meta.resolveSync`
+                        // & co. Every error but `HttpThread` comes from
+                        // reading the top-level directory.
                         let top_level_dir = self.fs_ref().top_level_dir;
                         match err {
                             crate::Error::HttpThread(_) => self.log_mut().add_resolve_error(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -30,13 +30,16 @@ unsafe extern "Rust" {
     /// reborrows `&mut *log` / `&mut *env` and reads `*install` if non-null.
     /// All three must point at process-lifetime Transpiler-owned storage; the
     /// returned `NonNull` names the `'static` `PackageManager` singleton.
-    /// Errs when the one-time init fails (e.g. the top-level directory is
-    /// unreadable); the failure is sticky across calls.
+    /// Errs with `Error::Sys` when the one-time init fails (e.g. the top-level
+    /// directory is unreadable); that failure is sticky across calls. Errs
+    /// with `Error::HttpThread` when the OS refused the HTTP client thread;
+    /// the next call tries again. The definition in `bun_install` names this
+    /// same `crate::Error`, so the two signatures cannot drift apart.
     fn __bun_resolver_init_package_manager(
         log: NonNull<bun_ast::Log>,
         install: Option<NonNull<bun_options_types::schema::api::BunInstall>>,
         env: NonNull<bun_dotenv::Loader>,
-    ) -> core::result::Result<NonNull<dyn AutoInstaller>, bun_errno::SystemErrno>;
+    ) -> core::result::Result<NonNull<dyn AutoInstaller>, crate::Error>;
 }
 use crate::cache::Set as CacheSet;
 use ::bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
@@ -821,10 +824,11 @@ impl<'a> Resolver<'a> {
     /// process-static singleton as a `dyn AutoInstaller`. We then wire
     /// `on_wake` and cache the pointer. Reached from
     /// the auto-install path (`load_node_modules` global-cache block) when
-    /// [`use_package_manager`] is `true`. Errs (without caching, but sticky
-    /// inside the factory) when the one-time init fails, e.g. the top-level
-    /// directory was deleted or is unreadable — callers surface that as a
-    /// resolve failure rather than panicking.
+    /// [`use_package_manager`] is `true`. Errs (without caching) when the
+    /// factory fails: the one-time init could not read the top-level
+    /// directory (sticky inside the factory), or the OS refused the HTTP
+    /// thread (retried on the next call) — callers surface that as a resolve
+    /// failure rather than panicking.
     pub fn get_package_manager(&mut self) -> crate::CrateResult<*mut dyn AutoInstaller> {
         if let Some(pm) = self.package_manager {
             return Ok(pm.as_ptr());
@@ -2880,25 +2884,40 @@ impl<'a> Resolver<'a> {
                 let manager_ptr: *mut dyn AutoInstaller = match self.get_package_manager() {
                     Ok(pm) => pm,
                     Err(err) => {
-                        // One-time init reads the top-level directory, which
-                        // can fail at runtime (cwd deleted, EACCES, a dropped
-                        // network drive). Report it as a catchable resolve
-                        // error; the `Metadata::Resolve` msg carries the text
-                        // for `import.meta.resolveSync` & co.
+                        // Report it as a catchable resolve error; the
+                        // `Metadata::Resolve` msg carries the text for
+                        // `import.meta.resolveSync` & co. Apart from the HTTP
+                        // thread, the one-time init fails when it cannot read
+                        // the top-level directory (cwd deleted, EACCES, a
+                        // dropped network drive).
                         let top_level_dir = self.fs_ref().top_level_dir;
-                        self.log_mut().add_resolve_error(
-                            None,
-                            bun_ast::Range::NONE,
-                            format_args!(
-                                "Cannot read directory \"{}\": {} while resolving \"{}\"",
-                                bstr::BStr::new(top_level_dir),
-                                bstr::BStr::new(err.name()),
-                                bstr::BStr::new(import_path)
+                        match err {
+                            crate::Error::HttpThread(_) => self.log_mut().add_resolve_error(
+                                None,
+                                bun_ast::Range::NONE,
+                                format_args!(
+                                    "Failed to start the HTTP client thread: {} while resolving \"{}\"",
+                                    bstr::BStr::new(err.name()),
+                                    bstr::BStr::new(import_path)
+                                ),
+                                import_path,
+                                kind,
+                                bun_ast::Error::ModuleNotFound,
                             ),
-                            import_path,
-                            kind,
-                            bun_ast::Error::ModuleNotFound,
-                        );
+                            _ => self.log_mut().add_resolve_error(
+                                None,
+                                bun_ast::Range::NONE,
+                                format_args!(
+                                    "Cannot read directory \"{}\": {} while resolving \"{}\"",
+                                    bstr::BStr::new(top_level_dir),
+                                    bstr::BStr::new(err.name()),
+                                    bstr::BStr::new(import_path)
+                                ),
+                                import_path,
+                                kind,
+                                bun_ast::Error::ModuleNotFound,
+                            ),
+                        }
                         if let Some(d) = self.debug_logs.as_mut() {
                             d.decrease_indent();
                         }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1392,8 +1392,8 @@ pub mod js_bundler {
                 Plugin::destroy(plugin);
             }
             let err = jsc::SystemError {
-                code: BunString::static_(err.code()).into(),
-                message: BunString::create_format(format_args!("{err}")).into(),
+                code: BunString::static_(err.code()),
+                message: BunString::create_format(format_args!("{err}")),
                 ..Default::default()
             }
             .to_error_instance(global_this);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1383,6 +1383,25 @@ pub mod js_bundler {
         let mut plugins: Option<*mut Plugin> = None;
         let config = Config::from_js(global_this, arguments[0], &mut plugins)?;
 
+        // A thread the OS refuses rejects this build; the next build tries to
+        // start it again. The plugin object is released the way a finished
+        // build's task releases it (`JSBundleCompletionTask::deinit`); `config`
+        // drops with its fields.
+        if let Err(err) = bun_bundler::bundle_v2::singleton::start::<
+            crate::api::js_bundle_completion_task::JSBundleCompletionTask,
+        >() {
+            if let Some(plugin) = plugins {
+                Plugin::destroy(plugin);
+            }
+            let err = jsc::SystemError {
+                code: BunString::static_(err.code()).into(),
+                message: BunString::create_format(format_args!("{err}")).into(),
+                ..Default::default()
+            }
+            .to_error_instance(global_this);
+            return Ok(jsc::JSPromise::rejected_promise(global_this, err).to_js());
+        }
+
         // `BundleV2.generateFromJavaScript` — the completion-task struct lives in
         // `crate::api::js_bundle_completion_task` (bun_runtime owns it because its
         // fields name `Config`/`Plugin`/`HTMLBundle::Route`; lower-tier crates

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1383,10 +1383,8 @@ pub mod js_bundler {
         let mut plugins: Option<*mut Plugin> = None;
         let config = Config::from_js(global_this, arguments[0], &mut plugins)?;
 
-        // A thread the OS refuses rejects this build; the next build tries to
-        // start it again. The plugin object is released the way a finished
-        // build's task releases it (`JSBundleCompletionTask::deinit`); `config`
-        // drops with its fields.
+        // The plugin object is released as `JSBundleCompletionTask::deinit`
+        // would release it; `config` drops.
         if let Err(err) = bun_bundler::bundle_v2::singleton::start::<
             crate::api::js_bundle_completion_task::JSBundleCompletionTask,
         >() {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -167,6 +167,7 @@ impl JSBundleCompletionTask {
     /// `BundleV2.createAndScheduleCompletionTask` — take a process-keepalive
     /// ref and hand the task to the bundle-thread singleton. The one ref `new`
     /// created travels with the task and is released by `on_complete_anytask`.
+    /// The caller has started the bundle thread (`singleton::start`) first.
     pub(crate) fn schedule(mut self) {
         self.poll_ref.ref_(self.global_this.bun_vm().loop_ctx());
         let plugins = self.plugins;

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -269,8 +269,7 @@ impl CreateCommand {
             long_running: false,
             ..Default::default()
         });
-        // Warm-up only: `send_sync` starts the thread itself and reports a
-        // refused thread as the error of the request that needed it.
+        // Warm-up; `send_sync` reports a refused thread.
         let _ = HTTP::http_thread::init(&Default::default());
 
         let mut create_options = CreateOptions::parse(ctx)?;

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -269,7 +269,9 @@ impl CreateCommand {
             long_running: false,
             ..Default::default()
         });
-        HTTP::http_thread::init(&Default::default());
+        // Warm-up only: `send_sync` starts the thread itself and reports a
+        // refused thread as the error of the request that needed it.
+        let _ = HTTP::http_thread::init(&Default::default());
 
         let mut create_options = CreateOptions::parse(ctx)?;
         let positionals = &create_options.positionals;

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -841,7 +841,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         if preconnect.is_empty() {
             return;
         }
-        bun_http::http_thread::init(&Default::default());
+        // A preconnect is only a hint: without the thread the URLs are still
+        // validated, and the script's own requests report the refused thread.
+        let http_thread_started = bun_http::http_thread::init(&Default::default()).is_ok();
 
         for url_str in preconnect {
             // SAFETY: `ctx.runtime_options.preconnect` is process-lifetime
@@ -874,7 +876,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 Global::exit(1);
             }
 
-            bun_http::async_http::preconnect(url, false);
+            if http_thread_started {
+                bun_http::async_http::preconnect(url, false);
+            }
         }
     }
 
@@ -3165,7 +3169,11 @@ impl RunCommand {
             return;
         }
 
-        bun_http::http_thread::init(&Default::default());
+        // Silent like every other download failure here: the images render
+        // as their alt text.
+        if bun_http::http_thread::init(&Default::default()).is_err() {
+            return;
+        }
 
         // Heap-allocate each Download so AsyncHTTP.task has a stable
         // address (see RemoteImageDownload doc comment).

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -841,8 +841,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         if preconnect.is_empty() {
             return;
         }
-        // A preconnect is only a hint: without the thread the URLs are still
-        // validated, and the script's own requests report the refused thread.
+        // A refused thread still validates the URLs; the script's own requests report it.
         let http_thread_started = bun_http::http_thread::init(&Default::default()).is_ok();
 
         for url_str in preconnect {
@@ -3169,8 +3168,6 @@ impl RunCommand {
             return;
         }
 
-        // Silent like every other download failure here: the images render
-        // as their alt text.
         if bun_http::http_thread::init(&Default::default()).is_err() {
             return;
         }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2128,8 +2128,7 @@ impl TestCommand {
             short_lived_globals: ctx.test_options.isolate,
             ..Default::default()
         });
-        // Warm-up only: a test that fetches starts the thread itself and
-        // reports a refused thread on its own request.
+        // Warm-up only. A test's own fetch() reports a refused thread.
         let _ = bun_http::http_thread::init(&Default::default());
 
         let enable_random = ctx.test_options.randomize;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2128,7 +2128,9 @@ impl TestCommand {
             short_lived_globals: ctx.test_options.isolate,
             ..Default::default()
         });
-        bun_http::http_thread::init(&Default::default());
+        // Warm-up only: a test that fetches starts the thread itself and
+        // reports a refused thread on its own request.
+        let _ = bun_http::http_thread::init(&Default::default());
 
         let enable_random = ctx.test_options.randomize;
         let seed: u32 = if enable_random {

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -535,7 +535,9 @@ impl UpgradeCommand {
     }
 
     fn _exec(ctx: Command::Context) -> crate::Result<()> {
-        HTTP::http_thread::init(&Default::default());
+        // An upgrade is nothing but downloads, so a refused thread ends it
+        // here, through the "upgrade manually" message of the caller.
+        HTTP::http_thread::init(&Default::default()).map_err(HTTP::Error::from)?;
 
         // SAFETY: FileSystem::init returns the process-global singleton; valid for 'static.
         let filesystem = unsafe { &mut *fs::FileSystem::init(None)? };

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -535,8 +535,6 @@ impl UpgradeCommand {
     }
 
     fn _exec(ctx: Command::Context) -> crate::Result<()> {
-        // An upgrade is nothing but downloads, so a refused thread ends it
-        // here, through the "upgrade manually" message of the caller.
         HTTP::http_thread::init(&Default::default()).map_err(HTTP::Error::from)?;
 
         // SAFETY: FileSystem::init returns the process-global singleton; valid for 'static.

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -535,7 +535,10 @@ impl UpgradeCommand {
     }
 
     fn _exec(ctx: Command::Context) -> crate::Result<()> {
-        HTTP::http_thread::init(&Default::default()).map_err(HTTP::Error::from)?;
+        HTTP::http_thread::init(&Default::default()).map_err(|err| {
+            err.print();
+            HTTP::Error::from(err)
+        })?;
 
         // SAFETY: FileSystem::init returns the process-global singleton; valid for 'static.
         let filesystem = unsafe { &mut *fs::FileSystem::init(None)? };

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -382,16 +382,10 @@ impl Route {
         let development = server.config().development;
         let vm = global.bun_vm().as_mut();
 
-        // Fails the route like a build error in `on_complete` does.
         if let Err(err) = bun_bundler::bundle_v2::singleton::start::<JSBundleCompletionTask>() {
             let mut log = Log::init();
             log.add_error_fmt(None, bun_ast::Loc::EMPTY, format_args!("{err}"));
-            if development.is_development() {
-                let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
-                let _ = log.print(writer);
-                bun_output::flush();
-            }
-            self.state.set(State::Err(log));
+            self.set_build_error(server, log);
             self.finish_building();
             return Ok(());
         }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -302,6 +302,7 @@ impl Route {
                         );
                     }
                     // TODO: use the code from DevServer.rs to render the error
+                    resp.write_status(b"500 Build Failed");
                     resp.end_without_body(true);
                 }
                 State::Html(html) => {

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -381,9 +381,7 @@ impl Route {
         let development = server.config().development;
         let vm = global.bun_vm().as_mut();
 
-        // A thread the OS refuses fails this route the way a build error does
-        // (`on_complete`): the waiting requests get the 500, and in development
-        // the error is printed. `plugins` stays the server's.
+        // Fails the route like a build error in `on_complete` does.
         if let Err(err) = bun_bundler::bundle_v2::singleton::start::<JSBundleCompletionTask>() {
             let mut log = Log::init();
             log.add_error_fmt(None, bun_ast::Loc::EMPTY, format_args!("{err}"));

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -385,8 +385,8 @@ impl Route {
         if let Err(err) = bun_bundler::bundle_v2::singleton::start::<JSBundleCompletionTask>() {
             let mut log = Log::init();
             log.add_error_fmt(None, bun_ast::Loc::EMPTY, format_args!("{err}"));
-            self.set_build_error(server, log);
-            self.finish_building();
+            this.set_build_error(server, log);
+            this.finish_building();
             return Ok(());
         }
 

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -381,6 +381,22 @@ impl Route {
         let development = server.config().development;
         let vm = global.bun_vm().as_mut();
 
+        // A thread the OS refuses fails this route the way a build error does
+        // (`on_complete`): the waiting requests get the 500, and in development
+        // the error is printed. `plugins` stays the server's.
+        if let Err(err) = bun_bundler::bundle_v2::singleton::start::<JSBundleCompletionTask>() {
+            let mut log = Log::init();
+            log.add_error_fmt(None, bun_ast::Loc::EMPTY, format_args!("{err}"));
+            if development.is_development() {
+                let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
+                let _ = log.print(writer);
+                bun_output::flush();
+            }
+            self.state.set(State::Err(log));
+            self.finish_building();
+            return Ok(());
+        }
+
         let mut config = JSBundlerConfig::default();
         // `Config` owns its fields and
         // drops on early-return.

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1866,6 +1866,23 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
+    // The request is about to be handed to the HTTP client thread. If the OS
+    // refuses to start it, that rejects this fetch the way a connect failure
+    // does (`FetchTasklet::on_reject`); a later fetch tries to start it again.
+    if let Err(err) = http::http_thread::init(&http::http_thread::InitOpts::default()) {
+        let err = jsc::SystemError {
+            code: BunString::static_(err.code()).into(),
+            message: BunString::create_format(format_args!("{err}")).into(),
+            path: BunString::clone_utf8(url.href).into(),
+            ..Default::default()
+        }
+        .to_type_error_instance(global_this);
+        // HTTPRequestBody has no Drop impl, so a bare `drop(body)` would leak
+        // the body's store ref or file descriptor.
+        body.detach();
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
+    }
+
     // Only create this after we have validated all the input.
     // or else we will leak it
     let promise = jsc::JSPromiseStrong::init(global_this);

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1869,9 +1869,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // A refused thread rejects like a connect failure does (`FetchTasklet::on_reject`).
     if let Err(err) = http::http_thread::init(&http::http_thread::InitOpts::default()) {
         let err = jsc::SystemError {
-            code: BunString::static_(err.code()).into(),
-            message: BunString::create_format(format_args!("{err}")).into(),
-            path: BunString::clone_utf8(url.href).into(),
+            code: BunString::static_(err.code()),
+            message: BunString::create_format(format_args!("{err}")),
+            path: BunString::clone_utf8(url.href),
             ..Default::default()
         }
         .to_type_error_instance(global_this);

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1866,9 +1866,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
-    // The request is about to be handed to the HTTP client thread. If the OS
-    // refuses to start it, that rejects this fetch the way a connect failure
-    // does (`FetchTasklet::on_reject`); a later fetch tries to start it again.
+    // A refused thread rejects like a connect failure does (`FetchTasklet::on_reject`).
     if let Err(err) = http::http_thread::init(&http::http_thread::InitOpts::default()) {
         let err = jsc::SystemError {
             code: BunString::static_(err.code()).into(),
@@ -1877,8 +1875,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             ..Default::default()
         }
         .to_type_error_instance(global_this);
-        // HTTPRequestBody has no Drop impl, so a bare `drop(body)` would leak
-        // the body's store ref or file descriptor.
+        // HTTPRequestBody has no Drop impl; a bare drop leaks its store ref or fd.
         body.detach();
         return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2339,12 +2339,14 @@ impl FetchTasklet {
         }
     }
 
+    /// The caller (`fetch_impl`) has started the HTTP thread with
+    /// `http_thread::init` before it created `promise`, so that a thread the
+    /// OS refuses rejects the fetch instead of leaving a promise behind.
     pub(crate) fn queue(
         global: &JSGlobalObject,
         fetch_options: FetchOptions,
         promise: jsc::JSPromiseStrong,
     ) -> crate::Result<*mut FetchTasklet> {
-        http::http_thread::init(&http::http_thread::InitOpts::default());
         let node = Self::get(global, fetch_options, promise)?;
 
         let node_ref = Self::from_raw_mut(node);

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2339,9 +2339,7 @@ impl FetchTasklet {
         }
     }
 
-    /// The caller (`fetch_impl`) has started the HTTP thread with
-    /// `http_thread::init` before it created `promise`, so that a thread the
-    /// OS refuses rejects the fetch instead of leaving a promise behind.
+    /// `fetch_impl` has called `http_thread::init` before it created `promise`.
     pub(crate) fn queue(
         global: &JSGlobalObject,
         fetch_options: FetchOptions,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -178,6 +178,20 @@ pub(crate) fn list_objects(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
 ) -> JsResult<()> {
+    // See `execute_simple_s3_request`: a thread the OS refuses fails the
+    // request through its callback before anything is allocated for it.
+    if let Err(err) = bun_http::http_thread::init(&Default::default()) {
+        let message = err.to_string();
+        callback(
+            S3ListObjectsResult::Failure(Error::S3Error {
+                code: err.code().as_bytes(),
+                message: message.as_bytes(),
+            }),
+            callback_context,
+        )?;
+        return Ok(());
+    }
+
     let mut search_params: Vec<u8> = Vec::<u8>::default();
 
     let _ = search_params.append_slice(b"?"); // OOM/capacity: fire-and-forget
@@ -361,7 +375,6 @@ pub(crate) fn list_objects(
     ));
 
     // queue http request
-    bun_http::http_thread::init(&Default::default());
     let mut batch = bun_threading::thread_pool::Batch::default();
     // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
     unsafe { task.http.assume_init_mut() }.schedule(&mut batch);
@@ -1165,6 +1178,22 @@ fn download_stream(
     ),
     callback_context: *mut c_void,
 ) -> *mut S3HttpDownloadStreamingTask {
+    // See `execute_simple_s3_request`: a thread the OS refuses fails the
+    // request through its callback before anything is allocated for it.
+    if let Err(err) = bun_http::http_thread::init(&Default::default()) {
+        let message = err.to_string();
+        callback(
+            &MutableString::default(),
+            false,
+            Some(Error::S3Error {
+                code: err.code().as_bytes(),
+                message: message.as_bytes(),
+            }),
+            callback_context,
+        );
+        return core::ptr::null_mut();
+    }
+
     let range: Option<Vec<u8>> = 'brk: {
         if let Some(size_) = size {
             let mut end = offset + size_;
@@ -1320,7 +1349,6 @@ fn download_stream(
     // enable streaming
     http.enable_response_body_streaming();
     // queue http request
-    bun_http::http_thread::init(&Default::default());
     let mut batch = bun_threading::thread_pool::Batch::default();
     http.schedule(&mut batch);
     // Out on the HTTP thread until its final callback: the VM aborts it at

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -178,8 +178,7 @@ pub(crate) fn list_objects(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
 ) -> JsResult<()> {
-    // See `execute_simple_s3_request`: a thread the OS refuses fails the
-    // request through its callback before anything is allocated for it.
+    // Before anything is allocated for the request, like a signing error.
     if let Err(err) = bun_http::http_thread::init(&Default::default()) {
         let message = err.to_string();
         callback(
@@ -1178,8 +1177,7 @@ fn download_stream(
     ),
     callback_context: *mut c_void,
 ) -> *mut S3HttpDownloadStreamingTask {
-    // See `execute_simple_s3_request`: a thread the OS refuses fails the
-    // request through its callback before anything is allocated for it.
+    // Before anything is allocated for the request, like a signing error.
     if let Err(err) = bun_http::http_thread::init(&Default::default()) {
         let message = err.to_string();
         callback(

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -566,6 +566,14 @@ pub(crate) fn execute_simple_s3_request(
         )?;
         return Ok(());
     }
+    // Start the HTTP thread before anything is allocated for the request, so
+    // a thread the OS refuses fails the request through its callback like a
+    // signing error does.
+    if let Err(err) = bun_http::http_thread::init(&Default::default()) {
+        let message = err.to_string();
+        callback.fail(err.code().as_bytes(), message.as_bytes(), callback_context)?;
+        return Ok(());
+    }
     let result = match this.sign_request::<false>(
         &SignOptions {
             path: options.path,
@@ -697,7 +705,6 @@ pub(crate) fn execute_simple_s3_request(
     // `schedule` below); scoped exclusive write of the `http` field.
     unsafe { (*task_ptr).http.write(async_http) };
     // queue http request
-    bun_http::http_thread::init(&Default::default());
     let mut batch = thread_pool::Batch::default();
     // SAFETY: `http` was initialised immediately above; scoped exclusive access.
     unsafe { (*task_ptr).http.assume_init_mut() }.schedule(&mut batch);

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -566,9 +566,7 @@ pub(crate) fn execute_simple_s3_request(
         )?;
         return Ok(());
     }
-    // Start the HTTP thread before anything is allocated for the request, so
-    // a thread the OS refuses fails the request through its callback like a
-    // signing error does.
+    // Before anything is allocated for the request, like a signing error.
     if let Err(err) = bun_http::http_thread::init(&Default::default()) {
         let message = err.to_string();
         callback.fail(err.code().as_bytes(), message.as_bytes(), callback_context)?;

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -426,6 +426,7 @@ impl Process {
         {
             let ctx = self.event_loop_ctx();
             if WaiterThread::should_use_waiter_thread() {
+                WaiterThread::start()?;
                 self.poller = Poller::WaiterThread(KeepAlive::default());
                 if let Poller::WaiterThread(w) = &mut self.poller {
                     w.ref_(ctx);
@@ -491,6 +492,7 @@ impl Process {
     pub(crate) fn rewatch_posix(&mut self) -> bun_sys::Result<()> {
         let ctx = self.event_loop_ctx();
         if WaiterThread::should_use_waiter_thread() {
+            WaiterThread::start()?;
             if !matches!(self.poller, Poller::WaiterThread(_)) {
                 self.poller = Poller::WaiterThread(KeepAlive::default());
             }
@@ -1306,11 +1308,10 @@ pub mod waiter_thread_posix {
     /// Shared borrow of the singleton — sole deref site for the set-once
     /// `INSTANCE` cell. All fields are either atomic (`started`),
     /// interior-mutable (`js_process.active` via `UnsafeCell`, `js_process.queue`
-    /// lock-free), or write-once-before-spawn (`eventfd`, set in `init()` under
-    /// the `started` fetch_max guard before any reader thread exists), so a
-    /// shared `&'static` is sound. The lone mutating write (`eventfd` in
-    /// `init()`) goes through the raw [`instance()`] pointer; no `&` from this
-    /// accessor is live across it.
+    /// lock-free), or write-once-before-spawn (`eventfd`, set in `start()` under
+    /// `START_LOCK` before any reader thread exists), so a shared `&'static` is
+    /// sound. The lone mutating write (`eventfd` in `start()`) goes through the
+    /// raw [`instance()`] pointer; no `&` from this accessor is live across it.
     #[inline]
     fn instance_ref() -> &'static WaiterThreadPosix {
         // SAFETY: see doc comment — process-lifetime singleton, fields are
@@ -1329,12 +1330,58 @@ pub mod waiter_thread_posix {
             bun_spawn_sys::waiter_thread_flag::get()
         }
 
+        /// Starts the thread the first time. When the OS refuses it, the
+        /// error goes to the caller and the next call tries again.
+        pub(crate) fn start() -> bun_sys::Result<()> {
+            debug_assert!(bun_spawn_sys::waiter_thread_flag::get());
+
+            if instance_ref().started.load(Ordering::Acquire) > 0 {
+                return Ok(());
+            }
+            let _guard = START_LOCK.lock_guard();
+            if instance_ref().started.load(Ordering::Acquire) > 0 {
+                return Ok(());
+            }
+
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if !instance_ref().eventfd.is_valid() {
+                // All by-value `c_uint`/`c_int` args; the kernel validates flags
+                // and returns -1/errno on failure — no memory-safety preconditions,
+                // so `safe fn` (Rust 2024) discharges the link-time proof.
+                unsafe extern "C" {
+                    safe fn eventfd(
+                        initval: core::ffi::c_uint,
+                        flags: core::ffi::c_int,
+                    ) -> core::ffi::c_int;
+                }
+                let fd = eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC);
+                if fd < 0 {
+                    return Err(bun_sys::Error::from_code_int(
+                        bun_sys::last_errno(),
+                        bun_sys::Tag::eventfd,
+                    ));
+                }
+                // SAFETY: the caller holds `START_LOCK` and the thread does not
+                // exist yet, so nothing reads `eventfd`.
+                unsafe { (*instance()).eventfd = Fd::from_native(fd) };
+            }
+
+            let thread = bun_threading::spawn_with_retry("process waiter", || {
+                std::thread::Builder::new()
+                    .stack_size(STACK_SIZE)
+                    .spawn(loop_)
+            })?;
+            drop(thread); // detach
+            instance_ref().started.store(1, Ordering::Release);
+            Ok(())
+        }
+
+        /// The caller's [`start`] succeeded.
         pub(crate) fn append(process: *mut Process) {
+            debug_assert!(instance_ref().started.load(Ordering::Acquire) > 0);
             // `js_process.queue` is an MPSC lock-free queue; `append` is the
             // producer half and only touches `queue`, never `active`.
             instance_ref().js_process.append(process);
-
-            init().unwrap_or_else(|_| panic!("Failed to start WaiterThread"));
 
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
@@ -1372,43 +1419,14 @@ pub mod waiter_thread_posix {
         }
     }
 
-    pub(crate) fn init() -> Result<(), std::io::Error> {
-        debug_assert!(bun_spawn_sys::waiter_thread_flag::get());
-
-        if instance_ref().started.fetch_max(1, Ordering::Relaxed) > 0 {
-            return Ok(());
-        }
-
-        #[cfg(any(target_os = "linux", target_os = "android"))]
-        {
-            // All by-value `c_uint`/`c_int` args; the kernel validates flags
-            // and returns -1/errno on failure — no memory-safety preconditions,
-            // so `safe fn` (Rust 2024) discharges the link-time proof.
-            unsafe extern "C" {
-                safe fn eventfd(
-                    initval: core::ffi::c_uint,
-                    flags: core::ffi::c_int,
-                ) -> core::ffi::c_int;
-            }
-            let fd = eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC);
-            if fd < 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            // SAFETY: single-writer init path (guarded by fetch_max above).
-            unsafe { (*instance()).eventfd = Fd::from_native(fd) };
-        }
-
-        let thread = std::thread::Builder::new()
-            .stack_size(STACK_SIZE)
-            .spawn(loop_)?;
-        drop(thread); // detach
-        Ok(())
-    }
+    /// Serializes [`WaiterThreadPosix::start`]. Not a `Once`: a refused
+    /// thread is tried again by the next call.
+    static START_LOCK: bun_threading::Mutex = bun_threading::Mutex::new();
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     extern "C" fn wakeup(_: c_int) {
         let one: [u8; 8] = (1usize).to_ne_bytes();
-        // eventfd is write-once in init() before this handler is installed.
+        // eventfd is write-once in start() before this handler is installed.
         let _ = bun_sys::write(instance_ref().eventfd, &one).unwrap_or(0);
     }
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2112,7 +2112,7 @@ pub(crate) fn download_to_path(
     env: &mut bun_dotenv::Loader,
     dest_z: &ZStr,
 ) -> crate::Result<()> {
-    bun_http::http_thread::init(&Default::default());
+    bun_http::http_thread::init(&Default::default()).map_err(bun_http::Error::from)?;
     let mut refresher = bun_core::Progress::Progress::default();
 
     {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1393,6 +1393,8 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    pub const pthread_create: Tag = Tag(108);
+    pub const eventfd: Tag = Tag(109);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1400,7 +1402,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 110] = [
             "TODO",
             "dup",
             "access",
@@ -1510,6 +1512,8 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "pthread_create",
+            "eventfd",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }

--- a/src/threading/lib.rs
+++ b/src/threading/lib.rs
@@ -13,6 +13,7 @@ pub mod reset_event;
 pub mod rwlock;
 #[path = "Semaphore.rs"]
 pub mod semaphore;
+pub mod spawn;
 #[path = "ThreadPool.rs"]
 pub mod thread_pool;
 pub mod work_pool;
@@ -34,6 +35,7 @@ pub use mutex::{Mutex, MutexGuard};
 pub use reset_event::ResetEvent;
 pub use rwlock::RwLock;
 pub use semaphore::Semaphore;
+pub use spawn::{SpawnError, spawn_with_retry};
 pub use thread_pool::ThreadPool;
 pub use unbounded_queue::{Link, Linked, UnboundedQueue};
 pub use wait_group::WaitGroup;

--- a/src/threading/spawn.rs
+++ b/src/threading/spawn.rs
@@ -1,32 +1,20 @@
-//! Starting the daemon threads bun creates on first use: the HTTP client
-//! thread, the bundle thread behind `Bun.build()`, the POSIX IO thread.
-//!
-//! The OS can refuse a thread. `pthread_create` returns `EAGAIN` when the
-//! process is at a thread or pid limit, or cannot map the stack; `CreateThread`
-//! fails with `ERROR_COMMITMENT_LIMIT` when the machine cannot commit the
-//! stack (bun commits 2 MB per thread, see the `/STACK:` flag in
-//! scripts/build/flags.ts). That is a limit of the machine, not a bug in bun,
-//! so the callers report it like any other error instead of crashing.
+//! Starting the threads bun creates on first use (the HTTP client thread, the
+//! bundle thread, the POSIX IO thread). A refused thread (`EAGAIN` at a thread
+//! limit, `ERROR_COMMITMENT_LIMIT` at the commit limit of the machine) is an
+//! error for the caller to report, not a crash.
 
 use core::fmt;
 use std::time::Duration;
 
 use bun_sys::SystemErrno;
 
-/// The schedule of the Go runtime (`_cgo_try_pthread_create`,
-/// `runtime.createThread`): 20 attempts, and a pause of n ms after the n-th
-/// failure. The limit is often gone a moment later, when the threads of an
-/// exiting process are reaped or Windows has grown the paging file. A limit
-/// that stays costs about 190 ms per call before the caller reports it.
+/// The schedule of the Go runtime: 20 attempts, n ms of sleep after the n-th
+/// failure, about 190 ms in total when the limit stays.
 const MAX_ATTEMPTS: u64 = 20;
 
-/// Calls `spawn` until it succeeds, per [`MAX_ATTEMPTS`]. Every error is
-/// retried: the OS reports the same limit under several codes (`EAGAIN`,
-/// `ERROR_ACCESS_DENIED`, `ERROR_COMMITMENT_LIMIT`), and the threads bun starts
-/// this way have fixed, valid attributes, so there is no other kind of error to
-/// fail fast on. `spawn` builds the thread again on every call, because
-/// `std::thread::Builder::spawn` consumes the closure even when it fails.
-/// `thread_name` names the thread in the error message.
+/// Calls `spawn` until it succeeds, per [`MAX_ATTEMPTS`]. `spawn` has to build
+/// the thread again on each call: `std::thread::Builder::spawn` consumes the
+/// closure even when it fails. `thread_name` goes into the error message.
 pub fn spawn_with_retry<T>(
     thread_name: &'static str,
     mut spawn: impl FnMut() -> std::io::Result<T>,
@@ -45,10 +33,8 @@ pub fn spawn_with_retry<T>(
     }
 }
 
-/// Every attempt of [`spawn_with_retry`] failed. `Display` gives the full
-/// message, with the text of the OS for the last error:
-/// `Failed to start the HTTP client thread: The paging file is too small for
-/// this operation to complete. (os error 1455)`.
+/// Every attempt of [`spawn_with_retry`] failed. `Display` is the message for
+/// the user, with the text of the OS for the last error.
 #[derive(Debug)]
 pub struct SpawnError {
     thread_name: &'static str,
@@ -56,9 +42,8 @@ pub struct SpawnError {
 }
 
 impl SpawnError {
-    /// The errno for `error.code` and for the error enums that wrap a
-    /// `SystemErrno`. A Windows code without an errno of its own, such as
-    /// `ERROR_COMMITMENT_LIMIT`, maps to `ENOMEM`.
+    /// A Windows code without an errno of its own (`ERROR_COMMITMENT_LIMIT`)
+    /// maps to `ENOMEM`.
     pub fn errno(&self) -> SystemErrno {
         #[cfg(windows)]
         const FALLBACK: SystemErrno = SystemErrno::ENOMEM;
@@ -78,8 +63,7 @@ impl SpawnError {
         <&'static str>::from(self.errno())
     }
 
-    /// What the user can do about the error. `None` when the text of the OS
-    /// already says it.
+    /// What the user can do about it, when the text of the OS does not say.
     pub fn hint(&self) -> Option<&'static str> {
         #[cfg(windows)]
         const HINT: (SystemErrno, &str) = (
@@ -95,8 +79,7 @@ impl SpawnError {
         (self.errno() == HINT.0).then_some(HINT.1)
     }
 
-    /// Prints the error and its hint to stderr, for the commands that cannot
-    /// continue without the thread.
+    /// Prints the error and its hint to stderr.
     pub fn print(&self) {
         bun_core::err_generic!("{}", self);
         if let Some(hint) = self.hint() {

--- a/src/threading/spawn.rs
+++ b/src/threading/spawn.rs
@@ -1,0 +1,118 @@
+//! Starting the daemon threads bun creates on first use: the HTTP client
+//! thread, the bundle thread behind `Bun.build()`, the POSIX IO thread.
+//!
+//! The OS can refuse a thread. `pthread_create` returns `EAGAIN` when the
+//! process is at a thread or pid limit, or cannot map the stack; `CreateThread`
+//! fails with `ERROR_COMMITMENT_LIMIT` when the machine cannot commit the
+//! stack (bun commits 2 MB per thread, see the `/STACK:` flag in
+//! scripts/build/flags.ts). That is a limit of the machine, not a bug in bun,
+//! so the callers report it like any other error instead of crashing.
+
+use core::fmt;
+use std::time::Duration;
+
+use bun_sys::SystemErrno;
+
+/// The schedule of the Go runtime (`_cgo_try_pthread_create`,
+/// `runtime.createThread`): 20 attempts, and a pause of n ms after the n-th
+/// failure. The limit is often gone a moment later, when the threads of an
+/// exiting process are reaped or Windows has grown the paging file. A limit
+/// that stays costs about 190 ms per call before the caller reports it.
+const MAX_ATTEMPTS: u64 = 20;
+
+/// Calls `spawn` until it succeeds, per [`MAX_ATTEMPTS`]. Every error is
+/// retried: the OS reports the same limit under several codes (`EAGAIN`,
+/// `ERROR_ACCESS_DENIED`, `ERROR_COMMITMENT_LIMIT`), and the threads bun starts
+/// this way have fixed, valid attributes, so there is no other kind of error to
+/// fail fast on. `spawn` builds the thread again on every call, because
+/// `std::thread::Builder::spawn` consumes the closure even when it fails.
+/// `thread_name` names the thread in the error message.
+pub fn spawn_with_retry<T>(
+    thread_name: &'static str,
+    mut spawn: impl FnMut() -> std::io::Result<T>,
+) -> Result<T, SpawnError> {
+    let mut attempt = 1;
+    loop {
+        let error = match spawn() {
+            Ok(thread) => return Ok(thread),
+            Err(error) => error,
+        };
+        if attempt == MAX_ATTEMPTS {
+            return Err(SpawnError { thread_name, error });
+        }
+        std::thread::sleep(Duration::from_millis(attempt));
+        attempt += 1;
+    }
+}
+
+/// Every attempt of [`spawn_with_retry`] failed. `Display` gives the full
+/// message, with the text of the OS for the last error:
+/// `Failed to start the HTTP client thread: The paging file is too small for
+/// this operation to complete. (os error 1455)`.
+#[derive(Debug)]
+pub struct SpawnError {
+    thread_name: &'static str,
+    error: std::io::Error,
+}
+
+impl SpawnError {
+    /// The errno for `error.code` and for the error enums that wrap a
+    /// `SystemErrno`. A Windows code without an errno of its own, such as
+    /// `ERROR_COMMITMENT_LIMIT`, maps to `ENOMEM`.
+    pub fn errno(&self) -> SystemErrno {
+        #[cfg(windows)]
+        const FALLBACK: SystemErrno = SystemErrno::ENOMEM;
+        #[cfg(not(windows))]
+        const FALLBACK: SystemErrno = SystemErrno::EAGAIN;
+
+        let Some(code) = self.error.raw_os_error() else {
+            return FALLBACK;
+        };
+        #[cfg(not(windows))]
+        let code = i64::from(code);
+        SystemErrno::init(code).unwrap_or(FALLBACK)
+    }
+
+    /// The name of [`errno`](Self::errno), for the `code` of a JS error.
+    pub fn code(&self) -> &'static str {
+        <&'static str>::from(self.errno())
+    }
+
+    /// What the user can do about the error. `None` when the text of the OS
+    /// already says it.
+    pub fn hint(&self) -> Option<&'static str> {
+        #[cfg(windows)]
+        const HINT: (SystemErrno, &str) = (
+            SystemErrno::ENOMEM,
+            "Windows could not commit memory for the stack of the thread. Close other programs, or make the paging file larger.",
+        );
+        #[cfg(not(windows))]
+        const HINT: (SystemErrno, &str) = (
+            SystemErrno::EAGAIN,
+            "The process is out of memory, or it reached a thread limit (ulimit -u, or the pids limit of its cgroup).",
+        );
+
+        (self.errno() == HINT.0).then_some(HINT.1)
+    }
+
+    /// Prints the error and its hint to stderr, for the commands that cannot
+    /// continue without the thread.
+    pub fn print(&self) {
+        bun_core::err_generic!("{}", self);
+        if let Some(hint) = self.hint() {
+            bun_core::note!("{}", hint);
+        }
+    }
+}
+
+impl fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to start the {} thread: {}",
+            self.thread_name, self.error
+        )
+    }
+}
+
+impl core::error::Error for SpawnError {}

--- a/src/threading/spawn.rs
+++ b/src/threading/spawn.rs
@@ -1,7 +1,8 @@
 //! Starting the threads bun creates on first use (the HTTP client thread, the
-//! bundle thread, the POSIX IO thread). A refused thread (`EAGAIN` at a thread
-//! limit, `ERROR_COMMITMENT_LIMIT` at the commit limit of the machine) is an
-//! error for the caller to report, not a crash.
+//! bundle thread, the IO and process waiter threads, the file watcher). A
+//! refused thread (`EAGAIN` at a thread limit, `ERROR_COMMITMENT_LIMIT` at the
+//! commit limit of the machine) is an error for the caller to report, not a
+//! crash.
 
 use core::fmt;
 use std::time::Duration;
@@ -50,12 +51,7 @@ impl SpawnError {
         #[cfg(not(windows))]
         const FALLBACK: SystemErrno = SystemErrno::EAGAIN;
 
-        let Some(code) = self.error.raw_os_error() else {
-            return FALLBACK;
-        };
-        #[cfg(not(windows))]
-        let code = i64::from(code);
-        SystemErrno::init(code).unwrap_or(FALLBACK)
+        SystemErrno::from_io_error(&self.error).unwrap_or(FALLBACK)
     }
 
     /// The name of [`errno`](Self::errno), for the `code` of a JS error.
@@ -99,3 +95,11 @@ impl fmt::Display for SpawnError {
 }
 
 impl core::error::Error for SpawnError {}
+
+/// For the callers whose own result type is `bun_sys::Result`. The thread name
+/// and the text of the OS are not part of a `bun_sys::Error`.
+impl From<SpawnError> for bun_sys::Error {
+    fn from(err: SpawnError) -> Self {
+        bun_sys::Error::new(err.errno(), bun_sys::Tag::pthread_create)
+    }
+}

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -237,7 +237,10 @@ impl Watcher {
         // Watcher must be Send across the spawned thread boundary; we pass a
         // raw pointer (as usize) and uphold the safety contract manually.
         let this = std::ptr::from_mut::<Watcher>(self) as usize;
-        let spawn = || {
+        // A --watch reload execve's and re-enters here at once. The first
+        // pthread_create can see a transient EAGAIN before the threads of the
+        // old image are reaped, which the retries cover.
+        let handle = bun_threading::spawn_with_retry("file watcher", || {
             std::thread::Builder::new()
                 .name("FileWatcher".into())
                 .spawn(move || {
@@ -246,30 +249,10 @@ impl Watcher {
                     // and the thread frees the Box.
                     let _ = unsafe { Watcher::thread_main(this as *mut Watcher) };
                 })
-        };
-        // A --watch reload execve's and immediately re-enters here; under CI load the first
-        // pthread_create can see a transient EAGAIN before the old image's threads are reaped.
-        // One short retry covers that without masking real resource exhaustion.
-        let handle = spawn().or_else(|first| {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            spawn().map_err(|_| first)
         });
-        self.thread = Some(handle.map_err(|e| {
+        self.thread = Some(handle.map_err(|err| {
             self.watchloop_handle.store(false);
-            // Windows: raw_os_error() is a Win32 GetLastError() code, so
-            // route it through the u32 (Win32Error) mapper rather than
-            // from_errno's i64 discriminant-cast path.
-            #[cfg(windows)]
-            let errno = e
-                .raw_os_error()
-                .and_then(|c| bun_errno::SystemErrno::init(c as u32))
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            #[cfg(not(windows))]
-            let errno = e
-                .raw_os_error()
-                .map(bun_errno::from_errno)
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            crate::Error::Sys(errno)
+            crate::Error::Sys(err.errno())
         })?);
         Ok(())
     }

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -156,8 +156,9 @@ __attribute__((constructor)) static void no_core(void) {
 int inotify_init1(int flags) {
   if (!real_inotify_init1) real_inotify_init1 = dlsym(RTLD_NEXT, "inotify_init1");
   /* Watcher::start() spawns through bun_threading::spawn_with_retry, which
-   * makes 20 attempts; fail all of them. */
-  armed = 20;
+   * makes 20 attempts. Arm many more, so that an unrelated thread created in
+   * the window cannot use them up. */
+  armed = 1000;
   return real_inotify_init1(flags);
 }
 

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -132,7 +132,7 @@ setInterval(() => {}, 1000);
 // Watcher::start() must propagate a failed thread spawn as an Err through its
 // Result return instead of aborting inside start() with `.expect()`. An
 // LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux
-// immediately before start()) and fails the very next pthread_create.
+// immediately before start()) and fails the pthread_create attempts that follow.
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead of panicking in start()", async () => {
   const SHIM_C = /* c */ `
@@ -155,8 +155,9 @@ __attribute__((constructor)) static void no_core(void) {
 
 int inotify_init1(int flags) {
   if (!real_inotify_init1) real_inotify_init1 = dlsym(RTLD_NEXT, "inotify_init1");
-  /* Watcher::start() retries once on EAGAIN; fail both attempts. */
-  armed = 2;
+  /* Watcher::start() spawns through bun_threading::spawn_with_retry, which
+   * makes 20 attempts; fail all of them. */
+  armed = 20;
   return real_inotify_init1(flags);
 }
 

--- a/test/js/bun/sys/thread-spawn-fail-shim.c
+++ b/test/js/bun/sys/thread-spawn-fail-shim.c
@@ -1,0 +1,32 @@
+// LD_PRELOAD shim for thread-spawn-fail.test.ts: while the file named by
+// REFUSE_THREADS_WHILE_EXISTS exists, every pthread_create fails with EAGAIN,
+// the way it does at a thread or pid limit. Each refusal is logged to stderr so
+// the test can count the attempts.
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
+static const char *marker;
+
+// Without the fix the child aborts. No core file, so CI does not count that as
+// a crash of the test runner; RLIMIT_CORE survives exec.
+__attribute__((constructor)) static void init(void) {
+  struct rlimit rl = {0, 0};
+  setrlimit(RLIMIT_CORE, &rl);
+  marker = getenv("REFUSE_THREADS_WHILE_EXISTS");
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
+  if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  if (marker && access(marker, F_OK) == 0) {
+    static const char line[] = "shim: pthread_create refused\n";
+    write(2, line, sizeof(line) - 1);
+    return EAGAIN;
+  }
+  return real_pthread_create(thread, attr, start, arg);
+}

--- a/test/js/bun/sys/thread-spawn-fail-shim.c
+++ b/test/js/bun/sys/thread-spawn-fail-shim.c
@@ -1,7 +1,8 @@
 // LD_PRELOAD shim for thread-spawn-fail.test.ts: while the file named by
 // REFUSE_THREADS_WHILE_EXISTS exists, every pthread_create fails with EAGAIN,
-// the way it does at a thread or pid limit. Each refusal is logged to stderr so
-// the test can count the attempts.
+// the way it does at a thread or pid limit. If REFUSE_THREADS_WITH_STACK_SIZE
+// is set too, only a thread that asks for exactly that stack size is refused.
+// Each refusal is logged to stderr so the test can count the attempts.
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
@@ -12,6 +13,7 @@
 
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 static const char *marker;
+static size_t refused_stack_size;
 
 // Without the fix the child aborts. No core file, so CI does not count that as
 // a crash of the test runner; RLIMIT_CORE survives exec.
@@ -19,11 +21,21 @@ __attribute__((constructor)) static void init(void) {
   struct rlimit rl = {0, 0};
   setrlimit(RLIMIT_CORE, &rl);
   marker = getenv("REFUSE_THREADS_WHILE_EXISTS");
+  const char *stack_size = getenv("REFUSE_THREADS_WITH_STACK_SIZE");
+  if (stack_size) refused_stack_size = strtoull(stack_size, NULL, 10);
+}
+
+// 0 when the caller passes no attributes and takes the default stack.
+static size_t requested_stack_size(const pthread_attr_t *attr) {
+  size_t size = 0;
+  if (attr) pthread_attr_getstacksize(attr, &size);
+  return size;
 }
 
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
   if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
-  if (marker && access(marker, F_OK) == 0) {
+  if (marker && access(marker, F_OK) == 0 &&
+      (refused_stack_size == 0 || requested_stack_size(attr) == refused_stack_size)) {
     static const char line[] = "shim: pthread_create refused\n";
     write(2, line, sizeof(line) - 1);
     return EAGAIN;

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -17,113 +17,85 @@ import { join } from "node:path";
 const canRun = isLinux && !isMusl && !!(Bun.which("cc") || Bun.which("clang") || Bun.which("gcc"));
 const shimPath = canRun ? compileFixture(join(import.meta.dir, "thread-spawn-fail-shim.c"), { flags: ["-ldl"] }) : "";
 
-// JSC starts its GC helper threads, and bmalloc its scavenger thread, when a
-// collection first needs them, and both abort when the OS refuses. A collection
-// while the marker exists (debug builds collect often) must therefore find them
-// running: a collection right before the marker starts them, and they stay up
-// for 10s of inactivity, far longer than the refused call takes.
-const REFUSE_THREADS = /* js */ `
+// The marker exists only while the call under test runs. JSC and bmalloc also
+// start threads on demand (GC helpers, the scavenger, and more at exit) and
+// abort when the OS refuses one, so the window has to be as short as possible,
+// and a collection right before it starts the threads a collection during it
+// would need (they stay up for 10s of inactivity).
+const WHILE_REFUSED = /* js */ `
 import { unlinkSync, writeFileSync } from "node:fs";
 const marker = process.env.REFUSE_THREADS_WHILE_EXISTS;
-function refuseThreads() {
+async function whileRefused(call) {
   Bun.gc(false);
   Bun.gc(true);
   writeFileSync(marker, "");
+  try {
+    return { resolved: await call() };
+  } catch (e) {
+    return { rejected: { name: e.name, code: e.code, message: e.message, path: e.path } };
+  } finally {
+    unlinkSync(marker);
+  }
 }
-function allowThreads() {
-  unlinkSync(marker);
+function print(value) {
+  console.log(JSON.stringify(value));
 }
 `;
 
 const FETCH_FIXTURE = /* js */ `
-${REFUSE_THREADS}
+${WHILE_REFUSED}
 using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
 const unhandled = new Promise(resolve => process.on("unhandledRejection", e => resolve(e.code)));
 
-refuseThreads();
-try {
-  await fetch(server.url);
-  console.log(JSON.stringify({ first: "resolved" }));
-} catch (e) {
-  console.log(JSON.stringify({ first: "rejected", name: e.name, code: e.code, message: e.message, path: e.path }));
-}
+print(await whileRefused(() => fetch(server.url)));
 // Nobody handles this one: it has to reach unhandledRejection like any other
 // failed fetch.
-fetch(server.url);
-console.log(JSON.stringify({ unhandled: await unhandled }));
-allowThreads();
-
-const res = await fetch(server.url);
-console.log(JSON.stringify({ second: await res.text() }));
+await whileRefused(() => void fetch(server.url));
+print({ unhandled: await unhandled });
+print({ afterwards: await (await fetch(server.url)).text() });
 `;
 
 // Built at runtime so the transpiler cannot resolve it. A bare specifier with
 // no node_modules anywhere above the file goes through auto-install, which
 // starts the HTTP thread before it creates the package manager.
 const AUTO_INSTALL_FIXTURE = /* js */ `
-${REFUSE_THREADS}
+${WHILE_REFUSED}
 const specifier = ["left", "pad"].join("-");
-refuseThreads();
-try {
-  console.log(JSON.stringify({ resolved: import.meta.resolveSync(specifier) }));
-} catch (e) {
-  console.log(JSON.stringify({ caught: e.message }));
-}
+print(await whileRefused(() => import.meta.resolveSync(specifier)));
 `;
 
 // One request per S3 code path that starts the thread: a simple request, a
 // listing and a streamed download. Each fails before it touches the network.
 const S3_FIXTURE = /* js */ `
-${REFUSE_THREADS}
+${WHILE_REFUSED}
 const client = new Bun.S3Client({
   accessKeyId: "key",
   secretAccessKey: "secret",
   bucket: "bucket",
   endpoint: "http://127.0.0.1:1",
 });
-const requests = {
-  text: () => client.file("a.txt").text(),
-  list: () => client.list(),
-  stream: () => new Response(client.file("a.txt").stream()).text(),
-};
-refuseThreads();
-for (const [name, request] of Object.entries(requests)) {
-  try {
-    await request();
-    console.log(JSON.stringify({ [name]: "resolved" }));
-  } catch (e) {
-    console.log(JSON.stringify({ [name]: "rejected", code: e.code, message: e.message }));
-  }
-}
+print(await whileRefused(() => client.file("a.txt").text()));
+print(await whileRefused(() => client.list()));
+print(await whileRefused(() => new Response(client.file("a.txt").stream()).text()));
 `;
 
 const BUILD_FIXTURE = /* js */ `
-${REFUSE_THREADS}
+${WHILE_REFUSED}
 const entrypoints = [import.meta.dir + "/entry.js"];
-
-refuseThreads();
-try {
-  await Bun.build({ entrypoints });
-  console.log(JSON.stringify({ first: "resolved" }));
-} catch (e) {
-  console.log(JSON.stringify({ first: "rejected", code: e.code, message: e.message }));
-}
-allowThreads();
-
+print(await whileRefused(() => Bun.build({ entrypoints })));
 const result = await Bun.build({ entrypoints });
-console.log(JSON.stringify({ second: result.success, text: await result.outputs[0].text() }));
+print({ afterwards: result.success, text: await result.outputs[0].text() });
 `;
 
 // The read runs on a work pool thread, so a regular file is read first, while
 // that thread can still be started. The pipe has no data, so the next read
-// parks on the IO thread, which is the one that is refused.
+// parks on the IO thread, which is the one that is refused. The process exits
+// inside the call.
 const STDIN_FIXTURE = /* js */ `
-${REFUSE_THREADS}
+${WHILE_REFUSED}
 await Bun.file(import.meta.path).text();
-refuseThreads();
 console.log("reading stdin");
-await Bun.stdin.text();
-console.log("unreachable");
+print(await whileRefused(() => Bun.stdin.text()));
 `;
 
 // The schedule of bun_threading::spawn_with_retry.
@@ -179,6 +151,8 @@ function jsonLines(stdout: string) {
     });
 }
 
+const HTTP_THREAD_REFUSED = "Failed to start the HTTP client thread: Resource temporarily unavailable (os error 11)";
+
 test.concurrent.skipIf(!canRun)(
   "fetch() rejects when the HTTP thread cannot be started; the next fetch starts it",
   async () => {
@@ -188,14 +162,15 @@ test.concurrent.skipIf(!canRun)(
     expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
       stdout: [
         {
-          first: "rejected",
-          name: "TypeError",
-          code: "EAGAIN",
-          message: "Failed to start the HTTP client thread: Resource temporarily unavailable (os error 11)",
-          path: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/$/),
+          rejected: {
+            name: "TypeError",
+            code: "EAGAIN",
+            message: HTTP_THREAD_REFUSED,
+            path: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/$/),
+          },
         },
         { unhandled: "EAGAIN" },
-        { second: "ok" },
+        { afterwards: "ok" },
       ],
       stderr: "",
       // Two fetches while refused, each one retried per the schedule.
@@ -210,7 +185,15 @@ test.concurrent.skipIf(!canRun)("auto-install reports a refused HTTP thread as a
   const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
 
   expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
-    stdout: [{ caught: 'Failed to start the HTTP client thread: EAGAIN while resolving "left-pad"' }],
+    stdout: [
+      {
+        rejected: {
+          name: "ResolveMessage",
+          code: "ERR_MODULE_NOT_FOUND",
+          message: 'Failed to start the HTTP client thread: EAGAIN while resolving "left-pad"',
+        },
+      },
+    ],
     stderr: "",
     refused: ATTEMPTS_PER_START,
     exitCode: 0,
@@ -221,16 +204,11 @@ test.concurrent.skipIf(!canRun)("S3 requests fail when the HTTP thread cannot be
   using dir = tempDir("refuse-threads-s3", { "fixture.js": S3_FIXTURE });
   const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
 
-  const rejected = {
-    code: "EAGAIN",
-    message: "Failed to start the HTTP client thread: Resource temporarily unavailable (os error 11)",
-  };
+  const rejected = (path: string) => ({
+    rejected: { name: "S3Error", code: "EAGAIN", message: HTTP_THREAD_REFUSED, path },
+  });
   expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
-    stdout: [
-      { text: "rejected", ...rejected },
-      { list: "rejected", ...rejected },
-      { stream: "rejected", ...rejected },
-    ],
+    stdout: [rejected("a.txt"), rejected(""), rejected("a.txt")],
     stderr: "",
     refused: 3 * ATTEMPTS_PER_START,
     exitCode: 0,
@@ -249,11 +227,13 @@ test.concurrent.skipIf(!canRun)(
     expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
       stdout: [
         {
-          first: "rejected",
-          code: "EAGAIN",
-          message: "Failed to start the bundler thread: Resource temporarily unavailable (os error 11)",
+          rejected: {
+            name: "Error",
+            code: "EAGAIN",
+            message: "Failed to start the bundler thread: Resource temporarily unavailable (os error 11)",
+          },
         },
-        { second: true, text: expect.stringContaining("42") },
+        { afterwards: true, text: expect.stringContaining("42") },
       ],
       stderr: "",
       refused: ATTEMPTS_PER_START,

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -1,0 +1,274 @@
+// Bun starts some threads on first use: the HTTP client thread (fetch, S3,
+// bun install, auto-install), the bundle thread (Bun.build) and, on POSIX, the
+// IO thread that waits on pipes. The OS can refuse a thread: pthread_create
+// fails with EAGAIN at a thread or pid limit, CreateThread fails with
+// ERROR_COMMITMENT_LIMIT when Windows cannot commit the stack. That is a limit
+// of the machine, so it has to come back as an error, not as a crash report.
+//
+// The LD_PRELOAD shim in thread-spawn-fail-shim.c makes every pthread_create
+// fail while a marker file exists. The fixtures create the marker right before
+// the call under test, so the threads Bun starts at startup are not affected,
+// and delete it again to check that the next call starts the thread after all.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, compileFixture, isLinux, isMusl, tempDir } from "harness";
+import { join } from "node:path";
+
+// bun-musl is statically linked, so LD_PRELOAD cannot intercept pthread_create.
+const canRun = isLinux && !isMusl && !!(Bun.which("cc") || Bun.which("clang") || Bun.which("gcc"));
+const shimPath = canRun ? compileFixture(join(import.meta.dir, "thread-spawn-fail-shim.c"), { flags: ["-ldl"] }) : "";
+
+// JSC starts its GC helper threads, and bmalloc its scavenger thread, when a
+// collection first needs them, and both abort when the OS refuses. A collection
+// while the marker exists (debug builds collect often) must therefore find them
+// running: a collection right before the marker starts them, and they stay up
+// for 10s of inactivity, far longer than the refused call takes.
+const REFUSE_THREADS = /* js */ `
+import { unlinkSync, writeFileSync } from "node:fs";
+const marker = process.env.REFUSE_THREADS_WHILE_EXISTS;
+function refuseThreads() {
+  Bun.gc(false);
+  Bun.gc(true);
+  writeFileSync(marker, "");
+}
+function allowThreads() {
+  unlinkSync(marker);
+}
+`;
+
+const FETCH_FIXTURE = /* js */ `
+${REFUSE_THREADS}
+using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
+const unhandled = new Promise(resolve => process.on("unhandledRejection", e => resolve(e.code)));
+
+refuseThreads();
+try {
+  await fetch(server.url);
+  console.log(JSON.stringify({ first: "resolved" }));
+} catch (e) {
+  console.log(JSON.stringify({ first: "rejected", name: e.name, code: e.code, message: e.message, path: e.path }));
+}
+// Nobody handles this one: it has to reach unhandledRejection like any other
+// failed fetch.
+fetch(server.url);
+console.log(JSON.stringify({ unhandled: await unhandled }));
+allowThreads();
+
+const res = await fetch(server.url);
+console.log(JSON.stringify({ second: await res.text() }));
+`;
+
+// Built at runtime so the transpiler cannot resolve it. A bare specifier with
+// no node_modules anywhere above the file goes through auto-install, which
+// starts the HTTP thread before it creates the package manager.
+const AUTO_INSTALL_FIXTURE = /* js */ `
+${REFUSE_THREADS}
+const specifier = ["left", "pad"].join("-");
+refuseThreads();
+try {
+  console.log(JSON.stringify({ resolved: import.meta.resolveSync(specifier) }));
+} catch (e) {
+  console.log(JSON.stringify({ caught: e.message }));
+}
+`;
+
+// One request per S3 code path that starts the thread: a simple request, a
+// listing and a streamed download. Each fails before it touches the network.
+const S3_FIXTURE = /* js */ `
+${REFUSE_THREADS}
+const client = new Bun.S3Client({
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  bucket: "bucket",
+  endpoint: "http://127.0.0.1:1",
+});
+const requests = {
+  text: () => client.file("a.txt").text(),
+  list: () => client.list(),
+  stream: () => new Response(client.file("a.txt").stream()).text(),
+};
+refuseThreads();
+for (const [name, request] of Object.entries(requests)) {
+  try {
+    await request();
+    console.log(JSON.stringify({ [name]: "resolved" }));
+  } catch (e) {
+    console.log(JSON.stringify({ [name]: "rejected", code: e.code, message: e.message }));
+  }
+}
+`;
+
+const BUILD_FIXTURE = /* js */ `
+${REFUSE_THREADS}
+const entrypoints = [import.meta.dir + "/entry.js"];
+
+refuseThreads();
+try {
+  await Bun.build({ entrypoints });
+  console.log(JSON.stringify({ first: "resolved" }));
+} catch (e) {
+  console.log(JSON.stringify({ first: "rejected", code: e.code, message: e.message }));
+}
+allowThreads();
+
+const result = await Bun.build({ entrypoints });
+console.log(JSON.stringify({ second: result.success, text: await result.outputs[0].text() }));
+`;
+
+// The read runs on a work pool thread, so a regular file is read first, while
+// that thread can still be started. The pipe has no data, so the next read
+// parks on the IO thread, which is the one that is refused.
+const STDIN_FIXTURE = /* js */ `
+${REFUSE_THREADS}
+await Bun.file(import.meta.path).text();
+refuseThreads();
+console.log("reading stdin");
+await Bun.stdin.text();
+console.log("unreachable");
+`;
+
+// The schedule of bun_threading::spawn_with_retry.
+const ATTEMPTS_PER_START = 20;
+
+async function runFixture(dir: string, options: { stdin?: "pipe" } = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    cwd: dir,
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
+      REFUSE_THREADS_WHILE_EXISTS: join(dir, "refuse-threads"),
+      // Without the fix the child crashes. Never upload that.
+      BUN_ENABLE_CRASH_REPORTING: "0",
+    },
+    stdin: options.stdin,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderrLines = stderr.split("\n");
+  const refused = stderrLines.filter(line => line === "shim: pthread_create refused").length;
+  return {
+    stdout,
+    // What the child itself wrote to stderr.
+    stderr: stderrLines.filter(line => line !== "shim: pthread_create refused").join("\n"),
+    refused,
+    exitCode,
+    signalCode: proc.signalCode,
+  };
+}
+
+/** The fixtures print one JSON object per line. A line that is not JSON (the
+ * fixture died) is kept as text, so the assertion shows what happened. */
+function jsonLines(stdout: string) {
+  return stdout
+    .split("\n")
+    .filter(line => line !== "")
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return line;
+      }
+    });
+}
+
+test.concurrent.skipIf(!canRun)(
+  "fetch() rejects when the HTTP thread cannot be started; the next fetch starts it",
+  async () => {
+    using dir = tempDir("refuse-threads-fetch", { "fixture.js": FETCH_FIXTURE });
+    const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
+
+    expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
+      stdout: [
+        {
+          first: "rejected",
+          name: "TypeError",
+          code: "EAGAIN",
+          message: "Failed to start the HTTP client thread: Resource temporarily unavailable (os error 11)",
+          path: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/$/),
+        },
+        { unhandled: "EAGAIN" },
+        { second: "ok" },
+      ],
+      stderr: "",
+      // Two fetches while refused, each one retried per the schedule.
+      refused: 2 * ATTEMPTS_PER_START,
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent.skipIf(!canRun)("auto-install reports a refused HTTP thread as a resolve error", async () => {
+  using dir = tempDir("refuse-threads-auto-install", { "fixture.js": AUTO_INSTALL_FIXTURE });
+  const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
+
+  expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
+    stdout: [{ caught: 'Failed to start the HTTP client thread: EAGAIN while resolving "left-pad"' }],
+    stderr: "",
+    refused: ATTEMPTS_PER_START,
+    exitCode: 0,
+  });
+});
+
+test.concurrent.skipIf(!canRun)("S3 requests fail when the HTTP thread cannot be started", async () => {
+  using dir = tempDir("refuse-threads-s3", { "fixture.js": S3_FIXTURE });
+  const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
+
+  const rejected = {
+    code: "EAGAIN",
+    message: "Failed to start the HTTP client thread: Resource temporarily unavailable (os error 11)",
+  };
+  expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
+    stdout: [
+      { text: "rejected", ...rejected },
+      { list: "rejected", ...rejected },
+      { stream: "rejected", ...rejected },
+    ],
+    stderr: "",
+    refused: 3 * ATTEMPTS_PER_START,
+    exitCode: 0,
+  });
+});
+
+test.concurrent.skipIf(!canRun)(
+  "Bun.build() rejects when the bundle thread cannot be started; the next build starts it",
+  async () => {
+    using dir = tempDir("refuse-threads-build", {
+      "fixture.js": BUILD_FIXTURE,
+      "entry.js": "export const answer = 42;\n",
+    });
+    const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
+
+    expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
+      stdout: [
+        {
+          first: "rejected",
+          code: "EAGAIN",
+          message: "Failed to start the bundler thread: Resource temporarily unavailable (os error 11)",
+        },
+        { second: true, text: expect.stringContaining("42") },
+      ],
+      stderr: "",
+      refused: ATTEMPTS_PER_START,
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent.skipIf(!canRun)(
+  "a read that needs the IO thread exits with an error when it cannot be started",
+  async () => {
+    using dir = tempDir("refuse-threads-stdin", { "fixture.js": STDIN_FIXTURE });
+    const { stdout, stderr, refused, exitCode, signalCode } = await runFixture(String(dir), { stdin: "pipe" });
+
+    expect({ stdout, stderr, refused, exitCode, signalCode }).toEqual({
+      stdout: "reading stdin\n",
+      stderr:
+        "error: Failed to start the IO thread: Resource temporarily unavailable (os error 11)\n" +
+        "note: The process is out of memory, or it reached a thread limit (ulimit -u, or the pids limit of its cgroup).\n",
+      refused: ATTEMPTS_PER_START,
+      exitCode: 1,
+      signalCode: null,
+    });
+  },
+);

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -1,6 +1,7 @@
 // Bun starts some threads on first use: the HTTP client thread (fetch, S3,
 // bun install, auto-install), the bundle thread (Bun.build) and, on POSIX, the
-// IO thread that waits on pipes. The OS can refuse a thread: pthread_create
+// IO thread that waits on pipes and the thread that waits for child processes
+// on a kernel without pidfd. The OS can refuse a thread: pthread_create
 // fails with EAGAIN at a thread or pid limit, CreateThread fails with
 // ERROR_COMMITMENT_LIMIT when Windows cannot commit the stack. That is a limit
 // of the machine, so it has to come back as an error, not as a crash report.
@@ -32,7 +33,7 @@ async function whileRefused(call) {
   try {
     return { resolved: await call() };
   } catch (e) {
-    return { rejected: { name: e.name, code: e.code, message: e.message, path: e.path } };
+    return { rejected: { name: e.name, code: e.code, syscall: e.syscall, message: e.message, path: e.path } };
   } finally {
     unlinkSync(marker);
   }
@@ -116,6 +117,25 @@ ${WHILE_REFUSED}
 await Bun.file(import.meta.path).text();
 console.log("reading stdin");
 print(await whileRefused(() => Bun.stdin.text()));
+`;
+
+// Without pidfd (BUN_FEATURE_FLAG_FORCE_WAITER_THREAD stands in for a kernel or
+// a seccomp filter without it), the first Bun.spawn() starts the thread that
+// waits for the children. The child is left running so that the refusal, not
+// its exit, decides the outcome. It is killed afterwards.
+const SPAWN_FIXTURE = /* js */ `
+${WHILE_REFUSED}
+const stdio = ["ignore", "ignore", "ignore"];
+let refusedChild;
+print(
+  await whileRefused(() => {
+    refusedChild = Bun.spawn({ cmd: ["sleep", "30"], stdio });
+    return refusedChild.exited;
+  }),
+);
+print({ exitCode: refusedChild.exitCode, signalCode: refusedChild.signalCode });
+process.kill(refusedChild.pid, "SIGKILL");
+print({ afterwards: await Bun.spawn({ cmd: ["sleep", "0"], stdio }).exited });
 `;
 
 // The schedule of bun_threading::spawn_with_retry.
@@ -319,6 +339,36 @@ test.concurrent.skipIf(!canRun)(
         "Failed to start the bundler thread: Resource temporarily unavailable (os error 11)",
       ),
       refused: ATTEMPTS_PER_START,
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent.skipIf(!canRun)(
+  "Bun.spawn() reports a refused process waiter thread through exited; the next spawn starts it",
+  async () => {
+    using dir = tempDir("refuse-threads-spawn", { "fixture.js": SPAWN_FIXTURE });
+    const { stdout, stderr, refused, exitCode } = await runFixture(String(dir), {
+      env: { BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" },
+    });
+
+    expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
+      stdout: [
+        {
+          rejected: {
+            name: "Error",
+            code: "EAGAIN",
+            syscall: "pthread_create",
+            message: "EAGAIN: resource temporarily unavailable, pthread_create",
+          },
+        },
+        { exitCode: null, signalCode: null },
+        { afterwards: 0 },
+      ],
+      stderr: "",
+      // Bun.spawn() tries to watch the child, then once more when it finds the
+      // child still running.
+      refused: 2 * ATTEMPTS_PER_START,
       exitCode: 0,
     });
   },

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -87,6 +87,26 @@ const result = await Bun.build({ entrypoints });
 print({ afterwards: result.success, text: await result.outputs[0].text() });
 `;
 
+// An HTML route builds on the same bundle thread. `hmr: false` takes the plain
+// route, which builds again on every request, so the request after the refused
+// one starts the thread. The HTTP client thread is started by the first request,
+// before threads are refused.
+const HTML_ROUTE_FIXTURE = /* js */ `
+${WHILE_REFUSED}
+import index from "./index.html";
+using server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  development: { hmr: false },
+  routes: { "/": index, "/ping": new Response("pong") },
+});
+await (await fetch(new URL("/ping", server.url))).text();
+const { resolved: refused } = await whileRefused(() => fetch(server.url));
+print({ status: refused.status, body: await refused.text() });
+const afterwards = await fetch(server.url);
+print({ afterwards: afterwards.status, html: (await afterwards.text()).includes("<h1>hello</h1>") });
+`;
+
 // The read runs on a work pool thread, so a regular file is read first, while
 // that thread can still be started. The pipe has no data, so the next read
 // parks on the IO thread, which is the one that is refused. The process exits
@@ -236,6 +256,30 @@ test.concurrent.skipIf(!canRun)(
         { afterwards: true, text: expect.stringContaining("42") },
       ],
       stderr: "",
+      refused: ATTEMPTS_PER_START,
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent.skipIf(!canRun)(
+  "an HTML route answers 500 when the bundle thread cannot be started; the next request starts it",
+  async () => {
+    using dir = tempDir("refuse-threads-html-route", {
+      "fixture.js": HTML_ROUTE_FIXTURE,
+      "index.html": "<!DOCTYPE html><html><body><h1>hello</h1></body></html>\n",
+    });
+    const { stdout, stderr, refused, exitCode } = await runFixture(String(dir));
+
+    expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
+      stdout: [
+        { status: 500, body: "" },
+        { afterwards: 200, html: true },
+      ],
+      // The development server prints the build error.
+      stderr: expect.stringContaining(
+        "Failed to start the bundler thread: Resource temporarily unavailable (os error 11)",
+      ),
       refused: ATTEMPTS_PER_START,
       exitCode: 0,
     });

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -161,6 +161,8 @@ async function runFixture(
 ) {
   const env: Record<string, string | undefined> = {
     ...bunEnv,
+    // The assertions match the strerror text of libc, which follows LC_MESSAGES.
+    LC_ALL: "C",
     LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
     REFUSE_THREADS_WHILE_EXISTS: join(dir, "refuse-threads"),
     // Without the fix the child crashes. Never upload that.

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -110,8 +110,9 @@ print({ afterwards: afterwards.status, html: (await afterwards.text()).includes(
 
 // The read runs on a work pool thread, so a regular file is read first, while
 // that thread can still be started. The pipe has no data, so the next read
-// parks on the IO thread, which is the one that is refused. The process exits
-// inside the call.
+// parks on the IO thread, which is the one that is refused (by stack size: the
+// pool may start one more worker for the read). The process exits inside the
+// call.
 const STDIN_FIXTURE = /* js */ `
 ${WHILE_REFUSED}
 await Bun.file(import.meta.path).text();
@@ -141,12 +142,18 @@ print({ afterwards: await Bun.spawn({ cmd: ["sleep", "0"], stdio }).exited });
 // The schedule of bun_threading::spawn_with_retry.
 const ATTEMPTS_PER_START = 20;
 
-// bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE, which the HTTP client
-// thread asks for. `bun install` runs no JS that could arm the marker at the
-// right moment, so the marker exists from the start, and the stack size singles
-// the HTTP thread out: the allocators start their scavenger threads before it
-// (with the default stack) and abort when one of those is refused.
+// With REFUSE_THREADS_WITH_STACK_SIZE the shim refuses only the thread that asks
+// for that stack size, which singles one of Bun's threads out from the others
+// that may start in the same window. The sizes are the ones the sources ask for.
+// bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE. `bun install` runs no
+// JS that could arm the marker, so the marker exists from the start, and the
+// size keeps the allocators' threads (default stack) out, which abort when
+// refused.
 const HTTP_THREAD_STACK_SIZE = 4 * 1024 * 1024;
+// src/io/lib.rs
+const IO_THREAD_STACK_SIZE = 2 * 1024 * 1024;
+// WaiterThreadPosix::STACK_SIZE in src/spawn/process.rs
+const WAITER_THREAD_STACK_SIZE = 512 * 1024;
 
 async function runFixture(
   dir: string,
@@ -349,7 +356,10 @@ test.concurrent.skipIf(!canRun)(
   async () => {
     using dir = tempDir("refuse-threads-spawn", { "fixture.js": SPAWN_FIXTURE });
     const { stdout, stderr, refused, exitCode } = await runFixture(String(dir), {
-      env: { BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" },
+      env: {
+        BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1",
+        REFUSE_THREADS_WITH_STACK_SIZE: String(WAITER_THREAD_STACK_SIZE),
+      },
     });
 
     expect({ stdout: jsonLines(stdout), stderr, refused, exitCode }).toEqual({
@@ -379,6 +389,7 @@ test.concurrent.skipIf(!canRun)(
   async () => {
     using dir = tempDir("refuse-threads-stdin", { "fixture.js": STDIN_FIXTURE });
     const { stdout, stderr, refused, exitCode, signalCode } = await runFixture(String(dir), {
+      env: { REFUSE_THREADS_WITH_STACK_SIZE: String(IO_THREAD_STACK_SIZE) },
       stdin: "pipe",
       exitsMidway: true,
     });

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -129,17 +129,24 @@ console.log("unreachable");
 // The schedule of bun_threading::spawn_with_retry.
 const ATTEMPTS_PER_START = 20;
 
-async function runFixture(dir: string, options: { stdin?: "pipe" } = {}) {
+async function runFixture(dir: string, options: { stdin?: "pipe"; exitsMidway?: boolean } = {}) {
+  const env: Record<string, string | undefined> = {
+    ...bunEnv,
+    LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
+    REFUSE_THREADS_WHILE_EXISTS: join(dir, "refuse-threads"),
+    // Without the fix the child crashes. Never upload that.
+    BUN_ENABLE_CRASH_REPORTING: "0",
+  };
+  if (options.exitsMidway) {
+    // The child exits from inside a read, so the natives that its JS objects
+    // and the read still own are never freed. LeakSanitizer cannot see
+    // through JSC cells to them and would report them (last option wins).
+    env.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":");
+  }
   await using proc = Bun.spawn({
     cmd: [bunExe(), "fixture.js"],
     cwd: dir,
-    env: {
-      ...bunEnv,
-      LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
-      REFUSE_THREADS_WHILE_EXISTS: join(dir, "refuse-threads"),
-      // Without the fix the child crashes. Never upload that.
-      BUN_ENABLE_CRASH_REPORTING: "0",
-    },
+    env,
     stdin: options.stdin,
     stdout: "pipe",
     stderr: "pipe",
@@ -259,7 +266,10 @@ test.concurrent.skipIf(!canRun)(
   "a read that needs the IO thread exits with an error when it cannot be started",
   async () => {
     using dir = tempDir("refuse-threads-stdin", { "fixture.js": STDIN_FIXTURE });
-    const { stdout, stderr, refused, exitCode, signalCode } = await runFixture(String(dir), { stdin: "pipe" });
+    const { stdout, stderr, refused, exitCode, signalCode } = await runFixture(String(dir), {
+      stdin: "pipe",
+      exitsMidway: true,
+    });
 
     expect({ stdout, stderr, refused, exitCode, signalCode }).toEqual({
       stdout: "reading stdin\n",

--- a/test/js/bun/sys/thread-spawn-fail.test.ts
+++ b/test/js/bun/sys/thread-spawn-fail.test.ts
@@ -121,13 +121,24 @@ print(await whileRefused(() => Bun.stdin.text()));
 // The schedule of bun_threading::spawn_with_retry.
 const ATTEMPTS_PER_START = 20;
 
-async function runFixture(dir: string, options: { stdin?: "pipe"; exitsMidway?: boolean } = {}) {
+// bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE, which the HTTP client
+// thread asks for. `bun install` runs no JS that could arm the marker at the
+// right moment, so the marker exists from the start, and the stack size singles
+// the HTTP thread out: the allocators start their scavenger threads before it
+// (with the default stack) and abort when one of those is refused.
+const HTTP_THREAD_STACK_SIZE = 4 * 1024 * 1024;
+
+async function runFixture(
+  dir: string,
+  options: { args?: string[]; env?: Record<string, string>; stdin?: "pipe"; exitsMidway?: boolean } = {},
+) {
   const env: Record<string, string | undefined> = {
     ...bunEnv,
     LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
     REFUSE_THREADS_WHILE_EXISTS: join(dir, "refuse-threads"),
     // Without the fix the child crashes. Never upload that.
     BUN_ENABLE_CRASH_REPORTING: "0",
+    ...options.env,
   };
   if (options.exitsMidway) {
     // The child exits from inside a read, so the natives that its JS objects
@@ -136,7 +147,7 @@ async function runFixture(dir: string, options: { stdin?: "pipe"; exitsMidway?: 
     env.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":");
   }
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "fixture.js"],
+    cmd: [bunExe(), ...(options.args ?? ["fixture.js"])],
     cwd: dir,
     env,
     stdin: options.stdin,
@@ -219,6 +230,33 @@ test.concurrent.skipIf(!canRun)("auto-install reports a refused HTTP thread as a
     exitCode: 0,
   });
 });
+
+test.concurrent.skipIf(!canRun)(
+  "bun install prints an error and exits 1 when the HTTP thread cannot be started",
+  async () => {
+    using dir = tempDir("refuse-threads-install", {
+      "package.json": JSON.stringify({ name: "refuse-threads", dependencies: {} }),
+      "refuse-threads": "",
+    });
+    const { stdout, stderr, refused, exitCode, signalCode } = await runFixture(String(dir), {
+      args: ["install"],
+      env: {
+        REFUSE_THREADS_WITH_STACK_SIZE: String(HTTP_THREAD_STACK_SIZE),
+        BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+      },
+    });
+
+    expect({ stdout, stderr, refused, exitCode, signalCode }).toEqual({
+      stdout: "",
+      stderr:
+        `error: ${HTTP_THREAD_REFUSED}\n` +
+        "note: The process is out of memory, or it reached a thread limit (ulimit -u, or the pids limit of its cgroup).\n",
+      refused: ATTEMPTS_PER_START,
+      exitCode: 1,
+      signalCode: null,
+    });
+  },
+);
 
 test.concurrent.skipIf(!canRun)("S3 requests fail when the HTTP thread cannot be started", async () => {
   using dir = tempDir("refuse-threads-s3", { "fixture.js": S3_FIXTURE });


### PR DESCRIPTION
### Problem
- When the OS refuses the HTTP client thread, bun files a crash report: `panic: Failed to start HTTP Client thread: The paging file is too small for this operation to complete. (os error 1455)`. Sentry has about 39,700 events in 112 locale groups, among them [BUN-2V2S](https://bun-p9.sentry.io/issues/BUN-2V2S/), [BUN-3PM1](https://bun-p9.sentry.io/issues/BUN-3PM1/) (via `fetch()`), [BUN-4Q06](https://bun-p9.sentry.io/issues/BUN-4Q06/) (Windows arm64, via `fetch()`) and [BUN-3RPP](https://bun-p9.sentry.io/issues/BUN-3RPP/) (Linux, `EAGAIN`). The machine is out of commit or threads, not bun. Fixes #20797.
- Cause: `src/http/HTTPThread.rs:1215` panics when the spawn fails. So do `src/bundler/BundleThread.rs:382` (`Bun.build()`), `src/io/lib.rs:888` (the POSIX IO thread) and `src/spawn/process.rs:1287` (the waitpid thread of `Bun.spawn()` without pidfd, `Failed to start WaiterThread`, 6 more groups).

### Fix
- `bun_threading::spawn_with_retry` (`src/threading/spawn.rs`) retries on the schedule of the Go runtime, 20 attempts with n ms after the n-th failure. Then it returns a `SpawnError`: the text of the OS error, an errno, a hint for the CLI.
- `http_thread::init` returns it, and the next call tries again. `fetch()` rejects with a `TypeError` (`code` `EAGAIN` or `ENOMEM`), S3 fails through its callbacks, `bun install` prints it and exits 1, auto-install reports a resolve error. The other callers are in the notes.
- `Bun.build()` rejects. An HTML route answers `500 Build Failed` (before: 200, empty body). `Bun.spawn()` rejects `exited` with the `EAGAIN` of `pthread_create`. The IO thread prints the error and exits 1. The file watcher drops its own retry and errno mapping for the helper and the new `SystemErrno::from_io_error`.
- Verified: `test/js/bun/sys/thread-spawn-fail.test.ts`, 8 cases, all crash on 1.4.0, and `test/cli/watch/watch.test.ts`. Also the fetch, resolve, bun-build-api, bun-serve-html, stdin and spawn suites.

### Background
- Bun starts these threads on first use. Every entry point calls `init` first. `init` returned nothing, because a failure had one outcome.
- `init` writes the `HTTP_THREAD` static before the spawn, because the new thread fills it in. A failed spawn keeps it, so a retry repeats only the spawn. The waiter thread keeps its eventfd the same way.
- The resolver reaches the installer through a link-time function. It now returns `bun_resolver::Error`, a type both crates name, with a new `HttpThread` variant for the message.
- The test injects the failure with an LD_PRELOAD shim on `pthread_create` (Linux glibc only). Windows takes the same code path on x64 and arm64: `Builder::spawn` returns the OS error there too.

<details><summary>Notes</summary>

- Other callers of `http_thread::init`: `send_sync` propagates the error, which covers `bun create` and the `bun build --compile` download. `bun upgrade` prints the full error first, then its own "upgrade manually" message. The warm-up calls in `bun test`, `bun create` and `--preconnect` ignore it, because the request that needs the thread reports it. The markdown image prefetch skips its downloads.
- The four groups named in the reports: BUN-2V2S (27,300 events, builds before the Rust port print `Unexpected`), BUN-3PM1 (1,250, English locale, via `fetch()`), BUN-3RPP and BUN-3QQW (Linux, `EAGAIN`), BUN-4Q06 (Windows arm64, Swedish locale, 1.4.0, via `fetch()` through `FetchTasklet::queue`, the path that now rejects the promise). #20797 is BUN-PF3, the `SystemResources` form of the same panic on Linux.
- The Sentry groups: the search `Failed to start HTTP Client thread` in the bun project lists all of them (one unrelated match, "Cannot Load CoreFoundation"). By message: `Unexpected` and `SystemResources` from builds before the Rust port, 14 groups, 35,900 events. `os error 1455` in about 90 locale groups, 3,700 events. `os error 11` (Linux `EAGAIN`) in 7 groups, 80 events. One event with `os error 1450`. Counted on 2026-08-21. Short ids: BUN-2V2S, BUN-2V5E, BUN-2W9M, BUN-3PM1, BUN-3PNC, BUN-3PK4, BUN-3QKZ, BUN-3Q6A, BUN-3SZP, BUN-3Q6N, BUN-3K0M, BUN-3QKS, BUN-3K32, BUN-3MAC, BUN-3QQW, BUN-36PC, BUN-2VAD, BUN-2VMF, BUN-3QBS, BUN-3TF5, BUN-2VZE, BUN-3KH4, BUN-3K20, BUN-3M9Q, BUN-3S4Q, BUN-3M52, BUN-4AZ8, BUN-3KQP, BUN-3FXR, BUN-31DC, BUN-3RPP, BUN-4CEY, BUN-4B18, BUN-3KRZ, BUN-3KCY, BUN-4BRK, BUN-3ZA4, BUN-3K08, BUN-4DAA, BUN-4CXH, BUN-4CGX, BUN-3NB4, BUN-4C57, BUN-3Y8T, BUN-3WFV, BUN-3SZB, BUN-3MFK, BUN-4CMD, BUN-4BVK, BUN-3QS4, BUN-3KSS, BUN-4D64, BUN-4D5A, BUN-4CVV, BUN-4BXP, BUN-4BRF, BUN-4B34, BUN-4B0N, BUN-445X, BUN-3P07, BUN-4CWT, BUN-4CJX, BUN-4CFC, BUN-4CB3, BUN-3VKA, BUN-3PCT, BUN-3M65, BUN-3J97, BUN-3C13, BUN-4M7K, BUN-4M0Q, BUN-4DE6, BUN-4D87, BUN-4D4N, BUN-4CSW, BUN-4BTW, BUN-4BSJ, BUN-44PA, BUN-44AV, BUN-41M1, BUN-41J6, BUN-3W8B, BUN-3TT1, BUN-3RR6, BUN-3REF, BUN-4M8T, BUN-4M3V, BUN-4KSN, BUN-4F1S, BUN-4ERM, BUN-4DEA, BUN-4D49, BUN-4D0N, BUN-4CXJ, BUN-4C0F, BUN-4C08, BUN-4BSP, BUN-4BB4, BUN-4AZS, BUN-4A54, BUN-43VP, BUN-41YZ, BUN-3ZKH, BUN-3YNA, BUN-3WVR, BUN-3WEW, BUN-3QCQ, BUN-3NZP, BUN-3MH4, BUN-3HTT, BUN-3C5W, BUN-3C3D, BUN-3391.
- Related, not covered here: [BUN-4KRY](https://bun-p9.sentry.io/issues/7680098104/) (Windows, 20 events since 2026-08-19, mostly standalone executables) is the same commit-limit condition at startup. `VM::VM` takes the `JSLockHolder`, `setStackPointerAtVMEntry` calls `updateStackLimits`, and `preCommitStackMemory` touches the main thread's stack down to the soft limit, about `maxPerThreadStackUsage` (5 MB, `OptionsList.h:119`). The link flag commits 2 MB. When the host cannot commit the rest, the guard page cannot move and Windows raises a stack overflow, so the report says `Stack overflow` in `JSC::preCommitStackMemory`. The gate in the fork's `updateStackLimits` (`VM.cpp:1297`) skips only the pre-entry commit. These events take the entry path. A fix is a WebKit change or a larger `/STACK` commit, not a thread spawn.
- Supersedes #32245 (HTTP, sticky failure, no retry), #38766 (HTTP, exit only) and #37753 (bundle thread), closed in favour of this PR, and #35218 (a third retry policy for the watcher). Related PRs that stay open: #33845 (IO thread, fails the read, can call `spawn_with_retry` inside its fallible `load`), #37769 (the waker of the bundle thread, needs a rebase onto `singleton::start`), #37738 (a thread pool without workers, its `from_io_error` is the one added here) and #36985 (the crash handler text for the threads that WTF and libpas start, which cannot fail softly). #37738 (a thread pool that never gets a worker hangs) is a different bug and still applies. The scenarios of the three superseded PRs' tests (`bun install` with EAGAIN, EPERM and an unmapped code, `fetch.preconnect()`, `Bun.build()` with both `throw` settings, ENOMEM, an unmapped code, a retry, an exit right after the failure, an HTML route) were run against a build of this branch with the expected messages adapted, and pass. #37753's `Watcher.rs` hunk only refactors an error path that main already has.
- The shim follows `test/cli/watch/watch.test.ts`, which also preloads a `pthread_create` shim.
- The waiter thread is on the same path as the Linux `EAGAIN` reports: containers with a pids limit are also where pidfd is blocked by seccomp. Sentry groups: BUN-3V91, BUN-37Y8, BUN-2XE1, BUN-4KN0, BUN-3MCY, BUN-2XXJ (15 events in 90 days). `exited` rejects through the existing `Status::Err` path that a failed pidfd registration takes, so the test sees the same error an `EMFILE` there produces. The child stays alive in that case, as before for `Status::Err`.
- The watcher kept a one-shot retry with an in-tree reason: a `--watch` reload execve's and the first `pthread_create` can see a transient `EAGAIN` before the threads of the old image are reaped. That is the transient case the schedule covers.
- Prior art for the retry: Go retries `pthread_create` on `EAGAIN` (golang/go#18146, golang/go#49438) and `_beginthread`/`CreateThread` on `EACCES`/`ERROR_ACCESS_DENIED` (golang/go#52572), 20 times with linear backoff, and still aborts afterwards. Chromium does not retry and classifies `ERROR_COMMITMENT_LIMIT` as OOM. This PR retries on every code, since 1455 is the code in the reports and a retry costs at most 190 ms on a machine that is about to get an error anyway. The retries sleep on the calling thread, so each failing `fetch()` blocks for that long.
- On Windows, a code without an errno (1455) maps to `ENOMEM`. The message keeps the text of the OS.
- A refused thread is not sticky in the auto-installer, unlike a failed one-time init: the HTTP thread is started before the sticky part.
- Threads that JSC and bmalloc start lazily are not covered: WTF `RELEASE_ASSERT`s on a failed thread creation, and the debug build of libpas asserts when its scavenger thread is refused. The test forces a collection right before it arms the shim, which starts those threads. They stay up for 10 s. `bun install` runs no JS, and with the shim armed from process start the debug build dies in libpas before it reaches the HTTP thread, so for that case the shim refuses only the thread that asks for the HTTP thread's 4 MiB stack (`REFUSE_THREADS_WITH_STACK_SIZE`). The scavenger threads take the default stack.
- `fetch()` builds its rejection with `JSPromise::rejected_promise`, not the deprecated helper the neighbouring early returns use, so an unhandled rejection is reported, and the test checks that. The existing early returns are silent when unhandled. That is reported separately.
- The `/STACK:0x1200000,0x200000` link flag (scripts/build/flags.ts) commits 2 MB per thread on Windows, which is what makes the first lazily started thread the one to hit the commit limit. #15985 raised it from 1 MB. Left unchanged here.
- The IO and the `Bun.spawn()` cases refuse by stack size (2 MiB and 512 KiB). CI once counted 21 refusals in the IO case: the work pool may start one more worker for the read inside the window. With the filter the count is exact, also in 5 of 5 runs without the warm-up read. A refused pool worker without the filter hangs or asserts the fixture, which is #37738.
- `HTMLBundle` reports the refused thread through `set_build_error`, which main added while this PR was open. The second rebase (onto 4bb20e529a) met main's `JSBundleCompletionTask::new` + `schedule` split and the `ThisPtr` receiver of `on_plugins_resolved`: `singleton::start` runs before `new`, and `schedule` documents that precondition. The third rebase (onto 82123d3a61) had one import conflict in `HTTPThread.rs`, and `jsc::SystemError` fields are plain `bun_core::String` now, so the `.into()` calls in the fetch and `Bun.build()` rejections are gone.
- CI state at c19819379e (before the second rebase): the GitHub checks (clippy, miri, format, lints) pass. On Buildkite (build 102686) the only tests that fail on every retry are the two that clone from gitlab.com, `bun-install.test.ts` (its four gitlab cases) and `complex-workspace.test.ts`, which get HTTP 403 from gitlab.com on every lane since build 102676. The same code passed them in build 102673. Both are reported separately. Everything else in the build passed, on the first run or on a retry, and the new test file passes on every lane in every run.
- `fetch-preconnect.test.ts` fails in this container with the released bun as well (`localhost` resolution). `bun-write.test.js` times out on its large-file cases in a debug build and passes in isolation. Both unrelated.
- `cargo check` of the touched crates passes for `x86_64-pc-windows-msvc`, `aarch64-apple-darwin` and `x86_64-unknown-freebsd`. `cargo clippy` and `cargo fmt` are clean, and `test/internal/source-lints` passes. The new test passed 10 of 10 runs, and 4 instances at once. The `bun install` case passed 12 of 12 runs, the `Bun.spawn()` case 10 of 10.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/sys/thread-spawn-fail.test.ts, test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->
