### PR TITLE
crash_handler: report an exhausted address space during JSC initialization as an error, not a crash

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -711,6 +711,11 @@ mod draft {
         Print(&'static [u8]),
         Resolver,
         Dlopen(&'static [u8]),
+        /// `JSC::initialize()` (`bun_jsc::initialize`). Its address space
+        /// reservations fail with a `RELEASE_ASSERT`, so a crash here is
+        /// checked for an exhausted address space first: see
+        /// [`exit_if_jsc_initialization_ran_out_of_address_space`].
+        InitializeJsc,
     }
 
     impl fmt::Display for Action {
@@ -723,6 +728,7 @@ mod draft {
                 Action::Dlopen(path) => {
                     write!(writer, "loading native module: {}", bstr::BStr::new(path))
                 }
+                Action::InitializeJsc => writer.write_str("initializing JavaScriptCore"),
             }
         }
     }
@@ -797,6 +803,10 @@ mod draft {
 
         match PANIC_STAGE.with(|s| s.get()) {
             0 => {
+                if matches!(current_action(), Some(Action::InitializeJsc)) {
+                    exit_if_jsc_initialization_ran_out_of_address_space();
+                }
+
                 bun_core::maybe_handle_panic_during_process_reload();
 
                 PANIC_STAGE.with(|s| s.set(1));
@@ -1243,6 +1253,95 @@ mod draft {
         }
 
         crash(reason);
+    }
+
+    /// The address space that the smallest reservation `JSC::initialize()` can
+    /// start with needs. JSC halves its 4 GB Structure heap request while the
+    /// reservation fails (`StructureAlignedMemoryAllocator.cpp`). 64 MB is the
+    /// last size mimalloc accepts as an arena, and `OSAllocator::
+    /// tryReserveUncommittedAligned` maps twice that to align it.
+    #[cfg(unix)]
+    const JSC_MINIMUM_RESERVATION_MB: usize = 128;
+
+    /// JSC crashes with a `RELEASE_ASSERT` when it cannot reserve the address
+    /// space for its heaps (`ulimit -v`, a container limit, strict overcommit).
+    /// That is not a bug to report: when the process cannot reserve
+    /// [`JSC_MINIMUM_RESERVATION_MB`] at the time of the crash, this prints
+    /// what is wrong and exits. Otherwise it returns and the crash is reported.
+    ///
+    /// Windows limits commit charge, not address space, so a crash there is
+    /// always reported.
+    fn exit_if_jsc_initialization_ran_out_of_address_space() {
+        #[cfg(unix)]
+        {
+            use bun_core::pretty_error;
+
+            if can_reserve_address_space(JSC_MINIMUM_RESERVATION_MB * 1024 * 1024) {
+                return;
+            }
+
+            pretty_error!(
+                "\n<r><red>error<r>: Bun ran out of virtual address space while initializing JavaScriptCore.\n\nJavaScriptCore reserves address space for its heaps at startup. This process could not reserve another {} MB.\n",
+                JSC_MINIMUM_RESERVATION_MB,
+            );
+            match address_space_limit() {
+                // `ulimit -v` sets and prints the limit in KB.
+                Some(limit) => pretty_error!(
+                    "\n<d>Current limit: {} KB (ulimit -v)<r>\n\nTo fix this, raise or remove the limit:\n\n  <cyan>ulimit -v unlimited<r>\n",
+                    limit / 1024,
+                ),
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                None => pretty_error!(
+                    "\nThis process has no <cyan>ulimit -v<r> limit. Check the memory limits of the container or sandbox it runs in, and <cyan>vm.overcommit_memory<r> if it is set to 2.\n",
+                ),
+                #[cfg(not(any(target_os = "linux", target_os = "android")))]
+                None => pretty_error!(
+                    "\nThis process has no <cyan>ulimit -v<r> limit. Check the memory limits of the container or sandbox it runs in.\n",
+                ),
+            }
+            Global::exit(1);
+        }
+    }
+
+    /// Maps and unmaps `len` bytes the way JSC reserves its heaps on POSIX.
+    #[cfg(unix)]
+    fn can_reserve_address_space(len: usize) -> bool {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        const FLAGS: c_int = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE;
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        const FLAGS: c_int = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+
+        // SAFETY: an anonymous mapping ignores the fd and offset; nothing is
+        // written through the mapping before it is unmapped again.
+        unsafe {
+            let ptr = libc::mmap(
+                core::ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                FLAGS,
+                -1,
+                0,
+            );
+            if ptr == libc::MAP_FAILED {
+                return false;
+            }
+            libc::munmap(ptr, len);
+        }
+        true
+    }
+
+    /// The soft `RLIMIT_AS` limit in bytes, `None` when it is unlimited.
+    #[cfg(unix)]
+    fn address_space_limit() -> Option<usize> {
+        // SAFETY: zeroed rlimit is valid POD; getrlimit only writes to it.
+        let mut lim: libc::rlimit = bun_core::ffi::zeroed();
+        // SAFETY: &mut lim is a valid out-pointer.
+        if unsafe { libc::getrlimit(libc::RLIMIT_AS, &raw mut lim) } != 0
+            || lim.rlim_cur == libc::RLIM_INFINITY
+        {
+            return None;
+        }
+        usize::try_from(lim.rlim_cur).ok()
     }
 
     /// This is called when `main` returns an error.

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -711,10 +711,7 @@ mod draft {
         Print(&'static [u8]),
         Resolver,
         Dlopen(&'static [u8]),
-        /// `JSC::initialize()` (`bun_jsc::initialize`). Its address space
-        /// reservations fail with a `RELEASE_ASSERT`, so a crash here is
-        /// checked for an exhausted address space first: see
-        /// [`exit_if_jsc_initialization_ran_out_of_address_space`].
+        /// Inside `JSC::initialize()`. See `exit_if_jsc_initialization_ran_out_of_address_space`.
         InitializeJsc,
     }
 
@@ -1255,22 +1252,16 @@ mod draft {
         crash(reason);
     }
 
-    /// The address space that the smallest reservation `JSC::initialize()` can
-    /// start with needs. JSC halves its 4 GB Structure heap request while the
-    /// reservation fails (`StructureAlignedMemoryAllocator.cpp`). 64 MB is the
-    /// last size mimalloc accepts as an arena, and `OSAllocator::
-    /// tryReserveUncommittedAligned` maps twice that to align it.
+    /// The smallest Structure heap JSC starts with is 64 MB (the last rung of
+    /// `StructureAlignedMemoryAllocator.cpp` that mimalloc accepts as an arena),
+    /// reserved as size + alignment.
     #[cfg(unix)]
     const JSC_MINIMUM_RESERVATION_MB: usize = 128;
 
-    /// JSC crashes with a `RELEASE_ASSERT` when it cannot reserve the address
-    /// space for its heaps (`ulimit -v`, a container limit, strict overcommit).
-    /// That is not a bug to report: when the process cannot reserve
-    /// [`JSC_MINIMUM_RESERVATION_MB`] at the time of the crash, this prints
-    /// what is wrong and exits. Otherwise it returns and the crash is reported.
-    ///
-    /// Windows limits commit charge, not address space, so a crash there is
-    /// always reported.
+    /// `JSC::initialize()` hits a `RELEASE_ASSERT` when its reservations fail.
+    /// If the process cannot reserve [`JSC_MINIMUM_RESERVATION_MB`] now, that is
+    /// the cause: print it and exit instead of reporting a crash. Unix only,
+    /// Windows limits commit charge rather than address space.
     fn exit_if_jsc_initialization_ran_out_of_address_space() {
         #[cfg(unix)]
         {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1252,16 +1252,13 @@ mod draft {
         crash(reason);
     }
 
-    /// The smallest Structure heap JSC starts with is 64 MB (the last rung of
-    /// `StructureAlignedMemoryAllocator.cpp` that mimalloc accepts as an arena),
-    /// reserved as size + alignment.
+    /// 64 MB is the smallest Structure heap rung that mimalloc accepts as an arena
+    /// (`StructureAlignedMemoryAllocator.cpp`). JSC reserves it as size + alignment.
     #[cfg(unix)]
     const JSC_MINIMUM_RESERVATION_MB: usize = 128;
 
-    /// `JSC::initialize()` hits a `RELEASE_ASSERT` when its reservations fail.
-    /// If the process cannot reserve [`JSC_MINIMUM_RESERVATION_MB`] now, that is
-    /// the cause: print it and exit instead of reporting a crash. Unix only,
-    /// Windows limits commit charge rather than address space.
+    /// A crash in `JSC::initialize()` while [`JSC_MINIMUM_RESERVATION_MB`] cannot be reserved
+    /// anymore is the environment's doing (`ulimit -v`): print that and exit instead of reporting it.
     fn exit_if_jsc_initialization_ran_out_of_address_space() {
         #[cfg(unix)]
         {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -497,6 +497,7 @@ pub fn initialize(options: InitializeOptions) {
     // `bun_analytics`.
     bun_core::analytics::Features::jsc_inc();
     let env = bun_sys::environ();
+    let _action = bun_crash_handler::scoped_action(bun_crash_handler::Action::InitializeJsc);
     // SAFETY: `env` borrows the libc `environ` global for the duration of the
     // call; `on_jsc_invalid_env_var` is `extern "C"` and only reads the (ptr,len)
     // it is handed. JSCInitialize is called exactly once at startup.

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -170,6 +170,74 @@ describe.if(isPosix)("cwd deleted before startup", () => {
   });
 });
 
+// JSC::initialize() reserves address space for its heaps and crashes with a
+// RELEASE_ASSERT when a reservation fails. ASAN builds skip: bun does not
+// install its signal handlers under ASAN, and ASAN itself needs terabytes of
+// address space, so it does not start under any `ulimit -v` that matters here.
+describe.if(isPosix && !isASAN)("crash while initializing JavaScriptCore", () => {
+  const outOfAddressSpace = "Bun ran out of virtual address space while initializing JavaScriptCore";
+
+  // Linux only: macOS does not enforce RLIMIT_AS. The limit at which JSC's
+  // reservation is the thing that no longer fits depends on the size of the
+  // binary and on what bun's own allocator reserved before it, so walk the
+  // limit up until a run ends that way. Such a run must end with the error
+  // message, not with a crash report.
+  test.if(isLinux)("under a small ulimit -v, exits with an error instead of a crash report", async () => {
+    const outcomes: string[] = [];
+    for (let limitMiB = 256; limitMiB <= 4096; limitMiB += 64) {
+      await using proc = Bun.spawn({
+        cmd: [
+          "/bin/sh",
+          "-c",
+          'ulimit -c 0 && ulimit -v "$1" && exec "$2" -e 1',
+          "sh",
+          String(limitMiB * 1024),
+          bunExe(),
+        ],
+        env: noReportEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      if (exitCode === 0) {
+        outcomes.push(`${limitMiB} MiB: started`);
+        continue;
+      }
+      if (!stderr.includes(outOfAddressSpace)) {
+        const summary = stderr.split("\n").find(line => line.includes("panic") || line.includes("error")) ?? "";
+        outcomes.push(`${limitMiB} MiB: exit ${exitCode} (${proc.signalCode}) ${summary}`);
+        continue;
+      }
+
+      expect(stderr).toContain(`Current limit: ${limitMiB * 1024} KB (ulimit -v)`);
+      expect(stderr).toContain("ulimit -v unlimited");
+      expect(stderr).not.toContain("panic");
+      expect(stderr).not.toContain("Bun has crashed");
+      expect(exitCode).toBe(1);
+      return;
+    }
+    throw new Error(`no limit between 256 MiB and 4 GiB ended with the address space error:\n${outcomes.join("\n")}`);
+  });
+
+  // A crash during initialization that the address space does not explain is
+  // a bug. Its report says where it happened. structureHeapSizeInKB must be a
+  // power of two: 3072 trips a RELEASE_ASSERT in the constructor that reserves
+  // the heap, before the reservation.
+  test("a crash that the address space does not explain is reported", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "1", "--debug-crash-handler-use-trace-string"],
+      env: { ...noReportEnv, BUN_JSC_structureHeapSizeInKB: "3072" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Crashed while initializing JavaScriptCore");
+    expect(stderr).not.toContain(outOfAddressSpace);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
 // Windows: the VEH handler must walk the stack from the fault CONTEXT record
 // (RtlVirtualUnwind), not from inside the handler. When the fault is in an
 // external DLL the old RtlCaptureStackBackTrace path could stop at

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,18 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isArm64,
+  isASAN,
+  isDebug,
+  isLinux,
+  isMacOS,
+  isPosix,
+  isWindows,
+  mergeWindowEnvs,
+  tempDir,
+} from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -10,6 +22,13 @@ const { getMachOImageZeroOffset } = crash_handler;
 // deliberate crashes must not upload there or the runner pins them on the
 // next unrelated failing test as "crash reported" and blocks its retries.
 const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" };
+
+// For children that die via SIG_DFL (rather than via a test hook that calls
+// suppress_core_dumps_if_necessary()): on the --coredump-upload CI lane the
+// runner flags leaked core files as a hard failure. ulimit -c 0 in a shell
+// wrapper is inherited by the bun child (and by anything it spawns); every
+// user is isPosix-gated so /bin/sh is available.
+const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
 
 // On Linux, debug builds symbolize crash traces by spawning llvm-symbolizer;
 // without it the fallback printer has no Rust symbol names to assert on.
@@ -223,9 +242,14 @@ describe.if(isPosix && !isASAN)("crash while initializing JavaScriptCore", () =>
   // a bug. Its report says where it happened. structureHeapSizeInKB must be a
   // power of two: 3072 trips a RELEASE_ASSERT in the constructor that reserves
   // the heap, before the reservation.
-  test("a crash that the address space does not explain is reported", async () => {
+  //
+  // Not on Apple Silicon: a release RELEASE_ASSERT there is `brk #0xbb08`, and
+  // macOS 26 kills the process with SIGKILL on that instruction before any
+  // SIGTRAP handler runs (a plain C program with a SIGTRAP handler dies the
+  // same way), so this crash is not observable by the crash handler at all.
+  test.if(!(isMacOS && isArm64))("a crash that the address space does not explain is reported", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "1", "--debug-crash-handler-use-trace-string"],
+      cmd: noCoreCmd([bunExe(), "-e", "1", "--debug-crash-handler-use-trace-string"]),
       env: { ...noReportEnv, BUN_JSC_structureHeapSizeInKB: "3072" },
       stdout: "pipe",
       stderr: "pipe",
@@ -453,13 +477,6 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
   expect(proc.exited).resolves.not.toBe(0);
   expect(sent).toBe(false);
 });
-
-// For children that die via SIG_DFL (rather than via a test hook that calls
-// suppress_core_dumps_if_necessary()): on the --coredump-upload CI lane the
-// runner flags leaked core files as a hard failure. ulimit -c 0 in a shell
-// wrapper is inherited by the bun child (and by anything it spawns); every
-// user is isPosix-gated so /bin/sh is available.
-const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
 
 // SIGABRT (libc abort(), mimalloc/glibc heap-corruption, std::terminate) and
 // SIGTRAP (WTF CRASH()/RELEASE_ASSERT, __builtin_trap() -> `brk` on aarch64)


### PR DESCRIPTION
### Problem
- Short of address space, `JSC::initialize()` aborts in `JSC::StructureMemoryManager::StructureMemoryManager()` (`WTFCrashWithInfo`, `abort() called`) and bun prints "Bun has crashed. This indicates a bug in Bun" with a report link. Sentry BUN-4NF7, bun 1.4.0 Linux x64.
- JSC halves its 4 GB Structure heap request down to 32 MB (`StructureAlignedMemoryAllocator.cpp:113`). The 32 MB rung always fails the `mi_manage_os_memory_ex` assert at `:147` (mimalloc needs 32768 KiB, gets 32704). If no rung fits, `:123` aborts. Both mean `ulimit -v`, a container limit or strict overcommit.
- A check before `JSC::initialize()` cannot catch it: bun's 1 GiB mimalloc arena or JSC's 1 GiB JIT pool can take the space just before the Structure heap (Notes).

### Fix
- `bun_jsc::initialize` sets `Action::InitializeJsc` (the existing `scoped_action`) around `JSCInitialize`.
- A crash with that action set first maps and unmaps 128 MB, what JSC's smallest usable reservation needs. If that fails, bun prints an error with the `ulimit -v` value and exits 1, with no report. Otherwise the crash is reported as before, plus a "Crashed while initializing JavaScriptCore" line.
- Correct because under 128 MB is free at either assert (`:147`: under 96 MB, `:123`: under 64 MB), and with less than that JSC cannot start, whatever else is wrong.
- Verified: two new tests in `test/cli/run/run-crash-handler.test.ts`. They fail on the 1.4.0 release and the unfixed canary, pass on a release build of this branch, and skip under ASAN (Notes).

### Background
- In release JSC, `RELEASE_ASSERT` is `abort()`. bun handles `SIGABRT` in `crash_handler()`, the one place that can tell this case from a bug.
- `CURRENT_ACTION` is a thread local the handler prints as "Crashed while ...". The crash is on the thread that called `JSC::initialize`, so the handler sees it.
- oven-sh/WebKit#483 fixes the `:147` half at the source: JSC falls back to its block bitmap and starts with a 32 MB heap. This change still covers `:123` after that bump.

<details><summary>Notes</summary>

Which assert: in the 1.4.0 x64 binary, frame `0x17ffc20` is the return address of the one `call WTFCrashWithInfo` in the constructor. It is shared by `:110` (`hasOneBitSet`, needs a user set `structureHeapSizeInKB`) and `:147` (`mov $0x93,%edi` on the `mi_manage_os_memory_ex` failure edge). `:123`, `:124` and `:126` take extra arguments and compile to direct `call abort@plt`, with no `WTFCrashWithInfo` frame. The Sentry trace has that frame, so it is `:147` (or `:110`).

Why mimalloc says no: the constructor hands it `32 MiB - 16 KiB` (one block is kept for StructureID 0). mimalloc aligns the start up to its 64 KiB slice size and then needs one whole chunk of slices, `MI_ARENA_MIN_SIZE` = 32 MiB. Every rung from 64 MB up passes.

Reproduction on the 1.4.0 release binary. Both print the trace string of BUN-4NF7 (`...gi+/vBq1l8vB...`, `gi+/vB` decodes to `0x17ffc20`):

```
bash -c 'ulimit -v 300000; exec bun -e 1'
BUN_JSC_structureHeapSizeInKB=32768 bun -e 1     # 65536 works
```

`MIMALLOC_SHOW_ERRORS=1` prints `cannot use OS memory since it is not large enough (size 32704 KiB, minimum required is 32768 KiB)` right before the panic.

Three `ulimit -v` windows abort on 1.4.0 x64 release: about 100 to 340 MB, 1.15 to 1.27 GB and 2.20 to 2.33 GB. `MIMALLOC_VERBOSE=1` and `BUN_JSC_verboseExecutablePoolAllocation=1` show what fills the upper two: `reserved 1048576 KiB memory` (bun's arena) for 1.15 to 1.27 GB, and a successful JIT pool reservation for 2.20 to 2.33 GB. Both happen after anything bun could check and before the Structure heap. Each window is about 128 MB wide, the width of the reservation that stops fitting. bun 1.3.14 dies under the same limits too (SIGILL or SIGTRAP, no output, up to about 400 MB), so this is a new report signature, not a regression.

Output of this branch under `ulimit -v 300000`:

```
error: Bun ran out of virtual address space while initializing JavaScriptCore.

JavaScriptCore reserves address space for its heaps at startup. This process could not reserve another 128 MB.

Current limit: 300000 KB (ulimit -v)

To fix this, raise or remove the limit:

  ulimit -v unlimited
```

Limits 1200000, 2200000 (`:123`) and 2280000 (`:147`) print the same. `BUN_JSC_structureHeapSizeInKB=3072` and `=32768`, with plenty of address space, still print the crash report plus `Crashed while initializing JavaScriptCore`.

The 128 MB: the last rung mimalloc accepts is 64 MB, and `OSAllocator::tryReserveUncommittedAligned` maps size + alignment on Linux to align it. The probe uses the same `mmap` flags as that reservation. The check runs before `PANICKING` is incremented, so `Global::exit` does not park.

Tests. The first walks `ulimit -v` up from 256 MiB in 64 MiB steps until a run ends with the error, so it does not depend on where the windows are for a given binary. On the unfixed canary it logs: 256 and 320 MiB abort, 1152 and 1216 MiB abort, 2176 and 2240 MiB abort, everything else starts. On the fixed build the first limit already ends with the error. The second test uses `structureHeapSizeInKB=3072` (`:110`) as a crash that the address space does not explain. Both skip under ASAN: bun installs no signal handlers there (`reset_on_posix`), and ASAN itself needs about 20 TB of address space, so it does not start under any `ulimit -v` that reaches these windows. `bun bd test` therefore skips them; the Linux release lanes run both and the macOS x64 lane runs the second. The whole file passes on the release build: 20 pass, 8 skip.

The second test also skips on Apple Silicon. A release `RELEASE_ASSERT` there is `brk #0xbb08`, and macOS 26 (checked on 26.6.2, the CI lane runs 26.4) terminates the process with SIGKILL on that instruction before any SIGTRAP handler runs: the PR's own darwin-aarch64 build dies with `Killed: 9` and an empty stderr, its `.ips` report says `EXC_BREAKPOINT`, `brk 47880`, signal SIGKILL, and a 20 line C program with a SIGTRAP handler behaves the same for `brk #0xbb08` while `brk #0` reaches the handler. So on that platform a JSC initialization crash is not observable by bun's crash handler at all, with or without this change. Both crashing children now also run under `ulimit -c 0` so the Alpine lanes, which collect core files, do not fail the file on the expected crash.

The check is `cfg(unix)`: Windows limits commit charge rather than address space, so the probe would not mean anything there. The Windows Sentry issues in the same constructor (BUN-482B, BUN-4AA0, BUN-3ZGR, on 1.3.14 and 1.4.0 canaries) are not explained by this analysis. They keep their crash report and also get the "Crashed while initializing JavaScriptCore" line, since the action is set on every platform.

Also run: `cargo check -p bun_crash_handler` for x86_64-pc-windows-msvc, x86_64-apple-darwin, x86_64-unknown-freebsd, aarch64-linux-android and x86_64-unknown-linux-musl, `cargo clippy -p bun_crash_handler`, `cargo check -p bun_jsc`, `bun bd test test/cli/run/run-crash-handler.test.ts` (ASAN, new tests skip).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->