### PR TITLE
sql: fire onclose only for pool connections that completed their handshake

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -762,10 +762,8 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
 
   #finishClose(err: any) {
     const connectionInfo = this.connectionInfo;
-    // A pool-initiated close (onFinish set) can kill a slot whose handshake
-    // never completed. That slot never fired onconnect, so skip the user's
-    // onclose to keep the two callbacks paired. A connect failure outside of
-    // close() still reports through onclose.
+    // A pool-initiated close (onFinish set) of a slot that never fired
+    // onconnect skips the user's onclose, so the two callbacks stay paired.
     const notifyUser = (this.flags & PooledConnectionFlags.onConnectFired) !== 0 || this.onFinish === null;
     try {
       // user code; a throw must not abort the pool bookkeeping below

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -762,12 +762,11 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
 
   #finishClose(err: any) {
     const connectionInfo = this.connectionInfo;
-    // A pool-initiated close (onFinish set) of a slot that never fired
-    // onconnect skips the user's onclose, so the two callbacks stay paired.
-    const notifyUser = (this.flags & PooledConnectionFlags.onConnectFired) !== 0 || this.onFinish === null;
+    const poolClosedSlotBeforeOnconnect =
+      this.onFinish !== null && !(this.flags & PooledConnectionFlags.onConnectFired);
     try {
       // user code; a throw must not abort the pool bookkeeping below
-      if (notifyUser && connectionInfo?.onclose) {
+      if (!poolClosedSlotBeforeOnconnect && connectionInfo?.onclose) {
         AsyncContextFrame.run(this.adapter.callbackAsyncContext, connectionInfo.onclose, connectionInfo, err);
       }
     } finally {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -591,6 +591,8 @@ const enum PooledConnectionFlags {
   reserved = 1 << 1,
   /// preReserved is used to indicate that the connection will be reserved in the future when queryCount drops to 0
   preReserved = 1 << 2,
+  /// onConnectFired is used to indicate that handleConnected ran for this slot, so the user's onconnect callback already fired (with null or an error)
+  onConnectFired = 1 << 3,
 }
 export type { PooledConnectionState };
 
@@ -657,6 +659,7 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
     if (err) {
       err = this.wrapError(err);
     }
+    this.flags |= PooledConnectionFlags.onConnectFired;
     const connectionInfo = this.connectionInfo;
     try {
       // user code; a throw must not abort the pool bookkeeping below
@@ -759,9 +762,14 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
 
   #finishClose(err: any) {
     const connectionInfo = this.connectionInfo;
+    // A pool-initiated close (onFinish set) can kill a slot whose handshake
+    // never completed. That slot never fired onconnect, so skip the user's
+    // onclose to keep the two callbacks paired. A connect failure outside of
+    // close() still reports through onclose.
+    const notifyUser = (this.flags & PooledConnectionFlags.onConnectFired) !== 0 || this.onFinish === null;
     try {
       // user code; a throw must not abort the pool bookkeeping below
-      if (connectionInfo?.onclose) {
+      if (notifyUser && connectionInfo?.onclose) {
         AsyncContextFrame.run(this.adapter.callbackAsyncContext, connectionInfo.onclose, connectionInfo, err);
       }
     } finally {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -808,10 +808,11 @@ abstract class BasePooledConnection<ConnectionHandle extends { close(): void; fl
     if (this.adapter.closed) {
       return;
     }
-    // reset error and state
+    // reset error and state; the new cycle has not fired onconnect yet
     this.storedError = null;
     this.connectStartedAt = 0;
     this.state = PooledConnectionState.pending;
+    this.flags &= ~PooledConnectionFlags.onConnectFired;
     // retry connection
     this.#beginConnecting();
   }

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -17,7 +17,7 @@
 // thing that can tear the connection down — without the fix these tests hang.
 
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { expect, mock, test } from "bun:test";
 import { neverAnsweringServer } from "./wire-frames";
 
 const drivers = [
@@ -36,6 +36,35 @@ for (const [name, scheme, closedCode] of drivers) {
       await accepted;
       await sql.close({ timeout: "0" });
       expect((await queryError).code).toBe(closedCode);
+    } finally {
+      server.close();
+    }
+  });
+
+  // https://github.com/oven-sh/bun/issues/39940
+  //
+  // close() used to fire the user's onclose callback once per pool slot in
+  // the pending state, even when that slot's handshake never completed and
+  // onconnect never fired, so onconnect/onclose pairing drifted by up to
+  // `max` per pool close.
+  test(`${name}: close() does not fire onclose for slots that never connected`, async () => {
+    const { port, server, accepted } = await neverAnsweringServer();
+    try {
+      const onconnect = mock();
+      const onclose = mock();
+      const sql = new SQL({
+        url: `${scheme}127.0.0.1:${port}/db`,
+        max: 5,
+        connectionTimeout: 0,
+        onconnect,
+        onclose,
+      });
+      const queryError = sql`SELECT 1`.catch(e => e);
+      await accepted;
+      await sql.close({ timeout: "0" });
+      expect((await queryError).code).toBe(closedCode);
+      expect(onconnect).not.toHaveBeenCalled();
+      expect(onclose).not.toHaveBeenCalled();
     } finally {
       server.close();
     }

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -18,7 +18,7 @@
 
 import { SQL } from "bun";
 import { expect, mock, test } from "bun:test";
-import { neverAnsweringServer } from "./wire-frames";
+import { listeningServer, neverAnsweringServer, pgAuthenticationOk, pgReadyForQuery } from "./wire-frames";
 
 const drivers = [
   ["postgres", "postgres://postgres@", "ERR_POSTGRES_CONNECTION_CLOSED"],
@@ -84,6 +84,55 @@ for (const [name, scheme, closedCode] of drivers) {
     }
   });
 }
+
+// https://github.com/oven-sh/bun/issues/39940
+//
+// The per-slot "fired onconnect" marker is per connect cycle. A slot that
+// connected once, closed, and is now redialing must not reuse the marker from
+// the previous cycle: a forced close() that lands mid-reconnect used to fire
+// a second onclose for a cycle whose onconnect never fired.
+test("postgres: close() mid-reconnect does not fire onclose for the unfinished cycle", async () => {
+  const firstClose = Promise.withResolvers<void>();
+  const onconnect = mock();
+  const onclose = mock(() => firstClose.resolve());
+  const secondAccepted = Promise.withResolvers<void>();
+  let firstSocket: import("node:net").Socket;
+  let connections = 0;
+  const { port, server } = await listeningServer(socket => {
+    if (++connections === 1) {
+      firstSocket = socket;
+      // complete the handshake so the slot fires onconnect
+      socket.once("data", () => socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()])));
+    } else {
+      // the reconnect stays mid-handshake
+      secondAccepted.resolve();
+    }
+  });
+  try {
+    const sql = new SQL({
+      url: `postgres://postgres@127.0.0.1:${port}/postgres`,
+      max: 1,
+      connectionTimeout: 0,
+      onconnect,
+      onclose,
+    });
+    await sql.connect();
+    expect(onconnect).toHaveBeenCalledTimes(1);
+    // drop the connection from the server side; onclose pairs with onconnect
+    firstSocket!.destroy();
+    await firstClose.promise;
+    expect(onclose).toHaveBeenCalledTimes(1);
+    // a new query redials the closed slot, then close() lands mid-handshake
+    const queryError = sql`SELECT 1`.catch(e => e);
+    await secondAccepted.promise;
+    await sql.close({ timeout: "0" });
+    expect((await queryError).code).toBe("ERR_POSTGRES_CONNECTION_CLOSED");
+    expect(onconnect).toHaveBeenCalledTimes(1);
+    expect(onclose).toHaveBeenCalledTimes(1);
+  } finally {
+    server.close();
+  }
+});
 
 // https://github.com/oven-sh/bun/issues/32198
 //

--- a/test/js/sql/sql-onconnect-onclose-throw.test.ts
+++ b/test/js/sql/sql-onconnect-onclose-throw.test.ts
@@ -236,14 +236,17 @@ process.exit(0);
 // Buffer.alloc frame construction here.
 //
 // The forced-close path (#32095) and the throwing-callback path (#32037) meet
-// in the pool connection's close handler: the user's onclose runs first and
-// may throw, and the bookkeeping that follows it must still settle the
-// promise returned by close(). A server that accepts the TCP connection but
-// never answers keeps the connection mid-handshake, and connectionTimeout: 0
-// disables the connect timer, so close() is the only teardown path; if the
-// throw skipped the bookkeeping these fixtures would never print "closed".
-// The mock server lives in the fixture process (it must observe `accepted`
-// before forcing close) and is imported from ./wire-frames by absolute path.
+// in the pool connection's close handler: the bookkeeping that settles the
+// promise returned by close() must run even when a user callback throws. A
+// server that accepts the TCP connection but never answers keeps the
+// connection mid-handshake, and connectionTimeout: 0 disables the connect
+// timer, so close() is the only teardown path; if the bookkeeping were
+// skipped these fixtures would never print "closed". Since #39940 a slot
+// that never completed its handshake fired no onconnect, so the forced close
+// skips its onclose too; the throwing onclose stays installed to pin that it
+// is not invoked. The mock server lives in the fixture process (it must
+// observe `accepted` before forcing close) and is imported from ./wire-frames
+// by absolute path.
 function forcedCloseFixture(adapter: "postgres" | "mysql") {
   const url = adapter === "postgres" ? "postgres://postgres@127.0.0.1:" : "mysql://root@127.0.0.1:";
   const db = adapter === "postgres" ? "/postgres" : "/db";
@@ -275,12 +278,10 @@ for (const [adapter, closedCode] of [
   ["mysql", "ERR_MYSQL_CONNECTION_CLOSED"],
 ] as const) {
   test.concurrent(
-    `${adapter}: a throwing onclose does not prevent forced close() from resolving mid-handshake`,
+    `${adapter}: forced close() mid-handshake resolves and skips onclose for the never-connected slot`,
     async () => {
       const { stdout, exitCode } = await runFixture(forcedCloseFixture(adapter));
-      expect(stdout).toBe(
-        `onclose: ${closedCode}\nuncaught: boom from onclose\nclosed\nquery rejected: ${closedCode}\n`,
-      );
+      expect(stdout).toBe(`closed\nquery rejected: ${closedCode}\n`);
       expect(exitCode).toBe(0);
     },
   );

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -862,6 +862,19 @@ if (isDockerEnabled()) {
       expect(error.code).toBe(`ERR_POSTGRES_LIFETIME_TIMEOUT`);
     });
 
+    // https://github.com/oven-sh/bun/issues/39940
+    // close() used to fire onclose once per pool slot, even for slots whose
+    // handshake never completed, so onconnect/onclose pairing drifted.
+    test("close() fires onclose only for connections that fired onconnect", async () => {
+      const onconnect = mock();
+      const onclose = mock();
+      const sql = postgres({ ...options, max: 10, onconnect, onclose });
+      await sql`select 1`;
+      await sql.close();
+      expect(onconnect).toHaveBeenCalled();
+      expect(onclose).toHaveBeenCalledTimes(onconnect.mock.calls.length);
+    });
+
     // Last one wins.
     test("Handles duplicate string column names", async () => {
       const result = await sql`select 1 as x, 2 as x, 3 as x`;


### PR DESCRIPTION
### Problem

- `sql.close()` fires the `onclose` callback once per configured pool slot (`max`), not once per connection that fired `onconnect`. With `max: 30` and 6 completed handshakes, the user sees `{ opened: 6, closed: 30 }`. Metrics that pair the two callbacks drift negative. Fixes #39940.
- The cause: the first query starts all `max` slots, and each slot begins its handshake at once. `#close()` in `src/js/internal/sql/shared.ts` then closes every pending slot, and `#finishClose` invoked the user's `onclose` unconditionally, even for slots that never completed the handshake and never fired `onconnect`.

### Fix

- Add a per-slot flag, `PooledConnectionFlags.onConnectFired`, set when `handleConnected` runs (that is exactly when the user's `onconnect` fires, with null or an error).
- `#finishClose` now skips the user's `onclose` when the close is pool-initiated (`onFinish` is set) and the flag is unset. The pool bookkeeping (query notification, `onFinish`, release) still runs, so `close()` settles as before.
- A connect failure outside `close()` (connection timeout, refused connection, spent retry budget) still reports through `onclose`. Existing tests assert that behavior and they still pass.
- Verified: new tests in `test/js/sql/sql-close-pending-connection.test.ts` (both drivers, fails on stock bun with 5 `onclose` calls for 0 connections) and `test/js/sql/sql.test.ts` (real postgres, `onclose` count equals `onconnect` count). Also ran the full `test/js/sql/` suite.

### Background

- The postgres and mysql adapters share one pool in `shared.ts`. Each slot is a `BasePooledConnection` that dials as soon as it is created.
- `handleConnected` is the native handshake callback and fires the user's `onconnect`. `handleClose` is the native socket-close callback and funnels into `#finishClose`, which fires the user's `onclose`.
- `onFinish` is set on a slot only by pool `close()`. It resolves the promise that `close()` awaits. That makes it a reliable marker for a pool-initiated close.
- One pinned expectation changed: `sql-onconnect-onclose-throw.test.ts` asserted that a forced `close()` of a mid-handshake slot fires a throwing `onclose`. That slot never fired `onconnect`, so the fixture now asserts `onclose` is not invoked and `close()` still resolves.

<details><summary>Notes</summary>

Repro (against a local postgres, `max: 30`): stock bun prints `{ opened: 6, closed: 30 }`, the fixed build prints equal counts across 10 runs (opened varies 2 to 24 per run, closed always matches).

Paths audited in `#finishClose`:

- Pool close of a connected slot: `onConnectFired` set, `onclose` fires, pairs with `onconnect`.
- Pool close of a pending slot: flag unset, `onFinish` set, `onclose` skipped (the bug).
- Connection timeout or refused connection outside close(): `onFinish` null, `onclose` fires. Asserted by "Connection timeout works" in `sql.test.ts` and by `sql-connect-error-reporting.test.ts` ("onclose fires once per closed connection, not per retry attempt").
- Handshake that completes while `close()` drains: `onconnect` fires, then the slot closes and `onclose` fires. Pairs.

The sqlite adapter opens its single connection in the constructor and fires `onconnect` there, so its `onclose` always pairs. No change needed.

Suites run locally: `test/js/sql/` in full. 28 failures in the generic mysql helper and transaction tests pre-exist with the stock bun against the local MariaDB service and are unrelated.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-close-pending-connection.test.ts test/js/sql/sql-onconnect-onclose-throw.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (6e906e468)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [365.57ms]
62 |       const queryError = sql`SELECT 1`.catch(e => e);
63 |       await accepted;
64 |       await sql.close({ timeout: "0" });
65 |       expect((await queryError).code).toBe(closedCode);
66 |       expect(onconnect).not.toHaveBeenCalled();
67 |       expect(onclose).not.toHaveBeenCalled();
                               ^
error: expect(received).not.toHaveBeenCalled()

Expected number of calls: 0
Received number of calls: 5

      at <anonymous> (/workspace/bun/test/js/sql/sql-close-pending-connection.test.ts:67:27)
(fail) postgres: close() does not fire onclose for slots that never connected [148.82ms]
(pass) postgres: forced close() resolves when called before the native handle is stored [65.47ms]
(pass) mysql: forced close() resolves while a co
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (957cf043d)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [10.62ms]
(pass) postgres: close() does not fire onclose for slots that never connected [3.62ms]
(pass) postgres: forced close() resolves when called before the native handle is stored [1.78ms]
(pass) mysql: forced close() resolves while a connection is mid-handshake [2.18ms]
(pass) mysql: close() does not fire onclose for slots that never connected [1.60ms]
(pass) mysql: forced close() resolves when called before the native handle is stored [1.30ms]
126 |     const queryError = sql`SELECT 1`.catch(e => e);
127 |     await secondAccepted.promise;
128 |     await sql.close({ timeout: "0" });
129 |     expect((await queryError).code).toBe("ERR_POSTGRES_CONNECTION_CLOSED");
130 |     expect(onconnect).toHaveBeenCalledTimes(1);
131 |     expect(onclose).toHaveBeenCalledTimes(1);
                          ^
error: expect(received).toHaveBeenCalledTimes(expected)

Expected number of calls: 1
Received number of calls: 2

      at <anonymous> (/workspace/bun/test/js/sql/sql-close-pending-connection.test.ts:131:2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-close-pending-connection.test.ts test/js/sql/sql-onconnect-onclose-throw.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (6e906e468)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [363.37ms]
(pass) postgres: close() does not fire onclose for slots that never connected [142.99ms]
(pass) postgres: forced close() resolves when called before the native handle is stored [28.91ms]
(pass) mysql: forced close() resolves while a connection is mid-handshake [34.03ms]
(pass) mysql: close() does not fire onclose for slots that never connected [83.61ms]
(pass) mysql: forced close() resolves when called before the native handle is stored [26.20ms]
(pass) postgres: close() mid-reconnect does not fire onclose for the unfinished cycle [210.39ms]
(pass) pool scans tolerate unassigned connection slots during pool start [52.79ms]

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if th
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (11756ms)
Bundle modules (65ms)
Postprocesss modules (28ms)
Bundle Functions (737ms)
Generate Code (24ms)

[12.63s] Bundled "src/js" for production
  2625 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 03s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+e0d8a5ed3
[build] done
bun test v1.4.0-canary.1 (e0d8a5ed3)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [7.40ms]
(pass) postgres: close() does not fire onclose for slots that never connected [2.51ms]
(pass) postgres: fo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/shared.ts                    | 10 ++-
 test/js/sql/sql-close-pending-connection.test.ts | 82 +++++++++++++++++++++++-
 test/js/sql/sql-onconnect-onclose-throw.test.ts  | 25 ++++----
 test/js/sql/sql.test.ts                          | 13 ++++
 4 files changed, 114 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/js/internal/sql/shared.ts                         3      8      0
test/js/sql/sql-close-pending-connection.test.ts      1      4      0
test/js/sql/sql-onconnect-onclose-throw.test.ts       1      2      0
test/js/sql/sql.test.ts                               1      2      0
```

</details>

**root cause** · written by the author bot

The pool's close path invoked the user's onclose callback for every allocated slot, including slots whose connections were still pending and had never completed the handshake or fired onconnect, so closed counts always matched the configured max. The fix records whether each pooled connection actually completed its onconnect cycle, resetting that marker on each reconnect attempt, and a pool initiated close of a slot that never reached onconnect now skips the onclose callback. As a result, onconnect and onclose pair up one to one for connections that were genuinely established, while pending…

<!-- robobun:evidence:end -->