### PR TITLE
watch: report a failed reload exec as an error instead of a panic

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4340,7 +4340,11 @@ pub fn maybe_handle_panic_during_process_reload() {
     }
 }
 
-/// Port of `bun.reloadProcess`. `may_return == true` → returns on failure; `false` → panics.
+/// Port of `bun.reloadProcess`. On failure the executable path and errno are printed, then
+/// `may_return == true` (the crash handler's auto-restart) returns and `false` exits with 1: the
+/// old image cannot safely carry on once `on_before_reload_process_posix` has reset the signal
+/// dispositions, and an executable that was removed or made unrunnable under a running `--watch`
+/// is not a bug, so it is not a panic either.
 /// `on_before_reload_process_posix` clears CLOEXEC on stdio/IPC and resets caught signal
 /// dispositions on all POSIX; the close_range sweep is Linux/BSD only.
 pub fn reload_process(clear_terminal: bool, may_return: bool) {
@@ -4431,20 +4435,29 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         let mut envp: Vec<*const core::ffi::c_char> = dupe_env.iter().map(|z| z.as_ptr()).collect();
         envp.push(core::ptr::null());
 
-        // we must clone selfExePath in case argv[0] was not an absolute path
-        let exec_path = self_exe_path().expect("unreachable").as_ptr();
+        let exec = |path: &ZStr| -> i32 {
+            libc::execve(path.as_ptr(), newargv.as_ptr().cast(), envp.as_ptr().cast());
+            // execve only returns on error.
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
+        };
 
-        libc::execve(exec_path, newargv.as_ptr().cast(), envp.as_ptr().cast());
-        // execve only returns on error.
-        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+        // we must clone selfExePath in case argv[0] was not an absolute path
+        let exec_path = self_exe_path().expect("unreachable");
+        let (failed_path, errno) = (exec_path.as_bytes(), exec(exec_path));
+
+        // Once the running binary is unlinked, /proc/self/exe reads "<path> (deleted)". After an
+        // in-place replacement (`bun upgrade`, a reinstall) the new binary is at <path>: exec it.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let (failed_path, errno) = match failed_path.strip_suffix(b" (deleted)") {
+            Some(path) if errno == libc::ENOENT => (path, exec(ZBox::from_bytes(path).as_zstr())),
+            _ => (failed_path, errno),
+        };
+
+        report_reload_failure(failed_path, errno);
         if may_return {
-            crate::output::pretty_errorln(format_args!(
-                "error: Failed to reload process: errno {}",
-                errno
-            ));
             return;
         }
-        panic!("Unexpected error while reloading: errno {}", errno);
+        crate::Global::exit(1);
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -4453,6 +4466,28 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         // is a build-time error, not a runtime panic.
         let _ = (clear_terminal, may_return);
         compile_error!("unsupported platform for reload_process");
+    }
+}
+
+#[cfg(unix)]
+#[cold]
+fn report_reload_failure(exec_path: &[u8], errno: i32) {
+    let exec_path = bstr::BStr::new(exec_path);
+    match (
+        crate::ErrnoNames::SYS.name(errno),
+        crate::coreutils_error_map::get(errno),
+    ) {
+        (Some(code), Some(message)) => crate::err_generic!(
+            "Failed to reload \"<b>{}<r>\": {}: {} <d>(execve)<r>",
+            exec_path,
+            code,
+            message
+        ),
+        _ => crate::err_generic!(
+            "Failed to reload \"<b>{}<r>\": errno {} <d>(execve)<r>",
+            exec_path,
+            errno
+        ),
     }
 }
 

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -2,8 +2,8 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
-import { readdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { copyFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { basename, join } from "node:path";
 
 let watchee: Subprocess;
 
@@ -201,6 +201,73 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   expect(stderr).toContain("Failed to start File Watcher: EAGAIN");
   expect(stdout).not.toContain("unreachable");
   expect(exitCode).not.toBe(0);
+});
+
+// A --watch reload re-execs the executable the session was started from. The
+// two tests below start the session from a private copy of the executable,
+// kept outside the watched directory, so that they can remove or replace it
+// between the first run and the reload.
+const ENTRY_FIRST = `console.log("iter first"); setInterval(() => {}, 1000);`;
+const ENTRY_SECOND = `console.log("iter second"); setInterval(() => {}, 1000);`;
+function spawnWatchFromCopiedExe(dir: string) {
+  const exe = join(dir, basename(bunExe()));
+  copyFileSync(bunExe(), exe);
+  const proc = spawn({
+    // --debug-crash-handler-use-trace-string skips the debug build's slow
+    // backtrace symbolication, so a reload that crashes fails these tests
+    // quickly instead of timing out.
+    cmd: [exe, "--debug-crash-handler-use-trace-string", "--watch", "entry.js"],
+    cwd: join(dir, "app"),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  watchee = proc;
+  return { exe, proc };
+}
+
+// The executable can be gone by the time a file change triggers the re-exec
+// (bun uninstalled, a version manager switched versions). execve then fails
+// with ENOENT. That is the user's environment, so it is reported as an error,
+// not as a panic with a crash report.
+it.skipIf(isWindows)("--watch reports an error when the executable it was started from is gone", async () => {
+  using dir = tempDir("watch-exe-removed", { "app/entry.js": ENTRY_FIRST });
+  const { exe, proc } = spawnWatchFromCopiedExe(String(dir));
+  const stderr = proc.stderr.text();
+
+  const { waitFor, release } = stdoutWaiter(proc);
+  await waitFor("iter first");
+  release();
+
+  rmSync(exe);
+  await Bun.write(join(String(dir), "app", "entry.js"), ENTRY_SECOND);
+
+  expect(await stderr).toContain(`error: Failed to reload "${exe}": ENOENT: No such file or directory (execve)`);
+  expect(await stderr).not.toContain("Bun has crashed");
+  expect(await proc.exited).toBe(1);
+});
+
+// `bun upgrade` and package reinstalls rename a new binary over the running
+// one. On Linux, /proc/self/exe then reads "<path> (deleted)", which no longer
+// execs; the reload has to land on the replacement at the original path.
+it.skipIf(isWindows)("--watch reloads into a binary that replaced the running one", async () => {
+  using dir = tempDir("watch-exe-replaced", { "app/entry.js": ENTRY_FIRST });
+  const { exe, proc } = spawnWatchFromCopiedExe(String(dir));
+  const stderr = proc.stderr.text();
+
+  const { waitFor, release } = stdoutWaiter(proc);
+  await waitFor("iter first");
+
+  copyFileSync(bunExe(), `${exe}.new`);
+  renameSync(`${exe}.new`, exe);
+  await Bun.write(join(String(dir), "app", "entry.js"), ENTRY_SECOND);
+  await waitFor("iter second");
+  release();
+
+  proc.kill("SIGKILL");
+  await proc.exited;
+  expect(await stderr).toBe("");
 });
 
 // A script that registers a SIGTERM handler and then spins in synchronous


### PR DESCRIPTION
### Problem
- A `--watch` reload crashes with `panic: Unexpected error while reloading: errno 2` plus a crash report when the executable the session was started from is gone or is not runnable any more (Sentry BUN-4NGV). Repro: copy bun, start `--watch` from the copy, `rm` the copy, save a file.
- The cause is `reload_process` in `src/bun_core/util.rs`. When `execve` returns, the `may_return == false` path (every `--watch` caller) calls `panic!`. This is an OS error from the user's environment, not an invariant.
- On Linux the same panic also hits an in-place upgrade. Once the running binary is unlinked, `/proc/self/exe` reads `<path> (deleted)`, and `self_exe_path()` is first computed at reload time, so `execve` fails with ENOENT even though the new binary sits at `<path>`.

### Fix
- On a failed `execve`, print `error: Failed to reload "<path>": ENOENT: No such file or directory (execve)` and exit with code 1. The crash handler's auto-restart (`may_return == true`) prints the same line and returns, as before. Every errno takes this route (EACCES, ETXTBSY, ENOMEM, ...).
- Exiting is correct because `on_before_reload_process_posix` has already reset the signal dispositions, so the old image cannot safely keep running. The callers that follow the call with `unreachable!()` are unchanged: the function still never returns to them.
- Linux and Android: when the first exec fails with ENOENT and the path ends in ` (deleted)`, exec the path without the suffix. An upgraded bun now reloads into the new binary. The error names the path that was tried last.
- Verified: `test/cli/watch/watch.test.ts`, two new tests (removed executable, replaced executable). Both fail on the released bun (panic, and the process dies before the second run). Also ran `test/cli/hot/watch.test.ts` and `test/cli/watch/watcher-trace.test.ts`.

### Background
- `bun --watch` does not reload modules in place. On a file change the watcher thread calls `reload_process`, which `execve`s the same executable with the same argv and env. The new process starts from scratch.
- `on_before_reload_process_posix` (`src/jsc/bindings/c-bindings.cpp`) runs right before the exec. It clears CLOEXEC on stdio, marks the other fds CLOEXEC and resets caught signal handlers to their defaults.
- `reload_process` lives in `bun_core`, which cannot depend on `bun_errno`. The errno name and text come from the `ErrnoNames` link interface and `coreutils_error_map`, the same tables `Output::err` uses.

<details><summary>Notes</summary>

- #31691 fixed the same crash in June. It is stale and conflicts with main now. This change differs from it in two points: every errno exits instead of a fixed list, and the message has the same shape as other syscall errors.
- The message was checked by hand on the watcher thread path (no kill-signal listeners, the default) and on the JS thread path (a `SIGTERM` listener registered). With colors on, the screen is cleared first and the error is the only line on the fresh screen.
- macOS has no `(deleted)` suffix. `_NSGetExecutablePath` returns the start path, so a replaced binary already reloads there. The replaced-binary test covers that behavior on both platforms and the retry on Linux.
- `self_exe_path()` still uses `.expect("unreachable")`. It only fails when `/proc` is not mounted on Linux. Not changed here.
- The new tests copy the executable into the temp dir, so they take about 0.6 s and 1.4 s with an 800 MB debug build here. Release binaries are much smaller. 30 reruns passed.
- `cargo check -p bun_core` passes for linux, musl, android, darwin, freebsd and windows targets. clippy and rustfmt are clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->