### PR TITLE
docs(sql): add a Dates and time zones section for timestamp UTC decoding

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1367,7 +1367,7 @@ Bun converts MySQL types to JavaScript types:
 | BIT(1)                                  | boolean                  | BIT(1) in MySQL                                                                                  |
 | GEOMETRY                                | Buffer                   | Binary character set; the bytes are a 4-byte SRID followed by WKB                                |
 
-`DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). PostgreSQL's `timestamp` (without time zone) behaves the same way, see [Timestamps and time zones](#timestamps-and-time-zones).
+`DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). PostgreSQL's `timestamp` (without time zone) behaves the same way. See [Timestamps and time zones](#timestamps-and-time-zones).
 
 #### Differences from PostgreSQL
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1274,6 +1274,24 @@ console.log(typeof x, x); // "bigint" 9223372036854777n
 
 ---
 
+## Dates and time zones
+
+A PostgreSQL `timestamp` (without time zone, OID 1114) value has no offset on the wire. The same is true for MySQL `DATETIME` and `TIMESTAMP` values. Bun decodes these values as **UTC**. The `Date` you get has the UTC wall clock that the database stored, regardless of the machine's time zone. The value is the same for `sql``.simple()` queries and for queries with parameters. Bun decodes a `date` value as UTC midnight.
+
+```ts
+// Column: created_at timestamp, stored value: 2024-01-15 12:00:00
+const [row] = await sql`SELECT created_at FROM events`;
+row.created_at.toISOString(); // "2024-01-15T12:00:00.000Z" on every host
+```
+
+With prepared statements (the default), Bun sends a bound `Date` parameter as its UTC instant. The host time zone does not change the value that Bun stores or the value that you read back.
+
+Bun currently decodes the elements of a PostgreSQL `timestamp[]` array as local time.
+
+`node-postgres` (`pg`), `postgres.js`, and PGlite decode a PostgreSQL `timestamp` as **local time** instead. `pg` also decodes a `date` as local midnight. If you migrate from one of them and the host is not UTC, the same stored value produces a `Date` for a different instant. `timestamptz` carries an explicit offset and decodes to the same instant in every driver. Prefer `timestamptz` for a column that stores a point in time.
+
+---
+
 ## Roadmap
 
 Things we haven't finished yet:
@@ -1367,7 +1385,7 @@ Bun converts MySQL types to JavaScript types:
 | BIT(1)                                  | boolean                  | BIT(1) in MySQL                                                                                  |
 | GEOMETRY                                | Buffer                   | Binary character set; the bytes are a 4-byte SRID followed by WKB                                |
 
-`DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). PostgreSQL's `timestamp` (without time zone) behaves the same way. See [Timestamps and time zones](#timestamps-and-time-zones).
+`DATETIME` and `TIMESTAMP` values have no time zone on the wire, so Bun reads them back as **UTC**. See [Dates and time zones](#dates-and-time-zones).
 
 #### Differences from PostgreSQL
 
@@ -1382,20 +1400,6 @@ The API is unified, but behavior differs:
 We haven't implemented `LOAD DATA INFILE` support yet.
 
 ### PostgreSQL-Specific Features
-
-#### Timestamps and time zones
-
-A `timestamp` (without time zone, OID 1114) value has no offset on the wire. Bun decodes it as **UTC**: the `Date` you get has the same UTC wall clock that was stored, regardless of the machine's time zone. Bun decodes it the same way in regular queries and in `sql``.simple()` queries. This matches how Bun writes values (a bound `Date` stores its UTC components), so a `Date` round-trips exactly on any host.
-
-```ts
-// Column: created_at timestamp, stored value: 2024-01-15 12:00:00
-const [row] = await sql`SELECT created_at FROM events`;
-row.created_at.toISOString(); // "2024-01-15T12:00:00.000Z" on every host
-```
-
-`node-postgres` (`pg`), `postgres.js`, and PGlite decode `timestamp` as **local time** instead. If you migrate from one of them and the host is not UTC, the same stored value produces a `Date` for a different instant. `timestamptz` carries an explicit offset and decodes the same in every driver. Prefer `timestamptz` when a column stores a point in time.
-
-#### Not yet implemented
 
 We haven't implemented these yet:
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1367,7 +1367,7 @@ Bun converts MySQL types to JavaScript types:
 | BIT(1)                                  | boolean                  | BIT(1) in MySQL                                                                                  |
 | GEOMETRY                                | Buffer                   | Binary character set; the bytes are a 4-byte SRID followed by WKB                                |
 
-`DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). The same applies to PostgreSQL's `timestamp` (without time zone); `timestamptz` carries an explicit offset and is unaffected.
+`DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). PostgreSQL's `timestamp` (without time zone) behaves the same way, see [Timestamps and time zones](#timestamps-and-time-zones).
 
 #### Differences from PostgreSQL
 
@@ -1382,6 +1382,20 @@ The API is unified, but behavior differs:
 We haven't implemented `LOAD DATA INFILE` support yet.
 
 ### PostgreSQL-Specific Features
+
+#### Timestamps and time zones
+
+A `timestamp` (without time zone) value has no offset on the wire. Bun decodes it as **UTC**: the `Date` you get has the same UTC wall clock that was stored, regardless of the machine's time zone. This matches how Bun writes values (a bound `Date` stores its UTC components), so a `Date` round-trips exactly on any host.
+
+```ts
+// Column: created_at timestamp, stored value: 2024-01-15 12:00:00
+const [row] = await sql`SELECT created_at FROM events`;
+row.created_at.toISOString(); // "2024-01-15T12:00:00.000Z" on every host
+```
+
+This differs from `node-postgres` (`pg`) and `postgres.js`, which decode `timestamp` as **local time**. If you migrate from those drivers and the host is not UTC, the same stored value produces a `Date` for a different instant. `timestamptz` carries an explicit offset and decodes the same in every driver. Prefer `timestamptz` when a column stores a point in time.
+
+#### Not yet implemented
 
 We haven't implemented these yet:
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1385,7 +1385,7 @@ We haven't implemented `LOAD DATA INFILE` support yet.
 
 #### Timestamps and time zones
 
-A `timestamp` (without time zone) value has no offset on the wire. Bun decodes it as **UTC**: the `Date` you get has the same UTC wall clock that was stored, regardless of the machine's time zone. This matches how Bun writes values (a bound `Date` stores its UTC components), so a `Date` round-trips exactly on any host.
+A `timestamp` (without time zone, OID 1114) value has no offset on the wire. Bun decodes it as **UTC**: the `Date` you get has the same UTC wall clock that was stored, regardless of the machine's time zone. Bun decodes it the same way in regular queries and in `sql``.simple()` queries. This matches how Bun writes values (a bound `Date` stores its UTC components), so a `Date` round-trips exactly on any host.
 
 ```ts
 // Column: created_at timestamp, stored value: 2024-01-15 12:00:00
@@ -1393,7 +1393,7 @@ const [row] = await sql`SELECT created_at FROM events`;
 row.created_at.toISOString(); // "2024-01-15T12:00:00.000Z" on every host
 ```
 
-This differs from `node-postgres` (`pg`) and `postgres.js`, which decode `timestamp` as **local time**. If you migrate from those drivers and the host is not UTC, the same stored value produces a `Date` for a different instant. `timestamptz` carries an explicit offset and decodes the same in every driver. Prefer `timestamptz` when a column stores a point in time.
+`node-postgres` (`pg`), `postgres.js`, and PGlite decode `timestamp` as **local time** instead. If you migrate from one of them and the host is not UTC, the same stored value produces a `Date` for a different instant. `timestamptz` carries an explicit offset and decodes the same in every driver. Prefer `timestamptz` when a column stores a point in time.
 
 #### Not yet implemented
 


### PR DESCRIPTION
Fixes #39879.

### Problem

- `Bun.SQL` decodes a PostgreSQL `timestamp` (without time zone, OID 1114) as UTC (`src/sql_jsc/postgres/types/date.rs:39`). `node-postgres`, `postgres.js`, and PGlite decode it as local time, so a migration shifts values on a non-UTC host.
- The docs state this only in a trailing clause of the MySQL type note (`docs/runtime/sql.mdx:1370`).

### Fix

- Add a `## Dates and time zones` section next to `## Numbers and BigInt`. It states the UTC rule once for PostgreSQL `timestamp` and MySQL `DATETIME` and `TIMESTAMP`, then covers `date` (UTC midnight), `timestamp[]` (local time today, fixed by #35505), and the drivers that differ. The MySQL note links to it.
- A `##` heading is correct because both adapters share the rule (one parser, `src/sql_jsc/shared/datetime_text.rs`) and only `##` and `###` headings appear in the page table of contents.
- The encode sentence is scoped to prepared statements (the default). With `prepare: false` a bound `Date` fails today (#29010, #39450).
- Verified: every claim ran against the local PostgreSQL and MariaDB with `TZ=Etc/GMT+7` (output in Notes). I read the `pg` and `postgres.js` parsers. Prettier passes. Docs only.

### Background

- A PostgreSQL `timestamp` has no offset on the wire. The binary format is UTC microseconds since 2000-01-01. Since #31212 Bun parses the text format (`.simple()`) as UTC too. Array elements still use `Date.parse`. #35505 fixes that and should drop the `timestamp[]` sentence.
- #39911 by @deepshekhardas documented the same fact. b187c78 folds in its extra facts with a `Co-authored-by` trailer.

<details><summary>Notes</summary>

Results on bun 1.4.0 with `TZ=Etc/GMT+7` (same results with `TZ=Asia/Kolkata`):

```
extended ts      = 2024-01-15T12:00:00.000Z
extended ts_arr  = [ "2024-01-15T19:00:00.000Z" ]   <- local time, see #35505
extended date    = 2024-01-15T00:00:00.000Z
extended tstz    = 2024-01-15T12:00:00.000Z
simple   ts      = 2024-01-15T12:00:00.000Z
simple   ts_arr  = [ "2024-01-15T19:00:00.000Z" ]
simple   date    = 2024-01-15T00:00:00.000Z
prepare=true  timestamp   round-trip: EXACT
prepare=true  timestamptz round-trip: EXACT
prepare=false timestamp   bind error: time zone "gmt-0700" not recognized
mysql text   dt = 2024-01-15T12:00:00.000Z | d = 2024-01-15T00:00:00.000Z
mysql binary dt = 2024-01-15T12:00:00.000Z | d = 2024-01-15T00:00:00.000Z
mysql .simple() dt = 2024-01-15T12:00:00.000Z
mysql round-trip dt: EXACT
```

- `postgres-date@1.0.7` (used by `pg`) builds `timestamp` and `date` values with the local-time `Date` constructor. `postgres@3.3.5` parses OIDs 1082, 1114, and 1184 with `new Date(text)`: the `timestamp` text shape parses as local time, the `date` shape as UTC. PGlite output is in the issue.
- The `#dates-and-time-zones` anchor matches the heading. The page already uses the `` `sql``.simple()` `` code span form in prose (lines 315, 331, 423, 1089).
- History: the first draft added a `####` subsection under "PostgreSQL-Specific Features" plus a "Not yet implemented" heading. Self-review found that heading level is not in the table of contents and that the text duplicated the MySQL note. Commit 9ed16c5 moved the text to a shared section and restored that part of the page to match main.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->
