### PR TITLE
Implement the replacer argument of YAML, TOML and JSON5 stringify

### DIFF
--- a/docs/runtime/json5.mdx
+++ b/docs/runtime/json5.mdx
@@ -153,7 +153,7 @@ JSON5.stringify({ inf: Infinity, ninf: -Infinity, nan: NaN });
 
 The `replacer` argument works like the `replacer` of `JSON.stringify`.
 
-Pass a function to change or drop values. Bun calls it once for the root value, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. Return `undefined` to drop a property. In an array, `undefined` becomes `null`.
+Pass a function to change or drop values. Bun calls it once for the root value, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. Return `undefined` to drop a property. In an array, `undefined` becomes `null`. If the function returns `undefined` for the root value, `JSON5.stringify` returns `undefined`.
 
 ```ts
 const data = { id: 1n, token: "secret", tags: ["a", "b"] };

--- a/docs/runtime/json5.mdx
+++ b/docs/runtime/json5.mdx
@@ -149,6 +149,34 @@ JSON5.stringify({ inf: Infinity, ninf: -Infinity, nan: NaN });
 // {inf:Infinity,ninf:-Infinity,nan:NaN}
 ```
 
+#### Replacer
+
+The `replacer` argument works like the `replacer` of `JSON.stringify`.
+
+Pass a function to change or drop values. Bun calls it once for the root value, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. Return `undefined` to drop a property. In an array, `undefined` becomes `null`.
+
+```ts
+const data = { id: 1n, token: "secret", tags: ["a", "b"] };
+
+JSON5.stringify(data, (key, value) => {
+  if (key === "token") return undefined;
+  if (typeof value === "bigint") return value.toString();
+  return value;
+});
+// {id:'1',tags:['a','b']}
+```
+
+Pass an array of property names to write only those properties. Bun applies the list to every object at every depth and writes the properties in the order of the list. Bun writes every element of an array.
+
+```ts
+JSON5.stringify({ b: 1, a: 2, token: "secret", nested: { a: 3, token: "secret" } }, ["a", "b", "nested"]);
+// {a:2,b:1,nested:{a:3}}
+```
+
+Unlike `JSON.stringify`, Bun does not call `toJSON` methods. The replacer receives values such as `Date` objects as they are.
+
+Bun ignores a `replacer` that is neither a function nor an array, as `JSON.stringify` does.
+
 ---
 
 ## Module Import

--- a/docs/runtime/toml.mdx
+++ b/docs/runtime/toml.mdx
@@ -158,7 +158,7 @@ The `replacer` argument works like the `replacer` of `JSON.stringify`.
 
 Pass a function to change or drop values. Bun calls it once for the document, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. The returned value follows the same rules as any other value:
 
-- `undefined` drops the property.
+- `undefined` drops the property. For the document itself, `TOML.stringify` returns `undefined`.
 - `null` throws.
 - A `Date` or a Temporal value becomes a date/time.
 - An array of objects becomes an array of tables.

--- a/docs/runtime/toml.mdx
+++ b/docs/runtime/toml.mdx
@@ -152,6 +152,47 @@ function, and symbol properties are skipped (inside arrays they throw,
 since TOML arrays cannot have holes), and passing one of those as the
 top-level value returns `undefined`, as `JSON.stringify` does.
 
+#### Replacer
+
+The `replacer` argument works like the `replacer` of `JSON.stringify`.
+
+Pass a function to change or drop values. Bun calls it once for the document, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. The returned value follows the same rules as any other value:
+
+- `undefined` drops the property.
+- `null` throws.
+- A `Date` or a Temporal value becomes a date/time.
+- An array of objects becomes an array of tables.
+
+```ts
+const config = { name: "app", token: "secret", limits: { requests: 100n } };
+
+Bun.TOML.stringify(config, (key, value) => {
+  if (key === "token") return undefined;
+  if (typeof value === "bigint") return Number(value);
+  return value;
+});
+// name = "app"
+//
+// [limits]
+// requests = 100
+```
+
+Pass an array of property names to write only those properties. Bun applies the list to the document and to every table in it, and writes the keys in the order of the list. Bun writes every element of an array.
+
+```ts
+const config = { token: "secret", name: "app", server: { token: "secret", port: 8080 } };
+
+Bun.TOML.stringify(config, ["name", "server", "port"]);
+// name = "app"
+//
+// [server]
+// port = 8080
+```
+
+Unlike `JSON.stringify`, Bun does not call `toJSON` methods. The replacer receives values such as `Date` objects as they are.
+
+Bun ignores a `replacer` that is neither a function nor an array, as `JSON.stringify` does.
+
 ---
 
 ## Module Import

--- a/docs/runtime/yaml.mdx
+++ b/docs/runtime/yaml.mdx
@@ -140,7 +140,7 @@ Bun.YAML.stringify(config, null, 2);
 
 The `replacer` argument works like the `replacer` of `JSON.stringify`.
 
-Pass a function to change or drop values. Bun calls it once for the root value, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. The returned value follows the same rules as any other value. Bun leaves out `undefined`. Bun calls the function once per key an object appears under, as `JSON.stringify` does, so such an object is written once per key instead of once with an anchor and aliases. A cycle keeps its anchor.
+Pass a function to change or drop values. Bun calls it once for the root value, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. The returned value follows the same rules as any other value. Bun leaves out `undefined`, and returns `undefined` when the function drops the root value. Bun calls the function once per key an object appears under, as `JSON.stringify` does, so such an object is written once per key instead of once with an anchor and aliases. A cycle keeps its anchor.
 
 ```ts
 const data = { id: 1n, token: "secret", tags: ["a", "b"] };

--- a/docs/runtime/yaml.mdx
+++ b/docs/runtime/yaml.mdx
@@ -5,7 +5,7 @@ description: Use Bun's built-in support for YAML files through both runtime APIs
 
 In Bun, YAML is a first-class citizen alongside JSON and TOML. You can:
 
-- Parse YAML strings with `Bun.YAML.parse`
+- Parse YAML strings with `Bun.YAML.parse` and write them with `Bun.YAML.stringify`
 - `import` & `require` YAML files as modules at runtime (including hot reloading & watch mode support)
 - `import` & `require` YAML files in frontend apps with Bun's bundler
 
@@ -120,6 +120,49 @@ try {
   console.error("Failed to parse YAML:", error.message);
 }
 ```
+
+### `Bun.YAML.stringify()`
+
+Convert a JavaScript value into a YAML string. Without the `space` argument, Bun writes flow style on one line. With it, Bun writes block style, indented by that many spaces (or by that string):
+
+```ts
+const config = { name: "app", port: 8080 };
+
+Bun.YAML.stringify(config);
+// {name: app,port: 8080}
+
+Bun.YAML.stringify(config, null, 2);
+// name: app
+// port: 8080
+```
+
+#### Replacer
+
+The `replacer` argument works like the `replacer` of `JSON.stringify`.
+
+Pass a function to change or drop values. Bun calls it once for the root value, with the key `""`, and once for every property and array element. The holder of the value is `this`. Bun writes what the function returns. The returned value follows the same rules as any other value. Bun leaves out `undefined`. Bun calls the function once per key an object appears under, as `JSON.stringify` does, so such an object is written once per key instead of once with an anchor and aliases. A cycle keeps its anchor.
+
+```ts
+const data = { id: 1n, token: "secret", tags: ["a", "b"] };
+
+Bun.YAML.stringify(data, (key, value) => {
+  if (key === "token") return undefined;
+  if (typeof value === "bigint") return value.toString();
+  return value;
+});
+// {id: "1",tags: [a,b]}
+```
+
+Pass an array of property names to write only those properties. Bun applies the list to every object at every depth and writes the properties in the order of the list. Bun writes every element of an array.
+
+```ts
+Bun.YAML.stringify({ b: 1, a: 2, token: "secret", nested: { a: 3, token: "secret" } }, ["a", "b", "nested"]);
+// {a: 2,b: 1,nested: {a: 3}}
+```
+
+Unlike `JSON.stringify`, Bun does not call `toJSON` methods. The replacer receives values such as `Date` objects as they are.
+
+Bun ignores a `replacer` that is neither a function nor an array, as `JSON.stringify` does.
 
 ---
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1098,7 +1098,17 @@ declare module "bun" {
      * @category Utilities
      *
      * @param input The JavaScript object to serialize.
-     * @param replacer Not supported; pass `undefined` or `null`.
+     * @param replacer Works like the `replacer` of `JSON.stringify`. A function is
+     * called once for the document (with the key `""`) and once for every property
+     * and array element, with the holder as `this`, and what it returns is written
+     * instead of the value. An array lists the properties to write, for the document
+     * and for every table in it, and puts them in that order; array elements are not
+     * filtered. A value the replacer returns follows the same rules as any other
+     * value: `undefined` drops the property, `null` throws, a `Date` or Temporal
+     * value becomes a date/time, and an array of tables is detected after replacement.
+     * Unlike `JSON.stringify`, no `toJSON` method is called: the replacer receives
+     * values such as `Date` objects as they are. Anything that is neither a function
+     * nor an array is ignored.
      * @param space Accepted for signature parity with `YAML.stringify` and
      * `JSON5.stringify`, but ignored: TOML output is line-oriented.
      * @returns A TOML document string, or `undefined` if the input is `undefined`, a function, or a symbol.
@@ -1108,9 +1118,19 @@ declare module "bun" {
      * import { TOML } from "bun";
      * TOML.stringify({ name: "app", server: { port: 8080 } });
      * // 'name = "app"\n\n[server]\nport = 8080\n'
+     *
+     * TOML.stringify({ name: "app", token: "secret" }, (key, value) => (key === "token" ? undefined : value));
+     * // 'name = "app"\n'
+     *
+     * TOML.stringify({ name: "app", token: "secret", server: { port: 8080 } }, ["name", "server", "port"]);
+     * // 'name = "app"\n\n[server]\nport = 8080\n'
      * ```
      */
-    export function stringify(input: unknown, replacer?: undefined | null, space?: string | number): string | undefined;
+    export function stringify(
+      input: unknown,
+      replacer?: ((this: any, key: string, value: any) => any) | (string | number)[] | null,
+      space?: string | number,
+    ): string | undefined;
   }
 
   /**
@@ -1507,12 +1527,22 @@ declare module "bun" {
      * @category Utilities
      *
      * @param input The JavaScript value to stringify.
-     * @param replacer Not supported.
+     * @param replacer Works like the `replacer` of `JSON.stringify`. A function is
+     * called once for the root value (with the key `""`) and once for every property
+     * and array element, with the holder as `this`, and what it returns is written
+     * instead of the value. An array lists the properties to write, for every object
+     * at every depth, and puts them in that order; array elements are not filtered.
+     * A value the replacer returns follows the same rules as any other value:
+     * `undefined` is left out. A function replacer runs once per key an object
+     * appears under, so such an object is written once per key instead of once with
+     * an anchor and aliases; a cycle keeps its anchor. Unlike `JSON.stringify`, no
+     * `toJSON` method is called: the replacer receives values such as `Date` objects
+     * as they are. Anything that is neither a function nor an array is ignored.
      * @param space A number for how many spaces each level of indentation gets, or a string used as indentation.
      *              Without this parameter, outputs flow-style (single-line) YAML.
      *              With this parameter, outputs block-style (multi-line) YAML.
      *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
-     * @returns A string containing the YAML document.
+     * @returns A YAML string, or `undefined` if the input is `undefined`, a function, or a symbol.
      *
      * @example
      * ```ts
@@ -1532,6 +1562,17 @@ declare module "bun" {
      * // abc: def
      * // num: 123
      *
+     * // With a replacer function
+     * console.log(YAML.stringify({ id: 1n, token: "secret" }, (key, value) => {
+     *   if (key === "token") return undefined;
+     *   return typeof value === "bigint" ? value.toString() : value;
+     * }));
+     * // {id: "1"}
+     *
+     * // With a replacer array
+     * console.log(YAML.stringify({ abc: "def", token: "secret", num: 123 }, ["num", "abc"]));
+     * // {num: 123,abc: def}
+     *
      * const cycle = {};
      * cycle.obj = cycle;
      * console.log(YAML.stringify(cycle, null, 2));
@@ -1539,7 +1580,11 @@ declare module "bun" {
      * // obj: *1
      * ```
      */
-    export function stringify(input: unknown, replacer?: undefined | null, space?: string | number): string;
+    export function stringify(
+      input: unknown,
+      replacer?: ((this: any, key: string, value: any) => any) | (string | number)[] | null,
+      space?: string | number,
+    ): string | undefined;
   }
 
   /**
@@ -2074,14 +2119,23 @@ declare module "bun" {
 
     /**
      * Convert a JavaScript value into a JSON5 string. Object keys that are
-     * valid identifiers are unquoted, strings use double quotes, `Infinity`
+     * valid identifiers are unquoted, strings use single quotes, `Infinity`
      * and `NaN` are represented as literals, and indented output includes
      * trailing commas.
      *
      * @category Utilities
      *
      * @param input The JavaScript value to stringify.
-     * @param replacer Not supported.
+     * @param replacer Works like the `replacer` of `JSON.stringify`. A function is
+     * called once for the root value (with the key `""`) and once for every property
+     * and array element, with the holder as `this`, and what it returns is written
+     * instead of the value. An array lists the properties to write, for every object
+     * at every depth, and puts them in that order; array elements are not filtered.
+     * A value the replacer returns follows the same rules as any other value:
+     * `undefined` drops a property and becomes `null` in an array. Unlike
+     * `JSON.stringify`, no `toJSON` method is called: the replacer receives values
+     * such as `Date` objects as they are. Anything that is neither a function nor an
+     * array is ignored.
      * @param space A number for how many spaces each level of indentation gets, or a string used as indentation.
      *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
      * @returns A JSON5 string, or `undefined` if the input is `undefined`, a function, or a symbol.
@@ -2091,16 +2145,26 @@ declare module "bun" {
      * import { JSON5 } from "bun";
      *
      * console.log(JSON5.stringify({ a: 1, b: "two" }));
-     * // {a:1,b:"two"}
+     * // {a:1,b:'two'}
      *
      * console.log(JSON5.stringify({ a: 1, b: 2 }, null, 2));
      * // {
      * //   a: 1,
      * //   b: 2,
      * // }
+     *
+     * console.log(JSON5.stringify({ a: 1n, b: 2 }, (key, value) => (typeof value === "bigint" ? value.toString() : value)));
+     * // {a:'1',b:2}
+     *
+     * console.log(JSON5.stringify({ a: 1, b: 2, c: 3 }, ["c", "a"]));
+     * // {c:3,a:1}
      * ```
      */
-    export function stringify(input: unknown, replacer?: undefined | null, space?: string | number): string | undefined;
+    export function stringify(
+      input: unknown,
+      replacer?: ((this: any, key: string, value: any) => any) | (string | number)[] | null,
+      space?: string | number,
+    ): string | undefined;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1111,7 +1111,7 @@ declare module "bun" {
      * nor an array is ignored.
      * @param space Accepted for signature parity with `YAML.stringify` and
      * `JSON5.stringify`, but ignored: TOML output is line-oriented.
-     * @returns A TOML document string, or `undefined` if the input is `undefined`, a function, or a symbol.
+     * @returns A TOML document string, or `undefined` if the input, or what the replacer returns for it, is `undefined`, a function, or a symbol.
      *
      * @example
      * ```js
@@ -1542,7 +1542,7 @@ declare module "bun" {
      *              Without this parameter, outputs flow-style (single-line) YAML.
      *              With this parameter, outputs block-style (multi-line) YAML.
      *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
-     * @returns A YAML string, or `undefined` if the input is `undefined`, a function, or a symbol.
+     * @returns A YAML string, or `undefined` if the input, or what the replacer returns for it, is `undefined`, a function, or a symbol.
      *
      * @example
      * ```ts
@@ -2138,7 +2138,7 @@ declare module "bun" {
      * array is ignored.
      * @param space A number for how many spaces each level of indentation gets, or a string used as indentation.
      *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
-     * @returns A JSON5 string, or `undefined` if the input is `undefined`, a function, or a symbol.
+     * @returns A JSON5 string, or `undefined` if the input, or what the replacer returns for it, is `undefined`, a function, or a symbol.
      *
      * @example
      * ```ts

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -284,6 +284,10 @@ impl JSValue {
     pub fn is_array(self) -> bool {
         self.is_cell() && self.js_type().is_array()
     }
+    /// ECMA-262 `IsArray`: [`Self::is_array`], or a `Proxy` of an array. Throws for a revoked `Proxy`.
+    pub fn is_array_including_proxy(self, global: &JSGlobalObject) -> JsResult<bool> {
+        crate::cpp::JSC__JSValue__isArrayIncludingProxy(self, global)
+    }
     #[inline]
     pub fn is_date(self) -> bool {
         self.is_cell() && self.js_type() == JSType::JSDate
@@ -1484,6 +1488,16 @@ impl JSValue {
         host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__putMayBeIndex(self, global, key, value)
         })
+    }
+    /// `[[Get]]` of any key, numeric keys included: the counterpart of [`Self::put_may_be_index`].
+    pub fn get_may_be_index(
+        self,
+        global: &JSGlobalObject,
+        key: &bun_core::String,
+    ) -> JsResult<JSValue> {
+        debug_assert!(self.is_object());
+        // SAFETY: `key` borrows a live `String` for the duration of the call.
+        unsafe { crate::cpp::JSC__JSValue__getMayBeIndex(self, global, key) }
     }
     pub fn put_to_property_key(
         target: JSValue,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4203,6 +4203,26 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__putMayBeIndex(JSC::Enco
     RETURN_IF_EXCEPTION(scope, );
 }
 
+// [[Get]] of any property name, index names included: the counterpart of JSC__JSValue__putMayBeIndex.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getMayBeIndex(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const BunString* key)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::Identifier identifier = JSC::Identifier::fromString(vm, key->toWTFString(BunString::NonNull));
+
+    JSC::JSObject* object = JSC::JSValue::decode(target).asCell()->getObject();
+    JSC::JSValue result = object->get(globalObject, identifier);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::encode(result);
+}
+
+// ECMA-262 IsArray: also true for a Proxy of an array. Throws for a revoked Proxy.
+extern "C" [[ZIG_EXPORT(check_slow)]] bool JSC__JSValue__isArrayIncludingProxy(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject)
+{
+    return JSC::isArray(globalObject, JSC::JSValue::decode(value));
+}
+
 extern "C" bool JSC__JSValue__deleteProperty(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const EncodedSlice* key)
 {
     JSC::JSValue targetValue = JSC::JSValue::decode(target);

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -67,6 +67,8 @@ pub mod native_promise_context;
 pub mod output_file_jsc;
 #[path = "api/standalone_graph_jsc.rs"]
 pub mod standalone_graph_jsc;
+#[path = "api/stringify_replacer.rs"]
+mod stringify_replacer;
 #[path = "api/TOMLObject.rs"]
 pub mod toml_object;
 #[path = "api/UnsafeObject.rs"]

--- a/src/runtime/api/JSON5Object.rs
+++ b/src/runtime/api/JSON5Object.rs
@@ -5,6 +5,8 @@ use bun_js_parser::lexer;
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, wtf};
 use bun_parsers::json5;
 
+use super::stringify_replacer::{Properties, Replacer};
+
 pub(crate) fn create(global: &JSGlobalObject) -> JSValue {
     jsc::create_host_function_object(
         global,
@@ -19,19 +21,19 @@ pub(crate) fn create(global: &JSGlobalObject) -> JSValue {
 fn stringify(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let [value, replacer, space_value] = frame.arguments_as_array::<3>();
 
+    let replacer = Replacer::from_js(global, replacer)?;
+    let value = match &replacer {
+        Some(replacer) => replacer.replace_root(global, value)?,
+        None => value,
+    };
+
     value.ensure_still_alive();
 
     if value.is_undefined() || value.is_symbol() || value.is_function() {
         return Ok(JSValue::UNDEFINED);
     }
 
-    if !replacer.is_undefined_or_null() {
-        return Err(global.throw(format_args!(
-            "JSON5.stringify does not support the replacer argument"
-        )));
-    }
-
-    let mut stringifier = Stringifier::init(global, space_value)?;
+    let mut stringifier = Stringifier::init(global, space_value, replacer)?;
 
     if let Err(err) = stringifier.stringify_value(global, value) {
         return match err {
@@ -88,6 +90,7 @@ struct Stringifier {
     // live on the native stack via the `stringify_value` recursion chain, so the
     // conservative GC scan keeps them alive.
     visiting: HashMap<JSValue, ()>,
+    replacer: Option<Replacer>,
 }
 
 #[derive(Debug)]
@@ -107,8 +110,7 @@ type StringifyResult<T> = Result<T, StringifyError>;
 enum Space {
     Minified,
     Number(u32),
-    /// +1 WTF ref owned for the lifetime of the `Stringifier`.
-    Str(bun_core::String),
+    Str(BunString),
 }
 
 impl Space {
@@ -136,14 +138,45 @@ impl Space {
 }
 
 impl Stringifier {
-    fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Stringifier> {
+    fn init(
+        global: &JSGlobalObject,
+        space_value: JSValue,
+        replacer: Option<Replacer>,
+    ) -> JsResult<Stringifier> {
         Ok(Stringifier {
             stack_check: StackCheck::init(),
             builder: wtf::StringBuilder::init(),
             indent: 0,
             space: Space::init(global, space_value)?,
             visiting: HashMap::default(),
+            replacer,
         })
+    }
+
+    fn replace_property(
+        &self,
+        global: &JSGlobalObject,
+        holder: JSValue,
+        name: &BunString,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        match &self.replacer {
+            Some(replacer) => replacer.replace_property(global, holder, name, value),
+            None => Ok(value),
+        }
+    }
+
+    fn replace_element(
+        &self,
+        global: &JSGlobalObject,
+        array: JSValue,
+        index: u32,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        match &self.replacer {
+            Some(replacer) => replacer.replace_element(global, array, index, value),
+            None => Ok(value),
+        }
     }
 
     fn stringify_value(&mut self, global: &JSGlobalObject, value: JSValue) -> StringifyResult<()> {
@@ -234,10 +267,13 @@ impl Stringifier {
 
         self.builder.append_lchar(b'[');
 
+        let mut index: u32 = 0;
         match self.space {
             Space::Minified => {
                 let mut first = true;
                 while let Some(item) = iter.next()? {
+                    let item = self.replace_element(global, value, index, item)?;
+                    index += 1;
                     if !first {
                         self.builder.append_lchar(b',');
                     }
@@ -253,6 +289,8 @@ impl Stringifier {
                 self.indent += 1;
                 let mut first = true;
                 while let Some(item) = iter.next()? {
+                    let item = self.replace_element(global, value, index, item)?;
+                    index += 1;
                     if !first {
                         self.builder.append_lchar(b',');
                     }
@@ -276,17 +314,9 @@ impl Stringifier {
     }
 
     fn stringify_object(&mut self, global: &JSGlobalObject, value: JSValue) -> StringifyResult<()> {
-        let iter = jsc::JSPropertyIterator::init(
-            global,
-            value.to_object(global)?,
-            jsc::JSPropertyIteratorOptions {
-                skip_empty_name: false,
-                include_value: true,
-                ..Default::default()
-            },
-        )?;
+        let mut properties = Properties::init(global, value, self.replacer.as_ref())?;
 
-        if iter.len == 0 {
+        if properties.len() == 0 {
             self.builder.append_latin1(b"{}");
             return Ok(());
         }
@@ -296,8 +326,13 @@ impl Stringifier {
         match self.space {
             Space::Minified => {
                 let mut first = true;
-                while let Some((prop_name, value)) = iter.next()? {
-                    if value.is_undefined() || value.is_symbol() || value.is_function() {
+                while let Some((prop_name, prop_value)) = properties.next()? {
+                    let prop_value =
+                        self.replace_property(global, value, &prop_name, prop_value)?;
+                    if prop_value.is_undefined()
+                        || prop_value.is_symbol()
+                        || prop_value.is_function()
+                    {
                         continue;
                     }
                     if !first {
@@ -306,14 +341,19 @@ impl Stringifier {
                     first = false;
                     self.append_key(&prop_name);
                     self.builder.append_lchar(b':');
-                    self.stringify_value(global, value)?;
+                    self.stringify_value(global, prop_value)?;
                 }
             }
             Space::Number(_) | Space::Str(_) => {
                 self.indent += 1;
                 let mut first = true;
-                while let Some((prop_name, value)) = iter.next()? {
-                    if value.is_undefined() || value.is_symbol() || value.is_function() {
+                while let Some((prop_name, prop_value)) = properties.next()? {
+                    let prop_value =
+                        self.replace_property(global, value, &prop_name, prop_value)?;
+                    if prop_value.is_undefined()
+                        || prop_value.is_symbol()
+                        || prop_value.is_function()
+                    {
                         continue;
                     }
                     if !first {
@@ -323,7 +363,7 @@ impl Stringifier {
                     self.newline();
                     self.append_key(&prop_name);
                     self.builder.append_latin1(b": ");
-                    self.stringify_value(global, value)?;
+                    self.stringify_value(global, prop_value)?;
                 }
                 self.indent -= 1;
                 if !first {

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -2,9 +2,12 @@ use bun_collections::HashMap;
 use bun_core::StackCheck;
 use bun_core::String as BunString;
 use bun_jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, TemporalType, wtf,
+    self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, MarkedArgumentBuffer,
+    TemporalType, wtf,
 };
 use bun_parsers::toml::TOML;
+
+use super::stringify_replacer::{Properties, Replacer};
 
 pub(crate) fn create(global: &JSGlobalObject) -> JSValue {
     bun_jsc::create_host_function_object(
@@ -59,44 +62,44 @@ fn stringify(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // TOML output is line-oriented and has no nesting indentation.
     let [value, replacer, _space] = frame.arguments_as_array::<3>();
 
+    let replacer = Replacer::from_js(global, replacer)?;
+    let value = match &replacer {
+        Some(replacer) => replacer.replace_root(global, value)?,
+        None => value,
+    };
+
     value.ensure_still_alive();
 
     if value.is_undefined() || value.is_symbol() || value.is_function() {
         return Ok(JSValue::UNDEFINED);
     }
 
-    if !replacer.is_undefined_or_null() {
-        return Err(global.throw(format_args!(
-            "TOML.stringify does not support the replacer argument"
-        )));
-    }
-
     let unwrapped = value.unwrap_boxed_primitive(global)?;
-    if !unwrapped.is_object()
-        || unwrapped.is_array()
-        || unwrapped.is_date()
-        || temporal_object_type(unwrapped).is_some()
-    {
+    if !unwrapped.is_object() || unwrapped.is_array() || is_date_time(unwrapped) {
         return Err(global.throw(format_args!(
             "TOML.stringify expects an object at the top level (a TOML document is a table)"
         )));
     }
 
-    let mut stringifier = Stringifier {
-        stack_check: StackCheck::init(),
-        builder: wtf::StringBuilder::init(),
-        visiting: HashMap::default(),
-        wrote: false,
-    };
-
-    if let Err(err) = stringifier.stringify_root(global, unwrapped) {
-        return match err {
-            StringifyError::Js(js_err) => Err(js_err),
-            StringifyError::StackOverflow => Err(global.throw_stack_overflow()),
+    MarkedArgumentBuffer::new(|roots| {
+        let mut stringifier = Stringifier {
+            stack_check: StackCheck::init(),
+            builder: wtf::StringBuilder::init(),
+            visiting: HashMap::default(),
+            wrote: false,
+            replacer,
+            roots,
         };
-    }
 
-    stringifier.builder.to_string(global)
+        if let Err(err) = stringifier.stringify_root(global, unwrapped) {
+            return match err {
+                StringifyError::Js(js_err) => Err(js_err),
+                StringifyError::StackOverflow => Err(global.throw_stack_overflow()),
+            };
+        }
+
+        stringifier.builder.to_string(global)
+    })
 }
 
 #[derive(Debug)]
@@ -117,44 +120,75 @@ type StringifyResult<T> = Result<T, StringifyError>;
 /// must be emitted as TOML floats so they round-trip through any reader.
 const MAX_SAFE_INTEGER_F: f64 = 9007199254740991.0;
 
-/// How a property value is laid out in the document.
-enum Layout {
-    /// `key = value` on the current table's line block.
-    Keyval,
-    /// `key = value` whose value is a Temporal object; carries the
-    /// classification so emission does not re-ask.
-    TemporalKeyval(TemporalType),
-    /// `[path.key]` section.
-    Table,
-    /// `[[path.key]]` section per element.
-    ArrayOfTables,
-    Skip,
+/// A value read once, through the replacer, in the order `JSON.stringify` reads it.
+enum Value {
+    /// A boolean, number, string, `Date` or Temporal object, or a `BigInt` (rejected when written).
+    Scalar(JSValue),
+    Array(Vec<Value>),
+    Table(Vec<Entry>),
 }
 
-struct Stringifier {
+struct Entry {
+    name: BunString,
+    value: Value,
+}
+
+/// Whether an array is written as `[[key]]` sections: non-empty, and every element a table.
+fn is_array_of_tables(items: &[Value]) -> bool {
+    !items.is_empty() && items.iter().all(|item| matches!(item, Value::Table(_)))
+}
+
+/// Reads the document once into `Value`s, then writes them.
+struct Stringifier<'a> {
     stack_check: StackCheck,
     builder: wtf::StringBuilder,
     // NOTE: `JSValue` keys live on the heap here, but every entry is also
-    // live on the native stack via the `stringify` recursion chain, so the
+    // live on the native stack via the `read` recursion chain, so the
     // conservative GC scan keeps them alive.
     visiting: HashMap<JSValue, ()>,
     /// Whether any line has been written (controls blank lines before headers).
     wrote: bool,
+    replacer: Option<Replacer>,
+    /// Keeps every `Value::Scalar` alive while a replacer or getter runs JS.
+    roots: &'a mut MarkedArgumentBuffer,
 }
 
-/// Header path of the table being emitted: a parent-linked chain of
-/// iterator-borrowed keys on the `stringify_table_body` recursion stack.
+/// Header path of the table being written: a parent-linked chain of `Entry` names on the write stack.
 struct Path<'p> {
     parent: Option<&'p Path<'p>>,
     key: &'p BunString,
 }
 
-impl Stringifier {
+impl Stringifier<'_> {
+    fn replace_property(
+        &self,
+        global: &JSGlobalObject,
+        holder: JSValue,
+        name: &BunString,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        match &self.replacer {
+            Some(replacer) => replacer.replace_property(global, holder, name, value),
+            None => Ok(value),
+        }
+    }
+
+    fn replace_element(
+        &self,
+        global: &JSGlobalObject,
+        array: JSValue,
+        index: u32,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        match &self.replacer {
+            Some(replacer) => replacer.replace_element(global, array, index, value),
+            None => Ok(value),
+        }
+    }
+
     fn stringify_root(&mut self, global: &JSGlobalObject, root: JSValue) -> StringifyResult<()> {
-        self.mark_visiting(global, root)?;
-        self.stringify_table_body(global, root, None, false)?;
-        self.visiting.remove(&root);
-        Ok(())
+        let entries = self.read_table(global, root)?;
+        self.write_table(global, &entries, None, false)
     }
 
     fn mark_visiting(&mut self, global: &JSGlobalObject, value: JSValue) -> StringifyResult<()> {
@@ -171,49 +205,71 @@ impl Stringifier {
         Ok(())
     }
 
-    /// Decides the layout of one (already unboxed) property value. Reads
-    /// array elements when classifying arrays.
-    fn layout_of(&mut self, global: &JSGlobalObject, value: JSValue) -> StringifyResult<Layout> {
-        if value.is_undefined() || value.is_symbol() || value.is_function() {
-            return Ok(Layout::Skip);
+    /// Reads one (already unboxed) value that a table or an array holds.
+    fn read(&mut self, global: &JSGlobalObject, value: JSValue) -> StringifyResult<Value> {
+        if !self.stack_check.is_safe_to_recurse() {
+            return Err(StringifyError::StackOverflow);
         }
         if value.is_array() {
-            // An array becomes [[key]] sections when it is non-empty and
-            // every element is a plain object; otherwise it is inline.
+            self.mark_visiting(global, value)?;
             let mut iter = value.array_iterator(global)?;
-            if iter.len == 0 {
-                return Ok(Layout::Keyval);
-            }
+            let mut items: Vec<Value> = Vec::new();
+            let mut index: u32 = 0;
             while let Some(item) = iter.next()? {
+                let item = self.replace_element(global, value, index, item)?;
+                index += 1;
                 let item = item.unwrap_boxed_primitive(global)?;
-                if !item.is_object()
-                    || item.is_array()
-                    || item.is_date()
-                    || item.is_function()
-                    || temporal_object_type(item).is_some()
-                {
-                    return Ok(Layout::Keyval);
+                if item.is_null() || item.is_undefined() || item.is_symbol() || item.is_function() {
+                    return Err(self.err_in_array(global, item));
                 }
+                items.push(self.read(global, item)?);
             }
-            return Ok(Layout::ArrayOfTables);
+            self.visiting.remove(&value);
+            return Ok(Value::Array(items));
         }
-        if value.is_object() && !value.is_date() {
-            if let Some(temporal_type) = temporal_object_type(value) {
-                return Ok(Layout::TemporalKeyval(temporal_type));
-            }
-            return Ok(Layout::Table);
+        if value.is_object() && !value.is_function() && !is_date_time(value) {
+            return Ok(Value::Table(self.read_table(global, value)?));
         }
-        Ok(Layout::Keyval)
+        self.roots.append(value);
+        Ok(Value::Scalar(value))
     }
 
-    /// Emits the body of one table: `key = value` lines first, then
-    /// `[sub.table]` and `[[array.of.tables]]` sections (a keyval after a
-    /// header would belong to that header, so the order is forced).
-    /// `own_header` defers `[path]`: a sub-section reached first implies it.
-    fn stringify_table_body(
+    /// Reads the properties of a table. `undefined`, function and symbol values are left out.
+    fn read_table(
         &mut self,
         global: &JSGlobalObject,
         table: JSValue,
+    ) -> StringifyResult<Vec<Entry>> {
+        self.mark_visiting(global, table)?;
+        let mut properties = Properties::init(global, table, self.replacer.as_ref())?;
+        let mut entries: Vec<Entry> = Vec::with_capacity(properties.len());
+        while let Some((name, value)) = properties.next()? {
+            let value = self.replace_property(global, table, &name, value)?;
+            let value = value.unwrap_boxed_primitive(global)?;
+            if value.is_undefined() || value.is_symbol() || value.is_function() {
+                continue;
+            }
+            if value.is_null() {
+                return Err(self.err_null_value(global, &name));
+            }
+            let value = self.read(global, value)?;
+            entries.push(Entry {
+                name: (*name).clone(),
+                value,
+            });
+        }
+        self.visiting.remove(&table);
+        Ok(entries)
+    }
+
+    /// Writes the body of one table: `key = value` lines first, then
+    /// `[sub.table]` and `[[array.of.tables]]` sections (a keyval after a
+    /// header would belong to that header, so the order is forced).
+    /// `own_header` defers `[path]`: a sub-section reached first implies it.
+    fn write_table(
+        &mut self,
+        global: &JSGlobalObject,
+        entries: &[Entry],
         path: Option<&Path<'_>>,
         own_header: bool,
     ) -> StringifyResult<()> {
@@ -222,77 +278,48 @@ impl Stringifier {
         }
         let mut header_pending = own_header;
 
-        let iter_options = jsc::JSPropertyIteratorOptions {
-            skip_empty_name: false,
-            include_value: true,
-            ..Default::default()
-        };
-
-        // Pass 1: keyvals.
-        let iter = jsc::JSPropertyIterator::init(global, table.to_object(global)?, iter_options)?;
-        while let Some((prop_name, prop_value)) = iter.next()? {
-            let value = prop_value.unwrap_boxed_primitive(global)?;
-            if value.is_null() {
-                return Err(self.err_null_value(global, &prop_name));
+        for entry in entries {
+            match &entry.value {
+                Value::Table(_) => continue,
+                Value::Array(items) if is_array_of_tables(items) => continue,
+                Value::Scalar(_) | Value::Array(_) => {}
             }
-            let known_temporal = match self.layout_of(global, value)? {
-                Layout::Keyval => None,
-                Layout::TemporalKeyval(temporal_type) => Some(temporal_type),
-                Layout::Table | Layout::ArrayOfTables | Layout::Skip => continue,
-            };
             if header_pending {
                 header_pending = false;
                 self.append_header(path, false);
             }
-            self.append_key_segment(&prop_name);
+            self.append_key_segment(&entry.name);
             self.builder.append_latin1(b" = ");
-            self.stringify_inline_value(global, value, known_temporal)?;
+            self.write_inline(global, &entry.value)?;
             self.builder.append_lchar(b'\n');
             self.wrote = true;
         }
 
-        // Pass 2: sections. Values are re-read; an array-of-tables element
-        // that is no longer a plain object during emission gets an error.
-        let iter = jsc::JSPropertyIterator::init(global, table.to_object(global)?, iter_options)?;
-        while let Some((prop_name, prop_value)) = iter.next()? {
-            let value = prop_value.unwrap_boxed_primitive(global)?;
-            match self.layout_of(global, value)? {
-                Layout::Keyval | Layout::TemporalKeyval(_) | Layout::Skip => {}
-                Layout::Table => {
+        for entry in entries {
+            match &entry.value {
+                Value::Table(sub_entries) => {
                     header_pending = false;
-                    self.mark_visiting(global, value)?;
                     let child = Path {
                         parent: path,
-                        key: &prop_name,
+                        key: &entry.name,
                     };
-                    self.stringify_table_body(global, value, Some(&child), true)?;
-                    self.visiting.remove(&value);
+                    self.write_table(global, sub_entries, Some(&child), true)?;
                 }
-                Layout::ArrayOfTables => {
+                Value::Array(items) if is_array_of_tables(items) => {
                     header_pending = false;
-                    self.mark_visiting(global, value)?;
                     let child = Path {
                         parent: path,
-                        key: &prop_name,
+                        key: &entry.name,
                     };
-                    let mut items = value.array_iterator(global)?;
-                    while let Some(item) = items.next()? {
-                        let item = item.unwrap_boxed_primitive(global)?;
-                        if !item.is_object()
-                            || item.is_array()
-                            || item.is_date()
-                            || item.is_function()
-                            || temporal_object_type(item).is_some()
-                        {
-                            return Err(self.err_changed(global));
-                        }
-                        self.mark_visiting(global, item)?;
+                    for item in items {
+                        let Value::Table(item_entries) = item else {
+                            unreachable!("is_array_of_tables checked every element");
+                        };
                         self.append_header(Some(&child), true);
-                        self.stringify_table_body(global, item, Some(&child), false)?;
-                        self.visiting.remove(&item);
+                        self.write_table(global, item_entries, Some(&child), false)?;
                     }
-                    self.visiting.remove(&value);
                 }
+                Value::Scalar(_) | Value::Array(_) => {}
             }
         }
 
@@ -304,21 +331,45 @@ impl Stringifier {
         Ok(())
     }
 
-    /// One value on the right-hand side of `=` (or inside an inline
-    /// array/table). `value` is already unboxed; `known_temporal` is the
-    /// classification `layout_of` already computed for it, if any.
-    fn stringify_inline_value(
-        &mut self,
-        global: &JSGlobalObject,
-        value: JSValue,
-        known_temporal: Option<TemporalType>,
-    ) -> StringifyResult<()> {
+    /// One value on the right-hand side of `=`, or inside an inline array or table.
+    fn write_inline(&mut self, global: &JSGlobalObject, value: &Value) -> StringifyResult<()> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(StringifyError::StackOverflow);
         }
 
-        if value.is_boolean() {
-            self.builder.append_latin1(if value.as_boolean() {
+        let scalar = match value {
+            Value::Scalar(scalar) => *scalar,
+            Value::Array(items) => {
+                self.builder.append_lchar(b'[');
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        self.builder.append_latin1(b", ");
+                    }
+                    self.write_inline(global, item)?;
+                }
+                self.builder.append_lchar(b']');
+                return Ok(());
+            }
+            Value::Table(entries) => {
+                // A table inside an inline value becomes an inline table.
+                if entries.is_empty() {
+                    self.builder.append_latin1(b"{}");
+                    return Ok(());
+                }
+                for (i, entry) in entries.iter().enumerate() {
+                    self.builder
+                        .append_latin1(if i == 0 { b"{ " } else { b", " });
+                    self.append_key_segment(&entry.name);
+                    self.builder.append_latin1(b" = ");
+                    self.write_inline(global, &entry.value)?;
+                }
+                self.builder.append_latin1(b" }");
+                return Ok(());
+            }
+        };
+
+        if scalar.is_boolean() {
+            self.builder.append_latin1(if scalar.as_boolean() {
                 b"true"
             } else {
                 b"false"
@@ -326,89 +377,38 @@ impl Stringifier {
             return Ok(());
         }
 
-        if value.is_number() {
-            self.append_number(value);
+        if scalar.is_number() {
+            self.append_number(scalar);
             return Ok(());
         }
 
-        if value.is_big_int() {
+        if scalar.is_big_int() {
             return Err(global
                 .throw(format_args!("TOML.stringify cannot serialize BigInt"))
                 .into());
         }
 
-        if value.is_string() {
-            let str = value.to_bun_string(global)?;
+        if scalar.is_string() {
+            let str = scalar.to_bun_string(global)?;
             self.append_basic_quoted(&str);
             return Ok(());
         }
 
-        if value.is_date() {
-            return self.append_datetime(global, value);
+        if scalar.is_date() {
+            return self.append_datetime(global, scalar);
         }
 
-        if let Some(temporal_type) = known_temporal.or_else(|| temporal_object_type(value)) {
-            return self.append_temporal(global, value, temporal_type);
+        if let Some(temporal_type) = temporal_object_type(scalar) {
+            return self.append_temporal(global, scalar, temporal_type);
         }
 
-        if value.is_array() {
-            self.mark_visiting(global, value)?;
-            self.builder.append_lchar(b'[');
-            let mut iter = value.array_iterator(global)?;
-            let mut first = true;
-            while let Some(item) = iter.next()? {
-                if !first {
-                    self.builder.append_latin1(b", ");
-                }
-                first = false;
-                let item = item.unwrap_boxed_primitive(global)?;
-                if item.is_null() || item.is_undefined() || item.is_symbol() || item.is_function() {
-                    return Err(self.err_in_array(global, item));
-                }
-                self.stringify_inline_value(global, item, None)?;
-            }
-            self.builder.append_lchar(b']');
-            self.visiting.remove(&value);
-            return Ok(());
-        }
-
-        // A plain object inside an inline context becomes an inline table.
-        self.mark_visiting(global, value)?;
-        let iter = jsc::JSPropertyIterator::init(
-            global,
-            value.to_object(global)?,
-            jsc::JSPropertyIteratorOptions {
-                skip_empty_name: false,
-                include_value: true,
-                ..Default::default()
-            },
-        )?;
-        let mut first = true;
-        while let Some((prop_name, value)) = iter.next()? {
-            let prop_value = value.unwrap_boxed_primitive(global)?;
-            if prop_value.is_undefined() || prop_value.is_symbol() || prop_value.is_function() {
-                continue;
-            }
-            if prop_value.is_null() {
-                return Err(self.err_null_value(global, &prop_name));
-            }
-            self.builder
-                .append_latin1(if first { b"{ " } else { b", " });
-            first = false;
-            self.append_key_segment(&prop_name);
-            self.builder.append_latin1(b" = ");
-            self.stringify_inline_value(global, prop_value, None)?;
-        }
-        self.builder
-            .append_latin1(if first { b"{}" } else { b" }" });
-        self.visiting.remove(&value);
-        Ok(())
+        // `read` only lets `null`, `undefined`, a symbol or a function through as an array element.
+        Err(self.err_in_array(global, scalar))
     }
 
     // ── output pieces ──────────────────────────────────────────────────────
 
-    /// `[a.b.c]` or `[[a.b.c]]`, preceded by a blank line when the document
-    /// already has content.
+    /// `[a.b.c]` or `[[a.b.c]]` from `path`, after a blank line when the document has content.
     fn append_header(&mut self, path: Option<&Path<'_>>, array_of_tables: bool) {
         if self.wrote {
             self.builder.append_lchar(b'\n');
@@ -577,14 +577,6 @@ impl Stringifier {
             .throw(format_args!("TOML cannot represent {} in an array", what))
             .into()
     }
-
-    fn err_changed(&mut self, global: &JSGlobalObject) -> StringifyError {
-        global
-            .throw(format_args!(
-                "TOML.stringify cannot serialize a value that changed during serialization"
-            ))
-            .into()
-    }
 }
 
 fn temporal_object_type(value: JSValue) -> Option<TemporalType> {
@@ -592,6 +584,11 @@ fn temporal_object_type(value: JSValue) -> Option<TemporalType> {
         TemporalType::None => None,
         t => Some(t),
     }
+}
+
+/// The objects written as one date/time value rather than as a table.
+fn is_date_time(value: JSValue) -> bool {
+    value.is_date() || temporal_object_type(value).is_some()
 }
 
 /// Whether TOML has a date/time literal for this type.

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -6,10 +6,11 @@ use bun_collections::{HashMap, StringHashMap};
 use bun_core::StackCheck;
 use bun_core::String as BunString;
 use bun_jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue,
-    JsError, JsResult, MarkedArgumentBuffer, wtf,
+    self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, MarkedArgumentBuffer, wtf,
 };
 use bun_parsers::yaml::{CyclicAliases, YAML, YamlParseError};
+
+use super::stringify_replacer::{Properties, Replacer};
 
 pub(crate) fn create(global_this: &JSGlobalObject) -> JSValue {
     jsc::create_host_function_object(
@@ -25,47 +26,78 @@ pub(crate) fn create(global_this: &JSGlobalObject) -> JSValue {
 fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
     let [value, replacer, space_value] = call_frame.arguments_as_array::<3>();
 
+    let replacer = Replacer::from_js(global, replacer)?;
+    let value = match &replacer {
+        Some(replacer) => replacer.replace_root(global, value)?,
+        None => value,
+    };
+
     value.ensure_still_alive();
 
     if value.is_undefined() || value.is_symbol() || value.is_function() {
         return Ok(JSValue::UNDEFINED);
     }
 
-    if !replacer.is_undefined_or_null() {
-        return Err(global.throw(format_args!(
-            "YAML.stringify does not support the replacer argument"
-        )));
-    }
+    MarkedArgumentBuffer::new(|roots| {
+        let mut stringifier = Stringifier::init(global, space_value, replacer, roots)?;
 
-    let mut stringifier = Stringifier::init(global, space_value)?;
+        let root = stringifier
+            .read(global, value, ValueOrigin::Root)
+            .map_err(|err| err.to_js_error(global))?;
 
-    stringifier
-        .find_anchors_and_aliases(global, value, ValueOrigin::Root)
-        .map_err(|err| err.to_js_error(global))?;
+        stringifier
+            .write(global, root)
+            .map_err(|err| err.to_js_error(global))?;
 
-    stringifier
-        .stringify(global, value)
-        .map_err(|err| err.to_js_error(global))?;
-
-    stringifier.builder.to_string(global)
+        stringifier.builder.to_string(global)
+    })
 }
 
-struct Stringifier {
+/// Reads the value once into `nodes` (which runs the replacer and finds the anchors), then writes.
+struct Stringifier<'a> {
     stack_check: StackCheck,
     builder: wtf::StringBuilder,
     indent: usize,
 
-    known_collections: HashMap<JSValue, AnchorAlias>,
+    replacer: Option<Replacer>,
+    /// Every collection read, in the order it was reached.
+    nodes: Vec<Node>,
+    /// Collection to its node. A function replacer keeps only the current path here, see `read`.
+    known_collections: HashMap<JSValue, NodeId>,
     array_item_counter: usize,
     prop_names: StringHashMap<usize>,
+    /// Keeps the values in `nodes` and `known_collections` alive while a replacer or getter runs.
+    roots: &'a mut MarkedArgumentBuffer,
 
     space: Space,
+}
+
+type NodeId = usize;
+
+struct Node {
+    anchor: AnchorAlias,
+    items: Items,
+}
+
+enum Items {
+    Array(Vec<Item>),
+    Object(Vec<(BunString, Item)>),
+}
+
+#[derive(Clone, Copy)]
+enum Item {
+    /// `null`, a number, a boolean or a string, unboxed.
+    Scalar(JSValue),
+    /// A collection written in full here, with an anchor if something refers to it.
+    Collection(NodeId),
+    /// `*anchor` of a collection written earlier.
+    Alias(NodeId),
 }
 
 enum Space {
     Minified,
     Number(u32),
-    Str(bun_core::String),
+    Str(BunString),
 }
 
 impl Space {
@@ -95,34 +127,20 @@ impl Space {
 }
 
 pub(crate) struct AnchorAlias {
-    anchored: bool,
+    /// Something refers to this collection, so it is written with an anchor.
     used: bool,
     name: AnchorAliasName,
-}
-
-impl Default for AnchorAlias {
-    fn default() -> Self {
-        // Exists only because `HashMap::get_or_put` requires `V: Default` to
-        // fill the freshly-inserted slot; the value is immediately overwritten
-        // by the caller (see `find_anchors_and_aliases`).
-        AnchorAlias {
-            anchored: false,
-            used: false,
-            name: AnchorAliasName::Root,
-        }
-    }
 }
 
 impl AnchorAlias {
     fn init(origin: ValueOrigin<'_>) -> AnchorAlias {
         AnchorAlias {
-            anchored: false,
             used: false,
             name: match origin {
                 ValueOrigin::Root => AnchorAliasName::Root,
                 ValueOrigin::ArrayItem => AnchorAliasName::ArrayItem(0),
                 ValueOrigin::PropValue(prop_name) => AnchorAliasName::PropValue {
-                    prop_name: (*prop_name).clone(),
+                    prop_name: prop_name.clone(),
                     counter: 0,
                 },
             },
@@ -183,8 +201,13 @@ impl StringifyError {
 
 bun_core::oom_from_alloc!(StringifyError);
 
-impl Stringifier {
-    fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Stringifier> {
+impl<'a> Stringifier<'a> {
+    fn init(
+        global: &JSGlobalObject,
+        space_value: JSValue,
+        replacer: Option<Replacer>,
+        roots: &'a mut MarkedArgumentBuffer,
+    ) -> JsResult<Stringifier<'a>> {
         let mut prop_names: StringHashMap<usize> = StringHashMap::default();
         // always rename anchors named "root" to avoid collision with
         // root anchor/alias
@@ -194,31 +217,31 @@ impl Stringifier {
             stack_check: StackCheck::init(),
             builder: wtf::StringBuilder::init(),
             indent: 0,
+            replacer,
+            nodes: Vec::new(),
             known_collections: HashMap::default(),
             array_item_counter: 0,
             prop_names,
+            roots,
             space: Space::init(global, space_value)?,
         })
     }
 
-    fn find_anchors_and_aliases(
+    /// Reads `value` through the replacer into a scalar, a new node, or an alias of an earlier node.
+    fn read(
         &mut self,
         global: &JSGlobalObject,
         value: JSValue,
         origin: ValueOrigin<'_>,
-    ) -> Result<(), StringifyError> {
+    ) -> Result<Item, StringifyError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(StringifyError::StackOverflow);
         }
 
         let unwrapped = value.unwrap_boxed_primitive(global)?;
 
-        if unwrapped.is_null() {
-            return Ok(());
-        }
-
-        if unwrapped.is_number() {
-            return Ok(());
+        if unwrapped.is_null() || unwrapped.is_number() || unwrapped.is_boolean() {
+            return Ok(Item::Scalar(unwrapped));
         }
 
         if unwrapped.is_big_int() {
@@ -227,118 +250,198 @@ impl Stringifier {
                 .into());
         }
 
-        if unwrapped.is_boolean() {
-            return Ok(());
-        }
-
         if unwrapped.is_string() {
-            return Ok(());
+            self.roots.append(unwrapped);
+            return Ok(Item::Scalar(unwrapped));
         }
 
         debug_assert!(unwrapped.is_object());
 
-        let object_entry = self.known_collections.get_or_put(unwrapped)?;
-        if object_entry.found_existing {
-            // this will become an alias. increment counters here because
-            // now the anchor/alias is confirmed used.
-
-            if object_entry.value_ptr.used {
-                return Ok(());
-            }
-
-            object_entry.value_ptr.used = true;
-
-            match &mut object_entry.value_ptr.name {
-                AnchorAliasName::Root => {
-                    // only one possible
-                }
-                AnchorAliasName::ArrayItem(counter) => {
-                    *counter = self.array_item_counter;
-                    self.array_item_counter += 1;
-                }
-                AnchorAliasName::PropValue { prop_name, counter } => {
-                    // Unsafe names use generated `value<counter>` anchors, keyed on
-                    // "value" so the counter is shared with literal "value" properties.
-                    let key: &[u8] = if can_use_prop_name_as_anchor(prop_name) {
-                        prop_name.byte_slice()
-                    } else {
-                        b"value"
-                    };
-                    let name_entry = self.prop_names.get_or_put(key)?;
-                    if name_entry.found_existing {
-                        *name_entry.value_ptr += 1;
-                    } else {
-                        *name_entry.value_ptr = 0;
-                    }
-
-                    *counter = *name_entry.value_ptr;
-                }
-            }
-            return Ok(());
+        if let Some(&id) = self.known_collections.get(&unwrapped) {
+            self.mark_used(id)?;
+            return Ok(Item::Alias(id));
         }
 
-        *object_entry.value_ptr = AnchorAlias::init(origin);
+        let id = self.nodes.len();
+        self.nodes.push(Node {
+            anchor: AnchorAlias::init(origin),
+            items: Items::Array(Vec::new()),
+        });
+        self.known_collections.put(unwrapped, id)?;
+        self.roots.append(unwrapped);
 
-        if unwrapped.is_array() {
+        let items = if unwrapped.is_array() {
             let mut iter = unwrapped.array_iterator(global)?;
+            let mut items: Vec<Item> = Vec::new();
+            let mut index: u32 = 0;
             while let Some(item) = iter.next()? {
+                let item = self.replace_element(global, unwrapped, index, item)?;
+                index += 1;
                 if item.is_undefined() || item.is_symbol() || item.is_function() {
                     continue;
                 }
-
-                self.find_anchors_and_aliases(global, item, ValueOrigin::ArrayItem)?;
+                items.push(self.read(global, item, ValueOrigin::ArrayItem)?);
             }
+            Items::Array(items)
+        } else {
+            let mut properties = Properties::init(global, unwrapped, self.replacer.as_ref())?;
+            let mut items: Vec<(BunString, Item)> = Vec::new();
+            while let Some((prop_name, value)) = properties.next()? {
+                let value = self.replace_property(global, unwrapped, &prop_name, value)?;
+                if value.is_undefined() || value.is_symbol() || value.is_function() {
+                    continue;
+                }
+                let item = self.read(global, value, ValueOrigin::PropValue(&prop_name))?;
+                items.push(((*prop_name).clone(), item));
+            }
+            Items::Object(items)
+        };
+        self.nodes[id].items = items;
+
+        // `JSON.stringify` calls a function replacer again for a repeat outside a cycle. Match it.
+        if self.replacer.as_ref().is_some_and(Replacer::is_function) {
+            self.known_collections.remove(&unwrapped);
+        }
+        Ok(Item::Collection(id))
+    }
+
+    /// Gives node `id` an anchor. The counters number the anchors in the order they are confirmed.
+    fn mark_used(&mut self, id: NodeId) -> Result<(), StringifyError> {
+        let anchor = &mut self.nodes[id].anchor;
+        if anchor.used {
             return Ok(());
         }
+        anchor.used = true;
 
-        // const generics: <SKIP_EMPTY_NAME, INCLUDE_VALUE>
-        let iter = JSPropertyIterator::init(
-            global,
-            unwrapped.to_object(global)?,
-            JSPropertyIteratorOptions {
-                skip_empty_name: false,
-                include_value: true,
-                ..Default::default()
-            },
-        )?;
-
-        while let Some((prop_name, value)) = iter.next()? {
-            if value.is_undefined() || value.is_symbol() || value.is_function() {
-                continue;
+        match &mut anchor.name {
+            AnchorAliasName::Root => {
+                // only one possible
             }
-            self.find_anchors_and_aliases(global, value, ValueOrigin::PropValue(&prop_name))?;
-        }
+            AnchorAliasName::ArrayItem(counter) => {
+                *counter = self.array_item_counter;
+                self.array_item_counter += 1;
+            }
+            AnchorAliasName::PropValue { prop_name, counter } => {
+                // An unsafe name becomes `value<counter>`, counted with literal "value" properties.
+                let key: &[u8] = if can_use_prop_name_as_anchor(prop_name) {
+                    prop_name.byte_slice()
+                } else {
+                    b"value"
+                };
+                let name_entry = self.prop_names.get_or_put(key)?;
+                if name_entry.found_existing {
+                    *name_entry.value_ptr += 1;
+                } else {
+                    *name_entry.value_ptr = 0;
+                }
 
+                *counter = *name_entry.value_ptr;
+            }
+        }
         Ok(())
     }
 
-    fn stringify(&mut self, global: &JSGlobalObject, value: JSValue) -> Result<(), StringifyError> {
-        let unwrapped = value.unwrap_boxed_primitive(global)?;
-        self.stringify_unwrapped(global, unwrapped)
+    fn replace_property(
+        &self,
+        global: &JSGlobalObject,
+        holder: JSValue,
+        name: &BunString,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        match &self.replacer {
+            Some(replacer) => replacer.replace_property(global, holder, name, value),
+            None => Ok(value),
+        }
     }
 
-    /// `unwrapped` has been through `unwrap_boxed_primitive`.
-    fn stringify_unwrapped(
-        &mut self,
+    fn replace_element(
+        &self,
         global: &JSGlobalObject,
-        unwrapped: JSValue,
-    ) -> Result<(), StringifyError> {
+        array: JSValue,
+        index: u32,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        match &self.replacer {
+            Some(replacer) => replacer.replace_element(global, array, index, value),
+            None => Ok(value),
+        }
+    }
+
+    fn write(&mut self, global: &JSGlobalObject, item: Item) -> Result<(), StringifyError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(StringifyError::StackOverflow);
         }
 
-        if unwrapped.is_null() {
+        let id = match item {
+            Item::Scalar(scalar) => return self.write_scalar(global, scalar),
+            Item::Alias(id) => {
+                self.builder.append_lchar(b'*');
+                self.append_anchor_name(id);
+                return Ok(());
+            }
+            Item::Collection(id) => id,
+        };
+
+        if self.nodes[id].anchor.used {
+            self.builder.append_lchar(b'&');
+            self.append_anchor_name(id);
+            match self.space {
+                Space::Minified => {
+                    self.builder.append_lchar(b' ');
+                }
+                Space::Number(_) | Space::Str(_) => {
+                    self.newline();
+                }
+            }
+        }
+
+        // Each node is written once; its items are not needed after this.
+        match core::mem::replace(&mut self.nodes[id].items, Items::Array(Vec::new())) {
+            Items::Array(items) => self.write_array(global, items),
+            Items::Object(items) => self.write_object(global, items),
+        }
+    }
+
+    fn append_anchor_name(&mut self, id: NodeId) {
+        match &self.nodes[id].anchor.name {
+            AnchorAliasName::Root => {
+                self.builder.append_latin1(b"root");
+            }
+            AnchorAliasName::ArrayItem(counter) => {
+                self.builder.append_latin1(b"item");
+                self.builder.append_usize(*counter);
+            }
+            AnchorAliasName::PropValue { prop_name, counter } => {
+                if !can_use_prop_name_as_anchor(prop_name) {
+                    self.builder.append_latin1(b"value");
+                    self.builder.append_usize(*counter);
+                } else {
+                    self.builder.append_string(prop_name);
+                    if *counter != 0 {
+                        self.builder.append_usize(*counter);
+                    }
+                }
+            }
+        }
+    }
+
+    fn write_scalar(
+        &mut self,
+        global: &JSGlobalObject,
+        scalar: JSValue,
+    ) -> Result<(), StringifyError> {
+        if scalar.is_null() {
             self.builder.append_latin1(b"null");
             return Ok(());
         }
 
-        if unwrapped.is_number() {
-            if unwrapped.is_int32() {
-                self.builder.append_int(unwrapped.as_int32());
+        if scalar.is_number() {
+            if scalar.is_int32() {
+                self.builder.append_int(scalar.as_int32());
                 return Ok(());
             }
 
-            let num = unwrapped.as_number();
+            let num = scalar.as_number();
             if num.is_infinite() && num.is_sign_negative() {
                 self.builder.append_latin1(b"-.inf");
                 // } else if num.is_infinite() && num.is_sign_positive() {
@@ -357,14 +460,8 @@ impl Stringifier {
             return Ok(());
         }
 
-        if unwrapped.is_big_int() {
-            return Err(global
-                .throw(format_args!("YAML.stringify cannot serialize BigInt"))
-                .into());
-        }
-
-        if unwrapped.is_boolean() {
-            if unwrapped.as_boolean() {
+        if scalar.is_boolean() {
+            if scalar.as_boolean() {
                 self.builder.append_latin1(b"true");
             } else {
                 self.builder.append_latin1(b"false");
@@ -372,134 +469,61 @@ impl Stringifier {
             return Ok(());
         }
 
-        if unwrapped.is_string() {
-            let value_str = unwrapped.to_bun_string(global)?;
-            self.append_string(&value_str);
+        debug_assert!(scalar.is_string());
+        let value_str = scalar.to_bun_string(global)?;
+        self.append_string(&value_str);
+        Ok(())
+    }
+
+    fn write_array(
+        &mut self,
+        global: &JSGlobalObject,
+        items: Vec<Item>,
+    ) -> Result<(), StringifyError> {
+        if items.is_empty() {
+            self.builder.append_latin1(b"[]");
             return Ok(());
         }
 
-        debug_assert!(unwrapped.is_object());
-
-        let has_anchor: Option<&mut AnchorAlias> = 'has_anchor: {
-            let Some(anchor) = self.known_collections.get_mut(&unwrapped) else {
-                break 'has_anchor None;
-            };
-
-            if !anchor.used {
-                break 'has_anchor None;
-            }
-
-            Some(anchor)
-        };
-
-        if let Some(anchor) = has_anchor {
-            self.builder
-                .append_lchar(if anchor.anchored { b'*' } else { b'&' });
-
-            match &anchor.name {
-                AnchorAliasName::Root => {
-                    self.builder.append_latin1(b"root");
-                }
-                AnchorAliasName::ArrayItem(counter) => {
-                    self.builder.append_latin1(b"item");
-                    self.builder.append_usize(*counter);
-                }
-                AnchorAliasName::PropValue { prop_name, counter } => {
-                    if !can_use_prop_name_as_anchor(prop_name) {
-                        self.builder.append_latin1(b"value");
-                        self.builder.append_usize(*counter);
-                    } else {
-                        self.builder.append_string(prop_name);
-                        if *counter != 0 {
-                            self.builder.append_usize(*counter);
-                        }
+        match self.space {
+            Space::Minified => {
+                self.builder.append_lchar(b'[');
+                for (i, item) in items.into_iter().enumerate() {
+                    if i > 0 {
+                        self.builder.append_lchar(b',');
                     }
+                    self.write(global, item)?;
                 }
+                self.builder.append_lchar(b']');
             }
+            Space::Number(_) | Space::Str(_) => {
+                self.builder
+                    .ensure_unused_capacity(items.len() * b"- ".len());
+                for (i, item) in items.into_iter().enumerate() {
+                    if i > 0 {
+                        self.newline();
+                    }
 
-            if anchor.anchored {
-                return Ok(());
-            }
+                    self.builder.append_latin1(b"- ");
 
-            // `anchored` is set before `newline()` (the order is irrelevant to
-            // output; doing it here releases the `anchor` borrow first).
-            anchor.anchored = true;
-            match self.space {
-                Space::Minified => {
-                    self.builder.append_lchar(b' ');
-                }
-                Space::Number(_) | Space::Str(_) => {
-                    self.newline();
+                    // don't need to print a newline here for any value
+
+                    self.indent += 1;
+                    self.write(global, item)?;
+                    self.indent -= 1;
                 }
             }
         }
 
-        if unwrapped.is_array() {
-            let mut iter = unwrapped.array_iterator(global)?;
+        Ok(())
+    }
 
-            if iter.len == 0 {
-                self.builder.append_latin1(b"[]");
-                return Ok(());
-            }
-
-            match self.space {
-                Space::Minified => {
-                    self.builder.append_lchar(b'[');
-                    let mut first = true;
-                    while let Some(item) = iter.next()? {
-                        if item.is_undefined() || item.is_symbol() || item.is_function() {
-                            continue;
-                        }
-
-                        if !first {
-                            self.builder.append_lchar(b',');
-                        }
-                        first = false;
-
-                        self.stringify(global, item)?;
-                    }
-                    self.builder.append_lchar(b']');
-                }
-                Space::Number(_) | Space::Str(_) => {
-                    self.builder
-                        .ensure_unused_capacity(iter.len as usize * b"- ".len());
-                    let mut first = true;
-                    while let Some(item) = iter.next()? {
-                        if item.is_undefined() || item.is_symbol() || item.is_function() {
-                            continue;
-                        }
-
-                        if !first {
-                            self.newline();
-                        }
-                        first = false;
-
-                        self.builder.append_latin1(b"- ");
-
-                        // don't need to print a newline here for any value
-
-                        self.indent += 1;
-                        self.stringify(global, item)?;
-                        self.indent -= 1;
-                    }
-                }
-            }
-
-            return Ok(());
-        }
-
-        // const generics: <SKIP_EMPTY_NAME, INCLUDE_VALUE>
-        let iter = JSPropertyIterator::init(
-            global,
-            unwrapped.to_object(global)?,
-            JSPropertyIteratorOptions {
-                skip_empty_name: false,
-                include_value: true,
-                ..Default::default()
-            },
-        )?;
-
-        if iter.len == 0 {
+    fn write_object(
+        &mut self,
+        global: &JSGlobalObject,
+        items: Vec<(BunString, Item)>,
+    ) -> Result<(), StringifyError> {
+        if items.is_empty() {
             self.builder.append_latin1(b"{}");
             return Ok(());
         }
@@ -507,53 +531,39 @@ impl Stringifier {
         match self.space {
             Space::Minified => {
                 self.builder.append_lchar(b'{');
-                let mut first = true;
-                while let Some((prop_name, value)) = iter.next()? {
-                    if value.is_undefined() || value.is_symbol() || value.is_function() {
-                        continue;
-                    }
-
-                    if !first {
+                for (i, (prop_name, item)) in items.into_iter().enumerate() {
+                    if i > 0 {
                         self.builder.append_lchar(b',');
                     }
-                    first = false;
 
                     self.append_string(&prop_name);
                     self.builder.append_latin1(b": ");
 
-                    self.stringify(global, value)?;
+                    self.write(global, item)?;
                 }
                 self.builder.append_lchar(b'}');
             }
             Space::Number(_) | Space::Str(_) => {
-                self.builder.ensure_unused_capacity(iter.len * b": ".len());
+                self.builder
+                    .ensure_unused_capacity(items.len() * b": ".len());
 
-                let mut first = true;
-                while let Some((prop_name, value)) = iter.next()? {
-                    if value.is_undefined() || value.is_symbol() || value.is_function() {
-                        continue;
-                    }
-
-                    if !first {
+                for (i, (prop_name, item)) in items.into_iter().enumerate() {
+                    if i > 0 {
                         self.newline();
                     }
-                    first = false;
 
                     self.append_string(&prop_name);
                     self.builder.append_latin1(b": ");
 
                     self.indent += 1;
 
-                    let prop_value = value.unwrap_boxed_primitive(global)?;
-                    if prop_value_needs_newline(prop_value) {
+                    // A collection or an alias starts on its own line.
+                    if !matches!(item, Item::Scalar(_)) {
                         self.newline();
                     }
 
-                    self.stringify_unwrapped(global, prop_value)?;
+                    self.write(global, item)?;
                     self.indent -= 1;
-                }
-                if first {
-                    self.builder.append_latin1(b"{}");
                 }
             }
         }
@@ -656,11 +666,6 @@ impl Stringifier {
         }
         self.builder.append_string(str);
     }
-}
-
-/// Does this (unwrapped) object property value need a newline? True for arrays and objects.
-fn prop_value_needs_newline(value: JSValue) -> bool {
-    !value.is_number() && !value.is_boolean() && !value.is_null() && !value.is_string()
 }
 
 /// Can this property name be emitted verbatim as an anchor/alias name?

--- a/src/runtime/api/stringify_replacer.rs
+++ b/src/runtime/api/stringify_replacer.rs
@@ -1,0 +1,161 @@
+//! `JSON.stringify`'s replacer for the YAML, TOML and JSON5 stringifiers.
+
+use std::rc::Rc;
+
+use bun_collections::StringHashMap;
+use bun_core::{String as BunString, StringView};
+use bun_jsc::{
+    JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSType, JSValue, JsResult,
+    StringJsc,
+};
+
+pub(crate) enum Replacer {
+    /// Called with the holder as `this` for the root (key `""`), every property and every element.
+    Function(JSValue),
+    /// `JSON.stringify`'s property list: the properties to write for every object, in this order.
+    Keys(Rc<[BunString]>),
+}
+
+impl Replacer {
+    /// `None` for what is neither callable nor an array, which `JSON.stringify` ignores too.
+    pub(crate) fn from_js(global: &JSGlobalObject, replacer: JSValue) -> JsResult<Option<Self>> {
+        if replacer.is_callable() {
+            return Ok(Some(Self::Function(replacer)));
+        }
+        if !replacer.is_array_including_proxy(global)? {
+            return Ok(None);
+        }
+
+        let mut keys: Vec<BunString> = Vec::new();
+        let mut seen: StringHashMap<()> = StringHashMap::default();
+        let mut items = replacer.array_iterator(global)?;
+        while let Some(item) = items.next()? {
+            // ECMA-262 JSON.stringify step 4.b.ii: strings and numbers, boxed or not.
+            let names_a_property = item.is_string() // also true for a String object
+                || item.is_number()
+                || (item.is_cell() && item.js_type() == JSType::NumberObject);
+            if !names_a_property {
+                continue;
+            }
+            let key = item.to_bun_string(global)?;
+            if seen.get_or_put(key.to_utf8().slice())?.found_existing {
+                continue;
+            }
+            keys.push(key);
+        }
+        Ok(Some(Self::Keys(Rc::from(keys))))
+    }
+
+    /// Whether the replacer is a function, which every occurrence of a value goes through.
+    pub(crate) fn is_function(&self) -> bool {
+        matches!(self, Self::Function(_))
+    }
+
+    /// The root after the replacer: `replacer.call({ "": value }, "", value)` for a function.
+    pub(crate) fn replace_root(
+        &self,
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        let Self::Function(function) = self else {
+            return Ok(value);
+        };
+        let holder = JSValue::create_empty_object(global, 1);
+        holder.put(global, b"", value);
+        function.call(global, holder, &[JSValue::js_empty_string(global), value])
+    }
+
+    /// `holder[name]` after the replacer.
+    pub(crate) fn replace_property(
+        &self,
+        global: &JSGlobalObject,
+        holder: JSValue,
+        name: &BunString,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        let Self::Function(function) = self else {
+            return Ok(value);
+        };
+        function.call(global, holder, &[name.to_js(global)?, value])
+    }
+
+    /// `array[index]` after the replacer.
+    pub(crate) fn replace_element(
+        &self,
+        global: &JSGlobalObject,
+        array: JSValue,
+        index: u32,
+        value: JSValue,
+    ) -> JsResult<JSValue> {
+        let Self::Function(function) = self else {
+            return Ok(value);
+        };
+        let key = JSValue::js_number_from_uint64(u64::from(index))
+            .to_js_string(global)?
+            .to_js();
+        function.call(global, array, &[key, value])
+    }
+}
+
+/// The properties a stringifier writes for one object: its own enumerable ones, or the listed ones.
+pub(crate) enum Properties<'a> {
+    Own(JSPropertyIterator<'a>),
+    Listed {
+        global: &'a JSGlobalObject,
+        object: JSValue,
+        keys: Rc<[BunString]>,
+        next: usize,
+    },
+}
+
+impl<'a> Properties<'a> {
+    pub(crate) fn init(
+        global: &'a JSGlobalObject,
+        object: JSValue,
+        replacer: Option<&Replacer>,
+    ) -> JsResult<Self> {
+        Ok(match replacer {
+            Some(Replacer::Keys(keys)) => Self::Listed {
+                global,
+                object,
+                keys: Rc::clone(keys),
+                next: 0,
+            },
+            _ => Self::Own(JSPropertyIterator::init(
+                global,
+                object.to_object(global)?,
+                JSPropertyIteratorOptions::new(false, true),
+            )?),
+        })
+    }
+
+    /// How many entries `next` can yield at most (a listed key the object lacks still counts).
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Own(iter) => iter.len,
+            Self::Listed { keys, .. } => keys.len(),
+        }
+    }
+
+    /// The next name (borrowed while `self` lives) and value; a missing key yields `undefined`.
+    pub(crate) fn next(&mut self) -> JsResult<Option<(StringView<'_>, JSValue)>> {
+        match self {
+            Self::Own(iter) => iter.next(),
+            Self::Listed {
+                global,
+                object,
+                keys,
+                next,
+            } => {
+                let Some(key) = keys.get(*next) else {
+                    return Ok(None);
+                };
+                *next += 1;
+                Ok(Some((
+                    StringView::new(key),
+                    object.get_may_be_index(global, key)?,
+                )))
+            }
+        }
+    }
+}

--- a/test/integration/bun-types/fixture/json5.ts
+++ b/test/integration/bun-types/fixture/json5.ts
@@ -1,0 +1,13 @@
+import { JSON5 } from "bun";
+import { expectType } from "./utilities";
+
+expectType(JSON5.parse("{a: 1}")).is<unknown>();
+// `undefined` when the input is `undefined`, a function, or a symbol.
+expectType(JSON5.stringify({ a: 1 })).is<string | undefined>();
+expectType(Bun.JSON5.stringify({ a: 1 }, null, 2)).is<string | undefined>();
+expectType(JSON5.stringify({ a: 1 }, (key, value) => (key === "a" ? undefined : value))).is<string | undefined>();
+expectType(JSON5.stringify({ a: 1 }, ["a", 1], "\t")).is<string | undefined>();
+// @ts-expect-error
+JSON5.stringify({ a: 1 }, "a");
+// @ts-expect-error
+JSON5.stringify({ a: 1 }, [true]);

--- a/test/integration/bun-types/fixture/toml.ts
+++ b/test/integration/bun-types/fixture/toml.ts
@@ -8,3 +8,8 @@ expectType(TOML.parse(data)).is<object>();
 // `undefined` when the input is `undefined`, a function, or a symbol.
 expectType(Bun.TOML.stringify({ abc: "def" })).is<string | undefined>();
 expectType(TOML.stringify({ abc: "def" })).is<string | undefined>();
+expectType(TOML.stringify({ abc: "def" }, (key, value) => (key === "abc" ? undefined : value))).is<string | undefined>();
+expectType(TOML.stringify({ abc: "def" }, ["abc"])).is<string | undefined>();
+expectType(TOML.stringify({ abc: "def" }, null, 2)).is<string | undefined>();
+// @ts-expect-error
+TOML.stringify({ abc: "def" }, {});

--- a/test/integration/bun-types/fixture/yaml.ts
+++ b/test/integration/bun-types/fixture/yaml.ts
@@ -3,8 +3,28 @@ import { expectType } from "./utilities";
 expectType(Bun.YAML.parse("")).is<unknown>();
 // @ts-expect-error
 expectType(Bun.YAML.parse({})).is<unknown>();
-expectType(Bun.YAML.stringify({ abc: "def"})).is<string>();
+// `undefined` when the input is `undefined`, a function, or a symbol, or when a replacer drops the root.
+expectType(Bun.YAML.stringify({ abc: "def" })).is<string | undefined>();
+expectType(Bun.YAML.stringify(undefined)).is<string | undefined>();
+expectType(Bun.YAML.stringify(() => {})).is<string | undefined>();
+expectType(Bun.YAML.stringify(Symbol("value"))).is<string | undefined>();
 // @ts-expect-error
-expectType(Bun.YAML.stringify("hi", {})).is<string>();
+expectType(Bun.YAML.stringify("hi", {})).is<string | undefined>();
 // @ts-expect-error
-expectType(Bun.YAML.stringify("hi", null, 123n)).is<string>();
+expectType(Bun.YAML.stringify("hi", null, 123n)).is<string | undefined>();
+
+// replacer: a function called with the holder as `this`, or a list of property names
+expectType(
+  Bun.YAML.stringify({ abc: "def" }, function (key, value) {
+    expectType(this).is<any>();
+    expectType(key).is<string>();
+    expectType(value).is<any>();
+    return key === "abc" ? undefined : value;
+  }),
+).is<string | undefined>();
+expectType(Bun.YAML.stringify({ abc: "def" }, ["abc", 0])).is<string | undefined>();
+expectType(Bun.YAML.stringify({ abc: "def" }, undefined, "\t")).is<string | undefined>();
+// @ts-expect-error
+Bun.YAML.stringify({ abc: "def" }, "abc");
+// @ts-expect-error
+Bun.YAML.stringify({ abc: "def" }, [Symbol("abc")]);

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -736,16 +736,264 @@ describe("stringify", () => {
     expect(JSON5.stringify([Infinity, -Infinity, NaN])).toEqual("[Infinity,-Infinity,NaN]");
   });
 
-  test("replacer function throws", () => {
-    expect(() => JSON5.stringify({ a: 1 }, (key: string, value: any) => value)).toThrow(
-      "JSON5.stringify does not support the replacer argument",
-    );
+  // The replacer follows the protocol of JSON.stringify's replacer, so most
+  // cases are checked against JSON.stringify on the same input.
+  describe("replacer function", () => {
+    test("is called like JSON.stringify's replacer: same keys, holders, values and order", () => {
+      const input = () => ({ a: 1, arr: [10, { b: 2, c: 3 }], o: { d: 4 } });
+      function record(calls: unknown[][]) {
+        return function (this: any, key: string, value: unknown) {
+          calls.push([key, value, this[key] === value, Array.isArray(this), Object.keys(this)]);
+          return value;
+        };
+      }
+      const json5Calls: unknown[][] = [];
+      const jsonCalls: unknown[][] = [];
+      expect(JSON5.stringify(input(), record(json5Calls))).toBe("{a:1,arr:[10,{b:2,c:3}],o:{d:4}}");
+      JSON.stringify(input(), record(jsonCalls));
+      expect(json5Calls).toEqual(jsonCalls);
+      expect(json5Calls[0]).toEqual(["", input(), true, false, [""]]);
+    });
+
+    test("the returned value is written in place of the original", () => {
+      const replacer = (key: string, value: unknown) => (typeof value === "bigint" ? value.toString() : value);
+      expect(JSON5.stringify({ id: 10n, list: [1n, { n: 2n }] }, replacer)).toBe("{id:'10',list:['1',{n:'2'}]}");
+      expect(
+        JSON5.stringify({ d: new Date(0) }, (key, value) => (value instanceof Date ? value.toISOString() : value)),
+      ).toBe("{d:'1970-01-01T00:00:00.000Z'}");
+    });
+
+    test("is applied to the properties of an object the replacer returned", () => {
+      const replacer = (key: string, value: unknown) =>
+        value instanceof Map ? Object.fromEntries(value) : typeof value === "bigint" ? `${value}n` : value;
+      const input = () => ({ m: new Map([["k", 1n]]) });
+      expect(JSON5.stringify(input(), replacer)).toBe("{m:{k:'1n'}}");
+      expect(JSON5.parse(JSON5.stringify(input(), replacer))).toEqual(JSON.parse(JSON.stringify(input(), replacer)));
+    });
+
+    test("undefined, a function or a symbol drops the property and writes null for an array element", () => {
+      const drop = (key: string, value: unknown) => (key === "a" || key === "0" ? undefined : value);
+      expect(JSON5.stringify({ a: 1, b: 2, list: [1, 2] }, drop)).toBe("{b:2,list:[null,2]}");
+      expect(JSON5.stringify({ a: 1, b: 2 }, (key, value) => (key === "a" ? () => {} : value))).toBe("{b:2}");
+      expect(JSON5.stringify({ a: 1, b: 2 }, (key, value) => (key === "a" ? Symbol("a") : value))).toBe("{b:2}");
+    });
+
+    test("holes are written as without a replacer", () => {
+      const holey = [1, , 3];
+      expect(JSON5.stringify(holey)).toBe("[1,null,3]");
+      expect(JSON5.stringify(holey, (key, value) => value)).toBe("[1,null,3]");
+      expect(JSON5.stringify(holey, ["x"])).toBe("[1,null,3]");
+      expect(JSON5.stringify({ list: new Array(2) }, ["list"])).toBe("{list:[null,null]}");
+    });
+
+    test("leaves the input as it was", () => {
+      const nested = { keep: 1, drop: 2, n: 3n };
+      const input = { nested, list: [nested, 4n], drop: 5 };
+      const snapshot = structuredClone(input);
+      const replacer = (key: string, value: unknown) =>
+        key === "drop" ? undefined : typeof value === "bigint" ? Number(value) : value;
+      expect(JSON5.stringify(input, replacer)).toBe("{nested:{keep:1,n:3},list:[{keep:1,n:3},4]}");
+      expect(JSON5.stringify(input, ["nested", "keep"])).toBe("{nested:{keep:1}}");
+      expect(input).toEqual(snapshot);
+      expect(input.nested).toBe(nested);
+      expect(input.list[0]).toBe(nested);
+    });
+
+    test('is called for the root with the key "" and a { "": value } holder', () => {
+      expect(JSON5.stringify("x", (key, value) => (key === "" ? { wrapped: value } : value))).toBe("{wrapped:'x'}");
+      expect(JSON5.stringify(undefined, () => 1)).toBe("1");
+      expect(JSON5.stringify(1, () => undefined)).toBeUndefined();
+      expect(JSON5.stringify(1, () => () => {})).toBeUndefined();
+    });
+
+    test("a boxed primitive returned by the replacer is unboxed; the replacer sees the original value as is", () => {
+      expect(JSON5.stringify({ a: 1 }, (key, value) => (key === "a" ? new String("boxed") : value))).toBe(
+        "{a:'boxed'}",
+      );
+      expect(JSON5.stringify({ a: new Number(7) }, (key, value) => (key === "a" ? typeof value : value))).toBe(
+        "{a:'object'}",
+      );
+    });
+
+    test("reads each property once", () => {
+      let reads = 0;
+      const input = {
+        get a() {
+          return ++reads;
+        },
+      };
+      expect(JSON5.stringify({ input }, (key, value) => value)).toBe("{input:{a:1}}");
+      expect(reads).toBe(1);
+    });
+
+    test("a replacer can break a cycle; one that does not still gets the circular error", () => {
+      const cyclic: any = { x: 1 };
+      cyclic.self = cyclic;
+      const seen = new WeakSet();
+      const breakCycles = (key: string, value: any) => {
+        if (typeof value === "object" && value !== null) {
+          if (seen.has(value)) return "[Circular]";
+          seen.add(value);
+        }
+        return value;
+      };
+      expect(JSON5.stringify(cyclic, breakCycles)).toBe("{x:1,self:'[Circular]'}");
+      expect(() => JSON5.stringify(cyclic, (key, value) => value)).toThrow("Converting circular structure to JSON5");
+    });
+
+    test("an object that appears twice is replaced and written twice, as JSON.stringify does", () => {
+      const shared = { x: 1 };
+      const input = { a: shared, b: shared };
+      const keys: string[] = [];
+      let n = 0;
+      const count = (key: string, value: unknown) => {
+        keys.push(key);
+        return key === "x" ? ++n : value;
+      };
+      expect(JSON5.stringify(input, count)).toBe("{a:{x:1},b:{x:2}}");
+      expect(keys).toEqual(["", "a", "x", "b", "x"]);
+      expect(JSON.stringify(input, count)).toBe('{"a":{"x":3},"b":{"x":4}}');
+    });
+
+    test("an exception thrown by the replacer propagates", () => {
+      expect(() =>
+        JSON5.stringify({ a: 1 }, () => {
+          throw new TypeError("from the replacer");
+        }),
+      ).toThrow(new TypeError("from the replacer"));
+    });
+
+    test("works together with space", () => {
+      expect(JSON5.stringify({ a: 1, b: 2 }, (key, value) => (key === "a" ? undefined : value), 2)).toBe(
+        "{\n  b: 2,\n}",
+      );
+    });
+
+    test("a callable that is not a function object is a replacer too", () => {
+      const replacer = new Proxy(() => {}, {
+        apply: (target, thisArg, [key, value]) => (key === "a" ? 2 : value),
+      });
+      expect(JSON5.stringify({ a: 1 }, replacer)).toBe("{a:2}");
+    });
+
+    test("throws a RangeError instead of overflowing the stack on a very deep value", () => {
+      const deep: any = {};
+      let current = deep;
+      for (let i = 0; i < 200_000; i++) {
+        current.next = {};
+        current = current.next;
+      }
+      expect(() => JSON5.stringify(deep, (key, value) => value)).toThrow(RangeError);
+      expect(() => JSON5.stringify(deep, ["next"])).toThrow(RangeError);
+    });
+
+    test("objects the replacer returns survive garbage collection during the walk", () => {
+      const input: Record<string, unknown> = {};
+      for (let i = 0; i < 30; i++) input[`k${i}`] = { i, inner: { j: i }, list: [i, { z: i }] };
+      let calls = 0;
+      const output = JSON5.stringify(input, (key, value) => {
+        if (++calls % 30 === 0) Bun.gc(true);
+        if (typeof value === "object" && value !== null && !Array.isArray(value) && key !== "") {
+          return { ...value, fresh: key };
+        }
+        return value;
+      });
+      const parsed: any = JSON5.parse(output!);
+      expect(Object.keys(parsed)).toHaveLength(30);
+      expect(parsed.k7).toEqual({
+        i: 7,
+        inner: { j: 7, fresh: "inner" },
+        list: [7, { z: 7, fresh: "1" }],
+        fresh: "k7",
+      });
+    });
   });
 
-  test("replacer array throws", () => {
-    expect(() => JSON5.stringify({ a: 1, b: 2 }, ["a"])).toThrow(
-      "JSON5.stringify does not support the replacer argument",
-    );
+  describe("replacer array", () => {
+    test("writes only the listed properties, in the order of the list, at every level", () => {
+      const input = { b: 1, a: 2, secret: 3, nested: { secret: 4, a: 5 }, list: [{ secret: 6, b: 7 }, 8] };
+      expect(JSON5.stringify(input, ["a", "b", "nested", "list"])).toBe("{a:2,b:1,nested:{a:5},list:[{b:7},8]}");
+    });
+
+    test("does not filter arrays, and leaves a primitive root alone", () => {
+      expect(JSON5.stringify([1, { a: 2, b: 3 }], ["a"])).toBe("[1,{a:2}]");
+      expect(JSON5.stringify({ a: 1 }, [])).toBe("{}");
+      expect(JSON5.stringify([{ a: 1 }], [])).toBe("[{}]");
+      expect(JSON5.stringify(5, ["a"])).toBe("5");
+      expect(JSON5.stringify("s", ["a"])).toBe("'s'");
+    });
+
+    test("accepts the entries JSON.stringify accepts: strings, numbers and their wrapper objects, deduplicated", () => {
+      class WithGetter {
+        own = 1;
+        other = 2;
+        get fromPrototype() {
+          return "getter";
+        }
+      }
+      const input = Object.assign(new WithGetter(), { 5: "five" });
+      const list = ["fromPrototype", "own", "missing", new String("other"), 5, null, true, {}, Symbol.iterator, "own"];
+      expect(JSON5.stringify(input, list as any)).toBe("{fromPrototype:'getter',own:1,other:2,'5':'five'}");
+      expect(JSON.stringify(input, list as any)).toBe('{"fromPrototype":"getter","own":1,"other":2,"5":"five"}');
+    });
+
+    test("writes the keys in the order of the list, index-like keys included", () => {
+      const input = { b: 1, 0: "zero", a: 2 };
+      expect(JSON5.stringify(input, ["b", "a", "0"])).toBe("{b:1,a:2,'0':'zero'}");
+      expect(JSON.stringify(input, ["b", "a", "0"])).toBe('{"b":1,"a":2,"0":"zero"}');
+    });
+
+    test("looks keys up by their full name", () => {
+      expect(JSON5.stringify({ ключ: 1, 键: 2, x: 3 }, ["键", "ключ"])).toBe("{键:2,ключ:1}");
+      expect(JSON5.stringify({ "": 1, x: 2 }, [""])).toBe("{'':1}");
+    });
+
+    test("reads each listed property once", () => {
+      let reads = 0;
+      const input = {
+        get a() {
+          return ++reads;
+        },
+      };
+      expect(JSON5.stringify({ input }, ["input", "a"])).toBe("{input:{a:1}}");
+      expect(reads).toBe(1);
+    });
+
+    test("an exception thrown while the list is read propagates", () => {
+      class Throws extends String {
+        override toString(): string {
+          throw new Error("from toString");
+        }
+      }
+      expect(() => JSON5.stringify({ a: 1 }, [new Throws("a")] as any)).toThrow("from toString");
+    });
+
+    test("works together with space", () => {
+      expect(JSON5.stringify({ a: 1, b: 2 }, ["b"], 2)).toBe("{\n  b: 2,\n}");
+    });
+
+    test("a Proxy of an array is a list too, read through its traps", () => {
+      const input = { a: 1, b: 2, c: 3 };
+      expect(JSON5.stringify(input, new Proxy(["b"], {}))).toBe("{b:2}");
+
+      const trapped = new Proxy(["a"], {
+        get(target, key, receiver) {
+          return key === "length" ? 2 : key === "1" ? "c" : Reflect.get(target, key, receiver);
+        },
+      });
+      expect(JSON5.stringify(input, trapped)).toBe("{a:1,c:3}");
+      expect(JSON.stringify(input, trapped)).toBe('{"a":1,"c":3}');
+
+      const { proxy, revoke } = Proxy.revocable(["a"], {});
+      revoke();
+      expect(() => JSON5.stringify(input, proxy)).toThrow(TypeError);
+    });
+  });
+
+  test("a replacer that is neither callable nor an array is ignored, as JSON.stringify ignores it", () => {
+    for (const replacer of [undefined, null, "a", 1, true, { 0: "a", length: 1 }]) {
+      expect(JSON5.stringify({ a: 1, b: 2 }, replacer as any)).toBe("{a:1,b:2}");
+    }
   });
 
   test("space parameter with number", () => {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -889,9 +889,133 @@ describe("TOML.stringify", () => {
     expect(TOML.stringify(undefined)).toBeUndefined();
   });
 
-  test("replacer is rejected; space is accepted and ignored", () => {
-    expect(() => TOML.stringify({}, (() => 1) as any)).toThrow("TOML.stringify does not support the replacer argument");
-    expect(TOML.stringify({ a: { b: 1 } }, null, 2)).toBe(TOML.stringify({ a: { b: 1 } }));
+  test("space is accepted and ignored", () => {
+    expect(TOML.stringify({ a: { b: 1 } }, null, 2)).toBe("[a]\nb = 1\n");
+    expect(TOML.stringify({ a: { b: 1 } }, null, "\t")).toBe("[a]\nb = 1\n");
+  });
+
+  // The replacer protocol (keys, holders, call order, how the list is read) is
+  // shared with JSON5.stringify and covered in json5.test.ts. These tests
+  // cover what is specific to the TOML output.
+  describe("replacer", () => {
+    test("a function replaces values in keyvals, tables, arrays and arrays of tables", () => {
+      const input = {
+        name: "app",
+        id: 7n,
+        server: { port: 8080n, secret: "s" },
+        points: [{ x: 1n, secret: "s" }, { x: 2n }],
+      };
+      const snapshot = structuredClone(input);
+      const calls: [string, boolean][] = [];
+      const replacer = function (this: unknown, key: string, value: unknown) {
+        calls.push([key, Array.isArray(this)]);
+        if (key === "secret") return undefined;
+        return typeof value === "bigint" ? Number(value) : value;
+      };
+      expect(TOML.stringify(input, replacer)).toBe(
+        'name = "app"\nid = 7\n\n[server]\nport = 8080\n\n[[points]]\nx = 1\n\n[[points]]\nx = 2\n',
+      );
+      expect(input).toEqual(snapshot);
+      // Once per property, in property order. An array element comes with its index, and the array is the holder.
+      expect(calls).toEqual([
+        ["", false],
+        ["name", false],
+        ["id", false],
+        ["server", false],
+        ["port", false],
+        ["secret", false],
+        ["points", false],
+        ["0", true],
+        ["x", false],
+        ["secret", false],
+        ["1", true],
+        ["x", false],
+      ]);
+    });
+
+    test("Date and Temporal values the replacer returns are still written as date/times", () => {
+      const input = {
+        date: new Date(0),
+        day: Temporal.PlainDate.from("1979-05-27"),
+        list: [Temporal.PlainTime.from("07:32:00")],
+      };
+      const keep = (key: string, value: unknown) => value;
+      expect(TOML.stringify(input, keep)).toBe(TOML.stringify(input));
+      expect(TOML.stringify(input, keep)).toBe("date = 1970-01-01T00:00:00Z\nday = 1979-05-27\nlist = [07:32:00]\n");
+      expect(TOML.stringify(input, ["date", "day"])).toBe("date = 1970-01-01T00:00:00Z\nday = 1979-05-27\n");
+      expect(TOML.stringify(input, (key, value) => (value instanceof Date ? value.getTime() : value))).toBe(
+        "date = 0\nday = 1979-05-27\nlist = [07:32:00]\n",
+      );
+    });
+
+    test("the layout follows the replaced values", () => {
+      const points = { points: [{ id: 1 }, { id: 2 }] };
+      expect(TOML.stringify(points)).toBe("[[points]]\nid = 1\n\n[[points]]\nid = 2\n");
+      expect(
+        TOML.stringify(points, (key, value: any) =>
+          key !== "" && typeof value === "object" && "id" in value ? `#${value.id}` : value,
+        ),
+      ).toBe('points = ["#1", "#2"]\n');
+
+      const names = { names: ["a", "b"] };
+      expect(TOML.stringify(names)).toBe('names = ["a", "b"]\n');
+      expect(TOML.stringify(names, (key, value) => (/^\d+$/.test(key) ? { name: value } : value))).toBe(
+        '[[names]]\nname = "a"\n\n[[names]]\nname = "b"\n',
+      );
+    });
+
+    test("replaced values follow the same rules as written values", () => {
+      const toNull = (key: string, value: unknown) => (key === "a" ? null : value);
+      expect(() => TOML.stringify({ a: 1 }, toNull)).toThrow(
+        "TOML cannot represent null (key 'a'); remove the key or use a sentinel value",
+      );
+      expect(TOML.stringify({ a: 1, b: 2 }, (key, value) => (key === "a" ? undefined : value))).toBe("b = 2\n");
+      expect(() => TOML.stringify({ list: [1, 2] }, (key, value) => (key === "0" ? undefined : value))).toThrow(
+        "TOML cannot represent undefined in an array",
+      );
+      expect(() => TOML.stringify({ n: 1 }, (key, value) => (key === "n" ? 1n : value))).toThrow(
+        "TOML.stringify cannot serialize BigInt",
+      );
+      const cyclic: any = { a: 1 };
+      cyclic.self = cyclic;
+      expect(() => TOML.stringify(cyclic, (key, value) => value)).toThrow("Converting circular structure to TOML");
+      expect(TOML.stringify(cyclic, (key, value) => (key === "self" ? "(cycle)" : value))).toBe(
+        'a = 1\nself = "(cycle)"\n',
+      );
+    });
+
+    test("the root goes through the replacer and must still come out as a table", () => {
+      expect(TOML.stringify(5, (key, value) => (key === "" ? { value } : value))).toBe("value = 5\n");
+      expect(() => TOML.stringify({ a: 1 }, () => 5)).toThrow(
+        "TOML.stringify expects an object at the top level (a TOML document is a table)",
+      );
+      expect(TOML.stringify({ a: 1 }, () => undefined)).toBeUndefined();
+    });
+
+    test("an array lists the keys to write in every table: root, sub-tables, inline tables and arrays of tables", () => {
+      const input = {
+        secret: "s",
+        name: "app",
+        server: { secret: "s", host: "h", tls: { secret: "s", cert: "c" } },
+        points: [{ secret: "s", id: 1 }],
+        mixed: [1, { secret: "s", id: 2 }],
+      };
+      expect(TOML.stringify(input, ["name", "server", "host", "tls", "cert", "points", "mixed", "id"])).toBe(
+        'name = "app"\nmixed = [1, { id = 2 }]\n\n[server]\nhost = "h"\n\n[server.tls]\ncert = "c"\n\n[[points]]\nid = 1\n',
+      );
+    });
+
+    test("an array decides the order of the keyvals and of the tables", () => {
+      const input = { a: 1, b: 2, t1: { x: 1 }, t2: { x: 2 } };
+      expect(TOML.stringify(input, ["b", "t2", "a", "t1", "x"])).toBe("b = 2\na = 1\n\n[t2]\nx = 2\n\n[t1]\nx = 1\n");
+      expect(TOML.stringify(input, [])).toBe("");
+    });
+
+    test("a replacer that is neither callable nor an array is ignored, as JSON.stringify ignores it", () => {
+      for (const replacer of [undefined, null, "a", 1, true, { 0: "a", length: 1 }]) {
+        expect(TOML.stringify({ a: 1, b: 2 }, replacer as any)).toBe("a = 1\nb = 2\n");
+      }
+    });
   });
 
   test("undefined, function, and symbol properties are skipped", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2869,8 +2869,89 @@ config:
       expect(YAML.stringify(Symbol("test"))).toBe(undefined);
     });
 
-    test("throws on replacer parameter", () => {
-      expect(() => YAML.stringify({ a: 1 }, () => {})).toThrow("YAML.stringify does not support the replacer argument");
+    // The replacer protocol (keys, holders, call order, how the list is read) is
+    // shared with JSON5.stringify and covered in json5.test.ts. These tests
+    // cover what is specific to the YAML output.
+    describe("replacer", () => {
+      test("a function replaces values in flow and block style", () => {
+        const input = { user: "ada", password: "hunter2", tokens: [1n, 2n] };
+        const replacer = (key: string, value: unknown) =>
+          key === "password" ? "***" : typeof value === "bigint" ? value.toString() : value;
+        expect(YAML.stringify(input, replacer)).toBe('{user: ada,password: "***",tokens: ["1","2"]}');
+        expect(YAML.stringify(input, replacer, 2)).toBe('user: ada\npassword: "***"\ntokens: \n  - "1"\n  - "2"');
+      });
+
+      test('a function is called for the root with the key ""', () => {
+        expect(YAML.stringify("x", (key, value) => (key === "" ? { wrapped: value } : value))).toBe("{wrapped: x}");
+        expect(YAML.stringify({ a: 1 }, () => undefined)).toBeUndefined();
+        expect(YAML.stringify(undefined, (key, value) => (key === "" ? [1] : value))).toBe("[1]");
+      });
+
+      test("undefined from the replacer is left out, in objects and in arrays", () => {
+        const drop = (key: string, value: unknown) => (key === "b" || key === "1" ? undefined : value);
+        expect(YAML.stringify({ a: 1, b: 2, list: [1, 2, 3] }, drop)).toBe("{a: 1,list: [1,3]}");
+        expect(YAML.stringify({ a: 1, b: 2, list: [1, 2, 3] }, drop, 2)).toBe("a: 1\nlist: \n  - 1\n  - 3");
+      });
+
+      test("a function replacer sees an object once per key it appears under, as with JSON.stringify", () => {
+        const shared = { x: 1 };
+        const input = { a: shared, b: shared };
+        expect(YAML.stringify(input)).toBe("{a: &a {x: 1},b: *a}");
+        // Each occurrence is replaced on its own, so the two are no longer one node.
+        const keys: string[] = [];
+        const keep = (key: string, value: unknown) => {
+          keys.push(key);
+          return value;
+        };
+        expect(YAML.stringify(input, keep)).toBe("{a: {x: 1},b: {x: 1}}");
+        expect(keys).toEqual(["", "a", "x", "b", "x"]);
+        let n = 0;
+        expect(YAML.stringify(input, (key, value) => (key === "x" ? ++n : value))).toBe("{a: {x: 1},b: {x: 2}}");
+        expect(input).toEqual({ a: { x: 1 }, b: { x: 1 } });
+        expect(input.a).toBe(shared);
+      });
+
+      test("a cycle the replacer keeps is written with an anchor; one it breaks is not", () => {
+        const cyclic: any = { name: "loop" };
+        cyclic.self = cyclic;
+        expect(YAML.stringify(cyclic, (key, value) => value, 2)).toBe(YAML.stringify(cyclic, null, 2));
+        expect(YAML.stringify(cyclic, (key, value) => value)).toBe("&root {name: loop,self: *root}");
+        expect(YAML.stringify(cyclic, (key, value) => (key === "self" ? "(cycle)" : value))).toBe(
+          "{name: loop,self: (cycle)}",
+        );
+      });
+
+      test("a BigInt or a Date the replacer converts no longer throws or turns into {}", () => {
+        expect(() => YAML.stringify({ big: 1n })).toThrow("YAML.stringify cannot serialize BigInt");
+        expect(YAML.stringify({ big: 1n }, (key, value) => (typeof value === "bigint" ? Number(value) : value))).toBe(
+          "{big: 1}",
+        );
+        expect(YAML.stringify({ d: new Date(0) })).toBe("{d: {}}");
+        expect(
+          YAML.stringify({ d: new Date(0) }, (key, value) => (value instanceof Date ? value.getTime() : value)),
+        ).toBe("{d: 0}");
+      });
+
+      test("an array lists the properties to write, in that order, at every level", () => {
+        const input = { b: 1, a: 2, secret: 3, nested: { secret: 4, a: 5 }, list: [{ secret: 6, b: 7 }, 8] };
+        expect(YAML.stringify(input, ["a", "b", "nested", "list"])).toBe("{a: 2,b: 1,nested: {a: 5},list: [{b: 7},8]}");
+        expect(YAML.stringify(input, ["nested", "a"], 2)).toBe("nested: \n  a: 5\na: 2");
+        expect(YAML.stringify(input, [])).toBe("{}");
+        expect(YAML.stringify("scalar", ["a"])).toBe("scalar");
+      });
+
+      test("an array keeps anchors and aliases between the listed values", () => {
+        const shared = { x: 1, y: 2 };
+        expect(YAML.stringify({ first: shared, skipped: 1, second: shared }, ["first", "second", "x"])).toBe(
+          "{first: &first {x: 1},second: *first}",
+        );
+      });
+
+      test("a replacer that is neither callable nor an array is ignored, as JSON.stringify ignores it", () => {
+        for (const replacer of [undefined, null, "a", 1, true, { 0: "a", length: 1 }]) {
+          expect(YAML.stringify({ a: 1, b: 2 }, replacer as any)).toBe("{a: 1,b: 2}");
+        }
+      });
     });
 
     test("handles functions", () => {
@@ -3873,26 +3954,17 @@ config:
         expect(() => YAML.stringify(deep)).toThrow("Maximum call stack size exceeded");
       });
 
-      test("stack overflow protection in the write pass", () => {
-        let deep = {};
-        let current = deep;
-        for (let i = 0; i < 1000000; i++) {
-          current.next = {};
-          current = current.next;
-        }
-
-        // stringify reads every property twice: once to find anchors and once
-        // to write. Hand the first read a shallow value so that only the write
-        // pass walks the deep structure.
+      test("reads every property once, before it writes", () => {
         let reads = 0;
         const root = {
           get value() {
-            return reads++ === 0 ? {} : deep;
+            reads++;
+            return { nested: [1, { deep: true }] };
           },
         };
 
-        expect(() => YAML.stringify(root)).toThrow("Maximum call stack size exceeded");
-        expect(reads).toBe(2);
+        expect(YAML.stringify(root)).toBe("{value: {nested: [1,{deep: true}]}}");
+        expect(reads).toBe(1);
       });
 
       test("handles arrays as root with references", () => {
@@ -4391,11 +4463,12 @@ refs:
           },
         };
 
+        // Each property is read once per call.
         const yaml1 = YAML.stringify(obj, null, 2);
         const yaml2 = YAML.stringify(obj, null, 2);
 
-        expect(yaml1).toBe("counter: 2");
-        expect(yaml2).toBe("counter: 4");
+        expect(yaml1).toBe("counter: 1");
+        expect(yaml2).toBe("counter: 2");
       });
 
       test.todo("handles circular getters", () => {


### PR DESCRIPTION
### Problem
- `Bun.YAML.stringify`, `Bun.TOML.stringify` and `Bun.JSON5.stringify` throw `X.stringify does not support the replacer argument` for any non-null replacer (`src/runtime/api/YAMLObject.rs:34` and siblings).
- YAML read every property twice (anchors, then the write) and TOML read each table twice, so a function replacer called there would run twice.

### Fix
- New `src/runtime/api/stringify_replacer.rs`. `Replacer` reads the argument and calls a function replacer as `JSON.stringify` does. `Properties` yields the own enumerable properties, or the listed ones in list order with one `[[Get]]` each.
- JSON5 calls the replacer inline in its one pass. TOML and YAML read the value once, depth first, in `JSON.stringify` order, into native records (`Value` in TOML, `Node` in YAML). The write pass runs no JS. Getters now run once in YAML (two upstream tests updated).
- A function replacer runs once per occurrence of a shared object, as in `JSON.stringify`, so YAML writes such an object once per key. A cycle still gets an anchor.
- Verified: `test/js/bun/json5/json5.test.ts` (compared call by call with `JSON.stringify`), `yaml.test.ts`, `toml.test.ts`. All new tests fail without this change. Also `bun-types`, source lints, clippy.

### Background
- A replacer is the second argument of `JSON.stringify`. A function gets every `(key, value)` pair, with the holder as `this`, and returns what to write. An array lists the names to write.
- A `JSValue` on the Rust heap is not a GC root. The records are live while the replacer runs JS, so every value they hold also goes into a `MarkedArgumentBuffer`, which the GC marks.
- `JSC__JSValue__getMayBeIndex` (next to `putMayBeIndex`) is the `[[Get]]` by any name that a key list needs.

<details><summary>Notes</summary>

- Behavior matches `JSON.stringify` call for call on the inputs tried (call order, keys, holders, values, result), with two exceptions: no `toJSON` is consulted (unchanged, and deliberately so: a format-specific hook would be its own design), and Symbol-keyed properties are written by description, which the stringifiers already did and #37010 fixes.
- `JSValue::get` is the options-bag accessor: it skips index-like names and stops before `Object.prototype`. `get_may_be_index` is the `[[Get]]` counterpart of `put_may_be_index`: any name, whole prototype chain, `undefined` when missing. The unused `JSC__JSValue__getPropertyValue` is left alone, because #39618 removes it.
- Without a replacer the stringifiers do the same JS work as before, or less: `Replacer::from_js` does two type checks and `Properties::init` wraps the same `JSPropertyIterator`. YAML reads each property once instead of twice. In the debug build, YAML of a 300k element array went from 2388 ms to 1083 ms. With a function replacer, the three stringifiers cost about 1.9x the function-replacer path of `JSON.stringify` per element.
- YAML with a function replacer: `known_collections` holds only the collections on the current path, so a repeat elsewhere is read again (and the replacer called again), as `JSON.stringify` does. Without a function replacer it holds every collection, so a repeat becomes an alias as before.
- TOML reads `null`, `undefined`, a symbol or a function in an array as an error at read time, so a replacer that returns one of them fails with the same message as before.
- `YAML.stringify` is declared `string | undefined` like its siblings, since a replacer can drop the root. This is #34162, credited in the commit.
- Rebased onto #40238 (`bun_core::String` owns its WTF ref). The three stringifiers now hold `String` values directly (`OwnedString` is gone), `Properties::next` yields a `StringView` like `JSPropertyIterator::next`, and TOML takes main's parent-linked `Path` for table headers instead of a `Vec`. A 256 KiB-string RSS probe over all three stringifiers, with and without replacers, shows no growth.
- A replacer that is neither callable nor an array is ignored, as with `JSON.stringify`. The array check is `JSValue::is_array_including_proxy`, a wrapper of `JSC::isArray` (the spec IsArray), so a Proxy of an array is a key list too. The `.d.ts` accepts a function, an array or `null`.
- Every example in the docs and the JSDoc was run against the debug build. The probes also ran under `BUN_JSC_validateExceptionChecks=1`.
- #34080 also adds `test/integration/bun-types/fixture/json5.ts`. Whichever lands second keeps both sets of lines.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/json5/json5.test.ts

<!-- robobun:evidence:end -->
