### PR TITLE
yaml: keep a boxed Number or Boolean property value on the key line in block style

### DIFF
--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -317,11 +317,19 @@ impl Stringifier {
     }
 
     fn stringify(&mut self, global: &JSGlobalObject, value: JSValue) -> Result<(), StringifyError> {
+        let unwrapped = value.unwrap_boxed_primitive(global)?;
+        self.stringify_unwrapped(global, unwrapped)
+    }
+
+    /// `unwrapped` has been through `unwrap_boxed_primitive`.
+    fn stringify_unwrapped(
+        &mut self,
+        global: &JSGlobalObject,
+        unwrapped: JSValue,
+    ) -> Result<(), StringifyError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(StringifyError::StackOverflow);
         }
-
-        let unwrapped = value.unwrap_boxed_primitive(global)?;
 
         if unwrapped.is_null() {
             self.builder.append_latin1(b"null");
@@ -546,11 +554,12 @@ impl Stringifier {
 
                     self.indent += 1;
 
-                    if prop_value_needs_newline(iter.value) {
+                    let prop_value = iter.value.unwrap_boxed_primitive(global)?;
+                    if prop_value_needs_newline(prop_value) {
                         self.newline();
                     }
 
-                    self.stringify(global, iter.value)?;
+                    self.stringify_unwrapped(global, prop_value)?;
                     self.indent -= 1;
                 }
                 if first {
@@ -663,7 +672,7 @@ impl Stringifier {
     }
 }
 
-/// Does this object property value need a newline? True for arrays and objects.
+/// Does this (unwrapped) object property value need a newline? True for arrays and objects.
 fn prop_value_needs_newline(value: JSValue) -> bool {
     !value.is_number() && !value.is_boolean() && !value.is_null() && !value.is_string()
 }

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -3873,6 +3873,28 @@ config:
         expect(() => YAML.stringify(deep)).toThrow("Maximum call stack size exceeded");
       });
 
+      test("stack overflow protection in the write pass", () => {
+        let deep = {};
+        let current = deep;
+        for (let i = 0; i < 1000000; i++) {
+          current.next = {};
+          current = current.next;
+        }
+
+        // stringify reads every property twice: once to find anchors and once
+        // to write. Hand the first read a shallow value so that only the write
+        // pass walks the deep structure.
+        let reads = 0;
+        const root = {
+          get value() {
+            return reads++ === 0 ? {} : deep;
+          },
+        };
+
+        expect(() => YAML.stringify(root)).toThrow("Maximum call stack size exceeded");
+        expect(reads).toBe(2);
+      });
+
       test("handles arrays as root with references", () => {
         const shared = { shared: true };
         const arr = [shared, "middle", shared];

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -3655,7 +3655,51 @@ config:
           str: new String("world"),
           bool: new Boolean(false),
         };
-        expect(YAML.stringify(obj, null, 2)).toBe("num: \n  3.14\nstr: world\nbool: \n  false");
+        expect(YAML.stringify(obj, null, 2)).toBe("num: 3.14\nstr: world\nbool: false");
+      });
+
+      test("boxed Number and Boolean property values stay on the key line in block style", () => {
+        expect(YAML.stringify({ a: new Number(1), b: new Boolean(true), c: new String("s"), d: 1 }, null, 2)).toBe(
+          "a: 1\nb: true\nc: s\nd: 1",
+        );
+        expect(YAML.stringify({ a: new Number(1), b: new Boolean(true), c: new String("s"), d: 1 })).toBe(
+          "{a: 1,b: true,c: s,d: 1}",
+        );
+      });
+
+      test("a boxed property value is written exactly like the primitive it wraps", () => {
+        class Port extends Number {}
+        class Flag extends Boolean {}
+        const boxed = {
+          numbers: { int: new Number(1), float: Object(2.5), nan: new Number(NaN), negativeZero: new Number(-0) },
+          flags: { enabled: new Boolean(true), disabled: Object(false), port: new Port(8080), flag: new Flag(false) },
+          list: [new Number(1), new Boolean(false), { count: new Number(2) }],
+        };
+        const plain = {
+          numbers: { int: 1, float: 2.5, nan: NaN, negativeZero: -0 },
+          flags: { enabled: true, disabled: false, port: 8080, flag: false },
+          list: [1, false, { count: 2 }],
+        };
+        for (const space of [2, 4, "\t", undefined]) {
+          expect(YAML.stringify(boxed, null, space)).toBe(YAML.stringify(plain, null, space));
+        }
+        expect(YAML.parse(YAML.stringify(boxed, null, 2))).toEqual(plain);
+      });
+
+      test("block style unwraps a boxed property value as many times as flow style", () => {
+        let calls = 0;
+        const port = new Number(7);
+        port.valueOf = () => {
+          calls++;
+          return 7;
+        };
+
+        expect(YAML.stringify({ port }, null, 2)).toBe("port: 7");
+        const blockStyleCalls = calls;
+
+        calls = 0;
+        expect(YAML.stringify({ port })).toBe("{port: 7}");
+        expect(blockStyleCalls).toBe(calls);
       });
 
       test("handles Date objects", () => {


### PR DESCRIPTION
### Problem

- `Bun.YAML.stringify({ a: new Number(1), b: new Boolean(true), c: new String("s"), d: 1 }, null, 2)` returns `"a: \n  1\nb: \n  true\nc: s\nd: 1"`. The boxed Number and Boolean get the layout of a collection. Every other path writes them inline.
- The block-style object branch of `Stringifier::stringify` (`src/runtime/api/YAMLObject.rs:549`) calls `prop_value_needs_newline` on the raw property value. A wrapper is an object, so it gets a newline. `stringify` then unwraps it and writes a scalar.

### Fix

- The branch unwraps the property value once, decides the layout on the result, and writes it through the new `stringify_unwrapped` (the old body of `stringify`). `stringify` is now the unwrap plus that call. Its other callers are unchanged.
- This is correct because the layout and the text now come from the same value, as in `TOML.stringify` (`TOMLObject.rs:233`). A wrapper produces the same bytes as the primitive it wraps. The number of `valueOf` calls does not change.
- The replacer in #39925 unboxes values before they reach this code. Without this fix the plain path and the replacer path would disagree once it lands.
- Verified: `test/js/bun/yaml/yaml.test.ts`, one test updated and three new, all four fail on bun 1.4.0. A fifth test pins the moved stack check. Also the two other yaml suites.

### Background

- Block style (a `space` argument) puts a collection value on the line after its key (`key:\n  - 1`) and a scalar on the key line (`key: 1`).
- A boxed primitive is a wrapper object such as `new Number(1)`. `JSValue::unwrap_boxed_primitive` (`src/jsc/bindings/bindings.cpp:2598`) returns the primitive inside a wrapper, and any other object as is. On a Number wrapper it runs `valueOf`.
- The old output was valid YAML, so this is a formatting fix. #39961 edits the same lines (trailing space after `key:`). The Notes give the merge of the two.

<details><summary>Notes</summary>

**Overlap with #39961.** Both PRs change the block-style object branch and the test "handles boxed primitives". The merge of the two is: unwrap, then `prop_value_needs_newline(prop_value)` picks `:` plus newline or `: `, then `stringify_unwrapped(global, prop_value)`. The test takes this PR's value, `"num: 3.14\nstr: world\nbool: false"`, because inline scalars keep the space after the colon in both PRs. Whichever PR lands second gets rebased.

**Why the fix exists.** No issue reports this. The old output was tested as intended since #22183. The reasons to change it are the ones above: the layout should follow the value that is written, which is what the TOML stringifier does (`TOMLObject.rs:233`, `:258`, `:385`), and #39925 would otherwise make the plain path and the replacer path disagree. #23501 asks for empty `[]` and `{}` values on the key line as well. That change needs the unwrapped value too and can build on `stringify_unwrapped`. It is not part of this PR.

A boxed String was not affected because `JSValue::is_string` is true for String objects too, so `prop_value_needs_newline` already answered false for it.

Output on bun 1.4.0 and on main before this change:

```
YAML.stringify({ a: new Number(1), b: new Boolean(true), c: new String("s"), d: 1 }, null, 2)
  "a: \n  1\nb: \n  true\nc: s\nd: 1"
YAML.stringify({ a: new Number(1) }, null, "\t")
  "a: \n\t1"
YAML.stringify([new Number(1), new Boolean(false)], null, 2)
  "- 1\n- false"            (array items were already inline)
YAML.stringify(new Number(1), null, 2)
  "1"                       (the root was already inline)
YAML.stringify({ a: new Number(1) })
  "{a: 1}"                  (flow style was already inline)
```

After the change the first two cases return `"a: 1\nb: true\nc: s\nd: 1"` and `"a: 1"`. The other three are unchanged.

**valueOf calls.** `unwrap_boxed_primitive` runs twice per value before and after this change: once in `find_anchors_and_aliases` and once before the value is written. A wrapper whose `valueOf` counts its calls sees 2 calls in block style and 2 in flow style, before and after. The new test asserts that the two styles agree, not the number itself. A wrapper whose `valueOf` throws on its second call now throws from the new unwrap in the object branch, and the error reaches the caller. `BUN_JSC_validateExceptionChecks=1` reports nothing for that case.

**Stack check.** The check moved from `stringify` into `stringify_unwrapped`, so both entries (the `stringify` wrapper and the direct call from the object branch) pass it. The check in the write pass is not redundant with the one in `find_anchors_and_aliases`: the write pass uses larger frames (on a release build, x64 Linux, the first pass accepts about 42,900 levels and the write pass about 28,600), so for depths between the two it is the write pass that throws. Before this PR no test reached it: the existing overflow test is caught by the first pass. The new test "stack overflow protection in the write pass" gives the first pass a shallow value through a getter and the write pass the deep chain, in flow style. The same test in block style is not possible at a sane cost: every nesting level adds its full indentation, so the output grows with the square of the depth. On the release build it takes 2.4 s and 841 MB before the check throws, and Windows and macOS have an 18 MB main thread stack, which makes it about four times worse.

`prop_value_needs_newline` keeps its logic. After the unwrap its argument is null, a number, a bigint, a boolean, a string, or a non-wrapper object. It answers true for the object case only. The bigint case throws in `stringify_unwrapped` before anything else is written, as before.

Suites run with the debug build: `test/js/bun/yaml/yaml.test.ts` (647 pass), `test/js/bun/yaml/yaml-test-suite.test.ts` and `test/js/bun/yaml/yaml-block-scalar-matrix.test.ts` (1486 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [2.67ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.35ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [2.87ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.86ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.04ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.09ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.09ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [2.89ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.75ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [2.98ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [2.90ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [3.21ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.54ms]
(pass) Bu
... (truncated)

release without fix: 4 failed, 18 skipped
bun test v1.4.0-canary.1 (6e906e468)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.09ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.03ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.19ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [2.71ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.38ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [2.89ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.84ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.06ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.13ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.06ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.26ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.80ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.03ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [2.92ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.85ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.57ms]
(pass) Bu
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 633ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/25] gen cpp.rs (cppbind)
[3/25] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/release/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[4/25] gen JS modules (bundle-modules)
Preprocess modules (8233ms)
Bundle modules (49ms)
Postprocesss modules (92ms)
Bundle Functions (868ms)
Generate Code (35ms)

[9.30s] Bundled "src/js" for production
  2625 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/YAMLObject.rs | 19 ++++++++----
 test/js/bun/yaml/yaml.test.ts | 68 ++++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 81 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/runtime/api/YAMLObject.rs      3      4      0
test/js/bun/yaml/yaml.test.ts      5      3      0
```

</details>

<!-- robobun:evidence:end -->