### PR TITLE
pm: add `bun pm cache pack` / `bun pm cache unpack` (single-file cache snapshot for CI)

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -328,6 +328,19 @@ To clear Bun's global module cache:
 bun pm cache rm
 ```
 
+To snapshot the cache entries the current lockfile needs into a single file, and restore them elsewhere:
+
+```bash terminal icon="terminal"
+# after an install, with a warm cache
+bun pm cache pack .ci/bun-cache.pack
+
+# on another machine / CI runner, before installing
+bun pm cache unpack .ci/bun-cache.pack
+bun install --frozen-lockfile
+```
+
+This exists for CI caches: object-store caches move one large sequential file much faster than tens of thousands of small ones, and restoring a directory cache pays a create+write per file before `bun install` even starts. The pack is uncompressed (CI cache layers already compress) and contains only the packages referenced by `bun.lock` that are present locally (optional packages for other platforms are skipped). `unpack` recreates only the entries missing from the target cache, so it is cheap to run unconditionally, and it refuses entries with absolute or traversing paths.
+
 ## migrate
 
 To migrate another package manager's lockfile without installing anything:

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -1,0 +1,431 @@
+//! `bun pm cache pack <file>` / `bun pm cache unpack <file>` — a single-file,
+//! uncompressed snapshot of exactly the cache entries the current lockfile
+//! needs.
+//!
+//! CI caches backed by object storage are dramatically faster at moving
+//! one large sequential file than tens of thousands of small ones, and the
+//! restore side of a directory cache pays a create+write per file *before*
+//! `bun install` even starts. With a pack, CI restores one file, `unpack`
+//! recreates only the missing cache folders (sequential reads, one rename per
+//! package), and `bun install --frozen-lockfile` then finds every tarball
+//! already extracted in the cache.
+//!
+//! Format (little endian, no compression — outer layers already zstd):
+//!   magic "BUNCACHEPACK\0v1\n"
+//!   repeated:  u8 kind | u32 path_len | path | u32 mode | u64 size | bytes
+//!     kind 1 = package folder start (path = cache folder name; size = 0)
+//!     kind 2 = regular file (path relative to the current folder)
+//!     kind 3 = symlink (bytes = link target)
+//!     kind 4 = directory (explicit, for empty dirs)
+//!     kind 0 = end of pack
+
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::PackageManager;
+use crate::lockfile_real::package::PackageColumns as _;
+use crate::package_manager_real::directories;
+use crate::resolution_real::Tag as ResolutionTag;
+
+const MAGIC: &[u8] = b"BUNCACHEPACK\0v1\n";
+
+pub struct PackSummary {
+    pub packages: u32,
+    pub files: u64,
+    pub bytes: u64,
+    pub skipped_missing: u32,
+}
+
+pub struct UnpackSummary {
+    pub packages: u32,
+    pub created: u32,
+    pub already_present: u32,
+    pub bytes: u64,
+}
+
+fn s(p: &[u8]) -> &str {
+    // cache folder names and package-relative paths are ASCII/UTF-8 by construction
+    unsafe { std::str::from_utf8_unchecked(p) }
+}
+
+/// The cache folder name for every fetchable package in the lockfile, and whether
+/// the package is expected on this platform (os/cpu/libc) — used only to decide
+/// whether a missing folder deserves a warning.
+pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
+    let mut out: Vec<(Vec<u8>, bool)> = Vec::new();
+    let count = pm.lockfile.packages.len();
+    for i in 0..count {
+        let (name, resolution, expected) = {
+            let pkgs = &pm.lockfile.packages;
+            let meta = &pkgs.items_meta()[i];
+            (
+                pkgs.items_name()[i],
+                pkgs.items_resolution()[i],
+                !meta.is_disabled(pm.options.cpu, pm.options.os),
+            )
+        };
+        let folder: Option<Vec<u8>> = match resolution.tag {
+            ResolutionTag::Npm => {
+                let name = pm.lockfile.str(&name).to_vec();
+                Some(
+                    directories::cached_npm_package_folder_name(
+                        pm,
+                        &name,
+                        resolution.npm().version,
+                        None,
+                    )
+                    .as_bytes()
+                    .to_vec(),
+                )
+            }
+            ResolutionTag::Git => Some(
+                directories::cached_git_folder_name(pm, resolution.git(), None)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            ResolutionTag::Github => Some(
+                directories::cached_github_folder_name(pm, resolution.github(), None)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            ResolutionTag::RemoteTarball => Some(
+                directories::cached_tarball_folder_name(pm, *resolution.remote_tarball(), None)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            _ => None,
+        };
+        if let Some(f) = folder {
+            if !f.is_empty() && !out.iter().any(|(e, _)| *e == f) {
+                out.push((f, expected));
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+fn write_record(
+    w: &mut impl Write,
+    kind: u8,
+    path: &[u8],
+    mode: u32,
+    data: &[u8],
+) -> std::io::Result<()> {
+    w.write_all(&[kind])?;
+    w.write_all(&(path.len() as u32).to_le_bytes())?;
+    w.write_all(path)?;
+    w.write_all(&mode.to_le_bytes())?;
+    w.write_all(&(data.len() as u64).to_le_bytes())?;
+    w.write_all(data)
+}
+
+fn pack_dir(
+    w: &mut impl Write,
+    root: &Path,
+    rel: &Path,
+    files: &mut u64,
+    bytes: &mut u64,
+) -> std::io::Result<()> {
+    let mut entries: Vec<std::fs::DirEntry> =
+        std::fs::read_dir(root.join(rel))?.flatten().collect();
+    entries.sort_by_key(|e| e.file_name());
+    if entries.is_empty() && !rel.as_os_str().is_empty() {
+        write_record(w, 4, rel.as_os_str().as_encoded_bytes(), 0o755, &[])?;
+    }
+    for e in entries {
+        let ft = e.file_type()?;
+        let child_rel = rel.join(e.file_name());
+        let relb = child_rel.as_os_str().as_encoded_bytes();
+        if ft.is_dir() {
+            pack_dir(w, root, &child_rel, files, bytes)?;
+        } else if ft.is_symlink() {
+            let target = std::fs::read_link(root.join(&child_rel))?;
+            write_record(w, 3, relb, 0o777, target.as_os_str().as_encoded_bytes())?;
+        } else if ft.is_file() {
+            let data = std::fs::read(root.join(&child_rel))?;
+            #[cfg(unix)]
+            let mode = {
+                use std::os::unix::fs::PermissionsExt;
+                e.metadata()?.permissions().mode()
+            };
+            #[cfg(not(unix))]
+            let mode = 0o644u32;
+            *files += 1;
+            *bytes += data.len() as u64;
+            write_record(w, 2, relb, mode, &data)?;
+        }
+    }
+    Ok(())
+}
+
+/// Write a pack of every cache folder the lockfile references that exists locally.
+pub fn pack(
+    pm: &mut PackageManager,
+    cache_dir: &[u8],
+    out_path: &[u8],
+) -> std::io::Result<PackSummary> {
+    let folders = cache_folder_names(pm);
+    let cache = PathBuf::from(s(cache_dir));
+    let tmp = format!("{}.tmp", s(out_path));
+    let file = std::fs::File::create(&tmp)?;
+    let mut w = BufWriter::with_capacity(1 << 20, file);
+    w.write_all(MAGIC)?;
+    let mut summary = PackSummary {
+        packages: 0,
+        files: 0,
+        bytes: 0,
+        skipped_missing: 0,
+    };
+    for (f, expected_here) in &folders {
+        let dir = cache.join(s(f));
+        if !dir.is_dir() {
+            // optional binaries for other platforms are legitimately absent
+            if *expected_here {
+                summary.skipped_missing += 1;
+            }
+            continue;
+        }
+        write_record(&mut w, 1, f, 0, &[])?;
+        pack_dir(
+            &mut w,
+            &dir,
+            Path::new(""),
+            &mut summary.files,
+            &mut summary.bytes,
+        )?;
+        summary.packages += 1;
+    }
+    write_record(&mut w, 0, b"", 0, &[])?;
+    w.flush()?;
+    drop(w);
+    std::fs::rename(&tmp, s(out_path))?;
+    Ok(summary)
+}
+
+fn read_exact_vec(r: &mut impl Read, n: usize) -> std::io::Result<Vec<u8>> {
+    let mut v = vec![0u8; n];
+    r.read_exact(&mut v)?;
+    Ok(v)
+}
+
+fn bad(msg: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg.to_string())
+}
+
+/// Reject anything that could write outside the folder being restored.
+fn safe_rel(path: &[u8]) -> bool {
+    !path.is_empty()
+        && path[0] != b'/'
+        && path[0] != b'\\'
+        && !path.contains(&0)
+        && !path.contains(&b':')
+        && !path
+            .split(|c| *c == b'/' || *c == b'\\')
+            .any(|seg| seg == b"..")
+}
+
+/// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
+fn safe_folder_name(name: &[u8]) -> bool {
+    if !safe_rel(name) || name.contains(&b'\\') || name == b"." || name == b".." {
+        return false;
+    }
+    let slashes = name.iter().filter(|c| **c == b'/').count();
+    slashes == 0 || (slashes == 1 && name[0] == b'@' && !name.ends_with(b"/"))
+}
+
+/// Restore missing cache folders from a pack. Existing folders are left untouched
+/// (their bytes are skipped without being written).
+pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
+    let result = unpack_impl(cache_dir, pack_path);
+    if result.is_err() {
+        // don't leave a half-written staging dir behind
+        let cache = PathBuf::from(s(cache_dir));
+        if let Ok(rd) = std::fs::read_dir(&cache) {
+            let mine = format!(".unpack-{}-", std::process::id());
+            for e in rd.flatten() {
+                if e.file_name()
+                    .as_encoded_bytes()
+                    .starts_with(mine.as_bytes())
+                {
+                    let _ = std::fs::remove_dir_all(e.path());
+                }
+            }
+        }
+    }
+    result
+}
+
+fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
+    let cache = PathBuf::from(s(cache_dir));
+    std::fs::create_dir_all(&cache)?;
+    let file = std::fs::File::open(s(pack_path))?;
+    let mut r = BufReader::with_capacity(1 << 20, file);
+    let magic = read_exact_vec(&mut r, MAGIC.len())?;
+    if magic != MAGIC {
+        return Err(bad("not a bun cache pack (bad magic)"));
+    }
+    let mut summary = UnpackSummary {
+        packages: 0,
+        created: 0,
+        already_present: 0,
+        bytes: 0,
+    };
+    // sweep staging dirs left by an earlier failed/killed unpack
+    if let Ok(rd) = std::fs::read_dir(&cache) {
+        for e in rd.flatten() {
+            if e.file_name().as_encoded_bytes().starts_with(b".unpack-") {
+                let _ = std::fs::remove_dir_all(e.path());
+            }
+        }
+    }
+    // current folder: (final path, staging path) — None while skipping an existing one
+    let mut current: Option<(PathBuf, PathBuf)> = None;
+    let mut skipping = false;
+    let pid = std::process::id();
+
+    let finish = |cur: &mut Option<(PathBuf, PathBuf)>,
+                  summary: &mut UnpackSummary|
+     -> std::io::Result<()> {
+        if let Some((final_path, staging)) = cur.take() {
+            match std::fs::rename(&staging, &final_path) {
+                Ok(()) => summary.created += 1,
+                Err(e) if final_path.is_dir() => {
+                    // lost a race with a concurrent unpack/install: theirs is as good as ours
+                    let _ = e;
+                    let _ = std::fs::remove_dir_all(&staging);
+                    summary.already_present += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    };
+
+    loop {
+        let mut kind = [0u8; 1];
+        r.read_exact(&mut kind)?;
+        let mut u32b = [0u8; 4];
+        r.read_exact(&mut u32b)?;
+        let path_len = u32::from_le_bytes(u32b) as usize;
+        if path_len > 4096 {
+            return Err(bad("path too long"));
+        }
+        let path = read_exact_vec(&mut r, path_len)?;
+        r.read_exact(&mut u32b)?;
+        let mode = u32::from_le_bytes(u32b);
+        let mut u64b = [0u8; 8];
+        r.read_exact(&mut u64b)?;
+        let size = u64::from_le_bytes(u64b);
+        match kind[0] {
+            0 => {
+                finish(&mut current, &mut summary)?;
+                break;
+            }
+            1 => {
+                finish(&mut current, &mut summary)?;
+                if !safe_folder_name(&path) {
+                    return Err(bad("unsafe cache folder name in pack"));
+                }
+                summary.packages += 1;
+                let final_path = cache.join(s(&path));
+                if final_path.exists() {
+                    skipping = true;
+                    summary.already_present += 1;
+                    current = None;
+                } else {
+                    skipping = false;
+                    if let Some(parent) = final_path.parent() {
+                        // `@scope/` directory for scoped packages
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    let staging = cache.join(format!(".unpack-{}-{}", pid, summary.packages));
+                    let _ = std::fs::remove_dir_all(&staging);
+                    std::fs::create_dir_all(&staging)?;
+                    current = Some((final_path, staging));
+                }
+                if size != 0 {
+                    return Err(bad("folder record with payload"));
+                }
+            }
+            2 | 3 | 4 => {
+                if size > (1u64 << 34) {
+                    return Err(bad("entry too large"));
+                }
+                if skipping || current.is_none() {
+                    // consume payload without writing
+                    std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
+                    continue;
+                }
+                if !safe_rel(&path) {
+                    return Err(bad("unsafe entry path in pack"));
+                }
+                let (_, staging) = current.as_ref().unwrap();
+                let dest = staging.join(s(&path));
+                // refuse to traverse a symlink materialized earlier in this package
+                {
+                    let mut p = staging.clone();
+                    let rel = std::path::Path::new(s(&path));
+                    let comps: Vec<_> = rel.components().collect();
+                    for (i, c) in comps.iter().enumerate() {
+                        p.push(c);
+                        if let Ok(m) = std::fs::symlink_metadata(&p) {
+                            if m.file_type().is_symlink() && (i + 1 < comps.len() || kind[0] != 3) {
+                                return Err(bad("pack entry traverses a symlink"));
+                            }
+                        }
+                    }
+                }
+                match kind[0] {
+                    4 => {
+                        std::fs::create_dir_all(&dest)?;
+                        std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
+                    }
+                    3 => {
+                        if size > 4096 {
+                            return Err(bad("symlink target too long"));
+                        }
+                        let target = read_exact_vec(&mut r, size as usize)?;
+                        // links inside a package may only point within it (no `..`, not absolute)
+                        let t: &[u8] = target.strip_prefix(b"./").unwrap_or(&target);
+                        if !safe_rel(t) {
+                            return Err(bad("unsafe symlink target in pack"));
+                        }
+                        if let Some(parent) = dest.parent() {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        #[cfg(unix)]
+                        std::os::unix::fs::symlink(s(&target), &dest)?;
+                        #[cfg(windows)]
+                        {
+                            // file symlinks need privileges on Windows; write a copy stub instead
+                            let _ = target;
+                        }
+                    }
+                    _ => {
+                        if let Some(parent) = dest.parent() {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        let mut f = std::fs::File::create(&dest)?;
+                        let copied = std::io::copy(&mut (&mut r).take(size), &mut f)?;
+                        if copied != size {
+                            return Err(bad("truncated pack"));
+                        }
+                        summary.bytes += size;
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            // keep the executable bit, never setuid/setgid/sticky or world-write
+                            let m = (mode & 0o755) | 0o600;
+                            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(m))?;
+                        }
+                        #[cfg(not(unix))]
+                        let _ = mode;
+                    }
+                }
+            }
+            _ => return Err(bad("unknown record kind")),
+        }
+    }
+    Ok(summary)
+}

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -44,8 +44,58 @@ pub struct UnpackSummary {
 }
 
 fn s(p: &[u8]) -> &str {
-    // cache folder names and package-relative paths are ASCII/UTF-8 by construction
+    // SAFETY: only used to build `Path`s / error text from cache folder names and
+    // package-relative paths, which are ASCII/UTF-8 by construction; the bytes are never
+    // inspected as `str` beyond that.
     unsafe { std::str::from_utf8_unchecked(p) }
+}
+
+fn zpath(p: &Path) -> bun_core::ZBox {
+    bun_core::ZBox::from_vec_with_nul({
+        let mut v = p.as_os_str().as_encoded_bytes().to_vec();
+        v.push(0);
+        v
+    })
+}
+
+fn is_dir(p: &Path) -> bool {
+    matches!(bun_sys::stat(&zpath(p)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+}
+
+fn path_exists(p: &Path) -> bool {
+    bun_sys::lstat(&zpath(p)).is_ok()
+}
+
+fn mkdir_p(p: &Path) -> std::io::Result<()> {
+    bun_sys::mkdir_recursive(p.as_os_str().as_encoded_bytes()).map_err(sys_err)
+}
+
+fn rm_rf(p: &Path) {
+    let _ = bun_sys::delete_tree_absolute(p.as_os_str().as_encoded_bytes());
+}
+
+#[allow(clippy::needless_pass_by_value)] // used as `.map_err(sys_err)`
+fn sys_err(e: bun_sys::Error) -> std::io::Error {
+    std::io::Error::from_raw_os_error(i32::from(e.errno))
+}
+
+/// `std::io::Read` over a `bun_sys::File`.
+struct FileReader(bun_sys::File);
+impl Read for FileReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf).map_err(sys_err)
+    }
+}
+/// `std::io::Write` over a `bun_sys::File`.
+struct FileWriter(bun_sys::File);
+impl Write for FileWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write_all(buf).map_err(sys_err)?;
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// The cache folder name for every fetchable package in the lockfile, and whether
@@ -143,7 +193,11 @@ fn pack_dir(
             let target = std::fs::read_link(root.join(&child_rel))?;
             write_record(w, 3, relb, 0o777, target.as_os_str().as_encoded_bytes())?;
         } else if ft.is_file() {
-            let data = std::fs::read(root.join(&child_rel))?;
+            let data = bun_sys::File::read_from(
+                bun_sys::Fd::cwd(),
+                root.join(&child_rel).as_os_str().as_encoded_bytes(),
+            )
+            .map_err(sys_err)?;
             #[cfg(unix)]
             let mode = {
                 use std::os::unix::fs::PermissionsExt;
@@ -168,8 +222,8 @@ pub fn pack(
     let folders = cache_folder_names(pm);
     let cache = PathBuf::from(s(cache_dir));
     let tmp = format!("{}.tmp", s(out_path));
-    let file = std::fs::File::create(&tmp)?;
-    let mut w = BufWriter::with_capacity(1 << 20, file);
+    let file = bun_sys::File::create(bun_sys::Fd::cwd(), tmp.as_bytes(), true).map_err(sys_err)?;
+    let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
     w.write_all(MAGIC)?;
     let mut summary = PackSummary {
         packages: 0,
@@ -179,7 +233,7 @@ pub fn pack(
     };
     for (f, expected_here) in &folders {
         let dir = cache.join(s(f));
-        if !dir.is_dir() {
+        if !is_dir(&dir) {
             // optional binaries for other platforms are legitimately absent
             if *expected_here {
                 summary.skipped_missing += 1;
@@ -248,7 +302,7 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
                     .as_encoded_bytes()
                     .starts_with(mine.as_bytes())
                 {
-                    let _ = std::fs::remove_dir_all(e.path());
+                    rm_rf(&e.path());
                 }
             }
         }
@@ -258,9 +312,10 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
 
 fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
     let cache = PathBuf::from(s(cache_dir));
-    std::fs::create_dir_all(&cache)?;
-    let file = std::fs::File::open(s(pack_path))?;
-    let mut r = BufReader::with_capacity(1 << 20, file);
+    mkdir_p(&cache)?;
+    let file = bun_sys::File::openat(bun_sys::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)
+        .map_err(sys_err)?;
+    let mut r = BufReader::with_capacity(1 << 20, FileReader(file));
     let magic = read_exact_vec(&mut r, MAGIC.len())?;
     if magic != MAGIC {
         return Err(bad("not a bun cache pack (bad magic)"));
@@ -275,7 +330,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     if let Ok(rd) = std::fs::read_dir(&cache) {
         for e in rd.flatten() {
             if e.file_name().as_encoded_bytes().starts_with(b".unpack-") {
-                let _ = std::fs::remove_dir_all(e.path());
+                rm_rf(&e.path());
             }
         }
     }
@@ -290,10 +345,10 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
         if let Some((final_path, staging)) = cur.take() {
             match std::fs::rename(&staging, &final_path) {
                 Ok(()) => summary.created += 1,
-                Err(e) if final_path.is_dir() => {
+                Err(e) if is_dir(&final_path) => {
                     // lost a race with a concurrent unpack/install: theirs is as good as ours
                     let _ = e;
-                    let _ = std::fs::remove_dir_all(&staging);
+                    rm_rf(&staging);
                     summary.already_present += 1;
                 }
                 Err(e) => return Err(e),
@@ -329,7 +384,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 summary.packages += 1;
                 let final_path = cache.join(s(&path));
-                if final_path.exists() {
+                if path_exists(&final_path) {
                     skipping = true;
                     summary.already_present += 1;
                     current = None;
@@ -337,18 +392,18 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     skipping = false;
                     if let Some(parent) = final_path.parent() {
                         // `@scope/` directory for scoped packages
-                        std::fs::create_dir_all(parent)?;
+                        mkdir_p(parent)?;
                     }
                     let staging = cache.join(format!(".unpack-{}-{}", pid, summary.packages));
-                    let _ = std::fs::remove_dir_all(&staging);
-                    std::fs::create_dir_all(&staging)?;
+                    rm_rf(&staging);
+                    mkdir_p(&staging)?;
                     current = Some((final_path, staging));
                 }
                 if size != 0 {
                     return Err(bad("folder record with payload"));
                 }
             }
-            2 | 3 | 4 => {
+            2..=4 => {
                 if size > (1u64 << 34) {
                     return Err(bad("entry too large"));
                 }
@@ -378,7 +433,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 match kind[0] {
                     4 => {
-                        std::fs::create_dir_all(&dest)?;
+                        mkdir_p(&dest)?;
                         std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
                     }
                     3 => {
@@ -392,7 +447,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                             return Err(bad("unsafe symlink target in pack"));
                         }
                         if let Some(parent) = dest.parent() {
-                            std::fs::create_dir_all(parent)?;
+                            mkdir_p(parent)?;
                         }
                         #[cfg(unix)]
                         std::os::unix::fs::symlink(s(&target), &dest)?;
@@ -404,23 +459,28 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     }
                     _ => {
                         if let Some(parent) = dest.parent() {
-                            std::fs::create_dir_all(parent)?;
+                            mkdir_p(parent)?;
                         }
-                        let mut f = std::fs::File::create(&dest)?;
-                        let copied = std::io::copy(&mut (&mut r).take(size), &mut f)?;
+                        let f = bun_sys::File::create(
+                            bun_sys::Fd::cwd(),
+                            dest.as_os_str().as_encoded_bytes(),
+                            true,
+                        )
+                        .map_err(sys_err)?;
+                        #[cfg(unix)]
+                        {
+                            // keep the executable bit, never setuid/setgid/sticky or world-write
+                            let m = (mode & 0o755) | 0o600;
+                            bun_sys::fchmod(f.handle(), m as bun_sys::Mode).map_err(sys_err)?;
+                        }
+                        #[cfg(not(unix))]
+                        let _ = mode;
+                        let mut w = FileWriter(f);
+                        let copied = std::io::copy(&mut (&mut r).take(size), &mut w)?;
                         if copied != size {
                             return Err(bad("truncated pack"));
                         }
                         summary.bytes += size;
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            // keep the executable bit, never setuid/setgid/sticky or world-write
-                            let m = (mode & 0o755) | 0o600;
-                            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(m))?;
-                        }
-                        #[cfg(not(unix))]
-                        let _ = mode;
                     }
                 }
             }

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -22,6 +22,8 @@
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
+use bun_core::strings;
+
 use crate::PackageManager;
 use crate::lockfile_real::package::PackageColumns as _;
 use crate::package_manager_real::directories;
@@ -43,11 +45,21 @@ pub struct UnpackSummary {
     pub bytes: u64,
 }
 
-fn s(p: &[u8]) -> &str {
-    // SAFETY: only used to build `Path`s / error text from cache folder names and
-    // package-relative paths, which are ASCII/UTF-8 by construction; the bytes are never
-    // inspected as `str` beyond that.
-    unsafe { std::str::from_utf8_unchecked(p) }
+/// `Path` view of path bytes. On POSIX any bytes are a valid `OsStr`; elsewhere the
+/// bytes must be UTF-8 and anything else is rejected as invalid data (archive-controlled
+/// names go through here too, so this is never unchecked).
+fn to_path(p: &[u8]) -> std::io::Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        Ok(PathBuf::from(std::ffi::OsStr::from_bytes(p)))
+    }
+    #[cfg(not(unix))]
+    {
+        std::str::from_utf8(p)
+            .map(PathBuf::from)
+            .map_err(|_| bad("path is not valid UTF-8"))
+    }
 }
 
 fn zpath(p: &Path) -> bun_core::ZBox {
@@ -60,6 +72,23 @@ fn zpath(p: &Path) -> bun_core::ZBox {
 
 fn is_dir(p: &Path) -> bool {
     matches!(bun_sys::stat(&zpath(p)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+}
+
+/// What sits at a cache-folder root: a real directory is packed, nothing is skipped,
+/// anything else (a symlink, a file, an unreadable entry) is an error rather than a
+/// silently incomplete pack.
+fn folder_root_kind(p: &Path) -> std::io::Result<Option<()>> {
+    match bun_sys::lstat(&zpath(p)) {
+        Ok(st) => match bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) {
+            bun_sys::FileKind::Directory => Ok(Some(())),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("cache entry {} is not a directory", p.display()),
+            )),
+        },
+        Err(e) if e.get_errno() == bun_sys::E::ENOENT => Ok(None),
+        Err(e) => Err(sys_err(e)),
+    }
 }
 
 fn path_exists(p: &Path) -> bool {
@@ -178,7 +207,7 @@ fn pack_dir(
     bytes: &mut u64,
 ) -> std::io::Result<()> {
     let mut entries: Vec<std::fs::DirEntry> =
-        std::fs::read_dir(root.join(rel))?.flatten().collect();
+        std::fs::read_dir(root.join(rel))?.collect::<std::io::Result<_>>()?;
     entries.sort_by_key(|e| e.file_name());
     if entries.is_empty() && !rel.as_os_str().is_empty() {
         write_record(w, 4, rel.as_os_str().as_encoded_bytes(), 0o755, &[])?;
@@ -220,9 +249,12 @@ pub fn pack(
     out_path: &[u8],
 ) -> std::io::Result<PackSummary> {
     let folders = cache_folder_names(pm);
-    let cache = PathBuf::from(s(cache_dir));
-    let tmp = format!("{}.tmp", s(out_path));
-    let file = bun_sys::File::create(bun_sys::Fd::cwd(), tmp.as_bytes(), true).map_err(sys_err)?;
+    let cache = to_path(cache_dir)?;
+    let out = to_path(out_path)?;
+    let mut tmp = out_path.to_vec();
+    let _ = write!(tmp, ".{}.tmp", std::process::id());
+    let tmp_path = to_path(&tmp)?;
+    let file = bun_sys::File::create(bun_sys::Fd::cwd(), &tmp, true).map_err(sys_err)?;
     let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
     w.write_all(MAGIC)?;
     let mut summary = PackSummary {
@@ -232,8 +264,8 @@ pub fn pack(
         skipped_missing: 0,
     };
     for (f, expected_here) in &folders {
-        let dir = cache.join(s(f));
-        if !is_dir(&dir) {
+        let dir = cache.join(to_path(f)?);
+        if folder_root_kind(&dir)?.is_none() {
             // optional binaries for other platforms are legitimately absent
             if *expected_here {
                 summary.skipped_missing += 1;
@@ -253,7 +285,10 @@ pub fn pack(
     write_record(&mut w, 0, b"", 0, &[])?;
     w.flush()?;
     drop(w);
-    std::fs::rename(&tmp, s(out_path))?;
+    if let Err(e) = std::fs::rename(&tmp_path, &out) {
+        rm_rf(&tmp_path);
+        return Err(e);
+    }
     Ok(summary)
 }
 
@@ -272,19 +307,17 @@ fn safe_rel(path: &[u8]) -> bool {
     !path.is_empty()
         && path[0] != b'/'
         && path[0] != b'\\'
-        && !path.contains(&0)
-        && !path.contains(&b':')
-        && !path
-            .split(|c| *c == b'/' || *c == b'\\')
-            .any(|seg| seg == b"..")
+        && !strings::contains_char(path, 0)
+        && !strings::contains_char(path, b':')
+        && !strings::split_any(path, b"/\\").any(|seg| seg == b"..")
 }
 
 /// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
 fn safe_folder_name(name: &[u8]) -> bool {
-    if !safe_rel(name) || name.contains(&b'\\') || name == b"." || name == b".." {
+    if !safe_rel(name) || strings::contains_char(name, b'\\') || name == b"." || name == b".." {
         return false;
     }
-    let slashes = name.iter().filter(|c| **c == b'/').count();
+    let slashes = strings::count_char(name, b'/');
     slashes == 0 || (slashes == 1 && name[0] == b'@' && !name.ends_with(b"/"))
 }
 
@@ -294,8 +327,9 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
     let result = unpack_impl(cache_dir, pack_path);
     if result.is_err() {
         // don't leave a half-written staging dir behind
-        let cache = PathBuf::from(s(cache_dir));
-        if let Ok(rd) = std::fs::read_dir(&cache) {
+        if let Ok(cache) = to_path(cache_dir)
+            && let Ok(rd) = std::fs::read_dir(&cache)
+        {
             let mine = format!(".unpack-{}-", std::process::id());
             for e in rd.flatten() {
                 if e.file_name()
@@ -311,7 +345,7 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
 }
 
 fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
-    let cache = PathBuf::from(s(cache_dir));
+    let cache = to_path(cache_dir)?;
     mkdir_p(&cache)?;
     let file = bun_sys::File::openat(bun_sys::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)
         .map_err(sys_err)?;
@@ -320,20 +354,24 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     if magic != MAGIC {
         return Err(bad("not a bun cache pack (bad magic)"));
     }
+    let mut record_no: u64 = 0;
+    // errors name the record so a corrupt pack can be identified and regenerated
+    let bad = |msg: &str, record_no: u64| -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{msg} (record #{record_no}); delete the pack file and re-create it with `bun pm cache pack`"
+            ),
+        )
+    };
     let mut summary = UnpackSummary {
         packages: 0,
         created: 0,
         already_present: 0,
         bytes: 0,
     };
-    // sweep staging dirs left by an earlier failed/killed unpack
-    if let Ok(rd) = std::fs::read_dir(&cache) {
-        for e in rd.flatten() {
-            if e.file_name().as_encoded_bytes().starts_with(b".unpack-") {
-                rm_rf(&e.path());
-            }
-        }
-    }
+    // Staging directories are named `.unpack-<pid>-<n>`; only this process's own are
+    // ever removed (on failure, by `unpack`), so a concurrent unpack is never disturbed.
     // current folder: (final path, staging path) — None while skipping an existing one
     let mut current: Option<(PathBuf, PathBuf)> = None;
     let mut skipping = false;
@@ -358,13 +396,14 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     };
 
     loop {
+        record_no += 1;
         let mut kind = [0u8; 1];
         r.read_exact(&mut kind)?;
         let mut u32b = [0u8; 4];
         r.read_exact(&mut u32b)?;
         let path_len = u32::from_le_bytes(u32b) as usize;
         if path_len > 4096 {
-            return Err(bad("path too long"));
+            return Err(bad("path too long", record_no));
         }
         let path = read_exact_vec(&mut r, path_len)?;
         r.read_exact(&mut u32b)?;
@@ -380,10 +419,10 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
             1 => {
                 finish(&mut current, &mut summary)?;
                 if !safe_folder_name(&path) {
-                    return Err(bad("unsafe cache folder name in pack"));
+                    return Err(bad("unsafe cache folder name in pack", record_no));
                 }
                 summary.packages += 1;
-                let final_path = cache.join(s(&path));
+                let final_path = cache.join(to_path(&path)?);
                 if path_exists(&final_path) {
                     skipping = true;
                     summary.already_present += 1;
@@ -400,12 +439,12 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     current = Some((final_path, staging));
                 }
                 if size != 0 {
-                    return Err(bad("folder record with payload"));
+                    return Err(bad("folder record with payload", record_no));
                 }
             }
             2..=4 => {
                 if size > (1u64 << 34) {
-                    return Err(bad("entry too large"));
+                    return Err(bad("entry too large", record_no));
                 }
                 if skipping || current.is_none() {
                     // consume payload without writing
@@ -413,20 +452,20 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     continue;
                 }
                 if !safe_rel(&path) {
-                    return Err(bad("unsafe entry path in pack"));
+                    return Err(bad("unsafe entry path in pack", record_no));
                 }
                 let (_, staging) = current.as_ref().unwrap();
-                let dest = staging.join(s(&path));
+                let rel = to_path(&path)?;
+                let dest = staging.join(&rel);
                 // refuse to traverse a symlink materialized earlier in this package
                 {
                     let mut p = staging.clone();
-                    let rel = std::path::Path::new(s(&path));
                     let comps: Vec<_> = rel.components().collect();
                     for (i, c) in comps.iter().enumerate() {
                         p.push(c);
                         if let Ok(m) = std::fs::symlink_metadata(&p) {
                             if m.file_type().is_symlink() && (i + 1 < comps.len() || kind[0] != 3) {
-                                return Err(bad("pack entry traverses a symlink"));
+                                return Err(bad("pack entry traverses a symlink", record_no));
                             }
                         }
                     }
@@ -438,23 +477,26 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     }
                     3 => {
                         if size > 4096 {
-                            return Err(bad("symlink target too long"));
+                            return Err(bad("symlink target too long", record_no));
                         }
                         let target = read_exact_vec(&mut r, size as usize)?;
                         // links inside a package may only point within it (no `..`, not absolute)
                         let t: &[u8] = target.strip_prefix(b"./").unwrap_or(&target);
                         if !safe_rel(t) {
-                            return Err(bad("unsafe symlink target in pack"));
+                            return Err(bad("unsafe symlink target in pack", record_no));
                         }
                         if let Some(parent) = dest.parent() {
                             mkdir_p(parent)?;
                         }
                         #[cfg(unix)]
-                        std::os::unix::fs::symlink(s(&target), &dest)?;
-                        #[cfg(windows)]
+                        std::os::unix::fs::symlink(to_path(&target)?, &dest)?;
+                        #[cfg(not(unix))]
                         {
-                            // file symlinks need privileges on Windows; write a copy stub instead
-                            let _ = target;
+                            let _ = (target, dest);
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Unsupported,
+                                "this pack contains symbolic links, which `bun pm cache unpack` cannot restore on this platform yet",
+                            ));
                         }
                     }
                     _ => {
@@ -478,13 +520,13 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         let mut w = FileWriter(f);
                         let copied = std::io::copy(&mut (&mut r).take(size), &mut w)?;
                         if copied != size {
-                            return Err(bad("truncated pack"));
+                            return Err(bad("truncated pack", record_no));
                         }
                         summary.bytes += size;
                     }
                 }
             }
-            _ => return Err(bad("unknown record kind")),
+            _ => return Err(bad("unknown record kind", record_no)),
         }
     }
     Ok(summary)

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -111,6 +111,7 @@ pub use lockfile_real::{DEFAULT_TRUSTED_DEPENDENCIES_LIST, default_trusted_depen
 pub mod audit_fix;
 #[path = "bin.rs"]
 pub mod bin_real;
+pub mod cache_pack;
 pub mod dedupe;
 pub mod hoisted_install;
 pub mod isolated_install;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -217,6 +217,8 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile\n\
   <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder\n\
   <b><green>bun pm<r> <blue>cache rm<r>             clear the cache\n\
+  <b><green>bun pm<r> <blue>cache pack<r> <d>file<r>      write the cache entries this lockfile needs into one file (for CI caches)\n\
+  <b><green>bun pm<r> <blue>cache unpack<r> <d>file<r>    restore cache entries from a pack\n\
   <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything\n\
   <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts\n\
   <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`\n\
@@ -433,6 +435,77 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"cache") {
             if pm.options.positionals.len() > 1
+                && (strings::eql_comptime(pm.options.positionals[1], b"pack")
+                    || strings::eql_comptime(pm.options.positionals[1], b"unpack"))
+            {
+                let is_pack = strings::eql_comptime(pm.options.positionals[1], b"pack");
+                let Some(file) = pm.options.positionals.get(2).copied() else {
+                    Output::err_generic(
+                        "usage: bun pm cache {} <file>",
+                        (if is_pack { "pack" } else { "unpack" },),
+                    );
+                    Global::exit(1);
+                };
+                let mut process_env = bun_dotenv::Loader::init();
+                process_env.load_process()?;
+                let cache_dir = fetch_cache_directory_path(&mut process_env, Some(&pm.options));
+                let start = std::time::Instant::now();
+                if is_pack {
+                    let log_level = pm.options.log_level;
+                    let load_lockfile = pm.load_lockfile_from_cwd::<true>();
+                    Self::handle_load_lockfile_errors_for(&load_lockfile, log_level, "cache pack");
+                    // SAFETY: pm_ptr is the unique owner; lockfile borrow released above.
+                    let pm = unsafe { &mut *pm_ptr };
+                    match bun_install::cache_pack::pack(pm, &cache_dir.path, file) {
+                        Ok(s) => {
+                            bun_core::prettyln!(
+                                "<green>Packed<r> {} package{} ({} files, {}) into <b>{}<r> <d>[{} ms]<r>",
+                                s.packages,
+                                if s.packages == 1 { "" } else { "s" },
+                                s.files,
+                                bun_core::fmt::size(s.bytes as usize, Default::default()),
+                                bstr::BStr::new(file),
+                                start.elapsed().as_millis(),
+                            );
+                            if s.skipped_missing > 0 {
+                                bun_core::prettyln!(
+                                    "<yellow>warn<r>: {} package{} not in the local cache were left out (run bun install first)",
+                                    s.skipped_missing,
+                                    if s.skipped_missing == 1 {
+                                        " was"
+                                    } else {
+                                        "s were"
+                                    },
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            Output::err_generic("cache pack failed: {}", (e,));
+                            Global::exit(1);
+                        }
+                    }
+                } else {
+                    match bun_install::cache_pack::unpack(&cache_dir.path, file) {
+                        Ok(s) => {
+                            bun_core::prettyln!(
+                                "<green>Unpacked<r> {} package{} ({} new, {} already cached, {}) <d>[{} ms]<r>",
+                                s.packages,
+                                if s.packages == 1 { "" } else { "s" },
+                                s.created,
+                                s.already_present,
+                                bun_core::fmt::size(s.bytes as usize, Default::default()),
+                                start.elapsed().as_millis(),
+                            );
+                        }
+                        Err(e) => {
+                            Output::err_generic("cache unpack failed: {}", (e,));
+                            Global::exit(1);
+                        }
+                    }
+                }
+                Output::flush();
+                Global::exit(0);
+            } else if pm.options.positionals.len() > 1
                 && strings::eql_comptime(pm.options.positionals[1], b"rm")
             {
                 let mut had_err = false;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -439,12 +439,16 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                     || strings::eql_comptime(pm.options.positionals[1], b"unpack"))
             {
                 let is_pack = strings::eql_comptime(pm.options.positionals[1], b"pack");
-                let Some(file) = pm.options.positionals.get(2).copied() else {
-                    Output::err_generic(
-                        "usage: bun pm cache {} <file>",
-                        (if is_pack { "pack" } else { "unpack" },),
-                    );
-                    Global::exit(1);
+                // exactly one non-empty <file>
+                let file = match pm.options.positionals.get(2..).unwrap_or(&[]) {
+                    [file] if !file.is_empty() => *file,
+                    rest => {
+                        Output::err_generic(
+                            "expected exactly one \\<file\\> argument, got {}\n  usage: bun pm cache {} \\<file\\>",
+                            (rest.len(), if is_pack { "pack" } else { "unpack" }),
+                        );
+                        Global::exit(1);
+                    }
                 };
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -61,7 +61,14 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   const cache1 = tmpdirSync();
   const cache2 = tmpdirSync();
   await writeFile(join(package_dir, "bunfig.toml"), bunfig());
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2", baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2", baz: "0.0.3" },
+    }),
+  );
 
   let r = await run(["install"], package_dir, cache1);
   expect(r.err).not.toContain("error:");
@@ -88,7 +95,9 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   expect(r.err).not.toContain("error:");
   expect(r.code).toBe(0);
   expect(urls.filter(u => u.endsWith(".tgz")).length).toBe(before);
-  expect(await Bun.file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toMatchObject({ name: "@barn/moo" });
+  expect(await Bun.file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toMatchObject({
+    name: "@barn/moo",
+  });
   expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
 
   // idempotent
@@ -112,9 +121,19 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   const rel = "./../../" + require("path").basename(victim);
   await writeFile(
     join(dir, "escape.pack"),
-    Buffer.concat([MAGIC, rec(1, "evil@1.0.0", 0, ""), rec(3, "esc", 0o777, rel), rec(2, "esc/pwned", 0o644, "owned"), rec(0, "", 0, "")]),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "evil@1.0.0", 0, ""),
+      rec(3, "esc", 0o777, rel),
+      rec(2, "esc/pwned", 0o644, "owned"),
+      rec(0, "", 0, ""),
+    ]),
   );
-  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", require("path").basename(cache)));
+  r = await run(
+    ["pm", "cache", "unpack", join(dir, "escape.pack")],
+    dir,
+    join(victim, "..", require("path").basename(cache)),
+  );
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
   expect(existsSync(join(victim, "pwned"))).toBeFalse();
@@ -122,7 +141,10 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
 
   // an absurd symlink target length
-  await writeFile(join(dir, "long.pack"), Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]));
+  await writeFile(
+    join(dir, "long.pack"),
+    Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]),
+  );
   r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
   expect(r.code).not.toBe(0);
 

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -1,0 +1,133 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { existsSync } from "fs";
+import { rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+setDefaultTimeout(1000 * 60 * 5);
+
+let urls: string[];
+beforeEach(async () => {
+  await dummyBeforeEach({ linker: "hoisted" });
+  urls = [];
+  setHandler(dummyRegistry(urls, { "0.1.0": {}, "0.0.2": {}, "0.0.3": {}, latest: "0.0.3" }));
+});
+afterEach(dummyAfterEach);
+
+async function run(args: string[], cwd: string, cacheDir: string) {
+  await using proc = spawn({
+    cmd: [bunExe(), ...args],
+    cwd,
+    env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+function bunfig() {
+  return Bun.TOML.stringify({ install: { registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } });
+}
+
+// length-prefixed record, mirroring the pack format
+function rec(kind: number, path: string, mode: number, data: string | Buffer) {
+  const p = Buffer.from(path);
+  const d = Buffer.from(data);
+  const h = Buffer.alloc(1 + 4 + p.length + 4 + 8);
+  h[0] = kind;
+  h.writeUInt32LE(p.length, 1);
+  p.copy(h, 5);
+  h.writeUInt32LE(mode, 5 + p.length);
+  h.writeBigUInt64LE(BigInt(d.length), 9 + p.length);
+  return Buffer.concat([h, d]);
+}
+const MAGIC = Buffer.from("BUNCACHEPACK\0v1\n");
+
+it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile needs", async () => {
+  const cache1 = tmpdirSync();
+  const cache2 = tmpdirSync();
+  await writeFile(join(package_dir, "bunfig.toml"), bunfig());
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2", baz: "0.0.3" } }));
+
+  let r = await run(["install"], package_dir, cache1);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+
+  const pack = join(package_dir, "cache.pack");
+  r = await run(["pm", "cache", "pack", pack], package_dir, cache1);
+  expect(r.err).not.toContain("error:");
+  expect(r.out).toContain("Packed 3 packages");
+  expect(existsSync(pack)).toBeTrue();
+
+  // restore into an empty cache dir …
+  r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
+  expect(r.err).not.toContain("error:");
+  expect(r.out).toContain("3 new");
+  const names = await readdirSorted(cache2);
+  expect(names.some(n => n.startsWith("bar@0.0.2"))).toBeTrue();
+  expect(existsSync(join(cache2, "@barn"))).toBeTrue();
+
+  // … and install from it: no tarball is downloaded again
+  await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+  const before = urls.filter(u => u.endsWith(".tgz")).length;
+  r = await run(["install", "--frozen-lockfile"], package_dir, cache2);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.filter(u => u.endsWith(".tgz")).length).toBe(before);
+  expect(await Bun.file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toMatchObject({ name: "@barn/moo" });
+  expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
+
+  // idempotent
+  r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
+  expect(r.out).toContain("0 new, 3 already cached");
+});
+
+it("bun pm cache unpack refuses hostile packs", async () => {
+  const cache = tmpdirSync();
+  const victim = tmpdirSync();
+  const dir = tmpdirSync();
+  await writeFile(join(dir, "package.json"), "{}");
+
+  // a folder name that tries to escape the cache dir
+  await writeFile(join(dir, "traversal.pack"), Buffer.concat([MAGIC, rec(1, "../xx", 0, ""), rec(0, "", 0, "")]));
+  let r = await run(["pm", "cache", "unpack", join(dir, "traversal.pack")], dir, cache);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("unsafe");
+
+  // a symlink out of the package followed by a file written through it
+  const rel = "./../../" + require("path").basename(victim);
+  await writeFile(
+    join(dir, "escape.pack"),
+    Buffer.concat([MAGIC, rec(1, "evil@1.0.0", 0, ""), rec(3, "esc", 0o777, rel), rec(2, "esc/pwned", 0o644, "owned"), rec(0, "", 0, "")]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", require("path").basename(cache)));
+  expect(r.code).not.toBe(0);
+  expect(r.err).toMatch(/unsafe|traverses/);
+  expect(existsSync(join(victim, "pwned"))).toBeFalse();
+  // no staging directory is left behind after a failed unpack
+  expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
+
+  // an absurd symlink target length
+  await writeFile(join(dir, "long.pack"), Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]));
+  r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
+  expect(r.code).not.toBe(0);
+
+  // not a pack at all
+  await writeFile(join(dir, "junk.pack"), "hello");
+  r = await run(["pm", "cache", "unpack", join(dir, "junk.pack")], dir, cache);
+  expect(r.code).not.toBe(0);
+});

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -159,11 +159,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
       rec(0, "", 0, ""),
     ]),
   );
-  r = await run(
-    ["pm", "cache", "unpack", join(dir, "escape.pack")],
-    dir,
-    join(victim, "..", basename(cache)),
-  );
+  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", basename(cache)));
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
   expect(existsSync(join(victim, "pwned"))).toBeFalse();

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -1,9 +1,9 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { existsSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
-import { join } from "path";
+import { bunExe, bunEnv as env, isWindows, readdirSorted, tempDir } from "harness";
+import { basename, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -17,7 +17,6 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-setDefaultTimeout(1000 * 60 * 5);
 
 let urls: string[];
 beforeEach(async () => {
@@ -58,8 +57,10 @@ function rec(kind: number, path: string, mode: number, data: string | Buffer) {
 const MAGIC = Buffer.from("BUNCACHEPACK\0v1\n");
 
 it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile needs", async () => {
-  const cache1 = tmpdirSync();
-  const cache2 = tmpdirSync();
+  using cache1Dir = tempDir("cache-pack-a", {});
+  using cache2Dir = tempDir("cache-pack-b", {});
+  const cache1 = String(cache1Dir);
+  const cache2 = String(cache2Dir);
   await writeFile(join(package_dir, "bunfig.toml"), bunfig());
   await writeFile(
     join(package_dir, "package.json"),
@@ -78,12 +79,14 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   r = await run(["pm", "cache", "pack", pack], package_dir, cache1);
   expect(r.err).not.toContain("error:");
   expect(r.out).toContain("Packed 3 packages");
+  expect(r.code).toBe(0);
   expect(existsSync(pack)).toBeTrue();
 
   // restore into an empty cache dir …
   r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
   expect(r.err).not.toContain("error:");
   expect(r.out).toContain("3 new");
+  expect(r.code).toBe(0);
   const names = await readdirSorted(cache2);
   expect(names.some(n => n.startsWith("bar@0.0.2"))).toBeTrue();
   expect(existsSync(join(cache2, "@barn"))).toBeTrue();
@@ -103,22 +106,49 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   // idempotent
   r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
   expect(r.out).toContain("0 new, 3 already cached");
+  expect(r.code).toBe(0);
+
+  // argument validation
+  r = await run(["pm", "cache", "pack"], package_dir, cache2);
+  expect(r.err).toContain("expected exactly one <file>");
+  expect(r.code).toBe(1);
+  r = await run(["pm", "cache", "unpack", pack, "extra"], package_dir, cache2);
+  expect(r.err).toContain("expected exactly one <file>");
+  expect(r.code).toBe(1);
 });
 
 it("bun pm cache unpack refuses hostile packs", async () => {
-  const cache = tmpdirSync();
-  const victim = tmpdirSync();
-  const dir = tmpdirSync();
-  await writeFile(join(dir, "package.json"), "{}");
+  using cacheDir = tempDir("cache-pack-c", {});
+  using victimDir = tempDir("cache-pack-v", {});
+  using dirDir = tempDir("cache-pack-d", { "package.json": "{}" });
+  const cache = String(cacheDir);
+  const victim = String(victimDir);
+  const dir = String(dirDir);
 
   // a folder name that tries to escape the cache dir
   await writeFile(join(dir, "traversal.pack"), Buffer.concat([MAGIC, rec(1, "../xx", 0, ""), rec(0, "", 0, "")]));
   let r = await run(["pm", "cache", "unpack", join(dir, "traversal.pack")], dir, cache);
-  expect(r.code).not.toBe(0);
   expect(r.err).toContain("unsafe");
+  expect(r.code).not.toBe(0);
+
+  // absolute folder name / absolute entry path
+  const abs = isWindows ? "C:\\evil" : "/tmp/evil";
+  await writeFile(join(dir, "absdir.pack"), Buffer.concat([MAGIC, rec(1, abs, 0, ""), rec(0, "", 0, "")]));
+  r = await run(["pm", "cache", "unpack", join(dir, "absdir.pack")], dir, cache);
+  expect(r.err).toContain("unsafe");
+  expect(r.code).not.toBe(0);
+  await writeFile(
+    join(dir, "absentry.pack"),
+    Buffer.concat([MAGIC, rec(1, "abs@1.0.0", 0, ""), rec(2, join(victim, "x"), 0o644, "x"), rec(0, "", 0, "")]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "absentry.pack")], dir, cache);
+  expect(r.err).toContain("unsafe");
+  expect(r.code).not.toBe(0);
+  expect(existsSync(join(victim, "x"))).toBeFalse();
+  expect((await readdirSorted(cache)).filter(n => !n.startsWith("."))).toEqual([]);
 
   // a symlink out of the package followed by a file written through it
-  const rel = "./../../" + require("path").basename(victim);
+  const rel = "./../../" + basename(victim);
   await writeFile(
     join(dir, "escape.pack"),
     Buffer.concat([
@@ -132,7 +162,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   r = await run(
     ["pm", "cache", "unpack", join(dir, "escape.pack")],
     dir,
-    join(victim, "..", require("path").basename(cache)),
+    join(victim, "..", basename(cache)),
   );
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
@@ -143,7 +173,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   // an absurd symlink target length
   await writeFile(
     join(dir, "long.pack"),
-    Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]),
+    Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, Buffer.alloc(10_000, "a")), rec(0, "", 0, "")]),
   );
   r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
   expect(r.code).not.toBe(0);


### PR DESCRIPTION
### What does this PR do?

Adds two subcommands for CI cache workflows:

```sh
bun pm cache pack   <file>   # snapshot the cache entries this lockfile needs into one file
bun pm cache unpack <file>   # restore the missing ones into the cache dir
```

**Why:** the usual advice is to cache bun's install cache directory between CI runs. Object-store backed caches move one large sequential file far faster than tens of thousands of small ones, and restoring a directory cache pays a `create + write` per file before `bun install` even starts. A pack is a single uncompressed stream (the CI cache layer already compresses), and `unpack` recreates only the folders that are missing, so it is cheap to run unconditionally before `bun install --frozen-lockfile`.

Details:
- `pack` walks the lockfile's packages (npm / git / github / remote tarball resolutions), maps them to their cache folder names, and writes `magic | (kind, path, mode, size, bytes)*` records — folder-start, file, symlink, dir. Optional packages for other os/cpu that were never downloaded are silently skipped; anything else missing from the local cache is counted and reported.
- `unpack` writes each package under `.unpack-<pid>-<n>` in the cache dir and renames it into place (an existing folder wins, so concurrent unpacks/installs are fine). It refuses: folder names that aren't `name@…` / `@scope/name@…`, entry paths that are absolute / contain `..` / drive letters / NUL, symlink targets that escape the package or exceed 4 KiB, and any file/dir entry that would be written *through* a symlink materialised earlier in the same package. Modes are masked to `0755` (no setuid/setgid), a failed unpack removes its staging dir, and stale staging dirs are swept on start.

Docs: `docs/pm/cli/pm.mdx` (`## cache`).

### How did you verify your code works?

New `test/cli/install/bun-pm-cache-pack.test.ts` (dummy registry):
- install (incl. a scoped package) with cache dir A → `pack` → `unpack` into empty cache dir B → `rm -rf node_modules` → `bun install --frozen-lockfile` against B downloads **no** tarballs and produces the same tree; a second `unpack` reports everything already cached.
- hostile packs: traversing folder name, `esc -> ./../../<dir>` symlink followed by a file entry `esc/pwned`, a 10 000-byte symlink target, and a non-pack file are all rejected, nothing is written outside the cache, and no staging dir is left behind.
- `test/cli/install/bun-pm.test.ts` still passes.
