### PR TITLE
Windows: one stdin uv_tty_t per VM, closed with the Worker that opened it

### DIFF
--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -405,6 +405,8 @@ bun_io::link_impl_EventLoopCtx! {
             (*this).after_event_loop_callback_ctx = ctx;
         },
         pipe_read_scratch() => &raw const *(*this).pipe_read_scratch,
+        // No raw mode on the mini loop: a reader of fd 0 opens its own tty.
+        stdin_tty() => core::ptr::null_mut(),
     }
 }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1236,7 +1236,7 @@ impl WindowsBufferedReader {
         let size = limit.clamp_len(suggested_size);
         // Tty reads must not target `_buffer`: libuv can retain the pointer
         // past reader teardown (see `uv::Tty::read_scratch` for the contract).
-        if matches!(self.source, Some(Source::Tty(_))) {
+        if matches!(self.source, Some(Source::Tty(_) | Source::StdinTty(_))) {
             let scratch = self
                 .source
                 .as_mut()
@@ -1311,7 +1311,7 @@ impl WindowsBufferedReader {
         // Use the event loop from the parent, not the global one
         // This is critical for spawnSync to use its isolated loop
         let loop_ = self.vtable.loop_();
-        let source = match Source::open(loop_.cast(), fd) {
+        let source = match Source::open(loop_.cast(), fd, Some(self.vtable.event_loop())) {
             sys::Result::Err(err) => return sys::Result::Err(err),
             sys::Result::Ok(source) => source,
         };
@@ -1408,7 +1408,7 @@ impl WindowsBufferedReader {
                 let mut b = unsafe { *buf };
                 let slice = unsafe { b.slice_mut() };
                 let data = &mut slice[..len];
-                if matches!(this.source, Some(Source::Tty(_))) {
+                if matches!(this.source, Some(Source::Tty(_) | Source::StdinTty(_))) {
                     // Tty chunks arrive in the tty-owned scratch; stage them
                     // into `_buffer` so `on_read` commits them like a pipe chunk.
                     this._buffer.reserve(len);
@@ -1668,7 +1668,7 @@ impl WindowsBufferedReader {
                     return sys::Result::Err(err);
                 }
             }
-            Source::Pipe(_) | Source::Tty(_) => {
+            Source::Pipe(_) | Source::Tty(_) | Source::StdinTty(_) => {
                 // SAFETY: source is a live Pipe/Tty stream handle.
                 if let Some(err) = unsafe {
                     uv::uv_read_start(
@@ -1707,7 +1707,7 @@ impl WindowsBufferedReader {
             Source::File(file) | Source::SyncFile(file) => {
                 file.stop();
             }
-            Source::Pipe(_) | Source::Tty(_) => {
+            Source::Pipe(_) | Source::Tty(_) | Source::StdinTty(_) => {
                 // SAFETY: stream handle is live (just matched a stream source).
                 unsafe { uv::uv_read_stop(source.to_stream()) };
             }
@@ -1759,18 +1759,26 @@ impl WindowsBufferedReader {
                 #[cfg(windows)]
                 Source::Tty(tty) => {
                     let p = tty.as_ptr();
-                    if crate::source::stdin_tty::is_stdin_tty(p) {
-                        // Node only ever closes stdin on process exit.
-                    } else {
-                        // SAFETY: tty is a live heap-allocated Tty*;
-                        // `Tty::close` keeps whole-struct provenance so
-                        // on_tty_close may reclaim the Box.
-                        unsafe {
-                            (*p).uv.data = p.cast::<c_void>();
-                            crate::source::Tty::close(p, Self::on_tty_close);
+                    // SAFETY: tty is a live heap-allocated Tty*;
+                    // `Tty::close` keeps whole-struct provenance so
+                    // on_tty_close may reclaim the Box.
+                    unsafe {
+                        (*p).uv.data = p.cast::<c_void>();
+                        crate::source::Tty::close(p, Self::on_tty_close);
+                    }
+                    self.flags.insert(WindowsFlags::IS_PAUSED);
+                }
+                #[cfg(windows)]
+                Source::StdinTty(tty) => {
+                    // Stays open for the VM's next stdin reader.
+                    let p = tty.as_ptr();
+                    // SAFETY: the VM's shared tty outlives this reader.
+                    unsafe {
+                        if (*p).uv.data == core::ptr::from_mut(self).cast::<c_void>() {
+                            uv::uv_read_stop(p.cast());
+                            (*p).uv.data = core::ptr::null_mut();
                         }
                     }
-
                     self.flags.insert(WindowsFlags::IS_PAUSED);
                 }
                 #[cfg(not(windows))]
@@ -1845,12 +1853,10 @@ impl WindowsBufferedReader {
     extern "C" fn on_tty_close(handle: *mut uv::uv_tty_t) {
         // `close_impl` set `handle.data = handle` and called `uv_close(handle)`;
         // libuv passes the same pointer back; `Tty::from_uv` recovers the
-        // owning `Tty`. Caller gates on `!is_stdin_tty`, so it is heap-owned,
-        // and no request is pending once this runs (`uv::Tty::read_scratch`).
-        let tty = crate::source::Tty::from_uv(handle);
-        debug_assert!(!crate::source::stdin_tty::is_stdin_tty(tty));
-        // SAFETY: non-stdin tty is heap-allocated; sole owner after uv_close.
-        drop(unsafe { bun_core::heap::take(tty) });
+        // owning `Tty`. Only a `Source::Tty` (heap, `open_tty`) is closed this
+        // way, and no request is pending once this runs (`uv::Tty::read_scratch`).
+        // SAFETY: heap-owned; sole owner after uv_close.
+        drop(unsafe { bun_core::heap::take(crate::source::Tty::from_uv(handle)) });
     }
 
     fn on_read(&mut self, amount: sys::Result<usize>, slice: &mut [u8], has_more: ReadState) {

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1186,13 +1186,14 @@ pub trait BaseWindowsPipeWriter: Sized {
             }
             Source::Tty(tty) => {
                 let p = tty.as_ptr();
-                // SAFETY: tty is heap-allocated (via open_tty) or the
-                // process-static stdin tty; freed in on_tty_close (gated on is_stdin_tty).
+                // SAFETY: tty is heap-allocated (open_tty); freed in on_tty_close.
                 unsafe { (*p).uv.data = p.cast::<c_void>() };
                 // SAFETY: tty is a live uv handle; `Tty::close` keeps
                 // whole-struct provenance so on_tty_close may reclaim the Box.
                 unsafe { crate::source::Tty::close(p, on_tty_close) };
             }
+            // Not produced for a writer (`start` opens without a reader context).
+            Source::StdinTty(_) => {}
         }
         *self.source_mut() = None;
         self.on_close_source();
@@ -1271,7 +1272,7 @@ pub trait BaseWindowsPipeWriter: Sized {
         // This is critical for spawnSync to use its isolated loop
         // SAFETY: parent is BACKREF set via set_parent; valid while writer alive.
         let loop_ = unsafe { Self::Parent::loop_(self.parent_ptr()) };
-        let mut source = match Source::open(loop_, fd) {
+        let mut source = match Source::open(loop_, fd, None) {
             sys::Result::Ok(source) => source,
             sys::Result::Err(err) => return sys::Result::Err(err),
         };
@@ -1324,12 +1325,9 @@ extern "C" fn on_pipe_close(handle: *mut uv::Pipe) {
 extern "C" fn on_tty_close(handle: *mut uv::uv_tty_t) {
     // `close()` set `handle.data = handle` and then called `uv_close(handle)`;
     // libuv passes the same pointer back; `Tty::from_uv` recovers the owning
-    // `Tty`. The stdin tty (fd 0) lives in static storage; never free it.
-    let tty = crate::source::Tty::from_uv(handle);
-    if !crate::source::stdin_tty::is_stdin_tty(tty) {
-        // SAFETY: non-stdin tty is heap-allocated (open_tty).
-        drop(unsafe { bun_core::heap::take(tty) });
-    }
+    // `Tty`. Only a `Source::Tty` (heap, `open_tty`) is closed this way.
+    // SAFETY: heap-owned; sole owner after uv_close.
+    drop(unsafe { bun_core::heap::take(crate::source::Tty::from_uv(handle)) });
 }
 
 /// Common parent requirements for Windows writers (event loop access + ref counting).

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -327,6 +327,8 @@ bun_dispatch::link_interface! {
             ctx: Option<core::ptr::NonNull<core::ffi::c_void>>,
         );
         fn pipe_read_scratch() -> *const PipeReadScratch;
+        // Null when the context has none (mini loop, POSIX).
+        fn stdin_tty() -> *mut StdinTty;
     }
 }
 
@@ -471,6 +473,11 @@ pub use pipe_read_scratch::{PipeReadScratch, PipeReadScratchGuard};
 #[cfg(windows)]
 #[path = "source.rs"]
 pub mod source;
+#[cfg(windows)]
+pub use source::StdinTty;
+/// Never exists on POSIX: [`EventLoopCtx::stdin_tty`] returns null there.
+#[cfg(not(windows))]
+pub enum StdinTty {}
 #[path = "write.rs"]
 pub mod write;
 

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -1,6 +1,5 @@
 use core::ffi::{c_int, c_void};
-use core::mem::MaybeUninit;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::ptr::NonNull;
 
 use bun_sys::windows::libuv as uv;
 // `is_closed`/`is_active`/`fd` are default trait methods on `UvHandle`;
@@ -17,14 +16,10 @@ pub use uv::Tty;
 
 pub enum Source {
     Pipe(Box<Pipe>),
-    /// `BackRef` not `Box`: the stdin tty (fd 0) lives in static storage
-    /// (`stdin_tty::value()`), and Box-from-static is UB. Heap-allocated ttys
-    /// use `heap::alloc`; destroy paths gate `heap::take` on `!is_stdin_tty()`.
-    /// In both cases the `Tty` strictly outlives every `Source` that holds it
-    /// (process-static, or freed only by the libuv close callback after the
-    /// `Source` is dropped), so the `BackRef` invariant holds and `Deref`
-    /// yields `&Tty` without a per-site `unsafe`.
+    /// From `open_tty`; the close callback frees it once the source closes it.
     Tty(bun_ptr::BackRef<Tty, bun_ptr::Mut>),
+    /// Borrowed from the VM's [`StdinTty`], which outlives it; never closed here.
+    StdinTty(bun_ptr::BackRef<Tty, bun_ptr::Mut>),
     File(Box<File>),
     SyncFile(Box<File>),
 }
@@ -240,23 +235,21 @@ impl File {
 }
 
 impl Source {
-    /// Exclusive borrow of the `Tty` arm. `BackRef` already gives safe `Deref`
-    /// for shared reads; mutation still needs the per-site exclusivity
-    /// guarantee (single-threaded uv loop, no other `&Tty` live), so this
-    /// remains the one centralised `unsafe` for tty mutation.
+    /// The one centralised `unsafe` for tty mutation.
     #[inline]
     fn tty_mut(tty: &mut bun_ptr::BackRef<Tty, bun_ptr::Mut>) -> &mut Tty {
-        // SAFETY: `BackRef` invariant guarantees liveness/alignment; the uv
-        // loop is single-threaded and `&mut Source` (or the sole `BackRef`
-        // returned from `open_tty`) is the only access path, so no `&Tty`
-        // overlaps this `&mut Tty`.
+        // SAFETY: the pointee is live (`BackRef` invariant) and every holder
+        // borrows it only within one call on the single loop thread, so no
+        // other `&Tty` overlaps this `&mut Tty`.
         unsafe { tty.get_mut() }
     }
 
     /// For a tty source, hand libuv the handle-owned read buffer with at
     /// least `size` spare bytes (`uv::Tty::read_scratch`); `None` otherwise.
     pub(crate) fn tty_read_scratch(&mut self, size: usize) -> Option<&mut [u8]> {
-        let Source::Tty(tty) = self else { return None };
+        let (Source::Tty(tty) | Source::StdinTty(tty)) = self else {
+            return None;
+        };
         let scratch = &mut Self::tty_mut(tty).read_scratch;
         scratch.clear();
         scratch.reserve(size);
@@ -268,7 +261,7 @@ impl Source {
     pub fn is_closed(&self) -> bool {
         match self {
             Source::Pipe(pipe) => pipe.is_closed(),
-            Source::Tty(tty) => tty.uv.is_closed(),
+            Source::Tty(tty) | Source::StdinTty(tty) => tty.uv.is_closed(),
             Source::SyncFile(file) | Source::File(file) => file.file == -1,
         }
     }
@@ -276,7 +269,7 @@ impl Source {
     pub(crate) fn is_active(&self) -> bool {
         match self {
             Source::Pipe(pipe) => pipe.is_active(),
-            Source::Tty(tty) => tty.uv.is_active(),
+            Source::Tty(tty) | Source::StdinTty(tty) => tty.uv.is_active(),
             Source::SyncFile(_) | Source::File(_) => true,
         }
     }
@@ -287,7 +280,7 @@ impl Source {
             // uv_stream_t as their first member.
             // `&mut self` so the returned `*mut` carries write provenance.
             Source::Pipe(pipe) => core::ptr::from_mut::<Pipe>(pipe.as_mut()).cast(),
-            Source::Tty(tty) => tty.as_ptr().cast(),
+            Source::Tty(tty) | Source::StdinTty(tty) => tty.as_ptr().cast(),
             Source::SyncFile(_) | Source::File(_) => unreachable!(),
         }
     }
@@ -298,7 +291,7 @@ impl Source {
             // Windows); tag kind=system so callers can round-trip through
             // `Fd::native()`.
             Source::Pipe(pipe) => Fd::from_system(pipe.fd()),
-            Source::Tty(tty) => Fd::from_system(tty.uv.fd()),
+            Source::Tty(tty) | Source::StdinTty(tty) => Fd::from_system(tty.uv.fd()),
             Source::SyncFile(file) | Source::File(file) => Fd::from_uv(file.file),
         }
     }
@@ -306,7 +299,7 @@ impl Source {
     pub fn set_data(&mut self, data: *mut c_void) {
         match self {
             Source::Pipe(pipe) => pipe.data = data,
-            Source::Tty(tty) => Self::tty_mut(tty).uv.data = data,
+            Source::Tty(tty) | Source::StdinTty(tty) => Self::tty_mut(tty).uv.data = data,
             Source::SyncFile(file) | Source::File(file) => file.fs.data = data,
         }
     }
@@ -331,6 +324,7 @@ impl Source {
             Source::Tty(tty) => {
                 uv::open_handles::set_owner(tty.as_ptr().cast(), owner, Some(close_via_owner))
             }
+            Source::StdinTty(_) => {}
             Source::SyncFile(file) | Source::File(file) => uv::open_handles::set_file_owner(
                 core::ptr::from_mut::<File>(file).cast(),
                 owner,
@@ -352,7 +346,7 @@ impl Source {
     pub fn ref_(&mut self) {
         match self {
             Source::Pipe(pipe) => pipe.ref_(),
-            Source::Tty(tty) => Self::tty_mut(tty).uv.ref_(),
+            Source::Tty(tty) | Source::StdinTty(tty) => Self::tty_mut(tty).uv.ref_(),
             Source::SyncFile(_) | Source::File(_) => {}
         }
     }
@@ -360,7 +354,7 @@ impl Source {
     pub fn unref(&mut self) {
         match self {
             Source::Pipe(pipe) => pipe.unref(),
-            Source::Tty(tty) => Self::tty_mut(tty).uv.unref(),
+            Source::Tty(tty) | Source::StdinTty(tty) => Self::tty_mut(tty).uv.unref(),
             Source::SyncFile(_) | Source::File(_) => {}
         }
     }
@@ -386,24 +380,19 @@ impl Source {
         bun_sys::Result::Ok(pipe)
     }
 
+    /// A tty of the caller's own; the shared stdin one is [`StdinTty::open`].
     pub(crate) fn open_tty(
         loop_: *mut uv::Loop,
         fd: Fd,
     ) -> bun_sys::Result<bun_ptr::BackRef<Tty, bun_ptr::Mut>> {
         bun_core::scoped_log!(PipeSource, "openTTY (fd = {})", fd);
 
-        let uv_fd = fd.uv();
-
-        if uv_fd == 0 {
-            return stdin_tty::get_stdin_tty(loop_);
-        }
-
         // Not `boxed_zeroed`: a zeroed `Vec` is UB.
         let mut tty: Box<Tty> = Box::new(Tty {
             uv: bun_core::ffi::zeroed(),
             read_scratch: Vec::new(),
         });
-        if let Some(err) = tty.init(loop_, uv_fd).to_error(bun_sys::Tag::open) {
+        if let Some(err) = tty.init(loop_, fd.uv()).to_error(bun_sys::Tag::open) {
             drop(tty);
             return bun_sys::Result::Err(err);
         }
@@ -426,7 +415,12 @@ impl Source {
         file
     }
 
-    pub(crate) fn open(loop_: *mut uv::Loop, fd: Fd) -> bun_sys::Result<Source> {
+    /// With a reader's context, a tty on fd 0 is that context's [`StdinTty`].
+    pub(crate) fn open(
+        loop_: *mut uv::Loop,
+        fd: Fd,
+        reader_ctx: Option<crate::EventLoopCtx>,
+    ) -> bun_sys::Result<Source> {
         let rc = uv::uv_guess_handle(fd.uv());
         bun_core::scoped_log!(
             PipeSource,
@@ -440,10 +434,18 @@ impl Source {
                 bun_sys::Result::Ok(pipe) => bun_sys::Result::Ok(Source::Pipe(pipe)),
                 bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             },
-            uv::HandleType::Tty => match Self::open_tty(loop_, fd) {
-                bun_sys::Result::Ok(tty) => bun_sys::Result::Ok(Source::Tty(tty)),
-                bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
-            },
+            uv::HandleType::Tty => {
+                if fd.uv() == 0 {
+                    if let Some(shared) = reader_ctx.and_then(|ctx| NonNull::new(ctx.stdin_tty())) {
+                        // SAFETY: points into the context's live rare data, on
+                        // its own thread; `open` does not re-enter.
+                        return unsafe { &mut *shared.as_ptr() }
+                            .open(loop_)
+                            .map(Source::StdinTty);
+                    }
+                }
+                Self::open_tty(loop_, fd).map(Source::Tty)
+            }
             uv::HandleType::File => bun_sys::Result::Ok(Source::File(Self::open_file(fd))),
             _ => {
                 let errno = bun_sys::windows::get_last_errno();
@@ -468,7 +470,7 @@ impl Source {
 
     pub(crate) fn set_raw_mode(&mut self, value: bool) -> bun_sys::Result<()> {
         match self {
-            Source::Tty(tty) => {
+            Source::Tty(tty) | Source::StdinTty(tty) => {
                 if let Some(err) = Self::tty_mut(tty)
                     .uv
                     .set_mode(if value {
@@ -493,61 +495,80 @@ impl Source {
     }
 }
 
-pub(crate) mod stdin_tty {
-    use super::*;
+/// A VM's one tty over fd 0, shared so that `setRawMode` restarts the pending read.
+#[derive(Default)]
+pub struct StdinTty {
+    /// Heap-allocated so that readers can hold `BackRef`s to it.
+    tty: Option<NonNull<Tty>>,
+}
 
-    // PORTING.md §Global mutable state: init guarded by `LOCK` + `INITIALIZED`;
-    // afterwards only accessed by uv on the loop thread. RacyCell.
-    static DATA: bun_core::RacyCell<MaybeUninit<Tty>> =
-        bun_core::RacyCell::new(MaybeUninit::uninit());
-    static LOCK: bun_threading::Mutex = bun_threading::Mutex::new();
-    static INITIALIZED: AtomicBool = AtomicBool::new(false);
-
-    #[inline]
-    fn value() -> *mut Tty {
-        DATA.get().cast::<Tty>()
-    }
-
-    pub(crate) fn is_stdin_tty(tty: *const Tty) -> bool {
-        core::ptr::eq(tty, value())
-    }
-
-    pub(super) fn get_stdin_tty(
+impl StdinTty {
+    pub(crate) fn open(
+        &mut self,
         loop_: *mut uv::Loop,
     ) -> bun_sys::Result<bun_ptr::BackRef<Tty, bun_ptr::Mut>> {
-        // bun_threading::Mutex::lock() returns `()` — must use lock_guard() for RAII
-        // unlock-on-drop, otherwise the mutex is held forever and the next call
-        // (e.g. Source__setRawModeStdin → open_tty(stdin)) deadlocks/UB-relocks.
-        let _guard = LOCK.lock_guard();
-
-        if !INITIALIZED.swap(true, Ordering::Relaxed) {
-            let p = value();
-            // SAFETY: value() points to static storage sized for Tty; lock
-            // held. uv_tty_init fills the `uv` half; `read_scratch` starts
-            // empty via a raw write (the storage is uninit, so a plain
-            // assignment would drop garbage).
-            let rc = unsafe { uv::uv_tty_init(loop_, core::ptr::addr_of_mut!((*p).uv), 0, 0) };
-            if let Some(err) = rc.to_error(bun_sys::Tag::open) {
-                INITIALIZED.store(false, Ordering::Relaxed);
-                return bun_sys::Result::Err(err);
+        let tty = match self.tty {
+            // Closed by the VM's teardown: stdin is gone for this VM.
+            // SAFETY: owned by `self`; `is_closing` only reads the flags.
+            Some(tty) if unsafe { (*tty.as_ptr()).uv.is_closing() } => {
+                return bun_sys::Result::Err(bun_sys::Error::from_code(
+                    bun_sys::E::BADF,
+                    bun_sys::Tag::open,
+                ));
             }
-            // SAFETY: as above; lock held, first initialization.
-            unsafe { core::ptr::addr_of_mut!((*p).read_scratch).write(Vec::new()) };
-        }
-
-        // Destroy path must gate `heap::take` on `!is_stdin_tty(ptr)`.
-        // SAFETY: `value()` is the process-global static tty (never null,
-        // never freed); uv writes through it.
-        bun_sys::Result::Ok(unsafe { bun_ptr::BackRef::from_raw_mut(value()) })
+            Some(tty) => tty,
+            None => {
+                bun_core::scoped_log!(PipeSource, "openTTY (fd = 0, shared)");
+                // Not `boxed_zeroed`: a zeroed `Vec` is UB.
+                let mut tty: Box<Tty> = Box::new(Tty {
+                    uv: bun_core::ffi::zeroed(),
+                    read_scratch: Vec::new(),
+                });
+                // Whole-struct provenance, as `Tty::init`; not `Tty::init`
+                // itself, which would list it as a tty its opener frees.
+                let uv_ptr = core::ptr::from_mut(&mut *tty).cast::<uv::uv_tty_t>();
+                // SAFETY: `uv` is the first `#[repr(C)]` field, sized for uv_tty_t.
+                let rc = unsafe { uv::uv_tty_init(loop_, uv_ptr, 0, 0) };
+                if let Some(err) = rc.to_error(bun_sys::Tag::open) {
+                    return bun_sys::Result::Err(err);
+                }
+                let tty = bun_core::heap::into_raw_nn(tty);
+                uv::open_handles::add_stdin_tty(tty.as_ptr().cast::<uv::uv_tty_t>());
+                self.tty = Some(tty);
+                tty
+            }
+        };
+        // SAFETY: owned by `self`, which outlives every holder; write
+        // provenance from `into_raw_nn`.
+        bun_sys::Result::Ok(unsafe { bun_ptr::BackRef::from_raw_mut(tty.as_ptr()) })
     }
 }
 
-/// The uv loop is taken as a parameter (reading it from the VM directly would
-/// be a T6 dependency); the C++ caller
-/// (`ProcessBindingTTYWrap.cpp`) supplies `defaultGlobalObject()->uvLoop()`.
+impl Drop for StdinTty {
+    fn drop(&mut self) {
+        let Some(tty) = self.tty.take() else {
+            return;
+        };
+        // SAFETY: leaked from a `Box` in `open`, freed nowhere else. A handle
+        // nobody closed (the exiting main thread) is still linked into its
+        // loop, so it is leaked rather than freed under libuv.
+        unsafe {
+            if (*tty.as_ptr()).uv.is_closed() {
+                drop(bun_core::heap::take(tty.as_ptr()));
+            }
+        }
+    }
+}
+
+/// `jsTTYSetMode` (`ProcessBindingTTYWrap.cpp`): the calling VM's [`StdinTty`].
 #[unsafe(no_mangle)]
 extern "C" fn Source__setRawModeStdin(uv_loop: *mut uv::Loop, raw: bool) -> c_int {
-    let mut tty = match Source::open_tty(uv_loop, Fd::stdin()) {
+    let Some(shared) = NonNull::new(crate::js_vm_ctx().stdin_tty()) else {
+        return bun_sys::E::NOTSUP as c_int;
+    };
+    // SAFETY: points into the calling VM's live rare data; JS thread, and
+    // `open` does not re-enter.
+    let mut tty = match unsafe { &mut *shared.as_ptr() }.open(uv_loop) {
         bun_sys::Result::Ok(tty) => tty,
         bun_sys::Result::Err(e) => return e.errno as c_int,
     };
@@ -557,9 +578,6 @@ extern "C" fn Source__setRawModeStdin(uv_loop: *mut uv::Loop, raw: bool) -> c_in
     // closely with POSIX platforms. This is also required to support some
     // control sequences at all on Windows, such as bracketed paste mode. The
     // Node.js readline implementation handles differences between these modes.
-    // `tty` is the static stdin tty (fd 0 → `get_stdin_tty`), live for the
-    // process — same invariant the `Source::Tty` arm relies on, so reuse the
-    // shared `tty_mut` accessor.
     if let Some(err) = Source::tty_mut(&mut tty)
         .uv
         .set_mode(if raw {

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -524,8 +524,7 @@ impl StdinTty {
                     uv: bun_core::ffi::zeroed(),
                     read_scratch: Vec::new(),
                 });
-                // Whole-struct provenance, as `Tty::init`; not `Tty::init`
-                // itself, which would list it as a tty its opener frees.
+                // Whole-struct pointer as in `Tty::init`, which would also list it as heap.
                 let uv_ptr = core::ptr::from_mut(&mut *tty).cast::<uv::uv_tty_t>();
                 // SAFETY: `uv` is the first `#[repr(C)]` field, sized for uv_tty_t.
                 let rc = unsafe { uv::uv_tty_init(loop_, uv_ptr, 0, 0) };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2293,6 +2293,16 @@ bun_io::link_impl_EventLoopCtx! {
             vm.after_event_loop_callback_ctx = ctx.map(|p| p.as_ptr());
         },
         pipe_read_scratch() => &raw const *(*vm_from_owner(this.cast()).rare_data_ptr()).pipe_read_scratch,
+        stdin_tty() => {
+            #[cfg(windows)]
+            {
+                &raw mut (*vm_from_owner(this.cast()).rare_data_ptr()).stdin_tty
+            }
+            #[cfg(not(windows))]
+            {
+                core::ptr::null_mut()
+            }
+        },
     }
 }
 

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -205,6 +205,9 @@ pub struct RareData {
     pub(crate) stdin_mode: Mode,
     pub stdout_store: Option<NonNull<c_void>>,
     pub(crate) stdout_mode: Mode,
+    /// Handed out through `EventLoopCtx::stdin_tty`.
+    #[cfg(windows)]
+    pub(crate) stdin_tty: Async::StdinTty,
 
     pub(crate) entropy_cache: Option<Box<EntropyCache>>,
 
@@ -301,6 +304,8 @@ impl Default for RareData {
             stdin_mode: 0,
             stdout_store: None,
             stdout_mode: 0,
+            #[cfg(windows)]
+            stdin_tty: Async::StdinTty::default(),
             entropy_cache: None,
             hot_map: None,
             cleanup_hooks: Vec::new(),
@@ -1062,7 +1067,7 @@ impl Drop for RareData {
     fn drop(&mut self) {
         // pipe_read_scratch / h2_padded_frame_buffer / spawn_sync_event_loop_ /
         // s3_default_client / default_csrf_secret / cleanup_hooks / path_buf /
-        // tls_default_ciphers:
+        // tls_default_ciphers / stdin_tty:
         // all dropped automatically via field Drop.
 
         if let Some(engine) = self.boring_ssl_engine.take() {

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -385,7 +385,7 @@ thread_local! {
 // ──────────────────────────────────────────────────────────────────────────
 // Open stream/process handles on this thread — Bun's HandleWrap list.
 //
-// Every `uv_pipe_t`, `uv_tty_t` (except the process-static stdin tty) and
+// Every `uv_pipe_t`, `uv_tty_t` (the shared stdin one via `add_stdin_tty`) and
 // `uv_process_t` this thread initialises is listed here from `init`/`spawn`
 // until the `uv_close` for it is issued (`UvHandle::close`,
 // `Pipe::close_and_destroy`). Whoever currently drives the handle records
@@ -1384,9 +1384,7 @@ impl Tty {
         let uv_ptr = core::ptr::from_mut(self).cast::<uv_tty_t>();
         // SAFETY: `uv` is the first `#[repr(C)]` field, sized for uv_tty_t.
         let rc = unsafe { uv_tty_init(loop_, uv_ptr, file, 0) };
-        // fd 0 is the process-static stdin tty (never freed, shared across
-        // threads by design); everything else is a heap tty owned by this thread.
-        if rc.0 == 0 && file != 0 {
+        if rc.0 == 0 {
             open_handles::add_tty(uv_ptr);
         }
         rc

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1363,8 +1363,7 @@ pub struct Tty {
     /// `alloc_cb` buffer, and a read cancelled by `uv_read_stop` is never
     /// handed back through `read_cb` — so the buffer must be owned by
     /// something libuv guarantees outlives the read. The handle is that
-    /// thing: its close callback only runs once no requests are pending,
-    /// and the process-static stdin tty is never closed at all.
+    /// thing: its close callback only runs once no requests are pending.
     pub read_scratch: Vec<u8>,
 }
 

--- a/src/libuv_sys/open_handles.rs
+++ b/src/libuv_sys/open_handles.rs
@@ -36,6 +36,8 @@ struct Entry {
 enum Kind {
     Pipe,
     Tty,
+    /// `bun_io::StdinTty`: never owned here; closed in place, freed by its owner.
+    StdinTty,
     Process,
 }
 
@@ -76,6 +78,9 @@ pub(super) fn add_pipe(p: *mut Pipe) {
 }
 pub(super) fn add_tty(t: *mut uv_tty_t) {
     add(t.cast(), Kind::Tty);
+}
+pub fn add_stdin_tty(t: *mut uv_tty_t) {
+    add(t.cast(), Kind::StdinTty);
 }
 pub(super) fn add_process(p: *mut Process) {
     add(p.cast(), Kind::Process);
@@ -120,10 +125,13 @@ pub fn set_file_owner(file: *mut c_void, owner: *mut c_void, close: CloseViaOwne
 
 /// `owner` now drives `handle` and closes it via `close(owner)`; pass a
 /// null `owner` to clear. No-op for handles not listed (never initialised
-/// on this thread, already closing, or the process-static stdin tty).
+/// on this thread, already closing) and for the shared stdin tty.
 pub fn set_owner(handle: *mut uv_handle_t, owner: *mut c_void, close: Option<CloseViaOwner>) {
     OPEN.with(|o| {
         if let Some(e) = o.borrow_mut().handles.get_mut(&handle) {
+            if e.kind == Kind::StdinTty {
+                return;
+            }
             e.owner = owner;
             e.close_via_owner = if owner.is_null() { None } else { close };
         }
@@ -192,6 +200,7 @@ pub fn stop_all_for_vm_teardown() {
             match e.kind {
                 Kind::Pipe => "pipe",
                 Kind::Tty => "tty",
+                Kind::StdinTty => "stdin tty",
                 Kind::Process => "process",
             },
             handle,
@@ -207,8 +216,8 @@ pub fn stop_all_for_vm_teardown() {
             // SAFETY: as above (a leaked Box<Tty> nobody adopted).
             (None, Kind::Tty) => unsafe {
                 unsafe extern "C" fn free_tty(t: *mut uv_tty_t) {
-                    // SAFETY: heap `Box<Tty>` (stdin's static tty is never
-                    // listed); `from_uv` recovers the owning box.
+                    // SAFETY: heap `Box<Tty>` (the shared stdin tty is
+                    // `Kind::StdinTty`); `from_uv` recovers the owning box.
                     drop(unsafe { Box::from_raw(super::Tty::from_uv(t)) });
                 }
                 uv_close(
@@ -221,8 +230,9 @@ pub fn stop_all_for_vm_teardown() {
             },
             // A process handle is embedded in its owner and always adopted at
             // spawn; an unowned one cannot be freed safely — close in place.
+            // The stdin tty too: its owner frees it once the loop is closed.
             // SAFETY: listed ⇒ an initialised, not-closing handle on this loop.
-            (None, Kind::Process) => unsafe { uv_close(handle, None) },
+            (None, Kind::StdinTty | Kind::Process) => unsafe { uv_close(handle, None) },
         }
     }
 }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -262,9 +262,9 @@ pub(crate) extern "C" fn Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(
                         }
                     }
                     bun_io::Source::Tty(tty) => {
-                        // SAFETY: `tty` is a live `BackRef<Tty>` (heap or static stdin tty);
-                        // `Tty` (via its first field, `uv::uv_tty_t`) embeds `uv_stream_t` as
-                        // its first member, so the cast is the libuv handle-subtype downcast.
+                        // SAFETY: `tty` is a live heap `BackRef<Tty>`; `Tty` (via its first
+                        // field, `uv::uv_tty_t`) embeds `uv_stream_t` as its first member, so
+                        // the cast is the libuv handle-subtype downcast.
                         let rc = unsafe {
                             uv::uv_stream_set_blocking(tty.as_ptr().cast::<uv::uv_stream_t>(), 1)
                         };

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
@@ -189,6 +189,119 @@ describe("ReadStream.prototype.setRawMode", () => {
       afterStdinCooked: false,
     });
     expect(await proc.exited).toBe(0);
+  });
+
+  // Windows keeps one uv_tty_t for fd 0 per VM (readers and setRawMode share
+  // it). It used to be one per process, on the loop of the first thread to touch
+  // stdin, so a Worker's exit closed it under the main thread (EBADF, EINVAL).
+  test("stdin still works on the main thread after a Worker used it first", async () => {
+    using dir = tempDir("tty-stdin-after-worker", {
+      "worker.js": `
+        const seen = {};
+        process.stdin.on("error", e => (seen.err = String(e)));
+        seen.isTTY = process.stdin.isTTY;
+        process.stdin.setRawMode(true);
+        seen.rawOn = process.stdin.isRaw;
+        process.stdin.setRawMode(false);
+        seen.rawOff = process.stdin.isRaw;
+        // Leaves a read pending on the worker's handle when it is terminated.
+        process.stdin.once("data", d => {
+          seen.line = String(d).trim();
+          postMessage(seen);
+        });
+        console.log("WORKER_READING");
+      `,
+      "main.js": `
+        // The parent test reads the report and then kills this process, so
+        // nothing here exits: an exit could race the report out of the pty.
+        const report = result => console.log("RESULT_BEGIN" + JSON.stringify(result) + "RESULT_END");
+        const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+        worker.onerror = e => report({ workerError: String(e.message) });
+        worker.onmessage = async ({ data: fromWorker }) => {
+          await worker.terminate();
+          const main = {};
+          let reading = false;
+          process.stdin.on("error", e => {
+            main.err = String(e);
+            if (reading) report({ worker: fromWorker, main });
+          });
+          main.isTTY = process.stdin.isTTY;
+          process.stdin.setRawMode(true);
+          main.rawOn = process.stdin.isRaw;
+          process.stdin.setRawMode(false);
+          main.rawOff = process.stdin.isRaw;
+          reading = true;
+          process.stdin.once("data", d => {
+            main.line = String(d).trim();
+            report({ worker: fromWorker, main });
+          });
+          console.log("MAIN_READING");
+        };
+      `,
+    });
+
+    const decoder = new TextDecoder();
+    // The terminal wraps long lines and moves the cursor around; match markers
+    // against the whole output with the escapes and line breaks removed (an
+    // escape sequence can be split across chunks, so strip the whole thing).
+    let raw = "";
+    let text = "";
+    const waiters: { marker: string; resolve: () => void }[] = [];
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      terminal: {
+        cols: 200,
+        rows: 24,
+        data(_t, chunk: Uint8Array) {
+          raw += decoder.decode(chunk, { stream: true });
+          text = Bun.stripANSI(raw).replace(/[\r\n]/g, "");
+          for (let i = waiters.length - 1; i >= 0; i--) {
+            if (text.includes(waiters[i].marker) || text.includes("RESULT_END")) {
+              waiters[i].resolve();
+              waiters.splice(i, 1);
+            }
+          }
+        },
+      },
+    });
+    const terminal = proc.terminal!;
+
+    const exited = proc.exited.then(code => {
+      throw new Error(`child exited with code ${code} before it reported; terminal output: ${JSON.stringify(text)}`);
+    });
+    exited.catch(() => {});
+    // Resolves on the marker, or on an early report (a failure the assertion
+    // below then shows); rejects if the child dies instead.
+    const phase = (marker: string) =>
+      Promise.race([
+        text.includes(marker) || text.includes("RESULT_END")
+          ? Promise.resolve()
+          : new Promise<void>(resolve => waiters.push({ marker, resolve })),
+        exited,
+      ]);
+
+    try {
+      await phase("WORKER_READING");
+      terminal.write("from-worker\r");
+      await phase("MAIN_READING");
+      terminal.write("from-main\r");
+      await phase("RESULT_END");
+    } finally {
+      proc.kill();
+      await proc.exited;
+      terminal.close();
+    }
+
+    const match = text.match(/RESULT_BEGIN(.*?)RESULT_END/);
+    if (!match) {
+      throw new Error("child did not report; terminal output was: " + JSON.stringify(text));
+    }
+    expect(JSON.parse(match[1])).toEqual({
+      worker: { isTTY: true, rawOn: true, rawOff: false, line: "from-worker" },
+      main: { isTTY: true, rawOn: true, rawOff: false, line: "from-main" },
+    });
   });
 });
 

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -198,7 +198,10 @@ describe("ReadStream.prototype.setRawMode", () => {
     using dir = tempDir("tty-stdin-after-worker", {
       "worker.js": `
         const seen = {};
-        process.stdin.on("error", e => (seen.err = String(e)));
+        process.stdin.on("error", e => {
+          seen.err = String(e);
+          postMessage(seen);
+        });
         seen.isTTY = process.stdin.isTTY;
         process.stdin.setRawMode(true);
         seen.rawOn = process.stdin.isRaw;
@@ -220,17 +223,15 @@ describe("ReadStream.prototype.setRawMode", () => {
         worker.onmessage = async ({ data: fromWorker }) => {
           await worker.terminate();
           const main = {};
-          let reading = false;
           process.stdin.on("error", e => {
             main.err = String(e);
-            if (reading) report({ worker: fromWorker, main });
+            report({ worker: fromWorker, main });
           });
           main.isTTY = process.stdin.isTTY;
           process.stdin.setRawMode(true);
           main.rawOn = process.stdin.isRaw;
           process.stdin.setRawMode(false);
           main.rawOff = process.stdin.isRaw;
-          reading = true;
           process.stdin.once("data", d => {
             main.line = String(d).trim();
             report({ worker: fromWorker, main });


### PR DESCRIPTION
### Problem
- Windows: after a Worker has used console stdin and exited, stdin is dead on the main thread. `setRawMode()` emits `setRawMode failed with errno: 9`. A read throws `EINVAL: invalid argument, open`. Reproduced on main (4448a2e21).
- `stdin_tty` (`src/io/source.rs`) kept one `uv_tty_t` for fd 0 per process, on the loop of the first caller. A Worker put it on its own loop, and `Loop::close_thread_loop` (`src/libuv_sys/libuv.rs:463`) closed it with that loop.

### Fix
- The handle is now `bun_io::StdinTty`, a field of the VM's `RareData`, reached through `EventLoopCtx::stdin_tty()`. A reader of fd 0 gets `Source::StdinTty`, a borrow it never closes. Writers and the mini loop get a tty of their own.
- The handle is listed in `open_handles` as `Kind::StdinTty`: a Worker's stop phase closes it in place, and no reader is recorded as its owner. `RareData` drops after the loop is closed and frees it then. A handle nobody closed (the exiting main thread) is left to its loop.
- Correct because the handle only has to be shared within one script execution context: `setRawMode` on fd 0 must reach the handle `process.stdin` reads from. A uv handle belongs to one loop, and each VM has its own, so it belongs with the VM's other per-context state.
- Verified: the new Worker test in `test/js/node/tty.test.ts` fails on Windows with main and passes with this change (debug build, 35 runs over three revisions). The stdin, terminal, filesink, spawn and worker suites also ran on Windows (Notes).

### Background
- libuv reads a Windows console through a `uv_tty_t`. `uv_tty_set_mode` restarts the read pending on that same handle. So `tty.ts` sends `setRawMode` for fd 0 to `Source__setRawModeStdin`, which must use the reader's handle.
- `RareData` holds a VM's lazily created per-context state (stdio stores, file polls, socket groups). `EventLoopCtx` is how `bun_io` reaches it, as `file_polls_ptr()` does, without naming the VM.
- `open_handles` (`src/libuv_sys/open_handles.rs`) is node's HandleWrap list: the handles a thread opened, each with the owner to close it through. A Worker's teardown closes them, then the loop. The stdin tty was the one handle not on it.

<details><summary>Notes</summary>

- First revision kept the slot in a `thread_local!`; moved into rare data on review.
- Rebased onto #31940, which made `uv::Tty` a wrapper that owns the console read buffer (`read_scratch`). `StdinTty` owns that wrapper, so the scratch is freed with the handle after its close completed, and `Source::StdinTty` takes the same tty-read path as `Source::Tty` (`tty_read_scratch`, the alloc and staging branches in `PipeReader.rs`). The #31940 regression test passes with the shared stdin tty on that path.
- Only a console stdin reaches this code. `Source::open` asks for the shared tty only when `uv_guess_handle(0)` reports a tty. A pipe or file stdin gets a handle per reader and was not affected. Stdin is never a console in CI, so the test runs the child in a `Bun.Terminal` (ConPTY on Windows), like the first test in the same file.
- How a Worker reaches it: a Web `Worker` in bun gets the real fd 0 as `process.stdin` (`constructStdin` in `BunProcess.cpp`, `getStdinStream`, `Bun.stdin.stream()`, then a `FileReader` on the Worker's loop). `jsTTYSetMode` runs on the Worker's thread, so `js_vm_ctx()` is the Worker's VM. A `node:worker_threads` Worker gets a port-backed `process.stdin`, but `Bun.stdin.stream()` and `new tty.ReadStream(0)` reach the same code from there.
- Probe on main after the Worker exited: `{"isTTY":true,"err":"Error: setRawMode failed with errno: 9","rawOn":false,"rawOff":false}`, then `error: EINVAL: invalid argument, open` from `process.stdin.once("data")`. With this change, `BUN_DEBUG_uv=1` prints `teardown: closing open stdin tty handle @... (owner 0x0)` while the Worker tears down, and the main thread then reads its line.
- Closing the tty in the stop phase also stops a read that is still pending on it (the test leaves one pending), while the reader's buffer is still alive. libuv fires no read or alloc callback for a handle whose read was stopped by its close, so the reader (freed with the VM) is never called back.
- `StdinTty::drop` frees the handle only if libuv has finished closing it (`UV_HANDLE_CLOSED`). For a Worker that is always the case by then: `uv_loop_close` succeeds only once every handle is closed and unlinked (`close_thread_loop`, teardown phase D), and `RareData` drops in E. If the loop close gave up (64 turns), the handle is leaked, not freed. The exiting main thread never closes it and leaks it as well.
- Two findings from the self-review were fixed in 45315d5. `StdinTty::open` now returns EBADF once the handle is closing or closed (a native continuation that starts a reader during the teardown drain would otherwise get a dead handle and, in debug, trip `debug_assert!(!source.is_closed())` in `PipeReader.rs`). The `Source::StdinTty` arm of `close_impl` stops the read and clears `tty.data` when this reader is still the one registered, so a reader that is dropped without `close()` leaves no dangling callback pointer. Before, the static had the same gap.
- Pre-existing and unchanged: two readers of fd 0 in one VM (`process.stdin` plus `Bun.stdin.stream()`) share one handle, so the second `set_data` replaces the first reader's callback pointer and its `uv_read_start` fails with EALREADY. Fixing that needs the shared handle to track its current reader.
- New reachability, a libuv limitation: two VMs can now each hold a console read (before, the Worker's `uv_read_start` failed with EALREADY on the shared handle). libuv keeps cooked-mode cancel state per process, so a Worker closed while the main thread also reads can make the main thread see one empty line. Node does not have this case because its Workers never get the real stdin.
- `EventLoopCtx::stdin_tty()` returns null for the mini loop and on POSIX (`StdinTty` is an uninhabited type there). No mini-loop code reads fd 0 through a `BufferedReader`. A writer never gets `Source::StdinTty` because `PipeWriter::start` opens without a context. `Bun.stdin.writer()` on Windows (a writer on fd 0, un-dup'd) now gets a tty of its own and closes that, instead of closing the shared handle under the readers (#34350).
- The test also passes on Linux (no shared handle there, 25 of 25 runs), so it is not gated to Windows. The failure before the fix can only be shown on Windows.
- On this Windows debug build, four rows of `worker-late-completion.test.ts`, the "message flood" test in `worker.test.ts`, and once in three runs the `Bun.connect()` stress test in `worker-terminate-lifetime.test.ts` (120 s budget) fail with or without this change. They depend on timing and do not touch stdin.
- Suites run on Windows with the final code: `test/js/node/tty.test.ts` (10 of 10 loops of the new test), `test/js/node/process/process-stdin.test.ts`, `test/js/bun/terminal/terminal-spawn.test.ts`, `test/js/bun/terminal/terminal-platform-gaps.test.ts`, `test/js/web/workers/worker-terminate-lifetime.test.ts`, `test/js/bun/util/filesink.test.ts`, `test/js/bun/spawn/spawn-streaming-stdin.test.ts`, `test/js/bun/spawn/spawn-streaming-stdout.test.ts`. `worker.test.ts` and `worker-late-completion.test.ts` ran on the first revision. On Linux (debug build): `tty.test.ts`, `process-stdin.test.ts`, `spawn-streaming-stdout.test.ts`. `cargo check` of `bun_io`, `bun_libuv_sys`, `bun_event_loop` and `bun_jsc` for `x86_64-pc-windows-msvc` and for Linux.
- CI: `test/bake/deinitialization.test.ts` crashes on the Windows lane on main as well (#39910, #39643 are open for it).
- Neighbouring open PRs, independent of this one: #34350 (the writer must not close the stdin tty), #30732 (pending cooked read and `setRawMode`).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tty.test.ts

<!-- robobun:evidence:end -->