### PR TITLE
esm: make "__esModule" in a module namespace false like Node

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -122,14 +122,10 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       esModule = namespace.__esModule;
       moduleExports = namespace["module.exports"];
     } catch {}
-    // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-    // Various libraries expect __esModule to be set when using ESM from require().
-    // We don't want to always inject the __esModule export into every module,
-    // And creating an Object wrapper causes the actual exports to not be own properties.
-    // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-    // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-    // https://github.com/oven-sh/bun/issues/14411
-    if (esModule === undefined) {
+    // Match Node: require(esm) marks the namespace with an own `__esModule: true`
+    // when the module has a `default` export (#14411). `in` is [[HasProperty]],
+    // which cannot throw for a TDZ export during a require cycle.
+    if (esModule === undefined && "default" in namespace) {
       try {
         namespace.__esModule = true;
       } catch {
@@ -210,14 +206,10 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
     esModule = namespace.__esModule;
     moduleExports = namespace["module.exports"];
   } catch {}
-  // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-  // Various libraries expect __esModule to be set when using ESM from require().
-  // We don't want to always inject the __esModule export into every module,
-  // And creating an Object wrapper causes the actual exports to not be own properties.
-  // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-  // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-  // https://github.com/oven-sh/bun/issues/14411
-  if (esModule === undefined) {
+  // Match Node: require(esm) marks the namespace with an own `__esModule: true`
+  // when the module has a `default` export (#14411). `in` is [[HasProperty]],
+  // which cannot throw for a TDZ export during a require cycle.
+  if (esModule === undefined && "default" in namespace) {
     try {
       namespace.__esModule = true;
     } catch {

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -348,13 +348,8 @@ JSModuleNamespaceObject* NodeVMModule::namespaceObject(JSC::JSGlobalObject* glob
     object = amr->getModuleNamespace(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (object) {
-        // The shared module namespace structure carries an __esModule accessor for
-        // CJS interop, but a Module Namespace Exotic Object is specified to have a
-        // null [[Prototype]], which is what vm modules must expose.
-        object->setPrototypeDirect(vm, jsNull());
         namespaceObject(vm, object);
     }
-    RETURN_IF_EXCEPTION(scope, {});
 
     return object;
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1913,31 +1913,6 @@ extern "C" napi_env ZigGlobalObject__makeNapiEnvForFFI(Zig::GlobalObject* global
 }
 
 extern "C" JSC::EncodedJSValue CryptoObject__create(JSGlobalObject*);
-JSC_DEFINE_CUSTOM_GETTER(moduleNamespacePrototypeGetESModuleMarker, (JSGlobalObject * globalObject, JSC::EncodedJSValue encodedThisValue, PropertyName))
-{
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-    JSModuleNamespaceObject* moduleNamespaceObject = dynamicDowncast<JSModuleNamespaceObject>(thisValue);
-    if (!moduleNamespaceObject || moduleNamespaceObject->m_hasESModuleMarker != WTF::TriState::True) {
-        return JSC::JSValue::encode(jsUndefined());
-    }
-
-    return JSC::JSValue::encode(jsBoolean(true));
-}
-
-JSC_DEFINE_CUSTOM_SETTER(moduleNamespacePrototypeSetESModuleMarker, (JSGlobalObject * globalObject, JSC::EncodedJSValue encodedThisValue, JSC::EncodedJSValue encodedValue, PropertyName))
-{
-    auto& vm = JSC::getVM(globalObject);
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-    JSModuleNamespaceObject* moduleNamespaceObject = dynamicDowncast<JSModuleNamespaceObject>(thisValue);
-    if (!moduleNamespaceObject) {
-        return false;
-    }
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue value = JSValue::decode(encodedValue);
-    WTF::TriState triState = value.toBoolean(globalObject) ? WTF::TriState::True : WTF::TriState::False;
-    moduleNamespaceObject->m_hasESModuleMarker = triState;
-    return true;
-}
 
 namespace {
 
@@ -2276,11 +2251,6 @@ void GlobalObject::finishCreation(VM& vm)
              init.set(
                  createMemoryFootprintStructure(
                      init.vm, static_cast<Zig::GlobalObject*>(init.owner)));
-         } },
-        { OBJECT_OFFSETOF(GlobalObject, m_moduleNamespaceObjectStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
-             JSObject* moduleNamespacePrototype = JSC::constructEmptyObject(init.vm, init.owner->nullPrototypeObjectStructure());
-             moduleNamespacePrototype->putDirectCustomAccessor(init.vm, init.vm.propertyNames->__esModule, CustomGetterSetter::create(init.vm, moduleNamespacePrototypeGetESModuleMarker, moduleNamespacePrototypeSetESModuleMarker), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::CustomAccessor | 0);
-             init.set(JSModuleNamespaceObject::createStructure(init.vm, init.owner, moduleNamespacePrototype));
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSBufferSubclassStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);

--- a/test/js/bun/namespace-prototype-pollution.test.ts
+++ b/test/js/bun/namespace-prototype-pollution.test.ts
@@ -19,8 +19,15 @@ test("namespace imports should not inherit from Object.prototype", async () => {
         console.log("PASS: prototype pollution prevented");
       }
 
-      // Verify __esModule still works
-      console.log("__esModule settable:", (mod.__esModule = true, mod.__esModule === true));
+      // The namespace is non-extensible with a null prototype, so __esModule
+      // is absent and an assignment throws (same as Node).
+      console.log("__esModule absent:", !("__esModule" in mod));
+      try {
+        mod.__esModule = true;
+        console.log("FAIL: __esModule assignment did not throw");
+      } catch {
+        console.log("__esModule assignment throws: true");
+      }
 
       // Original exports should work
       console.log("Original export:", mod.value);
@@ -38,6 +45,7 @@ test("namespace imports should not inherit from Object.prototype", async () => {
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("PASS: prototype pollution prevented");
-  expect(stdout).toContain("__esModule settable: true");
+  expect(stdout).toContain("__esModule absent: true");
+  expect(stdout).toContain("__esModule assignment throws: true");
   expect(stdout).toContain("Original export: original");
 });

--- a/test/js/bun/resolve/esModule.test.ts
+++ b/test/js/bun/resolve/esModule.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Top-level `await import(self)` is a spec-level deadlock under the new
 // pure-C++ module loader (Node prints an "unsettled top-level await" warning
@@ -8,24 +9,108 @@ import * as Self from "./esModule.test.ts";
 
 test("__esModule defaults to undefined", () => {
   expect(Self.__esModule).toBeUndefined();
+  expect("__esModule" in Self).toBe(false);
+  expect(Reflect.has(Self, "__esModule")).toBe(false);
 });
 
-test("__esModule is settable", () => {
-  Self.__esModule = true;
-  expect(Self.__esModule).toBe(true);
-  Self.__esModule = false;
-  expect(Self.__esModule).toBe(undefined);
-  Self.__esModule = true;
-  expect(Self.__esModule).toBe(true);
-  Self.__esModule = undefined;
+test("assigning __esModule to a non-extensible namespace throws like Node", () => {
+  // A namespace created by `import` is the spec's non-extensible exotic
+  // object, so the marker cannot be added to it. Node throws the same way.
+  expect(() => {
+    // @ts-expect-error intentional write to a namespace object
+    Self.__esModule = true;
+  }).toThrow(TypeError);
+  expect(Self.__esModule).toBeUndefined();
+  expect("__esModule" in Self).toBe(false);
 });
 
-test("require of self sets __esModule", () => {
+test("require of self does not set __esModule without a default export", () => {
   expect(Self.__esModule).toBeUndefined();
   {
     const Self = require("./esModule.test.ts");
-    expect(Self.__esModule).toBe(true);
+    expect(Self.__esModule).toBeUndefined();
   }
-  expect(Self.__esModule).toBe(true);
+  expect(Self.__esModule).toBeUndefined();
   expect(Object.getOwnPropertyNames(Self)).toBeEmpty();
+});
+
+// https://github.com/oven-sh/bun/issues/39866
+test.concurrent("'__esModule' in an ES module namespace is false", async () => {
+  using dir = tempDir("esmodule-in-namespace", {
+    "inner.mjs": "export const alpha = 1;\nexport const beta = 2;\n",
+    // The export shape of zod/index.js: a star re-export next to explicit exports.
+    "dep.mjs": 'import * as ns from "./inner.mjs";\nexport * from "./inner.mjs";\nexport { ns };\nexport default ns;\n',
+    "main.mjs": `
+import * as mod from "./dep.mjs";
+if ("__esModule" in mod) throw new Error("'__esModule' in mod must be false");
+if (Reflect.has(mod, "__esModule")) throw new Error("Reflect.has(mod, '__esModule') must be false");
+if (Object.hasOwn(mod, "__esModule")) throw new Error("Object.hasOwn(mod, '__esModule') must be false");
+
+// vitest's interopModule heuristic: a truthy '"__esModule" in mod.default'
+// replaces the module with its default export and drops the explicit exports.
+let m = mod;
+const defaultExport = "default" in m ? m.default : m;
+if (defaultExport !== null && typeof defaultExport === "object" && "__esModule" in defaultExport) {
+  m = defaultExport;
+}
+console.log(Object.keys(m).sort().join(","));
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("alpha,beta,default,ns\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require(esm) sets __esModule as an own property when a default export exists", async () => {
+  using dir = tempDir("require-esm-esmodule", {
+    "e.mjs": "export default { d: 1 };\nexport const x = 7;\n",
+    "noDefault.mjs": "export const x = 1;\n",
+    "hasEsm.mjs": "export const __esModule = 'user-set';\nexport default 1;\n",
+    "p.cjs": `
+const assert = require("node:assert");
+
+const n = require("./e.mjs");
+assert.strictEqual(n.__esModule, true);
+assert.strictEqual(Object.hasOwn(n, "__esModule"), true);
+assert.strictEqual(({ ...n }).__esModule, true);
+assert.strictEqual(Object.assign({}, n).__esModule, true);
+assert.strictEqual(Object.getPrototypeOf(n), null);
+
+// No default export: no __esModule marker (matches Node).
+const nd = require("./noDefault.mjs");
+assert.strictEqual(nd.__esModule, undefined);
+assert.strictEqual("__esModule" in nd, false);
+assert.strictEqual(Object.getPrototypeOf(nd), null);
+
+// A module that exports __esModule itself keeps the user's value.
+const h = require("./hasEsm.mjs");
+assert.strictEqual(h.__esModule, "user-set");
+assert.strictEqual(Object.hasOwn(h, "__esModule"), true);
+
+console.log("ok");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "p.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -156,7 +156,7 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
       original(module, filename);
     }));
     const mod = require("./extensions-fixture/secretly_esm");
-    expect(mod).toEqual({ default: 1 });
+    expect({ ...mod }).toEqual({ __esModule: true, default: 1 });
     expect(mocked).toBeCalled();
   } finally {
     require.extensions[".cjs"] = original;


### PR DESCRIPTION
### Problem
- Under Vite SSR / vitest, a module with `export * from "./x.js"` next to explicit exports loses the explicit ones. `zod` has this shape, so any vitest suite that imports zod fails at collection (`undefined is not an object ... __vite_ssr_import_10__.z.object`). Fixes #39866, and the zod reports in #21614.
- The cause is not the Vite transform. Bun puts a `__esModule` CustomGetterSetter on a shared module namespace prototype (`src/jsc/bindings/ZigGlobalObject.cpp:2320`), so `"__esModule" in ns` is true for every ES module namespace. Node reports false. Vitest's `interopModule` checks `"__esModule" in mod.default` and replaces the module with its default export, which drops the explicit exports.

### Fix
- Remove the prototype override. Module namespace objects use the spec's null prototype again, so `"__esModule" in ns` is false, `Object.getPrototypeOf(ns)` is null, and the NodeVM workaround that reset the prototype by hand goes away.
- The require(esm) interop marker still works: the vendored JSC now routes `__esModule` through an ordinary own-property put on the namespace object (`JSModuleNamespaceObject.cpp`, `USE(BUN_JSC_ADDITIONS)`), and `$esmNamespaceForCjs` already returns an extensible namespace. `CommonJS.ts` now also only sets the marker when the module has a `default` export, matching Node's documented require(esm) behavior.
- Verified: `test/js/bun/resolve/esModule.test.ts` (stock bun fails all 5), the vitest repro from the issue passes (`KEYS=alpha|beta|default|ns`), and the resolve, node/module, node/vm, plugins, mock, and import-attributes suites pass.

### Background
- `require(esm)` returns the module's namespace object. Transpiler interop helpers (`_interopRequireDefault`) look for `ns.__esModule` to decide whether `default` is the real default export, so Node adds an own `__esModule: true` to that namespace when the module has a default export.
- Bun implemented that marker as a lazily-set accessor on a shared namespace prototype (#14411). The accessor made the property reachable through the prototype chain of every namespace, even ones `require` never touched, which is what `in` observes.
- This is the bun-side half of #33894, re-landed. The JSC half it depended on (oven-sh/WebKit#279) is already in the WebKit version main builds against, so no WebKit pin is needed here.

<details><summary>Notes</summary>

- Namespaces created by `import` are non-extensible per spec, so `ns.__esModule = true` on them now throws a TypeError like Node does (Node: "Cannot add property __esModule, object is not extensible"). `CommonJS.ts` keeps the existing try/catch (#17816) for the import-first-then-require order, where the marker cannot be attached. The require-first order gets the marker because `$esmNamespaceForCjs` materializes the namespace extensible.
- Two remaining divergences from Node need the JSC enumeration side and are out of scope here: the own marker is skipped by string-only key enumeration (`Object.keys`, `Object.getOwnPropertyNames`, `JSON.stringify`) because `JSModuleNamespaceObject::getOwnPropertyNames` only walks structure properties in symbol-including modes, and the marker's descriptor is configurable (Node: non-configurable). Reads, `in`, `Object.hasOwn`, spread, and `Object.assign` all match Node.
- Test updates: `esModule.test.ts` rewritten for the new semantics plus the #39866 scenario (the zod export shape run through vitest's interop heuristic), `namespace-prototype-pollution.test.ts` now expects the assignment to throw, `require-extensions.test.ts` expects the own enumerable marker in spread. `import-attributes.test.ts` needed no change because JSON.stringify does not see the marker.
- Suites run with the debug build: test/js/bun/resolve (1 pre-existing timeout on main: load-same-js-file-a-lot), test/js/node/module, test/js/node/vm (1 pre-existing leak-test failure on main: script-leak), test/js/bun/test/mock*, test/js/bun/plugin/plugins.test.ts, test/js/bun/import-attributes, test/cli/run/esm-defineProperty, require-cache (leak subtests time out on main too under the debug/ASAN build).
- Rebase note: main reworked the require(esm) tail in `CommonJS.ts` (`$requireESM` now returns the namespace directly, and `__esModule` / `module.exports` are read inside a try/catch because a require cycle can hit a TDZ export). The resolution keeps that structure and adds the `"default" in namespace` gate outside the try/catch. That is safe because `in` is [[HasProperty]], which the spec forbids from reading a TDZ binding. The affected suites were re-run after the rebase.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/namespace-prototype-pollution.test.ts test/js/bun/resolve/esModule.test.ts test/js/node/module/require-extensions.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/namespace-prototype-pollution.test.ts:
43 | 
44 |   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
45 | 
46 |   expect(exitCode).toBe(0);
47 |   expect(stdout).toContain("PASS: prototype pollution prevented");
48 |   expect(stdout).toContain("__esModule absent: true");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "__esModule absent: true"
Received: "PASS: prototype pollution prevented\n__esModule absent: false\nFAIL: __esModule assignment did not throw\nOriginal export: original\n"

      at <anonymous> (/workspace/bun/test/js/bun/namespace-prototype-pollution.test.ts:48:18)
(fail) namespace imports should not inherit from Object.prototype [347.77ms]

test/js/bun/resolve/esModule.test.ts:
 7 | // blocking evaluation on itself.
 8 | import * as Self from "./esModule.test.ts";
 9 | 
10 | 
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (2ffd773b0)

test/js/bun/namespace-prototype-pollution.test.ts:
(pass) namespace imports should not inherit from Object.prototype [7.94ms]

test/js/bun/resolve/esModule.test.ts:
(pass) __esModule defaults to undefined [0.05ms]
(pass) assigning __esModule to a non-extensible namespace throws like Node [0.05ms]
(pass) require of self does not set __esModule without a default export [0.09ms]
(pass) '__esModule' in an ES module namespace is false [7.15ms]
(pass) require(esm) sets __esModule as an own property when a default export exists [7.48ms]

test/js/node/module/require-extensions.test.ts:
(pass) require.extensions shape makes sense [0.08ms]
(pass) custom require extension 1 [0.62ms]
(pass) custom require extension overwrite default loader [0.27ms]
(pass) custom require extension overwrite default loader with other default loader [0.19ms]
(pass) test that assigning properties weirdly wont do anything bad [0.05ms]
(pass) wrapping an existing extension with no logic [0.16ms]
(pass) wrapping an existing extension with mutated compile function [0.21ms]
(pass) wrapping an existing extension with mutated compile function ts [0.30ms]
(pass) wrappi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/namespace-prototype-pollution.test.ts test/js/bun/resolve/esModule.test.ts test/js/node/module/require-extensions.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/namespace-prototype-pollution.test.ts:
(pass) namespace imports should not inherit from Object.prototype [431.27ms]

test/js/bun/resolve/esModule.test.ts:
(pass) __esModule defaults to undefined [3.58ms]
(pass) assigning __esModule to a non-extensible namespace throws like Node [3.90ms]
(pass) require of self does not set __esModule without a default export [6.89ms]
(pass) '__esModule' in an ES module namespace is false [324.93ms]
(pass) require(esm) sets __esModule as an own property when a default export exists [418.28ms]

test/js/node/module/require-extensions.test.ts:
(pass) require.extensions shape makes sense [5.10ms]
(pass) custom require extension 1 [27.69ms]
(pass) custom require extension overwrite default loader [13.45ms]
(pass) custom require extension overwrite default loader with other default loader [8.46ms]
(pass) test that assigning properties wei
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 867ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8048ms)
Bundle modules (71ms)
Postprocesss modules (522ms)
Bundle Functions (726ms)
Generate Code (42ms)

[9.42s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/9] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/CommonJS.ts                       |  24 ++---
 src/jsc/bindings/NodeVMModule.cpp                 |   5 -
 src/jsc/bindings/ZigGlobalObject.cpp              |  30 ------
 test/js/bun/namespace-prototype-pollution.test.ts |  14 ++-
 test/js/bun/resolve/esModule.test.ts              | 107 +++++++++++++++++++---
 test/js/node/module/require-extensions.test.ts    |   2 +-
 6 files changed, 116 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/js/builtins/CommonJS.ts                            3      3      0
src/jsc/bindings/NodeVMModule.cpp                      2      3      0
src/jsc/bindings/ZigGlobalObject.cpp                   1      1      0
test/js/bun/namespace-prototype-pollution.test.ts      1      2      0
test/js/bun/resolve/esModule.test.ts                   1      1      0
test/js/node/module/require-extensions.test.ts         1      2      0
```

</details>

<!-- robobun:evidence:end -->
