### PR TITLE
The console iterator was tossing in an extra empty line at eof

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -63,7 +63,7 @@ export function asyncIterator(this: Console) {
         }
 
         if (done) {
-          if (pendingChunk) {
+          if (pendingChunk && pendingChunk.byteLength > 0) {
             yield decoder.decode(pendingChunk);
           }
           return;


### PR DESCRIPTION
### What does this PR do?
basically,
╔~/bun:console-iterator-bug
╚[0][12:30:32] 897$ ls | bun -e 'for await (const line of console)console.log(line.length)'
...
13
6
0

╔~/bun:console-iterator-bug
╚[0][12:33:21] 900$ ls | build/debug/bun-debug -e 'for await (const line of console)console.log(line.length)'
[cachefs] openat(7[/home/user/bun], /home/user/bun/package.json) = 8[/home/user/bun/package.json]
[sys] close(8[/home/user/bun/package.json])
...
18
13
6

the extra empty line on the end is gone, meaning bun -e 'for await (const line of console)' is now a viable replacement for awk, thought i still dont like having to specify const when using bun -e 'for await (line of console) 

### How did you verify your code works?
tests ran