### PR TITLE
test(bun-serve-static-stress): run fewer batches per case and compare whole responses

### DIFF
--- a/test/js/bun/http/bun-serve-static-helpers.ts
+++ b/test/js/bun/http/bun-serve-static-helpers.ts
@@ -1,4 +1,3 @@
-import type { Server } from "bun";
 import { expect } from "bun:test";
 import { fillRepeating, isASAN, isDebug, isWindows, rss } from "harness";
 
@@ -44,80 +43,163 @@ for (const [path, response] of Object.entries(routes)) {
   static_responses[path] = await response.clone().blob();
 }
 
-export const stressPaths = ["/foo", "/big", "/foo/bar"] as const;
+const fallbackBody = "fallback";
+const fallbackBlob = new Blob([fallbackBody]);
+
+// One instance per stress file. Every request for a path without a static
+// route lands in the fetch handler, which counts it.
+export class StressServer {
+  fallbackCalls = 0;
+  readonly server = Bun.serve({
+    static: routes,
+    port: 0,
+    fetch: () => {
+      this.fallbackCalls++;
+      return new Response(fallbackBody, { status: 404 });
+    },
+  });
+
+  constructor() {
+    this.server.unref();
+  }
+
+  stop() {
+    this.server.stop(true);
+  }
+}
+
+// "/missing" has no static route: it proves that the static matcher does not
+// capture other paths under load, and that the handler count below is exact.
+export const stressPaths = ["/foo", "/big", "/foo/bar", "/missing"] as const;
 export const stressMethods = ["arrayBuffer", "blob", "bytes", "text"] as const;
 
-export async function runStress(
-  server: Server,
-  path: (typeof stressPaths)[number],
-  accessBody: boolean,
-  method: (typeof stressMethods)[number],
-) {
-  const bytes = method === "blob" ? static_responses[path] : await static_responses[path][method]();
-  const expectedLength = String(static_responses[path].size);
+type StressPath = (typeof stressPaths)[number];
+type StressMethod = (typeof stressMethods)[number];
 
-  // macOS limits backlog to 128.
-  const batchSize = Math.ceil(64 / (isWindows ? 8 : 1));
-  // Debug/ASAN builds run the fetch loop ~10x slower than release; one warmup +
-  // measurement round at 64-wide still exercises the backpressure path on every
-  // /big request, and the delta assertion below catches a per-request body leak
-  // in a single measurement pass (64 * 4MB = 256MB >> threshold).
-  const iterations = Math.ceil((isASAN || isDebug ? 4 : 12) / (isWindows ? 8 : 1));
+interface PathExpectation {
+  status: number;
+  blob: Blob;
+  servedByFallback: boolean;
+  headers: Record<string, string | null>;
+}
 
-  async function iterate() {
-    let array = new Array(batchSize);
-    const route = `${server.url}${path.substring(1)}`;
-    for (let i = 0; i < batchSize; i++) {
-      array[i] = fetch(route)
-        .then(res => {
-          expect(res.status).toBe(200);
-          expect(res.url).toBe(route);
-          expect(res.headers.get("Content-Length")).toBe(expectedLength);
-          if (accessBody) {
-            res.body;
-          }
-          return res[method]();
-        })
-        .then(output => {
-          expect(output).toStrictEqual(bytes);
-        });
+function expectationFor(path: StressPath): PathExpectation {
+  const route = (routes as Record<string, Response>)[path];
+  if (route) {
+    const blob = static_responses[path];
+    return {
+      status: 200,
+      blob,
+      servedByFallback: false,
+      headers: {
+        "content-type": route.headers.get("Content-Type"),
+        "x-foo": route.headers.get("X-Foo"),
+        "content-length": String(blob.size),
+        "transfer-encoding": null,
+        "etag": expect.stringMatching(/^"[0-9a-f]+"$/),
+      },
+    };
+  }
+
+  return {
+    status: 404,
+    blob: fallbackBlob,
+    servedByFallback: true,
+    headers: {
+      "content-type": "text/plain;charset=utf-8",
+      "x-foo": null,
+      "content-length": String(fallbackBlob.size),
+      "transfer-encoding": null,
+      "etag": null,
+    },
+  };
+}
+
+function pickHeaders(headers: Headers, names: string[]): Record<string, string | null> {
+  return Object.fromEntries(names.map(name => [name, headers.get(name)] as const));
+}
+
+// toEqual does not read Blob contents: two Blobs of different bytes (or sizes)
+// compare equal. Expand a Blob so that the comparison covers its bytes. Blob.type
+// is left out: the buffered and the streamed body paths derive it differently.
+async function comparable(body: ArrayBuffer | Blob | Uint8Array | string) {
+  if (body instanceof Blob) {
+    return { size: body.size, bytes: await body.bytes() };
+  }
+  return body;
+}
+
+// macOS limits the listen backlog to 128, so one batch is 64 concurrent requests.
+const batchSize = isWindows ? 8 : 64;
+// The warm-up batch opens fetch's keep-alive connections; the measured batches
+// reuse them. A leak of one body per request on /big adds 64 * 4MB = 256MB of
+// RSS per measured batch. The bound sits between that signal and the noise of
+// rss(): mimalloc returns freed memory to the OS about 100ms after the free
+// (purge_delay), so one release reading can still include a batch of buffers
+// that the other reading does not. Observed post-GC deltas on /big: within
+// +-215MB in release (leak signal 1GB at 4 batches), -49MB to +29MB under ASAN,
+// whose allocator has no purge delay (leak signal 512MB at 2 batches).
+const measuredBatches = isASAN || isDebug ? 2 : 4;
+const rssDeltaBoundMB = isASAN || isDebug ? 192 : 512;
+
+export async function runStress(stress: StressServer, path: StressPath, accessBody: boolean, method: StressMethod) {
+  const expected = expectationFor(path);
+  const url = new URL(path, stress.server.url).href;
+  const headerNames = Object.keys(expected.headers);
+  const expectedResponse = {
+    status: expected.status,
+    url,
+    redirected: false,
+    headers: expected.headers,
+    bodyUsed: true,
+    body: await comparable(method === "blob" ? expected.blob : await expected.blob[method]()),
+  };
+
+  // The first mismatch rejects the batch. The responses still in flight then
+  // skip their comparison: diffing a 4MB body costs hundreds of ms per response,
+  // and 63 of them would run on into the next test.
+  let failed = false;
+
+  async function request() {
+    const res = await fetch(url);
+    if (accessBody) {
+      // Materialize the ReadableStream first; res[method]() then has to drain
+      // the stream instead of taking the buffered-body fast path.
+      expect(res.body).toBeInstanceOf(ReadableStream);
     }
-
-    await Promise.all(array);
-
-    Bun.gc();
-  }
-
-  for (let i = 0; i < iterations; i++) {
-    await iterate();
-  }
-
-  Bun.gc(true);
-  const baseline = (rss() / 1024 / 1024) | 0;
-  let lastRSS = baseline;
-  console.log("Start RSS", baseline);
-  for (let i = 0; i < iterations; i++) {
-    await iterate();
-    const rssMB = (rss() / 1024 / 1024) | 0;
-    if (lastRSS + 50 < rssMB) {
-      console.log("RSS Growth", rssMB - lastRSS);
+    const body = await comparable(await res[method]());
+    if (failed) return;
+    try {
+      expect({
+        status: res.status,
+        url: res.url,
+        redirected: res.redirected,
+        headers: pickHeaders(res.headers, headerNames),
+        bodyUsed: res.bodyUsed,
+        body,
+      }).toEqual(expectedResponse);
+    } catch (error) {
+      failed = true;
+      throw error;
     }
-    lastRSS = rssMB;
   }
-  Bun.gc(true);
 
-  const finalRSS = (rss() / 1024 / 1024) | 0;
-  const delta = finalRSS - baseline;
-  console.log("Final RSS", finalRSS);
-  console.log("Delta RSS", delta);
-  // ASAN's shadow memory + quarantine raise the absolute RSS floor.
-  expect(finalRSS).toBeLessThan(isASAN ? 6144 : 4092);
-  if (isASAN || isDebug) {
-    // With the reduced iteration count the absolute ceiling alone would miss a
-    // per-request body leak on the first /big case (4 iter * 64 * 4MB = 1GB is
-    // well under 6GB). Under ASAN the post-gc delta is stable within tens of
-    // MB, so bound it directly; release keeps 12 iterations where the ceiling
-    // is sufficient and mimalloc jitter on /big makes a tight delta flaky.
-    expect(delta).toBeLessThan(192);
+  async function batch() {
+    await Promise.all(Array.from({ length: batchSize }, request));
+    Bun.gc(true);
   }
+
+  const fallbackCallsBefore = stress.fallbackCalls;
+
+  await batch();
+  const baselineMB = rss() / 1024 / 1024;
+  for (let i = 0; i < measuredBatches; i++) {
+    await batch();
+  }
+  const deltaMB = Math.round(rss() / 1024 / 1024 - baselineMB);
+  console.log(`${path} ${method} RSS delta: ${deltaMB}MB`);
+
+  const requests = batchSize * (1 + measuredBatches);
+  expect(stress.fallbackCalls - fallbackCallsBefore).toBe(expected.servedByFallback ? requests : 0);
+  expect(deltaMB).toBeLessThan(rssDeltaBoundMB);
 }

--- a/test/js/bun/http/bun-serve-static-helpers.ts
+++ b/test/js/bun/http/bun-serve-static-helpers.ts
@@ -1,3 +1,4 @@
+import type { Server } from "bun";
 import { expect } from "bun:test";
 import { fillRepeating, isASAN, isDebug, isWindows, rss } from "harness";
 
@@ -43,80 +44,13 @@ for (const [path, response] of Object.entries(routes)) {
   static_responses[path] = await response.clone().blob();
 }
 
-const fallbackBody = "fallback";
-const fallbackBlob = new Blob([fallbackBody]);
-
-// One instance per stress file. Every request for a path without a static
-// route lands in the fetch handler, which counts it.
-export class StressServer {
-  fallbackCalls = 0;
-  readonly server = Bun.serve({
-    static: routes,
-    port: 0,
-    fetch: () => {
-      this.fallbackCalls++;
-      return new Response(fallbackBody, { status: 404 });
-    },
-  });
-
-  constructor() {
-    this.server.unref();
-  }
-
-  stop() {
-    this.server.stop(true);
-  }
-}
-
-// "/missing" has no static route: it proves that the static matcher does not
-// capture other paths under load, and that the handler count below is exact.
-export const stressPaths = ["/foo", "/big", "/foo/bar", "/missing"] as const;
+export const stressPaths = ["/foo", "/big", "/foo/bar"] as const;
 export const stressMethods = ["arrayBuffer", "blob", "bytes", "text"] as const;
 
-type StressPath = (typeof stressPaths)[number];
-type StressMethod = (typeof stressMethods)[number];
+const checkedHeaders = ["content-type", "content-length", "transfer-encoding", "x-foo", "etag"];
 
-interface PathExpectation {
-  status: number;
-  blob: Blob;
-  servedByFallback: boolean;
-  headers: Record<string, string | null>;
-}
-
-function expectationFor(path: StressPath): PathExpectation {
-  const route = (routes as Record<string, Response>)[path];
-  if (route) {
-    const blob = static_responses[path];
-    return {
-      status: 200,
-      blob,
-      servedByFallback: false,
-      headers: {
-        "content-type": route.headers.get("Content-Type"),
-        "x-foo": route.headers.get("X-Foo"),
-        "content-length": String(blob.size),
-        "transfer-encoding": null,
-        "etag": expect.stringMatching(/^"[0-9a-f]+"$/),
-      },
-    };
-  }
-
-  return {
-    status: 404,
-    blob: fallbackBlob,
-    servedByFallback: true,
-    headers: {
-      "content-type": "text/plain;charset=utf-8",
-      "x-foo": null,
-      "content-length": String(fallbackBlob.size),
-      "transfer-encoding": null,
-      "etag": null,
-    },
-  };
-}
-
-function pickHeaders(headers: Headers, names: string[]): Record<string, string | null> {
-  return Object.fromEntries(names.map(name => [name, headers.get(name)] as const));
+function pickHeaders(headers: Headers): Record<string, string | null> {
+  return Object.fromEntries(checkedHeaders.map(name => [name, headers.get(name)] as const));
 }
 
 // toEqual does not read Blob contents: two Blobs of different bytes (or sizes)
@@ -137,30 +71,40 @@ const batchSize = isWindows ? 8 : 64;
 // rss(): mimalloc returns freed memory to the OS about 100ms after the free
 // (purge_delay), so one release reading can still include a batch of buffers
 // that the other reading does not. Observed post-GC deltas on /big: within
-// +-215MB in release (leak signal 1GB at 4 batches), -49MB to +29MB under ASAN,
-// whose allocator has no purge delay (leak signal 512MB at 2 batches). The
-// 8-wide Windows batches put the signal (128MB, 64MB) under either bound, so
-// this check is only a sanity bound there. The Linux and macOS lanes cover leaks.
+// +-270MB on the release lanes (leak signal 1GB at 4 batches), within +-55MB
+// under ASAN, whose allocator has no purge delay (leak signal 512MB at 2
+// batches). The 8-wide Windows batches put the signal (128MB, 64MB) under
+// either bound, so this check is only a sanity bound there, as it was before.
 const measuredBatches = isASAN || isDebug ? 2 : 4;
 const rssDeltaBoundMB = isASAN || isDebug ? 192 : 512;
 
-export async function runStress(stress: StressServer, path: StressPath, accessBody: boolean, method: StressMethod) {
-  const expected = expectationFor(path);
-  const url = new URL(path, stress.server.url).href;
-  const headerNames = Object.keys(expected.headers);
+export async function runStress(
+  server: Server,
+  path: (typeof stressPaths)[number],
+  accessBody: boolean,
+  method: (typeof stressMethods)[number],
+) {
+  const route = routes[path];
+  const blob = static_responses[path];
+  const url = new URL(path, server.url).href;
   const expectedResponse = {
-    status: expected.status,
+    status: 200,
     url,
-    redirected: false,
-    headers: expected.headers,
+    headers: {
+      "content-type": route.headers.get("Content-Type"),
+      "content-length": String(blob.size),
+      "transfer-encoding": null,
+      "x-foo": route.headers.get("X-Foo"),
+      "etag": expect.stringMatching(/^"[0-9a-f]+"$/),
+    },
     bodyUsed: true,
-    body: await comparable(method === "blob" ? expected.blob : await expected.blob[method]()),
+    body: await comparable(method === "blob" ? blob : await blob[method]()),
   };
 
   // A batch reports its first failure once every request in it has finished.
-  // After that failure the other responses only drain their bodies: diffing a
-  // 4MB body costs hundreds of ms per response, and a request left in flight
-  // would be counted by the next case.
+  // After that failure the other responses only drain their bodies: a failing
+  // toEqual on a 4MB body takes about 0.3s in release and 16s under ASAN, so 63
+  // more of them would turn the failure into a timeout.
   let failure: { error: unknown } | undefined;
 
   async function request() {
@@ -176,8 +120,7 @@ export async function runStress(stress: StressServer, path: StressPath, accessBo
       expect({
         status: res.status,
         url: res.url,
-        redirected: res.redirected,
-        headers: pickHeaders(res.headers, headerNames),
+        headers: pickHeaders(res.headers),
         bodyUsed: res.bodyUsed,
         body,
       }).toEqual(expectedResponse);
@@ -189,10 +132,11 @@ export async function runStress(stress: StressServer, path: StressPath, accessBo
   async function batch() {
     await Promise.all(Array.from({ length: batchSize }, request));
     if (failure) throw failure.error;
+    // A static route releases its request before the last bytes reach the
+    // client (StaticRoute::on_response_complete), so nothing is pending here.
+    expect(server.pendingRequests).toBe(0);
     Bun.gc(true);
   }
-
-  const fallbackCallsBefore = stress.fallbackCalls;
 
   await batch();
   const baselineMB = rss() / 1024 / 1024;
@@ -201,8 +145,5 @@ export async function runStress(stress: StressServer, path: StressPath, accessBo
   }
   const deltaMB = Math.round(rss() / 1024 / 1024 - baselineMB);
   console.log(`${path} ${method} RSS delta: ${deltaMB}MB`);
-
-  const requests = batchSize * (1 + measuredBatches);
-  expect(stress.fallbackCalls - fallbackCallsBefore).toBe(expected.servedByFallback ? requests : 0);
   expect(deltaMB).toBeLessThan(rssDeltaBoundMB);
 }

--- a/test/js/bun/http/bun-serve-static-helpers.ts
+++ b/test/js/bun/http/bun-serve-static-helpers.ts
@@ -138,7 +138,9 @@ const batchSize = isWindows ? 8 : 64;
 // (purge_delay), so one release reading can still include a batch of buffers
 // that the other reading does not. Observed post-GC deltas on /big: within
 // +-215MB in release (leak signal 1GB at 4 batches), -49MB to +29MB under ASAN,
-// whose allocator has no purge delay (leak signal 512MB at 2 batches).
+// whose allocator has no purge delay (leak signal 512MB at 2 batches). The
+// 8-wide Windows batches put the signal (128MB, 64MB) under either bound, so
+// this check is only a sanity bound there. The Linux and macOS lanes cover leaks.
 const measuredBatches = isASAN || isDebug ? 2 : 4;
 const rssDeltaBoundMB = isASAN || isDebug ? 192 : 512;
 
@@ -155,21 +157,22 @@ export async function runStress(stress: StressServer, path: StressPath, accessBo
     body: await comparable(method === "blob" ? expected.blob : await expected.blob[method]()),
   };
 
-  // The first mismatch rejects the batch. The responses still in flight then
-  // skip their comparison: diffing a 4MB body costs hundreds of ms per response,
-  // and 63 of them would run on into the next test.
-  let failed = false;
+  // A batch reports its first failure once every request in it has finished.
+  // After that failure the other responses only drain their bodies: diffing a
+  // 4MB body costs hundreds of ms per response, and a request left in flight
+  // would be counted by the next case.
+  let failure: { error: unknown } | undefined;
 
   async function request() {
-    const res = await fetch(url);
-    if (accessBody) {
-      // Materialize the ReadableStream first; res[method]() then has to drain
-      // the stream instead of taking the buffered-body fast path.
-      expect(res.body).toBeInstanceOf(ReadableStream);
-    }
-    const body = await comparable(await res[method]());
-    if (failed) return;
     try {
+      const res = await fetch(url);
+      if (accessBody) {
+        // Materialize the ReadableStream first; res[method]() then has to drain
+        // the stream instead of taking the buffered-body fast path.
+        expect(res.body).toBeInstanceOf(ReadableStream);
+      }
+      const body = await comparable(await res[method]());
+      if (failure) return;
       expect({
         status: res.status,
         url: res.url,
@@ -179,13 +182,13 @@ export async function runStress(stress: StressServer, path: StressPath, accessBo
         body,
       }).toEqual(expectedResponse);
     } catch (error) {
-      failed = true;
-      throw error;
+      failure ??= { error };
     }
   }
 
   async function batch() {
     await Promise.all(Array.from({ length: batchSize }, request));
+    if (failure) throw failure.error;
     Bun.gc(true);
   }
 

--- a/test/js/bun/http/bun-serve-static-stress-access-body.test.ts
+++ b/test/js/bun/http/bun-serve-static-stress-access-body.test.ts
@@ -1,29 +1,23 @@
 // Stress half of bun-serve-static: body read via res[method]() *after* touching
 // res.body (materialises a ReadableStream before the buffered-read fast path).
 // Split from the sibling "-no-body" file so each half stays well inside the
-// per-file wall clock on a slow runner. Loop sizing lives in runStress.
-import type { Server } from "bun";
+// per-file wall clock on a slow runner. Loop sizing and assertions live in runStress.
 import { afterAll, beforeAll, describe, test } from "bun:test";
 import { isBroken, isMacOS } from "harness";
-import { routes, runStress, stressMethods, stressPaths } from "./bun-serve-static-helpers";
+import { runStress, stressMethods, stressPaths, StressServer } from "./bun-serve-static-helpers";
 
 describe.todoIf(isBroken && isMacOS)("static (stress, access .body)", () => {
-  let server: Server;
+  let stress: StressServer;
 
   beforeAll(() => {
-    server = Bun.serve({
-      static: routes,
-      port: 0,
-      fetch: () => new Response("fallback", { status: 404 }),
-    });
-    server.unref();
+    stress = new StressServer();
   });
 
   afterAll(() => {
-    server.stop(true);
+    stress.stop();
   });
 
   describe.each(stressPaths)("%s", path => {
-    test.each(stressMethods)("%s", method => runStress(server, path, true, method), 40 * 1000);
+    test.each(stressMethods)("%s", method => runStress(stress, path, true, method));
   });
 });

--- a/test/js/bun/http/bun-serve-static-stress-access-body.test.ts
+++ b/test/js/bun/http/bun-serve-static-stress-access-body.test.ts
@@ -1,23 +1,29 @@
 // Stress half of bun-serve-static: body read via res[method]() *after* touching
 // res.body (materialises a ReadableStream before the buffered-read fast path).
 // Split from the sibling "-no-body" file so each half stays well inside the
-// per-file wall clock on a slow runner. Loop sizing and assertions live in runStress.
+// per-file wall clock on a slow runner. Loop sizing lives in runStress.
+import type { Server } from "bun";
 import { afterAll, beforeAll, describe, test } from "bun:test";
 import { isBroken, isMacOS } from "harness";
-import { runStress, stressMethods, stressPaths, StressServer } from "./bun-serve-static-helpers";
+import { routes, runStress, stressMethods, stressPaths } from "./bun-serve-static-helpers";
 
 describe.todoIf(isBroken && isMacOS)("static (stress, access .body)", () => {
-  let stress: StressServer;
+  let server: Server;
 
   beforeAll(() => {
-    stress = new StressServer();
+    server = Bun.serve({
+      static: routes,
+      port: 0,
+      fetch: () => new Response("fallback", { status: 404 }),
+    });
+    server.unref();
   });
 
   afterAll(() => {
-    stress.stop();
+    server.stop(true);
   });
 
   describe.each(stressPaths)("%s", path => {
-    test.each(stressMethods)("%s", method => runStress(stress, path, true, method));
+    test.each(stressMethods)("%s", method => runStress(server, path, true, method));
   });
 });

--- a/test/js/bun/http/bun-serve-static-stress-no-body.test.ts
+++ b/test/js/bun/http/bun-serve-static-stress-no-body.test.ts
@@ -1,29 +1,23 @@
 // Stress half of bun-serve-static: body read via res[method]() *without* first
 // touching res.body (exercises the buffered-stream fast path added in #13704).
 // Split from the sibling "-access-body" file so each half stays well inside the
-// per-file wall clock on a slow runner. Loop sizing lives in runStress.
-import type { Server } from "bun";
+// per-file wall clock on a slow runner. Loop sizing and assertions live in runStress.
 import { afterAll, beforeAll, describe, test } from "bun:test";
 import { isBroken, isMacOS } from "harness";
-import { routes, runStress, stressMethods, stressPaths } from "./bun-serve-static-helpers";
+import { runStress, stressMethods, stressPaths, StressServer } from "./bun-serve-static-helpers";
 
 describe.todoIf(isBroken && isMacOS)("static (stress, don't access .body)", () => {
-  let server: Server;
+  let stress: StressServer;
 
   beforeAll(() => {
-    server = Bun.serve({
-      static: routes,
-      port: 0,
-      fetch: () => new Response("fallback", { status: 404 }),
-    });
-    server.unref();
+    stress = new StressServer();
   });
 
   afterAll(() => {
-    server.stop(true);
+    stress.stop();
   });
 
   describe.each(stressPaths)("%s", path => {
-    test.each(stressMethods)("%s", method => runStress(server, path, false, method), 40 * 1000);
+    test.each(stressMethods)("%s", method => runStress(stress, path, false, method));
   });
 });

--- a/test/js/bun/http/bun-serve-static-stress-no-body.test.ts
+++ b/test/js/bun/http/bun-serve-static-stress-no-body.test.ts
@@ -1,23 +1,29 @@
 // Stress half of bun-serve-static: body read via res[method]() *without* first
 // touching res.body (exercises the buffered-stream fast path added in #13704).
 // Split from the sibling "-access-body" file so each half stays well inside the
-// per-file wall clock on a slow runner. Loop sizing and assertions live in runStress.
+// per-file wall clock on a slow runner. Loop sizing lives in runStress.
+import type { Server } from "bun";
 import { afterAll, beforeAll, describe, test } from "bun:test";
 import { isBroken, isMacOS } from "harness";
-import { runStress, stressMethods, stressPaths, StressServer } from "./bun-serve-static-helpers";
+import { routes, runStress, stressMethods, stressPaths } from "./bun-serve-static-helpers";
 
 describe.todoIf(isBroken && isMacOS)("static (stress, don't access .body)", () => {
-  let stress: StressServer;
+  let server: Server;
 
   beforeAll(() => {
-    stress = new StressServer();
+    server = Bun.serve({
+      static: routes,
+      port: 0,
+      fetch: () => new Response("fallback", { status: 404 }),
+    });
+    server.unref();
   });
 
   afterAll(() => {
-    stress.stop();
+    server.stop(true);
   });
 
   describe.each(stressPaths)("%s", path => {
-    test.each(stressMethods)("%s", method => runStress(stress, path, false, method));
+    test.each(stressMethods)("%s", method => runStress(server, path, false, method));
   });
 });


### PR DESCRIPTION
### Problem
- `bun-serve-static-stress-access-body.test.ts` takes 35s on ubuntu 25.04 x64 (build 102501), `-no-body` up to 24s. `runStress` in `bun-serve-static-helpers.ts` ran 24 batches of 64 requests per case in release. A `/big` batch moves 64 x 4MB.
- Release needed that volume only for its leak check, a ceiling of `rss < 4092MB`.
- The `blob` cases never compared the body: `toStrictEqual` does not read Blobs.

### Fix
- One warm-up batch, then 4 measured batches in release and 2 under ASAN. Every build now bounds the post-GC RSS delta (512MB, 192MB). One leaked body per request adds 1GB or 512MB. Build 102617 shows `/big` deltas within +-270MB on the x64 and aarch64 release lanes, within +-55MB under ASAN.
- Each response is one `toEqual`: status, url, bodyUsed, five headers, exact body (a Blob becomes size + bytes). Each batch also asserts that `server.pendingRequests` is 0.
- The 40s per-test timeout is gone, CI passes its own. A batch finishes all of its requests, then reports its first failure. The other responses skip the diff: one failing 4MB `toEqual` takes 16s under ASAN.
- Verified back to back, access-body then no-body. `bun bd test`: 33.3s to 16.2s and 22.7s to 11.5s. Release: 32.0s to 7.3s and 21.4s to 5.8s. `bun-serve-static.test.ts`, which imports the helper, passes.

### Background
- A static route serves a `Response` snapshot taken at `Bun.serve({ static })`. `/big` is 4MB so that the first `send()` short-writes and the route takes its backpressure path.
- `StaticRoute::on_response_complete` releases the request when the kernel accepts the last write, before the client can read it. So `pendingRequests` is exact right after a batch, without polling.
- The access-body half reads `res.body` first, which creates a `ReadableStream`. `res[method]()` then drains it instead of taking the buffered fast path (#13704).
- mimalloc returns freed memory to the OS about 100ms after the free (`purge_delay`), so an `rss()` reading right after a batch can still include that batch. ASAN's allocator has no such delay.

<details><summary>Notes</summary>

Supersedes #35715, which cut the ASAN count to 2+2 and left release at 12+12.

History of this PR: fd4307e also added a `/missing` path with a fetch handler counter, through a `StressServer` wrapper in both test files. A self-review pointed out that `bun-serve-static.test.ts` already asserts the handler count and the fallback path with single requests, and that the 4 extra cases per file cost about 1.6s per file under ASAN. 8c546d3 removes them. The two test files now differ from main by the deleted timeout argument only. 693ec99 (review feedback) made a batch finish before it reports a failure.

Timing context: load average 33 to 40 during the four measurements above. Per case after the change, release: `/big` 1.2s to 1.9s, every other case under 20ms. Debug: `/big` 2.3s to 3.1s, every other case about 0.4s. The `/big` cases are the remaining cost. 3 batches (ASAN) is the minimum for a warm-up plus a delta.

Assertion changes in `runStress`, old to new:
- Old: status 200, `res.url`, Content-Length, body through `toStrictEqual` (a no-op for `blob`). New: one `toEqual` on `{ status, url, headers, bodyUsed, body }`. `headers` holds content-type, content-length, transfer-encoding (null), x-foo and etag (`expect.stringMatching(/^"[0-9a-f]+"$/)`). `body` is the exact ArrayBuffer, Uint8Array or string, or `{ size, bytes }` for a Blob.
- New: `res.body` is a `ReadableStream` in the access-body half.
- New: `server.pendingRequests` is 0 after every batch.
- RSS: the release ceiling `rss < 4092MB` is replaced by the delta bound. The ASAN bound of 192MB is unchanged.
- Removed: the 40s per-test timeout.

`Blob.type` is not compared. For `/big`, which has no content-type header, the buffered path returns a Blob of type `text/plain;charset=utf-8` and the stream path returns `""`. That is a `Response.blob()` difference, not a static route one, so these files pin neither value.

RSS bound data. Local release, `/big`, reading right after `Bun.gc(true)`: -177MB to +144MB in 48 samples of a noise harness, -215MB to +213MB across 80 `/big` cases of 20 file runs. Two or three `Bun.gc(true)` calls in a row, or 8 small requests before the reading, do not shrink the spread. A 250ms sleep before the reading shrinks it to -5MB to +11MB, which points at the purge delay. The test does not sleep, it uses the bound. A simulated leak (every body kept) measured +1021MB to +1044MB at 4 batches and +504MB to +525MB at 2. `bun bd` (ASAN): -49MB to +30MB in 24 samples plus 10 file runs, simulated leak +516MB and +672MB. CI build 102617 (the fd4307e shape, same loop): ubuntu x64 -269MB to +154MB, ubuntu aarch64 -192MB to +166MB, debian x64-asan -55MB to +23MB, windows x64 and aarch64 -56MB to +30MB. The 8-wide Windows batch cannot reach either bound with a leak (128MB or 64MB of signal), as it could not reach the old ceiling. The helper comment says so.

The RSS delta measures the fetch client's body buffers. The server serves every request from one shared blob (`StaticRoute.rs`), so the server side cannot leak whole bodies. The `pendingRequests` assertion is the server-side check. Whether the two stress files should fold into one `/big` test in `bun-serve-static.test.ts` is a separate decision for the owners. This PR keeps every path x method x body-access cell, as the task asked.

The cases stay sequential. Each `/big` case holds 64 connections, half of the macOS backlog, and measures RSS, so a concurrent `/big` case would add its buffers to the reading of another. The 8 other cases take under 20ms each in release.

`test/expected-durations.json` is not touched, the periodic regeneration picks up the new times.

Also run: `test/js/bun/http/bun-serve-static.test.ts` under `bun bd` (46 pass), prettier with the repo config on the three files, and a run with a deliberately wrong expected content-length (12 failures, one diff each, 2.4s).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->