### PR TITLE
install: add --offline and --prefer-offline to bun install

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -190,7 +190,7 @@ bun install --prefer-offline
 bun install --offline
 ```
 
-`--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. Combined with `--frozen-lockfile` this makes CI installs from a restored cache fully deterministic and network-free.
+`--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. With a complete restored cache, `--offline --frozen-lockfile` makes a CI install fully deterministic and network-free; `--prefer-offline` still fetches whatever the cache is missing.
 
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -178,6 +178,20 @@ Bun does not enable `--frozen-lockfile` automatically in CI; pass the flag or us
 
 To validate the lockfile without installing, use `bun install --frozen-lockfile --dry-run`.
 
+### Offline installs
+
+With a warm cache, `bun install` can run without the network:
+
+```bash terminal icon="terminal"
+# Use cached package metadata regardless of age; only fetch what is missing from the cache
+bun install --prefer-offline
+
+# Never touch the network; anything that is not already cached is an error
+bun install --offline
+```
+
+`--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. Combined with `--frozen-lockfile` this makes CI installs from a restored cache fully deterministic and network-free.
+
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 
 ---

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -508,11 +508,11 @@ prefer = "online"
 
 Valid values are:
 
-| Value       | Description                                                                                        |
-| ----------- | -------------------------------------------------------------------------------------------------- |
-| `"online"`  | Default. Check the registry for stale packages as needed.                                          |
+| Value       | Description                                                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `"online"`  | Default. Check the registry for stale packages as needed.                                                                           |
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline` (also honoured by `bun install`). |
-| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
+| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                                                 |
 
 ### `install.offline`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -511,8 +511,17 @@ Valid values are:
 | Value       | Description                                                                                        |
 | ----------- | -------------------------------------------------------------------------------------------------- |
 | `"online"`  | Default. Check the registry for stale packages as needed.                                          |
-| `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
+| `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline` (also honoured by `bun install`). |
 | `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
+
+### `install.offline`
+
+When `true`, `bun install` never touches the network: package metadata and tarballs must already be in the cache, and anything missing is an error. Default `false`. Equivalent to `bun install --offline`. For the softer "use the cache when possible" behaviour see `install.prefer = "offline"` / `--prefer-offline`.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+offline = true
+```
 
 ### `install.frozenLockfile`
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1565,6 +1565,10 @@ impl<'a> Parser<'a> {
             install.hoist = Some(v);
         }
 
+        if let Some(v) = install_obj.get(b"offline").and_then(|e| e.as_bool()) {
+            install.offline = Some(v);
+        }
+
         Ok(())
     }
 

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -807,6 +807,20 @@ impl NetworkTask {
             return Err(ForTarballError::InvalidURL);
         }
 
+        // Only reached when the tarball is not already in the cache.
+        if pm.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
+            pm.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "--offline: {} is not in the cache (would fetch {})",
+                    quote(tarball.name.slice()),
+                    quote(&self.url_buf),
+                ),
+            );
+            return Err(ForTarballError::InvalidURL);
+        }
+
         // Userinfo becomes a header and leaves the URL: `bun_url` keeps it in `origin`, which the redirect same-origin check compares.
         let url_authorization: Option<Vec<u8>> = match split_url_userinfo(&self.url_buf) {
             Some((userinfo, url_without_userinfo)) => {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1408,6 +1408,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         public_hoist_pattern,
         hoist_pattern,
         hoist,
+        offline,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1462,6 +1463,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         public_hoist_pattern,
         hoist_pattern,
         hoist,
+        offline,
     );
 }
 
@@ -2239,6 +2241,16 @@ pub fn init(
             ctx.install.as_deref(),
             subcommand,
         )?;
+
+        // `install.prefer = "offline"` in bunfig (also what `bun --prefer-offline` sets
+        // for the runtime's auto-install) means prefer-offline for `bun install` too,
+        // unless a flag already asked for more.
+        if manager.options.offline == options::OfflineMode::Online
+            && ctx.debug.offline_mode_setting
+                == Some(bun_options_types::offline_mode::OfflineMode::Offline)
+        {
+            manager.options.offline = options::OfflineMode::PreferOffline;
+        }
 
         if let Some(config) = ctx.install.as_deref_mut() {
             if let Some(p) = config.public_hoist_pattern.take() {

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -89,6 +89,12 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
         "--no-verify                           Skip verifying integrity of newly downloaded packages"
     ),
     clap::param!(
+        "--offline                             Never touch the network: resolve and install only from the local cache"
+    ),
+    clap::param!(
+        "--prefer-offline                      Use cached package metadata regardless of age; only fetch what is missing"
+    ),
+    clap::param!(
         "--ignore-scripts                      Skip lifecycle scripts in the project's package.json (dependency scripts are never run)"
     ),
     clap::param!(
@@ -520,6 +526,8 @@ pub struct CommandLineArguments {
     pub log_level: Options::LogLevel,
     pub(crate) no_progress: bool,
     pub(crate) no_verify: bool,
+    pub(crate) offline: bool,
+    pub(crate) prefer_offline: bool,
     pub(crate) ignore_scripts: bool,
     pub(crate) trusted: bool,
     pub(crate) no_summary: bool,
@@ -622,6 +630,8 @@ impl Default for CommandLineArguments {
             log_level: Options::LogLevel::default(),
             no_progress: false,
             no_verify: false,
+            offline: false,
+            prefer_offline: false,
             ignore_scripts: false,
             trusted: false,
             no_summary: false,
@@ -1288,6 +1298,8 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         cli.global = args.flag(b"--global");
         cli.force = args.flag(b"--force");
         cli.no_verify = args.flag(b"--no-verify");
+        cli.offline = args.flag(b"--offline");
+        cli.prefer_offline = args.flag(b"--prefer-offline");
         cli.no_cache = args.flag(b"--no-cache");
         // --silent checked first so `is_silent()` matches `--silent` exactly:
         // callers read it to suppress summaries/errors independently of verbose.

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -53,6 +53,7 @@ impl PackageManager {
             enable_manifest_cache_control: self.options.enable.manifest_cache_control(),
             cache_directory: enable_manifest_cache.then(|| get_cache_directory(self)),
             timestamp_for_manifest_cache_control: self.timestamp_for_manifest_cache_control,
+            accept_expired: self.options.offline != super::options::OfflineMode::Online,
         }
     }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1128,12 +1128,30 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         }
 
                                         // Was it recent enough to just load it without the network call?
-                                        if this.options.enable.manifest_cache_control() && !expired
+                                        // `--prefer-offline` / `--offline` accept a cached manifest of
+                                        // any age.
+                                        if (this.options.enable.manifest_cache_control() && !expired)
+                                            || this.options.offline != crate::package_manager_real::options::OfflineMode::Online
                                         {
                                             let _ = this.network_dedupe_map.remove(&task_id);
                                             continue 'retry_from_manifests_ptr;
                                         }
                                     }
+                                }
+
+                                if this.options.offline
+                                    == crate::package_manager_real::options::OfflineMode::Offline
+                                {
+                                    let _ = this.network_dedupe_map.remove(&task_id);
+                                    let _ = this.log_mut().add_error_fmt(
+                                        None,
+                                        bun_ast::Loc::EMPTY,
+                                        format_args!(
+                                            "--offline: no cached manifest for \"{}\" (run once online, or use --prefer-offline)",
+                                            bstr::BStr::new(&name_str),
+                                        ),
+                                    );
+                                    return Ok(());
                                 }
 
                                 if verbose_install() {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1128,10 +1128,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         }
 
                                         // Was it recent enough to just load it without the network call?
-                                        // `--prefer-offline` / `--offline` accept a cached manifest of
-                                        // any age.
-                                        if (this.options.enable.manifest_cache_control() && !expired)
-                                            || this.options.offline != crate::package_manager_real::options::OfflineMode::Online
+                                        // (`--prefer-offline` / `--offline` load cached manifests as fresh
+                                        // regardless of age — see `DiskCacheCtx::accept_expired` — so they
+                                        // take this branch too; an entry still marked expired here needs
+                                        // the extended manifest and must be fetched.)
+                                        if !expired
+                                            && (this.options.enable.manifest_cache_control()
+                                                || this.options.offline
+                                                    != crate::package_manager_real::options::OfflineMode::Online)
                                         {
                                             let _ = this.network_dedupe_map.remove(&task_id);
                                             continue 'retry_from_manifests_ptr;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,4 +1,18 @@
 use crate::bun_schema::api as Api;
+
+/// Network policy for this install.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum OfflineMode {
+    /// Default: revalidate stale manifests, download what is missing.
+    #[default]
+    Online,
+    /// `--prefer-offline` / `install.prefer = "offline"`: a cached manifest of any age
+    /// satisfies resolution; only what is missing from the cache is fetched.
+    PreferOffline,
+    /// `--offline` / `install.offline = true`: never touch the network; anything not
+    /// in the cache is an error.
+    Offline,
+}
 use bun_core::ZStr;
 use bun_core::{Output, env_var};
 use bun_paths::PathBuffer;
@@ -81,6 +95,9 @@ pub struct Options {
     /// fallback (pnpm's `hoist=false`); takes precedence over `hoist_pattern`.
     pub(crate) hoist: bool,
 
+    /// `--offline` / `--prefer-offline` (or `install.offline` / `install.prefer = "offline"`).
+    pub offline: OfflineMode,
+
     // Security scanner module path
     pub security_scanner: Option<&'static [u8]>,
 
@@ -156,6 +173,7 @@ impl Default for Options {
             public_hoist_pattern: None,
             hoist_pattern: None,
             hoist: true,
+            offline: OfflineMode::Online,
             security_scanner: None,
             minimum_release_age_ms: None,
             minimum_release_age_excludes: None,
@@ -473,6 +491,10 @@ impl Options {
 
             if let Some(hoist) = config.hoist {
                 self.hoist = hoist;
+            }
+
+            if config.offline == Some(true) {
+                self.offline = OfflineMode::Offline;
             }
 
             if let Some(security_scanner) = config.security_scanner.as_deref() {
@@ -804,6 +826,11 @@ impl Options {
 
             if cli.no_verify {
                 self.do_.set(Do::VERIFY_INTEGRITY, false);
+            }
+            if cli.offline {
+                self.offline = OfflineMode::Offline;
+            } else if cli.prefer_offline && self.offline == OfflineMode::Online {
+                self.offline = OfflineMode::PreferOffline;
             }
 
             if cli.yarn {

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -47,6 +47,10 @@ pub struct DiskCacheCtx {
     /// branch that reads it is gated on that flag).
     pub(crate) cache_directory: Option<Fd>,
     pub(crate) timestamp_for_manifest_cache_control: u32,
+    /// `--prefer-offline` / `--offline`: a cached manifest of any age counts as fresh
+    /// (it is stored as `Value::Manifest`, never `Value::Expired`), so resolution can
+    /// use it without a revalidation request.
+    pub(crate) accept_expired: bool,
 }
 
 impl PackageManifestMap {
@@ -187,9 +191,10 @@ impl PackageManifestMap {
                             return None;
                         }
 
-                        if ctx.enable_manifest_cache_control
-                            && manifest.pkg.public_max_age
-                                > ctx.timestamp_for_manifest_cache_control
+                        if ctx.accept_expired
+                            || (ctx.enable_manifest_cache_control
+                                && manifest.pkg.public_max_age
+                                    > ctx.timestamp_for_manifest_cache_control)
                         {
                             let value_ptr = vac.insert(Value::Manifest(manifest));
                             let Value::Manifest(m) = value_ptr else {

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -47,9 +47,10 @@ pub struct DiskCacheCtx {
     /// branch that reads it is gated on that flag).
     pub(crate) cache_directory: Option<Fd>,
     pub(crate) timestamp_for_manifest_cache_control: u32,
-    /// `--prefer-offline` / `--offline`: a cached manifest of any age counts as fresh
-    /// (it is stored as `Value::Manifest`, never `Value::Expired`), so resolution can
-    /// use it without a revalidation request.
+    /// `--prefer-offline` / `--offline`: a cached manifest counts as fresh regardless of
+    /// its age (stored as `Value::Manifest`), so resolution can use it without a
+    /// revalidation request. It is still stored as `Value::Expired` when the caller needs
+    /// the extended manifest and the cached one lacks it — age is waived, content is not.
     pub(crate) accept_expired: bool,
 }
 

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -258,6 +258,8 @@ pub mod api {
         pub public_hoist_pattern: Option<PnpmMatcher>,
         pub hoist_pattern: Option<PnpmMatcher>,
         pub hoist: Option<bool>,
+        /// `offline = true`: `bun install` never touches the network.
+        pub offline: Option<bool>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -16,13 +16,19 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-setDefaultTimeout(1000 * 60 * 5);
 
 let cache_dir: string;
+// temp dirs created by a test; removed after it
+let dirs: { [Symbol.dispose](): void }[] = [];
+function mkdtemp(): string {
+  const d = tempDir("offline", {});
+  dirs.push(d);
+  return String(d);
+}
 
 beforeEach(async () => {
   await dummyBeforeEach({ linker: "hoisted" });
-  cache_dir = tmpdirSync();
+  cache_dir = mkdtemp();
   // dummyBeforeEach disables the cache; these tests are about the cache
   await writeFile(
     join(package_dir, "bunfig.toml"),
@@ -31,7 +37,11 @@ beforeEach(async () => {
     }),
   );
 });
-afterEach(dummyAfterEach);
+afterEach(async () => {
+  await dummyAfterEach();
+  for (const d of dirs) d[Symbol.dispose]();
+  dirs = [];
+});
 
 async function install(cwd: string, args: string[]) {
   await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
@@ -39,12 +49,12 @@ async function install(cwd: string, args: string[]) {
   return { out, err, code };
 }
 
-async function newProject(deps: Record<string, string>) {
-  const dir = tmpdirSync();
+async function newProject(deps: Record<string, string>, cache = cache_dir) {
+  const dir = mkdtemp();
   await writeFile(
     join(dir, "bunfig.toml"),
     Bun.TOML.stringify({
-      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+      install: { cache: { dir: cache }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
     }),
   );
   await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
@@ -116,14 +126,15 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
 it("--prefer-offline and --offline use an expired cached manifest", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
-  );
-  expect((await install(package_dir, [])).code).toBe(0);
-  const before = urls.length;
   for (const flag of ["--prefer-offline", "--offline"]) {
-    const dir = await newProject({ baz: "^0.0.3" });
+    // each mode gets its own warmed cache so one cannot pre-fetch for the other
+    const cache = mkdtemp();
+    const warm = await newProject({ baz: "0.0.3" }, cache);
+    const w = await install(warm, []);
+    expect(w.err).not.toContain("error:");
+    expect(w.code).toBe(0);
+    const before = urls.length;
+    const dir = await newProject({ baz: "^0.0.3" }, cache);
     const r = await install(dir, ["--force", flag]);
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
@@ -140,9 +151,13 @@ it('install.prefer = "offline" and install.offline = true in bunfig.toml behave 
     join(package_dir, "package.json"),
     JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
   );
-  expect((await install(package_dir, [])).code).toBe(0);
+  {
+    const w = await install(package_dir, []);
+    expect(w.err).not.toContain("error:");
+    expect(w.code).toBe(0);
+  }
   const before = urls.length;
-  const dir2 = tmpdirSync();
+  const dir2 = mkdtemp();
   await writeFile(
     join(dir2, "bunfig.toml"),
     Bun.TOML.stringify({
@@ -155,7 +170,7 @@ it('install.prefer = "offline" and install.offline = true in bunfig.toml behave 
   expect(r.code).toBe(0);
   expect(urls.length).toBe(before);
 
-  const dir3 = tmpdirSync();
+  const dir3 = mkdtemp();
   await writeFile(
     join(dir3, "bunfig.toml"),
     Bun.TOML.stringify({

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -101,6 +101,25 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
   expect(urls.length).toBe(before);
 });
 
+// Regression: with an *expired* cached manifest (here forced via --force, which turns off
+// the max-age check) --prefer-offline / --offline must still resolve from it, not spin.
+it("--prefer-offline and --offline use an expired cached manifest", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  expect((await install(package_dir, [])).code).toBe(0);
+  const before = urls.length;
+  for (const flag of ["--prefer-offline", "--offline"]) {
+    const dir = await newProject({ baz: "^0.0.3" });
+    const r = await install(dir, ["--force", flag]);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    // resolved the range from the cached manifest (0.0.5 is listed there too, but its
+    // tarball was never downloaded; 0.0.3's was) — no manifest request either way
+    expect(urls.slice(before).filter(u => !u.endsWith(".tgz"))).toEqual([]);
+  }
+});
+
 it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behave like the flags", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -1,0 +1,131 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+setDefaultTimeout(1000 * 60 * 5);
+
+let cache_dir: string;
+
+beforeEach(async () => {
+  await dummyBeforeEach({ linker: "hoisted" });
+  cache_dir = tmpdirSync();
+  // dummyBeforeEach disables the cache; these tests are about the cache
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+  );
+});
+afterEach(dummyAfterEach);
+
+async function install(cwd: string, args: string[]) {
+  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+async function newProject(deps: Record<string, string>) {
+  const dir = tmpdirSync();
+  await writeFile(
+    join(dir, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+  );
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
+  return dir;
+}
+
+it("--prefer-offline resolves from cached manifests without touching the network", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  // 1. online install populates the manifest + tarball cache
+  let r = await install(package_dir, []);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  const before = urls.length;
+  expect(before).toBeGreaterThan(0);
+
+  // 2. a fresh project without a lockfile: the (possibly stale) cached manifest satisfies
+  //    the range and the tarball comes from the cache: zero requests
+  const dir2 = await newProject({ baz: "<=0.0.3" });
+  r = await install(dir2, ["--prefer-offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.slice(before)).toEqual([]);
+  expect(await readdirSorted(join(dir2, "node_modules", "baz"))).toContain("package.json");
+});
+
+it("--offline never issues a request and fails cleanly on a cache miss", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  let r = await install(package_dir, []);
+  expect(r.code).toBe(0);
+  const before = urls.length;
+
+  // everything cached → works
+  const dir2 = await newProject({ baz: "0.0.3" });
+  r = await install(dir2, ["--offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.length).toBe(before);
+
+  // manifest for `bar` was never fetched → clean error, still no request
+  const dir3 = await newProject({ bar: "0.0.2" });
+  r = await install(dir3, ["--offline"]);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("--offline");
+  expect(urls.length).toBe(before);
+
+  // manifest cached but that version's tarball evicted → clean error, no request
+  for (const entry of await readdirSorted(cache_dir)) {
+    if (entry.startsWith("baz@0.0.3")) await rm(join(cache_dir, entry), { recursive: true, force: true });
+  }
+  const dir4 = await newProject({ baz: "0.0.3" });
+  r = await install(dir4, ["--offline"]);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("--offline");
+  expect(urls.length).toBe(before);
+});
+
+it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behave like the flags", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  expect((await install(package_dir, [])).code).toBe(0);
+  const before = urls.length;
+  const dir2 = tmpdirSync();
+  await writeFile(
+    join(dir2, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", prefer: "offline", linker: "hoisted" } }),
+  );
+  await writeFile(join(dir2, "package.json"), JSON.stringify({ name: "app", dependencies: { baz: "^0.0.3" } }));
+  let r = await install(dir2, []);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.length).toBe(before);
+
+  const dir3 = tmpdirSync();
+  await writeFile(
+    join(dir3, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", offline: true, linker: "hoisted" } }),
+  );
+  await writeFile(join(dir3, "package.json"), JSON.stringify({ name: "app", dependencies: { bar: "0.0.2" } }));
+  r = await install(dir3, []);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("--offline");
+  expect(urls.length).toBe(before);
+});

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -26,7 +26,9 @@ beforeEach(async () => {
   // dummyBeforeEach disables the cache; these tests are about the cache
   await writeFile(
     join(package_dir, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
   );
 });
 afterEach(dummyAfterEach);
@@ -41,7 +43,9 @@ async function newProject(deps: Record<string, string>) {
   const dir = tmpdirSync();
   await writeFile(
     join(dir, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
   );
   await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
   return dir;
@@ -50,7 +54,10 @@ async function newProject(deps: Record<string, string>) {
 it("--prefer-offline resolves from cached manifests without touching the network", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   // 1. online install populates the manifest + tarball cache
   let r = await install(package_dir, []);
   expect(r.err).not.toContain("error:");
@@ -71,7 +78,10 @@ it("--prefer-offline resolves from cached manifests without touching the network
 it("--offline never issues a request and fails cleanly on a cache miss", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   let r = await install(package_dir, []);
   expect(r.code).toBe(0);
   const before = urls.length;
@@ -106,7 +116,10 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
 it("--prefer-offline and --offline use an expired cached manifest", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   expect((await install(package_dir, [])).code).toBe(0);
   const before = urls.length;
   for (const flag of ["--prefer-offline", "--offline"]) {
@@ -120,16 +133,21 @@ it("--prefer-offline and --offline use an expired cached manifest", async () => 
   }
 });
 
-it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behave like the flags", async () => {
+it('install.prefer = "offline" and install.offline = true in bunfig.toml behave like the flags', async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   expect((await install(package_dir, [])).code).toBe(0);
   const before = urls.length;
   const dir2 = tmpdirSync();
   await writeFile(
     join(dir2, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", prefer: "offline", linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", prefer: "offline", linker: "hoisted" },
+    }),
   );
   await writeFile(join(dir2, "package.json"), JSON.stringify({ name: "app", dependencies: { baz: "^0.0.3" } }));
   let r = await install(dir2, []);
@@ -140,7 +158,9 @@ it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behav
   const dir3 = tmpdirSync();
   await writeFile(
     join(dir3, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", offline: true, linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", offline: true, linker: "hoisted" },
+    }),
   );
   await writeFile(join(dir3, "package.json"), JSON.stringify({ name: "app", dependencies: { bar: "0.0.2" } }));
   r = await install(dir3, []);


### PR DESCRIPTION
### What does this PR do?

Adds two flags to `bun install` for cache-only workflows (CI with a restored cache, planes, flaky networks):

- `bun install --prefer-offline` — a cached manifest of **any age** satisfies resolution, so there are no revalidation requests; only manifests/tarballs that are genuinely missing from the cache are fetched. This is also what the existing `install.prefer = "offline"` bunfig setting now selects for `bun install` (previously that setting only affected the runtime's auto-install).
- `bun install --offline` (config: `install.offline = true`) — never touch the network. A manifest or tarball that isn't in the cache is a clear error naming the package (`--offline: no cached manifest for "x"` / `--offline: "x" is not in the cache`) rather than a request.

Implementation: a small `OfflineMode { Online, PreferOffline, Offline }` on the install `Options`; the manifest-cache freshness check in `PackageManagerEnqueue` accepts expired entries when not `Online`, refuses to enqueue a manifest download when `Offline`, and `NetworkTask::for_tarball` (only reached on a cache miss) refuses when `Offline`.

Docs: `docs/pm/cli/install.mdx` (new "Offline installs" section) and `docs/runtime/bunfig.mdx` (`install.offline`, note on `install.prefer`).

### How did you verify your code works?

New `test/cli/install/bun-install-offline.test.ts` (uses the existing dummy registry):
- warm the cache online, then a fresh project with `--prefer-offline` resolves and installs with **zero** registry requests;
- `--offline` with everything cached succeeds with zero requests; with an unknown package, and with a cached manifest but evicted tarball, it exits non-zero with the `--offline` message and still zero requests;
- `install.prefer = "offline"` and `install.offline = true` behave like the respective flags.

Also ran `test/cli/install/bun-install.test.ts` locally.
