### PR TITLE
test(readline): pin that createInterface() does not load fs, util, vm or os

### DIFF
--- a/test/js/node/readline/readline.node.test.ts
+++ b/test/js/node/readline/readline.node.test.ts
@@ -1,9 +1,10 @@
 // @ts-nocheck
+import { bunEnv, bunExe } from "harness";
 import { createTest } from "node-harness";
 import { EventEmitter } from "node:events";
 import readline from "node:readline";
 import { PassThrough, Writable } from "node:stream";
-const { beforeEach, describe, it, createDoneDotAll, createCallCheckCtx, assert } = createTest(import.meta.path);
+const { beforeEach, describe, it, expect, createDoneDotAll, createCallCheckCtx, assert } = createTest(import.meta.path);
 
 var {
   CSI,
@@ -2103,5 +2104,64 @@ describe("readline.createInterface()", () => {
 
     assert.strictEqual(closed, true);
     assert.strictEqual(rl.closed, true);
+  });
+});
+
+describe("module loading", () => {
+  it("createInterface() does not load node:fs, node:util, node:vm or node:os", async () => {
+    // Every Interface owns a ReplHistory (internal/repl/history), which only needs
+    // fs/os/path and internal/repl/node-shims (node:util, node:vm, ...) once the REPL
+    // asks it to persist history to a file. Each module below leaves a structure
+    // behind when it loads: node:fs creates the NodeJSFS binding, node:util creates
+    // the MIMEType class, node:vm creates the vm module classes, and node:os reads
+    // the lazy `os` entry of process.binding("constants").
+    const fixture = String.raw`
+      const { heapStats, describe } = require("bun:jsc");
+      const { EventEmitter } = require("node:events");
+      const readline = require("node:readline");
+
+      function loaded() {
+        const counts = heapStats().objectTypeCounts;
+        const constants = /\{([^}]*)\}/.exec(describe(process.binding("constants")))[1];
+        return {
+          fs: (counts.NodeJSFS ?? 0) > 0,
+          util: (counts.MIMEType ?? 0) > 0,
+          vm: (counts.NodeVMModule ?? 0) > 0,
+          os: constants.split(",").some(entry => entry.trim().split(":")[0] === "os"),
+        };
+      }
+
+      const input = new EventEmitter();
+      input.resume = input.pause = input.write = () => {};
+      const rl = readline.createInterface({ input, output: input, terminal: true });
+      let line;
+      rl.on("line", value => (line = value));
+      input.emit("data", "1 + 1\r");
+      const afterInterface = loaded();
+      rl.close();
+
+      require("node:fs");
+      require("node:util");
+      require("node:vm");
+      require("node:os");
+      console.log(JSON.stringify({ line, history: rl.history, afterInterface, markersWork: loaded() }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // markersWork guards the detector: if one of these modules stops creating its
+    // structure at load time, this test needs a new marker for it.
+    expect(JSON.parse(stdout)).toEqual({
+      line: "1 + 1",
+      history: ["1 + 1"],
+      afterInterface: { fs: false, util: false, vm: false, os: false },
+      markersWork: { fs: true, util: true, vm: true, os: true },
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Test only. The code this PR adopted landed on main in #39918 (333e502aea). This PR now adds the test for it.

### Problem
- Before #39918, `src/js/internal/repl/history.js` required `node:fs`, `node:os`, `node:path` and `internal/repl/node-shims` (`node:util`, `node:vm`) at load time. Every `readline.Interface` constructs a `ReplHistory`, so `createInterface()` evaluated 58 bundled modules instead of 41.
- #39918 landed without an automated test. A later edit could make `createInterface()` eager again.

### Fix
- Add a `module loading` block to `test/js/node/readline/readline.node.test.ts`. It creates an `Interface` in a child process, feeds it one line, and checks that `node:fs`, `node:util`, `node:vm` and `node:os` are not loaded.
- Each module leaves a marker when it loads: `node:fs` the `NodeJSFS` binding, `node:util` the `MIMEType` class, `node:vm` the `NodeVMModule` class, all counted by `bun:jsc` `heapStats()`. `node:os` reifies the lazy `os` entry of `process.binding("constants")`, which `describe()` shows.
- The child then requires the four modules and checks that every marker fires. A broken marker fails the test instead of passing it.
- Verified: the test fails on debug and release builds of 4448a2e212 (the commit before #39918). It passes on a debug build of main, 15 of 15 reruns. The whole file passes (81 tests).

### Background
- Builtin modules in `src/js` are evaluated the first time something requires them. A `require` inside a function defers the whole subtree.
- Bun has no list of loaded builtin modules (`process.moduleLoadList` is an empty stub). The markers stand in for it. `node:path` leaves no marker, so the test does not assert on it.

<details><summary>Notes</summary>

- History: this PR opened as an adoption of #39918 plus this test. #39918 merged on its own as 333e502aea, so the branch is rebased onto main and only the test remains. The title and body changed to match.
- On 4448a2e212 the child reports `fs`, `util`, `vm` and `os` all loaded after `createInterface()`, and all four markers fire. On main it reports none loaded, and all four markers fire after the explicit requires.
- `heapStats().objectTypeCounts` keys cells by `ClassInfo` name. `NodeJSFS`, `MIMEType` and `NodeVMModule` are native classes, so their prototype or binding objects show up under those names as soon as the module evaluates.
- `process.binding("constants")` defines `os` as a lazy static property. JSC adds it to the object's `Structure` on first access, and `describe()` prints the `Structure` property list.
- Suites run on the debug build: `test/js/node/readline/readline.node.test.ts` (81 pass), the new test alone with `--rerun-each=15` (15 pass).
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/readline/readline.node.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/readline/readline.node.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/readline/readline.node.test.ts:
(pass) CSI > should be defined [6.57ms]
(pass) CSI > should have all the correct clear sequences [7.30ms]
(pass) readline.clearScreenDown() > should put clear screen sequence into writable when called [82.10ms]
(pass) readline.clearScreenDown() > should throw on invalid callback [4.94ms]
(pass) readline.clearScreenDown() > should that clearScreenDown() does not throw on null or undefined stream [5.63ms]
(pass) readline.clearLine() > should clear to the left of cursor when given -1 as direction [5.55ms]
(pass) readline.clearLine() > should clear to the right of cursor when given 1 as direction [2.72ms]
(pass) readline.clearLine() > should clear whole line when given 0 as direction [2.21ms]
(pass) readline.clearLine() > should call callback after clearing line [4.15ms]
(pass) readline.clearLine() > should throw on an invalid callback [3.17ms]
(pass) readline.clearLine() > should not throw on null or undefined stream [6.67ms]
(pass) readline.moveCursor() > shouldn't write when moveCursor(0, 0) is called [35.29ms]
(pass) readline.moveCursor() > should throw on invalid callback [3.52ms]
(pass) readline.moveCursor() > should not throw on null or undefined stream [6.22ms]
(pass) readline.cursorTo() > should not throw on undefined or null as stream [11.27ms]
(pass) readline.cursorTo() > should not write if given invalid cursor position - [string, undefined] [1.70ms]
(pass) readline.cursorTo() > should not write if given invalid cursor position - [string, string] [2.03ms]
(pass) readline.cursorTo() > should throw when x is not a number [23.86ms]
(pass) readline.cursorTo() > should write when given value cursor positions [12.08ms]
(pass) readline.cursorTo() > should throw on invalid callback [4.36ms]
(pass) readline.cursorTo() > should throw if x or y is NaN [11.35ms]
(p
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/readline/readline.node.test.ts | 62 ++++++++++++++++++++++++++++-
 1 file changed, 61 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
test/js/node/readline/readline.node.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->
