### PR TITLE
webcrypto: RSA-PSS saltLength must fit in an int before it reaches OpenSSL

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp
@@ -31,8 +31,20 @@
 #include "CryptoAlgorithmRsaPssParams.h"
 #include "CryptoKeyRSA.h"
 #include "OpenSSLUtilities.h"
+#include <limits>
 
 namespace WebCore {
+
+// saltLength is a WebIDL unsigned long, but EVP_PKEY_CTX_set_rsa_pss_saltlen() takes an
+// int and gives negative values a meaning: RSA_PSS_SALTLEN_DIGEST (-1) and
+// RSA_PSS_SALTLEN_AUTO (-2), which on verify accepts a signature made with any salt
+// length. A value that does not fit in an int fails here instead of becoming one of them.
+static int setSaltLength(EVP_PKEY_CTX* ctx, size_t saltLength)
+{
+    if (saltLength > static_cast<size_t>(std::numeric_limits<int>::max()))
+        return 0;
+    return EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, static_cast<int>(saltLength));
+}
 
 static ExceptionOr<Vector<uint8_t>> signWithMD(const CryptoAlgorithmRsaPssParams& parameters, const CryptoKeyRSA& key, const Vector<uint8_t>& data, const EVP_MD* md)
 {
@@ -50,7 +62,7 @@ static ExceptionOr<Vector<uint8_t>> signWithMD(const CryptoAlgorithmRsaPssParams
     if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_PSS_PADDING) <= 0)
         return Exception { OperationError };
 
-    if (EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx.get(), parameters.saltLength) <= 0)
+    if (setSaltLength(ctx.get(), parameters.saltLength) <= 0)
         return Exception { OperationError };
 
     if (EVP_PKEY_CTX_set_signature_md(ctx.get(), md) <= 0)
@@ -96,7 +108,7 @@ static ExceptionOr<bool> verifyWithMD(const CryptoAlgorithmRsaPssParams& paramet
     if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_PSS_PADDING) <= 0)
         return Exception { OperationError };
 
-    if (EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx.get(), parameters.saltLength) <= 0)
+    if (setSaltLength(ctx.get(), parameters.saltLength) <= 0)
         return Exception { OperationError };
 
     if (EVP_PKEY_CTX_set_signature_md(ctx.get(), md) <= 0)

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -338,6 +338,70 @@ describe("oversized inputs", () => {
   });
 });
 
+describe("RSA-PSS saltLength", () => {
+  // saltLength is an unsigned long, but the OpenSSL setter takes an int whose
+  // negative values select a salt length: -1 is the digest length and -2 means
+  // "whatever fits" on sign and "accept any salt length" on verify. 2**32 - 1
+  // and 2**32 - 2 used to turn into exactly those two values.
+  it("rejects values that do not fit in an int instead of treating them as the -1/-2 selectors", async () => {
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "RSA-PSS", modulusLength: 1024, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+      false,
+      ["sign", "verify"],
+    );
+    const data = new TextEncoder().encode("hello");
+    const signedWithSalt20 = await crypto.subtle.sign({ name: "RSA-PSS", saltLength: 20 }, privateKey, data);
+
+    const sign = (saltLength: number) =>
+      crypto.subtle.sign({ name: "RSA-PSS", saltLength }, privateKey, data).then(
+        () => "signed",
+        e => `rejected ${e.name}`,
+      );
+    const verifySalt20Signature = (saltLength: number) =>
+      crypto.subtle.verify({ name: "RSA-PSS", saltLength }, publicKey, signedWithSalt20, data).then(
+        ok => String(ok),
+        e => `rejected ${e.name}`,
+      );
+
+    expect({
+      sign: {
+        "2**32 - 1": await sign(2 ** 32 - 1),
+        "2**32 - 2": await sign(2 ** 32 - 2),
+        "2**31": await sign(2 ** 31),
+        // Fits in an int; BoringSSL rejects it because it does not fit the key.
+        "2**31 - 1": await sign(2 ** 31 - 1),
+        // 1024-bit key, SHA-256: 128 - 32 - 2 = 94 is the largest salt that fits.
+        "95": await sign(95),
+        "94": await sign(94),
+      },
+      verify: {
+        "2**32 - 1": await verifySalt20Signature(2 ** 32 - 1),
+        "2**32 - 2": await verifySalt20Signature(2 ** 32 - 2),
+        "2**31": await verifySalt20Signature(2 ** 31),
+        "32": await verifySalt20Signature(32),
+        "20": await verifySalt20Signature(20),
+      },
+    }).toEqual({
+      sign: {
+        "2**32 - 1": "rejected OperationError",
+        "2**32 - 2": "rejected OperationError",
+        "2**31": "rejected OperationError",
+        "2**31 - 1": "rejected OperationError",
+        "95": "rejected OperationError",
+        "94": "signed",
+      },
+      verify: {
+        "2**32 - 1": "rejected OperationError",
+        "2**32 - 2": "rejected OperationError",
+        "2**31": "rejected OperationError",
+        // A salt length that does not match the signature is a failed verification, not an error.
+        "32": "false",
+        "20": "true",
+      },
+    });
+  });
+});
+
 describe("Ed25519", () => {
   describe("generateKey", () => {
     it("should return CryptoKeys without namedCurve in algorithm field", async () => {


### PR DESCRIPTION
### Problem
- `crypto.subtle.sign({ name: "RSA-PSS", saltLength: 4294967295 })` signs with a salt of the digest length, and `saltLength: 4294967294` signs with the largest salt that fits. `crypto.subtle.verify({ name: "RSA-PSS", saltLength: 4294967294 })` returns true for a signature made with any salt length. Node v26 rejects all of these with an `OperationError`. Bun 1.3.14 behaves the same as main, so this is not a regression.
- Cause: `RsaPssParams.saltLength` is a WebIDL `unsigned long`, stored as `size_t`. `signWithMD` and `verifyWithMD` in `src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp` (lines 53 and 99) pass it to `EVP_PKEY_CTX_set_rsa_pss_saltlen()`, which takes an `int`. 4294967295 arrives as `RSA_PSS_SALTLEN_DIGEST` (-1) and 4294967294 as `RSA_PSS_SALTLEN_AUTO` (-2). Other values at or above 2^31 arrive as other negative numbers, which BoringSSL rejects, so only these two change meaning.

### Fix
- `setSaltLength()` converts the value in one place for sign and verify. A value above `INT_MAX` fails, and the callers turn that into the same `OperationError` they already use for every other setup failure.
- This is correct because a salt length can never legitimately be that large (a salt has to fit in the modulus), and because a value that does fit in an `int` is still checked against the key by BoringSSL exactly as before: `saltLength: 95` on a 1024-bit key with SHA-256 still fails to sign, and a wrong salt length still verifies as `false`.
- Verified with `test/js/web/crypto/web-crypto.test.ts` ("RSA-PSS saltLength"). On main the four cells for 2^32 - 1 and 2^32 - 2 come back as `signed`, `signed`, `false` and `true`. The rest of `web-crypto.test.ts` (95 tests), `web-crypto-sha3.test.ts` and `test/js/node/test/parallel/test-webcrypto-sign-verify.js` pass.
- Related: #35374 adds a check in `SubtleCrypto.cpp` that rejects any `saltLength` above what the key allows, with Node's `ERR_OUT_OF_RANGE` cause. That check also covers these two values. This PR fixes the conversion underneath it, in the backend that performs the narrowing, and touches neither of its files. The test here holds with or without #35374.

### Background
RSA-PSS pads a message with a random salt before it is signed. The salt length is a parameter of both the signing and the verification operation. BoringSSL's setter uses negative values as selectors: -1 means "use the digest length" and -2 means "use the largest salt that fits" when signing and "accept whatever salt length the signature used" when verifying. WebCrypto has no such selectors: `saltLength` is always an explicit byte count. The WebIDL layer enforces the `unsigned long` range, so 2^32 and above are already a `TypeError`; the values just below 2^32 are the ones that survived the range check and then changed meaning in the implicit conversion to `int`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.78ms]
(pass) Web Crypto > keeps event loop alive [329.94ms]
(pass) Web Crypto > has globals [3.95ms]
(pass) Web Crypto > should encrypt and decrypt [16.88ms]
(pass) Web Crypto > should verify and sign [38.19ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.60ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.30ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.56ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2555.40ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [347.39ms]
379 |         "2**32 - 2": await verifySalt20Signature(2 ** 32 - 2),
380 |         "2**31": await verifySalt20Signature(2 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.05ms]
(pass) Web Crypto > keeps event loop alive [8.44ms]
(pass) Web Crypto > has globals [0.06ms]
(pass) Web Crypto > should encrypt and decrypt [0.35ms]
(pass) Web Crypto > should verify and sign [0.66ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.30ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.20ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.18ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [26.05ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [7.45ms]
379 |         "2**32 - 2": await verifySalt20Signature(2 ** 32 - 2),
380 |         "2**31": await verifySalt20Signature(2 ** 31),
381 |         "32": await verifySalt20Signature(32),
382 |         "20": await verifySalt20Signature(20),
383 |       },
384 |     }).toEqual({
             ^
error:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.85ms]
(pass) Web Crypto > keeps event loop alive [336.44ms]
(pass) Web Crypto > has globals [3.51ms]
(pass) Web Crypto > should encrypt and decrypt [17.56ms]
(pass) Web Crypto > should verify and sign [40.39ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [18.89ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [12.78ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [11.03ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2601.80ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [353.32ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [108.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 657ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-0.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 58s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+21d75372c
[build] done
bun test v1.4.0-canary.1 (21d75372c)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.05ms]
(pass) Web Crypto > keeps event loop alive [7.94ms]
(pass) Web Crypto > has globals [0.07ms]
(pass) Web Crypto > should encrypt and decrypt [0.38ms]
(pass) Web Crypto > should verify and sign [0.74ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.44ms]
(pass) Web Crypto > unwrapKey JWK error han
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp    | 16 +++++-
 test/js/web/crypto/web-crypto.test.ts              | 64 ++++++++++++++++++++++
 2 files changed, 78 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…sc/bindings/webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp      1      4      0
test/js/web/crypto/web-crypto.test.ts                         1      1      0
```

</details>

<!-- robobun:evidence:end -->