### PR TITLE
docs(sql): document timestamp without time zone decoded as UTC (fixes #39879)

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1383,6 +1383,10 @@ We haven't implemented `LOAD DATA INFILE` support yet.
 
 ### PostgreSQL-Specific Features
 
+#### `timestamp` without time zone
+
+`timestamp without time zone` (OID 1114) values are decoded as **UTC** so the text and binary paths agree and a bound `Date` round-trips exactly regardless of host timezone. This differs from `node-postgres` and `postgres.js` (and PGlite), which decode `timestamp` as local time — code migrating from those drivers on a non-UTC host will see values shifted by the local offset. `timestamptz` carries an explicit offset and is unaffected.
+
 We haven't implemented these yet:
 
 - `COPY` support


### PR DESCRIPTION
Fixes #39879

PostgreSQL 	imestamp without time zone (OID 1114) is decoded as UTC so text and binary paths agree and a bound Date round-trips regardless of host timezone. This differs from 
ode-postgres/postgres.js/PGlite which decode as local time.

Previously the behavior was documented only in the MySQL section at docs/runtime/sql.mdx:1370, inside a trailing clause. A PostgreSQL user had no reason to read that section and the PostgreSQL docs said nothing, leading to silent offset shifts when migrating from pg.

Adds a dedicated 	imestamp without time zone note under PostgreSQL-Specific Features.
