### PR TITLE
net: keep a Windows named-pipe socket alive while its read callbacks run

### DIFF
--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -208,6 +208,26 @@ impl WindowsNamedPipe {
         }
     }
 
+    /// Holds a ref on the owning context until the returned guard drops.
+    ///
+    /// The context frees itself from a task it queues when [`on_close`] releases
+    /// the connection's ref. A handler can close the socket and then spin the
+    /// event loop before it returns (`expect().resolves` blocks on a promise
+    /// that way), which runs that task. A callback that uses `self` after it
+    /// dispatched to a handler holds this guard, so the free waits until the
+    /// callback is done. The writer does the same around an in-flight write,
+    /// and `connect`/`open` around the connect.
+    ///
+    /// Only for paths that cannot run after `on_close` released the
+    /// connection's ref (reads stop and the wrapper goes away in
+    /// `release_resources`): a ref taken at zero would queue the free twice.
+    ///
+    /// [`on_close`]: Self::on_close
+    fn keep_alive(&self) -> impl Drop + '_ {
+        self.r#ref();
+        scopeguard::guard(self, |this| this.deref())
+    }
+
     fn on_writable(&self) {
         bun_output::scoped_log!(WindowsNamedPipe, "onWritable");
         // flush pending data
@@ -219,6 +239,7 @@ impl WindowsNamedPipe {
     #[cfg(windows)]
     fn on_read(&self, nread: usize) {
         bun_output::scoped_log!(WindowsNamedPipe, "onRead ({})", nread);
+        let _keep_alive = self.keep_alive();
         // SAFETY: `nread` bytes written by libuv into on_read_alloc's slice.
         self.incoming
             .with_mut(|incoming| unsafe { incoming.uv_commit(nread) });
@@ -297,6 +318,7 @@ impl WindowsNamedPipe {
     #[cfg(windows)]
     fn on_read_error(&self, err: bun_sys::E) {
         bun_output::scoped_log!(WindowsNamedPipe, "onReadError");
+        let _keep_alive = self.keep_alive();
         // `E::EOF` only exists in the Windows errno table (libuv UV_EOF mapping);
         // this type is Windows-only at runtime so the comparison is gated.
         #[cfg(windows)]
@@ -312,6 +334,7 @@ impl WindowsNamedPipe {
 
     fn on_error(&self, err: bun_sys::Error) {
         bun_output::scoped_log!(WindowsNamedPipe, "onError");
+        let _keep_alive = self.keep_alive();
         (self.handlers.on_error)(self.handlers.ctx, err);
         self.close();
     }
@@ -385,6 +408,7 @@ impl WindowsNamedPipe {
 
     fn on_handshake(&self, handshake_success: bool, ssl_error: us_bun_verify_error_t) {
         bun_output::scoped_log!(WindowsNamedPipe, "onHandshake");
+        let _keep_alive = self.keep_alive();
 
         self.ssl_error.set(CertError {
             error_no: ssl_error.error_no,
@@ -625,6 +649,7 @@ impl WindowsNamedPipe {
     ) -> bun_sys::Result<()> {
         #[cfg(windows)]
         debug_assert!(self.pipe.get().is_some());
+        let _keep_alive = self.keep_alive();
         self.update_flags(|f| f.set(Flags::DISCONNECTED, true));
 
         if let Some(tls) = ssl_ctx {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1769,6 +1769,85 @@ describe.skipIf(!isWindows)("Bun.connect named-pipe client Handlers lifecycle", 
   });
 });
 
+// A socket over a Windows named pipe frees its native context from a task
+// that is queued when the socket closes. A handler can close the socket and
+// then spin the event loop before it returns (`expect().resolves` blocks on
+// the promise and runs queued tasks), so the context is gone by the time the
+// libuv read callback that invoked the handler gets control back. The
+// callback must keep the context alive until it is done with it.
+describe.concurrent.skipIf(!isWindows)("named-pipe socket closed and event loop spun inside a read callback", () => {
+  // `trigger` is the server handler that tears the socket down: "end" runs
+  // from the EOF read callback, "data" from the data read callback.
+  function fixture(trigger: "end" | "data") {
+    return /* js */ `
+      import { expect } from "bun:test";
+
+      const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-${trigger}-teardown-" + Math.random().toString(36).slice(2);
+      const serverOpened = Promise.withResolvers();
+      const serverClosed = Promise.withResolvers();
+      const clientClosed = Promise.withResolvers();
+
+      function closeAndSpinEventLoop(socket) {
+        socket.end();
+        // Blocks until the promise settles. Every queued task, including the
+        // one that frees the native context of this socket, runs before this returns.
+        expect(new Promise(resolve => setImmediate(resolve))).resolves.toBeUndefined();
+      }
+
+      using server = Bun.listen({
+        unix: pipe,
+        socket: {
+          open() { serverOpened.resolve(); },
+          data(socket) { ${trigger === "data" ? "closeAndSpinEventLoop(socket);" : ""} },
+          end(socket) { ${trigger === "end" ? "closeAndSpinEventLoop(socket);" : ""} },
+          close() { serverClosed.resolve(); },
+          error() {},
+        },
+      });
+
+      const client = await Bun.connect({
+        unix: pipe,
+        socket: {
+          open() {},
+          data() {},
+          close() { clientClosed.resolve(); },
+          error() {},
+        },
+      });
+      await serverOpened.promise;
+
+      ${trigger === "data" ? 'client.write("x");' : "client.end();"}
+
+      await serverClosed.promise;
+      await clientClosed.promise;
+      console.log("OK");
+    `;
+  }
+
+  it.each(["end", "data"] as const)("%s handler", async trigger => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(trigger)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toMatchObject({
+      stdout: "OK",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});
+
 it("reload() backs out cleanly when a handler getter closes the socket mid-reload", async () => {
   // socket.reload() reads the new callbacks off the user object property by
   // property, so a getter can run arbitrary JS — including terminating the


### PR DESCRIPTION
### Problem
- `bun test` on Windows crashes in `BaseWindowsPipeWriter::close<WindowsStreamingWriter<WindowsNamedPipe>>` (`src/io/PipeWriter.rs:1183`, "Segmentation fault at address 0x00000000"), called from `WindowsNamedPipe::on_read_error`, the libuv EOF callback (crash report BUN-4NJ8). The data path is BUN-3R6R: `mi_free` on a bad pointer from `JsCell::set` in `WindowsNamedPipe::on_read` (`WindowsNamedPipe.rs:237`), 7 events, all Windows.
- `WindowsNamedPipeContext` frees itself from a task that `on_close` queues. A handler can close the socket and then spin the event loop before it returns (`expect(p).resolves` does: `wait_for_promise` calls `tick()`), which runs that task. `on_read_error` then calls `close_writer()` on the freed context, and `on_read` stores the read buffer back into it.

### Fix
- `WindowsNamedPipe::keep_alive` takes a ref on the context and releases it when the guard drops. `on_read`, `on_read_error`, `on_error`, `on_handshake` and `get_accepted_by` hold it. These are the entry points that use `self` after they dispatched to a handler.
- Correct because the context is refcounted. `on_close` releases the connection's ref, the guard releases the last one when the callback is done, and the free is queued then. The writer already does this around an in-flight write.
- Verified on Windows with a debug build: the two new cases in `test/js/bun/net/socket.test.ts` crash without the change and pass with it. The named-pipe and `node:net` suites listed in the notes pass.

### Background
- `WindowsNamedPipe` adapts a libuv pipe to the uSockets socket interface for `net` and `tls` pipe paths on Windows. Its owner, `WindowsNamedPipeContext`, holds one ref per open connection, in-flight write or connect. At zero it queues the task that frees it.
- `on_read` and `on_read_error` are libuv read callbacks. They dispatch to the JS socket and then use the object again.
- `wait_for_promise` users (`expect().resolves` among them) tick the task queue from inside JS, so the next tick can come before a native callback returns.

<details><summary>Notes</summary>

- Crash output without the change, debug build: the `end` case dies with "Segmentation fault at address 0xFFFFFFFFFFFFFFFF" (debug builds poison the freed block), the `data` case panics while it frees the poisoned `incoming` buffer. Release builds do not poison. The block reads as zeros or as a new object, so `writer.source` reads as `Some(Pipe(null))` and the store to `(*raw).data` faults at 0x0 (BUN-4NJ8), or the use stays silent. On the data path `self.incoming.set(data)` drops the `Vec` that the freed block still describes, and `mi_free` faults on its pointer (BUN-3R6R: 6 events from standalone executables, 1 from `bun test`, releases 1.4.0+fe06227f0 through 1.4.0+63bb0ca0d). The older report BUN-3JWE is the Zig `onRead` at the same point, right after `onData`.
- The test spawns one child per case so that the crash shows up as the exit code. The child prints "OK" even without the fix, because the main script finishes inside the spin. The exit code (3) is what fails.
- The tests are Windows-only. On POSIX a unix socket path goes through uSockets, not through this file. The fixture flow passes there with and without the change.
- Each guarded path runs only while the connection's ref is still held: reads stop and the TLS wrapper is dropped in `release_resources`, which `on_close` runs right after it releases that ref. A guard on a path that can run later would take a ref at zero and queue the free twice. The `keep_alive` doc comment states this, and `schedule_deinit` has a debug assertion for it.
- `on_close` is not guarded. The context releases its ref after `NewSocket::on_close` returns, and nothing after that point runs JS. `on_open`, `on_writable` and `on_timeout` dispatch as their last step. Writer completions hold the write's ref (`process_send` / `on_write_complete`), and `connect`/`open` hold one across the connect.
- Also ran on Windows with the change: `test/js/bun/net/socket.test.ts`, `test/js/bun/net/named-pipe-listen-error.test.ts`, `test/js/node/tls/node-tls-namedpipes.test.ts`, `test/js/node/net/node-net.test.ts`, `test/js/node/net/node-net-server.test.ts`. In `node-tls-namedpipes.test.ts`, "should work with named pipes and tls" (400 handshakes) takes about 5.8 s on the debug build on the VM used here and hits the 5 s default timeout, with or without this change. With `--timeout 120000` all 6 tests pass, including the TLSSocket count check at the end.
- The async connect failure path leaks the context (the connection's ref is never released). Found while reading this code. It is a separate bug and is tracked separately.
- `cargo check -p bun_runtime` and `cargo clippy -p bun_runtime` are clean on Linux.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->
