### PR TITLE
node:crypto: read integer arguments by value, not by JSValue representation

### DIFF
--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -583,17 +583,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateOneOf, (JSC::JSGlobalObject * global
 
 JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const int32_t> oneOf, int32_t* out)
 {
-    if (!value.isInt32()) {
-        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, "must be one of: "_s, value, oneOf);
-    }
-
-    int32_t value_num = value.asInt32();
-    for (int32_t oneOfNum : oneOf) {
-        if (value_num == oneOfNum) {
-            if (out) {
-                *out = oneOfNum;
+    // Node compares with ArrayPrototypeIncludes(), so a number matches by value whether
+    // the JSValue holds it as an int32 or as a double.
+    if (value.isNumber()) {
+        double value_num = value.asNumber();
+        for (int32_t oneOfNum : oneOf) {
+            if (value_num == static_cast<double>(oneOfNum)) {
+                if (out) {
+                    *out = oneOfNum;
+                }
+                return JSValue::encode(jsUndefined());
             }
-            return JSValue::encode(jsUndefined());
         }
     }
 

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -11,6 +11,7 @@
 #include "CryptoKeyRSA.h"
 #include "JSVerify.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <JavaScriptCore/MathCommon.h>
 #include "CryptoKeyRaw.h"
 #include "JSKeyObject.h"
 
@@ -520,12 +521,18 @@ std::optional<int32_t> getIntOption(JSC::JSGlobalObject* globalObject, ThrowScop
     if (value.isUndefined())
         return std::nullopt;
 
-    if (!value.isInt32()) {
-        Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, makeString("options."_s, name), value);
-        return std::nullopt;
+    // Node accepts `value === value >> 0`: any number whose value is an int32, -0 included.
+    // An integral number is not always an int32 JSValue (an element of a JSON array that also
+    // holds 1e10 is stored as a double), so decide by value, not by representation.
+    if (value.isNumber()) {
+        double number = value.asNumber();
+        int32_t integer = JSC::toInt32(number);
+        if (static_cast<double>(integer) == number)
+            return integer;
     }
 
-    return value.asInt32();
+    Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, makeString("options."_s, name), value);
+    return std::nullopt;
 }
 
 int32_t getPadding(JSC::JSGlobalObject* globalObject, ThrowScope& scope, JSValue options, const ncrypto::EVPKeyPointer& pkey)

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
@@ -71,10 +71,13 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
         }
     }
 
+    // Used when generatorValue is a number. Read through the validator: asInt32() is not
+    // valid for an integral number the JSValue holds as a double.
+    int32_t generatorNumber = 2;
     if (generatorValue.pureToBoolean() == TriState::False) {
         generatorValue = jsNumber(2);
     } else if (generatorValue.isNumber()) {
-        Bun::V::validateInt32(scope, globalObject, generatorValue, "generator"_s, jsUndefined(), jsUndefined());
+        Bun::V::validateInt32(scope, globalObject, generatorValue, "generator"_s, jsUndefined(), jsUndefined(), &generatorNumber);
         RETURN_IF_EXCEPTION(scope, {});
     } else if (!generatorValue.isString() && !isArrayBufferOrView(generatorValue)) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "generator"_s, "number, string, ArrayBuffer, Buffer, TypedArray, or DataView"_s, generatorValue);
@@ -99,10 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
             return {};
         }
 
-        int32_t generator = 0;
-        V::validateInt32(scope, globalObject, generatorValue, "generator"_s, jsUndefined(), jsUndefined(), &generator);
-        RETURN_IF_EXCEPTION(scope, {});
-
+        int32_t generator = generatorNumber;
         if (generator < 2) {
             ERR_put_error(ERR_LIB_DH, 0, DH_R_BAD_GENERATOR, __FILE__, __LINE__);
             throwCryptoError(globalObject, scope, ERR_get_error(), "Invalid generator"_s);
@@ -135,7 +135,7 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
         ncrypto::BignumPointer bn_g;
 
         if (generatorValue.isNumber()) {
-            int32_t generator = generatorValue.asInt32();
+            int32_t generator = generatorNumber;
             if (generator < 2) {
                 ERR_put_error(ERR_LIB_DH, 0, DH_R_BAD_GENERATOR, __FILE__, __LINE__);
                 throwCryptoError(globalObject, scope, ERR_get_error(), "Invalid generator"_s);

--- a/src/jsc/bindings/node/crypto/node_crypto_binding.cpp
+++ b/src/jsc/bindings/node/crypto/node_crypto_binding.cpp
@@ -190,8 +190,11 @@ JSC_DEFINE_HOST_FUNCTION(jsGetCipherInfo, (JSC::JSGlobalObject * lexicalGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue nameOrNid = callFrame->argument(0);
+    // Read through the validator: asInt32() is not valid for an integral number the
+    // JSValue holds as a double.
+    int32_t nid = 0;
     if (nameOrNid.isNumber()) {
-        Bun::V::validateInt32(scope, lexicalGlobalObject, nameOrNid, "nameOrNid"_s, jsUndefined(), jsUndefined());
+        Bun::V::validateInt32(scope, lexicalGlobalObject, nameOrNid, "nameOrNid"_s, jsUndefined(), jsUndefined(), &nid);
         RETURN_IF_EXCEPTION(scope, {});
     } else if (!nameOrNid.isString()) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "nameOrNid"_s, "string or number"_s, nameOrNid);
@@ -226,7 +229,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGetCipherInfo, (JSC::JSGlobalObject * lexicalGlobalOb
 
     const ncrypto::Cipher cipher = [&] {
         if (nameOrNid.isNumber()) {
-            return ncrypto::Cipher::FromNid(nameOrNid.asInt32());
+            return ncrypto::Cipher::FromNid(nid);
         }
 
         String name = nameOrNid.toWTFString(lexicalGlobalObject);

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -691,6 +691,99 @@ describe("DiffieHellman", () => {
   });
 });
 
+// An integer-valued Number is not always an int32 JSValue. An element of an array that
+// also holds a non-int32 number, or anything read out of a Float64Array, is stored as a
+// double. Node validates these arguments by value, so every case below works there.
+describe("integer arguments whose JSValue is a double", () => {
+  const asDouble = n => new Float64Array([n])[0];
+  const [, twentyFromJson] = JSON.parse("[1e10, 20]");
+
+  function errorCode(fn) {
+    try {
+      fn();
+      return "no error";
+    } catch (e) {
+      return e.code;
+    }
+  }
+
+  it("sign() and verify() accept padding and saltLength by value", () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 1024 });
+    const data = Buffer.from("msg");
+    const pss = crypto.constants.RSA_PKCS1_PSS_PADDING;
+    const signature = crypto.sign("sha256", data, { key: privateKey, padding: pss, saltLength: 20 });
+    const verifyWith = (options, sig = signature) =>
+      crypto.verify("sha256", data, { key: publicKey, padding: pss, ...options }, sig);
+
+    expect({
+      doubleSaltLength: verifyWith({ saltLength: asDouble(20) }),
+      saltLengthFromJsonArray: verifyWith({ saltLength: twentyFromJson }),
+      doublePadding: verifyWith({ padding: asDouble(pss), saltLength: 20 }),
+      createVerifyDoubleSaltLength: crypto
+        .createVerify("sha256")
+        .update(data)
+        .verify({ key: publicKey, padding: pss, saltLength: asDouble(20) }, signature),
+      signDoubleSaltLength: verifyWith(
+        { saltLength: 20 },
+        crypto.sign("sha256", data, { key: privateKey, padding: pss, saltLength: asDouble(20) }),
+      ),
+      createSignDoubleSaltLength: verifyWith(
+        { saltLength: 20 },
+        crypto
+          .createSign("sha256")
+          .update(data)
+          .sign({ key: privateKey, padding: pss, saltLength: asDouble(20) }),
+      ),
+      // Node's check is `value === value >> 0`, which accepts -0 as 0.
+      negativeZeroSaltLength: verifyWith(
+        { saltLength: -0 },
+        crypto.sign("sha256", data, { key: privateKey, padding: pss, saltLength: 0 }),
+      ),
+      fractionalSaltLength: errorCode(() => verifyWith({ saltLength: 20.5 })),
+      saltLengthPastInt32: errorCode(() => verifyWith({ saltLength: 2 ** 31 })),
+      stringSaltLength: errorCode(() => verifyWith({ saltLength: "20" })),
+    }).toEqual({
+      doubleSaltLength: true,
+      saltLengthFromJsonArray: true,
+      doublePadding: true,
+      createVerifyDoubleSaltLength: true,
+      signDoubleSaltLength: true,
+      createSignDoubleSaltLength: true,
+      negativeZeroSaltLength: true,
+      fractionalSaltLength: "ERR_INVALID_ARG_VALUE",
+      saltLengthPastInt32: "ERR_INVALID_ARG_VALUE",
+      stringSaltLength: "ERR_INVALID_ARG_VALUE",
+    });
+  });
+
+  it("generateKeySync('aes') accepts the length by value", () => {
+    expect({
+      double128: crypto.generateKeySync("aes", { length: asDouble(128) }).symmetricKeySize,
+      double256: crypto.generateKeySync("aes", { length: asDouble(256) }).symmetricKeySize,
+    }).toEqual({ double128: 16, double256: 32 });
+    for (const length of [128.5, 64, "128"]) {
+      expect(() => crypto.generateKeySync("aes", { length })).toThrow(
+        "The property 'options.length' must be one of: 128, 192, 256",
+      );
+    }
+  });
+
+  it("createDiffieHellman(prime, generator) reads a double generator", () => {
+    const prime = crypto.getDiffieHellman("modp5").getPrime();
+    const generatorOf = generator => crypto.createDiffieHellman(prime, generator).getGenerator().toString("hex");
+    // Before the fix the double was read as 0 and rejected as a bad generator.
+    expect({ double2: generatorOf(asDouble(2)), double5: generatorOf(asDouble(5)) }).toEqual({
+      double2: "02",
+      double5: "05",
+    });
+  });
+
+  it("getCipherInfo(nid) reads a double nid", () => {
+    const info = crypto.getCipherInfo("aes-128-cbc");
+    expect(crypto.getCipherInfo(asDouble(info.nid))).toEqual(info);
+  });
+});
+
 describe("ECDH", () => {
   it("should have correct method names", () => {
     const ecdh = crypto.createECDH("prime256v1");


### PR DESCRIPTION
### Problem
- An integer-valued Number is not always an int32 `JSValue`. `JSON.parse("[1e10, 20]")[1]`, an element of any array that also holds a non-int32 number, or a value read out of a `Float64Array` is stored as a double. Four `node:crypto` entry points decide by that representation. Node accepts every case below (checked against v26.3.0). Bun 1.3.14 behaves like main, so this is not a regression.
- `crypto.sign()`, `crypto.verify()`, `Sign#sign()` and `Verify#verify()` reject such a `padding` or `saltLength` with `ERR_INVALID_ARG_VALUE: The property 'options.saltLength' is invalid. Received 20`. They also reject `saltLength: -0`. Cause: `getIntOption()` in `src/jsc/bindings/node/crypto/CryptoUtil.cpp:523` tests `isInt32()`. `generateKeySync("aes", { length })` rejects a double-encoded 128 or 256 for the same reason in `V::validateOneOf()` (`NodeValidator.cpp:586`).
- `createDiffieHellman(prime, generator)` and `getCipherInfo(nid)` validate the number and then read it with `asInt32()` (`JSDiffieHellmanConstructor.cpp:138`, `node_crypto_binding.cpp:229`). A debug build fails `ASSERTION FAILED: isInt32()`. A release build reads 0, so the generator is reported as `BAD_GENERATOR` and the cipher comes back `undefined`.

### Fix
- `getIntOption()` does what Node's `value === value >> 0` does: a Number whose value survives `ToInt32` unchanged is accepted, whatever its representation, so `-0` becomes 0. Fractions, values outside int32 and non-numbers are still rejected with the same error.
- The int32 `validateOneOf()` compares the numeric value against the list, which is what Node's `Array#includes` does. Non-numbers still fail the same way.
- The Diffie-Hellman constructor and `getCipherInfo()` take the value from the `validateInt32()` call they already make, through its out parameter, which handles both representations. The constructor also loses its second, identical validation of the same argument.
- Verified with `test/js/node/crypto/node-crypto.test.js` ("integer arguments whose JSValue is a double"): all four tests fail on main. The rest of that file (212 tests), `crypto.key-objects.test.ts`, `crypto-rsa.test.js`, `crypto-oneshot.test.ts` and Node's `test-crypto-secret-keygen`, `test-crypto-dh*`, `test-crypto-getcipherinfo` and `test-crypto-sign-verify` pass.
- Related: #38401 adds Node's `. Received x` suffix to the `validateOneOf()` message. This PR does not touch that message. The test here matches the message prefix, so it holds either way.

### Background
JSC stores a Number either as an int32 or as a double inside the `JSValue`. Arithmetic and literals usually produce the int32 form, which is why `saltLength: 20` works and the bug looks intermittent from the outside. Arrays switch to double storage as soon as one element does not fit an int32, and typed arrays always produce doubles, so the same value 20 can arrive in either form. `JSValue::isInt32()` and `asInt32()` ask about the storage, not the value. `asNumber()` and the `validateInt32()` out parameter give the value in both cases. The other integer options in `node:crypto` (pbkdf2, scrypt, hkdf, key generation, cipher options) already go through the validators, so they are not affected.
