### PR TITLE
undici: stream node:stream Readable request bodies instead of throwing

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -1,6 +1,4 @@
 const EventEmitter = require("node:events");
-const StreamModule = require("node:stream");
-const { Readable } = StreamModule;
 const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapters");
 
 const ObjectCreate = Object.create;
@@ -194,16 +192,6 @@ async function request(
 
   if (inputBody && (method === "GET" || method === "HEAD")) {
     throw new Error("Body not allowed for GET or HEAD requests");
-  }
-
-  if (inputBody && inputBody.read && inputBody instanceof Readable) {
-    // TODO: Streaming via ReadableStream?
-    let data = "";
-    inputBody.setEncoding("utf8");
-    for await (const chunk of stream) {
-      data += chunk;
-    }
-    inputBody = new TextEncoder().encode(data);
   }
 
   if (maxRedirections != null && (!Number.isInteger(maxRedirections) || maxRedirections < 0)) {

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Readable } from "node:stream";
 import { request, fetch as undiciFetch } from "undici";
 
 import { createServer } from "../../../http-test-server";
@@ -51,13 +52,41 @@ describe("undici", () => {
     });
 
     it("should stream a node:stream Readable body", async () => {
-      const { Readable } = require("node:stream");
-      const { body } = await request(`${hostUrl}/post`, {
-        method: "POST",
-        body: Readable.from([Buffer.from("Hello "), Buffer.from([0xef, 0xbc, 0xb7]), "world"]),
+      const firstChunkReceived = Promise.withResolvers<void>();
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const received: number[] = [];
+          for await (const chunk of req.body!) {
+            received.push(...chunk);
+            firstChunkReceived.resolve();
+          }
+          return Response.json({
+            received,
+            transferEncoding: req.headers.get("transfer-encoding"),
+            contentLength: req.headers.get("content-length"),
+          });
+        },
       });
-      const json = (await body.json()) as { data: string; headers: Record<string, string> };
-      expect(json.data).toBe("Hello \uff37world");
+
+      // The second chunk exists only after the server has the first one, so
+      // the body has to go out while the Readable is still open.
+      async function* chunks() {
+        yield Buffer.from([0x00, 0xff, 0xfe]); // not valid UTF-8
+        await firstChunkReceived.promise;
+        yield "h\u00e9llo"; // string chunks go out as UTF-8
+      }
+
+      const { statusCode, body } = await request(server.url.href, {
+        method: "POST",
+        body: Readable.from(chunks()),
+      });
+      expect(await body.json()).toEqual({
+        received: [0x00, 0xff, 0xfe, ...Buffer.from("h\u00e9llo")],
+        transferEncoding: "chunked",
+        contentLength: null,
+      });
+      expect(statusCode).toBe(200);
     });
 
     it("should accept a URL class object", async () => {

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -50,6 +50,16 @@ describe("undici", () => {
       expect(json.data).toBe("Hello world");
     });
 
+    it("should stream a node:stream Readable body", async () => {
+      const { Readable } = require("node:stream");
+      const { body } = await request(`${hostUrl}/post`, {
+        method: "POST",
+        body: Readable.from([Buffer.from("Hello "), Buffer.from([0xef, 0xbc, 0xb7]), "world"]),
+      });
+      const json = (await body.json()) as { data: string; headers: Record<string, string> };
+      expect(json.data).toBe("Hello \uff37world");
+    });
+
     it("should accept a URL class object", async () => {
       const { body } = await request(new URL(`${hostUrl}/get`));
       expect(body).toBeDefined();


### PR DESCRIPTION
### Problem
- `require("undici").request(url, { method: "POST", body: readable })` with a `node:stream` `Readable` body always rejects with `TypeError: iterable should have an iterator symbol`. The shim tries to buffer the body first, but `for await (const chunk of stream)` at `src/js/thirdparty/undici.js:203` iterates the module-level `stream()` function, not the body.
- With the typo fixed, the block is still wrong. It decodes the body as UTF-8 and encodes it again, which corrupts bytes that are not valid UTF-8. It also holds the whole body in memory.

### Fix
- Remove the block. The `Readable` now goes to `fetch()` as the body unchanged. The shim's `require("node:stream")` has no other user, so it goes too.
- This is correct because `fetch()` accepts any async iterable as a request body (`src/jsc/bindings/webcore/streams/WebStreamsExports.cpp:89-100`), and a `Readable` is one. The body goes out with `Transfer-Encoding: chunked` while the `Readable` produces it. Buffer chunks go out as they are, string chunks as UTF-8.
- Verified: `test/js/first_party/undici/undici.test.ts` ("should stream a node:stream Readable body") fails on the released bun with the TypeError above and passes with this change. The rest of `test/js/first_party/undici/` passes too.

### Background
- `undici` resolves to the shim in `src/js/thirdparty/undici.js`. Its `request()` is a thin wrapper over `Bun.fetch`.
- fetch has no code path for node streams. `BodyValue::from_js` (`src/runtime/webcore/Body.rs:1004`) wraps any object with `Symbol.asyncIterator` in a pull-driven `ReadableStream`. `Readable` gets that method in `src/js/internal/streams/readable.ts:1258`.
- A `ReadableStream` body makes the HTTP client send the request chunked (`src/http/lib.rs:2540`) unless the caller sets `Content-Length`.

<details><summary>Notes</summary>

- The test posts to its own server. The server returns the bytes it received and the framing headers. The second chunk is produced only after the server has the first one, so a body that is buffered until the `Readable` ends makes the test fail.
- Probed the debug build with `fs.createReadStream` on a 70000 byte file: the bytes arrive intact, `transfer-encoding: chunked`, no `content-length`.
- An object-mode `Readable` that yields something other than a string or bytes rejects the request with `TypeError [ERR_INVALID_ARG_TYPE]: write() expects a string, ArrayBufferView, or ArrayBuffer`. A `Readable` that errors in the middle of the body rejects the request with that error.
- No `Content-Type` header is sent for a stream body. undici does the same.
- A redirect other than 303 with a stream body fails inside fetch (`RequestBodyNotReusable`). `request()` follows redirects only when `maxRedirections` is set. That did not change.
</details>
