### PR TITLE
node:fs: keep the lazy stream accessors working on a sealed or frozen exports object

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1273,6 +1273,14 @@ function globSync(pattern: string | string[], options): string[] {
   return Array.from(lazyGlob().globSync(pattern, options ?? kEmptyObject));
 }
 
+// The stream classes are accessors on `exports` so that loading node:fs does not load node:stream. The first read, or
+// an assignment, replaces the accessor with a data property. Once user code has sealed or frozen `exports` the accessor
+// is not configurable: Reflect.defineProperty returns false instead of throwing and the accessor stays in place.
+function materializeStream(name: string, value: unknown) {
+  Reflect.defineProperty(exports, name, { value, writable: true, configurable: true });
+  return value;
+}
+
 var exports = {
   appendFile,
   appendFileSync,
@@ -1378,54 +1386,34 @@ var exports = {
   Dir,
   Stats,
   get ReadStream() {
-    return (exports.ReadStream = require("internal/fs/streams").ReadStream);
+    return materializeStream("ReadStream", require("internal/fs/streams").ReadStream);
   },
   set ReadStream(value) {
-    Object.defineProperty(exports, "ReadStream", {
-      value,
-      writable: true,
-      configurable: true,
-    });
+    materializeStream("ReadStream", value);
   },
   get WriteStream() {
-    return (exports.WriteStream = require("internal/fs/streams").WriteStream);
+    return materializeStream("WriteStream", require("internal/fs/streams").WriteStream);
   },
   set WriteStream(value) {
-    Object.defineProperty(exports, "WriteStream", {
-      value,
-      writable: true,
-      configurable: true,
-    });
+    materializeStream("WriteStream", value);
   },
   get FileReadStream() {
-    return (exports.FileReadStream = require("internal/fs/streams").ReadStream);
+    return materializeStream("FileReadStream", require("internal/fs/streams").ReadStream);
   },
   set FileReadStream(value) {
-    Object.defineProperty(exports, "FileReadStream", {
-      value,
-      writable: true,
-      configurable: true,
-    });
+    materializeStream("FileReadStream", value);
   },
   get Utf8Stream() {
-    return (exports.Utf8Stream = require("internal/streams/fast-utf8-stream"));
+    return materializeStream("Utf8Stream", require("internal/streams/fast-utf8-stream"));
   },
   set Utf8Stream(value) {
-    Object.defineProperty(exports, "Utf8Stream", {
-      value,
-      writable: true,
-      configurable: true,
-    });
+    materializeStream("Utf8Stream", value);
   },
   get FileWriteStream() {
-    return (exports.FileWriteStream = require("internal/fs/streams").WriteStream);
+    return materializeStream("FileWriteStream", require("internal/fs/streams").WriteStream);
   },
   set FileWriteStream(value) {
-    Object.defineProperty(exports, "FileWriteStream", {
-      value,
-      writable: true,
-      configurable: true,
-    });
+    materializeStream("FileWriteStream", value);
   },
   promises,
 };

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -198,6 +198,60 @@ test.concurrent("import() namespace: same export list as before, enumerating it 
   });
 });
 
+// Object.seal / Object.freeze on the exports object (a lockdown helper, or a library freezing what it re-exports) makes
+// the accessors non-configurable, so they can never be replaced by the value they load. They still have to hand it
+// out: to require() callers, to every module that links one of these names, and to whatever enumerates a namespace.
+// The replacement used to be an Object.defineProperty that threw "Attempting to change configurable attribute of
+// unconfigurable property" out of every one of those reads.
+for (const lock of ["seal", "freeze"] as const) {
+  test.concurrent(`the accessors keep working after Object.${lock} of the exports object`, async () => {
+    const result = await runEntry(
+      `
+        const fs = require("node:fs");
+        Object.${lock}(fs);
+        // helper.mjs imports node:fs, so every ES module import of the builtin below happens after the ${lock}.
+        const { STREAMS, kinds, print } = await import("./helper.mjs");
+        const names = Object.fromEntries(STREAMS.map(name => [name, fs[name].name]));
+        // Linking streams.mjs is what reads ReadStream and FileWriteStream on its behalf.
+        const { ReadStream, FileWriteStream } = await import("./streams.mjs");
+        const ns = await import("node:fs");
+        const namespaceKeys = Object.keys(ns);
+        fs.WriteStream = "assigned";
+        print({
+          names,
+          secondReadIsStable: fs.ReadStream === fs.ReadStream && fs.FileReadStream === fs.ReadStream,
+          linked: ReadStream === fs.ReadStream && FileWriteStream === fs.FileWriteStream,
+          keysMatch: namespaceKeys.sort().join() === [...Object.keys(fs), "default"].sort().join(),
+          namespaceHasTheClasses: STREAMS.every(name => typeof ns[name] === "function" && ns[name] === fs[name]),
+          assignmentIsIgnored: fs.WriteStream === FileWriteStream,
+          stillAccessors: kinds(),
+        });
+      `,
+      {
+        "streams.mjs": `
+          import { ReadStream, FileWriteStream } from "node:fs";
+          export { ReadStream, FileWriteStream };
+        `,
+      },
+    );
+    expect(result).toEqual({
+      names: {
+        ReadStream: "ReadStream",
+        WriteStream: "WriteStream",
+        FileReadStream: "ReadStream",
+        FileWriteStream: "WriteStream",
+        Utf8Stream: "Utf8Stream",
+      },
+      secondReadIsStable: true,
+      linked: true,
+      keysMatch: true,
+      namespaceHasTheClasses: true,
+      assignmentIsIgnored: true,
+      stillAccessors: kinds(),
+    });
+  });
+}
+
 test.concurrent("re-exports bind through to the builtin's own binding", async () => {
   const result = await runEntry(
     `


### PR DESCRIPTION
### Problem
- After `Object.freeze(require("node:fs"))` (or `Object.seal`), every read of `fs.ReadStream`, `WriteStream`, `FileReadStream`, `FileWriteStream` or `Utf8Stream` throws `TypeError: Attempting to change configurable attribute of unconfigurable property`. The same throw rejects every module that links `import { ReadStream } from "node:fs"` and fails `Object.keys()` of the `import("node:fs")` namespace. Node returns the classes. Bun 1.4.0 and main behave the same.
- Cause: the five accessors in `src/js/node/fs.ts:1388` replace themselves with a data property on the first read. The replacement is an `Object.defineProperty` call. On a sealed or frozen object the accessor is not configurable, so the call throws out of the getter.

### Fix
- The getters and setters call one helper, `materializeStream`. It uses `Reflect.defineProperty` and returns the value. On a configurable accessor the result is the same data property as before. On a non-configurable one `Reflect.defineProperty` returns false, the accessor stays, and the getter still returns the class.
- On a locked object an assignment such as `fs.WriteStream = x` now does nothing, which is what a frozen data property does. Before, it threw the same TypeError.
- Verified: two new tests in `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` (seal and freeze) fail on 1.4.0 and pass with the fix. The rest of that file (the laziness readouts depend on the replacement still happening) and `test/js/node/fs/fs.test.ts` pass.

### Background
- `node:fs` keeps its stream classes behind accessors so that loading `node:fs` does not load `node:stream`. The first read loads `internal/fs/streams` and stores the class on the exports object.
- A builtin's exports object becomes an ES module namespace. Since #39812 an export backed by one of Bun's own getters is read when a module links to it, or when the namespace property is read. A throw in the getter therefore fails the importer, not only the `require()` caller.
- `Reflect.defineProperty` is `[[DefineOwnProperty]]` with the boolean result exposed. `Object.defineProperty` turns a false result into a TypeError.

<details><summary>Notes</summary>

Repro on 1.4.0:

```js
Object.freeze(require("node:fs"));
require("node:fs").ReadStream;            // throws
import("node:fs").then(m => m.ReadStream); // throws on the read
import("./a.mjs");                         // a.mjs: import { ReadStream } from "node:fs"  -> rejects
```

`import { readFileSync } from "node:fs"` still worked after a freeze because `readFileSync` is a plain data property. `Object.preventExtensions` also worked: it leaves the accessors configurable. A user-defined accessor on the exports object whose getter throws still fails the import (#39812 reads those at load time). That is unchanged and out of scope here.

Suites run with the debug build: `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` (25 pass), `test/js/node/fs/fs.test.ts` (517 pass, 6 skip), `test/js/node/test/parallel/test-fastutf8stream-write.js`, `test/js/bun/json5/json5-test-suite.test.ts`.
</details>
