### PR TITLE
install: stop a colliding npm alias from absorbing a peer's resolved package

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -673,9 +673,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     let mut version_was_replaced = true;
     let version: dependency::Version = 'version: {
         // An `npm:` alias names its registry target explicitly, so only plain
-        // dependencies may be redirected to a same-named alias elsewhere in the tree.
+        // dependencies may be redirected to a same-named alias elsewhere in the
+        // tree. An override that matches this dependency wins over the
+        // redirect: without this check the redirect would `break 'version`
+        // past the override lookup below and silently drop the override.
         if dependency.version.tag == dependency::version::Tag::Npm
             && !dependency.version.npm().is_alias
+            && (dependency.behavior.is_workspace()
+                || this
+                    .lockfile
+                    .overrides
+                    .get(&this.lockfile, id, name_hash)
+                    .is_none())
         {
             if let Some(aliased) = this.known_npm_aliases.get(&name_hash) {
                 let group = &dependency.version.npm().version;

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -674,9 +674,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     let version: dependency::Version = 'version: {
         // An `npm:` alias names its registry target explicitly, so only plain
         // dependencies may be redirected to a same-named alias elsewhere in the
-        // tree. An override that matches this dependency wins over the
-        // redirect: without this check the redirect would `break 'version`
-        // past the override lookup below and silently drop the override.
+        // tree, and a matching override wins over the redirect.
         if dependency.version.tag == dependency::version::Tag::Npm
             && !dependency.version.npm().is_alias
             && (dependency.behavior.is_workspace()

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1010,10 +1010,8 @@ impl Tree {
             // or hoist if peer version allows it
 
             if dependency.behavior.is_peer() {
-                // An npm alias can put a package under a dependency name that is
-                // not the package's own name. Deduping a peer onto such an entry
-                // would serve a different package than the one the lockfile bound
-                // the peer to, so only dedupe onto the same package name.
+                // Only dedupe onto the same package name: an npm alias can hold
+                // a different package than the one the lockfile bound this peer to.
                 let pkg_name_hashes = builder.lockfile().packages.items_name_hash();
                 if pkg_name_hashes[res_id as usize] != pkg_name_hashes[package_id as usize] {
                     return HoistDependencyResult::DependencyLoop; // 3

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1010,6 +1010,15 @@ impl Tree {
             // or hoist if peer version allows it
 
             if dependency.behavior.is_peer() {
+                // An npm alias can put a package under a dependency name that is
+                // not the package's own name. Deduping a peer onto such an entry
+                // would serve a different package than the one the lockfile bound
+                // the peer to, so only dedupe onto the same package name.
+                let pkg_name_hashes = builder.lockfile().packages.items_name_hash();
+                if pkg_name_hashes[res_id as usize] != pkg_name_hashes[package_id as usize] {
+                    return HoistDependencyResult::DependencyLoop; // 3
+                }
+
                 // An optional peer's binding follows the dedupe, but only in the tree being saved.
                 let dedupe = || {
                     if METHOD == BuilderMethod::Resolvable && dependency.behavior.is_optional_peer()

--- a/test/cli/install/hoist.test.ts
+++ b/test/cli/install/hoist.test.ts
@@ -1,5 +1,8 @@
-import { afterAll, beforeAll, test } from "bun:test";
+import { file } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { rm } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, runBunInstall } from "harness";
+import { join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -27,4 +30,67 @@ test("should handle resolving optional peer from multiple instances of same pack
 
   // this shouldn't hit an assertion
   await runBunInstall(bunEnv, packageDir);
+});
+
+// CI exports BUN_INSTALL_CACHE_DIR, which overrides the harness bunfig's per-test `cache`; concurrent cases sharing one cache race on Windows.
+const installEnv = (dir: string) => ({ ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") });
+
+const pkgSeenAt = async (dir: string, ...segments: string[]) => {
+  const { name, version } = await file(join(dir, "node_modules", ...segments, "package.json")).json();
+  return `${name}@${version}`;
+};
+
+// A root npm alias can occupy a peer's name with a different package. The peer
+// must not dedupe onto it; its own resolution nests next to the dependent.
+test.concurrent("a peer nests its own package when a root alias occupies the name", async () => {
+  const { packageDir } = await registry.createTestDir({
+    files: {
+      "package.json": JSON.stringify({
+        name: "pkg",
+        dependencies: {
+          "a-dep": "npm:no-deps@1.0.0",
+          "peer-a-dep-gte-1-0-2": "1.0.0",
+        },
+      }),
+    },
+  });
+
+  await runBunInstall(installEnv(packageDir), packageDir);
+
+  expect(await pkgSeenAt(packageDir, "a-dep")).toBe("no-deps@1.0.0");
+  expect(await pkgSeenAt(packageDir, "peer-a-dep-gte-1-0-2", "node_modules", "a-dep")).toBe("a-dep@1.0.10");
+});
+
+// https://github.com/oven-sh/bun/issues/39883
+test.concurrent("an overridden peer nests the override target when a root alias occupies the name", async () => {
+  const { packageDir } = await registry.createTestDir({
+    files: {
+      "package.json": JSON.stringify({
+        name: "pkg",
+        dependencies: {
+          "no-deps": "npm:a-dep@1.0.1",
+          "peer-deps-fixed": "1.0.0",
+        },
+        overrides: {
+          "peer-deps-fixed>no-deps": "npm:no-deps@1.0.0",
+        },
+      }),
+    },
+  });
+  const env = installEnv(packageDir);
+
+  await runBunInstall(env, packageDir);
+
+  const check = async () => {
+    expect(await pkgSeenAt(packageDir, "no-deps")).toBe("a-dep@1.0.1");
+    expect(await pkgSeenAt(packageDir, "peer-deps-fixed", "node_modules", "no-deps")).toBe("no-deps@1.0.0");
+  };
+  await check();
+
+  // the reported scenario: reinstall from the saved lockfile
+  const lockBefore = await file(join(packageDir, "bun.lock")).text();
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(env, packageDir, { frozenLockfile: true });
+  await check();
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockBefore);
 });


### PR DESCRIPTION
### Problem
- With `"typescript": "npm:@typescript/typescript6@6.0.2"` at the root and a transitive override that pins another package's `typescript` peer, the lockfile binds the peer to the override target but the installer never writes that copy to disk. Node resolution walks up and finds the root alias's package instead, so the override is silently lost (#39883). In a large tree the hoister makes this choice once per copy of the dependent, which surfaces as nondeterministic CI failures.
- Two causes. `Tree::hoist_dependency` (src/install/lockfile/Tree.rs:1012) dedupes a peer onto any same-name entry by version alone, so an alias that holds a different package absorbs the peer. And the same-name alias redirect in `enqueue_dependency_with_main_and_success_fn` (src/install/PackageManager/PackageManagerEnqueue.rs:677) runs before the override lookup and breaks past it, so a matching override is dropped before resolution.

### Fix
- The peer dedupe in the hoister now requires that the existing entry resolves to the same package name. Otherwise the peer nests next to its dependent, which is the resolution the lockfile already recorded. Disk and lockfile now agree.
- The alias redirect is skipped when an override matches the dependency. The override then applies the same way it does without the alias.
- An overridden peer still prefers an existing copy of its package in the tree and warns when that copy is out of range. The nested-overrides semantics from #38333 are unchanged.
- Verified: test/cli/install/hoist.test.ts (two new tests, both fail on stock bun). Also ran the overrides, nested-overrides, bun-install-registry, bun-lock, bun-workspaces, isolated-install, catalogs, bun-add, bun-update-transitive, bun-dedupe, frozen-lockfile-pruned, and public-hoist-pattern suites.

### Background
- The hoisted installer builds a tree that places each dependency edge as high in node_modules as possible. When a level already holds an entry with the same name, a peer edge dedupes onto it: nothing is placed, and the peer is served by that entry at runtime.
- A lockfile package entry stores the real registry name. An `npm:` alias creates a dependency whose name differs from its package's name, so a name match in the tree does not imply the same package.
- The tree is rebuilt from the lockfile on every install, so the fix applies to fresh installs and `--frozen-lockfile` alike.

<details><summary>Notes</summary>

Reproduction on the public registry (the issue's shape, linux x64 debug build):

- Override present (`"@phenomnomnominal/tsquery>typescript": "npm:typescript@6.0.3"`): before, `bun pm why typescript` showed the peer bound to typescript@6.0.3 but no nested copy existed under tsquery, so the package resolved the root alias (`@typescript/typescript6@6.0.2`). After, `node_modules/@phenomnomnominal/tsquery/node_modules/typescript` holds 6.0.3 and `Object.keys(ts.SyntaxKind)` works.
- No override: the peer binds to the other alias's target (typescript@7.0.2). Before, disk served the root alias while the lockfile said 7.0.2. After, the nested copy matches the lockfile. The out-of-range binding itself is the resolver's documented still-a-peer behavior and is out of scope here.
- Control without a colliding alias: unchanged, the override target is hoisted to the root as before.
- The reporter saw the outcome flip about 1 in 8 installs in a ~2620 package workspace. 17 installs of a 2000-package approximation did not flip in this environment, but the two states the reporter observed are exactly the two resolutions above. Removing the lockfile-vs-disk mismatch removes the input for the flip.
- A second `bun install` and a `--frozen-lockfile` reinstall leave bun.lock byte-identical in the new tests.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/hoist.test.ts
bun test v1.4.0 (6e906e468)

test/cli/install/hoist.test.ts:
(pass) should handle resolving optional peer from multiple instances of same package [316.82ms]
34 | 
35 | // CI exports BUN_INSTALL_CACHE_DIR, which overrides the harness bunfig's per-test `cache`; concurrent cases sharing one cache race on Windows.
36 | const installEnv = (dir: string) => ({ ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") });
37 | 
38 | const pkgSeenAt = async (dir: string, ...segments: string[]) => {
39 |   const { name, version } = await file(join(dir, "node_modules", ...segments, "package.json")).json();
                                                                                                    ^
ENOENT: no such file or directory, open '/tmp/verdaccio-test-_RE8JTy/node_modules/peer-a-dep-gte-1-0-2/node_modules/a-dep/package.json'
    path: "/tmp/verdaccio-test-_RE8JTy/node_modules/peer-a-dep-gte-1-0-2/node_modules/a-dep/package.json",
 syscall: "open",
   errno: -2,
    code: "ENOENT"

      at async <anon
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/cli/install/hoist.test.ts:
(pass) should handle resolving optional peer from multiple instances of same package [53.52ms]
34 | 
35 | // CI exports BUN_INSTALL_CACHE_DIR, which overrides the harness bunfig's per-test `cache`; concurrent cases sharing one cache race on Windows.
36 | const installEnv = (dir: string) => ({ ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") });
37 | 
38 | const pkgSeenAt = async (dir: string, ...segments: string[]) => {
39 |   const { name, version } = await file(join(dir, "node_modules", ...segments, "package.json")).json();
                                                                                                    ^
ENOENT: no such file or directory, open '/tmp/verdaccio-test-_4psYQt/node_modules/peer-deps-fixed/node_modules/no-deps/package.json'
    path: "/tmp/verdaccio-test-_4psYQt/node_modules/peer-deps-fixed/node_modules/no-deps/package.json",
 syscall: "open",
   errno: -2,
    code: "ENOENT"

      at async <anonymous> (/workspace/bun/test/cli/install/hoist.test.ts:39:96)
      at async <anonymous> (/workspace/bun/test/cli/install/hoist.test.ts:86:18)
      at async <anon
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/hoist.test.ts
bun test v1.4.0 (6e906e468)

test/cli/install/hoist.test.ts:
(pass) should handle resolving optional peer from multiple instances of same package [428.97ms]
(pass) a peer nests its own package when a root alias occupies the name [406.51ms]
(pass) an overridden peer nests the override target when a root alias occupies the name [657.17ms]

 3 pass
 0 fail
 34 expect() calls
Ran 3 tests across 1 file. [5.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1002ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerEnqueue.rs        |  9 ++-
 src/install/lockfile/Tree.rs                       |  7 +++
 test/cli/install/hoist.test.ts                     | 68 +++++++++++++++++++++-
 3 files changed, 82 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager/PackageManagerEnqueue.rs      4      7      0
src/install/lockfile/Tree.rs                             4      4      0
test/cli/install/hoist.test.ts                           1      4      0
```

</details>

**root cause** · written by the author bot

The root cause was in how bun install resolved a dependency name when an npm alias at the root occupied that same name: the alias redirect ran before the override lookup and could absorb a peer dependency, binding it to a different underlying package than the one the lockfile recorded, which made nested resolution nondeterministic under concurrent installs. The fix adds two guards, one in the enqueue path so a matching override takes precedence over a same-name alias redirect, and one in tree hoisting so a peer only dedupes onto an existing entry when the resolved package names actually mat…

<!-- robobun:evidence:end -->