### PR TITLE
napi: implement uv_idle_t, uv_prepare_t, uv_check_t and uv_timer_t on posix

### DIFF
--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -209,6 +209,8 @@ pub enum Tag {
     CronJob,
     GcRepeating,
     QuicEndpoint,
+    /// An N-API addon's `uv_timer_t` (posix, where Bun stands in for libuv).
+    UvTimer,
 }
 
 impl Tag {

--- a/src/jsc/bindings/libuv/generate_uv_posix_stubs_constants.ts
+++ b/src/jsc/bindings/libuv/generate_uv_posix_stubs_constants.ts
@@ -27,9 +27,10 @@ export const symbols = [
   // Defined in src/runtime/napi/uv_posix.rs
   // "uv_cancel",
   "uv_chdir",
-  "uv_check_init",
-  "uv_check_start",
-  "uv_check_stop",
+  // Defined in src/runtime/napi/uv_posix.rs
+  // "uv_check_init",
+  // "uv_check_start",
+  // "uv_check_stop",
   "uv_clock_gettime",
   // Defined in src/runtime/napi/uv_posix.rs
   // "uv_close",
@@ -132,9 +133,10 @@ export const symbols = [
   // "uv_has_ref",
   // Defined in uv-posix-polyfills.c
   // "uv_hrtime",
-  "uv_idle_init",
-  "uv_idle_start",
-  "uv_idle_stop",
+  // Defined in src/runtime/napi/uv_posix.rs
+  // "uv_idle_init",
+  // "uv_idle_start",
+  // "uv_idle_stop",
   "uv_if_indextoiid",
   "uv_if_indextoname",
   "uv_inet_ntop",
@@ -179,7 +181,8 @@ export const symbols = [
   // "uv_mutex_lock",
   // "uv_mutex_trylock",
   // "uv_mutex_unlock",
-  "uv_now",
+  // Defined in src/runtime/napi/uv_posix.rs
+  // "uv_now",
   // Defined in uv-posix-polyfills.c
   // "uv_once",
   // "uv_open_osfhandle",
@@ -219,9 +222,10 @@ export const symbols = [
   "uv_poll_init_socket",
   "uv_poll_start",
   "uv_poll_stop",
-  "uv_prepare_init",
-  "uv_prepare_start",
-  "uv_prepare_stop",
+  // Defined in src/runtime/napi/uv_posix.rs
+  // "uv_prepare_init",
+  // "uv_prepare_start",
+  // "uv_prepare_stop",
   "uv_print_active_handles",
   "uv_print_all_handles",
   "uv_process_get_pid",
@@ -296,13 +300,14 @@ export const symbols = [
   "uv_thread_setaffinity",
   "uv_thread_setname",
   "uv_thread_setpriority",
-  "uv_timer_again",
-  "uv_timer_get_due_in",
-  "uv_timer_get_repeat",
-  "uv_timer_init",
-  "uv_timer_set_repeat",
-  "uv_timer_start",
-  "uv_timer_stop",
+  // Defined in src/runtime/napi/uv_posix.rs
+  // "uv_timer_again",
+  // "uv_timer_get_due_in",
+  // "uv_timer_get_repeat",
+  // "uv_timer_init",
+  // "uv_timer_set_repeat",
+  // "uv_timer_start",
+  // "uv_timer_stop",
   "uv_translate_sys_error",
   "uv_try_write",
   "uv_try_write2",
@@ -337,7 +342,7 @@ export const symbols = [
   "uv_udp_using_recvmmsg",
   // Defined in src/runtime/napi/uv_posix.rs
   // "uv_unref",
-  "uv_update_time",
+  // "uv_update_time",
   "uv_uptime",
   "uv_utf16_length_as_wtf8",
   "uv_utf16_to_wtf8",

--- a/src/jsc/bindings/uv-posix-stubs.c
+++ b/src/jsc/bindings/uv-posix-stubs.c
@@ -56,24 +56,6 @@ UV_EXTERN int uv_chdir(const char* dir)
     __builtin_unreachable();
 }
 
-UV_EXTERN int uv_check_init(uv_loop_t*, uv_check_t* check)
-{
-    __bun_throw_not_implemented("uv_check_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_check_start(uv_check_t* check, uv_check_cb cb)
-{
-    __bun_throw_not_implemented("uv_check_start");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_check_stop(uv_check_t* check)
-{
-    __bun_throw_not_implemented("uv_check_stop");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_clock_gettime(uv_clock_id clock_id, uv_timespec64_t* ts)
 {
     __bun_throw_not_implemented("uv_clock_gettime");
@@ -750,24 +732,6 @@ UV_EXTERN uv_handle_type uv_guess_handle(uv_file file)
     __builtin_unreachable();
 }
 
-UV_EXTERN int uv_idle_init(uv_loop_t*, uv_idle_t* idle)
-{
-    __bun_throw_not_implemented("uv_idle_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb)
-{
-    __bun_throw_not_implemented("uv_idle_start");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_idle_stop(uv_idle_t* idle)
-{
-    __bun_throw_not_implemented("uv_idle_stop");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_if_indextoiid(unsigned int ifindex,
     char* buffer,
     size_t* size)
@@ -950,12 +914,6 @@ UV_EXTERN uint64_t uv_metrics_idle_time(uv_loop_t* loop)
 UV_EXTERN int uv_metrics_info(uv_loop_t* loop, uv_metrics_t* metrics)
 {
     __bun_throw_not_implemented("uv_metrics_info");
-    __builtin_unreachable();
-}
-
-UV_EXTERN uint64_t uv_now(const uv_loop_t*)
-{
-    __bun_throw_not_implemented("uv_now");
     __builtin_unreachable();
 }
 
@@ -1171,24 +1129,6 @@ UV_EXTERN int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb)
 UV_EXTERN int uv_poll_stop(uv_poll_t* handle)
 {
     __bun_throw_not_implemented("uv_poll_stop");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_prepare_init(uv_loop_t*, uv_prepare_t* prepare)
-{
-    __bun_throw_not_implemented("uv_prepare_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_prepare_start(uv_prepare_t* prepare, uv_prepare_cb cb)
-{
-    __bun_throw_not_implemented("uv_prepare_start");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_prepare_stop(uv_prepare_t* prepare)
-{
-    __bun_throw_not_implemented("uv_prepare_stop");
     __builtin_unreachable();
 }
 
@@ -1617,51 +1557,6 @@ UV_EXTERN int uv_thread_setpriority(uv_thread_t tid, int priority)
     __builtin_unreachable();
 }
 
-UV_EXTERN int uv_timer_again(uv_timer_t* handle)
-{
-    __bun_throw_not_implemented("uv_timer_again");
-    __builtin_unreachable();
-}
-
-UV_EXTERN uint64_t uv_timer_get_due_in(const uv_timer_t* handle)
-{
-    __bun_throw_not_implemented("uv_timer_get_due_in");
-    __builtin_unreachable();
-}
-
-UV_EXTERN uint64_t uv_timer_get_repeat(const uv_timer_t* handle)
-{
-    __bun_throw_not_implemented("uv_timer_get_repeat");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_timer_init(uv_loop_t*, uv_timer_t* handle)
-{
-    __bun_throw_not_implemented("uv_timer_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat)
-{
-    __bun_throw_not_implemented("uv_timer_set_repeat");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_timer_start(uv_timer_t* handle,
-    uv_timer_cb cb,
-    uint64_t timeout,
-    uint64_t repeat)
-{
-    __bun_throw_not_implemented("uv_timer_start");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_timer_stop(uv_timer_t* handle)
-{
-    __bun_throw_not_implemented("uv_timer_stop");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_translate_sys_error(int sys_errno)
 {
     __bun_throw_not_implemented("uv_translate_sys_error");
@@ -1873,12 +1768,6 @@ UV_EXTERN int uv_udp_try_send2(uv_udp_t* handle,
 UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle)
 {
     __bun_throw_not_implemented("uv_udp_using_recvmmsg");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_update_time(uv_loop_t*)
-{
-    __bun_throw_not_implemented("uv_update_time");
     __builtin_unreachable();
 }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1138,6 +1138,22 @@ pub(crate) unsafe fn __bun_fire_timer(
             crate::node::quic::QuicEndpoint::on_timer_fire(c);
             Ok(())
         }
+        EventLoopTimerTag::UvTimer => {
+            #[cfg(unix)]
+            {
+                use crate::napi::uv_posix::UvTimerNode;
+                let c: *mut UvTimerNode = owner!(UvTimerNode, event_loop_timer);
+                // SAFETY: per fn contract; the node of a started `uv_timer_t`.
+                unsafe { UvTimerNode::on_fire(c) }
+            }
+            #[cfg(not(unix))]
+            {
+                if cfg!(debug_assertions) {
+                    unreachable!("UvTimer timer on Windows, where addons get libuv's");
+                }
+                Ok(())
+            }
+        }
     };
     fired
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1047,6 +1047,16 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         return;
     }
 
+    // ── addons' uv_idle_t / uv_prepare_t ────────────────────────────────
+    // Before `has_pending_immediate` is read: their callbacks may queue work.
+    // SAFETY: `state` is the live per-thread `RuntimeState`; `uv_loop` is
+    // reached per-field, so the `timer` accesses its callbacks make through
+    // `runtime_state()` do not alias this borrow.
+    #[cfg(unix)]
+    let uv_idle_started = unsafe { (*state).uv_loop.before_poll() };
+    #[cfg(not(unix))]
+    let uv_idle_started = false;
+
     // Call `ctx.timer.getTimeout(..)` ONLY inside
     // `if (loop.isActive())` — `get_timeout` has side effects (pops + fires
     // due `WTFTimer` heap entries), so it must stay guarded by `is_active()`
@@ -1055,9 +1065,10 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         // Read `immediate_tasks` AFTER
         // `tickImmediateTasks` swaps `next_immediate_tasks` in, so this
         // reflects next-tick immediates (queued during the drain above).
-        // SAFETY: `el` is the live per-thread event loop.
+        // A started idle handle keeps the poll from blocking, as in libuv.
         // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = has_yielded_tasks
+            || uv_idle_started
             || !unsafe { &*el }.immediate_tasks.is_empty()
             || unsafe { &*el }.has_pending_tasks();
         // Fold the QUIC deadline into the poll timeout.
@@ -1116,6 +1127,9 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 
     #[cfg(unix)]
     {
+        // ── addons' uv_check_t: libuv runs them right after its poll ────
+        // SAFETY: as for `before_poll` above.
+        unsafe { (*state).uv_loop.after_poll() };
         // Note (§Forbidden aliased-&mut): `drain_timers` fires user
         // `setTimeout` callbacks which may re-enter `timer::All::insert`/
         // `remove` via `runtime_state()`. Pass raw `*mut Self` so no
@@ -1192,10 +1206,16 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         return;
     }
 
+    // SAFETY: see the matching call in `auto_tick`.
+    #[cfg(unix)]
+    let uv_idle_started = unsafe { (*state).uv_loop.before_poll() };
+    #[cfg(not(unix))]
+    let uv_idle_started = false;
+
     {
         // SAFETY: `el` is the live per-thread event loop.
-        // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = has_yielded_tasks
+            || uv_idle_started
             || !unsafe { &*el }.immediate_tasks.is_empty()
             || unsafe { &*el }.has_pending_tasks();
         // SAFETY: `loop_` is the live per-thread uws loop.
@@ -1243,6 +1263,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     #[cfg(unix)]
     {
+        // SAFETY: see the matching calls in `auto_tick`.
+        unsafe { (*state).uv_loop.after_poll() };
         // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
         // on `auto_tick` re: aliased-&mut across `fire()`.
         unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -4076,9 +4076,6 @@ mod uv_functions_to_export {
         pub(super) fn uv_barrier_wait();
         pub(super) fn uv_buf_init();
         pub(super) fn uv_chdir();
-        pub(super) fn uv_check_init();
-        pub(super) fn uv_check_start();
-        pub(super) fn uv_check_stop();
         pub(super) fn uv_clock_gettime();
         pub(super) fn uv_cond_broadcast();
         pub(super) fn uv_cond_destroy();
@@ -4172,9 +4169,6 @@ mod uv_functions_to_export {
         pub(super) fn uv_handle_size();
         pub(super) fn uv_handle_type_name();
         pub(super) fn uv_hrtime();
-        pub(super) fn uv_idle_init();
-        pub(super) fn uv_idle_start();
-        pub(super) fn uv_idle_stop();
         pub(super) fn uv_if_indextoiid();
         pub(super) fn uv_if_indextoname();
         pub(super) fn uv_inet_ntop();
@@ -4213,7 +4207,6 @@ mod uv_functions_to_export {
         pub(super) fn uv_mutex_lock();
         pub(super) fn uv_mutex_trylock();
         pub(super) fn uv_mutex_unlock();
-        pub(super) fn uv_now();
         pub(super) fn uv_once();
         pub(super) fn uv_open_osfhandle();
         pub(super) fn uv_os_environ();
@@ -4251,9 +4244,6 @@ mod uv_functions_to_export {
         pub(super) fn uv_poll_init_socket();
         pub(super) fn uv_poll_start();
         pub(super) fn uv_poll_stop();
-        pub(super) fn uv_prepare_init();
-        pub(super) fn uv_prepare_start();
-        pub(super) fn uv_prepare_stop();
         pub(super) fn uv_print_active_handles();
         pub(super) fn uv_print_all_handles();
         pub(super) fn uv_process_get_pid();
@@ -4323,13 +4313,6 @@ mod uv_functions_to_export {
         pub(super) fn uv_thread_setaffinity();
         pub(super) fn uv_thread_setname();
         pub(super) fn uv_thread_setpriority();
-        pub(super) fn uv_timer_again();
-        pub(super) fn uv_timer_get_due_in();
-        pub(super) fn uv_timer_get_repeat();
-        pub(super) fn uv_timer_init();
-        pub(super) fn uv_timer_set_repeat();
-        pub(super) fn uv_timer_start();
-        pub(super) fn uv_timer_stop();
         pub(super) fn uv_translate_sys_error();
         pub(super) fn uv_try_write();
         pub(super) fn uv_try_write2();
@@ -4361,7 +4344,6 @@ mod uv_functions_to_export {
         pub(super) fn uv_udp_try_send();
         pub(super) fn uv_udp_try_send2();
         pub(super) fn uv_udp_using_recvmmsg();
-        pub(super) fn uv_update_time();
         pub(super) fn uv_uptime();
         pub(super) fn uv_utf16_length_as_wtf8();
         pub(super) fn uv_utf16_to_wtf8();
@@ -4552,9 +4534,6 @@ pub(crate) fn fix_dead_code_elimination() {
             uv_barrier_wait,
             uv_buf_init,
             uv_chdir,
-            uv_check_init,
-            uv_check_start,
-            uv_check_stop,
             uv_clock_gettime,
             uv_cond_broadcast,
             uv_cond_destroy,
@@ -4648,9 +4627,6 @@ pub(crate) fn fix_dead_code_elimination() {
             uv_handle_size,
             uv_handle_type_name,
             uv_hrtime,
-            uv_idle_init,
-            uv_idle_start,
-            uv_idle_stop,
             uv_if_indextoiid,
             uv_if_indextoname,
             uv_inet_ntop,
@@ -4689,7 +4665,6 @@ pub(crate) fn fix_dead_code_elimination() {
             uv_mutex_lock,
             uv_mutex_trylock,
             uv_mutex_unlock,
-            uv_now,
             uv_once,
             uv_open_osfhandle,
             uv_os_environ,
@@ -4727,9 +4702,6 @@ pub(crate) fn fix_dead_code_elimination() {
             uv_poll_init_socket,
             uv_poll_start,
             uv_poll_stop,
-            uv_prepare_init,
-            uv_prepare_start,
-            uv_prepare_stop,
             uv_print_active_handles,
             uv_print_all_handles,
             uv_process_get_pid,
@@ -4799,13 +4771,6 @@ pub(crate) fn fix_dead_code_elimination() {
             uv_thread_setaffinity,
             uv_thread_setname,
             uv_thread_setpriority,
-            uv_timer_again,
-            uv_timer_get_due_in,
-            uv_timer_get_repeat,
-            uv_timer_init,
-            uv_timer_set_repeat,
-            uv_timer_start,
-            uv_timer_stop,
             uv_translate_sys_error,
             uv_try_write,
             uv_try_write2,
@@ -4837,7 +4802,6 @@ pub(crate) fn fix_dead_code_elimination() {
             uv_udp_try_send,
             uv_udp_try_send2,
             uv_udp_using_recvmmsg,
-            uv_update_time,
             uv_uptime,
             uv_utf16_length_as_wtf8,
             uv_utf16_to_wtf8,

--- a/src/runtime/napi/uv_posix.rs
+++ b/src/runtime/napi/uv_posix.rs
@@ -1,5 +1,6 @@
-//! libuv's loop-backed API for N-API addons on posix: `uv_default_loop`,
-//! `uv_async_t`, `uv_queue_work` and the `uv_handle_t` functions. Every other
+//! libuv's loop-backed API for N-API addons on posix: `uv_default_loop`, the
+//! `uv_async_t`, `uv_idle_t`, `uv_prepare_t`, `uv_check_t` and `uv_timer_t`
+//! handles, `uv_queue_work`, and the `uv_handle_t` functions. Every other
 //! `uv_*` symbol is a crash stub (uv-posix-stubs.c) or a header-only polyfill
 //! (uv-posix-polyfills.c). Bun has no libuv loop here, so these map onto the
 //! VM's event loop and keep libuv's ABI and thread contract:
@@ -12,14 +13,22 @@
 //! - `uv_async_send` sets the handle's `pending` flag and posts at most one
 //!   dispatch task per loop through the VM's [`VmHandle`] (libuv: the eventfd).
 //!   The task walks the loop's handles on the JS thread (libuv: `uv__async_io`).
+//! - The loop's `auto_tick` (jsc_hooks.rs) runs the started idle and prepare
+//!   handles before it polls, keeps the poll from blocking while an idle handle
+//!   is started, and runs the check handles after it: libuv's iteration.
+//! - A timer is a [`bun_event_loop::EventLoopTimer`] in the VM's timer heap,
+//!   owned by a [`UvTimerNode`] on the heap since it does not fit in the handle.
 //! - `uv_queue_work` is a [`Job`]: `work_cb` on the pool, `after_work_cb` in
 //!   its completion.
+//! - A handle keeps the process alive while it is both started and ref'd
+//!   ([`RefState`]); an async handle counts as started from init to close.
 
 use core::cell::Cell;
 use core::ffi::{CStr, c_char, c_int, c_uint, c_void};
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicI32, AtomicU8, AtomicU32, Ordering};
 
+use bun_core::{Timespec, TimespecMockMode};
 use bun_io::KeepAlive;
 use bun_jsc::event_loop::ConcurrentTaskItem as ConcurrentTask;
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -28,7 +37,8 @@ use bun_jsc::{
     LoopKind, Posted, VmHandle,
 };
 
-use crate::jsc_hooks::RuntimeState;
+use crate::jsc_hooks::{RuntimeState, timer_all_mut};
+use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 
 bun_output::declare_scope!(uv, hidden);
 
@@ -51,20 +61,66 @@ const UV_ECANCELED: c_int = -libc::ECANCELED;
 
 /// Positions in uv.h's `UV_HANDLE_TYPE_MAP` and `UV_REQ_TYPE_MAP`.
 const UV_ASYNC: c_uint = 1;
+const UV_CHECK: c_uint = 2;
+const UV_IDLE: c_uint = 6;
+const UV_PREPARE: c_uint = 9;
+const UV_TIMER: c_uint = 13;
 const UV_WORK: c_uint = 7;
 
 /// libuv's own `flags` values for these two states (src/uv-common.h).
 const UV_HANDLE_CLOSING: c_uint = 0x01;
 const UV_HANDLE_CLOSED: c_uint = 0x02;
 
-/// `sizeof` on 64-bit unix; the addon allocates both, so Bun's fields must fit.
+/// `sizeof` on 64-bit unix; the addon allocates these, so Bun's fields must fit.
 const UV_ASYNC_T_SIZE: usize = 128;
+const UV_WATCHER_T_SIZE: usize = 120;
+const UV_TIMER_T_SIZE: usize = 152;
 const UV_WORK_T_SIZE: usize = 128;
 
 type UvAsyncCb = unsafe extern "C" fn(*mut UvAsync);
+/// `uv_idle_cb`, `uv_prepare_cb` and `uv_check_cb` have this one shape.
+type UvWatcherCb = unsafe extern "C" fn(*mut UvWatcher);
+type UvTimerCb = unsafe extern "C" fn(*mut UvTimer);
 type UvCloseCb = unsafe extern "C" fn(*mut UvHandle);
 type UvWorkCb = unsafe extern "C" fn(*mut UvWork);
 type UvAfterWorkCb = unsafe extern "C" fn(*mut UvWork, c_int);
+
+/// The two bits libuv combines to decide whether a handle keeps the loop
+/// alive: started (`uv_is_active`) and ref'd (`uv_has_ref`, set at init). The
+/// `KeepAlive` follows their conjunction. Loop thread.
+struct RefState {
+    keep_alive: KeepAlive,
+    referenced: bool,
+    active: bool,
+}
+
+impl RefState {
+    fn new() -> RefState {
+        RefState {
+            keep_alive: KeepAlive::default(),
+            referenced: true,
+            active: false,
+        }
+    }
+
+    fn set_active(&mut self, active: bool) {
+        self.active = active;
+        self.sync();
+    }
+
+    fn set_referenced(&mut self, referenced: bool) {
+        self.referenced = referenced;
+        self.sync();
+    }
+
+    fn sync(&mut self) {
+        if self.active && self.referenced {
+            self.keep_alive.ref_(bun_io::js_vm_ctx());
+        } else {
+            self.keep_alive.unref(bun_io::js_vm_ctx());
+        }
+    }
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // uv_loop_t
@@ -96,9 +152,92 @@ pub(crate) struct UvLoop {
     /// The handles the running dispatch pass has not visited yet, last first.
     /// `uv_close` removes from both lists. JS thread.
     dispatching: JsCell<Vec<NonNull<UvAsync>>>,
+    idles: WatcherList,
+    prepares: WatcherList,
+    checks: WatcherList,
 }
 
 const _: () = assert!(core::mem::offset_of!(UvLoop, data) == 0);
+
+/// The started handles of one watcher kind, in start order, and the walk over
+/// them that every loop iteration makes (libuv's `uv__run_idle` and friends).
+/// JS thread.
+struct WatcherList {
+    started: JsCell<Vec<NonNull<UvWatcher>>>,
+    /// During a walk, the handles it has not reached yet, last first; each one
+    /// goes back into `started` before its callback, so a stop from any
+    /// callback finds it in one of the two lists.
+    walking: JsCell<Vec<NonNull<UvWatcher>>>,
+    /// A callback that runs the loop (a synchronous wait) reaches `walk` again
+    /// while one is on the stack; the inner one does nothing.
+    in_walk: Cell<bool>,
+}
+
+impl WatcherList {
+    fn new() -> WatcherList {
+        WatcherList {
+            started: JsCell::new(Vec::new()),
+            walking: JsCell::new(Vec::new()),
+            in_walk: Cell::new(false),
+        }
+    }
+
+    fn add(&self, watcher: NonNull<UvWatcher>) {
+        self.started.with_mut(|started| started.push(watcher));
+    }
+
+    fn remove(&self, watcher: NonNull<UvWatcher>) {
+        self.started
+            .with_mut(|started| started.retain(|w| *w != watcher));
+        self.walking
+            .with_mut(|walking| walking.retain(|w| *w != watcher));
+    }
+
+    fn is_empty(&self) -> bool {
+        self.started.get().is_empty()
+    }
+
+    fn walk(&self, vm: &VirtualMachine) {
+        if self.is_empty() || self.in_walk.replace(true) {
+            return;
+        }
+        self.started.with_mut(|started| {
+            self.walking.with_mut(|walking| {
+                debug_assert!(walking.is_empty());
+                core::mem::swap(started, walking);
+                walking.reverse();
+            })
+        });
+        let global = vm.global();
+        while let Some(watcher) = self.walking.with_mut(Vec::pop) {
+            self.started.with_mut(|started| started.push(watcher));
+            // SAFETY: a started handle is initialised and not closed (`uv_close`
+            // stops it first), and the addon keeps it alive until then.
+            let Some(cb) = (unsafe { (*watcher.as_ptr()).cb }) else {
+                continue;
+            };
+            {
+                let _scope = vm.enter_event_loop_scope();
+                // SAFETY: the addon's callback, on the loop thread, with a handle
+                // it started.
+                unsafe { cb(watcher.as_ptr()) };
+            }
+            if global.has_exception()
+                && bun_jsc::task::report_error_or_terminate(global, JsError::Thrown).is_err()
+            {
+                break;
+            }
+        }
+        // Left over only by a termination.
+        self.walking.with_mut(|walking| {
+            if !walking.is_empty() {
+                self.started
+                    .with_mut(|started| started.extend(walking.drain(..).rev()));
+            }
+        });
+        self.in_walk.set(false);
+    }
+}
 
 impl UvLoop {
     /// JS thread, from `init_runtime_state`. `handle` is `vm`'s [`VmHandle`].
@@ -110,6 +249,49 @@ impl UvLoop {
             dispatch_state: AtomicU8::new(DispatchState::Idle as u8),
             asyncs: JsCell::new(Vec::new()),
             dispatching: JsCell::new(Vec::new()),
+            idles: WatcherList::new(),
+            prepares: WatcherList::new(),
+            checks: WatcherList::new(),
+        }
+    }
+
+    /// From `auto_tick`, before the poll: runs the idle then the prepare
+    /// handles. True when an idle handle is (still) started, in which case the
+    /// poll must not block, as libuv's would not.
+    pub(crate) fn before_poll(&self) -> bool {
+        if self.idles.is_empty() && self.prepares.is_empty() {
+            return false;
+        }
+        // SAFETY: the VM owns the `RuntimeState` this loop lives in; JS thread.
+        let vm = unsafe { self.vm.as_ref() };
+        if !vm.script_allowed() {
+            return false;
+        }
+        self.idles.walk(vm);
+        self.prepares.walk(vm);
+        !self.idles.is_empty()
+    }
+
+    /// From `auto_tick`, after the poll: runs the check handles.
+    pub(crate) fn after_poll(&self) {
+        if self.checks.is_empty() {
+            return;
+        }
+        // SAFETY: as in `before_poll`.
+        let vm = unsafe { self.vm.as_ref() };
+        if vm.script_allowed() {
+            self.checks.walk(vm);
+        }
+    }
+
+    fn watchers(&self, type_: c_uint) -> &WatcherList {
+        match type_ {
+            UV_IDLE => &self.idles,
+            UV_PREPARE => &self.prepares,
+            _ => {
+                debug_assert_eq!(type_, UV_CHECK);
+                &self.checks
+            }
         }
     }
 
@@ -304,8 +486,8 @@ impl UvHandle {
 pub(crate) struct UvAsync {
     handle: UvHandle,
     async_cb: Option<UvAsyncCb>,
-    /// `uv_ref` / `uv_unref`. JS thread.
-    keep_alive: KeepAlive,
+    /// Active from init until close.
+    ref_state: RefState,
     /// libuv's busy counter: senders past their first check; `uv_close` waits it out.
     busy: AtomicI32,
     /// Set by a send, cleared by the dispatch pass, set for good by `uv_close`.
@@ -349,27 +531,6 @@ impl UvAsync {
             }
         }
     }
-
-    /// The task `uv_close` posted. The callback usually frees the handle.
-    fn run_close(this: *mut UvAsync) -> JsResult<()> {
-        // SAFETY: `uv_close` posted this for a handle the addon keeps alive
-        // until `close_cb` has run.
-        let (close_cb, loop_) = unsafe {
-            (*this).handle.flags |= UV_HANDLE_CLOSED;
-            ((*this).handle.close_cb, (*this).handle.loop_)
-        };
-        bun_output::scoped_log!(uv, "uv_async_t {:?}: close_cb", this);
-        if let Some(close_cb) = close_cb {
-            // SAFETY: the addon's callback, on the loop thread, with its handle.
-            unsafe { close_cb(this.cast::<UvHandle>()) };
-        }
-        // SAFETY: the loop outlives its handles (it is the VM's).
-        let global = unsafe { &*loop_ }.js_thread().global();
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
-        Ok(())
-    }
 }
 
 /// `int uv_async_init(uv_loop_t*, uv_async_t*, uv_async_cb)`. Loop thread. The
@@ -392,10 +553,10 @@ pub(crate) unsafe extern "C" fn uv_async_init(
     // SAFETY: fn contract; field-wise writes into uninitialised addon memory.
     unsafe {
         (&raw mut (*handle).async_cb).write(async_cb);
-        (&raw mut (*handle).keep_alive).write(KeepAlive::default());
+        (&raw mut (*handle).ref_state).write(RefState::new());
         (&raw mut (*handle).busy).write(AtomicI32::new(0));
         (&raw mut (*handle).pending).write(AtomicI32::new(0));
-        (*handle).keep_alive.ref_(bun_io::js_vm_ctx());
+        (*handle).ref_state.set_active(true);
     }
     // SAFETY: the loop is alive (fn contract); JS thread.
     unsafe { loop_ref.as_ref() }.register(async_);
@@ -426,18 +587,487 @@ pub(crate) unsafe extern "C" fn uv_async_send(handle: *mut UvAsync) -> c_int {
     0
 }
 
-/// For the functions that take any handle type: only async handles exist, so
-/// anything else crashes like `function`'s stub did.
+// ──────────────────────────────────────────────────────────────────────────
+// uv_idle_t / uv_prepare_t / uv_check_t
+// ──────────────────────────────────────────────────────────────────────────
+
+/// `struct uv_idle_s`, `uv_prepare_s` and `uv_check_s`, which uv.h declares
+/// alike: the prefix, the callback, then Bun's state where libuv keeps its
+/// queue links.
+#[repr(C)]
+pub(crate) struct UvWatcher {
+    handle: UvHandle,
+    cb: Option<UvWatcherCb>,
+    ref_state: RefState,
+}
+
+const _: () = assert!(core::mem::offset_of!(UvWatcher, handle) == 0);
+const _: () = assert!(core::mem::offset_of!(UvWatcher, cb) == 96);
+const _: () = assert!(core::mem::size_of::<UvWatcher>() <= UV_WATCHER_T_SIZE);
+
+impl UvWatcher {
+    /// `uv_{idle,prepare,check}_init`. Loop thread. The handle starts stopped.
+    ///
+    /// # Safety
+    /// `loop_` is null or one of this module's loops; `handle` is the handle
+    /// type's `sizeof` bytes the addon keeps until its `close_cb` has run.
+    unsafe fn init(loop_: *mut UvLoop, handle: *mut UvWatcher, type_: c_uint) -> c_int {
+        if loop_.is_null() || handle.is_null() {
+            return UV_EINVAL;
+        }
+        bun_output::scoped_log!(uv, "uv_handle_t {:?}: init as type {}", handle, type_);
+        UvHandle::init(handle.cast::<UvHandle>(), loop_, type_);
+        // SAFETY: fn contract; field-wise writes into uninitialised addon memory.
+        unsafe {
+            (&raw mut (*handle).cb).write(None);
+            (&raw mut (*handle).ref_state).write(RefState::new());
+        }
+        0
+    }
+
+    /// `uv_{idle,prepare,check}_start`. Loop thread. Starting a started (or a
+    /// closing) handle does nothing, as in libuv: the callback is not replaced.
+    ///
+    /// # Safety
+    /// `handle` was initialised by [`Self::init`].
+    unsafe fn start(handle: *mut UvWatcher, cb: Option<UvWatcherCb>) -> c_int {
+        // SAFETY: fn contract; loop thread. The loop outlives its handles.
+        unsafe {
+            if (*handle).ref_state.active || (*handle).handle.flags & UV_HANDLE_CLOSING != 0 {
+                return 0;
+            }
+            if cb.is_none() {
+                return UV_EINVAL;
+            }
+            (*handle).cb = cb;
+            (*(*handle).handle.loop_)
+                .watchers((*handle).handle.type_)
+                .add(NonNull::new_unchecked(handle));
+            (*handle).ref_state.set_active(true);
+        }
+        0
+    }
+
+    /// `uv_{idle,prepare,check}_stop`, and the stop inside `uv_close`. Loop
+    /// thread. Stopping a stopped handle does nothing.
+    ///
+    /// # Safety
+    /// As [`Self::start`].
+    unsafe fn stop(handle: *mut UvWatcher) {
+        // SAFETY: fn contract; loop thread. The loop outlives its handles.
+        unsafe {
+            if !(*handle).ref_state.active {
+                return;
+            }
+            (*(*handle).handle.loop_)
+                .watchers((*handle).handle.type_)
+                .remove(NonNull::new_unchecked(handle));
+            (*handle).ref_state.set_active(false);
+        }
+    }
+}
+
+/// Whether `handle` is the watcher type an entry point is for. Passing another
+/// type is a caller bug libuv asserts on; the entry points answer `UV_EINVAL`.
 ///
 /// # Safety
 /// `handle` points at an initialised handle.
-unsafe fn as_async(handle: *mut UvHandle, function: &'static CStr) -> NonNull<UvAsync> {
+unsafe fn watcher_of_type(handle: *mut UvWatcher, type_: c_uint) -> bool {
     // SAFETY: fn contract.
-    if unsafe { (*handle).type_ } != UV_ASYNC {
-        unsupported(function);
+    unsafe { (*handle).handle.type_ == type_ }
+}
+
+macro_rules! watcher_entry_points {
+    ($type_:expr, $init:ident, $start:ident, $stop:ident) => {
+        /// See [`UvWatcher::init`].
+        ///
+        /// # Safety
+        /// As [`UvWatcher::init`].
+        #[unsafe(no_mangle)]
+        pub(crate) unsafe extern "C" fn $init(loop_: *mut UvLoop, handle: *mut UvWatcher) -> c_int {
+            // SAFETY: fn contract.
+            unsafe { UvWatcher::init(loop_, handle, $type_) }
+        }
+
+        /// See [`UvWatcher::start`].
+        ///
+        /// # Safety
+        /// `handle` was initialised by one of this module's `uv_*_init`.
+        #[unsafe(no_mangle)]
+        pub(crate) unsafe extern "C" fn $start(
+            handle: *mut UvWatcher,
+            cb: Option<UvWatcherCb>,
+        ) -> c_int {
+            // SAFETY: fn contract.
+            if !unsafe { watcher_of_type(handle, $type_) } {
+                return UV_EINVAL;
+            }
+            // SAFETY: checked to be a watcher of this type.
+            unsafe { UvWatcher::start(handle, cb) }
+        }
+
+        /// See [`UvWatcher::stop`].
+        ///
+        /// # Safety
+        /// `handle` was initialised by one of this module's `uv_*_init`.
+        #[unsafe(no_mangle)]
+        pub(crate) unsafe extern "C" fn $stop(handle: *mut UvWatcher) -> c_int {
+            // SAFETY: fn contract.
+            if !unsafe { watcher_of_type(handle, $type_) } {
+                return UV_EINVAL;
+            }
+            // SAFETY: checked to be a watcher of this type.
+            unsafe { UvWatcher::stop(handle) };
+            0
+        }
+    };
+}
+
+watcher_entry_points!(UV_IDLE, uv_idle_init, uv_idle_start, uv_idle_stop);
+watcher_entry_points!(
+    UV_PREPARE,
+    uv_prepare_init,
+    uv_prepare_start,
+    uv_prepare_stop
+);
+watcher_entry_points!(UV_CHECK, uv_check_init, uv_check_start, uv_check_stop);
+
+// ──────────────────────────────────────────────────────────────────────────
+// uv_timer_t
+// ──────────────────────────────────────────────────────────────────────────
+
+/// `struct uv_timer_s`: the prefix, the callback, then Bun's state where libuv
+/// keeps its heap node and deadlines. The [`EventLoopTimer`] itself does not
+/// fit, so it lives in a [`UvTimerNode`] the handle owns from init to close.
+#[repr(C)]
+pub(crate) struct UvTimer {
+    handle: UvHandle,
+    timer_cb: Option<UvTimerCb>,
+    node: *mut UvTimerNode,
+    repeat_ms: u64,
+    ref_state: RefState,
+}
+
+const _: () = assert!(core::mem::offset_of!(UvTimer, handle) == 0);
+const _: () = assert!(core::mem::offset_of!(UvTimer, timer_cb) == 96);
+const _: () = assert!(core::mem::size_of::<UvTimer>() <= UV_TIMER_T_SIZE);
+
+/// The VM timer heap's view of a `uv_timer_t`. `dispatch.rs` recovers it from
+/// the `event_loop_timer` field when the heap fires it.
+pub(crate) struct UvTimerNode {
+    pub(crate) event_loop_timer: EventLoopTimer,
+    timer: *mut UvTimer,
+}
+
+impl UvTimerNode {
+    /// The heap popped the timer: libuv's `uv__run_timers` stops it, re-arms a
+    /// repeating one, and only then calls back, so the callback sees the state
+    /// the next iteration would and may stop or close the handle.
+    ///
+    /// # Safety
+    /// `this` is the node of a started timer; loop thread.
+    pub(crate) unsafe fn on_fire(this: *mut UvTimerNode) -> JsResult<()> {
+        // SAFETY: fn contract. The heap popped the node without touching its
+        // state; `FIRED` is what lets `update`/`remove` below know it is out.
+        let timer = unsafe {
+            (*this).event_loop_timer.state = EventLoopTimerState::FIRED;
+            (*this).timer
+        };
+        // SAFETY: a started timer is initialised and not closed; loop thread.
+        let (cb, repeat_ms, loop_) = unsafe {
+            (*timer).ref_state.set_active(false);
+            ((*timer).timer_cb, (*timer).repeat_ms, (*timer).handle.loop_)
+        };
+        if repeat_ms != 0 {
+            // SAFETY: as above; `cb` is set, the timer was started with it.
+            unsafe { UvTimer::arm(timer, repeat_ms) };
+        }
+        bun_output::scoped_log!(uv, "uv_timer_t {:?}: timer_cb", timer);
+        // SAFETY: the loop outlives its handles.
+        let vm = unsafe { &*(*loop_).vm.as_ptr() };
+        if let Some(cb) = cb {
+            let _scope = vm.enter_event_loop_scope();
+            // SAFETY: the addon's callback, on the loop thread, with its handle.
+            unsafe { cb(timer) };
+        }
+        if vm.global().has_exception() {
+            return Err(JsError::Thrown);
+        }
+        Ok(())
     }
-    // `type` says `uv_async_init` initialised this memory as a `UvAsync`.
-    NonNull::new(handle.cast::<UvAsync>()).expect("dereferenced above")
+}
+
+impl UvTimer {
+    /// Puts the timer into the heap `timeout_ms` from now and marks it started.
+    ///
+    /// # Safety
+    /// `handle` is an initialised, not closed timer; loop thread.
+    unsafe fn arm(handle: *mut UvTimer, timeout_ms: u64) {
+        let due = Timespec::ms_from_now(
+            TimespecMockMode::ForceRealTime,
+            i64::try_from(timeout_ms).unwrap_or(i64::MAX),
+        );
+        // SAFETY: fn contract; a not closed timer still owns its node.
+        unsafe {
+            timer_all_mut().update(&raw mut (*(*handle).node).event_loop_timer, &due);
+            (*handle).ref_state.set_active(true);
+        }
+    }
+
+    /// `uv_timer_stop`. Does nothing to a timer that is not started. The node's
+    /// own state says whether it is in the heap: the VM's teardown unlinks every
+    /// timer without telling its owner, and a fired node is already out.
+    ///
+    /// # Safety
+    /// As [`Self::arm`].
+    unsafe fn stop(handle: *mut UvTimer) {
+        // SAFETY: fn contract.
+        unsafe {
+            if !(*handle).ref_state.active {
+                return;
+            }
+            let event_loop_timer = &raw mut (*(*handle).node).event_loop_timer;
+            if (*event_loop_timer).state == EventLoopTimerState::ACTIVE {
+                timer_all_mut().remove(event_loop_timer);
+            }
+            (*handle).ref_state.set_active(false);
+        }
+    }
+
+    /// The stop inside `uv_close`. Nothing reads the node of a closing timer
+    /// (every function that would checks `active` or the closing flag first),
+    /// so it goes now rather than in the close task, which the VM may refuse.
+    ///
+    /// # Safety
+    /// As [`Self::arm`], and `handle` is being closed for the first time.
+    unsafe fn close(handle: *mut UvTimer) {
+        // SAFETY: fn contract; `stop` took the node out of the heap, and `node`
+        // is the `heap::alloc` of `uv_timer_init`.
+        unsafe {
+            UvTimer::stop(handle);
+            bun_core::heap::destroy((*handle).node);
+            (*handle).node = core::ptr::null_mut();
+        }
+    }
+
+    /// # Safety
+    /// `handle` points at an initialised handle.
+    unsafe fn check(handle: *mut UvTimer) -> bool {
+        // SAFETY: fn contract.
+        unsafe { (*handle).handle.type_ == UV_TIMER }
+    }
+}
+
+/// `int uv_timer_init(uv_loop_t*, uv_timer_t*)`. Loop thread.
+///
+/// # Safety
+/// `loop_` is null or one of this module's loops; `handle` is `sizeof(uv_timer_t)`
+/// bytes the addon keeps until its `close_cb` has run.
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_init(loop_: *mut UvLoop, handle: *mut UvTimer) -> c_int {
+    if loop_.is_null() || handle.is_null() {
+        return UV_EINVAL;
+    }
+    bun_output::scoped_log!(uv, "uv_timer_t {:?}: uv_timer_init", handle);
+    UvHandle::init(handle.cast::<UvHandle>(), loop_, UV_TIMER);
+    let node = bun_core::heap::alloc(UvTimerNode {
+        event_loop_timer: EventLoopTimer::init_paused(EventLoopTimerTag::UvTimer),
+        timer: handle,
+    });
+    // SAFETY: fn contract; field-wise writes into uninitialised addon memory.
+    unsafe {
+        (&raw mut (*handle).timer_cb).write(None);
+        (&raw mut (*handle).node).write(node);
+        (&raw mut (*handle).repeat_ms).write(0);
+        (&raw mut (*handle).ref_state).write(RefState::new());
+    }
+    0
+}
+
+/// `int uv_timer_start(uv_timer_t*, uv_timer_cb, uint64_t timeout, uint64_t
+/// repeat)`. Loop thread. A started timer is restarted.
+///
+/// # Safety
+/// `handle` was initialised by one of this module's `uv_*_init`.
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_start(
+    handle: *mut UvTimer,
+    cb: Option<UvTimerCb>,
+    timeout_ms: u64,
+    repeat_ms: u64,
+) -> c_int {
+    // SAFETY: fn contract.
+    if !unsafe { UvTimer::check(handle) } || cb.is_none() {
+        return UV_EINVAL;
+    }
+    // SAFETY: a timer; loop thread.
+    unsafe {
+        if (*handle).handle.flags & UV_HANDLE_CLOSING != 0 {
+            return UV_EINVAL;
+        }
+        (*handle).timer_cb = cb;
+        (*handle).repeat_ms = repeat_ms;
+        UvTimer::arm(handle, timeout_ms);
+    }
+    0
+}
+
+/// `int uv_timer_stop(uv_timer_t*)`. Loop thread.
+///
+/// # Safety
+/// As [`uv_timer_start`].
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_stop(handle: *mut UvTimer) -> c_int {
+    // SAFETY: fn contract.
+    if !unsafe { UvTimer::check(handle) } {
+        return UV_EINVAL;
+    }
+    // SAFETY: a timer; loop thread.
+    unsafe { UvTimer::stop(handle) };
+    0
+}
+
+/// `int uv_timer_again(uv_timer_t*)`. Loop thread. Restarts a repeating timer
+/// from now with its repeat value; `UV_EINVAL` for one never started.
+///
+/// # Safety
+/// As [`uv_timer_start`].
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_again(handle: *mut UvTimer) -> c_int {
+    // SAFETY: fn contract.
+    if !unsafe { UvTimer::check(handle) } {
+        return UV_EINVAL;
+    }
+    // SAFETY: a timer; loop thread.
+    unsafe {
+        if (*handle).timer_cb.is_none() {
+            return UV_EINVAL;
+        }
+        let repeat_ms = (*handle).repeat_ms;
+        if repeat_ms != 0 && (*handle).handle.flags & UV_HANDLE_CLOSING == 0 {
+            UvTimer::arm(handle, repeat_ms);
+        }
+    }
+    0
+}
+
+/// `void uv_timer_set_repeat(uv_timer_t*, uint64_t)`. Loop thread. Takes effect
+/// the next time the timer fires or `uv_timer_again` runs, as in libuv.
+///
+/// # Safety
+/// As [`uv_timer_start`].
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_set_repeat(handle: *mut UvTimer, repeat_ms: u64) {
+    // SAFETY: fn contract.
+    if unsafe { UvTimer::check(handle) } {
+        // SAFETY: a timer; loop thread.
+        unsafe { (*handle).repeat_ms = repeat_ms };
+    }
+}
+
+/// `uint64_t uv_timer_get_repeat(const uv_timer_t*)`. Loop thread.
+///
+/// # Safety
+/// As [`uv_timer_start`].
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_get_repeat(handle: *mut UvTimer) -> u64 {
+    // SAFETY: fn contract.
+    if !unsafe { UvTimer::check(handle) } {
+        return 0;
+    }
+    // SAFETY: a timer; loop thread.
+    unsafe { (*handle).repeat_ms }
+}
+
+/// `uint64_t uv_timer_get_due_in(const uv_timer_t*)`. Loop thread. Milliseconds
+/// until a started timer fires; 0 once due, or when it is not started.
+///
+/// # Safety
+/// As [`uv_timer_start`].
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn uv_timer_get_due_in(handle: *mut UvTimer) -> u64 {
+    // SAFETY: fn contract.
+    if !unsafe { UvTimer::check(handle) } {
+        return 0;
+    }
+    // SAFETY: a timer; loop thread; a started timer is not closed, so it owns
+    // its node.
+    let due = unsafe {
+        if !(*handle).ref_state.active {
+            return 0;
+        }
+        (*(*handle).node).event_loop_timer.next
+    };
+    let now = Timespec::now(TimespecMockMode::ForceRealTime);
+    u64::try_from(due.ms().wrapping_sub(now.ms())).unwrap_or(0)
+}
+
+/// `uint64_t uv_now(const uv_loop_t*)`: milliseconds on the clock the timers
+/// use. libuv caches it per iteration; this reads it, which is as accurate as
+/// the addon expects or more.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn uv_now(_loop: *const UvLoop) -> u64 {
+    u64::try_from(Timespec::now(TimespecMockMode::ForceRealTime).ms()).unwrap_or(0)
+}
+
+/// `void uv_update_time(uv_loop_t*)`: nothing to refresh, `uv_now` is live.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn uv_update_time(_loop: *mut UvLoop) {}
+
+// ──────────────────────────────────────────────────────────────────────────
+// uv_handle_t: the functions that take a handle of any type
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The functions that take any handle type switch on `type`. Any other value
+/// means memory no `uv_*_init` of this module wrote (a handle type Bun does not
+/// implement): crash the way `function`'s stub did.
+///
+/// # Safety
+/// `handle` points at an initialised handle.
+unsafe fn handle_type(handle: *mut UvHandle, function: &'static CStr) -> c_uint {
+    // SAFETY: fn contract.
+    match unsafe { (*handle).type_ } {
+        type_ @ (UV_ASYNC | UV_IDLE | UV_PREPARE | UV_CHECK | UV_TIMER) => type_,
+        _ => unsupported(function),
+    }
+}
+
+/// The handle's [`RefState`], wherever its type keeps it.
+///
+/// # Safety
+/// As [`handle_type`]; loop thread, and the returned pointer is used before
+/// the addon is called back.
+unsafe fn ref_state(handle: *mut UvHandle, function: &'static CStr) -> *mut RefState {
+    // SAFETY: fn contract; `type` says which struct `handle` is the prefix of.
+    unsafe {
+        match handle_type(handle, function) {
+            UV_ASYNC => &raw mut (*handle.cast::<UvAsync>()).ref_state,
+            UV_TIMER => &raw mut (*handle.cast::<UvTimer>()).ref_state,
+            _ => &raw mut (*handle.cast::<UvWatcher>()).ref_state,
+        }
+    }
+}
+
+/// The task `uv_close` posted: `close_cb`, one turn later. The callback usually
+/// frees the handle, so nothing reads it afterwards.
+fn run_close(handle: *mut UvHandle) -> JsResult<()> {
+    // SAFETY: `uv_close` posted this for a handle the addon keeps alive until
+    // `close_cb` has run; loop thread.
+    let (close_cb, loop_) = unsafe {
+        (*handle).flags |= UV_HANDLE_CLOSED;
+        ((*handle).close_cb, (*handle).loop_)
+    };
+    bun_output::scoped_log!(uv, "uv_handle_t {:?}: close_cb", handle);
+    if let Some(close_cb) = close_cb {
+        // SAFETY: the addon's callback, on the loop thread, with its handle.
+        unsafe { close_cb(handle) };
+    }
+    // SAFETY: the loop outlives its handles (it is the VM's).
+    let global = unsafe { &*loop_ }.js_thread().global();
+    if global.has_exception() {
+        return Err(JsError::Thrown);
+    }
+    Ok(())
 }
 
 /// `void uv_close(uv_handle_t*, uv_close_cb)`. Loop thread. Stops the handle now
@@ -448,46 +1078,49 @@ unsafe fn as_async(handle: *mut UvHandle, function: &'static CStr) -> NonNull<Uv
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_close(handle: *mut UvHandle, close_cb: Option<UvCloseCb>) {
     // SAFETY: fn contract.
-    let this = unsafe { as_async(handle, c"uv_close") };
-    let async_ = this.as_ptr();
-    // SAFETY: initialised (`as_async`); the loop thread alone uses these fields.
+    let type_ = unsafe { handle_type(handle, c"uv_close") };
+    // SAFETY: initialised; the loop thread alone uses the plain fields.
     let loop_ = unsafe {
-        if (*async_).handle.flags & UV_HANDLE_CLOSING != 0 {
+        if (*handle).flags & UV_HANDLE_CLOSING != 0 {
             return;
         }
-        (*async_).handle.flags |= UV_HANDLE_CLOSING;
-        (*async_).handle.close_cb = close_cb;
-        (*async_).keep_alive.unref(bun_io::js_vm_ctx());
+        (*handle).flags |= UV_HANDLE_CLOSING;
+        (*handle).close_cb = close_cb;
         // The loop outlives its handles.
-        &*(*async_).handle.loop_
+        &*(*handle).loop_
     };
-    bun_output::scoped_log!(uv, "uv_async_t {:?}: uv_close", handle);
-    // SAFETY: initialised and, until this line, not closed.
-    unsafe { UvAsync::stop_sends(this) };
-    loop_.unregister(this);
+    bun_output::scoped_log!(uv, "uv_handle_t {:?}: uv_close", handle);
+    // SAFETY: initialised as `type_` and, until here, not closed.
+    unsafe {
+        match type_ {
+            UV_ASYNC => {
+                let async_ = NonNull::new_unchecked(handle.cast::<UvAsync>());
+                UvAsync::stop_sends(async_);
+                loop_.unregister(async_);
+                (*async_.as_ptr()).ref_state.set_active(false);
+            }
+            UV_TIMER => UvTimer::close(handle.cast::<UvTimer>()),
+            _ => UvWatcher::stop(handle.cast::<UvWatcher>()),
+        }
+    }
     // The queued task keeps the loop alive until `close_cb` has run (libuv: the
     // closing list). Refused: the VM is gone, and with it that turn.
-    let task = ConcurrentTask::from_callback(async_, UvAsync::run_close);
+    let task = ConcurrentTask::from_callback(handle, run_close);
     if let Posted::Refused(task) = loop_.handle.post(LoopKind::Regular, task) {
         // SAFETY: refused ⇒ never queued, ours to free.
         unsafe { ConcurrentTask::release_refused(task) };
     }
 }
 
-/// `void uv_ref(uv_handle_t*)`. Loop thread. Idempotent; `uv_close`'s unref is final.
+/// `void uv_ref(uv_handle_t*)`. Loop thread. Idempotent; takes effect while the
+/// handle is active.
 ///
 /// # Safety
 /// As [`uv_close`].
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_ref(handle: *mut UvHandle) {
     // SAFETY: fn contract.
-    let async_ = unsafe { as_async(handle, c"uv_ref") }.as_ptr();
-    // SAFETY: as in `uv_close`.
-    unsafe {
-        if (*async_).handle.flags & UV_HANDLE_CLOSING == 0 {
-            (*async_).keep_alive.ref_(bun_io::js_vm_ctx());
-        }
-    }
+    unsafe { (*ref_state(handle, c"uv_ref")).set_referenced(true) };
 }
 
 /// `void uv_unref(uv_handle_t*)`. Loop thread. Idempotent.
@@ -497,9 +1130,7 @@ pub(crate) unsafe extern "C" fn uv_ref(handle: *mut UvHandle) {
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_unref(handle: *mut UvHandle) {
     // SAFETY: fn contract.
-    let async_ = unsafe { as_async(handle, c"uv_unref") }.as_ptr();
-    // SAFETY: as in `uv_close`.
-    unsafe { (*async_).keep_alive.unref(bun_io::js_vm_ctx()) };
+    unsafe { (*ref_state(handle, c"uv_unref")).set_referenced(false) };
 }
 
 /// `int uv_has_ref(const uv_handle_t*)`. Loop thread.
@@ -509,22 +1140,19 @@ pub(crate) unsafe extern "C" fn uv_unref(handle: *mut UvHandle) {
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_has_ref(handle: *mut UvHandle) -> c_int {
     // SAFETY: fn contract.
-    let async_ = unsafe { as_async(handle, c"uv_has_ref") }.as_ptr();
-    // SAFETY: as in `uv_close`.
-    c_int::from(unsafe { (*async_).keep_alive.is_active() })
+    c_int::from(unsafe { (*ref_state(handle, c"uv_has_ref")).referenced })
 }
 
-/// `int uv_is_active(const uv_handle_t*)`. Loop thread. libuv starts an async
-/// handle in its init, so: not closed.
+/// `int uv_is_active(const uv_handle_t*)`. Loop thread. Started, for the
+/// watchers and timers; not closed, for an async handle (libuv starts it in
+/// init).
 ///
 /// # Safety
 /// As [`uv_close`].
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_is_active(handle: *mut UvHandle) -> c_int {
     // SAFETY: fn contract.
-    let async_ = unsafe { as_async(handle, c"uv_is_active") }.as_ptr();
-    // SAFETY: as in `uv_close`.
-    c_int::from(unsafe { (*async_).handle.flags } & UV_HANDLE_CLOSING == 0)
+    c_int::from(unsafe { (*ref_state(handle, c"uv_is_active")).active })
 }
 
 /// `int uv_is_closing(const uv_handle_t*)`. Loop thread. True from `uv_close` on.
@@ -534,9 +1162,9 @@ pub(crate) unsafe extern "C" fn uv_is_active(handle: *mut UvHandle) -> c_int {
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_is_closing(handle: *mut UvHandle) -> c_int {
     // SAFETY: fn contract.
-    let async_ = unsafe { as_async(handle, c"uv_is_closing") }.as_ptr();
-    // SAFETY: as in `uv_close`.
-    let flags = unsafe { (*async_).handle.flags };
+    unsafe { handle_type(handle, c"uv_is_closing") };
+    // SAFETY: initialised; loop thread.
+    let flags = unsafe { (*handle).flags };
     c_int::from(flags & (UV_HANDLE_CLOSING | UV_HANDLE_CLOSED) != 0)
 }
 
@@ -713,13 +1341,31 @@ pub(crate) fn fix_dead_code_elimination() {
         uv_async_init,
         uv_async_send,
         uv_cancel,
+        uv_check_init,
+        uv_check_start,
+        uv_check_stop,
         uv_close,
         uv_default_loop,
         uv_has_ref,
+        uv_idle_init,
+        uv_idle_start,
+        uv_idle_stop,
         uv_is_active,
         uv_is_closing,
+        uv_now,
+        uv_prepare_init,
+        uv_prepare_start,
+        uv_prepare_stop,
         uv_queue_work,
         uv_ref,
+        uv_timer_again,
+        uv_timer_get_due_in,
+        uv_timer_get_repeat,
+        uv_timer_init,
+        uv_timer_set_repeat,
+        uv_timer_start,
+        uv_timer_stop,
         uv_unref,
+        uv_update_time,
     );
 }

--- a/src/runtime/napi/uv_posix.rs
+++ b/src/runtime/napi/uv_posix.rs
@@ -13,15 +13,13 @@
 //! - `uv_async_send` sets the handle's `pending` flag and posts at most one
 //!   dispatch task per loop through the VM's [`VmHandle`] (libuv: the eventfd).
 //!   The task walks the loop's handles on the JS thread (libuv: `uv__async_io`).
-//! - The loop's `auto_tick` (jsc_hooks.rs) runs the started idle and prepare
-//!   handles before it polls, keeps the poll from blocking while an idle handle
-//!   is started, and runs the check handles after it: libuv's iteration.
-//! - A timer is a [`bun_event_loop::EventLoopTimer`] in the VM's timer heap,
-//!   owned by a [`UvTimerNode`] on the heap since it does not fit in the handle.
+//! - `auto_tick` (jsc_hooks.rs) runs idle and prepare handles before its poll
+//!   and check handles after it, and does not block while an idle handle is started.
+//! - A timer is an [`EventLoopTimer`] in the VM's timer heap, in a heap-allocated
+//!   [`UvTimerNode`] because it does not fit in the handle.
 //! - `uv_queue_work` is a [`Job`]: `work_cb` on the pool, `after_work_cb` in
 //!   its completion.
-//! - A handle keeps the process alive while it is both started and ref'd
-//!   ([`RefState`]); an async handle counts as started from init to close.
+//! - A handle keeps the process alive while it is started and ref'd ([`RefState`]).
 
 use core::cell::Cell;
 use core::ffi::{CStr, c_char, c_int, c_uint, c_void};
@@ -85,9 +83,8 @@ type UvCloseCb = unsafe extern "C" fn(*mut UvHandle);
 type UvWorkCb = unsafe extern "C" fn(*mut UvWork);
 type UvAfterWorkCb = unsafe extern "C" fn(*mut UvWork, c_int);
 
-/// The two bits libuv combines to decide whether a handle keeps the loop
-/// alive: started (`uv_is_active`) and ref'd (`uv_has_ref`, set at init). The
-/// `KeepAlive` follows their conjunction. Loop thread.
+/// libuv's rule: a handle keeps the loop alive while it is both started
+/// (`uv_is_active`) and ref'd (`uv_has_ref`, the default). Loop thread.
 struct RefState {
     keep_alive: KeepAlive,
     referenced: bool,
@@ -159,17 +156,14 @@ pub(crate) struct UvLoop {
 
 const _: () = assert!(core::mem::offset_of!(UvLoop, data) == 0);
 
-/// The started handles of one watcher kind, in start order, and the walk over
-/// them that every loop iteration makes (libuv's `uv__run_idle` and friends).
-/// JS thread.
+/// The started handles of one watcher kind, in start order (libuv's
+/// `uv__run_idle` and friends). JS thread.
 struct WatcherList {
     started: JsCell<Vec<NonNull<UvWatcher>>>,
-    /// During a walk, the handles it has not reached yet, last first; each one
-    /// goes back into `started` before its callback, so a stop from any
-    /// callback finds it in one of the two lists.
+    /// The handles the running walk has not reached yet, last first; each goes
+    /// back into `started` before its callback, so a stop from a callback finds it.
     walking: JsCell<Vec<NonNull<UvWatcher>>>,
-    /// A callback that runs the loop (a synchronous wait) reaches `walk` again
-    /// while one is on the stack; the inner one does nothing.
+    /// Set while a walk is on the stack; a nested loop run skips its own.
     in_walk: Cell<bool>,
 }
 
@@ -255,9 +249,8 @@ impl UvLoop {
         }
     }
 
-    /// From `auto_tick`, before the poll: runs the idle then the prepare
-    /// handles. True when an idle handle is (still) started, in which case the
-    /// poll must not block, as libuv's would not.
+    /// From `auto_tick`, before the poll: runs idle then prepare handles. True
+    /// when an idle handle is started, which keeps the poll from blocking.
     pub(crate) fn before_poll(&self) -> bool {
         if self.idles.is_empty() && self.prepares.is_empty() {
             return false;
@@ -592,8 +585,7 @@ pub(crate) unsafe extern "C" fn uv_async_send(handle: *mut UvAsync) -> c_int {
 // ──────────────────────────────────────────────────────────────────────────
 
 /// `struct uv_idle_s`, `uv_prepare_s` and `uv_check_s`, which uv.h declares
-/// alike: the prefix, the callback, then Bun's state where libuv keeps its
-/// queue links.
+/// alike: the prefix, the callback, then Bun's state in libuv's queue links.
 #[repr(C)]
 pub(crate) struct UvWatcher {
     handle: UvHandle,
@@ -609,8 +601,8 @@ impl UvWatcher {
     /// `uv_{idle,prepare,check}_init`. Loop thread. The handle starts stopped.
     ///
     /// # Safety
-    /// `loop_` is null or one of this module's loops; `handle` is the handle
-    /// type's `sizeof` bytes the addon keeps until its `close_cb` has run.
+    /// `loop_` is null or one of this module's loops; `handle` is `sizeof` bytes
+    /// of its type that the addon keeps until its `close_cb` has run.
     unsafe fn init(loop_: *mut UvLoop, handle: *mut UvWatcher, type_: c_uint) -> c_int {
         if loop_.is_null() || handle.is_null() {
             return UV_EINVAL;
@@ -625,8 +617,8 @@ impl UvWatcher {
         0
     }
 
-    /// `uv_{idle,prepare,check}_start`. Loop thread. Starting a started (or a
-    /// closing) handle does nothing, as in libuv: the callback is not replaced.
+    /// `uv_{idle,prepare,check}_start`. Loop thread. A no-op on a started or
+    /// closing handle, as in libuv (the callback is not replaced).
     ///
     /// # Safety
     /// `handle` was initialised by [`Self::init`].
@@ -648,8 +640,7 @@ impl UvWatcher {
         0
     }
 
-    /// `uv_{idle,prepare,check}_stop`, and the stop inside `uv_close`. Loop
-    /// thread. Stopping a stopped handle does nothing.
+    /// `uv_{idle,prepare,check}_stop`, also from `uv_close`. Loop thread.
     ///
     /// # Safety
     /// As [`Self::start`].
@@ -667,8 +658,7 @@ impl UvWatcher {
     }
 }
 
-/// Whether `handle` is the watcher type an entry point is for. Passing another
-/// type is a caller bug libuv asserts on; the entry points answer `UV_EINVAL`.
+/// libuv asserts on a handle of the wrong type; the entry points answer `UV_EINVAL`.
 ///
 /// # Safety
 /// `handle` points at an initialised handle.
@@ -736,9 +726,9 @@ watcher_entry_points!(UV_CHECK, uv_check_init, uv_check_start, uv_check_stop);
 // uv_timer_t
 // ──────────────────────────────────────────────────────────────────────────
 
-/// `struct uv_timer_s`: the prefix, the callback, then Bun's state where libuv
-/// keeps its heap node and deadlines. The [`EventLoopTimer`] itself does not
-/// fit, so it lives in a [`UvTimerNode`] the handle owns from init to close.
+/// `struct uv_timer_s`: the prefix, the callback, then Bun's state in libuv's
+/// heap node and deadlines. The [`EventLoopTimer`] does not fit, so the handle
+/// owns a [`UvTimerNode`] from init to close.
 #[repr(C)]
 pub(crate) struct UvTimer {
     handle: UvHandle,
@@ -752,23 +742,22 @@ const _: () = assert!(core::mem::offset_of!(UvTimer, handle) == 0);
 const _: () = assert!(core::mem::offset_of!(UvTimer, timer_cb) == 96);
 const _: () = assert!(core::mem::size_of::<UvTimer>() <= UV_TIMER_T_SIZE);
 
-/// The VM timer heap's view of a `uv_timer_t`. `dispatch.rs` recovers it from
-/// the `event_loop_timer` field when the heap fires it.
+/// The timer heap's view of a `uv_timer_t`; `dispatch.rs` recovers it from
+/// `event_loop_timer` when the heap fires it.
 pub(crate) struct UvTimerNode {
     pub(crate) event_loop_timer: EventLoopTimer,
     timer: *mut UvTimer,
 }
 
 impl UvTimerNode {
-    /// The heap popped the timer: libuv's `uv__run_timers` stops it, re-arms a
-    /// repeating one, and only then calls back, so the callback sees the state
-    /// the next iteration would and may stop or close the handle.
+    /// The heap popped the timer. As libuv's `uv__run_timers`: stop it, re-arm a
+    /// repeating one, then call back, so the callback may stop or close the handle.
     ///
     /// # Safety
     /// `this` is the node of a started timer; loop thread.
     pub(crate) unsafe fn on_fire(this: *mut UvTimerNode) -> JsResult<()> {
-        // SAFETY: fn contract. The heap popped the node without touching its
-        // state; `FIRED` is what lets `update`/`remove` below know it is out.
+        // SAFETY: fn contract. `FIRED` tells `update`/`remove` the node is out
+        // of the heap.
         let timer = unsafe {
             (*this).event_loop_timer.state = EventLoopTimerState::FIRED;
             (*this).timer
@@ -814,9 +803,9 @@ impl UvTimer {
         }
     }
 
-    /// `uv_timer_stop`. Does nothing to a timer that is not started. The node's
-    /// own state says whether it is in the heap: the VM's teardown unlinks every
-    /// timer without telling its owner, and a fired node is already out.
+    /// `uv_timer_stop`. The node's own state says whether it is in the heap: a
+    /// fired node is out, and the VM's teardown unlinks timers without telling
+    /// their owners.
     ///
     /// # Safety
     /// As [`Self::arm`].
@@ -834,9 +823,8 @@ impl UvTimer {
         }
     }
 
-    /// The stop inside `uv_close`. Nothing reads the node of a closing timer
-    /// (every function that would checks `active` or the closing flag first),
-    /// so it goes now rather than in the close task, which the VM may refuse.
+    /// From `uv_close`. The node is freed here, not in the close task (which a
+    /// stopping VM refuses): nothing reads it once the closing flag is set.
     ///
     /// # Safety
     /// As [`Self::arm`], and `handle` is being closed for the first time.
@@ -861,8 +849,7 @@ impl UvTimer {
 /// `int uv_timer_init(uv_loop_t*, uv_timer_t*)`. Loop thread.
 ///
 /// # Safety
-/// `loop_` is null or one of this module's loops; `handle` is `sizeof(uv_timer_t)`
-/// bytes the addon keeps until its `close_cb` has run.
+/// As [`UvWatcher::init`].
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn uv_timer_init(loop_: *mut UvLoop, handle: *mut UvTimer) -> c_int {
     if loop_.is_null() || handle.is_null() {
@@ -927,8 +914,8 @@ pub(crate) unsafe extern "C" fn uv_timer_stop(handle: *mut UvTimer) -> c_int {
     0
 }
 
-/// `int uv_timer_again(uv_timer_t*)`. Loop thread. Restarts a repeating timer
-/// from now with its repeat value; `UV_EINVAL` for one never started.
+/// `int uv_timer_again(uv_timer_t*)`. Loop thread. Restarts a repeating timer;
+/// `UV_EINVAL` for one never started.
 ///
 /// # Safety
 /// As [`uv_timer_start`].
@@ -952,7 +939,7 @@ pub(crate) unsafe extern "C" fn uv_timer_again(handle: *mut UvTimer) -> c_int {
 }
 
 /// `void uv_timer_set_repeat(uv_timer_t*, uint64_t)`. Loop thread. Takes effect
-/// the next time the timer fires or `uv_timer_again` runs, as in libuv.
+/// at the next fire or `uv_timer_again`, as in libuv.
 ///
 /// # Safety
 /// As [`uv_timer_start`].
@@ -979,8 +966,8 @@ pub(crate) unsafe extern "C" fn uv_timer_get_repeat(handle: *mut UvTimer) -> u64
     unsafe { (*handle).repeat_ms }
 }
 
-/// `uint64_t uv_timer_get_due_in(const uv_timer_t*)`. Loop thread. Milliseconds
-/// until a started timer fires; 0 once due, or when it is not started.
+/// `uint64_t uv_timer_get_due_in(const uv_timer_t*)`. Loop thread. 0 once due
+/// or when not started.
 ///
 /// # Safety
 /// As [`uv_timer_start`].
@@ -990,8 +977,7 @@ pub(crate) unsafe extern "C" fn uv_timer_get_due_in(handle: *mut UvTimer) -> u64
     if !unsafe { UvTimer::check(handle) } {
         return 0;
     }
-    // SAFETY: a timer; loop thread; a started timer is not closed, so it owns
-    // its node.
+    // SAFETY: a timer; loop thread. A started timer is not closed, so it owns its node.
     let due = unsafe {
         if !(*handle).ref_state.active {
             return 0;
@@ -1002,9 +988,8 @@ pub(crate) unsafe extern "C" fn uv_timer_get_due_in(handle: *mut UvTimer) -> u64
     u64::try_from(due.ms().wrapping_sub(now.ms())).unwrap_or(0)
 }
 
-/// `uint64_t uv_now(const uv_loop_t*)`: milliseconds on the clock the timers
-/// use. libuv caches it per iteration; this reads it, which is as accurate as
-/// the addon expects or more.
+/// `uint64_t uv_now(const uv_loop_t*)`: the timer heap's clock in milliseconds,
+/// read live where libuv caches it per iteration.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn uv_now(_loop: *const UvLoop) -> u64 {
     u64::try_from(Timespec::now(TimespecMockMode::ForceRealTime).ms()).unwrap_or(0)
@@ -1018,9 +1003,8 @@ pub(crate) extern "C" fn uv_update_time(_loop: *mut UvLoop) {}
 // uv_handle_t: the functions that take a handle of any type
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The functions that take any handle type switch on `type`. Any other value
-/// means memory no `uv_*_init` of this module wrote (a handle type Bun does not
-/// implement): crash the way `function`'s stub did.
+/// A `type` no `uv_*_init` of this module writes is a handle type Bun does not
+/// implement: crash the way `function`'s stub did.
 ///
 /// # Safety
 /// `handle` points at an initialised handle.

--- a/test/napi/uv-stub-stuff/uv_impl.c
+++ b/test/napi/uv-stub-stuff/uv_impl.c
@@ -192,8 +192,9 @@ static napi_value test_tty_reset_mode_concurrent(napi_env env,
 }
 
 // ---------------------------------------------------------------------------
-// The loop-backed functions: uv_default_loop, uv_async_t, uv_queue_work, and
-// the header-only helpers around them. Every test below reports back through
+// The loop-backed functions: uv_default_loop, the uv_async_t, uv_idle_t,
+// uv_prepare_t, uv_check_t and uv_timer_t handles, uv_queue_work, and the
+// header-only helpers around them. Every test below reports back through
 // a JS callback `(event, a, b)` so the test can see the order of the
 // callbacks, and which thread and loop turn they ran on. The tests run these
 // in a child process: on a bun whose uv_* are still stubs they abort it.
@@ -249,6 +250,13 @@ static napi_value make_int32_array(napi_env env, const int32_t *values,
     napi_set_element(env, array, (uint32_t)i, value);
   }
   return array;
+}
+
+static void set_int32(napi_env env, napi_value object, const char *name,
+                      int32_t value) {
+  napi_value number;
+  napi_create_int32(env, value, &number);
+  napi_set_named_property(env, object, name, number);
 }
 
 static void get_args(napi_env env, napi_callback_info info, napi_value *args,
@@ -365,21 +373,52 @@ static napi_value test_loops(napi_env env, napi_callback_info info) {
   return result;
 }
 
-// testErrors(): [uv_async_init without a loop, uv_queue_work without a
-// work_cb, uv_cancel of a request that is not a work request], all UV_EINVAL.
+// testErrors(): the argument errors, all UV_EINVAL (see uv.test.ts for the
+// list). The two handles it initialises are closed again so that the process
+// exits; they are static because a handle must outlive its close.
 static void unused_async_cb(uv_async_t *handle) { (void)handle; }
+static void unused_idle_cb(uv_idle_t *handle) { (void)handle; }
+static void unused_timer_cb(uv_timer_t *handle) { (void)handle; }
+
+static uv_idle_t errors_idle;
+static uv_timer_t errors_timer;
 
 static napi_value test_errors(napi_env env, napi_callback_info info) {
+  uv_loop_t *loop = get_loop(env, false);
   uv_async_t async;
+  uv_check_t check;
+  uv_timer_t timer;
   uv_work_t work;
   uv_req_t not_work;
   memset(&not_work, 0, sizeof(not_work));
-  int32_t results[3] = {
+  if (uv_idle_init(loop, &errors_idle) != 0 ||
+      uv_timer_init(loop, &errors_timer) != 0) {
+    napi_throw_error(env, NULL, "init failed");
+    return NULL;
+  }
+  int32_t results[] = {
       uv_async_init(NULL, &async, unused_async_cb),
-      uv_queue_work(get_loop(env, false), &work, NULL, NULL),
+      uv_check_init(NULL, &check),
+      uv_timer_init(NULL, &timer),
+      uv_queue_work(loop, &work, NULL, NULL),
       uv_cancel(&not_work),
+      // No callback.
+      uv_idle_start(&errors_idle, NULL),
+      uv_timer_start(&errors_timer, NULL, 0, 0),
+      // Never started, so there is nothing to repeat.
+      uv_timer_again(&errors_timer),
+      // A handle of another type.
+      uv_prepare_start((uv_prepare_t *)&errors_idle,
+                       (uv_prepare_cb)unused_idle_cb),
+      uv_prepare_stop((uv_prepare_t *)&errors_idle),
+      uv_idle_start((uv_idle_t *)&errors_timer, unused_idle_cb),
+      uv_timer_start((uv_timer_t *)&errors_idle, unused_timer_cb, 0, 0),
+      uv_timer_stop((uv_timer_t *)&errors_idle),
+      uv_timer_again((uv_timer_t *)&errors_idle),
   };
-  return make_int32_array(env, results, 3);
+  uv_close((uv_handle_t *)&errors_idle, NULL);
+  uv_close((uv_handle_t *)&errors_timer, NULL);
+  return make_int32_array(env, results, sizeof(results) / sizeof(results[0]));
 }
 
 // --- uv_async_t -------------------------------------------------------------
@@ -682,9 +721,418 @@ static napi_value test_cancel_work(napi_env env, napi_callback_info info) {
   return result;
 }
 
+// --- uv_idle_t / uv_prepare_t / uv_check_t -----------------------------------
+
+struct watcher_test {
+  uv_idle_t idle;
+  uv_prepare_t prepare;
+  uv_check_t check;
+  struct reporter reporter;
+  int iterations;
+  bool close_requested;
+  int open;
+};
+
+// Reports "close <type name>": the name comes from the type the init stored.
+static void watcher_test_close_cb(uv_handle_t *handle) {
+  struct watcher_test *test = uv_handle_get_data(handle);
+  char event[32];
+  snprintf(event, sizeof(event), "close %s",
+           uv_handle_type_name(uv_handle_get_type(handle)));
+  report(&test->reporter, event, uv_is_closing(handle), uv_is_active(handle));
+  if (--test->open == 0) {
+    reporter_destroy(&test->reporter);
+    free(test);
+  }
+}
+
+// Called from inside a check callback: closes the handles from within the
+// walk over them, the check handle itself included.
+static void watcher_test_close_all(struct watcher_test *test) {
+  if (test->open == 3)
+    uv_close((uv_handle_t *)&test->idle, watcher_test_close_cb);
+  uv_close((uv_handle_t *)&test->prepare, watcher_test_close_cb);
+  uv_close((uv_handle_t *)&test->check, watcher_test_close_cb);
+  report(&test->reporter, "closing", uv_is_closing((uv_handle_t *)&test->check),
+         uv_is_active((uv_handle_t *)&test->check));
+}
+
+static struct watcher_test *init_watchers(napi_env env, napi_value callback,
+                                          bool with_idle) {
+  struct watcher_test *test = calloc(1, sizeof(*test));
+  reporter_init(&test->reporter, env, callback);
+  uv_loop_t *loop = get_loop(env, false);
+  int rc =
+      uv_prepare_init(loop, &test->prepare) | uv_check_init(loop, &test->check);
+  test->open = 2;
+  if (with_idle) {
+    rc |= uv_idle_init(loop, &test->idle);
+    test->open = 3;
+    uv_handle_set_data((uv_handle_t *)&test->idle, test);
+  }
+  if (rc != 0) {
+    napi_throw_error(env, NULL, "init failed");
+    return NULL;
+  }
+  uv_handle_set_data((uv_handle_t *)&test->prepare, test);
+  uv_handle_set_data((uv_handle_t *)&test->check, test);
+  return test;
+}
+
+static void loop_idle_cb(uv_idle_t *handle) {
+  struct watcher_test *test = handle->data;
+  test->iterations++;
+  report(&test->reporter, "idle", test->iterations,
+         uv_is_active((uv_handle_t *)handle));
+}
+
+static void loop_prepare_cb(uv_prepare_t *handle) {
+  struct watcher_test *test = handle->data;
+  report(&test->reporter, "prepare", test->iterations,
+         uv_is_active((uv_handle_t *)handle));
+}
+
+static void loop_check_cb(uv_check_t *handle) {
+  struct watcher_test *test = handle->data;
+  report(&test->reporter, "check", test->iterations,
+         uv_is_active((uv_handle_t *)handle));
+  if (test->iterations == 2)
+    watcher_test_close_all(test);
+}
+
+// testLoopWatchers(callback): an idle, a prepare and a check handle. The idle
+// handle counts the iterations, and it is what keeps the poll from blocking:
+// nothing else would wake the loop. Every iteration runs the three in libuv's
+// order; the check callback of the second iteration closes all three. Events:
+//   idle 1 1 / prepare 1 1 / check 1 1 / idle 2 1 / prepare 2 1 / check 2 1
+//   closing 1 0 / close idle 1 0 / close prepare 1 0 / close check 1 0
+static napi_value test_loop_watchers(napi_env env, napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct watcher_test *test = init_watchers(env, args[0], true);
+  if (test == NULL)
+    return NULL;
+  if ((uv_idle_start(&test->idle, loop_idle_cb) |
+       uv_prepare_start(&test->prepare, loop_prepare_cb) |
+       uv_check_start(&test->check, loop_check_cb)) != 0)
+    napi_throw_error(env, NULL, "start failed");
+  return NULL;
+}
+
+static struct watcher_test *io_test;
+
+static void io_prepare_cb(uv_prepare_t *handle) {
+  struct watcher_test *test = handle->data;
+  test->iterations++;
+  report(&test->reporter, "prepare", test->iterations,
+         uv_is_active((uv_handle_t *)handle));
+}
+
+static void io_check_cb(uv_check_t *handle) {
+  struct watcher_test *test = handle->data;
+  report(&test->reporter, "check", test->iterations,
+         uv_is_active((uv_handle_t *)handle));
+  if (test->close_requested) {
+    io_test = NULL;
+    watcher_test_close_all(test);
+  }
+}
+
+// testPrepareAndCheckAroundIo(callback): a prepare and a check handle and no
+// idle handle, so between the two the loop blocks in its poll until I/O
+// arrives. The script does some socket I/O and calls requestClose() from its
+// I/O callback. That callback runs inside the poll, so it lands between the
+// prepare and the check event of one iteration, and the check callback of
+// that iteration closes both handles.
+static napi_value test_prepare_and_check_around_io(napi_env env,
+                                                   napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct watcher_test *test = init_watchers(env, args[0], false);
+  if (test == NULL)
+    return NULL;
+  if ((uv_prepare_start(&test->prepare, io_prepare_cb) |
+       uv_check_start(&test->check, io_check_cb)) != 0) {
+    napi_throw_error(env, NULL, "start failed");
+    return NULL;
+  }
+  io_test = test;
+  return NULL;
+}
+
+static napi_value request_close(napi_env env, napi_callback_info info) {
+  if (io_test != NULL)
+    io_test->close_requested = true;
+  return NULL;
+}
+
+static uv_idle_t state_idle;
+static uv_check_t state_check;
+static void unused_check_cb(uv_check_t *handle) { (void)handle; }
+
+// testWatcherStates(): the start/stop state machine, observed synchronously.
+// Both handles are closed before the loop turns, so no callback ever runs and
+// the process exits; the started idle handle would otherwise spin forever.
+static napi_value test_watcher_states(napi_env env, napi_callback_info info) {
+  uv_loop_t *loop = get_loop(env, false);
+  uv_handle_t *idle = (uv_handle_t *)&state_idle;
+  uv_handle_t *check = (uv_handle_t *)&state_check;
+  napi_value result;
+  napi_create_object(env, &result);
+  set_int32(env, result, "init",
+            uv_idle_init(loop, &state_idle) |
+                uv_check_init(loop, &state_check));
+  set_int32(env, result, "activeAfterInit", uv_is_active(idle));
+  set_int32(env, result, "refAfterInit", uv_has_ref(idle));
+  set_int32(env, result, "typeIsIdle", uv_handle_get_type(idle) == UV_IDLE);
+  set_int32(env, result, "typeIsCheck", uv_handle_get_type(check) == UV_CHECK);
+  set_int32(env, result, "loopIsSet", uv_handle_get_loop(idle) == loop);
+  set_int32(env, result, "start", uv_idle_start(&state_idle, unused_idle_cb));
+  set_int32(env, result, "activeAfterStart", uv_is_active(idle));
+  set_int32(env, result, "startAgain",
+            uv_idle_start(&state_idle, unused_idle_cb));
+  set_int32(env, result, "stop", uv_idle_stop(&state_idle));
+  set_int32(env, result, "activeAfterStop", uv_is_active(idle));
+  set_int32(env, result, "stopAgain", uv_idle_stop(&state_idle));
+  set_int32(env, result, "restart", uv_idle_start(&state_idle, unused_idle_cb));
+  set_int32(env, result, "activeAfterRestart", uv_is_active(idle));
+  uv_unref(idle);
+  set_int32(env, result, "refAfterUnref", uv_has_ref(idle));
+  set_int32(env, result, "activeAfterUnref", uv_is_active(idle));
+  uv_ref(idle);
+  set_int32(env, result, "refAfterRef", uv_has_ref(idle));
+  set_int32(env, result, "checkStart",
+            uv_check_start(&state_check, unused_check_cb));
+  uv_close(idle, NULL);
+  uv_close(check, NULL);
+  set_int32(env, result, "activeAfterClose", uv_is_active(idle));
+  set_int32(env, result, "closingAfterClose", uv_is_closing(idle));
+  set_int32(env, result, "refAfterClose", uv_has_ref(idle));
+  set_int32(env, result, "startAfterClose",
+            uv_idle_start(&state_idle, unused_idle_cb));
+  set_int32(env, result, "activeAfterStartAfterClose", uv_is_active(idle));
+  return result;
+}
+
+// --- uv_timer_t --------------------------------------------------------------
+
+struct timer_test {
+  uv_timer_t handle;
+  struct reporter reporter;
+  int fires;
+};
+
+static void timer_test_close_cb(uv_handle_t *handle) {
+  struct timer_test *test = handle->data;
+  report(&test->reporter, "close timer", uv_is_closing(handle),
+         uv_is_active(handle));
+  reporter_destroy(&test->reporter);
+  free(test);
+}
+
+static struct timer_test *init_timer(napi_env env, napi_value callback) {
+  struct timer_test *test = calloc(1, sizeof(*test));
+  reporter_init(&test->reporter, env, callback);
+  test->handle.data = test;
+  if (uv_timer_init(get_loop(env, false), &test->handle) != 0) {
+    napi_throw_error(env, NULL, "uv_timer_init failed");
+    return NULL;
+  }
+  return test;
+}
+
+static napi_value timer_state(napi_env env, struct timer_test *test) {
+  uv_handle_t *handle = (uv_handle_t *)&test->handle;
+  napi_value result;
+  napi_create_object(env, &result);
+  set_int32(env, result, "typeIsTimer", uv_handle_get_type(handle) == UV_TIMER);
+  set_int32(env, result, "isActive", uv_is_active(handle));
+  set_int32(env, result, "hasRef", uv_has_ref(handle));
+  set_int32(env, result, "dueIn", (int32_t)uv_timer_get_due_in(&test->handle));
+  set_int32(env, result, "repeat", (int32_t)uv_timer_get_repeat(&test->handle));
+  return result;
+}
+
+static void timer_once_cb(uv_timer_t *handle) {
+  struct timer_test *test = handle->data;
+  // A one-shot timer is stopped by the time its callback runs, as in libuv.
+  report(&test->reporter, "timer", uv_is_active((uv_handle_t *)handle),
+         (int32_t)uv_timer_get_due_in(handle));
+  uv_close((uv_handle_t *)handle, timer_test_close_cb);
+}
+
+// testTimer(callback): a 10ms one-shot timer. The script returns at once; the
+// timer keeps the process alive until it fires. Events `timer 0 0`, then
+// `close timer 1 0`. Returns the state right after the start.
+static napi_value test_timer(napi_env env, napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct timer_test *test = init_timer(env, args[0]);
+  if (test == NULL)
+    return NULL;
+  if (uv_timer_start(&test->handle, timer_once_cb, 10, 0) != 0) {
+    napi_throw_error(env, NULL, "uv_timer_start failed");
+    return NULL;
+  }
+  return timer_state(env, test);
+}
+
+static void timer_repeat_cb(uv_timer_t *handle) {
+  struct timer_test *test = handle->data;
+  test->fires++;
+  // A repeating timer is armed again by the time its callback runs.
+  report(&test->reporter, "repeat", test->fires,
+         uv_is_active((uv_handle_t *)handle));
+  if (test->fires < 3)
+    return;
+  uv_timer_stop(handle);
+  report(&test->reporter, "stopped", uv_is_active((uv_handle_t *)handle),
+         (int32_t)uv_timer_get_repeat(handle));
+  uv_close((uv_handle_t *)handle, timer_test_close_cb);
+}
+
+// testTimerRepeat(callback): timeout 1ms, repeat 1ms. Events `repeat 1 1`,
+// `repeat 2 1`, `repeat 3 1`, `stopped 0 1`, `close timer 1 0`.
+static napi_value test_timer_repeat(napi_env env, napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct timer_test *test = init_timer(env, args[0]);
+  if (test == NULL)
+    return NULL;
+  uv_timer_start(&test->handle, timer_repeat_cb, 1, 1);
+  return timer_state(env, test);
+}
+
+// testTimerAgain(callback): a timer started to fire in an hour gets a 1ms
+// repeat and uv_timer_again, which restarts it with the repeat: the events
+// are testTimerRepeat's. Returns { dueInBefore, again, dueInAfter, repeat }.
+static napi_value test_timer_again(napi_env env, napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct timer_test *test = init_timer(env, args[0]);
+  if (test == NULL)
+    return NULL;
+  uv_timer_start(&test->handle, timer_repeat_cb, 60 * 60 * 1000, 0);
+  napi_value result;
+  napi_create_object(env, &result);
+  set_int32(env, result, "dueInBefore",
+            (int32_t)uv_timer_get_due_in(&test->handle));
+  uv_timer_set_repeat(&test->handle, 1);
+  set_int32(env, result, "again", uv_timer_again(&test->handle));
+  set_int32(env, result, "dueInAfter",
+            (int32_t)uv_timer_get_due_in(&test->handle));
+  set_int32(env, result, "repeat", (int32_t)uv_timer_get_repeat(&test->handle));
+  return result;
+}
+
+// testTimerRestart(callback): a started one-hour timer restarted as a 10ms
+// one: uv_timer_start on a started timer reschedules it, so the events are
+// testTimer's. Returns the state after the restart.
+static napi_value test_timer_restart(napi_env env, napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct timer_test *test = init_timer(env, args[0]);
+  if (test == NULL)
+    return NULL;
+  uv_timer_start(&test->handle, timer_once_cb, 60 * 60 * 1000, 0);
+  uv_timer_start(&test->handle, timer_once_cb, 10, 0);
+  return timer_state(env, test);
+}
+
+// testTimerClosedBeforeItFires(callback): a started one-hour timer that is
+// closed at once. The only event is `close timer 1 0`, and the process exits.
+// Returns the state right after uv_close.
+static napi_value test_timer_closed_before_it_fires(napi_env env,
+                                                    napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct timer_test *test = init_timer(env, args[0]);
+  if (test == NULL)
+    return NULL;
+  uv_timer_start(&test->handle, timer_once_cb, 60 * 60 * 1000, 0);
+  uv_close((uv_handle_t *)&test->handle, timer_test_close_cb);
+  // Allowed until close_cb has run; none of these may start it again.
+  uv_timer_start(&test->handle, timer_once_cb, 0, 0);
+  uv_timer_again(&test->handle);
+  uv_timer_stop(&test->handle);
+  return timer_state(env, test);
+}
+
+static void timer_unref_cb(uv_timer_t *handle) {
+  struct timer_test *test = handle->data;
+  report(&test->reporter, "fired", 0, 0);
+}
+
+// testTimerUnref(callback): a started one-hour timer that is unref'd. The
+// process must exit although the timer is never stopped or closed, so `fired`
+// is never reported. Returns the state after the unref.
+static napi_value test_timer_unref(napi_env env, napi_callback_info info) {
+  napi_value args[1];
+  get_args(env, info, args, 1);
+  struct timer_test *test = init_timer(env, args[0]);
+  if (test == NULL)
+    return NULL;
+  uv_timer_start(&test->handle, timer_unref_cb, 60 * 60 * 1000, 0);
+  uv_unref((uv_handle_t *)&test->handle);
+  return timer_state(env, test);
+}
+
+// testNow(): uv_now advances while the process spins for 5ms of uv_hrtime.
+// Returns { nowIsPositive, advancedMs }.
+static napi_value test_now(napi_env env, napi_callback_info info) {
+  uv_loop_t *loop = get_loop(env, false);
+  uv_update_time(loop);
+  uint64_t before = uv_now(loop);
+  uint64_t start = uv_hrtime();
+  while (uv_hrtime() - start < 5 * 1000 * 1000)
+    ;
+  uv_update_time(loop);
+  uint64_t after = uv_now(loop);
+  napi_value result;
+  napi_create_object(env, &result);
+  set_int32(env, result, "nowIsPositive", before > 0);
+  set_int32(env, result, "advancedMs", (int32_t)(after - before));
+  return result;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   // Register all test functions
   napi_value fn;
+
+  napi_create_function(env, NULL, 0, test_loop_watchers, NULL, &fn);
+  napi_set_named_property(env, exports, "testLoopWatchers", fn);
+
+  napi_create_function(env, NULL, 0, test_prepare_and_check_around_io, NULL,
+                       &fn);
+  napi_set_named_property(env, exports, "testPrepareAndCheckAroundIo", fn);
+
+  napi_create_function(env, NULL, 0, request_close, NULL, &fn);
+  napi_set_named_property(env, exports, "requestClose", fn);
+
+  napi_create_function(env, NULL, 0, test_watcher_states, NULL, &fn);
+  napi_set_named_property(env, exports, "testWatcherStates", fn);
+
+  napi_create_function(env, NULL, 0, test_timer, NULL, &fn);
+  napi_set_named_property(env, exports, "testTimer", fn);
+
+  napi_create_function(env, NULL, 0, test_timer_repeat, NULL, &fn);
+  napi_set_named_property(env, exports, "testTimerRepeat", fn);
+
+  napi_create_function(env, NULL, 0, test_timer_again, NULL, &fn);
+  napi_set_named_property(env, exports, "testTimerAgain", fn);
+
+  napi_create_function(env, NULL, 0, test_timer_restart, NULL, &fn);
+  napi_set_named_property(env, exports, "testTimerRestart", fn);
+
+  napi_create_function(env, NULL, 0, test_timer_closed_before_it_fires, NULL,
+                       &fn);
+  napi_set_named_property(env, exports, "testTimerClosedBeforeItFires", fn);
+
+  napi_create_function(env, NULL, 0, test_timer_unref, NULL, &fn);
+  napi_set_named_property(env, exports, "testTimerUnref", fn);
+
+  napi_create_function(env, NULL, 0, test_now, NULL, &fn);
+  napi_set_named_property(env, exports, "testNow", fn);
 
   napi_create_function(env, NULL, 0, test_version, NULL, &fn);
   napi_set_named_property(env, exports, "testVersion", fn);

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -184,12 +184,13 @@ describe.if(!isWindows)("uv stubs", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The loop-backed functions (uv_default_loop, uv_async_t, uv_queue_work) and
-  // the header-only ones around them run in a child process: the child's exit
-  // is part of what is tested (a ref'd handle or a queued request must keep it
-  // alive, an unref'd handle must not), and on a bun where these are still
-  // stubs the first call aborts the process. `script` sees `addon` and
-  // `report`, which prints one line per event the addon reports.
+  // The loop-backed functions (uv_default_loop, the async, idle, prepare, check
+  // and timer handles, uv_queue_work) and the header-only ones around them run
+  // in a child process: the child's exit is part of what is tested (a ref'd
+  // handle or a queued request must keep it alive, an unref'd handle must
+  // not), and on a bun where these are still stubs the first call aborts the
+  // process. `script` sees `addon` and `report`, which prints one line per
+  // event the addon reports.
   async function runInChild(script: string) {
     await using proc = Bun.spawn({
       cmd: [
@@ -264,11 +265,26 @@ describe.if(!isWindows)("uv stubs", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("UV_EINVAL for a missing loop, a missing work_cb and a non-work request", async () => {
+  test.concurrent("UV_EINVAL for a missing loop or callback and for a handle of another type", async () => {
     const { stdout, stderr, exitCode } = await runInChild(`console.log(JSON.stringify(addon.testErrors()));`);
     expect(stderr).toBe("");
     const EINVAL = -constants.errno.EINVAL;
-    expect(JSON.parse(stdout)).toEqual([EINVAL, EINVAL, EINVAL]);
+    expect(JSON.parse(stdout)).toEqual([
+      EINVAL, // uv_async_init without a loop
+      EINVAL, // uv_check_init without a loop
+      EINVAL, // uv_timer_init without a loop
+      EINVAL, // uv_queue_work without a work_cb
+      EINVAL, // uv_cancel of a request that is not a work request
+      EINVAL, // uv_idle_start without a callback
+      EINVAL, // uv_timer_start without a callback
+      EINVAL, // uv_timer_again of a timer that was never started
+      EINVAL, // uv_prepare_start of an idle handle
+      EINVAL, // uv_prepare_stop of an idle handle
+      EINVAL, // uv_idle_start of a timer
+      EINVAL, // uv_timer_start of an idle handle
+      EINVAL, // uv_timer_stop of an idle handle
+      EINVAL, // uv_timer_again of an idle handle
+    ]);
     expect(exitCode).toBe(0);
   });
 
@@ -380,6 +396,264 @@ describe.if(!isWindows)("uv stubs", () => {
     const cancelled = `cancel 0\nafter ${-constants.errno.ECANCELED} 124\n`;
     const tooLate = `cancel ${-constants.errno.EBUSY}\nafter 0 127\n`;
     expect([cancelled, tooLate]).toContain(stdout);
+    expect(exitCode).toBe(0);
+  });
+
+  // The handle tests below print the state the addon returns as one JSON line,
+  // then one line per event.
+  function stateAndEvents(stdout: string) {
+    const [state, ...events] = stdout.split("\n");
+    return { state: JSON.parse(state), events: events.join("\n") };
+  }
+
+  const loopWatcherEvents = [
+    "idle 1 1",
+    "prepare 1 1",
+    "check 1 1",
+    "idle 2 1",
+    "prepare 2 1",
+    "check 2 1",
+    "closing 1 0",
+    "close idle 1 0",
+    "close prepare 1 0",
+    "close check 1 0",
+    "",
+  ].join("\n");
+
+  test.concurrent("idle, prepare and check handles run once per loop iteration, in that order", async () => {
+    // Nothing but the idle handle keeps the loop turning: if it let the poll
+    // block, the child would hang here. See test_loop_watchers in uv_impl.c.
+    const { stdout, stderr, exitCode } = await runInChild(`addon.testLoopWatchers(report);`);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(loopWatcherEvents);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the watchers of a Worker run on the Worker's loop", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(`
+      const { Worker } = require("node:worker_threads");
+      const worker = new Worker(
+        \`
+          const { parentPort } = require("node:worker_threads");
+          require(${JSON.stringify(addonPath)}).testLoopWatchers((event, a, b) => parentPort.postMessage([event, a, b].join(" ")));
+        \`,
+        { eval: true },
+      );
+      worker.on("message", message => console.log(message));
+      worker.on("exit", code => console.log("worker exited", code));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(loopWatcherEvents + "worker exited 0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("prepare runs before the poll and check after it", async () => {
+    // The server's data callback runs inside the poll. The addon closes both
+    // handles from the check callback of the iteration it was called in. How
+    // many iterations the connection takes to get there varies.
+    const { stdout, stderr, exitCode } = await runInChild(`
+      addon.testPrepareAndCheckAroundIo(report);
+      const server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          data(socket) {
+            console.log("io");
+            addon.requestClose();
+            socket.end();
+            server.stop(true);
+          },
+        },
+      });
+      Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        socket: {
+          open(socket) {
+            socket.write("x");
+          },
+          data() {},
+        },
+      });
+    `);
+    expect(stderr).toBe("");
+    const lines = stdout.split("\n");
+    const io = lines.indexOf("io");
+    expect(io).toBeGreaterThan(0);
+    const iteration = (io + 1) / 2;
+    const expected: string[] = [];
+    for (let i = 1; i < iteration; i++) {
+      expected.push(`prepare ${i} 1`, `check ${i} 1`);
+    }
+    expected.push(
+      `prepare ${iteration} 1`,
+      "io",
+      `check ${iteration} 1`,
+      "closing 1 0",
+      "close prepare 1 0",
+      "close check 1 0",
+      "",
+    );
+    expect(lines).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the start and stop state machine of a watcher", async () => {
+    // The handles are closed before the script returns; the child exiting is
+    // part of the test, since the started idle handle would otherwise spin.
+    const { stdout, stderr, exitCode } = await runInChild(`console.log(JSON.stringify(addon.testWatcherStates()));`);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      init: 0,
+      activeAfterInit: 0,
+      refAfterInit: 1,
+      typeIsIdle: 1,
+      typeIsCheck: 1,
+      loopIsSet: 1,
+      start: 0,
+      activeAfterStart: 1,
+      startAgain: 0,
+      stop: 0,
+      activeAfterStop: 0,
+      stopAgain: 0,
+      restart: 0,
+      activeAfterRestart: 1,
+      refAfterUnref: 0,
+      activeAfterUnref: 1,
+      refAfterRef: 1,
+      checkStart: 0,
+      activeAfterClose: 0,
+      closingAfterClose: 1,
+      // The ref flag is independent of closing, as in libuv.
+      refAfterClose: 1,
+      // Starting a closing handle is a no-op that reports success, as in libuv.
+      startAfterClose: 0,
+      activeAfterStartAfterClose: 0,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an exception thrown by JS called from a watcher callback is uncaught", async () => {
+    // Every one of the six callbacks throws; the loop must go on to the check
+    // callback that closes the handles, so that the child exits.
+    const { stdout, stderr, exitCode } = await runInChild(`
+      addon.testLoopWatchers(() => { throw new Error("thrown from inside a watcher callback"); });
+    `);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("thrown from inside a watcher callback");
+    expect(exitCode).toBe(1);
+  });
+
+  const oneShotTimerEvents = "timer 0 0\nclose timer 1 0\n";
+  // See timer_repeat_cb in uv_impl.c: the third callback stops and closes it.
+  const repeatingTimerEvents = "repeat 1 1\nrepeat 2 1\nrepeat 3 1\nstopped 0 1\nclose timer 1 0\n";
+  const HOUR = 60 * 60 * 1000;
+
+  test.concurrent("a one-shot uv_timer_t keeps the process alive and fires once", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(`console.log(JSON.stringify(addon.testTimer(report)));`);
+    expect(stderr).toBe("");
+    const { state, events } = stateAndEvents(stdout);
+    expect(state).toEqual({ typeIsTimer: 1, isActive: 1, hasRef: 1, dueIn: expect.any(Number), repeat: 0 });
+    expect(state.dueIn).toBeGreaterThanOrEqual(0);
+    expect(state.dueIn).toBeLessThanOrEqual(10);
+    expect(events).toBe(oneShotTimerEvents);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a uv_timer_t in a Worker fires on the Worker's loop", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(`
+      const { Worker } = require("node:worker_threads");
+      const worker = new Worker(
+        \`
+          const { parentPort } = require("node:worker_threads");
+          const state = require(${JSON.stringify(addonPath)}).testTimer((event, a, b) => parentPort.postMessage([event, a, b].join(" ")));
+          parentPort.postMessage("started " + state.isActive);
+        \`,
+        { eval: true },
+      );
+      worker.on("message", message => console.log(message));
+      worker.on("exit", code => console.log("worker exited", code));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("started 1\n" + oneShotTimerEvents + "worker exited 0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a repeating uv_timer_t fires until it is stopped", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(
+      `console.log(JSON.stringify(addon.testTimerRepeat(report)));`,
+    );
+    expect(stderr).toBe("");
+    const { state, events } = stateAndEvents(stdout);
+    expect(state).toEqual({ typeIsTimer: 1, isActive: 1, hasRef: 1, dueIn: expect.any(Number), repeat: 1 });
+    expect(state.dueIn).toBeLessThanOrEqual(1);
+    expect(events).toBe(repeatingTimerEvents);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("uv_timer_set_repeat and uv_timer_again restart a timer with its repeat", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(`console.log(JSON.stringify(addon.testTimerAgain(report)));`);
+    expect(stderr).toBe("");
+    const { state, events } = stateAndEvents(stdout);
+    expect(state).toEqual({ dueInBefore: expect.any(Number), again: 0, dueInAfter: expect.any(Number), repeat: 1 });
+    expect(state.dueInBefore).toBeGreaterThan(HOUR / 2);
+    expect(state.dueInBefore).toBeLessThanOrEqual(HOUR);
+    expect(state.dueInAfter).toBeLessThanOrEqual(1);
+    expect(events).toBe(repeatingTimerEvents);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("uv_timer_start on a started timer reschedules it", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(
+      `console.log(JSON.stringify(addon.testTimerRestart(report)));`,
+    );
+    expect(stderr).toBe("");
+    const { state, events } = stateAndEvents(stdout);
+    expect(state).toEqual({ typeIsTimer: 1, isActive: 1, hasRef: 1, dueIn: expect.any(Number), repeat: 0 });
+    expect(state.dueIn).toBeLessThanOrEqual(10);
+    expect(events).toBe(oneShotTimerEvents);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("uv_close on a started timer: close_cb only, and the process exits", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(
+      `console.log(JSON.stringify(addon.testTimerClosedBeforeItFires(report)));`,
+    );
+    expect(stderr).toBe("");
+    expect(stateAndEvents(stdout)).toEqual({
+      state: { typeIsTimer: 1, isActive: 0, hasRef: 1, dueIn: 0, repeat: 0 },
+      events: "close timer 1 0\n",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an unref'd timer lets the process exit", async () => {
+    // The timer is left started; the child hanging for an hour is the failure.
+    const { stdout, stderr, exitCode } = await runInChild(`console.log(JSON.stringify(addon.testTimerUnref(report)));`);
+    expect(stderr).toBe("");
+    const { state, events } = stateAndEvents(stdout);
+    expect(state).toEqual({ typeIsTimer: 1, isActive: 1, hasRef: 0, dueIn: expect.any(Number), repeat: 0 });
+    expect(state.dueIn).toBeGreaterThan(HOUR / 2);
+    expect(events).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an exception thrown by JS called from timer_cb is uncaught", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(`
+      addon.testTimer(() => { throw new Error("thrown from inside timer_cb"); });
+    `);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("thrown from inside timer_cb");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("uv_now advances", async () => {
+    const { stdout, stderr, exitCode } = await runInChild(`console.log(JSON.stringify(addon.testNow()));`);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout);
+    expect(result).toEqual({ nowIsPositive: 1, advancedMs: expect.any(Number) });
+    // The addon spins for 5ms between the two readings.
+    expect(result.advancedMs).toBeGreaterThanOrEqual(4);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -560,6 +560,28 @@ describe.if(!isWindows)("uv stubs", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("uv_timer_t started from inside a JS timer callback, next to a JS timer", async () => {
+    // The timer heap is being drained while the addon arms its timers, as
+    // when an addon's constructor runs from a setTimeout callback. The three
+    // timers fire in an order that depends on the scheduler, so the events
+    // are compared as a set.
+    const { stdout, stderr, exitCode } = await runInChild(`
+      setTimeout(() => {
+        console.log(JSON.stringify(addon.testTimer(report)));
+        addon.testTimerRepeat(report);
+        setTimeout(() => console.log("js timer"), 10);
+      }, 1);
+    `);
+    expect(stderr).toBe("");
+    const { state, events } = stateAndEvents(stdout);
+    expect(state).toEqual({ typeIsTimer: 1, isActive: 1, hasRef: 1, dueIn: expect.any(Number), repeat: 0 });
+    const lines = (s: string) => s.trimEnd().split("\n");
+    expect(lines(events).sort()).toEqual(
+      [...lines(oneShotTimerEvents), ...lines(repeatingTimerEvents), "js timer"].sort(),
+    );
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("a uv_timer_t in a Worker fires on the Worker's loop", async () => {
     const { stdout, stderr, exitCode } = await runInChild(`
       const { Worker } = require("node:worker_threads");


### PR DESCRIPTION
Stacked on #39652, its base branch: review the last commit only.

### Problem
- On posix the `uv_timer_t`, `uv_check_t`, `uv_idle_t` and `uv_prepare_t` functions are crash stubs: `panic: unsupported uv function: uv_check_init`. After the two that #39652 implements, they are the stubs addons hit most (Sentry counts in Notes).
- `@sentry/profiling-node` (#19230) needs `uv_timer_t`. webtorrent's native dependency (#14234) dies in `uv_timer_init`.

### Fix
- `uv_idle_t`, `uv_prepare_t` and `uv_check_t` are one struct, `UvWatcher`. `auto_tick` (jsc_hooks.rs) runs idle and prepare handles before its poll and check handles after it. A started idle handle makes the poll non-blocking, as in libuv.
- `uv_timer_t` is an `EventLoopTimer` in the VM's timer heap. It does not fit in the handle, so `uv_timer_init` allocates a `UvTimerNode` and `uv_close` frees it. As in libuv, a due timer is stopped, re-armed if it repeats, then called back.
- `RefState` replaces each handle's `KeepAlive`: a handle keeps the process alive while it is started and ref'd. The `uv_handle_t` functions accept all five types. 18 stubs go away.
- Verified: `test/napi/uv.test.ts`, 15 new tests, all fail on the stock bun. Other suites in Notes.

### Background
- #39652 gives each VM a `UvLoop` that stands in for `uv_loop_t` on posix, where Bun has no libuv loop. This PR adds handle types to it.
- A libuv iteration: timers, idle handles, prepare handles, the poll, check handles. Bun's `auto_tick` is one iteration: it polls, then drains the timer heap.
- `timer::All` (src/runtime/timer) is the per-thread heap of all timers. `__bun_fire_timer` (dispatch.rs) finds the owner of a due timer by its tag. Towards #18546.

<details><summary>Notes</summary>

Sentry, 90 days: about 60 events name `uv_check_init` and 44 `uv_timer_init`, after about 500 for `uv_default_loop` and 190 for `uv_async_init`. Issues on the public 1.4.0 release, all macOS arm64 addons: BUN-4P00 (`uv_timer_init` from an addon constructor called by a JS timer, the shape `uv.test.ts` now covers) and BUN-4Q9K (`uv_idle_init` during `process.dlopen`).

Layout. The addon allocates each handle, so Bun's state has to fit in libuv's `sizeof`: `uv_idle_t`, `uv_prepare_t` and `uv_check_t` are 120 bytes with the callback at offset 96, `uv_timer_t` is 152 bytes, both asserted at compile time. `uv_now` and `uv_update_time` come with the timers.

Semantics kept from libuv: `uv_*_start` of a started or closing watcher returns 0 and changes nothing; a missing callback is `UV_EINVAL`; `uv_timer_start` of a closing timer is `UV_EINVAL`, of a started one a restart; `uv_timer_again` is `UV_EINVAL` for a timer never started and a no-op for one with no repeat; `uv_timer_set_repeat` takes effect at the next fire or `uv_timer_again`; inside its callback a one-shot timer reads as stopped and a repeating one as started; `uv_has_ref` keeps reporting the flag after `uv_close` (#39652 reported 0 there); a handle passed to the functions of another type gets `UV_EINVAL`, where libuv asserts. Differences: the watchers of one kind run in start order (libuv's queue happens to run them in reverse start order); `uv_timer_get_due_in` is 0 for a stopped timer (libuv reports the stale deadline); `uv_now` reads the clock the timer heap uses instead of a per-iteration cache.

The walk over a watcher list moves each handle back into the live list before its callback, the way #39652 dispatches async handles, so a stop or close from any callback finds it. A nested loop run from a callback finds `in_walk` set and skips the inner walk. `before_poll` and `after_poll` are in both `auto_tick` (waits, module loading) and `auto_tick_active` (the main run loop, Workers). Once the VM stops running script they do nothing, like the async dispatch; a terminated Worker's loop is woken and exits on its terminate flag.

The timer node is freed in `uv_close`, not in the close task: every function that reads the node checks `active` or the closing flag first (the closed-timer test calls each of them after `uv_close`, under ASAN in CI), and a VM that is shutting down can refuse the task. The VM's teardown unlinks every timer without telling its owner (`disarm_all_for_vm_teardown`), so `stop` reads the node's own state before it removes it.

Cost on the tick path when no addon uses these: three `Vec::is_empty` reads per tick. A reduced `setInterval-leak-fixture.js` (15 batches of 10,000 callbacks) on this debug build: 12.3 to 14.4 s on the base commit, 12.4 to 13.5 s with this change. The full fixture takes over five minutes on this debug build either way (4 s on the release bun), so the leak tests in `test/js/web/timers` time out here with and without this change; the other 45 tests in those four files pass.

Tests. The prepare/check test does socket I/O: the data callback runs inside the poll, so its `io` line has to land between `prepare N` and `check N` of one iteration (iteration 2 here), and the check callback of that iteration closes both handles from inside the walk. In the idle test the idle handle is the only thing turning the loop, so an idle handle that let the poll block would hang the child. The unref'd timer and the closed timer are one-hour timers: the child exiting is the assertion. The Worker tests check that watchers and timers land on the Worker's own loop and timer heap and let it exit. Two tests throw from every callback and check that the process still reaches the close that lets it exit, with exit code 1. The error test grew from 3 to 14 cases.

`@sentry/profiling-node` also needs `uv_cpu_info`, `uv_free_cpu_info` and V8 APIs, which are not in this change.

Suites run: `test/napi/uv.test.ts` (five runs, 37 pass each), `test/napi/uv_stub.test.ts`, `test/js/web/timers/{setTimeout,setInterval,setImmediate}.test.js` and `timer-heap-race.test.ts`, `cargo clippy -p bun_runtime -p bun_event_loop`, `bun scripts/rust-check-all.ts` (12 targets), `cargo fmt --check`, `clang-format:check`, prettier.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/uv.test.ts

<!-- robobun:evidence:end -->
