### PR TITLE
test(proxy-stress-concurrent): 300 probe iterations everywhere, exact assertions

### DIFF
--- a/test/js/bun/http/proxy-stress-concurrent.test.ts
+++ b/test/js/bun/http/proxy-stress-concurrent.test.ts
@@ -5,13 +5,19 @@
  * host:port, proxy_auth_hash, established_with_reject_unauthorized), and
  * there is one pool per TLS context: the default one plus one per `tls`
  * option that needs its own context (ca / cert / key ...). These tests churn
- * those pools: many parallel requests to one target, many targets through one
- * proxy, reuse out of both kinds of context, interleaved aborts, and a
- * subprocess leak probe that watches RSS over thousands of iterations.
+ * those pools: a subprocess leak probe per (proxy flavour, mode) cell, many
+ * parallel requests to one target, many targets through one proxy, reuse out
+ * of both kinds of context, and interleaved aborts.
+ *
+ * Every test builds its own proxy and origin, so every test is
+ * `test.concurrent`; the file-level hooks only clear the ambient proxy
+ * environment once. The proxy records one entry per accepted connection, and
+ * the number of connections a scenario opens is the property under test here,
+ * so the tests assert the exact connection list rather than a count.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isCI, isMacOS, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import { once } from "node:events";
 import net from "node:net";
 import { join } from "node:path";
@@ -36,16 +42,139 @@ afterAll(() => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Parallel requests to one origin through one proxy.
+// Subprocess leak / UAF probe: one child per (proxy flavour, mode) cell, each
+// running ITERATIONS fetch (and abort) cycles through a CONNECT proxy to an
+// https origin. proxy-stress-memory-fixture.ts documents the summary line it
+// prints. A bug shows up as:
+//   - a crash (UAF under ASAN, debug assert, segfault): stderr + exit code;
+//   - an object that is never freed: on the ASAN lanes the runner turns
+//     LeakSanitizer on for this file, and the child inherits that, so the
+//     report lands in stderr and the child exits non-zero after the very
+//     first leaked object;
+//   - a tunnel that is never released, reachable or not: each tunnel owns one
+//     SSL_CTX, so `sslCtxGrowth` comes back as one per request made after the
+//     warm-up (200 and more per cell) in every build;
+//   - anything else that grows per request: `rssGrowth`, release builds only.
+// None of these get more sensitive with more iterations; the abort modes only
+// get more samples of their race. 300 is the count the ASAN lanes (the ones
+// that would catch a UAF) have always run, and the most macOS and Windows can
+// take: they have 16k ephemeral ports, and every request leaves 2 loopback
+// connections in TIME_WAIT across 12 concurrent children (#33898, #33941).
+// The count is part of the expected outcomes below, so it is the same
+// everywhere.
+//
+// This block comes first in the file on purpose: under ASAN `bun test` runs
+// at most 5 tests at a time and these children are the long pole, so they
+// take the slots first and the in-process tests below fill in as they exit.
+// The slowest modes are listed first for the same reason.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("memory probe (subprocess)", () => {
+  const ITERATIONS = 300;
+  const HALF = ITERATIONS / 2;
+
+  type Outcome = { completed: number; failed: number; errors: Record<string, number> };
+  const allComplete: Outcome = { completed: ITERATIONS, failed: 0, errors: {} };
+  const allAborted: Outcome = { completed: 0, failed: ITERATIONS, errors: { AbortError: ITERATIONS } };
+
+  // `connects` is the number of CONNECT requests the child's proxy saw. A
+  // request aborted on the microtask after fetch() races the HTTP thread to
+  // the proxy, so for those two modes only the bounds are fixed (observed:
+  // anywhere from none to 98% of the aborted requests reach the proxy,
+  // depending on the build and on whether the proxy itself is TLS).
+  const EXPECTED: Record<string, { outcome: Outcome; connects: number | [min: number, max: number] }> = {
+    // Origin redirects once per request; keepalive is off, so each hop is its own tunnel.
+    "redirect": { outcome: allComplete, connects: 2 * ITERATIONS },
+    "complete": { outcome: allComplete, connects: ITERATIONS },
+    "concurrent-32": { outcome: allComplete, connects: ITERATIONS },
+    // 32 in flight, the odd-numbered half aborted on the next microtask.
+    "concurrent-32-abort": {
+      outcome: { completed: HALF, failed: HALF, errors: { AbortError: HALF } },
+      connects: [HALF, ITERATIONS],
+    },
+    // Aborted once the proxy has read the CONNECT head: exactly one CONNECT each.
+    "abort-after-connect": { outcome: allAborted, connects: ITERATIONS },
+    "abort-immediate": { outcome: allAborted, connects: [0, ITERATIONS] },
+  };
+
+  for (const { mode, proxyTls } of cartesian({
+    mode: Object.keys(EXPECTED),
+    proxyTls: [true, false] as const,
+  })) {
+    test.concurrent(
+      `${proxyTls ? "https" : "http"}-proxy → https-origin mode=${mode} ×${ITERATIONS}`,
+      async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            join(import.meta.dir, "proxy-stress-memory-fixture.ts"),
+            proxyTls ? "https" : "http",
+            mode,
+            String(ITERATIONS),
+          ],
+          env: {
+            ...bunEnv,
+            ...proxyFreeEnv,
+            TLS_CERT: tlsCert.cert,
+            TLS_KEY: tlsCert.key,
+            // UAFs on the HTTP thread must abort the process rather
+            // than race the main thread's clean exit.
+            ASAN_OPTIONS: (bunEnv.ASAN_OPTIONS ?? "") + ":abort_on_error=1:halt_on_error=1",
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        // Anything on stderr is a crash, a sanitizer report, or a fixture
+        // error; asserting it first puts the actual report in the failure.
+        expect(stderr).toBe("");
+        const { connects, sslCtxGrowth, rssGrowth, ...outcome } = JSON.parse(stdout);
+
+        const want = EXPECTED[mode];
+        expect(outcome).toEqual(want.outcome);
+        if (typeof want.connects === "number") {
+          expect(connects).toBe(want.connects);
+        } else {
+          expect(connects).toBeWithin(want.connects[0], want.connects[1] + 1);
+        }
+
+        // Steady state is 0 (the fixture waits for the last tunnel's context
+        // to be freed). A tunnel that is never released adds one per request
+        // made after the warm-up: 200 and more per cell, twice that in
+        // redirect mode.
+        expect(sslCtxGrowth).toBeLessThanOrEqual(2);
+
+        // RSS growth over the 200-odd requests after the warm-up. On a
+        // release build every cell measures 0 to 9 MB of allocator and JIT
+        // creep; 32 MB trips on anything from about 150 KB per request up,
+        // such as a response or TLS buffer kept per request. Per-request
+        // leaks of a few KB are what LeakSanitizer and `sslCtxGrowth` are
+        // for. Under ASAN freed memory sits in the quarantine, so RSS says
+        // nothing there.
+        if (!isASAN) expect(rssGrowth).toBeLessThan(32 * 1024 * 1024);
+
+        expect(exitCode).toBe(0);
+      },
+      120_000,
+    );
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parallel requests to one origin through one proxy. All N are dispatched
+// before the proxy (which runs on this thread) can relay anything, so none of
+// them can reuse a pooled connection: the proxy must see exactly N
+// connections, whatever the keepalive setting.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("parallel requests, single origin", () => {
+  const N = 32;
   for (const { proxyTls, originTls, keepalive } of cartesian({
     proxyTls: [false, true] as const,
     originTls: [false, true] as const,
     keepalive: [false, true] as const,
   })) {
-    const N = 32;
     test.concurrent(
       `${N}× parallel ${proxyTls ? "https" : "http"}-proxy → ${originTls ? "https" : "http"}-origin keepalive=${keepalive}`,
       async () => {
@@ -69,16 +198,11 @@ describe("parallel requests, single origin", () => {
           ),
         );
 
-        // Every request got its own response body back — no cross-talk.
-        for (let i = 0; i < N; i++) {
-          expect(results[i]).toEqual({ status: 200, body: String(i) });
-        }
-
-        // All traffic went through the proxy.
-        expect(proxy.connections.length).toBeGreaterThanOrEqual(1);
-        if (originTls) {
-          expect(proxy.connections.every(c => c.method === "CONNECT")).toBe(true);
-        }
+        // Every request got its own response body back: no cross-talk.
+        expect(results).toEqual(Array.from({ length: N }, (_, i) => ({ status: 200, body: String(i) })));
+        // All N went through the proxy: CONNECT tunnels to an https origin,
+        // absolute-form requests to an http one.
+        expect(proxy.connections.map(c => c.method)).toEqual(Array(N).fill(originTls ? "CONNECT" : "GET"));
       },
       30_000,
     );
@@ -94,47 +218,57 @@ describe("parallel requests, single origin", () => {
 
 describe("tunnel reuse", () => {
   for (const proxyTls of [false, true] as const) {
-    test(`${proxyTls ? "https" : "http"}-proxy → https-origin, 5 sequential requests reuse one CONNECT`, async () => {
-      await using origin = Bun.serve({
-        port: 0,
-        tls: tlsCert,
-        fetch: () => new Response("reused"),
-      });
-      await using proxy = await createAdversarialProxy({ tls: proxyTls });
-
-      for (let i = 0; i < 5; i++) {
-        const res = await fetch(origin.url, { proxy: proxy.url, keepalive: true, tls: laxTls });
-        expect(await res.text()).toBe("reused");
-        expect(res.status).toBe(200);
-      }
-      // laxTls carries a `ca`, so the connection to the proxy lives in that
-      // config's own TLS context. The finished tunnel must be pooled into
-      // that same context (where the next request looks for it), so a
-      // single CONNECT serves all five requests for both proxy flavours.
-      expect(proxy.connectCount()).toBe(1);
-    });
-
-    test(`${proxyTls ? "https" : "http"}-proxy → https-origin, different auth hashes use separate tunnels`, async () => {
-      await using origin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("ok") });
-      await using proxy = await createAdversarialProxy({ tls: proxyTls });
-
-      const creds = ["a:1", "b:2", "a:1"]; // third reuses the first tunnel
-      for (const c of creds) {
-        const res = await fetch(origin.url, {
-          proxy: `${proxyTls ? "https" : "http"}://${c}@127.0.0.1:${proxy.port}`,
-          keepalive: true,
-          tls: laxTls,
+    test.concurrent(
+      `${proxyTls ? "https" : "http"}-proxy → https-origin, 5 sequential requests reuse one CONNECT`,
+      async () => {
+        await using origin = Bun.serve({
+          port: 0,
+          tls: tlsCert,
+          fetch: () => new Response("reused"),
         });
-        expect(res.status).toBe(200);
-        await res.arrayBuffer();
-      }
-      // Different auth hashes must never share a tunnel; the repeat of the
-      // first credentials must find the first tunnel in the pool.
-      expect(proxy.connectCount()).toBe(2);
-      // The two CONNECTs carried different Proxy-Authorization.
-      const auths = proxy.connections.map(r => r.headers["proxy-authorization"]);
-      expect(auths[0]).not.toBe(auths[1]);
-    });
+        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+
+        const responses: Array<{ status: number; body: string }> = [];
+        for (let i = 0; i < 5; i++) {
+          const res = await fetch(origin.url, { proxy: proxy.url, keepalive: true, tls: laxTls });
+          responses.push({ status: res.status, body: await res.text() });
+        }
+        expect(responses).toEqual(Array(5).fill({ status: 200, body: "reused" }));
+        // laxTls carries a `ca`, so the connection to the proxy lives in that
+        // config's own TLS context. The finished tunnel must be pooled into
+        // that same context (where the next request looks for it), so a
+        // single CONNECT serves all five requests for both proxy flavours.
+        expect(proxy.connections.map(c => c.method)).toEqual(["CONNECT"]);
+      },
+    );
+
+    test.concurrent(
+      `${proxyTls ? "https" : "http"}-proxy → https-origin, different auth hashes use separate tunnels`,
+      async () => {
+        await using origin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("ok") });
+        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+
+        const creds = ["a:1", "b:2", "a:1"]; // third reuses the first tunnel
+        const statuses: number[] = [];
+        for (const c of creds) {
+          const res = await fetch(origin.url, {
+            proxy: `${proxyTls ? "https" : "http"}://${c}@127.0.0.1:${proxy.port}`,
+            keepalive: true,
+            tls: laxTls,
+          });
+          statuses.push(res.status);
+          await res.arrayBuffer();
+        }
+        expect(statuses).toEqual([200, 200, 200]);
+        // One CONNECT per distinct credential, each carrying its own
+        // Proxy-Authorization; the repeat of the first credentials found the
+        // first tunnel in the pool instead of opening a third.
+        expect(proxy.connections.map(c => [c.method, c.headers["proxy-authorization"]])).toEqual([
+          ["CONNECT", `Basic ${btoa("a:1")}`],
+          ["CONNECT", `Basic ${btoa("b:2")}`],
+        ]);
+      },
+    );
   }
 
   // A `tls` option that needs its own TLS context (`ca` here; cert/key etc.
@@ -225,8 +359,8 @@ describe("tunnel reuse", () => {
         }
 
         expect(responses).toEqual([RESPONSES[shape], RESPONSES[shape], RESPONSES[shape]]);
-        expect({ connects: proxy.connectCount(), originConnections: origin.connections }).toEqual({
-          connects: 1,
+        expect({ connects: proxy.connections.map(c => c.method), originConnections: origin.connections }).toEqual({
+          connects: ["CONNECT"],
           originConnections: 1,
         });
       },
@@ -239,34 +373,39 @@ describe("tunnel reuse", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("many origins, one proxy", () => {
+  const N_ORIGINS = 12;
   for (const proxyTls of [false, true] as const) {
-    test(`${proxyTls ? "https" : "http"}-proxy → 12 https origins, interleaved`, async () => {
-      const N_ORIGINS = 12;
-      const origins: Array<{ url: string; stop: () => void }> = [];
-      for (let i = 0; i < N_ORIGINS; i++) {
-        const body = `origin-${i}`;
-        const s = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response(body) });
-        origins.push({ url: String(s.url), stop: () => s.stop(true) });
-      }
-      await using proxy = await createAdversarialProxy({ tls: proxyTls });
+    test.concurrent(
+      `${proxyTls ? "https" : "http"}-proxy → ${N_ORIGINS} https origins, interleaved`,
+      async () => {
+        const origins = Array.from({ length: N_ORIGINS }, (_, i) =>
+          Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response(`origin-${i}`) }),
+        );
+        await using proxy = await createAdversarialProxy({ tls: proxyTls });
 
-      try {
-        // Two rounds so each origin is reused once.
-        for (let round = 0; round < 2; round++) {
-          for (let i = 0; i < N_ORIGINS; i++) {
-            const res = await fetch(origins[i].url, { proxy: proxy.url, keepalive: true, tls: laxTls });
-            expect(await res.text()).toBe(`origin-${i}`);
-            expect(res.status).toBe(200);
+        try {
+          // Two rounds so each origin is reused once.
+          const responses: Array<{ status: number; body: string }> = [];
+          for (let round = 0; round < 2; round++) {
+            for (const origin of origins) {
+              const res = await fetch(origin.url, { proxy: proxy.url, keepalive: true, tls: laxTls });
+              responses.push({ status: res.status, body: await res.text() });
+            }
           }
+          const round = origins.map((_, i) => ({ status: 200, body: `origin-${i}` }));
+          expect(responses).toEqual([...round, ...round]);
+          // Round one opened one CONNECT per origin, in order, and round two
+          // found every one of those tunnels in the pool: nothing bypassed
+          // the proxy and nothing was dialed twice, for both proxy flavours.
+          expect(proxy.connections.map(c => [c.method, c.target])).toEqual(
+            origins.map(origin => ["CONNECT", origin.url.host]),
+          );
+        } finally {
+          for (const origin of origins) origin.stop(true);
         }
-        // Every request went through the proxy as a CONNECT (none
-        // bypassed it), and round two reused every tunnel round one
-        // pooled, for both proxy flavours.
-        expect(proxy.connectCount()).toBe(N_ORIGINS);
-      } finally {
-        for (const o of origins) o.stop();
-      }
-    }, 45_000);
+      },
+      45_000,
+    );
   }
 });
 
@@ -277,42 +416,32 @@ describe("many origins, one proxy", () => {
 
 describe("reject_unauthorized pool gate", () => {
   for (const proxyTls of [false, true] as const) {
-    test(`${proxyTls ? "https" : "http"}-proxy → https-origin: lax then strict opens a fresh CONNECT`, async () => {
-      await using origin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("g") });
-      await using proxy = await createAdversarialProxy({ tls: proxyTls });
+    test.concurrent(
+      `${proxyTls ? "https" : "http"}-proxy → https-origin: lax then strict opens a fresh CONNECT`,
+      async () => {
+        await using origin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("g") });
+        await using proxy = await createAdversarialProxy({ tls: proxyTls });
 
-      // 1: lax
-      let res = await fetch(origin.url, {
-        proxy: proxy.url,
-        keepalive: true,
-        tls: { rejectUnauthorized: false },
-      });
-      expect(res.status).toBe(200);
-      await res.arrayBuffer();
-      expect(proxy.connectCount()).toBe(1);
-
-      // 2: strict with matching CA — must not reuse the lax tunnel.
-      res = await fetch(origin.url, {
-        proxy: proxy.url,
-        keepalive: true,
-        tls: { ca: tlsCert.cert, rejectUnauthorized: true },
-      });
-      expect(res.status).toBe(200);
-      await res.arrayBuffer();
-      expect(proxy.connectCount()).toBe(2);
-
-      // 3: strict again, reuses the strict tunnel. With an https proxy the
-      // strict tunnel lives in the `ca` config's own TLS context; it must
-      // have been pooled there, not in the default context.
-      res = await fetch(origin.url, {
-        proxy: proxy.url,
-        keepalive: true,
-        tls: { ca: tlsCert.cert, rejectUnauthorized: true },
-      });
-      expect(res.status).toBe(200);
-      await res.arrayBuffer();
-      expect(proxy.connectCount()).toBe(2);
-    }, 30_000);
+        const lax = { rejectUnauthorized: false };
+        const strict = { ca: tlsCert.cert, rejectUnauthorized: true };
+        const steps: Array<{ status: number; connects: number }> = [];
+        for (const tlsOption of [lax, strict, strict]) {
+          const res = await fetch(origin.url, { proxy: proxy.url, keepalive: true, tls: tlsOption });
+          await res.arrayBuffer();
+          steps.push({ status: res.status, connects: proxy.connectCount() });
+        }
+        // 1: lax pools a tunnel. 2: strict must not reuse it and opens its
+        // own. 3: strict again reuses the strict tunnel. With an https proxy
+        // the strict tunnel lives in the `ca` config's own TLS context; it
+        // must have been pooled there, not in the default context.
+        expect(steps).toEqual([
+          { status: 200, connects: 1 },
+          { status: 200, connects: 2 },
+          { status: 200, connects: 2 },
+        ]);
+      },
+      30_000,
+    );
   }
 });
 
@@ -324,9 +453,10 @@ describe("reject_unauthorized pool gate", () => {
 
 describe("large bidirectional", () => {
   const SIZE = 4 * 1024 * 1024;
+  const N = 4;
   for (const proxyTls of [false, true] as const) {
     test.concurrent(
-      `${proxyTls ? "https" : "http"}-proxy → https-origin, 4× concurrent ${SIZE}B echo`,
+      `${proxyTls ? "https" : "http"}-proxy → https-origin, ${N}× concurrent ${SIZE}B echo`,
       async () => {
         await using origin = Bun.serve({
           port: 0,
@@ -337,7 +467,7 @@ describe("large bidirectional", () => {
 
         const payload = makeBody(SIZE, "L");
         const results = await Promise.all(
-          Array.from({ length: 4 }, () =>
+          Array.from({ length: N }, () =>
             fetch(origin.url, {
               method: "POST",
               body: payload,
@@ -350,9 +480,12 @@ describe("large bidirectional", () => {
             }),
           ),
         );
-        for (const r of results) {
-          expect(r).toEqual({ status: 200, len: SIZE, ok: true });
-        }
+        expect(results).toEqual(Array(N).fill({ status: 200, len: SIZE, ok: true }));
+        // One tunnel per request, each of which relayed the whole payload
+        // in both directions (plus TLS framing).
+        expect(
+          proxy.connections.map(c => ({ method: c.method, relayedBothWays: c.bytesUp > SIZE && c.bytesDown > SIZE })),
+        ).toEqual(Array(N).fill({ method: "CONNECT", relayedBothWays: true }));
       },
       60_000,
     );
@@ -366,7 +499,7 @@ describe("large bidirectional", () => {
 // letting the stale byte reach the next request.
 // ─────────────────────────────────────────────────────────────────────────────
 
-test("idle pooled tunnel receiving data is evicted", async () => {
+test.concurrent("idle pooled tunnel receiving data is evicted", async () => {
   await using origin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("ok") });
 
   // Custom proxy that exposes each live client socket so the test can
@@ -401,160 +534,28 @@ test("idle pooled tunnel receiving data is evicted", async () => {
   });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
-  const proxyPort = (server.address() as net.AddressInfo).port;
+  const proxy = `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
 
   try {
     // First request: pools the tunnel.
-    let res = await fetch(origin.url, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
-      keepalive: true,
-      tls: laxTls,
-    });
-    expect(await res.text()).toBe("ok");
-    expect(connects).toBe(1);
+    let res = await fetch(origin.url, { proxy, keepalive: true, tls: laxTls });
+    expect({ body: await res.text(), connects }).toEqual({ body: "ok", connects: 1 });
 
-    // Tunnel is now parked. Push a stray byte into every live client
+    // Tunnel is now parked. Push a stray byte into the one live client
     // socket from the proxy side. The client's idle-data handler evicts
-    // the pooled entry, which RSTs the proxy connection.
-    const parked = [...liveClients];
-    expect(parked.length).toBe(1);
-    const closed = Promise.all(
-      parked.map(
-        c =>
-          new Promise<void>(resolve => {
-            if (c.destroyed) return resolve();
-            c.once("close", () => resolve());
-          }),
-      ),
-    );
-    for (const c of parked) c.write(Buffer.from([0x17, 0x03, 0x03, 0x00, 0x01, 0x00]));
+    // the pooled entry, which RSTs the proxy connection (so the socket may
+    // emit "error" before "close"; only "close" is awaited).
+    expect(liveClients.size).toBe(1);
+    const [parked] = liveClients;
+    const closed = new Promise<void>(resolve => parked.once("close", () => resolve()));
+    parked.write(Buffer.from([0x17, 0x03, 0x03, 0x00, 0x01, 0x00]));
     await closed;
 
     // Second request: must open a fresh CONNECT and succeed.
-    res = await fetch(origin.url, {
-      proxy: `http://127.0.0.1:${proxyPort}`,
-      keepalive: true,
-      tls: laxTls,
-    });
-    expect(await res.text()).toBe("ok");
-    expect(connects).toBe(2);
+    res = await fetch(origin.url, { proxy, keepalive: true, tls: laxTls });
+    expect({ body: await res.text(), connects }).toEqual({ body: "ok", connects: 2 });
   } finally {
     for (const c of liveClients) c.destroy();
     server.close();
-  }
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Subprocess-based memory / leak / UAF probe.
-//
-// Run a child that issues thousands of fetch/abort cycles through a proxy
-// to an https origin across every stage of the tunnel, tracking RSS. The
-// child exits non-zero on any crash (ASAN UAF, debug assert, segfault) and
-// reports RSS growth ratio so the test can fail on leaks.
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("memory probe (subprocess)", () => {
-  const MODES = [
-    "complete", // let every request finish
-    "abort-immediate", // abort on next microtask
-    "abort-after-connect", // abort once the proxy sees the CONNECT
-    "concurrent-32", // 32 in flight at once, all complete
-    "concurrent-32-abort", // 32 in flight, abort half at random
-    "redirect", // origin redirects once per request
-  ] as const;
-
-  for (const { proxyTls, mode } of cartesian({
-    proxyTls: [false, true] as const,
-    mode: MODES,
-  })) {
-    // ASAN inflates RSS and slows everything down; use fewer iterations
-    // there but still enough to surface a UAF. Windows and macOS are capped
-    // for a different reason: both use a 16,384-port ephemeral range
-    // (49152-65535), and 12 concurrent subprocesses x 1200 iterations x 2
-    // loopback connections each leave ~15k entries in TIME_WAIT (120s drain
-    // on Windows, 30s on macOS). On Windows that poisons later tests in the
-    // shard (listen(0)/connect() recycling into stale TIME_WAIT 4-tuples,
-    // observed as ERR_POSTGRES_CONNECTION_REFUSED / WSAENOTCONN in
-    // test/js/sql/postgres-binary-array-bounds.test.ts); on macOS the
-    // https-proxy fixtures themselves see a single ConnectionRefused at
-    // ~i=550 once TIME_WAIT passes ~15k.
-    const iterations = isASAN || isWindows || isMacOS ? 300 : isCI ? 1200 : 600;
-
-    test.concurrent(
-      `${proxyTls ? "https" : "http"}-proxy → https-origin mode=${mode} ×${iterations}`,
-      async () => {
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            join(import.meta.dir, "proxy-stress-memory-fixture.ts"),
-            proxyTls ? "https" : "http",
-            mode,
-            String(iterations),
-          ],
-          env: {
-            ...bunEnv,
-            ...proxyFreeEnv,
-            // UAFs on the HTTP thread must abort the process rather
-            // than race the main thread's clean exit.
-            ASAN_OPTIONS: ((bunEnv as any).ASAN_OPTIONS ?? "") + ":abort_on_error=1:halt_on_error=1",
-          },
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        if (exitCode !== 0) console.error("fixture stderr:\n" + stderr);
-
-        // Surface the child's final stats line before asserting.
-        const lines = stdout.trim().split("\n");
-        const lastLine = lines[lines.length - 1];
-        let result: {
-          completed: number;
-          failed: number;
-          firstError?: string;
-          rssStart: number;
-          rssEnd: number;
-          rssMax: number;
-        };
-        try {
-          result = JSON.parse(lastLine);
-        } catch {
-          console.error("fixture stdout:\n" + stdout);
-          throw new Error("fixture did not emit a JSON summary line");
-        }
-
-        expect(exitCode).toBe(0);
-        expect(result.completed + result.failed).toBe(iterations);
-        // Non-abort modes must complete every request; abort modes must
-        // have actually aborted something.
-        if (mode.includes("abort")) {
-          expect(result.failed).toBeGreaterThan(0);
-        } else {
-          // Carry `firstError` in the diff so a CI failure shows the
-          // actual fetch error, not just the count.
-          expect({ failed: result.failed, firstError: result.firstError }).toEqual({
-            failed: 0,
-            firstError: undefined,
-          });
-          expect(result.completed).toBe(iterations);
-        }
-
-        // RSS leak check: after a warm-up, RSS should plateau. Allow a
-        // generous 3× growth factor (ASAN, fragmentation, per-target pool
-        // entries) — a real leak of one tunnel/request shows as 10×+ with
-        // these iteration counts. Skip the threshold under ASAN because
-        // LeakSanitizer's shadow memory makes RSS non-representative; a
-        // UAF there shows up as a crash, not a slow leak.
-        if (!isASAN) {
-          const growth = result.rssEnd / Math.max(1, result.rssStart);
-          // Carry `mode` + the rounded ratio in the failing diff.
-          expect({ mode, growth: Number(growth.toFixed(2)), withinBound: growth < 3.0 }).toEqual({
-            mode,
-            growth: expect.any(Number),
-            withinBound: true,
-          });
-        }
-      },
-      120_000,
-    );
   }
 });

--- a/test/js/bun/http/proxy-stress-concurrent.test.ts
+++ b/test/js/bun/http/proxy-stress-concurrent.test.ts
@@ -129,7 +129,7 @@ describe("memory probe (subprocess)", () => {
         // Anything on stderr is a crash, a sanitizer report, or a fixture
         // error; asserting it first puts the actual report in the failure.
         expect(stderr).toBe("");
-        const { connects, sslCtxGrowth, rssGrowth, ...outcome } = JSON.parse(stdout);
+        const { connects, sslCtxGrowth, sslCtxInFlight, rssGrowth, ...outcome } = JSON.parse(stdout);
 
         const want = EXPECTED[mode];
         expect(outcome).toEqual(want.outcome);
@@ -142,8 +142,13 @@ describe("memory probe (subprocess)", () => {
         // Steady state is 0 (the fixture waits for the last tunnel's context
         // to be freed). A tunnel that is never released adds one per request
         // made after the warm-up: 200 and more per cell, twice that in
-        // redirect mode.
+        // redirect mode. `sslCtxInFlight` is the proof that this detector
+        // works: while tunnels were in flight the live count stood above the
+        // idle count by the number of tunnels (1 in the sequential modes, up
+        // to 32 in concurrent-32). If tunnels ever stop owning a context,
+        // this fails instead of the growth check going silent.
         expect(sslCtxGrowth).toBeLessThanOrEqual(2);
+        if (want.outcome.completed > 0) expect(sslCtxInFlight).toBeGreaterThanOrEqual(1);
 
         // RSS growth over the 200-odd requests after the warm-up. On a
         // release build every cell measures 0 to 9 MB of allocator and JIT
@@ -163,8 +168,9 @@ describe("memory probe (subprocess)", () => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Parallel requests to one origin through one proxy. All N are dispatched
-// before the proxy (which runs on this thread) can relay anything, so none of
-// them can reuse a pooled connection: the proxy must see exactly N
+// before the proxy (which runs on this thread) can relay anything, and N is
+// below the client's in-flight cap (256, BUN_CONFIG_MAX_HTTP_REQUESTS), so
+// none of them can reuse a pooled connection: the proxy must see exactly N
 // connections, whatever the keepalive setting.
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/test/js/bun/http/proxy-stress-memory-fixture.ts
+++ b/test/js/bun/http/proxy-stress-memory-fixture.ts
@@ -1,40 +1,57 @@
 /**
- * Subprocess fixture for proxy-stress-concurrent.test.ts: issue many
- * requests through a local CONNECT proxy to a local HTTPS origin, under
- * one of several modes (complete, abort-immediate, abort-after-connect,
- * concurrent-32, concurrent-32-abort, redirect), tracking RSS across the
- * run. Emits a single JSON summary line on stdout and exits 0 on clean
- * completion.
+ * Subprocess fixture for the "memory probe" block of
+ * proxy-stress-concurrent.test.ts.
+ *
+ * Issues <iterations> requests through a local CONNECT proxy (plain or TLS
+ * outer socket, selected by argv) to a local https origin, in one of the
+ * modes below, and prints exactly one JSON line:
+ *
+ *   completed     requests that returned status 200 with the expected body
+ *   failed        requests that rejected or returned something else
+ *   errors        `failed`, counted by error code (or error name)
+ *   connects      CONNECT requests the proxy received
+ *   sslCtxGrowth  live SSL_CTX count at the end minus the count after the
+ *                 warm-up. Every tunnel owns one SSL_CTX (ProxyTunnel::start
+ *                 builds it through us_ssl_ctx_from_options), so a tunnel
+ *                 that is never released shows up here as +1 per request,
+ *                 independent of how much memory it holds.
+ *   rssGrowth     RSS at the end minus RSS after the warm-up, in bytes
+ *
+ * The first quarter of the iterations is the warm-up (JIT, allocator and
+ * TLS first-use costs); both growth figures are measured over the rest.
  *
  * Usage: bun proxy-stress-memory-fixture.ts <http|https> <mode> <iterations>
+ * Env:   TLS_CERT, TLS_KEY: PEM used by the origin and by the https proxy.
+ *        The test passes them in so this child does not import "harness",
+ *        which costs about a second of start-up per child in a debug build.
  */
 
+import { sslCtxLiveCount } from "bun:internal-for-testing";
+import { once } from "node:events";
 import net from "node:net";
 import tls from "node:tls";
-import { once } from "node:events";
-import { tls as tlsCert } from "harness";
 
 const [proxyScheme, mode, iterStr] = process.argv.slice(2);
-const iterations = Number(iterStr ?? "600");
+const iterations = Number(iterStr);
 const isHttpsProxy = proxyScheme === "https";
+const tlsCert = { cert: process.env.TLS_CERT!, key: process.env.TLS_KEY! };
 
-type ConnectRecord = { count: number; resolveNext?: () => void };
-const connectRecord: ConnectRecord = { count: 0 };
-
-function notifyConnect() {
-  connectRecord.count++;
-  if (connectRecord.resolveNext) {
-    const r = connectRecord.resolveNext;
-    connectRecord.resolveNext = undefined;
-    r();
-  }
-}
-
-function waitForNextConnect(): Promise<void> {
-  return new Promise<void>(resolve => {
-    connectRecord.resolveNext = resolve;
-  });
-}
+type Abort = "never" | "microtask" | "after-connect";
+const MODES: Record<string, { concurrency: number; abort: (i: number) => Abort }> = {
+  // Let every request finish.
+  "complete": { concurrency: 1, abort: () => "never" },
+  // Abort on the microtask after fetch() returns: races the HTTP thread's connect.
+  "abort-immediate": { concurrency: 1, abort: () => "microtask" },
+  // Abort as soon as the proxy has read the CONNECT head.
+  "abort-after-connect": { concurrency: 1, abort: () => "after-connect" },
+  // 32 in flight at once, all complete.
+  "concurrent-32": { concurrency: 32, abort: () => "never" },
+  // 32 in flight at once, the odd ones aborted on the next microtask.
+  "concurrent-32-abort": { concurrency: 32, abort: i => (i % 2 === 1 ? "microtask" : "never") },
+  // The origin redirects once per request, so every iteration opens two tunnels.
+  "redirect": { concurrency: 1, abort: () => "never" },
+};
+const { concurrency, abort } = MODES[mode];
 
 // HTTPS origin. Optionally redirects once (for mode=redirect).
 const origin = Bun.serve({
@@ -49,8 +66,12 @@ const origin = Bun.serve({
   },
 });
 
-// A CONNECT proxy (HTTP or HTTPS outer socket). It intentionally tracks
-// connects so the fixture can synchronize aborts to the CONNECT boundary.
+let connects = 0;
+let onNextConnect: (() => void) | undefined;
+
+// A CONNECT proxy (plain or TLS outer socket). It counts CONNECT heads so
+// the test can check that every request went through it and so that
+// "after-connect" aborts can be synchronized to the CONNECT boundary.
 function handleClient(client: net.Socket) {
   client.on("error", () => {});
   let head = Buffer.alloc(0);
@@ -64,18 +85,23 @@ function handleClient(client: net.Socket) {
     head = Buffer.concat([head, chunk]);
     const end = head.indexOf("\r\n\r\n");
     if (end === -1) return;
-    notifyConnect();
+    const requestLine = head.subarray(0, head.indexOf("\r\n")).toString("latin1");
+    const [method, target] = requestLine.split(" ");
+    if (method === "CONNECT") {
+      connects++;
+      onNextConnect?.();
+      onNextConnect = undefined;
+    }
     const leftover = head.subarray(end + 4);
-    const firstLine = head.subarray(0, head.indexOf("\r\n")).toString("latin1");
-    const [, hostPort] = firstLine.split(" ");
-    const colon = hostPort!.lastIndexOf(":");
-    const host = hostPort!.slice(0, colon);
-    const port = Number(hostPort!.slice(colon + 1));
-    upstream = net.connect(port, host, () => {
+    // Dial the loopback address directly instead of resolving the target's
+    // `localhost` (as proxy-stress-helpers does); only the port is taken from
+    // the target.
+    const port = Number(target.slice(target.lastIndexOf(":") + 1));
+    upstream = net.connect(port, "127.0.0.1", () => {
       client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       if (leftover.length) upstream!.write(leftover);
-      // client → upstream relay is the outer on("data") handler above;
-      // only pipe the upstream → client direction here.
+      // client → upstream is relayed by the "data" handler above; only the
+      // upstream → client direction is piped.
       upstream!.pipe(client);
     });
     upstream.on("error", () => client.destroy());
@@ -88,113 +114,99 @@ const proxy = isHttpsProxy
   : net.createServer(handleClient);
 proxy.listen(0, "127.0.0.1");
 await once(proxy, "listening");
-const proxyPort = (proxy.address() as net.AddressInfo).port;
-const proxyUrl = `${isHttpsProxy ? "https" : "http"}://127.0.0.1:${proxyPort}`;
+const proxyUrl = `${proxyScheme}://127.0.0.1:${(proxy.address() as net.AddressInfo).port}`;
 
 const laxTls = { ca: tlsCert.cert, rejectUnauthorized: false } as const;
-const originUrl = (p: string) => `https://localhost:${origin.port}${p}`;
 
 let completed = 0;
 let failed = 0;
-let firstError: string | undefined;
-let rssStart = 0;
-let rssMax = 0;
+const errors: Record<string, number> = {};
 
-function recordError(i: number, e: unknown) {
+function recordFailure(key: string) {
   failed++;
-  if (firstError === undefined) {
-    const any = e as { code?: unknown; name?: unknown; message?: unknown };
-    firstError = `[i=${i}] ${any?.code ?? any?.name ?? "Error"}: ${any?.message ?? e}`;
-  }
+  errors[key] = (errors[key] ?? 0) + 1;
 }
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+function errorKey(e: unknown): string {
+  const any = e as { code?: unknown; name?: unknown };
+  return typeof any?.code === "string" ? any.code : typeof any?.name === "string" ? any.name : String(e);
+}
 
 async function one(i: number): Promise<void> {
   const path = mode === "redirect" ? "/start" : `/${i}`;
-  const ac = new AbortController();
-
-  if (mode === "abort-immediate") {
-    queueMicrotask(() => ac.abort());
-  } else if (mode === "abort-after-connect") {
-    waitForNextConnect().then(() => ac.abort());
+  const expectedBody = mode === "redirect" ? "ok-/final" : `ok-${path}`;
+  let signal: AbortSignal | undefined;
+  const when = abort(i);
+  if (when !== "never") {
+    const ac = new AbortController();
+    signal = ac.signal;
+    if (when === "microtask") queueMicrotask(() => ac.abort());
+    else new Promise<void>(resolve => (onNextConnect = resolve)).then(() => ac.abort());
   }
 
   try {
-    const res = await fetch(originUrl(path), {
+    const res = await fetch(`https://localhost:${origin.port}${path}`, {
       proxy: proxyUrl,
       keepalive: false,
       tls: laxTls,
-      signal: mode.startsWith("abort") ? ac.signal : undefined,
+      signal,
     });
-    await res.arrayBuffer();
-    completed++;
+    const body = await res.text();
+    if (res.status === 200 && body === expectedBody) {
+      completed++;
+    } else {
+      recordFailure(`unexpected response ${res.status} ${JSON.stringify(body)}`);
+    }
   } catch (e) {
-    recordError(i, e);
+    recordFailure(errorKey(e));
   }
 }
 
-async function run() {
-  // Warm-up: first 20 iterations establish baseline RSS (JIT, TLS session
-  // cache, first-time allocations). rssStart is sampled after.
-  const WARMUP = Math.min(20, Math.floor(iterations / 4));
+// Same choice as harness's rss().
+const rss: () => number =
+  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+    ? (Bun.unsafe.memoryFootprint as () => number)
+    : process.memoryUsage.rss;
 
-  if (mode === "concurrent-32" || mode === "concurrent-32-abort") {
-    let i = 0;
-    while (i < iterations) {
-      const batch = Math.min(32, iterations - i);
-      const tasks: Promise<void>[] = [];
-      for (let j = 0; j < batch; j++) {
-        const idx = i + j;
-        if (mode === "concurrent-32-abort" && idx % 2 === 1) {
-          const ac = new AbortController();
-          const p = fetch(originUrl(`/${idx}`), {
-            proxy: proxyUrl,
-            keepalive: false,
-            tls: laxTls,
-            signal: ac.signal,
-          })
-            .then(async r => {
-              await r.arrayBuffer();
-              completed++;
-            })
-            .catch(e => {
-              recordError(idx, e);
-            });
-          queueMicrotask(() => ac.abort());
-          tasks.push(p);
-        } else {
-          tasks.push(one(idx));
-        }
-      }
-      await Promise.all(tasks);
-      i += batch;
-      if (i >= WARMUP && rssStart === 0) {
-        Bun.gc(true);
-        rssStart = rss();
-      }
-      rssMax = Math.max(rssMax, rss());
-    }
-  } else {
-    for (let i = 0; i < iterations; i++) {
-      await one(i);
-      if (i === WARMUP) {
-        Bun.gc(true);
-        rssStart = rss();
-      }
-      rssMax = Math.max(rssMax, rss());
-    }
+const warmup = Math.floor(iterations / 4);
+let rssStart = -1;
+let sslCtxStart = -1;
+
+for (let done = 0; done < iterations; ) {
+  const batch = Math.min(concurrency, iterations - done);
+  await Promise.all(Array.from({ length: batch }, (_, j) => one(done + j)));
+  done += batch;
+  if (rssStart === -1 && done >= warmup) {
+    Bun.gc(true);
+    rssStart = rss();
+    sslCtxStart = sslCtxLiveCount();
   }
+}
 
+Bun.gc(true);
+const rssEnd = rss();
+
+// The HTTP thread frees the last request's tunnel (and its SSL_CTX) shortly
+// after the response is delivered; wait for the count to come back down
+// rather than read it mid-teardown. A leak keeps the count up and the loop
+// gives up at the deadline, so the growth is still reported.
+const deadline = Date.now() + 5_000;
+while (sslCtxLiveCount() > sslCtxStart && Date.now() < deadline) {
+  await Bun.sleep(5);
   Bun.gc(true);
-  const rssEnd = rss();
-  console.log(JSON.stringify({ completed, failed, firstError, rssStart, rssEnd, rssMax }));
 }
 
-await run();
+console.log(
+  JSON.stringify({
+    completed,
+    failed,
+    errors,
+    connects,
+    sslCtxGrowth: sslCtxLiveCount() - sslCtxStart,
+    rssGrowth: rssEnd - rssStart,
+  }),
+);
+
 origin.stop(true);
 proxy.close();
 process.exit(0);

--- a/test/js/bun/http/proxy-stress-memory-fixture.ts
+++ b/test/js/bun/http/proxy-stress-memory-fixture.ts
@@ -15,6 +15,10 @@
  *                 builds it through us_ssl_ctx_from_options), so a tunnel
  *                 that is never released shows up here as +1 per request,
  *                 independent of how much memory it holds.
+ *   sslCtxInFlight  the highest live SSL_CTX count sampled while tunnels were
+ *                 in flight, minus the lowest count sampled while none were.
+ *                 This is the number of tunnels alive at once that owned a
+ *                 context: the proof that `sslCtxGrowth` can see a leak.
  *   rssGrowth     RSS at the end minus RSS after the warm-up, in bytes
  *
  * The first quarter of the iterations is the warm-up (JIT, allocator and
@@ -24,6 +28,10 @@
  * Env:   TLS_CERT, TLS_KEY: PEM used by the origin and by the https proxy.
  *        The test passes them in so this child does not import "harness",
  *        which costs about a second of start-up per child in a debug build.
+ *        The rest of the environment is bunEnv, which is also what enables
+ *        the `bun:internal-for-testing` import below; to run this file by
+ *        hand, set BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 and
+ *        BUN_GARBAGE_COLLECTOR_LEVEL=0 as well.
  */
 
 import { sslCtxLiveCount } from "bun:internal-for-testing";
@@ -69,6 +77,13 @@ const origin = Bun.serve({
 let connects = 0;
 let onNextConnect: (() => void) | undefined;
 
+// SSL_CTX samples. `sslCtxStart` is taken after the warm-up; until then the
+// in-flight and idle samples are skipped, so that contexts created lazily
+// during the warm-up do not count as tunnels.
+let sslCtxStart = -1;
+let sslCtxIdleMin = Infinity;
+let sslCtxBusyMax = -Infinity;
+
 // A CONNECT proxy (plain or TLS outer socket). It counts CONNECT heads so
 // the test can check that every request went through it and so that
 // "after-connect" aborts can be synchronized to the CONNECT boundary.
@@ -100,6 +115,11 @@ function handleClient(client: net.Socket) {
     upstream = net.connect(port, "127.0.0.1", () => {
       client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       if (leftover.length) upstream!.write(leftover);
+      // The first upstream byte is the origin's TLS ServerHello: the client
+      // has started its tunnel by now, so its SSL_CTX is alive and counted.
+      upstream!.once("data", () => {
+        if (sslCtxStart !== -1) sslCtxBusyMax = Math.max(sslCtxBusyMax, sslCtxLiveCount());
+      });
       // client → upstream is relayed by the "data" handler above; only the
       // upstream → client direction is piped.
       upstream!.pipe(client);
@@ -170,17 +190,18 @@ const rss: () => number =
 
 const warmup = Math.floor(iterations / 4);
 let rssStart = -1;
-let sslCtxStart = -1;
 
 for (let done = 0; done < iterations; ) {
   const batch = Math.min(concurrency, iterations - done);
   await Promise.all(Array.from({ length: batch }, (_, j) => one(done + j)));
   done += batch;
+  // Nothing is in flight here.
   if (rssStart === -1 && done >= warmup) {
     Bun.gc(true);
     rssStart = rss();
     sslCtxStart = sslCtxLiveCount();
   }
+  if (sslCtxStart !== -1) sslCtxIdleMin = Math.min(sslCtxIdleMin, sslCtxLiveCount());
 }
 
 Bun.gc(true);
@@ -195,6 +216,8 @@ while (sslCtxLiveCount() > sslCtxStart && Date.now() < deadline) {
   await Bun.sleep(5);
   Bun.gc(true);
 }
+const sslCtxEnd = sslCtxLiveCount();
+sslCtxIdleMin = Math.min(sslCtxIdleMin, sslCtxEnd);
 
 console.log(
   JSON.stringify({
@@ -202,7 +225,8 @@ console.log(
     failed,
     errors,
     connects,
-    sslCtxGrowth: sslCtxLiveCount() - sslCtxStart,
+    sslCtxGrowth: sslCtxEnd - sslCtxStart,
+    sslCtxInFlight: sslCtxBusyMax === -Infinity ? 0 : sslCtxBusyMax - sslCtxIdleMin,
     rssGrowth: rssEnd - rssStart,
   }),
 );


### PR DESCRIPTION
### Problem
- `proxy-stress-concurrent.test.ts` takes 10 to 15 s on every CI lane. Nearly all of it is the memory probe: 12 children, 1200 iterations on Linux, 300 elsewhere.
- The iterations bought nothing. The only leak check was `rssEnd / rssStart < 3`. A leaked tunnel is 17 KB per request, about 20 MB over 1200 iterations on a 50 MB baseline, so the check passed with the leak.

### Fix
- Every cell runs 300 iterations. The test asserts an empty stderr, the exact outcome, the CONNECT count, `sslCtxGrowth <= 2`, that tunnels in flight did each hold a context (`sslCtxInFlight >= 1`), `rssGrowth < 32 MB` (release builds), then the exit code.
- Correct because each tunnel owns one SSL_CTX: a leaked tunnel adds one per request at any iteration count. A scratch build that skips the release fails all 8 tunnel cells (growth 203 to 450). On the ASAN lanes the LeakSanitizer report lands in the stderr assertion.
- The probe block is declared first, the 9 plain `test()` calls are concurrent, and the in-process tests assert exact response and connection lists.
- Verified: CI, same shards, this build against the one the sweep measured: alpine x64 15.0 s to 4.5 s, debian aarch64 12.4 s to 2.8 s, x64-asan 8.1 s to 5.9 s (table in the notes). `bun bd test`: 45 s to 30 s.

### Background
- Each probe cell spawns `proxy-stress-memory-fixture.ts`, which runs its own CONNECT proxy and https origin and prints one JSON line.
- `sslCtxLiveCount()` (`bun:internal-for-testing`) counts the SSL_CTX objects usockets has not freed. `ProxyTunnel::start` builds one per tunnel.
- On the ASAN lanes the runner sets `detect_leaks=1` for this file, `bun test` runs 5 tests at a time, and a plain `test()` waits for every running test.

<details><summary>Notes</summary>

#### CI wall time of the file per lane

Build 102501 is the main build the slow-test sweep measured; build 102632 is this PR. The file landed in the same shard of each lane in both builds. The darwin lanes did not select this file in either build (they run a time-boxed subset), so macOS is covered only by the measurements below and by the Windows and Linux creep data.

| Lane | Build 102501 (before) | Build 102632 (after) |
| --- | --- | --- |
| debian 13 aarch64 | 12.4 s | 2.8 s |
| debian 13 x64 | 10.3 s | 4.1 s |
| debian 13 x64-asan | 8.1 s | 5.9 s |
| ubuntu 25.04 aarch64 | 11.6 s | 3.6 s |
| ubuntu 25.04 x64 | 10.6 s | 3.4 s |
| alpine 3.23 aarch64 | 13.1 s | 3.6 s |
| alpine 3.23 x64 | 15.0 s | 4.5 s |
| windows 2019 x64 | 4.7 s | 3.9 s |
| windows 11 aarch64 | 5.5 s | 9.1 s |

The Windows aarch64 number went the wrong way, so I checked it on a Windows 11 aarch64 machine with the same canary: from an idle port pool the old file takes 4.44 s and 4.51 s, the new one 3.03 s to 3.06 s (3 runs, 0 failures). The whole shard took the same time in both builds (588 s and 583 s). In the PR build the touched file ran third in its shard, right after the shard's `bun install`, instead of in its usual position, which is the measurement artifact #33622 describes for touched files. What the check also showed: one run of this file leaves about 4,000 sockets in TIME_WAIT on Windows (the old file: about 3,500, because its proxy destroyed the upstream socket during the `localhost` lookup in the abort modes and so never connected), against a pool of 16,384. Running the file several times within the TIME_WAIT window exhausts the pool with either version; a single run, as CI does it, has about 4x headroom, and the failure shape is now readable (`errors: { ConnectionRefused: 29 }` in the diff, where the old test printed `Expected: 0, Received: 1`).

`test/expected-durations.json` records the old medians for this file (default 10,809 ms, asan 7,995 ms, musl 11,879 ms, windows 5,376 ms; its siblings are 160 to 950 ms) and `test/parallel-allowlist.json` lists it under `excludeFiles` because stress-named files never qualify for parallel execution. Both files are generated, so neither is edited here. The exclusion means the file runs on its own in its shard, so the per-lane difference above is the saving in shard time.

#### Local timings (this container, 12 CPUs, unless noted)

| Build | Before | After |
| --- | --- | --- |
| `bun bd test` (debug + ASAN), 5 and 6 runs | 45.0 to 46.6 s | 29.3 to 33.6 s |
| Same, with the CI ASAN lane environment (`detect_leaks=1`, exception validation) | not measured | 42.5 s, 42.6 s |
| Release binary, `CI=1` (what the Linux CI lanes ran: 1200 iterations), 3 runs each | 8.2 to 9.9 s | 2.0 to 2.1 s |
| Release binary, `CI=1`, pinned to 2 CPUs | 22.3 s, 23.8 s | 5.9 s, 7.0 s |
| Windows x64, release canary at the same commit | 2.80 s, 2.81 s | 1.86 s (3 runs) |

Where the debug time goes now: the 12 children, 5 at a time, end at about 27 s, and the in-process tests run in the slots the children free up. Child start-up in a debug build is 1.9 s instead of 3.0 to 3.9 s without the harness import (`bun:internal-for-testing` itself costs about 0.85 s of that, 20 ms in release). The per-iteration cost is unchanged: it is the TLS handshakes under test.

Stability: 0 failures in 6 debug runs, 20 release runs (5 of them pinned to 2 CPUs, 3 pinned to 1 CPU), 3 Windows runs, 60 direct fixture runs on Linux and 60 on Windows. The direct runs reported exactly the expected outcome and CONNECT count every time, and `sslCtxGrowth` was always 0.

#### Leak evidence

Scratch build: `close_proxy_tunnel` in `src/http/lib.rs` without the `t.deref()`. Not part of this PR.

- LeakSanitizer on that build: `856850 byte(s) leaked in 14050 allocation(s)` for 50 requests, `1713700` for 100. One leaked tunnel is 17,137 bytes in 281 allocations (SSL_CTX, SSL, session, CA store). The old ratio assertion needed about 85 KB per request to fail at 1200 iterations on Linux, and about 360 KB per request at 300 iterations on macOS and Windows.
- New test on that build with LeakSanitizer off (what a release lane relies on): the 8 cells that establish tunnels fail on `sslCtxGrowth` with 224, 225, 203, 204, 449, 450, 101 and 102 against `<= 2`. The 4 cells that abort before the CONNECT reply pass, because they establish no tunnel.
- New test on that build with the CI ASAN lane environment: `expect(stderr).toBe("")` fails with the report in the diff, `Direct leak of 55200 byte(s) in 300 object(s)` allocated in `ProxyTunnel::start`.
- The old test on that build failed only through LeakSanitizer, so only on the ASAN lanes.

RSS creep of the new fixture (growth after the first 75 iterations), 5 runs per cell on release builds: Linux 0 to 9.0 MB, Windows 0.8 to 8.3 MB, and 0 to 7 MB with all 12 children running at once. The 32 MB bound fails on about 150 KB per request and up. `tls-connect-socket-churn.test.ts` uses 16 MB for the same kind of secondary check.

The old fixture's proxy dialed the CONNECT target's `localhost`, and in the abort modes it destroyed that socket while the lookup was still running. That leaks the `TCPSocket` object in the child (the object stays protected, about 4 KB of JS heap per aborted request), which inflated the old probe's RSS numbers. The leak is in `node:net` and reproduces on main with `const s = net.connect(port, host); s.destroy();` in a loop: 500 iterations leave 500 more protected `TCPSocket` objects after `Bun.gc(true)` and a 3 s wait, while destroying after `connect` is clean. That is a separate bug and is not fixed here. The fixture now dials 127.0.0.1 like `proxy-stress-helpers` does.

#### Why `sslCtxInFlight` exists

`sslCtxGrowth` is only a leak detector while a tunnel owns its own SSL_CTX. If a later change shared one context across tunnels (the digest-keyed cache already does this for other consumers), the growth check would pass on a leak without anyone noticing. The fixture therefore also samples the live count while tunnels are in flight (at the origin's first TLS byte, relayed by the proxy) and reports the peak above the lowest idle sample. Observed: 1 in every sequential mode, 16 in concurrent-32-abort (the 16 completing requests of each batch), 19 to 32 in concurrent-32, 0 in the two modes that abort before the CONNECT reply. The test requires at least 1 in every mode that completes requests, so the day tunnels stop owning a context, the probe says so instead of going silent.

#### Review notes

Points checked while reviewing the change: a request can never make a second CONNECT, because `allow_retry` is only set when a pooled socket is reused (`HTTPContext.rs`) and the fixture uses `keepalive: false`, so the CONNECT upper bounds hold. The exactly-32-connections claim in "parallel requests" also depends on the in-flight cap, which defaults to 256 (`BUN_CONFIG_MAX_HTTP_REQUESTS`). macOS is the one platform not covered by a run: the darwin lanes did not pick this file in either build, so the 32 MB RSS bound rests on the Linux and Windows creep data and on the repo's other absolute bounds (2 to 30 MB in sibling leak tests). The Windows port footprint grew from about 3,500 to about 4,000 TIME_WAIT entries per run, against a pool of 16,384.

#### Assertion changes

Memory probe, per cell: `stderr === ""` before anything else. `toEqual` on `{completed, failed, errors}` (was: the sum equals the iterations, and `failed > 0` for abort modes). `connects` is exactly 300 for complete, concurrent-32 and abort-after-connect, 600 for redirect, within `[150, 300]` for concurrent-32-abort and `[0, 300]` for abort-immediate (was: unchecked). In the last two modes the microtask abort races the connect: between 0% and 98% of the aborted requests reached the proxy depending on the build and the proxy flavour, so those two are bounds. The child itself now checks status 200 and the per-request body, so cross-talk between tunnels becomes an `errors` entry. `sslCtxGrowth <= 2` is new. `rssGrowth < 32 MB` on release builds replaces the ratio. The exit code comes last.

In-process tests: "parallel requests" asserts the full 32-element response list and that the proxy recorded exactly 32 connections, all `CONNECT` for an https origin or all `GET` for an http one (was: at least 1, and `every CONNECT` for https only). "5 sequential requests" asserts the 5 responses and a connection list of exactly `["CONNECT"]`. "different auth hashes" asserts the 3 statuses and the exact `[method, Proxy-Authorization]` list for `a:1` and `b:2` (was: count 2 and "the headers differ"). "3 requests share one tunnel" asserts the connection list instead of the count. "many origins" asserts the 24 responses in order and the exact `[method, target]` list, one CONNECT per origin in order (was: count 12). "reject_unauthorized" asserts the `[status, connects]` sequence `[200, 1], [200, 2], [200, 2]` in one `toEqual`. "large bidirectional" asserts the 4 results in one `toEqual`, plus exactly 4 CONNECTs that each relayed more than the payload in both directions. The idle-eviction test asserts body and connection count together. It already waited for the close event, so nothing in this file sleeps.

Nothing was deleted or skipped. All 43 tests and every cell of every cartesian product remain. The `expect()` count went from 489 to 121 because loops of `toBe` became one `toEqual` each. The file-level `beforeAll`/`afterAll` only clears the proxy environment and did not serialize anything. The barriers were the 9 plain `test()` calls. Per-test timeouts are unchanged, since they are what lets the file pass under a plain `bun bd test` with its 5 s default. `proxy-stress-memory-fixture.ts` is used only by this test file. `proxy-stress-helpers.ts` is shared and untouched.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/proxy-stress-concurrent.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/proxy-stress-concurrent.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/http/proxy-stress-concurrent.test.ts:
(pass) memory probe (subprocess) > https-proxy → https-origin mode=concurrent-32 ×300 [10105.13ms]
(pass) memory probe (subprocess) > http-proxy → https-origin mode=complete ×300 [10123.38ms]
(pass) memory probe (subprocess) > https-proxy → https-origin mode=complete ×300 [11087.33ms]
(pass) memory probe (subprocess) > http-proxy → https-origin mode=redirect ×300 [13041.20ms]
(pass) memory probe (subprocess) > https-proxy → https-origin mode=redirect ×300 [17983.13ms]
(pass) memory probe (subprocess) > https-proxy → https-origin mode=concurrent-32-abort ×300 [8516.29ms]
(pass) memory probe (subprocess) > http-proxy → https-origin mode=concurrent-32 ×300 [9028.66ms]
(pass) memory probe (subprocess) > http-proxy → https-origin mode=concurrent-32-abort ×300 [8379.64ms]
(pass) parallel requests, single origin > 32× parallel http-proxy → http-origin keepalive=false [1598.08ms]
(pass) parallel requests, single origin > 32× parallel http-proxy → http-origin keepalive=true [701.71ms]
(pass) memory probe (subprocess) > https-proxy → https-origin mode=abort-after-connect ×300 [9008.92ms]
(pass) parallel requests, single origin > 32× parallel http-proxy → https-origin keepalive=true [867.59ms]
(pass) parallel requests, single origin > 32× parallel http-proxy → https-origin keepalive=false [1931.06ms]
(pass) parallel requests, single origin > 32× parallel https-proxy → http-origin keepalive=true [953.68ms]
(pass) memory probe (subprocess) > https-proxy → https-origin mode=abort-immediate ×300 [6219.93ms]
(pass) memory probe (subprocess) > http-proxy → https-origin mode=abort-immediate ×300 [5986.12ms]
(pass) parallel requests, single origin > 32× parallel https-proxy → http-origin keepalive=false [2274.07ms]
(pas
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/proxy-stress-concurrent.test.ts | 541 ++++++++++++-----------
 test/js/bun/http/proxy-stress-memory-fixture.ts  | 270 ++++++-----
 2 files changed, 427 insertions(+), 384 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
test/js/bun/http/proxy-stress-concurrent.test.ts      6     10      0
test/js/bun/http/proxy-stress-memory-fixture.ts       8     12      0
```

</details>

<!-- robobun:evidence:end -->