### PR TITLE
node:http: fail the write callbacks a dead connection can no longer drain

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1602,6 +1602,8 @@ function getNodeHTTPServerSocket() {
       handle.close();
     }
     #onClose() {
+      // Read before anything below can destroy this socket again with a different error.
+      const errored = this.errored;
       // freeParser equivalent: runs before 'close' listeners so they observe the
       // released parser (free() invoked, kOnTimeout nulled).
       releaseServerParserShim(this);
@@ -1641,6 +1643,9 @@ function getNodeHTTPServerSocket() {
       const pending = this.#pendingAbortMessage;
       this.#pendingAbortMessage = undefined;
       const message = this._httpMessage ?? (pending?.destroyed ? pending : undefined);
+      if (message) {
+        failPendingWriteCallbacks(message, errored);
+      }
       const req = message?.req;
 
       if (req && !req.destroyed && !req[kHandle]?.upgraded) {
@@ -1684,6 +1689,13 @@ function getNodeHTTPServerSocket() {
             process.nextTick(emitCloseNT, queuedRes);
           }
         }
+      }
+
+      // Queued ahead of the 'close' tick that destroy() below schedules; Writable fails the writes queued behind it.
+      const pendingWrite = this.#pendingCallback;
+      if (pendingWrite) {
+        this.#pendingCallback = null;
+        process.nextTick(pendingWrite, errored ?? $ERR_STREAM_DESTROYED("write"));
       }
 
       // Node's server connection socket emits 'close' whenever the TCP
@@ -3684,6 +3696,17 @@ function callWriteHeadIfObservable(self, headerState, fromEnd) {
 function allowWritesToContinue() {
   this._callPendingCallbacks();
   this.emit("drain");
+}
+
+// Node's Writable errorBuffer(): the native drain callback never fires once the socket is closed.
+function failPendingWriteCallbacks(res, errored) {
+  const callbacks = res[kPendingCallbacks];
+  const length = callbacks ? callbacks.length : 0;
+  if (length === 0) return;
+  res[kPendingCallbacks] = [];
+  for (let i = 0; i < length; i++) {
+    process.nextTick(callbacks[i], errored ?? $ERR_STREAM_DESTROYED("write"));
+  }
 }
 
 OriginalWriteHeadFn = ServerResponse.prototype.writeHead;

--- a/test/js/node/http/node-http-server-abort-events.test.ts
+++ b/test/js/node/http/node-http-server-abort-events.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import type { AddressInfo } from "node:net";
+import type { AddressInfo, Socket } from "node:net";
 import { connect } from "node:net";
 import { duplexPair } from "node:stream";
 
@@ -297,5 +297,173 @@ describe("res.destroy() defers 'close'", () => {
     destroyRecording(res, events);
     await closed.promise;
     expect(events).toEqual(["destroy()", "destroy() returned (closed: false)", "res.close (closed: true)"]);
+  });
+});
+
+// A write() callback whose bytes the connection has not taken yet normally
+// runs once the connection drains. When the connection dies first it must
+// still run, with an error, before 'close': Node's socket fails every write it
+// still holds (Writable errorBuffer) with the error the socket was destroyed
+// with, otherwise ERR_STREAM_DESTROYED. This applies to res.write() on a
+// response and to socket.write() on the raw socket of a CONNECT tunnel.
+describe("write callbacks still held back when the connection dies", () => {
+  const CHUNK = Buffer.alloc(4 * 1024 * 1024, "x");
+  // How many of these a fresh connection to a peer that never reads takes
+  // whole differs per platform (Windows takes the first one), so no test
+  // below assumes which write is the first held-back one.
+  const MAX_CHUNKS = 16;
+
+  type Target = ServerResponse | Socket;
+  type Connection = { res?: ServerResponse; socket: Socket; client: Socket };
+  type Teardown = (connection: Connection) => void;
+  type Script = (target: Target, connection: Connection, events: string[]) => void | Promise<void>;
+
+  const destroyError = new Error("boom");
+  function describeCallbackArgument(err: unknown) {
+    if (err == null) return "success";
+    if (err === destroyError) return "destroyError";
+    return (err as NodeJS.ErrnoException).code;
+  }
+
+  // The third column is what Bun hands every held-back callback. Node hands
+  // the write that was in flight the transport's error instead: ECANCELED for
+  // a local destroy, EPIPE or ECONNRESET when the peer went away.
+  const socketTeardowns: [string, Teardown, string][] = [
+    ["socket.destroy()", ({ socket }) => socket.destroy(), "ERR_STREAM_DESTROYED"],
+    ["socket.destroy(err)", ({ socket }) => socket.destroy(destroyError), "destroyError"],
+    ["the client destroying the connection", ({ client }) => client.destroy(), "ERR_STREAM_DESTROYED"],
+  ];
+  const responseTeardowns: [string, Teardown, string][] = [
+    ["res.destroy()", ({ res }) => res!.destroy(), "ERR_STREAM_DESTROYED"],
+    ["res.destroy(err)", ({ res }) => res!.destroy(destroyError), "destroyError"],
+    ...socketTeardowns,
+  ];
+  const transportErrorCodes = ["ECANCELED", "EPIPE", "ECONNRESET"];
+
+  // Rewrites `cbN:<received>` to `cbN:failed` when a held-back write may fail
+  // with what was received, so one toEqual checks the whole sequence and an
+  // unexpected value still shows up verbatim.
+  function markFailed(events: string[], expected: string) {
+    return events.map(event => {
+      const [name, received] = event.split(":");
+      return received === expected || transportErrorCodes.includes(received) ? `${name}:failed` : event;
+    });
+  }
+
+  function writeChunk(target: Target, name: string, events: string[], onSettled?: () => void) {
+    target.write(CHUNK, err => {
+      events.push(`${name}:${describeCallbackArgument(err)}`);
+      onSettled?.();
+    });
+  }
+
+  // Serves one connection from a client that never reads: a GET whose
+  // response is the target, or a CONNECT whose raw socket is the target.
+  // `script` runs from inside the listener. Resolves with the events recorded
+  // up to the target's 'close' and one macrotask beyond it, so a callback that
+  // runs a second time after 'close' shows up as well.
+  async function serveToNonReadingClient(kind: "response" | "tunnel", script: Script) {
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    const scriptDone = Promise.withResolvers<void>();
+    let client: Socket | undefined;
+    function start(target: Target, connection: Connection) {
+      target.on("close", () => {
+        events.push("close");
+        closed.resolve();
+      });
+      try {
+        scriptDone.resolve(script(target, connection, events));
+      } catch (err) {
+        scriptDone.reject(err);
+      }
+    }
+    const server = createServer((req, res) => start(res, { res, socket: req.socket, client: client! }));
+    server.on("connect", (req, socket) => {
+      socket.on("error", () => {});
+      start(socket, { socket, client: client! });
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      client = connect(port, "127.0.0.1");
+      client.on("error", () => {});
+      await once(client, "connect");
+      client.pause();
+      client.write(
+        kind === "response" ? "GET / HTTP/1.1\r\nHost: x\r\n\r\n" : "CONNECT x:443 HTTP/1.1\r\nHost: x:443\r\n\r\n",
+      );
+      await scriptDone.promise;
+      await closed.promise;
+      await new Promise(resolve => setImmediate(resolve));
+      return events;
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  }
+
+  // Writes chunks until one is held back: a chunk the connection took whole
+  // has reported success by the next macrotask, a held-back one has not. One
+  // more write is queued behind the held-back one and the connection is torn
+  // down in the same turn, so exactly those two callbacks are outstanding.
+  async function teardownOnceHeldBack(kind: "response" | "tunnel", teardown: Teardown, expected: string) {
+    let heldBack = 0;
+    const events = await serveToNonReadingClient(kind, async (target, connection, events) => {
+      for (let n = 1; ; n++) {
+        let settled = false;
+        writeChunk(target, `cb${n}`, events, () => (settled = true));
+        await new Promise(resolve => setImmediate(resolve));
+        if (!settled) {
+          heldBack = n;
+          break;
+        }
+        if (n === MAX_CHUNKS) throw new Error(`the connection took ${n} chunks without holding one back`);
+      }
+      writeChunk(target, `cb${heldBack + 1}`, events);
+      events.push("teardown");
+      teardown(connection);
+    });
+    const taken = Array.from({ length: heldBack - 1 }, (_, i) => `cb${i + 1}:success`);
+    expect(markFailed(events, expected)).toEqual([
+      ...taken,
+      "teardown",
+      `cb${heldBack}:failed`,
+      `cb${heldBack + 1}:failed`,
+      "close",
+    ]);
+  }
+
+  // Torn down before either write could settle. A chunk the connection took
+  // whole still reports success and a held-back one fails, but both callbacks
+  // run either way, once, and before 'close'.
+  async function teardownInsideListener(kind: "response" | "tunnel", teardown: Teardown, expected: string) {
+    const events = await serveToNonReadingClient(kind, (target, connection, events) => {
+      writeChunk(target, "cb1", events);
+      writeChunk(target, "cb2", events);
+      events.push("teardown");
+      teardown(connection);
+    });
+    const settled = markFailed(events, expected).map(event => event.replace(/:(success|failed)$/, ":settled"));
+    expect(settled).toEqual(["teardown", "cb1:settled", "cb2:settled", "close"]);
+  }
+
+  describe("res.write() on a response", () => {
+    test.concurrent.each(responseTeardowns)("%s once a write is held back", (_name, teardown, expected) =>
+      teardownOnceHeldBack("response", teardown, expected),
+    );
+    test.concurrent.each(responseTeardowns)("%s inside the request listener", (_name, teardown, expected) =>
+      teardownInsideListener("response", teardown, expected),
+    );
+  });
+
+  describe("socket.write() on a CONNECT tunnel", () => {
+    test.concurrent.each(socketTeardowns)("%s once a write is held back", (_name, teardown, expected) =>
+      teardownOnceHeldBack("tunnel", teardown, expected),
+    );
+    test.concurrent.each(socketTeardowns)("%s inside the connect listener", (_name, teardown, expected) =>
+      teardownInsideListener("tunnel", teardown, expected),
+    );
   });
 });


### PR DESCRIPTION
### Problem
- A write callback that waits for the connection to drain is never called if the connection dies first. Node calls it with an error before `'close'`. Both holders in `src/js/node/_http_server.ts` have the bug: `kPendingCallbacks` (`:3327`) and `#pendingCallback` (`:1966`).
- Only the native drain callback releases them, and it never fires once the socket is closed (`src/runtime/server/NodeHTTPResponse.rs:1855`). On a tunnel the stuck `_write` also blocks the `Writable`, which then drops every `write()` and `end()` callback queued behind it.

### Fix
- `NodeHTTPServerSocket#onClose` reads `this.errored` once and fails both holders on the next tick with it, otherwise with a fresh `ERR_STREAM_DESTROYED`. The ticks are queued ahead of the `'close'` ticks. Settling the `_write` callback makes `Writable` fail the writes queued behind it.
- Matches Node, whose destroyed socket fails each held write callback with `state.errored ?? new ERR_STREAM_DESTROYED('write')`. Node gives the one write in flight the transport's error instead. The native handle has no such error, so that write gets the same error (tables in Notes).
- The error is read first because `#onClose` destroys the socket again in some paths, with a different error. `#onClose` can run twice per connection, so each holder is cleared before it is failed.
- Verified: sixteen new cases in `test/js/node/http/node-http-server-abort-events.test.ts`, red on main, green here and under Node v26.3.0. More suites in Notes.

### Background
- `kPendingCallbacks` holds the `res.write()` callbacks whose bytes the native handle still buffers. `#pendingCallback` holds the `_write` callback of one `socket.write()` on a CONNECT tunnel, whose writes go through the socket's `Writable`.
- The native drain callback runs when the handle has flushed. It releases the holders as success and emits `'drain'`.
- `#onClose` runs after the connection's native socket closed, whatever the cause, and schedules `'close'` on the response and the socket.
- `socket.errored` is the error a `destroy(err)` call recorded. `res.destroy(err)` forwards `err` to the socket. A client abort records none.

<details><summary>Notes</summary>

Repro for the response: the handler writes a 4 MiB chunk twice with callbacks to a raw client that never reads, then the connection is torn down. Results per teardown, as `[cb1, cb2]`, measured on Linux:

| teardown | Node v26.3.0 | Bun before | Bun after |
| --- | --- | --- | --- |
| `res.destroy()` in the listener | `ERR_STREAM_DESTROYED` x2 | never called | `ERR_STREAM_DESTROYED` x2 |
| `res.destroy(err)` in the listener | `err` x2 | never called | `err` x2 |
| `req.socket.destroy()` in the listener | `ERR_STREAM_DESTROYED` x2 | never called | `ERR_STREAM_DESTROYED` x2 |
| `req.socket.destroy(err)` in the listener | `err` x2 | never called | `err` x2 |
| client destroys the connection | `EPIPE` x2 (or `ECONNRESET`) | never called | `ERR_STREAM_DESTROYED` x2 |
| `res.destroy()` after the listener returned | `ECANCELED` x2 | never called | `ERR_STREAM_DESTROYED` x2 |

Repro for the tunnel: a `'connect'` listener writes the chunk twice with callbacks and calls `socket.end(cb)`, then the connection is torn down after the listener returned. Results as `[cb1, cb2, end cb]`:

| teardown | Node v26.3.0 | Bun before | Bun after |
| --- | --- | --- | --- |
| `socket.destroy()` | `ECANCELED`, `ECANCELED`, `ECANCELED` | none called | `ERR_STREAM_DESTROYED` x3 |
| `socket.destroy(err)` | `ECANCELED`, `err`, `err` | none called | `err` x3 |
| client destroys the connection | `ECANCELED`, `ECONNRESET`, `ECONNRESET` | none called | `ERR_STREAM_DESTROYED` x3 |

In every row the callbacks run after the teardown call returned and before `'close'`, in Node and in Bun after the change. Node emits the socket's `'error'` (for `destroy(err)` and for a peer reset) before the callbacks, Bun emits it after them and only for `destroy(err)`. The error name, code, and message (`Cannot call write after a stream was destroyed`) are identical to Node's.

Why the settle is a tick later: `#onClose` can run synchronously inside the user's `destroy()` call, and Node never runs these callbacks synchronously. For the `_write` callback, `Writable`'s `onwrite` then runs `onwriteError`: the write's own callback, `errorBuffer()` for the queued writes and `end()` callbacks, and `errorOrDestroy()`, which is a no-op because the socket is already destroyed. The `errorBuffer()` tick that `Writable.destroy()` schedules itself is idempotent with this, whichever runs first. The tick is queued before `this.destroy()` so that on a native close it runs ahead of the `'close'` tick.

Why the error is read first: a response still attached to the connection makes `#onClose` destroy the request, and `IncomingMessage#_destroy` destroys the socket with the request's `ConnResetException` if the socket is not destroyed yet. `#onClose` also runs twice when the peer closes the connection: the native close handler captures the socket's `onclose` callback, notifies the response (whose abort handler destroys the socket, which runs `#onClose` once), then calls the captured callback. The `res[kPendingCallbacks] = []` reset and the `#pendingCallback = null` clear make the second run a no-op. Removing the reset makes the two client-abort response tests fail (checked by mutation). The double call itself is a native quirk left alone here.

Tests. Windows takes the whole first 4 MiB chunk, so the first version of these tests, which expected both of two writes to be held back, failed on the Windows lanes. The tests now come in two forms, over `res.write()` on a response (five teardowns) and `socket.write()` on a CONNECT tunnel (three teardowns). "Once a write is held back": write chunks until one's callback has not run by the next macrotask, queue one more write behind it, tear down in the same turn. Exactly those two callbacks are outstanding, so both must fail, with the expected error or one of Node's transport codes, before `'close'`, and every earlier chunk must have reported success. This form fails without the fix on every platform. "Inside the listener": two writes and a synchronous teardown. Which chunks the connection took is platform dependent, so this form only requires both callbacks to settle, with success or one of those errors, before `'close'`. For the response it covers the path where the dispatcher detaches the response before `#onClose` runs. Events are recorded until one macrotask after `'close'`, so a callback that runs twice shows up. Measured on a Windows x64 debug build of this branch: the whole file passes (5 runs), and without the fix (the canary build of main) the thirteen cases that observe a held-back write fail. The three tunnel cases of the "inside the listener" form pass there even without the fix, because Windows takes both tunnel chunks whole; on Linux they fail without the fix like the rest.

Scope. `res.end()` already releases `kPendingCallbacks` with no error, so `end()` followed by an abort still reports success for them. Node reports an error there. That is unchanged by this PR. A response still queued behind a pipelined response buffers its writes elsewhere, and Node drops those callbacks too (its `outputData` is never failed). The HTTP/1 fallback used by `server.emit('connection')` and `allowHTTP1` never parks callbacks. Open PR #35018 also settles `#pendingCallback` in `#onClose`, unconditionally with a `ConnResetException`, as a side part of a larger change. It needs a rebase, and that hunk becomes redundant with this one. Open PR #35207 changes the return values of `write()` and `end()` on a dead socket and does not touch either holder.

Other suites run on the debug build with the change: `node-http.test.ts` (the `issue#4295` proxy test fails identically without the change in this container, `ECONNREFUSED` on the local example site), `node-http-backpressure.test.ts`, `node-http-connect.test.ts` (its "tests should run on bun" case exceeds the 5 s budget on a debug build; the spawned `node-http-connect.node.mts` suite passes in 8 s when run directly), `node-http-with-ws.test.ts`, `node-http-server-socket-end-drain.test.ts`, `node-http-pinned-write.test.ts`, `node-http-transfer-encoding.test.ts`, and about 40 upstream `test/js/node/test/parallel/test-http-*` scripts about connect, upgrade, abort, destroy, outgoing, pipeline, and write callbacks.

Rebased onto main at db059d8ff0 (head dc2c8f8ffa). The only conflict was the re-indentation of the server socket class by #39628. The change itself is identical. The file plus `node-http.test.ts`, `node-http-with-ws.test.ts` and the CONNECT suite were re-run on the rebased build.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-abort-events.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-abort-events.test.ts:
(pass) aborted request body emits 'error' ECONNRESET and res 'close' before req 'close' [770.88ms]
(pass) res.destroy() defers 'close' > inside a 'finish' listener [441.27ms]
(pass) res.destroy() defers 'close' > inside the end() callback [443.88ms]
(pass) res.destroy() defers 'close' > before anything was written: 'close' comes from the connection teardown [511.02ms]
(pass) res.destroy() defers 'close' > on a response served over server.emit('connection') (ended first: false) [123.10ms]
(pass) res.destroy() defers 'close' > on a response served over server.emit('connection') (ended first: true) [51.72ms]
(pass) res.destroy() defers 'close' > after a partial body [678.91ms]
(pass) res.destroy() defers 'close' > after end(): 'close' follows 'finish' and the response still reaches the client [909.90ms]
(pass) res.destroy() defers 'close' > destroy(err) reports the error as res.errored inside 'close
... (truncated)

release without fix: 16 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/node/http/node-http-server-abort-events.test.ts:
(pass) aborted request body emits 'error' ECONNRESET and res 'close' before req 'close' [11.08ms]
(pass) res.destroy() defers 'close' > on a response served over server.emit('connection') (ended first: false) [2.21ms]
(pass) res.destroy() defers 'close' > on a response served over server.emit('connection') (ended first: true) [1.55ms]
(pass) res.destroy() defers 'close' > inside a 'finish' listener [14.18ms]
(pass) res.destroy() defers 'close' > inside the end() callback [12.31ms]
(pass) res.destroy() defers 'close' > on a response still queued behind a pipelined response [6.87ms]
(pass) res.destroy() defers 'close' > before anything was written: 'close' comes from the connection teardown [13.30ms]
(pass) res.destroy() defers 'close' > after a partial body [12.72ms]
(pass) res.destroy() defers 'close' > destroy(err) reports the error as res.errored inside 'close' [12.08ms]
(pass) res.destroy() defers 'close' > after end(): 'close' follows 'finish' and the response still reaches the client [16.91ms]
(pass) res.destroy() defers 'close' > after the request listener has return
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-abort-events.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-abort-events.test.ts:
(pass) aborted request body emits 'error' ECONNRESET and res 'close' before req 'close' [660.30ms]
(pass) res.destroy() defers 'close' > inside a 'finish' listener [320.45ms]
(pass) res.destroy() defers 'close' > inside the end() callback [357.07ms]
(pass) res.destroy() defers 'close' > before anything was written: 'close' comes from the connection teardown [502.12ms]
(pass) res.destroy() defers 'close' > on a response served over server.emit('connection') (ended first: false) [203.75ms]
(pass) res.destroy() defers 'close' > on a response served over server.emit('connection') (ended first: true) [59.50ms]
(pass) res.destroy() defers 'close' > after a partial body [787.78ms]
(pass) res.destroy() defers 'close' > after end(): 'close' follows 'finish' and the response still reaches the client [933.84ms]
(pass) res.destroy() defers 'close' > destroy(err) reports the error as res.errored inside 'close
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 774ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (10415ms)
Bundle modules (57ms)
Postprocesss modules (42ms)
Bundle Functions (779ms)
Generate Code (25ms)

[11.34s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  23 +++
 .../http/node-http-server-abort-events.test.ts     | 170 ++++++++++++++++++++-
 2 files changed, 192 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js/node/_http_server.ts                                 23     18      0
test/js/node/http/node-http-server-abort-events.test.ts      5      4      0
```

</details>

<!-- robobun:evidence:end -->
