### PR TITLE
install: return immediately when nothing that determines node_modules has changed

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -178,6 +178,10 @@ Bun does not enable `--frozen-lockfile` automatically in CI; pass the flag or us
 
 To validate the lockfile without installing, use `bun install --frozen-lockfile --dry-run`.
 
+### Repeat installs
+
+When nothing that affects `node_modules` has changed since the last successful install (lockfile, workspace manifests, config, flags, and the installed folders themselves), `bun install` detects this from a fingerprint kept in the cache directory and returns without re-verifying every package. On large workspaces this turns a repeat install into a few milliseconds. As with other package managers' equivalent optimisation, root lifecycle scripts do not re-run on such a no-op install; use `--force` (or set [`install.stateFile = false`](/runtime/bunfig#install-statefile)) to always do the full pass.
+
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 
 ---

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -514,6 +514,15 @@ Valid values are:
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
 | `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
 
+### `install.stateFile`
+
+After a successful install, `bun install` records a fingerprint of everything that determines `node_modules` — the lockfile, every workspace `package.json`, `bunfig.toml` / `.npmrc`, patch files, install-relevant environment variables and flags, and the modification times of `node_modules` entries and of local `file:` / `link:` sources — under the cache directory. When nothing changed, the next plain `bun install` verifies the fingerprint and returns immediately instead of re-checking every installed package. `--force`, `bun add`/`remove`/`update`, or any change to those inputs takes the normal path. Default `true`; set to `false` to always do the full check.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+stateFile = false
+```
+
 ### `install.frozenLockfile`
 
 When `true`, `bun install` does not update `bun.lock`. Default `false`. If `package.json` and the existing `bun.lock` disagree, the install errors.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1565,6 +1565,10 @@ impl<'a> Parser<'a> {
             install.hoist = Some(v);
         }
 
+        if let Some(v) = install_obj.get(b"stateFile").and_then(|e| e.as_bool()) {
+            install.install_state = Some(v);
+        }
+
         Ok(())
     }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1408,6 +1408,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         public_hoist_pattern,
         hoist_pattern,
         hoist,
+        install_state,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1462,6 +1463,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         public_hoist_pattern,
         hoist_pattern,
         hoist,
+        install_state,
     );
 }
 

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -81,6 +81,10 @@ pub struct Options {
     /// fallback (pnpm's `hoist=false`); takes precedence over `hoist_pattern`.
     pub(crate) hoist: bool,
 
+    /// Record/consult the whole-install fingerprint (`install_state.rs`) so a repeat
+    /// `bun install` with nothing to do returns immediately. `install.stateFile`.
+    pub install_state: bool,
+
     // Security scanner module path
     pub security_scanner: Option<&'static [u8]>,
 
@@ -156,6 +160,7 @@ impl Default for Options {
             public_hoist_pattern: None,
             hoist_pattern: None,
             hoist: true,
+            install_state: true,
             security_scanner: None,
             minimum_release_age_ms: None,
             minimum_release_age_excludes: None,
@@ -473,6 +478,10 @@ impl Options {
 
             if let Some(hoist) = config.hoist {
                 self.hoist = hoist;
+            }
+
+            if let Some(v) = config.install_state {
+                self.install_state = v;
             }
 
             if let Some(security_scanner) = config.security_scanner.as_deref() {

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -55,6 +55,46 @@ pub fn install_with_manager(
 ) -> crate::Result<()> {
     let log_level = manager.options.log_level;
 
+    // Fast path: nothing that determines node_modules has changed since the last
+    // successful install (see install_state.rs) — skip lockfile parsing, hoisting and
+    // the per-package verification walk entirely.
+    let state_root: Vec<u8> = strings::without_trailing_slash(
+        crate::package_manager_real::FileSystem::instance().top_level_dir(),
+    )
+    .to_vec();
+    if crate::install_state::applicable(manager) {
+        if let Some(s) = crate::install_state::is_up_to_date(manager, &state_root) {
+            if manager.options.do_.summary() {
+                // Same wording as the regular no-op path so scripts/tests keying on it keep working.
+                bun_core::pretty!("\n");
+                if s.packages != s.entries {
+                    bun_core::pretty!(
+                        "Checked <green>{} install{}<r> across {} package{} <d>(no changes)<r> ",
+                        s.entries,
+                        if s.entries == 1 { "" } else { "s" },
+                        s.packages,
+                        if s.packages == 1 { "" } else { "s" },
+                    );
+                } else {
+                    bun_core::pretty!(
+                        "<r><green>Done<r>! Checked {} package{}<r> <d>(no changes)<r> ",
+                        s.entries,
+                        if s.entries == 1 { "" } else { "s" },
+                    );
+                }
+                Output::print_start_end_stdout(ctx.start_time, bun_core::time::nano_timestamp());
+                bun_core::pretty!("\n");
+                Output::flush();
+            }
+            return Ok(());
+        }
+        // We are about to do real work; never leave a stale "clean" marker behind if
+        // this install dies half way.
+        crate::install_state::invalidate(manager, &state_root);
+    } else if manager.subcommand != Subcommand::Install || !manager.update_requests.is_empty() {
+        crate::install_state::invalidate(manager, &state_root);
+    }
+
     // Start resolving DNS for the default registry immediately.
     // Unless you're behind a proxy.
     if !manager.env().has_http_proxy() {
@@ -985,6 +1025,10 @@ pub fn install_with_manager(
 
     if install_summary.fail > 0 {
         manager.any_failed_to_install = true;
+    } else if !manager.log_mut().has_errors() {
+        let entries = u64::from(install_summary.success) + u64::from(install_summary.skipped);
+        let packages = manager.lockfile.packages.len() as u64;
+        crate::install_state::save(manager, &state_root, entries, packages);
     }
 
     Output::flush();

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -88,12 +88,10 @@ pub fn install_with_manager(
             }
             return Ok(());
         }
-        // We are about to do real work; never leave a stale "clean" marker behind if
-        // this install dies half way.
-        crate::install_state::invalidate(manager, &state_root);
-    } else if manager.subcommand != Subcommand::Install || !manager.update_requests.is_empty() {
-        crate::install_state::invalidate(manager, &state_root);
     }
+    // We are about to do real work (or were told to with --force / add / remove /
+    // update): never leave a stale "clean" marker behind if this install dies half way.
+    crate::install_state::invalidate(manager, &state_root);
 
     // Start resolving DNS for the default registry immediately.
     // Unless you're behind a proxy.

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -28,6 +28,7 @@ use std::io::Write as _;
 
 use crate::lockfile::package::PackageColumns as _;
 use bun_paths::SEP;
+use bun_sys::Fd;
 
 use crate::PackageManager;
 use crate::package_manager_real::Subcommand;
@@ -38,27 +39,47 @@ fn h(bytes: &[u8]) -> u64 {
     bun_wyhash::hash(bytes)
 }
 
-fn hash_file(path: &[u8]) -> Option<u64> {
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
-    match std::fs::read(p) {
-        Ok(b) => Some(h(&b)),
-        Err(_) => None,
-    }
+fn zpath(path: &[u8]) -> bun_core::ZBox {
+    let mut v = Vec::with_capacity(path.len() + 1);
+    v.extend_from_slice(path);
+    v.push(0);
+    bun_core::ZBox::from_vec_with_nul(v)
 }
 
+fn read_file(path: &[u8]) -> Option<Vec<u8>> {
+    bun_sys::File::read_from(Fd::cwd(), path).ok()
+}
+
+fn hash_file(path: &[u8]) -> Option<u64> {
+    read_file(path).map(|b| h(&b))
+}
+
+fn mtime_ns(st: &bun_sys::Stat) -> u64 {
+    let t = bun_sys::stat_mtime(st);
+    (t.sec as u64)
+        .wrapping_mul(1_000_000_000)
+        .wrapping_add(t.nsec as u64)
+}
+
+/// mtime of `path` (following symlinks), None if it does not exist.
 fn dir_stamp(path: &[u8]) -> Option<u64> {
+    bun_sys::stat(&zpath(path)).ok().map(|st| mtime_ns(&st))
+}
+
+/// mtime of `path` itself (not following symlinks), None if it does not exist.
+fn lstat_stamp(path: &[u8]) -> Option<u64> {
+    bun_sys::lstat(&zpath(path)).ok().map(|st| mtime_ns(&st))
+}
+
+fn is_directory(path: &[u8]) -> bool {
+    matches!(bun_sys::stat(&zpath(path)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+}
+
+/// Iterate a directory with std's reader; the path bytes are ours.
+fn read_dir(path: &[u8]) -> Option<std::fs::ReadDir> {
+    // SAFETY: only hands our own path bytes to `read_dir`; never inspected as `str`.
     let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
-    let m = std::fs::metadata(p).ok()?;
-    let t = m
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?;
-    Some(
-        t.as_secs()
-            .wrapping_mul(1_000_000_000)
-            .wrapping_add(u64::from(t.subsec_nanos())),
-    )
+    std::fs::read_dir(p).ok()
 }
 
 fn join(root: &[u8], rel: &[u8]) -> Vec<u8> {
@@ -139,14 +160,12 @@ fn state_path(manager: &mut PackageManager, root: &[u8], create_dir: bool) -> Op
     } else {
         join(root, b"node_modules/.cache")
     };
-    if !std::path::Path::new(unsafe { std::str::from_utf8_unchecked(&cache_path) }).is_dir() {
+    if !is_directory(&cache_path) {
         return None;
     }
     let dir = join(&cache_path, b".install-state");
     if create_dir {
-        let _ = std::fs::create_dir_all(std::path::Path::new(unsafe {
-            std::str::from_utf8_unchecked(&dir)
-        }));
+        let _ = bun_sys::mkdir_recursive(&dir);
     }
     let mut name: Vec<u8> = Vec::with_capacity(20);
     let _ = write!(&mut name, "{:016x}", h(root));
@@ -186,10 +205,7 @@ fn parse(text: &[u8]) -> Option<Recorded> {
 /// `Some(summary)` when the recorded state exists and every input is unchanged.
 pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Summary> {
     let sp = state_path(manager, root_dir, false)?;
-    let text = std::fs::read(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&sp)
-    }))
-    .ok()?;
+    let text = read_file(&sp)?;
     let rec = parse(&text)?;
     if rec.lines.is_empty() {
         return None;
@@ -206,11 +222,7 @@ pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Su
             b'a' => hash_file(path).is_none(),
             b'd' => dir_stamp(path) == Some(*val),
             b'n' => dir_stamp(path).is_none(),
-            b'l' => {
-                lstat_stamp(std::path::Path::new(unsafe {
-                    std::str::from_utf8_unchecked(path)
-                })) == Some(*val)
-            }
+            b'l' => lstat_stamp(path) == Some(*val),
             b'p' => manifest_stamp(path) == *val,
             b'e' => {
                 saw_env = true;
@@ -365,9 +377,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     // manifest (`packages/*` → `packages/`), recorded even when it does not exist yet,
     // so creating the first workspace under it is noticed.
     let root_manifest_path = join(root_dir, b"package.json");
-    if let Ok(root_json) = std::fs::read(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&root_manifest_path)
-    })) {
+    if let Some(root_json) = read_file(&root_manifest_path) {
         if let Some(globs) = workspace_globs(&root_json) {
             for g in globs {
                 let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
@@ -376,7 +386,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                     .position(|c| matches!(*c, b'*' | b'?' | b'[' | b'{' | b'!'))
                     .unwrap_or(g.len());
                 let lit = &g[..literal_end];
-                let dir_end = lit.iter().rposition(|c| *c == b'/').map_or(0, |i| i);
+                let dir_end = lit.iter().rposition(|c| *c == b'/').unwrap_or(0);
                 let prefix = &lit[..dir_end];
                 let abs = if prefix.is_empty() {
                     root_dir.to_vec()
@@ -453,47 +463,21 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     );
     let _ = writeln!(out, "s {entries:016x} {packages}");
 
-    let sp_str = unsafe { std::str::from_utf8_unchecked(&sp) };
-    let tmp = format!("{sp_str}.tmp");
-    if std::fs::write(&tmp, &out).is_ok() {
-        let _ = std::fs::rename(&tmp, sp_str);
+    let mut tmp = sp.clone();
+    tmp.extend_from_slice(b".tmp");
+    if let Ok(f) = bun_sys::File::create(Fd::cwd(), &tmp, true) {
+        if f.write_all(&out).is_ok() {
+            let _ = bun_sys::renameat(Fd::cwd(), &zpath(&tmp), Fd::cwd(), &zpath(&sp));
+        }
     }
-}
-
-fn lstat_stamp(path: &std::path::Path) -> Option<u64> {
-    let m = std::fs::symlink_metadata(path).ok()?;
-    let t = m
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?;
-    Some(
-        t.as_secs()
-            .wrapping_mul(1_000_000_000)
-            .wrapping_add(u64::from(t.subsec_nanos())),
-    )
 }
 
 /// `<mtime ns> ^ <size>` of a package's package.json, following symlinks (so an
 /// isolated-linker entry is checked in the store it points at). 0 when missing.
 fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
     let pj = join(pkg_dir, b"package.json");
-    match std::fs::metadata(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&pj)
-    })) {
-        Ok(m) => {
-            let t = m
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| {
-                    d.as_secs()
-                        .wrapping_mul(1_000_000_000)
-                        .wrapping_add(u64::from(d.subsec_nanos()))
-                })
-                .unwrap_or(0);
-            (t ^ m.len().rotate_left(40)) | 1
-        }
+    match bun_sys::stat(&zpath(&pj)) {
+        Ok(st) => (mtime_ns(&st) ^ (st.st_size as u64).rotate_left(40)) | 1,
         Err(_) => 0,
     }
 }
@@ -502,12 +486,13 @@ fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
 /// package.json stamp (`p`). Scope dirs are descended one level; bookkeeping dirs
 /// (`.bin`, `.bun`, …) get only the `l` stamp.
 fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
-    let Some(stamp) = lstat_stamp(p) else { return };
+    let Some(stamp) = lstat_stamp(dir) else {
+        return;
+    };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let Ok(rd) = std::fs::read_dir(p) else { return };
+    let Some(rd) = read_dir(dir) else { return };
     for e in rd.flatten() {
         let name = e.file_name();
         let name = name.as_encoded_bytes();
@@ -519,9 +504,7 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
             stamp_tree(out, &child, depth + 1);
             continue;
         }
-        if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
-            std::str::from_utf8_unchecked(&child)
-        })) {
+        if let Some(stamp) = lstat_stamp(&child) {
             let _ = write!(out, "l {stamp:016x} ");
             out.extend_from_slice(&child);
             out.push(b'\n');
@@ -532,6 +515,10 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
             out.push(b'\n');
         }
     }
+}
+
+fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
+    bun_core::strings::index_of(hay, needle).is_some()
 }
 
 /// The `workspaces` glob patterns of a root package.json (`["a/*"]` or
@@ -565,21 +552,13 @@ fn workspace_globs(json_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
     Some(out)
 }
 
-fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
-    hay.windows(needle.len()).any(|w| w == needle)
-}
-
 /// Collect existing subdirectories of `dir` up to `depth` levels (bounded), skipping
 /// node_modules / dot dirs, into `out`.
 fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut usize) {
     if depth == 0 || *budget == 0 {
         return;
     }
-    let Ok(rd) = std::fs::read_dir(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(dir)
-    })) else {
-        return;
-    };
+    let Some(rd) = read_dir(dir) else { return };
     for e in rd.flatten() {
         if *budget == 0 {
             return;
@@ -605,14 +584,13 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules
 /// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
 fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
-    let Some(stamp) = lstat_stamp(p) else {
+    let Some(stamp) = lstat_stamp(dir) else {
         return false;
     };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let Ok(rd) = std::fs::read_dir(p) else {
+    let Some(rd) = read_dir(dir) else {
         return false;
     };
     for e in rd.flatten() {
@@ -631,9 +609,7 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
             if !stamp_source_tree(out, &child, budget) {
                 return false;
             }
-        } else if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
-            std::str::from_utf8_unchecked(&child)
-        })) {
+        } else if let Some(stamp) = lstat_stamp(&child) {
             let _ = write!(out, "l {stamp:016x} ");
             out.extend_from_slice(&child);
             out.push(b'\n');
@@ -648,7 +624,5 @@ pub fn invalidate(manager: &mut PackageManager, root_dir: &[u8]) {
     let Some(sp) = state_path(manager, root_dir, false) else {
         return;
     };
-    let _ = std::fs::remove_file(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&sp)
-    }));
+    let _ = bun_sys::unlinkat(Fd::cwd(), &zpath(&sp));
 }

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -46,12 +46,26 @@ fn zpath(path: &[u8]) -> bun_core::ZBox {
     bun_core::ZBox::from_vec_with_nul(v)
 }
 
-fn read_file(path: &[u8]) -> Option<Vec<u8>> {
-    bun_sys::File::read_from(Fd::cwd(), path).ok()
+enum FileHash {
+    Present(u64),
+    /// ENOENT / ENOTDIR — a legitimately missing input (recorded as such)
+    Absent,
+    /// exists but could not be read (EACCES, EIO, …): never treated as a valid state
+    Unreadable,
 }
 
-fn hash_file(path: &[u8]) -> Option<u64> {
-    read_file(path).map(|b| h(&b))
+fn read_file(path: &[u8]) -> Result<Vec<u8>, bun_sys::Error> {
+    bun_sys::File::read_from(Fd::cwd(), path)
+}
+
+fn hash_file(path: &[u8]) -> FileHash {
+    match read_file(path) {
+        Ok(b) => FileHash::Present(h(&b)),
+        Err(e) if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) => {
+            FileHash::Absent
+        }
+        Err(_) => FileHash::Unreadable,
+    }
 }
 
 fn mtime_ns(st: &bun_sys::Stat) -> u64 {
@@ -133,6 +147,7 @@ pub fn applicable(manager: &PackageManager) -> bool {
         && !manager.options.dry_run
         && !manager.options.enable.force_install()
         && manager.options.positionals.len() <= 1
+        && manager.options.filter_patterns.is_empty()
         && manager.update_requests.is_empty()
         && manager.options.do_.install_packages()
         && manager.options.do_.load_lockfile()
@@ -205,7 +220,7 @@ fn parse(text: &[u8]) -> Option<Recorded> {
 /// `Some(summary)` when the recorded state exists and every input is unchanged.
 pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Summary> {
     let sp = state_path(manager, root_dir, false)?;
-    let text = read_file(&sp)?;
+    let text = read_file(&sp).ok()?;
     let rec = parse(&text)?;
     if rec.lines.is_empty() {
         return None;
@@ -217,9 +232,12 @@ pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Su
     };
     for (kind, val, path) in &rec.lines {
         let ok = match kind {
-            b'f' => hash_file(path) == Some(*val),
+            b'f' => matches!(hash_file(path), FileHash::Present(v) if v == *val),
+            // the project root this state belongs to (guards against a hash collision
+            // between two projects sharing one cache directory)
+            b'r' => path.as_slice() == root_dir,
             // recorded as absent: must still be absent
-            b'a' => hash_file(path).is_none(),
+            b'a' => matches!(hash_file(path), FileHash::Absent),
             b'd' => dir_stamp(path) == Some(*val),
             b'n' => dir_stamp(path).is_none(),
             b'l' => lstat_stamp(path) == Some(*val),
@@ -301,12 +319,12 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                         join(root_dir, rel)
                     };
                     match hash_file(&path) {
-                        Some(v) => {
+                        FileHash::Present(v) => {
                             let _ = write!(local_lines, "f {v:016x} ");
                             local_lines.extend_from_slice(&path);
                             local_lines.push(b'\n');
                         }
-                        None => {
+                        _ => {
                             ok = false;
                             break;
                         }
@@ -325,17 +343,23 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     };
     let mut out: Vec<u8> = Vec::with_capacity(4096);
     let _ = writeln!(out, "{VERSION_LINE}");
-    let file = |out: &mut Vec<u8>, p: Vec<u8>| match hash_file(&p) {
-        Some(v) => {
+    let _ = write!(out, "r {:016x} ", 0);
+    out.extend_from_slice(root_dir);
+    out.push(b'\n');
+    // any input that exists but cannot be read makes the state unrecordable
+    let mut unreadable = false;
+    let mut file = |out: &mut Vec<u8>, p: Vec<u8>| match hash_file(&p) {
+        FileHash::Present(v) => {
             let _ = write!(out, "f {v:016x} ");
             out.extend_from_slice(&p);
             out.push(b'\n');
         }
-        None => {
+        FileHash::Absent => {
             let _ = write!(out, "a {:016x} ", 0);
             out.extend_from_slice(&p);
             out.push(b'\n');
         }
+        FileHash::Unreadable => unreadable = true,
     };
     // lockfiles (whichever exist; absence is recorded too)
     file(&mut out, join(root_dir, b"bun.lock"));
@@ -343,18 +367,15 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     file(&mut out, join(root_dir, b"package.json"));
     file(&mut out, join(root_dir, b"bunfig.toml"));
     file(&mut out, join(root_dir, b".npmrc"));
-    if let Some(home) = manager
-        .env()
-        .get(b"HOME")
-        .or_else(|| manager.env().get(b"USERPROFILE"))
-    {
+    // global config, with the same precedence the loaders use: $XDG_CONFIG_HOME first
+    // (its .npmrc wins when it exists), then $HOME (USERPROFILE on Windows)
+    if let Some(xdg) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+        file(&mut out, join(xdg, b".bunfig.toml"));
+        file(&mut out, join(xdg, b".npmrc"));
+    }
+    if let Some(home) = bun_core::env_var::HOME.get_not_empty() {
         file(&mut out, join(home, b".npmrc"));
         file(&mut out, join(home, b".bunfig.toml"));
-    }
-    if let Some(xdg) = manager.env().get(b"XDG_CONFIG_HOME") {
-        file(&mut out, join(xdg, b".bunfig.toml"));
-        // the npmrc loader prefers $XDG_CONFIG_HOME/.npmrc over ~/.npmrc when present
-        file(&mut out, join(xdg, b".npmrc"));
     }
     // workspaces: manifest hash + parent dir stamp
     let buf = manager.lockfile.buffers.string_bytes.as_slice();
@@ -377,7 +398,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     // manifest (`packages/*` → `packages/`), recorded even when it does not exist yet,
     // so creating the first workspace under it is noticed.
     let root_manifest_path = join(root_dir, b"package.json");
-    if let Some(root_json) = read_file(&root_manifest_path) {
+    if let Ok(root_json) = read_file(&root_manifest_path) {
         if let Some(globs) = workspace_globs(&root_json) {
             for g in globs {
                 let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
@@ -452,6 +473,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     for nm in nm_dirs {
         stamp_tree(&mut out, &nm, 0);
     }
+    if unreadable {
+        return;
+    }
     out.extend_from_slice(&local_lines);
     let _ = writeln!(
         out,
@@ -461,10 +485,12 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     let _ = writeln!(out, "s {entries:016x} {packages}");
 
     let mut tmp = sp.clone();
-    tmp.extend_from_slice(b".tmp");
+    let _ = write!(tmp, ".{}.tmp", std::process::id());
     if let Ok(f) = bun_sys::File::create(Fd::cwd(), &tmp, true) {
-        if f.write_all(&out).is_ok() {
-            let _ = bun_sys::renameat(Fd::cwd(), &zpath(&tmp), Fd::cwd(), &zpath(&sp));
+        let renamed = f.write_all(&out).is_ok()
+            && bun_sys::renameat(Fd::cwd(), &zpath(&tmp), Fd::cwd(), &zpath(&sp)).is_ok();
+        if !renamed {
+            let _ = bun_sys::unlinkat(Fd::cwd(), &zpath(&tmp));
         }
     }
 }

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -1,0 +1,654 @@
+//! Whole-install fingerprint: the "nothing changed" fast path.
+//!
+//! After a successful `bun install`, the inputs that determine what ends up in
+//! node_modules are hashed and recorded in `<cache>/.install-state/<project>`:
+//!   * the lockfile bytes (bun.lock / bun.lockb),
+//!   * root and every workspace `package.json`,
+//!   * config files that shape an install (./bunfig.toml, ./.npmrc, ~/.npmrc,
+//!     ~/.bunfig.toml), and every referenced patch file,
+//!   * the install-relevant environment (`BUN_INSTALL*`, `BUN_CONFIG_*`,
+//!     `NPM_CONFIG_*`) and the exact command line,
+//!   * bun's version,
+//!   * the mtime of each workspace directory's *parent* (so a workspace added
+//!     under `packages/*` is noticed even though no existing file changed).
+//! On the next plain `bun install`, if the file exists and every recorded input
+//! still hashes the same, there is provably nothing to do: we print the summary
+//! and return without parsing the lockfile, re-hoisting, or touching one
+//! `node_modules/*/package.json` — O(inputs) instead of O(packages) work, which
+//! is the difference between milliseconds and seconds on large monorepos and on
+//! Windows.
+//!
+//! Anything that mutates the inputs (add/remove/update/pm trust/patch, editing a
+//! package.json, switching branches) changes a hash and takes the normal path.
+//! `--force`, `--frozen-lockfile` off a mismatched file, or `install.stateFile =
+//! false` bypass it. Like yarn 4, root lifecycle scripts do not re-run on a
+//! no-op install.
+
+use std::io::Write as _;
+
+use crate::lockfile::package::PackageColumns as _;
+use bun_paths::SEP;
+
+use crate::PackageManager;
+use crate::package_manager_real::Subcommand;
+
+const VERSION_LINE: &str = "bun-install-state v2";
+
+fn h(bytes: &[u8]) -> u64 {
+    bun_wyhash::hash(bytes)
+}
+
+fn hash_file(path: &[u8]) -> Option<u64> {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
+    match std::fs::read(p) {
+        Ok(b) => Some(h(&b)),
+        Err(_) => None,
+    }
+}
+
+fn dir_stamp(path: &[u8]) -> Option<u64> {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
+    let m = std::fs::metadata(p).ok()?;
+    let t = m
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(
+        t.as_secs()
+            .wrapping_mul(1_000_000_000)
+            .wrapping_add(u64::from(t.subsec_nanos())),
+    )
+}
+
+fn join(root: &[u8], rel: &[u8]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(root.len() + rel.len() + 1);
+    v.extend_from_slice(root);
+    if !v.ends_with(&[SEP]) && !v.ends_with(b"/") {
+        v.push(SEP);
+    }
+    v.extend_from_slice(rel);
+    v
+}
+
+/// The install-relevant part of the environment + argv, hashed.
+fn env_and_argv_hash(manager: &PackageManager) -> u64 {
+    let mut acc: Vec<u8> = Vec::with_capacity(1024);
+    let mut keys: Vec<&[u8]> = manager
+        .env()
+        .map
+        .map
+        .keys()
+        .iter()
+        .map(|k| &**k)
+        .filter(|k| {
+            k.starts_with(b"BUN_INSTALL")
+                || k.starts_with(b"BUN_CONFIG_")
+                || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
+        })
+        .collect();
+    keys.sort_unstable();
+    for k in keys {
+        acc.extend_from_slice(k);
+        acc.push(b'=');
+        acc.extend_from_slice(manager.env().get(k).unwrap_or(b""));
+        acc.push(0);
+    }
+    acc.push(1);
+    for a in bun_core::argv().into_iter().skip(1) {
+        acc.extend_from_slice(a);
+        acc.push(0);
+    }
+    acc.push(2);
+    acc.extend_from_slice(bun_core::Global::package_json_version.as_bytes());
+    h(&acc)
+}
+
+/// May this invocation use / record the fast path at all?
+pub fn applicable(manager: &PackageManager) -> bool {
+    manager.subcommand == Subcommand::Install
+        && manager.options.install_state
+        && !manager.options.global
+        && !manager.options.dry_run
+        && !manager.options.enable.force_install()
+        && manager.options.positionals.len() <= 1
+        && manager.update_requests.is_empty()
+        && manager.options.do_.install_packages()
+        && manager.options.do_.load_lockfile()
+}
+
+struct Recorded {
+    lines: Vec<(u8, u64, Vec<u8>)>, // kind ('f' file hash / 'd' dir stamp / 'e' env), value, path
+}
+
+/// `<cache dir>/.install-state/<hash of project root>` — kept out of node_modules so
+/// directory listings are unchanged, and per project so a shared cache is fine.
+fn state_path(manager: &mut PackageManager, root: &[u8], create_dir: bool) -> Option<Vec<u8>> {
+    // Resolve the cache directory *path* without forcing the directory into
+    // existence (a workspaces-only install never creates it, and directory
+    // listings must not change because of the state file): the state lives only
+    // inside a cache directory that already exists.
+    let cache_path: Vec<u8> = if !manager.cache_directory_path.as_bytes().is_empty() {
+        manager.cache_directory_path.as_bytes().to_vec()
+    } else if manager.options.enable.cache() {
+        crate::package_manager_real::directories::fetch_cache_directory_path(
+            manager.env_mut(),
+            Some(&manager.options),
+        )
+        .path
+    } else {
+        join(root, b"node_modules/.cache")
+    };
+    if !std::path::Path::new(unsafe { std::str::from_utf8_unchecked(&cache_path) }).is_dir() {
+        return None;
+    }
+    let dir = join(&cache_path, b".install-state");
+    if create_dir {
+        let _ = std::fs::create_dir_all(std::path::Path::new(unsafe {
+            std::str::from_utf8_unchecked(&dir)
+        }));
+    }
+    let mut name: Vec<u8> = Vec::with_capacity(20);
+    let _ = write!(&mut name, "{:016x}", h(root));
+    Some(join(&dir, &name))
+}
+
+/// What the fast path prints (mirrors the normal "no changes" summary).
+pub struct Summary {
+    pub entries: u64,
+    pub packages: u64,
+}
+
+fn parse(text: &[u8]) -> Option<Recorded> {
+    let mut lines = text.split(|c| *c == b'\n');
+    if lines.next()? != VERSION_LINE.as_bytes() {
+        return None;
+    }
+    let mut out = Vec::new();
+    for l in lines {
+        if l.is_empty() {
+            continue;
+        }
+        let kind = l[0];
+        let rest = l.get(2..)?;
+        let sp = rest.iter().position(|c| *c == b' ').unwrap_or(rest.len());
+        let val = u64::from_str_radix(core::str::from_utf8(&rest[..sp]).ok()?, 16).ok()?;
+        let path = if sp < rest.len() {
+            rest[sp + 1..].to_vec()
+        } else {
+            Vec::new()
+        };
+        out.push((kind, val, path));
+    }
+    Some(Recorded { lines: out })
+}
+
+/// `Some(summary)` when the recorded state exists and every input is unchanged.
+pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Summary> {
+    let sp = state_path(manager, root_dir, false)?;
+    let text = std::fs::read(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&sp)
+    }))
+    .ok()?;
+    let rec = parse(&text)?;
+    if rec.lines.is_empty() {
+        return None;
+    }
+    let mut saw_env = false;
+    let mut summary = Summary {
+        entries: 0,
+        packages: 0,
+    };
+    for (kind, val, path) in &rec.lines {
+        let ok = match kind {
+            b'f' => hash_file(path) == Some(*val),
+            // recorded as absent: must still be absent
+            b'a' => hash_file(path).is_none(),
+            b'd' => dir_stamp(path) == Some(*val),
+            b'n' => dir_stamp(path).is_none(),
+            b'l' => {
+                lstat_stamp(std::path::Path::new(unsafe {
+                    std::str::from_utf8_unchecked(path)
+                })) == Some(*val)
+            }
+            b'p' => manifest_stamp(path) == *val,
+            b'e' => {
+                saw_env = true;
+                env_and_argv_hash(manager) == *val
+            }
+            b's' => {
+                summary.entries = *val;
+                summary.packages = core::str::from_utf8(path)
+                    .ok()
+                    .and_then(|s| s.trim().parse().ok())
+                    .unwrap_or(0);
+                true
+            }
+            _ => false,
+        };
+        if !ok {
+            bun_output::scoped_log!(
+                PackageManager,
+                "install state: {} changed",
+                bstr::BStr::new(path)
+            );
+            return None;
+        }
+    }
+    // node_modules itself must still be there
+    if saw_env && dir_stamp(&join(root_dir, b"node_modules")).is_some() {
+        Some(summary)
+    } else {
+        None
+    }
+}
+
+/// Record the state after a successful install. Best effort: failures are ignored.
+pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, packages: u64) {
+    if !applicable(manager) {
+        return;
+    }
+    // Local sources (`file:` folders and tarballs, `link:`) are inputs too: their
+    // *contents* decide what gets materialized. Stamp them (recursive mtimes for
+    // folders, content hash for tarballs); a project with enormous local sources just
+    // doesn't get a state file.
+    let mut local_lines: Vec<u8> = Vec::new();
+    {
+        use crate::resolution_real::Tag;
+        let buf = manager.lockfile.buffers.string_bytes.as_slice();
+        let mut budget: usize = 20_000;
+        let mut ok = true;
+        for r in manager.lockfile.packages.slice().items_resolution().iter() {
+            match r.tag {
+                Tag::Folder | Tag::Symlink => {
+                    let rel = if r.tag == Tag::Folder {
+                        r.folder().slice(buf)
+                    } else {
+                        r.symlink().slice(buf)
+                    };
+                    if rel.is_empty() || bun_paths::is_absolute(rel) && r.tag == Tag::Symlink {
+                        // global `bun link` targets: outside the project, not tracked
+                        ok = false;
+                        break;
+                    }
+                    let dir = if bun_paths::is_absolute(rel) {
+                        rel.to_vec()
+                    } else {
+                        join(root_dir, rel)
+                    };
+                    if !stamp_source_tree(&mut local_lines, &dir, &mut budget) {
+                        ok = false;
+                        break;
+                    }
+                }
+                Tag::LocalTarball => {
+                    let rel = r.local_tarball().slice(buf);
+                    let path = if bun_paths::is_absolute(rel) {
+                        rel.to_vec()
+                    } else {
+                        join(root_dir, rel)
+                    };
+                    match hash_file(&path) {
+                        Some(v) => {
+                            let _ = write!(local_lines, "f {v:016x} ");
+                            local_lines.extend_from_slice(&path);
+                            local_lines.push(b'\n');
+                        }
+                        None => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if !ok {
+            invalidate(manager, root_dir);
+            return;
+        }
+    }
+    let Some(sp) = state_path(manager, root_dir, true) else {
+        return;
+    };
+    let mut out: Vec<u8> = Vec::with_capacity(4096);
+    let _ = writeln!(out, "{VERSION_LINE}");
+    let file = |out: &mut Vec<u8>, p: Vec<u8>| match hash_file(&p) {
+        Some(v) => {
+            let _ = write!(out, "f {v:016x} ");
+            out.extend_from_slice(&p);
+            out.push(b'\n');
+        }
+        None => {
+            let _ = write!(out, "a {:016x} ", 0);
+            out.extend_from_slice(&p);
+            out.push(b'\n');
+        }
+    };
+    // lockfiles (whichever exist; absence is recorded too)
+    file(&mut out, join(root_dir, b"bun.lock"));
+    file(&mut out, join(root_dir, b"bun.lockb"));
+    file(&mut out, join(root_dir, b"package.json"));
+    file(&mut out, join(root_dir, b"bunfig.toml"));
+    file(&mut out, join(root_dir, b".npmrc"));
+    if let Some(home) = manager
+        .env()
+        .get(b"HOME")
+        .or_else(|| manager.env().get(b"USERPROFILE"))
+    {
+        file(&mut out, join(home, b".npmrc"));
+        file(&mut out, join(home, b".bunfig.toml"));
+    }
+    if let Some(xdg) = manager.env().get(b"XDG_CONFIG_HOME") {
+        file(&mut out, join(xdg, b".bunfig.toml"));
+        // the npmrc loader prefers $XDG_CONFIG_HOME/.npmrc over ~/.npmrc when present
+        file(&mut out, join(xdg, b".npmrc"));
+    }
+    // workspaces: manifest hash + parent dir stamp
+    let buf = manager.lockfile.buffers.string_bytes.as_slice();
+    let mut parents: Vec<Vec<u8>> = Vec::new();
+    for ws in manager.lockfile.workspace_paths.values() {
+        let rel = ws.slice(buf);
+        if rel.is_empty() {
+            continue;
+        }
+        let dir = join(root_dir, rel);
+        file(&mut out, join(&dir, b"package.json"));
+        if let Some(parent) = bun_paths::dirname(&dir) {
+            let parent = parent.to_vec();
+            if !parents.contains(&parent) {
+                parents.push(parent);
+            }
+        }
+    }
+    // …plus the literal directory prefix of every `workspaces` glob in the root
+    // manifest (`packages/*` → `packages/`), recorded even when it does not exist yet,
+    // so creating the first workspace under it is noticed.
+    let root_manifest_path = join(root_dir, b"package.json");
+    if let Ok(root_json) = std::fs::read(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&root_manifest_path)
+    })) {
+        if let Some(globs) = workspace_globs(&root_json) {
+            for g in globs {
+                let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
+                let literal_end = g
+                    .iter()
+                    .position(|c| matches!(*c, b'*' | b'?' | b'[' | b'{' | b'!'))
+                    .unwrap_or(g.len());
+                let lit = &g[..literal_end];
+                let dir_end = lit.iter().rposition(|c| *c == b'/').map_or(0, |i| i);
+                let prefix = &lit[..dir_end];
+                let abs = if prefix.is_empty() {
+                    root_dir.to_vec()
+                } else {
+                    join(root_dir, prefix)
+                };
+                // `a/*/*` or `a/**`: directories below the literal prefix can gain
+                // workspaces too — stamp existing dirs down to the glob's depth (2 for **)
+                let rest = &g[literal_end..];
+                let extra_depth = if strings_contains(rest, b"**") {
+                    2
+                } else {
+                    rest.iter().filter(|c| **c == b'/').count()
+                };
+                if extra_depth > 0 {
+                    collect_dirs(&abs, extra_depth, &mut parents, &mut 2000);
+                }
+                if !parents.contains(&abs) {
+                    parents.push(abs);
+                }
+                // a fully literal workspace path: its own dir + manifest matter too
+                if literal_end == g.len() && !g.is_empty() {
+                    let ws_dir = join(root_dir, g);
+                    if !parents.contains(&ws_dir) {
+                        parents.push(ws_dir);
+                    }
+                }
+            }
+        }
+    }
+    parents.sort();
+    for p in parents {
+        match dir_stamp(&p) {
+            Some(stamp) => {
+                let _ = write!(out, "d {stamp:016x} ");
+                out.extend_from_slice(&p);
+                out.push(b'\n');
+            }
+            None => {
+                // absent now; must stay absent
+                let _ = write!(out, "n {:016x} ", 0);
+                out.extend_from_slice(&p);
+                out.push(b'\n');
+            }
+        }
+    }
+    // patch files
+    for pd in manager.lockfile.patched_dependencies.values() {
+        let rel = pd.path.slice(buf);
+        if !rel.is_empty() {
+            file(&mut out, join(root_dir, rel));
+        }
+    }
+    // node_modules directories (root + workspaces): the dir itself and each top-level
+    // entry. Removing or replacing a package, or deleting a file directly inside one
+    // (its package.json, say), bumps one of these mtimes; that is the tampering the
+    // per-package verify pass used to catch, at the cost of an lstat instead of an
+    // open+read+parse per package.
+    let mut nm_dirs: Vec<Vec<u8>> = vec![join(root_dir, b"node_modules")];
+    for ws in manager.lockfile.workspace_paths.values() {
+        let rel = ws.slice(buf);
+        if !rel.is_empty() {
+            nm_dirs.push(join(&join(root_dir, rel), b"node_modules"));
+        }
+    }
+    for nm in nm_dirs {
+        stamp_tree(&mut out, &nm, 0);
+    }
+    out.extend_from_slice(&local_lines);
+    let _ = writeln!(
+        out,
+        "e {:016x} env+argv+version",
+        env_and_argv_hash(manager)
+    );
+    let _ = writeln!(out, "s {entries:016x} {packages}");
+
+    let sp_str = unsafe { std::str::from_utf8_unchecked(&sp) };
+    let tmp = format!("{sp_str}.tmp");
+    if std::fs::write(&tmp, &out).is_ok() {
+        let _ = std::fs::rename(&tmp, sp_str);
+    }
+}
+
+fn lstat_stamp(path: &std::path::Path) -> Option<u64> {
+    let m = std::fs::symlink_metadata(path).ok()?;
+    let t = m
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(
+        t.as_secs()
+            .wrapping_mul(1_000_000_000)
+            .wrapping_add(u64::from(t.subsec_nanos())),
+    )
+}
+
+/// `<mtime ns> ^ <size>` of a package's package.json, following symlinks (so an
+/// isolated-linker entry is checked in the store it points at). 0 when missing.
+fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
+    let pj = join(pkg_dir, b"package.json");
+    match std::fs::metadata(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&pj)
+    })) {
+        Ok(m) => {
+            let t = m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| {
+                    d.as_secs()
+                        .wrapping_mul(1_000_000_000)
+                        .wrapping_add(u64::from(d.subsec_nanos()))
+                })
+                .unwrap_or(0);
+            (t ^ m.len().rotate_left(40)) | 1
+        }
+        Err(_) => 0,
+    }
+}
+
+/// Record `dir`, and for each entry: its own lstat mtime (`l`) plus its
+/// package.json stamp (`p`). Scope dirs are descended one level; bookkeeping dirs
+/// (`.bin`, `.bun`, …) get only the `l` stamp.
+fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
+    let Some(stamp) = lstat_stamp(p) else { return };
+    let _ = write!(out, "l {stamp:016x} ");
+    out.extend_from_slice(dir);
+    out.push(b'\n');
+    let Ok(rd) = std::fs::read_dir(p) else { return };
+    for e in rd.flatten() {
+        let name = e.file_name();
+        let name = name.as_encoded_bytes();
+        if name == b".cache" || name == b".install-state" {
+            continue;
+        }
+        let child = join(dir, name);
+        if depth < 1 && name.first() == Some(&b'@') {
+            stamp_tree(out, &child, depth + 1);
+            continue;
+        }
+        if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
+            std::str::from_utf8_unchecked(&child)
+        })) {
+            let _ = write!(out, "l {stamp:016x} ");
+            out.extend_from_slice(&child);
+            out.push(b'\n');
+        }
+        if name.first() != Some(&b'.') {
+            let _ = write!(out, "p {:016x} ", manifest_stamp(&child));
+            out.extend_from_slice(&child);
+            out.push(b'\n');
+        }
+    }
+}
+
+/// The `workspaces` glob patterns of a root package.json (`["a/*"]` or
+/// `{ "packages": [...] }` form).
+fn workspace_globs(json_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
+    let mut log = bun_ast::Log::init();
+    let arena = bun_alloc::Arena::new();
+    let source = bun_ast::Source::init_path_string(b"package.json", json_bytes);
+    let parsed = crate::bun_json::parse_package_json_utf8_with_opts(
+        crate::bun_json::JSONOptions {
+            json_warn_duplicate_keys: false,
+            ..crate::bun_json::PACKAGE_JSON_OPTS
+        },
+        &source,
+        &mut log,
+        &arena,
+    )
+    .ok()?;
+    let ws = parsed.root.get(b"workspaces")?;
+    let list = match ws.get(b"packages") {
+        Some(p) => p,
+        None => ws,
+    };
+    let mut items = list.as_array()?;
+    let mut out = Vec::new();
+    while let Some(item) = items.next() {
+        if let Some(s) = item.as_string(&arena) {
+            out.push(s.to_vec());
+        }
+    }
+    Some(out)
+}
+
+fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
+    hay.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Collect existing subdirectories of `dir` up to `depth` levels (bounded), skipping
+/// node_modules / dot dirs, into `out`.
+fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut usize) {
+    if depth == 0 || *budget == 0 {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(dir)
+    })) else {
+        return;
+    };
+    for e in rd.flatten() {
+        if *budget == 0 {
+            return;
+        }
+        let Ok(ft) = e.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let name = e.file_name();
+        let name = name.as_encoded_bytes();
+        if name == b"node_modules" || name.starts_with(b".") {
+            continue;
+        }
+        *budget -= 1;
+        let child = join(dir, name);
+        collect_dirs(&child, depth - 1, out, budget);
+        if !out.contains(&child) {
+            out.push(child);
+        }
+    }
+}
+
+/// Recursively record `l` stamps for a local-source directory (skipping node_modules
+/// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
+fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
+    let Some(stamp) = lstat_stamp(p) else {
+        return false;
+    };
+    let _ = write!(out, "l {stamp:016x} ");
+    out.extend_from_slice(dir);
+    out.push(b'\n');
+    let Ok(rd) = std::fs::read_dir(p) else {
+        return false;
+    };
+    for e in rd.flatten() {
+        if *budget == 0 {
+            return false;
+        }
+        *budget -= 1;
+        let name = e.file_name();
+        let name = name.as_encoded_bytes();
+        if name == b"node_modules" || name == b".git" {
+            continue;
+        }
+        let child = join(dir, name);
+        let Ok(ft) = e.file_type() else { return false };
+        if ft.is_dir() {
+            if !stamp_source_tree(out, &child, budget) {
+                return false;
+            }
+        } else if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
+            std::str::from_utf8_unchecked(&child)
+        })) {
+            let _ = write!(out, "l {stamp:016x} ");
+            out.extend_from_slice(&child);
+            out.push(b'\n');
+        }
+    }
+    true
+}
+
+/// Remove the state file (called before any install that will do real work, so a
+/// crash mid-install can never leave a "clean" marker behind).
+pub fn invalidate(manager: &mut PackageManager, root_dir: &[u8]) {
+    let Some(sp) = state_path(manager, root_dir, false) else {
+        return;
+    };
+    let _ = std::fs::remove_file(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&sp)
+    }));
+}

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -179,18 +179,18 @@ pub struct Summary {
 }
 
 fn parse(text: &[u8]) -> Option<Recorded> {
-    let mut lines = text.split(|c| *c == b'\n');
+    let mut lines = bun_core::strings::split(text, b"\n");
     if lines.next()? != VERSION_LINE.as_bytes() {
         return None;
     }
     let mut out = Vec::new();
-    for l in lines {
+    while let Some(l) = lines.next() {
         if l.is_empty() {
             continue;
         }
         let kind = l[0];
         let rest = l.get(2..)?;
-        let sp = rest.iter().position(|c| *c == b' ').unwrap_or(rest.len());
+        let sp = bun_core::strings::index_of_char_usize(rest, b' ').unwrap_or(rest.len());
         let val = u64::from_str_radix(core::str::from_utf8(&rest[..sp]).ok()?, 16).ok()?;
         let path = if sp < rest.len() {
             rest[sp + 1..].to_vec()
@@ -381,12 +381,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
         if let Some(globs) = workspace_globs(&root_json) {
             for g in globs {
                 let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
-                let literal_end = g
-                    .iter()
-                    .position(|c| matches!(*c, b'*' | b'?' | b'[' | b'{' | b'!'))
-                    .unwrap_or(g.len());
+                let literal_end = bun_core::strings::index_of_any(g, b"*?[{!").unwrap_or(g.len());
                 let lit = &g[..literal_end];
-                let dir_end = lit.iter().rposition(|c| *c == b'/').unwrap_or(0);
+                let dir_end = bun_core::strings::last_index_of_char(lit, b'/').unwrap_or(0);
                 let prefix = &lit[..dir_end];
                 let abs = if prefix.is_empty() {
                     root_dir.to_vec()
@@ -399,7 +396,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                 let extra_depth = if strings_contains(rest, b"**") {
                     2
                 } else {
-                    rest.iter().filter(|c| **c == b'/').count()
+                    bun_core::strings::count_char(rest, b'/')
                 };
                 if extra_depth > 0 {
                     collect_dirs(&abs, extra_depth, &mut parents, &mut 2000);

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -113,6 +113,7 @@ pub mod audit_fix;
 pub mod bin_real;
 pub mod dedupe;
 pub mod hoisted_install;
+pub mod install_state;
 pub mod isolated_install;
 pub mod lifecycle_script_runner;
 pub mod migration;

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -258,6 +258,8 @@ pub mod api {
         pub public_hoist_pattern: Option<PnpmMatcher>,
         pub hoist_pattern: Option<PnpmMatcher>,
         pub hoist: Option<bool>,
+        /// `stateFile = false` disables the whole-install fingerprint fast path.
+        pub install_state: Option<bool>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,7 @@ import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import { bunExe, bunEnv as env, readdirCacheSorted, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -1055,7 +1055,7 @@ it("should add dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -1470,7 +1470,7 @@ it("should add aliased dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
     "@GH@mishoo-UglifyJS-e219a9a@@@1",
     "uglify",
   ]);
@@ -1853,7 +1853,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
-  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
+  expect((await readdirCacheSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2214,7 +2214,7 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited1).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2275,7 +2275,7 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,16 @@ import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirCacheSorted, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import {
+  bunExe,
+  bunEnv as env,
+  readdirCacheSorted,
+  readdirSorted,
+  tmpdirSync,
+  toBeValidBin,
+  toBeWorkspaceLink,
+  toHaveBins,
+} from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -1055,7 +1064,9 @@ it("should add dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2214,7 +2225,9 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited1).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2275,7 +2288,9 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -2,7 +2,7 @@ import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { existsSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -41,14 +41,29 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {} }));
     await writeFile(
       join(package_dir, "bunfig.toml"),
-      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker } }),
+      Bun.TOML.stringify({
+        install: {
+          cache: { dir: join(package_dir, ".cache") },
+          registry: root_url + "/",
+          saveTextLockfile: true,
+          linker,
+        },
+      }),
     );
     await mkdir(join(package_dir, "packages", "a"), { recursive: true });
     await writeFile(
       join(package_dir, "package.json"),
-      JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { bar: "0.0.2" }, devDependencies: { qux: "0.0.2" } }),
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: { bar: "0.0.2" },
+        devDependencies: { qux: "0.0.2" },
+      }),
     );
-    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.3" } }));
+    await writeFile(
+      join(package_dir, "packages", "a", "package.json"),
+      JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.3" } }),
+    );
   });
   afterEach(dummyAfterEach);
 
@@ -66,7 +81,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(urls.length).toBe(before);
 
     // 2. a workspace manifest edit is noticed
-    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }));
+    await writeFile(
+      join(package_dir, "packages", "a", "package.json"),
+      JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }),
+    );
     r = await install(package_dir);
     expect(r.code).toBe(0);
     expect(r.err).toContain("Saved lockfile");
@@ -74,7 +92,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
 
     // 3. a new workspace appearing under the glob is noticed
     await mkdir(join(package_dir, "packages", "b"), { recursive: true });
-    await writeFile(join(package_dir, "packages", "b", "package.json"), JSON.stringify({ name: "b", version: "1.0.0" }));
+    await writeFile(
+      join(package_dir, "packages", "b", "package.json"),
+      JSON.stringify({ name: "b", version: "1.0.0" }),
+    );
     r = await install(package_dir);
     expect(r.code).toBe(0);
     expect(r.err).toContain("Saved lockfile");
@@ -118,7 +139,15 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     //    here as node_modules damage being repaired without any recorded state)
     await writeFile(
       join(package_dir, "bunfig.toml"),
-      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker, stateFile: false } }),
+      Bun.TOML.stringify({
+        install: {
+          cache: { dir: join(package_dir, ".cache") },
+          registry: root_url + "/",
+          saveTextLockfile: true,
+          linker,
+          stateFile: false,
+        },
+      }),
     );
     expect((await install(package_dir)).code).toBe(0);
     await rm(join(package_dir, ".cache", ".install-state"), { recursive: true, force: true });
@@ -130,7 +159,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     await mkdir(join(package_dir, "local"), { recursive: true });
     await writeFile(join(package_dir, "local", "package.json"), JSON.stringify({ name: "local", version: "1.0.0" }));
     await writeFile(join(package_dir, "local", "index.js"), "module.exports = 1;");
-    await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "root", dependencies: { local: "file:./local", bar: "0.0.2" } }));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", dependencies: { local: "file:./local", bar: "0.0.2" } }),
+    );
 
     let r = await install(package_dir);
     expect(r.err).not.toContain("error:");

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
@@ -134,9 +134,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.code).toBe(0);
     expect(r.out).not.toMatch(noChanges);
 
-    // 8. install.stateFile = false disables the fast path (the classic per-package check
-    //    still reports "no changes", but only after verifying every package — observable
-    //    here as node_modules damage being repaired without any recorded state)
+    // 8. install.stateFile = false disables the fast path: no state is recorded, and the
+    //    classic per-package verification still repairs node_modules
     await writeFile(
       join(package_dir, "bunfig.toml"),
       Bun.TOML.stringify({
@@ -151,7 +150,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     );
     expect((await install(package_dir)).code).toBe(0);
     await rm(join(package_dir, ".cache", ".install-state"), { recursive: true, force: true });
-    expect((await install(package_dir)).code).toBe(0);
+    await rm(join(package_dir, "node_modules", "bar", "package.json"));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
     expect(existsSync(join(package_dir, ".cache", ".install-state"))).toBeFalse();
   });
 
@@ -171,8 +173,11 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.code).toBe(0);
     expect(r.out).toMatch(noChanges);
 
-    await Bun.sleep(10);
-    await writeFile(join(package_dir, "local", "index.js"), "module.exports = 2;");
+    const src = join(package_dir, "local", "index.js");
+    const before = statSync(src).mtimeMs;
+    await writeFile(src, "module.exports = 2;");
+    // make the edit observable regardless of timestamp granularity
+    utimesSync(src, new Date(before + 2000), new Date(before + 2000));
     r = await install(package_dir);
     expect(r.code).toBe(0);
     expect(r.out).not.toMatch(noChanges);

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,5 +1,5 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
@@ -22,7 +22,6 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-setDefaultTimeout(1000 * 60 * 5);
 
 let urls: string[];
 

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,0 +1,153 @@
+import { file, spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { existsSync } from "fs";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+// The install-state fast path: after a successful install bun records a fingerprint of
+// everything that determines node_modules; a repeat `bun install` with nothing changed
+// verifies it and returns without re-walking node_modules. These tests check that it
+// engages, and — more importantly — every kind of change that must invalidate it does.
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+setDefaultTimeout(1000 * 60 * 5);
+
+let urls: string[];
+
+async function install(cwd: string, args: string[] = []) {
+  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+const noChanges = /\(no changes\)/;
+
+describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => {
+  beforeEach(async () => {
+    await dummyBeforeEach({ linker });
+    urls = [];
+    setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {} }));
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker } }),
+    );
+    await mkdir(join(package_dir, "packages", "a"), { recursive: true });
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { bar: "0.0.2" }, devDependencies: { qux: "0.0.2" } }),
+    );
+    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.3" } }));
+  });
+  afterEach(dummyAfterEach);
+
+  it("a repeat install is a no-op, and every relevant change invalidates it", async () => {
+    let r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.err).toContain("Saved lockfile");
+    expect(r.code).toBe(0);
+
+    // 1. nothing changed → no requests, same summary wording as the classic no-op
+    const before = urls.length;
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(noChanges);
+    expect(urls.length).toBe(before);
+
+    // 2. a workspace manifest edit is noticed
+    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.err).toContain("Saved lockfile");
+    expect(await file(join(package_dir, "bun.lock")).text()).toContain("baz@0.0.5");
+
+    // 3. a new workspace appearing under the glob is noticed
+    await mkdir(join(package_dir, "packages", "b"), { recursive: true });
+    await writeFile(join(package_dir, "packages", "b", "package.json"), JSON.stringify({ name: "b", version: "1.0.0" }));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.err).toContain("Saved lockfile");
+    expect(await file(join(package_dir, "bun.lock")).text()).toContain('"packages/b"');
+
+    // 4. removing something from node_modules is noticed and repaired
+    await rm(join(package_dir, "node_modules", "bar"), { recursive: true, force: true });
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
+    // (and after the repair we are clean again)
+    expect((await install(package_dir)).out).toMatch(noChanges);
+
+    // 5. deleting a file *inside* an installed package is noticed and repaired
+    await rm(join(package_dir, "node_modules", "bar", "package.json"));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
+
+    // 6. flags are part of the fingerprint: state recorded by an `--omit=dev` run is not
+    //    valid for a plain run (and vice versa)
+    const stateDir = join(package_dir, ".cache", ".install-state");
+    const stateFile = join(stateDir, (await Array.fromAsync(new Bun.Glob("*").scan(stateDir)))[0]);
+    const envLine = async () => (await file(stateFile).text()).split("\n").find(l => l.startsWith("e "));
+    const plainState = await envLine();
+    r = await install(package_dir, ["--omit=dev"]);
+    expect(r.code).toBe(0);
+    expect(await envLine()).not.toBe(plainState);
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(await envLine()).toBe(plainState);
+    expect((await install(package_dir)).out).toMatch(noChanges);
+
+    // 7. --force always does the work
+    r = await install(package_dir, ["--force"]);
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(noChanges);
+
+    // 8. install.stateFile = false disables the fast path (the classic per-package check
+    //    still reports "no changes", but only after verifying every package — observable
+    //    here as node_modules damage being repaired without any recorded state)
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker, stateFile: false } }),
+    );
+    expect((await install(package_dir)).code).toBe(0);
+    await rm(join(package_dir, ".cache", ".install-state"), { recursive: true, force: true });
+    expect((await install(package_dir)).code).toBe(0);
+    expect(existsSync(join(package_dir, ".cache", ".install-state"))).toBeFalse();
+  });
+
+  it("local file: dependencies: untouched is a no-op, an edited source re-installs", async () => {
+    await mkdir(join(package_dir, "local"), { recursive: true });
+    await writeFile(join(package_dir, "local", "package.json"), JSON.stringify({ name: "local", version: "1.0.0" }));
+    await writeFile(join(package_dir, "local", "index.js"), "module.exports = 1;");
+    await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "root", dependencies: { local: "file:./local", bar: "0.0.2" } }));
+
+    let r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(noChanges);
+
+    await Bun.sleep(10);
+    await writeFile(join(package_dir, "local", "index.js"), "module.exports = 2;");
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(noChanges);
+    const installed =
+      linker === "hoisted"
+        ? join(package_dir, "node_modules", "local", "index.js")
+        : join(package_dir, "node_modules", ".bun", "local@file+local", "node_modules", "local", "index.js");
+    expect(await file(installed).text()).toBe("module.exports = 2;");
+  });
+});

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9,6 +9,7 @@ import {
   isWindows,
   joinP,
   normalizeBunSnapshot,
+  readdirCacheSorted,
   readdirSorted,
   runBunInstall,
   tempDir,
@@ -4042,7 +4043,7 @@ describe.concurrent("bun-install", () => {
       expect(ctx.requested).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -4112,7 +4113,7 @@ describe.concurrent("bun-install", () => {
       expect(ctx.requested).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -4350,7 +4351,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -4482,7 +4483,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -5443,7 +5444,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-js", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-js"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5506,7 +5507,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5567,7 +5568,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "9694c5fe9c41ad51.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);
@@ -5755,7 +5756,7 @@ describe.concurrent("bun-install", () => {
 
       expect(await install()).toMatchObject({ exitCode: 0 });
       expect(await readdirSorted(join(cache, `@G@${sha}`))).toEqual([".bun-tag", "package.json"]);
-      const mirror = (await readdirSorted(cache)).find(entry => entry.endsWith(".git"))!;
+      const mirror = (await readdirCacheSorted(cache)).find(entry => entry.endsWith(".git"))!;
 
       // `git log` during resolution does not need the tree object, but `git checkout` cannot unpack without it.
       const treeObject = join(cache, mirror, "objects", treeSha.slice(0, 2), treeSha.slice(2));
@@ -5766,7 +5767,7 @@ describe.concurrent("bun-install", () => {
       const failed = await install();
       expect(failed.err).toContain('"git checkout" for "checkout-fails" failed');
       expect(failed.exitCode).not.toBe(0);
-      expect(await readdirSorted(cache)).toEqual([mirror]);
+      expect(await readdirCacheSorted(cache)).toEqual([mirror]);
 
       await write(treeObject, treeBytes);
       expect(await install()).toMatchObject({ exitCode: 0 });
@@ -5949,7 +5950,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-hash", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "9694c5fe9c41ad51.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5444,7 +5444,9 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-js", "bin", "uglifyjs"),
       );
-      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe(
+        "9694c5fe9c41ad51.git",
+      );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-js"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5507,7 +5509,9 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe(
+        "87d55589eb4217d2.git",
+      );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2038,6 +2038,14 @@ export async function readdirSorted(path: string): Promise<string[]> {
 }
 
 /**
+ * `readdirSorted` for bun's install cache directory: ignores bookkeeping entries that
+ * are not cached packages (currently the `.install-state` fingerprint dir).
+ */
+export async function readdirCacheSorted(path: string): Promise<string[]> {
+  return (await readdirSorted(path)).filter(e => e !== ".install-state");
+}
+
+/**
  * Helper function for making automatically lazily-executed promises.
  *
  * The difference is that the promise has not already started to be evaluated when it is created,


### PR DESCRIPTION
### What does this PR do?

Makes a repeat `bun install` with nothing to do close to free, without giving up correctness.

Today a no-op install still parses the lockfile, re-hoists, and walks `node_modules` opening and parsing every installed `package.json` to confirm name/version — O(packages) syscalls, which on large workspaces (and especially on Windows) is where almost all of the "no changes" time goes.

With this change, after a successful install bun records a fingerprint of the inputs that determine what ends up in `node_modules`, in `<cache>/.install-state/<hash of project root>`:

- content hashes of `bun.lock` / `bun.lockb`, the root and **every workspace** `package.json`, `./bunfig.toml`, `./.npmrc`, `~/.npmrc`, `~/.bunfig.toml`, `$XDG_CONFIG_HOME/{.bunfig.toml,.npmrc}`, and every referenced patch file (absence is recorded too);
- a hash of the install-relevant environment (`BUN_INSTALL*`, `BUN_CONFIG_*`, `NPM_CONFIG_*`), the exact argv, and bun's version (only the hash is stored);
- `lstat` stamps of each `node_modules` directory (root + workspaces), of its top-level entries and of each entry's `package.json` (through symlinks, so the isolated linker's store is covered);
- stamps of the parent directories of the `workspaces` globs — present *or absent*, and for nested globs the existing levels below the literal prefix — so a workspace added on a branch switch is noticed;
- for `file:` / `link:` / local-tarball dependencies, recursive stamps of the source (bounded; a project with enormous local sources just doesn't get a state file).

The next plain `bun install` re-hashes those few files, checks the stamps and, if everything matches, prints the usual `Checked N installs across M packages (no changes)` and returns. Anything else — `bun add/remove/update`, `--force`, `--global`, dry runs, positional filters, `install.stateFile = false`, or any changed input — takes the normal path. The state file is deleted *before* an install that does real work, so a crash mid-install can't leave a "clean" marker behind. As with other package managers' equivalent optimisation, root lifecycle scripts don't re-run on a no-op install.

The state lives in the cache dir (not `node_modules`) so directory listings are unchanged; a new `readdirCacheSorted()` test helper hides the bookkeeping dir from the few tests that snapshot the *cache* directory.

Docs: `install.stateFile` in `docs/runtime/bunfig.mdx`, a short "Repeat installs" note in `docs/pm/cli/install.mdx`.

### How did you verify your code works?

- New `test/cli/install/bun-install-state.test.ts` (dummy registry, both `hoisted` and `isolated`): repeat install is a no-op with zero requests; then each of these invalidates it and is acted on — editing a workspace `package.json`, adding a workspace under the glob, removing a package dir from `node_modules`, deleting a file inside an installed package, running with different flags, `--force`, `stateFile = false`; plus a `file:` dependency whose untouched source is a no-op and whose edited source is re-installed.
- Ran `bun-install`, `bun-add`, `bun-install-registry`, `bun-workspaces`, `isolated-install`, `bun-link`, `bun-lock`, `bun-remove`, `bun-update`, `bun-pm` and `bun-install-lifecycle-scripts` suites locally.
