### PR TITLE
ci: give PR builds an x64 darwin test lane again

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -188,7 +188,8 @@ const testPlatforms = [
   // lanes — see buildPlatforms).
   // These three version-specific lanes run on main and on opt-in (see
   // darwinTestsEnabled). PR builds instead get one aarch64 lane that any mac
-  // agent can take (prDarwinTestPlatforms), so the whole arm64 pool serves PRs.
+  // agent of that arch can take (prDarwinTestPlatforms), so the whole arm64
+  // pool serves one PR lane and the whole x64 pool the other.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
   { os: "darwin", arch: "x64", release: "14", tier: "latest" },
@@ -1574,7 +1575,10 @@ async function getPipeline(options = {}) {
   // on main along with its build.
   // Untiered: any arm64 mac agent, whatever macOS it runs, can take it.
   /** @type {Platform[]} */
-  const prDarwinTestPlatforms = [{ os: "darwin", arch: "aarch64", release: "any" }];
+  const prDarwinTestPlatforms = [
+    { os: "darwin", arch: "aarch64", release: "any" },
+    { os: "darwin", arch: "x64", release: "any" },
+  ];
   const darwinTestsEnabled = isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")


### PR DESCRIPTION
x64 darwin tests came off PR builds in #39191 when the fleet was down to 4 Intel minis. MacStadium returned the other 5 today, so there are 9 again.

This adds `darwin-x64-any-test-bun` to PR builds, shaped exactly like the existing aarch64 PR lane: untiered (`queue=test-darwin, os=darwin, arch=x64`, any Intel box), 2 shards, and the same `--skip-slower-than=10000` stopgap so it fits the pool at PR volume (~6-7 min shards; 9 slots ≈ 216 slot-hours/day vs ~180 needed). `main`, manual and `[macos tests]` builds still run the full `darwin-x64-14` lane.

`--dry-run`: PR → `darwin-aarch64-any-test-bun` + `darwin-x64-any-test-bun` (both skip-slow, par 2); main → `26` / `14` / `x64-14` unchanged. The x64 lane depends on `darwin-x64-build-bun`, which already runs on PRs.