### PR TITLE
crash_handler(windows): report a JSC initialization that ran out of memory as an error, not a crash

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -740,6 +740,8 @@ mod draft {
         Print(&'static [u8]),
         Resolver,
         Dlopen(&'static [u8]),
+        /// Inside `JSC::initialize()`. See `exit_if_jsc_initialization_ran_out_of_memory`.
+        InitializeJsc,
     }
 
     impl fmt::Display for Action {
@@ -752,6 +754,7 @@ mod draft {
                 Action::Dlopen(path) => {
                     write!(writer, "loading native module: {}", bstr::BStr::new(path))
                 }
+                Action::InitializeJsc => writer.write_str("initializing JavaScriptCore"),
             }
         }
     }
@@ -826,6 +829,10 @@ mod draft {
 
         match PANIC_STAGE.with(|s| s.get()) {
             0 => {
+                if matches!(current_action(), Some(Action::InitializeJsc)) {
+                    exit_if_jsc_initialization_ran_out_of_memory();
+                }
+
                 bun_core::maybe_handle_panic_during_process_reload();
 
                 PANIC_STAGE.with(|s| s.set(1));
@@ -1272,6 +1279,71 @@ mod draft {
         }
 
         crash(reason);
+    }
+
+    #[cfg(windows)]
+    const MIB: u64 = 1024 * 1024;
+
+    /// The largest single commit in `JSC::initialize()` is the metadata of the
+    /// Structure heap's mimalloc arena: 10.5 MiB for the 4 GiB heap
+    /// (`StructureAlignedMemoryAllocator.cpp`, `mi_manage_os_memory_ex`).
+    /// JSC cannot start in a process that has less than this left to commit.
+    #[cfg(windows)]
+    const JSC_MINIMUM_COMMIT_MIB: u64 = 16;
+
+    /// A crash inside `JSC::initialize()` while the process cannot commit
+    /// [`JSC_MINIMUM_COMMIT_MIB`] anymore is the machine's doing (its commit
+    /// limit or a job object's memory limit is used up), not a bug: print that
+    /// and exit instead of reporting it. JSC reacts to the failed commit with a
+    /// `RELEASE_ASSERT`, which is `abort()` on Windows, so this is reached from
+    /// `handle_abort_windows`.
+    fn exit_if_jsc_initialization_ran_out_of_memory() {
+        #[cfg(windows)]
+        {
+            use bun_core::pretty_error;
+            use bun_sys::windows;
+
+            if windows::can_commit((JSC_MINIMUM_COMMIT_MIB * MIB) as usize) {
+                return;
+            }
+
+            pretty_error!(
+                "\n<r><red>error<r>: Bun ran out of memory while initializing JavaScriptCore.\n\nJavaScriptCore commits memory for its heaps at startup. This process could not commit another {} MB.\n\n",
+                JSC_MINIMUM_COMMIT_MIB,
+            );
+            if let Ok(process) =
+                windows::GetProcessMemoryInfo(windows::kernel32::GetCurrentProcess())
+            {
+                pretty_error!(
+                    "<d>Committed by this process: {} MB<r>\n",
+                    process.PagefileUsage as u64 / MIB,
+                );
+            }
+            if let Some(machine) = windows::commit_charge() {
+                pretty_error!(
+                    "<d>Committed on this machine: {} MB of {} MB (physical memory plus page file)<r>\n",
+                    machine.limit.saturating_sub(machine.available) / MIB,
+                    machine.limit / MIB,
+                );
+            }
+            let job = windows::job_memory_limits();
+            if let Some(limit) = job.per_process {
+                pretty_error!(
+                    "<d>Job object limit: {} MB per process<r>\n",
+                    limit as u64 / MIB
+                );
+            }
+            if let Some(limit) = job.whole_job {
+                pretty_error!(
+                    "<d>Job object limit: {} MB for the whole job<r>\n",
+                    limit as u64 / MIB
+                );
+            }
+            pretty_error!(
+                "\nTo fix this, close other programs or enlarge the page file. If Bun runs in a container or a CI job, raise its memory limit.\n",
+            );
+            Global::exit(1);
+        }
     }
 
     /// This is called when `main` returns an error.

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -501,6 +501,7 @@ pub fn initialize_with(eval_mode: bool, short_lived_globals: bool) {
     // any long-running event loop; tell JSC to skip the worker threads it
     // otherwise spawns eagerly at VM creation (see `JSCInitialize`).
     let one_shot = is_one_shot_eval_invocation();
+    let _action = bun_crash_handler::scoped_action(bun_crash_handler::Action::InitializeJsc);
     // SAFETY: `env` borrows the libc `environ` global for the duration of the
     // call; `on_jsc_invalid_env_var` is `extern "C"` and only reads the (ptr,len)
     // it is handed. JSCInitialize is called exactly once at startup.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1316,6 +1316,8 @@ pub use bun_windows_sys::externs::ResizePseudoConsole;
 pub use bun_windows_sys::externs::ClosePseudoConsole;
 
 pub const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD = 0x2000;
+pub(crate) const JOB_OBJECT_LIMIT_PROCESS_MEMORY: DWORD = 0x100;
+pub(crate) const JOB_OBJECT_LIMIT_JOB_MEMORY: DWORD = 0x200;
 pub(crate) const JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION: DWORD = 0x400;
 pub(crate) const JOB_OBJECT_LIMIT_BREAKAWAY_OK: DWORD = 0x800;
 pub(crate) const JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK: DWORD = 0x00001000;
@@ -1496,7 +1498,8 @@ pub struct PROCESS_MEMORY_COUNTERS {
     pub(crate) QuotaPagedPoolUsage: usize,
     pub(crate) QuotaPeakNonPagedPoolUsage: usize,
     pub(crate) QuotaNonPagedPoolUsage: usize,
-    pub(crate) PagefileUsage: usize,
+    /// The commit charge of the process ("Commit size" in Task Manager).
+    pub PagefileUsage: usize,
     pub(crate) PeakPagefileUsage: usize,
 }
 
@@ -1522,6 +1525,127 @@ pub fn GetProcessMemoryInfo(process: HANDLE) -> Result<PROCESS_MEMORY_COUNTERS, 
     }
     Ok(out)
 }
+
+/// Commits `bytes` of fresh memory and releases it again. `false` means this
+/// process cannot commit that much anymore: the commit limit of the machine
+/// (physical memory plus page file) or the memory limit of its job object is
+/// used up.
+pub fn can_commit(bytes: usize) -> bool {
+    use kernel32::{MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE};
+    unsafe extern "system" {
+        fn VirtualAlloc(
+            lpAddress: *mut c_void,
+            dwSize: usize,
+            flAllocationType: DWORD,
+            flProtect: DWORD,
+        ) -> *mut c_void;
+        fn VirtualFree(lpAddress: *mut c_void, dwSize: usize, dwFreeType: DWORD) -> BOOL;
+    }
+    // SAFETY: a null address asks for a fresh region, so no memory in use is
+    // affected. The region is released right away (`MEM_RELEASE` takes a size
+    // of 0) and nothing reads or writes it in between.
+    unsafe {
+        let region = VirtualAlloc(
+            ptr::null_mut(),
+            bytes,
+            MEM_RESERVE | MEM_COMMIT,
+            PAGE_READWRITE,
+        );
+        if region.is_null() {
+            return false;
+        }
+        VirtualFree(region, 0, MEM_RELEASE);
+    }
+    true
+}
+
+/// The commit charge of the whole machine (`GlobalMemoryStatusEx`), in bytes.
+#[derive(Clone, Copy)]
+pub struct CommitCharge {
+    /// Physical memory plus the current size of the page file.
+    pub limit: u64,
+    /// How much of `limit` is not committed yet.
+    pub available: u64,
+}
+
+pub fn commit_charge() -> Option<CommitCharge> {
+    /// `MEMORYSTATUSEX` (`sysinfoapi.h`).
+    #[repr(C)]
+    #[derive(Default)]
+    struct MEMORYSTATUSEX {
+        dwLength: DWORD,
+        dwMemoryLoad: DWORD,
+        ullTotalPhys: u64,
+        ullAvailPhys: u64,
+        ullTotalPageFile: u64,
+        ullAvailPageFile: u64,
+        ullTotalVirtual: u64,
+        ullAvailVirtual: u64,
+        ullAvailExtendedVirtual: u64,
+    }
+    unsafe extern "system" {
+        // safe: the out-param is a `&mut` to a struct whose `dwLength` says
+        // how much of it the kernel may write.
+        safe fn GlobalMemoryStatusEx(lpBuffer: &mut MEMORYSTATUSEX) -> BOOL;
+    }
+    let mut status = MEMORYSTATUSEX {
+        dwLength: size_of::<MEMORYSTATUSEX>() as DWORD,
+        ..Default::default()
+    };
+    if GlobalMemoryStatusEx(&mut status) == 0 {
+        return None;
+    }
+    Some(CommitCharge {
+        limit: status.ullTotalPageFile,
+        available: status.ullAvailPageFile,
+    })
+}
+
+/// The memory limits of the job object this process runs in, in bytes. Both
+/// are `None` when the process is not in a job or the job does not limit
+/// memory. Windows charges committed memory against these limits, so a
+/// process that hits one fails to commit memory like a machine whose commit
+/// limit is used up. Containers and CI runners set them.
+#[derive(Clone, Copy, Default)]
+pub struct JobMemoryLimits {
+    /// `JOB_OBJECT_LIMIT_PROCESS_MEMORY`: the limit for each process in the job.
+    pub per_process: Option<usize>,
+    /// `JOB_OBJECT_LIMIT_JOB_MEMORY`: the limit for all processes in the job together.
+    pub whole_job: Option<usize>,
+}
+
+pub fn job_memory_limits() -> JobMemoryLimits {
+    unsafe extern "system" {
+        // safe: a null `hJob` is documented to mean the job of the calling
+        // process (a process outside of every job gets `FALSE`); the out-param
+        // is a `&mut` to the struct that `cbJobObjectInformationLength` sizes.
+        safe fn QueryInformationJobObject(
+            hJob: HANDLE,
+            JobObjectInformationClass: DWORD,
+            lpJobObjectInformation: &mut JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            cbJobObjectInformationLength: DWORD,
+            lpReturnLength: Option<&mut DWORD>,
+        ) -> BOOL;
+    }
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = bun_core::ffi::zeroed();
+    if QueryInformationJobObject(
+        ptr::null_mut(),
+        JobObjectExtendedLimitInformation,
+        &mut info,
+        size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
+        None,
+    ) == 0
+    {
+        return JobMemoryLimits::default();
+    }
+    let flags = info.BasicLimitInformation.LimitFlags;
+    JobMemoryLimits {
+        per_process: (flags & JOB_OBJECT_LIMIT_PROCESS_MEMORY != 0)
+            .then_some(info.ProcessMemoryLimit),
+        whole_job: (flags & JOB_OBJECT_LIMIT_JOB_MEMORY != 0).then_some(info.JobMemoryLimit),
+    }
+}
+
 pub use bun_windows_sys::externs::GetConsoleMode;
 pub use bun_windows_sys::externs::SetConsoleMode;
 

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -834,6 +834,8 @@ pub mod kernel32 {
         pub Type: u32,
     }
     pub const MEM_COMMIT: u32 = 0x1000;
+    pub const MEM_RESERVE: u32 = 0x2000;
+    pub const MEM_RELEASE: u32 = 0x8000;
     pub const MEM_FREE: u32 = 0x10000;
 
     pub const PAGE_NOACCESS: u32 = 0x01;

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,3 +1,4 @@
+import { dlopen, ptr } from "bun:ffi";
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
@@ -607,6 +608,139 @@ describe.if(isWindows)("Windows: aborts and traps are reported, exit status refl
     expect(exitCode).toBe(expectedExitCode);
   });
 });
+
+// JSC::initialize() fails with a RELEASE_ASSERT, an abort() (above), when it
+// cannot get the memory it needs. Out of memory is the machine's problem, so
+// that case ends with an error message; anything else that goes wrong in there
+// is still a crash.
+describe.if(isWindows)("Windows: crash while initializing JavaScriptCore", () => {
+  const outOfMemory = "Bun ran out of memory while initializing JavaScriptCore";
+
+  // structureHeapSizeInKB must be a power of two: 3072 trips a RELEASE_ASSERT
+  // in the constructor that reserves the Structure heap. Memory is fine, so
+  // the report says where it happened instead of blaming memory.
+  test.concurrent("a crash that memory does not explain is reported", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "1", "--debug-crash-handler-use-trace-string"],
+      env: { ...noReportEnv, BUN_JSC_structureHeapSizeInKB: "3072" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("abort() called");
+    expect(stderr).toContain("Crashed while initializing JavaScriptCore");
+    expect(stderr).not.toContain(outOfMemory);
+    expect(exitCode).not.toBe(0);
+  });
+
+  // Runs `bun -e 1` in a job object with a per-process memory limit, which is
+  // what containers and CI runners use. Windows charges committed memory
+  // against it. The limits under which JSC's initialization is what runs
+  // into it span the 10.5 MB that JSC commits for the Structure heap, and
+  // they start at whatever bun has committed by then, which depends on the
+  // build: 5 MB more than `bun --version` peaks at on a release build, 8 MB
+  // more on a debug build. So start 8 MB above that peak and walk up in steps
+  // smaller than the span. The run that lands in the span must end with the
+  // error message, not with a crash report and not silently. A run below the
+  // span dies of an ordinary allocation failure, a __fastfail, which Windows
+  // Error Reporting holds for over a second, so every step matters.
+  test.concurrent("out of memory during initialization exits with an error", async () => {
+    const kernel32 = openJobObjectApi();
+    const calibration = await runInJob(kernel32, undefined, [bunExe(), "--version"]);
+    expect(calibration.exitCode).toBe(0);
+    const startMiB = Math.floor(calibration.peakCommitMiB) + 8;
+
+    const outcomes: string[] = [];
+    for (let limitMiB = startMiB; limitMiB < startMiB + 256; limitMiB += 4) {
+      const { stderr, exitCode } = await runInJob(kernel32, limitMiB, [bunExe(), "-e", "1"]);
+      if (stderr.includes(outOfMemory)) {
+        expect(stderr).toContain(`Job object limit: ${limitMiB} MB per process`);
+        expect(stderr).not.toContain("panic");
+        expect(stderr).not.toContain("Bun has crashed");
+        expect(exitCode).toBe(1);
+        return;
+      }
+      const summary = stderr.split("\n").find(line => line.includes("panic") || line.includes("error")) ?? "";
+      outcomes.push(`${limitMiB} MiB: exit ${exitCode} ${summary}`.trimEnd());
+      // It ran, so every larger limit works too.
+      if (exitCode === 0) break;
+    }
+    throw new Error(
+      `bun --version peaked at ${calibration.peakCommitMiB.toFixed(1)} MiB, and no limit from ${startMiB} MiB up ended with the out of memory error:\n${outcomes.join("\n")}`,
+    );
+  });
+});
+
+function openJobObjectApi() {
+  return dlopen("kernel32.dll", {
+    CreateJobObjectW: { args: ["ptr", "ptr"], returns: "ptr" },
+    SetInformationJobObject: { args: ["ptr", "i32", "ptr", "u32"], returns: "i32" },
+    QueryInformationJobObject: { args: ["ptr", "i32", "ptr", "u32", "ptr"], returns: "i32" },
+    OpenProcess: { args: ["u32", "i32", "u32"], returns: "ptr" },
+    AssignProcessToJobObject: { args: ["ptr", "ptr"], returns: "i32" },
+    CloseHandle: { args: ["ptr"], returns: "i32" },
+    GetLastError: { args: [], returns: "u32" },
+  }).symbols;
+}
+
+// Starts `cmd.exe`, moves it into a new job object (with a per-process memory
+// limit of `limitMiB`, if given) while it waits for its stdin, then has it run
+// `argv`, which inherits the job. Returns what `argv` wrote to stderr, its exit
+// code, and the peak commit charge of a process in the job, which is `argv`'s
+// (cmd.exe stays far below it).
+async function runInJob(kernel32: ReturnType<typeof openJobObjectApi>, limitMiB: number | undefined, argv: string[]) {
+  const JobObjectExtendedLimitInformation = 9;
+  const JOB_OBJECT_LIMIT_PROCESS_MEMORY = 0x100;
+  const PROCESS_SET_QUOTA = 0x0100;
+  const PROCESS_TERMINATE = 0x0001;
+  // JOBOBJECT_EXTENDED_LIMIT_INFORMATION is 144 bytes. Field offsets:
+  const LimitFlags = 16;
+  const ProcessMemoryLimit = 112;
+  const PeakProcessMemoryUsed = 128;
+  const info = new DataView(new ArrayBuffer(144));
+
+  const job = kernel32.CreateJobObjectW(null, null);
+  if (!job) throw new Error(`CreateJobObjectW failed: ${kernel32.GetLastError()}`);
+  try {
+    if (limitMiB !== undefined) {
+      info.setUint32(LimitFlags, JOB_OBJECT_LIMIT_PROCESS_MEMORY, true);
+      info.setBigUint64(ProcessMemoryLimit, BigInt(limitMiB) * 1024n * 1024n, true);
+      if (!kernel32.SetInformationJobObject(job, JobObjectExtendedLimitInformation, ptr(info.buffer), 144)) {
+        throw new Error(`SetInformationJobObject failed: ${kernel32.GetLastError()}`);
+      }
+    }
+
+    // /Q: do not echo the commands. /D: skip the AutoRun registry entries.
+    await using shell = Bun.spawn({
+      cmd: ["cmd.exe", "/Q", "/D"],
+      env: noReportEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const shellProcess = kernel32.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, shell.pid);
+    if (!shellProcess) throw new Error(`OpenProcess failed: ${kernel32.GetLastError()}`);
+    try {
+      if (!kernel32.AssignProcessToJobObject(job, shellProcess)) {
+        throw new Error(`AssignProcessToJobObject failed: ${kernel32.GetLastError()}`);
+      }
+    } finally {
+      kernel32.CloseHandle(shellProcess);
+    }
+
+    shell.stdin.write(`${argv.map(arg => `"${arg}"`).join(" ")}\r\nexit %ERRORLEVEL%\r\n`);
+    await shell.stdin.end();
+    const [stderr, exitCode] = await Promise.all([shell.stderr.text(), shell.exited, shell.stdout.text()]);
+
+    if (!kernel32.QueryInformationJobObject(job, JobObjectExtendedLimitInformation, ptr(info.buffer), 144, null)) {
+      throw new Error(`QueryInformationJobObject failed: ${kernel32.GetLastError()}`);
+    }
+    const peakCommitMiB = Number(info.getBigUint64(PeakProcessMemoryUsed, true)) / (1024 * 1024);
+    return { stderr, exitCode, peakCommitMiB };
+  } finally {
+    kernel32.CloseHandle(job);
+  }
+}
 
 describe("automatic crash reporter", () => {
   for (const approach of ["panic", "segfault", "outOfMemory", "abort"]) {


### PR DESCRIPTION
Stacked on #38860 (its branch is the base, so the diff is this commit only). Windows counterpart of #39967.

### Problem
- Sentry BUN-482B, BUN-3ZGR, BUN-4AA0: Windows startup deaths in `JSC::StructureMemoryManager::StructureMemoryManager()`. Its `RELEASE_ASSERT`s are `abort()`, which until #38860 died silently with 0xC0000409, so they are not these events (Notes).
- The assert at `StructureAlignedMemoryAllocator.cpp:147` does fire: mimalloc commits 10.5 MiB of metadata for the Structure heap, which fails once the commit limit of the machine or of a job object is used up (canary under a 20 to 24 MB job limit). With #38860 that is a crash report for a condition of the machine.

### Fix
- `bun_jsc::initialize` sets `Action::InitializeJsc` around `JSCInitialize` (the lines #39967 adds too, the second PR to land drops them).
- A crash under that action first commits and releases 16 MiB. If that fails, bun prints the commit charge and the job limits and exits 1. Otherwise it reports as before, plus "Crashed while initializing JavaScriptCore".
- Correct because JSC cannot start in a process that cannot commit 16 MiB: its heap metadata alone needs 10.5 MiB.
- Verified: two tests in `test/cli/run/run-crash-handler.test.ts`. Both fail on #38860 alone. The file passes with this branch on Windows Server 2019. Also `cargo check` for both Windows targets.

### Background
- Commit charge: Windows backs a page with RAM or page file when it is committed, not when it is touched. A job object can cap it per process, which is how containers and CI runners limit memory.
- Structure heap: JSC reserves 4 GiB of address space for `Structure`s at startup and, since 1.4, gives it to mimalloc as an arena, whose metadata mimalloc commits up front.
- `CURRENT_ACTION` is the thread local printed as "Crashed while ...". The check runs first in `crash_handler()`, for every reason, so it covers the release `abort()` and the trap of a debug build.

<details><summary>Notes</summary>

Why the Sentry events are not these asserts: on Windows bun classifies access violations, illegal instructions, misalignment and stack overflow, and `abort()` raised none of them. "Segmentation fault at address X" is an access violation with X as the data address (0x7FF7B9289011, 0x1 and 0xFFFFFFFFFFFFFFFF in the three issues). Nothing in the constructor dereferences such addresses. Sentry was not reachable from this session, so the events themselves were not examined. Two related observations: the "(pre-init)" command of the 1.4.0 events means a `bun build --compile` executable (`boot_standalone` never sets the command character), so these come from end user machines. And under a 32 to 56 MB job limit the canary produces a real access violation report (a null dereference in `JSRunLoopTimer::Manager::scheduleTimer` during `VM::VM`, symbolicated with bun.report), so commit exhaustion does produce access violation reports in other frames.

Canary `1.4.0-canary.1+4448a2e21`, `bun -e 1` under a per process job memory limit (`JOB_OBJECT_LIMIT_PROCESS_MEMORY`):

```
>= 64 MB   runs
32-56 MB   crash report: Segmentation fault at address 0x0 (JSRunLoopTimer, VM creation)
28, 36 MB  "memory allocation of N bytes failed", exit 0xC0000409 (Rust, see #39635)
20, 24 MB  exit 0xC0000409, nothing printed        <- this constructor
<= 16 MB   Rust allocation failures before JSC
```

`MIMALLOC_VERBOSE=1` at 20 and 24 MB: `cannot commit OS memory (error: 1455 (0x5AF), address: 0x01E300010000, size: 0xA80000 bytes)`, then `unable to commit meta-data for OS memory`. 0xA80000 is 65536 slices times 168 bytes of `mi_page_t`. The address is the 4 GiB aligned heap plus one 64 KiB slice. The peak commit of the canary at this point is 17.4 MiB (job object `PeakProcessMemoryUsed`), so the limits that hit the constructor are 17.4 to 27.9 MiB, which matches the table.

`GlobalMemoryStatusEx` under a 96 MB job limit still reports the machine's 75 GB, which is why `QueryInformationJobObject` is printed too. With a null handle it returns the innermost job, verified through a nested job.

Output of this branch under a 30 MB job limit (debug build):

```
error: Bun ran out of memory while initializing JavaScriptCore.

JavaScriptCore commits memory for its heaps at startup. This process could not commit another 16 MB.

Committed by this process: 29 MB
Committed on this machine: 2571 MB of 75258 MB (physical memory plus page file)
Job object limit: 30 MB per process

To fix this, close other programs or enlarge the page file. If Bun runs in a container or a CI job, raise its memory limit.
```

Tests. The second test measures the peak commit of `bun --version` (12.2 MiB on the release canary, 18.3 MiB on the debug build) and walks the limit up from 8 MiB above it in 4 MiB steps, which is below the 10.5 MiB span of limits that hit JSC's initialization. JSC's initialization starts 5.2 MiB above that peak on the release canary (17.4 MiB) and about 8 MiB above it on the debug build, so the first or second step lands in the span. A step below the span dies of a Rust allocation failure, a `__fastfail`, which Windows Error Reporting holds for about 1.4 seconds: the test takes 2.5 seconds on the debug build (three runs) and should take one step on a release build. On #38860 alone, the debug build reports "Illegal instruction" (the trap a debug build dies of) at every limit from 30 to 90 MiB and the test fails after listing them. The release canary dies silently there. The first test uses `structureHeapSizeInKB=3072`, which trips the assert at line 110 with memory to spare: on #38860 alone it is reported without the "Crashed while" line.

Both tests are Windows only, so the fail-before check is deferred to the Windows CI lanes.

Also run: `cargo check -p bun_crash_handler -p bun_jsc -p bun_sys` natively and for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`, `cargo fmt --check`, prettier, `test/internal/source-lints/`, `test/cli/run/crash-report-command-char.test.ts`, and the crash cases of `test/cli/test/parallel.test.ts` on Windows.

</details>
