### PR TITLE
Raise the BigInt cap from 1 << 20 bits to 1 << 30 bits (WebKit bump)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c148a12dd82b9d88ea81d9d93840194f56490a61";
+export const WEBKIT_VERSION = "autobuild-preview-pr-484-0de7d205";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3121,7 +3121,7 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
 
     // JSC::tryCreateFromWords reads words[n-1] before its length check, so throw
     // here first. Value mirrors JSBigInt::maxLength (maxLengthBits / digitBits).
-    constexpr size_t jscBigIntMaxWords = (1 << 20) / (CHAR_BIT * sizeof(uint64_t));
+    constexpr size_t jscBigIntMaxWords = (1 << 30) / (CHAR_BIT * sizeof(uint64_t));
     if (word_count > jscBigIntMaxWords) {
         JSC::throwOutOfMemoryError(globalObject, scope);
         RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));

--- a/test/js/bun/jsc/bigint-max-length.test.ts
+++ b/test/js/bun/jsc/bigint-max-length.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+// Coverage for oven-sh/WebKit#484 (issue #39964). JSC capped a BigInt at
+// 1 << 20 bits, so workloads that run on Node.js (V8 allows 1 << 30 bits)
+// failed with "RangeError: Out of memory: BigInt generated from this
+// operation is too big". The cap is 1 << 30 bits now.
+
+describe.concurrent("BigInt maxLengthBits is 1 << 30", () => {
+  test("a left shift can exceed 2^20 bits", () => {
+    // One bit past the old cap.
+    const x = 1n << 1048576n;
+    expect(x.toString(2).length).toBe(1048577);
+    expect(x >> 1048576n).toBe(1n);
+  });
+
+  test("a product can exceed 2^20 bits", () => {
+    const a = (1n << 524300n) | 1n;
+    const b = a * a;
+    expect(b >> 1048600n).toBe(1n);
+    expect(b & 1n).toBe(1n);
+  });
+
+  test("addition at the old cap no longer overflows", () => {
+    const allOnes = (1n << 1048576n) - 1n;
+    expect(allOnes + 1n).toBe(1n << 1048576n);
+  });
+
+  test("2^n exponentiation works past the old cap", () => {
+    expect((2n ** 2000000n) >> 2000000n).toBe(1n);
+  });
+
+  test("asUintN widths past the old cap work", () => {
+    expect(BigInt.asUintN(2000000, -1n).toString(2).length).toBe(2000000);
+  });
+
+  test("operations past 2^30 bits still throw RangeError", () => {
+    // The exponent check rejects 2^30 before any allocation.
+    expect(() => 2n ** 1073741824n).toThrow(RangeError);
+    expect(() => 2n ** 4294967296n).toThrow(RangeError);
+  });
+});

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "utils.h"
 
@@ -4030,6 +4031,44 @@ static napi_value test_napi_status_codes_node26(const Napi::CallbackInfo &info) 
     print_status(
         "napi_create_bigint_words(INT_MAX+1)",
         napi_create_bigint_words(env, 0, (size_t)INT_MAX + 1, &one, &out),
+        true);
+  }
+
+  // napi_create_bigint_words: 20,000 words is 1.28 million bits, past JSC's
+  // old 1 << 20 bit cap but within the 1 << 30 bit cap both engines share
+  // now. It must round trip like Node.
+  {
+    napi_value out;
+    std::vector<uint64_t> words(20000, 0);
+    words.back() = 1;
+    napi_status s =
+        napi_create_bigint_words(env, 0, words.size(), words.data(), &out);
+    bool pending = false;
+    napi_is_exception_pending(env, &pending);
+    int sign = -1;
+    size_t count = 0;
+    uint64_t top = 0;
+    if (s == napi_ok) {
+      std::vector<uint64_t> readback(words.size() + 1);
+      count = readback.size();
+      napi_get_value_bigint_words(env, out, &sign, &count, readback.data());
+      top = count ? readback[count - 1] : 0;
+    }
+    printf("napi_create_bigint_words(20000 words): status=%d pending=%d "
+           "sign=%d count=%zu top=%llu\n",
+           (int)s, (int)pending, sign, count, (unsigned long long)top);
+  }
+
+  // napi_create_bigint_words: one word past the 1 << 30 bit cap. Both
+  // engines reject the count before reading the words, so a one-word buffer
+  // is safe.
+  {
+    napi_value out;
+    uint64_t one = 1;
+    print_status(
+        "napi_create_bigint_words(past cap)",
+        napi_create_bigint_words(env, 0, ((size_t)1 << 30) / 64 + 1, &one,
+                                 &out),
         true);
   }
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -620,9 +620,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("napi_create_bigint_words(INT_MAX+1): status=1 pending=0");
 
       // napi_create_bigint_words within the 1 << 30 bit cap round trips, past it throws
-      expect(result).toContain(
-        "napi_create_bigint_words(20000 words): status=0 pending=0 sign=0 count=20000 top=1",
-      );
+      expect(result).toContain("napi_create_bigint_words(20000 words): status=0 pending=0 sign=0 count=20000 top=1");
       expect(result).toContain("napi_create_bigint_words(past cap): status=10 pending=1");
 
       // napi_create_buffer / napi_create_buffer_copy: napi_generic_failure (9) on alloc failure

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -619,6 +619,12 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       // napi_create_bigint_words > INT_MAX: napi_invalid_arg, no throw
       expect(result).toContain("napi_create_bigint_words(INT_MAX+1): status=1 pending=0");
 
+      // napi_create_bigint_words within the 1 << 30 bit cap round trips, past it throws
+      expect(result).toContain(
+        "napi_create_bigint_words(20000 words): status=0 pending=0 sign=0 count=20000 top=1",
+      );
+      expect(result).toContain("napi_create_bigint_words(past cap): status=10 pending=1");
+
       // napi_create_buffer / napi_create_buffer_copy: napi_generic_failure (9) on alloc failure
       expect(result).toContain("napi_create_buffer(SIZE_MAX): status=9 pending=1");
       expect(result).toContain("napi_create_buffer_copy(SIZE_MAX): status=9 pending=1");


### PR DESCRIPTION
Fixes #39964

### Problem

- Any BigInt operation whose result passes 1 million bits throws `RangeError: Out of memory: BigInt generated from this operation is too big`. The machine is nowhere near out of memory. The issue hits this with a 3.5 million bit Fibonacci computation that Node and Deno finish in 200 ms.
- The cause is `maxLengthBits = 1 << 20` in JavaScriptCore (`JSBigInt.h:527` in the WebKit fork). V8 allows `1 << 30` bits, so this is a Node.js compat gap, not a memory condition.

### Fix

- oven-sh/WebKit#484 raises `maxLengthBits` to `1 << 30`, the same cap as V8. The JSC comment above the constant states the implementation supports about 2^31 bits, and an audit of every length check, the four static_asserts, and both toString paths (which guard against `JSString::MaxLength`) confirms the constant can go up alone.
- This PR bumps `WEBKIT_VERSION` to that change and adds `test/js/bun/jsc/bigint-max-length.test.ts`: shifts, products, addition, `2^n` exponentiation, and `asUintN` across the old 2^20-bit boundary, plus a check that past 2^30 bits the RangeError remains.
- Verified: the new test fails on stock bun (5 of 6 cases) and passes with the bump. The issue's fib(5,000,000) script completes. `test/js/bun/jsc/` passes except pre-existing DOMJIT debug-ASAN timeouts that reproduce with the previous WebKit pin.

### Background

- A BigInt in JSC stores 64-bit digits inline in one cell. `maxLengthBits` caps the digit count. Every arithmetic path checks the result length against it and throws the RangeError above when it passes the cap.
- The new cap allows a single BigInt of up to 128MB of digits, the same bound V8 enforces in Node.
- `WEBKIT_VERSION` currently points at the preview release for oven-sh/WebKit#484. It needs repointing to the merged main sha before this lands.

<details><summary>Notes</summary>

- Boundary probe on stock bun: a product of 1,048,401 bits succeeds, 1,048,577 bits throws, so the failure point is exactly 2^20 bits.
- The WebKit PR also scales the JSTests that encode the old limit (big-int-out-of-memory-tests, bigint-inc-dec-in-place, bigint-exponential-oom, three bigint-oom-in-codegen tests, eval-huge-big-int-memory-overflow, bigint-oom-import). A sweep of all 409 BigInt stress tests shows no new failures against a baseline JSC build.
- String to BigInt parsing in JSC is quadratic for every radix, so the test suite avoids parse-direction cases past the old cap. They take 40 s in a debug ASAN build. Sub-quadratic BigInt algorithms are a separate effort (#35904).
- Rebase note: each time main moves its WebKit pin (aea1f010, then c148a12d), the WebKit PR is rebased onto that pin and the preview tag repointed (now autobuild-preview-pr-484-0de7d205). The bump always carries only the BigInt change on top of the pin main already uses.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->

