### PR TITLE
Do not apply the bun -e one-shot startup heuristic to standalone executables

### DIFF
--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1653,7 +1653,7 @@ mod draft {
     ) -> Result<PnpmMatcher, FromExprError> {
         let mut buf: Vec<u8> = Vec::new();
 
-        // bun.jsc.initialize(false) is performed lazily inside the regex vtable
+        // `jsc::initialize` is performed lazily inside the regex vtable
         // compile hook (tier-6 owns it).
 
         let mut matchers: Vec<PnpmMatcherEntry> = Vec::new();

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1653,9 +1653,6 @@ mod draft {
     ) -> Result<PnpmMatcher, FromExprError> {
         let mut buf: Vec<u8> = Vec::new();
 
-        // `jsc::initialize` is performed lazily inside the regex vtable
-        // compile hook (tier-6 owns it).
-
         let mut matchers: Vec<PnpmMatcherEntry> = Vec::new();
         let mut has_include = false;
         let mut has_exclude = false;

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -172,9 +172,6 @@ impl PnpmMatcher {
         // `create_matcher` before then.
         let arena = Arena::new();
 
-        // `jsc::initialize` is performed lazily inside `__bun_regex_compile`
-        // (tier-6 owns it).
-
         let mut matchers: Vec<Matcher> = Vec::new();
         let mut has_include = false;
         let mut has_exclude = false;

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -86,7 +86,7 @@ use bun_core::{String as BunString, strings};
 // resolved at link time.
 unsafe extern "Rust" {
     /// Compile `pattern` with no flags. `None` ⇔ `error.InvalidRegExp`.
-    /// Performs `jsc::initialize(false)` lazily on first call.
+    /// Performs `jsc::initialize` lazily on first call.
     fn __bun_regex_compile(pattern: BunString) -> Option<NonNull<()>>;
     fn __bun_regex_matches(regex: NonNull<()>, input: &BunString) -> bool;
     fn __bun_regex_drop(regex: NonNull<()>);
@@ -172,8 +172,8 @@ impl PnpmMatcher {
         // `create_matcher` before then.
         let arena = Arena::new();
 
-        // bun.jsc.initialize(false) is now performed lazily inside
-        // `__bun_regex_compile` (tier-6 owns it).
+        // `jsc::initialize` is performed lazily inside `__bun_regex_compile`
+        // (tier-6 owns it).
 
         let mut matchers: Vec<Matcher> = Vec::new();
         let mut has_include = false;
@@ -360,7 +360,7 @@ pub fn create_matcher(raw: &[u8], buf: &mut Vec<u8>) -> Result<Matcher, CreateMa
     buf.push(b'$');
 
     // `__bun_regex_compile` is a link-time extern (cold path) and performs
-    // `jsc::initialize(false)` before compiling.
+    // `jsc::initialize` before compiling.
     let regex = compile_regex(BunString::clone_utf8(buf.as_slice()))
         .ok_or(CreateMatcherError::InvalidRegExp)?;
 

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -427,7 +427,7 @@ impl Macro {
             // CLI-path macro VM uses the caller's log sink and env loader.
 
             // JSC needs to be initialized if building from CLI
-            jsc::initialize(false);
+            jsc::initialize(jsc::InitializeOptions::default());
 
             let _vm = VirtualMachine::init(VirtualMachineInitOptions {
                 log: Some(NonNull::from(&mut *log)),

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -135,7 +135,7 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
     source_provider_url: &mut BunString,
 ) -> Option<Box<[u8]>> {
     crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
-    crate::initialize(false);
+    crate::initialize(crate::InitializeOptions::default());
     let (bytes, handle) = CachedBytecode::generate(format, source, source_provider_url)?;
     let owned = Box::<[u8]>::from(bytes);
     // `handle` was just produced by C++ and is valid until deref;

--- a/src/jsc/RegularExpression.rs
+++ b/src/jsc/RegularExpression.rs
@@ -91,9 +91,7 @@ impl RegularExpression {
 
 #[unsafe(no_mangle)]
 fn __bun_regex_compile(pattern: BunString) -> Option<core::ptr::NonNull<()>> {
-    // Can be the process's first JSC initialization: bunfig's `[install]
-    // hoistPattern` is compiled during config load, before the run command
-    // initializes JSC, so this has to make the same one-shot decision it would.
+    // bunfig's hoistPattern is compiled during config load, before the CLI initializes JSC itself.
     crate::initialize(crate::InitializeOptions {
         one_shot: crate::is_one_shot_eval_invocation(),
         ..Default::default()

--- a/src/jsc/RegularExpression.rs
+++ b/src/jsc/RegularExpression.rs
@@ -91,8 +91,13 @@ impl RegularExpression {
 
 #[unsafe(no_mangle)]
 fn __bun_regex_compile(pattern: BunString) -> Option<core::ptr::NonNull<()>> {
-    // Initialize JSC before first compile (idempotent).
-    crate::initialize(false);
+    // Can be the process's first JSC initialization: bunfig's `[install]
+    // hoistPattern` is compiled during config load, before the run command
+    // initializes JSC, so this has to make the same one-shot decision it would.
+    crate::initialize(crate::InitializeOptions {
+        one_shot: crate::is_one_shot_eval_invocation(),
+        ..Default::default()
+    });
     match RegularExpression::init(pattern, Flags::None) {
         Ok(r) => core::ptr::NonNull::new(r.cast()),
         Err(_) => None,

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -483,17 +483,12 @@ pub mod jsc_scheduler;
 #[path = "ProcessAutoKiller.rs"]
 pub mod process_auto_killer;
 
-/// The JSC option overrides that [`initialize`] applies; see `JSCInitialize` in
-/// ZigGlobalObject.cpp for what each one changes. The process is initialized
-/// once, so only the first [`initialize`] call's options take effect.
+/// Flags for `JSCInitialize` in ZigGlobalObject.cpp. JSC is set up once per process: the first call's flags win.
 #[derive(Clone, Copy, Default)]
 pub struct InitializeOptions {
-    /// `bun --print` and the REPL: JSC's `evalMode`, which keeps completion
-    /// values so the last expression's value can be printed.
+    /// JSC `evalMode`: keeps completion values, for `bun --print` and the REPL.
     pub eval_mode: bool,
-    /// The process runs one small script and exits (`bun -e` / `bun -p`, see
-    /// [`is_one_shot_eval_invocation`]), so JSC skips the concurrent JIT and
-    /// parallel GC marker threads it would otherwise start with the VM.
+    /// `bun -e` / `bun -p` ([`is_one_shot_eval_invocation`]): no concurrent JIT or parallel GC marker threads.
     pub one_shot: bool,
     /// `bun test --isolate`/`--parallel`: each file gets a fresh global and per-global JIT code is discarded with it.
     pub short_lived_globals: bool,
@@ -526,11 +521,7 @@ pub fn initialize(options: InitializeOptions) {
 ///
 /// Kept conservative on purpose: only the explicit eval flags qualify. `bun
 /// <file>` is *not* treated as one-shot (it may start a server), so server
-/// workloads keep the default multi-threaded JIT/GC configuration.
-///
-/// Reads the process argv, so it only has meaning when that argv is the `bun`
-/// CLI's own. A `bun build --compile` executable's argv belongs to the compiled
-/// program and must not be scanned.
+/// workloads keep the default multi-threaded JIT/GC configuration. Only valid for the `bun` CLI's own argv.
 pub fn is_one_shot_eval_invocation() -> bool {
     for arg in bun_core::argv().iter().skip(1) {
         if arg == b"-e" || arg == b"--eval" || arg == b"-p" || arg == b"--print" {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -483,33 +483,24 @@ pub mod jsc_scheduler;
 #[path = "ProcessAutoKiller.rs"]
 pub mod process_auto_killer;
 
-/// JSC startup for the `bun` CLI itself, whose argv says whether this is a
-/// one-shot eval (`bun -e` / `bun -p`).
-pub fn initialize(eval_mode: bool) {
-    initialize_with(eval_mode, false);
-}
-
-/// `short_lived_globals`: `bun test --isolate`/`--parallel`, where each file gets a fresh global and per-global JIT code is discarded with it.
-pub fn initialize_with(eval_mode: bool, short_lived_globals: bool) {
-    // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit before
-    // any long-running event loop; tell JSC to skip the worker threads it
-    // otherwise spawns eagerly at VM creation (see `JSCInitialize`).
-    jsc_initialize(
-        eval_mode,
-        is_one_shot_eval_invocation(),
-        short_lived_globals,
-    );
-}
-
-/// JSC startup for a `bun build --compile` executable. Its argv belongs to the
-/// compiled program, so a `-e` / `-p` in there is the program's own flag and
-/// must not select one-shot startup.
-pub fn initialize_standalone() {
-    jsc_initialize(false, false, false);
+/// The JSC option overrides that [`initialize`] applies; see `JSCInitialize` in
+/// ZigGlobalObject.cpp for what each one changes. The process is initialized
+/// once, so only the first [`initialize`] call's options take effect.
+#[derive(Clone, Copy, Default)]
+pub struct InitializeOptions {
+    /// `bun --print` and the REPL: JSC's `evalMode`, which keeps completion
+    /// values so the last expression's value can be printed.
+    pub eval_mode: bool,
+    /// The process runs one small script and exits (`bun -e` / `bun -p`, see
+    /// [`is_one_shot_eval_invocation`]), so JSC skips the concurrent JIT and
+    /// parallel GC marker threads it would otherwise start with the VM.
+    pub one_shot: bool,
+    /// `bun test --isolate`/`--parallel`: each file gets a fresh global and per-global JIT code is discarded with it.
+    pub short_lived_globals: bool,
 }
 
 /// Binding for JSCInitialize in ZigGlobalObject.cpp
-fn jsc_initialize(eval_mode: bool, one_shot: bool, short_lived_globals: bool) {
+pub fn initialize(options: InitializeOptions) {
     // The counter lives in `bun_core` so this crate doesn't depend on
     // `bun_analytics`.
     bun_core::analytics::Features::jsc_inc();
@@ -522,9 +513,9 @@ fn jsc_initialize(eval_mode: bool, one_shot: bool, short_lived_globals: bool) {
             env.as_ptr(),
             env.len(),
             on_jsc_invalid_env_var,
-            eval_mode,
-            one_shot,
-            short_lived_globals,
+            options.eval_mode,
+            options.one_shot,
+            options.short_lived_globals,
         )
     };
 }
@@ -536,7 +527,11 @@ fn jsc_initialize(eval_mode: bool, one_shot: bool, short_lived_globals: bool) {
 /// Kept conservative on purpose: only the explicit eval flags qualify. `bun
 /// <file>` is *not* treated as one-shot (it may start a server), so server
 /// workloads keep the default multi-threaded JIT/GC configuration.
-fn is_one_shot_eval_invocation() -> bool {
+///
+/// Reads the process argv, so it only has meaning when that argv is the `bun`
+/// CLI's own. A `bun build --compile` executable's argv belongs to the compiled
+/// program and must not be scanned.
+pub fn is_one_shot_eval_invocation() -> bool {
     for arg in bun_core::argv().iter().skip(1) {
         if arg == b"-e" || arg == b"--eval" || arg == b"-p" || arg == b"--print" {
             return true;

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -483,21 +483,37 @@ pub mod jsc_scheduler;
 #[path = "ProcessAutoKiller.rs"]
 pub mod process_auto_killer;
 
-/// Binding for JSCInitialize in ZigGlobalObject.cpp
+/// JSC startup for the `bun` CLI itself, whose argv says whether this is a
+/// one-shot eval (`bun -e` / `bun -p`).
 pub fn initialize(eval_mode: bool) {
     initialize_with(eval_mode, false);
 }
 
 /// `short_lived_globals`: `bun test --isolate`/`--parallel`, where each file gets a fresh global and per-global JIT code is discarded with it.
 pub fn initialize_with(eval_mode: bool, short_lived_globals: bool) {
+    // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit before
+    // any long-running event loop; tell JSC to skip the worker threads it
+    // otherwise spawns eagerly at VM creation (see `JSCInitialize`).
+    jsc_initialize(
+        eval_mode,
+        is_one_shot_eval_invocation(),
+        short_lived_globals,
+    );
+}
+
+/// JSC startup for a `bun build --compile` executable. Its argv belongs to the
+/// compiled program, so a `-e` / `-p` in there is the program's own flag and
+/// must not select one-shot startup.
+pub fn initialize_standalone() {
+    jsc_initialize(false, false, false);
+}
+
+/// Binding for JSCInitialize in ZigGlobalObject.cpp
+fn jsc_initialize(eval_mode: bool, one_shot: bool, short_lived_globals: bool) {
     // The counter lives in `bun_core` so this crate doesn't depend on
     // `bun_analytics`.
     bun_core::analytics::Features::jsc_inc();
     let env = bun_sys::environ();
-    // One-shot eval invocations (`bun -e ...` / `bun --print ...`) exit before
-    // any long-running event loop; tell JSC to skip the worker threads it
-    // otherwise spawns eagerly at VM creation (see `JSCInitialize`).
-    let one_shot = is_one_shot_eval_invocation();
     // SAFETY: `env` borrows the libc `environ` global for the duration of the
     // call; `on_jsc_invalid_env_var` is `extern "C"` and only reads the (ptr,len)
     // it is handed. JSCInitialize is called exactly once at startup.

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -97,7 +97,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
 
     // Create a VM + global for loading the config file, plugins, and
     // performing build time prerendering.
-    jsc::initialize(false);
+    jsc::initialize(jsc::InitializeOptions::default());
     bun_ast::initialize_store();
 
     let mut arena = Arena::new();

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -55,8 +55,10 @@ impl ReplCommand {
             )?;
         }
 
-        // Initialize JSC
-        jsc::initialize(true); // true for eval mode
+        jsc::initialize(jsc::InitializeOptions {
+            eval_mode: true,
+            ..Default::default()
+        });
 
         bun_ast::initialize_store();
         // The arena is threaded into VirtualMachine (vm.arena). `bun_alloc::Arena`

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1110,8 +1110,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     ) -> crate::Result<()> {
         use bun_standalone_graph::StandaloneModuleGraph::Flags as GraphFlags;
 
-        // argv belongs to the compiled program, so there is no `bun -e` to
-        // detect here: a `-e` or `-p` in it is the program's own flag.
+        // argv belongs to the compiled program, so a `-e` or `-p` in it is not ours.
         bun_jsc::initialize(bun_jsc::InitializeOptions::default());
         bun_analytics::features::standalone_executable.fetch_add(1, Ordering::Relaxed);
         bun_ast::initialize_store();

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -938,7 +938,11 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // dispatch hooks (`jsc_hooks::install_jsc_hooks`) are installed by
         // `main.rs` before `Cli::start`, so `VirtualMachine::init` already sees
         // a populated `RuntimeHooks` table.
-        bun_jsc::initialize(ctx.runtime_options.eval.eval_and_print);
+        bun_jsc::initialize(bun_jsc::InitializeOptions {
+            eval_mode: ctx.runtime_options.eval.eval_and_print,
+            one_shot: bun_jsc::is_one_shot_eval_invocation(),
+            ..Default::default()
+        });
         bun_ast::initialize_store();
 
         let vm_ptr = VirtualMachine::init(VmInitOptions {
@@ -1106,7 +1110,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     ) -> crate::Result<()> {
         use bun_standalone_graph::StandaloneModuleGraph::Flags as GraphFlags;
 
-        bun_jsc::initialize_standalone();
+        // argv belongs to the compiled program, so there is no `bun -e` to
+        // detect here: a `-e` or `-p` in it is the program's own flag.
+        bun_jsc::initialize(bun_jsc::InitializeOptions::default());
         bun_analytics::features::standalone_executable.fetch_add(1, Ordering::Relaxed);
         bun_ast::initialize_store();
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1106,7 +1106,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     ) -> crate::Result<()> {
         use bun_standalone_graph::StandaloneModuleGraph::Flags as GraphFlags;
 
-        bun_jsc::initialize(false);
+        bun_jsc::initialize_standalone();
         bun_analytics::features::standalone_executable.fetch_add(1, Ordering::Relaxed);
         bun_ast::initialize_store();
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2131,7 +2131,10 @@ impl TestCommand {
         // `exec()` never returns before process exit, so the heap allocation
         // outlives all observers.
         let mut env_loader: Box<DotEnv::Loader> = Box::new(DotEnv::Loader::init());
-        jsc::initialize_with(false, ctx.test_options.isolate);
+        jsc::initialize(jsc::InitializeOptions {
+            short_lived_globals: ctx.test_options.isolate,
+            ..Default::default()
+        });
         bun_http::http_thread::init(&Default::default());
 
         let enable_random = ctx.test_options.randomize;

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -1,5 +1,11 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
+
+// `BUN_JSC_dumpOptions=2` prints every JSC option as `   name=value` on stderr
+// once JSCInitialize has applied Bun's overrides.
+function jscOption(stderr: string, name: string): string | undefined {
+  return stderr.match(new RegExp(`^\\s*${name}=(\\S+)`, "m"))?.[1];
+}
 
 describe("bundler", () => {
   // Test that the --compile-exec-argv flag works for both runtime processing and execArgv
@@ -385,6 +391,64 @@ describe("bundler", () => {
       env: { BUN_OPTIONS: "--smol" },
       args: ["user-arg1", "user-arg2"],
       stdout: /SUCCESS: BUN_OPTIONS separated from passthrough args/,
+    },
+  });
+
+  // `bun -e` / `bun -p` start JSC in one-shot mode (no concurrent JIT, one GC
+  // marker). That is decided by scanning argv, and a compiled executable's argv
+  // belongs to the program, so `./app -p 8080` must keep the full configuration.
+  const expectFullJSCConfiguration = ({ stderr }: { stderr: string }) => {
+    expect(jscOption(stderr, "useConcurrentJIT")).toBe("true");
+  };
+  itBundled("compile/EvalFlagsInUserArgsDoNotMeanOneShotStartup", {
+    compile: true,
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `console.log(JSON.stringify(process.argv.slice(2)));`,
+    },
+    run: [
+      {
+        args: ["-e"],
+        env: { BUN_JSC_dumpOptions: "2" },
+        stdout: '["-e"]',
+        validate: expectFullJSCConfiguration,
+      },
+      {
+        args: ["-p", "8080"],
+        env: { BUN_JSC_dumpOptions: "2" },
+        stdout: '["-p","8080"]',
+        validate: expectFullJSCConfiguration,
+      },
+      {
+        args: ["--verbose", "--eval=x"],
+        env: { BUN_JSC_dumpOptions: "2" },
+        stdout: '["--verbose","--eval=x"]',
+        validate: expectFullJSCConfiguration,
+      },
+      {
+        args: ["--print=x"],
+        env: { BUN_JSC_dumpOptions: "2" },
+        stdout: '["--print=x"]',
+        validate: expectFullJSCConfiguration,
+      },
+    ],
+  });
+
+  // Same thing when compile-exec-argv is present: that path rebuilds argv as
+  // `[exe, ...execArgv, ...userArgs]` before JSC starts.
+  itBundled("compile/EvalFlagsInUserArgsDoNotMeanOneShotStartupWithExecArgv", {
+    compile: {
+      execArgv: ["--smol"],
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `console.log(JSON.stringify([process.execArgv, process.argv.slice(2)]));`,
+    },
+    run: {
+      args: ["--print"],
+      env: { BUN_JSC_dumpOptions: "2" },
+      stdout: '[["--smol"],["--print"]]',
+      validate: expectFullJSCConfiguration,
     },
   });
 });


### PR DESCRIPTION
### Problem
- A `bun build --compile` executable starts JSC in one-shot mode when its own arguments contain `-e`, `--eval`, `-p` or `--print`. `./app -p 8080` then runs with `useConcurrentJIT=false` and `numberOfGCMarkers=1`.
- `is_one_shot_eval_invocation` (`src/jsc/lib.rs`) scans process argv for those flags. Every `bun_jsc::initialize` call ran it, including `RunCommand::boot_standalone`, where argv belongs to the compiled program.

### Fix
- `bun_jsc::initialize` takes one `InitializeOptions` struct (`eval_mode`, `one_shot`, `short_lived_globals`) and does not scan argv. `initialize_with` is gone.
- The run command sets `one_shot` from `is_one_shot_eval_invocation` (now public). `boot_standalone` passes the default, so `one_shot` stays off. The other callers set the field they set before or pass the default.
- The lazy regex compile in `src/jsc/RegularExpression.rs` also passes `is_one_shot_eval_invocation`. bunfig's `[install] hoistPattern` compiles a regex during config load, before the run command initializes JSC, so under `bun -e` this can be the call that counts. It decided the same way before.
- Verified: `test/bundler/compile-argv.test.ts`. Two new tests run a compiled program with five argument shapes such as `./app -p 8080` (one built with `--compile-exec-argv`) and read `useConcurrentJIT=true` from the `BUN_JSC_dumpOptions=2` option dump. Both fail on the current release. Other callers: probed by hand (Notes).

### Background
- `JSCInitialize` (`src/jsc/bindings/ZigGlobalObject.cpp`) sets the JSC options once per process (`std::call_once`), so the first `initialize` call decides. `oneShotStartup` turns off the concurrent JIT and parallel GC marking, which `bun -e` never uses.
- A standalone executable is the bun binary with the bundled program appended. `Command::start` detects it and calls `boot_standalone`. Argv after the executable becomes the program's `process.argv`.

<details><summary>Notes</summary>

With the release bun (1.4.0), a compiled program that prints `process.argv.slice(2)`:

```
./app                useConcurrentJIT=true   numberOfGCMarkers=8
./app -e             useConcurrentJIT=false  numberOfGCMarkers=1
./app -p 8080        useConcurrentJIT=false  numberOfGCMarkers=1
./app --verbose -e   useConcurrentJIT=false  numberOfGCMarkers=1
./app --print=x      useConcurrentJIT=false  numberOfGCMarkers=1
./app --eval=x       useConcurrentJIT=false  numberOfGCMarkers=1
./app serve -e       useConcurrentJIT=true   numberOfGCMarkers=8
```

The last line shows the scan stops at the first positional argument, so only programs whose first non-flag argument is preceded by one of the eval flags were affected.

The tests run the compiled program as `./app -e`, `./app -p 8080`, `./app --verbose --eval=x`, `./app --print=x`, and (built with `--compile-exec-argv=--smol`) `./app --print`. Each run also checks that the flags reached `process.argv`.

Every caller of `initialize` was probed with `BUN_JSC_dumpOptions=2` on the debug build after the change. Each reports the same options as before:

- `bun -e 1`: `useConcurrentJIT=false`, `numberOfGCMarkers=1`, `evalMode=false`
- `bun -p 1` and `bun --smol --print=1`: the same, with `evalMode=true`
- `bun -e 1` in a directory whose bunfig.toml has `[install] hoistPattern`: still `useConcurrentJIT=false`, `numberOfGCMarkers=1`. The regex compile path is the first call here.
- `bun file.js`: `useConcurrentJIT=true`, `numberOfGCMarkers=8`
- `bun test --isolate`: `useConcurrentJIT=true`, `thresholdForFTLOptimizeAfterWarmUp=1000000`
- `bun repl`: `evalMode=true`, `useConcurrentJIT=true`
- `bun build` with a macro, `bun build --bytecode`, and `bun install` with an `.npmrc` hoist pattern still work.

The callers that now pass the default (`bun test` apart from `short_lived_globals`, bake, macros, bytecode cache) always run with a subcommand as the first positional argument. The scan returned false for them, so the default is the same value.

How to see that the regex compile can be the first JSC initialization: put `[install] hoistPattern = ["*x*"]` and an invalid `[run] silent = "x"` in bunfig.toml and run `BUN_JSC_dumpOptions=1 bun -e 1`. The JSC option dump is printed before the bunfig error. A side effect of this ordering is that `bun -p` loses `evalMode` in such a directory and prints `undefined` for call expressions. That happens on the current release too. This PR does not change it. It is tracked separately.

Suites run: `test/bundler/compile-argv.test.ts`, `test/cli/run/run-eval.test.ts`, and the JSC option tests in `test/cli/run/env.test.ts`.

The test asserts only `useConcurrentJIT`. `numberOfGCMarkers` defaults to the CPU count capped at 8, so it is 1 on a one-core machine even without one-shot startup. `useConcurrentJIT` is set to true unconditionally outside one-shot startup.
</details>
