### PR TITLE
JUnit report and GitHub Actions annotation: keep resolving relative frame source names against the cwd

### DIFF
--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -78,15 +78,25 @@ impl ZigStackFrame {
     /// The frame's source as a report that lists files relative to `dir` (the JUnit
     /// reporter, the GitHub Actions annotation) prints it.
     ///
-    /// Only an absolute path is made relative. A source URL that is not a path (a
-    /// `data:` or `blob:` URL, `node:fs`, the name from a `//# sourceURL=` comment)
-    /// is printed as-is, like [`SourceURLFormatter`] prints it. `relative` normalizes
-    /// its operands in fixed path buffers, so a source URL that is too long to be a
-    /// path is printed as-is too.
+    /// A path is made relative to `dir`. A relative name (a `node:vm` filename, a
+    /// `//# sourceURL=` comment, a sourcemap `sources` entry) counts from the cwd, as
+    /// `relative` resolves it. A URL (`data:`, `blob:`, `node:fs`, `webpack://...`) is
+    /// not a file under `dir` and is printed as-is, like [`SourceURLFormatter`] prints
+    /// it. `relative` normalizes its operands in fixed path buffers, so a name that does
+    /// not fit one is printed as-is too.
     ///
     /// The relative form lives in `relative`'s thread-local buffer until the next call.
     pub fn relative_source_url<'a>(dir: &[u8], source_url: &'a [u8]) -> &'a [u8] {
-        if !bun_paths::is_absolute(source_url) || source_url.len() >= bun_paths::MAX_PATH_BYTES {
+        let relativize = if bun_paths::is_absolute(source_url) {
+            source_url.len() < bun_paths::MAX_PATH_BYTES
+        } else if source_url.is_empty() || has_url_scheme(source_url) {
+            false
+        } else {
+            // `relative` joins a relative name onto this cwd before it relativizes it.
+            let cwd = bun_paths::fs::FileSystem::instance().top_level_dir();
+            cwd.len() + source_url.len() < bun_paths::MAX_PATH_BYTES
+        };
+        if !relativize {
             return source_url;
         }
         bun_paths::resolve_path::relative(dir, source_url)
@@ -117,6 +127,15 @@ impl ZigStackFrame {
             enable_color,
             remapped: self.remapped,
         }
+    }
+}
+
+/// `data:...`, `node:fs`, `webpack://app/x.ts`: a colon before the first separator.
+/// A Windows drive (`C:\`) is absolute and never gets here.
+fn has_url_scheme(name: &[u8]) -> bool {
+    match bun_core::strings::index_of_char_usize(name, b':') {
+        Some(colon) => bun_core::strings::index_of_any(&name[..colon], b"/\\").is_none(),
+        None => false,
     }
 }
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -725,17 +725,22 @@ describe("bun test", () => {
       const dataUrlModule = 'export default function fromDataUrl() { throw new Error("boom"); }//';
       const base64 = btoa(dataUrlModule + Buffer.alloc(padding, "x").toString());
       const longPath = "/" + Buffer.alloc(padding, "y").toString();
+      const longName = Buffer.alloc(padding, "z").toString();
       const stderr = runTest({
         input: `
           import { test } from "bun:test";
+          const thrower = (name, sourceURL) =>
+            (0, eval)("(function " + name + "() { throw new Error('boom'); })\\n//# sourceURL=" + sourceURL);
           test("data url", async () => {
             const source = ${JSON.stringify(dataUrlModule)} + Buffer.alloc(${padding}, "x").toString();
             const m = await import("data:text/javascript;base64," + btoa(source));
             m.default();
           });
-          test("long sourceURL", () => {
-            const sourceURL = "/" + Buffer.alloc(${padding}, "y").toString();
-            (0, eval)("(function fromLongPath() { throw new Error('boom'); })\\n//# sourceURL=" + sourceURL)();
+          test("long absolute sourceURL", () => {
+            thrower("fromLongPath", "/" + Buffer.alloc(${padding}, "y").toString())();
+          });
+          test("long relative sourceURL", () => {
+            thrower("fromLongName", Buffer.alloc(${padding}, "z").toString())();
           });
         `,
         env: {
@@ -744,24 +749,33 @@ describe("bun test", () => {
         expectExitCode: 1,
       });
       const annotations = stderr.split("\n").filter(line => line.startsWith("::error"));
-      expect(annotations).toHaveLength(2);
-      const [dataUrl, longSourceUrl] = annotations;
+      expect(annotations).toHaveLength(3);
+      const [dataUrl, longSourceUrl, longNameSourceUrl] = annotations;
       expect(dataUrl).toStartWith(`::error file=data%3Atext/javascript;base64%2C${base64},line=1,col=`);
       expect(dataUrl).toContain(`%0A      at fromDataUrl (data:text/javascript;base64,${base64}:1:`);
       expect(longSourceUrl).toStartWith(`::error file=${longPath},line=1,col=`);
       expect(longSourceUrl).toContain(`%0A      at fromLongPath (${longPath}:1:`);
+      expect(longNameSourceUrl).toStartWith(`::error file=${longName},line=1,col=`);
+      expect(longNameSourceUrl).toContain(`%0A      at fromLongName (${longName}:1:`);
     });
-    test("should make the annotation file relative to GITHUB_WORKSPACE only when it is a path", () => {
+    test("should make the annotation file relative to GITHUB_WORKSPACE for a path but not for a URL", () => {
       const cwd = createTest([
         {
           filename: "workspace.test.ts",
           contents: `
             import { test } from "bun:test";
+            import vm from "node:vm";
             test("in the test file", () => {
               throw new Error("boom");
             });
-            test("in a sourceURL that is not a path", () => {
+            test("in a sourceURL that is a URL", () => {
               (0, eval)("(function fromSourceUrl() { throw new Error('boom'); })\\n//# sourceURL=webpack://app/./src/x.ts")();
+            });
+            test("in a sourceURL that is a relative path", () => {
+              (0, eval)("(function fromRelativeSourceUrl() { throw new Error('boom'); })\\n//# sourceURL=./src/../src/y.ts")();
+            });
+            test("in a vm script with a relative filename", () => {
+              vm.runInThisContext("(function fromVm() { throw new Error('boom'); })", { filename: "lib/z.ts" })();
             });
           `,
         },
@@ -775,11 +789,14 @@ describe("bun test", () => {
         expectExitCode: 1,
       });
       const annotations = stderr.split("\n").filter(line => line.startsWith("::error"));
-      expect(annotations).toHaveLength(2);
-      const [testFile, sourceUrl] = annotations;
-      expect(testFile).toStartWith(`::error file=${basename(cwd)}${sep}workspace.test.ts,line=4,col=`);
+      expect(annotations).toHaveLength(4);
+      const [testFile, sourceUrl, relativeSourceUrl, vmFilename] = annotations;
+      expect(testFile).toStartWith(`::error file=${basename(cwd)}${sep}workspace.test.ts,line=5,col=`);
       expect(sourceUrl).toStartWith("::error file=webpack%3A//app/./src/x.ts,line=1,col=");
       expect(sourceUrl).toContain("%0A      at fromSourceUrl (webpack://app/./src/x.ts:1:");
+      // A relative name counts from the cwd, which is inside the workspace.
+      expect(relativeSourceUrl).toStartWith(`::error file=${[basename(cwd), "src", "y.ts"].join(sep)},line=1,col=`);
+      expect(vmFilename).toStartWith(`::error file=${[basename(cwd), "lib", "z.ts"].join(sep)},line=1,col=`);
     });
   });
   describe(".each", () => {

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -555,12 +555,13 @@ describe("junit reporter", () => {
     expect(exitCode).toBe(1);
   });
 
-  it("prints a stack frame whose source is not a file path as-is in <failure>", async () => {
+  it("relativizes a frame's path in <failure> and prints a URL or an over-long name as-is", async () => {
     // Longer than a path buffer on every platform (98302 bytes on Windows).
     const padding = 100_000;
     const dataUrlModule = 'export default function fromDataUrl() { throw new Error("boom"); }//';
     const dataUrl = "data:text/javascript;base64," + btoa(dataUrlModule + Buffer.alloc(padding, "x").toString());
     const longPath = "/" + Buffer.alloc(padding, "y").toString();
+    const longName = Buffer.alloc(padding, "z").toString();
 
     await using tmpDir = tempDir("junit-source-url", {
       "package.json": "{}",
@@ -573,14 +574,20 @@ describe("junit reporter", () => {
           const m = await import("data:text/javascript;base64," + btoa(source));
           m.default();
         });
-        test("sourceURL that is not a path", () => {
+        test("sourceURL that is a URL", () => {
           thrower("fromSourceUrl", "webpack://app/./src/x.ts")();
         });
-        test("sourceURL longer than a path", () => {
+        test("sourceURL that is an absolute path longer than a path buffer", () => {
           thrower("fromLongPath", "/" + Buffer.alloc(${padding}, "y").toString())();
         });
-        test("sourceURL that is a path", () => {
+        test("sourceURL that is a relative name longer than a path buffer", () => {
+          thrower("fromLongName", Buffer.alloc(${padding}, "z").toString())();
+        });
+        test("sourceURL that is an absolute path", () => {
           thrower("fromPath", import.meta.dir.replaceAll("\\\\", "/") + "/virtual/../generated.js")();
+        });
+        test("sourceURL that is a relative path", () => {
+          thrower("fromRelativePath", "./virtual/../relative.js")();
         });
       `,
     });
@@ -599,14 +606,18 @@ describe("junit reporter", () => {
     const result = await new Promise((resolve, reject) => {
       xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
     });
-    const [dataUrlCase, sourceUrlCase, longPathCase, pathCase] = result.testsuites.testsuite[0].testcase;
+    const [dataUrlCase, sourceUrlCase, longPathCase, longNameCase, pathCase, relativePathCase] =
+      result.testsuites.testsuite[0].testcase;
 
     expect(dataUrlCase.failure[0]._).toContain(`at fromDataUrl (${dataUrl}:1:`);
-    // The frame in the test file itself is still relative to the cwd.
+    // The frame in the test file itself is relative to the cwd.
     expect(dataUrlCase.failure[0]._).toContain("at dataUrlTest (source-url.test.js:");
     expect(sourceUrlCase.failure[0]._).toContain("at fromSourceUrl (webpack://app/./src/x.ts:1:");
     expect(longPathCase.failure[0]._).toContain(`at fromLongPath (${longPath}:1:`);
+    expect(longNameCase.failure[0]._).toContain(`at fromLongName (${longName}:1:`);
     expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
+    // A relative name counts from the cwd, so it is normalized like a path.
+    expect(relativePathCase.failure[0]._).toContain("at fromRelativePath (relative.js:1:");
   });
 });
 


### PR DESCRIPTION
### Problem
- #39828 made `ZigStackFrame::relative_source_url` (`src/jsc/ZigStackFrame.rs:89`) print every source that is not an absolute path as-is. That also covers a relative name: a `node:vm` filename, a relative `//# sourceURL=` name, or a relative sourcemap `sources` entry of a compiled binary.
- Before #39828, `resolve_path::relative` resolved such a name against the cwd. Under a `GITHUB_WORKSPACE` above the cwd the annotation named a file GitHub can link, `::error file=repo/src/x.ts`. Since #39828 it prints `file=src/x.ts`.

### Fix
- A relative name goes through `relative` again, when the name and the cwd fit a path buffer together. A URL (a colon before the first separator), an empty source, and an over-long name print as-is.
- Correct because this is the output both reports had for every name without a scheme before #39828. The change of #39828 is now limited to its two targets: a URL, which `relative` mangled, and a name that overflowed its buffers.
- The guard adds the cwd length because `relative` joins a relative name onto the cwd first. It reads the same cwd `relative` reads.
- Verified: the extended tests in `test/js/junit-reporter/junit.test.js` and `test/cli/test/bun-test.test.ts`. Their relative name cases fail on main. Both files and `test/js/bun/test/stack.test.ts` pass in full.

### Background
- `resolve_path::relative(from, to)` joins a `to` that is not absolute onto the cwd, normalizes both paths into thread-local buffers of `MAX_PATH_BYTES`, and builds the `../` form.
- The GitHub Actions annotation relativizes against `GITHUB_WORKSPACE` when it is set, else against the cwd. GitHub resolves `file=` against the workspace root. The JUnit reporter relativizes against the cwd.
- `has_url_scheme` treats a colon before the first `/` or `\` as a scheme. A Windows drive path (`C:\x`) is absolute and takes the first branch.

<details><summary>Notes</summary>

- Found by a self-review of #39828 after it merged: the new rule changed one more input than intended and no test pinned it. Verified on the released 1.4.0 build against a build of main, cwd `<tmp>/repo`, `GITHUB_WORKSPACE=<tmp>`: eval with `//# sourceURL=src/x.ts` prints `file=repo/src/x.ts` on 1.4.0 and `file=src/x.ts` on main. `vm.runInThisContext(code, { filename: "src/x.ts" })` prints the same pair. `//# sourceURL=./src/../y.ts` prints `file=repo/y.ts` on 1.4.0 and `file=./src/../y.ts` on main. With this change all three print the 1.4.0 form again.
- Names without a scheme that are not files (`native`, `[native code]`) also print as they did before #39828, that is relativized, which under a distinct `GITHUB_WORKSPACE` is `repo/native`. #38335 picks the frame for the annotation and covers that. An empty source stays as-is, which keeps the frame skip in the callers working under a distinct workspace (`relative(workspace, "")` would return the cwd). `[source:...]` names have a colon and print as-is.
- A drive-relative Windows name (`C:x.ts`) and a relative name with a colon before its first separator (`a:b.ts`) read as a scheme and print as-is. Before #39828 they were joined onto the cwd.
- The length guard for a relative name is `cwd.len() + name.len() < MAX_PATH_BYTES`. The `../` chain case close to the limit is the same `relative` defect as in #39828's notes, owned by #39658 and #38392. The new test cases pad a relative name to 100000 bytes, which exercises this guard. On main that case already passes, since main prints every relative name as-is. The relative path cases are the ones that fail on main.
- All the #39828 repros (long `data:` URL, long absolute `sourceURL`, `webpack://` and `http://` names) still print as that PR's tests expect. `test/js/bun/test/stack.test.ts` is unchanged and passes.
- Checked: `cargo fmt --all -- --check`, prettier on the two test files, `test/internal/source-lints`, `bun bd test` on `junit.test.js` (9 pass), `stack.test.ts` (7 pass, 1 todo) and `bun-test.test.ts` (97 pass, 6 todo).
</details>
