### PR TITLE
timers: make a write to [util.promisify.custom] on the timer globals throw

### DIFF
--- a/src/jsc/bindings/node/NodeTimers.cpp
+++ b/src/jsc/bindings/node/NodeTimers.cpp
@@ -240,9 +240,9 @@ static JSC::EncodedJSValue timersPromisesExport(JSGlobalObject* lexicalGlobalObj
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    JSValue timersPromises = globalObject->internalModuleRegistry()->requireId(lexicalGlobalObject, vm, InternalModuleRegistry::Field::NodeTimersPromises);
+    JSValue timersPromises = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::Field::NodeTimersPromises);
     RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, JSValue::encode(timersPromises.get(lexicalGlobalObject, Identifier::fromString(vm, name))));
+    RELEASE_AND_RETURN(scope, JSValue::encode(timersPromises.get(globalObject, Identifier::fromString(vm, name))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(setTimeoutPromisifyCustomGetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue, PropertyName))
@@ -263,11 +263,11 @@ JSC_DEFINE_CUSTOM_GETTER(setImmediatePromisifyCustomGetter, (JSGlobalObject * gl
 static JSValue createTimerFunction(VM& vm, JSObject* globalObject, ASCIILiteral name, NativeFunction function, JSC::CustomGetterSetter::CustomGetter promisifyCustomGetter)
 {
     auto* timerFunction = JSFunction::create(vm, globalObject->globalObject(), 1, name, function, ImplementationVisibility::Public);
-    // Same shape as Node's lib/timers.js: an enumerable, non-configurable accessor.
+    // Node's shape: enumerable, non-configurable, getter only. ReadOnly makes a write throw like Node's getter-only property.
     timerFunction->putDirectCustomAccessor(vm,
         Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.util.promisify.custom"_s)),
         CustomGetterSetter::create(vm, promisifyCustomGetter, nullptr),
-        PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete | 0);
+        PropertyAttribute::CustomAccessor | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | 0);
     return timerFunction;
 }
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -46,9 +46,9 @@ it("node.js util.promisify(setInterval) works", async () => {
 });
 
 it("timers expose util.promisify.custom as a lazy accessor without loading node:util first", async () => {
-  // Matches Node's lib/timers.js: an enumerable, non-configurable, getter-only accessor (a write throws)
-  // that resolves to timers/promises. The shape is read before any module is loaded, in the main thread
-  // and in a worker.
+  // Matches Node's lib/timers.js: an enumerable, non-configurable, getter-only accessor that resolves to
+  // timers/promises. A strict-mode write and Object.assign throw, a sloppy-mode write is a no-op. The shape
+  // is read before any module is loaded, in the main thread and in a worker.
   const shape = `const shape = fn => {
     const d = Object.getOwnPropertyDescriptor(fn, Symbol.for("nodejs.util.promisify.custom"));
     return d && { get: typeof d.get, set: typeof d.set, enumerable: d.enumerable, configurable: d.configurable };
@@ -59,31 +59,43 @@ it("timers expose util.promisify.custom as a lazy accessor without loading node:
       "-e",
       `${shape}
        const sym = Symbol.for("nodejs.util.promisify.custom");
-       const before = [setTimeout, setInterval, setImmediate].map(shape);
-       let write = "no throw";
-       try { Object.assign(setTimeout, { [sym]: 1 }); } catch (e) { write = e.constructor.name; }
+       const timers = [setTimeout, setInterval, setImmediate];
+       const before = timers.map(shape);
+       // new Function so that the directive is compiled as written, instead of going through the transpiler.
+       const write = (fn, body) => { try { new Function("fn", "sym", body)(fn, sym); return "no throw"; } catch (e) { return e.constructor.name; } };
+       const writes = timers.map(fn => ({
+         strict: write(fn, '"use strict"; fn[sym] = 1;'),
+         sloppy: write(fn, 'fn[sym] = 1;'),
+         assign: write(fn, 'Object.assign(fn, { [sym]: 1 });'),
+       }));
        const tp = require("node:timers/promises");
+       // Also proves the writes above changed nothing.
        const same = [setTimeout[sym] === tp.setTimeout, setInterval[sym] === tp.setInterval, setImmediate[sym] === tp.setImmediate];
        const { Worker } = require("node:worker_threads");
        const worker = new Worker(
          ${JSON.stringify(shape)} + 'require("node:worker_threads").parentPort.postMessage([setTimeout, setInterval, setImmediate].map(shape));',
          { eval: true },
        );
-       worker.once("message", inWorker => {
-         console.log(JSON.stringify({ before, write, same, inWorker }));
+       let inWorker;
+       worker.once("message", message => { inWorker = message; });
+       worker.once("exit", workerExitCode => {
+         console.log(JSON.stringify({ before, writes, same, inWorker, workerExitCode }));
        });`,
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "inherit",
+    stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   const accessor = { get: "function", set: "undefined", enumerable: true, configurable: false };
+  const rejected = { strict: "TypeError", sloppy: "no throw", assign: "TypeError" };
   expect(JSON.parse(stdout)).toEqual({
     before: [accessor, accessor, accessor],
-    write: "TypeError",
+    writes: [rejected, rejected, rejected],
     same: [true, true, true],
     inWorker: [accessor, accessor, accessor],
+    workerExitCode: 0,
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -47,39 +47,42 @@ it("node.js util.promisify(setInterval) works", async () => {
 
 it("timers expose util.promisify.custom as a lazy accessor without loading node:util first", async () => {
   // Matches Node's lib/timers.js: an enumerable, non-configurable, getter-only accessor that resolves to
-  // timers/promises. A strict-mode write and Object.assign throw, a sloppy-mode write is a no-op. The shape
-  // is read before any module is loaded, in the main thread and in a worker.
-  const shape = `const shape = fn => {
-    const d = Object.getOwnPropertyDescriptor(fn, Symbol.for("nodejs.util.promisify.custom"));
-    return d && { get: typeof d.get, set: typeof d.set, enumerable: d.enumerable, configurable: d.configurable };
+  // the timers/promises export of the same realm. A strict-mode write and Object.assign throw, a sloppy-mode
+  // write is a no-op. The same probe runs in the main thread and in a worker, before either loads a module.
+  const probe = `const probe = () => {
+    const sym = Symbol.for("nodejs.util.promisify.custom");
+    const timers = [setTimeout, setInterval, setImmediate];
+    const shape = fn => {
+      const d = Object.getOwnPropertyDescriptor(fn, sym);
+      return d && { get: typeof d.get, set: typeof d.set, enumerable: d.enumerable, configurable: d.configurable };
+    };
+    const before = timers.map(shape);
+    // new Function so that the directive is compiled as written, instead of going through the transpiler.
+    const write = (fn, body) => { try { new Function("fn", "sym", body)(fn, sym); return "no throw"; } catch (e) { return e.constructor.name; } };
+    const writes = timers.map(fn => ({
+      strict: write(fn, '"use strict"; fn[sym] = 1;'),
+      sloppy: write(fn, 'fn[sym] = 1;'),
+      assign: write(fn, 'Object.assign(fn, { [sym]: 1 });'),
+    }));
+    // Read after the writes, so this also proves they changed nothing.
+    const tp = require("node:timers/promises");
+    const same = [setTimeout[sym] === tp.setTimeout, setInterval[sym] === tp.setInterval, setImmediate[sym] === tp.setImmediate];
+    return { before, writes, same };
   };`;
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `${shape}
-       const sym = Symbol.for("nodejs.util.promisify.custom");
-       const timers = [setTimeout, setInterval, setImmediate];
-       const before = timers.map(shape);
-       // new Function so that the directive is compiled as written, instead of going through the transpiler.
-       const write = (fn, body) => { try { new Function("fn", "sym", body)(fn, sym); return "no throw"; } catch (e) { return e.constructor.name; } };
-       const writes = timers.map(fn => ({
-         strict: write(fn, '"use strict"; fn[sym] = 1;'),
-         sloppy: write(fn, 'fn[sym] = 1;'),
-         assign: write(fn, 'Object.assign(fn, { [sym]: 1 });'),
-       }));
-       const tp = require("node:timers/promises");
-       // Also proves the writes above changed nothing.
-       const same = [setTimeout[sym] === tp.setTimeout, setInterval[sym] === tp.setInterval, setImmediate[sym] === tp.setImmediate];
+      `${probe}
+       const main = probe();
        const { Worker } = require("node:worker_threads");
-       const worker = new Worker(
-         ${JSON.stringify(shape)} + 'require("node:worker_threads").parentPort.postMessage([setTimeout, setInterval, setImmediate].map(shape));',
-         { eval: true },
-       );
+       const worker = new Worker(${JSON.stringify(probe)} + 'require("node:worker_threads").parentPort.postMessage(probe());', {
+         eval: true,
+       });
        let inWorker;
-       worker.once("message", message => { inWorker = message; });
+       worker.once("message", result => { inWorker = result; });
        worker.once("exit", workerExitCode => {
-         console.log(JSON.stringify({ before, writes, same, inWorker, workerExitCode }));
+         console.log(JSON.stringify({ main, inWorker, workerExitCode }));
        });`,
     ],
     env: bunEnv,
@@ -90,13 +93,12 @@ it("timers expose util.promisify.custom as a lazy accessor without loading node:
   expect(stderr).toBe("");
   const accessor = { get: "function", set: "undefined", enumerable: true, configurable: false };
   const rejected = { strict: "TypeError", sloppy: "no throw", assign: "TypeError" };
-  expect(JSON.parse(stdout)).toEqual({
+  const expected = {
     before: [accessor, accessor, accessor],
     writes: [rejected, rejected, rejected],
     same: [true, true, true],
-    inWorker: [accessor, accessor, accessor],
-    workerExitCode: 0,
-  });
+  };
+  expect(JSON.parse(stdout)).toEqual({ main: expected, inWorker: expected, workerExitCode: 0 });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -46,17 +46,32 @@ it("node.js util.promisify(setInterval) works", async () => {
 });
 
 it("timers expose util.promisify.custom as a lazy accessor without loading node:util first", async () => {
-  // Matches Node's lib/timers.js: an enumerable, non-configurable getter that resolves to timers/promises.
+  // Matches Node's lib/timers.js: an enumerable, non-configurable, getter-only accessor (a write throws)
+  // that resolves to timers/promises. The shape is read before any module is loaded, in the main thread
+  // and in a worker.
+  const shape = `const shape = fn => {
+    const d = Object.getOwnPropertyDescriptor(fn, Symbol.for("nodejs.util.promisify.custom"));
+    return d && { get: typeof d.get, set: typeof d.set, enumerable: d.enumerable, configurable: d.configurable };
+  };`;
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `const sym = Symbol.for("nodejs.util.promisify.custom");
-       const shape = fn => { const d = Object.getOwnPropertyDescriptor(fn, sym); return d && { get: typeof d.get, set: typeof d.set, enumerable: d.enumerable, configurable: d.configurable }; };
+      `${shape}
+       const sym = Symbol.for("nodejs.util.promisify.custom");
        const before = [setTimeout, setInterval, setImmediate].map(shape);
+       let write = "no throw";
+       try { Object.assign(setTimeout, { [sym]: 1 }); } catch (e) { write = e.constructor.name; }
        const tp = require("node:timers/promises");
        const same = [setTimeout[sym] === tp.setTimeout, setInterval[sym] === tp.setInterval, setImmediate[sym] === tp.setImmediate];
-       console.log(JSON.stringify({ before, same }));`,
+       const { Worker } = require("node:worker_threads");
+       const worker = new Worker(
+         ${JSON.stringify(shape)} + 'require("node:worker_threads").parentPort.postMessage([setTimeout, setInterval, setImmediate].map(shape));',
+         { eval: true },
+       );
+       worker.once("message", inWorker => {
+         console.log(JSON.stringify({ before, write, same, inWorker }));
+       });`,
     ],
     env: bunEnv,
     stdout: "pipe",
@@ -64,7 +79,12 @@ it("timers expose util.promisify.custom as a lazy accessor without loading node:
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   const accessor = { get: "function", set: "undefined", enumerable: true, configurable: false };
-  expect(JSON.parse(stdout)).toEqual({ before: [accessor, accessor, accessor], same: [true, true, true] });
+  expect(JSON.parse(stdout)).toEqual({
+    before: [accessor, accessor, accessor],
+    write: "TypeError",
+    same: [true, true, true],
+    inWorker: [accessor, accessor, accessor],
+  });
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
Follow-up to #39919.

### Problem
- `setTimeout[util.promisify.custom]` (also `setInterval`, `setImmediate`) is a `CustomAccessor` with no setter since #39919. A write to it fails silently: `"use strict"; setTimeout[sym] = 1` does nothing, and `Object.assign(setTimeout, { [sym]: 1 })` returns. In Node both throw a `TypeError`, because the property is a getter-only accessor.
- The cause is `JSObject::putInlineSlow` (`vendor/WebKit/Source/JavaScriptCore/runtime/JSObject.cpp`, the `CustomAccessor` branch). For a custom accessor without a setter it returns `false` and does not throw. It throws `ReadonlyPropertyWriteError` only when the property has `ReadOnly`.

### Fix
- `createTimerFunction` (`src/jsc/bindings/node/NodeTimers.cpp`) adds `PropertyAttribute::ReadOnly` to the accessor. A strict-mode write and `Object.assign` now throw a `TypeError`. A sloppy-mode write is still a no-op, as in Node.
- The descriptor does not change. `PropertyDescriptor::setAccessorDescriptor` drops `ReadOnly`, so it stays `{get, set: undefined, enumerable: true, configurable: false}`. The X509Certificate, CryptoKey and FormData getters in this repo use the same `ReadOnly | CustomAccessor` combination.
- `timersPromisesExport` passes the resolved `Zig::GlobalObject` to `requireId` and `get`, as `ExposeNodeModuleGlobals.cpp` does. JSC calls a custom getter with the realm that owns the property, so this is consistency only.
- Verified: `test/js/node/timers/node-timers.test.ts`. One probe runs in the main thread and in a worker. It checks the descriptor shape, a strict write, a sloppy write and `Object.assign` on each of the three timers, and that each accessor resolves to that realm's `timers/promises` export. On main the strict and `Object.assign` entries come back as `"no throw"` in both realms. It passes here. `util-promisify.test.js`, `015201.test.ts` and Node's `test-timers-{timeout,immediate}-promisified.js`, `test-util-promisify.js`, `test-util-promisify-custom-names.mjs` pass.

### Background
- A `CustomGetterSetter` is a property backed by C++ getter and setter pointers. `PropertyAttribute::CustomAccessor` makes JSC report it as an accessor. The `ReadOnly` bit is checked before the accessor branch on a write, so it is the only way to make a setter-less custom accessor throw.
- `util.promisify(fn)` returns `fn[util.promisify.custom]` when it exists. Node's `lib/timers.js` defines it on the timer functions as an enumerable, non-configurable getter. #39919 moved Bun's version of that property into `NodeTimers.cpp`.

<details><summary>Notes</summary>

History: this PR started as an adoption of #39919 (same change, plus the items above) so that it could be carried to merge. #39919 merged on its own as a1f2e22, so the PR was rebased and now holds only the additions. The rebase had no textual conflicts to resolve by hand. The branch was reset onto main and the two changed files were re-applied, because the five files #39919 touched are identical on main and in the adopted commit.

Probe against Node 26 (descriptor shape, `Reflect.ownKeys`, strict write, `Object.assign` onto the function, `Reflect.set`, `delete`, redefinition, copying with `Object.assign` and `Object.getOwnPropertyDescriptors`, `util.promisify` identity, `util.inspect`, a `node:vm` context, replacing the global): identical with this PR, except for differences older than #39919. `setTimeout.length` is 1 in Bun and 2 in Node, Bun's native functions have no `prototype`, and Bun also defines the property on `setInterval`. Node does not. `node-timers.test.ts` tests `util.promisify(setInterval)`, so that stays.

Attributes of the globals themselves are not touched by this PR. For the record, `reifyStaticProperty` in `Lookup.h` stores `Function` and `PropertyCallback` entries with the same `attributesForStructure(entry attributes)`, and `Object.getOwnPropertyDescriptor(globalThis, "setTimeout")` is `{writable: true, enumerable: true, configurable: true}` on 1.4.0 and on main.

The leak tests in `test/js/web/timers/setTimeout.test.js` and `setInterval.test.js` fail locally on a debug ASAN build named `bun-debug`, because the fixtures widen the RSS threshold only for a binary named `bun-asan`. This is unrelated to the change. The other 44 tests in `test/js/web/timers/set*.test.*` pass.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->