### PR TITLE
s3: reject NUL in header-bearing options and credentials like CR/LF

### DIFF
--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -4,11 +4,12 @@
 
 use core::sync::atomic::Ordering;
 
-use bun_core::{String as BunString, Tag as BunStringTag, strings};
+use bun_core::{String as BunString, Tag as BunStringTag};
 use bun_jsc::{JSGlobalObject, JSValue, JsResult, RangeErrorOptions, StringJsc as _};
 
 use bun_s3_signing::{
     ACL, MultiPartUploadOptions, S3Credentials, S3CredentialsWithOptions, StorageClass,
+    contains_invalid_header_value_byte,
 };
 use bun_url::URL;
 
@@ -251,9 +252,9 @@ pub(crate) fn get_credentials_with_options(
             if let Some(utf8) =
                 get_truthy_string_utf8(opts, global_object, b"contentDisposition", true)?
             {
-                if contains_newline_or_cr(utf8.slice()) {
+                if contains_invalid_header_value_byte(utf8.slice()) {
                     return Err(global_object.throw_invalid_arguments(format_args!(
-                        "contentDisposition must not contain newline characters (CR/LF)"
+                        "contentDisposition must not contain CR/LF or NUL characters"
                     )));
                 }
                 new_credentials.content_disposition = Some(bun_ptr::RawSlice::new(utf8.slice()));
@@ -261,9 +262,9 @@ pub(crate) fn get_credentials_with_options(
             }
 
             if let Some(utf8) = get_truthy_string_utf8(opts, global_object, b"type", true)? {
-                if contains_newline_or_cr(utf8.slice()) {
+                if contains_invalid_header_value_byte(utf8.slice()) {
                     return Err(global_object.throw_invalid_arguments(format_args!(
-                        "type must not contain newline characters (CR/LF)"
+                        "type must not contain CR/LF or NUL characters"
                     )));
                 }
                 new_credentials.content_type = Some(bun_ptr::RawSlice::new(utf8.slice()));
@@ -273,9 +274,9 @@ pub(crate) fn get_credentials_with_options(
             if let Some(utf8) =
                 get_truthy_string_utf8(opts, global_object, b"contentEncoding", true)?
             {
-                if contains_newline_or_cr(utf8.slice()) {
+                if contains_invalid_header_value_byte(utf8.slice()) {
                     return Err(global_object.throw_invalid_arguments(format_args!(
-                        "contentEncoding must not contain newline characters (CR/LF)"
+                        "contentEncoding must not contain CR/LF or NUL characters"
                     )));
                 }
                 new_credentials.content_encoding = Some(bun_ptr::RawSlice::new(utf8.slice()));
@@ -288,8 +289,4 @@ pub(crate) fn get_credentials_with_options(
         }
     }
     Ok(new_credentials)
-}
-
-fn contains_newline_or_cr(value: &[u8]) -> bool {
-    strings::index_of_any(value, b"\r\n").is_some()
 }

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1420,9 +1420,7 @@ impl CanonicalRequest {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Returns true if the given slice contains a byte that is never valid in an
-/// HTTP header value (NUL, CR, LF). Same byte set `fetch()` rejects through
-/// `Headers`, see https://fetch.spec.whatwg.org/#concept-header-value.
+/// The byte set `Headers` rejects in a value: https://fetch.spec.whatwg.org/#concept-header-value
 pub fn contains_invalid_header_value_byte(value: &[u8]) -> bool {
     strings::contains_any(value, b"\0\r\n")
 }

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -476,6 +476,25 @@ impl S3Credentials {
         let service_name: &str = "s3";
 
         let aws_content_hash: &[u8] = content_hash.unwrap_or(b"UNSIGNED-PAYLOAD");
+
+        if contains_invalid_header_value_byte(aws_content_hash)
+            || search_params.is_some_and(contains_invalid_header_value_byte)
+            || acl.is_some_and(contains_invalid_header_value_byte)
+            || storage_class.is_some_and(contains_invalid_header_value_byte)
+            || content_md5
+                .as_deref()
+                .is_some_and(contains_invalid_header_value_byte)
+            || content_disposition.is_some_and(contains_invalid_header_value_byte)
+            || content_type.is_some_and(contains_invalid_header_value_byte)
+            || content_encoding.is_some_and(contains_invalid_header_value_byte)
+            || session_token.is_some_and(contains_invalid_header_value_byte)
+            || contains_invalid_header_value_byte(region)
+            || contains_invalid_header_value_byte(&self.access_key_id)
+            || contains_invalid_header_value_byte(&host)
+        {
+            return Err(SignError::InvalidHeaderValue);
+        }
+
         let mut tmp_buffer = [0u8; 4096];
 
         let authorization: Box<[u8]> = 'brk: {
@@ -806,23 +825,6 @@ impl S3Credentials {
             r.url = authorization;
             r.storage_class = sign_options.storage_class;
             return Ok(r);
-        }
-
-        if contains_invalid_header_value_byte(aws_content_hash)
-            || search_params.is_some_and(contains_invalid_header_value_byte)
-            || acl.is_some_and(contains_invalid_header_value_byte)
-            || storage_class.is_some_and(contains_invalid_header_value_byte)
-            || content_md5
-                .as_deref()
-                .is_some_and(contains_invalid_header_value_byte)
-            || content_disposition.is_some_and(contains_invalid_header_value_byte)
-            || content_encoding.is_some_and(contains_invalid_header_value_byte)
-            || session_token.is_some_and(contains_invalid_header_value_byte)
-            || contains_invalid_header_value_byte(region)
-            || contains_invalid_header_value_byte(&self.access_key_id)
-            || contains_invalid_header_value_byte(&host)
-        {
-            return Err(SignError::InvalidHeaderValue);
         }
 
         let url = alloc_print!(

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -808,17 +808,19 @@ impl S3Credentials {
             return Ok(r);
         }
 
-        if contains_newline_or_cr(aws_content_hash)
-            || search_params.is_some_and(contains_newline_or_cr)
-            || acl.is_some_and(contains_newline_or_cr)
-            || storage_class.is_some_and(contains_newline_or_cr)
-            || content_md5.as_deref().is_some_and(contains_newline_or_cr)
-            || content_disposition.is_some_and(contains_newline_or_cr)
-            || content_encoding.is_some_and(contains_newline_or_cr)
-            || session_token.is_some_and(contains_newline_or_cr)
-            || contains_newline_or_cr(region)
-            || contains_newline_or_cr(&self.access_key_id)
-            || contains_newline_or_cr(&host)
+        if contains_invalid_header_value_byte(aws_content_hash)
+            || search_params.is_some_and(contains_invalid_header_value_byte)
+            || acl.is_some_and(contains_invalid_header_value_byte)
+            || storage_class.is_some_and(contains_invalid_header_value_byte)
+            || content_md5
+                .as_deref()
+                .is_some_and(contains_invalid_header_value_byte)
+            || content_disposition.is_some_and(contains_invalid_header_value_byte)
+            || content_encoding.is_some_and(contains_invalid_header_value_byte)
+            || session_token.is_some_and(contains_invalid_header_value_byte)
+            || contains_invalid_header_value_byte(region)
+            || contains_invalid_header_value_byte(&self.access_key_id)
+            || contains_invalid_header_value_byte(&host)
         {
             return Err(SignError::InvalidHeaderValue);
         }
@@ -1418,10 +1420,11 @@ impl CanonicalRequest {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Returns true if the given slice contains any CR (\r) or LF (\n) characters,
-/// which would allow HTTP header injection if used in a header value.
-fn contains_newline_or_cr(value: &[u8]) -> bool {
-    strings::index_of_any(value, b"\r\n").is_some()
+/// Returns true if the given slice contains a byte that is never valid in an
+/// HTTP header value (NUL, CR, LF). Same byte set `fetch()` rejects through
+/// `Headers`, see https://fetch.spec.whatwg.org/#concept-header-value.
+pub fn contains_invalid_header_value_byte(value: &[u8]) -> bool {
+    strings::contains_any(value, b"\0\r\n")
 }
 
 fn is_valid_host_component(value: &[u8]) -> bool {

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -29,7 +29,7 @@ test("S3 file type option containing CR/LF or other control characters is not re
   // A `type` value embedding CR/LF is rejected outright at option-parsing time,
   // before any request is made, so it can never become extra request headers.
   expect(() => client.file("report.txt", { type: "text/plain\r\nx-amz-acl: public-read" })).toThrow(
-    "type must not contain newline characters (CR/LF)",
+    "type must not contain CR/LF or NUL characters",
   );
 
   // Other control characters in `type` must not be stored as the file's content

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,4 +1,24 @@
-import { expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+
+// The S3 client sends through an ambient HTTP_PROXY even for loopback endpoints,
+// so the upload below would never reach the local server in an environment that
+// sets one. Same approach as test/js/bun/http/proxy.test.ts: assign "" (a delete
+// does not reach the native env) for the duration of this file.
+const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"];
+const savedProxyEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    savedProxyEnv[key] = process.env[key];
+    process.env[key] = "";
+  }
+});
+
+afterAll(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    process.env[key] = savedProxyEnv[key] ?? "";
+  }
+});
 
 test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();

--- a/test/regression/issue/s3-header-injection.test.ts
+++ b/test/regression/issue/s3-header-injection.test.ts
@@ -1,8 +1,28 @@
 import { S3Client } from "bun";
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 // Test that CRLF characters in S3 options are rejected to prevent header injection.
 // See: HTTP Header Injection via S3 Content-Disposition Value
+
+// The S3 client sends through an ambient HTTP_PROXY even for loopback endpoints,
+// so the requests below would never reach the stub servers in an environment
+// that sets one. Same approach as test/js/bun/http/proxy.test.ts: assign "" (a
+// delete does not reach the native env) for the duration of this file.
+const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"];
+const savedProxyEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    savedProxyEnv[key] = process.env[key];
+    process.env[key] = "";
+  }
+});
+
+afterAll(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    process.env[key] = savedProxyEnv[key] ?? "";
+  }
+});
 
 describe("S3 header injection prevention", () => {
   test("contentDisposition with CRLF should throw", () => {
@@ -144,6 +164,103 @@ describe("S3 header injection prevention", () => {
 
     const receivedHeaders = await requestReceived;
     expect(receivedHeaders.get("content-disposition")).toBe('attachment; filename="report.pdf"');
+  });
+});
+
+// A raw TCP stub instead of Bun.serve: Bun.serve's parser would refuse a request
+// whose header carries a NUL byte before the fetch handler runs, so it could not
+// tell "the client never sent the request" apart from "the server dropped it".
+function rawEndpoint() {
+  const requests: string[] = [];
+  const server = Bun.listen<{ pending: string }>({
+    port: 0,
+    hostname: "127.0.0.1",
+    socket: {
+      open(socket) {
+        socket.data = { pending: "" };
+      },
+      data(socket, chunk) {
+        socket.data.pending += chunk.toString("latin1");
+        const end = socket.data.pending.indexOf("\r\n\r\n");
+        if (end === -1) {
+          return;
+        }
+        requests.push(socket.data.pending.slice(0, end));
+        socket.end('HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\nETag: "stub"\r\n\r\nok');
+      },
+      close() {},
+      error() {},
+    },
+  });
+  return {
+    requests,
+    endpoint: `http://127.0.0.1:${server.port}`,
+    [Symbol.dispose]() {
+      server.stop(true);
+    },
+  };
+}
+
+describe.concurrent("S3 NUL bytes in header values", () => {
+  // fetch() refuses a header value that contains NUL, CR or LF. The S3 client
+  // builds its headers itself, so it has to apply the same rule. CR/LF is
+  // covered above; these cover NUL, which used to reach the wire.
+  test.each([
+    ["contentDisposition", { contentDisposition: 'attachment; filename="a"\0b' }],
+    ["contentEncoding", { contentEncoding: "gzip\0identity" }],
+    ["type", { type: "text/plain\0x" }],
+  ])("upload option %s containing NUL is rejected before a request is made", (option, uploadOptions) => {
+    using stub = rawEndpoint();
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: stub.endpoint,
+      bucket: "test-bucket",
+    });
+
+    expect(() => client.write("test-file.txt", "Hello", uploadOptions)).toThrow(
+      `${option} must not contain CR/LF or NUL characters`,
+    );
+    expect(stub.requests).toEqual([]);
+  });
+
+  // These values go into x-amz-security-token and Authorization, which are
+  // assembled while the request is signed. Nothing may be sent for them.
+  test.each([
+    ["sessionToken", { sessionToken: "FAKE\0TOKEN" }],
+    ["accessKeyId", { accessKeyId: "AKIA\0FAKE" }],
+    ["region", { region: "us-east-1\0" }],
+  ])("credential %s containing NUL fails to sign and sends nothing", async (_name, credentials) => {
+    using stub = rawEndpoint();
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: stub.endpoint,
+      bucket: "test-bucket",
+      ...credentials,
+    });
+
+    await expect(client.file("test-file.txt").text()).rejects.toMatchObject({ code: "ERR_S3_INVALID_SIGNATURE" });
+    await expect(client.write("test-file.txt", "Hello")).rejects.toMatchObject({ code: "ERR_S3_INVALID_SIGNATURE" });
+    expect(stub.requests).toEqual([]);
+  });
+
+  test("the same credentials without NUL are sent", async () => {
+    using stub = rawEndpoint();
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: stub.endpoint,
+      bucket: "test-bucket",
+      sessionToken: "FAKETOKEN",
+    });
+
+    expect(await client.file("test-file.txt").text()).toBe("ok");
+
+    expect(stub.requests).toHaveLength(1);
+    const headers = stub.requests[0].split("\r\n").slice(1);
+    expect(headers).toContain("x-amz-security-token: FAKETOKEN");
+    expect(headers.some(line => line.startsWith("Authorization: AWS4-HMAC-SHA256 Credential=test-key/"))).toBe(true);
   });
 });
 

--- a/test/regression/issue/s3-header-injection.test.ts
+++ b/test/regression/issue/s3-header-injection.test.ts
@@ -171,7 +171,7 @@ describe("S3 header injection prevention", () => {
 // whose header carries a NUL byte before the fetch handler runs, so it could not
 // tell "the client never sent the request" apart from "the server dropped it".
 function rawEndpoint() {
-  const requests: string[] = [];
+  const seen = { requests: [] as string[], errors: [] as string[] };
   const server = Bun.listen<{ pending: string }>({
     port: 0,
     hostname: "127.0.0.1",
@@ -185,21 +185,29 @@ function rawEndpoint() {
         if (end === -1) {
           return;
         }
-        requests.push(socket.data.pending.slice(0, end));
+        seen.requests.push(socket.data.pending.slice(0, end));
         socket.end('HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\nETag: "stub"\r\n\r\nok');
       },
       close() {},
-      error() {},
+      error(_socket, error) {
+        seen.errors.push(String(error));
+      },
     },
   });
   return {
-    requests,
+    seen,
     endpoint: `http://127.0.0.1:${server.port}`,
     [Symbol.dispose]() {
       server.stop(true);
     },
   };
 }
+
+const nulCredentials = [
+  ["sessionToken", { sessionToken: "FAKE\0TOKEN" }],
+  ["accessKeyId", { accessKeyId: "AKIA\0FAKE" }],
+  ["region", { region: "us-east-1\0" }],
+] as const;
 
 describe.concurrent("S3 NUL bytes in header values", () => {
   // fetch() refuses a header value that contains NUL, CR or LF. The S3 client
@@ -221,29 +229,47 @@ describe.concurrent("S3 NUL bytes in header values", () => {
     expect(() => client.write("test-file.txt", "Hello", uploadOptions)).toThrow(
       `${option} must not contain CR/LF or NUL characters`,
     );
-    expect(stub.requests).toEqual([]);
+    expect(stub.seen).toEqual({ requests: [], errors: [] });
   });
 
   // These values go into x-amz-security-token and Authorization, which are
   // assembled while the request is signed. Nothing may be sent for them.
-  test.each([
-    ["sessionToken", { sessionToken: "FAKE\0TOKEN" }],
-    ["accessKeyId", { accessKeyId: "AKIA\0FAKE" }],
-    ["region", { region: "us-east-1\0" }],
-  ])("credential %s containing NUL fails to sign and sends nothing", async (_name, credentials) => {
-    using stub = rawEndpoint();
-    const client = new S3Client({
-      accessKeyId: "test-key",
-      secretAccessKey: "test-secret",
-      endpoint: stub.endpoint,
-      bucket: "test-bucket",
-      ...credentials,
-    });
+  test.each(nulCredentials)(
+    "credential %s containing NUL fails to sign and sends nothing",
+    async (_name, credentials) => {
+      using stub = rawEndpoint();
+      const client = new S3Client({
+        accessKeyId: "test-key",
+        secretAccessKey: "test-secret",
+        endpoint: stub.endpoint,
+        bucket: "test-bucket",
+        ...credentials,
+      });
 
-    await expect(client.file("test-file.txt").text()).rejects.toMatchObject({ code: "ERR_S3_INVALID_SIGNATURE" });
-    await expect(client.write("test-file.txt", "Hello")).rejects.toMatchObject({ code: "ERR_S3_INVALID_SIGNATURE" });
-    expect(stub.requests).toEqual([]);
-  });
+      await expect(client.file("test-file.txt").text()).rejects.toMatchObject({ code: "ERR_S3_INVALID_SIGNATURE" });
+      await expect(client.write("test-file.txt", "Hello")).rejects.toMatchObject({ code: "ERR_S3_INVALID_SIGNATURE" });
+      expect(stub.seen).toEqual({ requests: [], errors: [] });
+    },
+  );
+
+  // A presigned URL carries the same values in its query string, so it is
+  // refused too instead of embedding the byte in X-Amz-Credential.
+  test.each([...nulCredentials, ["sessionToken (CR/LF)", { sessionToken: "FAKE\r\nTOKEN" }]])(
+    "presign with %s containing NUL or CR/LF throws",
+    (_name, credentials) => {
+      const client = new S3Client({
+        accessKeyId: "test-key",
+        secretAccessKey: "test-secret",
+        endpoint: "http://127.0.0.1:1",
+        bucket: "test-bucket",
+        ...credentials,
+      });
+
+      expect(() => client.presign("test-file.txt")).toThrow(
+        expect.objectContaining({ code: "ERR_S3_INVALID_SIGNATURE" }),
+      );
+    },
+  );
 
   test("the same credentials without NUL are sent", async () => {
     using stub = rawEndpoint();
@@ -257,10 +283,12 @@ describe.concurrent("S3 NUL bytes in header values", () => {
 
     expect(await client.file("test-file.txt").text()).toBe("ok");
 
-    expect(stub.requests).toHaveLength(1);
-    const headers = stub.requests[0].split("\r\n").slice(1);
+    expect(stub.seen.errors).toEqual([]);
+    expect(stub.seen.requests).toHaveLength(1);
+    const headers = stub.seen.requests[0].split("\r\n").slice(1);
     expect(headers).toContain("x-amz-security-token: FAKETOKEN");
     expect(headers.some(line => line.startsWith("Authorization: AWS4-HMAC-SHA256 Credential=test-key/"))).toBe(true);
+    expect(client.presign("test-file.txt")).toContain("X-Amz-Credential=test-key%2F");
   });
 });
 


### PR DESCRIPTION
### Problem
- A NUL byte in an S3 option or credential reaches the wire. `sessionToken: "FAKE\0TOKEN"` is sent as `x-amz-security-token: FAKE\0TOKEN`. Same for `accessKeyId` and `region` (in `Authorization`), `contentDisposition` and `contentEncoding`. `fetch()` rejects these values.
- The two S3 checks only look for CR and LF: `src/runtime/webcore/s3/credentials_jsc.rs:254` (options) and `src/s3_signing/credentials.rs:811` (signing). The signing check also ran after `presign()` returned, so presigned URLs embedded the byte in `X-Amz-Credential`.

### Fix
- One helper, `contains_invalid_header_value_byte` in `bun_s3_signing`, rejects NUL, CR and LF. Both checks use it. The option error now reads `must not contain CR/LF or NUL characters`.
- This is the byte set the Fetch spec forbids in a header value. The sign-time check now runs before signing, so requests, `presign()`, env credentials and `s3://` URLs all get the same rule.
- The error paths do not change: the option check throws at call time, the sign-time check fails with `ERR_S3_INVALID_SIGNATURE` as for CR/LF today. `presign()` with CR/LF in a credential now throws instead of percent-encoding it.
- Verified: `test/regression/issue/s3-header-injection.test.ts` (10 new tests, all fail on 1.4.0), `test/js/bun/s3/s3-fd-validation.test.ts`, and the other local S3 suites.

### Background
- `S3Credentials::sign_request` (`src/s3_signing/credentials.rs`) builds `Authorization` and the other headers as raw picohttp headers. The HTTP client validates the URL, not the headers.
- `get_credentials_with_options` (`credentials_jsc.rs`) parses the JS options object. It is the only place that can name the bad option.
- The tests use a raw `Bun.listen` stub. `Bun.serve` answers 400 to a NUL header before `fetch()` runs, so it cannot show whether the client sent anything.

<details><summary>Notes</summary>

Found while going through a fuzz report on the S3 client. The rest of that report is already covered by open PRs: NO_PROXY and HTTPS_PROXY selection (#32046), 3xx handling (#35869), no content decoding on reads (#35871). Startup-only env credentials are documented behavior (`docs/runtime/s3.mdx`) and #39210 reworks that area.

Probe on bun 1.4.0 against a raw TCP stub. `fetch()` with the same header value throws `TypeError: Header 'x-amz-security-token' has invalid value`. The S3 client sent:

```
sessionToken NUL:        x-amz-security-token: FAKE\^@TOKEN
accessKeyId NUL:         Authorization: AWS4-HMAC-SHA256 Credential=AKIA\^@FAKE/...
region NUL:              Authorization: AWS4-HMAC-SHA256 Credential=.../us-\^@east-1/s3/aws4_request
contentDisposition NUL:  content-disposition: attachment\^@; filename=x
contentEncoding NUL:     content-encoding: gz\^@ip
sessionToken CRLF:       rejected (ERR_S3_INVALID_SIGNATURE), nothing sent
```

`type` with a NUL was already replaced by `application/octet-stream` through Blob type normalization. It is included in the option check for consistency with CR/LF.

Presign on 1.4.0 returned `...X-Amz-Credential=AKIA\^@FAKE%2F...` for a NUL in `accessKeyId` and the same for `region`. The token and the response overrides were percent-encoded. The check now runs before either path does any signing work, and it includes the presign response content type. The four presign tests fail on the first commit of this PR and pass on the current one.

Keys, bucket names and list parameters are percent-encoded. Endpoints with a NUL, CR, LF or space are rejected by the HTTP client as `InvalidURL`. The multipart upload id from the server is validated in `multipart.rs`. None of those needed a change.

Both test files now blank the proxy env vars for their duration, the same way `test/js/bun/http/proxy.test.ts` does. The S3 client sends loopback requests through an ambient `HTTP_PROXY` (#32046 covers that), so without this the local servers in these files never see a request in an environment with a proxy configured.

Other suites run with the debug build: `s3-list-objects`, `s3-argument-validation`, `s3-requester-pays`, `s3-storage-class`, `s3-insecure`, `s3-numeric-options-coerce`, `s3-queueSize-validation`, `s3-connection-close`, `s3-list-checksum-algorithm`, and the local blocks of `s3.test.ts`. Two `s3-list-objects` tests timed out once each on a loaded machine right after the 40k-entry "big responses" test and pass alone in well under 100 ms. They do not touch the changed code.

Fail-before output on 1.4.0:

```
(fail) S3 NUL bytes in header values > upload option contentDisposition containing NUL is rejected before a request is made
(fail) S3 NUL bytes in header values > upload option contentEncoding containing NUL is rejected before a request is made
(fail) S3 NUL bytes in header values > upload option type containing NUL is rejected before a request is made
(fail) S3 NUL bytes in header values > credential sessionToken containing NUL fails to sign and sends nothing
(fail) S3 NUL bytes in header values > credential accessKeyId containing NUL fails to sign and sends nothing
(fail) S3 NUL bytes in header values > credential region containing NUL fails to sign and sends nothing
(fail) S3 NUL bytes in header values > presign with sessionToken containing NUL or CR/LF throws
(fail) S3 NUL bytes in header values > presign with accessKeyId containing NUL or CR/LF throws
(fail) S3 NUL bytes in header values > presign with region containing NUL or CR/LF throws
(fail) S3 NUL bytes in header values > presign with sessionToken (CR/LF) containing NUL or CR/LF throws
 8 pass
 10 fail
```

With the fix: 18 pass in that file, 2 pass in `s3-fd-validation.test.ts`. The test stub records socket errors and each test asserts on requests and errors together.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-fd-validation.test.ts" "test/regression/issue/s3-header-injection.test.ts"
bun test v1.4.0 (6e906e468)

test/regression/issue/s3-header-injection.test.ts:
(pass) S3 header injection prevention > contentDisposition with CRLF should throw [23.97ms]
(pass) S3 header injection prevention > contentEncoding with CRLF should throw [15.75ms]
(pass) S3 header injection prevention > type (content-type) with CRLF should throw [15.06ms]
(pass) S3 header injection prevention > contentDisposition with only CR should throw [14.43ms]
(pass) S3 header injection prevention > contentDisposition with only LF should throw [14.81ms]
(pass) S3 header injection prevention > valid contentDisposition without CRLF should not throw [34.17ms]
224 |       secretAccessKey: "test-secret",
225 |       endpoint: stub.endpoint,
226 |       bucket: "test-bucket",
227 |     });
228 | 
229 |     expect(() => client.write("test-file.txt", "Hello", uploadOptions)).toThrow(
                                                                              ^
erro
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (7645ce97d)

test/regression/issue/s3-header-injection.test.ts:
(pass) S3 header injection prevention > contentDisposition with CRLF should throw [1.51ms]
(pass) S3 header injection prevention > contentEncoding with CRLF should throw [1.60ms]
(pass) S3 header injection prevention > type (content-type) with CRLF should throw [0.67ms]
(pass) S3 header injection prevention > contentDisposition with only CR should throw [0.65ms]
(pass) S3 header injection prevention > contentDisposition with only LF should throw [0.65ms]
(pass) S3 header injection prevention > valid contentDisposition without CRLF should not throw [1.48ms]
(pass) S3 NUL bytes in header values > upload option contentDisposition containing NUL is rejected before a request is made [0.26ms]
(pass) S3 NUL bytes in header values > upload option contentEncoding containing NUL is rejected before a request is made [0.05ms]
(pass) S3 NUL bytes in header values > upload option type containing NUL is rejected before a request is made [0.04ms]
(pass) S3 NUL bytes in header values > credential sessionToken containing NUL fails to sign and sends nothing [0.25ms]
(pass) S3 NUL bytes in header v
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-fd-validation.test.ts" "test/regression/issue/s3-header-injection.test.ts"
bun test v1.4.0 (6e906e468)

test/regression/issue/s3-header-injection.test.ts:
(pass) S3 header injection prevention > contentDisposition with CRLF should throw [28.07ms]
(pass) S3 header injection prevention > contentEncoding with CRLF should throw [16.52ms]
(pass) S3 header injection prevention > type (content-type) with CRLF should throw [17.34ms]
(pass) S3 header injection prevention > contentDisposition with only CR should throw [15.30ms]
(pass) S3 header injection prevention > contentDisposition with only LF should throw [15.61ms]
(pass) S3 header injection prevention > valid contentDisposition without CRLF should not throw [35.15ms]
(pass) S3 NUL bytes in header values > upload option contentDisposition containing NUL is rejected before a request is made [12.71ms]
(pass) S3 NUL bytes in header values > upload option contentEncoding containing NUL is rejected before a request is made [3.51ms]
(pass) S3 NUL bytes in header values > uploa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_s3_signing v0.0.0 (/workspace/bun/src/s3_signing)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/credentials_jsc.rs         |  19 ++-
 src/s3_signing/credentials.rs                     |  41 +++---
 test/js/bun/s3/s3-fd-validation.test.ts           |  24 +++-
 test/regression/issue/s3-header-injection.test.ts | 147 +++++++++++++++++++++-
 4 files changed, 198 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/runtime/webcore/s3/credentials_jsc.rs              1      5      0
src/s3_signing/credentials.rs                          7      7      0
test/js/bun/s3/s3-fd-validation.test.ts                2      2      0
test/regression/issue/s3-header-injection.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->