### PR TITLE
inspect: indent a multi-line string returned by a nested inspect.custom hook

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3840,9 +3840,7 @@ pub mod formatter {
             Ok(())
         }
 
-        /// The hook formats its value as if it were at the top level, so every
-        /// line after the first is indented to the nesting level of the value,
-        /// like util.inspect's `ret.replaceAll("\n", "\n" + indentation)`.
+        /// Re-indents the hook's result to the value's nesting level, like util.inspect.
         #[inline(never)]
         fn print_custom_inspect_string(
             &mut self,
@@ -5515,8 +5513,6 @@ pub mod formatter {
                     let _ = writer_.write_all(b"{}");
                 }
             } else {
-                // `handle_first_property` incremented both, in single-line
-                // mode too.
                 self.depth -= 1;
                 self.indent = self.indent.saturating_sub(1);
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5515,10 +5515,12 @@ pub mod formatter {
                     let _ = writer_.write_all(b"{}");
                 }
             } else {
+                // `handle_first_property` incremented both, in single-line
+                // mode too.
                 self.depth -= 1;
+                self.indent = self.indent.saturating_sub(1);
 
                 if iter_always_newline {
-                    self.indent = self.indent.saturating_sub(1);
                     self.print_comma::<C>(writer_).expect("unreachable");
                     let _ = writer_.write_all(b"\n");
                     let _ = self.write_indent(writer_);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3825,12 +3825,7 @@ pub mod formatter {
             })?;
             // Strings are printed directly, otherwise we recurse.
             if result.is_string() {
-                if writer_
-                    .write_fmt(format_args!("{}", result.fmt_string(self.global_this)))
-                    .is_err()
-                {
-                    self.failed = true;
-                }
+                self.print_custom_inspect_string(writer_, result)?;
             } else {
                 // A custom inspector that returns its own `this` would recurse
                 // forever; re-tag without the custom hook so it falls through to
@@ -3841,6 +3836,36 @@ pub mod formatter {
                     Tag::get(result, self.global_this)?
                 };
                 self.format::<C>(tag, writer_, result, self.global_this)?;
+            }
+            Ok(())
+        }
+
+        /// The hook formats its value as if it were at the top level, so every
+        /// line after the first is indented to the nesting level of the value,
+        /// like util.inspect's `ret.replaceAll("\n", "\n" + indentation)`.
+        #[inline(never)]
+        fn print_custom_inspect_string(
+            &mut self,
+            writer_: &mut dyn bun_io::Write,
+            value: JSValue,
+        ) -> JsResult<()> {
+            let str = value.to_slice(self.global_this)?;
+            let mut rest = str.slice();
+            let mut writer = WrappedWriter {
+                ctx: writer_,
+                failed: false,
+                estimated_line_length: &mut self.estimated_line_length,
+            };
+            if self.indent > 0 {
+                while let Some(newline) = strings::index_of_char_usize(rest, b'\n') {
+                    writer.write_all(&rest[..=newline]);
+                    writer.write_indent(self.indent);
+                    rest = &rest[newline + 1..];
+                }
+            }
+            writer.write_all(rest);
+            if writer.failed {
+                self.failed = true;
             }
             Ok(())
         }

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -43,6 +43,15 @@ describe("Bun.inspect", () => {
     );
   });
 
+  it("compact keeps the indentation balanced after an object", () => {
+    // The "more items" marker is the one line break compact mode still prints.
+    // It sits two levels deep, no matter how many objects came before it.
+    const items = Array.from({ length: 101 }, (_, i) => i);
+    const marker = ",\n    ... 1 more items ] }";
+    expect(Bun.inspect({ z: items }, { compact: true })).toEndWith(marker);
+    expect(Bun.inspect({ a: { x: 1 }, b: { x: 1 }, z: items }, { compact: true })).toEndWith(marker);
+  });
+
   it("depth < 0 throws", () => {
     expect(() => Bun.inspect({}, { depth: -1 })).toThrow();
     expect(() => Bun.inspect({}, { depth: -13210 })).toThrow();

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -220,6 +220,18 @@ for (const [name, inspect] of process.versions.bun
       expect(inspect([text])).toBe("[\n  a\r\n  b\n  \n]");
     });
 
+    test("compact: the indentation does not depend on the values printed before the hook", () => {
+      const compact = { compact: true };
+      // Node's compact layout indents an object property by 3, Bun's by 2.
+      const inObject = isBunInspect ? "X {\n    y: 1\n  }" : "X {\n     y: 1\n   }";
+      expect(inspect({ d: multiLine }, compact)).toBe(`{ d: ${inObject} }`);
+      expect(inspect({ a: { x: 1 }, b: { x: 1 }, d: multiLine }, compact)).toBe(
+        `{ a: { x: 1 }, b: { x: 1 }, d: ${inObject} }`,
+      );
+      expect(inspect({ a: { p: { q: 1 } }, d: multiLine }, compact)).toBe(`{ a: { p: { q: 1 } }, d: ${inObject} }`);
+      expect(inspect([{ x: 1 }, multiLine], compact)).toBe("[ { x: 1 }, X {\n    y: 1\n  } ]");
+    });
+
     test("built-in hook (URL)", () => {
       const url = new URL("http://example.com/path");
       const nested = inspect(url).replaceAll("\n", "\n  ");

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -157,6 +157,76 @@ for (const [name, inspect] of process.versions.bun
 
     expect(() => inspect(obj)).toThrow();
   });
+
+  // A hook formats its value as if it were printed at the top level. When the
+  // value is nested, every line after the first has to be indented to the
+  // nesting level, or the continuation lines end up in column 0.
+  describe(name + " indents a multi-line string returned by inspect.custom", () => {
+    const multiLine = { [customSymbol]: () => "X {\n  y: 1\n}" };
+
+    test("top level is printed as returned", () => {
+      expect(inspect(multiLine)).toBe("X {\n  y: 1\n}");
+    });
+
+    test("object property", () => {
+      expect(inspect({ c: multiLine })).toBe(
+        isBunInspect ? "{\n  c: X {\n    y: 1\n  },\n}" : "{\n  c: X {\n    y: 1\n  }\n}",
+      );
+    });
+
+    test("two levels deep", () => {
+      expect(inspect({ a: { c: multiLine } })).toBe(
+        isBunInspect
+          ? "{\n  a: {\n    c: X {\n      y: 1\n    },\n  },\n}"
+          : "{\n  a: {\n    c: X {\n      y: 1\n    }\n  }\n}",
+      );
+    });
+
+    test("array element", () => {
+      expect(inspect([multiLine])).toBe("[\n  X {\n    y: 1\n  }\n]");
+    });
+
+    test("Map value", () => {
+      expect(inspect(new Map([["k", multiLine]]))).toBe(
+        isBunInspect ? 'Map(1) {\n  "k": X {\n    y: 1\n  },\n}' : "Map(1) {\n  'k' => X {\n    y: 1\n  }\n}",
+      );
+    });
+
+    test("Set entry", () => {
+      expect(inspect(new Set([multiLine]))).toBe(
+        isBunInspect ? "Set(1) {\n  X {\n    y: 1\n  },\n}" : "Set(1) {\n  X {\n    y: 1\n  }\n}",
+      );
+    });
+
+    test("hook returned by a hook", () => {
+      const outer = { [customSymbol]: () => multiLine };
+      expect(inspect({ c: outer })).toBe(
+        isBunInspect ? "{\n  c: X {\n    y: 1\n  },\n}" : "{\n  c: X {\n    y: 1\n  }\n}",
+      );
+    });
+
+    test("latin1 and utf16 text", () => {
+      const latin1 = { [customSymbol]: () => "é {\n  ü: 1\n}" };
+      const utf16 = { [customSymbol]: () => "日本 {\n  語: 1\n}" };
+      expect(inspect({ a: latin1, b: utf16 })).toBe(
+        isBunInspect
+          ? "{\n  a: é {\n    ü: 1\n  },\n  b: 日本 {\n    語: 1\n  },\n}"
+          : "{\n  a: é {\n    ü: 1\n  },\n  b: 日本 {\n    語: 1\n  }\n}",
+      );
+    });
+
+    test("every newline is followed by the indentation, including a trailing one", () => {
+      const text = { [customSymbol]: () => "a\r\nb\n" };
+      expect(inspect([text])).toBe("[\n  a\r\n  b\n  \n]");
+    });
+
+    test("built-in hook (URL)", () => {
+      const url = new URL("http://example.com/path");
+      const nested = inspect(url).replaceAll("\n", "\n  ");
+      expect(nested).toContain("\n");
+      expect(inspect({ url })).toBe(isBunInspect ? `{\n  url: ${nested},\n}` : `{\n  url: ${nested}\n}`);
+    });
+  });
 }
 
 describe("Web Streams [nodejs.util.inspect.custom]", () => {

--- a/test/js/web/console/console-group.fixture.js
+++ b/test/js/web/console/console-group.fixture.js
@@ -87,3 +87,11 @@ console.group('Tab\tNewline\nQuote"Backslash');
 console.log("Special chars");
 console.groupEnd();
 console.groupEnd();
+
+// A multi-line string returned by an inspect.custom hook is indented to the
+// group level, and to the nesting level inside an object.
+const multiLine = { [Symbol.for("nodejs.util.inspect.custom")]: () => "X {\n  y: 1\n}" };
+console.group("Custom inspect");
+console.log(multiLine);
+console.log({ c: multiLine });
+console.groupEnd();

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -109,7 +109,16 @@ null
   Inside unicode group
   Tab\tNewline
 Quote"Backslash
-    Special chars"
+    Special chars
+Custom inspect
+  X {
+    y: 1
+  }
+  {
+    c: X {
+      y: 1
+    },
+  }"
 `);
   expect(stderr).toMatchInlineSnapshot(`
 "Warning log


### PR DESCRIPTION
### Problem
- The native formatter writes the string that a nested `[nodejs.util.inspect.custom]` hook returns verbatim. Its continuation lines start in column 0. `console.log({ u: new URL("http://a/b") })` prints the URL fields flush left.
- Cause: `print_custom_formatted_object` (`src/jsc/ConsoleObject.rs:3827`) ignores `indent`. Node and the JS port (`src/js/internal/util/inspect.js:1428`) re-indent it.
- In single-line mode (`compact: true`, `console.table`, error messages) `print_object` increments `indent` (`:2985`) and never decrements it (`:5521` runs in multi-line mode only).

### Fix
- The new `print_custom_inspect_string` writes the current indentation after each `\n` of the string. At indent 0 the string is unchanged.
- This is Node's rule, `ret.replaceAll("\n", "\n" + indentation)`. A hook formats its value as a top level value. Only the caller knows the nesting, so the caller adds the indentation.
- `print_object_tail` now decrements `indent` in both modes, next to `depth`. Without this, compact mode indents a hook result once per object printed before it. Multi-line mode already decremented, so its output does not change.
- Verified: `test/js/node/util/custom-inspect.test.js` (10 of the 11 new `Bun.inspect` cases fail on bun 1.4.0), `bun-inspect.test.ts` (pins the balance) and the `console.group` fixture in `test/js/web/console/`. The notes list the other suites.

### Background
- `node:util` has a JS port of Node's `inspect.js`. `console.log`, `Bun.inspect` and the `expect()` messages use the native `Formatter` in `src/jsc/ConsoleObject.rs`.
- `Formatter.indent` counts nesting levels. A container increments it around its children. `write_indent` writes two spaces per level. In single-line mode only the few writers that still break a line read it.
- A hook is a function stored under `Symbol.for("nodejs.util.inspect.custom")`. The `URL`, Web Streams and `BroadcastChannel` hooks build their string with `util.inspect`, so it often spans lines.

<details><summary>Notes</summary>

Repro:

```js
const custom = { [Symbol.for("nodejs.util.inspect.custom")]() { return "X {\n  y: 1\n}"; } };
console.log({ c: custom });
```

bun 1.4.0 and main before this change:

```
{
  c: X {
  y: 1
},
}
```

With this change (Node v26.3.0 prints the same, without the trailing comma):

```
{
  c: X {
    y: 1
  },
}
```

Indent leak in single-line mode, measured on this branch before the `print_object_tail` change: `Bun.inspect({ d: custom }, { compact: true })` indented the hook result by 4 spaces, with one `{ x: 1 }` sibling before it by 6, with three by 10. The pre-existing `... N more items` marker moved the same way (4 spaces, then 8 with two object siblings). After the change both stay at 4. The same applies to `Bun.inspect(buffer)` when `buffer.extra = { a: { x: 1 }, m: custom }`, which goes through the single-line inspector. The other readers of `indent` in single-line mode are the `type:` line of an `Event` and the `JSON.stringify` space argument in `print_json`. Both become independent of the siblings too.

Other observations:

- The same misalignment shows for arrays, Map and Set entries, and for hooks two levels deep. The new tests cover each container once, with a one entry container, so they do not depend on the array line breaking heuristic.
- `\r\n` and a trailing newline follow the same rule as any other newline. Node prints `a\r\n  b\n  ` for a hook that returns `"a\r\nb\n"` inside an array, and so does this change. The test pins it.
- Node's legacy `compact: true` layout indents an object property by 3 spaces and an array element by 2. Bun's compact layout indents both by 2. The compact test spells out both, and the `util.inspect` half of the file passes under Node v26.3.0 unchanged.
- The `util.inspect` twin of every new case passes before and after. The JS port already had the rule.
- A hook that returns an object is formatted by recursion, so a hook reached through another hook takes the same path (the "hook returned by a hook" case).
- The string is transcoded once with `JSValue::to_slice`, so Latin-1 and UTF-16 results take the same path. A `\n` byte cannot occur inside a multi-byte UTF-8 sequence, so the byte search is safe. The test covers both encodings.
- `estimated_line_length` is not updated for a hook result. The old code did not update it either, so the line breaking of the siblings does not change.
- `console.group` already indents the continuation lines of a nested object to the group depth. A hook result at the top level of a group now gets the same treatment. A plain multi-line string argument is not a hook result and is unchanged (see the `Tab\tNewline` case in the same fixture).
- Out of scope: a nested `Error` (`print_error`, which goes through the error printer in `VirtualMachine.rs`) and `BuildMessage` / `ResolveMessage` also print continuation lines in column 0. They are not hook results and have their own producers, so they need their own change.
- The test runner's own `pretty_format.rs` does not call custom hooks, so it is not affected.
- Suites run on the debug build with no new failures: `test/js/node/util/`, `test/js/bun/util/inspect.test.js`, `test/js/bun/util/inspect-error.test.js`, `test/js/web/console/`, `test/js/bun/console/`, `test/js/node/buffer.test.js`, `test/js/web/workers/message-event.test.ts`, `test/js/web/web-globals.test.js`, `test/js/web/url/url.test.ts`, `test/js/web/html/URLSearchParams.test.ts`, `test/js/web/broadcastchannel/broadcast-channel.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/bun/test/expect-extend-matcher-utils-throw.test.ts`, `test/js/web/fetch/headers.undici.test.ts`, and the Node tests `test-whatwg-url-custom-inspect.js`, `test-webstream-encoding-inspect.js`, `test-broadcastchannel-custom-inspect.js`, `test-eventtarget-custom-inspect-does-not-throw.js`, `test-util-inspect-proxy.js`.
- In `test/js/node/util/`, `util-inspect.test.js > no assertion failures 2` and the parseArgs stress test hit the 5 s timeout under the local debug ASAN build. Both pass with a larger timeout and only use the JS port. One run of the combined suites also died with SIGSEGV in `bun-inspect.test.ts > stack overflow is thrown when it should be for Error` after about 1400 tests in the same process. The same command passed on a second run. That test builds a 16k deep `Error` chain and does not involve a hook. The stack check it exercises is the subject of #34884.
- PR #39921 adds a native hook to the performance entry prototypes. After it lands, `console.log({ m: performance.mark("m") })` takes this path too.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/bun-inspect.test.ts test/js/node/util/custom-inspect.test.js test/js/web/console/console-log.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [853.13ms]
(pass) long arrays get cutoff [3.43ms]
71 |     .trim()
72 |     .replaceAll(filepath, "<file>")
73 |     // Normalize line numbers for consistency between debug and release builds
74 |     .replace(/\(\d+:\d+\)/g, "(N:NN)")
75 |     .replace(/<file>:\d+:\d+/g, "<file>:NN:NN");
76 |   expect(stdout).toMatchInlineSnapshot(`
                      ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "Basic group
    Inside basic group
  Outer group
    Inside outer group
    Inner group
      Inside inner group
    Back to outer group
  Level 1
    Level 2
      Level 3
        Deep inside
  undefined
  Empty nested
  Test extra end
    Inside
  Different logs
    Regular log
    Info log
    Debug log
  Complex types
    {
      a: 1,
      b: 2,
    }
    [ 1, 2, 3 ]
  null
    undefined
   
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3facbd73d)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [14.99ms]
(pass) long arrays get cutoff [0.10ms]
(pass) console.group [13.37ms]
(pass) console.log with SharedArrayBuffer [0.09ms]

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [0.02ms]
(pass) util.inspect calls inspect.custom [0.35ms]
(pass) util.inspect calls inspect.custom recursivly [0.05ms]
(pass) util.inspect calls inspect.custom recursivly nested [1.12ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [0.07ms]
(pass) util.inspect calls inspect.custom with valid options [0.08ms]
(pass) util.inspect stylize function works without color [0.05ms]
(pass) util.inspect stylize function works with color [0.10ms]
(pass) util.inspect stylize function gives correct depth [0.33ms]
(pass) util.inspect stylize function gives correct depth [0.08ms]
(pass) util.inspect non-callable does not get called [0.08ms]
(pass) util.inspect handles exceptions %s [0.06ms]
(pass) util.inspect handles exceptions %s
(pass) util.inspect indents a multi-line string returned by inspect.custom > top level is printed as returned [0.02
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/bun-inspect.test.ts test/js/node/util/custom-inspect.test.js test/js/web/console/console-log.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [863.05ms]
(pass) long arrays get cutoff [3.45ms]
(pass) console.group [715.12ms]
(pass) console.log with SharedArrayBuffer [4.57ms]

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [2.18ms]
(pass) util.inspect calls inspect.custom [18.46ms]
(pass) util.inspect calls inspect.custom recursivly [4.66ms]
(pass) util.inspect calls inspect.custom recursivly nested [58.21ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [5.49ms]
(pass) util.inspect calls inspect.custom with valid options [4.35ms]
(pass) util.inspect stylize function works without color [4.31ms]
(pass) util.inspect stylize function works with color [6.99ms]
(pass) util.inspect stylize function gives correct depth [17.72ms]
(pass) util.inspect stylize function gives correct depth [5.65ms]
(pass) util.inspect no
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                     | 37 ++++++++++---
 test/js/node/util/bun-inspect.test.ts        |  9 +++
 test/js/node/util/custom-inspect.test.js     | 82 ++++++++++++++++++++++++++++
 test/js/web/console/console-group.fixture.js |  8 +++
 test/js/web/console/console-log.test.ts      | 11 +++-
 5 files changed, 139 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/ConsoleObject.rs                         19      6      0
test/js/node/util/bun-inspect.test.ts             2      1      0
test/js/node/util/custom-inspect.test.js          1      3      0
test/js/web/console/console-group.fixture.js      1      2      0
test/js/web/console/console-log.test.ts           1      1      0
```

</details>

<!-- robobun:evidence:end -->