### PR TITLE
test(isolation): count live globals with BUN_GARBAGE_COLLECTOR_LEVEL=0

### DIFF
--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -853,8 +853,19 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 // full GC, and counts live GlobalObject cells. Pinned globals accumulate
 // (the last file sees 8); collectable ones plateau (current + a lagging one
 // or two).
+//
+// The child must run at BUN_GARBAGE_COLLECTOR_LEVEL=0 (the CI runner sets 1,
+// and bunEnv forwards it) so that the fixture's Bun.gc(true) calls are the
+// only collections in the run. At level 1 every expect() matcher requests one
+// more collection, which JSC runs on the JS thread from whatever stack depth
+// the next allocation happens at. Processing its conservative roots there
+// leaves pointers to the finishing file's global in stack slots that the next
+// file's Bun.gc(true) frames do not overwrite, so that scan keeps the global
+// alive, and each later extra collection carries the retained globals forward:
+// the count snowballed to 6-7 on alpine x64 with nothing pinning the globals.
 describe.concurrent("--isolate: collects globals pinned by leaked handles", () => {
   const LEAK_FILE_COUNT = 8;
+  const MAX_LIVE_GLOBALS = 4;
 
   function makeLeakFixture(dirt: string): Record<string, string> {
     const files: Record<string, string> = {};
@@ -875,10 +886,10 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     return files;
   }
 
-  async function maxLiveGlobals(dir: string): Promise<number> {
+  async function expectGlobalsCollectable(dir: string): Promise<void> {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--isolate"],
-      env: bunEnv,
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
       cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
@@ -888,7 +899,9 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     expect(exitCode).toBe(0);
     const counts = [...stdout.matchAll(/GLOBALS=(\d+)/g)].map(m => Number(m[1]));
     expect(counts).toHaveLength(LEAK_FILE_COUNT);
-    return Math.max(...counts);
+    expect(Math.max(...counts), `live globals seen by each file: ${counts.join(" ")}`).toBeLessThanOrEqual(
+      MAX_LIVE_GLOBALS,
+    );
   }
 
   test("fs.watch left open", async () => {
@@ -899,7 +912,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         const watcher = fs.watch(import.meta.dir, () => {});
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 
   test("Bun.serve left running", async () => {
@@ -909,7 +922,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         const server = Bun.serve({ port: 0, fetch: () => new Response("x") });
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 
   test("long setTimeout/setInterval left pending", async () => {
@@ -920,7 +933,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         setInterval(() => {}, 3_600_000);
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 
   test("AbortSignal.timeout with an abort listener left pending", async () => {
@@ -930,7 +943,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 
   test("AbortSignal.timeout with an abort listener left pending in a fake-timer heap", async () => {
@@ -942,7 +955,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 
   test("mock(), spyOn() and mock.module() left registered", async () => {
@@ -956,7 +969,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         mock.module("./mocked-dep", () => ({ default: 1 }));
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 
   test("Bun.plugin left registered", async () => {
@@ -973,7 +986,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         });
       `),
     );
-    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+    await expectGlobalsCollectable(String(dir));
   });
 });
 

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -854,15 +854,17 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 // (the last file sees 8); collectable ones plateau (current + a lagging one
 // or two).
 //
-// The child must run at BUN_GARBAGE_COLLECTOR_LEVEL=0 (the CI runner sets 1,
-// and bunEnv forwards it) so that the fixture's Bun.gc(true) calls are the
-// only collections in the run. At level 1 every expect() matcher requests one
-// more collection, which JSC runs on the JS thread from whatever stack depth
-// the next allocation happens at. Processing its conservative roots there
-// leaves pointers to the finishing file's global in stack slots that the next
-// file's Bun.gc(true) frames do not overwrite, so that scan keeps the global
-// alive, and each later extra collection carries the retained globals forward:
-// the count snowballed to 6-7 on alpine x64 with nothing pinning the globals.
+// The fixture's Bun.gc(true) calls must be the only collections in the child.
+// Any other collection (at BUN_GARBAGE_COLLECTOR_LEVEL=1, which the CI runner
+// sets and bunEnv forwards, every expect() matcher requests one; at any level
+// Bun.serve()'s listen hint and the idle GC timer request one through
+// GarbageCollectionController) is run by JSC on the JS thread from whatever
+// stack depth the next allocation happens at. Processing its conservative
+// roots there leaves pointers to the finishing file's global in stack slots
+// that the next file's Bun.gc(true) frames do not overwrite, so that scan keeps
+// the global alive, and each later extra collection carries the retained
+// globals forward: the count snowballed to 6-7 on alpine x64 with nothing
+// pinning the globals.
 describe.concurrent("--isolate: collects globals pinned by leaked handles", () => {
   const LEAK_FILE_COUNT = 8;
   const MAX_LIVE_GLOBALS = 4;
@@ -886,10 +888,10 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     return files;
   }
 
-  async function expectGlobalsCollectable(dir: string): Promise<void> {
+  async function maxLiveGlobals(dir: string): Promise<number> {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--isolate"],
-      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0", BUN_GC_TIMER_DISABLE: "1" },
       cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
@@ -899,9 +901,9 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     expect(exitCode).toBe(0);
     const counts = [...stdout.matchAll(/GLOBALS=(\d+)/g)].map(m => Number(m[1]));
     expect(counts).toHaveLength(LEAK_FILE_COUNT);
-    expect(Math.max(...counts), `live globals seen by each file: ${counts.join(" ")}`).toBeLessThanOrEqual(
-      MAX_LIVE_GLOBALS,
-    );
+    const max = Math.max(...counts);
+    expect(max, `live globals seen by each file: ${counts.join(" ")}`).toBeLessThanOrEqual(MAX_LIVE_GLOBALS);
+    return max;
   }
 
   test("fs.watch left open", async () => {
@@ -912,7 +914,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         const watcher = fs.watch(import.meta.dir, () => {});
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 
   test("Bun.serve left running", async () => {
@@ -922,7 +924,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         const server = Bun.serve({ port: 0, fetch: () => new Response("x") });
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 
   test("long setTimeout/setInterval left pending", async () => {
@@ -933,7 +935,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         setInterval(() => {}, 3_600_000);
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 
   test("AbortSignal.timeout with an abort listener left pending", async () => {
@@ -943,7 +945,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 
   test("AbortSignal.timeout with an abort listener left pending in a fake-timer heap", async () => {
@@ -955,7 +957,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 
   test("mock(), spyOn() and mock.module() left registered", async () => {
@@ -969,7 +971,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         mock.module("./mocked-dep", () => ({ default: 1 }));
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 
   test("Bun.plugin left registered", async () => {
@@ -986,7 +988,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
         });
       `),
     );
-    await expectGlobalsCollectable(String(dir));
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
 });
 

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -854,17 +854,12 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 // (the last file sees 8); collectable ones plateau (current + a lagging one
 // or two).
 //
-// The fixture's Bun.gc(true) calls must be the only collections in the child.
-// Any other collection (at BUN_GARBAGE_COLLECTOR_LEVEL=1, which the CI runner
-// sets and bunEnv forwards, every expect() matcher requests one; at any level
-// Bun.serve()'s listen hint and the idle GC timer request one through
-// GarbageCollectionController) is run by JSC on the JS thread from whatever
-// stack depth the next allocation happens at. Processing its conservative
-// roots there leaves pointers to the finishing file's global in stack slots
-// that the next file's Bun.gc(true) frames do not overwrite, so that scan keeps
-// the global alive, and each later extra collection carries the retained
-// globals forward: the count snowballed to 6-7 on alpine x64 with nothing
-// pinning the globals.
+// The fixture's own full GCs must be the only collections in the child, which
+// maxLiveGlobals asserts from the GC log. A collection requested from anywhere
+// else runs at whatever stack depth the next allocation has, and the stack
+// slots it leaves behind are what a later conservative scan picks up: with the
+// collection that BUN_GARBAGE_COLLECTOR_LEVEL=1 (set by the CI runner) adds
+// after every matcher, unpinned globals counted 6-7 on alpine x64.
 describe.concurrent("--isolate: collects globals pinned by leaked handles", () => {
   const LEAK_FILE_COUNT = 8;
   const MAX_LIVE_GLOBALS = 4;
@@ -891,7 +886,15 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
   async function maxLiveGlobals(dir: string): Promise<number> {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--isolate"],
-      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0", BUN_GC_TIMER_DISABLE: "1" },
+      env: {
+        ...bunEnv,
+        // Level 1 requests a collection after every expect() matcher. The GC
+        // timer knob also covers Bun.serve()'s listen hint, which goes through
+        // GarbageCollectionController::perform_gc() too.
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_GC_TIMER_DISABLE: "1",
+        BUN_JSC_logGC: "true",
+      },
       cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
@@ -899,6 +902,18 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain(`${LEAK_FILE_COUNT} pass`);
     expect(exitCode).toBe(0);
+
+    // The fixture requests two full collections per file and nothing else:
+    // these heaps never reach JSC's own allocation budget, so an eden
+    // collection was requested by Bun. The one permitted extra full collection
+    // is the VM teardown under BUN_DESTRUCT_VM_ON_EXIT, which the ASAN lanes set.
+    const full = stderr.match(/=> FullCollection/g)?.length ?? 0;
+    const eden = stderr.match(/=> EdenCollection/g)?.length ?? 0;
+    const collections = `${full} full and ${eden} eden collections ran, the fixture requests ${2 * LEAK_FILE_COUNT} full`;
+    expect(full, collections).toBeGreaterThanOrEqual(2 * LEAK_FILE_COUNT);
+    expect(full, collections).toBeLessThanOrEqual(2 * LEAK_FILE_COUNT + 1);
+    expect(eden, collections).toBe(0);
+
     const counts = [...stdout.matchAll(/GLOBALS=(\d+)/g)].map(m => Number(m[1]));
     expect(counts).toHaveLength(LEAK_FILE_COUNT);
     const max = Math.max(...counts);

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -905,13 +905,17 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
 
     // The fixture requests two full collections per file and nothing else:
     // these heaps never reach JSC's own allocation budget, so an eden
-    // collection was requested by Bun. The one permitted extra full collection
-    // is the VM teardown under BUN_DESTRUCT_VM_ON_EXIT, which the ASAN lanes set.
+    // collection was requested by Bun. The VM teardown under
+    // BUN_DESTRUCT_VM_ON_EXIT (set by the ASAN lanes, and parsed by bun as
+    // truthy unless it is one of these strings) runs one more full collection.
+    const destructsVm =
+      bunEnv.BUN_DESTRUCT_VM_ON_EXIT !== undefined &&
+      !["", "0", "false", "no", "off"].includes(bunEnv.BUN_DESTRUCT_VM_ON_EXIT.toLowerCase());
+    const expectedFull = 2 * LEAK_FILE_COUNT + (destructsVm ? 1 : 0);
     const full = stderr.match(/=> FullCollection/g)?.length ?? 0;
     const eden = stderr.match(/=> EdenCollection/g)?.length ?? 0;
-    const collections = `${full} full and ${eden} eden collections ran, the fixture requests ${2 * LEAK_FILE_COUNT} full`;
-    expect(full, collections).toBeGreaterThanOrEqual(2 * LEAK_FILE_COUNT);
-    expect(full, collections).toBeLessThanOrEqual(2 * LEAK_FILE_COUNT + 1);
+    const collections = `${full} full and ${eden} eden collections ran, expected ${expectedFull} full and 0 eden`;
+    expect(full, collections).toBe(expectedFull);
     expect(eden, collections).toBe(0);
 
     const counts = [...stdout.matchAll(/GLOBALS=(\d+)/g)].map(m => Number(m[1]));


### PR DESCRIPTION
### Problem
- The leak block of `test/cli/test/isolation.test.ts` went red on alpine x64 in build 102214. All 7 cases failed on both attempts: `expect(received).toBeLessThanOrEqual(expected)`, `Expected: <= 4`, `Received: 6`.
- Each fixture counts live `GlobalObject` cells after `Bun.gc(true)` in 8 isolated files, but the child ran other collections too. `bunEnv` forwards the CI runner's `BUN_GARBAGE_COLLECTOR_LEVEL=1`, at which `Expect::post_match` (`src/runtime/test_runner/expect.rs:1735`) requests one after every matcher. At any level, `Bun.serve()`'s listen hint (`src/runtime/server/mod.rs:3172`) and the idle GC timer request one through `GarbageCollectionController`.
- JSC runs such a collection on the JS thread at the next allocation, from an arbitrary stack depth. Its root processing leaves pointers to the finishing file's global in stack slots that the next `Bun.gc(true)` frames do not overwrite, so the conservative scan keeps the global alive. Each later extra collection carries the retained globals forward.

### Fix
- `maxLiveGlobals` spawns the child with `BUN_GARBAGE_COLLECTOR_LEVEL=0` and `BUN_GC_TIMER_DISABLE=1`, as `gc-controller-cadence.test.ts` does, and with `BUN_JSC_logGC`. It asserts that the log shows exactly the fixture's 16 full collections, plus the one teardown collection when the child's env enables `BUN_DESTRUCT_VM_ON_EXIT` (the ASAN lanes do), and no eden collection.
- The log assertion fails on every lane without the knobs: 7 eden collections per case at level 1, 8 more in the serve case from the listen hint. The bound on live globals alone passed here in that state and only failed on the one build whose stack layout exposed it.
- The block still tests what it did: a `Strong` or a protect that pins a global survives the fixture's own collections, and a release build from before #39818 still fails the mock and plugin cases. The helper now prints the count each file saw (a pin reads `1 2 3 4 5 6 7 8`). Its name, signature and callers are unchanged, so #39871, #39692 and #39639, which add cases through it, land in any order.
- Verified: `bun bd test test/cli/test/isolation.test.ts`, 27 pass, also with the ASAN lane's environment. Measured 16 full / 0 eden on the glibc release, musl release, debug ASAN and Windows canary builds.

### Background
- `bun test --isolate` runs each file in a new global on one VM. The swap unprotects the old global, so a full collection frees it unless a handle holds it.
- JSC scans the native stack conservatively. A word that points into a live cell keeps it alive, and a cell keeps its global alive through its `Structure`.
- `Bun.gc(true)` is always a full collection. These heaps never reach JSC's own allocation budget, so an eden collection in the log was requested by Bun code.
- `GarbageCollectionController` (`src/jsc/GarbageCollectionController.rs`) owns Bun's idle GC timer. Its `perform_gc` also serves the listen hint. `BUN_GC_TIMER_DISABLE` turns both off.

<details><summary>Notes</summary>

- Main builds 102067 (1b88ad323) and 102154 (b7b4ddda1b), both after #39818, ran this file on alpine x64 shard 4 and passed. No build in the previous three days failed this block. Whether a stale slot lines up depends on the stack layout of one binary. When it does, every run of that binary fails, which is what build 102214 showed on both attempts (6 or 7 in every case).
- Release build 6e906e468 (before #39818), timers fixture, 40 runs each: level 1 kept an extra global in 27 runs, level 0 in none. So the noise is older than #39818. #39818 is the last change to this block and added two of the seven cases. The two new cases and the five older ones failed alike in build 102214.
- The extra collection runs on the JS thread because `Heap::requestCollection` gives the mutator the conn and `Heap::collectInMutatorThread` runs the cycle at the next `stopIfNecessary()`. The fixture's own `Bun.gc(true)` calls always run from the same position, below the point the scan starts at, so they leave nothing for the next scan.
- Serve fixture at level 0 without the timer knob: 8 eden collections per run on glibc, musl and Windows. The debug build's serve counts went from `1 2 2 3 2 3 2 3` to `1 2 2 2 2 2 2 2` with the knob. The idle timer did not fire in any run measured here, but a slow run can reach its 1 s interval, and the same knob covers it.
- The expected full count is derived from the env the helper builds, so it is exact on every lane: 16, or 17 when `BUN_DESTRUCT_VM_ON_EXIT` is enabled. The test mirrors bun's parsing of that variable (truthy unless "", "0", "false", "no" or "off"). Measured 16 unset or "0" and 17 set on the glibc release, musl release and debug builds. The lower bound also proves the log is on, otherwise the eden check would pass for nothing.
- `BUN_JSC_randomIntegrityAuditRate=1.0` (also set by the runner) and `ulimit -s unlimited` (set on the alpine agents) do not change the counts.
- A JSC heap snapshot of the lagging global in a debug build shows no root edge to it. Only an unrecorded root, which is what the conservative scan produces, holds it. Debug builds count `1 2 2 2 2 2 2 2`, within the bound.
- The musl canary (1b88ad323, the binary of main build 102067) was run here through the loader of a musl toolchain, on the fixtures and as the runner of this block with the runner's environment variables set. It counts all ones. The binary of build 102214 is not reachable from here.
- Revision history: the first revision renamed the helper. The self-review found that the three open PRs above would then merge cleanly and fail at runtime, so the rename was dropped. The second review found that the bound on live globals could not detect the noise sources on any lane available here, which is what the log assertion now does. A bot review then asked for the exact full count instead of a range, which 4038c5a does. The callers' own `toBeLessThanOrEqual(4)` is now redundant with the helper's assertion and can be folded in once those PRs land.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/test/isolation.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/test/isolation.test.ts
bun test v1.4.0 (6e906e468)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [526.84ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [408.06ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [622.49ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [708.43ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [480.66ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [2621.50ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [2344.66ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [2671.89ms]
(pass) bun test --isolate > leaked subprocesses are killed for every isolated file, not just the first [2357.63ms]
(pass) bun test --isolate > with --isolate, leaked vi.useFakeTimers() is deactivated before next file [3215.34ms]
(pass) --isolate: delete require.cache evicts the SourceProvider cache [1326.99ms]
(pass) --isolate: SourceProvider cache covers CommonJS modules [1483.41ms]
(pass) bun test --isolate > module-scope subprocesses are killed for every isolated file, not just the first (--isolate) [2336.93ms]
(pass) --isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages [1110.12ms]
(pass) --isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export [518.85ms]
(pass) bun test --isolate > module-scope subprocesses are killed for every isolated file, not just the first (--parallel worker) [2331.41ms]
(pass) --isolate: collects globals pinned by leaked handles > long setTimeout/setInterval left pending [1426.88ms]
(pass) --isolate: collects globals
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/test/isolation.test.ts | 38 ++++++++++++++++++++++++++++++++++++--
 1 file changed, 36 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
test/cli/test/isolation.test.ts      8     11      0
```

</details>

<!-- robobun:evidence:end -->