### PR TITLE
Lay out the --compile payload by region and drop only source text pages

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1146,7 +1146,13 @@ pub(crate) fn to_bytes(
         let lo = modules.iter().map(|m| m.contents.offset).min().unwrap();
         let hi = modules.iter().map(|m| range(m.contents).end).max().unwrap();
         let others = modules.iter().flat_map(|m| {
-            [m.bytecode, m.module_info, m.sourcemap, m.name, m.bytecode_origin_path]
+            [
+                m.bytecode,
+                m.module_info,
+                m.sourcemap,
+                m.name,
+                m.bytecode_origin_path,
+            ]
         });
         for p in others.chain([offsets.modules_ptr, offsets.compile_exec_argv_ptr]) {
             let r = range(p);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -623,7 +623,10 @@ bitflags::bitflags! {
         const DISABLE_AUTOLOAD_BUNFIG       = 1 << 1;
         const DISABLE_AUTOLOAD_TSCONFIG     = 1 << 2;
         const DISABLE_AUTOLOAD_PACKAGE_JSON = 1 << 3;
-        // _padding: u28
+        /// Every file's `contents` lies in one run that no bytecode, module
+        /// info, name, or source map region overlaps (see `to_bytes`).
+        const SOURCE_TEXT_CONTIGUOUS        = 1 << 4;
+        // _padding: u27
     }
 }
 
@@ -819,6 +822,27 @@ unsafe fn slice_to_z(base: *const u8, len: usize, ptr: StringPointer) -> &'stati
     unsafe { ZStr::from_raw(base.add(off), n) }
 }
 
+/// The embedded bunfs key for an output file, relative to the prefix.
+///
+/// Windows: store the key with `/`. The template printer emits native
+/// `\` into `dest_path`, but `find_assume_standalone_path` normalizes
+/// lookups to `/`, so a `\` key would miss (ENOENT). `src/bundler/Chunk.rs`
+/// only normalizes a scratch copy, so we re-normalize here.
+fn module_dest_path(output_file: &OutputFile) -> std::borrow::Cow<'_, [u8]> {
+    let dest_path = bun_core::strings::remove_leading_dot_slash(&output_file.dest_path);
+    #[cfg(windows)]
+    {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        std::borrow::Cow::Owned(
+            path::resolve_path::platform_to_posix_buf::<u8>(dest_path, &mut buf).to_vec(),
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        std::borrow::Cow::Borrowed(dest_path)
+    }
+}
+
 pub(crate) fn to_bytes(
     prefix: &[u8],
     output_files: &[OutputFile],
@@ -876,9 +900,7 @@ pub(crate) fn to_bytes(
     string_builder.allocate()?;
 
     let mut modules: Vec<CompiledModuleGraphFile> = Vec::with_capacity(module_count);
-
-    let mut source_map_header_list: Vec<u8> = Vec::new();
-    let mut source_map_string_list: Vec<u8> = Vec::new();
+    let mut module_files: Vec<&OutputFile> = Vec::with_capacity(module_count);
 
     for output_file in output_files {
         if !output_file.output_kind.is_file_in_standalone_mode() {
@@ -888,18 +910,6 @@ pub(crate) fn to_bytes(
         let options::OutputFileValue::Buffer { bytes: buf_bytes } = &output_file.value else {
             continue;
         };
-
-        let dest_path = bun_core::strings::remove_leading_dot_slash(&output_file.dest_path);
-
-        // Windows: store the key with `/`. The template printer emits native
-        // `\` into `dest_path`, but `find_assume_standalone_path` normalizes
-        // lookups to `/`, so a `\` key would miss (ENOENT). `src/bundler/Chunk.rs`
-        // only normalizes a scratch copy, so we re-normalize here.
-        #[cfg(windows)]
-        let mut dest_path_buf = PathBuffer::uninit();
-        #[cfg(windows)]
-        let dest_path: &[u8] =
-            path::resolve_path::platform_to_posix_buf::<u8>(dest_path, &mut dest_path_buf);
 
         let bytecode: StringPointer = 'brk: {
             if output_file.bytecode_index != u32::MAX {
@@ -915,16 +925,10 @@ pub(crate) fn to_bytes(
                 //     (section_va + 8 + O) % 128 == 0
                 //     => O % 128 == 120
                 //
-                // - ELF (Linux): The module graph data is appended to the executable and
-                //   read into a heap-allocated buffer at runtime. The allocator provides
-                //   natural alignment, and there's no 8-byte section header offset.
-                //   However, using target_mod=120 is still safe because:
-                //   - If the buffer is 128-aligned: bytecode at offset 120 is at (128n + 120),
-                //     which when loaded at a 128-aligned address gives proper alignment.
-                //   - The extra 120 bytes of padding is acceptable overhead.
-                //
-                // This alignment strategy (target_mod=120) works for all platforms because
-                // it's the worst-case offset needed for the 8-byte header scenario.
+                // - ELF (Linux): the payload is mapped by the kernel as part of the
+                //   RW PT_LOAD (see exe_format/elf.rs) at a page-aligned address, also
+                //   preceded by the same 8-byte length header, so the same arithmetic
+                //   applies.
                 let bytecode = output_files[output_file.bytecode_index as usize]
                     .value
                     .as_slice();
@@ -978,6 +982,7 @@ pub(crate) fn to_bytes(
 
         if Environment::IS_CANARY || Environment::IS_DEBUG {
             if let Some(dump_code_dir) = bun_core::env_var::BUN_FEATURE_FLAG_DUMP_CODE.get() {
+                let dest_path = &*module_dest_path(output_file);
                 // `dest_path` keeps `..` for the embedded bunfs key below; neutralize
                 // every `..` segment here so the on-disk dump can't escape
                 // `dump_code_dir` (the join would otherwise normalize `..` above it).
@@ -1017,23 +1022,10 @@ pub(crate) fn to_bytes(
             }
         }
 
-        // When there's bytecode, store the bytecode output file's path as bytecode_origin_path.
-        // This path was used to generate the bytecode cache and must match at runtime.
-        let bytecode_origin_path: StringPointer = if output_file.bytecode_index != u32::MAX {
-            string_builder
-                .append_count_z(&output_files[output_file.bytecode_index as usize].dest_path)
-        } else {
-            StringPointer::default()
-        };
-
-        let mut module = CompiledModuleGraphFile {
-            name: string_builder.fmt_append_count_z(format_args!(
-                "{}{}",
-                bstr::BStr::new(prefix),
-                bstr::BStr::new(dest_path)
-            )),
+        modules.push(CompiledModuleGraphFile {
+            name: StringPointer::default(),
             loader: output_file.loader,
-            contents: string_builder.append_count_z(buf_bytes),
+            contents: StringPointer::default(),
             // Latin1 lets the runtime wrap the mmapped section bytes in a
             // zero-copy ExternalStringImpl. The printer escapes non-ASCII for
             // server-side JS, but `--banner`/`--footer`/hashbang and
@@ -1058,14 +1050,25 @@ pub(crate) fn to_bytes(
             },
             bytecode,
             module_info,
-            bytecode_origin_path,
+            bytecode_origin_path: StringPointer::default(),
             side: match output_file.side.unwrap_or(options::Side::Server) {
                 options::Side::Server => FileSide::Server,
                 options::Side::Client => FileSide::Client,
             },
             sourcemap: StringPointer::default(),
-        };
+        });
+        module_files.push(output_file);
+    }
 
+    // Region layout after the bytecode/module_info run above: source maps
+    // (unread until an error prints), then every file's source text as one run
+    // (`Flags::SOURCE_TEXT_CONTIGUOUS`, so `hint_source_pages_dont_need` can
+    // drop exactly it), then everything booting touches — names, origin paths,
+    // the module table — packed at the tail so startup faults in a few pages
+    // instead of one per embedded file.
+    let mut source_map_header_list: Vec<u8> = Vec::new();
+    let mut source_map_string_list: Vec<u8> = Vec::new();
+    for (module, output_file) in modules.iter_mut().zip(&module_files) {
         if output_file.source_map_index != u32::MAX {
             serialize_json_source_map_for_standalone(
                 &mut source_map_header_list,
@@ -1079,7 +1082,24 @@ pub(crate) fn to_bytes(
             source_map_header_list.clear();
             source_map_string_list.clear();
         }
-        modules.push(module);
+    }
+
+    for (module, output_file) in modules.iter_mut().zip(&module_files) {
+        module.contents = string_builder.append_count_z(output_file.value.as_slice());
+    }
+
+    for (module, output_file) in modules.iter_mut().zip(&module_files) {
+        module.name = string_builder.fmt_append_count_z(format_args!(
+            "{}{}",
+            bstr::BStr::new(prefix),
+            bstr::BStr::new(&*module_dest_path(output_file))
+        ));
+        // The bytecode cache was generated under the bytecode output file's
+        // path; the runtime must present exactly the same path to hit it.
+        if output_file.bytecode_index != u32::MAX {
+            module.bytecode_origin_path = string_builder
+                .append_count_z(&output_files[output_file.bytecode_index as usize].dest_path);
+        }
     }
 
     // SAFETY: `CompiledModuleGraphFile` is `#[repr(C)]` POD with no padding-dependent
@@ -1095,7 +1115,7 @@ pub(crate) fn to_bytes(
         modules_ptr: string_builder.append_count(modules_as_bytes),
         compile_exec_argv_ptr: string_builder.append_count_z(compile_exec_argv),
         byte_count: string_builder.len,
-        flags,
+        flags: flags | Flags::SOURCE_TEXT_CONTIGUOUS,
     };
 
     // SAFETY: `Offsets` is `#[repr(C)]` POD; same `modules_as_bytes` rationale as above.
@@ -1119,6 +1139,19 @@ pub(crate) fn to_bytes(
         debug_assert_eq!(graph.files.count(), modules.len());
         graph.files.unlock_pointers();
         graph.dirs.unlock_pointers();
+
+        // `Flags::SOURCE_TEXT_CONTIGUOUS`: no other region may fall inside the
+        // source-text run, or the runtime's MADV_DONTNEED would drop it.
+        let range = |p: StringPointer| p.offset..p.offset + p.length;
+        let lo = modules.iter().map(|m| m.contents.offset).min().unwrap();
+        let hi = modules.iter().map(|m| range(m.contents).end).max().unwrap();
+        let others = modules.iter().flat_map(|m| {
+            [m.bytecode, m.module_info, m.sourcemap, m.name, m.bytecode_origin_path]
+        });
+        for p in others.chain([offsets.modules_ptr, offsets.compile_exec_argv_ptr]) {
+            let r = range(p);
+            debug_assert!(p.length == 0 || r.end <= lo || r.start >= hi);
+        }
     }
 
     // StringBuilder owns the buffer; hand it back without copying. `cap` may
@@ -2235,82 +2268,89 @@ impl StandaloneModuleGraph {
         }
     }
 
-    /// Hint to the kernel that the embedded `__BUN`/`.bun` source pages are
-    /// unlikely to be accessed again after the entrypoint has been parsed.
-    /// The pages are clean file-backed COW, so any later read (lazy require,
-    /// stack-trace source lookup) faults back in transparently from the
-    /// executable on disk. Only applies when running as a compiled
-    /// standalone binary; `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`
+    /// Hint to the kernel that the embedded source text is unlikely to be
+    /// accessed again after the entrypoint has been evaluated. The pages are
+    /// clean file-backed COW, so any later read (lazy require, stack-trace
+    /// source lookup, `Bun.embeddedFiles`) faults back in transparently from
+    /// the executable on disk. Only the contiguous source-text run written by
+    /// `to_bytes` is dropped: JSC keeps decoding function bodies out of the
+    /// bytecode regions for the life of the process, and dropping those turns
+    /// every first call into a page fault. Only applies when running as a
+    /// compiled standalone binary; `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`
     /// skips the hint.
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
     pub fn hint_source_pages_dont_need() {
-        #[cfg(windows)]
+        let Some(graph) = Self::get_ref() else {
+            return;
+        };
+        if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE::get()
+            .unwrap_or(false)
         {
             return;
         }
+        let Some((start, end)) = graph.source_text_pages() else {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "hintSourcePagesDontNeed: no whole source-text page to drop"
+            );
+            return;
+        };
 
-        #[cfg(not(windows))]
-        {
-            let (base, len): (*mut u8, usize) = {
-                #[cfg(target_os = "macos")]
-                {
-                    match macho::get_data() {
-                        Some(b) => b,
-                        None => return,
-                    }
-                }
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                {
-                    match elf::get_data() {
-                        Some(b) => b,
-                        None => return,
-                    }
-                }
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
-                {
-                    return;
-                }
-            };
-
-            #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
-            {
-                if len == 0
-                    || bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE
-                        .get()
-                        .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let page: usize = bun_alloc::page_size();
-                let start = (base as usize) & !(page - 1);
-                let end_unaligned = base as usize + len;
-                let end = (end_unaligned + page - 1) & !(page - 1);
-
-                // This is a best-effort hint, so call libc madvise directly and
-                // just log on failure rather than treating errors as fatal.
-                // SAFETY: start..end covers a mapped range of the executable image.
-                let rc = unsafe {
-                    libc::madvise(
-                        start as *mut core::ffi::c_void,
-                        end - start,
-                        libc::MADV_DONTNEED,
-                    )
-                };
-                if rc != 0 {
-                    bun_core::scoped_log!(
-                        StandaloneModuleGraph,
-                        "hintSourcePagesDontNeed: madvise failed errno={}",
-                        bun_sys::last_errno()
-                    );
-                    return;
-                }
-                bun_core::scoped_log!(
-                    StandaloneModuleGraph,
-                    "hintSourcePagesDontNeed: MADV_DONTNEED {} bytes",
-                    end - start
-                );
-            }
+        // This is a best-effort hint, so call libc madvise directly and
+        // just log on failure rather than treating errors as fatal.
+        // SAFETY: start..end lies inside the mapped executable image, and
+        // MADV_DONTNEED neither reads nor writes through it.
+        let rc = unsafe {
+            libc::madvise(
+                start as *mut core::ffi::c_void,
+                end - start,
+                libc::MADV_DONTNEED,
+            )
+        };
+        if rc != 0 {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "hintSourcePagesDontNeed: madvise failed errno={}",
+                bun_sys::last_errno()
+            );
+        } else {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "hintSourcePagesDontNeed: MADV_DONTNEED {} bytes",
+                end - start
+            );
         }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
+    pub fn hint_source_pages_dont_need() {}
+
+    /// The whole pages covered by the files' `contents` regions: `(start, end)`
+    /// rounded inward, or `None` when the run does not cover a full page or the
+    /// payload was not written with `Flags::SOURCE_TEXT_CONTIGUOUS` (an older
+    /// `bun build` interleaves bytecode with the source text).
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
+    fn source_text_pages(&self) -> Option<(usize, usize)> {
+        if !self.flags.contains(Flags::SOURCE_TEXT_CONTIGUOUS) {
+            return None;
+        }
+        let (mut lo, mut hi) = (usize::MAX, 0usize);
+        for file in self.files.values() {
+            let contents = file.contents.as_bytes();
+            if contents.is_empty() {
+                continue;
+            }
+            let start = contents.as_ptr() as usize;
+            lo = lo.min(start);
+            hi = hi.max(start + contents.len());
+        }
+        if lo >= hi {
+            return None;
+        }
+        let page = bun_alloc::page_size();
+        let start = (lo + page - 1) & !(page - 1);
+        let end = hi & !(page - 1);
+        (end > start).then_some((start, end))
     }
 }
 

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 
 // Relies on the StandaloneModuleGraph scoped logger which is compiled out in
 // release builds.
-test.skipIf(isWindows || !isDebug)(
+test.concurrent.skipIf(isWindows || !isDebug)(
   "standalone madvise hint fires with top-level await entrypoint",
   async () => {
     using dir = tempDir("standalone-madvise-tla", {
@@ -85,3 +85,42 @@ test.skipIf(isWindows || !isDebug)(
   },
   30_000,
 );
+
+// The hint must cover only the source text, not the bytecode JSC keeps
+// decoding from. The string literal below lands in both the source and the
+// bytecode cache, so a hint spanning both reports at least double its size.
+test.concurrent.skipIf(isWindows || !isDebug)("standalone madvise hint covers only the embedded source text", async () => {
+  const literalBytes = 64 * 1024;
+  using dir = tempDir("standalone-madvise-range", {
+    "entry.ts": `const s = "${Buffer.alloc(literalBytes, "a").toString()}";\nconsole.log("len=" + s.length);\n`,
+  });
+
+  const out = path.join(String(dir), "compiled");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), "build", "--compile", "--bytecode", path.join(String(dir), "entry.ts"), "--outfile", out],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  expect(build.stderr.toString()).not.toContain("error:");
+  expect(build.exitCode).toBe(0);
+
+  await using proc = Bun.spawn({
+    cmd: [out],
+    env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain(`len=${literalBytes}`);
+  const hinted = stdout.match(/hintSourcePagesDontNeed: MADV_DONTNEED (\d+) bytes/);
+  expect(hinted).not.toBeNull();
+  const bytes = Number(hinted![1]);
+  // Whole pages inside the source run: at most the literal plus the small
+  // bundler wrapper around it, never the bytecode as well.
+  expect(bytes).toBeLessThan(literalBytes + 16 * 1024);
+  expect(bytes).toBeGreaterThan(literalBytes / 2);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -89,38 +89,42 @@ test.concurrent.skipIf(isWindows || !isDebug)(
 // The hint must cover only the source text, not the bytecode JSC keeps
 // decoding from. The string literal below lands in both the source and the
 // bytecode cache, so a hint spanning both reports at least double its size.
-test.concurrent.skipIf(isWindows || !isDebug)("standalone madvise hint covers only the embedded source text", async () => {
-  const literalBytes = 64 * 1024;
-  using dir = tempDir("standalone-madvise-range", {
-    "entry.ts": `const s = "${Buffer.alloc(literalBytes, "a").toString()}";\nconsole.log("len=" + s.length);\n`,
-  });
+test.concurrent.skipIf(isWindows || !isDebug)(
+  "standalone madvise hint covers only the embedded source text",
+  async () => {
+    const literalBytes = 64 * 1024;
+    using dir = tempDir("standalone-madvise-range", {
+      "entry.ts": `const s = "${Buffer.alloc(literalBytes, "a").toString()}";\nconsole.log("len=" + s.length);\n`,
+    });
 
-  const out = path.join(String(dir), "compiled");
-  const build = Bun.spawnSync({
-    cmd: [bunExe(), "build", "--compile", "--bytecode", path.join(String(dir), "entry.ts"), "--outfile", out],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  expect(build.stderr.toString()).not.toContain("error:");
-  expect(build.exitCode).toBe(0);
+    const out = path.join(String(dir), "compiled");
+    const build = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--compile", "--bytecode", path.join(String(dir), "entry.ts"), "--outfile", out],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    expect(build.stderr.toString()).not.toContain("error:");
+    expect(build.exitCode).toBe(0);
 
-  await using proc = Bun.spawn({
-    cmd: [out],
-    env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [out],
+      env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain(`len=${literalBytes}`);
-  const hinted = stdout.match(/hintSourcePagesDontNeed: MADV_DONTNEED (\d+) bytes/);
-  expect(hinted).not.toBeNull();
-  const bytes = Number(hinted![1]);
-  // Whole pages inside the source run: at most the literal plus the small
-  // bundler wrapper around it, never the bytecode as well.
-  expect(bytes).toBeLessThan(literalBytes + 16 * 1024);
-  expect(bytes).toBeGreaterThan(literalBytes / 2);
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-}, 30_000);
+    expect(stdout).toContain(`len=${literalBytes}`);
+    const hinted = stdout.match(/hintSourcePagesDontNeed: MADV_DONTNEED (\d+) bytes/);
+    expect(hinted).not.toBeNull();
+    const bytes = Number(hinted![1]);
+    // Whole pages inside the source run: at most the literal plus the small
+    // bundler wrapper around it, never the bytecode as well.
+    expect(bytes).toBeLessThan(literalBytes + 16 * 1024);
+    expect(bytes).toBeGreaterThan(literalBytes / 2);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
### What does this PR do?

`bun build --compile` writes the embedded payload file by file: `[bytecode][module info][origin path][name][source][source map]` repeated per module. Booting a compiled executable hashes every file name to build the module table, so it touches one page per embedded file, spread over the whole payload. `hint_source_pages_dont_need()` then `MADV_DONTNEED`s the *entire* payload, bytecode included, and JSC faults that bytecode straight back in.

This PR changes two things in `StandaloneModuleGraph.rs`:

1. **Region layout** in `to_bytes`: `[bytecode + module info] [source maps] [source text, one contiguous run] [names, origin paths, module table]`. Everything startup touches sits at the tail; source maps stay untouched until an error prints; the source text is a single run. The record format (`CompiledModuleGraphFile`, `Offsets`, trailer) is unchanged, so `from_bytes` needs no changes and `--target=bun-…-vX` still works in both directions.
2. **Narrow the madvise hint** to the whole pages strictly inside the source-text run. A new `Flags::SOURCE_TEXT_CONTIGUOUS` bit records that the payload was written with this layout; a runtime reading an old-layout payload (older `bun build`, newer runtime via `--target`) skips the hint instead of dropping bytecode. Older runtimes ignore the bit.

The debug round-trip check in `to_bytes` now also asserts that no other region falls inside the source-text run.

The hint covers only *whole* pages of the run, so an executable whose bundled source is smaller than one page gets no hint at all (previously it dropped the one shared page, bytecode included). Non-JS embedded files (`Bun.embeddedFiles`, `.node` addons) live in the same run and are dropped with it, as before; they fault back in transparently when read.

### Measurements

Both runtimes built from the same commit (same size, 58,488,800 bytes) and used to compile the same 1,478-file / 418 MB application (`--compile --bytecode --sourcemap`, 340 MB payload: 213 MB bytecode, 69 MB source, 47 MB source maps, 11 MB module info). macOS arm64.

Layout (from the module table):

| | before | after |
|---|---|---|
| pages touched by the boot-time name scan (16 KiB pages) | 1,386 (21.7 MB) | 11 (0.2 MB) |
| span of the source text | 340.7 MB (interleaved with 7,328 other regions) | 69.2 MB (contiguous, 0 other regions) |

Cold cache (`purge` before each run, fresh APFS clones validated once so first-launch signature checks are excluded; disk reads from `vm_stat` pageins, so they include whatever else re-faults after the purge):

| | before | after |
|---|---|---|
| `--version`, wall (3 runs) | 0.22–0.24 s | 0.11 s |
| `--version`, bytes read | 78–91 MB | 29–40 MB |
| first render, wall (5 runs, median) | 1.19 s (1.12–2.38) | 1.06 s (0.92–1.22) |
| first render, bytes read (5 runs, median) | 458 MB (407–575) | 389 MB (285–482) |

The `--version`-class start — anything that exits before loading the application — halves. A start that loads the application reads most of the bytecode anyway; the read volume drops but the wall-clock difference is within the run-to-run spread.

Warm start to first render (`/usr/bin/time -l`, 3 interleaved runs each):

| | before | after |
|---|---|---|
| wall (hyperfine, 20 runs ×2) | 378–385 ms ± 7–10 | 376 ms ± 6–8 |
| max RSS | 447–449 MB | 430–433 MB |
| minor faults | 33.5k | 32.6k |
| peak footprint (anonymous) | 244 MB | 244 MB |
| minor faults with `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` | 32.5k | 32.7k |

The last row is the madvise cost in isolation: before, the whole-payload hint adds ~1,000 faults (~16 MB of bytecode re-read) on top of a run with the hint disabled; after, the hint is free. Anonymous memory and warm wall time do not move, as expected — this change only affects file-backed pages. Bytecode cache hits are identical (575 hits / 1 miss at first render, both builds).

Linux numbers (`drop_caches`, PSS by region) to follow.

### How did you verify your code works?

- New test in `test/js/bun/compile/standalone-madvise-tla.test.ts`: compiles a `--bytecode` executable whose source is a 64 KiB literal and checks the `MADV_DONTNEED N bytes` debug log covers at most the source (N = 49,152 after; 147,456 = source + bytecode before, so it fails on the unfixed build).
- Existing madvise TLA test, `bundler_compile.test.ts` bytecode / embedded-files / source-map cases, `bun run rust:check-all`.
- Drove a debug build end-to-end: multi-file `--compile --bytecode --sourcemap` app with an embedded asset and a dynamic import — bytecode cache hit, source-mapped stack trace, `Bun.embeddedFiles`, lazy import all work.
