### PR TITLE
yaml: add the tags option to Bun.YAML.parse and Bun.YAML.tags with !env

### DIFF
--- a/docs/runtime/yaml.mdx
+++ b/docs/runtime/yaml.mdx
@@ -75,7 +75,7 @@ Bun's YAML parser supports the YAML 1.2 specification, including:
 - **Scalars**: strings, numbers, booleans, null values
 - **Collections**: sequences (arrays) and mappings (objects)
 - **Anchors and Aliases**: reusable nodes with `&` and `*`. Aliased collections share identity. An alias may refer to a collection that contains it, so `Bun.YAML.parse` can return cyclic objects. YAML imported as a module cannot be cyclic.
-- **Tags**: type hints like `!!str`, `!!int`, `!!float`, `!!bool`, `!!null`
+- **Tags**: type hints like `!!str`, `!!int`, `!!float`, `!!bool`, `!!null`, and your own tags through the `tags` option (see [Custom Tags](#custom-tags))
 - **Multi-line strings**: literal (`|`) and folded (`>`) scalars
 - **Comments**: using `#`
 - **Directives**: `%YAML` and `%TAG`
@@ -108,6 +108,67 @@ summary: >
 
 const data = Bun.YAML.parse(yaml);
 ```
+
+#### Custom Tags
+
+By default, a tag the parser does not know is ignored: `!point {x: 1}` parses as `{ x: 1 }`. The `tags` option of `Bun.YAML.parse()` maps tags to handler functions. A handler receives the tagged node and its return value takes the node's place in the result:
+
+```ts
+import { YAML } from "bun";
+
+const text = `
+origin: !point [0, 0]
+motd: !upper hello
+`;
+
+const data = YAML.parse(text, {
+  tags: {
+    "!point": ([x, y]) => ({ x, y }),
+    "!upper": text => text.toUpperCase(),
+  },
+});
+// { origin: { x: 0, y: 0 }, motd: "HELLO" }
+```
+
+A handler is called with two arguments:
+
+- The node without its tag. A scalar arrives as its text, so `!id 123` passes the string `"123"`. A sequence arrives as an array and a mapping as an object. Tagged nodes inside a collection have already been converted.
+- The tag, spelled as in the `tags` option.
+
+Keys of the `tags` option name a tag in one of three ways:
+
+- A local tag: `"!point"`
+- A tag of the `tag:yaml.org,2002:` namespace, with the `!!` shorthand: `"!!timestamp"`
+- A full tag URI, as a document would write it verbatim (`!<tag:example.com,2000:app/point>`) or through a `%TAG` directive: `"tag:example.com,2000:app/point"`
+
+Every alias of an anchored tagged node shares the one value its handler returned. An exception thrown by a handler is thrown by `Bun.YAML.parse()`.
+
+`Bun.YAML.tags` holds the handlers Bun provides. They are only used when passed:
+
+- `!env NAME` is `process.env.NAME`, or `undefined` when the variable is not set.
+- `!env [NAME, fallback]` is `fallback` when the variable is not set.
+
+```ts
+import { YAML } from "bun";
+
+const text = `
+port: !env [PORT, 3000]
+database: !env DATABASE_URL
+`;
+
+const config = YAML.parse(text, { tags: YAML.tags });
+// { port: 3000, database: undefined } when neither variable is set
+
+// Combine them with your own handlers
+YAML.parse(text, {
+  tags: {
+    ...YAML.tags,
+    "!secret": name => vault.read(name),
+  },
+});
+```
+
+Modules imported with `import` or `require` are parsed without tags.
 
 #### Error Handling
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1208,12 +1208,64 @@ declare module "bun" {
    */
   namespace YAML {
     /**
+     * Converts a node tagged with one of the tags in {@link ParseOptions.tags}.
+     *
+     * @param value The node without its tag: the text of a scalar (a tagged `123` is the string `"123"`),
+     *              the array of a sequence, or the object of a mapping. Tagged nodes inside it have
+     *              already been converted.
+     * @param tag The tag, spelled as in the `tags` option.
+     * @returns The value that takes the node's place in the result.
+     */
+    type TagHandler = (value: any, tag: string) => unknown;
+
+    interface ParseOptions {
+      /**
+       * Handlers for tagged nodes, keyed by tag: a local tag such as `"!env"`, a `"!!name"` tag of the
+       * `tag:yaml.org,2002:` namespace, or a full tag URI such as `"tag:example.com,2000:app/name"`.
+       * Tags that are not listed are ignored, as without this option. Every alias of an anchored
+       * tagged node shares the one value its handler returned.
+       *
+       * @example
+       * ```ts
+       * import { YAML } from "bun";
+       *
+       * const config = YAML.parse("port: !env [PORT, 3000]\nmotd: !upper hello", {
+       *   tags: {
+       *     ...YAML.tags,
+       *     "!upper": (text: string) => text.toUpperCase(),
+       *   },
+       * });
+       * // { port: 3000, motd: "HELLO" } when PORT is not set
+       * ```
+       */
+      tags?: Record<string, TagHandler>;
+    }
+
+    /**
+     * The tag handlers Bun provides. They are used only when passed as the `tags` option of {@link parse}.
+     *
+     * - `!env NAME` is `process.env.NAME`, or `undefined` when it is not set.
+     * - `!env [NAME, fallback]` is `fallback` when `NAME` is not set.
+     *
+     * @example
+     * ```ts
+     * import { YAML } from "bun";
+     *
+     * YAML.parse("home: !env HOME", { tags: YAML.tags }); // { home: "/home/me" }
+     * ```
+     */
+    const tags: {
+      readonly "!env": TagHandler;
+    };
+
+    /**
      * Parse a YAML string into a JavaScript value. Every alias (`*name`) of an anchored collection yields the
      * same object, and an alias may refer to a collection that contains it, so the result can be cyclic.
      *
      * @category Utilities
      *
      * @param input The YAML string to parse
+     * @param options Handlers for tagged nodes, see {@link ParseOptions}
      * @returns A JavaScript value, or an array of them for a multi-document stream
      *
      * @example
@@ -1226,9 +1278,10 @@ declare module "bun" {
      * console.log(YAML.parse("abc")) // "abc"
      * console.log(YAML.parse("- abc")) // [ "abc" ]
      * console.log(YAML.parse("abc: def")) // { "abc": "def" }
+     * console.log(YAML.parse("home: !env HOME", { tags: YAML.tags })) // { "home": "/home/me" }
      * ```
      */
-    export function parse(input: string): unknown;
+    export function parse(input: string, options?: ParseOptions): unknown;
 
     /**
      * Convert a JavaScript value into a YAML string. Strings are double quoted if they contain keywords, non-printable or

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -35,6 +35,32 @@ pub enum CyclicAliases {
     Reject,
 }
 
+/// The nodes of a parse that carried a custom tag (see
+/// [`YAML::parse_with_custom_tags`]). Such a node is replaced in the tree by
+/// an `E::Array` holding the node as its only item; `get` recognizes the
+/// array and returns the tag's index in the registered list. Aliases to an
+/// anchored tagged node share the array, so a consumer that tracks arrays by
+/// identity converts the tagged node once.
+#[derive(Default)]
+pub struct CustomTaggedNodes {
+    nodes: bun_collections::HashMap<usize, u32>,
+}
+
+impl CustomTaggedNodes {
+    pub fn get(&self, node: &Expr) -> Option<u32> {
+        if self.nodes.is_empty() {
+            return None;
+        }
+        self.nodes.get(&collection_id(node)?).copied()
+    }
+}
+
+/// The result of [`YAML::parse_with_custom_tags`].
+pub struct Parsed {
+    pub root: Expr,
+    pub custom_tagged: CustomTaggedNodes,
+}
+
 impl YAML {
     pub fn parse(
         source: &bun_ast::Source,
@@ -42,10 +68,27 @@ impl YAML {
         bump: &bun_alloc::Arena,
         cyclic_aliases: CyclicAliases,
     ) -> Result<Expr, YamlParseError> {
+        Ok(Self::parse_with_custom_tags(source, log, bump, cyclic_aliases, &[])?.root)
+    }
+
+    /// [`YAML::parse`] that also reports the nodes tagged with one of
+    /// `custom_tags`, which are left unresolved: a scalar keeps its text, a
+    /// collection its items. A name is matched against the tag as the
+    /// document's `%TAG` directives resolve it: `!env` for a primary-handle
+    /// tag, `tag:yaml.org,2002:timestamp` for `!!timestamp`, the URI itself
+    /// for a verbatim `!<...>` tag.
+    pub fn parse_with_custom_tags(
+        source: &bun_ast::Source,
+        log: &mut bun_ast::Log,
+        bump: &bun_alloc::Arena,
+        cyclic_aliases: CyclicAliases,
+        custom_tags: &[&[u8]],
+    ) -> Result<Parsed, YamlParseError> {
         bun_core::analytics::Features::yaml_parse_inc();
         source.check_parseable_len(log, "YAML document")?;
 
-        let mut parser: Parser<Utf8> = Parser::init(bump, source.contents(), cyclic_aliases);
+        let mut parser: Parser<Utf8> =
+            Parser::init(bump, source.contents(), cyclic_aliases, custom_tags);
 
         let stream = match parser.parse() {
             Ok(s) => s,
@@ -56,9 +99,9 @@ impl YAML {
             }
         };
 
-        match stream.docs.len() {
-            0 => Ok(Expr::init(E::Null {}, Loc::EMPTY)),
-            1 => Ok(stream.docs[0].root),
+        let root = match stream.docs.len() {
+            0 => Expr::init(E::Null {}, Loc::EMPTY),
+            1 => stream.docs[0].root,
             _ => {
                 // multi-document yaml streams are converted into arrays
                 let mut items: ast::ExprNodeList =
@@ -66,15 +109,20 @@ impl YAML {
                 for doc in &stream.docs {
                     items.push(doc.root);
                 }
-                Ok(Expr::init(
+                Expr::init(
                     E::Array {
                         items,
                         ..Default::default()
                     },
                     Loc::EMPTY,
-                ))
+                )
             }
-        }
+        };
+
+        Ok(Parsed {
+            root,
+            custom_tagged: core::mem::take(&mut parser.custom_tagged),
+        })
     }
 }
 
@@ -1090,7 +1138,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
             NodeTag::Str => {
                 // always becomes string
             }
-            NodeTag::Verbatim(_) | NodeTag::Unknown(_) => {
+            NodeTag::Verbatim(_) | NodeTag::Unknown(_) | NodeTag::Custom(_) => {
                 // also always becomes a string
             }
         }
@@ -1543,6 +1591,18 @@ pub enum NodeTag {
     Verbatim(StringRange),
     /// '!!unknown'
     Unknown(StringRange),
+    /// A tag the caller registered (`YAML::parse_with_custom_tags`), by its
+    /// index in the registered list. The node keeps its raw form (scalars
+    /// stay strings) and is reported through [`CustomTaggedNodes`].
+    Custom(u32),
+}
+
+/// What a tag handle expands to: the spec's default for `!` / `!!`, or the
+/// prefix a `%TAG` directive in the input declared for it.
+#[derive(Clone, Copy)]
+enum TagPrefix {
+    Default(&'static [u8]),
+    Declared(StringRange),
 }
 
 impl NodeTag {
@@ -1556,8 +1616,11 @@ impl NodeTag {
             | NodeTag::Verbatim(_)
             | NodeTag::Unknown(_) => Expr::init(E::Null {}, loc),
 
-            // non-specific tags become seq, map, or str
-            NodeTag::NonSpecific | NodeTag::Str => Expr::init(E::String::default(), loc),
+            // non-specific tags become seq, map, or str; a custom tag's empty
+            // node is the empty scalar.
+            NodeTag::NonSpecific | NodeTag::Str | NodeTag::Custom(_) => {
+                Expr::init(E::String::default(), loc)
+            }
         }
     }
 }
@@ -2140,7 +2203,16 @@ pub struct Parser<'i, Enc: Encoding> {
     /// An alias in this document resolved to an enclosing collection, so the
     /// graph has a cycle and `charge_alias_expansion` must watch for it.
     pub(crate) has_cyclic_alias: bool,
-    pub(crate) tag_handles: StringHashMap<()>,
+    /// `%TAG` directives of the current document: the prefix declared for
+    /// each named handle, and for the `!` and `!!` handles when their
+    /// defaults (`!` and `tag:yaml.org,2002:`) are overridden.
+    pub(crate) tag_handles: StringHashMap<StringRange>,
+    pub(crate) primary_tag_prefix: Option<StringRange>,
+    pub(crate) secondary_tag_prefix: Option<StringRange>,
+
+    /// Full tag names the caller wants reported; see `NodeTag::Custom`.
+    pub(crate) custom_tags: &'i [&'i [u8]],
+    pub(crate) custom_tagged: CustomTaggedNodes,
 
     /// Backing storage lent to `StringBuilder`; empty while a builder is live.
     pub(crate) whitespace_buf: Vec<Whitespace<Enc>>,
@@ -2164,6 +2236,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         bump: &'i bun_alloc::Arena,
         input: &'i [Enc::Unit],
         cyclic_aliases: CyclicAliases,
+        custom_tags: &'i [&'i [u8]],
     ) -> Self {
         // [206] l-document-prefix ::= c-byte-order-mark? l-comment*
         let start = Pos::from(Enc::bom_len(input));
@@ -2188,6 +2261,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             cyclic_aliases,
             has_cyclic_alias: false,
             tag_handles: StringHashMap::default(),
+            primary_tag_prefix: None,
+            secondary_tag_prefix: None,
+            custom_tags,
+            custom_tagged: CustomTaggedNodes::default(),
             whitespace_buf: Vec::new(),
             stack_check: StackCheck::init(),
             merge_props_budget: MappingProps::MAX_MERGED_PROPERTIES,
@@ -2304,7 +2381,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             // primary tag handle
             if self.is_s_white() {
                 self.skip_s_white();
-                self.parse_directive_tag_prefix()?;
+                self.primary_tag_prefix = Some(self.parse_directive_tag_prefix()?);
                 self.try_skip_to_new_line()?;
                 return Ok(Directive::Other);
             }
@@ -2313,7 +2390,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             if self.is_char(Enc::ch(b'!')) {
                 self.inc(1);
                 self.try_skip_s_white()?;
-                self.parse_directive_tag_prefix()?;
+                self.secondary_tag_prefix = Some(self.parse_directive_tag_prefix()?);
                 self.try_skip_to_new_line()?;
                 return Ok(Directive::Other);
             }
@@ -2325,10 +2402,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             self.try_skip_char(Enc::ch(b'!'))?;
             self.try_skip_s_white()?;
 
+            let prefix = self.parse_directive_tag_prefix()?;
             self.tag_handles
-                .put(Enc::key_bytes(handle.slice(self.input)), ())?;
+                .put(Enc::key_bytes(handle.slice(self.input)), prefix)?;
 
-            self.parse_directive_tag_prefix()?;
             self.try_skip_to_new_line()?;
             return Ok(Directive::Other);
         }
@@ -2348,19 +2425,21 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         Ok(Directive::Other)
     }
 
-    pub(crate) fn parse_directive_tag_prefix(&mut self) -> Result<(), ParseError> {
+    pub(crate) fn parse_directive_tag_prefix(&mut self) -> Result<StringRange, ParseError> {
+        let range = self.string_range();
+
         // local tag prefix
         if self.is_char(Enc::ch(b'!')) {
             self.inc(1);
             self.skip_ns_uri_chars();
-            return Ok(());
+            return Ok(range.end(self.pos));
         }
 
         // global tag prefix
         if let Some(char_len) = self.is_ns_tag_char() {
             self.inc(char_len as usize);
             self.skip_ns_uri_chars();
-            return Ok(());
+            return Ok(range.end(self.pos));
         }
 
         Err(ParseError::InvalidDirective)
@@ -2370,6 +2449,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         self.anchors.clear();
         self.has_cyclic_alias = false;
         self.tag_handles.clear();
+        self.primary_tag_prefix = None;
+        self.secondary_tag_prefix = None;
 
         let mut has_directives = false;
         let mut has_yaml_directive = false;
@@ -2528,10 +2609,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         k
     }
 
-    fn parse_flow_sequence(&mut self, anchor: Option<PendingAnchor>) -> Result<Expr, ParseError> {
+    fn parse_flow_sequence(
+        &mut self,
+        anchor: Option<PendingAnchor>,
+        tag: NodeTag,
+    ) -> Result<Expr, ParseError> {
         let sequence_start = self.token.start;
         self.parse_collection(
             anchor,
+            tag,
             sequence_start.loc(),
             Self::parse_flow_sequence_entries,
         )
@@ -2615,10 +2701,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         })
     }
 
-    fn parse_flow_mapping(&mut self, anchor: Option<PendingAnchor>) -> Result<Expr, ParseError> {
+    fn parse_flow_mapping(
+        &mut self,
+        anchor: Option<PendingAnchor>,
+        tag: NodeTag,
+    ) -> Result<Expr, ParseError> {
         let mapping_start = self.token.start;
         self.parse_collection(
             anchor,
+            tag,
             mapping_start.loc(),
             Self::parse_flow_mapping_entries,
         )
@@ -2739,10 +2830,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         })
     }
 
-    fn parse_block_sequence(&mut self, anchor: Option<PendingAnchor>) -> Result<Expr, ParseError> {
+    fn parse_block_sequence(
+        &mut self,
+        anchor: Option<PendingAnchor>,
+        tag: NodeTag,
+    ) -> Result<Expr, ParseError> {
         let sequence_start = self.token.start;
         self.parse_collection(
             anchor,
+            tag,
             sequence_start.loc(),
             Self::parse_block_sequence_entries,
         )
@@ -2839,18 +2935,19 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         key
     }
 
-    /// `anchor` is the [200] block collection's own anchor; an anchor on
-    /// `first_key` has already been bound by the caller.
+    /// `anchor` and `tag` are the [200] block collection's own properties;
+    /// those on `first_key` have already been applied by the caller.
     fn parse_block_mapping(
         &mut self,
         anchor: Option<PendingAnchor>,
+        tag: NodeTag,
         first_key: Expr,
         mapping_start: Pos,
         mapping_indent: Indent,
         mapping_line: Line,
         flow_pair_allowed: bool,
     ) -> Result<Expr, ParseError> {
-        self.parse_collection::<E::Object>(anchor, mapping_start.loc(), |p| {
+        self.parse_collection::<E::Object>(anchor, tag, mapping_start.loc(), |p| {
             p.parse_block_mapping_entries(
                 first_key,
                 mapping_indent,
@@ -3199,7 +3296,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             _ => false,
         };
 
-        if is_merge_key {
+        // A custom-tagged value is whatever the caller makes of it, not a
+        // mapping to merge.
+        if is_merge_key && !self.is_custom_tagged(&value) {
             self.reject_open_merge_source(&value)?;
             match &value.data {
                 ast::ExprData::EObject(value_obj) => {
@@ -3336,6 +3435,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     fn parse_collection<T: CollectionData>(
         &mut self,
         anchor: Option<PendingAnchor>,
+        tag: NodeTag,
         loc: Loc,
         body: impl FnOnce(&mut Self) -> Result<T, ParseError>,
     ) -> Result<Expr, ParseError> {
@@ -3343,7 +3443,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         let Some(anchor) = anchor else {
             *slot = body(self)?;
-            return Ok(node);
+            return self.apply_custom_tag(tag, node);
         };
 
         self.open_collections.push(OpenCollection {
@@ -3355,8 +3455,34 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         debug_assert!(closed.is_some_and(|c| collection_id(&c.node) == collection_id(&node)));
 
         *slot = result?;
+        let node = self.apply_custom_tag(tag, node)?;
         self.bind_anchor(anchor, node)?;
         Ok(node)
+    }
+
+    /// The finished `node` as its parent sees it: itself, or for a custom
+    /// tag the wrapper described on [`CustomTaggedNodes`]. Anchors bind to
+    /// the result, so aliases share the wrapper.
+    fn apply_custom_tag(&mut self, tag: NodeTag, node: Expr) -> Result<Expr, ParseError> {
+        let NodeTag::Custom(index) = tag else {
+            return Ok(node);
+        };
+        let mut items: ast::ExprNodeList = ast::ExprNodeList::init_capacity(1);
+        items.push(node);
+        let wrapper = Expr::init(
+            E::Array {
+                items,
+                ..Default::default()
+            },
+            node.loc,
+        );
+        let id = collection_id(&wrapper).expect("the wrapper is an array");
+        self.custom_tagged.nodes.put(id, index)?;
+        Ok(wrapper)
+    }
+
+    fn is_custom_tagged(&self, node: &Expr) -> bool {
+        self.custom_tagged.get(node).is_some()
     }
 
     /// Anchors bind when their node completes, so a name found in `anchors`
@@ -3511,24 +3637,28 @@ impl<Enc: Encoding> NodeProperties<Enc> {
     }
 
     pub(crate) fn set_tag(&mut self, tag_token: Token<Enc>) -> Result<(), ParseError> {
-        if let Some(previous_tag) = &self.has_tag {
-            if previous_tag.line == tag_token.line {
+        if let Some(previous_tag) = self.has_tag.take() {
+            if previous_tag.line == tag_token.line || self.has_mapping_tag.is_some() {
                 return Err(ParseError::MultipleTags);
             }
-            self.has_mapping_tag = Some(previous_tag.clone());
+            self.has_mapping_tag = Some(previous_tag);
         }
         self.has_tag = Some(tag_token);
         Ok(())
     }
 
     pub(crate) fn tag(&self) -> NodeTag {
-        self.has_tag
-            .as_ref()
-            .and_then(|t| match &t.data {
-                TokenData::Tag(tg) => Some(*tg),
-                _ => None,
-            })
-            .unwrap_or(NodeTag::None)
+        Self::token_tag(self.has_tag.as_ref())
+    }
+
+    fn token_tag(token: Option<&Token<Enc>>) -> NodeTag {
+        match token {
+            Some(Token {
+                data: TokenData::Tag(tag),
+                ..
+            }) => *tag,
+            _ => NodeTag::None,
+        }
     }
 
     pub(crate) fn tag_line(&self) -> Option<Line> {
@@ -3536,10 +3666,62 @@ impl<Enc: Encoding> NodeProperties<Enc> {
     }
 
     pub(crate) fn take_tag(&mut self) -> NodeTag {
-        let t = self.tag();
-        self.has_tag = None;
-        t
+        Self::token_tag(self.has_tag.take().as_ref())
     }
+
+    /// `take_flow_node_anchor` for the tag.
+    fn take_flow_node_tag(&mut self, line: Line) -> NodeTag {
+        Self::token_tag(self.has_tag.take_if(|tag| tag.line == line).as_ref())
+    }
+
+    /// `take_block_mapping_anchor` for the tag.
+    fn take_block_mapping_tag(&mut self, implicit_key_line: Line) -> Result<NodeTag, ParseError> {
+        let tags = self.take_implicit_key_tags(implicit_key_line)?;
+        debug_assert!(matches!(tags.key_tag, NodeTag::None));
+        Ok(tags.mapping_tag)
+    }
+
+    /// `take_implicit_key_anchors` for the tags: the same [200]/[193] line
+    /// split decides whether a tag is the implicit key's or the block
+    /// mapping's.
+    fn take_implicit_key_tags(
+        &mut self,
+        implicit_key_line: Line,
+    ) -> Result<ImplicitKeyTags, ParseError> {
+        if let Some(mapping_tag) = self.has_mapping_tag.take() {
+            let inner = self.has_tag.take();
+            if inner.as_ref().is_some_and(|t| t.line != implicit_key_line) {
+                return Err(ParseError::MultipleTags);
+            }
+            return Ok(ImplicitKeyTags {
+                key_tag: Self::token_tag(inner.as_ref()),
+                mapping_tag: Self::token_tag(Some(&mapping_tag)),
+            });
+        }
+
+        let Some(mystery_tag) = self.has_tag.take() else {
+            return Ok(ImplicitKeyTags {
+                key_tag: NodeTag::None,
+                mapping_tag: NodeTag::None,
+            });
+        };
+        let tag = Self::token_tag(Some(&mystery_tag));
+        if mystery_tag.line == implicit_key_line {
+            return Ok(ImplicitKeyTags {
+                key_tag: tag,
+                mapping_tag: NodeTag::None,
+            });
+        }
+        Ok(ImplicitKeyTags {
+            key_tag: NodeTag::None,
+            mapping_tag: tag,
+        })
+    }
+}
+
+pub(crate) struct ImplicitKeyTags {
+    key_tag: NodeTag,
+    mapping_tag: NodeTag,
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -3780,6 +3962,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             _ => NodeTag::None,
         };
         let e_node = resolved_tag.resolve_null(loc);
+        let e_node = self.apply_custom_tag(resolved_tag, e_node)?;
         if let Some(anchor) = anchor {
             self.bind_anchor(anchor, e_node)?;
         }
@@ -3958,6 +4141,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         let map = self.parse_block_mapping(
                             node_props.take_block_mapping_anchor(alias_line)?,
+                            node_props.take_block_mapping_tag(alias_line)?,
                             copy,
                             alias_start,
                             alias_indent,
@@ -3976,8 +4160,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let sequence_line = self.token.line;
                     let sequence_tab_after_indent = self.tab_after_indent;
                     let anchor = node_props.take_flow_node_anchor(sequence_line);
+                    let tag = node_props.take_flow_node_tag(sequence_line);
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
-                    let seq = self.parse_flow_sequence(anchor);
+                    let seq = self.parse_flow_sequence(anchor, tag);
                     self.unset_json_key(json_key);
                     let seq = seq?;
 
@@ -4016,6 +4201,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         let map = self.parse_block_mapping(
                             node_props.take_block_mapping_anchor(sequence_line)?,
+                            node_props.take_block_mapping_tag(sequence_line)?,
                             seq,
                             sequence_start,
                             sequence_indent,
@@ -4047,7 +4233,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             return Err(Self::unexpected_token());
                         }
                     }
-                    break 'node self.parse_block_sequence(node_props.has_anchor.take())?;
+                    let anchor = node_props.has_anchor.take();
+                    let tag = node_props.take_tag();
+                    break 'node self.parse_block_sequence(anchor, tag)?;
                 }
 
                 TokenData::MappingStart => {
@@ -4056,9 +4244,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mapping_line = self.token.line;
                     let mapping_tab_after_indent = self.tab_after_indent;
                     let anchor = node_props.take_flow_node_anchor(mapping_line);
+                    let tag = node_props.take_flow_node_tag(mapping_line);
 
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
-                    let map = self.parse_flow_mapping(anchor);
+                    let map = self.parse_flow_mapping(anchor, tag);
                     self.unset_json_key(json_key);
                     let map = map?;
 
@@ -4097,6 +4286,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         let parent_map = self.parse_block_mapping(
                             node_props.take_block_mapping_anchor(mapping_line)?,
+                            node_props.take_block_mapping_tag(mapping_line)?,
                             map,
                             mapping_start,
                             mapping_indent,
@@ -4140,8 +4330,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     // The first key of a new mapping. The mapping's node exists
                     // before its key is parsed so the key may alias it.
                     let flow_pair_allowed = opts.flow_pair_allowed;
+                    let anchor = node_props.has_anchor.take();
+                    let tag = node_props.take_tag();
                     break 'node self.parse_collection::<E::Object>(
-                        node_props.has_anchor.take(),
+                        anchor,
+                        tag,
                         mapping_start.loc(),
                         |p| {
                             let key = p.parse_block_explicit_key(
@@ -4174,15 +4367,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     // [200]/[193] split: a property on the `:` line is the
                     // e-node key's (`!!str : x` → key ""); on a prior line
-                    // it is the [200] block-collection's. Only the key's tag
-                    // affects resolution.
+                    // it is the [200] block-collection's.
                     let colon_line = self.token.line;
-                    let key_tag = if node_props.tag_line() == Some(colon_line) {
-                        node_props.take_tag()
-                    } else {
-                        NodeTag::None
-                    };
-                    let first_key = key_tag.resolve_null(self.token.start.loc());
+                    let tags = node_props.take_implicit_key_tags(colon_line)?;
+                    let first_key = tags.key_tag.resolve_null(self.token.start.loc());
+                    let first_key = self.apply_custom_tag(tags.key_tag, first_key)?;
 
                     let anchors = node_props.take_implicit_key_anchors(colon_line)?;
                     if let Some(key_anchor) = anchors.key_anchor {
@@ -4191,6 +4380,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                     let mapping = self.parse_block_mapping(
                         anchors.mapping_anchor,
+                        tags.mapping_tag,
                         first_key,
                         self.token.start,
                         self.token.indent,
@@ -4291,6 +4481,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
 
                         let implicit_key = scalar.data.to_expr(scalar_start, self.input, self.bump);
+                        let tags = node_props.take_implicit_key_tags(scalar_line)?;
+                        let implicit_key = self.apply_custom_tag(tags.key_tag, implicit_key)?;
 
                         let anchors = node_props.take_implicit_key_anchors(scalar_line)?;
                         if let Some(key_anchor) = anchors.key_anchor {
@@ -4299,6 +4491,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         let mapping = self.parse_block_mapping(
                             anchors.mapping_anchor,
+                            tags.mapping_tag,
                             implicit_key,
                             scalar_start,
                             scalar_indent,
@@ -4341,6 +4534,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             ast::ExprData::ENull(_) => tag.resolve_null(node.loc),
             _ => node,
         };
+        let resolved = self.apply_custom_tag(tag, resolved)?;
 
         if let Some(anchor) = has_anchor {
             self.bind_anchor(anchor, resolved)?;
@@ -5567,29 +5761,28 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 // c-verbatim-tag
                 self.inc(1);
 
-                let prefix = 'prefix: {
-                    if Enc::wide(self.next()) == 0x21 /* '!' */ {
-                        self.inc(1);
-                        let range = self.string_range();
-                        self.skip_ns_uri_chars();
-                        break 'prefix range.end(self.pos);
-                    }
-                    if let Some(len) = self.is_ns_tag_char() {
-                        let range = self.string_range();
-                        self.inc(len as usize);
-                        self.skip_ns_uri_chars();
-                        break 'prefix range.end(self.pos);
-                    }
+                let range = self.string_range();
+                if Enc::wide(self.next()) == 0x21 /* '!' */ {
+                    self.inc(1);
+                } else if let Some(len) = self.is_ns_tag_char() {
+                    self.inc(len as usize);
+                } else {
                     return Err(ParseError::UnexpectedCharacter);
-                };
+                }
+                self.skip_ns_uri_chars();
+                let uri = range.end(self.pos);
 
                 self.try_skip_char(Enc::ch(b'>'))?;
+
+                let tag = self
+                    .custom_tag(TagPrefix::Default(b""), uri)
+                    .unwrap_or(NodeTag::Verbatim(uri));
 
                 return Ok(Token::tag(TagInit {
                     start,
                     indent: self.line_indent,
                     line: self.line,
-                    tag: NodeTag::Verbatim(prefix),
+                    tag,
                 }));
             }
             0x21 /* '!' */ => {
@@ -5611,7 +5804,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
 
                 let shorthand = range.end(self.pos);
-                let tag = self.shorthand_to_tag(shorthand);
+                let prefix = self
+                    .secondary_tag_prefix
+                    .map_or(TagPrefix::Default(b"tag:yaml.org,2002:"), TagPrefix::Declared);
+                let tag = self
+                    .custom_tag(prefix, shorthand)
+                    .unwrap_or_else(|| self.shorthand_to_tag(shorthand));
 
                 return Ok(Token::tag(TagInit {
                     start,
@@ -5629,23 +5827,28 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                 if Enc::wide(self.next()) == 0x21 /* '!' */ {
                     self.inc(1);
-                    if !self
+                    let Some(prefix) = self
                         .tag_handles
-                        .contains_key(Enc::key_bytes(handle_or_shorthand.slice(self.input)))
-                    {
+                        .get(Enc::key_bytes(handle_or_shorthand.slice(self.input)))
+                        .copied()
+                    else {
                         self.pos = off;
                         return Err(ParseError::UnresolvedTagHandle);
-                    }
+                    };
 
                     range = self.string_range();
                     self.try_skip_ns_tag_chars()?;
                     let shorthand = range.end(self.pos);
 
+                    let tag = self
+                        .custom_tag(TagPrefix::Declared(prefix), shorthand)
+                        .unwrap_or(NodeTag::Unknown(shorthand));
+
                     return Ok(Token::tag(TagInit {
                         start,
                         indent: self.line_indent,
                         line: self.line,
-                        tag: NodeTag::Unknown(shorthand),
+                        tag,
                     }));
                 }
 
@@ -5653,7 +5856,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 self.skip_ns_tag_chars();
                 handle_or_shorthand = StringRange { off, end: self.pos };
 
-                let tag = self.shorthand_to_tag(handle_or_shorthand);
+                let prefix = self
+                    .primary_tag_prefix
+                    .map_or(TagPrefix::Default(b"!"), TagPrefix::Declared);
+                let tag = self
+                    .custom_tag(prefix, handle_or_shorthand)
+                    .unwrap_or_else(|| self.shorthand_to_tag(handle_or_shorthand));
 
                 Ok(Token::tag(TagInit {
                     start,
@@ -5663,6 +5871,31 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }))
             }
         }
+    }
+
+    /// The registered tag (`NodeTag::Custom`) whose full name is `prefix`
+    /// followed by the shorthand's `suffix`, if any.
+    fn custom_tag(&self, prefix: TagPrefix, suffix: StringRange) -> Option<NodeTag> {
+        if self.custom_tags.is_empty() {
+            return None;
+        }
+        let suffix = suffix.slice(self.input);
+        let prefix_len = match prefix {
+            TagPrefix::Default(bytes) => bytes.len(),
+            TagPrefix::Declared(range) => range.len(),
+        };
+        let index = self.custom_tags.iter().position(|name| {
+            if name.len() != prefix_len + suffix.len() {
+                return false;
+            }
+            let (name_prefix, name_suffix) = name.split_at(prefix_len);
+            let prefix_matches = match prefix {
+                TagPrefix::Default(bytes) => name_prefix == bytes,
+                TagPrefix::Declared(range) => eq_ascii::<Enc>(range.slice(self.input), name_prefix),
+            };
+            prefix_matches && eq_ascii::<Enc>(suffix, name_suffix)
+        })?;
+        Some(NodeTag::Custom(index as u32))
     }
 
     fn shorthand_to_tag(&self, shorthand: StringRange) -> NodeTag {

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -6,19 +6,64 @@ use bun_collections::{HashMap, StringHashMap};
 use bun_core::StackCheck;
 use bun_core::{OwnedString, String as BunString};
 use bun_jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue,
-    JsError, JsResult, MarkedArgumentBuffer, wtf,
+    self as jsc, CallFrame, JSFunction, JSGlobalObject, JSPropertyIterator,
+    JSPropertyIteratorOptions, JSValue, JsError, JsResult, MarkedArgumentBuffer, wtf,
 };
-use bun_parsers::yaml::{CyclicAliases, YAML, YamlParseError};
+use bun_parsers::yaml::{CustomTaggedNodes, CyclicAliases, YAML, YamlParseError};
 
 pub(crate) fn create(global_this: &JSGlobalObject) -> JSValue {
-    jsc::create_host_function_object(
+    let yaml = jsc::create_host_function_object(
         global_this,
         &[
-            ("parse", __jsc_host_parse, 1),
+            ("parse", __jsc_host_parse, 2),
             ("stringify", __jsc_host_stringify, 3),
         ],
-    )
+    );
+
+    // The tag handlers Bun ships, for the `tags` option of `parse`.
+    let tags = JSValue::create_empty_object(global_this, 1);
+    tags.put(
+        global_this,
+        b"!env",
+        JSFunction::create(
+            global_this,
+            "!env",
+            __jsc_host_env_tag,
+            2,
+            Default::default(),
+        ),
+    );
+    yaml.put(global_this, b"tags", tags);
+
+    yaml
+}
+
+/// `!env NAME` is `process.env.NAME`. `!env [NAME, fallback]` is `fallback`
+/// when `NAME` is not set.
+#[bun_jsc::host_fn]
+fn env_tag(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
+    let node = call_frame.argument(0);
+    let (name, fallback) = if node.is_string() {
+        (node, JSValue::UNDEFINED)
+    } else if node.is_array() {
+        (node.get_index(global, 0)?, node.get_index(global, 1)?)
+    } else {
+        return Err(global.throw_type_error(format_args!(
+            "!env expects a variable name or [name, fallback]"
+        )));
+    };
+    let name = name.to_slice(global)?;
+
+    let env = match global.to_js_value().get(global, "process")? {
+        Some(process) => process.get(global, "env")?,
+        None => None,
+    };
+    let Some(env) = env else {
+        return Ok(fallback);
+    };
+    Ok(env
+        .get_own_truthy(global, name.slice())?
+        .unwrap_or(fallback))
 }
 
 #[bun_jsc::host_fn]
@@ -1026,47 +1071,148 @@ fn is_inf_suffix(str: &BunString, i: usize) -> bool {
 
 #[bun_jsc::host_fn]
 pub(crate) fn parse(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
-    // `NullishInput::ToString` preserves YAML's coerce-undefined-to-"undefined" behavior.
-    super::with_text_format_source(
-        global,
-        call_frame,
-        b"input.yaml",
-        super::BlobOrBufferInput::Bytes,
-        super::NullishInput::ToString,
-        |arena, log, source| {
-            // `ParserCtx::to_js` materializes each `E::Array`/`E::Object`
-            // once by pointer identity, so a cyclic graph is fine here.
-            let root = match YAML::parse(source, log, arena, CyclicAliases::Allow) {
-                Ok(root) => root,
-                Err(YamlParseError::OutOfMemory) => return Err(JsError::OutOfMemory),
-                Err(YamlParseError::StackOverflow) => return Err(global.throw_stack_overflow()),
-                Err(YamlParseError::SyntaxError) => {
-                    if !log.msgs.is_empty() {
-                        let first_msg = &log.msgs[0];
-                        let error_text = &first_msg.data.text;
+    // One buffer roots the tag handlers and every collection under
+    // construction: a handler runs arbitrary JS in the middle of the walk.
+    MarkedArgumentBuffer::new(|args| {
+        // Read before the input is borrowed: getters on the options run JS.
+        let custom_tags = CustomTags::from_options(global, call_frame.argument(1), args)?;
+
+        // `NullishInput::ToString` preserves YAML's coerce-undefined-to-"undefined" behavior.
+        super::with_text_format_source(
+            global,
+            call_frame,
+            b"input.yaml",
+            super::BlobOrBufferInput::Bytes,
+            super::NullishInput::ToString,
+            |arena, log, source| {
+                let names: Vec<&[u8]> = custom_tags.entries.iter().map(|t| &*t.name).collect();
+                // `ParserCtx::to_js` materializes each `E::Array`/`E::Object`
+                // once by pointer identity, so a cyclic graph is fine here.
+                let parsed = match YAML::parse_with_custom_tags(
+                    source,
+                    log,
+                    arena,
+                    CyclicAliases::Allow,
+                    &names,
+                ) {
+                    Ok(parsed) => parsed,
+                    Err(YamlParseError::OutOfMemory) => return Err(JsError::OutOfMemory),
+                    Err(YamlParseError::StackOverflow) => {
+                        return Err(global.throw_stack_overflow());
+                    }
+                    Err(YamlParseError::SyntaxError) => {
+                        if !log.msgs.is_empty() {
+                            let first_msg = &log.msgs[0];
+                            let error_text = &first_msg.data.text;
+                            return Err(global.throw_value(global.create_syntax_error_instance(
+                                format_args!("YAML Parse error: {}", bstr::BStr::new(error_text)),
+                            )));
+                        }
                         return Err(global.throw_value(global.create_syntax_error_instance(
-                            format_args!("YAML Parse error: {}", bstr::BStr::new(error_text)),
+                            format_args!("YAML Parse error: Unable to parse YAML string"),
                         )));
                     }
-                    return Err(global.throw_value(global.create_syntax_error_instance(
-                        format_args!("YAML Parse error: Unable to parse YAML string"),
-                    )));
+                };
+
+                let mut ctx = ParserCtx {
+                    seen_objects: HashMap::default(),
+                    stack_check: StackCheck::init(),
+                    global,
+                    custom_tags: &custom_tags,
+                    custom_tagged: parsed.custom_tagged,
+                };
+
+                match ctx.to_js(args, parsed.root) {
+                    Ok(value) => Ok(value),
+                    Err(ToJsError::OutOfMemory) => Err(JsError::OutOfMemory),
+                    Err(ToJsError::JsError) => Err(JsError::Thrown),
+                    Err(ToJsError::StackOverflow) => Err(global.throw_stack_overflow()),
                 }
-            };
+            },
+        )
+    })
+}
 
-            let mut ctx = ParserCtx {
-                seen_objects: HashMap::default(),
-                stack_check: StackCheck::init(),
-                global,
-                root,
-                result: JSValue::ZERO,
-            };
+/// The `tags` option of `parse`: `{ "!env": (value, tag) => ... }`. The
+/// parser reports a tagged node by its index in `entries`.
+struct CustomTags {
+    entries: Vec<CustomTag>,
+}
 
-            MarkedArgumentBuffer::run(&mut ctx, ParserCtx::run);
+struct CustomTag {
+    /// The key as written, which the handler receives as its second argument.
+    key: Box<[u8]>,
+    /// The full tag name the parser matches: `!!x` is `tag:yaml.org,2002:x`.
+    name: Box<[u8]>,
+    /// Rooted in the `MarkedArgumentBuffer` for as long as this exists.
+    handler: JSValue,
+}
 
-            Ok(ctx.result)
-        },
-    )
+impl CustomTags {
+    fn from_options(
+        global: &JSGlobalObject,
+        options: JSValue,
+        args: &mut MarkedArgumentBuffer,
+    ) -> JsResult<CustomTags> {
+        let mut entries = Vec::new();
+
+        if options.is_undefined_or_null() {
+            return Ok(CustomTags { entries });
+        }
+        if !options.is_object() {
+            return Err(global.throw_invalid_argument_type_value("options", "object", options));
+        }
+        let tags = match options.get(global, "tags")? {
+            Some(tags) if !tags.is_null() => tags,
+            _ => return Ok(CustomTags { entries }),
+        };
+        if !tags.is_object() {
+            return Err(global.throw_invalid_property_type_value(b"tags", b"object", tags));
+        }
+        args.append(tags);
+
+        let mut iter = JSPropertyIterator::init(
+            global,
+            tags.to_object(global)?,
+            JSPropertyIteratorOptions {
+                skip_empty_name: true,
+                include_value: true,
+                ..Default::default()
+            },
+        )?;
+        while let Some(key) = iter.next()? {
+            let handler = iter.value;
+            let key = key.to_owned_slice().into_boxed_slice();
+            if !handler.is_callable() {
+                return Err(global.throw_invalid_property_type_value(&key, b"function", handler));
+            }
+            let name = Self::tag_name(global, &key)?;
+            args.append(handler);
+            entries.push(CustomTag { key, name, handler });
+        }
+
+        Ok(CustomTags { entries })
+    }
+
+    /// A key names a tag the way a document spells it: `!local`, `!!yaml`
+    /// (short for `tag:yaml.org,2002:yaml`), or a full tag URI.
+    fn tag_name(global: &JSGlobalObject, key: &[u8]) -> JsResult<Box<[u8]>> {
+        if let Some(suffix) = key.strip_prefix(b"!!") {
+            if !suffix.is_empty() {
+                return Ok([b"tag:yaml.org,2002:".as_slice(), suffix]
+                    .concat()
+                    .into_boxed_slice());
+            }
+        } else if (key.starts_with(b"!") && key.len() > 1)
+            || bun_core::strings::contains_char(key, b':')
+        {
+            return Ok(key.into());
+        }
+        Err(global.throw_type_error(format_args!(
+            "YAML tag \"{}\" must be a local tag (\"!name\"), a \"!!name\" tag, or a tag URI",
+            bstr::BStr::new(key)
+        )))
+    }
 }
 
 struct ParserCtx<'a> {
@@ -1074,9 +1220,8 @@ struct ParserCtx<'a> {
     stack_check: StackCheck,
 
     global: &'a JSGlobalObject,
-    root: Expr,
-
-    result: JSValue,
+    custom_tags: &'a CustomTags,
+    custom_tagged: CustomTaggedNodes,
 }
 
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug)]
@@ -1117,28 +1262,6 @@ impl From<bun_ast::ToJSError> for ToJsError {
 impl<'a> ParserCtx<'a> {
     // deinit: seen_objects has Drop; no explicit impl needed.
 
-    extern "C" fn run(ctx: *mut ParserCtx<'a>, args: *mut MarkedArgumentBuffer) {
-        // SAFETY: MarkedArgumentBuffer::run passes valid non-null pointers for the duration of the call
-        let (ctx, args) = unsafe { (&mut *ctx, &mut *args) };
-        let root = ctx.root;
-        ctx.result = match ctx.to_js(args, root) {
-            Ok(v) => v,
-            Err(ToJsError::OutOfMemory) => {
-                ctx.result = ctx.global.throw_out_of_memory_value();
-                return;
-            }
-            Err(ToJsError::JsError) => {
-                ctx.result = JSValue::ZERO;
-                return;
-            }
-            Err(ToJsError::StackOverflow) => {
-                let _ = ctx.global.throw_stack_overflow();
-                ctx.result = JSValue::ZERO;
-                return;
-            }
-        };
-    }
-
     fn to_js(&mut self, args: &mut MarkedArgumentBuffer, expr: Expr) -> Result<JSValue, ToJsError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(ToJsError::StackOverflow);
@@ -1155,6 +1278,21 @@ impl<'a> ParserCtx<'a> {
                 let key = e_array.as_ptr().cast_const().cast::<c_void>();
                 if let Some(arr) = self.seen_objects.get(&key) {
                     return Ok(*arr);
+                }
+
+                if let Some(index) = self.custom_tagged.get(&expr) {
+                    // The wrapper the parser put around a custom-tagged node;
+                    // its one item is the node. Remembered under the wrapper's
+                    // identity so aliases to the node get the same result.
+                    let node = self.to_js(args, e_array.slice()[0])?;
+                    let tag = &self.custom_tags.entries[index as usize];
+                    let tag_key = jsc::bun_string_jsc::create_utf8_for_js(self.global, &tag.key)?;
+                    let value =
+                        tag.handler
+                            .call(self.global, JSValue::UNDEFINED, &[node, tag_key])?;
+                    args.append(value);
+                    self.seen_objects.put(key, value)?;
+                    return Ok(value);
                 }
 
                 let arr =

--- a/test/integration/bun-types/fixture/yaml.ts
+++ b/test/integration/bun-types/fixture/yaml.ts
@@ -8,3 +8,24 @@ expectType(Bun.YAML.stringify({ abc: "def"})).is<string>();
 expectType(Bun.YAML.stringify("hi", {})).is<string>();
 // @ts-expect-error
 expectType(Bun.YAML.stringify("hi", null, 123n)).is<string>();
+
+expectType(Bun.YAML.parse("", {})).is<unknown>();
+expectType(Bun.YAML.parse("", { tags: Bun.YAML.tags })).is<unknown>();
+expectType(
+  Bun.YAML.parse("", {
+    tags: {
+      ...Bun.YAML.tags,
+      "!upper": (value: string, tag: string) => value.toUpperCase(),
+      "!wrap": value => ({ value }),
+    },
+  }),
+).is<unknown>();
+expectType(Bun.YAML.tags["!env"]).is<Bun.YAML.TagHandler>();
+const options: Bun.YAML.ParseOptions = { tags: { "!env": Bun.YAML.tags["!env"] } };
+expectType(Bun.YAML.parse("", options)).is<unknown>();
+// @ts-expect-error
+Bun.YAML.parse("", { tags: { "!upper": "not a function" } });
+// @ts-expect-error
+Bun.YAML.parse("", "tags");
+// @ts-expect-error
+Bun.YAML.tags["!env"] = () => undefined;

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1559,14 +1559,14 @@ folded: >
           expect(() => YAML.parse("&a\n&b\n&c d: 1\n")).toThrow("Multiple anchors");
         });
 
-        test.todo("two tags before e-node `:` — [200]/[193] line split (tag analogue)", () => {
-          // The MappingValue arm clears has_anchor/has_mapping_anchor but not
-          // has_mapping_tag, so the post-loop guard over-rejects the valid
-          // 2-tag case. set_tag also lacks the has_mapping_tag.is_some()
-          // overflow guard that set_anchor has, so a 3rd tag on a 3rd line
-          // silently overwrites instead of erroring.
+        test("two tags before e-node `:` — [200]/[193] line split (tag analogue)", () => {
+          // The outer tag is the [200] block collection's, the inner one the
+          // implicit first key's, so the inner one must share the key's line.
           expect(YAML.parse("!!map\n!!str : x\n")).toEqual({ "": "x" });
+          expect(YAML.parse("!!map\n!!str a: x\n")).toEqual({ a: "x" });
           expect(() => YAML.parse("!!a\n!!b\n!!c d: 1\n")).toThrow("Multiple tags");
+          expect(() => YAML.parse("- !!a\n  !!b\n  a: 1\n")).toThrow("Multiple tags");
+          expect(() => YAML.parse("!!a\n!!b\nx\n")).toThrow("Multiple tags");
         });
       });
 
@@ -5006,6 +5006,401 @@ describe("plain scalar whitespace handling", () => {
 
   test("bare dash after a mapping key is a block-sequence indicator, not a plain scalar", () => {
     expect(() => YAML.parse("g: -")).toThrow(SyntaxError);
+  });
+});
+
+describe("parse with the tags option", () => {
+  const upper = { "!upper": (value: string) => value.toUpperCase() };
+  const wrap = { "!wrap": (value: unknown) => ({ wrapped: value }) };
+
+  describe("scalars", () => {
+    test("the handler receives the scalar's text and its result replaces the node", () => {
+      expect(YAML.parse("a: !upper hi\nb: hi\n", { tags: upper })).toEqual({ a: "HI", b: "hi" });
+      expect(YAML.parse("- !upper hi\n- hi\n", { tags: upper })).toEqual(["HI", "hi"]);
+      expect(YAML.parse("!upper hi\n", { tags: upper })).toBe("HI");
+      expect(YAML.parse("[!upper a, {b: !upper c}]\n", { tags: upper })).toEqual(["A", { b: "C" }]);
+    });
+
+    test("plain scalars are not resolved by the core schema first", () => {
+      const seen: unknown[] = [];
+      const tags = {
+        "!raw": (value: unknown) => {
+          seen.push(value);
+          return value;
+        },
+      };
+      expect(YAML.parse("- !raw 123\n- !raw true\n- !raw ~\n- !raw null\n- !raw 0x10\n- 123\n", { tags })).toEqual([
+        "123",
+        "true",
+        "~",
+        "null",
+        "0x10",
+        123,
+      ]);
+      expect(seen).toEqual(["123", "true", "~", "null", "0x10"]);
+    });
+
+    test("quoted and block scalars", () => {
+      expect(YAML.parse('a: !upper "hi there"\nb: !upper |\n  line one\n  line two\n', { tags: upper })).toEqual({
+        a: "HI THERE",
+        b: "LINE ONE\nLINE TWO\n",
+      });
+    });
+
+    test("a tag with no content is the empty scalar", () => {
+      const tags = { "!empty": (value: unknown) => ({ got: value }) };
+      expect(YAML.parse("a: !empty\nb: 1\n", { tags })).toEqual({ a: { got: "" }, b: 1 });
+      expect(YAML.parse("[!empty , !empty ]\n", { tags })).toEqual([{ got: "" }, { got: "" }]);
+      expect(YAML.parse("!empty\n", { tags })).toEqual({ got: "" });
+      expect(YAML.parse("- !empty\n- 1\n", { tags })).toEqual([{ got: "" }, 1]);
+    });
+
+    test("a tagged value that is abandoned to the parent does not affect the next key", () => {
+      expect(YAML.parse("a: !upper\n0xFF: c\n", { tags: upper })).toEqual({ a: "", 255: "c" });
+    });
+
+    test("a tagged implicit key", () => {
+      expect(YAML.parse("!upper a: 1\nb: 2\n", { tags: upper })).toEqual({ A: 1, b: 2 });
+      expect(YAML.parse("{!upper a: 1}\n", { tags: upper })).toEqual({ A: 1 });
+      expect(YAML.parse("? !upper a\n: 1\n", { tags: upper })).toEqual({ A: 1 });
+    });
+
+    test("registering a core tag hands the handler the raw text", () => {
+      const tags = { "!!int": (value: string) => BigInt(value) };
+      expect(YAML.parse("a: !!int 9007199254740993\nb: 2\n", { tags })).toEqual({ a: 9007199254740993n, b: 2 });
+    });
+  });
+
+  describe("collections", () => {
+    test("flow and block sequences", () => {
+      expect(YAML.parse("a: !wrap [1, 2]\n", { tags: wrap })).toEqual({ a: { wrapped: [1, 2] } });
+      expect(YAML.parse("a: !wrap\n  - 1\n  - 2\n", { tags: wrap })).toEqual({ a: { wrapped: [1, 2] } });
+      expect(YAML.parse("!wrap\n- 1\n- 2\n", { tags: wrap })).toEqual({ wrapped: [1, 2] });
+      expect(YAML.parse("- !wrap [1]\n- [1]\n", { tags: wrap })).toEqual([{ wrapped: [1] }, [1]]);
+    });
+
+    test("flow and block mappings", () => {
+      expect(YAML.parse("a: !wrap {b: 1}\n", { tags: wrap })).toEqual({ a: { wrapped: { b: 1 } } });
+      expect(YAML.parse("a: !wrap\n  b: 1\n  c: 2\n", { tags: wrap })).toEqual({ a: { wrapped: { b: 1, c: 2 } } });
+      expect(YAML.parse("!wrap\nb: 1\nc: 2\n", { tags: wrap })).toEqual({ wrapped: { b: 1, c: 2 } });
+      expect(YAML.parse("- !wrap\n  b: 1\n- b: 1\n", { tags: wrap })).toEqual([{ wrapped: { b: 1 } }, { b: 1 }]);
+      expect(YAML.parse("!wrap\n? b\n: 1\n", { tags: wrap })).toEqual({ wrapped: { b: 1 } });
+      expect(YAML.parse("a: !wrap\n  : 1\n", { tags: wrap })).toEqual({ a: { wrapped: { null: 1 } } });
+    });
+
+    test("a tag on the first key's line belongs to the key, on its own line to the mapping", () => {
+      const tags = { ...upper, ...wrap };
+      expect(YAML.parse("!upper a: 1\n", { tags })).toEqual({ A: 1 });
+      expect(YAML.parse("!wrap\na: 1\n", { tags })).toEqual({ wrapped: { a: 1 } });
+      expect(YAML.parse("!wrap\n!upper a: 1\n", { tags })).toEqual({ wrapped: { A: 1 } });
+      expect(YAML.parse("!wrap\n!upper : 1\n", { tags })).toEqual({ wrapped: { "": 1 } });
+      expect(YAML.parse("!wrap\n!wrap [a]: 1\n", { tags })).toEqual({ wrapped: { "[object Object]": 1 } });
+      expect(YAML.parse("!wrap\n!wrap {}: 1\n", { tags })).toEqual({ wrapped: { "[object Object]": 1 } });
+    });
+
+    test("nested tags are applied inside out", () => {
+      const tags = { ...upper, ...wrap };
+      expect(YAML.parse("!wrap\na: !wrap [!upper x]\nb: !upper y\n", { tags })).toEqual({
+        wrapped: { a: { wrapped: ["X"] }, b: "Y" },
+      });
+    });
+
+    test("handlers see the values other handlers produced", () => {
+      const tags = {
+        "!date": (value: string) => new Date(value),
+        "!range": ([from, to]: [Date, Date]) => to.getTime() - from.getTime(),
+      };
+      expect(YAML.parse("!range [!date 2001-01-01T00:00:00Z, !date 2001-01-02T00:00:00Z]\n", { tags })).toBe(
+        86_400_000,
+      );
+    });
+
+    test("a custom-tagged value under a merge key is an ordinary property", () => {
+      const input = "base: &base {x: 1}\na:\n  <<: *base\n  y: 2\nb:\n  <<: !wrap {x: 1}\n  y: 2\n";
+      expect(YAML.parse(input, { tags: wrap })).toEqual({
+        base: { x: 1 },
+        a: { x: 1, y: 2 },
+        b: { "<<": { wrapped: { x: 1 } }, y: 2 },
+      });
+    });
+  });
+
+  describe("handler calls", () => {
+    test("receives the tag as written and is called with an undefined this", () => {
+      const calls: unknown[] = [];
+      const tags = {
+        "!a": function (this: unknown, value: unknown, tag: string) {
+          calls.push([this, value, tag]);
+          return 1;
+        },
+        "!!b": (value: unknown, tag: string) => {
+          calls.push([value, tag]);
+          return 2;
+        },
+      };
+      expect(YAML.parse("- !a x\n- !!b y\n- !<tag:yaml.org,2002:b> z\n", { tags })).toEqual([1, 2, 2]);
+      expect(calls).toEqual([
+        [undefined, "x", "!a"],
+        ["y", "!!b"],
+        ["z", "!!b"],
+      ]);
+    });
+
+    test("any return value is used, including undefined and null", () => {
+      const tags = {
+        "!undef": () => undefined,
+        "!nil": () => null,
+        "!fn": () => Math.max,
+      };
+      const parsed = YAML.parse("a: !undef x\nb: !nil x\nc: !fn x\nd: [!undef x]\n", { tags });
+      expect(parsed).toEqual({ a: undefined, b: null, c: Math.max, d: [undefined] });
+      expect(Object.keys(parsed)).toEqual(["a", "b", "c", "d"]);
+    });
+
+    test("an exception thrown by a handler propagates", () => {
+      const error = new Error("from the handler");
+      const tags = {
+        "!boom": () => {
+          throw error;
+        },
+      };
+      expect(() => YAML.parse("a: 1\nb: !boom x\n", { tags })).toThrow(error);
+    });
+
+    test("a handler may call parse itself", () => {
+      const tags = { "!yaml": (value: string) => YAML.parse(value, { tags }) };
+      expect(YAML.parse("outer: !yaml |\n  inner: !yaml |\n    x: [1, 2]\n", { tags })).toEqual({
+        outer: { inner: { x: [1, 2] } },
+      });
+    });
+
+    test("works with a Buffer input", () => {
+      expect(YAML.parse(Buffer.from("a: !upper hi\n"), { tags: upper })).toEqual({ a: "HI" });
+    });
+
+    test("applies to every document of a stream", () => {
+      expect(YAML.parse("!upper a\n---\n!upper b\n", { tags: upper })).toEqual(["A", "B"]);
+    });
+  });
+
+  describe("anchors and aliases", () => {
+    test("an alias to a tagged scalar shares the handler's one result", () => {
+      let calls = 0;
+      const tags = {
+        "!obj": (value: string) => {
+          calls++;
+          return { value };
+        },
+      };
+      const parsed = YAML.parse("a: &x !obj hi\nb: *x\n", { tags });
+      expect(parsed).toEqual({ a: { value: "hi" }, b: { value: "hi" } });
+      expect(parsed.a).toBe(parsed.b);
+      expect(calls).toBe(1);
+    });
+
+    test("an alias to a tagged collection shares the handler's one result", () => {
+      let calls = 0;
+      const tags = {
+        "!wrap": (value: unknown) => {
+          calls++;
+          return { wrapped: value };
+        },
+      };
+      for (const input of [
+        "a: &x !wrap [1]\nb: *x\n",
+        "a: !wrap &x [1]\nb: *x\n",
+        "a: &x !wrap\n  - 1\nb: *x\n",
+        "a: &x !wrap {c: 1}\nb: *x\n",
+        "a: &x !wrap\n  c: 1\nb: *x\n",
+        "a: &x\n  !wrap\n  c: 1\nb: *x\n",
+      ]) {
+        calls = 0;
+        const parsed = YAML.parse(input, { tags });
+        expect(parsed.a, input).toBe(parsed.b);
+        expect(parsed.a.wrapped, input).toBeDefined();
+        expect(calls, input).toBe(1);
+      }
+    });
+
+    test("an alias from inside a tagged collection refers to the untagged collection", () => {
+      const parsed = YAML.parse("&x !wrap [*x]\n", { tags: wrap });
+      expect(parsed.wrapped[0]).toBe(parsed.wrapped);
+    });
+
+    test("merge keys still expand alongside tags", () => {
+      expect(YAML.parse("base: &b {x: !upper a}\nd:\n  <<: *b\n  y: 1\n", { tags: upper })).toEqual({
+        base: { x: "A" },
+        d: { x: "A", y: 1 },
+      });
+    });
+  });
+
+  describe("tag names", () => {
+    test("a !! key matches the yaml.org tag in shorthand and verbatim form", () => {
+      const tags = { "!!timestamp": (value: string) => new Date(value) };
+      const date = new Date("2001-12-14T00:00:00Z");
+      expect(YAML.parse("- !!timestamp 2001-12-14\n- !<tag:yaml.org,2002:timestamp> 2001-12-14\n", { tags })).toEqual([
+        date,
+        date,
+      ]);
+      expect(YAML.parse("a: !timestamp 2001-12-14\n", { tags })).toEqual({ a: "2001-12-14" });
+    });
+
+    test("a tag URI key matches verbatim tags and %TAG handles", () => {
+      const tags = { "tag:example.com,2000:app/foo": (value: string) => ({ foo: value }) };
+      expect(YAML.parse("!<tag:example.com,2000:app/foo> x\n", { tags })).toEqual({ foo: "x" });
+      expect(YAML.parse("%TAG !e! tag:example.com,2000:app/\n---\n!e!foo x\n", { tags })).toEqual({ foo: "x" });
+      expect(YAML.parse("%TAG ! tag:example.com,2000:app/\n---\n!foo x\n", { tags })).toEqual({ foo: "x" });
+      expect(YAML.parse("%TAG !! tag:example.com,2000:app/\n---\n!!foo x\n", { tags })).toEqual({ foo: "x" });
+    });
+
+    test("a remapped handle no longer produces the local tag", () => {
+      const tags = { "!foo": () => "local" };
+      expect(YAML.parse("!foo x\n", { tags })).toBe("local");
+      expect(YAML.parse("!<!foo> x\n", { tags })).toBe("local");
+      expect(YAML.parse("%TAG ! tag:example.com,2000:app/\n---\n!foo x\n", { tags })).toBe("x");
+    });
+
+    test("a %TAG directive only applies to its own document", () => {
+      const tags = { "!foo": () => "local", "tag:example.com,2000:app/foo": () => "global" };
+      expect(YAML.parse("%TAG ! tag:example.com,2000:app/\n---\n!foo x\n---\n!foo x\n", { tags })).toEqual([
+        "global",
+        "local",
+      ]);
+      expect(YAML.parse("%TAG !e! tag:example.com,2000:app/\n---\n!e!foo x\n---\n!foo x\n", { tags })).toEqual([
+        "global",
+        "local",
+      ]);
+    });
+
+    test("a local tag prefix in %TAG", () => {
+      const tags = { "!my-light": (value: string) => `light:${value}` };
+      expect(YAML.parse("%TAG !m! !my-\n---\n!m!light green\n", { tags })).toBe("light:green");
+    });
+
+    test("unregistered tags behave as without the option", () => {
+      const input = "- !foo 1\n- !!str 1\n- !!int '1'\n- !bar [1]\n- !!map {a: 1}\n- !<tag:example.com,2000:x> 1\n";
+      expect(YAML.parse(input, { tags: upper })).toEqual(YAML.parse(input));
+      expect(YAML.parse(input, { tags: upper })).toEqual(["1", "1", "1", [1], { a: 1 }, "1"]);
+    });
+  });
+
+  describe("option validation", () => {
+    test("accepts a missing, undefined or null options argument", () => {
+      expect(YAML.parse("a: !upper b\n")).toEqual({ a: "b" });
+      expect(YAML.parse("a: !upper b\n", undefined)).toEqual({ a: "b" });
+      expect(YAML.parse("a: !upper b\n", null as any)).toEqual({ a: "b" });
+      expect(YAML.parse("a: !upper b\n", {})).toEqual({ a: "b" });
+      expect(YAML.parse("a: !upper b\n", { tags: undefined })).toEqual({ a: "b" });
+      expect(YAML.parse("a: !upper b\n", { tags: null as any })).toEqual({ a: "b" });
+      expect(YAML.parse("a: !upper b\n", { tags: {} })).toEqual({ a: "b" });
+    });
+
+    test("rejects options that are not an object", () => {
+      expect(() => YAML.parse("a: 1", "tags" as any)).toThrow(TypeError);
+      expect(() => YAML.parse("a: 1", 1 as any)).toThrow(TypeError);
+    });
+
+    test("rejects tags that are not an object", () => {
+      expect(() => YAML.parse("a: 1", { tags: "!upper" as any })).toThrow(TypeError);
+      expect(() => YAML.parse("a: 1", { tags: true as any })).toThrow(TypeError);
+    });
+
+    test("rejects a handler that is not a function", () => {
+      expect(() => YAML.parse("a: 1", { tags: { "!upper": "x" as any } })).toThrow(
+        'The "!upper" property must be of type function. Received string',
+      );
+      expect(() => YAML.parse("a: 1", { tags: { "!upper": undefined as any } })).toThrow(TypeError);
+    });
+
+    test("rejects a key that cannot name a tag", () => {
+      for (const key of ["upper", "!", "!!"]) {
+        expect(() => YAML.parse("a: 1", { tags: { [key]: () => 1 } }), key).toThrow(
+          `YAML tag "${key}" must be a local tag ("!name"), a "!!name" tag, or a tag URI`,
+        );
+      }
+    });
+
+    test("validates the options before parsing", () => {
+      expect(() => YAML.parse("a: [", { tags: { "!x": 1 as any } })).toThrow(TypeError);
+    });
+
+    test("getters on the options run once", () => {
+      let reads = 0;
+      const options = {
+        get tags() {
+          reads++;
+          return upper;
+        },
+      };
+      expect(YAML.parse("!upper a\n", options)).toBe("A");
+      expect(reads).toBe(1);
+    });
+  });
+
+  describe("YAML.tags", () => {
+    const name = "BUN_YAML_TEST_ENV_TAG";
+
+    test("!env reads process.env at parse time", () => {
+      delete process.env[name];
+      try {
+        expect(YAML.parse(`a: !env ${name}\n`, { tags: YAML.tags })).toEqual({ a: undefined });
+        process.env[name] = "set";
+        expect(YAML.parse(`a: !env ${name}\n`, { tags: YAML.tags })).toEqual({ a: "set" });
+        expect(YAML.parse(`a: !env "${name}"\n`, { tags: YAML.tags })).toEqual({ a: "set" });
+        process.env[name] = "";
+        expect(YAML.parse(`a: !env ${name}\n`, { tags: YAML.tags })).toEqual({ a: "" });
+      } finally {
+        delete process.env[name];
+      }
+    });
+
+    test("!env [name, fallback] uses the fallback when the variable is not set", () => {
+      delete process.env[name];
+      try {
+        expect(YAML.parse(`a: !env [${name}, 3000]\n`, { tags: YAML.tags })).toEqual({ a: 3000 });
+        expect(YAML.parse(`a: !env [${name}, {b: 1}]\n`, { tags: YAML.tags })).toEqual({ a: { b: 1 } });
+        expect(YAML.parse(`a: !env [${name}]\n`, { tags: YAML.tags })).toEqual({ a: undefined });
+        expect(YAML.parse(`a: !env\n  - ${name}\n  - fallback\n`, { tags: YAML.tags })).toEqual({ a: "fallback" });
+        process.env[name] = "4000";
+        expect(YAML.parse(`a: !env [${name}, 3000]\n`, { tags: YAML.tags })).toEqual({ a: "4000" });
+      } finally {
+        delete process.env[name];
+      }
+    });
+
+    test("!env does not read inherited properties", () => {
+      expect(YAML.parse("a: !env toString\nb: !env __proto__\n", { tags: YAML.tags })).toEqual({
+        a: undefined,
+        b: undefined,
+      });
+    });
+
+    test("!env rejects a mapping", () => {
+      expect(() => YAML.parse("a: !env {b: 1}\n", { tags: YAML.tags })).toThrow(
+        "!env expects a variable name or [name, fallback]",
+      );
+    });
+
+    test("the built-in handlers combine with custom ones", () => {
+      process.env[name] = "value";
+      try {
+        const tags = { ...YAML.tags, ...upper };
+        expect(YAML.parse(`a: !env ${name}\nb: !upper ${name}\n`, { tags })).toEqual({
+          a: "value",
+          b: name,
+        });
+        expect(YAML.parse(`!upper ${name}\n`, { tags: { "!upper": YAML.tags["!env"] } })).toBe("value");
+      } finally {
+        delete process.env[name];
+      }
+    });
+
+    test("is a plain object of functions", () => {
+      expect(Object.keys(YAML.tags)).toEqual(["!env"]);
+      expect(typeof YAML.tags["!env"]).toBe("function");
+      expect(YAML.tags["!env"].name).toBe("!env");
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.YAML.parse` drops every tag it does not know: `!point {x: 1}` parses as `{x: 1}`. There is no way to map a tag to a runtime value, which every other YAML library offers (`customTags` in `yaml`, `defineScalarTag` in js-yaml 5, `add_constructor` in PyYAML).
- Requested by @dylan-conway in Slack: a `tags` option for custom tags, plus a set of tags Bun provides, starting with `!env`.

### Fix
- `Bun.YAML.parse(text, { tags })` takes a record of handlers keyed by tag: `"!local"`, `"!!name"` (the `tag:yaml.org,2002:` namespace) or a full tag URI. A handler gets the node without its tag (the text of a scalar, the array or object of a collection, inner tags already applied) and the key as written. Its return value takes the node's place. Unlisted tags behave as before.
- `Bun.YAML.tags` holds Bun's handlers. `!env NAME` is `process.env.NAME`, `!env [NAME, fallback]` falls back when unset. It is opt in: `{ tags: YAML.tags }` or spread next to your own.
- Parser (`src/parsers/yaml.rs`): `YAML::parse_with_custom_tags` takes the names. The scanner resolves each tag through the document's `%TAG` prefixes, which it now records, and emits `NodeTag::Custom(index)` for a registered one. The finished node is wrapped in a one item `E::Array` recorded in `CustomTaggedNodes`, before its anchor binds, so aliases share the wrapper. `YAMLObject.rs` converts the item, calls the handler and caches the result by wrapper identity.
- Verified: `test/js/bun/yaml/yaml.test.ts` (42 new tests, 41 fail on the released build). Also the rest of `test/js/bun/yaml/`, the bun-types test and `test/internal/source-lints/`.

### Background
- A YAML tag is a name attached to one node. `!x` is a local tag, `!!x` is short for the URI `tag:yaml.org,2002:x`, `!<uri>` is verbatim. A `%TAG` directive remaps a handle for one document, so names are matched after expansion.
- In block context a tag on the first key's line belongs to the key, one on an earlier line to the mapping. Anchors already follow this rule (`take_implicit_key_anchors`); this PR applies the same split to tags (`take_implicit_key_tags`), which also makes `!!map\n!!str : x` parse and a third tag on a node an error, as for anchors.
- Handlers run user JS while the result is being built, so the handlers and every collection under construction are rooted in one `MarkedArgumentBuffer`, and the options are read before the input bytes are borrowed.

<details><summary>Notes</summary>

- Prior art checked: `yaml` 2.9, js-yaml 4 and 5, Deno std/yaml, PyYAML, Psych, go-yaml v3. None ships an env tag; apps do (Home Assistant and ESPHome `!env_var NAME default`, MkDocs `!ENV [NAME, default]`). The `[name, fallback]` form follows MkDocs. No library reads the environment by default, which is why `YAML.tags` is opt in.
- `!env` reads the `process.env` object rather than the native env map so that assignments to `process.env` at runtime are visible.
- A custom tagged value under a `<<` merge key is kept as an ordinary `"<<"` property instead of being merged. An alias from inside a tagged collection (`&a !t [*a]`) refers to the untagged collection; the handler receives an array that contains itself.
- Imported `.yaml` modules, `pnpm-lock.yaml` migration and the bundler call `YAML::parse`, which registers no tags; their output only changes for documents with two or more tags on one node, which now fail or split as anchors do.
- Keys that cannot name a tag (`"env"`, `"!"`, `"!!"`) throw a `TypeError` so a missing `!` is not a silent no op. Percent escapes in tags are matched literally.
- A JSON style reviver, discussed in the same thread, is left for a follow up. `parse(text, options)` leaves room for `parse(text, reviver, options)` as in the `yaml` package.
- #38147 (open) reworks how the scanner applies scalar tags in the same functions and will need a rebase on whichever lands second. The two are independent: this PR keeps scan time resolution for unregistered tags.
- Names considered for the preset: `YAML.tags`, `YAML.defaultTags`. `YAML.tags` reads best at the call site; happy to rename.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 41 failed, 17 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.31ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.05ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.02ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.80ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.09ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.33ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.27ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [2.93ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.74ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [2.96ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [2.95ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [3.47ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.92ms]
(pass) Bu
... (truncated)

release without fix: 41 failed, 17 skipped
bun test v1.4.0-canary.1 (6e906e468)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.11ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.03ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.25ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 17 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.22ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.14ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.51ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.86ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.14ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.17ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.18ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.43ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.93ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.84ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.07ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.56ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.93ms]
(pass) Bu
... (truncated)

release with fix: 17 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     83f6c6207a
  features     baseline

23 deps, 129 codegen, 1172 objects in 810ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [15.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [6.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1243] fetch zlib
[zlib] up to date
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen ProcessBindingConstants.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/yaml.mdx                      |  63 ++++-
 packages/bun-types/bun.d.ts                |  55 +++-
 src/parsers/yaml.rs                        | 379 +++++++++++++++++++++------
 src/runtime/api/YAMLObject.rs              | 268 ++++++++++++++-----
 test/integration/bun-types/fixture/yaml.ts |  23 +-
 test/js/bun/yaml/yaml.test.ts              | 407 ++++++++++++++++++++++++++++-
 6 files changed, 1048 insertions(+), 147 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
docs/runtime/yaml.mdx                           1      2      0
packages/bun-types/bun.d.ts                     1      1      0
src/parsers/yaml.rs                            17     31      0
src/runtime/api/YAMLObject.rs                   6      3      0
test/integration/bun-types/fixture/yaml.ts      1      1      0
test/js/bun/yaml/yaml.test.ts                   1      2      0
```

</details>

<!-- robobun:evidence:end -->