### PR TITLE
spawn(windows): stop closing an exposed extra stdio pipe handle twice

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1449,7 +1449,8 @@ fn spawn_maybe_sync(
                             Box::leak(pipe).close(Subprocess::on_pipe_close)
                         }
                         spawn::WindowsStdioResult::BufferFd(fd) => fd.close(),
-                        spawn::WindowsStdioResult::Unavailable => {}
+                        spawn::WindowsStdioResult::UnownedFd(_)
+                        | spawn::WindowsStdioResult::Unavailable => {}
                     }
                 }
             }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -883,14 +883,44 @@ impl Subprocess<'_> {
         array.push(global, JSValue::NULL)?; // TODO: align this with options
         array.push(global, JSValue::NULL)?; // TODO: align this with options
 
+        // Once the values are visible to JS the caller owns them (it hands
+        // them to `net.connect({ fd })`, which closes them with the socket).
+        // Our `uv_pipe_t` would close the same HANDLE again when this
+        // Subprocess is finalized, so expose a duplicate instead. The pipe is
+        // closed right away: as long as our handle stayed open, the child
+        // would not see EOF when the caller closes its copy. The duplicate is
+        // kept so later reads return the same value.
+        #[cfg(windows)]
+        this.stdio_pipes.with_mut(|pipes| {
+            for slot in pipes.iter_mut() {
+                let buffer = match core::mem::take(slot) {
+                    StdioResult::Buffer(buffer) => buffer,
+                    other => {
+                        *slot = other;
+                        continue;
+                    }
+                };
+                let handle = buffer.fd();
+                // On failure the slot stays `Unavailable` and reads as null.
+                if handle != bun_sys::windows::libuv::INVALID_HANDLE_VALUE {
+                    if let Ok(dup) = bun_sys::dup(bun_sys::Fd::from_system(handle)) {
+                        *slot = StdioResult::UnownedFd(dup);
+                    }
+                }
+                // `uv_close` is async; `close_and_destroy` frees the pipe from
+                // the close callback.
+                // SAFETY: Box-allocated uv::Pipe owned by this slot until now.
+                unsafe { bun_sys::windows::libuv::Pipe::close_and_destroy(Box::into_raw(buffer)) };
+            }
+        });
+
         for item in this.stdio_pipes.get().iter() {
             #[cfg(windows)]
             {
-                if let StdioResult::Buffer(buffer) = item {
-                    // `UvHandle::fd()` returns a `HANDLE` (`*mut c_void`);
-                    // expose the numeric handle value.
-                    let fdno: usize = buffer.fd() as usize;
-                    array.push(global, JSValue::js_number(fdno as f64))?;
+                if let StdioResult::UnownedFd(fd) = item {
+                    // Expose the numeric HANDLE value.
+                    let handle: usize = fd.native() as usize;
+                    array.push(global, JSValue::js_number(handle as f64))?;
                 } else {
                     array.push(global, JSValue::NULL)?;
                 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1810,7 +1810,7 @@ impl PipeReader {
                 reader.set_source(bun_io::Source::File(bun_io::Source::open_file(fd)));
                 StdioResult::BufferFd(fd)
             }
-            StdioResult::Unavailable => panic!("Shouldn't happen."),
+            StdioResult::UnownedFd(_) | StdioResult::Unavailable => panic!("Shouldn't happen."),
         };
 
         // Allocate directly into the Arc so the address is stable BEFORE we

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1460,6 +1460,12 @@ pub enum WindowsStdioResult {
     Unavailable,
     Buffer(Box<uv::Pipe>),
     BufferFd(Fd),
+    /// A stdio slot at index >= 3 whose value `Subprocess.stdio` has exposed:
+    /// a duplicate of the pipe's HANDLE that the caller owns and closes
+    /// (`net.connect({ fd })` adopts it). The `Buffer` it came from is closed
+    /// when the slot is downgraded, so nothing here closes this handle. The
+    /// counterpart of the POSIX `ExtraPipe::UnownedFd`.
+    UnownedFd(Fd),
 }
 
 #[cfg(windows)]

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -138,7 +138,9 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                     // takes ownership via `heap::take`.
                     unsafe { boxed.writer.set_pipe(bun_core::heap::into_raw(pipe)) };
                 }
-                WindowsStdioResult::BufferFd(_) | WindowsStdioResult::Unavailable => {
+                WindowsStdioResult::BufferFd(_)
+                | WindowsStdioResult::UnownedFd(_)
+                | WindowsStdioResult::Unavailable => {
                     unreachable!("StaticPipeWriter stdin requires WindowsStdioResult::Buffer");
                 }
             }

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1174,6 +1174,84 @@ describe("close handling", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "PASS", stderr: "", exitCode: 0 });
     });
+
+    it.if(isWindows)("'pipe' at index >= 3: the handle .stdio exposes is not closed again at GC", async () => {
+      // On Windows .stdio[3] is a HANDLE value. net.connect({fd}) adopts it
+      // and closes it with the socket. The getter used to expose the handle
+      // of its own uv_pipe_t and close that handle again when the Subprocess
+      // was GC'd. Windows reuses a closed handle value at once, so the second
+      // close destroyed whatever owned the value by then (a worker thread's
+      // handle, in the crash reports). Here the new owner is an event we put
+      // into the value on purpose: it stays signaled unless something closes
+      // it out from under us.
+      const fixture = /* js */ `
+        import { dlopen } from "bun:ffi";
+        import { connect } from "node:net";
+        const k32 = dlopen("kernel32.dll", {
+          CreateEventW: { args: ["ptr", "i32", "i32", "ptr"], returns: "ptr" },
+          SetHandleInformation: { args: ["ptr", "u32", "u32"], returns: "i32" },
+          WaitForSingleObject: { args: ["ptr", "u32"], returns: "u32" },
+          CloseHandle: { args: ["ptr"], returns: "i32" },
+        }).symbols;
+        const WAIT_OBJECT_0 = 0;
+        const isOpen = handle => k32.SetHandleInformation(handle, 0, 0) !== 0;
+
+        // Returns the handle value .stdio[3] exposed, now occupied by our
+        // event, or null when something else took the value first. The
+        // Subprocess is unreachable once this returns.
+        async function spawnReadAndReoccupy() {
+          const proc = Bun.spawn({
+            cmd: [process.execPath, "-e", "require('fs').writeSync(3, 'hi')"],
+            stdio: ["ignore", "ignore", "ignore", "pipe"],
+          });
+          const handle = proc.stdio[3];
+          if (typeof handle !== "number") throw new Error("stdio[3] is " + String(handle));
+          if (proc.stdio[3] !== handle) throw new Error("stdio[3] changed between reads");
+          const socket = connect({ fd: handle });
+          let data = "";
+          socket.on("data", chunk => (data += chunk));
+          // EOF when the child exits; the socket closes the handle.
+          await new Promise(resolve => socket.once("close", resolve));
+          await proc.exited;
+          if (data !== "hi") throw new Error("read " + JSON.stringify(data) + " through stdio[3]");
+          if (isOpen(handle)) return null;
+
+          // Allocate until the kernel gives the value back to us.
+          const misses = [];
+          let occupied = false;
+          for (let i = 0; i < 4096 && !occupied && !isOpen(handle); i++) {
+            const event = Number(k32.CreateEventW(null, 1, 1, null));
+            if (event === handle) occupied = true;
+            else misses.push(event);
+          }
+          for (const event of misses) k32.CloseHandle(event);
+          return occupied ? handle : null;
+        }
+
+        const events = [];
+        for (let i = 0; i < 3; i++) {
+          const handle = await spawnReadAndReoccupy();
+          if (handle !== null) events.push(handle);
+        }
+        for (let i = 0; i < 8; i++) {
+          Bun.gc(true);
+          await Bun.sleep(0);
+        }
+        const closedAgain = events.filter(event => k32.WaitForSingleObject(event, 0) !== WAIT_OBJECT_0);
+        for (const event of events) k32.CloseHandle(event);
+        if (closedAgain.length) {
+          throw new Error("the Subprocess finalizer closed " + closedAgain.length + "/" + events.length + " handle values it had handed out");
+        }
+        console.log("PASS");
+      `;
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "PASS", stderr: "", exitCode: 0 });
+    });
   });
 });
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -969,6 +969,72 @@ it.skipIf(isWindows)("extra stdio pipes are not double-closed on GC", async () =
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "OK", stderr: "", exitCode: 0 });
 });
 
+// Windows: the extra "pipe" slots are HANDLE values that child_process wraps
+// in net.Sockets (net.connect({fd})); each socket closes its handle. The
+// Subprocess used to keep its own uv_pipe_t on the same HANDLE and close the
+// value again when it was GC'd. Windows reuses a closed handle value at once,
+// so that second close destroyed whatever owned the value by then (here the
+// files opened right after the sockets closed, in the crash reports a worker
+// thread's handle). test/js/bun/spawn/spawn.test.ts pins the exact handle
+// value down; this checks the child_process wiring on top of it.
+it.if(isWindows)("extra stdio 'pipe' sockets deliver data and GC of the ChildProcess closes nothing else", async () => {
+  const fixture = /* js */ `
+    const { spawn } = require("node:child_process");
+    const fs = require("node:fs");
+
+    // The ChildProcess is unreachable once this returns; only the files
+    // opened into the freed handle values are kept.
+    async function spawnAndReadThenOpenFiles(files) {
+      const child = spawn(
+        process.execPath,
+        ["-e", "const fs = require('fs'); for (const fd of [3, 4, 5]) fs.writeSync(fd, 'fd' + fd);"],
+        { stdio: ["ignore", "ignore", "ignore", "pipe", "pipe", "pipe"] },
+      );
+      const sockets = child.stdio.slice(3);
+      if (sockets.length !== 3 || sockets.some(s => s == null)) throw new Error("expected 3 extra sockets");
+      // Each socket closes on the EOF it sees once the child exits.
+      const received = sockets.map(socket => {
+        let data = "";
+        socket.on("data", chunk => (data += chunk));
+        return new Promise(resolve => socket.once("close", () => resolve(data)));
+      });
+      await new Promise(resolve => child.once("exit", resolve));
+      const data = await Promise.all(received);
+      if (data.join(",") !== "fd3,fd4,fd5") throw new Error("bad data: " + JSON.stringify(data));
+      for (let i = 0; i < 32; i++) files.push(fs.openSync(process.execPath, "r"));
+    }
+
+    const files = [];
+    for (let round = 0; round < 3; round++) {
+      await spawnAndReadThenOpenFiles(files);
+      Bun.gc(true);
+      await Bun.sleep(0);
+    }
+    for (let i = 0; i < 4; i++) {
+      Bun.gc(true);
+      await Bun.sleep(0);
+    }
+    let dead = 0;
+    for (const fd of files) {
+      try {
+        fs.fstatSync(fd);
+      } catch {
+        dead++;
+      }
+    }
+    if (dead) throw new Error("GC of the ChildProcess closed " + dead + " unrelated handles");
+    console.log("OK");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "OK", stderr: "", exitCode: 0 });
+});
+
 // For fd 0-2, "ignore" opens /dev/null. For fd >= 3, Node leaves the fd
 // closed; Bun used to open /dev/null on the slot, so children probing
 // "is fd N open?" observed a different answer than under Node.


### PR DESCRIPTION
### Problem
- On Windows, `Subprocess.stdio[i]` for `i >= 3` exposes the HANDLE of the parent-side `uv_pipe_t` (`src/runtime/api/bun/subprocess.rs`, `get_stdio`). `node:child_process` passes that value to `net.connect({ fd })` (`src/js/node/child_process.ts:1281`), which adopts it into a second `uv_pipe_t` (`src/runtime/socket/Listener.rs:1195`) and closes it with the socket. The Subprocess kept the first `uv_pipe_t` and closed the same HANDLE value again in `finalize_streams`. Windows reuses a closed handle value at once, so the second close destroyed whatever owned the value by then. `child_process.spawn(cmd, { stdio: ["pipe", "pipe", "pipe", "pipe"] })` is enough to hit it (Playwright and ffmpeg launchers use such pipes).
- Found while investigating the crash `failed to join on thread: ... (os error 6)` in `WebWorker::join` (Sentry BUN-4NEC, Windows, 1.4.0): the std thread handle of a Worker had been closed by someone else in the process. This stale close is one Bun-side way for that to happen. The tags of the report (`spawn`, `workers_spawned`) fit, but one report cannot prove it was this one.
- #33828 fixed the same ownership problem on POSIX. The Windows arm was left out, and its regression tests skip on Windows.

### Fix
- `get_stdio` on Windows duplicates each `Buffer` slot's handle with `bun_sys::dup`, closes its own pipe right away, and stores the duplicate as the new `WindowsStdioResult::UnownedFd`. Reads return the duplicate's value, and `finalize_streams` and the VM teardown path leave it alone. This is the Windows form of the POSIX downgrade to `ExtraPipe::UnownedFd`.
- The pipe is closed at once, not at finalize: while Bun's handle stayed open, the child would not see EOF after the caller closed its copy. The duplicate refers to the same pipe, so `net.connect` reads it as before.
- If `dup` fails, the slot stays `Unavailable` and reads as `null`. The three exhaustive matches on `WindowsStdioResult` gain the new arm.
- Verified on a Windows x64 debug build: the two new tests in `test/js/bun/spawn/spawn.test.ts` and `test/js/node/child_process/child_process.test.ts` fail 6 of 6 runs on the current canary and pass on this build. `spawn.test.ts`, `child_process.test.ts` and the spawn IPC tests pass on that build.

### Background
- A `uv_pipe_t` owns its OS handle: `uv_close` on it calls `CloseHandle`. `Bun.connect({ fd })` on Windows turns a HANDLE value into a CRT fd with `_open_osfhandle` and gives it to a new `uv_pipe_t`, so after that call two `uv_pipe_t` owned one handle.
- On Windows files, pipes, events, processes and threads share one handle table per process, and a freed value is reissued at once. A stale `CloseHandle` therefore closes an unrelated object. `Fd::close` asserts on this only in debug builds, and this path did not go through it at all.
- `stdio_pipes` holds the slots for indexes 3 and up. `finalize_streams` (GC) and `stop_for_vm_teardown` (a Worker exiting) close every slot that still holds a pipe.

<details><summary>Notes</summary>

- The spawn.test.ts test pins the mechanism down exactly. After the socket closed the exposed value, it allocates events until the kernel reissues that value, drops the Subprocess, runs the GC and checks the event is still signaled. On the unfixed build every checked value is closed again (3 of 3 in each of 6 runs). An iteration is skipped when something else reissues the value first. On the debug build that is usually the second of the three iterations, the other two were conclusive in 8 of 8 runs. On the release canary all three were conclusive in 6 of 6 runs.
- The child_process.test.ts test covers the wiring on top: the three sockets deliver the child's data, and the files opened after the sockets closed survive the GC of the ChildProcess. On the unfixed build 3 or 6 of them die with EBADF in every run.
- Debug timings on the Windows machine used here: about 1.9 s and 2.1 s per test, most of it three debug-build child starts each.
- Not changed: `Listener.rs` interprets a `{ fd }` number as a CRT fd first and only then as a HANDLE, so a HANDLE value that happens to match an open CRT fd number is still adopted as the wrong object. Separate issue.
- The related stale close in `Dir::cwd()` (`src/sys/dir.rs`, Windows only, needs a concurrent `process.chdir()`) is handled separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->