### PR TITLE
install: compile hoist patterns on first match so config load does not initialize JSC

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1544,9 +1544,7 @@ impl<'a> Parser<'a> {
         let remap = |e: FromExprError| -> crate::Error {
             match e {
                 FromExprError::OutOfMemory => crate::Error::Alloc(bun_alloc::AllocError),
-                FromExprError::UnexpectedExpr | FromExprError::InvalidRegExp => {
-                    crate::Error::InvalidBunfig
-                }
+                FromExprError::UnexpectedExpr => crate::Error::InvalidBunfig,
             }
         };
         if let Some(public_hoist_pattern_expr) = install_obj.get(b"publicHoistPattern") {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1500,8 +1500,7 @@ mod draft {
                 match pnpm_matcher_from_expr(&public_hoist_pattern_expr, log, source, bump) {
                     Ok(v) => Some(v),
                     Err(FromExprError::OutOfMemory) => return Err(AllocError),
-                    Err(_) => {
-                        // error.InvalidRegExp, error.UnexpectedExpr
+                    Err(FromExprError::UnexpectedExpr) => {
                         log.reset();
                         None
                     }
@@ -1513,8 +1512,7 @@ mod draft {
                 match pnpm_matcher_from_expr(&hoist_pattern_expr, log, source, bump) {
                     Ok(v) => Some(v),
                     Err(FromExprError::OutOfMemory) => return Err(AllocError),
-                    Err(_) => {
-                        // error.InvalidRegExp, error.UnexpectedExpr
+                    Err(FromExprError::UnexpectedExpr) => {
                         log.reset();
                         None
                     }
@@ -1633,8 +1631,8 @@ mod draft {
     }
 
     use bun_install_types::NodeLinker::{
-        Behavior as PnpmBehavior, CreateMatcherError, FromExprError, Matcher as PnpmMatcherEntry,
-        PnpmMatcher, create_matcher,
+        Behavior as PnpmBehavior, FromExprError, Matcher as PnpmMatcherEntry, PnpmMatcher,
+        create_matcher,
     };
 
     /// `PnpmMatcher.fromExpr` operating on
@@ -1651,11 +1649,6 @@ mod draft {
         source: &Source,
         bump: &Arena,
     ) -> Result<PnpmMatcher, FromExprError> {
-        let mut buf: Vec<u8> = Vec::new();
-
-        // bun.jsc.initialize(false) is performed lazily inside the regex vtable
-        // compile hook (tier-6 owns it).
-
         let mut matchers: Vec<PnpmMatcherEntry> = Vec::new();
         let mut has_include = false;
         let mut has_exclude = false;
@@ -1663,23 +1656,7 @@ mod draft {
         match &expr.data {
             ExprData::EString(s) => {
                 let mut s = *s;
-                let pattern = s.slice(bump);
-                let matcher = match create_matcher(pattern, &mut buf) {
-                    Ok(m) => m,
-                    Err(CreateMatcherError::OutOfMemory) => return Err(FromExprError::OutOfMemory),
-                    Err(CreateMatcherError::InvalidRegExp) => {
-                        log.add_error_fmt_opts(
-                            format_args!("Invalid regex: {}", bstr::BStr::new(pattern)),
-                            bun_ast::AddErrorOptions {
-                                loc: expr.loc,
-                                redact_sensitive_information: true,
-                                source: Some(source),
-                                ..Default::default()
-                            },
-                        );
-                        return Err(FromExprError::InvalidRegExp);
-                    }
-                };
+                let matcher = create_matcher(s.slice(bump));
                 has_include = has_include || !matcher.is_exclude;
                 has_exclude = has_exclude || matcher.is_exclude;
                 matchers.push(matcher);
@@ -1687,24 +1664,7 @@ mod draft {
             ExprData::EArray(patterns) => {
                 for pattern_expr in patterns.items.slice() {
                     if let Some(pattern) = pattern_expr.as_string_cloned(bump)? {
-                        let matcher = match create_matcher(pattern, &mut buf) {
-                            Ok(m) => m,
-                            Err(CreateMatcherError::OutOfMemory) => {
-                                return Err(FromExprError::OutOfMemory);
-                            }
-                            Err(CreateMatcherError::InvalidRegExp) => {
-                                log.add_error_fmt_opts(
-                                    format_args!("Invalid regex: {}", bstr::BStr::new(pattern)),
-                                    bun_ast::AddErrorOptions {
-                                        loc: pattern_expr.loc,
-                                        redact_sensitive_information: true,
-                                        source: Some(source),
-                                        ..Default::default()
-                                    },
-                                );
-                                return Err(FromExprError::InvalidRegExp);
-                            }
-                        };
+                        let matcher = create_matcher(pattern);
                         has_include = has_include || !matcher.is_exclude;
                         has_exclude = has_exclude || matcher.is_exclude;
                         matchers.push(matcher);

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -73,6 +73,7 @@ pub mod npm {
 // (`__bun_regex_*`) defined `#[no_mangle]` in `bun_jsc::regular_expression`.
 // ══════════════════════════════════════════════════════════════════════════
 
+use core::cell::OnceCell;
 use core::ptr::NonNull;
 
 use bun_alloc::Arena;
@@ -85,42 +86,59 @@ use bun_core::{String as BunString, strings};
 // `bun_jsc::regular_expression`; declared here as `extern "Rust"` and
 // resolved at link time.
 unsafe extern "Rust" {
-    /// Compile `pattern` with no flags. `None` ⇔ `error.InvalidRegExp`.
-    /// Performs `jsc::initialize(false)` lazily on first call.
+    /// Compile `pattern` with no flags. `None` ⇔ the pattern does not compile.
+    /// Initializes JSC first (idempotent), so it must only run from
+    /// [`RegularExpression::matches`]; see the type's docs.
     fn __bun_regex_compile(pattern: BunString) -> Option<NonNull<()>>;
     fn __bun_regex_matches(regex: NonNull<()>, input: &BunString) -> bool;
     fn __bun_regex_drop(regex: NonNull<()>);
 }
 
-/// Owned, type-erased JSC regex; drops through the vtable.
+/// Owned, type-erased compiled JSC regex; drops through the vtable.
 // FORWARD_DECL(b0): bun_jsc::RegularExpression — stored as raw NonNull<()>
 // (NOT Box<ZST>: a zero-sized opaque Box is a dangling sentinel that would
 // leak the real JSC allocation and skip its destructor).
-pub struct RegularExpression(NonNull<()>);
+struct CompiledRegularExpression(NonNull<()>);
 
-impl RegularExpression {
-    #[inline]
-    fn matches(&self, input: &BunString) -> bool {
-        // SAFETY: self.0 was produced by `__bun_regex_compile`.
-        unsafe { __bun_regex_matches(self.0, input) }
-    }
-}
-
-impl Drop for RegularExpression {
+impl Drop for CompiledRegularExpression {
     fn drop(&mut self) {
         // SAFETY: self.0 was produced by `__bun_regex_compile`; runs JSC destructor + free.
         unsafe { __bun_regex_drop(self.0) }
     }
 }
 
-/// Compile `pattern` into a Yarr regex via the link-time extern. `pub` so
-/// higher-tier callers re-use this single declaration site instead of
-/// duplicating the `__bun_regex_*` extern block (one declarer per upward call,
-/// per PORTING.md §extern-Rust-ban).
-#[inline]
-fn compile_regex(pattern: BunString) -> Option<RegularExpression> {
-    // SAFETY: link-time extern; pattern ownership transfers.
-    unsafe { __bun_regex_compile(pattern) }.map(RegularExpression)
+/// A package-name pattern, compiled on first use.
+///
+/// Matchers are built while bunfig.toml / .npmrc load, before the command
+/// initializes JSC. `__bun_regex_compile` initializes JSC, and the first
+/// `jsc::initialize` of the process fixes JSC's options, so compiling here
+/// would drop the options the command passes later (`bun -p` needs eval mode
+/// to keep the script's completion value, `bun test --isolate` its JIT
+/// thresholds). Only the install linker matches, so compiling there leaves
+/// the first call to the command.
+pub struct RegularExpression {
+    /// The anchored pattern built by [`create_matcher`].
+    source: Box<[u8]>,
+    /// `None` if the pattern failed to compile; it then never matches. The
+    /// escaping in [`create_matcher`] leaves Yarr's pattern size limit as the
+    /// only way to fail.
+    compiled: OnceCell<Option<CompiledRegularExpression>>,
+}
+
+impl RegularExpression {
+    fn matches(&self, input: &BunString) -> bool {
+        let compiled = self.compiled.get_or_init(|| {
+            // SAFETY: link-time extern; pattern ownership transfers.
+            unsafe { __bun_regex_compile(BunString::clone_utf8(&self.source)) }
+                .map(CompiledRegularExpression)
+        });
+        match compiled {
+            // SAFETY: `regex.0` was produced by `__bun_regex_compile` and stays
+            // live until `regex` drops.
+            Some(regex) => unsafe { __bun_regex_matches(regex.0, input) },
+            None => false,
+        }
+    }
 }
 
 pub struct PnpmMatcher {
@@ -148,7 +166,6 @@ pub enum Behavior {
 #[derive(Debug, strum::IntoStaticStr)]
 pub enum FromExprError {
     OutOfMemory,
-    InvalidRegExp,
     UnexpectedExpr,
 }
 bun_core::impl_tag_error!(FromExprError);
@@ -166,14 +183,9 @@ impl PnpmMatcher {
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
     ) -> Result<PnpmMatcher, FromExprError> {
-        let mut buf: Vec<u8> = Vec::new();
         // Scratch arena for `E::String::slice` / `as_string_cloned`.
-        // Freed on return; the patterns are consumed by
-        // `create_matcher` before then.
+        // Freed on return; `create_matcher` copies the patterns before then.
         let arena = Arena::new();
-
-        // bun.jsc.initialize(false) is now performed lazily inside
-        // `__bun_regex_compile` (tier-6 owns it).
 
         let mut matchers: Vec<Matcher> = Vec::new();
         let mut has_include = false;
@@ -181,23 +193,7 @@ impl PnpmMatcher {
 
         match expr.data {
             ast::ExprData::EString(mut s) => {
-                let pattern = s.slice(&arena);
-                let matcher = match create_matcher(pattern, &mut buf) {
-                    Ok(m) => m,
-                    Err(CreateMatcherError::OutOfMemory) => return Err(FromExprError::OutOfMemory),
-                    Err(CreateMatcherError::InvalidRegExp) => {
-                        log.add_error_fmt_opts(
-                            format_args!("Invalid regex: {}", bstr::BStr::new(pattern)),
-                            bun_ast::AddErrorOptions {
-                                loc: expr.loc,
-                                redact_sensitive_information: true,
-                                source: Some(source),
-                                ..Default::default()
-                            },
-                        );
-                        return Err(FromExprError::InvalidRegExp);
-                    }
-                };
+                let matcher = create_matcher(s.slice(&arena));
                 has_include = has_include || !matcher.is_exclude;
                 has_exclude = has_exclude || matcher.is_exclude;
                 matchers.push(matcher);
@@ -205,24 +201,7 @@ impl PnpmMatcher {
             ast::ExprData::EArray(patterns) => {
                 for pattern_expr in patterns.slice() {
                     if let Some(pattern) = pattern_expr.as_string_cloned(&arena)? {
-                        let matcher = match create_matcher(pattern, &mut buf) {
-                            Ok(m) => m,
-                            Err(CreateMatcherError::OutOfMemory) => {
-                                return Err(FromExprError::OutOfMemory);
-                            }
-                            Err(CreateMatcherError::InvalidRegExp) => {
-                                log.add_error_fmt_opts(
-                                    format_args!("Invalid regex: {}", bstr::BStr::new(pattern)),
-                                    bun_ast::AddErrorOptions {
-                                        loc: pattern_expr.loc,
-                                        redact_sensitive_information: true,
-                                        source: Some(source),
-                                        ..Default::default()
-                                    },
-                                );
-                                return Err(FromExprError::InvalidRegExp);
-                            }
-                        };
+                        let matcher = create_matcher(pattern);
                         has_include = has_include || !matcher.is_exclude;
                         has_exclude = has_exclude || matcher.is_exclude;
                         matchers.push(matcher);
@@ -324,18 +303,7 @@ impl PnpmMatcher {
     }
 }
 
-#[derive(Debug, strum::IntoStaticStr)]
-pub enum CreateMatcherError {
-    OutOfMemory,
-    InvalidRegExp,
-}
-bun_core::impl_tag_error!(CreateMatcherError);
-
-bun_core::oom_from_alloc!(CreateMatcherError);
-
-pub fn create_matcher(raw: &[u8], buf: &mut Vec<u8>) -> Result<Matcher, CreateMatcherError> {
-    buf.clear();
-
+pub fn create_matcher(raw: &[u8]) -> Matcher {
     let mut trimmed = strings::trim(raw, &strings::WHITESPACE_CHARS);
 
     let mut is_exclude = false;
@@ -345,27 +313,24 @@ pub fn create_matcher(raw: &[u8], buf: &mut Vec<u8>) -> Result<Matcher, CreateMa
     }
 
     if trimmed == b"*" {
-        return Ok(Matcher {
+        return Matcher {
             pattern: Pattern::MatchAll,
             is_exclude,
-        });
+        };
     }
 
-    // Vec::push aborts on
-    // OOM under the global mimalloc allocator, so no error mapping is needed.
-    // `escape_reg_exp_*` writes through
-    // `io::Write` for `Vec<u8>`, which is infallible.
-    buf.push(b'^');
-    let _ = escape_reg_exp_for_package_name_matching(trimmed, buf);
-    buf.push(b'$');
+    // `escape_reg_exp_*` writes through `io::Write` for `Vec<u8>`, which is
+    // infallible.
+    let mut source: Vec<u8> = Vec::with_capacity(trimmed.len() + 2);
+    source.push(b'^');
+    let _ = escape_reg_exp_for_package_name_matching(trimmed, &mut source);
+    source.push(b'$');
 
-    // `__bun_regex_compile` is a link-time extern (cold path) and performs
-    // `jsc::initialize(false)` before compiling.
-    let regex = compile_regex(BunString::clone_utf8(buf.as_slice()))
-        .ok_or(CreateMatcherError::InvalidRegExp)?;
-
-    Ok(Matcher {
-        pattern: Pattern::Regex(regex),
+    Matcher {
+        pattern: Pattern::Regex(RegularExpression {
+            source: source.into_boxed_slice(),
+            compiled: OnceCell::new(),
+        }),
         is_exclude,
-    })
+    }
 }

--- a/src/jsc/RegularExpression.rs
+++ b/src/jsc/RegularExpression.rs
@@ -91,7 +91,9 @@ impl RegularExpression {
 
 #[unsafe(no_mangle)]
 fn __bun_regex_compile(pattern: BunString) -> Option<core::ptr::NonNull<()>> {
-    // Initialize JSC before first compile (idempotent).
+    // Idempotent. `bun install` never initializes JSC otherwise; every other
+    // command has already done so with its own options by the time the
+    // matcher first runs (see `bun_install_types::NodeLinker::RegularExpression`).
     crate::initialize(false);
     match RegularExpression::init(pattern, Flags::None) {
         Ok(r) => core::ptr::NonNull::new(r.cast()),

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,7 +1,7 @@
 import { SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
 
@@ -172,6 +172,34 @@ describe("--print for cjs/esm", () => {
     });
     expect(stdout.toString()).toBe("true\n");
     expect(exitCode).toBe(0);
+  });
+
+  // The hoist patterns in [install] are regexes. Compiling them while
+  // bunfig.toml loaded initialized JSC before `bun -p` could turn on eval
+  // mode, so the script's completion value was dropped and every --print
+  // printed undefined.
+  describe.each(["hoistPattern", "publicHoistPattern"])("with install.%s in bunfig.toml", key => {
+    test.concurrent.each([
+      { expr: "Math.max(1, 9)", expected: "9" },
+      { expr: "[1, 2].map(x => x * 2)", expected: "[ 2, 4 ]" },
+      { expr: "1 + 1", expected: "2" },
+      { expr: "(await 1) + 1", expected: "2" },
+    ])("bun -p $expr", async ({ expr, expected }) => {
+      using dir = tempDir("eval-install-pattern", {
+        "bunfig.toml": `[install]\n${key} = ["*eslint*", "!eslint-plugin-*"]\n`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-p", expr],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(`${expected}\n`);
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -475,6 +475,34 @@ describe.concurrent("bun test --isolate", () => {
   });
 });
 
+// --isolate raises JSC's FTL warm-up threshold. JSC options are set once per
+// process, by whoever initializes JSC first. The [install] hoist patterns are
+// regexes, and compiling them while bunfig.toml loaded used to initialize JSC
+// with the default options before `bun test` could pass its own.
+test.concurrent("--isolate: JSC options survive a bunfig.toml with an install hoist pattern", async () => {
+  using dir = tempDir("isolate-bunfig-hoist-pattern", {
+    "bunfig.toml": `[install]\nhoistPattern = ["*eslint*"]\n`,
+    "a.test.ts": `
+      import { test, expect } from "bun:test";
+      test("passes", () => {
+        expect(1).toBe(1);
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate", "./a.test.ts"],
+    env: { ...bunEnv, BUN_JSC_dumpOptions: "2" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const threshold = stderr.split("\n").find(line => line.includes("thresholdForFTLOptimizeAfterWarmUp="));
+  expect(threshold?.trim()).toBe("thresholdForFTLOptimizeAfterWarmUp=1000000");
+  expect(normalizeBunSnapshot(stderr, dir)).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});
+
 // The eviction test below proves the SourceProvider cache is active (control:
 // b sees stale v1 → cache hit) and that delete require.cache evicts it
 // (treatment: b sees fresh v2). A/B timing was removed as flaky; this is the


### PR DESCRIPTION
### Problem
- With `[install] hoistPattern` or `publicHoistPattern` in the project's `bunfig.toml`, `bun -p '1 + 1'` prints `undefined`. Every `--print` value is lost. `bun test --isolate` there keeps the default FTL threshold (64000, not 1000000).
- Cause: `create_matcher` (`src/install_types/NodeLinker.rs`) compiled each pattern while the config loaded. `__bun_regex_compile` (`src/jsc/RegularExpression.rs`) calls `jsc::initialize` first, without `eval_mode` or `short_lived_globals`. `JSCInitialize` applies its options once per process, so the command's own call later (`run_command.rs:941`, `TestCommand::exec`) did nothing.

### Fix
- `RegularExpression` in `NodeLinker.rs` stores the escaped pattern and compiles it in `matches`, through a `OnceCell`. `create_matcher` no longer touches JSC. The other hunks remove the error type only the eager compile could produce.
- Correct because only the install linker calls `is_match` (`build_store`, `prune.rs`). A command that runs JS has initialized JSC with its own options before then. `bun install` never does otherwise, so `__bun_regex_compile` still initializes JSC, now with the defaults (Notes on #39880).
- Two other visible changes. Commands that never run JS (`bun run <script>`, a `bun install` that does not reach the isolated linker) no longer initialize JSC when a hoist pattern is configured. And since the escaping makes every metacharacter literal, Yarr rejects a pattern only above its 1 MiB size limit: such a pattern now never matches instead of failing the config load.
- Verified: `test/cli/run/run-eval.test.ts` (8 new cases) and `test/cli/test/isolation.test.ts` (1 new case) fail on bun 1.4.0 and pass here. The install pattern suites pass too (Notes).

### Background
- `PnpmMatcher` is the include/exclude list behind the bunfig and `.npmrc` hoist patterns. Each entry is a Yarr regex. Run and test commands parse `[install]` too, so every command builds it.
- `jsc::initialize` hands per-command options to `JSCInitialize`, which applies them inside `std::call_once`. Later calls are no-ops.
- `JSC::Options::evalMode` is a Bun addition to JSC. With it set, the bytecode generator keeps the completion value of module and function bodies. `bun -p` prints that value.

<details><summary>Notes</summary>

Layering: `bun_install_types` sits below `bun_jsc`, so it reaches Yarr through the link-time `__bun_regex_*` functions defined in `src/jsc/RegularExpression.rs`. That is why the JSC initialization lives in `__bun_regex_compile` and not in the matcher.

Probes with bun 1.4.0 in a directory whose `bunfig.toml` has `hoistPattern`:

```
$ bun -p 'Math.max(1, 9)'
undefined
$ bun -p 5
undefined
$ BUN_JSC_dumpOptions=2 bun -p 5 2>&1 | grep evalMode
   evalMode=false                      # evalMode=true without the bunfig
$ BUN_JSC_dumpOptions=2 bun test --isolate 2>&1 | grep thresholdForFTLOptimizeAfterWarmUp
   thresholdForFTLOptimizeAfterWarmUp=64000   # 1000000 without the bunfig
```

With this change both print `9` / `5`, `evalMode=true`, and the threshold is `1000000`. `.npmrc` `hoist-pattern` did not show the symptom because only install commands read `.npmrc`, but it builds the same matcher and gets the same lazy compile. The same goes for the global `~/.bunfig.toml`: `Tag::read_global_config` (`src/options_types/command_tag.rs`) is true only for the install family, so a hoist pattern there never affected `bun -p` or `bun test` (checked: with the pattern only in `$XDG_CONFIG_HOME/.bunfig.toml`, 1.4.0 prints `2` for `bun -p '1 + 1'`).

The side effect named in Fix, checked with `BUN_JSC_dumpOptions=1`, which prints a header when JSC initializes: `bun install` in a package with no dependencies and a hoist pattern in `.bunfig.toml` prints the header on 1.4.0 and nothing with this change. A self-review pass over the diff found nothing else to change in the code. It pointed out the two description errors fixed above, and suggested two follow-ups that this PR does not need: a JSC-free matcher for these `*` patterns, and a debug check in `jsc::initialize` for a later call that asks for options the first call did not set.

`bun -p 5` is affected too, not only calls: with `evalMode` off, JSC's `BytecodeGenerator` sets `m_defaultAllowCallIgnoreResultOptimization` for module and function code, and `SourceElements::emitBytecode` then never materializes a completion value.

The bug dates from the feature (#23567): the Zig `PnpmMatcher.fromExpr` called `bun.jsc.initialize(false)` eagerly. It is not a regression from the Rust port.

The removed error path: a pattern made of every regex metacharacter, `\`, `/`, newlines, and non-ASCII loads fine on 1.4.0, because `escape_reg_exp_for_package_name_matching` escapes all of them (`*` becomes `.*`). A 1.1 million character pattern is the one input that produced `error: Invalid regex` on 1.4.0 (and that error fired for `bun -p` too, which never uses the pattern). It now loads, and in `bun install` it never matches.

Related: #34869 moves the `bun test -t` regex compile after `jsc::initialize` in `test_command.rs`, a different pre-init compile, and does not overlap with this PR. #39880 (merged, synced into this branch in 2bcef5c) made `jsc::initialize` take `InitializeOptions` and had `__bun_regex_compile` pass `one_shot` from argv because the compile ran during config load. With the compile moved to the first match, that call is the first one only inside the install commands, where the scan returns false, so it passes the default like the other subcommand callers in #39880. Checked on the merged debug build in a hoistPattern directory: `bun -e` keeps `useConcurrentJIT=false`, `bun -p` gets `evalMode=true`, `bun test --isolate` gets the 1000000 threshold, and `test/bundler/compile-argv.test.ts` passes.

`is_match` runs on the main thread only (`build_store` is sequential), and the matcher types were already `!Send + !Sync` through the raw Yarr pointer, so the `OnceCell` changes no thread contract.

Suites run with the debug build: `test/cli/run/run-eval.test.ts` (45 pass), `test/cli/test/isolation.test.ts` (28 pass), `test/cli/install/public-hoist-pattern.test.ts` (14 pass, bunfig and `.npmrc` patterns), `test/cli/install/isolated-install.test.ts -t hoist` (6 pass), `test/cli/install/bun-prune.test.ts -t publicHoistPattern` (2 pass), `test/cli/install/config-precedence.test.ts` (51 pass), `test/cli/install/npmrc.test.ts` (40 pass).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->