### PR TITLE
S3: read the endpoint the way new URL() reads it

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -274,11 +274,12 @@ impl Loader {
 
             let mut endpoint: Box<[u8]> = Box::default();
             let mut insecure_http = false;
-            if let Some(endpoint_) = self
+            if let Some(endpoint_url) = self
                 .get(b"S3_ENDPOINT")
                 .or_else(|| self.get(b"AWS_ENDPOINT"))
+                .and_then(URL::from_s3_endpoint)
             {
-                let url = URL::parse(endpoint_);
+                let url = endpoint_url.url();
                 endpoint = Box::from(url.host_with_path());
                 insecure_http = url.is_http();
             }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -274,14 +274,13 @@ impl Loader {
 
             let mut endpoint: Box<[u8]> = Box::default();
             let mut insecure_http = false;
-            if let Some(endpoint_url) = self
+            if let Some(parsed) = self
                 .get(b"S3_ENDPOINT")
                 .or_else(|| self.get(b"AWS_ENDPOINT"))
-                .and_then(URL::from_s3_endpoint)
+                .and_then(URL::parse_s3_endpoint)
             {
-                let url = endpoint_url.url();
-                endpoint = Box::from(url.host_with_path());
-                insecure_http = url.is_http();
+                endpoint = parsed.host_with_path;
+                insecure_http = parsed.is_http;
             }
 
             let bucket: Box<[u8]> = self

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -116,14 +116,12 @@ pub(crate) fn get_credentials_with_options(
                         if str.tag() != BunStringTag::Empty && str.tag() != BunStringTag::Dead {
                             let utf8 = str.to_utf8();
                             let endpoint = utf8.slice();
-                            if let Some(endpoint_url) = URL::from_s3_endpoint(endpoint) {
-                                let url = endpoint_url.url();
-                                new_credentials.credentials.endpoint =
-                                    Box::<[u8]>::from(url.host_with_path());
+                            if let Some(parsed) = URL::parse_s3_endpoint(endpoint) {
+                                new_credentials.credentials.endpoint = parsed.host_with_path;
 
                                 // Default to https://
                                 // Only use http:// if the endpoint specifically starts with 'http://'
-                                new_credentials.credentials.insecure_http = url.is_http();
+                                new_credentials.credentials.insecure_http = parsed.is_http;
 
                                 new_credentials.changed_credentials = true;
                             } else if !endpoint.is_empty() {

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -116,11 +116,10 @@ pub(crate) fn get_credentials_with_options(
                         if str.tag() != BunStringTag::Empty && str.tag() != BunStringTag::Dead {
                             let utf8 = str.to_utf8();
                             let endpoint = utf8.slice();
-                            let url = URL::parse(endpoint);
-                            let normalized_endpoint = url.host_with_path();
-                            if !normalized_endpoint.is_empty() {
+                            if let Some(endpoint_url) = URL::from_s3_endpoint(endpoint) {
+                                let url = endpoint_url.url();
                                 new_credentials.credentials.endpoint =
-                                    Box::<[u8]>::from(normalized_endpoint);
+                                    Box::<[u8]>::from(url.host_with_path());
 
                                 // Default to https://
                                 // Only use http:// if the endpoint specifically starts with 'http://'

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -7,7 +7,7 @@ use core::cell::RefCell;
 
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
 use bun_core::{self, fmt as bun_fmt};
-use bun_core::{String as BunString, Tag as BunStringTag, strings};
+use bun_core::{OwnedString, String as BunString, Tag as BunStringTag, strings};
 use bun_paths::resolve_path::{self, platform};
 use bun_wyhash::hash as wyhash;
 
@@ -149,6 +149,30 @@ pub mod whatwg {
             URL__deinit(self)
         }
     }
+
+    /// A `URL` this handle owns; `Drop` frees it.
+    pub struct Parsed(core::ptr::NonNull<URL>);
+
+    impl Parsed {
+        pub fn from_utf8(input: &[u8]) -> Option<Self> {
+            URL::from_utf8(input).map(Self)
+        }
+    }
+
+    impl core::ops::Deref for Parsed {
+        type Target = URL;
+        fn deref(&self) -> &URL {
+            // SAFETY: `from_utf8` returned a live heap `WTF::URL` that only `Drop` frees.
+            unsafe { self.0.as_ref() }
+        }
+    }
+
+    impl Drop for Parsed {
+        fn drop(&mut self) {
+            // SAFETY: this handle is the only owner of the `WTF::URL`, so it is deleted once.
+            unsafe { self.0.as_mut() }.deinit();
+        }
+    }
 }
 // Re-export the free helpers at crate root so lower-tier callers can write
 // `bun_url::join(...)` / `bun_url::href_from_string(...)` (install, http, bake, js_parser).
@@ -232,6 +256,13 @@ impl OwnedURL {
     pub fn from_href(href: Box<[u8]>) -> Self {
         Self { href }
     }
+}
+
+/// What `S3Credentials` keeps of an endpoint. See `URL::parse_s3_endpoint`.
+pub struct S3Endpoint {
+    /// `host[:port][/prefix]`, the form `URL::host_with_path` returns.
+    pub host_with_path: Box<[u8]>,
+    pub is_http: bool,
 }
 
 impl<'a> URL<'a> {
@@ -329,25 +360,40 @@ impl<'a> URL<'a> {
         Ok(OwnedURL { href: owned })
     }
 
-    /// An S3 endpoint, `[scheme://]host[:port][/prefix]` with `https` as the default scheme,
-    /// normalized by WTF::URL so that `host_with_path()` names the host `new URL(endpoint)`
-    /// names. `parse` alone ends the authority only at `/` and `?`, so it reads
-    /// `http://a:1#@b:2` and `http://a:1\@b:2` as host `b:2`.
+    /// Reads an S3 endpoint, `[scheme://]host[:port][/prefix]` with `https` as the default
+    /// scheme, the way `new URL(endpoint)` reads it. Host, port and path are taken from WTF::URL,
+    /// which ends the authority at `#`, `\` and the last `@` and keeps credentials out of the
+    /// host. `parse` does neither: it reads `http://a:1#@b:2` as host `b:2`, and a normalized
+    /// `http://user@b:2/` as host `user@b:2`.
     ///
-    /// Returns `None` when `parse` finds no host, and keeps the input as written when WTF::URL
-    /// rejects it, so this accepts exactly the endpoints `parse` accepts.
-    pub fn from_s3_endpoint(input: &[u8]) -> Option<OwnedURL> {
+    /// Returns `None` when `parse` finds no host, and what `parse` reads when WTF::URL rejects
+    /// the input, so exactly the endpoints `parse` accepts are accepted.
+    pub fn parse_s3_endpoint(input: &[u8]) -> Option<S3Endpoint> {
         let as_written = URL::parse(input);
         if as_written.host_with_path().is_empty() {
             return None;
         }
         let normalized = if as_written.protocol.is_empty() {
-            let with_scheme = [b"https://".as_slice(), input].concat();
-            URL::from_string(&BunString::borrow_utf8(&with_scheme))
+            whatwg::Parsed::from_utf8(&[b"https://".as_slice(), input].concat())
         } else {
-            URL::from_string(&BunString::borrow_utf8(input))
+            whatwg::Parsed::from_utf8(input)
         };
-        Some(normalized.unwrap_or_else(|_| OwnedURL::from_href(Box::from(input))))
+        let Some(url) = normalized else {
+            return Some(S3Endpoint {
+                host_with_path: Box::from(as_written.host_with_path()),
+                is_http: as_written.is_http(),
+            });
+        };
+        let is_http = OwnedString::new(url.protocol()).eql_comptime(b"http");
+        // `whatwg::URL::hostname` is the host with its port.
+        let mut host_with_path = OwnedString::new(url.hostname()).to_utf8_bytes();
+        let pathname = OwnedString::new(url.pathname());
+        let path = pathname.to_utf8();
+        host_with_path.extend_from_slice(strings::without_suffix_comptime(path.slice(), b"/"));
+        Some(S3Endpoint {
+            host_with_path: host_with_path.into_boxed_slice(),
+            is_http,
+        })
     }
 
     pub fn display_protocol(&self) -> &[u8] {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -360,9 +360,8 @@ impl<'a> URL<'a> {
         Ok(OwnedURL { href: owned })
     }
 
-    /// Reads `[scheme://]host[:port][/prefix]` (`https` by default) with WTF::URL, so the host is
-    /// the one `new URL(endpoint)` names; `parse` reads `http://a:1#@b:2` as host `b:2`.
-    /// `None` when `parse` finds no host; what `parse` reads when WTF::URL rejects the input.
+    /// `[scheme://]host[:port][/prefix]`, `https` by default, read with WTF::URL so that the host
+    /// is the one `new URL(endpoint)` names. `None` when `parse` finds no host.
     pub fn parse_s3_endpoint(input: &[u8]) -> Option<S3Endpoint> {
         let as_written = URL::parse(input);
         if as_written.host_with_path().is_empty() {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -360,14 +360,9 @@ impl<'a> URL<'a> {
         Ok(OwnedURL { href: owned })
     }
 
-    /// Reads an S3 endpoint, `[scheme://]host[:port][/prefix]` with `https` as the default
-    /// scheme, the way `new URL(endpoint)` reads it. Host, port and path are taken from WTF::URL,
-    /// which ends the authority at `#`, `\` and the last `@` and keeps credentials out of the
-    /// host. `parse` does neither: it reads `http://a:1#@b:2` as host `b:2`, and a normalized
-    /// `http://user@b:2/` as host `user@b:2`.
-    ///
-    /// Returns `None` when `parse` finds no host, and what `parse` reads when WTF::URL rejects
-    /// the input, so exactly the endpoints `parse` accepts are accepted.
+    /// Reads `[scheme://]host[:port][/prefix]` (`https` by default) with WTF::URL, so the host is
+    /// the one `new URL(endpoint)` names; `parse` reads `http://a:1#@b:2` as host `b:2`.
+    /// `None` when `parse` finds no host; what `parse` reads when WTF::URL rejects the input.
     pub fn parse_s3_endpoint(input: &[u8]) -> Option<S3Endpoint> {
         let as_written = URL::parse(input);
         if as_written.host_with_path().is_empty() {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -360,8 +360,7 @@ impl<'a> URL<'a> {
         Ok(OwnedURL { href: owned })
     }
 
-    /// `[scheme://]host[:port][/prefix]`, `https` by default, read with WTF::URL so that the host
-    /// is the one `new URL(endpoint)` names. `None` when `parse` finds no host.
+    /// `input` is `[scheme://]host[:port][/prefix]`, `https` by default. `None` when it has no host.
     pub fn parse_s3_endpoint(input: &[u8]) -> Option<S3Endpoint> {
         let as_written = URL::parse(input);
         if as_written.host_with_path().is_empty() {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -329,6 +329,27 @@ impl<'a> URL<'a> {
         Ok(OwnedURL { href: owned })
     }
 
+    /// An S3 endpoint, `[scheme://]host[:port][/prefix]` with `https` as the default scheme,
+    /// normalized by WTF::URL so that `host_with_path()` names the host `new URL(endpoint)`
+    /// names. `parse` alone ends the authority only at `/` and `?`, so it reads
+    /// `http://a:1#@b:2` and `http://a:1\@b:2` as host `b:2`.
+    ///
+    /// Returns `None` when `parse` finds no host, and keeps the input as written when WTF::URL
+    /// rejects it, so this accepts exactly the endpoints `parse` accepts.
+    pub fn from_s3_endpoint(input: &[u8]) -> Option<OwnedURL> {
+        let as_written = URL::parse(input);
+        if as_written.host_with_path().is_empty() {
+            return None;
+        }
+        let normalized = if as_written.protocol.is_empty() {
+            let with_scheme = [b"https://".as_slice(), input].concat();
+            URL::from_string(&BunString::borrow_utf8(&with_scheme))
+        } else {
+            URL::from_string(&BunString::borrow_utf8(input))
+        };
+        Some(normalized.unwrap_or_else(|_| OwnedURL::from_href(Box::from(input))))
+    }
+
     pub fn display_protocol(&self) -> &[u8] {
         if !self.protocol.is_empty() {
             return self.protocol;

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -91,6 +91,61 @@ describe("S3Client region option", () => {
   });
 });
 
+describe("S3Client endpoint option", () => {
+  const options = {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    bucket: "bucket",
+    region: "us-east-1",
+  };
+
+  // presign() builds the request URL from the stored endpoint exactly like a
+  // request would, without opening a connection, so the ports below are never dialed.
+  it.each([
+    "http://127.0.0.1:1#@127.0.0.1:2",
+    "http://127.0.0.1:1\\@127.0.0.1:2",
+    "http://127.0.0.1:1?@127.0.0.1:2",
+    "http://user:p@ss@127.0.0.1:1",
+    "http://127.0.0.1:1/x/../prefix/",
+    "http://127.1:1",
+    "https://acct.supabase.co/storage/v1/s3",
+    "https://[::1]:9000",
+  ])("signs for the origin and path that new URL(%j) names", endpoint => {
+    const expected = new URL(endpoint);
+    const presigned = new S3Client({ ...options, endpoint }).presign("key.txt");
+    // Compared as text: new URL(presigned) would hide a leaked userinfo, a raw
+    // dot-segment or a non-canonical IPv4 spelling again.
+    expect(presigned.split("?")[0]).toBe(`${expected.origin}${expected.pathname.replace(/\/$/, "")}/bucket/key.txt`);
+  });
+
+  it("defaults to https when the endpoint has no scheme", () => {
+    const presigned = new S3Client({ ...options, endpoint: "s3.example.com" }).presign("key.txt");
+    expect(presigned.split("?")[0]).toBe("https://s3.example.com/bucket/key.txt");
+  });
+
+  it("applies the same parsing to S3_ENDPOINT", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log(new URL(Bun.s3.presign("key.txt")).host)`],
+      env: {
+        ...bunEnv,
+        AWS_ENDPOINT: undefined,
+        S3_ENDPOINT: "http://127.0.0.1:1#@127.0.0.1:2",
+        S3_ACCESS_KEY_ID: "test",
+        S3_SECRET_ACCESS_KEY: "test",
+        S3_BUCKET: "bucket",
+        S3_REGION: "us-east-1",
+      },
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("127.0.0.1:1\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("S3 endpoints without a region component", () => {
   it("defaults the signing region to us-east-1", async () => {
     await using proc = Bun.spawn({

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -106,6 +106,8 @@ describe("S3Client endpoint option", () => {
     "http://127.0.0.1:1\\@127.0.0.1:2",
     "http://127.0.0.1:1?@127.0.0.1:2",
     "http://user:p@ss@127.0.0.1:1",
+    "http://user:@127.0.0.1:1",
+    "http://user@127.0.0.1:1",
     "http://127.0.0.1:1/x/../prefix/",
     "http://127.1:1",
     "https://acct.supabase.co/storage/v1/s3",


### PR DESCRIPTION
### Problem
- `new Bun.S3Client({ endpoint: "http://127.0.0.1:A#@127.0.0.1:B" })` signs for `127.0.0.1:B` and sends `PUT /bkt/k`, `Authorization` and the body there. `new URL(endpoint).host` is `127.0.0.1:A`. `http://A\@B` behaves the same. A service that checks a tenant's endpoint with `new URL()` sends signed requests to a host it did not approve.
- Cause: `credentials_jsc.rs:119` and `env_loader.rs:281` give the raw string to `bun_url::URL::parse`, whose credential and host scanning stop only at `/` and `?`, and store its `host_with_path()`. Dot segments and `127.1` are sent as written for the same reason.

### Fix
- `URL::parse_s3_endpoint` (`src/url/lib.rs`) keeps the existing `parse` host check, so the accepted set does not change. It then parses the string with WTF::URL (`https://` prepended when there is no scheme) and stores its scheme, host with port, and path. When WTF::URL rejects the input, it stores what `parse` reads, as today. Both stores call it.
- WTF::URL ends the authority at `#`, `\` and the last `@`, resolves dot segments, canonicalizes the host and never puts credentials in it. The stored form is unchanged, so `guess_region`, inspect output and path-prefix endpoints still work. The notes list the visible side effects.
- Verified: `test/js/bun/s3/s3-list-encode-overflow.test.ts` (the network-free presign tests), 8 of the 12 new cases fail on 1.4.0. Also `test/js/bun/s3/`: 156 pass, 1 timeout (notes).

### Background
- `S3Credentials.endpoint` stores `host[:port][/prefix]` without a scheme. `sign_request` (`src/s3_signing/credentials.rs:384`) signs the part before the first `/` as the host and sends it as `Host`. The stored bytes are both signed for and connected to.
- Bun has two URL parsers. WTF::URL (WebKit) is the WHATWG parser behind `new URL()`. `bun_url::URL::parse` slices an href that is already normalized. `URL::from_string` and `OwnedURL` bridge the two.
- #38043 changes `URL::parse` itself for `user@host:port` and keeps `#` in the authority on purpose. The two changes are independent. #16183 is the umbrella issue for that parser.

<details><summary>Notes</summary>

Repro on release 1.4.0 with two `Bun.serve` listeners A and B on 127.0.0.1 (run without `HTTP_PROXY` set, since S3 ignores `NO_PROXY`, #32045):

```
endpoint http://127.0.0.1:A#@127.0.0.1:B    new URL().host = 127.0.0.1:A
  A: (nothing)
  B: PUT /bkt/k host=127.0.0.1:B x-amz-security-token=SESSIONTOKENEXAMPLE
endpoint http://127.0.0.1:A\@127.0.0.1:B    same
```

presign() on 1.4.0 for the spellings in the test:

```
http://127.0.0.1:A#@127.0.0.1:B   -> http://127.0.0.1:B/bkt/k?...
http://127.0.0.1:A\@127.0.0.1:B   -> http://127.0.0.1:B/bkt/k?...
http://127.0.0.1:A?@127.0.0.1:B   -> http://A/bkt/k?...           (the port text becomes the host)
http://u:p@ss@127.0.0.1:A         -> http://ss@127.0.0.1:A/bkt/k?...   (a request resolves ss@127.0.0.1)
http://127.0.0.1:A/x/../prefix/   -> http://127.0.0.1:A/x/../prefix/bkt/k?...
http://127.1:A                    -> http://127.1:A/bkt/k?...
```

With the change every one of them starts with `http://127.0.0.1:A/`. `\@` becomes the path prefix `/@127.0.0.1:B/`, which is what `new URL()` reports for it. `S3_ENDPOINT` and `AWS_ENDPOINT` (`env_loader.rs`) had the same problem and get the same treatment; the test covers `S3_ENDPOINT` in a child process.

The test compares the presigned URL as text. `new URL(presigned)` would itself strip a leaked `ss@`, resolve `/x/../` and canonicalize `127.1`, and so hide the credential, dot-segment and `127.1` cases.

Why the `parse` host check is kept: `s3.test.ts` expects `endpoint: "🙂.🥯"` and `"..asd.@%&&&%%"` to throw `ERR_INVALID_ARG_TYPE`, and WTF::URL accepts the first as an IDN host. With the old check in front, this change only alters what is stored for endpoints that were already accepted.

Visible side effects besides the fix: a default port in the endpoint (`http://h:80`) is now left out of the `Host` header, and a mixed-case host is lowercased. Both come from the WTF::URL serialization.

Why the raw fallback: WTF::URL rejects a port such as `:99999`, which today is accepted and connects to 80/443. #37003 turns that into an error. This change leaves it alone so the two do not overlap.

Also unchanged: `guess_bucket`, the scheme-less R2 and `s3.us-west-1.amazonaws.com` endpoints in `s3.test.ts` (stored byte for byte as before), and a Supabase style `https://host/storage/v1/s3` prefix (covered by the new test).

The S3 suite was run with the proxy variables of this environment unset. The one timeout is `s3-list-objects.test.ts` "Should fall back to NoSuchKey ...". Its `describe.concurrent` block runs it next to "Should work with big responses", which takes about 18 s in this debug ASAN build, so it exceeds its 5 s budget. It passes when run alone with this build, and the stored endpoint for `server.url.href` is byte-identical with and without the change.

`bun_s3_signing` does not depend on `bun_url`, and `bun_dotenv` must not name `bun_s3_signing` types, so the helper lives in `bun_url` next to `host_with_path()`, whose only callers were these two stores.

An earlier revision normalized the string with WTF::URL and sliced the resulting href with `URL::parse` again. Review caught that this inherited the `user@host:port` reading of `URL::parse` (#16181): WTF::URL serializes `http://user:@h:1` as `http://user@h:1/`, so that endpoint would have stored `user@h:1` where it stores `h:1` today. The helper now reads scheme, host with port and path from the WTF::URL components directly, and the `user:@` and `user@` spellings are in the test. The second one is wrong on 1.4.0 as well.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-list-encode-overflow.test.ts"
bun test v1.4.0 (6e906e468)

test/js/bun/s3/s3-list-encode-overflow.test.ts:
(pass) S3Client.list() option encoding > should not panic when prefix is longer than 1024 bytes when encoded [25.53ms]
(pass) S3Client.list() option encoding > should not panic when delimiter is longer than 1024 bytes when encoded [2.12ms]
(pass) S3Client.list() option encoding > should not panic when continuationToken is longer than 1024 bytes when encoded [1.78ms]
(pass) S3Client.list() option encoding > should not panic when startAfter is longer than 1024 bytes when encoded [2.24ms]
(pass) S3 object keys containing '?' or '#' > includes the full object key in the presigned URL path [9.33ms]
(pass) S3Client region option > rejects the region us-east-1/other.example.com because it is not a valid host name component [5.83ms]
(pass) S3Client region option > rejects the region us-east-1?x because it is not a valid host name component [1.85ms]
(pass) S3Client region option > rejects the region us-east-1#x because i
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (58d38cf2f)

test/js/bun/s3/s3-list-encode-overflow.test.ts:
(pass) S3Client.list() option encoding > should not panic when prefix is longer than 1024 bytes when encoded [0.15ms]
(pass) S3Client.list() option encoding > should not panic when delimiter is longer than 1024 bytes when encoded [0.03ms]
(pass) S3Client.list() option encoding > should not panic when continuationToken is longer than 1024 bytes when encoded [0.02ms]
(pass) S3Client.list() option encoding > should not panic when startAfter is longer than 1024 bytes when encoded [0.01ms]
(pass) S3 object keys containing '?' or '#' > includes the full object key in the presigned URL path [0.14ms]
(pass) S3Client region option > rejects the region us-east-1/other.example.com because it is not a valid host name component [0.07ms]
(pass) S3Client region option > rejects the region us-east-1?x because it is not a valid host name component [0.01ms]
(pass) S3Client region option > rejects the region us-east-1#x because it is not a valid host name component
(pass) S3Client region option > rejects the region us east 1 because it is not a valid host name component
(pass) S3Client region option 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-list-encode-overflow.test.ts"
bun test v1.4.0 (6e906e468)

test/js/bun/s3/s3-list-encode-overflow.test.ts:
(pass) S3Client.list() option encoding > should not panic when prefix is longer than 1024 bytes when encoded [10.88ms]
(pass) S3Client.list() option encoding > should not panic when delimiter is longer than 1024 bytes when encoded [28.39ms]
(pass) S3Client.list() option encoding > should not panic when continuationToken is longer than 1024 bytes when encoded [3.34ms]
(pass) S3Client.list() option encoding > should not panic when startAfter is longer than 1024 bytes when encoded [2.50ms]
(pass) S3 object keys containing '?' or '#' > includes the full object key in the presigned URL path [14.80ms]
(pass) S3Client region option > rejects the region us-east-1/other.example.com because it is not a valid host name component [8.69ms]
(pass) S3Client region option > rejects the region us-east-1?x because it is not a valid host name component [2.69ms]
(pass) S3Client region option > rejects the region us-east-1#x because
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 770ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_paths v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/dotenv/env_loader.rs                       |  8 ++--
 src/runtime/webcore/s3/credentials_jsc.rs      |  9 ++--
 src/url/lib.rs                                 | 62 +++++++++++++++++++++++++-
 test/js/bun/s3/s3-list-encode-overflow.test.ts | 57 +++++++++++++++++++++++
 4 files changed, 125 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/dotenv/env_loader.rs                            3      2      0
src/runtime/webcore/s3/credentials_jsc.rs           2      2      0
src/url/lib.rs                                      6     11      0
test/js/bun/s3/s3-list-encode-overflow.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->