### PR TITLE
feat(test): add --find-related-tests

### DIFF
--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -237,6 +237,16 @@ Use the `--rerun-each` flag to run each test multiple times. This surfaces flaky
 bun test --rerun-each 100
 ```
 
+## Run tests related to source files
+
+Use `--find-related-tests` to run only test files that import one or more source files, directly or transitively. This is useful when a focused change should not run the entire test suite.
+
+```sh terminal icon="terminal"
+bun test --find-related-tests src/util.ts src/parser.ts
+```
+
+The Jest-compatible `--findRelatedTests` spelling is also supported. Package imports are treated as external, so the search follows local project files without scanning `node_modules`.
+
 ## Randomize test execution order
 
 Use the `--randomize` flag to run tests in a random order. This helps detect tests that depend on shared state or execution order.

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -438,6 +438,9 @@ pub struct TestOptions {
     /// Otherwise the value is a git ref (commit, branch, tag) to diff
     /// against.
     pub changed: Option<Box<[u8]>>,
+    /// `bun test --find-related-tests <path>...`. When non-empty, only test
+    /// files whose module graph reaches one of these source files are run.
+    pub related_files: Vec<Box<[u8]>>,
     /// `bun test --shard=M/N`. When set, test files are sorted by path
     /// and only every Nth file (starting from M-1) is run. index is
     /// 1-based; both are validated at parse time so `1 <= index <= count`.
@@ -509,6 +512,7 @@ impl Default for TestOptions {
             parallel_delay_ms: None,
             test_worker: false,
             changed: None,
+            related_files: Vec::new(),
             shard: None,
             timings_files: Vec::new(),
             update_timings: false,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -614,6 +614,9 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
         "--changed <STR>?                 Only run test files affected by changed files according to git. Optionally pass a commit or branch to compare against."
     ),
     parse_param!(
+        "--find-related-tests/--findRelatedTests <STR>...  Only run test files related to the given source files."
+    ),
+    parse_param!(
         "--isolate                        Run each test file in a fresh global object. Leaked handles from one file cannot affect another."
     ),
     parse_param!(
@@ -1899,6 +1902,22 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     }
     if let Some(since) = args.option(b"--changed") {
         ctx.test_options.changed = Some(since.into());
+    }
+    for path in args.options(b"--find-related-tests") {
+        if !ctx
+            .test_options
+            .related_files
+            .iter()
+            .any(|existing| &**existing == *path)
+        {
+            ctx.test_options.related_files.push((*path).into());
+        }
+    }
+    if ctx.test_options.changed.is_some() && !ctx.test_options.related_files.is_empty() {
+        bun_core::pretty_errorln!(
+            "<r><red>error<r>: --changed and --find-related-tests cannot be used together"
+        );
+        Global::exit(1);
     }
     if let Some(shard) = args.option(b"--shard") {
         let Some(sep) = strings::index_of_char(shard, b'/') else {

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -31,7 +31,7 @@ use bun_jsc::EventLoopHandle;
 use bun_jsc::virtual_machine::VirtualMachine;
 #[cfg(not(windows))]
 use bun_paths::SEP;
-use bun_paths::{self, PathBuffer, platform, resolve_path};
+use bun_paths::{PathBuffer, platform, resolve_path};
 use bun_ptr::Interned;
 #[cfg(not(windows))]
 use bun_resolver::fs::RealFS;
@@ -47,8 +47,8 @@ pub(crate) struct Result<'a> {
     /// The filtered list of test files. Slice of the original `test_files`
     /// allocation, owned by the caller.
     pub(crate) test_files: &'a mut [Interned],
-    /// Number of files git reported as changed.
-    pub(crate) changed_count: usize,
+    /// Number of source files used to seed the reverse import walk.
+    pub(crate) source_count: usize,
     /// Number of test files before filtering.
     pub(crate) total_tests: usize,
     /// Absolute paths of every local source file that participates in the
@@ -97,10 +97,48 @@ pub(crate) fn filter<'a>(
         }
     };
 
+    filter_source_files(ctx, vm, test_files, changed_files, "--changed")
+}
+
+/// Filter `test_files` to the entries related to explicitly supplied source
+/// paths. Relative paths are resolved from Bun's top-level working directory.
+pub(crate) fn filter_related<'a>(
+    ctx: &Command::Context,
+    vm: &mut VirtualMachine,
+    test_files: &'a mut [Interned],
+    related_files: &[Box<[u8]>],
+) -> core::result::Result<Result<'a>, crate::Error> {
+    let top_level_dir: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let mut source_files = StringSet::new();
+
+    for path in related_files {
+        let absolute = resolve_path::join_abs::<platform::Auto>(top_level_dir, path);
+
+        if !sys::exists(absolute) {
+            Output::err_generic(
+                "<b>--find-related-tests<r>: source file not found: {s}",
+                (bun_fmt::quote(path),),
+            );
+            Global::exit(1);
+        }
+
+        let _ = source_files.insert(absolute);
+    }
+
+    filter_source_files(ctx, vm, test_files, source_files, "--find-related-tests")
+}
+
+fn filter_source_files<'a>(
+    ctx: &Command::Context,
+    vm: &mut VirtualMachine,
+    test_files: &'a mut [Interned],
+    source_files: StringSet,
+    option_name: &str,
+) -> core::result::Result<Result<'a>, crate::Error> {
     if test_files.is_empty() {
         return Ok(Result {
             test_files: &mut test_files[0..0],
-            changed_count: changed_files.count(),
+            source_count: source_files.count(),
             total_tests: 0,
             module_graph_files: Vec::new(),
         });
@@ -108,11 +146,11 @@ pub(crate) fn filter<'a>(
 
     // With a clean working tree and no --watch, nothing can be affected and
     // there is no watcher to seed, so skip the module-graph scan entirely.
-    if changed_files.count() == 0 && ctx.debug.hot_reload != HotReload::Watch {
+    if source_files.count() == 0 && ctx.debug.hot_reload != HotReload::Watch {
         let total = test_files.len();
         return Ok(Result {
             test_files: &mut test_files[0..0],
-            changed_count: 0,
+            source_count: 0,
             total_tests: total,
             module_graph_files: Vec::new(),
         });
@@ -137,8 +175,8 @@ pub(crate) fn filter<'a>(
             Ok(t) => t,
             Err(err) => {
                 Output::err_generic(
-                    "Failed to initialize module graph scanner for --changed: {s}",
-                    (err.name(),),
+                    "Failed to initialize module graph scanner for {s}: {s}",
+                    (option_name, err.name()),
                 );
                 Global::exit(1);
             }
@@ -176,14 +214,15 @@ pub(crate) fn filter<'a>(
         Err(err) => {
             // Fall back to running every test rather than aborting the run.
             bun_core::warn!(
-                "--changed: failed to build module graph ({}); running all tests",
+                "{}: failed to build module graph ({}); running all tests",
+                option_name,
                 err.name()
             );
             Output::flush();
             let total = test_files.len();
             return Ok(Result {
                 test_files,
-                changed_count: changed_files.count(),
+                source_count: source_files.count(),
                 total_tests: total,
                 module_graph_files: Vec::new(),
             });
@@ -257,8 +296,8 @@ pub(crate) fn filter<'a>(
     let mut queue: Vec<u32> = Vec::new();
 
     {
-        for changed_path in changed_files.keys() {
-            if let Some(&idx) = path_to_index.get(changed_path.as_ref()) {
+        for source_path in source_files.keys() {
+            if let Some(&idx) = path_to_index.get(source_path.as_ref()) {
                 if !affected.is_set(idx as usize) {
                     affected.set(idx as usize);
                     queue.push(idx);
@@ -287,7 +326,7 @@ pub(crate) fn filter<'a>(
     for i in 0..total {
         let tf = test_files[i];
         let maybe_source = slot_to_source[i];
-        let keep = changed_files.contains(tf.as_bytes())
+        let keep = source_files.contains(tf.as_bytes())
             || maybe_source.is_some_and(|src| affected.is_set(src as usize));
 
         if keep {
@@ -310,7 +349,7 @@ pub(crate) fn filter<'a>(
 
     Ok(Result {
         test_files: &mut test_files[0..write],
-        changed_count: changed_files.count(),
+        source_count: source_files.count(),
         total_tests: total,
         module_graph_files: graph_files,
     })

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2566,9 +2566,6 @@ impl TestCommand {
             }
         } else if !ctx.test_options.related_files.is_empty() {
             'brk: {
-                if all_test_files.is_empty() {
-                    break 'brk &mut all_test_files[..];
-                }
                 let result = match ChangedFilesFilter::filter_related(
                     &ctx,
                     vm,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2541,21 +2541,62 @@ impl TestCommand {
                     }
                 };
                 changed_module_graph_files = result.module_graph_files;
-                if result.test_files.is_empty() && result.changed_count == 0 {
+                if result.test_files.is_empty() && result.source_count == 0 {
                     pretty_error!("<r><d>--changed:<r> no changed files, nothing to run\n");
                     pass_with_no_tests_from_filter = true;
                 } else if result.test_files.is_empty() {
                     pretty_error!(
                         "<r><d>--changed:<r> {} changed file{}, but no test files are affected\n",
-                        result.changed_count,
-                        if result.changed_count == 1 { "" } else { "s" }
+                        result.source_count,
+                        if result.source_count == 1 { "" } else { "s" }
                     );
                     pass_with_no_tests_from_filter = true;
                 } else {
                     pretty_error!(
                         "<r><d>--changed:<r> {} changed file{}, running {}/{} test file{}\n",
-                        result.changed_count,
-                        if result.changed_count == 1 { "" } else { "s" },
+                        result.source_count,
+                        if result.source_count == 1 { "" } else { "s" },
+                        result.test_files.len(),
+                        result.total_tests,
+                        if result.total_tests == 1 { "" } else { "s" }
+                    );
+                }
+                Output::flush();
+                break 'brk result.test_files;
+            }
+        } else if !ctx.test_options.related_files.is_empty() {
+            'brk: {
+                if all_test_files.is_empty() {
+                    break 'brk &mut all_test_files[..];
+                }
+                let result = match ChangedFilesFilter::filter_related(
+                    &ctx,
+                    vm,
+                    &mut all_test_files[..],
+                    &ctx.test_options.related_files,
+                ) {
+                    Ok(r) => r,
+                    Err(err) => {
+                        Output::err(
+                            err,
+                            "--find-related-tests: unable to determine related tests",
+                            (),
+                        );
+                        Global::exit(1);
+                    }
+                };
+                if result.test_files.is_empty() {
+                    pretty_error!(
+                        "<r><d>--find-related-tests:<r> {} source file{}, but no test files are related\n",
+                        result.source_count,
+                        if result.source_count == 1 { "" } else { "s" }
+                    );
+                    pass_with_no_tests_from_filter = true;
+                } else {
+                    pretty_error!(
+                        "<r><d>--find-related-tests:<r> {} source file{}, running {}/{} test file{}\n",
+                        result.source_count,
+                        if result.source_count == 1 { "" } else { "s" },
                         result.test_files.len(),
                         result.total_tests,
                         if result.total_tests == 1 { "" } else { "s" }

--- a/test/cli/test/find-related-tests.test.ts
+++ b/test/cli/test/find-related-tests.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+const fixture = {
+  "package.json": JSON.stringify({ name: "related-tests", type: "module" }),
+  "src/helper.ts": `export const helper = () => 1;\n`,
+  "src/util.ts": `import { helper } from "./helper";\nexport const util = () => helper() + 1;\n`,
+  "src/other.ts": `export const other = () => 9;\n`,
+  "a.test.ts": `import { test, expect } from "bun:test";\nimport { util } from "./src/util";\ntest("a", () => expect(util()).toBe(2));\n`,
+  "b.test.ts": `import { test, expect } from "bun:test";\nimport { other } from "./src/other";\ntest("b", () => expect(other()).toBe(9));\n`,
+  "c.test.ts": `import { test, expect } from "bun:test";\ntest("c", () => expect(1).toBe(1));\n`,
+  "README.md": "unrelated\n",
+};
+
+const testFiles = ["a.test.ts", "b.test.ts", "c.test.ts"];
+
+async function runRelated(cwd: string, paths: string[], flag = "--find-related-tests") {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", flag, ...paths],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function ranFiles(stderr: string): string[] {
+  return testFiles.filter(name => stderr.includes(`${name}:`)).sort();
+}
+
+describe.concurrent("bun test --find-related-tests", () => {
+  test("selects a test through a transitive dependency", async () => {
+    using dir = tempDir("find-related-transitive", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), ["src/helper.ts"]);
+
+    expect(ranFiles(stderr)).toEqual(["a.test.ts"]);
+    expect(stderr).toContain("1 source file, running 1/3 test file");
+    expect(exitCode).toBe(0);
+  });
+
+  test("selects the union for multiple source files", async () => {
+    using dir = tempDir("find-related-multiple", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), ["src/helper.ts", "src/other.ts"]);
+
+    expect(ranFiles(stderr)).toEqual(["a.test.ts", "b.test.ts"]);
+    expect(stderr).toContain("2 source files, running 2/3 test files");
+    expect(exitCode).toBe(0);
+  });
+
+  test("accepts an absolute source path", async () => {
+    using dir = tempDir("find-related-absolute", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), [join(String(dir), "src", "other.ts")]);
+
+    expect(ranFiles(stderr)).toEqual(["b.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("supports Jest's camel-case flag", async () => {
+    using dir = tempDir("find-related-alias", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), ["src/util.ts"], "--findRelatedTests");
+
+    expect(ranFiles(stderr)).toEqual(["a.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("an unrelated source exits successfully without running tests", async () => {
+    using dir = tempDir("find-related-unrelated", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), ["README.md"]);
+
+    expect(ranFiles(stderr)).toEqual([]);
+    expect(stderr).toContain("no test files are related");
+    expect(exitCode).toBe(0);
+  });
+
+  test("reports a missing source file", async () => {
+    using dir = tempDir("find-related-missing", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), ["src/missing.ts"]);
+
+    expect(stderr).toContain("source file not found");
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/cli/test/find-related-tests.test.ts
+++ b/test/cli/test/find-related-tests.test.ts
@@ -86,8 +86,9 @@ describe.concurrent("bun test --find-related-tests", () => {
       "package.json": fixture["package.json"],
     });
 
-    const { stderr, exitCode } = await runRelated(String(dir), ["src/missing.ts"]);
+    const { stdout, stderr, exitCode } = await runRelated(String(dir), ["src/missing.ts"]);
 
+    expect(stdout).toBeEmpty();
     expect(stderr).toContain("source file not found");
     expect(exitCode).not.toBe(0);
   });
@@ -95,10 +96,11 @@ describe.concurrent("bun test --find-related-tests", () => {
   test("rejects --changed with --find-related-tests", async () => {
     using dir = tempDir("find-related-changed", fixture);
 
-    const { stderr, exitCode } = await runRelated(String(dir), ["src/helper.ts"], "--find-related-tests", [
+    const { stdout, stderr, exitCode } = await runRelated(String(dir), ["src/helper.ts"], "--find-related-tests", [
       "--changed",
     ]);
 
+    expect(stdout).toBeEmpty();
     expect(stderr).toContain("--changed and --find-related-tests cannot be used together");
     expect(exitCode).not.toBe(0);
   });

--- a/test/cli/test/find-related-tests.test.ts
+++ b/test/cli/test/find-related-tests.test.ts
@@ -15,9 +15,9 @@ const fixture = {
 
 const testFiles = ["a.test.ts", "b.test.ts", "c.test.ts"];
 
-async function runRelated(cwd: string, paths: string[], flag = "--find-related-tests") {
+async function runRelated(cwd: string, paths: string[], flag = "--find-related-tests", extraArgs: string[] = []) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", flag, ...paths],
+    cmd: [bunExe(), "test", ...extraArgs, flag, ...paths],
     cwd,
     env: bunEnv,
     stdout: "pipe",
@@ -82,11 +82,24 @@ describe.concurrent("bun test --find-related-tests", () => {
   });
 
   test("reports a missing source file", async () => {
-    using dir = tempDir("find-related-missing", fixture);
+    using dir = tempDir("find-related-missing", {
+      "package.json": fixture["package.json"],
+    });
 
     const { stderr, exitCode } = await runRelated(String(dir), ["src/missing.ts"]);
 
     expect(stderr).toContain("source file not found");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("rejects --changed with --find-related-tests", async () => {
+    using dir = tempDir("find-related-changed", fixture);
+
+    const { stderr, exitCode } = await runRelated(String(dir), ["src/helper.ts"], "--find-related-tests", [
+      "--changed",
+    ]);
+
+    expect(stderr).toContain("--changed and --find-related-tests cannot be used together");
     expect(exitCode).not.toBe(0);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds Jest-compatible `bun test --find-related-tests <paths...>` and `--findRelatedTests` support.

The implementation reuses the reverse import graph introduced for `--changed`: source paths seed the graph walk, and only test entry points that reach those files directly or transitively are kept. Local project imports are followed while packages remain external, so `node_modules` is not scanned.

It also:

- accepts multiple source files and unions their related tests;
- accepts relative and absolute source paths;
- treats an existing source with no related tests as a successful no-op;
- reports missing source files as an error;
- rejects combining `--changed` with `--find-related-tests`;
- documents the new flag and its Jest spelling.

Fixes #22717.

## Tests

- `cargo fmt --all --check`
- `cargo check -p bun_runtime`
- Prettier check for the new test and documentation
- Added CLI coverage for transitive imports, multiple and absolute paths, the camel-case alias, unrelated sources, and missing files
