### PR TITLE
install: back off between retries (honour Retry-After), don't halve concurrency on the first network error

### DIFF
--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -140,7 +140,25 @@ impl AnyEventLoop {
         context: *mut core::ffi::c_void,
         is_done: fn(*mut core::ffi::c_void) -> bool,
     ) {
+        // SAFETY: forwarded contract.
+        unsafe { Self::tick_raw_with_deadline(this, context, is_done, |_| None) }
+    }
+
+    /// `tick_raw` with an optional per-iteration upper bound on how long the loop may
+    /// block waiting for I/O: `max_block_ms(context)` is consulted before each tick and,
+    /// when it returns `Some(ms)`, the Mini loop wakes after at most `ms` even if no
+    /// socket is ready (the JS loop already has its own timers).
+    ///
+    /// # Safety
+    /// Same as `tick_raw`.
+    pub unsafe fn tick_raw_with_deadline(
+        this: *mut Self,
+        context: *mut core::ffi::c_void,
+        is_done: fn(*mut core::ffi::c_void) -> bool,
+        max_block_ms: fn(*mut core::ffi::c_void) -> Option<u64>,
+    ) {
         while !is_done(context) {
+            let bound = max_block_ms(context);
             // SAFETY: per fn contract — reborrow strictly after `is_done`
             // returns; the borrow ends at the bottom of this loop body before
             // the next `is_done` call.
@@ -155,7 +173,10 @@ impl AnyEventLoop {
                     // `&mut mini` across `is_done`. A single `tick_once`
                     // borrow ends at the bottom of this match arm before the
                     // next `is_done` reborrow.
-                    mini.tick_once(context);
+                    match bound {
+                        Some(ms) => mini.tick_once_with_timeout(context, ms),
+                        None => mini.tick_once(context),
+                    }
                 }
             }
         }

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -320,6 +320,31 @@ impl MiniEventLoop {
         }
     }
 
+    /// Like `tick_once` but never blocks longer than `timeout_ms` waiting for I/O.
+    /// Used by callers that keep their own deadlines (e.g. install retry backoff)
+    /// and must run again even if no socket becomes ready.
+    #[inline]
+    pub fn tick_once_with_timeout(&mut self, context: *mut c_void, timeout_ms: u64) {
+        if self.tick_concurrent_with_count() == 0 && self.tasks.readable_length() == 0 {
+            let ts = bun_core::Timespec {
+                sec: i64::try_from(timeout_ms / 1000).unwrap_or(i64::MAX),
+                nsec: i64::try_from((timeout_ms % 1000) * 1_000_000).unwrap_or(0),
+            };
+            // SAFETY: see `loop_ptr()` invariant.
+            unsafe {
+                (*self.loop_ptr()).inc();
+                (*self.loop_ptr()).tick_with_timeout(Some(&ts), 0 /* NOW_NS_UNKNOWN */);
+                (*self.loop_ptr()).dec();
+            }
+            self.on_after_event_loop();
+        }
+
+        while let Some(task) = self.tasks.read_item() {
+            // SAFETY: see tick_once.
+            unsafe { (*task).run(context) };
+        }
+    }
+
     pub(crate) fn tick_without_idle(&mut self, context: *mut c_void) {
         loop {
             let _ = self.tick_concurrent_with_count();

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -990,10 +990,7 @@ impl PackageManager {
         // SAFETY: `this` is valid per fn contract; `&raw mut` does not create a
         // reference, only a place projection.
         let event_loop: *mut AnyEventLoop = unsafe { &raw mut (*this).event_loop };
-        // SAFETY: `tick_raw` reborrows `*event_loop` only between `is_done`
-        // calls (never across them), so the callback's `&mut PackageManager`
-        // never overlaps a live `&mut AnyEventLoop`.
-        fn retry_deadline<C>(_p: *mut c_void) -> Option<u64> {
+        fn retry_deadline(_p: *mut c_void) -> Option<u64> {
             // Retry backoff deadlines are the only timer the install loop keeps: when any
             // are pending, never block in the socket loop past the earliest one.
             let pm = PackageManager::get();
@@ -1003,12 +1000,15 @@ impl PackageManager {
                 .map(|(t, _)| t.saturating_sub(now).max(1))
                 .min()
         }
+        // SAFETY: `tick_raw_with_deadline` reborrows `*event_loop` only between
+        // `is_done` calls (never across them), so the callback's `&mut PackageManager`
+        // never overlaps a live `&mut AnyEventLoop`.
         unsafe {
             AnyEventLoop::tick_raw_with_deadline(
                 event_loop,
                 (&raw mut erased).cast::<c_void>(),
                 trampoline::<C>,
-                retry_deadline::<C>,
+                retry_deadline,
             )
         };
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -359,6 +359,9 @@ pub struct PackageManager {
     pub(crate) network_tarball_batch: thread_pool::Batch,
     pub(crate) network_resolve_batch: thread_pool::Batch,
     pub(crate) network_task_fifo: NetworkQueue,
+    /// Network tasks waiting out a retry backoff: (not-before ms timestamp, task).
+    /// Drained into `network_task_fifo` by `flush_due_retries` (see runTasks).
+    pub(crate) retry_queue: Vec<(u64, *mut NetworkTask)>,
     pub(crate) patch_apply_batch: thread_pool::Batch,
     pub(crate) patch_calc_hash_batch: thread_pool::Batch,
     pub(crate) patch_task_fifo: PatchTaskFifo,
@@ -990,11 +993,22 @@ impl PackageManager {
         // SAFETY: `tick_raw` reborrows `*event_loop` only between `is_done`
         // calls (never across them), so the callback's `&mut PackageManager`
         // never overlaps a live `&mut AnyEventLoop`.
+        fn retry_deadline<C>(_p: *mut c_void) -> Option<u64> {
+            // Retry backoff deadlines are the only timer the install loop keeps: when any
+            // are pending, never block in the socket loop past the earliest one.
+            let pm = PackageManager::get();
+            let now = bun_core::time::milli_timestamp().max(0) as u64;
+            pm.retry_queue
+                .iter()
+                .map(|(t, _)| t.saturating_sub(now).max(1))
+                .min()
+        }
         unsafe {
-            AnyEventLoop::tick_raw(
+            AnyEventLoop::tick_raw_with_deadline(
                 event_loop,
                 (&raw mut erased).cast::<c_void>(),
                 trampoline::<C>,
+                retry_deadline::<C>,
             )
         };
     }
@@ -2040,6 +2054,7 @@ pub fn init(
             }
         );
         wr!(network_task_fifo, NetworkQueue::init());
+        wr!(retry_queue, Vec::new());
         wr!(patch_task_fifo, PatchTaskFifo::init());
         wr!(log, ctx.log);
         wr!(root_dir, entries_option);
@@ -2483,6 +2498,7 @@ fn init_with_runtime_once(
             }
         );
         wr!(network_task_fifo, NetworkQueue::init());
+        wr!(retry_queue, Vec::new());
         wr!(log, std::ptr::from_mut(log));
         wr!(root_dir, root_dir);
         wr!(ast_arena, bun_alloc::Arena::new());

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -570,6 +570,57 @@ pub fn enqueue_network_task(this: &mut PackageManager, task: *mut NetworkTask) {
     this.network_task_fifo.write_item_assume_capacity(task);
 }
 
+/// Backoff before retry `attempt` (1-based): 250ms, 500ms, 1s, 2s, 4s… capped at 10s,
+/// with ±20% jitter so a fleet of installs doesn't retry in lockstep. A `Retry-After`
+/// hint (seconds) from the server wins when larger.
+pub fn retry_backoff_ms(attempt: u16, retry_after_secs: Option<u32>) -> u64 {
+    let base: u64 = 250u64.saturating_mul(1u64 << (attempt.saturating_sub(1).min(6) as u64));
+    let base = base.min(10_000);
+    let jitter = (bun_core::fast_random() % (base / 5 + 1)) as i64 - (base / 10) as i64;
+    let ms = (base as i64 + jitter).max(50) as u64;
+    match retry_after_secs {
+        Some(s) => ms.max(u64::from(s).saturating_mul(1000).min(60_000)),
+        None => ms,
+    }
+}
+
+/// Re-enqueue `task` after a backoff instead of immediately: registries answer 429/5xx
+/// under load and an instant retry storm only makes it worse.
+pub fn enqueue_network_task_for_retry(
+    this: &mut PackageManager,
+    task: *mut NetworkTask,
+    attempt: u16,
+    retry_after_secs: Option<u32>,
+) {
+    let delay = retry_backoff_ms(attempt, retry_after_secs);
+    let not_before = (bun_core::time::milli_timestamp().max(0) as u64).saturating_add(delay);
+    this.retry_queue.push((not_before, task));
+}
+
+/// Move retries whose backoff elapsed into the network fifo. Returns how many are
+/// still waiting (callers use it to keep the loop alive).
+pub fn flush_due_retries(this: &mut PackageManager) -> usize {
+    if this.retry_queue.is_empty() {
+        return 0;
+    }
+    let now = bun_core::time::milli_timestamp().max(0) as u64;
+    let mut i = 0;
+    while i < this.retry_queue.len() {
+        if this.retry_queue[i].0 <= now {
+            let (_, task) = this.retry_queue.swap_remove(i);
+            if this.network_task_fifo.writable_length() == 0 {
+                // fifo full: put it back and let the caller's flush drain first
+                this.retry_queue.push((0, task));
+                break;
+            }
+            this.network_task_fifo.write_item_assume_capacity(task);
+        } else {
+            i += 1;
+        }
+    }
+    this.retry_queue.len()
+}
+
 /// Hands the task to the patch-task fifo as a raw pointer; it is reclaimed once
 /// in `run_tasks` after the thread pool pushes it onto `patch_task_queue`.
 pub fn enqueue_patch_task(this: &mut PackageManager, task: Box<PatchTask>) {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -576,7 +576,8 @@ pub fn enqueue_network_task(this: &mut PackageManager, task: *mut NetworkTask) {
 pub fn retry_backoff_ms(attempt: u16, retry_after_secs: Option<u32>) -> u64 {
     let base: u64 = 250u64.saturating_mul(1u64 << (attempt.saturating_sub(1).min(6) as u64));
     let base = base.min(10_000);
-    let jitter = (bun_core::fast_random() % (base / 5 + 1)) as i64 - (base / 10) as i64;
+    // uniform in [-base/5, +base/5]
+    let jitter = (bun_core::fast_random() % (2 * (base / 5) + 1)) as i64 - (base / 5) as i64;
     let ms = (base as i64 + jitter).max(50) as u64;
     match retry_after_secs {
         Some(s) => ms.max(u64::from(s).saturating_mul(1000).min(60_000)),

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -285,6 +285,12 @@ fn run_tasks_erased(
         }
     };
 
+    // retries whose backoff has elapsed go back on the wire first
+    if !manager.retry_queue.is_empty() {
+        manager.flush_network_queue();
+        let _ = manager.schedule_tasks();
+    }
+
     let patch_tasks_batch = manager.patch_task_queue.pop_batch();
     let mut patch_tasks_iter = patch_tasks_batch.iterator();
     loop {
@@ -469,13 +475,17 @@ fn run_tasks_erased(
                     }
                 }
 
-                if !has_network_error && task.response.metadata.is_none() {
+                // Connection-level failure (no HTTP response at all). One blip should not
+                // throttle the whole install: only after the SAME request has failed twice
+                // do we assume the link is saturated and shed 25% of concurrency (once per
+                // run_tasks pass, never below the floor).
+                if !has_network_error && task.response.metadata.is_none() && task.retried >= 1 {
                     has_network_error = true;
                     let min = manager.options.min_simultaneous_requests;
                     let max = AsyncHTTP::max_simultaneous_requests().load(Ordering::Relaxed);
                     if max > min {
                         AsyncHTTP::max_simultaneous_requests()
-                            .store(min.max(max / 2), Ordering::Relaxed);
+                            .store(min.max(max - max / 4), Ordering::Relaxed);
                     }
                 }
 
@@ -498,7 +508,13 @@ fn run_tasks_erased(
 
                     if task.retried < manager.options.max_retry_count {
                         task.retried += 1;
-                        enqueue::enqueue_network_task(manager, task_ptr);
+                        let retry_after = retry_after_secs(task);
+                        enqueue::enqueue_network_task_for_retry(
+                            manager,
+                            task_ptr,
+                            task.retried,
+                            retry_after,
+                        );
 
                         if manager.options.log_level.is_verbose() {
                             bun_ast::add_warning_pretty!(
@@ -745,13 +761,17 @@ fn run_tasks_erased(
                 // arrives here is taking the buffered path.
                 debug_assert!(!task.streaming_committed);
 
-                if !has_network_error && task.response.metadata.is_none() {
+                // Connection-level failure (no HTTP response at all). One blip should not
+                // throttle the whole install: only after the SAME request has failed twice
+                // do we assume the link is saturated and shed 25% of concurrency (once per
+                // run_tasks pass, never below the floor).
+                if !has_network_error && task.response.metadata.is_none() && task.retried >= 1 {
                     has_network_error = true;
                     let min = manager.options.min_simultaneous_requests;
                     let max = AsyncHTTP::max_simultaneous_requests().load(Ordering::Relaxed);
                     if max > min {
                         AsyncHTTP::max_simultaneous_requests()
-                            .store(min.max(max / 2), Ordering::Relaxed);
+                            .store(min.max(max - max / 4), Ordering::Relaxed);
                     }
                 }
 
@@ -776,8 +796,14 @@ fn run_tasks_erased(
                         // Streaming never committed (asserted above), so
                         // the pre-allocated stream is safe to reuse for
                         // the retry attempt.
+                        let retry_after = retry_after_secs(task);
                         task.reset_streaming_for_retry();
-                        enqueue::enqueue_network_task(manager, task_ptr);
+                        enqueue::enqueue_network_task_for_retry(
+                            manager,
+                            task_ptr,
+                            task.retried,
+                            retry_after,
+                        );
 
                         if manager.options.log_level.is_verbose() {
                             bun_ast::add_warning_pretty!(
@@ -1678,7 +1704,10 @@ fn run_tasks_erased(
 
 #[inline]
 pub fn pending_task_count(manager: &PackageManager) -> u32 {
-    manager.pending_tasks.load(Ordering::Acquire)
+    // Retries waiting out their backoff are pending work too (they were decremented
+    // when their failed attempt was processed and are re-counted by `schedule_tasks`
+    // once flushed back onto the wire).
+    manager.pending_tasks.load(Ordering::Acquire) + manager.retry_queue.len() as u32
 }
 
 #[inline]
@@ -1711,6 +1740,7 @@ impl PackageManager {
 }
 
 pub fn flush_network_queue(this: &mut PackageManager) {
+    enqueue::flush_due_retries(this);
     while let Some(network_task) = this.network_task_fifo.read_item() {
         // SAFETY: fifo stores live `*mut NetworkTask` pushed by
         // `enqueue_network_task`; exclusive ownership transferred here.
@@ -2089,4 +2119,14 @@ fn process_dependency_list_for_ctx(
         },
         install_peer,
     )
+}
+
+/// `Retry-After: <seconds>` from a 429/503 response, if present and sane.
+fn retry_after_secs(task: &NetworkTask) -> Option<u32> {
+    let md = task.response.metadata.as_ref()?;
+    let v = md
+        .header(b"retry-after")
+        .or_else(|| md.header(b"Retry-After"))?;
+    let s = core::str::from_utf8(v).ok()?.trim();
+    s.parse::<u32>().ok().filter(|n| *n <= 120)
 }

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -459,21 +459,21 @@ it("backs off between retries and honours Retry-After", async () => {
     });
   });
   await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
-  const { stderr, exited } = spawn({
+  await using proc = spawn({
     cmd: [bunExe(), "add", "BaR", "--linker=hoisted"],
     cwd: package_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "ignore",
     stderr: "pipe",
     env,
   });
-  const err = await stderr.text();
+  const [, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(err).not.toContain("error:");
   expect(err).toContain("Saved lockfile");
-  expect(await exited).toBe(0);
+  expect(code).toBe(0);
   expect(tarballHits.length).toBe(3);
   // Retry-After: 1 → at least ~1s before the second attempt
   expect(tarballHits[1] - tarballHits[0]).toBeGreaterThanOrEqual(900);
-  // second retry waits ~500ms ± jitter (never immediate)
-  expect(tarballHits[2] - tarballHits[1]).toBeGreaterThanOrEqual(150);
+  // second retry waits 500ms ± 20% (so ≥ 400ms; small allowance for timer granularity)
+  expect(tarballHits[2] - tarballHits[1]).toBeGreaterThanOrEqual(380);
 });

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -439,3 +439,41 @@ describe.each(["hoisted", "isolated"])("linker=%s", linker => {
     }
   });
 });
+
+// Retries are spaced out (exponential backoff) instead of fired back-to-back, and a
+// `Retry-After` header on a 429/503 is honoured.
+it("backs off between retries and honours Retry-After", async () => {
+  const tarballHits: number[] = [];
+  setHandler(async request => {
+    const { pathname } = new URL(request.url);
+    if (pathname.endsWith(".tgz")) {
+      tarballHits.push(performance.now());
+      if (tarballHits.length === 1) return new Response("busy", { status: 503, headers: { "Retry-After": "1" } });
+      if (tarballHits.length === 2) return new Response("oops", { status: 500 });
+      return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+    }
+    return Response.json({
+      name: "BaR",
+      versions: { "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } } },
+      "dist-tags": { latest: "0.0.2" },
+    });
+  });
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "BaR", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(err).toContain("Saved lockfile");
+  expect(await exited).toBe(0);
+  expect(tarballHits.length).toBe(3);
+  // Retry-After: 1 → at least ~1s before the second attempt
+  expect(tarballHits[1] - tarballHits[0]).toBeGreaterThanOrEqual(900);
+  // second retry waits ~500ms ± jitter (never immediate)
+  expect(tarballHits[2] - tarballHits[1]).toBeGreaterThanOrEqual(150);
+});


### PR DESCRIPTION
### What does this PR do?

Makes `bun install`'s network retry behaviour friendlier to flaky links and rate-limiting registries:

- **Backoff between retries.** Failed manifest and tarball requests used to be re-enqueued immediately (up to 5 attempts back to back). They now wait `250ms · 2^n` with ±20% jitter, capped at 10s, and a `Retry-After` header on a 429/503 response is honoured when it asks for longer.
- **No more global slowdown after one blip.** Previously the *first* connection-level failure of *any* request halved `max_simultaneous_requests` (down to a floor of 4) for the remainder of the install. Now concurrency is only reduced — by 25%, at most once per `run_tasks` pass — after the *same* request has failed at the connection level twice.

Implementation notes:
- Pending retries live in a small `retry_queue` on the `PackageManager` (`(not_before_ms, *mut NetworkTask)`), are counted by `pending_task_count()`, and are flushed back onto the network fifo by `flush_network_queue` once due.
- So that an "only retries are pending" state can't park forever in the socket loop, `sleep_until` now goes through a new `AnyEventLoop::tick_raw_with_deadline` / `MiniEventLoop::tick_once_with_timeout`, which bounds each tick by the earliest retry deadline (no behaviour change while the queue is empty).

### How did you verify your code works?

- New test in `test/cli/install/bun-install-retry.test.ts` (`backs off between retries and honours Retry-After`): a registry that answers the tarball with `503 + Retry-After: 1`, then `500`, then `200`; asserts the install succeeds, that ≥ ~1s elapses before the second attempt and that the third attempt is not immediate.
- Existing retry tests in that file still pass (they take a little longer now that retries are spaced out).
