### PR TITLE
build: keep frame pointers on Windows with clang-cl

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -384,9 +384,10 @@ export const globalFlags: Flag[] = [
     desc: "Keep frame pointers (for profiling and backtraces)",
   },
   {
-    flag: "/Oy-",
+    // clang-cl drops /Oy- on x64 and keeps only non-leaf frames on arm64
+    flag: ["/clang:-fno-omit-frame-pointer", "/clang:-mno-omit-leaf-frame-pointer"],
     when: c => c.windows,
-    desc: "Keep frame pointers",
+    desc: "Keep frame pointers (for profiling and backtraces)",
   },
 
   // ─── Visibility ───

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -454,7 +454,7 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   if ((cfg.linux && cfg.abi !== "android") || cfg.freebsd) {
     rustflags.push("-Crelocation-model=static");
   }
-  // Keep frame pointers — matches the C++ side's `-fno-omit-frame-pointer` / `/Oy-`
+  // Keep frame pointers — matches the C++ side's `-fno-omit-frame-pointer`
   // (flags.ts:293-301). Needed so profilers and crash backtraces can walk Rust frames.
   rustflags.push("-Cforce-frame-pointers=yes");
   // Parallel frontend: rustc's default is single-threaded for parse / macro


### PR DESCRIPTION
### What does this PR do?

`scripts/build/flags.ts` passed `/Oy-` to clang-cl to keep frame pointers. clang-cl drops that flag on x64 (`-mframe-pointer=none`), and on arm64 it keeps only non-leaf frames.

This replaces it with `/clang:-fno-omit-frame-pointer /clang:-mno-omit-leaf-frame-pointer`, which gives `-mframe-pointer=all` on both arches. This matches the unix flags and the Rust `-Cforce-frame-pointers=yes`.

Checked with `clang-cl -###` on LLVM 19, 21 and 22:

| flags | x64 | arm64 |
|---|---|---|
| `/O2 /Oy-` | none | non-leaf |
| `/O2 /clang:-fno-omit-frame-pointer /clang:-mno-omit-leaf-frame-pointer` | all | all |

Companion WebKit change: oven-sh/WebKit `claude/windows-frame-pointers` (same issue in `OptionsMSVC.cmake`).

### How did you verify your code works?

`clang-cl -###` output above. No Windows build on this host.