### PR TITLE
install: warn when a workspace package declares patchedDependencies

### DIFF
--- a/docs/pm/cli/patch.mdx
+++ b/docs/pm/cli/patch.mdx
@@ -13,7 +13,7 @@ Features:
 
 - Generates `.patch` files that Bun applies to dependencies in `node_modules` on install
 - You can commit `.patch` files to your repository and reuse them across installs, projects, and machines
-- `"patchedDependencies"` in `package.json` keeps track of patched packages
+- `"patchedDependencies"` in `package.json` keeps track of patched packages. Bun only reads it from the root `package.json`, not from workspace packages. `bun install` warns when a workspace package declares it.
 - Patches packages in `node_modules/` while preserving the integrity of Bun's [Global Cache](/pm/global-cache)
 - Test your changes locally before committing them with `bun patch --commit <pkg>`
 - To preserve disk space and keep `bun install` fast, Bun commits patched packages to the Global Cache and shares them across projects where possible

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -126,6 +126,36 @@ fn invalid_trusted_dependencies(
     crate::Error::InvalidPackageJSON
 }
 
+const IGNORED_PATCHED_DEPENDENCIES: &[u8] =
+    b"\"patchedDependencies\" is ignored in a workspace package. Move it to the root package.json";
+
+/// Warns once per file. The differ parses every workspace package, and one
+/// whose dependencies changed is parsed again, into the same log, when it is
+/// re-resolved.
+#[cold]
+fn warn_ignored_patched_dependencies(
+    log: &mut bun_ast::Log,
+    source: &bun_ast::Source,
+    key_loc: bun_ast::Loc,
+) {
+    let warned = log.msgs.iter().any(|msg| {
+        *msg.data.text == *IGNORED_PATCHED_DEPENDENCIES
+            && msg
+                .data
+                .location
+                .as_ref()
+                .is_some_and(|location| *location.file == *source.path.text)
+    });
+    if warned {
+        return;
+    }
+    log.add_range_warning(
+        Some(source),
+        source.range_of_string(key_loc),
+        IGNORED_PATCHED_DEPENDENCIES,
+    );
+}
+
 // `SemverIntType` defaults to `u64`, the only instantiation the lockfile/PM
 // call sites name unqualified.
 //
@@ -2224,6 +2254,10 @@ impl Package<u64> {
                         }
                     }
                 }
+            }
+        } else if FEATURES.is_workspace {
+            if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
+                warn_ignored_patched_dependencies(log, source, patched_deps.loc);
             }
         }
 

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1156,16 +1156,34 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
 +hello world
 `;
 
-  // A package that patches its own `no-deps` dependency.
+  // A package that patches its own `no-deps` dependency. Pretty-printed so the
+  // `patchedDependencies` key is on line 7 of the file. `rest` is appended
+  // after it and does not move it.
+  const patchingDepPackageJson = (rest: Record<string, unknown> = {}) =>
+    JSON.stringify(
+      {
+        name: "patching-dep",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+        patchedDependencies: { "no-deps@1.0.0": "patches/no-deps@1.0.0.patch" },
+        ...rest,
+      },
+      null,
+      2,
+    );
   const patchingDep = {
-    "package.json": JSON.stringify({
-      name: "patching-dep",
-      version: "1.0.0",
-      dependencies: { "no-deps": "1.0.0" },
-      patchedDependencies: { "no-deps@1.0.0": "patches/no-deps@1.0.0.patch" },
-    }),
+    "package.json": patchingDepPackageJson(),
     patches: { "no-deps@1.0.0.patch": noDepsPatch },
   };
+
+  // The location each "patchedDependencies is ignored" warning points at,
+  // relative to the workspace root.
+  const ignoredWarnings = (err: string) =>
+    [
+      ...err.matchAll(
+        /^warn: "patchedDependencies" is ignored in a workspace package\. Move it to the root package\.json\r?\n\s+at .*?[\\/](packages[\\/][^\r\n]*)/gm,
+      ),
+    ].map(match => match[1].replaceAll("\\", "/"));
 
   // A consumer that installs the same `no-deps` that `patching-dep` patches.
   const consumerPackageJson = (dependencies: Record<string, string>, rest: Record<string, unknown> = {}) =>
@@ -1185,16 +1203,20 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
   // CI exports BUN_INSTALL_CACHE_DIR, which overrides the per-directory cache
   // in bunfig.toml. The tests below run concurrently, and two cold installs of
   // the same package into one cache replace each other's cache directory.
-  const install = (packageDir: string, env = bunEnv) =>
-    runBunInstall({ ...env, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") }, packageDir);
+  type InstallOptions = Parameters<typeof runBunInstall>[2];
 
-  const lockfileHasPatches = async (packageDir: string) =>
-    (await Bun.file(join(packageDir, "bun.lock")).text()).includes("patchedDependencies");
+  const install = (packageDir: string, env = bunEnv, options?: InstallOptions) =>
+    runBunInstall({ ...env, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") }, packageDir, options);
+
+  const lockfile = (packageDir: string) => Bun.file(join(packageDir, "bun.lock")).text();
+
+  const lockfileHasPatches = async (packageDir: string) => (await lockfile(packageDir)).includes("patchedDependencies");
 
   const noDepsFile = (packageDir: string, name: string) => Bun.file(join(packageDir, "node_modules", "no-deps", name));
 
-  async function installUnpatched(packageDir: string, env = bunEnv) {
-    await install(packageDir, env);
+  // Installs, checks that the dependency's patch was not applied, and returns stderr.
+  async function installUnpatched(packageDir: string, env = bunEnv, options?: InstallOptions) {
+    const { err } = await install(packageDir, env, options);
     expect({
       noDeps: await noDepsFile(packageDir, "package.json").json(),
       patched: await noDepsFile(packageDir, "patched.txt").exists(),
@@ -1204,6 +1226,7 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
       patched: false,
       lockfileHasPatches: false,
     });
+    return err;
   }
 
   test.concurrent("apply when the declaring package is the install root", async () => {
@@ -1272,7 +1295,10 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
       await installUnpatched(packageDir);
     });
 
-    test.concurrent("workspace member", async () => {
+    // A workspace member is the one manifest of the project itself that is not
+    // the root, so its `patchedDependencies` gets a warning. The other cases
+    // above are not warned about (`runBunInstall` fails on any warning).
+    test.concurrent("workspace member is warned about once per install", async () => {
       const { packageDir } = await registry.createTestDir({
         bunfigOpts: { linker },
         files: {
@@ -1280,7 +1306,24 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
           packages: { dep: patchingDep },
         },
       });
-      await installUnpatched(packageDir);
+      const warned = ["packages/dep/package.json:7:3"];
+
+      // Fresh install: the member is parsed when the workspace dependency resolves.
+      expect(ignoredWarnings(await installUnpatched(packageDir, bunEnv, { allowWarnings: true }))).toEqual(warned);
+
+      // Nothing changed: the member is parsed again by the lockfile differ.
+      expect(
+        ignoredWarnings(await installUnpatched(packageDir, bunEnv, { allowWarnings: true, savesLockfile: false })),
+      ).toEqual(warned);
+
+      // The member's dependencies changed: the differ parses it, then it is
+      // parsed once more when it is re-resolved. Still one warning.
+      await Bun.write(
+        join(packageDir, "packages", "dep", "package.json"),
+        patchingDepPackageJson({ devDependencies: { "a-dep": "1.0.1" } }),
+      );
+      expect(ignoredWarnings(await installUnpatched(packageDir, bunEnv, { allowWarnings: true }))).toEqual(warned);
+      expect(await lockfile(packageDir)).toContain("a-dep");
     });
   });
 });


### PR DESCRIPTION
### Problem
- Since #39816, `bun install` reads `patchedDependencies` from the root package.json only. A workspace package that declares it installs unpatched, exit code 0, no diagnostic. 1.4.0 applied these entries, so the upgrade drops them in silence.
- `Package::parse_with_json` (`src/install/lockfile/Package.rs:2218` on main) skips the field because `Features::WORKSPACE` has `patched_dependencies: false`. Nothing reports the skip.

### Fix
- A manifest parsed with `Features::WORKSPACE` that has a `patchedDependencies` key adds a warning to the install log. It points at the key and says to move it to the root package.json. Exit code stays 0. `--silent` hides it like every log warning.
- One warning per file. A changed workspace package is parsed twice per install into the same log (see Background). The helper returns early when the log already has the warning for that file. Without this, that case printed it twice.
- `file:`, tarball, and git dependencies are not warned about. Their manifests belong to another project. Their tests still fail on any warning.
- Verified: `test/cli/install/bun-install-patch.test.ts`, "workspace member is warned about once per install", both linkers, fails on main. The other patch, workspace, and migration suites pass (Notes).

### Background
- `Features` is the per-manifest parse configuration. `MAIN` is the root package.json, `WORKSPACE` a workspace package. The other sets are manifests from outside the project.
- Two paths parse a workspace package. The folder resolver parses it when the root's workspace dependency resolves. With a lockfile, the differ (`Diff::generate`) parses every member first, then re-resolves the members whose dependencies changed. That is the second parse.
- `bun_ast::Log` collects the diagnostics of one install and prints them once after resolution.

<details><summary>Notes</summary>

Manual check with the debug build. Root `{"workspaces":["packages/*"]}`, two members that declare `patchedDependencies`, no registry needed:

```
4 |   "patchedDependencies": {
      ^
warn: "patchedDependencies" is ignored in a workspace package. Move it to the root package.json
   at /tmp/wsp/packages/m1/package.json:4:3
```

One warning per member on the fresh install, on the no-op second install (differ path), and after adding a dependency to `m1` (differ, then re-resolve). `--silent` prints nothing. Exit code 0 in every case.

The dedupe is load-bearing. With the early return removed, the three installs above printed 1, 1, and 2 warnings, and the third step of the new test failed on both linkers.

Why the dedupe reads the log instead of a set on `PackageManager`: `bun add --filter` with a relational pattern parses every member with `Features::WORKSPACE` into a scratch log before the install (`workspace_manifests::relation_graph`), and `package_json_write_back` does it again after. A set on the manager would be filled by the scratch parse and would hide the warning from the real install. The scratch logs are separate `Log` values, so reading the log that is about to be printed gives one warning per printed log.

The test fixture is now pretty-printed so the key sits on line 7. The new test pins the location `packages/dep/package.json:7:3` and counts the warnings across the three installs. The other tests in the block (`file:`, tarball, git, on both linkers) keep the default `runBunInstall` check that fails on any `warn:`, which is the negative case.

The docs line in `docs/pm/cli/patch.mdx` states the root-only rule and the warning. It matches the wording of the same rule for overrides in `docs/pm/overrides.mdx`.

A `patchedDependencies` key nested under `pnpm` in a member is not affected. The warning checks the top-level key, which is the one bun reads from the root.

Suites run with the debug build: bun-install-patch (whole file), bun-patch, bun-workspaces, bun-add-filter, bad-workspace, frozen-lockfile-missing-workspace, bun-lock, bun-update-transitive, bun-dedupe, frozen-lockfile-pruned, migration/migrate, pnpm-migration-complete, pnpm-lock-v9, pnpm-comprehensive, js/bun/patch, and test/internal/source-lints. All pass. pnpm-migration-complete hit its 5 s timeout once while other suites were running and passed alone in 2.9 s.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-patch.test.ts

<!-- robobun:evidence:end -->