### PR TITLE
bundler: resolve a barrel's import records once

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -72,13 +72,6 @@ bitflags::bitflags! {
 
         const WAS_ORIGINALLY_REQUIRE = 1 << 9;
 
-        /// The bundler already ran resolution for this record. Also set when
-        /// resolution leaves `source_index` invalid: the import is external,
-        /// failed to resolve, or is waiting for an onResolve plugin. The
-        /// barrel optimization resolves a barrel's records again when it
-        /// un-defers one of them; records with this flag are skipped.
-        const RESOLVE_STARTED = 1 << 10;
-
         /// If true, this import can be removed if it's unused
         const IS_EXTERNAL_WITHOUT_SIDE_EFFECTS = 1 << 11;
 

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -72,6 +72,13 @@ bitflags::bitflags! {
 
         const WAS_ORIGINALLY_REQUIRE = 1 << 9;
 
+        /// The bundler already ran resolution for this record. Also set when
+        /// resolution leaves `source_index` invalid: the import is external,
+        /// failed to resolve, or is waiting for an onResolve plugin. The
+        /// barrel optimization resolves a barrel's records again when it
+        /// un-defers one of them; records with this flag are skipped.
+        const RESOLVE_STARTED = 1 << 10;
+
         /// If true, this import can be removed if it's unused
         const IS_EXTERNAL_WITHOUT_SIDE_EFFECTS = 1 << 11;
 

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -315,13 +315,11 @@ struct BarrelWorkItem<'a> {
     is_star: bool,
 }
 
-/// Resolve, process, and patch import records for a single barrel.
-/// Used to inline-resolve deferred records whose source_index is still invalid.
-fn resolve_barrel_records(
-    this: &mut BundleV2,
-    barrel_idx: u32,
-    barrels_to_resolve: &mut ArrayHashMap<u32, ()>,
-) -> i32 {
+/// Resolve, process, and patch import records for a single barrel. Called
+/// right after the BFS un-defers a record in it; `resolve_import_records`
+/// only touches the records it has not handled before, so this resolves the
+/// records un-deferred since the previous call.
+fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32) -> i32 {
     let idx = barrel_idx as usize;
     let target = this.graph.ast.items_target()[idx];
     let loader = this.graph.input_files.items_loader()[idx];
@@ -360,15 +358,18 @@ fn resolve_barrel_records(
 
     this.graph.ast.items_import_records_mut()[idx] = barrel_ir;
 
-    let _ = barrels_to_resolve.swap_remove(&barrel_idx);
     scheduled
 }
 
 /// After a new file's import records are patched with source_indices,
 /// record what this file requests from each target in requested_exports
 /// (eagerly, before barrels are known), then BFS through barrel chains
-/// to un-defer needed records. Un-deferred records are re-resolved through
-/// resolveImportRecords (same path as initial resolution).
+/// to un-defer needed records. Un-deferred records are resolved through
+/// resolveImportRecords (same path as initial resolution) as soon as they are
+/// un-deferred, so the BFS can continue into the modules they point at. A
+/// request for a record that was never deferred resolves nothing: that record
+/// was handled when the barrel itself was resolved, whether or not it ended
+/// up with a source_index (external, unresolved, or onResolve plugin pending).
 /// Returns the number of newly scheduled parse tasks.
 pub(crate) fn schedule_barrel_deferred_imports(
     this: &mut BundleV2,
@@ -679,8 +680,6 @@ pub(crate) fn schedule_barrel_deferred_imports(
     // dedup via requested_exports to prevent cycles.
     let initial_queue_len = queue.len();
 
-    let mut barrels_to_resolve: ArrayHashMap<u32, ()> = ArrayHashMap::default();
-
     let mut newly_scheduled: i32 = 0;
     let mut qi: usize = 0;
     while qi < queue.len() {
@@ -740,16 +739,12 @@ pub(crate) fn schedule_barrel_deferred_imports(
                 if flags.contains(import_record::Flags::IS_UNUSED)
                     && !flags.contains(import_record::Flags::IS_INTERNAL)
                 {
-                    if un_defer_record(barrel_ir, idx) {
-                        barrels_to_resolve.put(barrel_idx, ())?;
-                        un_deferred_any = true;
-                    }
+                    un_deferred_any |= un_defer_record(barrel_ir, idx);
                 }
             }
             // Resolve now: propagation below needs source indices.
             if un_deferred_any {
-                newly_scheduled +=
-                    resolve_barrel_records(this, barrel_idx, &mut barrels_to_resolve);
+                newly_scheduled += resolve_barrel_records(this, barrel_idx);
             }
 
             // A namespace request covers every export: request each
@@ -846,18 +841,12 @@ pub(crate) fn schedule_barrel_deferred_imports(
                     continue;
                 }
                 if un_defer_record(barrel_ir, star_idx as usize) {
-                    barrels_to_resolve.put(barrel_idx, ())?;
+                    // Resolve now: propagation below needs the source index.
+                    newly_scheduled += resolve_barrel_records(this, barrel_idx);
                 }
-                let mut star_rec_si = barrel_ir.as_slice()[star_idx as usize].source_index;
-                if !star_rec_si.is_valid() {
-                    // Deferred record was never resolved — resolve inline now.
-                    newly_scheduled +=
-                        resolve_barrel_records(this, barrel_idx, &mut barrels_to_resolve);
-                    // Re-derive after resolution may have mutated slices.
-                    star_rec_si = this.graph.ast.items_import_records_mut()[barrel_idx as usize]
-                        .as_slice()[star_idx as usize]
-                        .source_index;
-                }
+                let star_rec_si = this.graph.ast.items_import_records()[barrel_idx as usize]
+                    .as_slice()[star_idx as usize]
+                    .source_index;
                 if star_rec_si.is_valid() {
                     queue.push(BarrelWorkItem {
                         barrel_source_index: star_rec_si.get(),
@@ -872,7 +861,8 @@ pub(crate) fn schedule_barrel_deferred_imports(
 
         let barrel_ir = &mut this.graph.ast.items_import_records_mut()[barrel_idx as usize];
         if un_defer_record(barrel_ir, resolution.import_record_index as usize) {
-            barrels_to_resolve.put(barrel_idx, ())?;
+            // Resolve now: propagation below needs the source index.
+            newly_scheduled += resolve_barrel_records(this, barrel_idx);
         }
 
         // `original_alias` is an arena-backed `StoreStr` valid for the
@@ -881,36 +871,21 @@ pub(crate) fn schedule_barrel_deferred_imports(
             Some(p) => p.slice(),
             None => alias,
         };
-        if (resolution.import_record_index as usize) < barrel_ir.len() {
-            let mut rec_si =
-                barrel_ir.as_slice()[resolution.import_record_index as usize].source_index;
-            if !rec_si.is_valid() {
-                // Deferred record was never resolved — resolve inline now.
-                newly_scheduled +=
-                    resolve_barrel_records(this, barrel_idx, &mut barrels_to_resolve);
-                rec_si = this.graph.ast.items_import_records_mut()[barrel_idx as usize].as_slice()
-                    [resolution.import_record_index as usize]
-                    .source_index;
-            }
-            if rec_si.is_valid() {
-                // When the barrel re-exports a namespace import (`import * as X; export { X }`),
-                // propagate as a star import so the target barrel loads all exports.
-                queue.push(BarrelWorkItem {
-                    barrel_source_index: rec_si.get(),
-                    alias: propagate_alias,
-                    is_star: resolution.alias_is_star,
-                });
-            }
+        let rec_si = this.graph.ast.items_import_records()[barrel_idx as usize]
+            .as_slice()
+            .get(resolution.import_record_index as usize)
+            .map(|rec| rec.source_index);
+        if let Some(rec_si) = rec_si.filter(|si| si.is_valid()) {
+            // When the barrel re-exports a namespace import (`import * as X; export { X }`),
+            // propagate as a star import so the target barrel loads all exports.
+            queue.push(BarrelWorkItem {
+                barrel_source_index: rec_si.get(),
+                alias: propagate_alias,
+                is_star: resolution.alias_is_star,
+            });
         }
 
         qi += 1;
-    }
-
-    // Re-resolve any remaining un-deferred records through the normal resolution path.
-    while barrels_to_resolve.count() > 0 {
-        let barrel_source_index = barrels_to_resolve.keys()[0];
-        newly_scheduled +=
-            resolve_barrel_records(this, barrel_source_index, &mut barrels_to_resolve);
     }
 
     Ok(newly_scheduled)

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -315,10 +315,8 @@ struct BarrelWorkItem<'a> {
     is_star: bool,
 }
 
-/// Resolve the records (`un_deferred`, ascending indices) that the BFS just
-/// un-deferred in one barrel, schedule the modules they point at, and patch
-/// their source indices. The barrel's other records were handled when the
-/// barrel itself was resolved and are left alone.
+/// Resolve the records the BFS just un-deferred in one barrel (`un_deferred`,
+/// ascending indices), schedule their modules, and patch their source indices.
 fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32, un_deferred: &[u32]) -> i32 {
     let idx = barrel_idx as usize;
     let target = this.graph.ast.items_target()[idx];
@@ -365,12 +363,9 @@ fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32, un_deferred: &[u
 /// After a new file's import records are patched with source_indices,
 /// record what this file requests from each target in requested_exports
 /// (eagerly, before barrels are known), then BFS through barrel chains
-/// to un-defer needed records. Each record is resolved through
-/// resolveImportRecords (same path as initial resolution) as soon as it is
-/// un-deferred, so the BFS can continue into the module it points at. Only
-/// the un-deferred records are resolved: a request for a record that was
-/// never deferred resolves nothing, whether or not that record has a
-/// source_index (external, unresolved, or onResolve plugin pending).
+/// to un-defer needed records. Each un-deferred record is resolved at once
+/// through resolveImportRecords (same path as initial resolution), so the BFS
+/// can continue into the module it points at.
 /// Returns the number of newly scheduled parse tasks.
 pub(crate) fn schedule_barrel_deferred_imports(
     this: &mut BundleV2,

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -315,11 +315,11 @@ struct BarrelWorkItem<'a> {
     is_star: bool,
 }
 
-/// Resolve, process, and patch import records for a single barrel. Called
-/// right after the BFS un-defers a record in it; `resolve_import_records`
-/// only touches the records it has not handled before, so this resolves the
-/// records un-deferred since the previous call.
-fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32) -> i32 {
+/// Resolve the records (`un_deferred`, ascending indices) that the BFS just
+/// un-deferred in one barrel, schedule the modules they point at, and patch
+/// their source indices. The barrel's other records were handled when the
+/// barrel itself was resolved and are left alone.
+fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32, un_deferred: &[u32]) -> i32 {
     let idx = barrel_idx as usize;
     let target = this.graph.ast.items_target()[idx];
     let loader = this.graph.input_files.items_loader()[idx];
@@ -338,6 +338,7 @@ fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32) -> i32 {
         source: &source,
         loader,
         target,
+        only_records: Some(un_deferred),
     });
 
     this.graph.input_files.items_source_mut()[idx] = source;
@@ -351,7 +352,7 @@ fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32) -> i32 {
             source_path,
             loader,
             target,
-            force_save: true,
+            only_records: Some(un_deferred),
             ..Default::default()
         },
     );
@@ -364,12 +365,12 @@ fn resolve_barrel_records(this: &mut BundleV2, barrel_idx: u32) -> i32 {
 /// After a new file's import records are patched with source_indices,
 /// record what this file requests from each target in requested_exports
 /// (eagerly, before barrels are known), then BFS through barrel chains
-/// to un-defer needed records. Un-deferred records are resolved through
-/// resolveImportRecords (same path as initial resolution) as soon as they are
-/// un-deferred, so the BFS can continue into the modules they point at. A
-/// request for a record that was never deferred resolves nothing: that record
-/// was handled when the barrel itself was resolved, whether or not it ended
-/// up with a source_index (external, unresolved, or onResolve plugin pending).
+/// to un-defer needed records. Each record is resolved through
+/// resolveImportRecords (same path as initial resolution) as soon as it is
+/// un-deferred, so the BFS can continue into the module it points at. Only
+/// the un-deferred records are resolved: a request for a record that was
+/// never deferred resolves nothing, whether or not that record has a
+/// source_index (external, unresolved, or onResolve plugin pending).
 /// Returns the number of newly scheduled parse tasks.
 pub(crate) fn schedule_barrel_deferred_imports(
     this: &mut BundleV2,
@@ -731,20 +732,15 @@ pub(crate) fn schedule_barrel_deferred_imports(
         let barrel_ir = &mut this.graph.ast.items_import_records_mut()[barrel_idx as usize];
 
         if item_is_star {
-            // Read flags by index, then mutate (borrowck).
-            let len = barrel_ir.len();
-            let mut un_deferred_any = false;
-            for idx in 0..len {
-                let flags = barrel_ir.as_slice()[idx].flags;
-                if flags.contains(import_record::Flags::IS_UNUSED)
-                    && !flags.contains(import_record::Flags::IS_INTERNAL)
-                {
-                    un_deferred_any |= un_defer_record(barrel_ir, idx);
+            let mut un_deferred: Vec<u32> = Vec::new();
+            for idx in 0..barrel_ir.len() {
+                if un_defer_record(barrel_ir, idx) {
+                    un_deferred.push(idx as u32);
                 }
             }
             // Resolve now: propagation below needs source indices.
-            if un_deferred_any {
-                newly_scheduled += resolve_barrel_records(this, barrel_idx);
+            if !un_deferred.is_empty() {
+                newly_scheduled += resolve_barrel_records(this, barrel_idx, &un_deferred);
             }
 
             // A namespace request covers every export: request each
@@ -842,7 +838,7 @@ pub(crate) fn schedule_barrel_deferred_imports(
                 }
                 if un_defer_record(barrel_ir, star_idx as usize) {
                     // Resolve now: propagation below needs the source index.
-                    newly_scheduled += resolve_barrel_records(this, barrel_idx);
+                    newly_scheduled += resolve_barrel_records(this, barrel_idx, &[star_idx]);
                 }
                 let star_rec_si = this.graph.ast.items_import_records()[barrel_idx as usize]
                     .as_slice()[star_idx as usize]
@@ -862,7 +858,8 @@ pub(crate) fn schedule_barrel_deferred_imports(
         let barrel_ir = &mut this.graph.ast.items_import_records_mut()[barrel_idx as usize];
         if un_defer_record(barrel_ir, resolution.import_record_index as usize) {
             // Resolve now: propagation below needs the source index.
-            newly_scheduled += resolve_barrel_records(this, barrel_idx);
+            newly_scheduled +=
+                resolve_barrel_records(this, barrel_idx, &[resolution.import_record_index]);
         }
 
         // `original_alias` is an arena-backed `StoreStr` valid for the

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5879,6 +5879,7 @@ pub mod bv2_impl {
                 source: &result.source,
                 loader: result.loader,
                 target,
+                only_records: None,
             });
 
             if let Some(err) = resolve_result.last_error {
@@ -5937,6 +5938,8 @@ pub mod bv2_impl {
         pub(crate) source: &'a bun_ast::Source,
         pub(crate) loader: Loader,
         pub(crate) target: options::Target,
+        /// See `only_selected_record`.
+        pub(crate) only_records: Option<&'a [u32]>,
     }
 
     pub(crate) struct ResolveImportRecordResult {
@@ -5944,10 +5947,20 @@ pub mod bv2_impl {
         pub(crate) last_error: Option<Error>,
     }
 
+    /// `only_records` is `None` when a file is resolved after it was parsed: every
+    /// record takes part. Barrel un-deferral passes the indices (ascending) of the
+    /// records it just un-deferred. The other records of the barrel were handled
+    /// when the barrel was parsed, and a record that is external, failed to
+    /// resolve, or waits for an onResolve plugin has no `source_index` to show it.
+    #[inline]
+    fn only_selected_record(only_records: Option<&[u32]>, record_index: usize) -> bool {
+        only_records.is_none_or(|only| only.binary_search(&(record_index as u32)).is_ok())
+    }
+
     impl<'a> BundleV2<'a> {
-        /// Resolve all unresolved import records for a module. Skips records that
-        /// are already resolved (valid source_index), that an earlier call
-        /// already handled (`RESOLVE_STARTED`), unused, or internal.
+        /// Resolve all unresolved import records for a module (or only
+        /// `ctx.only_records`). Skips records that are already resolved (valid
+        /// source_index), unused, or internal.
         /// Returns a resolve queue of new modules to schedule, plus any fatal error.
         /// Used by both initial parse resolution and barrel un-deferral.
         pub(crate) fn resolve_import_records(
@@ -5957,6 +5970,8 @@ pub mod bv2_impl {
             let source = ctx.source;
             let loader = ctx.loader;
             let source_dir = source.path.source_dir();
+            let only_records = ctx.only_records;
+            debug_assert!(only_records.is_none_or(<[u32]>::is_sorted));
             let mut estimated_resolve_queue_count: usize = 0;
             for import_record in ctx.import_records.iter_mut() {
                 if import_record
@@ -5980,12 +5995,17 @@ pub mod bv2_impl {
                     import_record.source_index = Index::INVALID;
                 }
 
-                estimated_resolve_queue_count += (!(import_record.flags.intersects(
-                    bun_ast::ImportRecordFlags::IS_INTERNAL
-                        | bun_ast::ImportRecordFlags::IS_UNUSED
-                        | bun_ast::ImportRecordFlags::RESOLVE_STARTED,
-                ) || import_record.source_index.is_valid()))
+                estimated_resolve_queue_count += (!(import_record
+                    .flags
+                    .contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
+                    || import_record
+                        .flags
+                        .contains(bun_ast::ImportRecordFlags::IS_UNUSED)
+                    || import_record.source_index.is_valid()))
                     as usize;
+            }
+            if let Some(only) = only_records {
+                estimated_resolve_queue_count = estimated_resolve_queue_count.min(only.len());
             }
             let mut resolve_queue = ResolveQueue::default();
             resolve_queue.reserve(estimated_resolve_queue_count);
@@ -5993,6 +6013,10 @@ pub mod bv2_impl {
             let mut last_error: Option<Error> = None;
 
             'outer: for (i, import_record) in ctx.import_records.iter_mut().enumerate() {
+                if !only_selected_record(only_records, i) {
+                    continue;
+                }
+
                 // Preserve original import specifier before resolution modifies path
                 if import_record.original_path.is_empty() {
                     import_record.original_path = import_record.path.text;
@@ -6005,17 +6029,9 @@ pub mod bv2_impl {
                 || import_record.flags.contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
                 // Don't resolve pre-resolved imports
                 || import_record.source_index.is_valid()
-                // Don't resolve a record twice. Barrel un-deferral runs this over
-                // the whole list again, and a record that came out external,
-                // unresolved, or waiting on an onResolve plugin has no
-                // source_index to show that it was already handled.
-                || import_record.flags.contains(bun_ast::ImportRecordFlags::RESOLVE_STARTED)
                 {
                     continue;
                 }
-                import_record
-                    .flags
-                    .insert(bun_ast::ImportRecordFlags::RESOLVE_STARTED);
 
                 if let Some(fw) = &self.framework {
                     if fw.server_components.is_some() {
@@ -6765,9 +6781,10 @@ pub mod bv2_impl {
         pub(crate) loader: Loader,
         pub(crate) target: options::Target,
         pub(crate) redirect_import_record_index: u32,
-        /// When true, always save source indices regardless of dev_server/loader.
-        /// Used for barrel un-deferral where records must always be connected.
-        pub(crate) force_save: bool,
+        /// See `only_selected_record`. Barrel un-deferral (`Some`) always saves
+        /// the source indices of the records it passes, regardless of
+        /// dev_server/loader: the BFS follows them into the next barrel.
+        pub(crate) only_records: Option<&'a [u32]>,
     }
 
     impl Default for PatchImportRecordsCtx<'_> {
@@ -6778,7 +6795,7 @@ pub mod bv2_impl {
                 loader: Loader::File,
                 target: Target::Browser,
                 redirect_import_record_index: u32::MAX,
-                force_save: false,
+                only_records: None,
             }
         }
     }
@@ -6796,7 +6813,8 @@ pub mod bv2_impl {
             // across the `&mut self.graph.build_graphs[...]` borrow
             // below, so address the disjoint `self.graph.*` fields directly instead.
             let input_file_loaders = self.graph.input_files.items_loader();
-            let save_import_record_source_index = ctx.force_save
+            debug_assert!(ctx.only_records.is_none_or(<[u32]>::is_sorted));
+            let save_import_record_source_index = ctx.only_records.is_some()
                 || self.dev_server.is_none()
                 || ctx.loader == Loader::Html
                 || ctx.loader.is_css();
@@ -6823,6 +6841,9 @@ pub mod bv2_impl {
             // so borrowck sees it as disjoint from `self.graph.input_files` above.
             let path_to_source_index_map = &mut self.graph.build_graphs[ctx.target];
             for (i, record) in import_records.as_mut_slice().iter_mut().enumerate() {
+                if !only_selected_record(ctx.only_records, i) {
+                    continue;
+                }
                 if let Some(source_index) = path_to_source_index_map.get_path(&record.path) {
                     if save_import_record_source_index
                         || input_file_loaders[source_index as usize].is_css()
@@ -7134,7 +7155,7 @@ pub mod bv2_impl {
                             loader: result.loader,
                             target: result.ast.target,
                             redirect_import_record_index: result.ast.redirect_import_record_index,
-                            force_save: false,
+                            only_records: None,
                         },
                     );
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5947,20 +5947,17 @@ pub mod bv2_impl {
         pub(crate) last_error: Option<Error>,
     }
 
-    /// `only_records` is `None` when a file is resolved after it was parsed: every
-    /// record takes part. Barrel un-deferral passes the indices (ascending) of the
-    /// records it just un-deferred. The other records of the barrel were handled
-    /// when the barrel was parsed, and a record that is external, failed to
-    /// resolve, or waits for an onResolve plugin has no `source_index` to show it.
+    /// `only_records`: barrel un-deferral passes the ascending indices of the records
+    /// it just un-deferred. A missing `source_index` does not mean a record is still
+    /// unresolved (external, failed, or waiting for an onResolve plugin).
     #[inline]
     fn only_selected_record(only_records: Option<&[u32]>, record_index: usize) -> bool {
         only_records.is_none_or(|only| only.binary_search(&(record_index as u32)).is_ok())
     }
 
     impl<'a> BundleV2<'a> {
-        /// Resolve all unresolved import records for a module (or only
-        /// `ctx.only_records`). Skips records that are already resolved (valid
-        /// source_index), unused, or internal.
+        /// Resolve all unresolved import records for a module, or only `ctx.only_records`.
+        /// Skips records that are already resolved (valid source_index), unused, or internal.
         /// Returns a resolve queue of new modules to schedule, plus any fatal error.
         /// Used by both initial parse resolution and barrel un-deferral.
         pub(crate) fn resolve_import_records(
@@ -6781,9 +6778,8 @@ pub mod bv2_impl {
         pub(crate) loader: Loader,
         pub(crate) target: options::Target,
         pub(crate) redirect_import_record_index: u32,
-        /// See `only_selected_record`. Barrel un-deferral (`Some`) always saves
-        /// the source indices of the records it passes, regardless of
-        /// dev_server/loader: the BFS follows them into the next barrel.
+        /// See `only_selected_record`. `Some` also saves the source indices regardless
+        /// of dev_server/loader: the barrel BFS follows them.
         pub(crate) only_records: Option<&'a [u32]>,
     }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5946,7 +5946,8 @@ pub mod bv2_impl {
 
     impl<'a> BundleV2<'a> {
         /// Resolve all unresolved import records for a module. Skips records that
-        /// are already resolved (valid source_index), unused, or internal.
+        /// are already resolved (valid source_index), that an earlier call
+        /// already handled (`RESOLVE_STARTED`), unused, or internal.
         /// Returns a resolve queue of new modules to schedule, plus any fatal error.
         /// Used by both initial parse resolution and barrel un-deferral.
         pub(crate) fn resolve_import_records(
@@ -5979,13 +5980,11 @@ pub mod bv2_impl {
                     import_record.source_index = Index::INVALID;
                 }
 
-                estimated_resolve_queue_count += (!(import_record
-                    .flags
-                    .contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
-                    || import_record
-                        .flags
-                        .contains(bun_ast::ImportRecordFlags::IS_UNUSED)
-                    || import_record.source_index.is_valid()))
+                estimated_resolve_queue_count += (!(import_record.flags.intersects(
+                    bun_ast::ImportRecordFlags::IS_INTERNAL
+                        | bun_ast::ImportRecordFlags::IS_UNUSED
+                        | bun_ast::ImportRecordFlags::RESOLVE_STARTED,
+                ) || import_record.source_index.is_valid()))
                     as usize;
             }
             let mut resolve_queue = ResolveQueue::default();
@@ -6006,9 +6005,17 @@ pub mod bv2_impl {
                 || import_record.flags.contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
                 // Don't resolve pre-resolved imports
                 || import_record.source_index.is_valid()
+                // Don't resolve a record twice. Barrel un-deferral runs this over
+                // the whole list again, and a record that came out external,
+                // unresolved, or waiting on an onResolve plugin has no
+                // source_index to show that it was already handled.
+                || import_record.flags.contains(bun_ast::ImportRecordFlags::RESOLVE_STARTED)
                 {
                     continue;
                 }
+                import_record
+                    .flags
+                    .insert(bun_ast::ImportRecordFlags::RESOLVE_STARTED);
 
                 if let Some(fw) = &self.framework {
                     if fw.server_components.is_some() {

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -1395,6 +1395,41 @@ describe("bundler", () => {
     run: { stdout: "resolved-by-plugin" },
   });
 
+  // --- Each barrel record is resolved once ---
+
+  // a.js is only discovered through the barrel, so its request for Broken and C
+  // always arrives after the barrel deferred both. Un-deferring Broken reports
+  // the failure. Un-deferring C must not resolve Broken (and report it) again.
+  itBundled("barrel/UnDeferReportsUnresolvableSiblingOnce", {
+    files: {
+      "/entry.js": /* js */ `
+        import { A } from 'oncelib';
+        console.log(A);
+      `,
+      "/node_modules/oncelib/package.json": JSON.stringify({
+        name: "oncelib",
+        main: "./index.js",
+        sideEffects: false,
+      }),
+      "/node_modules/oncelib/index.js": /* js */ `
+        export { A } from './a.js';
+        export { Broken } from './missing.js';
+        export { C } from './c.js';
+      `,
+      "/node_modules/oncelib/a.js": /* js */ `
+        import { Broken, C } from 'oncelib';
+        export const A = Broken + C;
+      `,
+      "/node_modules/oncelib/c.js": /* js */ `
+        export const C = "c";
+      `,
+    },
+    outfile: "/out.js",
+    bundleErrors: {
+      "/node_modules/oncelib/index.js": ['Could not resolve: "./missing.js"'],
+    },
+  });
+
   // A re-export that resolves as external never gets a source_index. Requests
   // for it from importers must not resolve the barrel again, so the onResolve
   // plugin runs once for the record.
@@ -1440,10 +1475,10 @@ describe("bundler", () => {
     };
   });
 
-  // Un-deferring one record resolves the barrel again. Records that were
-  // already resolved, including the external one, are skipped by that pass.
-  // late.js is loaded only after the react answer, so its request for A
-  // arrives after the barrel deferred a.js.
+  // Un-deferring a.js resolves only that record. The external record, which
+  // also has no source_index, is not dispatched to the plugin again. late.js is
+  // loaded only after the react answer, so its request for A arrives after the
+  // barrel deferred a.js.
   itBundled("barrel/ExternalReExportNotResolvedAgainOnUnDefer", () => {
     const resolved: string[] = [];
     return {

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -1395,6 +1395,135 @@ describe("bundler", () => {
     run: { stdout: "resolved-by-plugin" },
   });
 
+  // A re-export that resolves as external never gets a source_index. Requests
+  // for it from importers must not resolve the barrel again, so the onResolve
+  // plugin runs once for the record.
+  itBundled("barrel/ExternalReExportResolvesOnce", () => {
+    const resolved: string[] = [];
+    return {
+      files: {
+        "/entry.js": /* js */ `
+          import { React } from 'extlib';
+          import { other } from './other.js';
+          console.log(React, other);
+        `,
+        "/other.js": /* js */ `
+          import { React } from 'extlib';
+          export const other = React;
+        `,
+        "/node_modules/extlib/package.json": JSON.stringify({
+          name: "extlib",
+          main: "./index.js",
+          sideEffects: false,
+        }),
+        "/node_modules/extlib/index.js": /* js */ `
+          export { default as React } from 'react';
+          export { B } from './b.js';
+        `,
+        // Nobody imports B, so b.js must stay deferred.
+        "/node_modules/extlib/b.js": /* js */ `
+          export const B = <<<SYNTAX_ERROR>>>;
+        `,
+      },
+      outfile: "/out.js",
+      plugins(builder) {
+        resolved.length = 0;
+        builder.onResolve({ filter: /^react$/ }, args => {
+          resolved.push(args.path);
+          return { path: args.path, external: true };
+        });
+      },
+      onAfterBundle(api) {
+        expect(resolved).toEqual(["react"]);
+        api.expectFile("/out.js").toContain('from "react"');
+      },
+    };
+  });
+
+  // Un-deferring one record resolves the barrel again. Records that were
+  // already resolved, including the external one, are skipped by that pass.
+  // late.js is loaded only after the react answer, so its request for A
+  // arrives after the barrel deferred a.js.
+  itBundled("barrel/ExternalReExportNotResolvedAgainOnUnDefer", () => {
+    const resolved: string[] = [];
+    return {
+      files: {
+        "/entry.js": /* js */ `
+          import { React } from 'latelib';
+          import './late.js';
+          console.log(React);
+        `,
+        "/late.js": ``,
+        "/node_modules/latelib/package.json": JSON.stringify({
+          name: "latelib",
+          main: "./index.js",
+          sideEffects: false,
+        }),
+        "/node_modules/latelib/index.js": /* js */ `
+          export { default as React } from 'react';
+          export { A } from './a.js';
+          export { B } from './b.js';
+        `,
+        "/node_modules/latelib/a.js": /* js */ `
+          export const A = "late-lib-a";
+        `,
+        // Nobody imports B, so b.js must stay deferred.
+        "/node_modules/latelib/b.js": /* js */ `
+          export const B = <<<SYNTAX_ERROR>>>;
+        `,
+      },
+      outfile: "/out.js",
+      plugins(builder) {
+        resolved.length = 0;
+        const reactResolved = Promise.withResolvers<void>();
+        builder.onResolve({ filter: /^react$/ }, args => {
+          resolved.push(args.path);
+          reactResolved.resolve();
+          return { path: args.path, external: true };
+        });
+        builder.onLoad({ filter: /late\.js$/ }, async () => {
+          await reactResolved.promise;
+          return { contents: `import { A } from 'latelib'; console.log(A);`, loader: "js" };
+        });
+      },
+      onAfterBundle(api) {
+        expect(resolved).toEqual(["react"]);
+        api.expectFile("/out.js").toContain('from "react"');
+        api.expectFile("/out.js").toContain("late-lib-a");
+      },
+    };
+  });
+
+  // When the plugin does not answer, the record falls back to the resolver and
+  // the failure is reported. Resolving the barrel again reported it twice.
+  itBundled("barrel/UnresolvableReExportReportedOnce", {
+    files: {
+      "/entry.js": /* js */ `
+        import { Missing } from 'missinglib';
+        console.log(Missing);
+      `,
+      "/node_modules/missinglib/package.json": JSON.stringify({
+        name: "missinglib",
+        main: "./index.js",
+        sideEffects: false,
+      }),
+      "/node_modules/missinglib/index.js": /* js */ `
+        export { Missing } from 'not-installed-pkg';
+        export { B } from './b.js';
+      `,
+      "/node_modules/missinglib/b.js": /* js */ `
+        export const B = "b";
+      `,
+    },
+    outfile: "/out.js",
+    plugins(builder) {
+      builder.onResolve({ filter: /^not-installed-pkg$/ }, () => undefined);
+    },
+    bundleErrors: {
+      "/node_modules/missinglib/index.js": ['Could not resolve: "not-installed-pkg"'],
+    },
+  });
+
   // --- Load plugin + barrel optimization ---
 
   itBundled("barrel/LoadPlugin", {


### PR DESCRIPTION
### Problem
- A `sideEffects: false` barrel is resolved again, as a whole, when an importer asks for a re-export without `source_index` or un-defers one of its records. With no plugins, Bun 1.4.0 reports `Could not resolve: "./missing.js"` twice for one broken re-export. An `onResolve` plugin for an external re-export runs 2 to 3 times for one record.
- `schedule_barrel_deferred_imports` (`src/bundler/barrel_imports.rs:852`, `:887` on main) reads a missing `source_index` as "never resolved". An external, failed, or plugin-pending record never gets one.
- `resolve_barrel_records` passes the whole list. `resolve_import_records` (`src/bundler/bundle_v2.rs:6002`) skips only records with a `source_index`.

### Fix
- The BFS resolves a barrel only when the current item un-deferred a record in it, and passes those indices. The `barrels_to_resolve` map and the final loop are gone.
- `ResolveImportRecordCtx` and `PatchImportRecordsCtx` get `only_records`. Both loops skip every other record. It replaces `force_save`, which covered the same case. No `ImportRecord` flag is added.
- Correct because records are deferred before the barrel is resolved. Every other record was resolved with the barrel, which also requested its target. An un-deferred record is in the list and resolves as before.
- Verified: four new tests in `test/bundler/bundler_barrel.test.ts`, each fails on main. Other suites in Notes.

### Background
- A barrel is a module of a `sideEffects: false` (or `optimizeImports`) package whose exports are all re-exports. Before it is resolved, `apply_barrel_optimization` marks the re-exports nobody asked for yet `IS_UNUSED`: they are deferred.
- When a later file imports such a name, `schedule_barrel_deferred_imports` clears the flag (un-defers) and calls `resolve_barrel_records`: `resolve_import_records`, then `patch_import_record_source_indices`, which writes the `source_index` of each module found. The BFS follows it into the next barrel.
- Only a record that points at a module of the bundle gets a `source_index`. An external record gets none, a failed one is disabled, and an `onResolve` match is answered later by the JS thread.

<details><summary>Notes</summary>

Plugin-free repro. Bun 1.4.0 prints 2, this branch prints 1. `a.js` is found through the barrel, so its request always arrives after the barrel deferred `Broken` and `C`:

```sh
mkdir -p /tmp/b5/node_modules/lib && cd /tmp/b5
echo '{"name":"lib","main":"index.js","sideEffects":false}' > node_modules/lib/package.json
printf 'export { A } from "./a.js";\nexport { Broken } from "./missing.js";\nexport { C } from "./c.js";\n' > node_modules/lib/index.js
printf 'import { Broken, C } from "lib";\nexport const A = "a:" + Broken + C;\n' > node_modules/lib/a.js
echo 'export const C = "c";' > node_modules/lib/c.js
printf 'import { A } from "lib"; console.log(A);\n' > entry.js
bun -e 'const r = await Bun.build({ entrypoints: ["./entry.js"], throw: false }); console.log(r.logs.length)'
```

When the second importer is an ordinary file instead, the count depends on whether that file is parsed before or after the barrel, so the same build reports 1 or 2 errors from run to run.

Plugin repro: a barrel with `export { default as React } from "react"` and an `onResolve` plugin that returns `{ path, external: true }`. The plugin runs when the barrel is resolved, again from the barrel's own `schedule_barrel_deferred_imports` call (the seeded request for `React` finds no `source_index`), and again for each later importer. The plugin case that needs the index list and not only the barrel change is a later importer that un-defers a different record: `barrel/ExternalReExportNotResolvedAgainOnUnDefer`.

The second pass could also fail. `export { x } from "bun:whatever"` in a barrel, target `bun`, fails on main with `Could not resolve: "whatever"`: the `bun:` arm strips the prefix, and the second pass resolves the stripped name as a package. It builds with this change. No test for it, the same pass is what the other tests pin.

Relation to #35053: its barrel test hits the same second pass and adds `IS_EXTERNAL` so that pass skips its rewritten record. With this change the pass does not reach that record. This PR takes no flag bit.

Dev server: import records there get no `source_index` from the normal parse path, so before this change a request for a never-deferred record also resolved the barrel again, and `force_save` wrote indices onto all of its records. The work item that pass produced duplicated the request the barrel's own call made in phase 1 (`barrel_imports.rs:462-510` and `:550-586`) and was dropped by the `requested_exports` check. Un-deferred records still get their indices written. The barrel tests in `test/bake/dev/bundle.test.ts` pass.

Not changed: a plugin answer that arrives after the BFS does not request anything from the module it resolves to. Same before and after.

The first revision of this PR used an `ImportRecordFlags::RESOLVE_STARTED` bit instead of the index list. Bit 10 is the last free bit of the `u16`, and #35053 and #38461 both take it, so the self-review asked for this shape. The barrel change alone fixes two of the four tests. The index list is what fixes `barrel/UnDeferReportsUnresolvableSiblingOnce` and `barrel/ExternalReExportNotResolvedAgainOnUnDefer`.

Suites run on the debug build: `bundler_barrel`, `bundler_plugin`, `bundler_plugin_chain`, `bundler_edgecase`, `bundler_npm`, `bundler_browser`, `bundler_bun`, `bundler_cjs`, `bundler_splitting`, `bundler_regressions`, `bundler_allow_unresolved`, `metafile`, `bun-build-api`, `native-plugin`, `bake/dev/bundle`, `bake/dev/plugins`, `bake/dev/esm`, `bake/dev/hot`, `regression/issue/29264`. With the `src/` changes stashed, the new tests fail on the same debug build. The plugin-free test failed 15 of 15 runs on Bun 1.4.0.

</details>
