### PR TITLE
util.inspect: use the shared native validateObject / ERR_INVALID_ARG_TYPE

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -198,145 +198,7 @@ function assert(p, message) {
   if (!p) throw new AssertionError(message);
 }
 
-const codes = {}; // exported from errors.js
-{
-  // errors.js
-  // Sorted by a rough estimate on most frequently used entries.
-  const kTypes = [
-    "string",
-    "function",
-    "number",
-    "object",
-    // Accept 'Function' and 'Object' as alternative to the lower cased version.
-    "Function",
-    "Object",
-    "boolean",
-    "bigint",
-    "symbol",
-  ];
-  const classRegExp = /^([A-Z][a-z0-9]*)+$/;
-  const messages = new SafeMap();
-  const sym = "ERR_INVALID_ARG_TYPE";
-  messages.set(sym, (name, expected, actual) => {
-    assert(typeof name === "string", "'name' must be a string");
-    if (!$isJSArray(expected)) expected = [expected];
-
-    let msg = "The ";
-    if (StringPrototypeEndsWith(name, " argument"))
-      msg += `${name} `; // For cases like 'first argument'
-    else msg += `"${name}" ${StringPrototypeIncludes(name, ".") ? "property" : "argument"} `;
-    msg += "must be ";
-
-    const types = [];
-    const instances = [];
-    const other = [];
-    for (const value of expected) {
-      assert(typeof value === "string", "All expected entries have to be of type string");
-      if (ArrayPrototypeIncludes(kTypes, value)) ArrayPrototypePush.$call(types, StringPrototypeToLowerCase(value));
-      else if (RegExpPrototypeTest(classRegExp, value)) ArrayPrototypePush.$call(instances, value);
-      else {
-        assert(value !== "object", 'The value "object" should be written as "Object"');
-        ArrayPrototypePush.$call(other, value);
-      }
-    }
-    // Special handle `object` in case other instances are allowed to outline the differences between each other.
-    if (instances.length > 0) {
-      const pos = ArrayPrototypeIndexOf(types, "object");
-      if (pos !== -1) {
-        ArrayPrototypeSplice(types, pos, 1);
-        ArrayPrototypePush.$call(instances, "Object");
-      }
-    }
-    const typesLength = types.length;
-    if (typesLength > 0) {
-      if (typesLength > 2) msg += `one of type ${ArrayPrototypeJoin(types, ", ")}, or ${ArrayPrototypePop(types)}`;
-      else if (typesLength === 2) msg += `one of type ${types[0]} or ${types[1]}`;
-      else msg += `of type ${types[0]}`;
-      if (instances.length > 0 || other.length > 0) msg += " or ";
-    }
-    const instancesLength = instances.length;
-    if (instancesLength > 0) {
-      if (instancesLength > 2)
-        msg += `an instance of ${ArrayPrototypeJoin(instances, ", ")}, or ${ArrayPrototypePop(instances)}`;
-      else msg += `an instance of ${instances[0]}` + (instancesLength === 2 ? ` or ${instances[1]}` : "");
-      if (other.length > 0) msg += " or ";
-    }
-    const otherLength = other.length;
-    if (otherLength > 0) {
-      if (otherLength > 2) {
-        const last = ArrayPrototypePop(other);
-        msg += `one of ${ArrayPrototypeJoin(other, ", ")}, or ${last}`;
-      } else if (otherLength === 2) {
-        msg += `one of ${other[0]} or ${other[1]}`;
-      } else {
-        if (StringPrototypeToLowerCase(other[0]) !== other[0]) msg += "an ";
-        msg += `${other[0]}`;
-      }
-    }
-
-    let actualName;
-    if (actual == null) msg += `. Received ${actual}`;
-    else if (typeof actual === "function" && (actualName = actual.name)) msg += `. Received function ${actualName}`;
-    else if (typeof actual === "object") {
-      const actualCtor = actual.constructor;
-      const actualCtorName = actualCtor ? actualCtor.name : undefined;
-      if (actualCtorName) msg += `. Received an instance of ${actualCtorName}`;
-      else msg += `. Received ${inspect(actual, { depth: -1 })}`;
-    } else {
-      let inspected = inspect(actual, { colors: false });
-      if (inspected.length > 25) inspected = `${StringPrototypeSlice(inspected, 0, 25)}...`;
-      msg += `. Received type ${typeof actual} (${inspected})`;
-    }
-    return msg;
-  });
-  codes[sym] = function NodeError(...args) {
-    const limit = Error.stackTraceLimit;
-    Error.stackTraceLimit = 0;
-    const error = new TypeError();
-    Error.stackTraceLimit = limit; // Reset the limit and setting the name property.
-
-    const msg = messages.get(sym);
-    assert(typeof msg === "function");
-    assert(
-      msg.length <= args.length, // Default options do not count.
-      `Code: ${sym}; The provided arguments length (${args.length}) does not match the required ones (${msg.length}).`,
-    );
-    const message = msg.$apply(error, args);
-
-    ObjectDefineProperty(error, "message", { value: message, enumerable: false, writable: true, configurable: true });
-    ObjectDefineProperty(error, "toString", {
-      value() {
-        return `${this.name} [${sym}]: ${this.message}`;
-      },
-      enumerable: false,
-      writable: true,
-      configurable: true,
-    });
-    // addCodeToName + captureLargerStackTrace
-    let err = error;
-    const userStackTraceLimit = Error.stackTraceLimit;
-    Error.stackTraceLimit = Infinity;
-    ErrorCaptureStackTrace(err);
-    Error.stackTraceLimit = userStackTraceLimit; // Reset the limit
-    err.name = `${TypeError.name} [${sym}]`; // Add the error code to the name to include it in the stack trace.
-    void err.stack; // Access the stack to generate the error message including the error code from the name.
-    delete err.name; // Reset the name to the actual name.
-    error.code = sym;
-    return error;
-  };
-}
-/**
- * @param {unknown} value
- * @param {string} name
- * @param {{ allowArray?: boolean, allowFunction?: boolean, nullable?: boolean }} [options] */
-const validateObject = (value, name, allowArray = false) => {
-  if (
-    value === null ||
-    (!allowArray && $isJSArray(value)) ||
-    (typeof value !== "object" && typeof value !== "function")
-  )
-    throw new codes.ERR_INVALID_ARG_TYPE(name, "Object", value);
-};
+const { validateObject, kValidateObjectAllowArray } = require("internal/validators");
 
 const SymbolToPrimitive = Symbol.toPrimitive;
 
@@ -2758,7 +2620,7 @@ function format(...args) {
 }
 
 function formatWithOptions(inspectOptions, ...args) {
-  validateObject(inspectOptions, "inspectOptions", { allowArray: true });
+  validateObject(inspectOptions, "inspectOptions", kValidateObjectAllowArray);
   return formatWithOptionsInternal(inspectOptions, args);
 }
 
@@ -2924,7 +2786,7 @@ const ansi = new RegExp(
 );
 
 function stripVTControlCharacters(str) {
-  if (typeof str !== "string") throw new codes.ERR_INVALID_ARG_TYPE("str", "string", str);
+  if (typeof str !== "string") throw $ERR_INVALID_ARG_TYPE("str", "string", str);
   // All ANSI escape sequences start with ESC (7-bit) or CSI (8-bit).
   if (StringPrototypeIndexOf(str, "\u001B") === -1 && StringPrototypeIndexOf(str, "\u009B") === -1) {
     return str;

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -63,7 +63,6 @@ const BooleanPrototypeValueOf = uncurryThis(Boolean.prototype.valueOf);
 const DatePrototypeGetTime = uncurryThis(Date.prototype.getTime);
 const DatePrototypeToISOString = uncurryThis(Date.prototype.toISOString);
 const DatePrototypeToString = uncurryThis(Date.prototype.toString);
-const ErrorCaptureStackTrace = Error.captureStackTrace;
 const ErrorPrototypeToString = uncurryThis(Error.prototype.toString);
 const FunctionPrototypeBind = uncurryThis(Function.prototype.bind);
 const FunctionPrototypeToString = uncurryThis(Function.prototype.toString);

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -125,6 +125,8 @@ hideFromStack(validateLinkHeaderValue);
 hideFromStack(validateString, validateFunction, validateBoolean);
 hideFromStack(getValidatedPath, getValidatedFsPath, throwIfNullBytesInFileName);
 
+// Must match jsFunction_validateObject in NodeValidator.cpp. The values are node's:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L224-L227
 const kValidateObjectNone = 0;
 const kValidateObjectAllowNullable = 1 << 0;
 const kValidateObjectAllowArray = 1 << 1;

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -125,8 +125,17 @@ hideFromStack(validateLinkHeaderValue);
 hideFromStack(validateString, validateFunction, validateBoolean);
 hideFromStack(getValidatedPath, getValidatedFsPath, throwIfNullBytesInFileName);
 
+const kValidateObjectNone = 0;
+const kValidateObjectAllowNullable = 1 << 0;
+const kValidateObjectAllowArray = 1 << 1;
+const kValidateObjectAllowFunction = 1 << 2;
+
 export default {
-  /** (value, name) */
+  kValidateObjectNone,
+  kValidateObjectAllowNullable,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowFunction,
+  /** (value, name[, kValidateObject* flags]) */
   validateObject: $newCppFunction("NodeValidator.cpp", "jsFunction_validateObject", 2),
   validateLinkHeaderValue: validateLinkHeaderValue,
   checkIsHttpToken: checkIsHttpToken,

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -602,6 +602,8 @@ JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject
 
 // validateObject(value, name[, options]) where options is Node's bitmask:
 // kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction.
+// The values must match internal/validators.ts. They are node's:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L224-L270
 JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = globalObject->vm();

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -600,19 +600,35 @@ JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject
     return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, "must be one of: "_s, value, oneOf);
 }
 
+// validateObject(value, name[, options]) where options is Node's bitmask:
+// kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction.
 JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto value = callFrame->argument(0);
+    int32_t options = callFrame->argument(2).isInt32() ? callFrame->argument(2).asInt32() : 0;
+    constexpr int32_t kValidateObjectAllowNullable = 1 << 0;
+    constexpr int32_t kValidateObjectAllowArray = 1 << 1;
+    constexpr int32_t kValidateObjectAllowFunction = 1 << 2;
 
-    bool isArray = JSC::isArray(globalObject, value);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (value.isNull() || isArray || value.isCallable()) {
+    if (value.isNull()) {
+        if (options & kValidateObjectAllowNullable)
+            return JSValue::encode(jsUndefined());
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
     }
-
+    if (value.isCallable()) {
+        if (options & kValidateObjectAllowFunction)
+            return JSValue::encode(jsUndefined());
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
+    }
+    if (!(options & kValidateObjectAllowArray)) {
+        bool isArray = JSC::isArray(globalObject, value);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (isArray)
+            return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
+    }
     if (!value.isObject()) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
     }

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -22,6 +22,7 @@
 // Tests adapted from https://github.com/nodejs/node/blob/main/test/parallel/test-util.js
 
 import assert from "assert";
+import { exposedInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import util from "util";
@@ -402,6 +403,32 @@ describe("util", () => {
         ...err,
         message: 'The "str" argument must be of type string. Received type number (1)',
       }),
+    );
+  });
+  // The validateObject block of node's test/parallel/test-validators.js (v26.3.0).
+  it("validateObject honors the kValidateObject* flags like Node", () => {
+    const { validateObject, kValidateObjectAllowNullable, kValidateObjectAllowArray, kValidateObjectAllowFunction } =
+      exposedInternals["internal/validators"];
+    const err = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
+    const fn = () => {};
+
+    validateObject({}, "foo");
+    validateObject({ a: 42, b: "foo" }, "foo");
+    for (const val of [undefined, null, true, false, 0, 0.0, 42, "", "string", [], fn]) {
+      expect(() => validateObject(val, "foo")).toThrow(expect.objectContaining(err));
+    }
+
+    validateObject(null, "foo", kValidateObjectAllowNullable);
+    validateObject([], "foo", kValidateObjectAllowArray);
+    validateObject(fn, "foo", kValidateObjectAllowFunction);
+    validateObject({}, "foo", kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction);
+
+    // Each flag only admits its own kind of value.
+    expect(() => validateObject(null, "foo", kValidateObjectAllowArray)).toThrow(expect.objectContaining(err));
+    expect(() => validateObject([], "foo", kValidateObjectAllowNullable)).toThrow(expect.objectContaining(err));
+    expect(() => validateObject(fn, "foo", kValidateObjectAllowNullable)).toThrow(expect.objectContaining(err));
+    expect(() => validateObject(undefined, "foo", kValidateObjectAllowNullable)).toThrow(
+      expect.objectContaining({ ...err, message: 'The "foo" argument must be of type object. Received undefined' }),
     );
   });
 

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -383,6 +383,25 @@ describe("util", () => {
   it("format", () => {
     expect(util.format("%s:%s", "foo")).toBe("foo:%s");
   });
+  it("formatWithOptions and inspect.defaultOptions validate their options like Node", () => {
+    const err = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
+    // Arrays are allowed for formatWithOptions (kValidateObjectAllowArray), functions and null are not.
+    expect(util.formatWithOptions([], "%s", 1)).toBe("1");
+    expect(() => util.formatWithOptions(() => {}, "x")).toThrow(expect.objectContaining(err));
+    expect(() => util.formatWithOptions(null, "x")).toThrow(expect.objectContaining(err));
+    const saved = { ...util.inspect.defaultOptions };
+    try {
+      expect(() => (util.inspect.defaultOptions = () => {})).toThrow(expect.objectContaining(err));
+      expect(() => (util.inspect.defaultOptions = [])).toThrow(expect.objectContaining(err));
+      expect(() => (util.inspect.defaultOptions = { depth: 3 })).not.toThrow();
+    } finally {
+      util.inspect.defaultOptions = saved;
+    }
+    expect(() => util.stripVTControlCharacters(1)).toThrow(
+      expect.objectContaining({ ...err, message: 'The "str" argument must be of type string. Received type number (1)' }),
+    );
+  });
+
   it("formatWithOptions", () => {
     expect(util.formatWithOptions({ colors: true }, "%s:%s", "foo")).toBe("foo:%s");
     expect(util.formatWithOptions({ colors: true }, "wow(%o)", { obj: true })).toBe(

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -384,51 +384,71 @@ describe("util", () => {
   it("format", () => {
     expect(util.format("%s:%s", "foo")).toBe("foo:%s");
   });
+  // Messages verified against the node v26.3.0 binary.
+  const invalidArgType = message =>
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError", message });
   it("formatWithOptions and inspect.defaultOptions validate their options like Node", () => {
-    const err = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
+    function opts() {}
     // Arrays are allowed for formatWithOptions (kValidateObjectAllowArray), functions and null are not.
     expect(util.formatWithOptions([], "%s", 1)).toBe("1");
-    expect(() => util.formatWithOptions(() => {}, "x")).toThrow(expect.objectContaining(err));
-    expect(() => util.formatWithOptions(null, "x")).toThrow(expect.objectContaining(err));
+    expect(() => util.formatWithOptions(opts, "x")).toThrow(
+      invalidArgType('The "inspectOptions" argument must be of type object. Received function opts'),
+    );
+    expect(() => util.formatWithOptions(null, "x")).toThrow(
+      invalidArgType('The "inspectOptions" argument must be of type object. Received null'),
+    );
     const saved = { ...util.inspect.defaultOptions };
     try {
-      expect(() => (util.inspect.defaultOptions = () => {})).toThrow(expect.objectContaining(err));
-      expect(() => (util.inspect.defaultOptions = [])).toThrow(expect.objectContaining(err));
+      expect(() => (util.inspect.defaultOptions = opts)).toThrow(
+        invalidArgType('The "options" argument must be of type object. Received function opts'),
+      );
+      expect(() => (util.inspect.defaultOptions = [])).toThrow(
+        invalidArgType('The "options" argument must be of type object. Received an instance of Array'),
+      );
       expect(() => (util.inspect.defaultOptions = { depth: 3 })).not.toThrow();
     } finally {
       util.inspect.defaultOptions = saved;
     }
     expect(() => util.stripVTControlCharacters(1)).toThrow(
-      expect.objectContaining({
-        ...err,
-        message: 'The "str" argument must be of type string. Received type number (1)',
-      }),
+      invalidArgType('The "str" argument must be of type string. Received type number (1)'),
     );
   });
-  // The validateObject block of node's test/parallel/test-validators.js (v26.3.0).
+  // Ported from the validateObject block of node's test/parallel/test-validators.js (v26.3.0).
   it("validateObject honors the kValidateObject* flags like Node", () => {
     const { validateObject, kValidateObjectAllowNullable, kValidateObjectAllowArray, kValidateObjectAllowFunction } =
       exposedInternals["internal/validators"];
-    const err = { code: "ERR_INVALID_ARG_TYPE", name: "TypeError" };
-    const fn = () => {};
+    const err = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" });
+    function fn() {}
+    const allFlags = kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction;
 
     validateObject({}, "foo");
     validateObject({ a: 42, b: "foo" }, "foo");
     for (const val of [undefined, null, true, false, 0, 0.0, 42, "", "string", [], fn]) {
-      expect(() => validateObject(val, "foo")).toThrow(expect.objectContaining(err));
+      expect(() => validateObject(val, "foo")).toThrow(err);
     }
 
     validateObject(null, "foo", kValidateObjectAllowNullable);
     validateObject([], "foo", kValidateObjectAllowArray);
     validateObject(fn, "foo", kValidateObjectAllowFunction);
-    validateObject({}, "foo", kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction);
+    for (const val of [{}, null, [], fn]) {
+      expect(() => validateObject(val, "foo", allFlags)).not.toThrow();
+    }
 
     // Each flag only admits its own kind of value.
-    expect(() => validateObject(null, "foo", kValidateObjectAllowArray)).toThrow(expect.objectContaining(err));
-    expect(() => validateObject([], "foo", kValidateObjectAllowNullable)).toThrow(expect.objectContaining(err));
-    expect(() => validateObject(fn, "foo", kValidateObjectAllowNullable)).toThrow(expect.objectContaining(err));
-    expect(() => validateObject(undefined, "foo", kValidateObjectAllowNullable)).toThrow(
-      expect.objectContaining({ ...err, message: 'The "foo" argument must be of type object. Received undefined' }),
+    expect(() => validateObject(null, "foo", kValidateObjectAllowArray | kValidateObjectAllowFunction)).toThrow(
+      invalidArgType('The "foo" argument must be of type object. Received null'),
+    );
+    expect(() => validateObject([], "foo", kValidateObjectAllowNullable | kValidateObjectAllowFunction)).toThrow(
+      invalidArgType('The "foo" argument must be of type object. Received an instance of Array'),
+    );
+    expect(() => validateObject(fn, "foo", kValidateObjectAllowNullable | kValidateObjectAllowArray)).toThrow(
+      invalidArgType('The "foo" argument must be of type object. Received function fn'),
+    );
+    expect(() => validateObject(undefined, "foo", allFlags)).toThrow(
+      invalidArgType('The "foo" argument must be of type object. Received undefined'),
+    );
+    expect(() => validateObject("string", "foo", allFlags)).toThrow(
+      invalidArgType("The \"foo\" argument must be of type object. Received type string ('string')"),
     );
   });
 

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -398,7 +398,10 @@ describe("util", () => {
       util.inspect.defaultOptions = saved;
     }
     expect(() => util.stripVTControlCharacters(1)).toThrow(
-      expect.objectContaining({ ...err, message: 'The "str" argument must be of type string. Received type number (1)' }),
+      expect.objectContaining({
+        ...err,
+        message: 'The "str" argument must be of type string. Received type number (1)',
+      }),
     );
   });
 


### PR DESCRIPTION
### Problem
- `src/js/internal/util/inspect.js` carried a private copy (about 140 lines) of Node's `ERR_INVALID_ARG_TYPE` message builder and its own `validateObject`. Only `util.formatWithOptions`, the `util.inspect.defaultOptions` and `replDefaults` setters, and `util.stripVTControlCharacters` used it. Every other module uses the native `$ERR_INVALID_ARG_TYPE` and `internal/validators`.
- The copy accepted functions. `util.formatWithOptions(() => {}, "x")` and `util.inspect.defaultOptions = () => {}` succeed in Bun. Node throws `ERR_INVALID_ARG_TYPE` for both.

### Fix
- Delete the copy. `inspect.js` now throws `$ERR_INVALID_ARG_TYPE` and calls the shared `validateObject`.
- `jsFunction_validateObject` (`src/jsc/bindings/NodeValidator.cpp`) accepts Node's optional third argument, a bitmask of `kValidateObjectAllowNullable`, `kValidateObjectAllowArray` and `kValidateObjectAllowFunction`. `internal/validators` exports the constants. Without the argument the function behaves as before. `formatWithOptions` passes `kValidateObjectAllowArray`, as Node does.
- Codes and messages are the ones Node v26.3.0 prints. The notes list every case I compared.
- Verified: `test/js/node/util/util.test.js`. Two new tests (the public surface, and the three flags through `exposedInternals`, ported from the `validateObject` block of Node's `test-validators.js`) fail with the old `src/` and pass with this diff. Also ran all of `test/js/node/util/` and the vendored `test-util*.js` and `test-repl-colors.js`.

### Background
- `$ERR_INVALID_ARG_TYPE` is an intrinsic of the builtin modules. The bundler rewrites it to the native error constructor in `ErrorCode.cpp`, so all modules print the same messages.
- `internal/validators` is the JS module that exposes the native validators in `NodeValidator.cpp`. `validateObject` is a `$newCppFunction` binding.
- Node's `validateObject(value, name, options)` takes the same bitmask ([validators.js#L224-L270](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L224-L270)). The constants live in both `validators.ts` and `NodeValidator.cpp` and have to match. Both places now cite that source.

<details><summary>Notes</summary>

Messages compared with `node` v26.3.0 for `formatWithOptions`, the `defaultOptions` setter and `stripVTControlCharacters` with `[]`, a function, `null`, `undefined`, `5`, `'test'`, `5n`, a symbol, a `Date`, a null prototype object and `{ depth: 3 }`: identical in every case.

Differences from the deleted copy, all of which now match Node v26:
- functions are rejected by `validateObject`.
- a function without a name renders as `Received function ` (the copy printed `Received type function ([Function (anonymous)])`).
- long bigints and symbols are no longer cut to 25 characters plus `...`. Node v26 does not cut them either. Strings are still cut.

The existing `node-inspect-tests` already assert the `null`, `'bad'` and `inspectOptions` messages and still pass.

`inspect.replDefaults`: Bun defines this accessor eagerly in `inspect.js`. Node only defines it in the standalone REPL (`kStandaloneREPL` in `repl.js`), and that setter also calls `validateObject(options, "options")`. So the setter now rejects functions and arrays the same way the REPL setter does in Node and in Bun's `repl.js`.

Node's whole `test/parallel/test-validators.js` is not vendored here because its `validateArray` block fails on main for an unrelated reason: the `minLength` message renders the name as `type string ('foo')` (`ErrorCode.cpp:1066`) and uses the pre-v26 reason text. That is tracked separately.

Pre-existing and unchanged: `determineSpecificType` prints the inspected value for an object whose `constructor` property is falsy, where Node prints `[Object]`.

Adoption changes on top of the original commit: removed the now unused `ErrorCaptureStackTrace` binding (oxlint failed on it), added the flags test, added the source citations, and made both tests assert the full messages.

`util-inspect.test.js` "no assertion failures 2" and the `parse-args` stress test exceed the 5 s timeout on my debug build with and without this diff (7 to 11 s, host load average about 40). Not related to this change.
</details>
