### PR TITLE
s3: escape part ETags in the CompleteMultipartUpload body

### DIFF
--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -97,7 +97,7 @@ use bstr::BStr;
 
 use bun_alloc::AllocError;
 use bun_collections::IntegerBitSet;
-use bun_core::{declare_scope, scoped_log};
+use bun_core::{declare_scope, scoped_log, strings};
 use bun_io::KeepAlive;
 use bun_io::StreamBuffer;
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -230,6 +230,18 @@ pub struct UploadPart {
 pub struct UploadPartResult {
     pub(crate) number: u16,
     pub(crate) etag: Box<[u8]>,
+}
+
+/// Appends `text` as XML character data. Only `&`, `<` and `>` need an entity
+/// reference there, so a quoted ETag (the shape every S3 implementation sends)
+/// is copied unchanged.
+fn append_xml_text(out: &mut Vec<u8>, mut text: &[u8]) {
+    while let Some(i) = strings::index_of_any(text, b"&<>") {
+        out.extend_from_slice(&text[..i]);
+        out.extend_from_slice(strings::xml_escape_entity(text[i]).expect("byte is in the set"));
+        text = &text[i + 1..];
+    }
+    out.extend_from_slice(text);
 }
 
 impl UploadPart {
@@ -602,13 +614,10 @@ impl MultiPartUpload {
                     // sort the etags
                     index_sort::sort_slice_by(etags, |a, b| a.number.cmp(&b.number));
                     for tag in etags.drain(..) {
-                        write!(
-                            list,
-                            "<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>",
-                            tag.number,
-                            BStr::new(&tag.etag),
-                        )
-                        .expect("oom");
+                        write!(list, "<Part><PartNumber>{}</PartNumber><ETag>", tag.number)
+                            .expect("oom");
+                        append_xml_text(list, &tag.etag);
+                        list.extend_from_slice(b"</ETag></Part>");
                         // tag.etag (Box<[u8]>) freed at end of iteration
                     }
                 });

--- a/test/js/bun/s3/s3-multipart-complete-etag.test.ts
+++ b/test/js/bun/s3/s3-multipart-complete-etag.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// CompleteMultipartUpload echoes the ETag response header of every UploadPart
+// back to the endpoint inside an XML body. An ETag may legally contain `&`, `<`
+// and `>` (RFC 9110 etagc), which XML character data cannot hold as is.
+const partEtags: Record<number, string> = {
+  1: '"a&b<c>d"',
+  2: '"0123456789abcdef0123456789abcdef"',
+  3: 'W/"weak&tag"',
+};
+
+// The S3 client does not honor NO_PROXY, so an inherited proxy would hijack
+// the request to the stub server. Run in a subprocess with proxy env cleared.
+const envWithoutProxy = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+const fixture = `
+const partEtags = ${JSON.stringify(partEtags)};
+let completeBody = null;
+
+using server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const url = new URL(req.url);
+    if (req.method === "POST" && url.searchParams.has("uploads")) {
+      return new Response(
+        "<InitiateMultipartUploadResult><Bucket>bucket</Bucket><Key>obj</Key><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>",
+        { headers: { "Content-Type": "application/xml" } },
+      );
+    }
+    if (req.method === "PUT" && url.searchParams.has("partNumber")) {
+      await req.arrayBuffer();
+      return new Response(null, { headers: { ETag: partEtags[url.searchParams.get("partNumber")] } });
+    }
+    if (req.method === "POST" && url.searchParams.get("uploadId") === "upload-1") {
+      completeBody = await req.text();
+      return new Response(
+        '<CompleteMultipartUploadResult><Bucket>bucket</Bucket><Key>obj</Key><ETag>"final"</ETag></CompleteMultipartUploadResult>',
+        { headers: { "Content-Type": "application/xml" } },
+      );
+    }
+    return new Response("unexpected " + req.method + " " + url.search, { status: 500 });
+  },
+});
+
+const client = new Bun.S3Client({
+  accessKeyId: "test",
+  secretAccessKey: "test",
+  bucket: "bucket",
+  endpoint: server.url.href,
+});
+
+// 5 MiB is the smallest part size the writer accepts. Two full parts plus a
+// short tail give three UploadPart requests and one CompleteMultipartUpload.
+const partSize = 5 * 1024 * 1024;
+const writer = client.file("obj").writer({ partSize, queueSize: 1 });
+writer.write(Buffer.alloc(partSize, "a"));
+writer.write(Buffer.alloc(partSize, "b"));
+writer.write(Buffer.alloc(16, "c"));
+await writer.end();
+
+console.log(JSON.stringify(completeBody));
+`;
+
+test("CompleteMultipartUpload escapes the part ETags it writes into the XML body", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: envWithoutProxy,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const body: string = JSON.parse(stdout);
+  // `&`, `<` and `>` become entity references. A quote is valid character
+  // data, so the usual quoted ETag is written byte for byte as the endpoint
+  // sent it.
+  expect(body).toBe(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+      '<Part><PartNumber>1</PartNumber><ETag>"a&amp;b&lt;c&gt;d"</ETag></Part>' +
+      '<Part><PartNumber>2</PartNumber><ETag>"0123456789abcdef0123456789abcdef"</ETag></Part>' +
+      '<Part><PartNumber>3</PartNumber><ETag>W/"weak&amp;tag"</ETag></Part>' +
+      "</CompleteMultipartUpload>",
+  );
+  // The endpoint parses the body as XML and gets its own ETags back.
+  expect(Bun.XML.parse(body)).toEqual({
+    CompleteMultipartUpload: {
+      "@xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+      Part: [
+        { PartNumber: "1", ETag: partEtags[1] },
+        { PartNumber: "2", ETag: partEtags[2] },
+        { PartNumber: "3", ETag: partEtags[3] },
+      ],
+    },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- The multipart upload copies the `ETag` header of each UploadPart response into the CompleteMultipartUpload body as is: `<ETag>"a&b<c"</ETag>`. RFC 9110 allows `&`, `<` and `>` in an ETag. XML character data does not, so the endpoint rejects the commit after every part was uploaded.
- The write is the `Part` loop in `MultiPartUpload::done` (`src/runtime/webcore/s3/multipart.rs:605`). AWS ETags are quoted hex, so only other S3 endpoints hit this.

### Fix
- `append_xml_text` writes `&`, `<` and `>` as entity references (`strings::xml_escape_entity`) and copies every other byte as is. The `Part` loop uses it for the ETag.
- Correct because XML 1.0 section 2.4 requires a reference for `&` and `<` in character data, and for `>` in `]]>`. Quotes are valid character data, so a quoted ETag, including `W/"..."`, gives the same body as before.
- This is the only XML request body the S3 client builds, so there is no sibling site.
- Verified: `test/js/bun/s3/s3-multipart-complete-etag.test.ts` fails on bun 1.4.0 and passes with the fix. The other S3 suites pass (list in Notes).

### Background
- Each part is a PUT whose response carries an `ETag` header. CompleteMultipartUpload posts an XML body with one `PartNumber` and `ETag` per part. The endpoint compares them with the parts it stored.
- An entity tag (RFC 9110 section 8.8.3) is an opaque quoted string. Any printable byte except `"` is legal inside the quotes.
- In XML character data (the text between tags), `&` starts an entity reference and `<` starts a tag. Quotes need a reference only inside attribute values.

<details><summary>Notes</summary>

- Repro: a `Bun.serve` stub answers UploadPart with `ETag: "a&b<c>d"`. Bun 1.4.0 sends `<ETag>"a&b<c>d"</ETag>` in the commit body. The test records the body, compares the exact bytes, then parses it with `Bun.XML.parse` to show that the endpoint gets its ETags back.
- The ETag arrives at `simple_request.rs:374` and is stored as received (`multipart.rs:292`). Escaping happens at the write, the one place that sees every value.
- No validation of the ETag bytes is added. The HTTP/1.1 parser rejects control bytes other than HT in a header value, and the HTTP/2 client rejects NUL, CR and LF (`is_malformed_response_value`). After the escape, HT and every printable ASCII byte are valid character data. Bytes above 0x7F (`obs-text`) pass through unchanged, as before. The upload id is validated (`multipart.rs:669`) because it goes into the request line, which is a different problem.
- `Bun.XML.stringify` (`XMLObject.rs`, `append_text`) also writes character data with only `&`, `<` and `>` escaped.
- `"` is left as is on purpose. `&quot;` would change the body of every real upload, and an endpoint that compares the ETag text without an XML parser would stop matching.
- Test placement: `test/js/bun/s3/` has one file per topic. The stub runs in a subprocess with the proxy env cleared, as `s3-connection-close.test.ts` does, because the S3 client does not honor `NO_PROXY`.
- Suites run with the debug build: `s3.test.ts`, `s3-storage-class.test.ts`, `s3-requester-pays.test.ts`, `s3-connection-close.test.ts`, `s3-list-checksum-algorithm.test.ts`, `test/regression/issue/s3-header-injection.test.ts`, `test/internal/source-lints/byte-search.test.ts`.
</details>
