### PR TITLE
Reject an IP literal that inet_aton does not consume whole

### DIFF
--- a/src/bun_core/ip_address.rs
+++ b/src/bun_core/ip_address.rs
@@ -71,8 +71,7 @@ pub fn to_ip_address(input: &[u8]) -> Option<IpAddr> {
     if input.is_empty() || input.len() >= buf.len() {
         return None;
     }
-    // No numeric host contains whitespace. inet_aton(3) stops at it and ignores the rest, so
-    // `127.0.0.1 evil.example` would parse; the `__inet_aton_exact` behind getaddrinfo does not.
+    // inet_aton(3) stops at whitespace and ignores what follows; getaddrinfo's numeric parse does not.
     if crate::strings::index_of_any(input, b" \t\n\r\x0b\x0c").is_some() {
         return None;
     }

--- a/src/bun_core/ip_address.rs
+++ b/src/bun_core/ip_address.rs
@@ -71,6 +71,11 @@ pub fn to_ip_address(input: &[u8]) -> Option<IpAddr> {
     if input.is_empty() || input.len() >= buf.len() {
         return None;
     }
+    // No numeric host contains whitespace. inet_aton(3) stops at it and ignores the rest, so
+    // `127.0.0.1 evil.example` would parse; the `__inet_aton_exact` behind getaddrinfo does not.
+    if crate::strings::index_of_any(input, b" \t\n\r\x0b\x0c").is_some() {
+        return None;
+    }
     // A `%zone` suffix belongs to a numeric v6 host; resolving the zone is the caller's business.
     let head = crate::strings::index_of_char_usize(input, b'%').unwrap_or(input.len());
     buf[..head].copy_from_slice(&input[..head]);

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 // `Bun.connect` to a hostname that fails to resolve must surface the resolver
 // error (code `ENOTFOUND`, `syscall: "getaddrinfo"`, `hostname`), matching
@@ -99,6 +99,64 @@ test("a resolver error delivered to both connectError() and the promise is not r
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, exitCode }).toEqual({ stdout: "ok\n", exitCode: 0 });
   void stderr;
+});
+
+// uSockets parses the hostname as an IP literal before it resolves it. That
+// parse went through inet_aton(3), which stops at whitespace, so every
+// hostname below connected to 127.0.0.1 (or 0.0.0.12) and a hostname
+// allow-list that had inspected the full string never saw the resolver reject it.
+test("Bun.connect does not dial the IPv4 prefix of a hostname with trailing text", async () => {
+  const { promise: accepted, resolve: onAccept } = Promise.withResolvers<void>();
+  let acceptedCount = 0;
+  using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        acceptedCount++;
+        onAccept();
+        socket.end();
+      },
+      data() {},
+    },
+  });
+
+  const hostnames = [
+    "127.0.0.1 db.allowed.example",
+    "127.1 .allowed.example",
+    "0x7f.1 junk",
+    "127.0.0.1\tx",
+    "127.0.0.1\n",
+    "12\t7.0.0.1",
+  ];
+  const results: unknown[] = [];
+  for (const hostname of hostnames) {
+    results.push(
+      await Bun.connect({
+        hostname,
+        port: listener.port,
+        socket: { open() {}, data() {} },
+      }).then(
+        socket => {
+          socket.end();
+          return "connected";
+        },
+        (e: any) => ({ syscall: e.syscall, hostname: e.hostname }),
+      ),
+    );
+  }
+  expect(results).toEqual(hostnames.map(hostname => ({ syscall: "getaddrinfo", hostname })));
+
+  // The inet_aton shorthand itself is still taken. Windows has no inet_aton; it
+  // leaves these spellings to the resolver.
+  const socket = await Bun.connect({
+    hostname: isWindows ? "127.0.0.1" : "127.1",
+    port: listener.port,
+    socket: { open() {}, data() {} },
+  });
+  await accepted;
+  socket.end();
+  expect(acceptedCount).toBe(1);
 });
 
 test("consecutive Bun.connect calls to the same unresolvable hostname all get the resolver error", async () => {

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -121,12 +121,16 @@ test("Bun.connect does not dial the IPv4 prefix of a hostname with trailing text
     },
   });
 
+  // One hostname per byte C's isspace() accepts: space, \t, \n, \v, \f, \r.
   const hostnames = [
     "127.0.0.1 db.allowed.example",
     "127.1 .allowed.example",
     "0x7f.1 junk",
     "127.0.0.1\tx",
     "127.0.0.1\n",
+    "127.0.0.1\vx",
+    "127.0.0.1\fx",
+    "127.0.0.1\rx",
     "12\t7.0.0.1",
   ];
   const results: unknown[] = [];


### PR DESCRIPTION
### Problem
- `Bun.connect({ hostname: "127.0.0.1 db.allowed.example", port })` connects to 127.0.0.1. `"12\t7.0.0.1"` connects to 0.0.0.12. `Bun.SQL`, the HTTP client, UDP and QUIC use the same parse. 1.3.14 reported `connectError`. An allow-list that checks the whole hostname does not protect these callers.
- Cause: `to_ip_address` (`src/bun_core/ip_address.rs:83`) parses IPv4 with libc `inet_aton(3)`, which stops at the first whitespace and ignores the rest. #36619 (1.4.0) replaced the strict `inet_pton` in uSockets' `try_parse_ip` with this function.

### Fix
- `to_ip_address` returns `None` when the input contains ASCII whitespace. The string then goes to the resolver, which rejects it, as in 1.3.14.
- Text after whitespace is the only thing `inet_aton` accepts that the `__inet_aton_exact` behind getaddrinfo does not, in glibc and in the BSD libc. The shorthand spellings this function exists for (`127.1`, `0x7f000001`) still parse. musl and Windows were already strict.
- The one function covers every caller: `Bun__parseIpAddress` (TCP, TLS, QUIC), `udp_socket.rs` and the macOS `dns_sd` routing.
- Verified: `test/js/bun/net/socket-dns-error.test.ts`, new test fails on 1.4.0 (eight of the nine spellings connect, the ninth dials 0.0.0.12). `test/js/bun/net/`, `udp/`, `dns/` and `node-dns.test.js` have the same failure set with and without the change.

### Background
- uSockets' connect (`packages/bun-usockets/src/context.c:617`) first asks `Bun__parseIpAddress` (`src/runtime/socket/SocketAddress.rs`) whether the host is numeric. When it is, the socket connects at once and the resolver never sees the string.
- `inet_aton(3)` is the BSD parser for the legacy IPv4 spellings. getaddrinfo accepts the same spellings through a variant that must consume the whole string.
- `Bun.listen`, `node:net` and `dns.lookup` were not affected. They validate with `isIP` or call getaddrinfo directly.

<details><summary>Notes</summary>

Repro (release 1.4.0, listener on 127.0.0.1):

```
"127.0.0.1 db.allowed.example"     -> CONNECTED 127.0.0.1
"127.1 .allowed.test"              -> CONNECTED 127.0.0.1
"0x7f.1 junk"                      -> CONNECTED 127.0.0.1
"127.0.0.1\tx"                     -> CONNECTED 127.0.0.1
"127.0.0.1\n"                      -> CONNECTED 127.0.0.1
"12\t7.0.0.1"                      -> connectError ECONNREFUSED   (connect(2) to 0.0.0.12)
```

With the change all nine report `syscall: "getaddrinfo"`, and `127.1`, `0x7f000001` and `127.0.0.1` still connect.

Why whitespace is the whole difference: glibc `inet_aton_end` (resolv/inet_addr.c) ends with `if (c != '\0' && (!isascii (c) || !isspace (c))) goto ret_0;`, and `__inet_aton_exact` additionally requires `*endp == 0`. The BSD implementation that macOS uses has the same trailing-character check. Each octet must start with a digit, so whitespace cannot occur inside the number either. musl's `inet_aton` rejects any trailing character.

The check sits before the IPv6 branch as well, so `"::1%eth0 junk"` is also left to the resolver instead of connecting with scope id 0.

The test pins `syscall` and `hostname` rather than the error code: on macOS the resolver behind `Bun.connect` is `DNSServiceGetAddrInfo`, whose code for a malformed name may differ from glibc's `ENOTFOUND`. The final connect uses `127.1` on POSIX and `127.0.0.1` on Windows, where `to_ip_address` is `inet_pton` and the shorthand is the OS resolver's business.

Also run with the debug build: `test/js/bun/http/serve-http3.test.ts` (QUIC uses the same parse), 52 pass.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket-dns-error.test.ts

<!-- robobun:evidence:end -->
