### PR TITLE
readline: stop loading fs/util/vm/os/path for every Interface

### DIFF
--- a/src/js/internal/readline/interface.js
+++ b/src/js/internal/readline/interface.js
@@ -58,9 +58,8 @@ let kFirstEventParam;
 const { clearScreenDown, cursorTo, moveCursor } = require("internal/readline/callbacks");
 
 const { StringDecoder } = require("node:string_decoder");
-// history.js eagerly loads node:{fs,os,path,timers}; keep it lazy so a bare
-// require("node:readline") for cursorTo/clearLine stays cheap. Constructing
-// an Interface always calls setupHistoryManager, so readLines() still loads it.
+// Keep history.js lazy so a bare require("node:readline") for cursorTo/clearLine
+// stays cheap. Constructing an Interface always calls setupHistoryManager.
 let ReplHistory;
 
 const kMaxUndoRedoStackSize = 2048;

--- a/src/js/internal/repl/history.js
+++ b/src/js/internal/repl/history.js
@@ -20,13 +20,19 @@ const {
 
 const { validateNumber, validateArray } = require("internal/validators");
 
-const path = require("node:path");
-const fs = require("node:fs");
-const os = require("node:os");
-let debug = require("internal/repl/node-shims").debuglog("repl", fn => {
-  debug = fn;
-});
-const permission = require("internal/repl/node-shims");
+// Every readline Interface constructs a ReplHistory, but only the REPL (with a
+// history file) touches fs/os/path or the node-shims helpers, so load those on
+// first use instead of pulling node:fs, node:util, node:vm etc. into every
+// readline.createInterface() / FileHandle.readLines().
+let fs, os, path, permission;
+const lazyFs = () => (fs ??= require("node:fs"));
+const lazyOs = () => (os ??= require("node:os"));
+const lazyPath = () => (path ??= require("node:path"));
+const lazyPermission = () => (permission ??= require("internal/repl/node-shims"));
+let debug = (...args) => {
+  debug = require("internal/repl/node-shims").debuglog("repl");
+  return debug(...args);
+};
 const { clearTimeout, setTimeout } = require("node:timers");
 const { reverseString } = require("internal/readline/utils");
 
@@ -272,7 +278,7 @@ class ReplHistory {
   [kResolveHistoryPath]() {
     if (!this[kHistoryPath]) {
       try {
-        this[kHistoryPath] = path.join(os.homedir(), ".node_repl_history");
+        this[kHistoryPath] = lazyPath().join(lazyOs().homedir(), ".node_repl_history");
         return this[kHistoryPath];
       } catch (err) {
         debug(err.stack);
@@ -283,6 +289,7 @@ class ReplHistory {
   }
 
   [kHasWritePermission]() {
+    const permission = lazyPermission();
     return !(permission.isEnabled() && permission.has("fs.write", this[kHistoryPath]) === false);
   }
 
@@ -300,12 +307,12 @@ class ReplHistory {
       // Open and close file first to ensure it exists
       // History files are conventionally not readable by others
       // 0o0600 = read/write for owner only
-      const hnd = await fs.promises.open(this[kHistoryPath], "a+", 0o0600);
+      const hnd = await lazyFs().promises.open(this[kHistoryPath], "a+", 0o0600);
       await hnd.close();
 
       let data;
       try {
-        data = await fs.promises.readFile(this[kHistoryPath], "utf8");
+        data = await lazyFs().promises.readFile(this[kHistoryPath], "utf8");
       } catch (err) {
         return this[kHandleHistoryInitError](err, onReadyCallback);
       }
@@ -318,7 +325,7 @@ class ReplHistory {
 
       validateArray(this[kHistory], "history");
 
-      const handle = await fs.promises.open(this[kHistoryPath], "r+");
+      const handle = await lazyFs().promises.open(this[kHistoryPath], "r+");
       this[kHistoryHandle] = handle;
 
       await handle.truncate(0);


### PR DESCRIPTION
### What does this PR do?

Every `readline.Interface` constructs a `ReplHistory`, and `internal/repl/history` eagerly required `node:fs`, `node:os`, `node:path` and `internal/repl/node-shims` — which itself loads `node:util` (and `internal/util/inspect`), `node:module` and `node:vm`. Only the REPL's persistent-history file path uses any of those.

This makes those requires lazy (first use), so `readline.createInterface()` and `fs.promises` `FileHandle.readLines()` stop evaluating them. Measured on a debug build by tracing which bundled modules are read for `readline.createInterface({ input })`: **58 → 41 modules**, no longer including `node:fs`, `fs/promises`, `internal/fs/glob`, `internal/fs/streams`, `node:util`, `internal/util/inspect`, `node:vm`, `node:url`, `node:os`, `node:path`, `internal/repl/node-shims`, `internal/util/{colors,mime,comparisons,deprecate}`.

No behavior change; the REPL still loads them when it resolves/reads/writes the history file, and `NODE_DEBUG=repl` logging still goes through the same `debuglog`.

### How did you verify your code works?

- `test/js/node/readline/readline.node.test.ts` (80 pass) and `test/js/bun/repl/repl.test.ts` (177 pass) on the debug build.
- Drove the debug binary: `rl.question()` over stdin, `FileHandle.readLines()`, and `bun repl` with a fresh `$HOME` writing `.bun_repl_history`.
