### PR TITLE
WebSocket: keep the port in Host for an IPv6 literal

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1178,19 +1178,32 @@ impl Display for URLFormatter<'_> {
 // HostFormatter
 // ───────────────────────────────────────────────────────────────────────────
 
+/// Writes `host`, then `:port` unless `host` already carries one or `port` is the scheme default.
 pub struct HostFormatter<'a> {
+    /// `example.com`, `example.com:8080`, `[::1]` or `[::1]:8080`.
     pub host: &'a [u8],
     pub port: Option<u16>,
     pub is_https: bool,
 }
 
+impl HostFormatter<'_> {
+    fn host_has_port(&self) -> bool {
+        // The colons inside an IPv6 literal's brackets are not a port separator.
+        let after_brackets = match self.host.first() {
+            Some(b'[') => crate::strings::index_of_char_usize(self.host, b']')
+                .map_or(self.host, |end| &self.host[end + 1..]),
+            _ => self.host,
+        };
+        crate::strings::contains_char(after_brackets, b':')
+    }
+}
+
 impl Display for HostFormatter<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if crate::strings::index_of_char_usize(self.host, b':').is_some() {
-            return write_bytes(f, self.host);
-        }
-
         write_bytes(f, self.host)?;
+        if self.host_has_port() {
+            return Ok(());
+        }
 
         let is_port_optional = self.port.is_none()
             || (self.is_https && self.port == Some(443))

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { createHash } from "node:crypto";
 
+// harness's isIPv6() looks for IPv6 interface addresses and is hardcoded false
+// on BuildKite Linux; all the IPv6 test below needs is a loopback bind.
+function hasIPv6Loopback() {
+  try {
+    Bun.listen({ hostname: "::1", port: 0, socket: { data() {} } }).stop(true);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("WebSocket upgrade", () => {
   // https://github.com/oven-sh/bun/issues/2896
   // BUN_CONFIG_WS_HANDSHAKE_TIMEOUT=1: uSockets sweeps every 4 s, so the
@@ -73,6 +84,41 @@ describe("WebSocket upgrade", () => {
       upgrade: "websocket",
     });
 
+    ws.close();
+  });
+
+  // RFC 9110 §7.2: Host carries the port whenever it is not the scheme default,
+  // for an IPv6 literal too. The Host writer used to take the colons inside the
+  // brackets for a port and send `Host: [::1]`.
+  test.concurrent.skipIf(!hasIPv6Loopback())("Host carries the port for an IPv6 literal", async () => {
+    const received = Promise.withResolvers<string | null>();
+    await using server = Bun.serve({
+      hostname: "::1",
+      port: 0,
+      fetch(request, server) {
+        const host = request.headers.get("host");
+        if (server.upgrade(request)) {
+          received.resolve(host);
+          return;
+        }
+        received.reject(new Error("upgrade failed"));
+        return new Response("upgrade failed", { status: 500 });
+      },
+      websocket: {
+        open(ws) {
+          ws.close();
+        },
+        message() {},
+      },
+    });
+
+    const opened = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://[::1]:${server.port}/`);
+    ws.addEventListener("open", () => opened.resolve());
+    ws.addEventListener("error", opened.reject);
+    await opened.promise;
+
+    expect(await received.promise).toBe(`[::1]:${server.port}`);
     ws.close();
   });
 


### PR DESCRIPTION
### Problem
- `new WebSocket("ws://[::1]:PORT/")` sends `Host: [::1]`. The same client sends `Host: 127.0.0.1:PORT` for an IPv4 host, and Node sends `Host: [::1]:PORT`. RFC 9110 section 7.2 requires the port when it is not the scheme default, so an IPv6 backend on another port gets the wrong virtual host.
- Cause: `HostFormatter` (`src/bun_core/fmt.rs:1189`) writes `host` unchanged when it contains a `:`. The check detects a value that already carries a port. An IPv6 literal always contains colons, so the port is never appended.

### Fix
- When the host starts with `[`, `HostFormatter` looks for the colon after the closing `]`. Other hosts are checked as before.
- Values that already carry a port (`example.com:8080`, `[::1]:8080`) and callers that pass `port: None` are written as before. So the other two callers, `bun_url::URL::display_host` and the HTTP/3 request URL in `server_body.rs`, produce the same output as today.
- Verified: `test/js/web/websocket/websocket-upgrade.test.ts`, new test fails on 1.4.0 with `Host: [::1]`. Also `test/js/web/websocket/` (254 pass, 2 failures need ws.postman-echo.com) and `test/js/bun/http/serve-http3.test.ts`.

### Background
- The WebSocket client builds its upgrade request in `build_request_body` (`src/http_jsc/websocket_client/WebSocketUpgradeClient.rs`). `WebSocket.cpp` gives it `m_url.host()`, which for an IPv6 URL is the bracketed literal without a port, and the port as a separate number. `HostFormatter` joins the two into the `Host` header.
- `HostFormatter` also accepts a host that already contains the port, because `bun_url::URL::host` is stored in that form. That is what the colon check was for.
- `fetch()` is not affected. Its client writes `url.host`, which is already `host:port`.

<details><summary>Notes</summary>

Repro on release 1.4.0 with a raw `net` listener on `::1`:

```
ws://[::1]:44609/      ->  Host: [::1]
ws://127.0.0.1:44011/  ->  Host: 127.0.0.1:44011
ws://localhost:44085/  ->  Host: localhost:44085
```

With the change the first line is `Host: [::1]:44609`. `[::ffff:7f00:1]` behaves the same way.

The test binds `Bun.serve` to `::1` and reads the `Host` header of the upgrade request. It skips when the machine cannot bind an IPv6 loopback socket. The harness's `isIPv6()` is not used because it reports interface addresses and is hardcoded to false on BuildKite Linux.

The proxy path of the client (`build_connect_request`) formats `host:port` itself and was already correct.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/websocket/websocket-upgrade.test.ts:
116 |     const ws = new WebSocket(`ws://[::1]:${server.port}/`);
117 |     ws.addEventListener("open", () => opened.resolve());
118 |     ws.addEventListener("error", opened.reject);
119 |     await opened.promise;
120 | 
121 |     expect(await received.promise).toBe(`[::1]:${server.port}`);
                                         ^
error: expect(received).toBe(expected)

Expected: "[::1]:36495"
Received: "[::1]"

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-upgrade.test.ts:121:36)
(pass) WebSocket upgrade > sends the expected upgrade request headers [232.15ms]
(fail) WebSocket upgrade > Host carries the port for an IPv6 literal [207.50ms]
(pass) WebSocket upgrade > Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4 [224.83ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4328.95ms]

 3 pass
 1 fail
 75 expect() calls
Ran 4 tests across 1 file.
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/js/web/websocket/websocket-upgrade.test.ts:
116 |     const ws = new WebSocket(`ws://[::1]:${server.port}/`);
117 |     ws.addEventListener("open", () => opened.resolve());
118 |     ws.addEventListener("error", opened.reject);
119 |     await opened.promise;
120 | 
121 |     expect(await received.promise).toBe(`[::1]:${server.port}`);
                                         ^
error: expect(received).toBe(expected)

Expected: "[::1]:36373"
Received: "[::1]"

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-upgrade.test.ts:121:36)
(pass) WebSocket upgrade > sends the expected upgrade request headers [9.09ms]
(fail) WebSocket upgrade > Host carries the port for an IPv6 literal [6.74ms]
(pass) WebSocket upgrade > Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4 [6.70ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4011.06ms]

 3 pass
 1 fail
 75 expect() calls
Ran 4 tests across 1 file. [4.21s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > sends the expected upgrade request headers [226.19ms]
(pass) WebSocket upgrade > Host carries the port for an IPv6 literal [200.00ms]
(pass) WebSocket upgrade > Sec-WebSocket-Key is 16 uniformly random bytes, not a UUIDv4 [217.82ms]
(pass) WebSocket upgrade > fails the handshake when the server never responds [4328.81ms]

 4 pass
 0 fail
 75 expect() calls
Ran 4 tests across 1 file. [6.84s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     58d38cf2f9
  features     baseline

23 deps, 129 codegen, 1172 objects in 817ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [12.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] gen bindgenv2
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/fmt.rs                             | 21 ++++++++---
 test/js/web/websocket/websocket-upgrade.test.ts | 46 +++++++++++++++++++++++++
 2 files changed, 63 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/bun_core/fmt.rs                                  3      1      0
test/js/web/websocket/websocket-upgrade.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->