### PR TITLE
process.dlopen: replay a non-context-aware V8 addon only while no other live VM owns it

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -406,6 +406,16 @@ extern "C" void CrashHandler__setDlOpenAction(const char* action);
 extern "C" bool Bun__VM__allowAddons(void* vm);
 extern "C" int32_t Bun__addonNeedsGlibcOnMusl(const char* path, size_t len, char* soname_out, size_t soname_cap);
 
+// A library that registered modules on an earlier load stays loaded through that load's reference.
+static void closeDLHandle(Bun::DLHandleMap::DLHandle handle)
+{
+#if OS(WINDOWS)
+    FreeLibrary(handle);
+#else
+    dlclose(handle);
+#endif
+}
+
 JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((minsize)), (JSC::JSGlobalObject * globalObject_, JSC::CallFrame* callFrame))
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(globalObject_);
@@ -602,7 +612,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
 
             // Save all V8 C++ module registrations
             for (auto* mod : pendingV8Modules) {
-                Bun::DLHandleMap::singleton().add(handle, mod);
+                Bun::DLHandleMap::singleton().add(handle, mod, vm);
             }
         }
 
@@ -650,11 +660,18 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
             globalObject->m_pendingNapiModuleAndExports[1].clear();
         });
 
+        if (!Bun::DLHandleMap::singleton().claimForVM(handle, vm)) {
+            closeDLHandle(handle);
+            // Node.js's error for this case: the addon's static constructor only registers once.
+            return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
+                makeString("Module did not self-register: '"_s, filename, "'."_s));
+        }
+
         // Replay all registrations from this handle. napi ones only queue into
         // m_pendingNapiModules; a V8 one runs its nm_register_func right here.
         for (auto& registration : *cachedModules) {
-            if (auto* const* nodeModule = std::get_if<node::node_module*>(&registration)) {
-                node::node_module_register(*nodeModule);
+            if (auto* v8Module = std::get_if<Bun::V8ModuleRegistration>(&registration)) {
+                node::node_module_register(v8Module->module);
                 RETURN_IF_EXCEPTION(scope, {});
             } else {
                 napi_module_register(std::get<napi_module*>(registration));
@@ -703,11 +720,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
 #endif
 
     if (!napi_register_module_v1) {
-#if OS(WINDOWS)
-        FreeLibrary(handle);
-#else
-        dlclose(handle);
-#endif
+        closeDLHandle(handle);
 
         if (!scope.exception()) [[likely]] {
             JSC::throwTypeError(globalObject, scope, "symbol 'napi_register_module_v1' not found in native module. Is this a Node API (napi) module?"_s);

--- a/src/jsc/bindings/DLHandleMap.h
+++ b/src/jsc/bindings/DLHandleMap.h
@@ -3,6 +3,7 @@
 #include "root.h"
 #include "v8/node.h"
 #include "napi.h"
+#include <JavaScriptCore/VM.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/Vector.h>
@@ -16,8 +17,21 @@
 
 namespace Bun {
 
+struct V8ModuleRegistration {
+    node::node_module* module;
+
+    // The live VM that last ran the init of a module that bindsToVM(). See claimForVM and vmDestroyed.
+    std::optional<JSC::VMIdentifier> owner;
+
+    // nm_register_func (NODE_MODULE, NAN) keeps its handles in statics: one live VM at a time. A rejected module runs nothing.
+    static bool bindsToVM(const node::node_module& mod)
+    {
+        return !mod.nm_context_register_func && mod.nm_register_func && mod.nm_version == REPORTED_NODEJS_ABI_VERSION;
+    }
+};
+
 // A module can be either V8 C++ style or NAPI style
-using DLModuleRegistration = std::variant<node::node_module*, napi_module*>;
+using DLModuleRegistration = std::variant<V8ModuleRegistration, napi_module*>;
 
 // Thread-safe map for tracking dlopen handles to module registrations.
 // This allows re-loading the same native module multiple times, matching Node.js behavior.
@@ -27,6 +41,8 @@ using DLModuleRegistration = std::variant<node::node_module*, napi_module*>;
 // its static constructors run and call node_module_register() or napi_module_register().
 // On subsequent loads, dlopen() returns the same handle but the constructors don't run again.
 // We use this map to look up and replay all saved registrations.
+//
+// Node.js refuses every second load of a module that bindsToVM(); Bun only refuses it while another live VM owns it (#23136).
 class DLHandleMap {
 public:
 #if OS(WINDOWS)
@@ -46,15 +62,19 @@ public:
         return *s_instance;
     }
 
-    // Add a V8 C++ module registration to the vector for this handle
-    void add(DLHandle handle, node::node_module* module)
+    // Add a V8 C++ module registration to the vector for this handle. `vm` just ran its init.
+    void add(DLHandle handle, node::node_module* module, JSC::VM& vm)
     {
         ASSERT(handle != nullptr);
         ASSERT(module != nullptr);
 
+        std::optional<JSC::VMIdentifier> owner;
+        if (V8ModuleRegistration::bindsToVM(*module))
+            owner = vm.identifier();
+
         WTF::Locker locker { m_lock };
         auto& registrations = m_map.ensure(handle, [] { return WTF::Vector<DLModuleRegistration>(); }).iterator->value;
-        registrations.append(DLModuleRegistration(module));
+        registrations.append(DLModuleRegistration(V8ModuleRegistration { module, owner }));
     }
 
     // Add a NAPI module registration to the vector for this handle
@@ -81,6 +101,53 @@ public:
         }
 
         return it->value;
+    }
+
+    // Makes `vm` own this handle's bindsToVM() modules before replaying them. False, and no change, while another live VM owns one.
+    bool claimForVM(DLHandle handle, JSC::VM& vm)
+    {
+        ASSERT(handle != nullptr);
+        auto identifier = vm.identifier();
+
+        WTF::Locker locker { m_lock };
+
+        auto it = m_map.find(handle);
+        ASSERT(it != m_map.end());
+        if (it == m_map.end()) {
+            return true;
+        }
+
+        auto& registrations = it->value;
+        for (auto& registration : registrations) {
+            auto* v8Module = std::get_if<V8ModuleRegistration>(&registration);
+            if (v8Module && v8Module->owner && *v8Module->owner != identifier) {
+                return false;
+            }
+        }
+
+        for (auto& registration : registrations) {
+            auto* v8Module = std::get_if<V8ModuleRegistration>(&registration);
+            if (v8Module && V8ModuleRegistration::bindsToVM(*v8Module->module)) {
+                v8Module->owner = identifier;
+            }
+        }
+
+        return true;
+    }
+
+    // Called once the VM no longer exists, so nothing can run the modules it owned any more.
+    void vmDestroyed(JSC::VMIdentifier identifier)
+    {
+        WTF::Locker locker { m_lock };
+
+        for (auto& registrations : m_map.values()) {
+            for (auto& registration : registrations) {
+                auto* v8Module = std::get_if<V8ModuleRegistration>(&registration);
+                if (v8Module && v8Module->owner == identifier) {
+                    v8Module->owner.reset();
+                }
+            }
+        }
     }
 
 private:

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -155,6 +155,7 @@
 #include "streams/JSWritableStreamDefaultWriter.h"
 #include "libusockets.h"
 #include "ModuleLoader.h"
+#include "DLHandleMap.h"
 #include "napi_external.h"
 #include "napi_handle_scope.h"
 #include "napi_type_tag.h"
@@ -4167,6 +4168,7 @@ extern "C" void Bun__GlobalObject__clearExceptionsForExit(Zig::GlobalObject* glo
 
 static void destroyVM(JSC::VM& vm)
 {
+    auto identifier = vm.identifier();
     vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
     // Every JSLockHolder still on the native stack (process.exit() from inside a JS callback,
     // the worker thread's manual API lock) holds a RefPtr<VM> that will never destruct because
@@ -4175,6 +4177,7 @@ static void destroyVM(JSC::VM& vm)
     for (uint32_t n = vm.refCount(); n > 1; --n)
         vm.derefSuppressingSaferCPPChecking();
     vm.derefSuppressingSaferCPPChecking();
+    Bun::DLHandleMap::singleton().vmDestroyed(identifier);
 }
 
 extern "C" void Zig__GlobalObject__prepareForDestruction(Zig::GlobalObject* globalObject)

--- a/test/js/node/process/dlopen-duplicate-load.test.ts
+++ b/test/js/node/process/dlopen-duplicate-load.test.ts
@@ -1,19 +1,28 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, canBuildNodeAddons, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, canBuildNodeAddons, nodeExeMatchingAbi, tempDirWithFiles } from "harness";
 import { join } from "path";
 
-// These tests share one node-gyp-built V8 addon (the compile dominates the wall
-// time), covering two previously-broken paths:
+// These tests share one node-gyp build of three V8 addons (the compile
+// dominates the wall time), covering three previously-broken paths:
 // - duplicate loads: the second dlopen of the same module used to fail with
 //   "symbol 'napi_register_module_v1' not found" because static constructors
 //   only run once, so the module registration wasn't replayed
 // - non-object exports: null/undefined/primitive exports used to segfault
+// - non-context-aware addons (NODE_MODULE, the NAN pattern): a load from a
+//   second thread used to run the addon's init again. The init keeps V8 handles
+//   in statics, so the first thread's statics then pointed into the other
+//   thread's heap and it crashed once that heap was gone. Node refuses the load
+//   while the thread that loaded the addon is alive.
 
 describe.skipIf(!canBuildNodeAddons())("process.dlopen native addon", () => {
   let addonPath: string;
+  let nonContextAwarePath: string;
+  let mismatchedAbiPath: string;
+  let workerFixturePath: string;
+  let nodeExe: string;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     const addonSource = `
 #include <node.h>
 
@@ -44,19 +53,175 @@ void Initialize(Local<Object> exports,
 NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
 `;
 
+    // The shape NAN generates: NODE_MODULE (no context register function) and
+    // a static Persistent that the init fills in for the isolate it ran in.
+    const nonContextAwareSource = `
+#include <node.h>
+
+namespace demo {
+
+using v8::Context;
+using v8::Function;
+using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
+using v8::Isolate;
+using v8::Local;
+using v8::Number;
+using v8::Object;
+using v8::Persistent;
+using v8::String;
+using v8::Value;
+
+Persistent<FunctionTemplate> constructor;
+int init_count = 0;
+
+void Hello(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world").ToLocalChecked());
+}
+
+void InitCount(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(Number::New(args.GetIsolate(), init_count));
+}
+
+// Reads the static the init filled in, like a NAN class's NewInstance.
+void MakeInstance(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Local<FunctionTemplate> tpl = Local<FunctionTemplate>::New(isolate, constructor);
+  Local<Function> fn = tpl->GetFunction(context).ToLocalChecked();
+  args.GetReturnValue().Set(fn->NewInstance(context).ToLocalChecked());
+}
+
+void Initialize(Local<Object> exports, Local<Value> module, void* priv) {
+  Isolate* isolate = Isolate::GetCurrent();
+  init_count++;
+  constructor.Reset(isolate, FunctionTemplate::New(isolate, Hello));
+  NODE_SET_METHOD(exports, "hello", Hello);
+  NODE_SET_METHOD(exports, "initCount", InitCount);
+  NODE_SET_METHOD(exports, "makeInstance", MakeInstance);
+}
+
+}  // namespace demo
+
+NODE_MODULE(non_context_aware, demo::Initialize)
+`;
+
+    // A non-context-aware addon built for another ABI: its init never runs, so
+    // every load, from any thread, must report the ABI mismatch.
+    const mismatchedAbiSource = `
+#include <node.h>
+#include <cstdlib>
+
+void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> module, void* priv) {
+  abort();
+}
+
+extern "C" {
+static node::node_module _module = {
+    42,                     // nm_version
+    0,                      // nm_flags
+    nullptr,                // nm_dso_handle
+    "mismatched_abi.cpp",   // nm_filename
+    Initialize,             // nm_register_func
+    nullptr,                // nm_context_register_func
+    "mismatched_abi",       // nm_modname
+    nullptr,                // nm_priv
+    nullptr,                // nm_link
+};
+
+NODE_C_CTOR(_register_mismatched_abi) {
+  node_module_register(&_module);
+}
+}
+`;
+
     const bindingGyp = `
 {
   "targets": [
     {
       "target_name": "addon",
       "sources": [ "addon.cpp" ]
+    },
+    {
+      "target_name": "non_context_aware",
+      "sources": [ "non_context_aware.cpp" ]
+    },
+    {
+      "target_name": "mismatched_abi",
+      "sources": [ "mismatched_abi.cpp" ]
     }
   ]
 }
 `;
 
+    // Loads the addon at $ADDON_PATH on the main thread and in a Worker and
+    // prints one JSON report. Runs under Node as well, to compare.
+    //
+    // Main thread first (default): main loads, the Worker loads, the Worker
+    // exits, main uses the exports it already has.
+    //
+    // Worker first ($WORKER_LOADS_FIRST): the Worker loads and then blocks on a
+    // message from main, main loads while the Worker is alive, the Worker
+    // exits, main loads again.
+    const workerFixture = `
+const { Worker, isMainThread, parentPort } = require("node:worker_threads");
+
+function describeExports(exports) {
+  const report = { hello: exports.hello() };
+  if (exports.initCount) report.initCount = exports.initCount();
+  if (exports.makeInstance) report.instance = typeof exports.makeInstance();
+  return report;
+}
+
+function load() {
+  const m = { exports: {} };
+  try {
+    process.dlopen(m, process.env.ADDON_PATH);
+  } catch (e) {
+    return { report: { loaded: false, code: e.code, message: e.message } };
+  }
+  return { report: { loaded: true, ...describeExports(m.exports) }, exports: m.exports };
+}
+
+if (!isMainThread) {
+  parentPort.postMessage(load().report);
+  parentPort.on("message", () => process.exit(0));
+} else {
+  const workerLoadsFirst = !!process.env.WORKER_LOADS_FIRST;
+  const result = {};
+  const main = workerLoadsFirst ? undefined : load();
+  if (main) result.main = main.report;
+
+  const worker = new Worker(__filename);
+  worker.on("message", report => {
+    result.worker = report;
+    if (workerLoadsFirst) result.mainWhileWorkerAlive = load().report;
+    worker.postMessage("exit");
+  });
+  worker.on("error", e => {
+    result.workerError = e.message;
+  });
+  worker.on("exit", exitCode => {
+    result.workerExitCode = exitCode;
+    if (workerLoadsFirst) {
+      result.mainAfterWorkerExit = load().report;
+    } else if (main.exports) {
+      // makeInstance reads the static the init filled in. It must still point
+      // into this thread's heap now that the worker is gone.
+      if (process.isBun) Bun.gc(true);
+      result.mainExportsAfterWorkerExit = describeExports(main.exports);
+    }
+    console.log(JSON.stringify(result));
+  });
+}
+`;
+
     const dir = tempDirWithFiles("dlopen-duplicate-test", {
       "addon.cpp": addonSource,
+      "non_context_aware.cpp": nonContextAwareSource,
+      "mismatched_abi.cpp": mismatchedAbiSource,
+      "worker-fixture.js": workerFixture,
       "binding.gyp": bindingGyp,
       "package.json": JSON.stringify({
         name: "test",
@@ -77,7 +242,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       }),
     });
 
-    // Build the addon
+    // Build the addons
     const build = spawnSync({
       cmd: [bunExe(), "install"],
       cwd: dir,
@@ -87,10 +252,14 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
     });
 
     if (!build.success) {
-      throw new Error("Failed to build native addon");
+      throw new Error("Failed to build native addons");
     }
 
     addonPath = join(dir, "build", "Release", "addon.node");
+    nonContextAwarePath = join(dir, "build", "Release", "non_context_aware.node");
+    mismatchedAbiPath = join(dir, "build", "Release", "mismatched_abi.node");
+    workerFixturePath = join(dir, "worker-fixture.js");
+    nodeExe = await nodeExeMatchingAbi();
   }, 180_000);
 
   // Each test spawns an isolated child (dlopen state is process-global), so
@@ -237,6 +406,122 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       expect(stdout).toContain("Type: string");
       expect(stdout).toContain("Value: primitive");
       expect(exitCode).toBe(0);
+    });
+  });
+
+  describe.concurrent("process.dlopen of an addon that is already loaded", () => {
+    async function runJsonFixture(cmd: string[], env: Record<string, string>) {
+      await using proc = Bun.spawn({
+        cmd,
+        env: { ...bunEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ exe: cmd[0], stderr, exitCode }).toEqual({ exe: cmd[0], stderr: "", exitCode: 0 });
+      return JSON.parse(stdout);
+    }
+
+    // Runs the worker fixture under the bun being tested and under the node
+    // whose addon ABI the addons were built for, and returns both reports.
+    function loadInMainAndWorker(addon: string, order: "main first" | "worker first") {
+      const env = {
+        ADDON_PATH: addon,
+        ...(order === "worker first" ? { WORKER_LOADS_FIRST: "1" } : {}),
+      };
+      return Promise.all([
+        runJsonFixture([bunExe(), workerFixturePath], env),
+        runJsonFixture([nodeExe, workerFixturePath], env),
+      ]);
+    }
+
+    const selfRegisterError = (addon: string) => ({
+      loaded: false,
+      code: "ERR_DLOPEN_FAILED",
+      message: `Module did not self-register: '${addon}'.`,
+    });
+
+    test("a context-aware addon loads in a Worker after the main thread", async () => {
+      const [bun, node] = await loadInMainAndWorker(addonPath, "main first");
+      expect(bun).toEqual({
+        main: { loaded: true, hello: "world" },
+        worker: { loaded: true, hello: "world" },
+        workerExitCode: 0,
+        mainExportsAfterWorkerExit: { hello: "world" },
+      });
+      expect(node).toEqual(bun);
+    });
+
+    test("a context-aware addon loads on the main thread while and after a Worker has it", async () => {
+      const [bun, node] = await loadInMainAndWorker(addonPath, "worker first");
+      expect(bun).toEqual({
+        worker: { loaded: true, hello: "world" },
+        mainWhileWorkerAlive: { loaded: true, hello: "world" },
+        workerExitCode: 0,
+        mainAfterWorkerExit: { loaded: true, hello: "world" },
+      });
+      expect(node).toEqual(bun);
+    });
+
+    test("a non-context-aware addon loaded by the main thread is refused in a Worker", async () => {
+      const [bun, node] = await loadInMainAndWorker(nonContextAwarePath, "main first");
+      expect(bun).toEqual({
+        main: { loaded: true, hello: "world", initCount: 1, instance: "object" },
+        worker: selfRegisterError(nonContextAwarePath),
+        workerExitCode: 0,
+        mainExportsAfterWorkerExit: { hello: "world", initCount: 1, instance: "object" },
+      });
+      expect(node).toEqual(bun);
+    });
+
+    test("a non-context-aware addon loaded by a Worker is refused on the main thread until the Worker exits", async () => {
+      const [bun, node] = await loadInMainAndWorker(nonContextAwarePath, "worker first");
+      expect(bun).toEqual({
+        worker: { loaded: true, hello: "world", initCount: 1, instance: "object" },
+        mainWhileWorkerAlive: selfRegisterError(nonContextAwarePath),
+        workerExitCode: 0,
+        mainAfterWorkerExit: { loaded: true, hello: "world", initCount: 2, instance: "object" },
+      });
+      // Once the Worker is gone, node dlcloses the addon and the next load starts
+      // it over. Whether that works depends on the libc actually unloading it
+      // (glibc does, musl does not), so only the steps before it are compared.
+      const { mainAfterWorkerExit: _bunAfter, ...bunWhileAlive } = bun;
+      const { mainAfterWorkerExit: _nodeAfter, ...nodeWhileAlive } = node;
+      expect(nodeWhileAlive).toEqual(bunWhileAlive);
+    });
+
+    // Node's own message differs, so this one is not compared with node.
+    test("an addon built for another ABI reports the mismatch from a Worker too", async () => {
+      const abiError = {
+        loaded: false,
+        message:
+          `The module 'mismatched_abi' was compiled against a different Node.js ABI version using NODE_MODULE_VERSION 42. ` +
+          `This version of Bun requires NODE_MODULE_VERSION ${process.versions.modules}. Please try re-compiling or re-installing the module.`,
+      };
+      expect(await runJsonFixture([bunExe(), workerFixturePath], { ADDON_PATH: mismatchedAbiPath })).toEqual({
+        main: abiError,
+        worker: abiError,
+        workerExitCode: 0,
+      });
+    });
+
+    // Node refuses this load too. Bun runs the init again on the thread whose
+    // heap the addon's statics already point into; `bun --hot` relies on that.
+    test("a non-context-aware addon loads again on the thread that first loaded it", async () => {
+      const script = `
+        const load = () => {
+          const m = { exports: {} };
+          process.dlopen(m, process.env.ADDON_PATH);
+          return { hello: m.exports.hello(), initCount: m.exports.initCount(), instance: typeof m.exports.makeInstance() };
+        };
+        const first = load();
+        const second = load();
+        console.log(JSON.stringify({ first, second }));
+      `;
+      expect(await runJsonFixture([bunExe(), "-e", script], { ADDON_PATH: nonContextAwarePath })).toEqual({
+        first: { hello: "world", initCount: 1, instance: "object" },
+        second: { hello: "world", initCount: 2, instance: "object" },
+      });
     });
   });
 });


### PR DESCRIPTION
### Problem
- A `NODE_MODULE` addon (the NAN shape, no `nm_context_register_func`) loaded on the main thread loads again in a Worker. The second init points its statics into the Worker's isolate. After the Worker exits the main thread reads them: `panic(main thread): Segmentation fault`, features `workers_spawned workers_terminated process_dlopen(2)` (marker crashes BUN-4D3K, BUN-3HKE, BUN-2V7T).
- Cause: `Process_functionDlopen` replays every cached registration (`src/jsc/bindings/BunProcess.cpp:640` on main) and `node_module_register` runs `nm_register_func` in any VM (`src/jsc/bindings/v8/node.cpp:173`). Node 26.3.0 refuses this load: `ERR_DLOPEN_FAILED`, `Module did not self-register: '<path>'.`

### Fix
- `DLHandleMap` records which live VM owns each module whose init binds it to a VM (`V8ModuleRegistration::bindsToVM`). A load from another VM while that owner is alive throws Node's error, drops its dlopen reference and replays nothing. `claimForVM` claims under the map lock, so two VMs loading at once cannot both win.
- `destroyVM` releases what the dead VM owned, so the next loader replays the module. Node behaves the same for a Worker-per-job program: it dlcloses a Worker's addons when the Worker dies (`env.cc`), and the next load starts the addon over.
- Context-aware registrations (#21432), NAPI registrations and modules that `node_module_register` rejects replay as before. So does a second load from the owning VM itself: Node refuses it, but nothing was unloaded, and `--hot` (#23136) depends on it.
- Verified: `test/js/node/process/dlopen-duplicate-load.test.ts`, 6 new tests, 2 fail unfixed, 4 also compare the fixture's report with the ABI-matching node. Also `test/v8/v8.test.ts`.

### Background
- A context-aware addon keeps its state per context, so its init runs in every context. A non-context-aware addon keeps it in statics, so Node lets one environment at a time hold it.
- A `.node` file registers itself from static constructors during its first `dlopen` only. `DLHandleMap` (`src/jsc/bindings/DLHandleMap.h`) caches them per handle for later loads to replay. Bun never unloads an addon.
- In Bun's V8 shim each global object owns a `v8::Isolate` and each thread runs its own `JSC::VM`. `JSC::VM::identifier()` comes from a process-wide counter, so a dead VM's identifier is never reused.

<details><summary>Notes</summary>

Orderings for the `NODE_MODULE` addon the test builds (a `static Persistent<FunctionTemplate>` that the init fills in). node is 26.3.0 on glibc, before is bun 1.4.0.

| ordering | node | before | this PR |
| --- | --- | --- | --- |
| main loads, then a Worker | refused | loads, main segfaults after the Worker exits | refused |
| a Worker loads, main loads while it is alive | refused | loads | refused |
| three Workers alive at once | 1 loads, 2 refused | 3 load | 1 loads, 2 refused |
| a Worker loads and exits, then the next Worker or main loads | loads (fresh) | loads (init again) | loads (init again) |
| the same thread loads twice | refused | loads | loads |

The first version of this PR kept the refusal keyed to the first VM forever, which refused the fourth row. The self-review found that, and a race in the Worker-first test: main loaded while the Worker was still exiting, which node answers either way (26 refused, 14 loaded in 40 runs). The fixture now keeps the Worker blocked on a message for the "while alive" step and loads again only after the `exit` event. Node's answer for that last step depends on whether its libc really unloads the addon (`DLib::Close` keeps it on musl), so that step is pinned for bun only.

Node's rule (`node_binding.cc`, `DLOpen`): when the constructors did not run again, it takes the saved module and throws `Module did not self-register` unless the module has `nm_context_register_func`. `Environment::~Environment` closes a Worker's addons, never the main thread's. `ERR_NON_CONTEXT_AWARE_DISABLED` exists only for `--force-context-aware`, which Bun does not implement.

The release runs after `~VM` in `destroyVM`, so nothing of that VM can run the addon once another VM repoints its statics. A Worker's VM is destroyed before the parent receives `exit` (`web_worker.rs`, `shutdown`: teardown first, then `WebWorker__workerGlobalScopeDestroyed`), so a load from the `exit` handler is deterministic. A static that an init does not reset (a lazily filled one) still points at the dead VM after such a replay. bun 1.4.0 has that for every replay, so this PR does not make it worse. Node does not have it because it unloads.

Behavior change: addons of the `NODE_MODULE` shape (cpu-features, heapdump, node-rdkafka, nodegit, bignum and others) loaded from a second live thread in bun 1.4.0 and now get Node's error there. Their Worker-capable variants (`NAN_MODULE_WORKER_ENABLED`, `NODE_MODULE_INIT`) export `node_register_module_v<ABI>` instead of self-registering. Loading those needs #36649. It registers a module with `nm_context_register_func`, which this check lets replay. #34746 changes the same function for an unrelated exception check.

A context-aware addon that keeps per-isolate state in statics anyway crashes the same way on both runtimes. That is the addon's bug, and refusing it would break the contract, so it is unchanged.

Scoped out: an addon that keeps a `napi_ref` in a static across envs reads a dead env's cell. Node frees those refs at env teardown, so that use is invalid there as well. Invalidating refs per env is a separate change to the `NapiRef` lifecycle.

Other suites under the debug ASAN build in this container: `worker_destruction.test.ts` exceeds its 5 s budget (its fixture spawns 50 Workers and needs about 10 s here, exit code 0), the c-ares test in `worker-terminate-lifetime.test.ts` reports a LeakSanitizer leak in `node_fs_binding::Binding::new`, and 2 of 181 `napi.test.ts` tests hit the timeout (three 1.6 s spawns each). None of those stacks involve this change.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/dlopen-duplicate-load.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/process/dlopen-duplicate-load.test.ts:
bun install v1.4.1 (4448a2e21)
Resolving dependencies
Resolved, downloaded and extracted [78]
Saved lockfile

$ "/workspace/bun/build/debug/bun-debug" --bun node-gyp rebuild
gyp info it worked if it ends with ok
gyp info using node-gyp@11.5.0
gyp info using node@26.3.0 | linux | x64
gyp info find Python using Python version 3.13.5 found at "/usr/bin/python3"

gyp info spawn /usr/bin/python3
gyp info spawn args [
gyp info spawn args '/tmp/dlopen-duplicate-test_QsM1ZS/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/tmp/dlopen-duplicate-test_QsM1ZS/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/tmp/dlopen-duplicate-test_QsM1ZS/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/root/.cache/node-gyp/26.3.0/include/node/common.gypi',
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (e2ecc554f)

test/js/node/process/dlopen-duplicate-load.test.ts:
bun install v1.4.1-canary.1 (e2ecc554f)
Saved lockfile

$ "/workspace/bun/build/release/bun" --bun node-gyp rebuild
gyp info it worked if it ends with ok
gyp info using node-gyp@11.5.0
gyp info using node@26.3.0 | linux | x64
gyp info find Python using Python version 3.13.5 found at "/usr/bin/python3"

gyp info spawn /usr/bin/python3
gyp info spawn args [
gyp info spawn args '/tmp/dlopen-duplicate-test_JjTWh5/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/tmp/dlopen-duplicate-test_JjTWh5/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/tmp/dlopen-duplicate-test_JjTWh5/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/root/.cache/node-gyp/26.3.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/26.3.0',
gyp info spawn args '-Dnode_gyp_dir=/tmp/dlopen-duplicate-test_JjTWh5/no
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/dlopen-duplicate-load.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/process/dlopen-duplicate-load.test.ts:
bun install v1.4.1 (4448a2e21)
Saved lockfile

$ "/workspace/bun/build/debug/bun-debug" --bun node-gyp rebuild
gyp info it worked if it ends with ok
gyp info using node-gyp@11.5.0
gyp info using node@26.3.0 | linux | x64
gyp info find Python using Python version 3.13.5 found at "/usr/bin/python3"

gyp info spawn /usr/bin/python3
gyp info spawn args [
gyp info spawn args '/tmp/dlopen-duplicate-test_AH2Bgz/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/tmp/dlopen-duplicate-test_AH2Bgz/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/tmp/dlopen-duplicate-test_AH2Bgz/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/root/.cache/node-gyp/26.3.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 620ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/31] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/31] gen cpp.rs (cppbind)
[4/31] gen JS modules (bundle-modules)
Preprocess modules (7453ms)
Bundle modules (40ms)
Postprocesss modules (52ms)
Bundle Functions (727ms)
Generate Code (29ms)

[8.31s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[4/26] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunProcess.cpp                    |  29 +-
 src/jsc/bindings/DLHandleMap.h                     |  75 +++++-
 src/jsc/bindings/ZigGlobalObject.cpp               |   3 +
 test/js/node/process/dlopen-duplicate-load.test.ts | 297 ++++++++++++++++++++-
 4 files changed, 386 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/BunProcess.cpp                         4     10      0
src/jsc/bindings/DLHandleMap.h                          6     15      0
src/jsc/bindings/ZigGlobalObject.cpp                    3      2      0
test/js/node/process/dlopen-duplicate-load.test.ts      7     29      0
```

</details>

<!-- robobun:evidence:end -->