### PR TITLE
timers: define [util.promisify.custom] natively as a lazy accessor

### DIFF
--- a/src/js/internal/promisify.ts
+++ b/src/js/internal/promisify.ts
@@ -71,28 +71,6 @@ var promisify = function promisify(original) {
 };
 promisify.custom = kCustomPromisifiedSymbol;
 
-// Load node:timers/promises promisified functions onto the global timers.
-{
-  const { setTimeout: timeout, setImmediate: immediate, setInterval: interval } = globalThis;
-  const {
-    setTimeout: timeoutPromise,
-    setImmediate: immediatePromise,
-    setInterval: intervalPromise,
-  } = require("node:timers/promises");
-
-  if (timeout && $isCallable(timeout)) {
-    defineCustomPromisify(timeout, timeoutPromise);
-  }
-
-  if (immediate && $isCallable(immediate)) {
-    defineCustomPromisify(immediate, immediatePromise);
-  }
-
-  if (interval && $isCallable(interval)) {
-    defineCustomPromisify(interval, intervalPromise);
-  }
-}
-
 export default {
   defineCustomPromisifyArgs,
   promisify,

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -17,9 +17,9 @@
   queueMicrotask                  functionQueueMicrotask                               Function 1
   removeEventListener             jsFunctionRemoveEventListener                        Function 2
   reportError                     functionReportError                                  Function 1
-  setImmediate                    functionSetImmediate                                 Function 1
-  setInterval                     functionSetInterval                                  Function 1
-  setTimeout                      functionSetTimeout                                   Function 1
+  setImmediate                    createSetImmediateFunction                           PropertyCallback
+  setInterval                     createSetIntervalFunction                            PropertyCallback
+  setTimeout                      createSetTimeoutFunction                             PropertyCallback
   structuredClone                 WebCore::jsFunctionStructuredClone                    Function 2
 
   global                          GlobalObject_getGlobalThis                           PropertyCallback

--- a/src/jsc/bindings/node/NodeTimers.cpp
+++ b/src/jsc/bindings/node/NodeTimers.cpp
@@ -2,6 +2,9 @@
 
 #include "ErrorCode.h"
 #include "headers.h"
+#include "ZigGlobalObject.h"
+#include "InternalModuleRegistry.h"
+#include <JavaScriptCore/CustomGetterSetter.h>
 
 namespace Bun {
 
@@ -230,6 +233,57 @@ JSC_DEFINE_HOST_FUNCTION(functionClearTimeout,
 #endif
 
     return Bun__Timer__clearTimeout(globalObject, JSC::JSValue::encode(timer_or_num));
+}
+
+static JSC::EncodedJSValue timersPromisesExport(JSGlobalObject* lexicalGlobalObject, ASCIILiteral name)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSValue timersPromises = globalObject->internalModuleRegistry()->requireId(lexicalGlobalObject, vm, InternalModuleRegistry::Field::NodeTimersPromises);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, JSValue::encode(timersPromises.get(lexicalGlobalObject, Identifier::fromString(vm, name))));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(setTimeoutPromisifyCustomGetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue, PropertyName))
+{
+    return timersPromisesExport(globalObject, "setTimeout"_s);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(setIntervalPromisifyCustomGetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue, PropertyName))
+{
+    return timersPromisesExport(globalObject, "setInterval"_s);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(setImmediatePromisifyCustomGetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue, PropertyName))
+{
+    return timersPromisesExport(globalObject, "setImmediate"_s);
+}
+
+static JSValue createTimerFunction(VM& vm, JSObject* globalObject, ASCIILiteral name, NativeFunction function, JSC::CustomGetterSetter::CustomGetter promisifyCustomGetter)
+{
+    auto* timerFunction = JSFunction::create(vm, globalObject->globalObject(), 1, name, function, ImplementationVisibility::Public);
+    // Same shape as Node's lib/timers.js: an enumerable, non-configurable accessor.
+    timerFunction->putDirectCustomAccessor(vm,
+        Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.util.promisify.custom"_s)),
+        CustomGetterSetter::create(vm, promisifyCustomGetter, nullptr),
+        PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete | 0);
+    return timerFunction;
+}
+
+JSValue createSetTimeoutFunction(VM& vm, JSObject* globalObject)
+{
+    return createTimerFunction(vm, globalObject, "setTimeout"_s, functionSetTimeout, setTimeoutPromisifyCustomGetter);
+}
+
+JSValue createSetIntervalFunction(VM& vm, JSObject* globalObject)
+{
+    return createTimerFunction(vm, globalObject, "setInterval"_s, functionSetInterval, setIntervalPromisifyCustomGetter);
+}
+
+JSValue createSetImmediateFunction(VM& vm, JSObject* globalObject)
+{
+    return createTimerFunction(vm, globalObject, "setImmediate"_s, functionSetImmediate, setImmediatePromisifyCustomGetter);
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/node/NodeTimers.h
+++ b/src/jsc/bindings/node/NodeTimers.h
@@ -11,4 +11,11 @@ JSC_DECLARE_HOST_FUNCTION(functionClearTimeout);
 JSC_DECLARE_HOST_FUNCTION(functionClearInterval);
 JSC_DECLARE_HOST_FUNCTION(functionClearImmediate);
 
+// Lazy property callbacks for the global object table: create setTimeout /
+// setInterval / setImmediate with Node's `[util.promisify.custom]` accessor,
+// which resolves to the node:timers/promises implementation on first read.
+JSC::JSValue createSetTimeoutFunction(JSC::VM&, JSC::JSObject* globalObject);
+JSC::JSValue createSetIntervalFunction(JSC::VM&, JSC::JSObject* globalObject);
+JSC::JSValue createSetImmediateFunction(JSC::VM&, JSC::JSObject* globalObject);
+
 } // namespace Bun

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -45,6 +45,29 @@ it("node.js util.promisify(setInterval) works", async () => {
   expect(end - start).toBeGreaterThan(9);
 });
 
+it("timers expose util.promisify.custom as a lazy accessor without loading node:util first", async () => {
+  // Matches Node's lib/timers.js: an enumerable, non-configurable getter that resolves to timers/promises.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const sym = Symbol.for("nodejs.util.promisify.custom");
+       const shape = fn => { const d = Object.getOwnPropertyDescriptor(fn, sym); return d && { get: typeof d.get, set: typeof d.set, enumerable: d.enumerable, configurable: d.configurable }; };
+       const before = [setTimeout, setInterval, setImmediate].map(shape);
+       const tp = require("node:timers/promises");
+       const same = [setTimeout[sym] === tp.setTimeout, setInterval[sym] === tp.setInterval, setImmediate[sym] === tp.setImmediate];
+       console.log(JSON.stringify({ before, same }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const accessor = { get: "function", set: "undefined", enumerable: true, configurable: false };
+  expect(JSON.parse(stdout)).toEqual({ before: [accessor, accessor, accessor], same: [true, true, true] });
+  expect(exitCode).toBe(0);
+});
+
 it("node.js util.promisify(setImmediate) works", async () => {
   const setImmediate = promisify(globalThis.setImmediate);
   await setImmediate();


### PR DESCRIPTION
### What does this PR do?

In Node, `setTimeout`, `setInterval` and `setImmediate` carry a `[util.promisify.custom]` property from startup: `lib/timers.js` defines it as an enumerable, non-configurable getter that lazily loads `timers/promises`. In Bun the property only appeared after `internal/promisify` was first loaded (via `node:util`, `node:fs`, `node:readline`, `node:crypto` or `node:http2`), was a plain data property, and installing it eagerly required `node:timers/promises`.

This creates the three global timer functions through property callbacks in the global object table that attach the accessor natively (`NodeTimers.cpp`), so:
- the property exists before any module is loaded, in the main thread and workers, with Node's descriptor shape (`get`/no `set`, `enumerable: true`, `configurable: false`);
- `node:timers/promises` is only evaluated when the property is actually read;
- the eager block in `src/js/internal/promisify.ts` is removed.

`util.promisify(setTimeout) === require("timers/promises").setTimeout` etc. still hold, and the globals remain overwritable (fake-timer libraries).

### How did you verify your code works?

- New subprocess test in `test/js/node/timers/node-timers.test.ts` asserting the descriptor shape before `node:util` is loaded and identity with `timers/promises`; fails on current release, passes here.
- `test/js/node/timers/node-timers.test.ts`, `test/js/node/util/util-promisify.test.js`, and Node's `test-timers-{timeout,interval,immediate}-promisified.js`, `test-util-promisify.js`, `test-util-promisify-custom-names.mjs` pass on the debug build.
- Drove the debug binary: worker thread sees the accessor, `for await (const _ of setInterval[custom](1))` works, `globalThis.setTimeout = ...` still assignable.
