### PR TITLE
node:async_hooks: do not inspect user stores in debug assertion messages

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -28,10 +28,8 @@ declare function $debug(...args: any[]): void;
  * error if the first argument is falsy.  The source code passed to `check` is
  * inlined in the message, but in addition you can pass additional messages.
  *
- * `message` is evaluated on every call and formatted only on failure. Pass
- * values as-is: `Bun.inspect()` of a user value runs user code on every call.
- *
  * @note gets removed in release builds. Do not put code with side effects in the `check`.
+ * @note the `message` arguments are evaluated on every call. Pass values, not `Bun.inspect(value)`.
  */
 declare function $assert(check: any, ...message: any[]): asserts check;
 

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -28,10 +28,8 @@ declare function $debug(...args: any[]): void;
  * error if the first argument is falsy.  The source code passed to `check` is
  * inlined in the message, but in addition you can pass additional messages.
  *
- * The `message` arguments are evaluated on every call, even when `check`
- * passes. They are only formatted (with console.warn) when it fails, so pass
- * values as-is instead of pre-formatting them with `Bun.inspect()`: inspecting
- * a user-provided value can run user code.
+ * `message` is evaluated on every call and formatted only on failure. Pass
+ * values as-is: `Bun.inspect()` of a user value runs user code on every call.
  *
  * @note gets removed in release builds. Do not put code with side effects in the `check`.
  */

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -28,6 +28,11 @@ declare function $debug(...args: any[]): void;
  * error if the first argument is falsy.  The source code passed to `check` is
  * inlined in the message, but in addition you can pass additional messages.
  *
+ * The `message` arguments are evaluated on every call, even when `check`
+ * passes. They are only formatted (with console.warn) when it fails, so pass
+ * values as-is instead of pre-formatting them with `Bun.inspect()`: inspecting
+ * a user-provided value can run user code.
+ *
  * @note gets removed in release builds. Do not put code with side effects in the `check`.
  */
 declare function $assert(check: any, ...message: any[]): asserts check;

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -33,12 +33,8 @@ function sameValue(a, b) {
   return a !== a && b !== b;
 }
 
-// Only run during debug
-//
-// The assertion messages below pass the array itself, never Bun.inspect(array):
-// $assert evaluates its message arguments on every call and only formats them
-// on failure. Inspecting the array eagerly would run user code (a store's
-// custom inspect hook) on every set(), and that code may re-enter run().
+// Only run during debug. The messages pass the array as-is: Bun.inspect() of a
+// user store would run its custom inspect hook on every set().
 function assertValidAsyncContextArray(array: unknown): array is ReadonlyArray<any> | undefined {
   // undefined is OK
   if (array === undefined) return true;
@@ -283,9 +279,7 @@ class AsyncLocalStorage {
           }
         }
         const expectedStore = hasPrevious ? previous_value : this.#defaultValue;
-        // Pass the store itself, not Bun.inspect(store): the message arguments
-        // are evaluated on every exit from run(), and inspecting a user store
-        // can run user code that re-enters run() (see assertValidAsyncContextArray).
+        // expectedStore goes in as-is, not Bun.inspect()ed: see assertValidAsyncContextArray.
         $assert(
           sameValue(this.getStore(), expectedStore),
           "run: previous_value",

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -34,19 +34,20 @@ function sameValue(a, b) {
 }
 
 // Only run during debug
+//
+// The assertion messages below pass the array itself, never Bun.inspect(array):
+// $assert evaluates its message arguments on every call and only formats them
+// on failure. Inspecting the array eagerly would run user code (a store's
+// custom inspect hook) on every set(), and that code may re-enter run().
 function assertValidAsyncContextArray(array: unknown): array is ReadonlyArray<any> | undefined {
   // undefined is OK
   if (array === undefined) return true;
   // Otherwise, it must be an array
-  $assert(
-    Array.isArray(array),
-    "AsyncContextData must be an array or undefined, got",
-    Bun.inspect(array, { depth: 1 }),
-  );
+  $assert(Array.isArray(array), "AsyncContextData must be an array or undefined, got", array);
   // the array has to be even
-  $assert(array.length % 2 === 0, "AsyncContextData should be even-length, got", Bun.inspect(array, { depth: 1 }));
+  $assert(array.length % 2 === 0, "AsyncContextData should be even-length, got", array);
   // if it is zero-length, use undefined instead
-  $assert(array.length > 0, "AsyncContextData should be undefined if empty, got", Bun.inspect(array, { depth: 1 }));
+  $assert(array.length > 0, "AsyncContextData should be undefined if empty, got", array);
   for (var i = 0; i < array.length; i += 2) {
     $assert(
       array[i] instanceof AsyncLocalStorage,
@@ -282,10 +283,13 @@ class AsyncLocalStorage {
           }
         }
         const expectedStore = hasPrevious ? previous_value : this.#defaultValue;
+        // Pass the store itself, not Bun.inspect(store): the message arguments
+        // are evaluated on every exit from run(), and inspecting a user store
+        // can run user code that re-enters run() (see assertValidAsyncContextArray).
         $assert(
           sameValue(this.getStore(), expectedStore),
           "run: previous_value",
-          Bun.inspect(expectedStore),
+          expectedStore,
           "was not restored, i see",
           this.getStore(),
         );

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -33,8 +33,7 @@ function sameValue(a, b) {
   return a !== a && b !== b;
 }
 
-// Only run during debug. The messages pass the array as-is: Bun.inspect() of a
-// user store would run its custom inspect hook on every set().
+// Only run during debug
 function assertValidAsyncContextArray(array: unknown): array is ReadonlyArray<any> | undefined {
   // undefined is OK
   if (array === undefined) return true;
@@ -279,7 +278,6 @@ class AsyncLocalStorage {
           }
         }
         const expectedStore = hasPrevious ? previous_value : this.#defaultValue;
-        // expectedStore goes in as-is, not Bun.inspect()ed: see assertValidAsyncContextArray.
         $assert(
           sameValue(this.getStore(), expectedStore),
           "run: previous_value",

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -230,7 +230,9 @@ describe("AsyncLocalStorage", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "store\nundefined\n", stderr: "", exitCode: 0 });
+    expect(stderr).toBe("");
+    expect(stdout).toBe("store\nundefined\n");
+    expect(exitCode).toBe(0);
   });
 
   // Same assertions, observed directly: the context array and the store that
@@ -270,7 +272,9 @@ describe("AsyncLocalStorage", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0\n", stderr: "", exitCode: 0 });
+    expect(stderr).toBe("");
+    expect(stdout).toBe("0\n");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -200,6 +200,78 @@ describe("AsyncLocalStorage", () => {
       alsA.disable();
     }
   });
+
+  // Debug builds assert that run() restored the previous store. The assertion
+  // message used to be built with Bun.inspect(previousStore) on every exit from
+  // run(), so a store whose custom inspect re-enters run() recursed until
+  // "Maximum call stack size exceeded". Release builds strip the assertions,
+  // so this only fails on a debug build. Subprocess: isolates the overflow.
+  test.concurrent("run() does not inspect a store whose custom inspect re-enters run()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { AsyncLocalStorage } = require("async_hooks");
+         const { inspect } = require("util");
+         const als = new AsyncLocalStorage();
+         const store = {
+           [inspect.custom]() {
+             return als.run("inner", () => "store");
+           },
+         };
+         als.run(store, () => {
+           als.run("nested", () => {});
+           console.log(inspect(store));
+         });
+         console.log(als.getStore());`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "store\nundefined\n", stderr: "", exitCode: 0 });
+  });
+
+  // Same assertions, observed directly: the context array and the store that
+  // run() restores (a previous value or the defaultValue) go into the debug
+  // assertions as values. Formatting them eagerly ran the store's custom
+  // inspect on every set() and every exit from run(). Debug builds only.
+  test.concurrent("never inspects the stores it holds", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { AsyncLocalStorage } = require("async_hooks");
+         let inspected = 0;
+         const store = {
+           [Symbol.for("nodejs.util.inspect.custom")]() {
+             inspected++;
+             return "store";
+           },
+         };
+         const als = new AsyncLocalStorage();
+         // store is in the context array and is the value the nested calls restore
+         als.run(store, () => {
+           als.run("nested", () => {});
+           als.exit(() => {});
+           als.getStore();
+         });
+         als.enterWith(store);
+         als.run("other", () => {});
+         als.disable();
+         // no previous value: run() checks that defaultValue is visible again
+         const withDefault = new AsyncLocalStorage({ defaultValue: store });
+         withDefault.run("value", () => {});
+         console.log(inspected);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0\n", stderr: "", exitCode: 0 });
+  });
 });
 
 test("AsyncResource", () => {


### PR DESCRIPTION
### Problem
- Debug builds only. `AsyncLocalStorage.run()` fails with `RangeError: Maximum call stack size exceeded` when the store it restores has a custom inspect hook that calls `run()` on the same storage. Release builds and Node print `ok`.
- The restore check in `run()` (`src/js/node/async_hooks.ts:288`) and `assertValidAsyncContextArray()` (lines 41 to 49) put `Bun.inspect()` of user stores in their `$assert` messages. Debug builds evaluate those on every `set()` and every exit from `run()`. A hook that re-enters `run()` exits through the same check, which inspects the same store again.

### Fix
- Pass the values themselves to `$assert`. The helper formats them only when a check fails. The checks do not change.
- Correct because `AsyncLocalStorage` must not observe the values it holds. Node never reads a store. A debug-build probe that counts hook calls went from 46 to 0, the release count.
- The `$assert` doc in `src/js/builtins.d.ts` now says that the message arguments are evaluated on every call.
- Verified: two new tests in `test/js/node/async_hooks/AsyncLocalStorage.test.ts`. Both fail on an unfixed debug build only, because release builds strip `$assert`. Also ran `test/js/node/async_hooks/`.

### Background
- The async context is one flat array, `[storage, store, ...]`. `set()` installs a new array. `run()` installs its store and restores the previous one in `finally`.
- `$assert(check, ...message)` is a build-time macro of the built-in JS modules. Release builds remove it. Debug builds call a helper that logs `message` and throws when `check` is false.
- `Bun.inspect()` calls an object's `[Symbol.for("nodejs.util.inspect.custom")]` method. A store is user data, so this runs user code.

<details><summary>Notes</summary>

Repro from the report. `bun bd x.js` fails with a stack that alternates `run (node:async_hooks:232)` and the hook. `bun x.js` (1.4.0) and `node x.js` print `ok`. A Next.js 16 standalone server dies the same way on its first request under `bun-debug`.

```js
const { AsyncLocalStorage } = require("node:async_hooks");
const als = new AsyncLocalStorage();
const store = {
  [Symbol.for("nodejs.util.inspect.custom")]() {
    return als.run("inner", () => "store");
  },
};
als.run(store, () => {
  als.run("nested", () => {});
});
console.log("ok");
```

Why it never ends: `run("nested")` exits with `previous_value === store`, so the restore check inspects `store`. The hook calls `run("inner")`. The context holds `store` at that point, so `run("inner")` takes the full path and inspects `store` again on exit. Each level is in the same state as the level above it.

A user call of `util.inspect(store)` inside `als.run(store, ...)` starts the same loop. The first new test covers both triggers. The second test counts hook calls across `run()`, nested `run()`, `exit()`, `getStore()`, `enterWith()`, `disable()` and a storage with `defaultValue: store` (the `finally` check inspects `defaultValue` when there is no previous value). It expects 0. The probe under Fix is a longer version of that script.

The tests spawn a subprocess so that the stack overflow of an unfixed build cannot take the test file down with it.

Scope. After this change, no `$assert` call site in `src/js` formats a value in its message (73 sites, 32 of them with a message). The macro itself still evaluates the message arguments on every call: `src/codegen/replacements.ts:199-223` emits them as plain call arguments, and the helper in `src/codegen/client-js.ts` reads them only on failure. `$debug` has the same shape, so its arguments are also evaluated while logging is off. A self-review of this diff raised that as the larger follow-up: emit the `$assert` message arguments as a thunk, and gate the `$debug` expansion on the log-enabled flag. That is a codegen change that touches every built-in module, so it is not part of this fix. The call-site change here stays correct under either macro shape, and both tests stay valid for it. The `@note` in `builtins.d.ts` describes the macro as it is today and goes away with that follow-up.

`test/js/node/async_hooks/` on the debug build: 135 pass, 2 fail. The 2 failures are timeouts in `AsyncLocalStorage-tracking.test.ts`: `https-request` needs public internet, and `http-clientrequest` takes about 3 seconds alone under ASAN here and passes when run by itself. Neither touches this change.

CI: 178 of 179 jobs pass. The red job is Windows 2019 x64 on `test/js/bun/http/bun-server.test.ts`, a heap wrapper-count test that fails on main as well. It is reported separately.
</details>
