### PR TITLE
test(serve): create the websocket client outside the scope that holds the server

### DIFF
--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -20,6 +20,7 @@ Use `bun:test` with files that end in `*.test.{ts,js,jsx,tsx,mjs,cjs}`. If it's 
 
 - **Do not write flaky tests**. Unless explicitly asked, **never wait for time to pass in tests**. Always wait for the condition to be met instead of waiting for an arbitrary amount of time. **Never use hardcoded port numbers**. Always use `port: 0` to get a random port.
 - **Prefer concurrent tests over sequential tests**: When multiple tests in the same file spawn processes or write files, make them concurrent with `test.concurrent` or `describe.concurrent` unless it's very difficult to make them concurrent.
+- **In a test that expects an object to be collected, the callbacks that run last must not share a scope with that object.** JSC scans the native stack conservatively, and a pointer to the JS function that native code called most recently (an event handler, a timer callback, a promise reaction) can stay in a live native frame for many event loop turns. A function keeps its whole scope alive, so a callback declared next to the object keeps the object alive too. Declare such callbacks in a scope that does not contain the object (see "server stays alive while a websocket is connected" in `test/js/bun/http/bun-server.test.ts`).
 
 ### Spawning processes
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -20,7 +20,6 @@ Use `bun:test` with files that end in `*.test.{ts,js,jsx,tsx,mjs,cjs}`. If it's 
 
 - **Do not write flaky tests**. Unless explicitly asked, **never wait for time to pass in tests**. Always wait for the condition to be met instead of waiting for an arbitrary amount of time. **Never use hardcoded port numbers**. Always use `port: 0` to get a random port.
 - **Prefer concurrent tests over sequential tests**: When multiple tests in the same file spawn processes or write files, make them concurrent with `test.concurrent` or `describe.concurrent` unless it's very difficult to make them concurrent.
-- **In a test that expects an object to be collected, the callbacks that run last must not share a scope with that object.** JSC scans the native stack conservatively, and a pointer to the JS function that native code called most recently (an event handler, a timer callback, a promise reaction) can stay in a live native frame for many event loop turns. A function keeps its whole scope alive, so a callback declared next to the object keeps the object alive too. Declare such callbacks in a scope that does not contain the object (see "server stays alive while a websocket is connected" in `test/js/bun/http/bun-server.test.ts`).
 
 ### Spawning processes
 

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3181,11 +3181,25 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
         const echoed = Promise.withResolvers();
         const closed = Promise.withResolvers();
 
-        // Scope server so the only post-stop root is the connected websocket.
-        // Assign client directly to the outer var rather than returning it —
-        // returning keeps the async frame's scope (which contains server)
-        // alive via the resolved-value chain in JSC.
+        // The client and its handlers are created here, outside the scope that
+        // holds server. The client's close handler is the last function native
+        // code calls before the measurement below, and a pointer to it stays on
+        // the native stack (conservatively scanned) for a while. Had it been
+        // created next to server, it would share server's scope and keep the
+        // server alive through that stale pointer, which is not what this test
+        // measures.
         let client;
+        function connect(url) {
+          client = new WebSocket(url);
+          client.onopen = () => clientOpen.resolve();
+          client.onmessage = e => echoed.resolve(e.data);
+          client.onclose = () => closed.resolve();
+        }
+
+        // Scope server so the only post-stop root is the connected websocket.
+        // Nothing is returned from the arrow: a returned value would keep the
+        // async frame's scope (which contains server) alive via the
+        // resolved-value chain in JSC.
         await (async () => {
           const server = Bun.serve({
             port: 0,
@@ -3197,10 +3211,7 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
               message(ws, m) { ws.send(server.port + ":" + m); },
             },
           });
-          client = new WebSocket(server.url.href.replace("http", "ws"));
-          client.onopen = () => clientOpen.resolve();
-          client.onmessage = e => echoed.resolve(e.data);
-          client.onclose = () => closed.resolve();
+          connect(server.url.href.replace("http", "ws"));
           await opened.promise;      // server-side ws created (roots wrapper)
           await clientOpen.promise;  // client ready to send (avoid InvalidStateError)
           server.stop(); // graceful — listener gone, ws stays


### PR DESCRIPTION
### Problem
- `bun-server.test.ts` "server stays alive while a websocket is connected, then collects after close" fails on every Windows x64 run since b7b4ddda1b (#39732): `afterClose` is 2, expected 1.
- The server survives through the client's `onclose` handler, whose scope holds `server`. A GC debugging snapshot shows no retainer for the handler. Its address sits in a slot of `uv_run`'s frame that nothing writes, and `uv_run` is live during every GC the test runs. #39732 moved the stale copy there. The test structure is the latent cause.

### Fix
- Create the client and its handlers in a function outside the scope that holds `server`. The stale pointer then retains nothing the test measures. The server side of the test is unchanged.
- Correct because the surviving reference came from the test, not from the code under test. `whileConnected > baseline` still holds through the `ServerWebSocket` root.
- Verified with the b7b4ddda1b Windows x64 CI `bun.exe`: main's test fails 3 of 3 runs, the fixed test passes 5 of 5, the whole file passes. The gate cannot show the failure: it needs the Windows release layout.

### Background
- JSC scans the native stack conservatively. `sanitizeStack` zeroes dead stack below the stack pointer, not a stale word inside a live frame.
- A function keeps the scope it was created in alive, so a pointer to any function created next to `server` keeps `server` alive.
- The close event runs from a tick-level task, so its callee's address lands where the next tick's `uv_run` frame sits. Server-side handlers run inside `uv_run`, deeper.

<details><summary>Notes</summary>

Evidence, taken with the b7b4ddda1b Windows x64 CI artifacts (`bun.exe` is byte-identical to `bun-profile.exe`, so its PDB applies). Every step ran in the same synchronous JS turn as a `fullGC()` that kept the server alive.

1. `require("bun:jsc").generateHeapSnapshotForDebugging()`: the retained `DebugHTTPServer` instance has one incoming edge, `Variable "server"` from a `JSLexicalEnvironment`. That environment's only live referrer is the `Function` of the client's `onclose` handler (named `clientOnClose` for the experiment). The function has zero incoming edges and no `roots` entry. Neither the server cell nor the environment is on the stack.

2. Stack walk (frame records through the JS frames, then `RtlLookupFunctionEntry` and `RtlVirtualUnwind`), 30 frames from the ffi host function to the thread start, symbolized with `llvm-symbolizer` against the PDB. The function's address is on the live stack exactly once, inside frame 16: `uv_run`, `vendor/libuv/src/win/core.c:815` (the `uv__run_timers` call after poll), frame size 0x1110, word at frame offset 0xa40. Below it: `uv__run_timers`, the `Bun.sleep` timer fire, `EventLoop::exit` draining microtasks, `runInternalMicrotask`, `asyncModuleExecutionResume`, the test's JS. Above it: `tick_with_timeout`, `wait_for_promise`, `run_command`, `main`.

3. Disassembly of `uv_run`: 8 pushes plus 0x10c8 bytes, 0x1110 in total, matching the walk. The inlined `uv__poll` passes its `OVERLAPPED_ENTRY overlappeds[128]` to `GetQueuedCompletionStatusEx` at `rsp+0x70` with count 0x80. Offset 0xa40 is array byte 0x9d0: entry 78, field offset 16, `Internal`. The array is never initialized. Only a poll that returns 79 or more completions writes that slot.

4. The fixed script on the same binary collects the server on the first attempt, 8 of 8 runs. The stale copy of the close handler is still on the stack (in that stack shape it sits in `runInternalMicrotask`'s frame). It now retains only the handler and its own scope. This is why the fix is in the test and not in libuv: the array is the largest window, not the only one.

5. The 1b88ad323b binary passes both versions. Main build 102067 (1b88ad323b) was green on this lane, 102154 (b7b4ddda1b) red, and #39732's own builds 102053 and 102077 were red on it before merge.

6. Whole-file run with the fixed file and the b7b4ddda1b binary: 79 pass, 1 skip, 0 fail. On Linux, `bun bd test test/js/bun/http/bun-server.test.ts -t "handler GC tracing"`: 10 pass.

#39858 changes the same test differently and does not address the chain above. #39882 adds the diagnosis rule this followed. A runtime mitigation (for example a `sanitizeStackForVM` call from the event loop before it polls) would have a per-tick cost and is a separate decision.

</details>
