### PR TITLE
perf_hooks: stop the event-loop-delay monitor when bun test --isolate retires its realm

### DIFF
--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -425,7 +425,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
 
 // Extern declarations for the native timer implementation
 extern "C" void Timer_enableEventLoopDelayMonitoring(void* vm, JSC::EncodedJSValue histogram, int32_t resolution);
-extern "C" void Timer_disableEventLoopDelayMonitoring(void* vm);
+extern "C" void Timer_disableEventLoopDelayMonitoring();
 
 // Create histogram for event loop delay monitoring
 JSC_DEFINE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -512,7 +512,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_disableEventLoopDelay, (JSGlobalObject * glo
     }
 
     // Call into native code to disable monitoring
-    Timer_disableEventLoopDelayMonitoring(bunVM(globalObject));
+    Timer_disableEventLoopDelayMonitoring();
 
     return JSValue::encode(jsUndefined());
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1759,8 +1759,7 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
     // intact: `swap_global_for_test_isolation` runs `cancel_all_timeout_objects`
     // next, which walks both heaps and releases `TimeoutObject` pins and
     // discards `AbortSignalTimeout` timers at a point where no user JS can
-    // touch the outgoing signals. Same for the `monitorEventLoopDelay()`
-    // monitor, whose histogram belongs to the outgoing global.
+    // touch the outgoing signals.
     {
         let all = timer_all();
         // SAFETY: `state` is non-null so `timer_all()` is non-null; single

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1759,12 +1759,8 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
     // intact: `swap_global_for_test_isolation` runs `cancel_all_timeout_objects`
     // next, which walks both heaps and releases `TimeoutObject` pins and
     // discards `AbortSignalTimeout` timers at a point where no user JS can
-    // touch the outgoing signals.
-    //
-    // The `monitorEventLoopDelay()` monitor lives there too, but its
-    // histogram belongs to the outgoing global. Left enabled, it would keep
-    // firing into a histogram the swap (or `~VM`) is about to collect, and a
-    // later file's `enable()` would find the slot taken.
+    // touch the outgoing signals. Same for the `monitorEventLoopDelay()`
+    // monitor, whose histogram belongs to the outgoing global.
     {
         let all = timer_all();
         // SAFETY: `state` is non-null so `timer_all()` is non-null; single
@@ -1776,9 +1772,8 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             unsafe { (*all).fake_timers.reset_for_isolation(global) };
         }
         if !all.is_null() {
-            // SAFETY: as above; only the `event_loop_delay` field is borrowed,
-            // and `disable` reaches the heap through `timer_all()` like every
-            // other `All`-embedded timer owner (disjoint-field access).
+            // SAFETY: as above; `disable` borrows only `event_loop_delay` and
+            // reaches the heap through `timer_all()` (disjoint-field access).
             unsafe { (*all).event_loop_delay.disable() };
         }
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1760,6 +1760,11 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
     // next, which walks both heaps and releases `TimeoutObject` pins and
     // discards `AbortSignalTimeout` timers at a point where no user JS can
     // touch the outgoing signals.
+    //
+    // The `monitorEventLoopDelay()` monitor lives there too, but its
+    // histogram belongs to the outgoing global. Left enabled, it would keep
+    // firing into a histogram the swap (or `~VM`) is about to collect, and a
+    // later file's `enable()` would find the slot taken.
     {
         let all = timer_all();
         // SAFETY: `state` is non-null so `timer_all()` is non-null; single
@@ -1769,6 +1774,12 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             // SAFETY: as above; only touches `fake_timers.active` and the
             // `CURRENT_TIME` static.
             unsafe { (*all).fake_timers.reset_for_isolation(global) };
+        }
+        if !all.is_null() {
+            // SAFETY: as above; only the `event_loop_delay` field is borrowed,
+            // and `disable` reaches the heap through `timer_all()` like every
+            // other `All`-embedded timer owner (disjoint-field access).
+            unsafe { (*all).event_loop_delay.disable() };
         }
     }
     // Entries that stay registered across a test-isolation swap.

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -23,10 +23,8 @@ extern "C" fn Timer_enableEventLoopDelayMonitoring(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn Timer_disableEventLoopDelayMonitoring(vm: *mut VirtualMachine) {
-    // SAFETY: vm is a valid non-null pointer passed from C++.
-    let vm = unsafe { &mut *vm };
+extern "C" fn Timer_disableEventLoopDelayMonitoring(_vm: *mut VirtualMachine) {
     let state = crate::jsc_hooks::runtime_state();
     // SAFETY: see `Timer_enableEventLoopDelayMonitoring`.
-    unsafe { (*state).timer.event_loop_delay.disable(vm) };
+    unsafe { (*state).timer.event_loop_delay.disable() };
 }

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -23,7 +23,7 @@ extern "C" fn Timer_enableEventLoopDelayMonitoring(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn Timer_disableEventLoopDelayMonitoring(_vm: *mut VirtualMachine) {
+extern "C" fn Timer_disableEventLoopDelayMonitoring() {
     let state = crate::jsc_hooks::runtime_state();
     // SAFETY: see `Timer_enableEventLoopDelayMonitoring`.
     unsafe { (*state).timer.event_loop_delay.disable() };

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -427,11 +427,8 @@ impl DateHeaderTimer {
 }
 
 pub struct EventLoopDelayMonitor {
-    /// Weak rather than Strong: the histogram belongs to one realm, and this
-    /// per-thread monitor outlives the realms `bun test --isolate` retires. A
-    /// Strong would pin every retired realm whose file left the monitor on.
-    /// `jsc_hooks::stop_active_handles` releases it (via [`Self::disable`])
-    /// before `~VM`, because `All` itself is dropped after the heap is gone.
+    /// Weak, so a leaked monitor does not pin the retired `--isolate` realm.
+    /// `stop_active_handles` drops it before `~VM` (`All` outlives the heap).
     histogram: bun_jsc::Weak<()>,
     pub(crate) event_loop_timer: EventLoopTimer,
     pub(crate) resolution_ms: i32,

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -427,18 +427,11 @@ impl DateHeaderTimer {
 }
 
 pub struct EventLoopDelayMonitor {
-    /// The histogram `monitorEventLoopDelay().enable()` registered. Its
-    /// realm's `perf_hooks` module holds the only strong reference, so the
-    /// cell (and the `hdr_histogram` it owns) dies with that realm, while this
-    /// monitor is per thread and outlives it (`bun test --isolate` retires a
-    /// realm per file). Observed weakly so [`Self::on_fire`] sees the cell go
-    /// away instead of recording into freed memory; a `Strong` would pin the
-    /// retired realm for as long as a leaked monitor stays enabled.
-    ///
-    /// Released by [`Self::disable`], which `jsc_hooks::stop_active_handles`
-    /// runs at every file swap and in the teardown stop phase, while the JSC
-    /// heap the handle lives in is still alive (`All` itself is dropped after
-    /// `~VM`).
+    /// Weak rather than Strong: the histogram belongs to one realm, and this
+    /// per-thread monitor outlives the realms `bun test --isolate` retires. A
+    /// Strong would pin every retired realm whose file left the monitor on.
+    /// `jsc_hooks::stop_active_handles` releases it (via [`Self::disable`])
+    /// before `~VM`, because `All` itself is dropped after the heap is gone.
     histogram: bun_jsc::Weak<()>,
     pub(crate) event_loop_timer: EventLoopTimer,
     pub(crate) resolution_ms: i32,
@@ -462,9 +455,6 @@ impl EventLoopDelayMonitor {
         crate::jsc_hooks::timer_all()
     }
 
-    /// Start recording into `histogram` every `resolution_ms`. A histogram
-    /// that is already registered (one a retired `--isolate` realm left
-    /// behind, for example) is dropped in favour of this one.
     fn enable(
         &mut self,
         vm: &mut bun_jsc::virtual_machine::VirtualMachine,
@@ -489,8 +479,6 @@ impl EventLoopDelayMonitor {
         unsafe { (*Self::timer_all()).insert(elt) };
     }
 
-    /// Stop recording and release the histogram handle (see the field doc for
-    /// the sweep that also calls this).
     pub(crate) fn disable(&mut self) {
         if !self.enabled {
             return;
@@ -498,8 +486,7 @@ impl EventLoopDelayMonitor {
         self.enabled = false;
         self.histogram = bun_jsc::Weak::default();
         self.last_fire_ns = 0;
-        // Not ACTIVE while `on_fire` has the node popped and is deciding
-        // whether to re-arm it.
+        // FIRED (not linked) when called from `on_fire`.
         if self.event_loop_timer.state == EventLoopTimerState::ACTIVE {
             let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
             // SAFETY: see `enable` — disjoint-field access on `All`.
@@ -518,8 +505,6 @@ impl EventLoopDelayMonitor {
         if !self.enabled {
             return;
         }
-        // The histogram was collected (its realm is gone): nothing can read it
-        // any more, so stop instead of re-arming.
         let Some(histogram) = self.histogram.get() else {
             self.disable();
             return;

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -427,10 +427,19 @@ impl DateHeaderTimer {
 }
 
 pub struct EventLoopDelayMonitor {
-    // TODO: bare `JSValue` heap field with no Strong/visitChildren rooting —
-    // the histogram object can be GC'd while `monitorEventLoopDelay` is active.
-    // Needs JsRef-style rooting.
-    js_histogram: JSValue,
+    /// The histogram `monitorEventLoopDelay().enable()` registered. Its
+    /// realm's `perf_hooks` module holds the only strong reference, so the
+    /// cell (and the `hdr_histogram` it owns) dies with that realm, while this
+    /// monitor is per thread and outlives it (`bun test --isolate` retires a
+    /// realm per file). Observed weakly so [`Self::on_fire`] sees the cell go
+    /// away instead of recording into freed memory; a `Strong` would pin the
+    /// retired realm for as long as a leaked monitor stays enabled.
+    ///
+    /// Released by [`Self::disable`], which `jsc_hooks::stop_active_handles`
+    /// runs at every file swap and in the teardown stop phase, while the JSC
+    /// heap the handle lives in is still alive (`All` itself is dropped after
+    /// `~VM`).
+    histogram: bun_jsc::Weak<()>,
     pub(crate) event_loop_timer: EventLoopTimer,
     pub(crate) resolution_ms: i32,
     pub(crate) last_fire_ns: u64,
@@ -439,7 +448,7 @@ pub struct EventLoopDelayMonitor {
 impl Default for EventLoopDelayMonitor {
     fn default() -> Self {
         Self {
-            js_histogram: JSValue::default(),
+            histogram: bun_jsc::Weak::default(),
             event_loop_timer: EventLoopTimer::init_paused(EventLoopTimerTag::EventLoopDelayMonitor),
             resolution_ms: 10,
             last_fire_ns: 0,
@@ -453,16 +462,17 @@ impl EventLoopDelayMonitor {
         crate::jsc_hooks::timer_all()
     }
 
+    /// Start recording into `histogram` every `resolution_ms`. A histogram
+    /// that is already registered (one a retired `--isolate` realm left
+    /// behind, for example) is dropped in favour of this one.
     fn enable(
         &mut self,
-        _vm: &mut bun_jsc::virtual_machine::VirtualMachine,
+        vm: &mut bun_jsc::virtual_machine::VirtualMachine,
         histogram: JSValue,
         resolution_ms: i32,
     ) {
-        if self.enabled {
-            return;
-        }
-        self.js_histogram = histogram;
+        self.disable();
+        self.histogram = bun_jsc::Weak::create_passive(histogram, vm.global());
         self.resolution_ms = resolution_ms;
         self.enabled = true;
 
@@ -479,16 +489,22 @@ impl EventLoopDelayMonitor {
         unsafe { (*Self::timer_all()).insert(elt) };
     }
 
-    fn disable(&mut self, _vm: &mut bun_jsc::virtual_machine::VirtualMachine) {
+    /// Stop recording and release the histogram handle (see the field doc for
+    /// the sweep that also calls this).
+    pub(crate) fn disable(&mut self) {
         if !self.enabled {
             return;
         }
         self.enabled = false;
-        self.js_histogram = JSValue::default();
+        self.histogram = bun_jsc::Weak::default();
         self.last_fire_ns = 0;
-        let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: see `enable` — disjoint-field access on `All`.
-        unsafe { (*Self::timer_all()).remove(elt) };
+        // Not ACTIVE while `on_fire` has the node popped and is deciding
+        // whether to re-arm it.
+        if self.event_loop_timer.state == EventLoopTimerState::ACTIVE {
+            let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
+            // SAFETY: see `enable` — disjoint-field access on `All`.
+            unsafe { (*Self::timer_all()).remove(elt) };
+        }
     }
 
     /// Record `now - last_fire_ns`
@@ -498,9 +514,16 @@ impl EventLoopDelayMonitor {
         _vm: &mut bun_jsc::virtual_machine::VirtualMachine,
         now: &bun_event_loop::EventLoopTimer::Timespec,
     ) {
-        if !self.enabled || self.js_histogram.is_empty() {
+        self.event_loop_timer.state = EventLoopTimerState::FIRED;
+        if !self.enabled {
             return;
         }
+        // The histogram was collected (its realm is gone): nothing can read it
+        // any more, so stop instead of re-arming.
+        let Some(histogram) = self.histogram.get() else {
+            self.disable();
+            return;
+        };
 
         let now_ns = now.ns();
         if self.last_fire_ns > 0 {
@@ -518,7 +541,7 @@ impl EventLoopDelayMonitor {
                         delay_ns: i64,
                     );
                 }
-                JSNodePerformanceHooksHistogram_recordDelay(self.js_histogram, delay_ns);
+                JSNodePerformanceHooksHistogram_recordDelay(histogram, delay_ns);
             }
         }
 

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -362,6 +362,71 @@ describe.concurrent("bun test --isolate", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("with --isolate, a leaked monitorEventLoopDelay() is disabled before next file", async () => {
+    // The monitor is per thread while its histogram belongs to the file's
+    // global. A file that enables it and never disables it used to leave the
+    // monitor recording into the collected histogram of the retired global for
+    // the rest of the run. Two things are observable from the next file: a
+    // fresh histogram that reuses the freed cell receives the stale records,
+    // and the next file's own enable() is a no-op because the monitor is still
+    // marked enabled, so its histogram never records anything.
+    const monitorFixtures = {
+      "a-monitor.test.ts": `
+        import { test, expect } from "bun:test";
+        import { monitorEventLoopDelay } from "node:perf_hooks";
+        test("leak an enabled monitor", () => {
+          expect(monitorEventLoopDelay({ resolution: 1 }).enable()).toBe(true);
+          // intentionally never calling disable()
+        });
+      `,
+      "b-histogram.test.ts": `
+        import { test, expect } from "bun:test";
+        import { createHistogram, monitorEventLoopDelay } from "node:perf_hooks";
+        test("previous file's monitor is gone and this file's own works", async () => {
+          // Collect file A's histogram first so a decoy below lands in its cell.
+          Bun.gc(true);
+          const decoys = Array.from({ length: 8 }, () => createHistogram());
+
+          const own = monitorEventLoopDelay({ resolution: 1 });
+          expect(own.enable()).toBe(true);
+          const deadline = Date.now() + 5000;
+          while (own.count === 0 && Date.now() < deadline) {
+            // Stall the loop, then yield so the monitor's timer can measure it.
+            const until = Date.now() + 10;
+            while (Date.now() < until) {}
+            await Bun.sleep(2);
+          }
+          own.disable();
+
+          expect(decoys.map(h => h.count)).toEqual(decoys.map(() => 0));
+          expect(own.count).toBeGreaterThan(0);
+        });
+      `,
+    };
+    const files = ["./a-monitor.test.ts", "./b-histogram.test.ts"];
+
+    using isolated = tempDir("isolate-event-loop-delay", monitorFixtures);
+    const serial = await runTests(String(isolated), ["--isolate", "--timeout=10000"], files);
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("2 pass");
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("0 fail");
+    expect(serial.exitCode).toBe(0);
+
+    // One worker takes both files (scale-up gated) so the same sweep runs
+    // between files inside a --parallel worker.
+    using parallel = tempDir("isolate-event-loop-delay-parallel", monitorFixtures);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", "--timeout=10000", ...files],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
+      cwd: String(parallel),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("2 pass");
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
   test("leaked subprocesses are killed for every isolated file, not just the first", async () => {
     using dir = tempDir("isolate-subprocess", {
       "a-spawn.test.ts": `
@@ -848,6 +913,9 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 //   sets and plugin callback lists were held through Strong handles, so any
 //   file that created a mock or registered a plugin formed an uncollectable
 //   root -> realm object -> global cycle (#31771's linear growth in practice).
+// - monitorEventLoopDelay().enable(): the per-thread monitor holds the file's
+//   histogram. It is disabled at the swap and only ever holds the histogram
+//   weakly, so an enabled monitor must not keep the file's global alive.
 //
 // Each fixture runs 8 isolated files that leak one handle apiece, forces a
 // full GC, and counts live GlobalObject cells. Pinned globals accumulate
@@ -971,6 +1039,17 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
             build.module("leaked-virtual-module", () => ({ exports: {}, loader: "object" }));
           },
         });
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
+
+  test("monitorEventLoopDelay() left enabled", async () => {
+    using dir = tempDir(
+      "isolate-leak-event-loop-delay",
+      makeLeakFixture(`
+        import { monitorEventLoopDelay } from "node:perf_hooks";
+        monitorEventLoopDelay({ resolution: 1 }).enable();
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);


### PR DESCRIPTION
### Problem
- A file that leaves `monitorEventLoopDelay().enable()` on keeps the monitor firing after `bun test --isolate` (or `--parallel`) retired its global. Each fire is a write-after-free in `hdr_record_value` under `EventLoopDelayMonitor::on_fire` (`JSNodePerformanceHooksHistogram_recordDelay`). Sentry BUN-41KQ, Windows, 23 events.
- `All.event_loop_delay` (`src/runtime/timer/mod.rs:429`) is per thread and held the histogram as a bare `JSValue` that only the retired realm kept alive. The swap did not touch the monitor, and `enable()` returned early while enabled, so the next file could not replace the dead histogram.

### Fix
- The monitor holds the histogram in a passive `bun_jsc::Weak`, and `on_fire` stops once the cell is gone. A `Strong` would pin the retired realm instead.
- `stop_active_handles` disables the monitor, next to the fake-timers reset. It runs at every file swap and in the teardown stop phase, so the `Weak` goes while the heap is alive and the next file finds the monitor free.
- `enable()` replaces whatever is registered. `disable()` unlinks the timer only when it is `ACTIVE`, since `on_fire` calls it with the node popped.
- Verified: two new cases in `test/cli/test/isolation.test.ts`. The first fails on stock bun and on an unfixed ASAN build. Also ran the whole file and the perf_hooks suites.

### Background
- `--isolate` runs each file in a fresh global on one thread. Between files, `stop_active_handles` closes what the file leaked, then the swap replaces the global. The per-thread `timer::All` survives. Leaked fake timers (fb03d39a7d) were the same problem.
- `EventLoopDelayMonitor` is one `EventLoopTimer` embedded in `All`. Every `resolution` ms it records the delay into the histogram and re-arms itself.
- `bun_jsc::Weak` wraps a `JSC::Weak`. It reads empty once the GC reaps the cell, before the sweep runs `~HistogramData` (`hdr_close`). The handle lives in the JSC heap, and `All` is dropped after `~VM`, so the stop phase has to release it.

<details><summary>Notes</summary>

- Repro on release 1.4.0 (Linux, 5/5): file A enables a 1 ms monitor in a test. File B runs `Bun.gc(true)`, calls `createHistogram()`, and idles 150 ms. `bun test --isolate a b` prints `count = 139..140` for B's histogram: the freed cell is reused by B's histogram and the stale `record()` calls land in it (`totalCount` lives in the cell). Without `--isolate` the count stays 0. Windows decommits freed pages instead, hence the Windows-only Sentry events (23 since 1.3.14, 2 on 1.4.0).
- The first new test asserts two things because the failure mode depends on the allocator. On release bun, a decoy histogram allocated after `Bun.gc(true)` receives the stale records (837 in my run). On the ASAN debug build the cell is not reused, and the failure is that file B's own `enable()` is a no-op, so its histogram stays empty. Each build fails on one of the two assertions.
- The second new case is in the "collects globals pinned by leaked handles" block. It passes before and after this change (a bare `JSValue` does not pin either). It is there to keep a future `Strong` out of this field.
- `JSNodePerformanceHooksHistogram_recordDelay` keeps its `uncheckedDowncast`. The value now comes out of a live `Weak` and was type checked by `jsFunction_enableEventLoopDelay`. A checked cast cannot detect a freed cell anyway.
- Probed on the ASAN build with the monitor left enabled: three Worker terminations and the main thread under `BUN_DESTRUCT_VM_ON_EXIT=1`. No report. A monitor inside a Worker still records.
- A ShadowRealm that enables the monitor and is then dropped did not reproduce in a short probe. The `Weak` covers that shape too if such a realm is collected.
- Suites run against the debug build: all of `test/cli/test/isolation.test.ts` (28 pass), `test/js/node/perf_hooks/perf_hooks.test.ts`, `test/js/node/test/sequential/test-performance-eventloopdelay.js`.
- Related open PRs take other routes and do not handle the file swap. #31837 roots the histogram with a Strong, which would pin one retired realm per file. #33591 makes each `monitorEventLoopDelay()` call independent (a Strong per monitor, no isolation or teardown step). This PR is the small crash fix on the current design. Either of those needs the `stop_active_handles` step if it lands later.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts
bun test v1.4.0 (6e906e468)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [366.34ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [329.40ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [447.74ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [458.95ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [350.43ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [2045.84ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [1793.79ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [1802.39ms]
(pass) bun test --isolate > with --isolate, leaked vi.useFakeTimers() is deactivated before next file [2504.91ms]
(pass) bun test --isolate > leaked subprocesses are
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4653fc97c)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [30.06ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [37.98ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [41.89ms]
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [44.36ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [41.27ms]
(pass) --isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export [24.88ms]
(pass) --isolate: delete require.cache evicts the SourceProvider cache [37.93ms]
(pass) --isolate: SourceProvider cache covers CommonJS modules [34.53ms]
(pass) --isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages [32.54ms]
(pass) bun test --isolate > leaked subprocesses are killed for every isolated file, not just the first [47.75ms]
(pass) bun test --isolate > module-scope subprocesses are killed for every isolated file, not just the first (--isolate) [53.23ms]
(pass) bun test --isolate > with --
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts
bun test v1.4.0 (6e906e468)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [444.93ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [480.41ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [654.97ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [722.74ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [498.11ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [2523.27ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [2256.11ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [2835.55ms]
(pass) bun test --isolate > with --isolate, a leaked monitorEventLoopDelay() is disabled before next file [2686.55ms]
(pass) bun test --isolate > with --isolate, lea
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 951ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (11794ms)
Bundle modules (84ms)
Postprocesss modules (46ms)
Bundle Functions (900ms)
Generate Code (41ms)

[12.89s] Bundled "src/js" for production
  2625 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../JSNodePerformanceHooksHistogramPrototype.cpp   |  4 +-
 src/runtime/jsc_hooks.rs                           |  5 ++
 src/runtime/timer/EventLoopDelayMonitor.rs         |  6 +-
 src/runtime/timer/mod.rs                           | 39 ++++++-----
 test/cli/test/isolation.test.ts                    | 79 ++++++++++++++++++++++
 5 files changed, 110 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…c/bindings/JSNodePerformanceHooksHistogramPrototype.cpp      2      2      0
src/runtime/jsc_hooks.rs                                      4      5      0
src/runtime/timer/EventLoopDelayMonitor.rs                    2      2      0
src/runtime/timer/mod.rs                                      7      8      0
test/cli/test/isolation.test.ts                               1      4      0
```

</details>

<!-- robobun:evidence:end -->