### PR TITLE
Bump WebKit (oven-sh/WebKit#485 preview): JSC and WTF crashes on macOS 26 arm64 reach the crash handler again

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-485-c9ed9248";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,17 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isASAN,
+  isDebug,
+  isLinux,
+  isMacOS,
+  isPosix,
+  isWindows,
+  mergeWindowEnvs,
+  tempDir,
+} from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -443,6 +454,27 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
 
     await resolve_handler.promise;
     expect(sent).toBe(true);
+  });
+
+  // JavaScriptCore, WTF and bun's own C++ crash through WTF's RELEASE_ASSERT /
+  // CRASH(): a trap instruction on macOS, abort() elsewhere. On arm64 that trap
+  // was `brk #0xbb08`, which macOS 26 answers with SIGKILL before any SIGTRAP
+  // handler runs, so the child died with an empty stderr. Bun's WebKit emits
+  // `brk #0` there (oven-sh/WebKit#485). This drives a real JSC assertion, not
+  // the `trap` hook with its own instruction: structureHeapSizeInKB must be a
+  // power of two, and 3072 fails the RELEASE_ASSERT in StructureMemoryManager's
+  // constructor during JSC::initialize(). ASAN builds install no signal handlers.
+  test.skipIf(isASAN).concurrent("a JavaScriptCore release assertion produces a crash report", async () => {
+    await using proc = Bun.spawn({
+      cmd: noCoreCmd([bunExe(), "-e", "1", "--debug-crash-handler-use-trace-string"]),
+      env: { ...noReportEnv, BUN_JSC_structureHeapSizeInKB: "3072" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(isMacOS ? "Trap instruction" : "abort() called");
+    expect(stderr).toContain("oh no: Bun has crashed");
+    expect(proc.signalCode).toBe(isMacOS ? "SIGTRAP" : "SIGABRT");
   });
 
   // process.abort() is a deliberate user action, not a Bun crash. It must still


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to the preview build of oven-sh/WebKit#485 and adds the test. Re-pin to the merged commit before merging.

### Problem
- On macOS 26 arm64, a failed WTF `RELEASE_ASSERT` or `CRASH()` (JSC, WTF, bun's own C++) ends in `Killed: 9` with an empty stderr and no crash report. Repro: `BUN_JSC_structureHeapSizeInKB=3072 bun -e 1` (`StructureAlignedMemoryAllocator.cpp:110`). Linux and macOS x64 print a report.
- On arm64 these macros emit `brk #0xbb08` (`wtf/Assertions.h:291`). macOS 26 kills the process on that immediate before it delivers SIGTRAP, so bun's `sigaction` handler never runs, during startup or later (JSC owns a Mach port for `EXC_BAD_ACCESS` only).

### Fix
- oven-sh/WebKit#485 makes the fork emit `brk #0`: `WTF_FATAL_CRASH_CODE` and `WTF_FATAL_CRASH_INST` under `USE(BUN_JSC_ADDITIONS)`, plus bmalloc's `BBreakpointTrap()`. Every arm64 crash site, bun's own C++ included, derives from them.
- Correct because `brk #0` reaches a SIGTRAP handler on the macOS 26 CI machines (the `trap` test hook uses it), WebKit's ASAN configuration already uses these values, and nothing reads the immediate back.
- The test makes JSC fail a real `RELEASE_ASSERT` on every POSIX platform and expects the report: `Trap instruction` and SIGTRAP on macOS, `abort() called` and SIGABRT elsewhere. On the old pin, darwin-aarch64 gets SIGKILL and an empty stderr.
- Verified: `test/cli/run/run-crash-handler.test.ts` on Linux (release canary, and `bun bd` on this pin), and on CI's macOS 26.4 arm64 shard with this pin: 20 pass, 0 fail, the new test among them (Notes).

### Background
- In a release build `RELEASE_ASSERT` is `CRASH_WITH_INFO()`: on Darwin an inline `asm` of `WTF_FATAL_CRASH_INST`, elsewhere `abort()`.
- `WEBKIT_VERSION` (`scripts/build/deps/webkit.ts`) is the engine pin: the build downloads that oven-sh/WebKit release. A WebKit PR's preview release pins the same way.

<details><summary>Notes</summary>

Evidence for the cause (gathered on the darwin-aarch64 build of #39967, macOS 26.6.2; the CI lane runs 26.4, with `structureHeapSizeInKB=32768`, which fails the assert at `:147` instead): the `.ips` report for the killed process says `EXC_BREAKPOINT`, `brk 47880` (0xbb08), signal SIGKILL, x0 = 0x93 = 147 (the line number `WTFCrashWithInfo` puts in x0), and no handler frames. A 20 line C program that installs a SIGTRAP handler and executes `brk #0xbb08` is killed the same way. The same program with `brk #0` runs its handler. There is no macOS machine in this environment, so the arm64 side of the test is proven by CI only.

Post-startup crashes: `activateSignalHandlersFor` is only called for `Signal::AccessFault` (`VMTraps.cpp:208`, `WasmFaultSignalHandler.cpp:143`), so the process never owns an `EXC_BREAKPOINT` port and a later `brk` is handled by the kernel like the one inside `JSC::initialize()`. The macOS arm64 "Trap instruction" reports Sentry still receives must come from macOS before 26, or from other immediates (`__builtin_trap()` is `brk #1`).

What the macros feed: `CRASH()`, the inline `WTFCrashWithInfo`, the `WTFCrashWithInfoImpl` overloads in `Assertions.cpp`, `JSLock.cpp`, `MacroAssemblerARM64::breakpoint()` and its default argument, `MacroAssemblerARM64.cpp`, the offlineasm `break` and the LLInt spacer. Nothing decodes the immediate: `ARM64Assembler::isBrk` masks it out and has no callers, VM traps and Wasm faults are access faults (`replaceWithVMHalt` is `dc zva xzr`) handled by PC lookup, and LLInt code is recognised by address range. libpas has a third copy of the instruction, but bun's WebKit builds use `USE_MIMALLOC`, under which `LIBPAS_ENABLED` is 0 and `pas_utils.c` compiles to nothing. Windows arm64 is unaffected either way: bun's VEH (`classify_exception_windows`) reports access violations, illegal instructions, misalignment and stack overflow only, so a `brk` is not reported there with either immediate, and neither 0 nor 0xbb08 is an immediate Windows' own intrinsics use (`__debugbreak()` is `brk #0xF000`). Preprocessing a TU against the prebuilt `cmakeconfig.h` of the old pin gives `"brk #0x0"` / `0x0` with the change, `"brk #0xbb08"` without it, and the upstream values with `USE_BUN_JSC_ADDITIONS` set to 0.

The preview is oven-sh/WebKit `ceb9f90fb7`, the commit main pins since #40767, plus the one commit (`c9ed9248`). So the engine under test is exactly main's engine with the `brk #0` change. Earlier previews of the same two-file change sat on `51a6d25c64` (`autobuild-preview-pr-485-1262c7b5`, CI build 102710), `aea1f010b6` (`autobuild-preview-pr-485-9b04f938`, builds 104060 and 104075), `c148a12dd8` (`autobuild-preview-pr-485-1336a391`), `cb61607f1a` (`autobuild-preview-pr-485-2cae5307`, build 105593, where the macOS 26.6.1 shard ran the new test: 28 pass, 0 fail) `1cb96a7b0e` (`autobuild-preview-pr-485-eb06812c`, build 105910), `76882271d7` (`autobuild-preview-pr-485-5cd9ee3d`), `2da33d53e3` (`autobuild-preview-pr-485-28b44640`) and `7259739917` (`autobuild-preview-pr-485-c3bf2c74`, build 106844, where the macOS 26.6.1 shard ran the new test: 28 pass, 0 fail; that preview also carried the Scoop CI fix, which oven-sh/WebKit#523 has since solved on main by dropping Scoop) `0bb01ed526` (`autobuild-preview-pr-485-d12dc20e`) `f5deafe090` (`autobuild-preview-pr-485-b3c7ff97`, build 107203) `1817c3c37f` (`autobuild-preview-pr-485-55036dec`, never pushed: main moved again while it built) and `c4ddc0cf52` (`autobuild-preview-pr-485-ccdf49f1`, build 107648). Each re-pin onto main's new engine changed nothing in the WebKit diff.

Alternatives not taken: `CRASH()` as `abort()` on Darwin (bun handles SIGABRT, but frame 0 of the report would be inside `abort()` instead of at the assert, and it diverges more from upstream), and a Mach exception port for `EXC_BREAKPOINT` in bun's crash handler (a lot of signal safety sensitive code for the same result).

Test details: it lives in the `SIGABRT/SIGTRAP are caught by the crash handler` describe, which is `isPosix` (Windows does not report `abort()` or `int3` yet, #38860), and uses the file's `noCoreCmd` wrapper (the child dies through `SIG_DFL`, so the coredump-upload lanes need `ulimit -c 0`). The expected signal is the same in debug and release builds: a failing `RELEASE_ASSERT` in a debug build goes through `ASSERT`, which also ends in `CRASH_WITH_INFO()`. CI on this pin (build 102710): the darwin aarch64 test job is two shards, one on macOS 15.7.7 and one on macOS 26.4. The crash handler file ran on the 26.4 shard: 20 pass, 7 skip, 0 fail. The 7 skips are the Linux debug and Windows tests, so the new test ran and passed there, as did the two `raised SIGABRT/SIGTRAP` tests. Results here (Linux x64): `USE_SYSTEM_BUN=1 bun test` on the 1.4.0 canary passes it (`abort() called`, SIGABRT). `bun bd test` on this pin (`process.versions.webkit` is `preview-pr-485-1262c7b5`, and the shipped `wtf/Assertions.h` carries the change): this file 17 pass, 10 skip, 0 fail; `test/js/bun/jsc/` (without the slow `domjit` file) plus `test/js/bun/util/inspect.test.js` 135 pass, 1 skip, 0 fail. `test/js/web/fetch/fetch.test.ts` has failures in this container, but the same tests fail the same way (`ConnectionRefused` to `localhost`) on the old pin, checked by switching the pin back and relinking. #39967 adds a test with the same trigger, skipped on Apple Silicon because of this bug. Once both are in, that skip can go. The two branches touch the same import line, so whichever lands second needs a one line rebase. Rebased once onto main after #39953 landed: it moved `noCoreCmd` to file scope and removed the `raised SIGABRT/SIGTRAP` tests next to which this test sat, so the resolution kept main's version of both and re-added only the new test and its two imports.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 12 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->











