### PR TITLE
fetch: keep a numeric timeout from aborting in-flight requests on the 4s sweep tick

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -284,10 +284,8 @@ pub static OVERRIDDEN_DEFAULT_USER_AGENT: std::sync::OnceLock<&'static [u8]> =
 /// absolute deadline for the header block to complete (undici `headersTimeout`
 /// semantics). 0 disables the timer (matching `disable_timeout = true`).
 /// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes.
-/// `HTTPThread::on_start` replaces this initial value with the configured one
-/// padded for the timer-wheel sweep (see [`normalize_idle_timeout_seconds`]),
-/// so the timer fires at the configured duration plus up to one wheel period,
-/// never earlier.
+/// `HTTPThread::on_start` stores it padded for the timer-wheel sweep (see
+/// [`normalize_idle_timeout_seconds`]).
 pub(crate) static IDLE_TIMEOUT_SECONDS: AtomicU32 = AtomicU32::new(300);
 
 /// Safe accessor for [`IDLE_TIMEOUT_SECONDS`].
@@ -296,22 +294,18 @@ pub(crate) fn idle_timeout_seconds() -> c_uint {
     IDLE_TIMEOUT_SECONDS.load(Ordering::Relaxed)
 }
 
-/// Normalise an idle timeout (seconds) for uSockets' timer wheels so the
-/// sweep never fires *earlier* than asked. Both wheels tick on a fixed
-/// period (4s short wheel, 60s long wheel) whose phase is unrelated to when
-/// a socket arms its timer, so a timer armed for N ticks can fire up to one
-/// whole period early — `timeout: 100` armed as 1 tick died at the next 4s
-/// sweep, aborting whatever request was in flight (#39952). Pad by one
-/// period: short-wheel values get one 4s tick, long-wheel values (armed in
-/// whole minutes, above 240s) get one minute. The long counter wraps `% 240`
-/// minutes, so clamp so the padded value stays at 239 min. 0 = disabled.
+/// Normalise an idle timeout (seconds) for uSockets' timer wheels. The sweep
+/// phase is unrelated to when a socket arms its timer, so a timer armed for N
+/// ticks can fire up to one period (4s short wheel, 60s long wheel) before
+/// the requested duration (#39952). Pad by one period so it never fires
+/// early, and clamp so the padded value stays at the long wheel's 239 min
+/// maximum. 0 = disabled.
 #[inline]
 pub fn normalize_idle_timeout_seconds(raw: u64) -> c_uint {
     if raw == 0 {
         return 0;
     }
-    /// `LIBUS_TIMEOUT_GRANULARITY` (packages/bun-usockets/src/libusockets.h):
-    /// the short-wheel sweep period in seconds.
+    /// `LIBUS_TIMEOUT_GRANULARITY` (packages/bun-usockets/src/libusockets.h).
     const SWEEP_SECONDS: u64 = 4;
     let raw = raw.min(238 * 60);
     (if raw + SWEEP_SECONDS > 240 {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -283,12 +283,11 @@ pub static OVERRIDDEN_DEFAULT_USER_AGENT: std::sync::OnceLock<&'static [u8]> =
 /// body-phase reads; response-header reads do not re-arm it, so it is an
 /// absolute deadline for the header block to complete (undici `headersTimeout`
 /// semantics). 0 disables the timer (matching `disable_timeout = true`).
-/// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes — the
-/// previous hard-coded value — so unchanged environments see identical
-/// behaviour except that the handshake phase is now also covered. The stored
-/// value is already padded for the timer-wheel sweep (see
-/// [`normalize_idle_timeout_seconds`]), so the timer fires at the configured
-/// duration plus up to one wheel period, never earlier.
+/// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes.
+/// `HTTPThread::on_start` replaces this initial value with the configured one
+/// padded for the timer-wheel sweep (see [`normalize_idle_timeout_seconds`]),
+/// so the timer fires at the configured duration plus up to one wheel period,
+/// never earlier.
 pub(crate) static IDLE_TIMEOUT_SECONDS: AtomicU32 = AtomicU32::new(300);
 
 /// Safe accessor for [`IDLE_TIMEOUT_SECONDS`].

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -285,9 +285,10 @@ pub static OVERRIDDEN_DEFAULT_USER_AGENT: std::sync::OnceLock<&'static [u8]> =
 /// semantics). 0 disables the timer (matching `disable_timeout = true`).
 /// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes — the
 /// previous hard-coded value — so unchanged environments see identical
-/// behaviour except that the handshake phase is now also covered. Values
-/// above 240s are served by uSockets' minute-granularity long timer (see
-/// [`SocketTimeout::set_timeout`]), so they round up to the next whole minute.
+/// behaviour except that the handshake phase is now also covered. The stored
+/// value is already padded for the timer-wheel sweep (see
+/// [`normalize_idle_timeout_seconds`]), so the timer fires at the configured
+/// duration plus up to one wheel period, never earlier.
 pub(crate) static IDLE_TIMEOUT_SECONDS: AtomicU32 = AtomicU32::new(300);
 
 /// Safe accessor for [`IDLE_TIMEOUT_SECONDS`].
@@ -296,17 +297,28 @@ pub(crate) fn idle_timeout_seconds() -> c_uint {
     IDLE_TIMEOUT_SECONDS.load(Ordering::Relaxed)
 }
 
-/// Normalise an idle timeout (seconds) for uSockets' timers: the long-timeout
-/// counter wraps `% 240` minutes, so clamp to 239 min, and values above 240s
-/// are served by the minute-granularity long timer, so round them up to a
-/// whole minute so the floor-to-minute path never fires *earlier* than asked.
+/// Normalise an idle timeout (seconds) for uSockets' timer wheels so the
+/// sweep never fires *earlier* than asked. Both wheels tick on a fixed
+/// period (4s short wheel, 60s long wheel) whose phase is unrelated to when
+/// a socket arms its timer, so a timer armed for N ticks can fire up to one
+/// whole period early — `timeout: 100` armed as 1 tick died at the next 4s
+/// sweep, aborting whatever request was in flight (#39952). Pad by one
+/// period: short-wheel values get one 4s tick, long-wheel values (armed in
+/// whole minutes, above 240s) get one minute. The long counter wraps `% 240`
+/// minutes, so clamp so the padded value stays at 239 min. 0 = disabled.
 #[inline]
 pub fn normalize_idle_timeout_seconds(raw: u64) -> c_uint {
-    let raw = raw.min(239 * 60);
-    (if raw > 240 {
-        raw.div_ceil(60) * 60
+    if raw == 0 {
+        return 0;
+    }
+    /// `LIBUS_TIMEOUT_GRANULARITY` (packages/bun-usockets/src/libusockets.h):
+    /// the short-wheel sweep period in seconds.
+    const SWEEP_SECONDS: u64 = 4;
+    let raw = raw.min(238 * 60);
+    (if raw + SWEEP_SECONDS > 240 {
+        (raw.div_ceil(60) + 1) * 60
     } else {
-        raw
+        raw + SWEEP_SECONDS
     }) as c_uint
 }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -306,12 +306,17 @@ pub fn normalize_idle_timeout_seconds(raw: u64) -> c_uint {
         return 0;
     }
     /// `LIBUS_TIMEOUT_GRANULARITY` (packages/bun-usockets/src/libusockets.h).
-    const SWEEP_SECONDS: u64 = 4;
-    let raw = raw.min(238 * 60);
-    (if raw + SWEEP_SECONDS > 240 {
-        (raw.div_ceil(60) + 1) * 60
+    const SHORT_WHEEL_PERIOD_SECONDS: u64 = 4;
+    const LONG_WHEEL_PERIOD_SECONDS: u64 = 60;
+    /// `SocketTimeout::set_timeout` routes values above this to the long wheel.
+    const SHORT_WHEEL_MAX_SECONDS: u64 = 240;
+    /// The long counter wraps `% 240` minutes; one minute of pad stays below.
+    const MAX_RAW_SECONDS: u64 = 238 * LONG_WHEEL_PERIOD_SECONDS;
+    let raw = raw.min(MAX_RAW_SECONDS);
+    (if raw + SHORT_WHEEL_PERIOD_SECONDS > SHORT_WHEEL_MAX_SECONDS {
+        (raw.div_ceil(LONG_WHEEL_PERIOD_SECONDS) + 1) * LONG_WHEEL_PERIOD_SECONDS
     } else {
-        raw + SWEEP_SECONDS
+        raw + SHORT_WHEEL_PERIOD_SECONDS
     }) as c_uint
 }
 

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3534,7 +3534,11 @@ it("a numeric `timeout` does not abort in-flight requests on the 4s sweep tick",
   });
   const errors: string[] = [];
   const start = Date.now();
-  const worker = async () => {
+  const worker = async (offsetMs: number) => {
+    // Stagger the start so the workers' request waves interleave: workers
+    // launched together stay phase-locked, and their inter-request gaps
+    // could all line up with the sweep tick.
+    await Bun.sleep(offsetMs);
     while (Date.now() - start < WINDOW_MS && errors.length === 0) {
       const t0 = Date.now();
       try {
@@ -3547,7 +3551,7 @@ it("a numeric `timeout` does not abort in-flight requests on the 4s sweep tick",
   };
   // Three staggered workers so a sweep tick always lands on an in-flight
   // request in the unfixed build.
-  await Promise.all([worker(), worker(), worker()]);
+  await Promise.all([worker(0), worker(SLEEP_MS / 3), worker((2 * SLEEP_MS) / 3)]);
   expect(errors).toEqual([]);
 }, 20_000);
 

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3496,9 +3496,9 @@ it("the idle timer is an absolute deadline for the response header block (not re
       );
 
     // /h: DRIP_N bytes * DRIP_MS = ~20s of drip before the response would
-    // complete; the 5s idle deadline (uSockets 4s-tick sweep, so ~5-9s) must
-    // fire first. A build that re-arms on every partial header read resolves
-    // 200 after the full drip instead.
+    // complete; the 5s idle deadline (armed padded on uSockets' 4s-tick
+    // sweep, so it fires at ~8-12s) must fire first. A build that re-arms on
+    // every partial header read resolves 200 after the full drip instead.
     // /b: headers arrive in one write, then the 3-byte body trickles at
     // DRIP_MS/byte (~8s). Each body chunk re-arms the idle timer, so this
     // resolves despite taking longer than IDLE_MS overall.
@@ -3513,6 +3513,43 @@ it("the idle timer is an absolute deadline for the response header block (not re
     await new Promise<void>(r => server.close(() => r()));
   }
 }, 60_000);
+
+// https://github.com/oven-sh/bun/issues/39952
+it("a numeric `timeout` does not abort in-flight requests on the 4s sweep tick", async () => {
+  // Regression: a `timeout` of 4000ms or less was armed as a single tick of
+  // uSockets' 4s sweep timer, whose phase is unrelated to the request, so the
+  // next sweep aborted whichever request was in flight, no matter how long it
+  // had been running. Keep at least one request in flight for longer than one
+  // full sweep period: none may abort, because each request idles only
+  // ~SLEEP_MS against a 1000ms budget.
+  const SLEEP_MS = 600;
+  const WINDOW_MS = 5_500; // one full 4s sweep period at any phase, plus slop
+  await using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    async fetch() {
+      await Bun.sleep(SLEEP_MS);
+      return new Response("ok");
+    },
+  });
+  const errors: string[] = [];
+  const start = Date.now();
+  const worker = async () => {
+    while (Date.now() - start < WINDOW_MS && errors.length === 0) {
+      const t0 = Date.now();
+      try {
+        const res = await fetch(server.url, { timeout: 1000 });
+        await res.text();
+      } catch (e) {
+        errors.push(`${(e as Error).name} after ${Date.now() - t0}ms on the request started at t=${t0 - start}ms`);
+      }
+    }
+  };
+  // Three staggered workers so a sweep tick always lands on an in-flight
+  // request in the unfixed build.
+  await Promise.all([worker(), worker(), worker()]);
+  expect(errors).toEqual([]);
+}, 20_000);
 
 it.skipIf(isWindows)("sends the exact Content-Length for a file body of 100 GB", async () => {
   using dir = tempDir("fetch-large-file-body", { "large.bin": "" });

--- a/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
+++ b/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
@@ -81,13 +81,15 @@ const bump = (k: string) => counts.set(k, (counts.get(k) ?? 0) + 1);
 
 const failures: string[] = [];
 
-// Launched up front so the ~1s idle-timeout waits overlap the batch loop.
+// Launched up front so the idle-timeout waits overlap the batch loop. The 1s
+// env override is padded for the 4s sweep tick, so on_timeout fires at ~4-8s;
+// the AbortSignal budget must be larger for that path to stay reachable.
 const stallJobs: Promise<void>[] = [];
 for (let i = 0; i < 3; i++) {
   stallJobs.push(
     fetch(`https://localhost:${stallPort}/`, {
       tls: { ca: validTls.cert },
-      signal: AbortSignal.timeout(1200),
+      signal: AbortSignal.timeout(10_000),
     }).then(
       res => {
         failures.push(`stalled handshake fetch resolved with status ${res.status}`);

--- a/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
+++ b/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
@@ -106,7 +106,14 @@ for (let i = 0; i < 3; i++) {
   );
 }
 
-for (let batch = 0; batch < 8; batch++) {
+// Churn until the stalled handshakes settle (on_timeout at ~4-8s, or the 10s
+// AbortSignal) so their teardown lands while the HTTP thread is busy.
+let stallsSettled = false;
+Promise.all(stallJobs).then(() => {
+  stallsSettled = true;
+});
+
+for (let batch = 0; batch < 8 || !stallsSettled; batch++) {
   const jobs: Promise<void>[] = [];
 
   // Plain mismatched-cert fetches: must reject with the altname error.
@@ -183,9 +190,9 @@ for (let batch = 0; batch < 8; batch++) {
 }
 
 // Stalled handshakes run concurrently with the batches above (launched before
-// the loop, awaited here); BUN_CONFIG_HTTP_IDLE_TIMEOUT=1 fails each through
-// on_timeout mid-handshake, the AbortSignal keeps the fixture bounded either
-// way.
+// the loop, which churns until they settle); BUN_CONFIG_HTTP_IDLE_TIMEOUT=1
+// fails each through on_timeout mid-handshake, the AbortSignal keeps the
+// fixture bounded either way.
 await Promise.all(stallJobs);
 
 mismatchServer.close();

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -295,7 +295,9 @@ describe.concurrent("fetch-tls", () => {
     // Fixture reports unexpected outcomes on stdout.
     expect(stdout).toStartWith("OK ");
     expect(exitCode).toBe(0);
-  });
+    // The fixture's stalled handshakes wait for the padded 1s idle timer,
+    // which the 4s sweep fires at ~4-8s, so this outlives the 5s default.
+  }, 30_000);
 
   // When checkServerIdentity is provided, the HTTP thread sends an intermediate
   // progress update carrying the server certificate before response headers


### PR DESCRIPTION
### Problem
- Regression in 1.4.0 (#39952): a numeric `fetch({ timeout })` of 4000 ms or less aborts whatever request is in flight on a fixed 4 s tick, with `TimeoutError`. A 19 ms request dies against a 1000 ms budget. 1.3.14 is not affected.
- The cause is `normalize_idle_timeout_seconds` (`src/http/lib.rs:304`). Since #33647, a numeric `timeout` arms the socket idle timer. Values up to 4000 ms become one tick of uSockets' 4 s sweep (`(seconds + 3) >> 2` in `packages/bun-usockets/src/socket.c:102`). The sweep phase is unrelated to the request, so one tick fires 0 to 4 s after arming.

### Fix
- `normalize_idle_timeout_seconds` now pads the armed value by one wheel period: 4 s on the short wheel, one minute on the long wheel (values above 240 s, armed in whole minutes).
- This makes the timer fire at the requested duration plus at most one period, never earlier. The old code could fire up to one period early on both wheels.
- #33647 stays intact: a large `timeout` still extends the idle deadline past the 5 minute default, and `timeout: 0` or `false` still disables the timer.
- Verified: a new test in `test/js/web/fetch/fetch.test.ts` keeps requests in flight across a full sweep period with `timeout: 1000`. Stock bun aborts three of them at t=4 s. Also ran `fetch.tls.test.ts`, `fetch-http2-client.test.ts`, `bun-install-stalled-tls.test.ts`, `websocket-upgrade.test.ts` and the issue repro (0 aborts in both arms).

### Background
- The HTTP client arms an idle timer on every socket (default `BUN_CONFIG_HTTP_IDLE_TIMEOUT` = 300 s). When it fires, `HTTPClient::on_timeout` fails the request with `TimeoutError`.
- uSockets keeps two timer wheels: a short wheel swept every 4 s and a long wheel swept every minute. A timer armed for N ticks fires at the Nth sweep after arming, so the first tick can arrive almost at once.
- The padded 1 s override in two existing tests now fires at 4 to 8 s instead of 0 to 4 s. The TLS churn fixture and its test budget are adjusted for that window.

<details><summary>Notes</summary>

- The 4000/4100 threshold in the issue follows from the tick math: 4100 ms rounds to 5 s, which is 2 ticks, and per-request re-arming means the second tick is never reached by a short request.
- The long wheel had the same phase slop (up to one minute early for values above 240 s). The pad fixes both wheels, so the normalize function's "never fires earlier than asked" claim is now true.
- The pad moves the wheel boundary: values above 236 s now go to the long wheel, rounded up one minute past the requested value.
- `normalize_idle_timeout_seconds` callers: the per-request `timeout` (`AsyncHTTP::init`), the global default (`HTTPThread::on_start`), and the WebSocket handshake timeout (`WebSocketUpgradeClient`). All are HTTP-client side. `Bun.serve` timers are untouched.
- Full `fetch.test.ts` run: 324 pass, 40 fail. The 40 failures are container-environment failures (ConnectionRefused on `localhost` servers) and reproduce identically on main without this diff.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->