### PR TITLE
Make import.meta.main a native accessor instead of a JS builtin

### DIFF
--- a/src/js/builtins/ImportMetaObject.ts
+++ b/src/js/builtins/ImportMetaObject.ts
@@ -1,6 +1,0 @@
-type ImportMetaObject = Partial<ImportMeta>;
-
-$getter;
-export function main(this: ImportMetaObject) {
-  return this.path === Bun.main && Bun.isMainThread;
-}

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -529,6 +529,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_main, (JSGlobalObject * lexica
     // Only Zig::GlobalObject creates ImportMetaObject structures (see createStructure). Its Bun.main and thread
     // are the ones that matter, no matter which realm reads the property.
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(thisObject->globalObject());
+    if (!globalObject->scriptExecutionContext()->isMainThread())
+        return JSValue::encode(jsBoolean(false));
+
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -538,7 +541,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_main, (JSGlobalObject * lexica
     bool isMain = JSValue::strictEqual(globalObject, path, bunMain);
     RETURN_IF_EXCEPTION(scope, {});
 
-    return JSValue::encode(jsBoolean(isMain && globalObject->scriptExecutionContext()->isMainThread()));
+    return JSValue::encode(jsBoolean(isMain));
 }
 
 static const HashTableValue ImportMetaObjectPrototypeValues[] = {

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -583,10 +583,10 @@ public:
         return Structure::create(vm, globalObject, globalObject->objectPrototype(), TypeInfo(ObjectType, StructureFlags), info());
     }
 
-    static ImportMetaObjectPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, bool isBake = false)
+    static ImportMetaObjectPrototype* create(JSC::VM& vm, JSC::Structure* structure, bool isBake = false)
     {
         ImportMetaObjectPrototype* prototype = new (NotNull, Bun::allocatePlainObjectCell(vm, sizeof(ImportMetaObjectPrototype))) ImportMetaObjectPrototype(vm, structure);
-        prototype->finishCreation(vm, globalObject, isBake);
+        prototype->finishCreation(vm, isBake);
         return prototype;
     }
 
@@ -597,7 +597,7 @@ public:
         return &vm.plainObjectSpace();
     }
 
-    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject, bool isBake)
+    void finishCreation(JSC::VM& vm, bool isBake)
     {
         Base::finishCreation(vm);
 
@@ -625,7 +625,6 @@ const ClassInfo ImportMetaObjectPrototype::s_info = {
 JSC::Structure* ImportMetaObject::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, bool isBake)
 {
     ImportMetaObjectPrototype* prototype = ImportMetaObjectPrototype::create(vm,
-        globalObject,
         ImportMetaObjectPrototype::createStructure(vm, globalObject),
         isBake);
 

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -519,12 +519,35 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_env, (JSGlobalObject * jsGloba
     return JSValue::encode(globalObject->m_processEnvObject.getInitializedOnMainThread(globalObject));
 }
 
+extern "C" JSC::EncodedJSValue SYSV_ABI BunObject_getter_main(JSC::JSGlobalObject*);
+
+JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_main, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
+{
+    ImportMetaObject* thisObject = dynamicDowncast<ImportMetaObject>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+
+    JSValue path = thisObject->pathProperty.getInitializedOnMainThread(thisObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSValue bunMain = JSValue::decode(BunObject_getter_main(globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
+    bool isMain = JSValue::strictEqual(lexicalGlobalObject, path, bunMain);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(jsBoolean(isMain && globalObject->scriptExecutionContext()->isMainThread()));
+}
+
 static const HashTableValue ImportMetaObjectPrototypeValues[] = {
     { "dir"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_dir, 0 } },
     { "dirname"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_dir, 0 } },
     { "env"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_env, 0 } },
     { "file"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_file, 0 } },
     { "filename"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_path, 0 } },
+    { "main"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_main, 0 } },
     { "path"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_path, 0 } },
     { "require"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_require, jsImportMetaObjectSetter_require } },
     { "resolve"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, functionImportMeta__resolve, 0 } },
@@ -539,6 +562,7 @@ static const HashTableValue ImportMetaObjectBakePrototypeValues[] = {
     { "env"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_env, 0 } },
     { "file"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_file, 0 } },
     { "filename"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_path, 0 } },
+    { "main"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_main, 0 } },
     { "path"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_path, 0 } },
     { "require"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsImportMetaObjectGetter_require, jsImportMetaObjectSetter_require } },
     { "resolve"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, functionImportMeta__resolve, 0 } },
@@ -574,9 +598,6 @@ public:
     {
         Base::finishCreation(vm);
 
-        auto* clientData = WebCore::clientData(vm);
-        auto& builtinNames = clientData->builtinNames();
-
         // Use the appropriate prototype values based on whether this is a bake import meta object
         if (isBake) {
             Bun::reifyStaticPropertyTable(vm, ImportMetaObject::info(), ImportMetaObjectBakePrototypeValues, *this);
@@ -584,14 +605,6 @@ public:
             Bun::reifyStaticPropertyTable(vm, ImportMetaObject::info(), ImportMetaObjectPrototypeValues, *this);
         }
         Bun::putToStringTagWithoutTransition(vm, this, info());
-
-        auto mainGetter = JSFunction::create(vm, globalObject, importMetaObjectMainCodeGenerator(vm), globalObject);
-
-        this->putDirectAccessor(
-            this->globalObject(),
-            builtinNames.mainPublicName(),
-            GetterSetter::create(vm, globalObject, mainGetter, mainGetter),
-            JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | 0);
     }
 
     ImportMetaObjectPrototype(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -40,7 +40,6 @@
 
 #include "JSDOMURL.h"
 #include <JavaScriptCore/JSNativeStdFunction.h>
-#include <JavaScriptCore/GetterSetter.h>
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
@@ -527,15 +526,16 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_main, (JSGlobalObject * lexica
     if (!thisObject) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    auto& vm = JSC::getVM(lexicalGlobalObject);
+    // Only Zig::GlobalObject creates ImportMetaObject structures (see createStructure). Its Bun.main and thread
+    // are the ones that matter, no matter which realm reads the property.
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(thisObject->globalObject());
+    auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
 
     JSValue path = thisObject->pathProperty.getInitializedOnMainThread(thisObject);
-    RETURN_IF_EXCEPTION(scope, {});
     JSValue bunMain = JSValue::decode(BunObject_getter_main(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
-    bool isMain = JSValue::strictEqual(lexicalGlobalObject, path, bunMain);
+    bool isMain = JSValue::strictEqual(globalObject, path, bunMain);
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(isMain && globalObject->scriptExecutionContext()->isMainThread()));

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { isModuleResolveFilenameSlowPathEnabled } from "bun:internal-for-testing";
 import { expect, it, mock } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import Module from "node:module";
 import { tmpdir } from "node:os";
@@ -29,6 +29,40 @@ it("import.meta.main", () => {
     stdout: "inherit",
     stdin: null,
   });
+  expect(exitCode).toBe(0);
+});
+
+it("import.meta.main follows a Bun.main override and is false in workers", async () => {
+  using dir = tempDir("import-meta-main", {
+    "entry.mjs": `
+      import { Worker, isMainThread, parentPort } from "node:worker_threads";
+      if (isMainThread) {
+        const worker = new Worker(new URL(import.meta.url));
+        const fromWorker = new Promise(resolve => worker.once("message", resolve));
+        const other = await import("./other.mjs");
+        const before = [import.meta.main, other.main()];
+        Bun.main = other.path;
+        const after = [import.meta.main, other.main()];
+        console.log(JSON.stringify({ before, after, worker: await fromWorker }));
+        await worker.terminate();
+      } else {
+        parentPort.postMessage(import.meta.main);
+      }
+    `,
+    "other.mjs": `
+      export const path = import.meta.path;
+      export const main = () => import.meta.main;
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(JSON.parse(stdout)).toEqual({ before: [true, false], after: [false, true], worker: false });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -32,7 +32,7 @@ it("import.meta.main", () => {
   expect(exitCode).toBe(0);
 });
 
-it("import.meta.main follows a Bun.main override, is readable from a vm context, and is false in workers", async () => {
+it("import.meta.main follows a Bun.main override but not an own path property, is readable from a vm context, and is false in workers", async () => {
   using dir = tempDir("import-meta-main", {
     "entry.mjs": `
       import { runInNewContext } from "node:vm";
@@ -44,11 +44,16 @@ it("import.meta.main follows a Bun.main override, is readable from a vm context,
           worker.once("error", reject);
         });
         const other = await import("./other.mjs");
+        const entryPath = import.meta.path;
         const before = [import.meta.main, other.main()];
         const vmContext = [import.meta, other.meta].map(meta => runInNewContext("meta.main", { meta }));
         Bun.main = other.path;
         const after = [import.meta.main, other.main()];
-        console.log(JSON.stringify({ before, vmContext, after, worker: await fromWorker }));
+        // main is computed from the module's own path, so swapping the visible path properties changes nothing.
+        Object.defineProperty(import.meta, "path", { value: other.path });
+        Object.defineProperty(other.meta, "path", { value: entryPath });
+        const ownPath = [import.meta.main, other.main()];
+        console.log(JSON.stringify({ before, vmContext, after, ownPath, worker: await fromWorker }));
         await worker.terminate();
       } else {
         parentPort.postMessage(import.meta.main);
@@ -72,6 +77,7 @@ it("import.meta.main follows a Bun.main override, is readable from a vm context,
     before: [true, false],
     vmContext: [true, false],
     after: [false, true],
+    ownPath: [false, true],
     worker: false,
   });
   expect(exitCode).toBe(0);

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -32,24 +32,30 @@ it("import.meta.main", () => {
   expect(exitCode).toBe(0);
 });
 
-it("import.meta.main follows a Bun.main override and is false in workers", async () => {
+it("import.meta.main follows a Bun.main override, is readable from a vm context, and is false in workers", async () => {
   using dir = tempDir("import-meta-main", {
     "entry.mjs": `
+      import { runInNewContext } from "node:vm";
       import { Worker, isMainThread, parentPort } from "node:worker_threads";
       if (isMainThread) {
         const worker = new Worker(new URL(import.meta.url));
-        const fromWorker = new Promise(resolve => worker.once("message", resolve));
+        const fromWorker = new Promise((resolve, reject) => {
+          worker.once("message", resolve);
+          worker.once("error", reject);
+        });
         const other = await import("./other.mjs");
         const before = [import.meta.main, other.main()];
+        const vmContext = [import.meta, other.meta].map(meta => runInNewContext("meta.main", { meta }));
         Bun.main = other.path;
         const after = [import.meta.main, other.main()];
-        console.log(JSON.stringify({ before, after, worker: await fromWorker }));
+        console.log(JSON.stringify({ before, vmContext, after, worker: await fromWorker }));
         await worker.terminate();
       } else {
         parentPort.postMessage(import.meta.main);
       }
     `,
     "other.mjs": `
+      export const meta = import.meta;
       export const path = import.meta.path;
       export const main = () => import.meta.main;
     `,
@@ -62,7 +68,12 @@ it("import.meta.main follows a Bun.main override and is false in workers", async
     stderr: "inherit",
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(JSON.parse(stdout)).toEqual({ before: [true, false], after: [false, true], worker: false });
+  expect(JSON.parse(stdout)).toEqual({
+    before: [true, false],
+    vmContext: [true, false],
+    after: [false, true],
+    worker: false,
+  });
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### What does this PR do?

`import.meta.main` was the only `import.meta` property still implemented as a bundled JS getter (`src/js/builtins/ImportMetaObject.ts`), materialized as a `JSFunction` per global and installed with `putDirectAccessor`. This moves it into the same static `CustomAccessor` table as `dir`/`path`/`url` in `ImportMetaObject.cpp`, computing `path === Bun.main && isMainThread` natively, and deletes the JS builtin.

No behavior change intended:
- still `true` only for the entry module on the main thread
- still follows a `Bun.main = ...` override (goes through the same `Bun.main` getter)
- still `false` inside `worker_threads` workers
- `import.meta.main = x` still shadows with an own property, same as the sibling accessors

Part of incrementally moving `src/js` builtins to native where the JS layer adds nothing.

### How did you verify your code works?

- `bun bd test test/js/bun/resolve/import-meta.test.js` (33 pass), including a new test that pins the `Bun.main` override and worker cases.
- Drove the debug binary directly: entry script / dynamically imported module / worker entry / `Bun.main` override / assignment shadowing / `require.main === module` alongside `import.meta.main` under `-e` — output identical to the current release.
- Forced a clean regen of `WebCoreJSBuiltins.{h,cpp}` to confirm nothing else referenced the removed generator.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/import-meta.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/54] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/54] gen cpp.rs (cppbind)
[3/54] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/54] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/debug/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[5/54] gen JS modules (bundle-modules)
Preprocess modules (8104ms)
Bundle modules (55ms)
Postprocesss modules (172ms)
Bundle Functions (728ms)
Generate Code (11ms)

[9.09s] Bundled "src/js" for development
  2813 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[5/48] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[45
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a4bc96e77)

test/js/bun/resolve/import-meta.test.js:
(pass) import.meta.require is settable [0.07ms]
(pass) import.meta.main [6.92ms]
(pass) import.meta.main follows a Bun.main override but not an own path property, is readable from a vm context, and is false in workers [41.77ms]
(pass) import.meta.resolveSync [0.06ms]
(pass) Module.createRequire [0.13ms]
(pass) Module.createRequire works with a file url [0.04ms]
(pass) Module.createRequire works with a file url with a space [0.09ms]
(pass) Module.createRequire does not use file url as the referrer (err message check) [0.33ms]
(pass) require with a query string works on dynamically created content [0.70ms]
(pass) import.meta.require (json) [0.07ms]
(pass) const f = require;require(json) [0.04ms]
(pass) Module.createRequire().resolve [0.03ms]
(pass) Module._cache [0.11ms]
(pass) Module._resolveFilename() [0.04ms]
(pass) Module.createRequire(file://url).resolve(file://url) [0.04ms]
(pass) import.meta.require.resolve [0.02ms]
(pass) import.meta.require (javascript) [0.27ms]
(pass) import() require + TLA [0.51ms]
(pass) import.meta.require (javascript, live bindings) [0.53ms]
(pass) import.meta
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/import-meta.test.js
bun test v1.4.0 (6e906e468)

test/js/bun/resolve/import-meta.test.js:
(pass) import.meta.require is settable [13.17ms]
(pass) import.meta.main [297.43ms]
(pass) import.meta.main follows a Bun.main override but not an own path property, is readable from a vm context, and is false in workers [2314.45ms]
(pass) import.meta.resolveSync [2.69ms]
(pass) Module.createRequire [6.82ms]
(pass) Module.createRequire works with a file url [3.87ms]
(pass) Module.createRequire works with a file url with a space [4.35ms]
(pass) Module.createRequire does not use file url as the referrer (err message check) [8.23ms]
(pass) require with a query string works on dynamically created content [18.04ms]
(pass) import.meta.require (json) [3.78ms]
(pass) const f = require;require(json) [2.79ms]
(pass) Module.createRequire().resolve [2.87ms]
(pass) Module._cache [6.04ms]
(pass) Module._resolveFilename() [2.59ms]
(pass) Module.createRequire(file://url).resolve(file://url) [3.03ms]
(pass) import.meta.require.resolve [2.05ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a32803f9b0
  features     baseline

23 deps, 129 codegen, 1172 objects in 677ms

ninja: Entering directory `/workspace/bun/build/release'
[1/39] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/39] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/39] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/release/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[4/39] gen cpp.rs (cppbind)
[5/39] gen JS modules (bundle-modules)
Preprocess modules (8160ms)
Bundle modules (50ms)
Postprocesss modules (252ms)
Bundle Functions (737ms)
Generate Code (32ms)

[9.25s] Bundled "src/js" for production
  2625 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[5/34] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/ImportMetaObject.ts     |  6 ----
 src/jsc/bindings/ImportMetaObject.cpp   | 47 +++++++++++++++++++----------
 test/js/bun/resolve/import-meta.test.js | 53 ++++++++++++++++++++++++++++++++-
 3 files changed, 83 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/builtins/ImportMetaObject.ts          0      0      0
src/jsc/bindings/ImportMetaObject.cpp        2      4      0
test/js/bun/resolve/import-meta.test.js      1      2      0
```

</details>

<!-- robobun:evidence:end -->