### PR TITLE
test: dial a local blackhole listener instead of TEST-NET-1 in the never-connecting tests

### DIFF
--- a/test/blackhole.ts
+++ b/test/blackhole.ts
@@ -1,0 +1,93 @@
+import { dlopen } from "bun:ffi";
+import { isLinux, isWindows, libcPathForDlopen } from "harness";
+import net from "node:net";
+
+export interface Blackhole {
+  hostname: string;
+  port: number;
+  [Symbol.dispose](): void;
+}
+
+/**
+ * A TCP address whose connect(2) returns EINPROGRESS and never completes, for
+ * tests that need a socket to stay in the connecting state until they close
+ * it. Tests used to dial a TEST-NET-1 address (192.0.2.1) for this, which only
+ * works on a network that silently drops the packets. Some CI hosts get an
+ * ICMP unreachable back within milliseconds or have no route at all, and the
+ * connect then fails instead.
+ *
+ * On Linux and macOS this is a listener on 127.0.0.1 that nobody accepts from.
+ * Once its accept queue is full, the kernel drops every further SYN, and a
+ * connect to the port sits in SYN_SENT until it is closed. Bun's own listeners
+ * accept every connection and do not expose the backlog, so the listener is a
+ * raw libc socket, and a few connections of our own fill its queue. The queue
+ * is kernel state, so child processes can dial the address too.
+ *
+ * Windows answers a full accept queue with RST, so there this is still
+ * TEST-NET-1, which the Windows CI network drops.
+ */
+export async function blackholeListener(): Promise<Blackhole> {
+  if (isWindows) {
+    return { hostname: "192.0.2.1", port: 80, [Symbol.dispose]() {} };
+  }
+
+  const libc = dlopen(libcPathForDlopen(), {
+    socket: { args: ["int", "int", "int"], returns: "int" },
+    bind: { args: ["int", "ptr", "u32"], returns: "int" },
+    listen: { args: ["int", "int"], returns: "int" },
+    getsockname: { args: ["int", "ptr", "ptr"], returns: "int" },
+    close: { args: ["int"], returns: "int" },
+  });
+  const AF_INET = 2;
+  const SOCK_STREAM = 1;
+
+  // struct sockaddr_in for 127.0.0.1, port 0. Linux starts it with a 16-bit
+  // native-endian sin_family; the BSDs with sin_len followed by sin_family.
+  const addr = new Uint8Array(16);
+  if (isLinux) {
+    new DataView(addr.buffer).setUint16(0, AF_INET, true);
+  } else {
+    addr[0] = addr.byteLength;
+    addr[1] = AF_INET;
+  }
+  addr.set([127, 0, 0, 1], 4);
+
+  const fd = libc.symbols.socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) throw new Error("socket() failed");
+  const fillers: net.Socket[] = [];
+  const dispose = () => {
+    for (const filler of fillers) filler.destroy();
+    libc.symbols.close(fd);
+  };
+
+  try {
+    if (libc.symbols.bind(fd, addr, addr.byteLength) !== 0) throw new Error("bind() failed");
+    // The smallest queue each kernel allows: Linux admits backlog + 1
+    // connections, and macOS turns a backlog of 0 into the default.
+    if (libc.symbols.listen(fd, isLinux ? 0 : 1) !== 0) throw new Error("listen() failed");
+    const addrLen = new Uint32Array([addr.byteLength]);
+    if (libc.symbols.getsockname(fd, addr, addrLen) !== 0) throw new Error("getsockname() failed");
+    const port = (addr[2] << 8) | addr[3];
+
+    // More fillers than either kernel admits. The first SYN is always
+    // admitted, so at least one filler connects. The others stay in SYN_SENT.
+    // Every filler has called connect(2) before the "connect" event below can
+    // be delivered, so the queue is full before any later connect sends its
+    // SYN.
+    const { promise: filled, resolve: onFilled } = Promise.withResolvers<void>();
+    for (let i = 0; i < 8; i++) {
+      fillers.push(
+        net
+          .connect(port, "127.0.0.1")
+          .on("error", () => {})
+          .once("connect", onFilled),
+      );
+    }
+    await filled;
+
+    return { hostname: "127.0.0.1", port, [Symbol.dispose]: dispose };
+  } catch (error) {
+    dispose();
+    throw error;
+  }
+}

--- a/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
+++ b/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
@@ -1,3 +1,4 @@
+import { blackholeListener } from "blackhole";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 
@@ -9,9 +10,10 @@ import { bunEnv, bunExe, isASAN } from "harness";
 // active (non-pooled) sockets.
 //
 // This test fills the cache past ssl_context_cache_max_size (60) with distinct
-// TLS configs whose connects never complete (TEST-NET-1), so every cache entry
-// has an active connecting socket. The 61st distinct config triggers
-// evictOldestSslContext. Aborting all requests then drains the tracker.
+// TLS configs whose connects never complete (a blackhole listener), so every
+// cache entry has an active connecting socket. The 61st distinct config
+// triggers evictOldestSslContext. Aborting all requests then drains the
+// tracker.
 //
 // In debug+ASAN builds the existing assertUnpoisoned check at
 // HTTPThread.processEvents catches the freed socket deterministically, so one
@@ -19,13 +21,16 @@ import { bunEnv, bunExe, isASAN } from "harness";
 // reused; the fixture spams same-size-class allocations to make that likely
 // (~30% per run before the fix), so loop a few times.
 test("aborting fetches whose custom SSL context was evicted does not crash", async () => {
-  // The fixture relies on connects to TEST-NET-1 staying in-flight; strip any
-  // ambient HTTP(S) proxy so those connects aren't intercepted. Raise the
-  // per-process request cap so all 65+200 requests plus both barriers start in
-  // one FIFO drain pass (default cap is 256; 65+200+1 would defer the second
-  // barrier behind async .invalid DNS failures).
+  // The fixture relies on its connects staying in-flight; strip any ambient
+  // HTTP(S) proxy so those connects aren't intercepted. Raise the per-process
+  // request cap so all 65+200 requests plus both barriers start in one FIFO
+  // drain pass (default cap is 256; 65+200+1 would defer the second barrier
+  // behind async .invalid DNS failures).
   const env: Record<string, string | undefined> = { ...bunEnv, BUN_CONFIG_MAX_HTTP_REQUESTS: "512" };
   for (const k of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"]) delete env[k];
+
+  using blackhole = await blackholeListener();
+  const fixture = fixtureFor(`https://${blackhole.hostname}:${blackhole.port}/`);
 
   const runs = isASAN ? 1 : 5;
   const results = await Promise.all(
@@ -51,7 +56,7 @@ test("aborting fetches whose custom SSL context was evicted does not crash", asy
 // fetch queued after the 65 SSL fetches therefore cannot start until every
 // SSL context exists and eviction has fired for indices 60..64, so awaiting
 // that barrier fetch replaces the 5s/0.5s sleeps the original fixture used.
-const fixture = /* js */ `
+const fixtureFor = (blackholeUrl: string) => /* js */ `
 const N = 65; // > ssl_context_cache_max_size (60)
 const controllers = [];
 const promises = [];
@@ -66,7 +71,7 @@ for (let i = 0; i < N; i++) {
   const ac = new AbortController();
   controllers.push(ac);
   promises.push(
-    fetch("https://192.0.2.1/", {
+    fetch(${JSON.stringify(blackholeUrl)}, {
       signal: ac.signal,
       tls: { serverName: "host" + i + ".test" },
     }).catch(() => {})

--- a/test/js/bun/io/fetch/fetch-abort-slow-connect.test.ts
+++ b/test/js/bun/io/fetch/fetch-abort-slow-connect.test.ts
@@ -1,80 +1,18 @@
-import { dlopen } from "bun:ffi";
+import { blackholeListener, type Blackhole } from "blackhole";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { isLinux, isWindows, libcPathForDlopen } from "harness";
-import net from "node:net";
 
-// A URL whose TCP connect returns EINPROGRESS and never completes. A TEST-NET-1
-// address (192.0.2.1) only behaves that way on a network that silently drops
-// the packets. Some CI hosts get an ICMP unreachable back within milliseconds
-// or have no route at all, and the fetch then fails before the signal fires.
-//
-// A listener nobody accepts from behaves that way on any network: once its
-// accept queue is full, the kernel drops every further SYN, and a connect to
-// the port sits in SYN_SENT until it is closed. Bun's own listeners accept
-// every connection and do not expose the backlog, so this one is a raw libc
-// socket, and a few connections of our own fill its queue. Windows answers a
-// full queue with RST instead, so it keeps dialing TEST-NET-1, which its CI
-// network drops.
+// The connect to `url` returns EINPROGRESS and never completes, so each fetch
+// below is still connecting when its signal fires.
+let blackhole: Blackhole;
 let url: string;
-const cleanup: (() => void)[] = [];
 
 beforeAll(async () => {
-  if (isWindows) {
-    url = "http://192.0.2.1:80/";
-    return;
-  }
-
-  const libc = dlopen(libcPathForDlopen(), {
-    socket: { args: ["int", "int", "int"], returns: "int" },
-    bind: { args: ["int", "ptr", "u32"], returns: "int" },
-    listen: { args: ["int", "int"], returns: "int" },
-    getsockname: { args: ["int", "ptr", "ptr"], returns: "int" },
-    close: { args: ["int"], returns: "int" },
-  });
-  const AF_INET = 2;
-  const SOCK_STREAM = 1;
-
-  // struct sockaddr_in for 127.0.0.1, port 0. Linux starts it with a 16-bit
-  // native-endian sin_family; the BSDs with sin_len followed by sin_family.
-  const addr = new Uint8Array(16);
-  if (isLinux) {
-    new DataView(addr.buffer).setUint16(0, AF_INET, true);
-  } else {
-    addr[0] = addr.byteLength;
-    addr[1] = AF_INET;
-  }
-  addr.set([127, 0, 0, 1], 4);
-
-  const fd = libc.symbols.socket(AF_INET, SOCK_STREAM, 0);
-  if (fd < 0) throw new Error("socket() failed");
-  cleanup.push(() => libc.symbols.close(fd));
-  if (libc.symbols.bind(fd, addr, addr.byteLength) !== 0) throw new Error("bind() failed");
-  // The smallest queue each kernel allows: Linux admits backlog + 1
-  // connections, and macOS turns a backlog of 0 into the default.
-  if (libc.symbols.listen(fd, isLinux ? 0 : 1) !== 0) throw new Error("listen() failed");
-  const addrLen = new Uint32Array([addr.byteLength]);
-  if (libc.symbols.getsockname(fd, addr, addrLen) !== 0) throw new Error("getsockname() failed");
-  const port = (addr[2] << 8) | addr[3];
-
-  // More fillers than either kernel admits. The first SYN is always admitted,
-  // so at least one filler connects. The others stay in SYN_SENT. Every
-  // filler has called connect(2) before the "connect" event below can be
-  // delivered, so the queue is full before any later connect sends its SYN.
-  const { promise: filled, resolve: onFilled } = Promise.withResolvers<void>();
-  const fillers = Array.from({ length: 8 }, () =>
-    net
-      .connect(port, "127.0.0.1")
-      .on("error", () => {})
-      .once("connect", onFilled),
-  );
-  cleanup.push(() => fillers.forEach(filler => filler.destroy()));
-  await filled;
-
-  url = `http://127.0.0.1:${port}/`;
+  blackhole = await blackholeListener();
+  url = `http://${blackhole.hostname}:${blackhole.port}/`;
 });
 
 afterAll(() => {
-  while (cleanup.length) cleanup.pop()!();
+  blackhole?.[Symbol.dispose]();
 });
 
 test.concurrent("fetch aborts when connect() returns EINPROGRESS but never completes", async () => {

--- a/test/js/bun/io/fetch/fetch-abort-slow-connect.test.ts
+++ b/test/js/bun/io/fetch/fetch-abort-slow-connect.test.ts
@@ -1,16 +1,86 @@
-import { expect, test } from "bun:test";
+import { dlopen } from "bun:ffi";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { isLinux, isWindows, libcPathForDlopen } from "harness";
+import net from "node:net";
+
+// A URL whose TCP connect returns EINPROGRESS and never completes. A TEST-NET-1
+// address (192.0.2.1) only behaves that way on a network that silently drops
+// the packets. Some CI hosts get an ICMP unreachable back within milliseconds
+// or have no route at all, and the fetch then fails before the signal fires.
+//
+// A listener nobody accepts from behaves that way on any network: once its
+// accept queue is full, the kernel drops every further SYN, and a connect to
+// the port sits in SYN_SENT until it is closed. Bun's own listeners accept
+// every connection and do not expose the backlog, so this one is a raw libc
+// socket, and a few connections of our own fill its queue. Windows answers a
+// full queue with RST instead, so it keeps dialing TEST-NET-1, which its CI
+// network drops.
+let url: string;
+const cleanup: (() => void)[] = [];
+
+beforeAll(async () => {
+  if (isWindows) {
+    url = "http://192.0.2.1:80/";
+    return;
+  }
+
+  const libc = dlopen(libcPathForDlopen(), {
+    socket: { args: ["int", "int", "int"], returns: "int" },
+    bind: { args: ["int", "ptr", "u32"], returns: "int" },
+    listen: { args: ["int", "int"], returns: "int" },
+    getsockname: { args: ["int", "ptr", "ptr"], returns: "int" },
+    close: { args: ["int"], returns: "int" },
+  });
+  const AF_INET = 2;
+  const SOCK_STREAM = 1;
+
+  // struct sockaddr_in for 127.0.0.1, port 0. Linux starts it with a 16-bit
+  // native-endian sin_family; the BSDs with sin_len followed by sin_family.
+  const addr = new Uint8Array(16);
+  if (isLinux) {
+    new DataView(addr.buffer).setUint16(0, AF_INET, true);
+  } else {
+    addr[0] = addr.byteLength;
+    addr[1] = AF_INET;
+  }
+  addr.set([127, 0, 0, 1], 4);
+
+  const fd = libc.symbols.socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) throw new Error("socket() failed");
+  cleanup.push(() => libc.symbols.close(fd));
+  if (libc.symbols.bind(fd, addr, addr.byteLength) !== 0) throw new Error("bind() failed");
+  // The smallest queue each kernel allows: Linux admits backlog + 1
+  // connections, and macOS turns a backlog of 0 into the default.
+  if (libc.symbols.listen(fd, isLinux ? 0 : 1) !== 0) throw new Error("listen() failed");
+  const addrLen = new Uint32Array([addr.byteLength]);
+  if (libc.symbols.getsockname(fd, addr, addrLen) !== 0) throw new Error("getsockname() failed");
+  const port = (addr[2] << 8) | addr[3];
+
+  // More fillers than either kernel admits. The first SYN is always admitted,
+  // so at least one filler connects. The others stay in SYN_SENT. Every
+  // filler has called connect(2) before the "connect" event below can be
+  // delivered, so the queue is full before any later connect sends its SYN.
+  const { promise: filled, resolve: onFilled } = Promise.withResolvers<void>();
+  const fillers = Array.from({ length: 8 }, () =>
+    net
+      .connect(port, "127.0.0.1")
+      .on("error", () => {})
+      .once("connect", onFilled),
+  );
+  cleanup.push(() => fillers.forEach(filler => filler.destroy()));
+  await filled;
+
+  url = `http://127.0.0.1:${port}/`;
+});
+
+afterAll(() => {
+  while (cleanup.length) cleanup.pop()!();
+});
 
 test.concurrent("fetch aborts when connect() returns EINPROGRESS but never completes", async () => {
-  // Use TEST-NET-1 (192.0.2.0/24) from RFC 5737
-  // These IPs are reserved for documentation and testing.
-  // Connecting to them will cause connect() to return EINPROGRESS
-  // but the connection will never complete because there's no route.
-  const nonRoutableIP = "192.0.2.1";
-  const port = 80;
-
   const start = performance.now();
   try {
-    await fetch(`http://${nonRoutableIP}:${port}/`, {
+    await fetch(url, {
       signal: AbortSignal.timeout(50),
     });
     expect.unreachable("Fetch should have aborted");
@@ -22,11 +92,8 @@ test.concurrent("fetch aborts when connect() returns EINPROGRESS but never compl
 });
 
 test.concurrent("fetch aborts immediately during EINPROGRESS connect", async () => {
-  const nonRoutableIP = "192.0.2.1";
-  const port = 80;
-
   // Start the fetch
-  const fetchPromise = fetch(`http://${nonRoutableIP}:${port}/`, {
+  const fetchPromise = fetch(url, {
     signal: AbortSignal.timeout(1),
   });
 
@@ -42,12 +109,9 @@ test.concurrent("fetch aborts immediately during EINPROGRESS connect", async () 
 });
 
 test.concurrent("pre-aborted signal prevents connection attempt", async () => {
-  const nonRoutableIP = "192.0.2.1";
-  const port = 80;
-
   const start = performance.now();
   try {
-    await fetch(`http://${nonRoutableIP}:${port}/`, {
+    await fetch(url, {
       signal: AbortSignal.abort(),
     });
     expect.unreachable("Fetch should have aborted");

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1,3 +1,4 @@
+import { blackholeListener } from "blackhole";
 import { RedisClient } from "bun";
 import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { describe, expect, mock, test } from "bun:test";
@@ -87,14 +88,19 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
     });
 
     test("should handle connection timeout", async () => {
-      // Use a non-routable IP address with a very short timeout
-      const client = new RedisClient("redis://192.0.2.1:6379", {
-        connectionTimeout: 2, // 2ms second timeout
+      // The connect never completes, so the short timeout is what fails it.
+      using blackhole = await blackholeListener();
+      const client = new RedisClient(`redis://${blackhole.hostname}:${blackhole.port}`, {
+        connectionTimeout: 2,
         autoReconnect: false,
       });
-      expect(async () => {
-        await client.get("any-key");
-      }).toThrowErrorMatchingInlineSnapshot(`"Connection timeout reached after 2ms"`);
+      try {
+        await expect(client.get("any-key")).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Connection timeout reached after 2ms"`,
+        );
+      } finally {
+        await client.close();
+      }
     });
 
     test("should report correct connected status", async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,6 +7,7 @@
     "baseUrl": ".",
     "paths": {
       "harness": ["./harness.ts"],
+      "blackhole": ["./blackhole.ts"],
       "mkfifo": ["./mkfifo.ts"],
       "node-harness": ["./js/node/harness.ts"],
       "deno:harness": ["./js/deno/harness.ts"],


### PR DESCRIPTION
### Problem
- `fetch-abort-slow-connect.test.ts` fails on darwin whenever shard 0 lands on the mac host `darwin-arm64-bingus` (builds 102348, 102370): `expect(e.name).toBe("TimeoutError")` at line 19 gets `"TypeError"` after 3.5 ms.
- Three tests dial TEST-NET-1 (`192.0.2.1`) to get a connect that never completes. That host, first seen in CI today, gets an ICMP unreachable back in 20 ms instead. The connect error beats `AbortSignal.timeout(50)`. On such a host `fetch-abort-ssl-context-eviction.test.ts` runs with no connecting sockets, and the valkey timeout test gets a connect error.
- #31584 quarantined the first file on darwin for this reason, #36780 removed the quarantine. Bun is not involved.

### Fix
- `test/blackhole.ts` exports `blackholeListener()`: a raw libc listener on `127.0.0.1` that nobody accepts from, with eight connections of our own in its accept queue. The kernel drops the SYN of every later connect, so a dial sits in `SYN_SENT` until it is closed. The three tests dial it.
- A dropped packet produces the same socket state, so each test exercises the path it did before (`register_abort_tracker` after `connect` in `src/http/lib.rs`, eviction with active sockets, the valkey timeout).
- Windows answers a full accept queue with RST, so the helper returns TEST-NET-1 there, as before.
- Verified: the three files pass with `bun bd test` here, where the old slow-connect file fails. On `bingus` the old file fails 3 of 3 runs, the listener version passes 5 of 5. With the listener, the eviction fixture's 65 TLS fetches sit in `SYN-SENT` (`ss`).

### Background
- What a connect to TEST-NET-1 (RFC 5737) does depends on the first router that refuses it: a silent drop, an ICMP unreachable, or no route at all.
- The accept queue (backlog) holds completed connections the process has not accepted yet. When it is full, Linux and macOS drop new SYNs. Windows sends RST.
- Bun's own listeners accept everything and do not expose the backlog, hence libc through `bun:ffi`, on the `test/mkfifo.ts` pattern. Linux admits `backlog + 1` connections. macOS treats 0 as the default, so the helper passes 1 there.

<details><summary>Notes</summary>

- Build 102370 darwin shard 0 ran on agent `darwin-aarch64-26.6.2-1`, host `darwin-arm64-bingus` (172.92.21.195, LAN gateway 192.168.50.1, connected at 06:13 UTC). Build 102348 shard 0 ran on the same host and failed the same way. Shard 1 jobs on that host pass. Shard 0 jobs on `hardtack`, `crouton` and `breadstick` pass. The agent name `darwin-aarch64-26.6.2-1` is shared by `bingus` and `hardtack`. `bingus` served none of the last 60 main builds (since Aug 19) while every other persistent mac did, so today's PR jobs were its first.
- Probes from the host: `192.0.2.1:80` fails in 22 ms with `No route to host` (`EHOSTUNREACH`). `203.0.113.1` gets `Network is unreachable`. `198.51.100.1`, `240.0.0.1` and `10.255.255.1` hang. From `hardtack`, `192.0.2.1` hangs for the full 5 s probe window.
- This container has no route to `192.0.2.1` at all. The old slow-connect file fails here too: `connect` fails synchronously with `ENETUNREACH` (`UnreachableError` with the release build), and under the debug build both connect tests fail. The eviction test passed here before this change with every connect already failed.
- History: #22842 added the slow-connect file. #31584 added a `[ DARWIN ] ... [ FLAKY ]` entry to `test/expectations.txt` because the darwin agents of that time had no route to `192.0.2.1`, and asked for a local hanging connect as the follow-up. #36780 removed the entry after a probe build passed. This PR is that follow-up.
- The first revision of this PR set the listener up inline in the slow-connect file. A self-review pointed out that `dns-interleave.test.ts` and `valkey-gc.test.ts` already carry inline copies of the same listener and that the eviction test had the same dependence, so the listener moved to `test/blackhole.ts` and the two other tests were converted. The inline copies in `dns-interleave.test.ts` (binds specific addresses inside a child script) and `valkey-gc.test.ts` (inside a child script) and `connect-autoselectfamily-destroy-fixture.js` (needs two addresses, skips itself today) are left for a follow-up. #32949 adds another inline copy and could use the helper once this lands.
- Old slow-connect file on `bingus` with bun 1.3.13: 3 of 3 runs fail the first test (`Received: "Error"`, 3.3 to 4.0 ms). The listener version, byte for byte the code now in `test/blackhole.ts`, passes 5 of 5 runs there and 3 of 3 on a darwin x64 host (macOS 14).
- Socket states during a run, from `ss -tan` and `netstat -an`. Linux: `LISTEN` with recv-q 1, one filler `ESTAB`, seven fillers plus the fetch in `SYN-SENT`. macOS 26 on `bingus`: one filler `ESTABLISHED`, seven fillers plus the fetch in `SYN_SENT`. With 65 TLS fetches (distinct `serverName`s, as in the eviction fixture) against the listener, `ss` shows 72 `SYN-SENT` sockets after 300 ms and all 65 reject with `AbortError` on abort.
- The valkey describe block needs docker and is skipped in this container. The converted test body was run here as an ungated copy with the release and the debug build (passes, `"Connection timeout reached after 2ms"`). `expect(asyncFn).toThrow...` in bun:test returns synchronously, so the old form could not be followed by `client.close()`. The `.rejects` form is awaited, verified to resolve only after the rejection, and asserts the same message.
- The second slow-connect test (`AbortSignal.timeout(1)`) had the same dependence. It passed on `bingus` only because the ICMP reply took longer than 1 ms.
- Windows CI has passed the slow-connect file all along (`test/expected-durations.json` lists it at 114 ms there), so TEST-NET-1 stays as the Windows branch inside the helper. A full accept queue on Windows produces `ECONNREFUSED` (see the note in `test/js/bun/http/request-smuggling.test.ts`), not a pending connect. The eviction test now dials port 80 instead of 443 there, which makes no difference for a dropped SYN.
- `src/http/lib.rs:2884` refers to the slow-connect file by path. The path is unchanged, as are the entries in `test/parallel-denylist.txt` and `test/expected-durations.json`.
- Also ran: `connection-failures.test.ts` under `bun bd test` (46 pass, 13 skipped for docker), the slow-connect file with `USE_SYSTEM_BUN=1`, and six debug-build runs of it in a row.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->