### PR TITLE
assert: render Myers diffs natively

### DIFF
--- a/src/js/internal/assert/assertion_error.ts
+++ b/src/js/internal/assert/assertion_error.ts
@@ -19,21 +19,12 @@ const StringPrototypeSlice = String.prototype.slice;
 const StringPrototypeSplit = String.prototype.split;
 
 declare namespace Internal {
-  const enum Operation {
-    Insert = 0,
-    Delete = 1,
-    Equal = 2,
-  }
-  interface Diff {
-    kind: Operation;
-    value: string;
-  }
-
-  function myersDiff(actual: string, expected: string, checkCommaDisparity?: boolean, lines?: boolean): string;
-  // todo
-
-  function printMyersDiff(...args: any[]): any;
-  function printSimpleMyersDiff(...args: any[]): any;
+  function printSimpleMyersDiff(actual: string, expected: string): string;
+  function printMyersDiff(
+    actual: string,
+    expected: string,
+    checkCommaDisparity: boolean,
+  ): { message: string; skipped: boolean };
 }
 
 const kReadableOperator = {

--- a/src/js/internal/assert/assertion_error.ts
+++ b/src/js/internal/assert/assertion_error.ts
@@ -4,7 +4,7 @@ const { SafeSet } = require("internal/primordials");
 const { inspect } = require("internal/util/inspect");
 const colors = require("internal/util/colors");
 const { validateObject } = require("internal/validators");
-const { myersDiff, printMyersDiff, printSimpleMyersDiff } = require("internal/assert/myers_diff") as typeof Internal;
+const { printMyersDiff, printSimpleMyersDiff } = require("internal/assert/myers_diff") as typeof Internal;
 
 const ErrorCaptureStackTrace = Error.captureStackTrace;
 const ObjectAssign = Object.assign;
@@ -113,9 +113,7 @@ function getColoredMyersDiff(actual, expected) {
   const header = `${colors.green}actual${colors.white} ${colors.red}expected${colors.white}`;
   const skipped = false;
 
-  // const diff = myersDiff(StringPrototypeSplit.$call(actual, ""), StringPrototypeSplit.$call(expected, ""));
-  const diff = myersDiff(actual, expected, false, false);
-  let message = printSimpleMyersDiff(diff);
+  let message = printSimpleMyersDiff(actual, expected);
 
   if (skipped) {
     message += "...";
@@ -224,8 +222,7 @@ function createErrDiff(actual, expected, operator, customMessage, diffType = "si
     const checkCommaDisparity = actual != null && typeof actual === "object";
     let myersDiffMessage;
     try {
-      const diff = myersDiff(inspectedActual, inspectedExpected, checkCommaDisparity, true);
-      myersDiffMessage = printMyersDiff(diff);
+      myersDiffMessage = printMyersDiff(inspectedActual, inspectedExpected, checkCommaDisparity);
     } catch {
       myersDiffMessage = undefined;
     }

--- a/src/js/internal/assert/myers_diff.ts
+++ b/src/js/internal/assert/myers_diff.ts
@@ -17,95 +17,26 @@ interface Diff {
 }
 
 declare namespace Internal {
-  export function myersDiff(
-    actual: string[],
-    expected: string[],
-    checkCommaDisparity?: boolean,
-    lines?: boolean,
-  ): Diff[];
+  export function myersDiff(actual: string, expected: string, checkCommaDisparity?: boolean, lines?: boolean): Diff[];
+  /** Diffs by char and renders the `printSimpleMyersDiff` string. */
+  export function printSimpleMyersDiff(actual: string, expected: string, colors: object): string;
+  /** Diffs by line and renders the `printMyersDiff` message, collapsing long unchanged runs. */
+  export function printMyersDiff(
+    actual: string,
+    expected: string,
+    checkCommaDisparity: boolean,
+    colors: object,
+  ): { message: string; skipped: boolean };
 }
 
-const kNopLinesToCollapse = 5;
+const native = $rust("node_assert_binding.rs", "generate") as typeof Internal;
 
-const { myersDiff } = $rust("node_assert_binding.rs", "generate") as typeof Internal;
-
-function printSimpleMyersDiff(diff: Diff[]) {
-  let message = "";
-
-  for (let diffIdx = diff.length - 1; diffIdx >= 0; diffIdx--) {
-    let { kind, value } = diff[diffIdx];
-    if (typeof value === "number") {
-      value = String.fromCharCode(value);
-    }
-    switch (kind) {
-      case Operation.Insert:
-        message += `${colors.green}${value}${colors.white}`;
-        break;
-      case Operation.Delete:
-        message += `${colors.red}${value}${colors.white}`;
-        break;
-      case Operation.Equal:
-        message += `${colors.white}${value}${colors.white}`;
-        break;
-      default:
-        throw new TypeError(`Invalid diff operation kind: ${kind}`); // should be unreachable
-    }
-  }
-
-  return `\n${message}`;
+function printSimpleMyersDiff(actual: string, expected: string) {
+  return native.printSimpleMyersDiff(actual, expected, colors);
 }
 
-function printMyersDiff(diff: Diff[], _simple = false) {
-  let message = "";
-  let skipped = false;
-  let nopCount = 0;
-
-  for (let diffIdx = diff.length - 1; diffIdx >= 0; diffIdx--) {
-    const { kind, value } = diff[diffIdx];
-    $assert(
-      typeof value !== "number",
-      "printMyersDiff is only called for line diffs, which never return numeric char code values.",
-    );
-    const previousType = diffIdx < diff.length - 1 ? diff[diffIdx + 1].kind : null;
-    const typeChanged = previousType && kind !== previousType;
-
-    if (typeChanged && previousType === Operation.Equal) {
-      // Avoid grouping if only one line would have been grouped otherwise
-      if (nopCount === kNopLinesToCollapse + 1) {
-        message += `${colors.white}  ${diff[diffIdx + 1].value}\n`;
-      } else if (nopCount === kNopLinesToCollapse + 2) {
-        message += `${colors.white}  ${diff[diffIdx + 2].value}\n`;
-        message += `${colors.white}  ${diff[diffIdx + 1].value}\n`;
-      }
-      if (nopCount >= kNopLinesToCollapse + 3) {
-        message += `${colors.blue}...${colors.white}\n`;
-        message += `${colors.white}  ${diff[diffIdx + 1].value}\n`;
-        skipped = true;
-      }
-      nopCount = 0;
-    }
-
-    switch (kind) {
-      case Operation.Insert:
-        message += `${colors.green}+${colors.white} ${value}\n`;
-        break;
-      case Operation.Delete:
-        message += `${colors.red}-${colors.white} ${value}\n`;
-        break;
-      case Operation.Equal:
-        if (nopCount < kNopLinesToCollapse) {
-          message += `${colors.white}  ${value}\n`;
-        }
-        nopCount++;
-        break;
-      default:
-        throw new TypeError(`Invalid diff operation kind: ${kind}`); // should be unreachable
-    }
-  }
-
-  message = message.trimEnd();
-
-  return { message: `\n${message}`, skipped };
+function printMyersDiff(actual: string, expected: string, checkCommaDisparity: boolean) {
+  return native.printMyersDiff(actual, expected, checkCommaDisparity, colors);
 }
 
-export default { myersDiff, printMyersDiff, printSimpleMyersDiff };
+export default { myersDiff: native.myersDiff, printMyersDiff, printSimpleMyersDiff };

--- a/src/runtime/node/node_assert.rs
+++ b/src/runtime/node/node_assert.rs
@@ -1,7 +1,7 @@
 use bun_core::String as BunString;
 use bun_core::strings::EncodingNonAscii;
 use bun_jsc::js_object::PojoFields;
-use bun_jsc::{FromAny, JSGlobalObject, JSObject, JSValue, JsError, JsResult};
+use bun_jsc::{FromAny, JSGlobalObject, JSObject, JSValue, JsError, JsResult, StringJsc};
 
 use super::assert::myers_diff as MyersDiff;
 use super::assert::myers_diff::{Diff, DiffKind, Line};
@@ -27,6 +27,7 @@ pub(crate) fn myers_diff(
     check_comma_disparity: bool,
     // split `actual` and `expected` into lines before diffing
     lines: bool,
+    output: Output<'_>,
 ) -> JsResult<JSValue> {
     // Short circuit on empty strings. Note that, in release builds where
     // assertions are disabled, if `actual` and `expected` are both dead, this
@@ -34,66 +35,57 @@ pub(crate) fn myers_diff(
     // moot since BunStrings with non-zero reference counds should never be
     // dead.
     if actual.length() == 0 && expected.length() == 0 {
-        return JSValue::create_empty_array(global, 0);
+        return emit::<u8, u8>(global, &Vec::new(), &output);
     }
 
-    let actual_encoding = actual.encoding();
-    let expected_encoding = expected.encoding();
-
-    if lines {
-        if actual_encoding != expected_encoding {
-            let actual_utf8 = actual.to_utf8_without_ref();
-            let expected_utf8 = expected.to_utf8_without_ref();
-
-            return diff_lines::<u8>(
-                global,
-                actual_utf8.slice(),
-                expected_utf8.slice(),
-                check_comma_disparity,
-            );
-        }
-
-        return match actual_encoding {
-            EncodingNonAscii::Latin1 | EncodingNonAscii::Utf8 => diff_lines::<u8>(
-                global,
-                actual.byte_slice(),
-                expected.byte_slice(),
-                check_comma_disparity,
-            ),
-            EncodingNonAscii::Utf16 => diff_lines::<u16>(
-                global,
-                actual.utf16(),
-                expected.utf16(),
-                check_comma_disparity,
-            ),
+    // JS strings arrive as Latin-1 or UTF-16. When the two sides differ, widen the
+    // Latin-1 side so both diff over the same code unit.
+    let actual_is_16 = actual.encoding() == EncodingNonAscii::Utf16;
+    let expected_is_16 = expected.encoding() == EncodingNonAscii::Utf16;
+    if !actual_is_16 && !expected_is_16 {
+        let (a, e) = (actual.byte_slice(), expected.byte_slice());
+        return if lines {
+            diff_lines::<u8>(global, a, e, check_comma_disparity, &output)
+        } else {
+            diff_chars::<u8>(global, a, e, &output)
         };
     }
 
-    if actual_encoding != expected_encoding {
-        let _actual_utf8 = actual.to_utf8_without_ref();
-        let _expected_utf8 = expected.to_utf8_without_ref();
-
-        // Intentionally diffs the original byte slices, not the just-computed utf8
-        // slices — preserved verbatim for behavioral parity with the original
-        // implementation, which did the same (likely a pre-existing bug there).
-        return diff_chars::<u8>(global, actual.byte_slice(), expected.byte_slice());
-    }
-
-    match actual_encoding {
-        EncodingNonAscii::Latin1 | EncodingNonAscii::Utf8 => {
-            diff_chars::<u8>(global, actual.byte_slice(), expected.byte_slice())
-        }
-        EncodingNonAscii::Utf16 => diff_chars::<u16>(global, actual.utf16(), expected.utf16()),
+    let widen =
+        |s: &BunString| -> Vec<u16> { s.byte_slice().iter().map(|&b| u16::from(b)).collect() };
+    let actual_wide: Vec<u16>;
+    let expected_wide: Vec<u16>;
+    let a: &[u16] = if actual_is_16 {
+        actual.utf16()
+    } else {
+        actual_wide = widen(actual);
+        &actual_wide
+    };
+    let e: &[u16] = if expected_is_16 {
+        expected.utf16()
+    } else {
+        expected_wide = widen(expected);
+        &expected_wide
+    };
+    if lines {
+        diff_lines::<u16>(global, a, e, check_comma_disparity, &output)
+    } else {
+        diff_chars::<u16>(global, a, e, &output)
     }
 }
 
-fn diff_chars<T>(global: &JSGlobalObject, actual: &[T], expected: &[T]) -> JsResult<JSValue>
+fn diff_chars<T>(
+    global: &JSGlobalObject,
+    actual: &[T],
+    expected: &[T],
+    output: &Output<'_>,
+) -> JsResult<JSValue>
 where
-    T: Line + FromAny,
+    T: Line + FromAny + CodeUnit + DiffText<T>,
 {
     let diff: MyersDiff::DiffList<T> = MyersDiff::Differ::<T, false>::diff(actual, expected)
         .map_err(|err| map_diff_error(global, err))?;
-    diff_list_to_js(global, &diff)
+    emit::<T, T>(global, &diff, output)
 }
 
 fn diff_lines<'s, T>(
@@ -101,10 +93,11 @@ fn diff_lines<'s, T>(
     actual: &'s [T],
     expected: &'s [T],
     check_comma_disparity: bool,
+    output: &Output<'_>,
 ) -> JsResult<JSValue>
 where
-    T: PartialEq + Copy + From<u8>,
-    &'s [T]: Line + FromAny,
+    T: PartialEq + Copy + From<u8> + CodeUnit,
+    &'s [T]: Line + FromAny + DiffText<T>,
 {
     let a = MyersDiff::split::<T>(actual);
     let e = MyersDiff::split::<T>(expected);
@@ -116,7 +109,7 @@ where
         MyersDiff::Differ::<&'s [T], false>::diff(a.as_slice(), e.as_slice())
             .map_err(|err| map_diff_error(global, err))?
     };
-    diff_list_to_js(global, &diff)
+    emit::<T, &'s [T]>(global, &diff, output)
 }
 
 fn diff_list_to_js<T>(
@@ -129,6 +122,215 @@ where
     JSValue::create_array_from_iter(global, diff_list.iter(), |line| {
         Ok(JSObject::create_null_proto(line, global)?.to_js())
     })
+}
+
+/// What `myers_diff` should hand back to JS.
+pub(crate) enum Output<'a> {
+    /// `Diff[]` — `{ kind, value }` objects (internal/assert/myers_diff `myersDiff`).
+    List,
+    /// The `printSimpleMyersDiff` string for a char diff.
+    Simple(&'a Colors),
+    /// The `printMyersDiff` `{ message, skipped }` object for a line diff.
+    Lines(&'a Colors),
+}
+
+/// ANSI sequences from internal/util/colors (empty when colors are off).
+pub(crate) struct Colors {
+    pub green: Vec<u8>,
+    pub red: Vec<u8>,
+    pub white: Vec<u8>,
+    pub blue: Vec<u8>,
+}
+
+/// Output code unit: Latin-1 bytes or UTF-16.
+pub(crate) trait CodeUnit: Copy + From<u8> + PartialEq {
+    fn to_bun_string(out: &[Self]) -> BunString;
+    fn as_u32(self) -> u32;
+}
+impl CodeUnit for u8 {
+    fn to_bun_string(out: &[u8]) -> BunString {
+        BunString::clone_latin1(out)
+    }
+    fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+impl CodeUnit for u16 {
+    fn to_bun_string(out: &[u16]) -> BunString {
+        BunString::clone_utf16(out)
+    }
+    fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// A diff value (single char or borrowed line) that can be appended to the output.
+pub(crate) trait DiffText<C: CodeUnit>: Copy {
+    fn append_to(self, out: &mut Vec<C>);
+}
+impl DiffText<u8> for u8 {
+    fn append_to(self, out: &mut Vec<u8>) {
+        out.push(self);
+    }
+}
+impl DiffText<u16> for u16 {
+    fn append_to(self, out: &mut Vec<u16>) {
+        out.push(self);
+    }
+}
+impl<'a, C: CodeUnit> DiffText<C> for &'a [C] {
+    fn append_to(self, out: &mut Vec<C>) {
+        out.extend_from_slice(self);
+    }
+}
+
+#[inline]
+fn append_ascii<C: CodeUnit>(out: &mut Vec<C>, bytes: &[u8]) {
+    out.extend(bytes.iter().map(|&b| C::from(b)));
+}
+
+/// `String.prototype.trimEnd` whitespace set (WhiteSpace + LineTerminator).
+fn is_js_whitespace(c: u32) -> bool {
+    matches!(
+        c,
+        0x09..=0x0D
+            | 0x20
+            | 0xA0
+            | 0x1680
+            | 0x2000..=0x200A
+            | 0x2028
+            | 0x2029
+            | 0x202F
+            | 0x205F
+            | 0x3000
+            | 0xFEFF
+    )
+}
+
+fn emit<C, T>(
+    global: &JSGlobalObject,
+    diff_list: &MyersDiff::DiffList<T>,
+    output: &Output<'_>,
+) -> JsResult<JSValue>
+where
+    C: CodeUnit,
+    T: FromAny + Copy + DiffText<C>,
+{
+    match output {
+        Output::List => diff_list_to_js(global, diff_list),
+        Output::Simple(colors) => {
+            let out = render_simple::<C, T>(diff_list, colors);
+            C::to_bun_string(&out).transfer_to_js(global)
+        }
+        Output::Lines(colors) => {
+            let (out, skipped) = render_lines::<C, T>(diff_list, colors);
+            let result = JSValue::create_empty_object(global, 2);
+            result.put(
+                global,
+                BunString::static_(b"message"),
+                C::to_bun_string(&out).transfer_to_js(global)?,
+            );
+            result.put(
+                global,
+                BunString::static_(b"skipped"),
+                JSValue::from(skipped),
+            );
+            Ok(result)
+        }
+    }
+}
+
+/// internal/assert/myers_diff `printSimpleMyersDiff`: the char diff inline, colored per op.
+fn render_simple<C: CodeUnit, T: DiffText<C>>(diff: &[Diff<T>], colors: &Colors) -> Vec<C> {
+    let mut out: Vec<C> = Vec::with_capacity(diff.len() + 1);
+    append_ascii(&mut out, b"\n");
+    for d in diff.iter().rev() {
+        let color = match d.kind {
+            DiffKind::Insert => &colors.green,
+            DiffKind::Delete => &colors.red,
+            DiffKind::Equal => &colors.white,
+        };
+        append_ascii(&mut out, color);
+        d.value.append_to(&mut out);
+        append_ascii(&mut out, &colors.white);
+    }
+    out
+}
+
+/// internal/assert/myers_diff `printMyersDiff`: one line per entry with `+`/`-`/`  `
+/// prefixes, collapsing runs of more than 5 unchanged lines into `...`.
+fn render_lines<C: CodeUnit, T: DiffText<C>>(diff: &[Diff<T>], colors: &Colors) -> (Vec<C>, bool) {
+    const NOP_LINES_TO_COLLAPSE: usize = 5;
+    let mut out: Vec<C> = Vec::new();
+    append_ascii(&mut out, b"\n");
+    let mut skipped = false;
+    let mut nop_count: usize = 0;
+
+    let equal_line = |out: &mut Vec<C>, value: T| {
+        append_ascii(out, &colors.white);
+        append_ascii(out, b"  ");
+        value.append_to(out);
+        append_ascii(out, b"\n");
+    };
+
+    for idx in (0..diff.len()).rev() {
+        let Diff { kind, value } = diff[idx];
+        let previous_kind = if idx + 1 < diff.len() {
+            Some(diff[idx + 1].kind)
+        } else {
+            None
+        };
+
+        if previous_kind == Some(DiffKind::Equal) && kind != DiffKind::Equal {
+            // Avoid grouping if only one line would have been grouped otherwise
+            if nop_count == NOP_LINES_TO_COLLAPSE + 1 {
+                equal_line(&mut out, diff[idx + 1].value);
+            } else if nop_count == NOP_LINES_TO_COLLAPSE + 2 {
+                equal_line(&mut out, diff[idx + 2].value);
+                equal_line(&mut out, diff[idx + 1].value);
+            }
+            if nop_count >= NOP_LINES_TO_COLLAPSE + 3 {
+                append_ascii(&mut out, &colors.blue);
+                append_ascii(&mut out, b"...");
+                append_ascii(&mut out, &colors.white);
+                append_ascii(&mut out, b"\n");
+                equal_line(&mut out, diff[idx + 1].value);
+                skipped = true;
+            }
+            nop_count = 0;
+        }
+
+        match kind {
+            DiffKind::Insert => {
+                append_ascii(&mut out, &colors.green);
+                append_ascii(&mut out, b"+");
+                append_ascii(&mut out, &colors.white);
+                append_ascii(&mut out, b" ");
+                value.append_to(&mut out);
+                append_ascii(&mut out, b"\n");
+            }
+            DiffKind::Delete => {
+                append_ascii(&mut out, &colors.red);
+                append_ascii(&mut out, b"-");
+                append_ascii(&mut out, &colors.white);
+                append_ascii(&mut out, b" ");
+                value.append_to(&mut out);
+                append_ascii(&mut out, b"\n");
+            }
+            DiffKind::Equal => {
+                if nop_count < NOP_LINES_TO_COLLAPSE {
+                    equal_line(&mut out, value);
+                }
+                nop_count += 1;
+            }
+        }
+    }
+
+    // `message.trimEnd()` (the leading "\n" is prepended after trimming in JS, so keep it).
+    while out.len() > 1 && is_js_whitespace(out[out.len() - 1].as_u32()) {
+        out.pop();
+    }
+    (out, skipped)
 }
 
 /// Field reflection for `Diff<T>` so [`JSObject::create_null_proto`] can

--- a/src/runtime/node/node_assert.rs
+++ b/src/runtime/node/node_assert.rs
@@ -7,27 +7,19 @@ use super::assert::myers_diff as MyersDiff;
 use super::assert::myers_diff::{Diff, DiffKind, Line};
 
 /// Compare `actual` and `expected`, producing a diff that would turn `actual`
-/// into `expected`.
+/// into `expected`, and hand it to JS in the shape `output` asks for.
 ///
-/// Lines in the returned diff have the same encoding as `actual` and
-/// `expected`. Lines borrow from these inputs, but the diff list itself must
-/// be deallocated.
-///
-/// Use an arena allocator, otherwise this will leak memory.
+/// The result has the encoding of the inputs: Latin-1 when both sides are
+/// Latin-1, otherwise UTF-16.
 ///
 /// ## Invariants
 /// If not met, this function will panic.
-/// - `actual` and `expected` are alive and have the same encoding.
+/// - `actual` and `expected` are alive.
 pub(crate) fn myers_diff(
     global: &JSGlobalObject,
     actual: &BunString,
     expected: &BunString,
-    // If true, strings that have a trailing comma but are otherwise equal are
-    // considered equal.
-    check_comma_disparity: bool,
-    // split `actual` and `expected` into lines before diffing
-    lines: bool,
-    output: Output<'_>,
+    output: &Output<'_>,
 ) -> JsResult<JSValue> {
     // Short circuit on empty strings. Note that, in release builds where
     // assertions are disabled, if `actual` and `expected` are both dead, this
@@ -35,8 +27,20 @@ pub(crate) fn myers_diff(
     // moot since BunStrings with non-zero reference counds should never be
     // dead.
     if actual.length() == 0 && expected.length() == 0 {
-        return emit::<u8, u8>(global, &Vec::new(), &output);
+        return emit::<u8, u8>(global, &Vec::new(), output);
     }
+
+    let (lines, check_comma_disparity) = match *output {
+        Output::List {
+            lines,
+            check_comma_disparity,
+        } => (lines, check_comma_disparity),
+        Output::Simple(_) => (false, false),
+        Output::Lines {
+            check_comma_disparity,
+            ..
+        } => (true, check_comma_disparity),
+    };
 
     // JS strings arrive as Latin-1 or UTF-16. When the two sides differ, widen the
     // Latin-1 side so both diff over the same code unit.
@@ -45,9 +49,9 @@ pub(crate) fn myers_diff(
     if !actual_is_16 && !expected_is_16 {
         let (a, e) = (actual.byte_slice(), expected.byte_slice());
         return if lines {
-            diff_lines::<u8>(global, a, e, check_comma_disparity, &output)
+            diff_lines::<u8>(global, a, e, check_comma_disparity, output)
         } else {
-            diff_chars::<u8>(global, a, e, &output)
+            diff_chars::<u8>(global, a, e, output)
         };
     }
 
@@ -68,9 +72,9 @@ pub(crate) fn myers_diff(
         &expected_wide
     };
     if lines {
-        diff_lines::<u16>(global, a, e, check_comma_disparity, &output)
+        diff_lines::<u16>(global, a, e, check_comma_disparity, output)
     } else {
-        diff_chars::<u16>(global, a, e, &output)
+        diff_chars::<u16>(global, a, e, output)
     }
 }
 
@@ -124,14 +128,24 @@ where
     })
 }
 
-/// What `myers_diff` should hand back to JS.
+/// What `myers_diff` should hand back to JS. The variant also decides how the
+/// inputs are diffed: by char or by line.
 pub(crate) enum Output<'a> {
-    /// `Diff[]` — `{ kind, value }` objects (internal/assert/myers_diff `myersDiff`).
-    List,
+    /// `Diff[]` of `{ kind, value }` objects (internal/assert/myers_diff `myersDiff`).
+    List {
+        /// Split `actual` and `expected` into lines before diffing.
+        lines: bool,
+        /// Lines that differ only by a trailing comma compare equal.
+        check_comma_disparity: bool,
+    },
     /// The `printSimpleMyersDiff` string for a char diff.
     Simple(&'a Colors),
     /// The `printMyersDiff` `{ message, skipped }` object for a line diff.
-    Lines(&'a Colors),
+    Lines {
+        colors: &'a Colors,
+        /// Lines that differ only by a trailing comma compare equal.
+        check_comma_disparity: bool,
+    },
 }
 
 /// ANSI sequences from internal/util/colors (empty when colors are off).
@@ -216,13 +230,13 @@ where
     C: CodeUnit,
     T: FromAny + Copy + DiffText<C>,
 {
-    match output {
-        Output::List => diff_list_to_js(global, diff_list),
+    match *output {
+        Output::List { .. } => diff_list_to_js(global, diff_list),
         Output::Simple(colors) => {
             let out = render_simple::<C, T>(diff_list, colors);
             C::to_bun_string(&out).transfer_to_js(global)
         }
-        Output::Lines(colors) => {
+        Output::Lines { colors, .. } => {
             let (out, skipped) = render_lines::<C, T>(diff_list, colors);
             let result = JSValue::create_empty_object(global, 2);
             result.put(

--- a/src/runtime/node/node_assert_binding.rs
+++ b/src/runtime/node/node_assert_binding.rs
@@ -14,19 +14,86 @@ use super::node_assert;
 /// ```
 #[bun_jsc::host_fn]
 fn myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let check_comma_disparity = frame.argument(2).is_truthy();
+    let lines = frame.argument(3).is_truthy();
+    run(
+        global,
+        frame,
+        "myersDiff",
+        check_comma_disparity,
+        lines,
+        node_assert::Output::List,
+    )
+}
+
+/// `printSimpleMyersDiff(actual, expected, colors)`: char diff rendered to a string.
+#[bun_jsc::host_fn]
+fn print_simple_myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let colors = colors_from_js(global, frame.argument(2))?;
+    run(
+        global,
+        frame,
+        "printSimpleMyersDiff",
+        false,
+        false,
+        node_assert::Output::Simple(&colors),
+    )
+}
+
+/// `printMyersDiff(actual, expected, checkCommaDisparity, colors)`: line diff rendered to
+/// `{ message, skipped }`.
+#[bun_jsc::host_fn]
+fn print_myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let check_comma_disparity = frame.argument(2).is_truthy();
+    let colors = colors_from_js(global, frame.argument(3))?;
+    run(
+        global,
+        frame,
+        "printMyersDiff",
+        check_comma_disparity,
+        true,
+        node_assert::Output::Lines(&colors),
+    )
+}
+
+/// Reads `{ green, red, white, blue }` (internal/util/colors) as ASCII escape sequences.
+fn colors_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<node_assert::Colors> {
+    let get = |name: &'static str| -> JsResult<Vec<u8>> {
+        if !value.is_object() {
+            return Ok(Vec::new());
+        }
+        let Some(v) = value.get(global, name)? else {
+            return Ok(Vec::new());
+        };
+        if !v.is_string() {
+            return Ok(Vec::new());
+        }
+        let s = bstring::OwnedString::new(v.to_bun_string(global)?);
+        Ok(s.to_utf8_without_ref().slice().to_vec())
+    };
+    Ok(node_assert::Colors {
+        green: get("green")?,
+        red: get("red")?,
+        white: get("white")?,
+        blue: get("blue")?,
+    })
+}
+
+fn run(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    name: &'static str,
+    check_comma_disparity: bool,
+    lines: bool,
+    output: node_assert::Output<'_>,
+) -> JsResult<JSValue> {
     let nargs = frame.arguments_count();
     if nargs < 2 {
-        return Err(global.throw_not_enough_arguments("printMyersDiff", 2, nargs as usize));
+        return Err(global.throw_not_enough_arguments(name, 2, nargs as usize));
     }
 
     let actual_arg: JSValue = frame.argument(0);
     let expected_arg: JSValue = frame.argument(1);
-    let (check_comma_disparity, lines): (bool, bool) = match nargs {
-        0 | 1 => unreachable!(),
-        2 => (false, false),
-        3 => (frame.argument(2).is_truthy(), false),
-        _ => (frame.argument(2).is_truthy(), frame.argument(3).is_truthy()),
-    };
 
     if !actual_arg.is_string() {
         return Err(global.throw_invalid_argument_type_value("actual", "string", actual_arg));
@@ -44,19 +111,19 @@ fn myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     debug_assert!(expected_str.tag() != bstring::Tag::Dead);
 
     node_assert::myers_diff(
-        // allocator param dropped (was arena-backed; non-AST crate uses global mimalloc)
         global,
         &actual_str,
         &expected_str,
         check_comma_disparity,
         lines,
+        output,
     )
 }
 
 // =============================================================================
 
 pub(crate) fn generate(global: &JSGlobalObject) -> JSValue {
-    let exports = JSValue::create_empty_object(global, 1);
+    let exports = JSValue::create_empty_object(global, 3);
 
     exports.put(
         global,
@@ -66,6 +133,28 @@ pub(crate) fn generate(global: &JSGlobalObject) -> JSValue {
             "myersDiff",
             __jsc_host_myers_diff,
             2,
+            Default::default(),
+        ),
+    );
+    exports.put(
+        global,
+        bstring::String::static_(b"printSimpleMyersDiff"),
+        JSFunction::create(
+            global,
+            "printSimpleMyersDiff",
+            __jsc_host_print_simple_myers_diff,
+            3,
+            Default::default(),
+        ),
+    );
+    exports.put(
+        global,
+        bstring::String::static_(b"printMyersDiff"),
+        JSFunction::create(
+            global,
+            "printMyersDiff",
+            __jsc_host_print_myers_diff,
+            4,
             Default::default(),
         ),
     );

--- a/src/runtime/node/node_assert_binding.rs
+++ b/src/runtime/node/node_assert_binding.rs
@@ -9,21 +9,22 @@ use super::node_assert;
 ///     Delete = 1,
 ///     Equal  = 2,
 /// }
-/// type Diff = { operation: DiffType, text: string };
-/// declare function myersDiff(actual: string, expected: string): Diff[];
+/// // `value` is a line, or a char code when `lines` is false.
+/// type Diff = { kind: DiffType, value: string | number };
+/// declare function myersDiff(
+///     actual: string,
+///     expected: string,
+///     checkCommaDisparity?: boolean,
+///     lines?: boolean,
+/// ): Diff[];
 /// ```
 #[bun_jsc::host_fn]
 fn myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    let check_comma_disparity = frame.argument(2).is_truthy();
-    let lines = frame.argument(3).is_truthy();
-    run(
-        global,
-        frame,
-        "myersDiff",
-        check_comma_disparity,
-        lines,
-        node_assert::Output::List,
-    )
+    let output = node_assert::Output::List {
+        check_comma_disparity: frame.argument(2).is_truthy(),
+        lines: frame.argument(3).is_truthy(),
+    };
+    run(global, frame, "myersDiff", &output)
 }
 
 /// `printSimpleMyersDiff(actual, expected, colors)`: char diff rendered to a string.
@@ -34,9 +35,7 @@ fn print_simple_myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         global,
         frame,
         "printSimpleMyersDiff",
-        false,
-        false,
-        node_assert::Output::Simple(&colors),
+        &node_assert::Output::Simple(&colors),
     )
 }
 
@@ -46,14 +45,11 @@ fn print_simple_myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 fn print_myers_diff(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let check_comma_disparity = frame.argument(2).is_truthy();
     let colors = colors_from_js(global, frame.argument(3))?;
-    run(
-        global,
-        frame,
-        "printMyersDiff",
+    let output = node_assert::Output::Lines {
+        colors: &colors,
         check_comma_disparity,
-        true,
-        node_assert::Output::Lines(&colors),
-    )
+    };
+    run(global, frame, "printMyersDiff", &output)
 }
 
 /// Reads `{ green, red, white, blue }` (internal/util/colors) as ASCII escape sequences.
@@ -83,9 +79,7 @@ fn run(
     global: &JSGlobalObject,
     frame: &CallFrame,
     name: &'static str,
-    check_comma_disparity: bool,
-    lines: bool,
-    output: node_assert::Output<'_>,
+    output: &node_assert::Output<'_>,
 ) -> JsResult<JSValue> {
     let nargs = frame.arguments_count();
     if nargs < 2 {
@@ -110,14 +104,7 @@ fn run(
     debug_assert!(actual_str.tag() != bstring::Tag::Dead);
     debug_assert!(expected_str.tag() != bstring::Tag::Dead);
 
-    node_assert::myers_diff(
-        global,
-        &actual_str,
-        &expected_str,
-        check_comma_disparity,
-        lines,
-        output,
-    )
+    node_assert::myers_diff(global, &actual_str, &expected_str, output)
 }
 
 // =============================================================================

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -92,3 +92,41 @@ describe("assert.partialDeepStrictEqual", () => {
     assert.partialDeepStrictEqual([arr], arr);
   });
 });
+
+describe("AssertionError diff rendering", () => {
+  // Expected messages captured from node v24 (ANSI stripped).
+  const messageOf = fn => {
+    try {
+      fn();
+    } catch (e) {
+      return Bun.stripANSI(e.message);
+    }
+    throw new Error("did not throw");
+  };
+
+  test("line diff keeps Latin-1 text and trailing spaces intact", () => {
+    expect(messageOf(() => assert.deepStrictEqual({ s: "línea\nütf" }, { s: "linea\nutf" }))).toBe(
+      "Expected values to be strictly deep-equal:\n+ actual - expected\n\n  {\n+   s: 'línea\\nütf'\n-   s: 'linea\\nutf'\n  }\n",
+    );
+    expect(messageOf(() => assert.deepStrictEqual({ k: "v    " }, { k: "w" }))).toBe(
+      "Expected values to be strictly deep-equal:\n+ actual - expected\n\n  {\n+   k: 'v    '\n-   k: 'w'\n  }\n",
+    );
+  });
+
+  test("mixed Latin-1 / UTF-16 sides diff by code unit", () => {
+    expect(messageOf(() => assert.deepStrictEqual({ s: "café\nx" }, { s: "😀\nx" }))).toBe(
+      "Expected values to be strictly deep-equal:\n+ actual - expected\n\n  {\n+   s: 'café\\nx'\n-   s: '😀\\nx'\n  }\n",
+    );
+    expect(messageOf(() => assert.strictEqual("café", "caf😀"))).toBe(
+      "Expected values to be strictly equal:\n\n'café' !== 'caf😀'\n",
+    );
+  });
+
+  test("long unchanged runs collapse with ... and report skipped lines", () => {
+    const a = Array.from({ length: 30 }, (_, i) => i);
+    const b = a.map((v, i) => (i === 3 || i === 25 ? -1 : v));
+    expect(messageOf(() => assert.deepStrictEqual(a, b))).toBe(
+      "Expected values to be strictly deep-equal:\n+ actual - expected\n... Skipped lines\n\n  [\n    0,\n    1,\n    2,\n+   3,\n-   -1,\n    4,\n    5,\n    6,\n    7,\n    8,\n...\n    24,\n+   25,\n-   -1,\n    26,\n    27,\n    28,\n    29\n  ]\n",
+    );
+  });
+});

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const { bunEnv, bunExe } = require("harness");
 
 test("assert from require as a function does not throw", () => assert(true));
 test("assert from require as a function does throw", () => {
@@ -113,12 +114,20 @@ describe("AssertionError diff rendering", () => {
     );
   });
 
+  test("line diff prints UTF-16 lines as text", () => {
+    expect(messageOf(() => assert.deepStrictEqual({ s: "😀\nx" }, { s: "😺\nx" }))).toBe(
+      "Expected values to be strictly deep-equal:\n+ actual - expected\n\n  {\n+   s: '😀\\nx'\n-   s: '😺\\nx'\n  }\n",
+    );
+    const a = Array.from({ length: 30 }, (_, i) => `値${i}`);
+    const b = a.map((v, i) => (i === 2 || i === 27 ? "x" : v));
+    expect(messageOf(() => assert.deepStrictEqual(a, b))).toBe(
+      "Expected values to be strictly deep-equal:\n+ actual - expected\n... Skipped lines\n\n  [\n    '値0',\n    '値1',\n+   '値2',\n-   'x',\n    '値3',\n    '値4',\n    '値5',\n    '値6',\n    '値7',\n...\n    '値26',\n+   '値27',\n-   'x',\n    '値28',\n    '値29'\n  ]\n",
+    );
+  });
+
   test("mixed Latin-1 / UTF-16 sides diff by code unit", () => {
     expect(messageOf(() => assert.deepStrictEqual({ s: "café\nx" }, { s: "😀\nx" }))).toBe(
       "Expected values to be strictly deep-equal:\n+ actual - expected\n\n  {\n+   s: 'café\\nx'\n-   s: '😀\\nx'\n  }\n",
-    );
-    expect(messageOf(() => assert.strictEqual("café", "caf😀"))).toBe(
-      "Expected values to be strictly equal:\n\n'café' !== 'caf😀'\n",
     );
   });
 
@@ -128,5 +137,47 @@ describe("AssertionError diff rendering", () => {
     expect(messageOf(() => assert.deepStrictEqual(a, b))).toBe(
       "Expected values to be strictly deep-equal:\n+ actual - expected\n... Skipped lines\n\n  [\n    0,\n    1,\n    2,\n+   3,\n-   -1,\n    4,\n    5,\n    6,\n    7,\n    8,\n...\n    24,\n+   25,\n-   -1,\n    26,\n    27,\n    28,\n    29\n  ]\n",
     );
+  });
+
+  // The per-character diff is only used when colors are on, so it runs in a child with FORCE_COLOR.
+  test("colored char diff handles Latin-1, UTF-16 and mixed inputs", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const assert = require("node:assert");
+         const messageOf = fn => { try { fn(); } catch (e) { return e.message; } };
+         console.log(JSON.stringify([
+           messageOf(() => assert.strictEqual("wörld, hello!", "world, hello!")),
+           messageOf(() => assert.strictEqual("a😀b, hello!", "a😺b, hello!")),
+           messageOf(() => assert.strictEqual("wörld, hello!", "😀rld, hello!")),
+         ]));`,
+      ],
+      env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+
+    const green = "\x1b[32m";
+    const red = "\x1b[31m";
+    const white = "\x1b[39m";
+    // Every UTF-16 code unit is wrapped in its own color pair, as in node.
+    const wrap = (color, s) =>
+      s
+        .split("")
+        .map(c => `${color}${c}${white}`)
+        .join("");
+    const same = s => wrap(white, s);
+    const added = s => wrap(green, s);
+    const removed = s => wrap(red, s);
+    const charDiff = body =>
+      `Expected values to be strictly equal:\n${green}actual${white} ${red}expected${white}\n\n${body}\n`;
+    expect(JSON.parse(stdout)).toEqual([
+      charDiff(same("'w") + added("ö") + removed("o") + same("rld, hello!'")),
+      charDiff(same("'a\ud83d") + added("\ude00") + removed("\ude3a") + same("b, hello!'")),
+      charDiff(same("'") + added("wö") + removed("😀") + same("rld, hello!'")),
+    ]);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- Native `myersDiff()` returned a JS array of `{ kind, value }` objects, one per line or char. `myers_diff.ts` built the diff text from it.
- The `value` conversion corrupted text. `FromAny for &[u8]` (`src/jsc/JSValue.rs`) decodes a Latin-1 line as UTF-8, so `{ s: "línea" }` printed as `'l�nea'`. `FromAny for &[u16]` returns an array of numbers, so a diff with emoji or CJK on both sides printed `+ 32,32,115,58,...` instead of the line.
- With one Latin-1 side and one UTF-16 side, the char diff compared raw bytes of two encodings and printed garbage.

### Fix
- `printMyersDiff` and `printSimpleMyersDiff` now render in `node_assert.rs`, into one Latin-1 or UTF-16 buffer, and return one string (or `{ message, skipped }`). The JS module only passes the `internal/util/colors` escapes. `myersDiff` (the raw list) is still exported.
- When the encodings differ, the Latin-1 side is widened to UTF-16 first. Both diff kinds then compare code units, as Node does.
- `Output` carries the diff mode (`lines`, `check_comma_disparity`) next to the render mode, so the two can not be mismatched.
- Verified: `test/js/node/assert/assert.test.cjs` (three new tests fail on main), the rest of `test/js/node/assert/` and the 17 vendored `test-assert*.js` files.

### Background
- `deepStrictEqual` diffs the inspected values by line. `strictEqual` on strings diffs by char, only with colors on, so that test spawns a child with `FORCE_COLOR=1`.
- A JS string is stored as Latin-1 or UTF-16. `byte_slice()` / `utf16()` on `bun_core::String` give its code units. Latin-1 bytes above 0x7F are not valid UTF-8.
- `FromAny` is the generic Rust to JS conversion. It has no notion of string encoding.

<details><summary>Notes</summary>

Differential check against Node: 31 `strictEqual` / `deepStrictEqual` / `partialDeepStrictEqual` failures (objects, arrays, comma disparity, `...` collapsing at 6, 7, 8 and 9 equal lines, empty strings, trailing whitespace, Latin-1, UTF-16 and mixed inputs), with and without `FORCE_COLOR`. With this branch the output is byte for byte identical to Node in every case except `partialDeepStrictEqual`, where Node 26 has a newer gray rendering that main does not have either. Against the current release exactly six cases change: the Latin-1, UTF-16 and mixed cases above.

The three new tests that fail on main are the Latin-1 line diff, the UTF-16 line diff, and the colored char diff. The trailing spaces assertion in the Latin-1 test also passes on main. It stays as coverage of the `trimEnd` port in `render_lines`. `test/js/node/assert/` is 411 tests.

The clippy (`needless_pass_by_value`) and mordant (`bare_bool_args`) findings on the first revision are fixed by passing `Output` by reference and moving the two flags into its variants.
</details>
