### PR TITLE
webstreams: propagate exceptions through helpers, convert only at boundaries

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -118,32 +118,6 @@ static void settlePullPromiseRejected(JSGlobalObject* globalObject, JSAsyncItera
     }
 }
 
-// BOUNDARY handler, called only from the host functions below (promise reactions and the
-// direct source's pull): whatever the pump threw is the stream's error — the original
-// `catch (e) { closingError = e }`. If delivering it throws as well (a `code` getter,
-// iterator.throw(), iterator.return()), that second error settles the pull promise instead; with
-// no pull promise left to settle it stays pending for the caller's runner to report.
-static void asyncIterRejectWithPendingException(JSGlobalObject* globalObject, ThrowScope& scope, JSAsyncIteratorSourceOperation* op)
-{
-    JSValue error = takeException(scope);
-    RETURN_IF_EXCEPTION(scope, );
-    asyncIterFinishWithError(globalObject, op, error);
-    if (!scope.exception() || !op->m_pullPromise) [[likely]]
-        return;
-    error = takeException(scope);
-    RETURN_IF_EXCEPTION(scope, );
-    op->m_iterator.clear();
-    settlePullPromiseRejected(globalObject, op, error);
-}
-
-static EncodedJSValue asyncIterReactionEnd(JSGlobalObject* globalObject, ThrowScope& scope, JSAsyncIteratorSourceOperation* op)
-{
-    if (scope.exception()) [[unlikely]]
-        asyncIterRejectWithPendingException(globalObject, scope, op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
-}
-
 // The success tail: controller.end(), then iterator.return(), then resolve the pull promise.
 static void asyncIterFinishSuccess(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
 {
@@ -196,13 +170,9 @@ static void asyncIterFinishWithError(JSGlobalObject* globalObject, JSAsyncIterat
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
-    bool isInvalidThis = errorCodeIs(globalObject, error, "ERR_INVALID_THIS"_s);
-    RETURN_IF_EXCEPTION(scope, );
-    if (isInvalidThis)
+    if (errorCodeIs(vm, error, "ERR_INVALID_THIS"_s))
         RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
-
-    bool swallowByCode = errorCodeIs(globalObject, error, "ERR_INVALID_STATE"_s);
-    RETURN_IF_EXCEPTION(scope, );
+    bool swallowByCode = errorCodeIs(vm, error, "ERR_INVALID_STATE"_s);
 
     JSObject* iterator = op->m_iterator.get();
     op->m_iterator.clear();
@@ -358,57 +328,58 @@ static void driveAsyncIterator(JSGlobalObject* globalObject, JSAsyncIteratorSour
     }
 }
 
-// -- [reaction-convention] handlers: (value, contextCell). These are BOUNDARIES: entered from
-// a promise reaction, so an exception left pending here would reach nobody; it becomes the
-// stream's error via asyncIterReactionEnd. --
+// -- [reaction-convention] handlers: (value, contextCell). Entered from a promise reaction, so
+// these are boundaries (enterStreams): whatever the pump throws is the stream's error — the
+// original `catch (e) { closingError = e }`. --
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceNextFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
-    if (op->m_done) {
-        op->m_running = false;
-        return JSValue::encode(jsUndefined());
-    }
-    if (op->m_cancelled)
-        asyncIterReturnIteratorAndSettle(globalObject, op);
-    else if (asyncIterHandleNextResult(globalObject, op, callFrame->argument(0)) == NextStep::ContinueLoop && !scope.exception())
-        driveAsyncIterator(globalObject, op);
-    return asyncIterReactionEnd(globalObject, scope, op);
+    JSValue result = callFrame->argument(0);
+    return enterStreams(globalObject, [&] {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        if (op->m_done) {
+            op->m_running = false;
+            return;
+        }
+        if (op->m_cancelled)
+            RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
+        auto step = asyncIterHandleNextResult(globalObject, op, result);
+        RETURN_IF_EXCEPTION(scope, );
+        if (step == NextStep::ContinueLoop)
+            RELEASE_AND_RETURN(scope, driveAsyncIterator(globalObject, op)); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceFlushFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
-    if (op->m_done)
-        return JSValue::encode(jsUndefined());
-    if (op->m_cancelled)
-        asyncIterReturnIteratorAndSettle(globalObject, op);
-    else if (op->m_iteratorDone) // The drained write may have been the iterator's final value.
-        asyncIterFinishSuccess(globalObject, op);
-    else
-        driveAsyncIterator(globalObject, op);
-    return asyncIterReactionEnd(globalObject, scope, op);
+    return enterStreams(globalObject, [&] {
+        if (op->m_done)
+            return;
+        if (op->m_cancelled)
+            return asyncIterReturnIteratorAndSettle(globalObject, op);
+        if (op->m_iteratorDone) // The drained write may have been the iterator's final value.
+            return asyncIterFinishSuccess(globalObject, op);
+        driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
 }
 
 // Any rejection feeding the loop (next(), flush(true), end(), return()) takes the error path.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceErrored, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
-    if (op->m_done)
-        return JSValue::encode(jsUndefined());
-    asyncIterFinishWithError(globalObject, op, callFrame->argument(0));
-    return asyncIterReactionEnd(globalObject, scope, op);
+    JSValue rejection = callFrame->argument(0);
+    return enterStreams(globalObject, [&] {
+        if (!op->m_done)
+            asyncIterFinishWithError(globalObject, op, rejection); }, [&](JSValue error) {
+        // Delivering the rejection threw (iterator.throw()/return()); that error settles the pull.
+        op->m_iterator.clear();
+        settlePullPromiseRejected(globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceEndFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
-    asyncIterReturnIteratorAndSettle(globalObject, op);
-    return asyncIterReactionEnd(globalObject, scope, op);
+    return enterStreams(globalObject, [&] { asyncIterReturnIteratorAndSettle(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
 }
 
 // iterator.return() fulfilled after the stream already ended.
@@ -443,7 +414,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceErrorSwallowed
 // -- [bound-convention] direct-source methods: (opCell, ...callArgs) --
 
 // pull(controller): one drive of the iterator runs at a time; every pull while it runs gets
-// the same promise. BOUNDARY: pull() answers with a promise, so a throw from the drive rejects it.
+// the same promise. pull() answers with that promise, so a throw from the drive is the stream's
+// error (enterStreams), never a synchronous throw into the direct controller.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -461,9 +433,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGl
     auto* pullPromise = JSPromise::create(vm, globalObject->promiseStructure());
     op->m_pullPromise.set(vm, op, pullPromise);
     op->m_running = true;
-    driveAsyncIterator(globalObject, op);
-    if (scope.exception()) [[unlikely]]
-        asyncIterRejectWithPendingException(globalObject, scope, op);
+    enterStreams(globalObject, [&] { driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(pullPromise);
 }

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -118,49 +118,58 @@ static void settlePullPromiseRejected(JSGlobalObject* globalObject, JSAsyncItera
     }
 }
 
-// The pump met an abrupt completion. An ordinary one is delivered through the error tail; the VM's
-// termination (takeAbruptCompletion leaves it pending and returns nothing) has no error to deliver and no
-// script may run over it: drop the iterator and the pull promise unsettled and let it propagate.
-static void asyncIterFinishAbrupt(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op, TopExceptionScope& scope)
+// BOUNDARY handler, called only from the host functions below (promise reactions and the
+// direct source's pull): whatever the pump threw is the stream's error — the original
+// `catch (e) { closingError = e }`. If delivering it throws as well (a `code` getter,
+// iterator.throw(), iterator.return()), that second error settles the pull promise instead; with
+// no pull promise left to settle it stays pending for the caller's runner to report.
+static void asyncIterRejectWithPendingException(JSGlobalObject* globalObject, ThrowScope& scope, JSAsyncIteratorSourceOperation* op)
 {
-    if (JSValue error = takeAbruptCompletion(globalObject, scope)) [[likely]] {
-        asyncIterFinishWithError(globalObject, op, error);
+    JSValue error = takeException(scope);
+    RETURN_IF_EXCEPTION(scope, );
+    asyncIterFinishWithError(globalObject, op, error);
+    if (!scope.exception() || !op->m_pullPromise) [[likely]]
         return;
-    }
-    op->m_done = true;
-    op->m_running = false;
+    error = takeException(scope);
+    RETURN_IF_EXCEPTION(scope, );
     op->m_iterator.clear();
-    op->m_pullPromise.clear();
+    settlePullPromiseRejected(globalObject, op, error);
+}
+
+static EncodedJSValue asyncIterReactionEnd(JSGlobalObject* globalObject, ThrowScope& scope, JSAsyncIteratorSourceOperation* op)
+{
+    if (scope.exception()) [[unlikely]]
+        asyncIterRejectWithPendingException(globalObject, scope, op);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
 }
 
 // The success tail: controller.end(), then iterator.return(), then resolve the pull promise.
 static void asyncIterFinishSuccess(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
     JSValue endResult;
     if (JSObject* controller = op->m_controller.get()) {
         MarkedArgumentBuffer noArgs;
         endResult = invokeOptionalMethod(globalObject, controller, WebCore::builtinNames(vm).endPublicName(), noArgs);
-        if (scope.exception()) [[unlikely]] {
-            asyncIterFinishAbrupt(globalObject, op, scope);
-            return;
-        }
+        RETURN_IF_EXCEPTION(scope, );
     }
     if (auto* endPromise = asPromise(endResult)) {
         endPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceEndFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
         return;
     }
-    asyncIterReturnIteratorAndSettle(globalObject, op);
+    RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
 }
 
-// iterator.return() (so a generator's `finally` runs), then resolve the pull promise.
+// iterator.return() (so a generator's `finally` runs), then resolve the pull promise; a throw or
+// rejection from return() rejects it instead (the original awaited it).
 static void asyncIterReturnIteratorAndSettle(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
     JSObject* iterator = op->m_iterator.get();
     op->m_iterator.clear();
@@ -170,34 +179,30 @@ static void asyncIterReturnIteratorAndSettle(JSGlobalObject* globalObject, JSAsy
     }
     MarkedArgumentBuffer noArgs;
     JSValue returned = invokeOptionalMethod(globalObject, iterator, vm.propertyNames->returnKeyword, noArgs);
-    if (scope.exception()) [[unlikely]] {
-        // The iterator's own cleanup failure is subsumed: the stream already ended.
-        scope.clearExceptionExceptTermination();
-        settlePullPromiseResolved(globalObject, op);
-        return;
-    }
+    RETURN_IF_EXCEPTION(scope, );
     if (auto* returnPromise = asPromise(returned)) {
-        markPromiseAsHandled(vm, returnPromise);
-        returnPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceCleanupSettled(), runtime->onAsyncIterableSourceCleanupSettled(), jsUndefined(), op);
+        returnPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceCleanupSettled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
         return;
     }
     settlePullPromiseResolved(globalObject, op);
 }
 
-// Error tail: an already-gone consumer (ERR_INVALID_THIS) returns the iterator quietly;
-// otherwise notify it via iterator.throw(error) and settle once that settles.
+// Error tail (the original `finally` with a closingError): an already-gone consumer
+// (ERR_INVALID_THIS) returns the iterator quietly; otherwise notify it via iterator.throw(error)
+// and settle once that settles.
 static void asyncIterFinishWithError(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op, JSValue error)
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
-    if (errorCodeIs(globalObject, error, "ERR_INVALID_THIS"_s)) {
-        asyncIterReturnIteratorAndSettle(globalObject, op);
-        return;
-    }
+    bool isInvalidThis = errorCodeIs(globalObject, error, "ERR_INVALID_THIS"_s);
+    RETURN_IF_EXCEPTION(scope, );
+    if (isInvalidThis)
+        RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
 
     bool swallowByCode = errorCodeIs(globalObject, error, "ERR_INVALID_STATE"_s);
+    RETURN_IF_EXCEPTION(scope, );
 
     JSObject* iterator = op->m_iterator.get();
     op->m_iterator.clear();
@@ -206,11 +211,7 @@ static void asyncIterFinishWithError(JSGlobalObject* globalObject, JSAsyncIterat
         MarkedArgumentBuffer args;
         args.append(error);
         thrown = invokeOptionalMethod(globalObject, iterator, vm.propertyNames->throwKeyword, args);
-        if (scope.exception()) [[unlikely]] {
-            // The iterator's own cleanup failure is subsumed by the original error.
-            scope.clearExceptionExceptTermination();
-            thrown = {};
-        }
+        RETURN_IF_EXCEPTION(scope, );
     }
     // The cancelled check happens when the settle runs: a cancellation arriving while
     // iterator.throw() is pending must still suppress the rejection.
@@ -239,25 +240,18 @@ enum class NextStep : uint8_t {
 static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op, JSValue result)
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
-    JSValue doneValue = jsUndefined();
-    JSValue value = jsUndefined();
     if (!result.isObject()) {
         // Matches awaiting a malformed iterator: iteration results must be objects.
-        JSObject* error = createTypeError(globalObject, "Async iterator result is not an object"_s);
-        asyncIterFinishWithError(globalObject, op, error);
+        throwTypeError(globalObject, scope, "Async iterator result is not an object"_s);
         return NextStep::Finished;
     }
-    {
-        doneValue = result.get(globalObject, vm.propertyNames->done);
-        if (scope.exception()) [[unlikely]]
-            goto abrupt;
-        value = result.get(globalObject, vm.propertyNames->value);
-        if (scope.exception()) [[unlikely]]
-            goto abrupt;
-    }
+    JSValue doneValue = result.get(globalObject, vm.propertyNames->done);
+    RETURN_IF_EXCEPTION(scope, NextStep::Finished);
+    JSValue value = result.get(globalObject, vm.propertyNames->value);
+    RETURN_IF_EXCEPTION(scope, NextStep::Finished);
 
     if (doneValue.toBoolean(globalObject))
         op->m_iteratorDone = true;
@@ -265,32 +259,29 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
     // The done/value getters run user JS that can cancel the stream.
     if (op->m_cancelled) {
         asyncIterReturnIteratorAndSettle(globalObject, op);
-        return NextStep::Finished;
+        RELEASE_AND_RETURN(scope, NextStep::Finished);
     }
 
     if (!value.isUndefinedOrNull()) {
         JSObject* controller = op->m_controller.get();
         if (!controller) {
             asyncIterFinishSuccess(globalObject, op);
-            return NextStep::Finished;
+            RELEASE_AND_RETURN(scope, NextStep::Finished);
         }
         MarkedArgumentBuffer writeArgs;
         writeArgs.append(value);
         JSValue wrote = invokeOptionalMethod(globalObject, controller, WebCore::builtinNames(vm).writePublicName(), writeArgs);
-        if (scope.exception()) [[unlikely]]
-            goto abrupt;
+        RETURN_IF_EXCEPTION(scope, NextStep::Finished);
         if (wrote && wrote.isNumber() && wrote.asNumber() < 0) {
             // The HTTP sink reports backpressure with a negative return: wait for the drain.
             MarkedArgumentBuffer flushArgs;
             flushArgs.append(jsBoolean(true));
             JSValue flushed = invokeOptionalMethod(globalObject, controller, builtinNames(vm).flushPublicName(), flushArgs);
-            if (scope.exception()) [[unlikely]]
-                goto abrupt;
+            RETURN_IF_EXCEPTION(scope, NextStep::Finished);
             JSPromise* flushPromise = asPromise(flushed);
             if (!flushPromise) {
                 flushPromise = promiseResolvedWith(globalObject, flushed ? flushed : jsUndefined());
-                if (scope.exception()) [[unlikely]]
-                    goto abrupt;
+                RETURN_IF_EXCEPTION(scope, NextStep::Finished);
             }
             flushPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceFlushFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
             return NextStep::Suspended;
@@ -306,13 +297,9 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
 
     if (op->m_iteratorDone) {
         asyncIterFinishSuccess(globalObject, op);
-        return NextStep::Finished;
+        RELEASE_AND_RETURN(scope, NextStep::Finished);
     }
     return NextStep::ContinueLoop;
-
-abrupt:
-    asyncIterFinishAbrupt(globalObject, op, scope);
-    return NextStep::Finished;
 }
 
 // The pump loop. Synchronously-fulfilled next() results are consumed in place (writes batch
@@ -321,7 +308,7 @@ abrupt:
 static void driveAsyncIterator(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
     while (true) {
@@ -329,10 +316,8 @@ static void driveAsyncIterator(JSGlobalObject* globalObject, JSAsyncIteratorSour
             op->m_running = false;
             return;
         }
-        if (op->m_cancelled) {
-            asyncIterReturnIteratorAndSettle(globalObject, op);
-            return;
-        }
+        if (op->m_cancelled)
+            RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
         JSObject* iterator = op->m_iterator.get();
         if (!iterator) {
             settlePullPromiseResolved(globalObject, op);
@@ -340,104 +325,93 @@ static void driveAsyncIterator(JSGlobalObject* globalObject, JSAsyncIteratorSour
         }
         MarkedArgumentBuffer nextArgs;
         nextArgs.append(op->m_controller ? JSValue(op->m_controller.get()) : jsUndefined());
-        JSValue nextResult;
-        {
-            JSValue nextFunction = iterator->get(globalObject, vm.propertyNames->next);
-            if (!scope.exception()) [[likely]] {
-                if (op->m_cancelled) {
-                    // A `next` getter cancelled the stream; do not resume the iterator.
-                    asyncIterReturnIteratorAndSettle(globalObject, op);
-                    return;
-                }
-                nextResult = JSC::call(globalObject, nextFunction, iterator, nextArgs, "iterator.next is not a function"_s);
-            }
-            if (scope.exception()) [[unlikely]] {
-                asyncIterFinishAbrupt(globalObject, op, scope);
-                return;
-            }
-        }
+        JSValue nextFunction = iterator->get(globalObject, vm.propertyNames->next);
+        RETURN_IF_EXCEPTION(scope, );
         if (op->m_cancelled) {
-            asyncIterReturnIteratorAndSettle(globalObject, op);
-            return;
+            // A `next` getter cancelled the stream; do not resume the iterator.
+            RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
         }
+        JSValue nextResult = JSC::call(globalObject, nextFunction, iterator, nextArgs, "iterator.next is not a function"_s);
+        RETURN_IF_EXCEPTION(scope, );
+        if (op->m_cancelled)
+            RELEASE_AND_RETURN(scope, asyncIterReturnIteratorAndSettle(globalObject, op));
         JSPromise* nextPromise = asPromise(nextResult);
         if (!nextPromise) {
             // `await` semantics: adopt thenables; plain results become fulfilled promises.
             nextPromise = promiseResolvedWith(globalObject, nextResult);
-            if (scope.exception()) [[unlikely]] {
-                asyncIterFinishAbrupt(globalObject, op, scope);
-                return;
-            }
+            RETURN_IF_EXCEPTION(scope, );
         }
         auto status = nextPromise->status();
         if (status == JSPromise::Status::Fulfilled) {
-            if (asyncIterHandleNextResult(globalObject, op, nextPromise->result()) != NextStep::ContinueLoop)
+            auto step = asyncIterHandleNextResult(globalObject, op, nextPromise->result());
+            RETURN_IF_EXCEPTION(scope, );
+            if (step != NextStep::ContinueLoop)
                 return;
             continue;
         }
         if (status == JSPromise::Status::Rejected) {
             markPromiseAsHandled(vm, nextPromise);
-            asyncIterFinishWithError(globalObject, op, nextPromise->result());
-            return;
+            RELEASE_AND_RETURN(scope, asyncIterFinishWithError(globalObject, op, nextPromise->result()));
         }
         nextPromise->performPromiseThenWithContext(vm, globalObject, runtime->onAsyncIterableSourceNextFulfilled(), runtime->onAsyncIterableSourceErrored(), jsUndefined(), op);
         return;
     }
 }
 
-// -- [reaction-convention] handlers: (value, contextCell) --
+// -- [reaction-convention] handlers: (value, contextCell). These are BOUNDARIES: entered from
+// a promise reaction, so an exception left pending here would reach nobody; it becomes the
+// stream's error via asyncIterReactionEnd. --
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceNextFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
     if (op->m_done) {
         op->m_running = false;
         return JSValue::encode(jsUndefined());
     }
-    if (op->m_cancelled) {
+    if (op->m_cancelled)
         asyncIterReturnIteratorAndSettle(globalObject, op);
-        return JSValue::encode(jsUndefined());
-    }
-    if (asyncIterHandleNextResult(globalObject, op, callFrame->argument(0)) == NextStep::ContinueLoop)
+    else if (asyncIterHandleNextResult(globalObject, op, callFrame->argument(0)) == NextStep::ContinueLoop && !scope.exception())
         driveAsyncIterator(globalObject, op);
-    return JSValue::encode(jsUndefined());
+    return asyncIterReactionEnd(globalObject, scope, op);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceFlushFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
     if (op->m_done)
         return JSValue::encode(jsUndefined());
-    if (op->m_cancelled) {
+    if (op->m_cancelled)
         asyncIterReturnIteratorAndSettle(globalObject, op);
-        return JSValue::encode(jsUndefined());
-    }
-    // The drained write may have been the iterator's final value.
-    if (op->m_iteratorDone)
+    else if (op->m_iteratorDone) // The drained write may have been the iterator's final value.
         asyncIterFinishSuccess(globalObject, op);
     else
         driveAsyncIterator(globalObject, op);
-    return JSValue::encode(jsUndefined());
+    return asyncIterReactionEnd(globalObject, scope, op);
 }
 
-// Any rejection feeding the loop (next(), flush(true), end()) takes the error path.
+// Any rejection feeding the loop (next(), flush(true), end(), return()) takes the error path.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceErrored, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
     if (op->m_done)
         return JSValue::encode(jsUndefined());
     asyncIterFinishWithError(globalObject, op, callFrame->argument(0));
-    return JSValue::encode(jsUndefined());
+    return asyncIterReactionEnd(globalObject, scope, op);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceEndFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
     asyncIterReturnIteratorAndSettle(globalObject, op);
-    return JSValue::encode(jsUndefined());
+    return asyncIterReactionEnd(globalObject, scope, op);
 }
 
-// Registered as both reactions of iterator.return()'s promise: the stream already ended.
+// iterator.return() fulfilled after the stream already ended.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceCleanupSettled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
@@ -469,7 +443,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceErrorSwallowed
 // -- [bound-convention] direct-source methods: (opCell, ...callArgs) --
 
 // pull(controller): one drive of the iterator runs at a time; every pull while it runs gets
-// the same promise.
+// the same promise. BOUNDARY: pull() answers with a promise, so a throw from the drive rejects it.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -488,12 +462,14 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGl
     op->m_pullPromise.set(vm, op, pullPromise);
     op->m_running = true;
     driveAsyncIterator(globalObject, op);
+    if (scope.exception()) [[unlikely]]
+        asyncIterRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(pullPromise);
 }
 
 // cancel(reason): reason ? iterator.throw(reason) : iterator.return(); the result is
-// returned so the stream's cancel promise chains onto it.
+// returned so the stream's cancel promise chains onto it, and a throw propagates to the caller.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourceCancel, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -520,12 +496,15 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourceCancel, (JS
     return JSValue::encode(result ? result : jsUndefined());
 }
 
-// close(): the consumer is gone; the iterator's finally still runs via return().
+// close(): the consumer is gone; the iterator's finally still runs via return(), and a throw from
+// it propagates to whoever closed the source.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourceClose, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(0));
     op->m_cancelled = true;
     asyncIterReturnIteratorAndSettle(globalObject, op);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -118,6 +118,14 @@ static void settlePullPromiseRejected(JSGlobalObject* globalObject, JSAsyncItera
     }
 }
 
+// The boundaries' last resort: delivering an error ran a hook (iterator.throw()/return()) that
+// threw as well; drop the iterator and reject the pull with that. Runs no user JS.
+static void asyncIterAbandon(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op, JSValue error)
+{
+    op->m_iterator.clear();
+    settlePullPromiseRejected(globalObject, op, error);
+}
+
 // The success tail: controller.end(), then iterator.return(), then resolve the pull promise.
 static void asyncIterFinishSuccess(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op)
 {
@@ -347,7 +355,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceNextFulfilled,
         auto step = asyncIterHandleNextResult(globalObject, op, result);
         RETURN_IF_EXCEPTION(scope, );
         if (step == NextStep::ContinueLoop)
-            RELEASE_AND_RETURN(scope, driveAsyncIterator(globalObject, op)); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
+            RELEASE_AND_RETURN(scope, driveAsyncIterator(globalObject, op)); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); }, [&](JSValue error) { asyncIterAbandon(globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceFlushFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -360,7 +368,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceFlushFulfilled
             return asyncIterReturnIteratorAndSettle(globalObject, op);
         if (op->m_iteratorDone) // The drained write may have been the iterator's final value.
             return asyncIterFinishSuccess(globalObject, op);
-        driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
+        driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); }, [&](JSValue error) { asyncIterAbandon(globalObject, op, error); });
 }
 
 // Any rejection feeding the loop (next(), flush(true), end(), return()) takes the error path.
@@ -370,16 +378,13 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceErrored, (JSGl
     JSValue rejection = callFrame->argument(0);
     return enterStreams(globalObject, [&] {
         if (!op->m_done)
-            asyncIterFinishWithError(globalObject, op, rejection); }, [&](JSValue error) {
-        // Delivering the rejection threw (iterator.throw()/return()); that error settles the pull.
-        op->m_iterator.clear();
-        settlePullPromiseRejected(globalObject, op, error); });
+            asyncIterFinishWithError(globalObject, op, rejection); }, [&](JSValue error) { asyncIterAbandon(globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceEndFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto* op = uncheckedDowncast<JSAsyncIteratorSourceOperation>(callFrame->uncheckedArgument(1));
-    return enterStreams(globalObject, [&] { asyncIterReturnIteratorAndSettle(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
+    return enterStreams(globalObject, [&] { asyncIterReturnIteratorAndSettle(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); }, [&](JSValue error) { asyncIterAbandon(globalObject, op, error); });
 }
 
 // iterator.return() fulfilled after the stream already ended.
@@ -415,7 +420,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceErrorSwallowed
 
 // pull(controller): one drive of the iterator runs at a time; every pull while it runs gets
 // the same promise. pull() answers with that promise, so a throw from the drive is the stream's
-// error (enterStreams), never a synchronous throw into the direct controller.
+// error (enterStreams) rather than a synchronous throw into the direct controller.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -433,7 +438,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundAsyncIterableSourcePull, (JSGl
     auto* pullPromise = JSPromise::create(vm, globalObject->promiseStructure());
     op->m_pullPromise.set(vm, op, pullPromise);
     op->m_running = true;
-    enterStreams(globalObject, [&] { driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); });
+    enterStreams(globalObject, [&] { driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); }, [&](JSValue error) { asyncIterAbandon(globalObject, op, error); });
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(pullPromise);
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -826,37 +826,38 @@ JSValue readableStreamIntoArray(JSGlobalObject* globalObject, WebCore::JSReadabl
     RETURN_IF_EXCEPTION(scope, {});
     const ControllerKind controllerKind = stream->m_controllerKind;
     bool isQueueBacked = controllerKind == ControllerKind::Default || controllerKind == ControllerKind::Byte;
-    if (!isQueueBacked) {
-        // Direct (and controller-less) streams keep the generic readMany loop. readMany() throws
-        // synchronously on an already-errored stream; this returns a promise, so that is a rejection.
-        JSValue many = readableStreamDefaultReaderReadMany(globalObject, reader);
-        JSValue result;
-        if (!scope.exception())
-            result = intoArrayLoop(vm, globalObject, reader, chunks, many);
-        if (scope.exception())
-            RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-        if (auto* promise = dynamicDowncast<JSPromise>(result))
-            return promise;
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, result));
-    }
-    // Queue-backed streams: one persistent op {reader, chunks, result promise} carries the
-    // pump across every read, so a pending hop costs one reaction registration and nothing else.
-    JSPromise* pendingRead = nullptr;
-    ConsumerFillStep step = readableStreamDefaultReaderFillFromQueue(globalObject, reader, chunks, &pendingRead);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (step == ConsumerFillStep::Done) {
-        readableStreamDefaultReaderRelease(globalObject, reader);
-        RETURN_IF_EXCEPTION(scope, {});
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, chunks));
-    }
-    auto* domGlobalObject = defaultGlobalObject(globalObject);
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    auto* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
-    auto* op = JSReadableStreamIntoArrayOperation::create(vm, runtime->intoArrayOperationStructure(domGlobalObject), reader, chunks, resultPromise);
-    pendingRead->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadFulfilled(), runtime->onIntoArrayReadRejected(), jsUndefined(), op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return resultPromise;
+    // From here on this returns a promise (promiseFromSteps): readMany() throwing synchronously on an
+    // already-errored stream, a getter throwing while draining, are its rejection.
+    RELEASE_AND_RETURN(scope, promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        if (!isQueueBacked) {
+            // Direct (and controller-less) streams keep the generic readMany loop.
+            JSValue many = readableStreamDefaultReaderReadMany(globalObject, reader);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            JSValue result = intoArrayLoop(vm, globalObject, reader, chunks, many);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            if (auto* promise = dynamicDowncast<JSPromise>(result))
+                return promise;
+            RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, result));
+        }
+        // Queue-backed streams: one persistent op {reader, chunks, result promise} carries the
+        // pump across every read, so a pending hop costs one reaction registration and nothing else.
+        JSPromise* pendingRead = nullptr;
+        ConsumerFillStep step = readableStreamDefaultReaderFillFromQueue(globalObject, reader, chunks, &pendingRead);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (step == ConsumerFillStep::Done) {
+            readableStreamDefaultReaderRelease(globalObject, reader);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, chunks));
+        }
+        auto* domGlobalObject = defaultGlobalObject(globalObject);
+        auto* runtime = JSStreamsRuntime::from(globalObject);
+        auto* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+        auto* op = JSReadableStreamIntoArrayOperation::create(vm, runtime->intoArrayOperationStructure(domGlobalObject), reader, chunks, resultPromise);
+        pendingRead->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadFulfilled(), runtime->onIntoArrayReadRejected(), jsUndefined(), op);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return resultPromise;
+    }));
 }
 
 enum class ChunkArrayConversion : uint8_t { ArrayBuffer,
@@ -959,17 +960,18 @@ static JSValue consumeDirectStreamBody(JSC::VM& vm, JSGlobalObject* globalObject
     RELEASE_AND_RETURN(scope, directConsumeLoopStep(vm, globalObject, context));
 }
 
+// This returns a promise (promiseFromSteps): every synchronous abrupt completion is its rejection.
 static JSValue consumeDirectStream(JSGlobalObject* globalObject, WebCore::JSReadableStream* stream, DirectSinkKind kind)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    // This returns a promise: every synchronous abrupt completion becomes its rejection.
-    JSValue result = consumeDirectStreamBody(vm, globalObject, stream, kind);
-    if (scope.exception())
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (auto* promise = dynamicDowncast<JSPromise>(result))
-        return promise;
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, result));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        JSValue result = consumeDirectStreamBody(vm, globalObject, stream, kind);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (auto* promise = dynamicDowncast<JSPromise>(result))
+            return promise;
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, result));
+    });
 }
 
 JSValue readableStreamToTextDirect(JSGlobalObject* globalObject, WebCore::JSReadableStream* stream)
@@ -1075,16 +1077,16 @@ JSValue consumeDirectStreamToArrayBuffer(JSGlobalObject* globalObject, WebCore::
     installOneShotMethods(vm, globalObject, sink);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // The callback boundary for the direct source's pull(): a synchronous throw errors the stream and
-    // rejects the returned promise; a returned promise's rejection is handled by its reaction.
+    // The boundary into the direct source's pull(): its completion is converted here — a synchronous
+    // throw errors the stream and rejects the returned promise; a returned promise's rejection is
+    // handled by its reaction.
     JSValue firstPull = oneShotCallPull(vm, globalObject, pullFunction, sink);
-    if (scope.exception()) {
-        JSValue error = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, {});
+    if (JSC::Exception* exception = scope.exception()) {
+        TRY_CLEAR_EXCEPTION(scope, {});
         stream->m_lockedWithoutReader = false;
-        readableStreamError(globalObject, stream, error);
+        readableStreamError(globalObject, stream, exception->value());
         RETURN_IF_EXCEPTION(scope, {});
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, exception->value()));
     }
     if (auto* pullPromise = dynamicDowncast<JSPromise>(firstPull)) {
         auto* derived = JSPromise::create(vm, globalObject->promiseStructure());
@@ -1161,19 +1163,21 @@ static JSValue convertChunkArrayPromise(JSC::VM& vm, JSGlobalObject* globalObjec
         return arrayResult;
     auto* runtime = JSStreamsRuntime::from(globalObject);
     if (arrayPromise->status() == JSPromise::Status::Fulfilled) {
-        JSValue converted = convertChunks(globalObject, arrayPromise->result(), kind);
-        if (scope.exception()) [[unlikely]] {
-            // Text consumers are promise-returning: a synchronous conversion failure rejects. The
-            // buffer consumers have always thrown it synchronously.
-            if (kind == ChunkArrayConversion::Text)
-                RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-            return {};
-        }
-        releaseInternalChunkArray(globalObject, arrayPromise->result());
-        RETURN_IF_EXCEPTION(scope, {});
-        auto* fulfilled = JSPromise::create(vm, globalObject->promiseStructure());
-        fulfilled->fulfill(vm, converted);
-        return fulfilled;
+        auto convertNow = [&] -> JSPromise* {
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            JSValue converted = convertChunks(globalObject, arrayPromise->result(), kind);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            releaseInternalChunkArray(globalObject, arrayPromise->result());
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            auto* fulfilled = JSPromise::create(vm, globalObject->promiseStructure());
+            fulfilled->fulfill(vm, converted);
+            return fulfilled;
+        };
+        // Text consumers are promise-returning: a synchronous conversion failure rejects. The buffer
+        // consumers have always thrown it synchronously.
+        if (kind == ChunkArrayConversion::Text)
+            RELEASE_AND_RETURN(scope, promiseFromSteps(globalObject, convertNow));
+        RELEASE_AND_RETURN(scope, convertNow());
     }
     JSFunction* onFulfilled = nullptr;
     switch (kind) {
@@ -1249,16 +1253,17 @@ JSValue readableStreamToJSON(JSGlobalObject* globalObject, WebCore::JSReadableSt
         return textResult;
     auto* runtime = JSStreamsRuntime::from(globalObject);
     if (textPromise->status() == JSPromise::Status::Fulfilled) {
-        // .json() returns a promise: a parse failure is its rejection.
-        WTF::String text = textPromise->result().toWTFString(globalObject);
-        JSValue parsed;
-        if (!scope.exception())
-            parsed = JSONParseWithException(globalObject, text);
-        if (scope.exception())
-            RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-        auto* fulfilled = JSPromise::create(vm, globalObject->promiseStructure());
-        fulfilled->fulfill(vm, parsed);
-        return fulfilled;
+        // .json() returns a promise (promiseFromSteps): a parse failure is its rejection.
+        RELEASE_AND_RETURN(scope, promiseFromSteps(globalObject, [&] -> JSPromise* {
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            WTF::String text = textPromise->result().toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            JSValue parsed = JSONParseWithException(globalObject, text);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            auto* fulfilled = JSPromise::create(vm, globalObject->promiseStructure());
+            fulfilled->fulfill(vm, parsed);
+            return fulfilled;
+        }));
     }
     auto* derived = JSPromise::create(vm, globalObject->promiseStructure());
     textPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadableStreamToJSONFulfilled(), jsUndefined(), derived, jsUndefined());
@@ -1557,30 +1562,25 @@ static bool intoArrayStep(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableS
     return step == Bun::WebStreams::ConsumerFillStep::Done;
 }
 
-// BOUNDARY: the read's fulfilment reaction. A throw while consuming the result (a `done`/`value`
-// getter, the refill, releasing the reader) is the operation's rejection.
+// The read's fulfilment reaction (enterStreams): a throw while consuming the result (a `done`/
+// `value` getter, the refill) is the operation's rejection.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(callFrame->uncheckedArgument(1));
     auto* reader = op->m_reader.get();
     auto* resultPromise = op->m_result.get();
 
-    JSPromise* pendingRead = nullptr;
-    bool finished = intoArrayStep(vm, globalObject, op, callFrame->argument(0), pendingRead);
-    if (scope.exception()) [[unlikely]] {
-        JSValue thrown = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, {});
-        intoArraySettle(vm, globalObject, reader, resultPromise, {}, thrown);
-    } else if (finished)
-        intoArraySettle(vm, globalObject, reader, resultPromise, op->m_chunks.get(), {});
-    else {
+    JSValue readResult = callFrame->argument(0);
+    return enterStreams(globalObject, [&] {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        JSPromise* pendingRead = nullptr;
+        bool finished = intoArrayStep(vm, globalObject, op, readResult, pendingRead);
+        RETURN_IF_EXCEPTION(scope, );
+        if (finished)
+            RELEASE_AND_RETURN(scope, intoArraySettle(vm, globalObject, reader, resultPromise, op->m_chunks.get(), {}));
         auto* runtime = JSStreamsRuntime::from(globalObject);
-        pendingRead->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadFulfilled(), runtime->onIntoArrayReadRejected(), jsUndefined(), op);
-    }
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+        pendingRead->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadFulfilled(), runtime->onIntoArrayReadRejected(), jsUndefined(), op); }, [&](JSValue error) { intoArraySettle(vm, globalObject, reader, resultPromise, {}, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1084,8 +1084,11 @@ JSValue consumeDirectStreamToArrayBuffer(JSGlobalObject* globalObject, WebCore::
     if (JSC::Exception* exception = scope.exception()) {
         TRY_CLEAR_EXCEPTION(scope, {});
         stream->m_lockedWithoutReader = false;
-        readableStreamError(globalObject, stream, exception->value());
-        RETURN_IF_EXCEPTION(scope, {});
+        // pull() may already have errored the stream through the sink before throwing.
+        if (stream->m_state == ReadableStreamState::Readable) {
+            readableStreamError(globalObject, stream, exception->value());
+            RETURN_IF_EXCEPTION(scope, {});
+        }
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, exception->value()));
     }
     if (auto* pullPromise = dynamicDowncast<JSPromise>(firstPull)) {

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1533,14 +1533,18 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadManyFulfilled, (JSGl
     RELEASE_AND_RETURN(scope, JSValue::encode(Bun::WebStreams::intoArrayLoop(vm, globalObject, reader, chunks, callFrame->argument(0))));
 }
 
-// The persistent-op pump: settle the op's result promise with an error, releasing the reader.
-// Settle, then release the reader (the original `finally { reader.releaseLock() }`).
+// The persistent-op pump: settle, then release the reader (the original
+// `finally { reader.releaseLock() }`). If that release throws after a successful settle, the
+// boundary delivers the error here again with the result already fulfilled; only the first
+// settle counts.
 static void intoArraySettle(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSPromise* resultPromise, JSValue chunks, JSValue error)
 {
-    if (error)
-        resultPromise->reject(vm, error);
-    else
-        resultPromise->fulfill(vm, chunks);
+    if (resultPromise->status() == JSPromise::Status::Pending) {
+        if (error)
+            resultPromise->reject(vm, error);
+        else
+            resultPromise->fulfill(vm, chunks);
+    }
     if (reader->m_stream)
         Bun::WebStreams::readableStreamDefaultReaderRelease(globalObject, reader);
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -36,7 +36,6 @@
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringBuilder.h>
@@ -828,22 +827,14 @@ JSValue readableStreamIntoArray(JSGlobalObject* globalObject, WebCore::JSReadabl
     const ControllerKind controllerKind = stream->m_controllerKind;
     bool isQueueBacked = controllerKind == ControllerKind::Default || controllerKind == ControllerKind::Byte;
     if (!isQueueBacked) {
-        // Direct (and controller-less) streams keep the generic readMany loop.
+        // Direct (and controller-less) streams keep the generic readMany loop. readMany() throws
+        // synchronously on an already-errored stream; this returns a promise, so that is a rejection.
+        JSValue many = readableStreamDefaultReaderReadMany(globalObject, reader);
         JSValue result;
-        {
-            // readMany() throws synchronously on an already-errored stream; convert every
-            // synchronous abrupt completion to a rejection.
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            JSValue many = readableStreamDefaultReaderReadMany(globalObject, reader);
-            if (!catchScope.exception())
-                result = intoArrayLoop(vm, globalObject, reader, chunks, many);
-            if (catchScope.exception()) {
-                JSValue error = takeAbruptCompletion(globalObject, catchScope);
-                if (error.isEmpty())
-                    return {};
-                RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
-            }
-        }
+        if (!scope.exception())
+            result = intoArrayLoop(vm, globalObject, reader, chunks, many);
+        if (scope.exception())
+            RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
         if (auto* promise = dynamicDowncast<JSPromise>(result))
             return promise;
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, result));
@@ -851,19 +842,9 @@ JSValue readableStreamIntoArray(JSGlobalObject* globalObject, WebCore::JSReadabl
     // Queue-backed streams: one persistent op {reader, chunks, result promise} carries the
     // pump across every read, so a pending hop costs one reaction registration and nothing else.
     JSPromise* pendingRead = nullptr;
-    JSValue thrown;
-    ConsumerFillStep step = ConsumerFillStep::Done;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        step = readableStreamDefaultReaderFillFromQueue(globalObject, reader, chunks, &pendingRead);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return {};
-        }
-    }
-    if (!thrown.isEmpty()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    ConsumerFillStep step = readableStreamDefaultReaderFillFromQueue(globalObject, reader, chunks, &pendingRead);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     if (step == ConsumerFillStep::Done) {
         readableStreamDefaultReaderRelease(globalObject, reader);
         RETURN_IF_EXCEPTION(scope, {});
@@ -982,18 +963,10 @@ static JSValue consumeDirectStream(JSGlobalObject* globalObject, WebCore::JSRead
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue result;
-    {
-        // Today's function is async: every synchronous abrupt completion becomes a rejection.
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        result = consumeDirectStreamBody(vm, globalObject, stream, kind);
-        if (catchScope.exception()) {
-            JSValue error = takeAbruptCompletion(globalObject, catchScope);
-            if (error.isEmpty())
-                return {};
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
-        }
-    }
+    // This returns a promise: every synchronous abrupt completion becomes its rejection.
+    JSValue result = consumeDirectStreamBody(vm, globalObject, stream, kind);
+    if (scope.exception())
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     if (auto* promise = dynamicDowncast<JSPromise>(result))
         return promise;
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, result));
@@ -1102,19 +1075,16 @@ JSValue consumeDirectStreamToArrayBuffer(JSGlobalObject* globalObject, WebCore::
     installOneShotMethods(vm, globalObject, sink);
     RETURN_IF_EXCEPTION(scope, {});
 
-    JSValue firstPull;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        firstPull = oneShotCallPull(vm, globalObject, pullFunction, sink);
-        if (catchScope.exception()) {
-            JSValue error = takeAbruptCompletion(globalObject, catchScope);
-            if (error.isEmpty())
-                return {};
-            stream->m_lockedWithoutReader = false;
-            readableStreamError(globalObject, stream, error);
-            RETURN_IF_EXCEPTION(scope, {});
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
-        }
+    // The callback boundary for the direct source's pull(): a synchronous throw errors the stream and
+    // rejects the returned promise; a returned promise's rejection is handled by its reaction.
+    JSValue firstPull = oneShotCallPull(vm, globalObject, pullFunction, sink);
+    if (scope.exception()) {
+        JSValue error = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, {});
+        stream->m_lockedWithoutReader = false;
+        readableStreamError(globalObject, stream, error);
+        RETURN_IF_EXCEPTION(scope, {});
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     }
     if (auto* pullPromise = dynamicDowncast<JSPromise>(firstPull)) {
         auto* derived = JSPromise::create(vm, globalObject->promiseStructure());
@@ -1191,22 +1161,12 @@ static JSValue convertChunkArrayPromise(JSC::VM& vm, JSGlobalObject* globalObjec
         return arrayResult;
     auto* runtime = JSStreamsRuntime::from(globalObject);
     if (arrayPromise->status() == JSPromise::Status::Fulfilled) {
-        JSValue converted;
-        JSValue thrown;
-        {
-            // Text consumers are promise-returning: a synchronous conversion failure rejects.
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            converted = convertChunks(globalObject, arrayPromise->result(), kind);
-            if (catchScope.exception()) [[unlikely]] {
-                thrown = takeAbruptCompletion(globalObject, catchScope);
-                if (thrown.isEmpty()) [[unlikely]]
-                    return {};
-            }
-        }
-        if (!thrown.isEmpty()) [[unlikely]] {
+        JSValue converted = convertChunks(globalObject, arrayPromise->result(), kind);
+        if (scope.exception()) [[unlikely]] {
+            // Text consumers are promise-returning: a synchronous conversion failure rejects. The
+            // buffer consumers have always thrown it synchronously.
             if (kind == ChunkArrayConversion::Text)
-                RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-            throwException(globalObject, scope, thrown);
+                RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
             return {};
         }
         releaseInternalChunkArray(globalObject, arrayPromise->result());
@@ -1289,19 +1249,13 @@ JSValue readableStreamToJSON(JSGlobalObject* globalObject, WebCore::JSReadableSt
         return textResult;
     auto* runtime = JSStreamsRuntime::from(globalObject);
     if (textPromise->status() == JSPromise::Status::Fulfilled) {
+        // .json() returns a promise: a parse failure is its rejection.
+        WTF::String text = textPromise->result().toWTFString(globalObject);
         JSValue parsed;
-        {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            WTF::String text = textPromise->result().toWTFString(globalObject);
-            if (!catchScope.exception())
-                parsed = JSONParseWithException(globalObject, text);
-            if (catchScope.exception()) {
-                JSValue error = takeAbruptCompletion(globalObject, catchScope);
-                if (error.isEmpty())
-                    return {};
-                RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
-            }
-        }
+        if (!scope.exception())
+            parsed = JSONParseWithException(globalObject, text);
+        if (scope.exception())
+            RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
         auto* fulfilled = JSPromise::create(vm, globalObject->promiseStructure());
         fulfilled->fulfill(vm, parsed);
         return fulfilled;
@@ -1572,88 +1526,59 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadManyFulfilled, (JSGl
 }
 
 // The persistent-op pump: settle the op's result promise with an error, releasing the reader.
-static void intoArrayFinishWithError(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSPromise* __restrict resultPromise, JSValue error)
+// Settle, then release the reader (the original `finally { reader.releaseLock() }`).
+static void intoArraySettle(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSPromise* resultPromise, JSValue chunks, JSValue error)
 {
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        if (reader->m_stream)
-            Bun::WebStreams::readableStreamDefaultReaderRelease(globalObject, reader);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue releaseError = takeAbruptCompletion(globalObject, catchScope);
-            if (releaseError.isEmpty())
-                return;
-        }
-    }
-    resultPromise->reject(vm, error);
+    if (error)
+        resultPromise->reject(vm, error);
+    else
+        resultPromise->fulfill(vm, chunks);
+    if (reader->m_stream)
+        Bun::WebStreams::readableStreamDefaultReaderRelease(globalObject, reader);
 }
 
+// One step of the queue-backed pump: consume the read result, refill from the queue; true = done.
+static bool intoArrayStep(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStreamIntoArrayOperation* op, JSValue readResult, JSPromise*& pendingRead)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!readResult.isObject()) [[unlikely]]
+        return true;
+    JSValue done = asObject(readResult)->get(globalObject, vm.propertyNames->done);
+    RETURN_IF_EXCEPTION(scope, true);
+    JSValue value = asObject(readResult)->get(globalObject, vm.propertyNames->value);
+    RETURN_IF_EXCEPTION(scope, true);
+    if (done.toBoolean(globalObject))
+        return true;
+    auto* chunks = op->m_chunks.get();
+    chunks->push(globalObject, value);
+    RETURN_IF_EXCEPTION(scope, true);
+    auto step = Bun::WebStreams::readableStreamDefaultReaderFillFromQueue(globalObject, op->m_reader.get(), chunks, &pendingRead);
+    RETURN_IF_EXCEPTION(scope, true);
+    return step == Bun::WebStreams::ConsumerFillStep::Done;
+}
+
+// BOUNDARY: the read's fulfilment reaction. A throw while consuming the result (a `done`/`value`
+// getter, the refill, releasing the reader) is the operation's rejection.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(callFrame->uncheckedArgument(1));
     auto* reader = op->m_reader.get();
-    auto* chunks = op->m_chunks.get();
     auto* resultPromise = op->m_result.get();
 
-    JSValue thrown;
-    bool finished = false;
     JSPromise* pendingRead = nullptr;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        do {
-            JSValue readResult = callFrame->argument(0);
-            if (!readResult.isObject()) [[unlikely]] {
-                finished = true;
-                break;
-            }
-            JSValue done = asObject(readResult)->get(globalObject, vm.propertyNames->done);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-            JSValue value = asObject(readResult)->get(globalObject, vm.propertyNames->value);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-            if (done.toBoolean(globalObject)) {
-                finished = true;
-                break;
-            }
-            chunks->push(globalObject, value);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-            auto step = Bun::WebStreams::readableStreamDefaultReaderFillFromQueue(globalObject, reader, chunks, &pendingRead);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-            if (step == Bun::WebStreams::ConsumerFillStep::Done)
-                finished = true;
-        } while (false);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return JSValue::encode(jsUndefined());
-        }
+    bool finished = intoArrayStep(vm, globalObject, op, callFrame->argument(0), pendingRead);
+    if (scope.exception()) [[unlikely]] {
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, {});
+        intoArraySettle(vm, globalObject, reader, resultPromise, {}, thrown);
+    } else if (finished)
+        intoArraySettle(vm, globalObject, reader, resultPromise, op->m_chunks.get(), {});
+    else {
+        auto* runtime = JSStreamsRuntime::from(globalObject);
+        pendingRead->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadFulfilled(), runtime->onIntoArrayReadRejected(), jsUndefined(), op);
     }
-    if (!thrown.isEmpty()) [[unlikely]] {
-        intoArrayFinishWithError(vm, globalObject, reader, resultPromise, thrown);
-        RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
-    }
-    if (finished) {
-        {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            if (reader->m_stream)
-                Bun::WebStreams::readableStreamDefaultReaderRelease(globalObject, reader);
-            if (catchScope.exception()) [[unlikely]] {
-                JSValue releaseError = takeAbruptCompletion(globalObject, catchScope);
-                if (releaseError.isEmpty())
-                    return JSValue::encode(jsUndefined());
-                resultPromise->reject(vm, releaseError);
-                RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
-            }
-        }
-        resultPromise->fulfill(vm, chunks);
-        RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
-    }
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    pendingRead->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadFulfilled(), runtime->onIntoArrayReadRejected(), jsUndefined(), op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
@@ -1663,8 +1588,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadRejected, (JSGlobalO
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     const auto* op = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(callFrame->uncheckedArgument(1));
-    intoArrayFinishWithError(vm, globalObject, op->m_reader.get(), op->m_result.get(), callFrame->argument(0));
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
+    intoArraySettle(vm, globalObject, op->m_reader.get(), op->m_result.get(), {}, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadManyRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -23,9 +23,7 @@
 #include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
-#include <JavaScriptCore/AggregateError.h>
 #include <JavaScriptCore/ArgList.h>
-#include <JavaScriptCore/ErrorType.h>
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSBoundFunction.h>

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -642,51 +642,54 @@ static JSPromise* nativeSourcePullImpl(JSC::VM& vm, JSGlobalObject* globalObject
     return nullptr;
 }
 
+// The pull and cancel algorithms return a promise (promiseFromSteps): a throw is its rejection.
 JSPromise* nativeSourcePull(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-    // A pull algorithm returns a promise: a throw is its rejection.
-    JSPromise* asyncResult = nativeSourcePullImpl(vm, globalObject, adapter, controller);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (asyncResult)
-        return asyncResult;
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
+        JSPromise* asyncResult = nativeSourcePullImpl(vm, globalObject, adapter, controller);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (asyncResult)
+            return asyncResult;
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, JSValue reason)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-    // A cancel algorithm returns a promise: a throw is its rejection.
-    adapter->clearPendingView(vm);
-    adapter->clearController(vm);
-    if (JSObject* handle = adapter->handle())
-        invokeNativeHandleCancel(vm, globalObject, handle, reason);
-    if (!scope.exception())
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
+        adapter->clearPendingView(vm);
+        adapter->clearController(vm);
+        if (JSObject* handle = adapter->handle()) {
+            invokeNativeHandleCancel(vm, globalObject, handle, reason);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+        }
         nativeSourceSever(globalObject, adapter);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 JSPromise* cancelPendingNativeSource(JSGlobalObject* globalObject, JSReadableStream* stream, JSValue reason)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    ASSERT(stream->m_bunMode == BunStreamMode::NativePending);
-    ASSERT(stream->m_controllerKind == ControllerKind::None);
-    stream->m_bunMode = BunStreamMode::Default;
-    JSObject* handle = stream->nativeHandleDetached() ? nullptr : stream->m_nativePtr.get().getObject();
-    if (!handle)
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        ASSERT(stream->m_bunMode == BunStreamMode::NativePending);
+        ASSERT(stream->m_controllerKind == ControllerKind::None);
+        stream->m_bunMode = BunStreamMode::Default;
+        JSObject* handle = stream->nativeHandleDetached() ? nullptr : stream->m_nativePtr.get().getObject();
+        if (handle) {
+            invokeNativeHandleCancel(vm, globalObject, handle, reason);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+        }
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
-    invokeNativeHandleCancel(vm, globalObject, handle, reason);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 // The [bound-convention] onDrain body: a dead consumer drops the chunk.
@@ -894,7 +897,6 @@ using WebCore::JSReadStreamIntoSinkOperation;
 static void rsisIssueRead(JSGlobalObject*, JSReadStreamIntoSinkOperation*);
 static void rsisFinish(JSGlobalObject*, JSReadStreamIntoSinkOperation*);
 static void rsisAbrupt(JSC::VM&, JSGlobalObject*, JSReadStreamIntoSinkOperation*, JSValue error);
-static void rsisRejectWithPendingException(JSGlobalObject*, ThrowScope&, JSReadStreamIntoSinkOperation*);
 
 static JSValue rsisSinkWrite(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue chunk)
 {
@@ -916,22 +918,12 @@ static JSValue rsisSinkEnd(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStre
     return invokeMethod(vm, globalObject, op->m_sink.get(), builtinNames(vm).endPublicName(), noArgs);
 }
 
-static void rsisSinkClose(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue error)
+static void rsisSinkClose(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* sink, JSValue error)
 {
     MarkedArgumentBuffer args;
     args.append(error);
     ASSERT(!args.hasOverflowed());
-    invokeMethod(vm, globalObject, op->m_sink.get(), builtinNames(vm).closePublicName(), args);
-}
-
-// BOUNDARY handler for the pump: called only by the host functions that drive a pump segment
-// (promise reactions, the sink's onReady/onClose, readStreamIntoSink itself). Whatever the segment
-// threw is the pump's `catch (e)`.
-static void rsisRejectWithPendingException(JSGlobalObject* globalObject, ThrowScope& scope, JSReadStreamIntoSinkOperation* op)
-{
-    JSValue error = takeException(scope);
-    RETURN_IF_EXCEPTION(scope, );
-    rsisAbrupt(getVM(globalObject), globalObject, op, error);
+    invokeMethod(vm, globalObject, sink, builtinNames(vm).closePublicName(), args);
 }
 
 // Detach the native byte transform from this sink. Called BEFORE sink end()/close()
@@ -991,49 +983,31 @@ static void rsisFinish(JSGlobalObject* globalObject, JSReadStreamIntoSinkOperati
     RELEASE_AND_RETURN(scope, resolvePromise(globalObject, result, endResult));
 }
 
-static JSValue aggregateErrors(JSGlobalObject* globalObject, JSValue first, JSValue second)
-{
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* errors = constructEmptyArray(globalObject, nullptr, 0);
-    RETURN_IF_EXCEPTION(scope, {});
-    errors->putDirectIndex(globalObject, 0, first);
-    RETURN_IF_EXCEPTION(scope, {});
-    errors->putDirectIndex(globalObject, 1, second);
-    RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined()));
-}
-
-// The pump's `catch (e)` + `finally`, run at a BOUNDARY (rsisRejectWithPendingException, or the
-// read's rejection reaction): cancel the source, close the sink with the error, tear down, and reject
-// the result — with an AggregateError of both if closing the sink throws as well. The reader is
-// deliberately orphaned, never released.
+// The pump's `catch (e)` + `finally`, delivered at a boundary (the enterStreams `deliver` of the host
+// functions driving the pump, or the read's rejection reaction): tear down, reject the result, then
+// cancel the source and close the sink with the error. The result is settled before those hooks run,
+// so a throw from them propagates without leaving the pump unsettled. The reader is deliberately
+// orphaned, never released.
 static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue error)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     op->m_didThrow = true;
     op->m_reader.clear();
     auto* result = op->m_result.get();
-    JSValue rejectionValue = error;
-    if (auto* stream = op->m_stream.get(); stream && !isReadableStreamLocked(stream)) {
+    JSObject* sink = op->m_didClose ? nullptr : op->m_sink.get();
+    op->m_didClose = true;
+    JSReadableStream* stream = op->m_stream.get();
+    rsisFinally(vm, globalObject, op);
+    RETURN_IF_EXCEPTION(scope, );
+    rejectPromise(globalObject, result, error);
+    RETURN_IF_EXCEPTION(scope, );
+    if (stream && !isReadableStreamLocked(stream)) {
         auto* cancelPromise = readableStreamCancel(globalObject, stream, error);
         RETURN_IF_EXCEPTION(scope, );
         markPromiseAsHandled(vm, cancelPromise);
     }
-    rsisDetachNativeTransform(globalObject, op);
-    if (op->m_sink && !op->m_didClose) {
-        op->m_didClose = true;
-        rsisSinkClose(vm, globalObject, op, error);
-        if (scope.exception()) [[unlikely]] {
-            JSValue secondError = takeException(scope);
-            RETURN_IF_EXCEPTION(scope, );
-            rejectionValue = aggregateErrors(globalObject, error, secondError);
-            RETURN_IF_EXCEPTION(scope, );
-        }
-    }
-    rsisFinally(vm, globalObject, op);
-    RETURN_IF_EXCEPTION(scope, );
-    RELEASE_AND_RETURN(scope, rejectPromise(globalObject, result, rejectionValue));
+    if (sink)
+        RELEASE_AND_RETURN(scope, rsisSinkClose(vm, globalObject, sink, error));
 }
 
 // One sink.write(chunk). wrote<0 = backpressure: stash tail on m_pendingBatch, suspend; m_onPull resumes.
@@ -1271,10 +1245,8 @@ JSPromise* readStreamIntoSink(JSGlobalObject* globalObject, JSReadableStream* st
     op->m_sink.set(vm, op, sink);
     auto* result = JSPromise::create(vm, globalObject->promiseStructure());
     op->m_result.set(vm, op, result);
-    // BOUNDARY: this returns the pump's promise, so a throw while starting it is its rejection.
-    rsisBegin(vm, globalObject, op);
-    if (scope.exception()) [[unlikely]]
-        rsisRejectWithPendingException(globalObject, scope, op);
+    // This returns the pump's promise, so a throw while starting the pump is its rejection.
+    atStreamsBoundary(globalObject, [&] { rsisBegin(vm, globalObject, op); }, [&](JSValue error) { rsisAbrupt(vm, globalObject, op, error); });
     RETURN_IF_EXCEPTION(scope, nullptr);
     return result;
 }
@@ -1328,18 +1300,13 @@ using namespace Bun::WebStreams;
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onNativePullFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(callFrame->argument(1));
-    Bun::WebStreams::nativeSourcePullFulfilled(vm, globalObject, adapter, callFrame->argument(0));
-    // BOUNDARY: a decode/enqueue failure while delivering the pull result errors the stream (the
-    // spec's "upon rejection of pullPromise"); with no live controller it is left to the runner.
-    if (auto* controller = adapter->controller(); scope.exception() && controller) [[unlikely]] {
-        JSValue thrown = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, {});
-        readableStreamDefaultControllerError(globalObject, controller, thrown);
-    }
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    JSValue result = callFrame->argument(0);
+    // A decode/enqueue failure while delivering the pull result errors the stream (the spec's "upon
+    // rejection of pullPromise"); an already-gone consumer has nothing left to error.
+    return enterStreams(globalObject, [&] { Bun::WebStreams::nativeSourcePullFulfilled(vm, globalObject, adapter, result); }, [&](JSValue error) {
+        if (auto* controller = adapter->controller())
+            readableStreamDefaultControllerError(globalObject, controller, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onNativePullRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -1365,39 +1332,24 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onNativeSourceCallCloseMicrotask, (
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkReadManyFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
     JSValue many = callFrame->argument(0);
-    Bun::WebStreams::rsisContinueWithMany(vm, globalObject, op, many);
-    if (scope.exception()) [[unlikely]]
-        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { Bun::WebStreams::rsisContinueWithMany(vm, globalObject, op, many); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkChunk, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
     JSValue chunk = callFrame->argument(0);
-    Bun::WebStreams::rsisHandleChunk(vm, globalObject, op, chunk);
-    if (scope.exception()) [[unlikely]]
-        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { Bun::WebStreams::rsisHandleChunk(vm, globalObject, op, chunk); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkClose, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
-    Bun::WebStreams::rsisFinish(globalObject, op);
-    if (scope.exception()) [[unlikely]]
-        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { Bun::WebStreams::rsisFinish(globalObject, op); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -1445,41 +1397,33 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadDirectStreamOnClose, (JSGl
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadStreamIntoSinkOnClose, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(0));
-    Bun::WebStreams::readStreamIntoSinkOnCloseImpl(vm, globalObject, op, callFrame->argument(1), callFrame->argument(2));
-    if (scope.exception()) [[unlikely]]
-        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { Bun::WebStreams::readStreamIntoSinkOnCloseImpl(vm, globalObject, op, callFrame->argument(1), callFrame->argument(2)); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadStreamIntoSinkOnReady, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(0));
-    // A native transform arm may be parked on m_nativeSinkReadyPromise without the
-    // pump itself being suspended (output bypasses the pump's read loop). Resolve it
-    // regardless of m_waitingOnSink so the transform's in-flight write can settle.
-    if (auto* ts = op->m_nativeTransform.get()) {
-        if (auto* ready = ts->m_nativeSinkReadyPromise.get()) {
-            ts->m_nativeSinkReadyPromise.clear();
-            Bun::WebStreams::resolvePromise(globalObject, ready, jsUndefined());
-            scope.assertNoException();
-        } else if (ts->m_codecPromise) {
-            Bun::WebStreams::nativeCodecContinue(globalObject, ts);
-            RETURN_IF_EXCEPTION(scope, {});
+    return enterStreams(globalObject, [&] {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        // A native transform arm may be parked on m_nativeSinkReadyPromise without the
+        // pump itself being suspended (output bypasses the pump's read loop). Resolve it
+        // regardless of m_waitingOnSink so the transform's in-flight write can settle.
+        if (auto* ts = op->m_nativeTransform.get()) {
+            if (auto* ready = ts->m_nativeSinkReadyPromise.get()) {
+                ts->m_nativeSinkReadyPromise.clear();
+                Bun::WebStreams::resolvePromise(globalObject, ready, jsUndefined());
+                scope.assertNoException();
+            } else if (ts->m_codecPromise) {
+                Bun::WebStreams::nativeCodecContinue(globalObject, ts);
+                RETURN_IF_EXCEPTION(scope, );
+            }
         }
-    }
-    if (!op->m_waitingOnSink)
-        return JSValue::encode(jsUndefined());
-    op->m_waitingOnSink = false;
-    Bun::WebStreams::rsisContinueAfterReady(vm, globalObject, op);
-    if (scope.exception()) [[unlikely]]
-        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+        if (!op->m_waitingOnSink)
+            return;
+        op->m_waitingOnSink = false;
+        RELEASE_AND_RETURN(scope, Bun::WebStreams::rsisContinueAfterReady(vm, globalObject, op)); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -984,8 +984,8 @@ static void rsisFinish(JSGlobalObject* globalObject, JSReadStreamIntoSinkOperati
 }
 
 // The pump's `catch (e)` + `finally`, delivered at a boundary (the enterStreams `deliver` of the host
-// functions driving the pump, or the read's rejection reaction): tear down, reject the result, then
-// cancel the source and close the sink with the error. The result is settled before those hooks run,
+// functions driving the pump, or the read's rejection reaction): reject the result, tear down, then
+// cancel the source and close the sink with the error. The result is settled before anything else,
 // so a throw from them propagates without leaving the pump unsettled. The reader is deliberately
 // orphaned, never released.
 static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue error)
@@ -997,9 +997,9 @@ static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIn
     JSObject* sink = op->m_didClose ? nullptr : op->m_sink.get();
     op->m_didClose = true;
     JSReadableStream* stream = op->m_stream.get();
-    rsisFinally(vm, globalObject, op);
-    RETURN_IF_EXCEPTION(scope, );
     rejectPromise(globalObject, result, error);
+    RETURN_IF_EXCEPTION(scope, );
+    rsisFinally(vm, globalObject, op);
     RETURN_IF_EXCEPTION(scope, );
     if (stream && !isReadableStreamLocked(stream)) {
         auto* cancelPromise = readableStreamCancel(globalObject, stream, error);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -39,7 +39,6 @@
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -282,23 +281,6 @@ static void startJSSinkController(JSC::VM& vm, JSGlobalObject* globalObject, JSO
     throwTypeError(globalObject, scope, "Unknown direct controller. This is a bug in Bun."_s);
 }
 
-// ReadableStream.prototype.cancel semantics; the result promise is only ever markAsHandled'd.
-static void publicStreamCancelIgnoringResult(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* stream, JSValue reason)
-{
-    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    JSPromise* promise = nullptr;
-    if (isReadableStreamLocked(stream))
-        promise = promiseRejectedWith(globalObject, createTypeError(globalObject, "ReadableStream is locked"_s));
-    else
-        promise = readableStreamCancel(globalObject, stream, reason);
-    if (catchScope.exception()) [[unlikely]] {
-        takeAbruptCompletion(globalObject, catchScope);
-        return;
-    }
-    if (promise)
-        markPromiseAsHandled(vm, promise);
-}
-
 static void clearStreamControllerSlots(JSReadableStream* stream)
 {
     stream->m_controller.clear();
@@ -343,46 +325,40 @@ static bool nativeCloserFlag(JSC::VM& vm, JSGlobalObject* globalObject, JSNative
     return flag.toBoolean(globalObject);
 }
 
-// Terminal severing: the handle's callback slots, the handle edge, and the pending view.
+// Terminal severing: the handle edge, the pending view, and the handle's callback slots.
 static void nativeSourceSever(JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto& vm = getVM(globalObject);
-    if (JSObject* handle = adapter->handle()) {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        PutPropertySlot onCloseSlot(handle, false);
-        handle->methodTable()->put(handle, globalObject, builtinNames(vm).onClosePublicName(), jsUndefined(), onCloseSlot);
-        if (!catchScope.exception()) {
-            PutPropertySlot onDrainSlot(handle, false);
-            handle->methodTable()->put(handle, globalObject, builtinNames(vm).onDrainPublicName(), jsUndefined(), onDrainSlot);
-        }
-        if (catchScope.exception()) [[unlikely]] {
-            if (takeAbruptCompletion(globalObject, catchScope).isEmpty())
-                return;
-        }
-    }
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* handle = adapter->handle();
     adapter->clearHandle(vm);
     adapter->clearPendingView(vm);
+    if (!handle)
+        return;
+    PutPropertySlot onCloseSlot(handle, false);
+    handle->methodTable()->put(handle, globalObject, builtinNames(vm).onClosePublicName(), jsUndefined(), onCloseSlot);
+    RETURN_IF_EXCEPTION(scope, );
+    PutPropertySlot onDrainSlot(handle, false);
+    handle->methodTable()->put(handle, globalObject, builtinNames(vm).onDrainPublicName(), jsUndefined(), onDrainSlot);
+    RELEASE_AND_RETURN(scope, );
 }
 
-// The queued callClose job body: close the controller if the consumer is still alive, then sever.
+// The queued callClose job body (run from its own microtask, which reports what this throws):
+// sever, then close the controller if the consumer is still alive.
 static void nativeSourceCallClose(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = adapter->controller();
     adapter->clearController(vm);
-    if (controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        if (adapter->m_textMode)
-            nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, {}, /* flush */ true);
-        if (!catchScope.exception())
-            readableStreamDefaultControllerClose(globalObject, controller);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return;
-            Bun__reportError(globalObject, JSValue::encode(thrown));
-        }
-    }
     nativeSourceSever(globalObject, adapter);
+    RETURN_IF_EXCEPTION(scope, );
+    if (!controller || !readableStreamDefaultControllerCanCloseOrEnqueue(controller))
+        return;
+    if (adapter->m_textMode) {
+        nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, {}, /* flush */ true);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+    RELEASE_AND_RETURN(scope, readableStreamDefaultControllerClose(globalObject, controller));
 }
 
 static void scheduleNativeSourceCallClose(JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
@@ -671,19 +647,10 @@ JSPromise* nativeSourcePull(JSGlobalObject* globalObject, JSReadableStreamDefaul
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-    JSValue thrown;
-    JSPromise* asyncResult = nullptr;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        asyncResult = nativeSourcePullImpl(vm, globalObject, adapter, controller);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-        }
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    // A pull algorithm returns a promise: a throw is its rejection.
+    JSPromise* asyncResult = nativeSourcePullImpl(vm, globalObject, adapter, controller);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     if (asyncResult)
         return asyncResult;
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
@@ -694,23 +661,15 @@ JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefa
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        adapter->clearPendingView(vm);
-        adapter->clearController(vm);
-        if (JSObject* handle = adapter->handle())
-            invokeNativeHandleCancel(vm, globalObject, handle, reason);
-        if (!catchScope.exception())
-            nativeSourceSever(globalObject, adapter);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-        }
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    // A cancel algorithm returns a promise: a throw is its rejection.
+    adapter->clearPendingView(vm);
+    adapter->clearController(vm);
+    if (JSObject* handle = adapter->handle())
+        invokeNativeHandleCancel(vm, globalObject, handle, reason);
+    if (!scope.exception())
+        nativeSourceSever(globalObject, adapter);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 
@@ -724,18 +683,9 @@ JSPromise* cancelPendingNativeSource(JSGlobalObject* globalObject, JSReadableStr
     JSObject* handle = stream->nativeHandleDetached() ? nullptr : stream->m_nativePtr.get().getObject();
     if (!handle)
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        invokeNativeHandleCancel(vm, globalObject, handle, reason);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-        }
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    invokeNativeHandleCancel(vm, globalObject, handle, reason);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 
@@ -789,49 +739,22 @@ static void nativeSourcePullRejected(JSC::VM& vm, JSGlobalObject* globalObject, 
         readableStreamDefaultControllerError(globalObject, controller, error);
         RETURN_IF_EXCEPTION(scope, );
     }
-    nativeSourceSever(globalObject, adapter);
+    RELEASE_AND_RETURN(scope, nativeSourceSever(globalObject, adapter));
 }
 
 //                       The native-sink path
 
-// readDirectStreamOnClose: the state-mutation half runs only when a stream is provided.
+// readDirectStreamOnClose. The state-mutation half runs only when a stream is provided; everything
+// that can throw (the sink's end(), the user's cancel(reason)) runs after the state is final, and a
+// throw from it propagates to whoever closed.
 static void readDirectStreamCloseImpl(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectSinkCloseState* state, JSValue streamValue, JSValue reason)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // The sink closed (or is closing): end() detaches the controller cell from the native
-    // sink so a later GC of the cell cannot release a reference it does not own.
-    if (JSObject* sinkController = state->m_sinkController.get()) {
-        state->m_sinkController.clear();
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        MarkedArgumentBuffer noArgs;
-        invokeMethod(vm, globalObject, sinkController, builtinNames(vm).endPublicName(), noArgs);
-        if (catchScope.exception()) [[unlikely]]
-            catchScope.clearExceptionExceptTermination();
-    }
+    JSObject* sinkController = state->m_sinkController.get();
+    state->m_sinkController.clear();
     JSObject* underlyingSource = state->m_underlyingSource.get();
     state->m_underlyingSource.clear();
-    if (underlyingSource) {
-        JSValue cancelFunction = underlyingSource->get(globalObject, builtinNames(vm).cancelPublicName());
-        RETURN_IF_EXCEPTION(scope, );
-        bool hasCancel = cancelFunction.toBoolean(globalObject);
-        if (hasCancel) {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            if (cancelFunction.isCallable()) {
-                MarkedArgumentBuffer cancelArgs;
-                cancelArgs.append(reason);
-                ASSERT(!cancelArgs.hasOverflowed());
-                JSValue cancelResult = call(globalObject, cancelFunction, getCallData(cancelFunction), underlyingSource, cancelArgs);
-                if (!catchScope.exception()) {
-                    if (auto* cancelPromise = dynamicDowncast<JSPromise>(cancelResult))
-                        markPromiseAsHandled(vm, cancelPromise);
-                }
-            }
-            if (catchScope.exception()) [[unlikely]] {
-                if (takeAbruptCompletion(globalObject, catchScope).isEmpty())
-                    return;
-            }
-        }
-    }
+
     if (auto* stream = dynamicDowncast<JSReadableStream>(streamValue)) {
         clearStreamControllerSlots(stream);
         stream->m_reader.clear();
@@ -851,6 +774,27 @@ static void readDirectStreamCloseImpl(JSC::VM& vm, JSGlobalObject* globalObject,
         state->m_closePromise.clear();
         resolvePromise(globalObject, closePromise, jsUndefined());
         RETURN_IF_EXCEPTION(scope, );
+    }
+
+    // The sink closed (or is closing): end() detaches the controller cell from the native
+    // sink so a later GC of the cell cannot release a reference it does not own.
+    if (sinkController) {
+        MarkedArgumentBuffer noArgs;
+        invokeMethod(vm, globalObject, sinkController, builtinNames(vm).endPublicName(), noArgs);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+    if (underlyingSource) {
+        JSValue cancelFunction = underlyingSource->get(globalObject, builtinNames(vm).cancelPublicName());
+        RETURN_IF_EXCEPTION(scope, );
+        if (cancelFunction.isCallable()) {
+            MarkedArgumentBuffer cancelArgs;
+            cancelArgs.append(reason);
+            ASSERT(!cancelArgs.hasOverflowed());
+            JSValue cancelResult = call(globalObject, cancelFunction, getCallData(cancelFunction), underlyingSource, cancelArgs);
+            RETURN_IF_EXCEPTION(scope, );
+            if (auto* cancelPromise = dynamicDowncast<JSPromise>(cancelResult))
+                markPromiseAsHandled(vm, cancelPromise);
+        }
     }
 }
 
@@ -950,6 +894,7 @@ using WebCore::JSReadStreamIntoSinkOperation;
 static void rsisIssueRead(JSGlobalObject*, JSReadStreamIntoSinkOperation*);
 static void rsisFinish(JSGlobalObject*, JSReadStreamIntoSinkOperation*);
 static void rsisAbrupt(JSC::VM&, JSGlobalObject*, JSReadStreamIntoSinkOperation*, JSValue error);
+static void rsisRejectWithPendingException(JSGlobalObject*, ThrowScope&, JSReadStreamIntoSinkOperation*);
 
 static JSValue rsisSinkWrite(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue chunk)
 {
@@ -979,22 +924,14 @@ static void rsisSinkClose(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStrea
     invokeMethod(vm, globalObject, op->m_sink.get(), builtinNames(vm).closePublicName(), args);
 }
 
-// Runs one synchronous segment of the pump; an abrupt completion becomes the pump's catch path.
-template<typename Body>
-static void rsisRunCatching(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, const Body& body)
+// BOUNDARY handler for the pump: called only by the host functions that drive a pump segment
+// (promise reactions, the sink's onReady/onClose, readStreamIntoSink itself). Whatever the segment
+// threw is the pump's `catch (e)`.
+static void rsisRejectWithPendingException(JSGlobalObject* globalObject, ThrowScope& scope, JSReadStreamIntoSinkOperation* op)
 {
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        body();
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return;
-        }
-    }
-    if (!thrown.isEmpty())
-        rsisAbrupt(vm, globalObject, op, thrown);
+    JSValue error = takeException(scope);
+    RETURN_IF_EXCEPTION(scope, );
+    rsisAbrupt(getVM(globalObject), globalObject, op, error);
 }
 
 // Detach the native byte transform from this sink. Called BEFORE sink end()/close()
@@ -1019,16 +956,10 @@ static void rsisFinally(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamI
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (auto* reader = op->m_reader.get()) {
-        {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            readableStreamDefaultReaderRelease(globalObject, reader);
-            if (catchScope.exception()) [[unlikely]] {
-                if (takeAbruptCompletion(globalObject, catchScope).isEmpty())
-                    return;
-            }
-        }
         reader->m_pipeOperation.clear();
         op->m_reader.clear();
+        readableStreamDefaultReaderRelease(globalObject, reader);
+        RETURN_IF_EXCEPTION(scope, );
     }
     rsisDetachNativeTransform(globalObject, op);
     op->m_sink.clear();
@@ -1060,32 +991,44 @@ static void rsisFinish(JSGlobalObject* globalObject, JSReadStreamIntoSinkOperati
     RELEASE_AND_RETURN(scope, resolvePromise(globalObject, result, endResult));
 }
 
-// The pump's `catch (e)`: the reader is deliberately orphaned, never released.
+static JSValue aggregateErrors(JSGlobalObject* globalObject, JSValue first, JSValue second)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* errors = constructEmptyArray(globalObject, nullptr, 0);
+    RETURN_IF_EXCEPTION(scope, {});
+    errors->putDirectIndex(globalObject, 0, first);
+    RETURN_IF_EXCEPTION(scope, {});
+    errors->putDirectIndex(globalObject, 1, second);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined()));
+}
+
+// The pump's `catch (e)` + `finally`, run at a BOUNDARY (rsisRejectWithPendingException, or the
+// read's rejection reaction): cancel the source, close the sink with the error, tear down, and reject
+// the result — with an AggregateError of both if closing the sink throws as well. The reader is
+// deliberately orphaned, never released.
 static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue error)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     op->m_didThrow = true;
     op->m_reader.clear();
     auto* result = op->m_result.get();
-    if (auto* stream = op->m_stream.get())
-        publicStreamCancelIgnoringResult(vm, globalObject, stream, error);
     JSValue rejectionValue = error;
+    if (auto* stream = op->m_stream.get(); stream && !isReadableStreamLocked(stream)) {
+        auto* cancelPromise = readableStreamCancel(globalObject, stream, error);
+        RETURN_IF_EXCEPTION(scope, );
+        markPromiseAsHandled(vm, cancelPromise);
+    }
     rsisDetachNativeTransform(globalObject, op);
     if (op->m_sink && !op->m_didClose) {
         op->m_didClose = true;
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         rsisSinkClose(vm, globalObject, op, error);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue secondError = takeAbruptCompletion(globalObject, catchScope);
-            if (secondError.isEmpty())
-                return;
-            auto* errors = constructEmptyArray(globalObject, nullptr, 0);
+        if (scope.exception()) [[unlikely]] {
+            JSValue secondError = takeException(scope);
             RETURN_IF_EXCEPTION(scope, );
-            errors->putDirectIndex(globalObject, 0, error);
+            rejectionValue = aggregateErrors(globalObject, error, secondError);
             RETURN_IF_EXCEPTION(scope, );
-            errors->putDirectIndex(globalObject, 1, secondError);
-            RETURN_IF_EXCEPTION(scope, );
-            rejectionValue = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         }
     }
     rsisFinally(vm, globalObject, op);
@@ -1328,50 +1271,45 @@ JSPromise* readStreamIntoSink(JSGlobalObject* globalObject, JSReadableStream* st
     op->m_sink.set(vm, op, sink);
     auto* result = JSPromise::create(vm, globalObject->promiseStructure());
     op->m_result.set(vm, op, result);
-    rsisRunCatching(vm, globalObject, op, [&] {
-        rsisBegin(vm, globalObject, op);
-    });
+    // BOUNDARY: this returns the pump's promise, so a throw while starting it is its rejection.
+    rsisBegin(vm, globalObject, op);
+    if (scope.exception()) [[unlikely]]
+        rsisRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, nullptr);
     return result;
 }
 
-// readStreamIntoSinkOnClose(op, stream, reason) — the JSSink onClose [bound-convention] body.
+// readStreamIntoSinkOnClose(op, stream, reason) — the JSSink onClose [bound-convention] body. Its
+// host function routes a throw from here into the pump's catch path, so m_result always settles.
 static void readStreamIntoSinkOnCloseImpl(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op, JSValue streamValue, JSValue reason)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
+    const bool wasClosed = op->m_didThrow || op->m_didClose;
+    op->m_didClose = true;
     rsisDetachNativeTransform(globalObject, op);
     // The sink closed underneath the pump (which may stay suspended forever): end() FIRST,
     // before the fallible cancel below, so the controller cell always detaches from the
     // native sink instead of being collected attached (its destructor would over-release).
     if (JSObject* sink = op->m_sink.get()) {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         MarkedArgumentBuffer noArgs;
         invokeMethod(vm, globalObject, sink, builtinNames(vm).endPublicName(), noArgs);
-        if (catchScope.exception()) [[unlikely]]
-            catchScope.clearExceptionExceptTermination();
+        RETURN_IF_EXCEPTION(scope, );
     }
-    if (!op->m_didThrow && !op->m_didClose) {
+    if (!wasClosed) {
         auto* stream = dynamicDowncast<JSReadableStream>(streamValue);
         if (stream && stream->m_state != ReadableStreamState::Closed) {
             auto* cancelPromise = readableStreamCancel(globalObject, stream, reason);
-            if (scope.exception()) [[unlikely]] {
-                op->m_didClose = true;
-                return;
-            }
+            RETURN_IF_EXCEPTION(scope, );
             // The sink initiated this cancel (peer abort / sink close); the source's
             // cancel() rejection has no consumer, so keep it out of unhandledRejection.
             if (cancelPromise)
                 markPromiseAsHandled(vm, cancelPromise);
         }
     }
-    op->m_didClose = true;
     // end() detached m_onPull; drive a parked pump to completion so m_result settles.
     if (op->m_waitingOnSink) {
         op->m_waitingOnSink = false;
-        scope.release();
-        rsisRunCatching(vm, globalObject, op, [&] {
-            rsisContinueAfterReady(vm, globalObject, op);
-        });
+        RELEASE_AND_RETURN(scope, rsisContinueAfterReady(vm, globalObject, op));
     }
 }
 
@@ -1392,24 +1330,15 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onNativePullFulfilled, (JSGlobalObj
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* adapter = uncheckedDowncast<JSNativeStreamSourceAdapter>(callFrame->argument(1));
-    JSValue result = callFrame->argument(0);
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        Bun::WebStreams::nativeSourcePullFulfilled(vm, globalObject, adapter, result);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return {};
-        }
+    Bun::WebStreams::nativeSourcePullFulfilled(vm, globalObject, adapter, callFrame->argument(0));
+    // BOUNDARY: a decode/enqueue failure while delivering the pull result errors the stream (the
+    // spec's "upon rejection of pullPromise"); with no live controller it is left to the runner.
+    if (auto* controller = adapter->controller(); scope.exception() && controller) [[unlikely]] {
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, {});
+        readableStreamDefaultControllerError(globalObject, controller, thrown);
     }
-    // Boundary: an internal decode failure errors the stream instead of escaping.
-    if (!thrown.isEmpty()) {
-        if (auto* controller = adapter->controller()) {
-            readableStreamDefaultControllerError(globalObject, controller, thrown);
-            RETURN_IF_EXCEPTION(scope, {});
-        }
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 
@@ -1439,9 +1368,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkReadManyFulfill
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
     JSValue many = callFrame->argument(0);
-    Bun::WebStreams::rsisRunCatching(vm, globalObject, op, [&] {
-        Bun::WebStreams::rsisContinueWithMany(vm, globalObject, op, many);
-    });
+    Bun::WebStreams::rsisContinueWithMany(vm, globalObject, op, many);
+    if (scope.exception()) [[unlikely]]
+        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
@@ -1452,9 +1381,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkChunk, (JSGloba
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
     JSValue chunk = callFrame->argument(0);
-    Bun::WebStreams::rsisRunCatching(vm, globalObject, op, [&] {
-        Bun::WebStreams::rsisHandleChunk(vm, globalObject, op, chunk);
-    });
+    Bun::WebStreams::rsisHandleChunk(vm, globalObject, op, chunk);
+    if (scope.exception()) [[unlikely]]
+        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
@@ -1464,9 +1393,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkClose, (JSGloba
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
-    Bun::WebStreams::rsisRunCatching(vm, globalObject, op, [&] {
-        Bun::WebStreams::rsisFinish(globalObject, op);
-    });
+    Bun::WebStreams::rsisFinish(globalObject, op);
+    if (scope.exception()) [[unlikely]]
+        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
@@ -1519,6 +1448,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadStreamIntoSinkOnClose, (JS
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(0));
     Bun::WebStreams::readStreamIntoSinkOnCloseImpl(vm, globalObject, op, callFrame->argument(1), callFrame->argument(2));
+    if (scope.exception()) [[unlikely]]
+        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
@@ -1544,9 +1475,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadStreamIntoSinkOnReady, (JS
     if (!op->m_waitingOnSink)
         return JSValue::encode(jsUndefined());
     op->m_waitingOnSink = false;
-    Bun::WebStreams::rsisRunCatching(vm, globalObject, op, [&] {
-        Bun::WebStreams::rsisContinueAfterReady(vm, globalObject, op);
-    });
+    Bun::WebStreams::rsisContinueAfterReady(vm, globalObject, op);
+    if (scope.exception()) [[unlikely]]
+        Bun::WebStreams::rsisRejectWithPendingException(globalObject, scope, op);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1332,6 +1332,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkReadManyFulfill
     auto& vm = getVM(globalObject);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
     JSValue many = callFrame->argument(0);
+    // A read queued before the pump failed can still be delivered afterwards; the op is torn down.
+    if (op->m_didThrow)
+        return JSValue::encode(jsUndefined());
     return enterStreams(globalObject, [&] { Bun::WebStreams::rsisContinueWithMany(vm, globalObject, op, many); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
@@ -1340,6 +1343,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkChunk, (JSGloba
     auto& vm = getVM(globalObject);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
     JSValue chunk = callFrame->argument(0);
+    // A read queued before the pump failed can still be delivered afterwards; the op is torn down.
+    if (op->m_didThrow)
+        return JSValue::encode(jsUndefined());
     return enterStreams(globalObject, [&] { Bun::WebStreams::rsisHandleChunk(vm, globalObject, op, chunk); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
@@ -1347,6 +1353,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkClose, (JSGloba
 {
     auto& vm = getVM(globalObject);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
+    // A read queued before the pump failed can still be delivered afterwards; the op is torn down.
+    if (op->m_didThrow)
+        return JSValue::encode(jsUndefined());
     return enterStreams(globalObject, [&] { Bun::WebStreams::rsisFinish(globalObject, op); }, [&](JSValue error) { Bun::WebStreams::rsisAbrupt(vm, globalObject, op, error); });
 }
 
@@ -1355,6 +1364,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadStreamIntoSinkRejected, (JSGl
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* op = uncheckedDowncast<JSReadStreamIntoSinkOperation>(callFrame->argument(1));
+    if (op->m_didThrow)
+        return JSValue::encode(jsUndefined());
     Bun::WebStreams::rsisAbrupt(vm, globalObject, op, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -136,31 +136,29 @@ struct CodecStepResult {
     // The coder stopped at its output bound; the chunk needs another step.
     bool more { false };
     bool sinkBackpressure { false };
-    // Codec error or failed delivery; empty on success (and on VM termination).
-    JSValue thrown;
 };
 
 // One step on this thread, delivered straight into the native JSSink when one is attached
-// (no JSUint8Array), otherwise enqueued. `input` is only passed on a chunk's first step.
+// (no JSUint8Array), otherwise enqueued. `input` is only passed on a chunk's first step. A codec
+// error or failed delivery throws.
 static CodecStepResult runStepHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish)
 {
     auto& vm = getVM(globalObject);
-    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     CodecStepResult step;
     if (void* sinkPtr = stream->m_nativeSinkPtr) {
         JSValue wrote = JSValue::decode(CompressionStreamCoder__transformInto(coder, globalObject, input, inputLen, finish, stream->m_nativeSinkId, sinkPtr, &step.more));
-        if (!catchScope.exception())
-            step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
-    } else {
-        JSValue out = JSValue::decode(CompressionStreamCoder__transform(coder, globalObject, input, inputLen, finish, &step.more));
-        if (!catchScope.exception()) {
-            auto* view = dynamicDowncast<JSArrayBufferView>(out);
-            if (view && view->length())
-                transformStreamDefaultControllerEnqueue(globalObject, stream->m_controller.get(), out);
-        }
+        RETURN_IF_EXCEPTION(scope, step);
+        step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
+        return step;
     }
-    if (catchScope.exception()) [[unlikely]]
-        step.thrown = takeAbruptCompletion(globalObject, catchScope);
+    JSValue out = JSValue::decode(CompressionStreamCoder__transform(coder, globalObject, input, inputLen, finish, &step.more));
+    RETURN_IF_EXCEPTION(scope, step);
+    auto* view = dynamicDowncast<JSArrayBufferView>(out);
+    if (view && view->length()) {
+        transformStreamDefaultControllerEnqueue(globalObject, stream->m_controller.get(), out);
+        RETURN_IF_EXCEPTION(scope, step);
+    }
     return step;
 }
 
@@ -169,7 +167,6 @@ enum class CodecOutcome : uint8_t {
     // Done, but its last write left the sink full: the transform promise becomes
     // m_nativeSinkReadyPromise and settles when the sink drains, as any backpressured write.
     DoneSinkFull,
-    Failed,
     // Nothing to settle: output is still pending and the consumer is full (it will continue
     // the chunk), or a terminal reached from inside a delivery already abandoned it.
     Pending,
@@ -180,10 +177,10 @@ static bool consumerFull(JSTransformStream* stream, const CodecStepResult& step)
     return stream->m_nativeSinkPtr ? step.sinkBackpressure : stream->m_backpressure;
 }
 
-// Steps on this thread until the chunk completes, fails, or its consumer is full. `input` is
-// only fed on the first step. The caller holds m_nativeStateInUse, so a terminal reached from
+// Steps on this thread until the chunk completes, fails (throws), or its consumer is full. `input`
+// is only fed on the first step. The caller holds m_nativeStateInUse, so a terminal reached from
 // inside a delivery defers the coder release instead of freeing it under the loop.
-static CodecOutcome stepChunkHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish, JSValue& thrown)
+static CodecOutcome stepChunkHere(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, const uint8_t* input, size_t inputLen, bool finish)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -191,13 +188,9 @@ static CodecOutcome stepChunkHere(JSGlobalObject* globalObject, JSTransformStrea
     bool continuation = !!stream->m_codecPromise;
     for (;;) {
         CodecStepResult step = runStepHere(globalObject, stream, coder, input, inputLen, finish);
-        RETURN_IF_EXCEPTION(scope, CodecOutcome::Failed);
+        RETURN_IF_EXCEPTION(scope, CodecOutcome::Pending);
         if (continuation && !stream->m_codecPromise)
             return CodecOutcome::Pending;
-        if (!step.thrown.isEmpty()) {
-            thrown = step.thrown;
-            return CodecOutcome::Failed;
-        }
         bool full = consumerFull(stream, step);
         if (!step.more)
             return full && stream->m_nativeSinkPtr ? CodecOutcome::DoneSinkFull : CodecOutcome::Done;
@@ -238,15 +231,12 @@ static void settleCodecChunk(JSGlobalObject* globalObject, JSTransformStream* st
 }
 
 // Applies the outcome of a step that ran from a later turn to the pending chunk.
-static void settlePendingChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecOutcome outcome, JSValue thrown)
+static void settlePendingChunk(JSGlobalObject* globalObject, JSTransformStream* stream, CodecOutcome outcome)
 {
     auto& vm = getVM(globalObject);
     switch (outcome) {
     case CodecOutcome::Done:
         settleCodecChunk(globalObject, stream, JSValue());
-        return;
-    case CodecOutcome::Failed:
-        settleCodecChunk(globalObject, stream, thrown);
         return;
     case CodecOutcome::DoneSinkFull:
         if (auto* promise = takeCodecPromise(stream))
@@ -257,8 +247,8 @@ static void settlePendingChunk(JSGlobalObject* globalObject, JSTransformStream* 
     }
 }
 
-// The transform / flush arm (under runNativeArm). Abrupt completions become a rejected
-// promise: an arm must never throw synchronously into ProcessWrite/ProcessClose.
+// The transform / flush arm (under runNativeArm). It returns a promise, so a failed step is its
+// rejection: an arm must never throw synchronously into ProcessWrite/ProcessClose.
 static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream* stream, void* coder, JSValue chunk, const uint8_t* input, size_t inputLen, bool finish)
 {
     auto& vm = getVM(globalObject);
@@ -275,14 +265,12 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
         return promise;
     }
 
-    JSValue thrown;
-    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, input, inputLen, finish, thrown);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, input, inputLen, finish);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     switch (outcome) {
     case CodecOutcome::Done:
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, jsUndefined()));
-    case CodecOutcome::Failed:
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
     case CodecOutcome::DoneSinkFull: {
         auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
         stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
@@ -312,12 +300,19 @@ void nativeCodecContinue(JSGlobalObject* globalObject, JSTransformStream* stream
             return;
         RELEASE_AND_RETURN(scope, dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false));
     }
-    JSValue thrown;
     stream->m_nativeStateInUse = true;
-    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, nullptr, 0, false, thrown);
+    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, nullptr, 0, false);
     stream->m_nativeStateInUse = false;
-    RETURN_IF_EXCEPTION(scope, void());
-    settlePendingChunk(globalObject, stream, outcome, thrown);
+    if (scope.exception()) [[unlikely]] {
+        // BOUNDARY: this continues the pending chunk on its behalf, so a failed step is that
+        // chunk's rejection. If a terminal reached inside the step already abandoned the chunk,
+        // that terminal carries the error and there is nothing left to settle.
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, );
+        if (stream->m_codecPromise)
+            settleCodecChunk(globalObject, stream, thrown);
+    } else
+        settlePendingChunk(globalObject, stream, outcome);
     // An abandon from inside the loop deferred its release to here.
     RELEASE_AND_RETURN(scope, nativeTransformReleaseStateIfIdle(stream));
 }
@@ -336,18 +331,10 @@ static JSPromise* compressionStreamTransformImpl(JSGlobalObject* globalObject, J
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thrown;
     WTF::CString scratch;
-    std::optional<std::span<const uint8_t>> bytes;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        bytes = bufferSourceBytes(globalObject, chunk, scratch);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    std::optional<std::span<const uint8_t>> bytes = bufferSourceBytes(globalObject, chunk, scratch);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     if (!bytes) [[unlikely]]
         return nullptr;
     RELEASE_AND_RETURN(scope, transformChunk(globalObject, stream, stream->m_coder, chunk, bytes->data(), bytes->size(), false));
@@ -373,9 +360,36 @@ JSPromise* decompressionStreamFlush(JSGlobalObject* globalObject, JSDecompressio
     return transformChunk(globalObject, stream, stream->m_coder, jsUndefined(), nullptr, 0, true);
 }
 
+// Hands an off-thread step's output to the consumer (native sink or readable). Throws on a failed
+// delivery.
+static CodecStepResult deliverAsyncOutput(JSGlobalObject* globalObject, JSTransformStream* stream, const uint8_t* out, size_t outLen, bool more)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    CodecStepResult step;
+    step.more = more;
+    if (void* sinkPtr = stream->m_nativeSinkPtr) {
+        JSValue wrote = JSValue::decode(Bun__NativeTransformSink__writeBytes(stream->m_nativeSinkId, sinkPtr, globalObject, out, outLen));
+        RETURN_IF_EXCEPTION(scope, step);
+        step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
+        return step;
+    }
+    auto copied = JSC::ArrayBuffer::tryCreate(std::span<const uint8_t>(out, outLen));
+    if (!copied) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return step;
+    }
+    auto* view = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), WTF::move(copied), 0, outLen);
+    RETURN_IF_EXCEPTION(scope, step);
+    transformStreamDefaultControllerEnqueue(globalObject, stream->m_controller.get(), JSValue(view));
+    RETURN_IF_EXCEPTION(scope, step);
+    return step;
+}
+
 // JS-thread completion of an off-thread step. `out` borrows the coder's buffer, so it is
 // consumed BEFORE m_asyncCodecInFlight is cleared and the coder may be released or
-// re-dispatched. Returns into Rust, so this is an exception boundary rather than a throw scope.
+// re-dispatched. BOUNDARY: entered from the event loop with no JS above it; a failed delivery is
+// the pending chunk's rejection.
 extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);
@@ -388,27 +402,14 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
 
     CodecStepResult step;
     step.more = more;
-    bool abandoned = !stream->m_codecPromise;
+    JSValue thrown;
     if (error) {
-        step.thrown = JSValue::decode(error);
-    } else if (outLen && !abandoned) {
-        if (void* sinkPtr = stream->m_nativeSinkPtr) {
-            JSValue wrote = JSValue::decode(Bun__NativeTransformSink__writeBytes(stream->m_nativeSinkId, sinkPtr, globalObject, out, outLen));
-            if (!scope.exception())
-                step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
-        } else {
-            auto copied = JSC::ArrayBuffer::tryCreate(std::span<const uint8_t>(out, outLen));
-            if (!copied) [[unlikely]] {
-                step.thrown = JSC::createOutOfMemoryError(globalObject);
-            } else {
-                auto* view = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), WTF::move(copied), 0, outLen);
-                if (!scope.exception())
-                    transformStreamDefaultControllerEnqueue(globalObject, stream->m_controller.get(), JSValue(view));
-            }
-        }
+        thrown = JSValue::decode(error);
+    } else if (outLen && stream->m_codecPromise) {
+        step = deliverAsyncOutput(globalObject, stream, out, outLen, more);
         if (scope.exception()) [[unlikely]] {
-            step.thrown = takeAbruptCompletion(globalObject, scope);
-            if (step.thrown.isEmpty()) {
+            thrown = takeException(scope);
+            if (!thrown) {
                 // VM termination: the chunk stays pending; teardown's finalizer releases the coder.
                 Bun__VM__takeTerminationOutsideScript(globalObject);
                 stream->m_asyncCodecInFlight = false;
@@ -423,10 +424,10 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
         nativeTransformReleaseStateIfIdle(stream);
         return;
     }
-    if (!step.thrown.isEmpty())
-        settleCodecChunk(globalObject, stream, step.thrown);
+    if (thrown)
+        settleCodecChunk(globalObject, stream, thrown);
     else if (!step.more)
-        settlePendingChunk(globalObject, stream, consumerFull(stream, step) && stream->m_nativeSinkPtr ? CodecOutcome::DoneSinkFull : CodecOutcome::Done, JSValue());
+        settlePendingChunk(globalObject, stream, consumerFull(stream, step) && stream->m_nativeSinkPtr ? CodecOutcome::DoneSinkFull : CodecOutcome::Done);
     else if (!consumerFull(stream, step)) {
         if (void* coder = coderOf(stream)) [[likely]]
             dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false);

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -265,24 +265,26 @@ static JSPromise* transformChunk(JSGlobalObject* globalObject, JSTransformStream
         return promise;
     }
 
-    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, input, inputLen, finish);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    switch (outcome) {
-    case CodecOutcome::Done:
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, jsUndefined()));
-    case CodecOutcome::DoneSinkFull: {
-        auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
-        return ready;
-    }
-    case CodecOutcome::Pending: {
-        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_codecPromise.set(vm, stream, promise);
-        return promise;
-    }
-    }
-    RELEASE_ASSERT_NOT_REACHED();
+    RELEASE_AND_RETURN(scope, promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, input, inputLen, finish);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        switch (outcome) {
+        case CodecOutcome::Done:
+            RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, jsUndefined()));
+        case CodecOutcome::DoneSinkFull: {
+            auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
+            stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
+            return ready;
+        }
+        case CodecOutcome::Pending: {
+            auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+            stream->m_codecPromise.set(vm, stream, promise);
+            return promise;
+        }
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }));
 }
 
 void nativeCodecContinue(JSGlobalObject* globalObject, JSTransformStream* stream)
@@ -300,19 +302,19 @@ void nativeCodecContinue(JSGlobalObject* globalObject, JSTransformStream* stream
             return;
         RELEASE_AND_RETURN(scope, dispatchStepOffThread(globalObject, stream, coder, jsUndefined(), nullptr, 0, false));
     }
-    stream->m_nativeStateInUse = true;
-    CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, nullptr, 0, false);
-    stream->m_nativeStateInUse = false;
-    if (scope.exception()) [[unlikely]] {
-        // BOUNDARY: this continues the pending chunk on its behalf, so a failed step is that
-        // chunk's rejection. If a terminal reached inside the step already abandoned the chunk,
-        // that terminal carries the error and there is nothing left to settle.
-        JSValue thrown = takeException(scope);
+    // This resumes the pending chunk on its behalf (atStreamsBoundary): a failed step is that
+    // chunk's rejection. If a terminal reached inside the step already abandoned the chunk, that
+    // terminal carries the error and there is nothing left to settle.
+    atStreamsBoundary(globalObject, [&] {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        stream->m_nativeStateInUse = true;
+        CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, nullptr, 0, false);
+        stream->m_nativeStateInUse = false;
         RETURN_IF_EXCEPTION(scope, );
+        settlePendingChunk(globalObject, stream, outcome); }, [&](JSValue thrown) {
         if (stream->m_codecPromise)
-            settleCodecChunk(globalObject, stream, thrown);
-    } else
-        settlePendingChunk(globalObject, stream, outcome);
+            settleCodecChunk(globalObject, stream, thrown); });
+    RETURN_IF_EXCEPTION(scope, );
     // An abandon from inside the loop deferred its release to here.
     RELEASE_AND_RETURN(scope, nativeTransformReleaseStateIfIdle(stream));
 }
@@ -329,15 +331,15 @@ void nativeCodecAbandon(JSGlobalObject* globalObject, JSTransformStream* stream)
 template<typename JSStream>
 static JSPromise* compressionStreamTransformImpl(JSGlobalObject* globalObject, JSStream* stream, JSValue chunk)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    WTF::CString scratch;
-    std::optional<std::span<const uint8_t>> bytes = bufferSourceBytes(globalObject, chunk, scratch);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (!bytes) [[unlikely]]
-        return nullptr;
-    RELEASE_AND_RETURN(scope, transformChunk(globalObject, stream, stream->m_coder, chunk, bytes->data(), bytes->size(), false));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        WTF::CString scratch;
+        std::optional<std::span<const uint8_t>> bytes = bufferSourceBytes(globalObject, chunk, scratch);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (!bytes) [[unlikely]]
+            return nullptr;
+        RELEASE_AND_RETURN(scope, transformChunk(globalObject, stream, stream->m_coder, chunk, bytes->data(), bytes->size(), false));
+    });
 }
 
 JSPromise* compressionStreamTransform(JSGlobalObject* globalObject, JSCompressionStream* stream, JSTransformStreamDefaultController*, JSValue chunk)
@@ -388,8 +390,8 @@ static CodecStepResult deliverAsyncOutput(JSGlobalObject* globalObject, JSTransf
 
 // JS-thread completion of an off-thread step. `out` borrows the coder's buffer, so it is
 // consumed BEFORE m_asyncCodecInFlight is cleared and the coder may be released or
-// re-dispatched. BOUNDARY: entered from the event loop with no JS above it; a failed delivery is
-// the pending chunk's rejection.
+// re-dispatched. Entered from the event loop with no JS above it (a TopExceptionScope, and
+// atStreamsBoundary for the delivery): a failed delivery is the pending chunk's rejection.
 extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);
@@ -406,15 +408,12 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
     if (error) {
         thrown = JSValue::decode(error);
     } else if (outLen && stream->m_codecPromise) {
-        step = deliverAsyncOutput(globalObject, stream, out, outLen, more);
+        atStreamsBoundary(globalObject, [&] { step = deliverAsyncOutput(globalObject, stream, out, outLen, more); }, [&](JSValue error) { thrown = error; });
         if (scope.exception()) [[unlikely]] {
-            thrown = takeException(scope);
-            if (!thrown) {
-                // VM termination: the chunk stays pending; teardown's finalizer releases the coder.
-                Bun__VM__takeTerminationOutsideScript(globalObject);
-                stream->m_asyncCodecInFlight = false;
-                return;
-            }
+            // VM termination: the chunk stays pending; teardown's finalizer releases the coder.
+            Bun__VM__takeTerminationOutsideScript(globalObject);
+            stream->m_asyncCodecInFlight = false;
+            return;
         }
     }
 

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -447,7 +447,7 @@ static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject,
 // Errors the stream with `error`: rejects the pending read, errors the stream, tears the sink down,
 // then runs the user's close(error) hook. The stream is fully errored before anything that can throw
 // (the sink teardown, the hook) runs, so a throw from those propagates with the stream consistent.
-void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue error)
+bool JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue error)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -457,24 +457,40 @@ void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue
     JSObject* underlyingSource = m_underlyingSource.get();
     directStreamControllerClearSource(this);
 
+    bool delivered = false;
     if (auto* pendingRead = m_pendingRead.get()) {
         m_pendingRead.clear();
         rejectPromise(globalObject, pendingRead, error);
-        RETURN_IF_EXCEPTION(scope, );
+        RETURN_IF_EXCEPTION(scope, false);
+        delivered = true;
     }
     auto* stream = m_stream.get();
     if (stream && stream->m_state == ReadableStreamState::Readable) {
         readableStreamError(globalObject, stream, error);
-        RETURN_IF_EXCEPTION(scope, );
+        RETURN_IF_EXCEPTION(scope, false);
+        delivered = true;
     }
 
     // onClose() already closed the sink and ran the user's close() if the controller was closed
     // (end() arming the final chunk leaves the stream Readable), so doing it again would double it.
     if (wasClosed)
-        return;
+        return delivered;
     closeDirectSinkForError(vm, globalObject, this, error);
+    RETURN_IF_EXCEPTION(scope, false);
+    callUnderlyingSourceClose(vm, globalObject, underlyingSource, error);
+    RETURN_IF_EXCEPTION(scope, false);
+    return delivered;
+}
+
+// The reactions' deliver: error the stream; an error nothing was left to receive (the stream had
+// already closed) is thrown on for the runner to report rather than dropped.
+static void deliverDirectError(JSGlobalObject* globalObject, JSDirectStreamController* controller, JSValue error)
+{
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+    bool delivered = controller->handleError(globalObject, error);
     RETURN_IF_EXCEPTION(scope, );
-    RELEASE_AND_RETURN(scope, callUnderlyingSourceClose(vm, globalObject, underlyingSource, error));
+    if (!delivered)
+        throwException(globalObject, scope, error);
 }
 
 // Invokes the user's pull() once, bracketed by m_pullInFlight (the spec sets [[pulling]]
@@ -793,8 +809,10 @@ static void directPullFulfilled(JSC::VM& vm, JSGlobalObject* globalObject, JSDir
         controller->m_deferClose = 0;
         controller->m_deferFlush = 0;
         RETURN_IF_EXCEPTION(scope, );
-        if (!abrupt.isEmpty())
-            RELEASE_AND_RETURN(scope, controller->handleError(globalObject, abrupt));
+        if (!abrupt.isEmpty()) {
+            controller->handleError(globalObject, abrupt);
+            RELEASE_AND_RETURN(scope, );
+        }
         if (deferredClose == 1) {
             JSValue reason = controller->m_deferCloseReason.get();
             controller->m_deferCloseReason.clear();
@@ -826,7 +844,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObj
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(1));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    return enterStreams(globalObject, [&] { directPullFulfilled(vm, globalObject, controller); }, [&](JSValue error) { controller->handleError(globalObject, error); });
+    return enterStreams(globalObject, [&] { directPullFulfilled(vm, globalObject, controller); }, [&](JSValue error) { deliverDirectError(globalObject, controller, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -853,7 +871,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectEndOfTickFlush, (JSGlobalOb
     controller->m_endOfTickFlushArmed = false;
     if (controller->m_closed || !controller->m_stream)
         return JSValue::encode(jsUndefined());
-    return enterStreams(globalObject, [&] { controller->onFlush(globalObject); }, [&](JSValue error) { controller->handleError(globalObject, error); });
+    return enterStreams(globalObject, [&] { controller->onFlush(globalObject); }, [&](JSValue error) { deliverDirectError(globalObject, controller, error); });
 }
 
 // The FIVE public own methods are JSBoundFunctions over these [bound-convention] targets.

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -763,24 +763,23 @@ static bool directControllerHasWaitingConsumer(JSDirectStreamController* control
 }
 
 // Settlement reactions of the user pull()'s returned promise ([reaction-convention]).
-JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
+// The pull promise's fulfilment reaction (enterStreams): drain, then re-pull while a consumer is
+// waiting. Whatever throws in here (a chunkSteps callback, a deferred close, the source's hooks)
+// errors the stream.
+static void directPullFulfilled(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)
 {
-    auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(1));
-    if (!controller) [[unlikely]]
-        return JSValue::encode(jsUndefined());
     auto* stream = controller->m_stream.get();
     if (controller->m_closed || !stream || stream->m_state != ReadableStreamState::Readable) {
         controller->m_pullInFlight = false;
         controller->m_pullAgain = false;
-        return JSValue::encode(jsUndefined());
+        return;
     }
     // Drain anything this pull wrote while no reader was waiting. m_pullInFlight stays set
     // so onFlush's delivery-branch re-arm fires for a pull that wrote without c.flush().
     controller->onFlush(globalObject);
     controller->m_pullInFlight = false;
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, );
     bool pullAgain = takeDirectPullAgain(controller);
     // Edge-triggered (m_pullAgain) AND level-checked (a consumer is waiting), the spec's
     // ShouldCallPull equivalent; loop so a synchronous re-pull chains to the next consumer.
@@ -793,24 +792,21 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObj
         int8_t deferredFlush = controller->m_deferFlush;
         controller->m_deferClose = 0;
         controller->m_deferFlush = 0;
-        RETURN_IF_EXCEPTION(scope, {});
-        if (!abrupt.isEmpty()) {
-            controller->handleError(globalObject, abrupt);
-            RETURN_IF_EXCEPTION(scope, {});
-            return JSValue::encode(jsUndefined());
-        }
+        RETURN_IF_EXCEPTION(scope, );
+        if (!abrupt.isEmpty())
+            RELEASE_AND_RETURN(scope, controller->handleError(globalObject, abrupt));
         if (deferredClose == 1) {
             JSValue reason = controller->m_deferCloseReason.get();
             controller->m_deferCloseReason.clear();
             controller->onClose(globalObject, reason);
-            RETURN_IF_EXCEPTION(scope, {});
+            RETURN_IF_EXCEPTION(scope, );
         } else {
             // An async re-pull left m_pullInFlight set: its own fulfillment reaction drains
             // and picks up m_pullAgain.
             if (controller->m_pullInFlight) {
                 if (deferredFlush == 1)
                     controller->onFlush(globalObject);
-                RETURN_IF_EXCEPTION(scope, {});
+                RETURN_IF_EXCEPTION(scope, );
                 break;
             }
             // Sync re-pull: drain with m_pullInFlight bracketed so onFlush's delivery-branch
@@ -818,11 +814,19 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObj
             controller->m_pullInFlight = true;
             controller->onFlush(globalObject);
             controller->m_pullInFlight = false;
-            RETURN_IF_EXCEPTION(scope, {});
+            RETURN_IF_EXCEPTION(scope, );
         }
         pullAgain = takeDirectPullAgain(controller);
     }
-    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = getVM(globalObject);
+    auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(1));
+    if (!controller) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { directPullFulfilled(vm, globalObject, controller); }, [&](JSValue error) { controller->handleError(globalObject, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -870,16 +874,20 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
     return JSValue::encode(wrote);
 }
 
+// controller.close(): if closing fails part-way (the sink's end(), the source's close() hook),
+// the stream cannot complete normally — it is errored with that failure (so a pending read
+// settles) and the failure is still thrown to the caller of close().
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectClose, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
     if (!controller || controller->m_closed) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    controller->onClose(globalObject, callFrame->argument(1));
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { controller->onClose(globalObject, callFrame->argument(1)); }, [&](JSValue error) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        controller->handleError(globalObject, error);
+        RETURN_IF_EXCEPTION(scope, );
+        throwException(globalObject, scope, error); });
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectFlush, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -644,13 +644,25 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
         return;
     // No "Closing" stream state exists: m_closed set here is what blocks re-entry.
     m_closed = true;
-
-    callUnderlyingSourceClose(vm, globalObject, m_underlyingSource.get(), reason);
-    RETURN_IF_EXCEPTION(scope, );
+    JSObject* underlyingSource = m_underlyingSource.get();
     directStreamControllerClearSource(this);
 
     JSValue flushed = endDirectSink(vm, globalObject, this);
     RETURN_IF_EXCEPTION(scope, );
+    finishClose(globalObject, flushed);
+    RETURN_IF_EXCEPTION(scope, );
+    // The user's close(reason) hook runs once the stream is fully closed, so a throw from it
+    // propagates to whoever closed with nothing left half-done.
+    RELEASE_AND_RETURN(scope, callUnderlyingSourceClose(vm, globalObject, underlyingSource, reason));
+}
+
+// The rest of close(): hand end()'s final chunk to whoever is reading (or arm it for the next read),
+// then close the stream.
+void JSDirectStreamController::finishClose(JSGlobalObject* globalObject, JSValue flushed)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* stream = m_stream.get();
 
     if (byteLengthOf(flushed)) {
         if (auto* pendingRead = m_pendingRead.get()) {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -479,10 +479,10 @@ void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue
 
 // Invokes the user's pull() once, bracketed by m_pullInFlight (the spec sets [[pulling]]
 // before invoking pullAlgorithm); left set only when a promise's settlement reaction will
-// clear it. This is the callback boundary for pull(): its synchronous throw is returned as a
-// value (the caller errors the stream with it and rejects the read), a returned promise's
-// rejection goes to onDirectPullRejected. Empty on normal return, and on VM termination
-// (which is left pending).
+// clear it. This is the boundary into the user's pull(): as for the spec's promise-returning
+// pullAlgorithm, its completion is converted here — a synchronous throw is returned as a value
+// (the caller errors the stream with it and rejects the read), a returned promise's rejection goes
+// to onDirectPullRejected. Empty on normal return, and on VM termination (left pending).
 static JSValue callDirectPull(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -493,11 +493,10 @@ static JSValue callDirectPull(JSC::VM& vm, JSGlobalObject* globalObject, JSDirec
     MarkedArgumentBuffer args;
     args.append(controller);
     JSValue result = JSC::call(globalObject, pullFunction ? JSValue(pullFunction) : jsUndefined(), underlyingSource, args, "underlyingSource.pull is not a function"_s);
-    if (scope.exception()) [[unlikely]] {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
         controller->m_pullInFlight = false;
-        JSValue abrupt = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, {});
-        return abrupt;
+        TRY_CLEAR_EXCEPTION(scope, {});
+        return exception->value();
     }
     if (auto* pullPromise = dynamicDowncast<JSPromise>(result)) {
         auto* runtime = JSStreamsRuntime::from(globalObject);
@@ -651,16 +650,7 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
     directStreamControllerClearSource(this);
 
     JSValue flushed = endDirectSink(vm, globalObject, this);
-    if (scope.exception()) [[unlikely]] {
-        // A read waiting on this close owns the end() failure; with none, the closer does.
-        auto* pendingRead = m_pendingRead.get();
-        if (!pendingRead)
-            return;
-        JSValue thrown = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, );
-        m_pendingRead.clear();
-        RELEASE_AND_RETURN(scope, rejectPromise(globalObject, pendingRead, thrown));
-    }
+    RETURN_IF_EXCEPTION(scope, );
 
     if (byteLengthOf(flushed)) {
         if (auto* pendingRead = m_pendingRead.get()) {
@@ -837,27 +827,17 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullRejected, (JSGlobalObje
     return JSValue::encode(jsUndefined());
 }
 
-// BOUNDARY: runs from the end-of-tick queue with nothing above it. A throw from onFlush (e.g. a
-// read request's chunkSteps) errors the stream; if erroring the stream throws too, that is left
-// for the tick runner to report.
+// Runs from the end-of-tick queue with nothing above it (enterStreams): a throw from onFlush
+// (e.g. a read request's chunkSteps) errors the stream.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectEndOfTickFlush, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(1));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
     controller->m_endOfTickFlushArmed = false;
     if (controller->m_closed || !controller->m_stream)
         return JSValue::encode(jsUndefined());
-    controller->onFlush(globalObject);
-    if (scope.exception()) [[unlikely]] {
-        JSC::JSValue error = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, {});
-        controller->handleError(globalObject, error);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { controller->onFlush(globalObject); }, [&](JSValue error) { controller->handleError(globalObject, error); });
 }
 
 // The FIVE public own methods are JSBoundFunctions over these [bound-convention] targets.

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -25,7 +25,6 @@
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -428,11 +427,10 @@ static void closeDirectSinkForError(JSC::VM& vm, JSGlobalObject* globalObject, J
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-// The Bun-only `underlyingSource.close(reason)` lifecycle callback; the call is swallowed.
-static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller, JSValue reason)
+// The Bun-only `underlyingSource.close(reason)` lifecycle callback.
+static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* underlyingSource, JSValue reason)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSObject* underlyingSource = controller->m_underlyingSource.get();
     if (!underlyingSource)
         return;
     JSValue closeFunction = underlyingSource->get(globalObject, builtinNames(vm).closePublicName());
@@ -440,38 +438,23 @@ static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject,
     auto callData = JSC::getCallData(closeFunction);
     if (callData.type == CallData::Type::None)
         return;
-    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     MarkedArgumentBuffer args;
     args.append(reason);
     JSC::call(globalObject, closeFunction, callData, underlyingSource, args);
-    if (catchScope.exception()) [[unlikely]] {
-        if (takeAbruptCompletion(globalObject, catchScope).isEmpty())
-            return;
-    }
+    RELEASE_AND_RETURN(scope, );
 }
 
+// Errors the stream with `error`: rejects the pending read, errors the stream, tears the sink down,
+// then runs the user's close(error) hook. The stream is fully errored before anything that can throw
+// (the sink teardown, the hook) runs, so a throw from those propagates with the stream consistent.
 void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue error)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     const bool wasClosed = m_closed;
-    if (!wasClosed) {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        closeDirectSinkForError(vm, globalObject, this, error);
-        if (catchScope.exception()) [[unlikely]] {
-            if (takeAbruptCompletion(globalObject, catchScope).isEmpty())
-                return;
-        }
-    }
     m_closed = true;
-
-    // onClose() already ran the user's close() if the sink was closed (end() arming the
-    // final chunk leaves the stream Readable), so running it again would double it.
-    if (!wasClosed) {
-        callUnderlyingSourceClose(vm, globalObject, this, error);
-        RETURN_IF_EXCEPTION(scope, );
-    }
+    JSObject* underlyingSource = m_underlyingSource.get();
     directStreamControllerClearSource(this);
 
     if (auto* pendingRead = m_pendingRead.get()) {
@@ -479,15 +462,27 @@ void JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue
         rejectPromise(globalObject, pendingRead, error);
         RETURN_IF_EXCEPTION(scope, );
     }
-
     auto* stream = m_stream.get();
-    if (stream && stream->m_state == ReadableStreamState::Readable)
-        RELEASE_AND_RETURN(scope, readableStreamError(globalObject, stream, error));
+    if (stream && stream->m_state == ReadableStreamState::Readable) {
+        readableStreamError(globalObject, stream, error);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+
+    // onClose() already closed the sink and ran the user's close() if the controller was closed
+    // (end() arming the final chunk leaves the stream Readable), so doing it again would double it.
+    if (wasClosed)
+        return;
+    closeDirectSinkForError(vm, globalObject, this, error);
+    RETURN_IF_EXCEPTION(scope, );
+    RELEASE_AND_RETURN(scope, callUnderlyingSourceClose(vm, globalObject, underlyingSource, error));
 }
 
 // Invokes the user's pull() once, bracketed by m_pullInFlight (the spec sets [[pulling]]
 // before invoking pullAlgorithm); left set only when a promise's settlement reaction will
-// clear it. Returns the synchronous abrupt completion (empty on normal return/termination).
+// clear it. This is the callback boundary for pull(): its synchronous throw is returned as a
+// value (the caller errors the stream with it and rejects the read), a returned promise's
+// rejection goes to onDirectPullRejected. Empty on normal return, and on VM termination
+// (which is left pending).
 static JSValue callDirectPull(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -495,18 +490,13 @@ static JSValue callDirectPull(JSC::VM& vm, JSGlobalObject* globalObject, JSDirec
     JSObject* pullFunction = controller->m_pull.get();
     JSObject* underlyingSource = controller->m_underlyingSource.get();
     controller->m_pullInFlight = true;
-    JSValue result;
-    JSValue abrupt;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        MarkedArgumentBuffer args;
-        args.append(controller);
-        result = JSC::call(globalObject, pullFunction ? JSValue(pullFunction) : jsUndefined(), underlyingSource, args, "underlyingSource.pull is not a function"_s);
-        if (catchScope.exception()) [[unlikely]]
-            abrupt = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!abrupt.isEmpty()) {
+    MarkedArgumentBuffer args;
+    args.append(controller);
+    JSValue result = JSC::call(globalObject, pullFunction ? JSValue(pullFunction) : jsUndefined(), underlyingSource, args, "underlyingSource.pull is not a function"_s);
+    if (scope.exception()) [[unlikely]] {
         controller->m_pullInFlight = false;
+        JSValue abrupt = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, {});
         return abrupt;
     }
     if (auto* pullPromise = dynamicDowncast<JSPromise>(result)) {
@@ -656,26 +646,20 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
     // No "Closing" stream state exists: m_closed set here is what blocks re-entry.
     m_closed = true;
 
-    callUnderlyingSourceClose(vm, globalObject, this, reason);
+    callUnderlyingSourceClose(vm, globalObject, m_underlyingSource.get(), reason);
     RETURN_IF_EXCEPTION(scope, );
     directStreamControllerClearSource(this);
 
-    JSValue flushed;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        flushed = endDirectSink(vm, globalObject, this);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (!thrown)
-                return;
-            if (auto* pendingRead = m_pendingRead.get()) {
-                m_pendingRead.clear();
-                rejectPromise(globalObject, pendingRead, thrown);
-                return;
-            }
-            throwException(globalObject, scope, thrown);
+    JSValue flushed = endDirectSink(vm, globalObject, this);
+    if (scope.exception()) [[unlikely]] {
+        // A read waiting on this close owns the end() failure; with none, the closer does.
+        auto* pendingRead = m_pendingRead.get();
+        if (!pendingRead)
             return;
-        }
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, );
+        m_pendingRead.clear();
+        RELEASE_AND_RETURN(scope, rejectPromise(globalObject, pendingRead, thrown));
     }
 
     if (byteLengthOf(flushed)) {
@@ -853,24 +837,23 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullRejected, (JSGlobalObje
     return JSValue::encode(jsUndefined());
 }
 
+// BOUNDARY: runs from the end-of-tick queue with nothing above it. A throw from onFlush (e.g. a
+// read request's chunkSteps) errors the stream; if erroring the stream throws too, that is left
+// for the tick runner to report.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectEndOfTickFlush, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(1));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
     controller->m_endOfTickFlushArmed = false;
     if (controller->m_closed || !controller->m_stream)
         return JSValue::encode(jsUndefined());
-    // onFlush may throw (e.g. a read request's chunkSteps threw). This is a boundary:
-    // convert the abrupt completion into the direct controller's error action so the
-    // stream errors instead of surfacing as an uncaught nextTick exception. If erroring
-    // the stream itself throws, that is left for the tick runner to report.
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     controller->onFlush(globalObject);
     if (scope.exception()) [[unlikely]] {
-        JSC::JSValue error = takeAbruptCompletion(globalObject, scope);
-        RETURN_IF_EXCEPTION(scope, {}); // termination is left pending
+        JSC::JSValue error = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, {});
         controller->handleError(globalObject, error);
         RETURN_IF_EXCEPTION(scope, {});
     }

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -116,7 +116,8 @@ public:
     // `flush()` — BRANCH ORDER IS LOAD-BEARING.
     void onFlush(JSC::JSGlobalObject*);
     // handleDirectStreamError.
-    void handleError(JSC::JSGlobalObject*, JSC::JSValue error);
+    // true if a pending read or the stream received the error; false if there was nothing left to error.
+    bool handleError(JSC::JSGlobalObject*, JSC::JSValue error);
     void finishClose(JSC::JSGlobalObject*, JSC::JSValue flushed);
 
 private:

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -117,6 +117,7 @@ public:
     void onFlush(JSC::JSGlobalObject*);
     // handleDirectStreamError.
     void handleError(JSC::JSGlobalObject*, JSC::JSValue error);
+    void finishClose(JSC::JSGlobalObject*, JSC::JSValue flushed);
 
 private:
     JSDirectStreamController(JSC::VM&, JSC::Structure*, Bun::WebStreams::DirectSinkKind);

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -31,7 +31,6 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/TypedArrayType.h>
 #include <algorithm>
 #include <cstring>
@@ -91,28 +90,6 @@ static JSC::JSArrayBufferView* constructViewOfType(JSC::JSGlobalObject* globalOb
     return nullptr;
 }
 
-// WebIDL "invoke a callback function" with a Promise<T> return type: an abrupt completion is
-// converted into a rejected promise (a completion-record conversion), never a synchronous throw.
-static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
 // The [[pullAlgorithm]] dispatch. The reachable kind set on a byte controller is exactly
 // {JavaScript, Nothing, ByteTeeBranch}; the switch is total over SourceKind.
 // Returns nullptr with no exception pending when the pull completed synchronously with a
@@ -132,25 +109,7 @@ static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGl
             return nullptr;
         }
         StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
-        JSC::JSValue result;
-        JSC::JSValue thrown;
-        {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            auto callData = JSC::getCallData(pullMethod);
-            ASSERT(callData.type != JSC::CallData::Type::None);
-            result = JSC::call(globalObject, pullMethod, callData, controller->m_algorithms.underlyingObject.get(), args);
-            if (catchScope.exception()) [[unlikely]]
-                thrown = takeAbruptCompletion(globalObject, catchScope);
-        }
-        if (!thrown.isEmpty()) [[unlikely]]
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-        if (result.isEmpty()) [[unlikely]]
-            return nullptr;
-        if (!result.isObject()) [[likely]]
-            return nullptr;
-        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
-            return resultPromise;
-        RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromiseFast(globalObject, pullMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SourceKind::Nothing:
         return nullptr;
@@ -184,7 +143,7 @@ static JSC::JSPromise* performByteControllerCancelAlgorithm(JSC::VM& vm, JSC::JS
             return nullptr;
         }
         StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, cancelMethod, controller->m_algorithms.underlyingObject.get(), args));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromise(globalObject, cancelMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SourceKind::Nothing:
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
@@ -817,21 +776,16 @@ void readableByteStreamControllerEnqueueClonedChunkToQueue(JSGlobalObject* globa
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RefPtr<JSC::ArrayBuffer> cloneResult;
-    {
-        // CloneArrayBuffer is interpreted as a completion record: an abrupt completion errors
-        // the controller and is then rethrown.
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        cloneResult = cloneArrayBuffer(vm, globalObject, buffer, byteOffset, byteLength);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty()) [[unlikely]]
-                return;
-            readableByteStreamControllerError(globalObject, controller, thrown);
-            RETURN_IF_EXCEPTION(scope, void());
-            throwException(globalObject, scope, thrown);
-            return;
-        }
+    RefPtr<JSC::ArrayBuffer> cloneResult = cloneArrayBuffer(vm, globalObject, buffer, byteOffset, byteLength);
+    if (scope.exception()) [[unlikely]] {
+        // Spec step 2: "If cloneResult is an abrupt completion, perform
+        // ! ReadableByteStreamControllerError(controller, cloneResult.[[Value]]) and return cloneResult."
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, );
+        readableByteStreamControllerError(globalObject, controller, thrown);
+        RETURN_IF_EXCEPTION(scope, );
+        throwException(globalObject, scope, thrown);
+        return;
     }
     readableByteStreamControllerEnqueueChunkToQueue(controller, WTF::move(cloneResult), 0, byteLength);
 }
@@ -1042,20 +996,14 @@ void readableByteStreamControllerPullInto(JSGlobalObject* globalObject, JSReadab
     size_t byteOffset = view->byteOffset();
     size_t byteLength = view->byteLength();
     RefPtr<JSC::ArrayBuffer> viewedBuffer = view->possiblySharedBuffer();
-    RefPtr<JSC::ArrayBuffer> buffer;
-    JSValue transferAbruptCompletion;
-    {
-        // "If bufferResult is an abrupt completion", route it to the read-into request's error steps.
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        buffer = transferArrayBufferImpl(globalObject, *viewedBuffer);
-        if (catchScope.exception()) [[unlikely]] {
-            transferAbruptCompletion = takeAbruptCompletion(globalObject, catchScope);
-            if (transferAbruptCompletion.isEmpty()) [[unlikely]]
-                return;
-        }
+    RefPtr<JSC::ArrayBuffer> buffer = transferArrayBufferImpl(globalObject, *viewedBuffer);
+    if (scope.exception()) [[unlikely]] {
+        // Spec step 10: "If bufferResult is an abrupt completion, perform readIntoRequest's error
+        // steps given bufferResult.[[Value]] and return."
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, );
+        RELEASE_AND_RETURN(scope, readIntoRequest->errorSteps(globalObject, thrown));
     }
-    if (!transferAbruptCompletion.isEmpty()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, readIntoRequest->errorSteps(globalObject, transferAbruptCompletion));
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
     JSPullIntoDescriptor* pullIntoDescriptor = JSPullIntoDescriptor::create(vm, JSStreamsRuntime::from(globalObject)->pullIntoDescriptorStructure(zigGlobalObject));
     pullIntoDescriptor->m_bufferByteLength = buffer->byteLength();

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -777,14 +777,13 @@ void readableByteStreamControllerEnqueueClonedChunkToQueue(JSGlobalObject* globa
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     RefPtr<JSC::ArrayBuffer> cloneResult = cloneArrayBuffer(vm, globalObject, buffer, byteOffset, byteLength);
-    if (scope.exception()) [[unlikely]] {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
         // Spec step 2: "If cloneResult is an abrupt completion, perform
         // ! ReadableByteStreamControllerError(controller, cloneResult.[[Value]]) and return cloneResult."
-        JSValue thrown = takeException(scope);
+        TRY_CLEAR_EXCEPTION(scope, );
+        readableByteStreamControllerError(globalObject, controller, exception->value());
         RETURN_IF_EXCEPTION(scope, );
-        readableByteStreamControllerError(globalObject, controller, thrown);
-        RETURN_IF_EXCEPTION(scope, );
-        throwException(globalObject, scope, thrown);
+        throwException(globalObject, scope, exception);
         return;
     }
     readableByteStreamControllerEnqueueChunkToQueue(controller, WTF::move(cloneResult), 0, byteLength);
@@ -997,12 +996,11 @@ void readableByteStreamControllerPullInto(JSGlobalObject* globalObject, JSReadab
     size_t byteLength = view->byteLength();
     RefPtr<JSC::ArrayBuffer> viewedBuffer = view->possiblySharedBuffer();
     RefPtr<JSC::ArrayBuffer> buffer = transferArrayBufferImpl(globalObject, *viewedBuffer);
-    if (scope.exception()) [[unlikely]] {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
         // Spec step 10: "If bufferResult is an abrupt completion, perform readIntoRequest's error
         // steps given bufferResult.[[Value]] and return."
-        JSValue thrown = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, );
-        RELEASE_AND_RETURN(scope, readIntoRequest->errorSteps(globalObject, thrown));
+        TRY_CLEAR_EXCEPTION(scope, );
+        RELEASE_AND_RETURN(scope, readIntoRequest->errorSteps(globalObject, exception->value()));
     }
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
     JSPullIntoDescriptor* pullIntoDescriptor = JSPullIntoDescriptor::create(vm, JSStreamsRuntime::from(globalObject)->pullIntoDescriptorStructure(zigGlobalObject));

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -641,18 +641,16 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototypeFunction_pipeTo, (JSGlobalObje
         RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "ReadableStream.prototype.pipeTo requires a WritableStream destination"_s))));
 
     // WebIDL: a promise-returning operation turns an argument-conversion failure into a rejection.
-    ConvertedStreamPipeOptions options = convertStreamPipeOptions(vm, lexicalGlobalObject, callFrame->argument(1));
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWithPendingException(lexicalGlobalObject, scope)));
-
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "Cannot pipe a locked ReadableStream"_s))));
-    if (isWritableStreamLocked(destination))
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "Cannot pipe to a locked WritableStream"_s))));
-
-    auto* promise = readableStreamPipeTo(lexicalGlobalObject, stream, destination, options.preventClose, options.preventAbort, options.preventCancel, options.signal);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(promise);
+    RELEASE_AND_RETURN(scope, JSValue::encode(promiseFromSteps(lexicalGlobalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        ConvertedStreamPipeOptions options = convertStreamPipeOptions(vm, lexicalGlobalObject, callFrame->argument(1));
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (isReadableStreamLocked(stream))
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "Cannot pipe a locked ReadableStream"_s)));
+        if (isWritableStreamLocked(destination))
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "Cannot pipe to a locked WritableStream"_s)));
+        RELEASE_AND_RETURN(scope, readableStreamPipeTo(lexicalGlobalObject, stream, destination, options.preventClose, options.preventAbort, options.preventCancel, options.signal));
+    })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototypeFunction_tee, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -32,7 +32,6 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 
 namespace WebCore {
 
@@ -641,18 +640,10 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototypeFunction_pipeTo, (JSGlobalObje
     if (!destination)
         RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "ReadableStream.prototype.pipeTo requires a WritableStream destination"_s))));
 
-    ConvertedStreamPipeOptions options;
-    {
-        // WebIDL: a promise-returning operation turns an argument-conversion failure into a rejection.
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        options = convertStreamPipeOptions(vm, lexicalGlobalObject, callFrame->argument(1));
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(lexicalGlobalObject, catchScope);
-            if (thrown.isEmpty())
-                return {};
-            RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, thrown)));
-        }
-    }
+    // WebIDL: a promise-returning operation turns an argument-conversion failure into a rejection.
+    ConvertedStreamPipeOptions options = convertStreamPipeOptions(vm, lexicalGlobalObject, callFrame->argument(1));
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWithPendingException(lexicalGlobalObject, scope)));
 
     if (isReadableStreamLocked(stream))
         RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "Cannot pipe a locked ReadableStream"_s))));

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -30,7 +30,6 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
 
 namespace Bun {
@@ -415,18 +414,10 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_read, (JSGl
     if (!reader) [[unlikely]]
         RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "ReadableStreamBYOBReader.prototype.read can only be called on a ReadableStreamBYOBReader"_s))));
 
-    // A promise-returning operation turns argument-conversion failures into rejections.
-    BYOBReadArguments arguments;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        arguments = convertBYOBReadArguments(vm, lexicalGlobalObject, callFrame->argument(0), callFrame->argument(1));
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(lexicalGlobalObject, catchScope);
-            if (thrown.isEmpty())
-                return {};
-            RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, thrown)));
-        }
-    }
+    // WebIDL: a promise-returning operation turns argument-conversion failures into rejections.
+    BYOBReadArguments arguments = convertBYOBReadArguments(vm, lexicalGlobalObject, callFrame->argument(0), callFrame->argument(1));
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWithPendingException(lexicalGlobalObject, scope)));
     JSArrayBufferView* view = arguments.view;
     uint64_t minRequested = arguments.min;
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -415,35 +415,37 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_read, (JSGl
         RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "ReadableStreamBYOBReader.prototype.read can only be called on a ReadableStreamBYOBReader"_s))));
 
     // WebIDL: a promise-returning operation turns argument-conversion failures into rejections.
-    BYOBReadArguments arguments = convertBYOBReadArguments(vm, lexicalGlobalObject, callFrame->argument(0), callFrame->argument(1));
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWithPendingException(lexicalGlobalObject, scope)));
-    JSArrayBufferView* view = arguments.view;
-    uint64_t minRequested = arguments.min;
+    RELEASE_AND_RETURN(scope, JSValue::encode(promiseFromSteps(lexicalGlobalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        BYOBReadArguments arguments = convertBYOBReadArguments(vm, lexicalGlobalObject, callFrame->argument(0), callFrame->argument(1));
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        JSArrayBufferView* view = arguments.view;
+        uint64_t minRequested = arguments.min;
 
-    if (!view->byteLength())
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The view passed to read() must have a non-zero byteLength"_s))));
-    RefPtr<ArrayBuffer> viewedBuffer = view->possiblySharedBuffer();
-    if (!viewedBuffer || !viewedBuffer->byteLength())
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The view passed to read() is backed by a zero-length ArrayBuffer"_s))));
-    if (viewedBuffer->isDetached() || view->isDetached())
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The view passed to read() is backed by a detached ArrayBuffer"_s))));
-    if (!minRequested)
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'min' option must be greater than 0"_s))));
-    TypedArrayType viewType = typedArrayType(view->type());
-    uint64_t minLimit = viewType == TypeDataView ? static_cast<uint64_t>(view->byteLength()) : static_cast<uint64_t>(view->length());
-    if (minRequested > minLimit)
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createRangeError(lexicalGlobalObject, "The 'min' option cannot be larger than the view passed to read()"_s))));
-    if (!reader->m_stream)
-        RELEASE_AND_RETURN(scope, JSValue::encode(promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The reader is not attached to a stream"_s))));
+        if (!view->byteLength())
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The view passed to read() must have a non-zero byteLength"_s)));
+        RefPtr<ArrayBuffer> viewedBuffer = view->possiblySharedBuffer();
+        if (!viewedBuffer || !viewedBuffer->byteLength())
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The view passed to read() is backed by a zero-length ArrayBuffer"_s)));
+        if (viewedBuffer->isDetached() || view->isDetached())
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The view passed to read() is backed by a detached ArrayBuffer"_s)));
+        if (!minRequested)
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'min' option must be greater than 0"_s)));
+        TypedArrayType viewType = typedArrayType(view->type());
+        uint64_t minLimit = viewType == TypeDataView ? static_cast<uint64_t>(view->byteLength()) : static_cast<uint64_t>(view->length());
+        if (minRequested > minLimit)
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, createRangeError(lexicalGlobalObject, "The 'min' option cannot be larger than the view passed to read()"_s)));
+        if (!reader->m_stream)
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: The reader is not attached to a stream"_s)));
 
-    auto* domGlobalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto* runtime = JSStreamsRuntime::from(lexicalGlobalObject);
-    auto* promise = JSPromise::create(vm, lexicalGlobalObject->promiseStructure());
-    auto* readIntoRequest = JSReadIntoRequest::create(vm, runtime->readIntoRequestStructure(domGlobalObject), ReadIntoRequestKind::Promise, promise);
-    readableStreamBYOBReaderRead(lexicalGlobalObject, reader, view, minRequested, readIntoRequest);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(promise);
+        auto* domGlobalObject = defaultGlobalObject(lexicalGlobalObject);
+        auto* runtime = JSStreamsRuntime::from(lexicalGlobalObject);
+        auto* promise = JSPromise::create(vm, lexicalGlobalObject->promiseStructure());
+        auto* readIntoRequest = JSReadIntoRequest::create(vm, runtime->readIntoRequestStructure(domGlobalObject), ReadIntoRequestKind::Promise, promise);
+        readableStreamBYOBReaderRead(lexicalGlobalObject, reader, view, minRequested, readIntoRequest);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return promise;
+    })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_releaseLock, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -564,14 +564,13 @@ void readableStreamDefaultControllerEnqueue(JSGlobalObject* globalObject, JSRead
         }
         if (!scope.exception()) [[likely]]
             controller->m_queue.enqueueValueWithSize(globalObject, controller, chunk, chunkSize);
-        if (scope.exception()) [[unlikely]] {
+        if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
             // Spec steps 4.b / 5.b: "If result is an abrupt completion, perform
             // ! ReadableStreamDefaultControllerError(controller, result.[[Value]]) and return result."
-            JSValue thrown = takeException(scope);
+            TRY_CLEAR_EXCEPTION(scope, );
+            readableStreamDefaultControllerError(globalObject, controller, exception->value());
             RETURN_IF_EXCEPTION(scope, );
-            readableStreamDefaultControllerError(globalObject, controller, thrown);
-            RETURN_IF_EXCEPTION(scope, );
-            throwException(globalObject, scope, thrown);
+            throwException(globalObject, scope, exception);
             return;
         }
     }

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -22,7 +22,6 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <limits>
 #include <wtf/Locker.h>
 
@@ -30,28 +29,6 @@ namespace Bun {
 namespace WebStreams {
 
 using namespace JSC;
-
-// WebIDL "invoke a callback function" with a Promise<T> return type: an abrupt completion is
-// converted into a rejected promise (a completion-record conversion), never a synchronous throw.
-static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
 
 // The [[pullAlgorithm]] dispatch. ByteTeeBranch is byte-controller-only and CrossRealm sources
 // are never created (transferable streams are unimplemented); the switch is total over SourceKind.
@@ -72,28 +49,7 @@ static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::J
             return nullptr;
         }
         StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
-        JSC::JSValue result;
-        JSC::JSValue thrown;
-        {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            auto callData = JSC::getCallData(pullMethod);
-            ASSERT(callData.type != JSC::CallData::Type::None);
-            result = JSC::call(globalObject, pullMethod, callData, controller->m_algorithms.underlyingObject.get(), args);
-            if (catchScope.exception()) [[unlikely]]
-                thrown = takeAbruptCompletion(globalObject, catchScope);
-        }
-        if (!thrown.isEmpty()) [[unlikely]]
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-        if (result.isEmpty()) [[unlikely]]
-            return nullptr;
-        if (!result.isObject()) [[likely]]
-            return nullptr;
-        // A vanilla JSPromise with an unpatched .then needs no wrapper: the caller uses
-        // performPromiseThenWithContext (internal reactions), so skipping promiseResolvedWith's
-        // thenable adoption is unobservable. Subclasses / patched .then fall through.
-        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
-            return resultPromise;
-        RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromiseFast(globalObject, pullMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SourceKind::Nothing:
         return nullptr;
@@ -131,7 +87,7 @@ static JSC::JSPromise* performDefaultControllerCancelAlgorithm(JSC::VM& vm, JSC:
             return nullptr;
         }
         StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, cancelMethod, controller->m_algorithms.underlyingObject.get(), args));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromise(globalObject, cancelMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SourceKind::Nothing:
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
@@ -593,55 +549,28 @@ void readableStreamDefaultControllerEnqueue(JSGlobalObject* globalObject, JSRead
     } else {
         double chunkSize = 1;
         if (JSObject* sizeAlgorithm = controller->m_strategySizeAlgorithm.get()) {
-            JSValue chunkSizeValue;
-            {
-                // The strategy size() call is interpreted as a completion record: an abrupt
-                // completion errors the controller and is then rethrown.
-                auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                auto callData = JSC::getCallData(sizeAlgorithm);
-                ASSERT(callData.type != JSC::CallData::Type::None);
-                JSC::MarkedArgumentBuffer args;
-                args.append(chunk);
-                if (args.hasOverflowed()) [[unlikely]] {
-                    throwOutOfMemoryError(globalObject, scope);
-                    return;
-                }
-                chunkSizeValue = JSC::call(globalObject, sizeAlgorithm, callData, jsUndefined(), args);
-                if (catchScope.exception()) [[unlikely]] {
-                    JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-                    if (thrown.isEmpty()) [[unlikely]]
-                        return;
-                    readableStreamDefaultControllerError(globalObject, controller, thrown);
-                    RETURN_IF_EXCEPTION(scope, void());
-                    throwException(globalObject, scope, thrown);
-                    return;
-                }
-            }
-            // Web IDL: the size callback returns an `unrestricted double` — a full ToNumber
-            // (can run user JS); a throw from it is the same abrupt completion as size() throwing.
-            {
-                auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                chunkSize = chunkSizeValue.toNumber(globalObject);
-                if (catchScope.exception()) [[unlikely]] {
-                    JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-                    if (thrown.isEmpty()) [[unlikely]]
-                        return;
-                    readableStreamDefaultControllerError(globalObject, controller, thrown);
-                    RETURN_IF_EXCEPTION(scope, void());
-                    throwException(globalObject, scope, thrown);
-                    return;
-                }
-            }
-        }
-        // EnqueueValueWithSize is interpreted as a completion record: same recovery.
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        controller->m_queue.enqueueValueWithSize(globalObject, controller, chunk, chunkSize);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty()) [[unlikely]]
+            auto callData = JSC::getCallData(sizeAlgorithm);
+            ASSERT(callData.type != JSC::CallData::Type::None);
+            JSC::MarkedArgumentBuffer args;
+            args.append(chunk);
+            if (args.hasOverflowed()) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
                 return;
+            }
+            JSValue chunkSizeValue = JSC::call(globalObject, sizeAlgorithm, callData, jsUndefined(), args);
+            // Web IDL: the size callback returns an `unrestricted double` — a full ToNumber.
+            if (!scope.exception()) [[likely]]
+                chunkSize = chunkSizeValue.toNumber(globalObject);
+        }
+        if (!scope.exception()) [[likely]]
+            controller->m_queue.enqueueValueWithSize(globalObject, controller, chunk, chunkSize);
+        if (scope.exception()) [[unlikely]] {
+            // Spec steps 4.b / 5.b: "If result is an abrupt completion, perform
+            // ! ReadableStreamDefaultControllerError(controller, result.[[Value]]) and return result."
+            JSValue thrown = takeException(scope);
+            RETURN_IF_EXCEPTION(scope, );
             readableStreamDefaultControllerError(globalObject, controller, thrown);
-            RETURN_IF_EXCEPTION(scope, void());
+            RETURN_IF_EXCEPTION(scope, );
             throwException(globalObject, scope, thrown);
             return;
         }

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -736,9 +736,14 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_read, (J
     auto* runtime = JSStreamsRuntime::from(lexicalGlobalObject);
     auto* promise = JSPromise::create(vm, lexicalGlobalObject->promiseStructure());
     auto* readRequest = JSReadRequest::create(vm, runtime->readRequestStructure(domGlobalObject), ReadRequestKind::Promise, promise);
-    readableStreamDefaultReaderRead(lexicalGlobalObject, reader, readRequest);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(promise);
+    // WebIDL: read() returns a promise, so a throw from the pull it triggers (a direct source's
+    // hooks) is a rejection, never a synchronous throw.
+    RELEASE_AND_RETURN(scope, JSValue::encode(promiseFromSteps(lexicalGlobalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        readableStreamDefaultReaderRead(lexicalGlobalObject, reader, readRequest);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return promise;
+    })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_readMany, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -494,15 +494,12 @@ static void pipeChunkDeferredWrite(JSGlobalObject* globalObject, JSStreamPipeToO
     }
 }
 
-// [reaction-convention] BOUNDARY: the deferred sink write, queued as a plain job (no result
-// capability). argument(0) = the chunk; context = InternalFieldTuple{op, the promise published as
+// [reaction-convention] the deferred sink write, queued as a plain job (enterStreams).
+// argument(0) = the chunk; context = InternalFieldTuple{op, the promise published as
 // m_currentWrite}, which adopts the real write's settlement. The shutdown paths wait on that
 // published promise, so a throw here must never leave it pending: it is rejected with the error.
-// A throw after it already settled has no owner and is left for the microtask runner to report.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onPipeChunkDeferredWrite, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* context = dynamicDowncast<InternalFieldTuple>(callFrame->argument(1));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -510,14 +507,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onPipeChunkDeferredWrite, (JSGlobal
     if (!op) [[unlikely]]
         return JSValue::encode(jsUndefined());
     auto* trackingPromise = uncheckedDowncast<JSPromise>(context->getInternalField(1));
-    pipeChunkDeferredWrite(globalObject, op, trackingPromise, callFrame->argument(0));
-    if (scope.exception() && trackingPromise->status() == JSPromise::Status::Pending) [[unlikely]] {
-        JSValue error = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, {});
-        rejectPromise(globalObject, trackingPromise, error);
-    }
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsUndefined());
+    return enterStreams(globalObject, [&] { pipeChunkDeferredWrite(globalObject, op, trackingPromise, callFrame->argument(0)); }, [&](JSValue error) {
+        if (trackingPromise->status() == JSPromise::Status::Pending)
+            rejectPromise(globalObject, trackingPromise, error); });
 }
 
 // [reaction-convention] shutdown-action settlement. The context is the op cell; the

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -454,17 +454,55 @@ WEB_STREAMS_DEFINE_PIPE_REACTION_TRAMPOLINE(onPipeWritesFinishedForShutdown, onW
 #undef WEB_STREAMS_DEFINE_PIPE_REACTION_TRAMPOLINE
 #undef WEB_STREAMS_DEFINE_PIPE_REACTION_TRAMPOLINE_WITH_VALUE
 
-// [reaction-convention] the deferred sink write, queued as a plain job (no result
-// capability, so any throw must settle the published promise itself). argument(0) = the
-// chunk; context = InternalFieldTuple{op, the promise published as m_currentWrite}, which
-// adopts the real write's settlement. After the head write, chunks the source already has
-// queued are written in place while the destination reports capacity: no read request, no
-// extra microtask per chunk. The dequeue and the write both run user JS, so every guard is
-// re-established around each of them.
+// The deferred sink write's body (onPipeChunkDeferredWrite below). After the head write, chunks
+// the source already has queued are written in place while the destination reports capacity: no
+// read request, no extra microtask per chunk. The dequeue and the write both run user JS, so
+// every guard is re-established around each of them.
+static void pipeChunkDeferredWrite(JSGlobalObject* globalObject, JSStreamPipeToOperation* op, JSPromise* trackingPromise, JSValue chunk)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (op->m_finalized)
+        RELEASE_AND_RETURN(scope, resolvePromise(globalObject, trackingPromise, jsUndefined()));
+    auto* writePromise = writableStreamDefaultWriterWrite(globalObject, op->m_writer.get(), chunk);
+    RETURN_IF_EXCEPTION(scope, );
+    writePromise->performPromiseThenWithContext(vm, globalObject, jsUndefined(), jsUndefined(), trackingPromise, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, );
+
+    while (!op->m_finalized && !op->m_shuttingDown) {
+        auto* writer = op->m_writer.get();
+        auto desiredSize = writableStreamDefaultWriterGetDesiredSize(writer);
+        if (!desiredSize || *desiredSize <= 0)
+            return;
+        auto* reader = op->m_reader.get();
+        if (!reader)
+            return;
+        JSValue next = readableStreamDefaultReaderTryReadFromQueue(globalObject, reader);
+        RETURN_IF_EXCEPTION(scope, );
+        if (!next)
+            return;
+        // The dequeue can run the source's pull(): re-check before touching the writer.
+        // A dequeued chunk must still be written if a shutdown merely began (the
+        // shutdown waits on m_currentWrite); only a finalized op or a replaced writer
+        // makes the write invalid.
+        if (op->m_finalized || op->m_writer.get() != writer)
+            return;
+        auto* nextWrite = writableStreamDefaultWriterWrite(globalObject, writer, next);
+        RETURN_IF_EXCEPTION(scope, );
+        publishPipeWrite(globalObject, op, nextWrite);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+}
+
+// [reaction-convention] BOUNDARY: the deferred sink write, queued as a plain job (no result
+// capability). argument(0) = the chunk; context = InternalFieldTuple{op, the promise published as
+// m_currentWrite}, which adopts the real write's settlement. The shutdown paths wait on that
+// published promise, so a throw here must never leave it pending: it is rejected with the error.
+// A throw after it already settled has no owner and is left for the microtask runner to report.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onPipeChunkDeferredWrite, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* context = dynamicDowncast<InternalFieldTuple>(callFrame->argument(1));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -472,53 +510,13 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onPipeChunkDeferredWrite, (JSGlobal
     if (!op) [[unlikely]]
         return JSValue::encode(jsUndefined());
     auto* trackingPromise = uncheckedDowncast<JSPromise>(context->getInternalField(1));
-    do {
-        if (op->m_finalized) {
-            resolvePromise(globalObject, trackingPromise, jsUndefined());
-            break;
-        }
-        auto* writePromise = writableStreamDefaultWriterWrite(globalObject, op->m_writer.get(), callFrame->argument(0));
-        if (catchScope.exception()) [[unlikely]]
-            break;
-        writePromise->performPromiseThenWithContext(vm, globalObject, jsUndefined(), jsUndefined(), trackingPromise, jsUndefined());
-        if (catchScope.exception()) [[unlikely]]
-            break;
-
-        while (!op->m_finalized && !op->m_shuttingDown) {
-            auto* writer = op->m_writer.get();
-            auto desiredSize = writableStreamDefaultWriterGetDesiredSize(writer);
-            if (!desiredSize || *desiredSize <= 0)
-                break;
-            auto* reader = op->m_reader.get();
-            if (!reader)
-                break;
-            JSValue next = readableStreamDefaultReaderTryReadFromQueue(globalObject, reader);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-            if (!next)
-                break;
-            // The dequeue can run the source's pull(): re-check before touching the writer.
-            // A dequeued chunk must still be written if a shutdown merely began (the
-            // shutdown waits on m_currentWrite); only a finalized op or a replaced writer
-            // makes the write invalid.
-            if (op->m_finalized || op->m_writer.get() != writer)
-                break;
-            auto* nextWrite = writableStreamDefaultWriterWrite(globalObject, writer, next);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-            publishPipeWrite(globalObject, op, nextWrite);
-            if (catchScope.exception()) [[unlikely]]
-                break;
-        }
-    } while (false);
-    if (catchScope.exception()) [[unlikely]] {
-        JSValue error = takeAbruptCompletion(globalObject, catchScope);
-        if (error.isEmpty())
-            return JSValue::encode(jsUndefined());
-        // The shutdown paths wait on the published m_currentWrite: never leave it pending.
-        if (trackingPromise->status() == JSPromise::Status::Pending)
-            rejectPromise(globalObject, trackingPromise, error);
+    pipeChunkDeferredWrite(globalObject, op, trackingPromise, callFrame->argument(0));
+    if (scope.exception() && trackingPromise->status() == JSPromise::Status::Pending) [[unlikely]] {
+        JSValue error = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, {});
+        rejectPromise(globalObject, trackingPromise, error);
     }
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -23,7 +23,6 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 
 // TextDecoder.rs
 extern "C" void* TextDecoder__createForStream(JSC::JSGlobalObject*, JSC::EncodedJSValue label, bool fatal, bool ignoreBOM, bool* outUtf8FastPath, BunString* outEncodingLabel);
@@ -348,31 +347,25 @@ static std::optional<std::span<const uint8_t>> textDecoderStreamBytes(JSGlobalOb
     return std::nullopt;
 }
 
-// Abrupt completions from decode OR enqueue become a rejected promise — a transform
-// algorithm must never throw synchronously into ProcessWrite/ProcessClose.
+// A transform/flush algorithm returns a promise (spec "transformAlgorithm ... returns a promise
+// rejected with" on failure): a throw from decode or enqueue is that rejection, never a synchronous
+// throw into ProcessWrite/ProcessClose.
 static JSPromise* decodeAndEnqueue(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller, const uint8_t* input, size_t inputLen, bool streaming)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        JSValue decoded;
-        if (stream->m_decoder) {
-            decoded = JSValue::decode(TextDecoder__decodeForStream(stream->m_decoder, globalObject, input, inputLen, streaming));
-        } else {
-            auto* s = streamingUTF8Decode(globalObject, std::span<const uint8_t> { input, inputLen }, stream->m_utf8State, /* flush */ !streaming);
-            decoded = s ? JSValue(s) : jsUndefined();
-        }
-        if (!catchScope.exception() && decoded.isString() && asString(decoded)->length())
-            transformStreamDefaultControllerEnqueue(globalObject, controller, decoded);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
+    JSValue decoded;
+    if (stream->m_decoder) {
+        decoded = JSValue::decode(TextDecoder__decodeForStream(stream->m_decoder, globalObject, input, inputLen, streaming));
+    } else {
+        auto* s = streamingUTF8Decode(globalObject, std::span<const uint8_t> { input, inputLen }, stream->m_utf8State, /* flush */ !streaming);
+        decoded = s ? JSValue(s) : jsUndefined();
     }
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    if (!scope.exception() && decoded.isString() && asString(decoded)->length())
+        transformStreamDefaultControllerEnqueue(globalObject, controller, decoded);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 
@@ -380,17 +373,9 @@ JSPromise* textDecoderStreamTransform(JSGlobalObject* globalObject, JSTextDecode
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thrown;
-    std::optional<std::span<const uint8_t>> bytes;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        bytes = textDecoderStreamBytes(globalObject, chunk);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    std::optional<std::span<const uint8_t>> bytes = textDecoderStreamBytes(globalObject, chunk);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     RELEASE_AND_RETURN(scope, decodeAndEnqueue(globalObject, stream, controller, bytes->data(), bytes->size(), true));
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -347,14 +347,12 @@ static std::optional<std::span<const uint8_t>> textDecoderStreamBytes(JSGlobalOb
     return std::nullopt;
 }
 
-// A transform/flush algorithm returns a promise (spec "transformAlgorithm ... returns a promise
-// rejected with" on failure): a throw from decode or enqueue is that rejection, never a synchronous
-// throw into ProcessWrite/ProcessClose.
-static JSPromise* decodeAndEnqueue(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller, const uint8_t* input, size_t inputLen, bool streaming)
+// The transform/flush algorithms return a promise, so a throw from decode or enqueue is that
+// promise's rejection (promiseFromSteps), never a synchronous throw into ProcessWrite/ProcessClose.
+static void decodeAndEnqueue(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller, const uint8_t* input, size_t inputLen, bool streaming)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-
     JSValue decoded;
     if (stream->m_decoder) {
         decoded = JSValue::decode(TextDecoder__decodeForStream(stream->m_decoder, globalObject, input, inputLen, streaming));
@@ -362,26 +360,31 @@ static JSPromise* decodeAndEnqueue(JSGlobalObject* globalObject, JSTextDecoderSt
         auto* s = streamingUTF8Decode(globalObject, std::span<const uint8_t> { input, inputLen }, stream->m_utf8State, /* flush */ !streaming);
         decoded = s ? JSValue(s) : jsUndefined();
     }
-    if (!scope.exception() && decoded.isString() && asString(decoded)->length())
-        transformStreamDefaultControllerEnqueue(globalObject, controller, decoded);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    RETURN_IF_EXCEPTION(scope, );
+    if (decoded.isString() && asString(decoded)->length())
+        RELEASE_AND_RETURN(scope, transformStreamDefaultControllerEnqueue(globalObject, controller, decoded));
 }
 
 JSPromise* textDecoderStreamTransform(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    std::optional<std::span<const uint8_t>> bytes = textDecoderStreamBytes(globalObject, chunk);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, decodeAndEnqueue(globalObject, stream, controller, bytes->data(), bytes->size(), true));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        std::optional<std::span<const uint8_t>> bytes = textDecoderStreamBytes(globalObject, chunk);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        decodeAndEnqueue(globalObject, stream, controller, bytes->data(), bytes->size(), true);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 JSPromise* textDecoderStreamFlush(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller)
 {
-    return decodeAndEnqueue(globalObject, stream, controller, nullptr, 0, false);
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        decodeAndEnqueue(globalObject, stream, controller, nullptr, 0, false);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 } // namespace WebStreams

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -281,31 +281,33 @@ static void enqueueIfNonEmptyView(JSGlobalObject* globalObject, JSTransformStrea
 // encoder writes straight to it via its reusable scratch buffer (no JSUint8Array).
 static JSPromise* encodeAndEnqueue(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk, bool flush)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    bool sinkBackpressure = false;
-    if (void* sinkPtr = stream->m_nativeSinkPtr) {
-        JSValue wrote = JSValue::decode(flush
-                ? TextEncoderStreamEncoder__flushIntoSink(stream->m_encoder, globalObject, stream->m_nativeSinkId, sinkPtr)
-                : TextEncoderStreamEncoder__encodeIntoSink(stream->m_encoder, globalObject, JSValue::encode(chunk), stream->m_nativeSinkId, sinkPtr));
-        if (!scope.exception())
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        bool sinkBackpressure = false;
+        if (void* sinkPtr = stream->m_nativeSinkPtr) {
+            JSValue wrote = JSValue::decode(flush
+                    ? TextEncoderStreamEncoder__flushIntoSink(stream->m_encoder, globalObject, stream->m_nativeSinkId, sinkPtr)
+                    : TextEncoderStreamEncoder__encodeIntoSink(stream->m_encoder, globalObject, JSValue::encode(chunk), stream->m_nativeSinkId, sinkPtr));
+            RETURN_IF_EXCEPTION(scope, nullptr);
             sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
-    } else {
-        JSValue buffer = JSValue::decode(flush
-                ? TextEncoderStreamEncoder__flushForStream(stream->m_encoder, globalObject)
-                : TextEncoderStreamEncoder__encodeForStream(stream->m_encoder, globalObject, JSValue::encode(chunk)));
-        if (!scope.exception() && !buffer.isEmpty())
-            enqueueIfNonEmptyView(globalObject, controller, buffer);
-    }
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (sinkBackpressure) {
-        auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
-        stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
-        return ready;
-    }
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+        } else {
+            JSValue buffer = JSValue::decode(flush
+                    ? TextEncoderStreamEncoder__flushForStream(stream->m_encoder, globalObject)
+                    : TextEncoderStreamEncoder__encodeForStream(stream->m_encoder, globalObject, JSValue::encode(chunk)));
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            if (!buffer.isEmpty()) {
+                enqueueIfNonEmptyView(globalObject, controller, buffer);
+                RETURN_IF_EXCEPTION(scope, nullptr);
+            }
+        }
+        if (sinkBackpressure) {
+            auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
+            stream->m_nativeSinkReadyPromise.set(vm, stream, ready);
+            return ready;
+        }
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 JSPromise* textEncoderStreamTransform(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -22,7 +22,6 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 
 // TextEncoderStreamEncoder.rs
 extern "C" void* TextEncoderStreamEncoder__createForStream();
@@ -277,37 +276,30 @@ static void enqueueIfNonEmptyView(JSGlobalObject* globalObject, JSTransformStrea
 }
 
 // Abrupt completions from encode (ToString runs user JS) OR enqueue become a rejected
-// promise — a transform algorithm must never throw synchronously into
-// ProcessWrite/ProcessClose. When a native JSSink is attached (m_nativeSinkPtr), the
+// promise (a transform algorithm returns a promise; a throw is its rejection, never a synchronous
+// throw into ProcessWrite/ProcessClose). When a native JSSink is attached (m_nativeSinkPtr), the
 // encoder writes straight to it via its reusable scratch buffer (no JSUint8Array).
 static JSPromise* encodeAndEnqueue(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk, bool flush)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue thrown;
     bool sinkBackpressure = false;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        if (void* sinkPtr = stream->m_nativeSinkPtr) {
-            JSValue wrote = JSValue::decode(flush
-                    ? TextEncoderStreamEncoder__flushIntoSink(stream->m_encoder, globalObject, stream->m_nativeSinkId, sinkPtr)
-                    : TextEncoderStreamEncoder__encodeIntoSink(stream->m_encoder, globalObject, JSValue::encode(chunk), stream->m_nativeSinkId, sinkPtr));
-            if (!catchScope.exception())
-                sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
-        } else {
-            JSValue buffer = JSValue::decode(flush
-                    ? TextEncoderStreamEncoder__flushForStream(stream->m_encoder, globalObject)
-                    : TextEncoderStreamEncoder__encodeForStream(stream->m_encoder, globalObject, JSValue::encode(chunk)));
-            if (!catchScope.exception() && !buffer.isEmpty())
-                enqueueIfNonEmptyView(globalObject, controller, buffer);
-        }
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
+    if (void* sinkPtr = stream->m_nativeSinkPtr) {
+        JSValue wrote = JSValue::decode(flush
+                ? TextEncoderStreamEncoder__flushIntoSink(stream->m_encoder, globalObject, stream->m_nativeSinkId, sinkPtr)
+                : TextEncoderStreamEncoder__encodeIntoSink(stream->m_encoder, globalObject, JSValue::encode(chunk), stream->m_nativeSinkId, sinkPtr));
+        if (!scope.exception())
+            sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
+    } else {
+        JSValue buffer = JSValue::decode(flush
+                ? TextEncoderStreamEncoder__flushForStream(stream->m_encoder, globalObject)
+                : TextEncoderStreamEncoder__encodeForStream(stream->m_encoder, globalObject, JSValue::encode(chunk)));
+        if (!scope.exception() && !buffer.isEmpty())
+            enqueueIfNonEmptyView(globalObject, controller, buffer);
     }
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     if (sinkBackpressure) {
         auto* ready = JSPromise::create(vm, globalObject->promiseStructure());
         stream->m_nativeSinkReadyPromise.set(vm, stream, ready);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -47,11 +47,12 @@ static JSReadableStreamDefaultController* transformReadableController(JSTransfor
 // completion, return a promise rejected with result.[[Value]]. Otherwise a promise resolved with undefined."
 static JSPromise* defaultTransformAlgorithm(JSC::VM& vm, JSGlobalObject* globalObject, JSTransformStreamDefaultController* controller, JSValue chunk)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    transformStreamDefaultControllerEnqueue(globalObject, controller, chunk);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        transformStreamDefaultControllerEnqueue(globalObject, controller, chunk);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    });
 }
 
 // The [[transformAlgorithm]] dispatch; the switch is total over TransformerKind.
@@ -403,13 +404,12 @@ void transformStreamDefaultControllerEnqueue(JSGlobalObject* globalObject, JSTra
         return;
     }
     readableStreamDefaultControllerEnqueue(globalObject, readableController, chunk);
-    if (scope.exception()) [[unlikely]] {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
         // Spec steps 4-5: "If enqueueResult is an abrupt completion, perform
         // ! TransformStreamErrorWritableAndUnblockWrite(stream, enqueueResult.[[Value]]) and throw
         // stream.[[readable]].[[storedError]]."
-        JSValue thrown = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, );
-        transformStreamErrorWritableAndUnblockWrite(globalObject, stream, thrown);
+        TRY_CLEAR_EXCEPTION(scope, );
+        transformStreamErrorWritableAndUnblockWrite(globalObject, stream, exception->value());
         RETURN_IF_EXCEPTION(scope, void());
         // The readable is not necessarily Errored here: the user size() callback may have
         // closed it before throwing, leaving [[storedError]] unset — then we throw undefined.

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -25,7 +25,6 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 
 namespace Bun {
 namespace WebStreams {
@@ -43,44 +42,15 @@ static JSReadableStreamDefaultController* transformReadableController(JSTransfor
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
 }
 
-// WebIDL callback invoke returning Promise<undefined>: an abrupt completion becomes a
-// rejected promise (a sanctioned completion-record catch). Returns nullptr on VM termination.
-static JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* method, JSValue thisValue, const MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue result;
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = getCallData(method);
-        ASSERT(callData.type != CallData::Type::None);
-        result = call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
-// The default [[transformAlgorithm]]: enqueue the chunk unchanged; the enqueue's abrupt
-// completion becomes a rejected promise (a sanctioned completion-record catch).
+// The default [[transformAlgorithm]] (SetUpTransformStreamDefaultControllerFromTransformer step 2):
+// "Let result be TransformStreamDefaultControllerEnqueue(controller, chunk). If result is an abrupt
+// completion, return a promise rejected with result.[[Value]]. Otherwise a promise resolved with undefined."
 static JSPromise* defaultTransformAlgorithm(JSC::VM& vm, JSGlobalObject* globalObject, JSTransformStreamDefaultController* controller, JSValue chunk)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        transformStreamDefaultControllerEnqueue(globalObject, controller, chunk);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    // takeAbruptCompletion leaves a VM termination pending and returns the empty value.
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    transformStreamDefaultControllerEnqueue(globalObject, controller, chunk);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 
@@ -98,7 +68,7 @@ static JSPromise* performTransformAlgorithm(JSC::VM& vm, JSGlobalObject* globalO
                 throwOutOfMemoryError(globalObject, scope);
                 return nullptr;
             }
-            RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, transformMethod, controller->m_transformer.get(), args));
+            RELEASE_AND_RETURN(scope, invokeCallbackReturningPromise(globalObject, transformMethod, controller->m_transformer.get(), args));
         }
         break;
     case TransformerKind::Identity:
@@ -432,19 +402,13 @@ void transformStreamDefaultControllerEnqueue(JSGlobalObject* globalObject, JSTra
         throwTypeError(globalObject, scope, "Cannot enqueue a chunk into a TransformStream whose readable side is closed or has already requested close"_s);
         return;
     }
-    JSValue thrown;
-    {
-        // The readable-side enqueue interpreted as a completion record (a sanctioned
-        // completion-record catch): an abrupt completion errors the WRITABLE side and
-        // rethrows the readable's stored error.
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        readableStreamDefaultControllerEnqueue(globalObject, readableController, chunk);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    // takeAbruptCompletion leaves a VM termination pending and returns the empty value.
-    RETURN_IF_EXCEPTION(scope, void());
-    if (!thrown.isEmpty()) [[unlikely]] {
+    readableStreamDefaultControllerEnqueue(globalObject, readableController, chunk);
+    if (scope.exception()) [[unlikely]] {
+        // Spec steps 4-5: "If enqueueResult is an abrupt completion, perform
+        // ! TransformStreamErrorWritableAndUnblockWrite(stream, enqueueResult.[[Value]]) and throw
+        // stream.[[readable]].[[storedError]]."
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, );
         transformStreamErrorWritableAndUnblockWrite(globalObject, stream, thrown);
         RETURN_IF_EXCEPTION(scope, void());
         // The readable is not necessarily Errored here: the user size() callback may have

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -22,62 +22,12 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
 
 namespace Bun {
 namespace WebStreams {
 
 using namespace JSC;
-
-// WebIDL "invoke a callback function" with a Promise<T> return type: an abrupt completion is
-// converted into a rejected promise (a completion-record conversion), never a synchronous throw.
-static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
-// As invokePromiseReturningMethod, but returns nullptr for a synchronous non-thenable completion
-// and returns a vanilla JSPromise unwrapped (isThenFastAndNonObservable); the caller queues the
-// upon-fulfillment handler directly when the result is nullptr or already Fulfilled.
-static JSC::JSPromise* invokePromiseReturningMethodFast(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty()) [[unlikely]]
-        return nullptr;
-    if (!result.isObject()) [[likely]]
-        return nullptr;
-    if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
-        return resultPromise;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
 
 // The [[writeAlgorithm]] dispatch. The reachable SinkKind set on a writable default
 // controller is {JavaScript, Nothing, Transform} (CrossRealm: transferable streams are not
@@ -99,7 +49,7 @@ static JSC::JSPromise* performWriteAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* g
             JSC::throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethodFast(vm, globalObject, writeMethod, controller->m_algorithms.underlyingObject.get(), args));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromiseFast(globalObject, writeMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SinkKind::Nothing:
         return nullptr;
@@ -124,7 +74,7 @@ static JSC::JSPromise* performCloseAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* g
         if (!closeMethod)
             return nullptr;
         JSC::MarkedArgumentBuffer args;
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethodFast(vm, globalObject, closeMethod, controller->m_algorithms.underlyingObject.get(), args));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromiseFast(globalObject, closeMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SinkKind::Nothing:
         return nullptr;
@@ -152,7 +102,7 @@ static JSC::JSPromise* performAbortAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* g
             JSC::throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, abortMethod, controller->m_algorithms.underlyingObject.get(), args));
+        RELEASE_AND_RETURN(scope, invokeCallbackReturningPromise(globalObject, abortMethod, controller->m_algorithms.underlyingObject.get(), args));
     }
     case SinkKind::Nothing:
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
@@ -585,30 +535,20 @@ double writableStreamDefaultControllerGetChunkSize(JSGlobalObject* globalObject,
     if (!sizeAlgorithm)
         return 1;
 
-    // "interpreting the result as a completion record": the size() call AND the WebIDL
-    // `unrestricted double` conversion of its return value (the sanctioned size() catch family).
-    double size = 1;
-    JSValue thrown;
-    bool abrupt = false;
     MarkedArgumentBuffer args;
     args.append(chunk);
     ASSERT(!args.hasOverflowed());
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = getCallData(sizeAlgorithm);
-        ASSERT(callData.type != CallData::Type::None);
-        JSValue returnValue = call(globalObject, sizeAlgorithm, callData, jsUndefined(), args);
-        if (!catchScope.exception())
-            size = returnValue.toNumber(globalObject);
-        if (catchScope.exception()) [[unlikely]] {
-            abrupt = true;
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-        }
-    }
-    if (abrupt) [[unlikely]] {
-        // A VM termination is never consumed: it is still pending on the scope.
-        if (thrown.isEmpty())
-            return 1;
+    auto callData = getCallData(sizeAlgorithm);
+    ASSERT(callData.type != CallData::Type::None);
+    JSValue returnValue = call(globalObject, sizeAlgorithm, callData, jsUndefined(), args);
+    double size = 1;
+    if (!scope.exception()) [[likely]]
+        size = returnValue.toNumber(globalObject); // WebIDL `unrestricted double`
+    if (scope.exception()) [[unlikely]] {
+        // Spec step 3: "If returnValue is an abrupt completion, perform
+        // ! WritableStreamDefaultControllerErrorIfNeeded(controller, returnValue.[[Value]]) and return 1."
+        JSValue thrown = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, 1);
         writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, thrown);
         RETURN_IF_EXCEPTION(scope, 1);
         return 1;
@@ -661,22 +601,13 @@ void writableStreamDefaultControllerWrite(JSGlobalObject* globalObject, JSWritab
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // "If enqueueResult is an abrupt completion" — EnqueueValueWithSize's RangeError on an
-    // invalid size is interpreted as a completion record (no user JS runs).
-    JSValue enqueueError;
-    bool abrupt = false;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        controller->m_queue.enqueueValueWithSize(globalObject, controller, chunk, chunkSize);
-        if (catchScope.exception()) [[unlikely]] {
-            abrupt = true;
-            enqueueError = takeAbruptCompletion(globalObject, catchScope);
-        }
-    }
-    if (abrupt) [[unlikely]] {
-        // A VM termination is never consumed: it is still pending on the scope.
-        if (enqueueError.isEmpty())
-            return;
+    controller->m_queue.enqueueValueWithSize(globalObject, controller, chunk, chunkSize);
+    if (scope.exception()) [[unlikely]] {
+        // Spec step 2: "If enqueueResult is an abrupt completion, perform
+        // ! WritableStreamDefaultControllerErrorIfNeeded(controller, enqueueResult.[[Value]]) and return."
+        // (EnqueueValueWithSize's RangeError on an invalid size; no user JS runs.)
+        JSValue enqueueError = takeException(scope);
+        RETURN_IF_EXCEPTION(scope, );
         RELEASE_AND_RETURN(scope, writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, enqueueError));
     }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -544,12 +544,11 @@ double writableStreamDefaultControllerGetChunkSize(JSGlobalObject* globalObject,
     double size = 1;
     if (!scope.exception()) [[likely]]
         size = returnValue.toNumber(globalObject); // WebIDL `unrestricted double`
-    if (scope.exception()) [[unlikely]] {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
         // Spec step 3: "If returnValue is an abrupt completion, perform
         // ! WritableStreamDefaultControllerErrorIfNeeded(controller, returnValue.[[Value]]) and return 1."
-        JSValue thrown = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, 1);
-        writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, thrown);
+        TRY_CLEAR_EXCEPTION(scope, 1);
+        writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, exception->value());
         RETURN_IF_EXCEPTION(scope, 1);
         return 1;
     }
@@ -602,13 +601,12 @@ void writableStreamDefaultControllerWrite(JSGlobalObject* globalObject, JSWritab
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     controller->m_queue.enqueueValueWithSize(globalObject, controller, chunk, chunkSize);
-    if (scope.exception()) [[unlikely]] {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
         // Spec step 2: "If enqueueResult is an abrupt completion, perform
         // ! WritableStreamDefaultControllerErrorIfNeeded(controller, enqueueResult.[[Value]]) and return."
         // (EnqueueValueWithSize's RangeError on an invalid size; no user JS runs.)
-        JSValue enqueueError = takeException(scope);
-        RETURN_IF_EXCEPTION(scope, );
-        RELEASE_AND_RETURN(scope, writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, enqueueError));
+        TRY_CLEAR_EXCEPTION(scope, );
+        RELEASE_AND_RETURN(scope, writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, exception->value()));
     }
 
     auto* stream = controller->m_stream.get();

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -31,7 +31,6 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/MicrotaskQueue.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
 
 namespace Bun {
@@ -887,17 +886,11 @@ JSPromise* fromIterablePullAlgorithm(JSGlobalObject* globalObject, JSReadableStr
     const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
     IterationRecord iteratorRecord { context->m_iterator.get(), context->m_nextMethod.get() };
 
-    JSValue nextResult;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        nextResult = iteratorNextExported(globalObject, iteratorRecord);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-        }
-    }
+    // Spec steps 3-4: "Let nextResult be IteratorNext(iteratorRecord). If nextResult is an abrupt
+    // completion, return a promise rejected with nextResult.[[Value]]."
+    JSValue nextResult = iteratorNextExported(globalObject, iteratorRecord);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     auto* nextPromise = promiseResolvedWith(globalObject, nextResult);
     RETURN_IF_EXCEPTION(scope, nullptr);
     auto* result = JSPromise::create(vm, globalObject->promiseStructure());
@@ -915,17 +908,11 @@ JSPromise* fromIterableCancelAlgorithm(JSGlobalObject* globalObject, JSReadableS
     const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
     JSObject* iterator = context->m_iterator.get();
 
-    JSValue returnMethod;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        returnMethod = iterator->get(globalObject, vm.propertyNames->returnKeyword);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-        }
-    }
+    // Spec steps 3-4 / 6-7: GetMethod(iterator, "return") and Call(returnMethod, ...) are completion
+    // records; an abrupt one is "return a promise rejected with [[Value]]".
+    JSValue returnMethod = iterator->get(globalObject, vm.propertyNames->returnKeyword);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     if (returnMethod.isUndefinedOrNull())
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
     if (!returnMethod.isCallable()) {
@@ -934,21 +921,13 @@ JSPromise* fromIterableCancelAlgorithm(JSGlobalObject* globalObject, JSReadableS
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, notCallable));
     }
 
-    JSValue returnResult;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(returnMethod);
-        MarkedArgumentBuffer args;
-        args.append(reason);
-        ASSERT(!args.hasOverflowed());
-        returnResult = JSC::call(globalObject, returnMethod, callData, iterator, args);
-        if (catchScope.exception()) [[unlikely]] {
-            JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-        }
-    }
+    auto callData = JSC::getCallData(returnMethod);
+    MarkedArgumentBuffer args;
+    args.append(reason);
+    ASSERT(!args.hasOverflowed());
+    JSValue returnResult = JSC::call(globalObject, returnMethod, callData, iterator, args);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     auto* returnPromise = promiseResolvedWith(globalObject, returnResult);
     RETURN_IF_EXCEPTION(scope, nullptr);
     auto* result = JSPromise::create(vm, globalObject->promiseStructure());
@@ -1020,18 +999,10 @@ JSPromise* textDecodePullAlgorithm(JSGlobalObject* globalObject, JSReadableStrea
     auto* runtime = JSStreamsRuntime::from(globalObject);
     auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
     auto* readRequest = WebCore::JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::TextDecode, controller);
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        readableStreamDefaultReaderRead(globalObject, reader, readRequest);
-        if (catchScope.exception()) [[unlikely]] {
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-            if (thrown.isEmpty())
-                return nullptr;
-        }
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    // A pull algorithm returns a promise: a throw from the read is its rejection.
+    readableStreamDefaultReaderRead(globalObject, reader, readRequest);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 
@@ -1341,14 +1312,13 @@ static EncodedJSValue byteTeeChunkStepsMicrotask(JSGlobalObject* globalObject, J
     auto* chunk1 = uncheckedDowncast<JSArrayBufferView>(chunk);
     JSArrayBufferView* chunk2 = chunk1;
     if (!teeState->m_canceled1 && !teeState->m_canceled2) {
-        JSUint8Array* cloneResult = nullptr;
+        // Spec chunk steps 3.2: "If cloneResult is an abrupt completion" error both branches and
+        // resolve cancelPromise with ReadableStreamCancel(stream, cloneResult.[[Value]]).
+        JSUint8Array* cloneResult = cloneAsUint8Array(globalObject, chunk1);
         {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            cloneResult = cloneAsUint8Array(globalObject, chunk1);
-            if (catchScope.exception()) [[unlikely]] {
-                JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-                if (thrown.isEmpty())
-                    return {};
+            if (scope.exception()) [[unlikely]] {
+                JSValue thrown = takeException(scope);
+                RETURN_IF_EXCEPTION(scope, {});
                 if (controller1) {
                     readableByteStreamControllerError(globalObject, controller1, thrown);
                     RETURN_IF_EXCEPTION(scope, {});
@@ -1404,14 +1374,12 @@ static EncodedJSValue byteTeeReadIntoChunkStepsMicrotask(JSGlobalObject* globalO
     bool otherCanceled = forBranch2 ? teeState->m_canceled1 : teeState->m_canceled2;
 
     if (!otherCanceled) {
-        JSUint8Array* clonedChunk = nullptr;
+        // Same spec step as the default-reader chunk steps: a clone failure errors both branches.
+        JSUint8Array* clonedChunk = cloneAsUint8Array(globalObject, chunk);
         {
-            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            clonedChunk = cloneAsUint8Array(globalObject, chunk);
-            if (catchScope.exception()) [[unlikely]] {
-                JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
-                if (thrown.isEmpty())
-                    return {};
+            if (scope.exception()) [[unlikely]] {
+                JSValue thrown = takeException(scope);
+                RETURN_IF_EXCEPTION(scope, {});
                 if (byobController) {
                     readableByteStreamControllerError(globalObject, byobController, thrown);
                     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -880,60 +880,57 @@ JSReadableStream* readableStreamFromIterable(JSGlobalObject* globalObject, JSVal
 // ReadableStream.from's pullAlgorithm.
 JSPromise* fromIterablePullAlgorithm(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
-    IterationRecord iteratorRecord { context->m_iterator.get(), context->m_nextMethod.get() };
-
     // Spec steps 3-4: "Let nextResult be IteratorNext(iteratorRecord). If nextResult is an abrupt
     // completion, return a promise rejected with nextResult.[[Value]]."
-    JSValue nextResult = iteratorNextExported(globalObject, iteratorRecord);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    auto* nextPromise = promiseResolvedWith(globalObject, nextResult);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* result = JSPromise::create(vm, globalObject->promiseStructure());
-    nextPromise->performPromiseThenWithContext(vm, globalObject, runtime->onFromIterablePullFulfilled(), jsUndefined(), result, controller);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    return result;
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* runtime = JSStreamsRuntime::from(globalObject);
+        const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
+        IterationRecord iteratorRecord { context->m_iterator.get(), context->m_nextMethod.get() };
+        JSValue nextResult = iteratorNextExported(globalObject, iteratorRecord);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        auto* nextPromise = promiseResolvedWith(globalObject, nextResult);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        auto* result = JSPromise::create(vm, globalObject->promiseStructure());
+        nextPromise->performPromiseThenWithContext(vm, globalObject, runtime->onFromIterablePullFulfilled(), jsUndefined(), result, controller);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return result;
+    });
 }
 
 // ReadableStream.from's cancelAlgorithm.
 JSPromise* fromIterableCancelAlgorithm(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, JSValue reason)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
-    JSObject* iterator = context->m_iterator.get();
-
     // Spec steps 3-4 / 6-7: GetMethod(iterator, "return") and Call(returnMethod, ...) are completion
     // records; an abrupt one is "return a promise rejected with [[Value]]".
-    JSValue returnMethod = iterator->get(globalObject, vm.propertyNames->returnKeyword);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (returnMethod.isUndefinedOrNull())
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
-    if (!returnMethod.isCallable()) {
-        JSObject* notCallable = createTypeError(globalObject, "The async iterator's return property must be callable"_s);
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* runtime = JSStreamsRuntime::from(globalObject);
+        const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
+        JSObject* iterator = context->m_iterator.get();
+        JSValue returnMethod = iterator->get(globalObject, vm.propertyNames->returnKeyword);
         RETURN_IF_EXCEPTION(scope, nullptr);
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, notCallable));
-    }
-
-    auto callData = JSC::getCallData(returnMethod);
-    MarkedArgumentBuffer args;
-    args.append(reason);
-    ASSERT(!args.hasOverflowed());
-    JSValue returnResult = JSC::call(globalObject, returnMethod, callData, iterator, args);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    auto* returnPromise = promiseResolvedWith(globalObject, returnResult);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* result = JSPromise::create(vm, globalObject->promiseStructure());
-    returnPromise->performPromiseThenWithContext(vm, globalObject, runtime->onFromIterableCancelFulfilled(), jsUndefined(), result, controller);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    return result;
+        if (returnMethod.isUndefinedOrNull())
+            RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+        if (!returnMethod.isCallable()) {
+            throwTypeError(globalObject, scope, "The async iterator's return property must be callable"_s);
+            return nullptr;
+        }
+        auto callData = JSC::getCallData(returnMethod);
+        MarkedArgumentBuffer args;
+        args.append(reason);
+        ASSERT(!args.hasOverflowed());
+        JSValue returnResult = JSC::call(globalObject, returnMethod, callData, iterator, args);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        auto* returnPromise = promiseResolvedWith(globalObject, returnResult);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        auto* result = JSPromise::create(vm, globalObject->promiseStructure());
+        returnPromise->performPromiseThenWithContext(vm, globalObject, runtime->onFromIterableCancelFulfilled(), jsUndefined(), result, controller);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return result;
+    });
 }
 
 // The [reaction-convention] body of onFromIterablePullFulfilled(iterResult, controller).
@@ -1000,10 +997,12 @@ JSPromise* textDecodePullAlgorithm(JSGlobalObject* globalObject, JSReadableStrea
     auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
     auto* readRequest = WebCore::JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::TextDecode, controller);
     // A pull algorithm returns a promise: a throw from the read is its rejection.
-    readableStreamDefaultReaderRead(globalObject, reader, readRequest);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    RELEASE_AND_RETURN(scope, promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        readableStreamDefaultReaderRead(globalObject, reader, readRequest);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    }));
 }
 
 JSPromise* textDecodeCancelAlgorithm(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, JSValue reason)
@@ -1316,9 +1315,9 @@ static EncodedJSValue byteTeeChunkStepsMicrotask(JSGlobalObject* globalObject, J
         // resolve cancelPromise with ReadableStreamCancel(stream, cloneResult.[[Value]]).
         JSUint8Array* cloneResult = cloneAsUint8Array(globalObject, chunk1);
         {
-            if (scope.exception()) [[unlikely]] {
-                JSValue thrown = takeException(scope);
-                RETURN_IF_EXCEPTION(scope, {});
+            if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+                TRY_CLEAR_EXCEPTION(scope, {});
+                JSValue thrown = exception->value();
                 if (controller1) {
                     readableByteStreamControllerError(globalObject, controller1, thrown);
                     RETURN_IF_EXCEPTION(scope, {});
@@ -1377,9 +1376,9 @@ static EncodedJSValue byteTeeReadIntoChunkStepsMicrotask(JSGlobalObject* globalO
         // Same spec step as the default-reader chunk steps: a clone failure errors both branches.
         JSUint8Array* clonedChunk = cloneAsUint8Array(globalObject, chunk);
         {
-            if (scope.exception()) [[unlikely]] {
-                JSValue thrown = takeException(scope);
-                RETURN_IF_EXCEPTION(scope, {});
+            if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+                TRY_CLEAR_EXCEPTION(scope, {});
+                JSValue thrown = exception->value();
                 if (byobController) {
                     readableByteStreamControllerError(globalObject, byobController, thrown);
                     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -40,28 +40,6 @@ static JSReadableStreamDefaultController* transformReadableController(JSTransfor
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
 }
 
-// WebIDL callback invoke returning Promise<undefined>: an abrupt completion becomes a
-// rejected promise (a sanctioned completion-record catch). Returns nullptr on VM termination.
-static JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* method, JSValue thisValue, const MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue result;
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = getCallData(method);
-        ASSERT(callData.type != CallData::Type::None);
-        result = call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
 // [[flushAlgorithm]] dispatch (needed only by the default sink close algorithm below).
 static JSPromise* performFlushAlgorithm(JSC::VM& vm, JSGlobalObject* globalObject, JSTransformStreamDefaultController* controller)
 {
@@ -72,7 +50,7 @@ static JSPromise* performFlushAlgorithm(JSC::VM& vm, JSGlobalObject* globalObjec
             MarkedArgumentBuffer args;
             args.append(controller);
             ASSERT(!args.hasOverflowed());
-            RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, method, controller->m_transformer.get(), args));
+            RELEASE_AND_RETURN(scope, invokeCallbackReturningPromise(globalObject, method, controller->m_transformer.get(), args));
         }
         break;
     case TransformerKind::Identity:
@@ -98,7 +76,7 @@ static JSPromise* performCancelAlgorithm(JSC::VM& vm, JSGlobalObject* globalObje
             MarkedArgumentBuffer args;
             args.append(reason);
             ASSERT(!args.hasOverflowed());
-            RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, method, controller->m_transformer.get(), args));
+            RELEASE_AND_RETURN(scope, invokeCallbackReturningPromise(globalObject, method, controller->m_transformer.get(), args));
         }
     }
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -149,26 +149,70 @@ JSC::JSPromise* promiseFulfilledWith(JSC::JSGlobalObject*, JSC::JSValue); // use
 JSC::JSBoundFunction* createStreamsBoundHandler(JSC::JSGlobalObject*, JSC::JSFunction* target, JSC::JSCell* context);
 // obj.name(...args); returns the EMPTY value when `name` is not callable. userJS: yes — WebStreamsMisc.cpp
 JSC::JSValue invokeOptionalMethod(JSC::JSGlobalObject*, JSC::JSObject*, const JSC::Identifier& name, const JSC::MarkedArgumentBuffer&);
-// BOUNDARY helper for an algorithm whose contract is "returns a promise" (pull/cancel/write/
-// transform algorithms, promise-returning API methods): the exception it is about to return with
-// becomes the rejected promise it returns instead. nullptr only with a VM termination pending.
-JSC::JSPromise* promiseRejectedWithPendingException(JSC::JSGlobalObject*, JSC::ThrowScope&); // userJS: no — WebStreamsMisc.cpp
 // WebIDL "invoke a callback function" whose declared return type is Promise<T> (underlying
-// source/sink/transformer methods): the callback's completion is converted HERE, per WebIDL — a
-// throw becomes a rejected promise, any other result a resolved one — because the spec reacts to
-// that promise (e.g. "upon rejection of pullPromise, error the controller"); the throw must not
-// escape to whichever API call happened to trigger the algorithm.
+// source/sink/transformer methods). This is the boundary *into* user code: per WebIDL the
+// callback's completion is converted right here — a throw becomes a rejected promise, any other
+// result a resolved one — because the spec reacts to that promise (e.g. "upon rejection of
+// pullPromise, error the controller"), and only this frame knows which controller that is.
 // nullptr only with a VM termination pending. userJS: yes — WebStreamsMisc.cpp
 JSC::JSPromise* invokeCallbackReturningPromise(JSC::JSGlobalObject*, JSC::JSObject* callback, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer&);
 // Same conversion, minus wrappers the internal reaction machinery does not need: nullptr with
 // nothing pending for a synchronous non-thenable result (the caller runs its fulfilment step
 // inline), and a vanilla JSPromise returned unwrapped. userJS: yes — WebStreamsMisc.cpp
 JSC::JSPromise* invokeCallbackReturningPromiseFast(JSC::JSGlobalObject*, JSC::JSObject* callback, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer&);
-// error.code === code (a `code` getter can throw). userJS: yes — WebStreamsMisc.cpp
-bool errorCodeIs(JSC::JSGlobalObject*, JSC::JSValue error, WTF::ASCIILiteral code);
 JSC::JSPromise* promiseResolvedWith(JSC::JSGlobalObject*, JSC::JSValue); // userJS: yes — WebStreamsMisc.cpp
 // "a promise rejected with r" (rejection never does a `then` lookup)
 JSC::JSPromise* promiseRejectedWith(JSC::JSGlobalObject*, JSC::JSValue); // userJS: no — WebStreamsMisc.cpp
+
+// ─── Exception boundaries ─────────────────────────────────────────────────────────────────────
+// Every function in this subsystem propagates: DECLARE_THROW_SCOPE + RETURN_IF_EXCEPTION and
+// nothing else — no helper looks at, takes, or is handed a pending exception. An exception stops in
+// exactly two kinds of frame, and these templates are those frames:
+//
+//   enterStreams(globalObject, step, deliver) — the body of a host function that JSC enters from a
+//     promise reaction, a queued microtask, or the event loop (atStreamsBoundary: the same for the
+//     few such entry points that are not host functions). Nothing above it would receive an
+//     exception, and whoever is waiting for the outcome waits on a promise/stream, not on this
+//     stack: whatever `step` threw is handed to `deliver(error)`, which errors that stream /
+//     rejects that promise. If delivering throws as well, that is left pending for the caller's
+//     runner to report.
+//   promiseFromSteps(globalObject, step) — the body of a function whose contract is "returns a
+//     promise" (a source/sink/transformer algorithm, a promise-returning API method, a WebIDL
+//     callback declared to return Promise<T>): whatever `step` threw is the rejection of the
+//     promise it returns.
+//
+// A VM termination is never converted; both return at once and leave it pending.
+template<typename Step, typename Deliver>
+ALWAYS_INLINE void atStreamsBoundary(JSC::JSGlobalObject* globalObject, Step&& step, Deliver&& deliver)
+{
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    step();
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+        TRY_CLEAR_EXCEPTION(scope, );
+        RELEASE_AND_RETURN(scope, deliver(exception->value()));
+    }
+}
+
+template<typename Step, typename Deliver>
+ALWAYS_INLINE JSC::EncodedJSValue enterStreams(JSC::JSGlobalObject* globalObject, Step&& step, Deliver&& deliver)
+{
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    atStreamsBoundary(globalObject, std::forward<Step>(step), std::forward<Deliver>(deliver));
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+template<typename Step>
+ALWAYS_INLINE JSC::JSPromise* promiseFromSteps(JSC::JSGlobalObject* globalObject, Step&& step)
+{
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    JSC::JSPromise* result = step();
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+        TRY_CLEAR_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, exception->value()));
+    }
+    return result;
+}
 // "resolve promise with v" — SAME `Object.prototype.then` hazard as promiseResolvedWith:
 // resolving with ANY object (user-controlled or our own) runs user JS.
 void resolvePromise(JSC::JSGlobalObject*, JSC::JSPromise*, JSC::JSValue); // userJS: yes — WebStreamsMisc.cpp
@@ -196,15 +240,8 @@ void rejectStreamClosedPromise(JSC::VM&, JSWritableStream*, JSC::JSValue error);
 void webStreamControllerError(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue error); // userJS: yes — ReadableStreamOperations.cpp
 void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSValue error); // userJS: yes — WritableStreamOperations.cpp
 
-// Exceptions propagate (ThrowScope + RETURN_IF_EXCEPTION) through every helper in this
-// subsystem. They are converted into a value only at a BOUNDARY: a host function entered from a
-// promise reaction / microtask / the event loop (nothing above it would receive the exception),
-// an operation whose contract is "returns a promise" (WebIDL: a throw is a rejection), or a spec
-// step that literally reads the completion value ("if result is an abrupt completion, error the
-// stream with result.[[Value]]"). This is the primitive those places use: it clears and returns
-// the pending exception's value; for a VM termination it returns the EMPTY value and leaves the
-// termination pending — the caller returns (RETURN_IF_EXCEPTION) and never runs anything over it.
-JSC::JSValue takeException(JSC::ExceptionScope&); // userJS: no — WebStreamsMisc.cpp
+// error.code === code, for an own data property `code` (no getters or proxies run). userJS: no — WebStreamsMisc.cpp
+bool errorCodeIs(JSC::VM&, JSC::JSValue error, WTF::ASCIILiteral code);
 
 // Joins any pending bytes, strips a single leading BOM per stream (ignoreBOM=false), holds
 // back a trailing incomplete sequence (unless `flush`), and decodes the remaining span via

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -26,7 +26,6 @@
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/MarkedVector.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/ThrowScope.h>
 #include <optional>
 #include <utility>
@@ -113,8 +112,7 @@ struct QueuingStrategyDict {
     JSC::JSValue size; // callable or empty (empty ⇒ the default `() => 1`)
 };
 
-// WebStreamsMisc.cpp — shared utilities, promise helpers, dictionary conversion, and the ONE
-// sanctioned catch helper.
+// WebStreamsMisc.cpp — shared utilities, promise helpers, dictionary conversion.
 
 // spec ExtractHighWaterMark(strategy, defaultHWM). Throws RangeError (NaN / negative).
 double extractHighWaterMark(JSC::JSGlobalObject*, const QueuingStrategyDict&, double defaultHWM); // userJS: no — WebStreamsMisc.cpp
@@ -151,7 +149,22 @@ JSC::JSPromise* promiseFulfilledWith(JSC::JSGlobalObject*, JSC::JSValue); // use
 JSC::JSBoundFunction* createStreamsBoundHandler(JSC::JSGlobalObject*, JSC::JSFunction* target, JSC::JSCell* context);
 // obj.name(...args); returns the EMPTY value when `name` is not callable. userJS: yes — WebStreamsMisc.cpp
 JSC::JSValue invokeOptionalMethod(JSC::JSGlobalObject*, JSC::JSObject*, const JSC::Identifier& name, const JSC::MarkedArgumentBuffer&);
-// error.code === code, swallowing any lookup exception. userJS: yes — WebStreamsMisc.cpp
+// BOUNDARY helper for an algorithm whose contract is "returns a promise" (pull/cancel/write/
+// transform algorithms, promise-returning API methods): the exception it is about to return with
+// becomes the rejected promise it returns instead. nullptr only with a VM termination pending.
+JSC::JSPromise* promiseRejectedWithPendingException(JSC::JSGlobalObject*, JSC::ThrowScope&); // userJS: no — WebStreamsMisc.cpp
+// WebIDL "invoke a callback function" whose declared return type is Promise<T> (underlying
+// source/sink/transformer methods): the callback's completion is converted HERE, per WebIDL — a
+// throw becomes a rejected promise, any other result a resolved one — because the spec reacts to
+// that promise (e.g. "upon rejection of pullPromise, error the controller"); the throw must not
+// escape to whichever API call happened to trigger the algorithm.
+// nullptr only with a VM termination pending. userJS: yes — WebStreamsMisc.cpp
+JSC::JSPromise* invokeCallbackReturningPromise(JSC::JSGlobalObject*, JSC::JSObject* callback, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer&);
+// Same conversion, minus wrappers the internal reaction machinery does not need: nullptr with
+// nothing pending for a synchronous non-thenable result (the caller runs its fulfilment step
+// inline), and a vanilla JSPromise returned unwrapped. userJS: yes — WebStreamsMisc.cpp
+JSC::JSPromise* invokeCallbackReturningPromiseFast(JSC::JSGlobalObject*, JSC::JSObject* callback, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer&);
+// error.code === code (a `code` getter can throw). userJS: yes — WebStreamsMisc.cpp
 bool errorCodeIs(JSC::JSGlobalObject*, JSC::JSValue error, WTF::ASCIILiteral code);
 JSC::JSPromise* promiseResolvedWith(JSC::JSGlobalObject*, JSC::JSValue); // userJS: yes — WebStreamsMisc.cpp
 // "a promise rejected with r" (rejection never does a `then` lookup)
@@ -183,11 +196,15 @@ void rejectStreamClosedPromise(JSC::VM&, JSWritableStream*, JSC::JSValue error);
 void webStreamControllerError(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue error); // userJS: yes — ReadableStreamOperations.cpp
 void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSValue error); // userJS: yes — WritableStreamOperations.cpp
 
-// THE ONE SANCTIONED CATCH of the subsystem. Returns the thrown value after
-// clearExceptionExceptTermination(); returns the EMPTY JSValue if the exception is a VM
-// termination (which the caller must propagate, never consume). Never call bare
-// clearException() anywhere in the subsystem.
-JSC::JSValue takeAbruptCompletion(JSC::JSGlobalObject*, JSC::TopExceptionScope&); // userJS: no — WebStreamsMisc.cpp
+// Exceptions propagate (ThrowScope + RETURN_IF_EXCEPTION) through every helper in this
+// subsystem. They are converted into a value only at a BOUNDARY: a host function entered from a
+// promise reaction / microtask / the event loop (nothing above it would receive the exception),
+// an operation whose contract is "returns a promise" (WebIDL: a throw is a rejection), or a spec
+// step that literally reads the completion value ("if result is an abrupt completion, error the
+// stream with result.[[Value]]"). This is the primitive those places use: it clears and returns
+// the pending exception's value; for a VM termination it returns the EMPTY value and leaves the
+// termination pending — the caller returns (RETURN_IF_EXCEPTION) and never runs anything over it.
+JSC::JSValue takeException(JSC::ExceptionScope&); // userJS: no — WebStreamsMisc.cpp
 
 // Joins any pending bytes, strips a single leading BOM per stream (ignoreBOM=false), holds
 // back a trailing incomplete sequence (unless `flush`), and decodes the remaining span via
@@ -356,7 +373,7 @@ void readableByteStreamControllerCommitPullIntoDescriptor(JSC::JSGlobalObject*, 
 JSC::JSArrayBufferView* readableByteStreamControllerConvertPullIntoDescriptor(JSC::JSGlobalObject*, JSPullIntoDescriptor*); // userJS: no (intrinsic view construction only) — JSReadableByteStreamController.cpp
 void readableByteStreamControllerEnqueue(JSC::JSGlobalObject*, JSReadableByteStreamController*, JSC::JSArrayBufferView* chunk); // userJS: yes; throws — JSReadableByteStreamController.cpp
 void readableByteStreamControllerEnqueueChunkToQueue(JSReadableByteStreamController*, RefPtr<JSC::ArrayBuffer>&&, size_t byteOffset, size_t byteLength); // userJS: no — JSReadableByteStreamController.cpp
-void readableByteStreamControllerEnqueueClonedChunkToQueue(JSC::JSGlobalObject*, JSReadableByteStreamController*, JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength); // userJS: yes (a takeAbruptCompletion catch site; errors the controller then rethrows) — JSReadableByteStreamController.cpp
+void readableByteStreamControllerEnqueueClonedChunkToQueue(JSC::JSGlobalObject*, JSReadableByteStreamController*, JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength); // userJS: yes (per spec a clone failure errors the controller and is rethrown) — JSReadableByteStreamController.cpp
 void readableByteStreamControllerEnqueueDetachedPullIntoToQueue(JSC::JSGlobalObject*, JSReadableByteStreamController*, JSPullIntoDescriptor*); // userJS: yes; throws — JSReadableByteStreamController.cpp
 void readableByteStreamControllerError(JSC::JSGlobalObject*, JSReadableByteStreamController*, JSC::JSValue error); // userJS: yes — JSReadableByteStreamController.cpp
 void readableByteStreamControllerFillHeadPullIntoDescriptor(JSReadableByteStreamController*, size_t size, JSPullIntoDescriptor*); // userJS: no — JSReadableByteStreamController.cpp
@@ -435,8 +452,7 @@ void writableStreamDefaultControllerClose(JSC::JSGlobalObject*, JSWritableStream
 void writableStreamDefaultControllerError(JSC::JSGlobalObject*, JSWritableStreamDefaultController*, JSC::JSValue error); // userJS: yes — JSWritableStreamDefaultController.cpp
 void writableStreamDefaultControllerErrorIfNeeded(JSC::JSGlobalObject*, JSWritableStreamDefaultController*, JSC::JSValue error); // userJS: yes — JSWritableStreamDefaultController.cpp
 bool writableStreamDefaultControllerGetBackpressure(JSWritableStreamDefaultController*); // userJS: no — JSWritableStreamDefaultController.cpp
-// Calls the user size(); a sanctioned takeAbruptCompletion catch site (converts the abrupt
-// completion into ErrorIfNeeded and returns 1 — it NEVER throws out).
+// Calls the user size(); per spec an abrupt completion becomes ErrorIfNeeded and the size is 1.
 double writableStreamDefaultControllerGetChunkSize(JSC::JSGlobalObject*, JSWritableStreamDefaultController*, JSC::JSValue chunk); // userJS: yes — JSWritableStreamDefaultController.cpp
 double writableStreamDefaultControllerGetDesiredSize(JSWritableStreamDefaultController*); // userJS: no — JSWritableStreamDefaultController.cpp
 void writableStreamDefaultControllerProcessClose(JSC::JSGlobalObject*, JSWritableStreamDefaultController*); // userJS: yes (user close algorithm) — JSWritableStreamDefaultController.cpp
@@ -465,8 +481,7 @@ JSC::JSPromise* transformStreamDefaultSourcePullAlgorithm(JSC::JSGlobalObject*, 
 // JSTransformStreamDefaultController.cpp
 
 void transformStreamDefaultControllerClearAlgorithms(JSTransformStreamDefaultController*); // userJS: no — JSTransformStreamDefaultController.cpp
-// A sanctioned takeAbruptCompletion catch site (catches the readable-side enqueue's abrupt
-// completion, errors the writable, then throws stream.[[readable]].[[storedError]]).
+// Per spec, a readable-side enqueue failure errors the writable and throws [[readable]].[[storedError]].
 void transformStreamDefaultControllerEnqueue(JSC::JSGlobalObject*, JSTransformStreamDefaultController*, JSC::JSValue chunk); // userJS: yes; throws — JSTransformStreamDefaultController.cpp
 void nativeTransformReleaseState(JSTransformStream*); // userJS: no — JSTransformStreamDefaultController.cpp
 // Performs a release ClearAlgorithms deferred, once nothing holds the native state any more.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -252,7 +252,7 @@ void rejectStreamClosedPromise(JSC::VM&, JSWritableStream*, JSC::JSValue error);
 void webStreamControllerError(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue error); // userJS: yes — ReadableStreamOperations.cpp
 void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSValue error); // userJS: yes — WritableStreamOperations.cpp
 
-// error.code === code, for an own data property `code` (no getters or proxies run). userJS: no — WebStreamsMisc.cpp
+// error.code === code, for an own or inherited data property `code` (no getters or proxies run). userJS: no — WebStreamsMisc.cpp
 bool errorCodeIs(JSC::VM&, JSC::JSValue error, WTF::ASCIILiteral code);
 
 // Joins any pending bytes, strips a single leading BOM per stream (ignoreBOM=false), holds

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -174,8 +174,9 @@ JSC::JSPromise* promiseRejectedWith(JSC::JSGlobalObject*, JSC::JSValue); // user
 //     few such entry points that are not host functions). Nothing above it would receive an
 //     exception, and whoever is waiting for the outcome waits on a promise/stream, not on this
 //     stack: whatever `step` threw is handed to `deliver(error)`, which errors that stream /
-//     rejects that promise. If delivering throws as well, that is left pending for the caller's
-//     runner to report.
+//     rejects that promise. If delivering throws as well (it may run user hooks), the optional
+//     `lastResort(error)` — which must run no user JS — settles the operation with that second
+//     error; without one it is left pending for the caller's runner to report.
 //   promiseFromSteps(globalObject, step) — the body of a function whose contract is "returns a
 //     promise" (a source/sink/transformer algorithm, a promise-returning API method, a WebIDL
 //     callback declared to return Promise<T>): whatever `step` threw is the rejection of the
@@ -193,11 +194,22 @@ ALWAYS_INLINE void atStreamsBoundary(JSC::JSGlobalObject* globalObject, Step&& s
     }
 }
 
-template<typename Step, typename Deliver>
-ALWAYS_INLINE JSC::EncodedJSValue enterStreams(JSC::JSGlobalObject* globalObject, Step&& step, Deliver&& deliver)
+template<typename Step, typename Deliver, typename LastResort>
+ALWAYS_INLINE void atStreamsBoundary(JSC::JSGlobalObject* globalObject, Step&& step, Deliver&& deliver, LastResort&& lastResort)
 {
     auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
     atStreamsBoundary(globalObject, std::forward<Step>(step), std::forward<Deliver>(deliver));
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+        TRY_CLEAR_EXCEPTION(scope, );
+        RELEASE_AND_RETURN(scope, lastResort(exception->value()));
+    }
+}
+
+template<typename Step, typename... Handlers>
+ALWAYS_INLINE JSC::EncodedJSValue enterStreams(JSC::JSGlobalObject* globalObject, Step&& step, Handlers&&... handlers)
+{
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    atStreamsBoundary(globalObject, std::forward<Step>(step), std::forward<Handlers>(handlers)...);
     RETURN_IF_EXCEPTION(scope, {});
     return JSC::JSValue::encode(JSC::jsUndefined());
 }

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -582,8 +582,6 @@ JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSWritableStream
     return promise;
 }
 
-// The ONE sanctioned completion-record catch: the spec's "interpreting X as a completion
-// record" sites only. Empty return = a VM termination the caller must propagate.
 } // namespace WebStreams
 } // namespace Bun
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -19,7 +19,6 @@
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSTypedArrays.h>
-#include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/TypedArrayType.h>
 #include <cmath>
 
@@ -396,24 +395,56 @@ JSValue invokeOptionalMethod(JSGlobalObject* globalObject, JSObject* object, con
     RELEASE_AND_RETURN(scope, JSC::call(globalObject, method, object, args, "method is not a function"_s));
 }
 
+JSPromise* promiseRejectedWithPendingException(JSGlobalObject* globalObject, ThrowScope& scope)
+{
+    JSValue thrown = takeException(scope);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return promiseRejectedWith(globalObject, thrown);
+}
+
+JSPromise* invokeCallbackReturningPromise(JSGlobalObject* globalObject, JSObject* callback, JSValue thisValue, const MarkedArgumentBuffer& args)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto callData = JSC::getCallData(callback);
+    ASSERT(callData.type != JSC::CallData::Type::None);
+    JSValue result = JSC::call(globalObject, callback, callData, thisValue, args);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
+    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+}
+
+JSPromise* invokeCallbackReturningPromiseFast(JSGlobalObject* globalObject, JSObject* callback, JSValue thisValue, const MarkedArgumentBuffer& args)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto callData = JSC::getCallData(callback);
+    ASSERT(callData.type != JSC::CallData::Type::None);
+    JSValue result = JSC::call(globalObject, callback, callData, thisValue, args);
+    if (scope.exception()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
+    if (!result.isObject()) [[likely]]
+        return nullptr;
+    // A vanilla JSPromise with an unpatched .then needs no wrapper: callers use
+    // performPromiseThenWithContext (internal reactions), so skipping promiseResolvedWith's
+    // thenable adoption is unobservable. Subclasses / patched .then fall through.
+    if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
+        return resultPromise;
+    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+}
+
 bool errorCodeIs(JSGlobalObject* globalObject, JSValue error, ASCIILiteral code)
 {
     auto& vm = getVM(globalObject);
-    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     if (!error || !error.isObject())
         return false;
-    JSValue codeValue = asObject(error)->getIfPropertyExists(globalObject, WebCore::builtinNames(vm).codePublicName());
-    if (catchScope.exception()) [[unlikely]] {
-        catchScope.clearExceptionExceptTermination();
-        return false;
-    }
-    if (!codeValue || !codeValue.isString())
+    JSValue codeValue = asObject(error)->get(globalObject, WebCore::builtinNames(vm).codePublicName());
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!codeValue.isString())
         return false;
     String codeString = asString(codeValue)->value(globalObject);
-    if (catchScope.exception()) [[unlikely]] {
-        catchScope.clearExceptionExceptTermination();
-        return false;
-    }
+    RETURN_IF_EXCEPTION(scope, false);
     return codeString == StringView(code);
 }
 
@@ -562,12 +593,12 @@ JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSWritableStream
 
 // The ONE sanctioned completion-record catch: the spec's "interpreting X as a completion
 // record" sites only. Empty return = a VM termination the caller must propagate.
-JSValue takeAbruptCompletion(JSGlobalObject*, TopExceptionScope& catchScope)
+JSValue takeException(JSC::ExceptionScope& scope)
 {
-    const JSC::Exception* exception = catchScope.exception();
+    JSC::Exception* exception = scope.exception();
     ASSERT(exception);
     JSValue thrown = exception->value();
-    if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+    if (!scope.tryClearException()) [[unlikely]]
         return {};
     return thrown;
 }

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -428,10 +428,11 @@ JSPromise* invokeCallbackReturningPromiseFast(JSGlobalObject* globalObject, JSOb
 
 bool errorCodeIs(VM& vm, JSValue error, ASCIILiteral code)
 {
-    JSObject* object = error ? error.getObject() : nullptr;
-    if (!object)
-        return false;
-    JSValue codeValue = object->getDirect(vm, WebCore::builtinNames(vm).codePublicName());
+    // Own or inherited *data* property only (Bun's coded errors keep `code` on a per-code
+    // prototype); structures' stored prototypes are followed, so no getter or proxy trap runs.
+    JSValue codeValue;
+    for (JSObject* object = error ? error.getObject() : nullptr; object && !codeValue; object = object->getPrototypeDirect().getObject())
+        codeValue = object->getDirect(vm, WebCore::builtinNames(vm).codePublicName());
     auto* codeString = codeValue ? dynamicDowncast<JSString>(codeValue) : nullptr;
     if (!codeString)
         return false;

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -395,57 +395,48 @@ JSValue invokeOptionalMethod(JSGlobalObject* globalObject, JSObject* object, con
     RELEASE_AND_RETURN(scope, JSC::call(globalObject, method, object, args, "method is not a function"_s));
 }
 
-JSPromise* promiseRejectedWithPendingException(JSGlobalObject* globalObject, ThrowScope& scope)
-{
-    JSValue thrown = takeException(scope);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    return promiseRejectedWith(globalObject, thrown);
-}
-
 JSPromise* invokeCallbackReturningPromise(JSGlobalObject* globalObject, JSObject* callback, JSValue thisValue, const MarkedArgumentBuffer& args)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto callData = JSC::getCallData(callback);
-    ASSERT(callData.type != JSC::CallData::Type::None);
-    JSValue result = JSC::call(globalObject, callback, callData, thisValue, args);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        auto callData = JSC::getCallData(callback);
+        ASSERT(callData.type != JSC::CallData::Type::None);
+        JSValue result = JSC::call(globalObject, callback, callData, thisValue, args);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+    });
 }
 
 JSPromise* invokeCallbackReturningPromiseFast(JSGlobalObject* globalObject, JSObject* callback, JSValue thisValue, const MarkedArgumentBuffer& args)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto callData = JSC::getCallData(callback);
-    ASSERT(callData.type != JSC::CallData::Type::None);
-    JSValue result = JSC::call(globalObject, callback, callData, thisValue, args);
-    if (scope.exception()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, promiseRejectedWithPendingException(globalObject, scope));
-    if (!result.isObject()) [[likely]]
-        return nullptr;
-    // A vanilla JSPromise with an unpatched .then needs no wrapper: callers use
-    // performPromiseThenWithContext (internal reactions), so skipping promiseResolvedWith's
-    // thenable adoption is unobservable. Subclasses / patched .then fall through.
-    if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
-        return resultPromise;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+    return promiseFromSteps(globalObject, [&] -> JSPromise* {
+        auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+        auto callData = JSC::getCallData(callback);
+        ASSERT(callData.type != JSC::CallData::Type::None);
+        JSValue result = JSC::call(globalObject, callback, callData, thisValue, args);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (!result.isObject()) [[likely]]
+            return nullptr;
+        // A vanilla JSPromise with an unpatched .then needs no wrapper: callers use
+        // performPromiseThenWithContext (internal reactions), so skipping promiseResolvedWith's
+        // thenable adoption is unobservable. Subclasses / patched .then fall through.
+        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
+            return resultPromise;
+        RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
+    });
 }
 
-bool errorCodeIs(JSGlobalObject* globalObject, JSValue error, ASCIILiteral code)
+bool errorCodeIs(VM& vm, JSValue error, ASCIILiteral code)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!error || !error.isObject())
+    JSObject* object = error ? error.getObject() : nullptr;
+    if (!object)
         return false;
-    JSValue codeValue = asObject(error)->get(globalObject, WebCore::builtinNames(vm).codePublicName());
-    RETURN_IF_EXCEPTION(scope, false);
-    if (!codeValue.isString())
+    JSValue codeValue = object->getDirect(vm, WebCore::builtinNames(vm).codePublicName());
+    auto* codeString = codeValue ? dynamicDowncast<JSString>(codeValue) : nullptr;
+    if (!codeString)
         return false;
-    String codeString = asString(codeValue)->value(globalObject);
-    RETURN_IF_EXCEPTION(scope, false);
-    return codeString == StringView(code);
+    auto value = codeString->tryGetValue();
+    return WTF::equal(value.data, StringView(code));
 }
 
 // Shared [bound-convention] wrapper: target(contextCell, ...callArgs).
@@ -593,16 +584,6 @@ JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSWritableStream
 
 // The ONE sanctioned completion-record catch: the spec's "interpreting X as a completion
 // record" sites only. Empty return = a VM termination the caller must propagate.
-JSValue takeException(JSC::ExceptionScope& scope)
-{
-    JSC::Exception* exception = scope.exception();
-    ASSERT(exception);
-    JSValue thrown = exception->value();
-    if (!scope.tryClearException()) [[unlikely]]
-        return {};
-    return thrown;
-}
-
 } // namespace WebStreams
 } // namespace Bun
 

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -52,3 +52,30 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
   expect(stdout).not.toContain("null is not an object");
   expect(exitCode).toBe(0);
 });
+
+test("an error from an async-iterable body whose `code` getter throws surfaces that getter's error", async () => {
+  // The source inspects `error.code` (ERR_INVALID_THIS / ERR_INVALID_STATE handling); if that
+  // lookup throws, its exception is what the read rejects with rather than being ignored.
+  const getterError = new Error("code getter threw");
+  const original = {
+    get code() {
+      throw getterError;
+    },
+  };
+  const response = new Response({
+    async *[Symbol.asyncIterator]() {
+      yield "x";
+      throw original;
+    },
+  });
+  await expect(response.text()).rejects.toBe(getterError);
+
+  const plain = new Error("plain");
+  await expect(
+    new Response({
+      async *[Symbol.asyncIterator]() {
+        throw plain;
+      },
+    }).text(),
+  ).rejects.toBe(plain);
+});

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -52,30 +52,3 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
   expect(stdout).not.toContain("null is not an object");
   expect(exitCode).toBe(0);
 });
-
-test("an error from an async-iterable body whose `code` getter throws surfaces that getter's error", async () => {
-  // The source inspects `error.code` (ERR_INVALID_THIS / ERR_INVALID_STATE handling); if that
-  // lookup throws, its exception is what the read rejects with rather than being ignored.
-  const getterError = new Error("code getter threw");
-  const original = {
-    get code() {
-      throw getterError;
-    },
-  };
-  const response = new Response({
-    async *[Symbol.asyncIterator]() {
-      yield "x";
-      throw original;
-    },
-  });
-  await expect(response.text()).rejects.toBe(getterError);
-
-  const plain = new Error("plain");
-  await expect(
-    new Response({
-      async *[Symbol.asyncIterator]() {
-        throw plain;
-      },
-    }).text(),
-  ).rejects.toBe(plain);
-});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -574,10 +574,12 @@ it("ReadableStream (direct): an underlyingSource close() hook that throws is not
 
 it("ReadableStream (direct): controller.close() outside pull with a throwing close() hook settles the pending read and throws to the closer", async () => {
   let controller;
+  const pulled = Promise.withResolvers();
   const stream = new ReadableStream({
     type: "direct",
     pull(c) {
       controller = c;
+      pulled.resolve();
     },
     close() {
       throw new Error("close hook threw");
@@ -585,7 +587,7 @@ it("ReadableStream (direct): controller.close() outside pull with a throwing clo
   });
   const reader = stream.getReader();
   const pending = reader.read();
-  await Bun.sleep(0); // let pull() run and hand us the controller
+  await pulled.promise;
   controller.write("late");
   expect(() => controller.close()).toThrow("close hook threw");
   const first = await pending;

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -543,6 +543,22 @@ it("ReadableStream (direct)", async () => {
   expect((await reader.read()).done).toBe(true);
 });
 
+it("ReadableStream (direct): an underlyingSource close() hook that throws is not swallowed", async () => {
+  // close() runs when the controller closes; its exception propagates out of controller.close()
+  // (here: out of pull), which errors the stream like any other pull() throw.
+  const stream = new ReadableStream({
+    type: "direct",
+    pull(controller) {
+      controller.write("hello");
+      controller.close();
+    },
+    close() {
+      throw new Error("close hook threw");
+    },
+  });
+  await expect(new Response(stream).text()).rejects.toThrow("close hook threw");
+});
+
 it("ReadableStream (bytes)", async () => {
   var stream = new ReadableStream({
     start(controller) {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -557,6 +557,41 @@ it("ReadableStream (direct): an underlyingSource close() hook that throws is not
     },
   });
   await expect(new Response(stream).text()).rejects.toThrow("close hook threw");
+
+  // Same through a reader: pull() (and so read()) fails with the hook's error.
+  const stream2 = new ReadableStream({
+    type: "direct",
+    pull(controller) {
+      controller.write("hello");
+      controller.close();
+    },
+    close() {
+      throw new Error("close hook threw");
+    },
+  });
+  await expect(stream2.getReader().read()).rejects.toThrow("close hook threw");
+});
+
+it("ReadableStream (direct): controller.close() outside pull with a throwing close() hook settles the pending read and throws to the closer", async () => {
+  let controller;
+  const stream = new ReadableStream({
+    type: "direct",
+    pull(c) {
+      controller = c;
+    },
+    close() {
+      throw new Error("close hook threw");
+    },
+  });
+  const reader = stream.getReader();
+  const pending = reader.read();
+  await Bun.sleep(0); // let pull() run and hand us the controller
+  controller.write("late");
+  expect(() => controller.close()).toThrow("close hook threw");
+  const first = await pending;
+  expect(first.done).toBe(false);
+  expect(new TextDecoder().decode(first.value)).toBe("late");
+  expect((await reader.read()).done).toBe(true);
 });
 
 it("ReadableStream (bytes)", async () => {


### PR DESCRIPTION
### What does this PR do?

The native web-streams implementation (`src/jsc/bindings/webcore/streams/`) caught JS exceptions in ~60 places *inside helpers* — a `TopExceptionScope` + `takeAbruptCompletion` in the middle of the stack. After this change the rule is structural:

**Helpers only propagate.** Every function is `DECLARE_THROW_SCOPE` + `RETURN_IF_EXCEPTION`; no helper inspects, takes, or is handed a pending exception (`takeAbruptCompletion` and every `TopExceptionScope` in a helper are gone).

**Exceptions are converted only at a boundary, and the boundaries are two templates** (`WebStreamsInternals.h`):
- `enterStreams(globalObject, step, deliver)` — the body of a host function that JSC enters from a promise reaction, a queued microtask, or the event loop. Nothing above it would receive an exception and the party waiting for the outcome waits on a promise/stream, so whatever `step` threw is handed to `deliver(error)`, which errors that stream / rejects that promise. (`atStreamsBoundary` is the same for the three such entries that are not host functions: `readStreamIntoSink`'s start, `nativeCodecContinue`, the off-thread codec delivery.)
- `promiseFromSteps(globalObject, step)` — the body of anything whose contract is "returns a promise": pull/cancel/write/transform algorithms, promise-returning API methods (`pipeTo`, BYOB `read`, `.text()`/`.json()`/…), and WebIDL "invoke a callback returning `Promise<T>`" (`invokeCallbackReturningPromise`, one shared function replacing five file-local copies). A throw is that promise's rejection.

The only other places that read a completion are the six spec steps that literally say so ("if result is an abrupt completion, perform …Error(controller, result.[[Value]]) and return result": default-controller enqueue `size()`, byte-controller clone/transfer, transform enqueue, writable `size()`/enqueue, byte-tee clone) and the two direct-source `pull()` call sites, each written inline with JSC's `TRY_CLEAR_EXCEPTION` next to the quoted step.

Cleanup hooks that used to be swallowed (`try {} catch {}` carried over from the old JS builtins) now propagate: a direct stream's `underlyingSource.close()` hook, an async-iterable body's `iterator.return()`/`iterator.throw()`, sink `end()`/`close()`/`cancel()` during teardown, releasing a reader in `finally`. Where teardown must complete regardless, it is reordered so the stream/promise state is final before the hook that can throw runs (`JSDirectStreamController::handleError`, `readDirectStreamCloseImpl`, `nativeSourceCallClose`, `rsisAbrupt`). `errorCodeIs` reads an own data property (`getDirect`), so it runs no JS at all.

User-visible:
- A `type: "direct"` `ReadableStream` whose `close()` hook throws: the throw propagates out of `controller.close()` and errors the stream (was ignored).
- `readStreamIntoSink` (bodies piped into native sinks): the pump's promise rejects with the original error; a second failure from closing the sink is reported by the runner instead of being folded into an `AggregateError`.
- `ReadableStreamBYOBReader.read()` / `pipeTo()` never throw synchronously; every failure is a rejection.

### How did you verify your code works?

New test in `streams.test.js` (fails on release, passes here). Ran `streams.test.js`, `compression.test.ts`, `sync-pull-fast-path`, `body.test.ts`, `body-stream.test.ts` (9086), `body-clone`, `body-async-iterator`, `text-{en,de}coder-stream`, `async-iterator-stream`, `serve-direct-readable-stream`, `serve-error-handler-stream`, `filesink`, `node-stream`, `readablestreamtoarraybuffer`, `pipeTo-*`, `native-source-onclose-leak`, and the `test/js/node/test/parallel/test-*webstream*`/`test-whatwg-*stream*` scripts under `BUN_JSC_validateExceptionChecks=1` on a debug build — all pass.
