### PR TITLE
watch: park a thread that crashes while the watcher thread is in execve

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -303,9 +303,8 @@ static void unset_cloexec(int fd)
 
 static pthread_t reloading_thread;
 
-// While reloading_thread is inside execve, the kernel fails clone() on every other thread with
-// EAGAIN, and WTF::Thread::create aborts on that. Such a thread parks here until the execve tears
-// it down. A crash on reloading_thread itself stays fatal.
+// The execve on reloading_thread makes clone() fail with EAGAIN on every other thread, and
+// WTF::Thread::create aborts on that. The thread parks here and the execve tears it down.
 static void park_thread_crashing_during_reload(int sig)
 {
     if (pthread_equal(pthread_self(), reloading_thread)) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -6,6 +6,9 @@
 #include <wtf/WTFConfig.h>
 #include <sys/resource.h>
 #include <fcntl.h>
+#include <pthread.h>
+#include <algorithm>
+#include <iterator>
 #include <sys/stat.h>
 #include <signal.h>
 #include <unistd.h>
@@ -298,6 +301,35 @@ static void unset_cloexec(int fd)
     fcntl(fd, F_SETFD, flags);
 }
 
+// The thread that is about to execve. Set by on_before_reload_process_posix.
+static pthread_t reloading_thread;
+
+// Handler for the crash signals between on_before_reload_process_posix and execve.
+//
+// The other threads keep running until execve passes its point of no return, and while the
+// reloading thread is inside execve the kernel fails every clone() they make with EAGAIN
+// (kernel/fork.c copy_fs(), while fs->in_exec is set). A GC that starts its marker threads in
+// that window aborts in WTF::Thread::create. Park the thread instead: execve tears it down with
+// the rest of the old image and the reload goes through. The crash handler gets its threads out
+// of the way too (maybe_handle_panic_during_process_reload), but ASAN builds install no crash
+// handler, and SA_RESETHAND limits it to one thread. A crash on the reloading thread itself is
+// fatal as usual: parking it would hang the reload.
+static void park_thread_crashing_during_reload(int sig)
+{
+    if (pthread_equal(pthread_self(), reloading_thread)) {
+        struct sigaction dfl {};
+        dfl.sa_handler = SIG_DFL;
+        sigemptyset(&dfl.sa_mask);
+        sigaction(sig, &dfl, nullptr);
+        // The signal is blocked while its handler runs, so this is delivered, with the default
+        // action, as soon as the handler returns.
+        raise(sig);
+        return;
+    }
+    for (;;)
+        pause();
+}
+
 extern "C" void on_before_reload_process_posix()
 {
     unset_cloexec(STDIN_FILENO);
@@ -321,6 +353,17 @@ extern "C" void on_before_reload_process_posix()
             unset_cloexec(static_cast<int>(fd));
     }
 
+    // See park_thread_crashing_during_reload. SIGSEGV and SIGBUS are not parked: JSC's handlers
+    // for them stay installed (see below) and chain to the crash handler, which steps aside on
+    // its own during a reload.
+    static const int parked_crash_signals[] = { SIGABRT, SIGILL, SIGTRAP, SIGFPE };
+    reloading_thread = pthread_self();
+    struct sigaction park {};
+    park.sa_handler = park_thread_crashing_during_reload;
+    sigemptyset(&park.sa_mask);
+    for (int s : parked_crash_signals)
+        sigaction(s, &park, nullptr);
+
     // Reset caught dispositions so a SIGTERM arriving between here and execve isn't queued-then-
     // lost. Inherited SIG_IGN is left alone. SIGSEGV/SIGBUS/RT/sigThreadSuspendResume are left
     // for execve to reset atomically — resetting them here races JSC's sampler/GC threads fatally.
@@ -329,6 +372,8 @@ extern "C" void on_before_reload_process_posix()
     sigemptyset(&sa.sa_mask);
     for (int s = 1; s < NSIG; s++) {
         if (s == SIGKILL || s == SIGSTOP || s == SIGSEGV || s == SIGBUS)
+            continue;
+        if (std::find(std::begin(parked_crash_signals), std::end(parked_crash_signals), s) != std::end(parked_crash_signals))
             continue;
 #if OS(LINUX)
         if (s == g_wtfConfig.sigThreadSuspendResume)

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -301,19 +301,11 @@ static void unset_cloexec(int fd)
     fcntl(fd, F_SETFD, flags);
 }
 
-// The thread that is about to execve. Set by on_before_reload_process_posix.
 static pthread_t reloading_thread;
 
-// Handler for the crash signals between on_before_reload_process_posix and execve.
-//
-// The other threads keep running until execve passes its point of no return, and while the
-// reloading thread is inside execve the kernel fails every clone() they make with EAGAIN
-// (kernel/fork.c copy_fs(), while fs->in_exec is set). A GC that starts its marker threads in
-// that window aborts in WTF::Thread::create. Park the thread instead: execve tears it down with
-// the rest of the old image and the reload goes through. The crash handler gets its threads out
-// of the way too (maybe_handle_panic_during_process_reload), but ASAN builds install no crash
-// handler, and SA_RESETHAND limits it to one thread. A crash on the reloading thread itself is
-// fatal as usual: parking it would hang the reload.
+// While reloading_thread is inside execve, the kernel fails clone() on every other thread with
+// EAGAIN, and WTF::Thread::create aborts on that. Such a thread parks here until the execve tears
+// it down. A crash on reloading_thread itself stays fatal.
 static void park_thread_crashing_during_reload(int sig)
 {
     if (pthread_equal(pthread_self(), reloading_thread)) {
@@ -321,8 +313,7 @@ static void park_thread_crashing_during_reload(int sig)
         dfl.sa_handler = SIG_DFL;
         sigemptyset(&dfl.sa_mask);
         sigaction(sig, &dfl, nullptr);
-        // The signal is blocked while its handler runs, so this is delivered, with the default
-        // action, as soon as the handler returns.
+        // Blocked until this handler returns, then delivered with the default action.
         raise(sig);
         return;
     }
@@ -353,9 +344,7 @@ extern "C" void on_before_reload_process_posix()
             unset_cloexec(static_cast<int>(fd));
     }
 
-    // See park_thread_crashing_during_reload. SIGSEGV and SIGBUS are not parked: JSC's handlers
-    // for them stay installed (see below) and chain to the crash handler, which steps aside on
-    // its own during a reload.
+    // The crash handler's signals, minus SIGSEGV and SIGBUS, which JSC's handlers below keep.
     static const int parked_crash_signals[] = { SIGABRT, SIGILL, SIGTRAP, SIGFPE };
     reloading_thread = pthread_self();
     struct sigaction park {};

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -134,6 +134,21 @@ setInterval(() => {}, 1000);
 // LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux
 // immediately before start()) and fails the very next pthread_create.
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+/** Compiles `dir/shim.c` to a shared object and returns the value to put in LD_PRELOAD. */
+async function compileShim(dir: string): Promise<string> {
+  const shimPath = join(dir, "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(dir, "shim.c"), "-ldl", "-lpthread"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  return bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath;
+}
+
 it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead of panicking in start()", async () => {
   const SHIM_C = /* c */ `
 #define _GNU_SOURCE
@@ -173,23 +188,14 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
     "shim.c": SHIM_C,
     "watchee.js": "console.log('unreachable');\n",
   });
-  const shimPath = join(String(dir), "shim.so");
-  await using ccProc = Bun.spawn({
-    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
-  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  const LD_PRELOAD = await compileShim(String(dir));
 
-  const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
     // --debug-crash-handler-use-trace-string skips the debug build's slow
     // backtrace symbolication so the child exits promptly.
     cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "--watch", "watchee.js"],
     cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+    env: { ...bunEnv, LD_PRELOAD },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -212,8 +218,8 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
 //
 // The LD_PRELOAD shim stands in for the kernel so that the race is deterministic: from the moment
 // bun calls execve() it fails every pthread_create in the process, tells the script to run its
-// first collection, waits for the failed pthread_create and for the abort behind it to land, and
-// only then execs for real.
+// first collection, and execs for real once the crash behind that failure has been parked. bun
+// parks a thread in pause(), which the shim interposes too, so that is directly observable.
 //
 // The JS thread is not necessarily the only thread that crashes in that window (every thread that
 // creates a thread right then fails the same way), and the crash handler, with SA_RESETHAND, used to
@@ -231,20 +237,29 @@ it.skipIf(!isLinux || !cc)(
 #include <pthread.h>
 #include <stdlib.h>
 #include <sys/resource.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 static int (*real_execve)(const char *, char *const *, char *const *);
+static int (*real_pause)(void);
 static volatile int in_execve;
-static volatile int failed_create;
-static volatile int abort_thread_ready;
-static volatile int trap_thread_ready;
+/* The threads that crash: the one whose pthread_create fails, the aborting one, the trapping one. */
+static volatile long crashing[3];
+static volatile long parked[16];
+static volatile int parked_count;
 
-/* Without the fix the abort takes the default action; keep its core file out of CI's crash scan. */
-__attribute__((constructor)) static void no_core(void) {
+__attribute__((constructor)) static void init(void) {
+  /* Without the fix the crashes take the default action; keep the core file out of CI's crash scan. */
   struct rlimit rl = {0, 0};
   setrlimit(RLIMIT_CORE, &rl);
+  /* pause() below runs inside bun's signal handler, where dlsym is not safe. */
+  real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  real_execve = dlsym(RTLD_NEXT, "execve");
+  real_pause = dlsym(RTLD_NEXT, "pause");
 }
+
+static long tid(void) { return syscall(SYS_gettid); }
 
 static void create_marker(const char *env) {
   const char *path = getenv(env);
@@ -252,24 +267,38 @@ static void create_marker(const char *env) {
   if (fd >= 0) close(fd);
 }
 
+/* bun parks a thread that crashes during the reload in pause(). */
+int pause(void) {
+  int i = __sync_fetch_and_add(&parked_count, 1);
+  if (i < 16) parked[i] = tid();
+  return real_pause();
+}
+
+static int is_parked(long t) {
+  int n = parked_count < 16 ? parked_count : 16;
+  for (int i = 0; i < n; i++)
+    if (t && parked[i] == t) return 1;
+  return 0;
+}
+
 static void *abort_thread(void *unused) {
   (void)unused;
+  crashing[1] = tid();
   create_marker("RELOAD_TEST_ABORTED_MARKER");
-  abort_thread_ready = 1;
   abort();
 }
 
 static void *trap_thread(void *unused) {
   (void)unused;
+  crashing[2] = tid();
   create_marker("RELOAD_TEST_TRAPPED_MARKER");
-  trap_thread_ready = 1;
   __builtin_trap();
 }
 
 int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), void *arg) {
   if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
   if (in_execve) {
-    failed_create = 1;
+    crashing[0] = tid();
     create_marker("RELOAD_TEST_FAILED_CREATE_MARKER");
     return EAGAIN;
   }
@@ -278,18 +307,16 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
 
 int execve(const char *path, char *const argv[], char *const envp[]) {
   pthread_t t;
-  if (!real_execve) real_execve = dlsym(RTLD_NEXT, "execve");
-  if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
   in_execve = 1;
   create_marker("RELOAD_TEST_IN_EXECVE_MARKER");
-  for (int i = 0; i < 2000 && !failed_create; i++) usleep(5000);
+  for (int i = 0; i < 10000 && !crashing[0]; i++) usleep(1000);
   real_pthread_create(&t, 0, abort_thread, 0);
   real_pthread_create(&t, 0, trap_thread, 0);
-  for (int i = 0; i < 2000 && !(abort_thread_ready && trap_thread_ready); i++) usleep(5000);
-  /* The thread whose pthread_create failed aborts right away, and the two threads above crash as
-   * soon as they have set their flag. Give the signals time to land: without the fix the first of
-   * them has killed the process long before this returns. */
-  usleep(1000000);
+  /* Without the fix the first crash kills the process while this waits. The deadline only matters
+   * for a build that gets a crashing thread out of the way without pause(); the reload must still
+   * go through then. */
+  for (int i = 0; i < 10000 && !(is_parked(crashing[0]) && is_parked(crashing[1]) && is_parked(crashing[2])); i++)
+    usleep(1000);
   return real_execve(path, argv, envp);
 }
 `;
@@ -307,23 +334,14 @@ int execve(const char *path, char *const argv[], char *const envp[]) {
     });
     // Kept outside the watched directory so that the markers do not show up as file events.
     using markers = tempDir("watch-reload-abort-in-execve-markers", {});
-    const shimPath = join(String(dir), "shim.so");
-    await using ccProc = Bun.spawn({
-      cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
-    if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+    const LD_PRELOAD = await compileShim(String(dir));
 
-    const existing = bunEnv.LD_PRELOAD;
     const proc = spawn({
       cmd: [bunExe(), "--watch", "app.js"],
       cwd: String(dir),
       env: {
         ...bunEnv,
-        LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+        LD_PRELOAD,
         RELOAD_TEST_IN_EXECVE_MARKER: join(String(markers), "in-execve"),
         RELOAD_TEST_FAILED_CREATE_MARKER: join(String(markers), "failed-create"),
         RELOAD_TEST_ABORTED_MARKER: join(String(markers), "aborted"),
@@ -363,6 +381,48 @@ int execve(const char *path, char *const argv[], char *const envp[]) {
   },
   30000,
 );
+
+// The other branch of the same handler: a crash on the reloading thread itself, after the
+// handler is installed, has to stay fatal. Parked, it would leave a watcher that never reloads.
+it.skipIf(!isLinux || !cc)("--watch dies when the watcher thread itself aborts on its way into execve", async () => {
+  using dir = tempDir("watch-reload-abort-on-reloading-thread", {
+    "shim.c": /* c */ `
+#include <stdlib.h>
+#include <sys/resource.h>
+
+/* The abort is the expected outcome; keep its core file out of CI's crash scan. */
+__attribute__((constructor)) static void no_core(void) {
+  struct rlimit rl = {0, 0};
+  setrlimit(RLIMIT_CORE, &rl);
+}
+
+int execve(const char *path, char *const argv[], char *const envp[]) {
+  (void)path; (void)argv; (void)envp;
+  abort();
+}
+`,
+    "app.js": `require("node:fs").writeSync(1, "iter first\\n"); setInterval(() => {}, 1000);`,
+  });
+  const LD_PRELOAD = await compileShim(String(dir));
+
+  const proc = spawn({
+    cmd: [bunExe(), "--watch", "app.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  watchee = proc;
+  const stderr = proc.stderr.text();
+  const { waitFor, release } = stdoutWaiter(proc);
+
+  await waitFor("iter first");
+  await Bun.write(join(String(dir), "app.js"), `console.log("unreachable");`);
+  await proc.exited;
+  release();
+
+  expect(proc.signalCode, await stderr).toBe("SIGABRT");
+});
 
 // A script that registers a SIGTERM handler and then spins in synchronous
 // code must still restart on file change: the watcher thread posts the reload

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -214,8 +214,14 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
 // bun calls execve() it fails every pthread_create in the process, tells the script to run its
 // first collection, waits for the failed pthread_create and for the abort behind it to land, and
 // only then execs for real.
+//
+// The JS thread is not necessarily the only thread that crashes in that window (every thread that
+// creates a thread right then fails the same way), and the crash handler, with SA_RESETHAND, used to
+// step aside for one of them at most. So before the shim execs it also crashes two threads of its
+// own: one aborts like WTF does on Linux, one traps like WTF does on macOS (SIGILL on x64, SIGTRAP
+// on aarch64). All three have to be parked for the reload to go through.
 it.skipIf(!isLinux || !cc)(
-  "--watch still reloads when a thread aborts while the watcher thread is in execve",
+  "--watch still reloads when threads abort or trap while the watcher thread is in execve",
   async () => {
     const SHIM_C = /* c */ `
 #define _GNU_SOURCE
@@ -231,6 +237,8 @@ static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)
 static int (*real_execve)(const char *, char *const *, char *const *);
 static volatile int in_execve;
 static volatile int failed_create;
+static volatile int abort_thread_ready;
+static volatile int trap_thread_ready;
 
 /* Without the fix the abort takes the default action; keep its core file out of CI's crash scan. */
 __attribute__((constructor)) static void no_core(void) {
@@ -244,6 +252,20 @@ static void create_marker(const char *env) {
   if (fd >= 0) close(fd);
 }
 
+static void *abort_thread(void *unused) {
+  (void)unused;
+  create_marker("RELOAD_TEST_ABORTED_MARKER");
+  abort_thread_ready = 1;
+  abort();
+}
+
+static void *trap_thread(void *unused) {
+  (void)unused;
+  create_marker("RELOAD_TEST_TRAPPED_MARKER");
+  trap_thread_ready = 1;
+  __builtin_trap();
+}
+
 int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), void *arg) {
   if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
   if (in_execve) {
@@ -255,12 +277,18 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
 }
 
 int execve(const char *path, char *const argv[], char *const envp[]) {
+  pthread_t t;
   if (!real_execve) real_execve = dlsym(RTLD_NEXT, "execve");
+  if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
   in_execve = 1;
   create_marker("RELOAD_TEST_IN_EXECVE_MARKER");
   for (int i = 0; i < 2000 && !failed_create; i++) usleep(5000);
-  /* The thread whose pthread_create failed aborts right away. Give that abort time to land:
-   * without the fix it has killed the process long before this returns. */
+  real_pthread_create(&t, 0, abort_thread, 0);
+  real_pthread_create(&t, 0, trap_thread, 0);
+  for (int i = 0; i < 2000 && !(abort_thread_ready && trap_thread_ready); i++) usleep(5000);
+  /* The thread whose pthread_create failed aborts right away, and the two threads above crash as
+   * soon as they have set their flag. Give the signals time to land: without the fix the first of
+   * them has killed the process long before this returns. */
   usleep(1000000);
   return real_execve(path, argv, envp);
 }
@@ -298,6 +326,8 @@ int execve(const char *path, char *const argv[], char *const envp[]) {
         LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
         RELOAD_TEST_IN_EXECVE_MARKER: join(String(markers), "in-execve"),
         RELOAD_TEST_FAILED_CREATE_MARKER: join(String(markers), "failed-create"),
+        RELOAD_TEST_ABORTED_MARKER: join(String(markers), "aborted"),
+        RELOAD_TEST_TRAPPED_MARKER: join(String(markers), "trapped"),
         // Nothing may collect before the script does, or the marker threads already exist by the
         // time the reload starts and the collection below creates none.
         BUN_GARBAGE_COLLECTOR_LEVEL: "0",
@@ -328,8 +358,8 @@ int execve(const char *path, char *const argv[], char *const envp[]) {
     await proc.exited;
     await stderr;
 
-    // The reload went through the failure, not around it.
-    expect(await Bun.file(join(String(markers), "failed-create")).exists()).toBe(true);
+    // The reload went through the three crashes, not around them.
+    expect(readdirSync(String(markers)).sort()).toEqual(["aborted", "failed-create", "in-execve", "trapped"]);
   },
   30000,
 );

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -203,6 +203,137 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   expect(exitCode).not.toBe(0);
 });
 
+// The watcher thread reloads with execve() while the other threads are still running. While a
+// thread is inside execve, the kernel fails every clone() made by the other threads of the process
+// with EAGAIN. JSC starts its GC marker threads at the first collection, so a reload that lands on
+// that collection makes WTF::Thread::create abort on the JS thread. reload_process has to keep such
+// a thread out of the way (it parks it) so that the execve still goes through; when it reset the
+// crash signals to SIG_DFL first, the abort took the whole process down instead of reloading it.
+//
+// The LD_PRELOAD shim stands in for the kernel so that the race is deterministic: from the moment
+// bun calls execve() it fails every pthread_create in the process, tells the script to run its
+// first collection, waits for the failed pthread_create and for the abort behind it to land, and
+// only then execs for real.
+it.skipIf(!isLinux || !cc)(
+  "--watch still reloads when a thread aborts while the watcher thread is in execve",
+  async () => {
+    const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
+static int (*real_execve)(const char *, char *const *, char *const *);
+static volatile int in_execve;
+static volatile int failed_create;
+
+/* Without the fix the abort takes the default action; keep its core file out of CI's crash scan. */
+__attribute__((constructor)) static void no_core(void) {
+  struct rlimit rl = {0, 0};
+  setrlimit(RLIMIT_CORE, &rl);
+}
+
+static void create_marker(const char *env) {
+  const char *path = getenv(env);
+  int fd = path ? open(path, O_WRONLY | O_CREAT, 0644) : -1;
+  if (fd >= 0) close(fd);
+}
+
+int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), void *arg) {
+  if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  if (in_execve) {
+    failed_create = 1;
+    create_marker("RELOAD_TEST_FAILED_CREATE_MARKER");
+    return EAGAIN;
+  }
+  return real_pthread_create(t, a, f, arg);
+}
+
+int execve(const char *path, char *const argv[], char *const envp[]) {
+  if (!real_execve) real_execve = dlsym(RTLD_NEXT, "execve");
+  in_execve = 1;
+  create_marker("RELOAD_TEST_IN_EXECVE_MARKER");
+  for (int i = 0; i < 2000 && !failed_create; i++) usleep(5000);
+  /* The thread whose pthread_create failed aborts right away. Give that abort time to land:
+   * without the fix it has killed the process long before this returns. */
+  usleep(1000000);
+  return real_execve(path, argv, envp);
+}
+`;
+    using dir = tempDir("watch-reload-abort-in-execve", {
+      "shim.c": SHIM_C,
+      "app.js": `
+      const { existsSync, writeSync } = require("node:fs");
+      writeSync(1, "iter first\\n");
+      while (!existsSync(process.env.RELOAD_TEST_IN_EXECVE_MARKER)) Bun.sleepSync(2);
+      // The first collection of this process: JSC creates its marker threads right here, on this
+      // thread, and the shim fails the pthread_create.
+      Bun.gc(true);
+      setInterval(() => {}, 1000);
+    `,
+    });
+    // Kept outside the watched directory so that the markers do not show up as file events.
+    using markers = tempDir("watch-reload-abort-in-execve-markers", {});
+    const shimPath = join(String(dir), "shim.so");
+    await using ccProc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+    if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+
+    const existing = bunEnv.LD_PRELOAD;
+    const proc = spawn({
+      cmd: [bunExe(), "--watch", "app.js"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+        RELOAD_TEST_IN_EXECVE_MARKER: join(String(markers), "in-execve"),
+        RELOAD_TEST_FAILED_CREATE_MARKER: join(String(markers), "failed-create"),
+        // Nothing may collect before the script does, or the marker threads already exist by the
+        // time the reload starts and the collection below creates none.
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_GC_TIMER_DISABLE: "1",
+        // The marker count is derived from the CPU count otherwise; one marker means no threads.
+        BUN_JSC_numberOfGCMarkers: "4",
+      },
+      stdout: "pipe",
+      // Drained below: WTF reports the failed pthread_create (and a debug build its assertion) on
+      // stderr before the abort, and a full pipe would block the aborting thread instead.
+      stderr: "pipe",
+    });
+    watchee = proc;
+    const stderr = proc.stderr.text();
+    const { waitFor, release } = stdoutWaiter(proc);
+
+    await waitFor("iter first");
+    await Bun.write(
+      join(String(dir), "app.js"),
+      `require("node:fs").writeSync(1, "iter second\\n"); setInterval(() => {}, 1000);`,
+    );
+    // Without the fix this rejects with "stream closed": the abort on the JS thread killed the
+    // process before the watcher thread reached execve.
+    await waitFor("iter second");
+
+    release();
+    proc.kill("SIGKILL");
+    await proc.exited;
+    await stderr;
+
+    // The reload went through the failure, not around it.
+    expect(await Bun.file(join(String(markers), "failed-create")).exists()).toBe(true);
+  },
+  30000,
+);
+
 // A script that registers a SIGTERM handler and then spins in synchronous
 // code must still restart on file change: the watcher thread posts the reload
 // to the JS thread first (so listeners can run), but forces the reload itself


### PR DESCRIPTION
### Problem
- `test-changed.test.ts` (`--changed --watch`) is red on the alpine lanes and flaky on the aarch64 lanes. The `bun test --watch` child dies during a reload: `SIGABRT` in `WTF::Thread::create` (`Threading.cpp:330`, `RELEASE_ASSERT(success)`), under the idle GC in `Bun__JSC_onBeforeWait`.
- The watcher thread reloads with `execve` while the JS thread keeps running. While one thread is inside `execve`, the kernel fails every `clone` from the other threads with `EAGAIN`. The JS thread was creating the GC marker threads right then. WTF aborts on that.
- #34660 made the abort fatal: `on_before_reload_process_posix` (`src/jsc/bindings/c-bindings.cpp`) resets `SIGABRT` to `SIG_DFL` before the `execve`. Until then the crash handler ended only the thread. #39541 made the race frequent: the marker threads now appear at the first collection, which here coincides with the next touch.

### Fix
- `on_before_reload_process_posix` installs a handler for `SIGABRT`, `SIGILL`, `SIGTRAP` and `SIGFPE`, outside the reset loop. It parks every thread except the reloading one in `pause()`. On the reloading thread it restores `SIG_DFL` and raises again.
- Correct because the crashing thread belongs to the image that the `execve` replaces. The `execve` does not need it and tears it down with the rest. `SIGSEGV` and `SIGBUS` stay with JSC's handlers, as before.
- Verified: two new cases in `test/cli/watch/watch.test.ts`. In the first, the JS thread aborts on the failed `pthread_create`, two more threads abort and trap in the same window, and the reload has to go through all three. It fails on the canary and on an unfixed debug build and passes 24/24 with the fix. The second checks that an abort on the watcher thread itself still ends the process. Other suites: see the notes.

### Background
- `--watch` restarts by calling `execve` on its own binary from the watcher thread (`reload_process`, `src/bun_core/util.rs`). The other threads run until the `execve` kills them.
- JSC creates its GC helper threads when a collection first needs them, on the thread that runs the collection. Here that is the JS thread.
- The crash handler used to end a thread that crashed during a reload. ASAN builds have none, and `SA_RESETHAND` limits it to one thread. The new handler has neither limit.

<details><summary>Notes</summary>

- Failing builds: 102050 (alpine 3.23 x64) and 102111 (alpine 3.23 aarch64), both with a core.
- Other suites run with the fix: `test/cli/watch/`, `test/cli/test/test-changed.test.ts`, `test/cli/hot/watch.test.ts`, `test/cli/run/run-crash-handler.test.ts`, the node `test-watch-mode-kill-signal-*` tests. All pass.
- #36825 (Aug 3) proposed a handler of this kind inside `reload_process`, before #34660 landed. Installed there, the handler is removed again by the reset loop that #34660 added to `on_before_reload_process_posix`, and the branch is based on the old `reload_process`. This PR installs the handler in the function that does the reset.
- Kernel behavior, checked on 6.17 with a 40 line C program (one thread calls `execve`, another calls `pthread_create` in a loop): `pthread_create` returned `EAGAIN` in 26 of 30 runs, up to 7 times in a row, and the `execve` went through each time. Linux sets `fs->in_exec` in `check_unsafe_exec` and `copy_fs` rejects `clone(CLONE_FS)` while it is set.
- The two alpine cores show a plain `abort()` under `WTFCrashWithInfo` with no crash handler frames. Other alpine cores from the same days (builds 101261, 101857, 101866) do show `crash_handler` frames. That is how the reset of the dispositions was identified as the reason the abort is fatal.
- CI history (annotations of about 1400 builds): 0 hits in 300 builds from Aug 5 to 7 and 300 from Aug 12 to 13. 16 hits between Aug 19 03:25 UTC and Aug 21 (13 on ubuntu 25.04 aarch64, 1 on debian 13 aarch64, 2 on alpine). #39541 merged Aug 19 00:49 UTC. The glibc lanes pass on retry, so they count as flaky. The alpine lanes upload the core and fail hard.
- The natural race did not reproduce on this x64 glibc machine: 0 of 60 runs of the test-changed case on the unfixed canary, 0 of 40 with `BUN_JSC_numberOfGCMarkers=64`. The shim test drives the same path: `Bun.gc` -> `collectInMutatorThread` -> `ParallelHelperPool` -> `WTF::Thread::create` -> `EAGAIN` -> `abort()` on the JS thread, between the reset and the `execve`. Unfixed release and debug builds both die with `SIGABRT` there, and the failing `pthread_create` runs on the thread whose tid is the pid.
- A handler for `SIGABRT` alone, or one with `SA_RESETHAND`, fails the test: the shim's extra threads raise `SIGABRT` and `SIGILL` (`SIGTRAP` on aarch64) after the JS thread has already been parked.
- The second case covers the other branch of the handler. By hand, `__builtin_trap()` on the watcher thread ends the process with `SIGILL` the same way.
- The shim does not wait for a fixed time before it execs. bun parks a crashing thread in `pause()`, the shim interposes that too, and it execs once the three crashing threads have called it (about 20 ms after the `execve()` call on the debug build). Without the fix the process is dead within a few ms of the failed `pthread_create`. The first version of the test slept 1 s here instead, which the self-review flagged.
- ASAN builds had no protection here in any version, so the race was always fatal there. The new handler is what lets the test run on the ASAN lanes.
- `maybe_handle_panic_during_process_reload` is unchanged. It still covers Rust panics during a reload, which do not go through a signal.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/test-changed.test.ts test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->