### PR TITLE
napi: mark external buffers untransferable, like Node

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2421,6 +2421,18 @@ private:
     bool m_finalized { false };
 };
 
+// JSC creates a view's ArrayBuffer wrapper lazily on the first `.buffer` access; create it now
+// (the getter returns this same object for as long as the view or the wrapper is alive) so it
+// can carry the mark. See NapiExternalBufferDestructor. The caller checks for an exception.
+static void markExternalBufferUntransferable(Zig::GlobalObject* globalObject, JSC::JSUint8Array* buffer)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* jsArrayBuffer = buffer->possiblySharedJSBuffer(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
+    WebCore::markAsUntransferable(vm, *jsArrayBuffer);
+}
+
 extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     void* data,
     napi_finalize finalize_cb,
@@ -2439,6 +2451,10 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
         // TODO: is there a way to create a detached uint8 array?
         auto arrayBuffer = JSC::ArrayBuffer::createUninitialized(0, 1);
         auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, 0);
+        NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
+        // Nothing here can cross a thread (the finalizer below hangs off the cell, and the buffer is
+        // detached), but Node marks this buffer too, and isMarkedAsUntransferable() reports it.
+        markExternalBufferUntransferable(globalObject, buffer);
         NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
         buffer->existingBuffer()->detach(vm);
 
@@ -2461,12 +2477,8 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, length);
     NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
 
-    // JSC creates the ArrayBuffer wrapper lazily on the first `.buffer` access; create it now
-    // (the getter returns this same object for as long as the view or the wrapper is alive)
-    // so it can carry the mark. See NapiExternalBufferDestructor.
-    auto* jsArrayBuffer = buffer->possiblySharedJSBuffer(globalObject);
+    markExternalBufferUntransferable(globalObject, buffer);
     NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
-    WebCore::markAsUntransferable(vm, *jsArrayBuffer);
 
     // Arm only after successful creation: if anything above threw, the destructor
     // runs disarmed and skips finalize_cb (caller retains ownership).

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2362,16 +2362,10 @@ extern "C" napi_status napi_create_buffer_copy(napi_env env, size_t length,
 // if the env is torn down first (a Worker exiting while the addon still holds the buffer) —
 // from NapiEnv::cleanup() together with the other bound finalizers, as Node's env teardown
 // finalizes every remaining reference (test_worker_buffer_callback/test-free-called).
-//
-// Both of those assume the contents stay on the env's thread: run() mutates the env (whose
-// refcount is not atomic) and calls the addon with it, and cleanup() frees the bytes out from
-// under whoever else holds them. postMessage would move the contents to another thread, so
-// the ArrayBuffer wrapper is marked untransferable, as Node does for every buffer with a free
-// callback (both napi_create_external_* functions end up in this Buffer::New overload):
-// https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
-// Transferring it is a DataCloneError (test_worker_buffer_callback/test.js). The mark is on
-// the wrapper, so ArrayBuffer.prototype.transfer() still yields an unmarked one over the same
-// contents; Node's mark has the same gap.
+// Both need the contents on the env's thread (NapiEnv is not thread safe, and cleanup() frees
+// the bytes), so the ArrayBuffer wrapper is marked untransferable, as Node marks every buffer
+// with a free callback: https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
+// ArrayBuffer.prototype.transfer() still yields an unmarked wrapper; Node has the same gap.
 class NapiExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
     NapiExternalBufferDestructor(WTF::Ref<NapiEnv>&& env, napi_finalize cb, void* hint)
@@ -2421,9 +2415,8 @@ private:
     bool m_finalized { false };
 };
 
-// JSC creates a view's ArrayBuffer wrapper lazily on the first `.buffer` access; create it now
-// (the getter returns this same object for as long as the view or the wrapper is alive) so it
-// can carry the mark. See NapiExternalBufferDestructor. The caller checks for an exception.
+// The `.buffer` wrapper, which JSC would otherwise create lazily, carries the mark (see
+// NapiExternalBufferDestructor). The caller checks for an exception.
 static void markExternalBufferUntransferable(Zig::GlobalObject* globalObject, JSC::JSUint8Array* buffer)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -2452,8 +2445,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
         auto arrayBuffer = JSC::ArrayBuffer::createUninitialized(0, 1);
         auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, 0);
         NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
-        // Nothing here can cross a thread (the finalizer below hangs off the cell, and the buffer is
-        // detached), but Node marks this buffer too, and isMarkedAsUntransferable() reports it.
+        // Nothing here can cross a thread, but Node marks this buffer too (isMarkedAsUntransferable).
         markExternalBufferUntransferable(globalObject, buffer);
         NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
         buffer->existingBuffer()->detach(vm);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2362,8 +2362,7 @@ extern "C" napi_status napi_create_buffer_copy(napi_env env, size_t length,
 // if the env is torn down first (a Worker exiting while the addon still holds the buffer) —
 // from NapiEnv::cleanup() together with the other bound finalizers, as Node's env teardown
 // finalizes every remaining reference (test_worker_buffer_callback/test-free-called).
-// Neither works once the contents have been transferred to another thread, so the wrapper is
-// marked untransferable, as in Node: https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
+// Neither survives a transfer to another thread, hence the untransferable mark, as in Node: https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
 class NapiExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
     NapiExternalBufferDestructor(WTF::Ref<NapiEnv>&& env, napi_finalize cb, void* hint)

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -63,6 +63,7 @@
 #include <JavaScriptCore/StringObject.h>
 #include <JavaScriptCore/JSWeakMapInlines.h>
 #include "ScriptExecutionContext.h"
+#include "SerializedScriptValue.h"
 
 #include "../modules/ObjectModule.h"
 
@@ -2361,6 +2362,16 @@ extern "C" napi_status napi_create_buffer_copy(napi_env env, size_t length,
 // if the env is torn down first (a Worker exiting while the addon still holds the buffer) —
 // from NapiEnv::cleanup() together with the other bound finalizers, as Node's env teardown
 // finalizes every remaining reference (test_worker_buffer_callback/test-free-called).
+//
+// Both of those assume the contents stay on the env's thread: run() mutates the env (whose
+// refcount is not atomic) and calls the addon with it, and cleanup() frees the bytes out from
+// under whoever else holds them. postMessage would move the contents to another thread, so
+// the ArrayBuffer wrapper is marked untransferable, as Node does for every buffer with a free
+// callback (both napi_create_external_* functions end up in this Buffer::New overload):
+// https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
+// Transferring it is a DataCloneError (test_worker_buffer_callback/test.js). The mark is on
+// the wrapper, so ArrayBuffer.prototype.transfer() still yields an unmarked one over the same
+// contents; Node's mark has the same gap.
 class NapiExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
     NapiExternalBufferDestructor(WTF::Ref<NapiEnv>&& env, napi_finalize cb, void* hint)
@@ -2450,7 +2461,14 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, length);
     NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
 
-    // Arm only after successful creation: if create threw, the destructor
+    // JSC creates the ArrayBuffer wrapper lazily on the first `.buffer` access; create it now
+    // (the getter returns this same object for as long as the view or the wrapper is alive)
+    // so it can carry the mark. See NapiExternalBufferDestructor.
+    auto* jsArrayBuffer = buffer->possiblySharedJSBuffer(globalObject);
+    NAPI_RETURN_STATUS_IF_EXCEPTION(env, napi_generic_failure);
+    WebCore::markAsUntransferable(vm, *jsArrayBuffer);
+
+    // Arm only after successful creation: if anything above threw, the destructor
     // runs disarmed and skips finalize_cb (caller retains ownership).
     destructorPtr->arm(data);
 
@@ -2482,6 +2500,8 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
     auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(external_data), byte_length }, WTF::move(destructor));
 
     auto* buffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), WTF::move(arrayBuffer));
+    // See NapiExternalBufferDestructor.
+    WebCore::markAsUntransferable(vm, *buffer);
     // Arm only after successful creation so that if a future change makes
     // create() throw, the destructor runs disarmed and skips finalize_cb.
     destructorPtr->arm(external_data);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2362,10 +2362,8 @@ extern "C" napi_status napi_create_buffer_copy(napi_env env, size_t length,
 // if the env is torn down first (a Worker exiting while the addon still holds the buffer) —
 // from NapiEnv::cleanup() together with the other bound finalizers, as Node's env teardown
 // finalizes every remaining reference (test_worker_buffer_callback/test-free-called).
-// Both need the contents on the env's thread (NapiEnv is not thread safe, and cleanup() frees
-// the bytes), so the ArrayBuffer wrapper is marked untransferable, as Node marks every buffer
-// with a free callback: https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
-// ArrayBuffer.prototype.transfer() still yields an unmarked wrapper; Node has the same gap.
+// Neither works once the contents have been transferred to another thread, so the wrapper is
+// marked untransferable, as in Node: https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490
 class NapiExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
     NapiExternalBufferDestructor(WTF::Ref<NapiEnv>&& env, napi_finalize cb, void* hint)
@@ -2415,8 +2413,7 @@ private:
     bool m_finalized { false };
 };
 
-// The `.buffer` wrapper, which JSC would otherwise create lazily, carries the mark (see
-// NapiExternalBufferDestructor). The caller checks for an exception.
+// Creates the `.buffer` wrapper (JSC would do so lazily) and marks it. The caller checks for an exception.
 static void markExternalBufferUntransferable(Zig::GlobalObject* globalObject, JSC::JSUint8Array* buffer)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4306,6 +4306,23 @@ size_t SerializedScriptValue::computeMemoryCost() const
     return cost;
 }
 
+static void markObjectWithPrivateName(VM& vm, JSObject& object, const Identifier& privateName)
+{
+    if (object.getDirect(vm, privateName))
+        return;
+    object.putDirect(vm, privateName, jsBoolean(true), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | 0);
+}
+
+void markAsUncloneable(VM& vm, JSObject& object)
+{
+    markObjectWithPrivateName(vm, object, builtinNames(vm).isUncloneablePrivateName());
+}
+
+void markAsUntransferable(VM& vm, JSObject& object)
+{
+    markObjectWithPrivateName(vm, object, builtinNames(vm).isUntransferablePrivateName());
+}
+
 static ExceptionOr<std::unique_ptr<ArrayBufferContentsArray>> transferArrayBuffers(VM& vm, const Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers)
 {
     if (arrayBuffers.isEmpty())

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -102,8 +102,7 @@ using WasmModuleArray = Vector<RefPtr<JSC::Wasm::Module>>;
 using WasmMemoryHandleArray = Vector<RefPtr<JSC::SharedArrayBufferContents>>;
 #endif
 
-// node's markAsUncloneable() / markAsUntransferable(): a private name user JS cannot see or remove.
-// Serialization rejects a tagged object, found in the value or in the transfer list respectively.
+// worker_threads.markAsUncloneable() / markAsUntransferable(): create() rejects a tagged object.
 void markAsUncloneable(JSC::VM&, JSC::JSObject&);
 void markAsUntransferable(JSC::VM&, JSC::JSObject&);
 

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -102,10 +102,8 @@ using WasmModuleArray = Vector<RefPtr<JSC::Wasm::Module>>;
 using WasmMemoryHandleArray = Vector<RefPtr<JSC::SharedArrayBufferContents>>;
 #endif
 
-// node's markAsUncloneable() / markAsUntransferable(): the tag is a DontEnum JSC private name
-// (node uses a v8 Private), invisible to and unforgeable from user JS, and not removable.
-// Serialization rejects a tagged object with a DataCloneError: anywhere in the value for
-// uncloneable, in the transfer list for untransferable.
+// node's markAsUncloneable() / markAsUntransferable(): a private name user JS cannot see or remove.
+// Serialization rejects a tagged object, found in the value or in the transfer list respectively.
 void markAsUncloneable(JSC::VM&, JSC::JSObject&);
 void markAsUntransferable(JSC::VM&, JSC::JSObject&);
 

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -39,14 +39,16 @@
 #include <wtf/text/WTFString.h>
 #include "JavaScriptCore/WasmModule.h"
 
-#if ENABLE(WEBASSEMBLY)
 namespace JSC {
+class JSObject;
+class VM;
+#if ENABLE(WEBASSEMBLY)
 namespace Wasm {
 class Module;
 class MemoryHandle;
 }
-}
 #endif
+}
 
 namespace WebCore {
 
@@ -99,6 +101,13 @@ using ArrayBufferContentsArray = Vector<JSC::ArrayBufferContents>;
 using WasmModuleArray = Vector<RefPtr<JSC::Wasm::Module>>;
 using WasmMemoryHandleArray = Vector<RefPtr<JSC::SharedArrayBufferContents>>;
 #endif
+
+// node's markAsUncloneable() / markAsUntransferable(): the tag is a DontEnum JSC private name
+// (node uses a v8 Private), invisible to and unforgeable from user JS, and not removable.
+// Serialization rejects a tagged object with a DataCloneError: anywhere in the value for
+// uncloneable, in the transfer list for untransferable.
+void markAsUncloneable(JSC::VM&, JSC::JSObject&);
+void markAsUntransferable(JSC::VM&, JSC::JSObject&);
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue> {

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -250,28 +250,18 @@ JSC_DEFINE_HOST_FUNCTION(jsMessagePortIsActive, (JSGlobalObject * lexicalGlobalO
     return JSC::JSValue::encode(jsBoolean(false));
 }
 
-// markAsUncloneable/markAsUntransferable tag objects with a DontEnum JSC private name
-// (node uses a v8 Private): invisible to and unforgeable from user JS, and not removable,
-// so marking cannot be undone. Primitives are a documented no-op.
-static void markObjectWithPrivateName(JSC::VM& vm, JSC::JSValue value, const JSC::Identifier& privateName)
-{
-    JSC::JSObject* object = value.getObject();
-    if (!object || object->getDirect(vm, privateName))
-        return;
-    object->putDirect(vm, privateName, JSC::jsBoolean(true), JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | 0);
-}
-
+// Primitives are a documented no-op for both.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionMarkAsUncloneable, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    auto& vm = lexicalGlobalObject->vm();
-    markObjectWithPrivateName(vm, callFrame->argument(0), builtinNames(vm).isUncloneablePrivateName());
+    if (auto* object = callFrame->argument(0).getObject())
+        markAsUncloneable(lexicalGlobalObject->vm(), *object);
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionMarkAsUntransferable, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    auto& vm = lexicalGlobalObject->vm();
-    markObjectWithPrivateName(vm, callFrame->argument(0), builtinNames(vm).isUntransferablePrivateName());
+    if (auto* object = callFrame->argument(0).getObject())
+        markAsUntransferable(lexicalGlobalObject->vm(), *object);
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/test/napi/napi-app/external-buffer-worker.js
+++ b/test/napi/napi-app/external-buffer-worker.js
@@ -1,0 +1,29 @@
+const { parentPort } = require("node:worker_threads");
+const nativeTests = require("./build/Debug/napitests.node");
+
+// The buffers belong to this worker's env: when the worker exits, the env's
+// teardown runs their finalizers and frees the bytes. Transferring them to the
+// parent would hand it bytes that are about to be freed, so that is refused and
+// the parent gets copies instead.
+const arrayBuffer = nativeTests.create_external_arraybuffer_for_transfer(4);
+const buffer = nativeTests.create_external_buffer_for_transfer(4);
+const copies = { arraybuffer: Array.from(new Uint8Array(arrayBuffer)), buffer: Array.from(buffer) };
+
+const transfers = {};
+for (const [kind, ab] of [
+  ["arraybuffer", arrayBuffer],
+  ["buffer", buffer.buffer],
+]) {
+  try {
+    parentPort.postMessage({ kind, ab }, [ab]);
+    transfers[kind] = "transferred";
+  } catch (e) {
+    transfers[kind] = `${e.name} code=${e.code}`;
+  }
+  transfers[`${kind}ByteLength`] = ab.byteLength;
+}
+parentPort.postMessage({ transfers, copies, stats: nativeTests.external_for_transfer_stats() });
+
+// Still referenced when the worker exits, so the env's teardown (not GC) is
+// what finalizes them.
+globalThis.keep = [arrayBuffer, buffer];

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1648,6 +1648,18 @@ nativeTests.test_external_buffer_untransferable = () => {
     const copy = structuredClone(arrayBuffer);
     console.log(`${kind}: copy=[${new Uint8Array(copy).join(",")}] byteLength=${arrayBuffer.byteLength}`);
   }
+  // Length 0 is a separate path inside napi_create_external_buffer; it is marked all the same.
+  // (Only the mark and the transfer are compared: bun detaches this buffer, node does not.)
+  for (const kind of ["arraybuffer", "buffer"]) {
+    const created =
+      kind === "arraybuffer"
+        ? nativeTests.create_external_arraybuffer_for_transfer(0)
+        : nativeTests.create_external_buffer_for_transfer(0);
+    keepAlive.push(created);
+    const arrayBuffer = kind === "arraybuffer" ? created : created.buffer;
+    console.log(`empty ${kind}: isMarkedAsUntransferable(arrayBuffer)=${isMarkedAsUntransferable(arrayBuffer)}`);
+    attempt(`empty ${kind}: structuredClone`, () => structuredClone(arrayBuffer, { transfer: [arrayBuffer] }));
+  }
   console.log("stats:", JSON.stringify(nativeTests.external_for_transfer_stats()));
 };
 

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1599,6 +1599,75 @@ nativeTests.test_finalizer_registered_during_env_cleanup = async () => {
   console.log("late=" + nativeTests.late_finalizer_run_count());
 };
 
+// The ArrayBuffer behind napi_create_external_arraybuffer / napi_create_external_buffer is
+// untransferable (node: Buffer::New with a free callback marks it so): its finalizer belongs
+// to the env that created it, and that env's teardown frees the bytes. Every transfer entry
+// point refuses it with a DataCloneError and leaves it, the rest of the transfer list, and the
+// finalizer untouched; cloning without a transfer still copies it.
+nativeTests.test_external_buffer_untransferable = () => {
+  const { MessageChannel, Worker, isMarkedAsUntransferable } = require("node:worker_threads");
+  const attempt = (label, transfer) => {
+    try {
+      transfer();
+      console.log(`${label}: transferred`);
+    } catch (e) {
+      console.log(`${label}: ${e.name} code=${e.code}`);
+    }
+  };
+  // Everything created here stays alive until the stats are printed, so the
+  // only way a finalizer can run is a transfer attempt running it.
+  const keepAlive = [];
+  for (const kind of ["arraybuffer", "buffer"]) {
+    const created =
+      kind === "arraybuffer"
+        ? nativeTests.create_external_arraybuffer_for_transfer(8)
+        : nativeTests.create_external_buffer_for_transfer(8);
+    keepAlive.push(created);
+    const arrayBuffer = kind === "arraybuffer" ? created : created.buffer;
+    console.log(
+      `${kind}: isMarkedAsUntransferable(created)=${isMarkedAsUntransferable(created)}`,
+      `isMarkedAsUntransferable(arrayBuffer)=${isMarkedAsUntransferable(arrayBuffer)}`,
+      `ownKeys=${Reflect.ownKeys(arrayBuffer).length}`,
+    );
+
+    attempt(`${kind}: structuredClone`, () => structuredClone(arrayBuffer, { transfer: [arrayBuffer] }));
+    const { port1, port2 } = new MessageChannel();
+    attempt(`${kind}: MessagePort.postMessage`, () => port1.postMessage(arrayBuffer, [arrayBuffer]));
+    port1.close();
+    port2.close();
+    attempt(
+      `${kind}: new Worker transferList`,
+      () => new Worker("", { eval: true, workerData: arrayBuffer, transferList: [arrayBuffer] }),
+    );
+    const plain = new ArrayBuffer(2);
+    attempt(`${kind}: structuredClone after a plain ArrayBuffer`, () =>
+      structuredClone([plain, arrayBuffer], { transfer: [plain, arrayBuffer] }),
+    );
+    console.log(`${kind}: byteLength=${arrayBuffer.byteLength} plain.byteLength=${plain.byteLength}`);
+
+    const copy = structuredClone(arrayBuffer);
+    console.log(`${kind}: copy=[${new Uint8Array(copy).join(",")}] byteLength=${arrayBuffer.byteLength}`);
+  }
+  console.log("stats:", JSON.stringify(nativeTests.external_for_transfer_stats()));
+};
+
+// A worker creates the buffers and exits: the parent can only ever have copies,
+// and the worker's env teardown finalizes both on the thread that created them.
+nativeTests.test_external_buffer_worker_exit = async () => {
+  const { Worker } = require("node:worker_threads");
+  const path = require("node:path");
+  const worker = new Worker(path.join(__dirname, "external-buffer-worker.js"));
+  const messages = [];
+  const exitCode = await new Promise((resolve, reject) => {
+    worker.on("message", message => messages.push(message));
+    worker.on("error", reject);
+    worker.on("exit", resolve);
+  });
+  console.log("worker exited with", exitCode);
+  console.log("messages:", JSON.stringify(messages));
+  console.log("stats after exit:", JSON.stringify(nativeTests.external_for_transfer_stats()));
+};
+
 // Bun-only: an orphaned threadsafe function is freed by whichever thread drops
 // its last reference, including a call that reports napi_closing. Every
 // iteration must end with as many live threadsafe functions as it started with.

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2794,6 +2794,74 @@ static napi_value test_external_buffer_with_pending_exception(
   return ok(env);
 }
 
+// External buffers for module.js's transfer tests
+// (test_external_buffer_untransferable, test_external_buffer_worker_exit).
+// The finalizer receives the env of the thread that created the buffer, so it
+// records whether it ran on that thread. The counters are process-wide: the
+// worker test creates its buffers in a worker and reads the counters from the
+// main thread after the worker has exited.
+static std::atomic<int> external_for_transfer_finalized{0};
+static std::atomic<int> external_for_transfer_finalized_off_thread{0};
+
+struct ExternalForTransfer {
+  std::thread::id creating_thread;
+};
+
+static void external_for_transfer_finalize(napi_env, void *data, void *hint) {
+  auto *owner = static_cast<ExternalForTransfer *>(hint);
+  if (owner->creating_thread != std::this_thread::get_id()) {
+    external_for_transfer_finalized_off_thread++;
+  }
+  external_for_transfer_finalized++;
+  delete owner;
+  free(data);
+}
+
+// The bytes are 1, 2, 3, ... so a copy made on another thread can be checked.
+static uint8_t *external_for_transfer_bytes(size_t length) {
+  auto *bytes = static_cast<uint8_t *>(malloc(length));
+  for (size_t i = 0; i < length; i++) {
+    bytes[i] = static_cast<uint8_t>(i + 1);
+  }
+  return bytes;
+}
+
+// create_external_arraybuffer_for_transfer(length): ArrayBuffer
+static napi_value
+create_external_arraybuffer_for_transfer(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  size_t length = info[0].As<Napi::Number>().Uint32Value();
+  uint8_t *bytes = external_for_transfer_bytes(length);
+  napi_value result;
+  NODE_API_CALL(env, napi_create_external_arraybuffer(
+                         env, bytes, length, external_for_transfer_finalize,
+                         new ExternalForTransfer{std::this_thread::get_id()},
+                         &result));
+  return result;
+}
+
+// create_external_buffer_for_transfer(length): Buffer
+static napi_value
+create_external_buffer_for_transfer(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  size_t length = info[0].As<Napi::Number>().Uint32Value();
+  uint8_t *bytes = external_for_transfer_bytes(length);
+  napi_value result;
+  NODE_API_CALL(env, napi_create_external_buffer(
+                         env, length, bytes, external_for_transfer_finalize,
+                         new ExternalForTransfer{std::this_thread::get_id()},
+                         &result));
+  return result;
+}
+
+static napi_value external_for_transfer_stats(const Napi::CallbackInfo &info) {
+  Napi::Object stats = Napi::Object::New(info.Env());
+  stats.Set("finalized", external_for_transfer_finalized.load());
+  stats.Set("finalizedOffThread",
+            external_for_transfer_finalized_off_thread.load());
+  return stats;
+}
+
 // With an exception pending (via napi_throw_error), every napi call that
 // Node.js gates with NAPI_PREAMBLE must return napi_pending_exception and
 // perform NO side effects. Before the fix, NAPI_PREAMBLE only consulted the
@@ -4435,6 +4503,9 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
                     test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
+  REGISTER_FUNCTION(env, exports, create_external_arraybuffer_for_transfer);
+  REGISTER_FUNCTION(env, exports, create_external_buffer_for_transfer);
+  REGISTER_FUNCTION(env, exports, external_for_transfer_stats);
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
   REGISTER_FUNCTION(env, exports, make_ungated_calls_spinner);
   REGISTER_FUNCTION(env, exports, test_ungated_calls_with_engine_exception);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2818,8 +2818,10 @@ static void external_for_transfer_finalize(napi_env, void *data, void *hint) {
 }
 
 // The bytes are 1, 2, 3, ... so a copy made on another thread can be checked.
+// Never NULL, even for length 0: both runtimes treat a NULL pointer as its own
+// case (node runs the finalizer on the next loop turn).
 static uint8_t *external_for_transfer_bytes(size_t length) {
-  auto *bytes = static_cast<uint8_t *>(malloc(length));
+  auto *bytes = static_cast<uint8_t *>(malloc(length == 0 ? 1 : length));
   for (size_t i = 0; i < length; i++) {
     bytes[i] = static_cast<uint8_t>(i + 1);
   }

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -432,6 +432,49 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  // The finalizer of an external buffer belongs to the env that created it, and that env's
+  // teardown frees the bytes, so the bytes must not be transferred to another thread.
+  describe("external buffers are untransferable", () => {
+    it("every transfer entry point throws DataCloneError and leaves the buffer intact", async () => {
+      const result = await checkSameOutput("test_external_buffer_untransferable", []);
+      const expected = (kind: string) =>
+        [
+          `${kind}: isMarkedAsUntransferable(created)=${kind === "arraybuffer"} isMarkedAsUntransferable(arrayBuffer)=true ownKeys=0`,
+          `${kind}: structuredClone: DataCloneError code=25`,
+          `${kind}: MessagePort.postMessage: DataCloneError code=25`,
+          `${kind}: new Worker transferList: DataCloneError code=25`,
+          `${kind}: structuredClone after a plain ArrayBuffer: DataCloneError code=25`,
+          `${kind}: byteLength=8 plain.byteLength=2`,
+          `${kind}: copy=[1,2,3,4,5,6,7,8] byteLength=8`,
+        ].join("\n");
+      expect(result).toBe(
+        [expected("arraybuffer"), expected("buffer"), 'stats: {"finalized":0,"finalizedOffThread":0}'].join("\n"),
+      );
+    });
+
+    it("a worker's buffers reach the parent as copies and are finalized by the worker's env teardown", async () => {
+      const result = await checkSameOutput("test_external_buffer_worker_exit", []);
+      const message = JSON.stringify({
+        transfers: {
+          arraybuffer: "DataCloneError code=25",
+          arraybufferByteLength: 4,
+          buffer: "DataCloneError code=25",
+          bufferByteLength: 4,
+        },
+        copies: { arraybuffer: [1, 2, 3, 4], buffer: [1, 2, 3, 4] },
+        stats: { finalized: 0, finalizedOffThread: 0 },
+      });
+      expect(result).toBe(
+        [
+          "worker exited with 0",
+          `messages: [${message}]`,
+          'stats after exit: {"finalized":2,"finalizedOffThread":0}',
+          "resolved to undefined",
+        ].join("\n"),
+      );
+    });
+  });
+
   describe("pending-exception gate", () => {
     it("refuses and performs no side effects while a napi exception is pending", async () => {
       const result = await checkSameOutput("test_pending_exception_gate", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -447,8 +447,19 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
           `${kind}: byteLength=8 plain.byteLength=2`,
           `${kind}: copy=[1,2,3,4,5,6,7,8] byteLength=8`,
         ].join("\n");
+      const expectedEmpty = (kind: string) =>
+        [
+          `empty ${kind}: isMarkedAsUntransferable(arrayBuffer)=true`,
+          `empty ${kind}: structuredClone: DataCloneError code=25`,
+        ].join("\n");
       expect(result).toBe(
-        [expected("arraybuffer"), expected("buffer"), 'stats: {"finalized":0,"finalizedOffThread":0}'].join("\n"),
+        [
+          expected("arraybuffer"),
+          expected("buffer"),
+          expectedEmpty("arraybuffer"),
+          expectedEmpty("buffer"),
+          'stats: {"finalized":0,"finalizedOffThread":0}',
+        ].join("\n"),
       );
     });
 

--- a/test/napi/node-napi-tests/test/node-api/test_worker_buffer_callback/do.test.ts
+++ b/test/napi/node-napi-tests/test/node-api/test_worker_buffer_callback/do.test.ts
@@ -6,8 +6,7 @@ test("build", async () => {
 });
 
 for (const file of Array.from(new Bun.Glob("*.js").scanSync(import.meta.dir))) {
-  // test.js: AssertionError: Missing expected exception (DataCloneError).
-  test.todoIf(["test.js"].includes(file))(file, () => {
+  test(file, () => {
     run(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);
   });
 }


### PR DESCRIPTION
### Problem
- A `postMessage` transfer of a `napi_create_external_buffer` or `napi_create_external_arraybuffer` buffer moves its contents, and `NapiExternalBufferDestructor` (`src/jsc/bindings/napi.cpp:2366`) with them, to another thread. The destructor holds a `Ref<NapiEnv>` of the creating env and is on its cleanup list.
- Receiver frees first: `run()` mutates the env from the wrong thread and calls the addon's `finalize_cb` there.
- Creating worker exits first: `NapiEnv::cleanup()` calls `finalize_cb`, and the addon frees bytes the receiver still reads.

### Fix
- Both functions mark the `ArrayBuffer` wrapper untransferable, on every path, including the empty buffer. The transfer list check in `SerializedScriptValue::create` then throws `DataCloneError`. `napi_create_external_buffer` creates the wrapper eagerly: JSC otherwise creates it on the first `.buffer` access.
- Matches Node. Its `Buffer::New` marks every buffer that has a free callback, and both napi functions go through it (https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L484-L490). Node's `test_worker_buffer_callback/test.js` flips from `todo` to passing.
- The mark helpers move from `Worker.cpp` to `SerializedScriptValue.cpp`, next to the check. The fix is `markExternalBufferUntransferable` and the `markAsUntransferable` call in `napi.cpp`.
- Verified: `test/napi/napi.test.ts` (two new tests) and `test_worker_buffer_callback/do.test.ts`.

### Background
- An external buffer wraps memory the addon owns. When the contents die, JSC runs the destructor stored in them.
- A `NapiEnv` is one loaded addon in one VM. Only its own thread may touch it. A Worker that exits runs every finalizer still bound to its envs.
- A transfer detaches the source `ArrayBuffer` and moves its contents, destructor included, into the message.
- `worker_threads.markAsUntransferable()` sets a private name that the transfer list check rejects. `isMarkedAsUntransferable()` now reports these buffers, as in Node.

<details><summary>Notes</summary>

Found by code reading during a look at the GC marker crash family (Sentry BUN-4D3K / BUN-3HKE / BUN-2V7T), whose reports combine `process.dlopen` with `Worker`. It is not confirmed to be their cause. Both sequences reproduce with a small addon on the unfixed debug build:

- A worker creates an external ArrayBuffer, transfers it to the parent, and exits. In the parent's `exit` handler the addon reports `freeCount: 1`, and `Buffer.from(received).toString("hex")` returns garbage instead of `0102...`. ASAN does not flag it: the addon is not instrumented and its `free` does not go through the ASAN allocator.
- The parent creates one and transfers it to a worker. The worker drops it and collects. The addon reports `wrongThreadCount: 1`: `finalize_cb` ran on the worker thread with the parent's env.

Node, same addon: every transfer attempt (`structuredClone`, `MessagePort.postMessage`, `Worker.postMessage`, `new Worker` with `transferList`) throws `DataCloneError` code 25. The source stays attached. A plain `ArrayBuffer` earlier in the same transfer list stays attached too. `isMarkedAsUntransferable(buf.buffer)` is true and `isMarkedAsUntransferable(buf)` is false. The new tests run one script under Node and Bun (`checkSameOutput`) and also assert the full output. Both fail on the unfixed build.

Behavior change: such a transfer used to succeed in Bun. It now throws, as in Node. A `postMessage` without a transfer list still copies the bytes.

Review round: the empty buffer path of `napi_create_external_buffer` (detached, finalizer on the cell) has no thread hazard, but Node marks it too, so it is marked as well and the fixture covers length 0 for both functions. The in-code comments were cut down to one line each.

Suites run: the rest of `test/napi/napi.test.ts`, the upstream `test_typedarray`, `test_array`, `test_buffer`, `test_worker_terminate`, `test_worker_terminate_finalization` and `test_worker_buffer_callback` suites, `test/js/node/worker_threads/worker_threads.test.ts`, the two upstream `mark-as-*` worker tests, `structured-clone.test.ts`, `worker-postmessage-transfer.test.ts`, `message-channel.test.ts`, and `test/internal/source-lints`.

Alternatives considered:
- Pinning the `ArrayBuffer` also blocks a transfer. But `napi_detach_arraybuffer` (`napi.cpp:1315`) and BYOB stream reads check `isDetachable()`, so external buffers would stop being detachable. Node documents them as detachable.
- Posting `run()` to the creating env's VM needs an atomic env refcount, and it does not cover the worker-exit case. Node has a thread safe deleter and the mark. The mark alone removes both sequences.
- `ArrayBuffer.prototype.transfer()` returns a fresh, unmarked wrapper over the same contents, which is then transferable. Node has the same gap (checked with the same addon). To close it, the mark would have to live on the contents, which JSC does not expose.
- The report also names `NapiFinalizerTask::schedule` in `src/runtime/napi/napi_body.rs`. It tests "some VM is on this thread" instead of "the env's VM is on this thread". This PR removes the only way to reach it from another VM's thread, and `bun_vm()` asserts the VM identity in debug builds. It is left unchanged here.

Cost: `napi_create_external_buffer` now allocates the `JSArrayBuffer` wrapper and one property slot up front, about 100 bytes per buffer. `napi_create_external_arraybuffer` only gains the property. Node allocates the same objects.

Unrelated: `napi > bigint conversion to int64/uint64 > returns the right error code` times out on the debug build in this container with or without this change. It spawns the fixture three times in a row, and each spawn takes about 1.7 s here.
</details>
