### PR TITLE
test(request): make request-clone-leak.test.ts 5x faster and assert the requests work

### DIFF
--- a/test/js/web/request/request-clone-leak.test.ts
+++ b/test/js/web/request/request-clone-leak.test.ts
@@ -1,114 +1,113 @@
+import { gcAndSweep } from "bun:jsc";
 import { expect, test } from "bun:test";
-import { isASAN, rss } from "harness";
+import { isASAN, isDebug, rss } from "harness";
 
-const ASAN_MULTIPLIER = isASAN ? 1 / 10 : 1;
+const MB = 1024 * 1024;
 
-const constructorArgs = [
-  [
-    new Request("http://foo/", {
-      body: "ahoyhoy",
-      method: "POST",
-    }),
-  ],
-  [
-    "http://foo/",
-    {
-      body: "ahoyhoy",
-      method: "POST",
-    },
-  ],
-  [
-    new URL("http://foo/"),
-    {
-      body: "ahoyhoy",
-      method: "POST",
-    },
-  ],
-  [
-    new Request("http://foo/", {
-      body: "ahoyhoy",
-      method: "POST",
-      headers: {
-        "test-header": "value",
-      },
-    }),
-  ],
-  [
-    "http://foo/",
-    {
-      body: "ahoyhoy",
-      method: "POST",
-      headers: {
-        "test-header": "value",
-      },
-    },
-  ],
-  [
-    new URL("http://foo/"),
-    {
-      body: "ahoyhoy",
-      method: "POST",
-      headers: {
-        "test-header": "value",
-      },
-    },
-  ],
-];
-for (let i = 0; i < constructorArgs.length; i++) {
-  const args = constructorArgs[i];
-  test("new Request(test #" + i + ")", () => {
-    Bun.gc(true);
+// This file guards the leak fixed in #12387: `new Request(request)` orphaned the
+// body slot that the constructor allocates before it copies the input. The slot
+// is a 184 byte `HiveRef<Body.Value>` in release builds (400 bytes in debug
+// builds), which mimalloc serves from its 192 byte class. A build with the bug
+// therefore grows by `iterations * 192` bytes during the measured loop.
+const leakedBytesPerIteration = 192;
 
-    for (let i = 0; i < 1000 * ASAN_MULTIPLIER; i++) {
+// Release builds run the full loop. The leak above grows RSS by 18 MB. A clean
+// run grows by 0 MB, give or take 1 MB of allocator jitter, so a limit of half
+// the leak keeps a wide margin on both sides.
+//
+// Debug builds construct a Request about 100x slower than release, and ASAN's
+// quarantine keeps every block the loop frees resident, so RSS cannot separate
+// a 192 byte per iteration leak from the noise there. Those builds run a short
+// loop, and the RSS check is only a backstop for gross leaks (a clean run grows
+// by 0 to 3 MB). LeakSanitizer reports the small leaks on the ASAN lane: the
+// loops below leak about 8000 slots on a build with the bug.
+const shortLoop = isDebug || isASAN;
+const iterations = shortLoop ? 1_000 : 100_000;
+const gcEvery = shortLoop ? 250 : 5_000;
+const maxGrowth = shortLoop ? 16 * MB : (iterations * leakedBytesPerIteration) / 2;
+
+const url = "http://foo/";
+const method = "POST";
+const body = "ahoyhoy";
+
+const cases: {
+  name: string;
+  args: ConstructorParameters<typeof Request>;
+  headers: [string, string][];
+}[] = [];
+
+for (const headers of [[], [["test-header", "value"]]] as [string, string][][]) {
+  const init: RequestInit = { body, method };
+  if (headers.length > 0) init.headers = headers;
+  const suffix = headers.length > 0 ? " with headers" : "";
+  cases.push(
+    { name: `new Request(request)${suffix}`, args: [new Request(url, init)], headers },
+    { name: `new Request(string, init)${suffix}`, args: [url, init], headers },
+    { name: `new Request(URL, init)${suffix}`, args: [new URL(url), init], headers },
+  );
+}
+
+function churn(construct: () => void, count: number) {
+  for (let i = 0; i < count; i++) construct();
+}
+
+// The JIT tiers `churn` up once per process. The compiler threads and code
+// pages this brings in add 6 to 11 MB of RSS on a debug build, and they would
+// land in whichever loop happens to be running. Pay for them before the first
+// baseline is taken.
+churn(() => {}, 1_000_000);
+
+// gcAndSweep() frees every dead Request before it returns, and unlike Bun.gc()
+// it neither deletes the JIT code (which would recompile `churn` in every batch)
+// nor purges the allocator, so RSS stays a plain high-water mark.
+function rssAfterChurn(construct: () => void) {
+  for (let done = 0; done < iterations; done += gcEvery) {
+    churn(construct, gcEvery);
+    gcAndSweep();
+  }
+  return rss();
+}
+
+// The warm-up runs the exact workload that is measured afterwards, so the
+// allocator and the JS heap reach their high-water mark before the baseline is
+// taken. Only memory that the second run does not free shows up in the delta.
+function expectNoRssGrowth(construct: () => void) {
+  const before = rssAfterChurn(construct);
+  const growth = rssAfterChurn(construct) - before;
+
+  expect(
+    growth,
+    `RSS grew by ${(growth / MB).toFixed(1)} MB over ${iterations} iterations, the limit is ${(maxGrowth / MB).toFixed(1)} MB`,
+  ).toBeLessThan(maxGrowth);
+}
+
+for (const { name, args, headers } of cases) {
+  test(`${name}: construction does not leak`, async () => {
+    const request = new Request(...args);
+    expect({
+      url: request.url,
+      method: request.method,
+      headers: [...request.headers],
+      body: await request.text(),
+    }).toEqual({ url, method, headers, body });
+
+    expectNoRssGrowth(() => {
       new Request(...args);
-    }
-
-    Bun.gc(true);
-    const baseline = (rss() / 1024 / 1024) | 0;
-    for (let i = 0; i < 2000 * ASAN_MULTIPLIER; i++) {
-      for (let j = 0; j < 500; j++) {
-        new Request(...args);
-      }
-      Bun.gc();
-    }
-    Bun.gc(true);
-
-    const memory = (rss() / 1024 / 1024) | 0;
-    const delta = Math.max(memory, baseline) - Math.min(baseline, memory);
-    console.log("RSS delta: ", delta, "MB");
-    // ASAN's quarantine and redzones retain freed pages so RSS over-reports
-    // even when nothing leaks; CI samples show 30-50 MB delta with ASAN's 1/10
-    // iteration multiplier vs <10 MB native. The unfixed leak presents as
-    // 100+ MB so 64 MB still catches it.
-    expect(delta).toBeLessThan(isASAN ? 64 : 30);
+    });
   });
 
-  test("request.clone(test #" + i + ")", () => {
-    Bun.gc(true);
+  test(`${name}: request.clone() does not leak`, async () => {
+    const request = new Request(...args);
+    const clone = request.clone();
+    expect({
+      url: clone.url,
+      method: clone.method,
+      headers: [...clone.headers],
+      bodies: await Promise.all([request.text(), clone.text()]),
+    }).toEqual({ url, method, headers, bodies: [body, body] });
 
-    for (let i = 0; i < 1000 * ASAN_MULTIPLIER; i++) {
-      const request = new Request(...args);
-      request.clone();
-    }
-
-    Bun.gc(true);
-    const baseline = (rss() / 1024 / 1024) | 0;
-    for (let i = 0; i < 2000 * ASAN_MULTIPLIER; i++) {
-      for (let j = 0; j < 500 * ASAN_MULTIPLIER; j++) {
-        const request = new Request(...args);
-        request.clone();
-      }
-      Bun.gc();
-    }
-    Bun.gc(true);
-
-    const memory = (rss() / 1024 / 1024) | 0;
-    const delta = Math.max(memory, baseline) - Math.min(baseline, memory);
-    console.log("RSS delta: ", delta, "MB");
-    // ASAN's quarantine and redzones retain freed pages so RSS over-reports
-    // even when nothing leaks; CI samples show 30-50 MB delta with ASAN's 1/10
-    // iteration multiplier vs <10 MB native. The unfixed leak presents as
-    // 100+ MB so 64 MB still catches it.
-    expect(delta).toBeLessThan(isASAN ? 64 : 30);
+    expectNoRssGrowth(() => {
+      new Request(...args).clone();
+    });
   });
 }

--- a/test/js/web/request/request-clone-leak.test.ts
+++ b/test/js/web/request/request-clone-leak.test.ts
@@ -1,4 +1,3 @@
-import { gcAndSweep } from "bun:jsc";
 import { expect, test } from "bun:test";
 import { isASAN, isDebug, rss } from "harness";
 
@@ -20,7 +19,9 @@ const leakedBytesPerIteration = 192;
 // a 192 byte per iteration leak from the noise there. Those builds run a short
 // loop, and the RSS check is only a backstop for gross leaks (a clean run grows
 // by 0 to 3 MB). LeakSanitizer reports the small leaks on the ASAN lane: the
-// loops below leak about 8000 slots on a build with the bug.
+// loops below leak about 8000 slots on a build with the bug. That report is only
+// attributed to this file when it runs on its own, which is why the file is in
+// test/parallel-denylist.txt.
 const shortLoop = isDebug || isASAN;
 const iterations = shortLoop ? 1_000 : 100_000;
 const gcEvery = shortLoop ? 250 : 5_000;
@@ -32,46 +33,57 @@ const body = "ahoyhoy";
 
 const cases: {
   name: string;
-  args: ConstructorParameters<typeof Request>;
-  headers: [string, string][];
+  testHeader: string | null;
+  // Returns a new constructor each time. A constructor may carry state, so the
+  // functional check and the measured loop of a test each take their own.
+  makeConstruct: () => () => Request;
 }[] = [];
 
-for (const headers of [[], [["test-header", "value"]]] as [string, string][][]) {
+for (const testHeader of [null, "value"]) {
   const init: RequestInit = { body, method };
-  if (headers.length > 0) init.headers = headers;
-  const suffix = headers.length > 0 ? " with headers" : "";
+  if (testHeader !== null) init.headers = { "test-header": testHeader };
+  const urlObject = new URL(url);
+  const suffix = testHeader === null ? "" : " with headers";
   cases.push(
-    { name: `new Request(request)${suffix}`, args: [new Request(url, init)], headers },
-    { name: `new Request(string, init)${suffix}`, args: [url, init], headers },
-    { name: `new Request(URL, init)${suffix}`, args: [new URL(url), init], headers },
+    {
+      name: `new Request(request)${suffix}`,
+      testHeader,
+      // Each request is built from the previous one. This works whether
+      // `new Request(request)` tees the input body, as it does today, or moves
+      // it, as the fetch spec says. One shared input would only work with tee.
+      makeConstruct: () => {
+        let input = new Request(url, init);
+        return () => (input = new Request(input));
+      },
+    },
+    { name: `new Request(string, init)${suffix}`, testHeader, makeConstruct: () => () => new Request(url, init) },
+    { name: `new Request(URL, init)${suffix}`, testHeader, makeConstruct: () => () => new Request(urlObject, init) },
   );
 }
 
-function churn(construct: () => void, count: number) {
+function churn(construct: () => unknown, count: number) {
   for (let i = 0; i < count; i++) construct();
 }
 
-// The JIT tiers `churn` up once per process. The compiler threads and code
-// pages this brings in add 6 to 11 MB of RSS on a debug build, and they would
-// land in whichever loop happens to be running. Pay for them before the first
+// The first hot loop in the process makes the JIT compile `churn` and start its
+// compiler threads. That adds 6 to 11 MB of RSS on a debug build, and it would
+// land in whichever loop happens to be running. Pay for it before the first
 // baseline is taken.
 churn(() => {}, 1_000_000);
 
-// gcAndSweep() frees every dead Request before it returns, and unlike Bun.gc()
-// it neither deletes the JIT code (which would recompile `churn` in every batch)
-// nor purges the allocator, so RSS stays a plain high-water mark.
-function rssAfterChurn(construct: () => void) {
+function rssAfterChurn(construct: () => unknown) {
   for (let done = 0; done < iterations; done += gcEvery) {
     churn(construct, gcEvery);
-    gcAndSweep();
+    Bun.gc(true);
   }
   return rss();
 }
 
-// The warm-up runs the exact workload that is measured afterwards, so the
-// allocator and the JS heap reach their high-water mark before the baseline is
-// taken. Only memory that the second run does not free shows up in the delta.
-function expectNoRssGrowth(construct: () => void) {
+// The warm-up runs the exact workload that is measured afterwards, and both
+// readings are taken at the same point of that sequence, right after a full
+// collection. The allocator and the JS heap reach their steady state during the
+// warm-up, so the delta is memory that the second run allocated and did not free.
+function expectNoRssGrowth(construct: () => unknown) {
   const before = rssAfterChurn(construct);
   const growth = rssAfterChurn(construct) - before;
 
@@ -81,33 +93,33 @@ function expectNoRssGrowth(construct: () => void) {
   ).toBeLessThan(maxGrowth);
 }
 
-for (const { name, args, headers } of cases) {
+// The functional checks look up the one header the case sets rather than
+// listing every header, so they do not depend on which headers Bun adds for a
+// string body on its own.
+for (const { name, testHeader, makeConstruct } of cases) {
   test(`${name}: construction does not leak`, async () => {
-    const request = new Request(...args);
+    const request = makeConstruct()();
     expect({
       url: request.url,
       method: request.method,
-      headers: [...request.headers],
+      testHeader: request.headers.get("test-header"),
       body: await request.text(),
-    }).toEqual({ url, method, headers, body });
+    }).toEqual({ url, method, testHeader, body });
 
-    expectNoRssGrowth(() => {
-      new Request(...args);
-    });
+    expectNoRssGrowth(makeConstruct());
   });
 
   test(`${name}: request.clone() does not leak`, async () => {
-    const request = new Request(...args);
+    const request = makeConstruct()();
     const clone = request.clone();
     expect({
       url: clone.url,
       method: clone.method,
-      headers: [...clone.headers],
+      testHeader: clone.headers.get("test-header"),
       bodies: await Promise.all([request.text(), clone.text()]),
-    }).toEqual({ url, method, headers, bodies: [body, body] });
+    }).toEqual({ url, method, testHeader, bodies: [body, body] });
 
-    expectNoRssGrowth(() => {
-      new Request(...args).clone();
-    });
+    const construct = makeConstruct();
+    expectNoRssGrowth(() => construct().clone());
   });
 }

--- a/test/parallel-denylist.txt
+++ b/test/parallel-denylist.txt
@@ -164,6 +164,7 @@ js/web/explicit-resource-management.test.ts
 js/web/fetch/fetch-proxy-tls-intern-race.test.ts
 js/web/fetch/fetch-tls-abortsignal-timeout.test.ts
 js/web/fetch/utf8-bom.test.ts
+js/web/request/request-clone-leak.test.ts
 js/web/streams/streams-leak.test.ts
 js/web/workers/worker-late-completion.test.ts
 js/web/workers/worker-terminate-funnels.test.ts


### PR DESCRIPTION
### Problem
- `request-clone-leak.test.ts` takes 20s on the slowest CI lane: 12 tests, each 1,000,000 constructions and 2,000 `Bun.gc()` calls.
- A debug ASAN build fails it: timeouts, and a clean run read 65 MB against the 64 MB limit.
- Nothing checks that the requests or clones work.

### Fix
- Each test warms up with the workload it then measures: 100,000 iterations (1,000 on debug and ASAN builds), `Bun.gc(true)` every 5,000. A no-op loop at load time pays the JIT's one-time cost first.
- The slot that #12387 leaked costs 192 bytes per iteration in release: a leaking build grows by 18 MB, the limit is 9 MB. Clean runs read 0 MB, give or take 1 MB (96 readings).
- ASAN's quarantine hides such a leak from RSS. There the limit is a 16 MB backstop and LeakSanitizer detects the slots (7,748 allocations with the leak re-created). The parallel batch does not attribute that report to a file, so the file goes into `parallel-denylist.txt`.
- Each test first asserts url, method, the header the case sets, and the body text with one `toEqual`. Clone tests read both bodies. The `new Request(request)` cases build each request from the previous one, so they still work once the constructor moves the body (#35858). Verified: CI builds 102774 and 102780 run the file in 0.7s to 2.7s on every lane (windows aarch64 2.7s, was 20s). Locally, `bun bd test` went from 135s with 6 failures to 10.1s with 12 passes.

### Background
- `new Request()` allocates a body slot (a 184 byte `HiveRef<Body::Value>`) before it reads its arguments. With a Request argument, `clone_into` replaces it. #12387 made the constructor release the first one.
- One warm-up run brings the allocator and the JS heap to a steady state. Both readings follow a full collection, so the delta is what the second run did not free.
- The asan lane sets `detect_leaks=1` for a file that runs alone (`scripts/runner.node.mjs:907`). The parallel batch only blames files with failing test cases (`:1058`).
- The generic part of this file could become a harness helper. That is a follow-up. This PR stays scoped to the slow file.

<details><summary>Notes</summary>

Timings were taken on a shared 16 core box with a load average of 40 to 75, so they are upper bounds.

Before:

```
USE_SYSTEM_BUN=1 bun test test/js/web/request/request-clone-leak.test.ts   12 pass, 16.48s (sys time 15.5s: Bun.gc() purges mimalloc on every call, 24,000 calls per file)
bun bd test test/js/web/request/request-clone-leak.test.ts                 6 pass 6 fail, 133s and 140s in two runs
```

The debug failures were the construction tests timing out after 5s (17s to 35s each at 100,000 iterations) and `new Request(test #1)` reading a 65 MB delta on a clean build.

After (current revision):

```
USE_SYSTEM_BUN=1 bun test ...   12 pass, 2.62s to 2.89s over 8 runs
bun bd test ...                 12 pass, 9.8s to 10.3s over 4 runs
```

CI durations of this revision, two builds (102774 and 102780, all lanes 12 pass), with the numbers from the slow-test sweep for the old file in parentheses:

```
windows 11 aarch64   2.64s / 2.66s  (20s)        alpine 3.23 aarch64   2.46s / 2.37s  (13s)
windows 2019 x64     2.17s / 2.29s  (13s)        alpine 3.23 x64       1.95s / 1.92s
ubuntu 25.04 aarch64 2.16s / 2.01s  (12s)        debian 13 x64         1.78s / 1.65s  (8s to 10s)
debian 13 aarch64    2.06s / 2.02s  (12s)        ubuntu 25.04 x64      1.68s / 1.90s  (8s to 10s)
debian 13 x64-asan   0.70s / 0.71s  (10s)
```

The darwin PR lanes skip files whose recorded duration is above 10s, and `test/expected-durations.json` still carries the old 13.7s, so they did not run the file in this build. That entry is regenerated from CI, not edited by hand.

Growth readings (KB) from a copy of the file that logs the delta. Release, 8 runs of 12 tests: between -2816 and +1024. Debug ASAN, 4 runs: between -1024 and +3084, limit 16384.

Leak size. `cargo check -p bun_runtime --release` with a const array probe reports `size_of::<HiveRef<Value>>() == 184` (`Value` is 168, its largest variant is `ValueError`). On the debug build it is 400, because `Blob` is 376 bytes there (104 in release). mimalloc's size classes between 128 and 256 bytes are 160, 192, 224 and 256, so the slot is served as 192 bytes. 100,000 iterations therefore leak 18.3 MiB. The first 254 slots come from the pool and cost nothing.

Re-created leak. I removed the seed slot recovery in the `cleanup` closure of `Request::construct_into` (`src/runtime/webcore/Request.rs:1017`), rebuilt the debug binary and ran this revision of the file:

```
plain environment:                                         12 pass (the 16 MB backstop does not see 1,000 x 512 bytes, as the file says)
BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=...detect_leaks=1 LSAN_OPTIONS=...leaksan.supp (what scripts/runner.node.mjs:907 sets for this file):
  SUMMARY: AddressSanitizer: 3099200 byte(s) leaked in 7748 allocation(s), exit 134
```

7,748 is the 4 `new Request(request)` tests times (1 + 2 x 1,000) chained constructions, minus the pooled slots. Every allocation stack ends in `Request::construct_into` at `Request.rs:988`. The source was restored and rebuilt afterwards, and the clean build passes in the same environment.

Release cross-check without a release rebuild: a copy of the file that keeps every constructed request in an array fails all 12 tests with 38 MB to 52 MB of growth (about 415 bytes of RSS per retained request, measured separately as a linear 414 bytes per object slope) against the 9.2 MB limit.

Trade-off made on purpose: the old file also caught the leak through RSS on the asan lane (about 51 MB of leak on top of 45 MB to 65 MB of quarantine growth, against a 64 MB limit, which is also why it read 65 MB on a clean build). The new file relies on LeakSanitizer there and keeps RSS detection on the 10 release lanes. The runner enables LeakSanitizer for this file (it is not in `test/no-validate-leaksan.txt`) and turns a report into a `leak` failure at `scripts/runner.node.mjs:1628`. In the parallel batch the report is not attributed to any file (`:1056` to `:1060` only look at junit failure counts), and this speed-up would have made the file eligible for the batch at the next allowlist regeneration (it is in `excludeFiles` of `parallel-allowlist.json` only through the 15s asan duration rule). Hence the `parallel-denylist.txt` line. #36867 (open) adds the same line. A plain `bun bd test` run has `detect_leaks=0` (`src/bun_bin/lib.rs:84`), so a local run of a leaking debug build only fails through the runner or with `ASAN_OPTIONS=detect_leaks=1`.

GC primitive. The first revision used `gcAndSweep()` from `bun:jsc` and claimed that `Bun.gc(true)` would recompile the loop in every batch. That was wrong: `deleteAllUnlinkedCodeBlocks` leaves the linked code of live functions alone, and a compile log shows the same compiles with both. Interleaved runs of the two (6 each, 12 cases each) both read a maximum of +1 MB, so this revision uses `Bun.gc(true)` like the other leak tests.

JIT warm-up. Without the no-op loop, `/proc/self/smaps` showed 4 to 5 MB of new resident pages in the `bun-debug` mapping plus 1 to 4 MB of anonymous memory when the loop function tiered up, and at 1,000 iterations that landed in the measured loop of the 7th test in 4 of 4 runs (9 to 11 MB readings). The warm-up moves it before the first test.

Functional checks. They look up `test-header` rather than comparing the whole header list, because #33677 (open) changes which headers a string body adds. The `new Request(request)` cases chain (each request is built from the previous one) so that they keep working when #35858 makes the constructor move the input body. Both open PRs touch the old version of this file and will need a small rebase on top of this one.

Other suites with the debug build: `request.test.ts` and `request-subclass.test.ts` pass, `body-clone.test.ts` passes (63 tests), `test/internal/parallel-allowlist.test.ts` passes. `request-method-getter.test.ts` hits the 5s timeout in all 6 of its tests on this debug ASAN build with or without this change (its loops run 512k iterations). It is unrelated and not touched here.

Follow-up, not in this PR: about 25 leak tests share the old file's shape (`Bun.gc(true)` plus `rss()` plus a hand-picked MB bound). The warm-up, batching and leak-size-derived limit here are generic and could move into `test/harness.ts` next to `rss()`. This PR keeps to the one slow file it was opened for.

</details>
