### PR TITLE
node:vm: give each context its own global object structure

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -937,17 +937,20 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMG
         [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNodeVMGlobalObject; });
 }
 
-NodeVMGlobalObject* NodeVMGlobalObject::create(JSC::VM& vm, JSC::Structure* structure, NodeVMContextOptions options, JSValue importer)
+NodeVMGlobalObject* NodeVMGlobalObject::create(JSC::VM& vm, NodeVMContextOptions options, JSValue importer)
 {
+    // JSGlobalObject::finishCreation stores the global in its structure's realm, so a
+    // structure shared between contexts would keep the last context created alive.
+    auto* structure = createStructure(vm);
     auto* cell = new (NotNull, JSC::allocateCell<NodeVMGlobalObject>(vm)) NodeVMGlobalObject(vm, structure, options, importer);
     cell->finishCreation(vm);
     return cell;
 }
 
-Structure* NodeVMGlobalObject::createStructure(JSC::VM& vm, JSC::JSValue prototype)
+Structure* NodeVMGlobalObject::createStructure(JSC::VM& vm)
 {
     // ~IsImmutablePrototypeExoticObject is necessary for JSDOM to work (it relies on __proto__ = on the GlobalObject).
-    return JSC::Structure::create(vm, nullptr, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags & ~IsImmutablePrototypeExoticObject), info());
+    return JSC::Structure::create(vm, nullptr, jsNull(), JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags & ~IsImmutablePrototypeExoticObject), info());
 }
 
 void unsafeEvalNoop(JSGlobalObject*, const WTF::String&) {}
@@ -1529,11 +1532,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
     return JSValue::encode(function);
 }
 
-Structure* createNodeVMGlobalObjectStructure(JSC::VM& vm)
-{
-    return NodeVMGlobalObject::createStructure(vm, jsNull());
-}
-
 JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -1578,9 +1576,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
 
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
 
-    auto* targetContext = NodeVMGlobalObject::create(vm,
-        zigGlobalObject->NodeVMGlobalObjectStructure(),
-        contextOptions, importer);
+    auto* targetContext = NodeVMGlobalObject::create(vm, contextOptions, importer);
 
     RETURN_IF_EXCEPTION(scope, {});
 
@@ -1800,11 +1796,6 @@ void configureNodeVM(JSC::VM& vm, Zig::GlobalObject* globalObject)
             init.setPrototype(prototype);
             init.setStructure(structure);
             init.setConstructor(constructor);
-        });
-
-    globalObject->m_cachedNodeVMGlobalObjectStructure.initLater(
-        [](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
-            init.set(createNodeVMGlobalObjectStructure(init.vm));
         });
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -939,8 +939,7 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMG
 
 NodeVMGlobalObject* NodeVMGlobalObject::create(JSC::VM& vm, NodeVMContextOptions options, JSValue importer)
 {
-    // JSGlobalObject::finishCreation stores the global in its structure's realm, so a
-    // structure shared between contexts would keep the last context created alive.
+    // One structure per context: JSGlobalObject::finishCreation makes the global the realm of its structure.
     auto* structure = createStructure(vm);
     auto* cell = new (NotNull, JSC::allocateCell<NodeVMGlobalObject>(vm)) NodeVMGlobalObject(vm, structure, options, importer);
     cell->finishCreation(vm);

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -123,8 +123,7 @@ public:
     static constexpr JSC::DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm);
-    static NodeVMGlobalObject* create(JSC::VM& vm, JSC::Structure* structure, NodeVMContextOptions options, JSValue importer);
-    static Structure* createStructure(JSC::VM& vm, JSC::JSValue prototype);
+    static NodeVMGlobalObject* create(JSC::VM& vm, NodeVMContextOptions options, JSValue importer);
     static const JSC::GlobalObjectMethodTable& globalObjectMethodTable();
 
     DECLARE_INFO;
@@ -163,11 +162,11 @@ private:
     NodeVMContextOptions m_contextOptions {};
 
     NodeVMGlobalObject(VM& vm, Structure* structure, NodeVMContextOptions contextOptions, JSValue importer);
+    static Structure* createStructure(JSC::VM& vm);
 };
 
 // Helper functions to create vm contexts and run code
 JSC::JSValue createNodeVMBinding(Zig::GlobalObject*);
-Structure* createNodeVMGlobalObjectStructure(JSC::VM&);
 void configureNodeVM(JSC::VM&, Zig::GlobalObject*);
 
 // VM module functions

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -557,11 +557,8 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
 
     contextOptions.notContextified = notContextified;
 
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
     JSObject* context = asObject(contextObjectValue);
-    auto* targetContext = NodeVMGlobalObject::create(vm,
-        zigGlobalObject->NodeVMGlobalObjectStructure(),
-        contextOptions, importer);
+    auto* targetContext = NodeVMGlobalObject::create(vm, contextOptions, importer);
     RETURN_IF_EXCEPTION(scope, {});
 
     if (notContextified) {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -286,7 +286,6 @@ public:
     JSC::JSFunction* modulePrototypeUnderscoreCompileFunction() const { return m_modulePrototypeUnderscoreCompileFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* requireESMFromHijackedExtension() const { return m_commonJSRequireESMFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
 
-    Structure* NodeVMGlobalObjectStructure() const { return m_cachedNodeVMGlobalObjectStructure.getInitializedOnMainThread(this); }
     JSObject* lazyTestModuleObject() const { return m_lazyTestModuleObject.getInitializedOnMainThread(this); }
     Structure* CommonJSModuleObjectStructure() const { return m_commonJSModuleObjectStructure.getInitializedOnMainThread(this); }
     Structure* JSSocketAddressDTOStructure() const { return m_JSSocketAddressDTOStructure.getInitializedOnMainThread(this); }
@@ -624,7 +623,6 @@ public:
     V(public, LazyPropertyOfGlobalObject<Bun::JSCommonJSExtensions>, m_lazyRequireExtensionsObject)          \
     V(private, LazyPropertyOfGlobalObject<JSObject>, m_lazyTestModuleObject)                                 \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_testMatcherUtilsObject)                                \
-    V(public, LazyPropertyOfGlobalObject<Structure>, m_cachedNodeVMGlobalObjectStructure)                    \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_commonJSModuleObjectStructure)                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketAddressDTOStructure)                         \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSReactElementStructure)                             \

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1993,29 +1993,23 @@ test.concurrent("a context nothing references is collected while it is still the
         return new WeakRef(sandbox);
       },
     };
-    // Creating the context leaves pointers to it in the stack memory below the current frame. The
-    // collector scans the stack conservatively, and the frames Bun.gc() pushes over that memory do not
-    // overwrite all of it, so some of those pointers would still count as roots. Filling that memory
-    // with frames of numbers first removes them.
-    function scrub(depth, a, b, c, d, e, f, g, h) {
-      if (depth === 0) return a + b + c + d + e + f + g + h;
-      return scrub(depth - 1, b, c, d, e, f, g, h, a + 1);
+    // The collector scans the stack conservatively, and the call that creates a context leaves pointers
+    // to it in the stack memory that call used. So the context is created 1000 frames down: when the
+    // loop below calls Bun.gc(), all of that memory is below the stack pointer and is not scanned.
+    function createDeep(makeRef, depth) {
+      if (depth > 0) return createDeep(makeRef, depth - 1);
+      return makeRef();
     }
-    // Each round runs one frame deeper than the one before, so the frames it pushes land on different
-    // addresses. A stray pointer can pin one round. The shared structure pinned the context in every round.
-    function contextIsCollected(makeRef, extraFrames) {
-      if (extraFrames > 0) return contextIsCollected(makeRef, extraFrames - 1);
-      const ref = makeRef();
-      scrub(500, 1, 2, 3, 4, 5, 6, 7, 8);
-      // Bun.gc() also ends this job's keep-alive of WeakRef targets before it collects.
-      Bun.gc(true);
-      return ref.deref() === undefined;
-    }
+    // A case counts as collectable when any of its rounds collected the context. The shared structure
+    // kept the context alive in every round.
     const collectedRounds = {};
     for (const name in cases) {
       collectedRounds[name] = 0;
       for (let round = 0; round < 3; round++) {
-        if (contextIsCollected(cases[name], round)) collectedRounds[name]++;
+        const ref = createDeep(cases[name], 1000);
+        // Bun.gc() also ends this job's keep-alive of WeakRef targets before it collects.
+        Bun.gc(true);
+        if (ref.deref() === undefined) collectedRounds[name]++;
       }
     }
     console.log(JSON.stringify(collectedRounds));

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1996,10 +1996,18 @@ test.concurrent("a context nothing references is collected while it is still the
     // The collector scans the stack conservatively, and the call that creates a context leaves pointers
     // to it in the stack memory that call used. So the context is created 1000 frames down: when the
     // loop below calls Bun.gc(), all of that memory is below the stack pointer and is not scanned.
+    // A call inside a try block is never a tail call, so JSC cannot turn the recursion into a jump in
+    // strict code. Without the frames the output would look like the bug's, so the check below is loud.
     function createDeep(makeRef, depth) {
-      if (depth > 0) return createDeep(makeRef, depth - 1);
-      return makeRef();
+      try {
+        if (depth > 0) return createDeep(makeRef, depth - 1);
+        return makeRef();
+      } finally {
+      }
     }
+    Error.stackTraceLimit = 2000;
+    const framesAtLeaf = createDeep(() => new Error().stack.split("\n").length - 1, 1000);
+    if (framesAtLeaf < 1000) throw new Error("createDeep is only " + framesAtLeaf + " frames deep");
     // A case counts as collectable when any of its rounds collected the context. The shared structure
     // kept the context alive in every round.
     const collectedRounds = {};

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1964,16 +1964,15 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
   });
 });
 
-test.concurrent("a context nothing references is collected, including the most recently created one", async () => {
+test.concurrent("a context nothing references is collected while it is still the newest context", async () => {
   // Every NodeVMGlobalObject used to be created from one Structure cached on the main global.
-  // JSGlobalObject::finishCreation records the global as that structure's realm, and the GC marks a
-  // structure's realm, so the cached structure kept whichever context was created last alive until the
-  // next one replaced it. Each case below is measured while its context is the most recent one.
+  // JSGlobalObject::finishCreation makes the new global the realm of its structure, and the GC marks
+  // a structure's realm, so the cached structure kept the context created last alive until the next
+  // one took its place. Each round below therefore checks a context while it is still the newest one.
   const fixture = String.raw`
     const vm = require("node:vm");
-    const { heapStats, releaseWeakRefs } = require("bun:jsc");
-    // Each case creates a context in its own call and only returns a WeakRef, so no frame of this
-    // program holds the sandbox while the collections below run.
+    // Each case returns a WeakRef to the object the context's global holds (the sandbox, or the
+    // DONT_CONTEXTIFY stand-in for it), so that object can only be collected together with the global.
     const cases = {
       createContext() {
         const sandbox = {};
@@ -1994,31 +1993,43 @@ test.concurrent("a context nothing references is collected, including the most r
         return new WeakRef(sandbox);
       },
     };
-    const results = {};
-    for (const name in cases) {
-      const ref = cases[name]();
-      let collected = false;
-      for (let attempt = 0; attempt < 5 && !collected; attempt++) {
-        // Come back from the event loop first: the call that created the context can leave pointers
-        // to it on the part of the stack the collector scans conservatively. new WeakRef() and
-        // deref() also keep their target alive until the current job ends.
-        await new Promise(resolve => setImmediate(resolve));
-        releaseWeakRefs();
-        Bun.gc(true);
-        collected = ref.deref() === undefined;
-      }
-      results[name] = { collected, contextsAlive: heapStats().objectTypeCounts.NodeVMGlobalObject ?? 0 };
+    // Creating the context leaves pointers to it in the stack memory below the current frame. The
+    // collector scans the stack conservatively, and the frames Bun.gc() pushes over that memory do not
+    // overwrite all of it, so some of those pointers would still count as roots. Filling that memory
+    // with frames of numbers first removes them.
+    function scrub(depth, a, b, c, d, e, f, g, h) {
+      if (depth === 0) return a + b + c + d + e + f + g + h;
+      return scrub(depth - 1, b, c, d, e, f, g, h, a + 1);
     }
-    console.log(JSON.stringify(results));
+    // Each round runs one frame deeper than the one before, so the frames it pushes land on different
+    // addresses. A stray pointer can pin one round. The shared structure pinned the context in every round.
+    function contextIsCollected(makeRef, extraFrames) {
+      if (extraFrames > 0) return contextIsCollected(makeRef, extraFrames - 1);
+      const ref = makeRef();
+      scrub(500, 1, 2, 3, 4, 5, 6, 7, 8);
+      // Bun.gc() also ends this job's keep-alive of WeakRef targets before it collects.
+      Bun.gc(true);
+      return ref.deref() === undefined;
+    }
+    const collectedRounds = {};
+    for (const name in cases) {
+      collectedRounds[name] = 0;
+      for (let round = 0; round < 3; round++) {
+        if (contextIsCollected(cases[name], round)) collectedRounds[name]++;
+      }
+    }
+    console.log(JSON.stringify(collectedRounds));
   `;
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    createContext: { collected: true, contextsAlive: 0 },
-    createContextDontContextify: { collected: true, contextsAlive: 0 },
-    runInNewContext: { collected: true, contextsAlive: 0 },
-    scriptRunInNewContext: { collected: true, contextsAlive: 0 },
+  const collectedRounds: Record<string, number> = JSON.parse(stdout);
+  const collectable = Object.fromEntries(Object.entries(collectedRounds).map(([name, rounds]) => [name, rounds > 0]));
+  expect(collectable).toEqual({
+    createContext: true,
+    createContextDontContextify: true,
+    runInNewContext: true,
+    scriptRunInNewContext: true,
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1963,3 +1963,62 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+test.concurrent("a context nothing references is collected, including the most recently created one", async () => {
+  // Every NodeVMGlobalObject used to be created from one Structure cached on the main global.
+  // JSGlobalObject::finishCreation records the global as that structure's realm, and the GC marks a
+  // structure's realm, so the cached structure kept whichever context was created last alive until the
+  // next one replaced it. Each case below is measured while its context is the most recent one.
+  const fixture = String.raw`
+    const vm = require("node:vm");
+    const { heapStats, releaseWeakRefs } = require("bun:jsc");
+    // Each case creates a context in its own call and only returns a WeakRef, so no frame of this
+    // program holds the sandbox while the collections below run.
+    const cases = {
+      createContext() {
+        const sandbox = {};
+        vm.createContext(sandbox);
+        return new WeakRef(sandbox);
+      },
+      createContextDontContextify() {
+        return new WeakRef(vm.createContext(vm.constants.DONT_CONTEXTIFY));
+      },
+      runInNewContext() {
+        const sandbox = {};
+        vm.runInNewContext("1", sandbox);
+        return new WeakRef(sandbox);
+      },
+      scriptRunInNewContext() {
+        const sandbox = {};
+        new vm.Script("1").runInNewContext(sandbox);
+        return new WeakRef(sandbox);
+      },
+    };
+    const results = {};
+    for (const name in cases) {
+      const ref = cases[name]();
+      let collected = false;
+      for (let attempt = 0; attempt < 5 && !collected; attempt++) {
+        // Come back from the event loop first: the call that created the context can leave pointers
+        // to it on the part of the stack the collector scans conservatively. new WeakRef() and
+        // deref() also keep their target alive until the current job ends.
+        await new Promise(resolve => setImmediate(resolve));
+        releaseWeakRefs();
+        Bun.gc(true);
+        collected = ref.deref() === undefined;
+      }
+      results[name] = { collected, contextsAlive: heapStats().objectTypeCounts.NodeVMGlobalObject ?? 0 };
+    }
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    createContext: { collected: true, contextsAlive: 0 },
+    createContextDontContextify: { collected: true, contextsAlive: 0 },
+    runInNewContext: { collected: true, contextsAlive: 0 },
+    scriptRunInNewContext: { collected: true, contextsAlive: 0 },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- The `node:vm` context created last is never garbage collected. Its `NodeVMGlobalObject`, its sandbox, and all they reference survive a full GC with no JS reference left. Only the next `createContext()` or `runInNewContext()` releases it, so one dead context is retained at a time. Every `bun --interactive` session retains one this way: `internal/repl/utils.js:801` runs `vm.runInNewContext()` once at startup.
- All contexts used one `Structure` cached on the main global, `m_cachedNodeVMGlobalObjectStructure` (`NodeVM.cpp:1801`, used at `NodeVM.cpp:1577` and `NodeVMScript.cpp:562`). `JSGlobalObject::finishCreation` calls `structure()->setRealm(vm, this)` (`JSGlobalObject.cpp:3924`), so the realm of the shared structure was always the newest context. `Structure::visitChildren` marks the realm (`Structure.cpp:1412`), and the main global marks the cached structure.

### Fix
- `NodeVMGlobalObject::create` creates a structure per context. Both creation sites use it. The cached structure, its accessor, and `createNodeVMGlobalObjectStructure` are removed.
- JSC assumes this model: a structure has one realm. Every other global in Bun gets its own structure (`Zig::GlobalObject::createStructure`, ShadowRealm globals included).
- The extra structure is garbage at once. `JSGlobalObject::init` calls `convertToDictionary`, and the dictionary transition drops the link to it (`Structure::pin`). No property is read or written through a global's first structure before `init()` replaces it, so inline caches are not affected.
- Verified: the new test in `test/js/node/vm/vm.test.ts` checks a context of each kind while it is the newest one. It fails on bun 1.4.0 in all four cases. Also `test/js/node/vm/` and the 97 upstream `test-vm-*` files.

### Background
- A `Structure` is JSC's hidden class, the shape an object points to. It also stores its realm (`m_realm`), the global object it belongs to, and the GC marks the realm with the structure.
- `JSGlobalObject::finishCreation` writes the new global into the realm of the structure it was constructed with. `init()` then moves the global to its own dictionary structure. The constructor's structure is meant for one global.
- `NodeVMGlobalObject` is the `JSGlobalObject` behind one `vm` context. It holds the sandbox in `m_sandbox`. The cached structure was a `LazyProperty` of the main global, which marks all of those.

<details><summary>Notes</summary>

Repro (bun 1.4.0, `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun repro.mjs`):

```js
import vm from "node:vm";
import { fullGC, releaseWeakRefs, heapStats } from "bun:jsc";
const { jscInternals } = require("bun:internal-for-testing");
let addr;
(function () {
  const sandbox = { big: new Array(1000).fill(0) };
  addr = jscInternals.rawCellAddress(sandbox);
  vm.createContext(sandbox);
})();
Bun.gc(true); releaseWeakRefs(); fullGC();
console.log(jscInternals.isLiveCellAtRawAddress(addr), heapStats().objectTypeCounts.NodeVMGlobalObject); // true 1
vm.createContext({});
Bun.gc(true); releaseWeakRefs(); fullGC();
console.log(jscInternals.isLiveCellAtRawAddress(addr), heapStats().objectTypeCounts.NodeVMGlobalObject); // false 1
```

With this change both lines print `false 0`.

Under the bug, `vm.runInNewContext()` kept two globals alive. The JS layer calls `createContext()`, then the native `Script#runInNewContext` creates a second `NodeVMGlobalObject`. The structure pinned the second one, the second one pins the sandbox, and the sandbox is the key of the `vmModuleContextMap` entry whose value is the first one.

How the test deals with the conservative scan. The collector scans the stack of the JS thread from the stack pointer up, and the call that creates a context stores pointers to it in the stack memory it uses. Two earlier versions of the test created the context right below the frame that later called `Bun.gc()`. Both passed locally in every run and kept one or two of the cases alive in every round on the x64 ASAN lane (and once on Windows aarch64): a pointer the creating call stored was in a slot that nothing wrote again before the collector scanned it, and which slot that is depends on the build. The fixture now creates the context 1000 frames down the stack and collects from the top, so everything the creating call stored is below the stack pointer when the collector scans. Results with the fixed debug build: 3 of 3 rounds for every case in 20 of 20 runs under `-e` and 5 of 5 runs from a file. The same fixture with a depth of 0 keeps three of the four cases alive on the fixed build, which shows what the depth removes. On bun 1.4.0, with the depth, every case collects in 0 rounds: the structure is a real root. A case counts as collectable when any of its 3 rounds collected, which the bug can never satisfy. The depth has one more dependency: both returns in `createDeep` are in tail position, and JSC performs proper tail calls in strict code. The fixture is sloppy CommonJS only because it uses `require`. With `import` instead, the recursion collapsed to 2 frames and the fixed build printed 0 rounds for every case, the same output as the bug. The body of `createDeep` therefore sits in a `try`/`finally` (a call inside a `try` block is never in tail position), and the fixture measures the depth once and throws if fewer than 1000 frames are on the stack. With that, the `import` variant also collects in 3 of 3 rounds, and the variant without the `try` fails with `createDeep is only 2 frames deep` instead of the bug's output.

Suites run with the debug build: `test/js/node/vm/` (all files) and the 97 `test/js/node/test/parallel/test-vm-*` files. `test/js/node/vm/script-leak.test.ts` takes about 16 s under the local ASAN debug build and hits the local 5 s default timeout with or without this change. It passes with the timeout CI uses, and it only uses `runInThisContext`.

Demand signal. `bun --interactive` calls `vm.runInNewContext("Object.getOwnPropertyNames(globalThis)")` from `src/js/internal/repl/utils.js:801` when the REPL loads, and never again. Piping `Bun.gc(true); require("bun:jsc").heapStats().objectTypeCounts.NodeVMGlobalObject ?? 0` into `bun --interactive` prints `2` on bun 1.4.0 (the JS `runInNewContext()` creates two globals, see above) and `0` with this branch. #39994 works around the same root in its fixture by creating one extra context. That extra `createContext()` can go once both land. Another session found this bug while it worked on `JSCTaskScheduler.cpp`. There is no issue for it.

Rebased onto main after #39581. The only conflict was in `ZigGlobalObject.h`: #39581 removed the dead `m_cachedGlobalProxyStructure` on the lines next to `m_cachedNodeVMGlobalObjectStructure`, which this PR removes. Both lines are gone.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->
