### PR TITLE
Read timer ids, the vm module timeout and the inspect depth by value, not by JSValue representation

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1286,24 +1286,7 @@ impl FormatOptions {
 
         if arg1.is_object() {
             if let Some(opt) = arg1.get_truthy(global_this, "depth")? {
-                if opt.is_int32() {
-                    let arg = opt.to_int32();
-                    if arg < 0 {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "expected depth to be greater than or equal to 0, got {arg}"
-                        )));
-                    }
-                    self.max_depth = u32::try_from(arg.min(i32::from(u16::MAX))).unwrap() as u16;
-                } else if opt.is_number() {
-                    let v = opt.coerce_f64(global_this)?;
-                    if v.is_infinite() {
-                        self.max_depth = u16::MAX;
-                    } else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "expected depth to be an integer, got {v}"
-                        )));
-                    }
-                }
+                self.set_depth(global_this, opt)?;
             }
             if let Some(opt) = arg1.get_boolean_loose(global_this, "colors")? {
                 self.enable_colors = opt;
@@ -1317,29 +1300,35 @@ impl FormatOptions {
         } else {
             // formatOptions.show_hidden = arg1.toBoolean();
             if !arguments.is_empty() {
-                let depth_arg = arg1;
-                if depth_arg.is_int32() {
-                    let arg = depth_arg.to_int32();
-                    if arg < 0 {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "expected depth to be greater than or equal to 0, got {arg}"
-                        )));
-                    }
-                    self.max_depth = u32::try_from(arg.min(i32::from(u16::MAX))).unwrap() as u16;
-                } else if depth_arg.is_number() {
-                    let v = depth_arg.coerce_f64(global_this)?;
-                    if v.is_infinite() {
-                        self.max_depth = u16::MAX;
-                    } else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "expected depth to be an integer, got {v}"
-                        )));
-                    }
-                }
+                self.set_depth(global_this, arg1)?;
                 if arguments.len() > 1 && !arguments[1].is_empty_or_undefined_or_null() {
                     self.enable_colors = arguments[1].to_boolean();
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// `depth`: a non-negative integer (clamped to `u16::MAX`) or `Infinity`; non-numbers are
+    /// ignored. Decided on the number's value, so an integer JSC boxed as a double (a
+    /// `Float64Array` element, `-0`) is accepted like its int32 twin.
+    fn set_depth(&mut self, global_this: &JSGlobalObject, depth: JSValue) -> JsResult<()> {
+        if !depth.is_number() {
+            return Ok(());
+        }
+        let depth = depth.as_number();
+        if depth.is_infinite() {
+            self.max_depth = u16::MAX;
+        } else if depth.trunc() != depth {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "expected depth to be an integer, got {depth}"
+            )));
+        } else if depth < 0.0 {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "expected depth to be greater than or equal to 0, got {depth}"
+            )));
+        } else {
+            self.max_depth = depth.min(f64::from(u16::MAX)) as u16;
         }
         Ok(())
     }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -542,10 +542,12 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeVmModuleEvaluate, (JSC::JSGlobalObject * globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // vm.ts validated the timeout by value (or passes -1 for none); the number may still be boxed
+    // as a double, which isUInt32() rejects.
     JSValue timeoutValue = callFrame->argument(0);
     uint32_t timeout = 0;
-    if (timeoutValue.isUInt32()) {
-        timeout = timeoutValue.asUInt32();
+    if (timeoutValue.isUInt32AsAnyInt()) {
+        timeout = timeoutValue.asUInt32AsAnyInt();
     }
 
     JSValue breakOnSigintValue = callFrame->argument(1);

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -283,6 +283,14 @@ impl All {
         ))
     }
 
+    /// The id a JS number names, whether JSC holds it as an int32 or as a double.
+    fn timer_id_from_number(value: JSValue) -> Option<i32> {
+        let number = value.as_number();
+        // `as` saturates and maps NaN to 0; the round trip rejects those and fractions.
+        let id = number as i32;
+        (f64::from(id) == number).then_some(id)
+    }
+
     fn remove_timer_by_id(&mut self, id: i32) -> Option<*mut TimeoutObject> {
         let value: *mut EventLoopTimer = if let Some(idx) = self.maps.set_timeout.get_index(&id) {
             self.maps.set_timeout.swap_remove_at(idx).1
@@ -307,9 +315,14 @@ impl All {
         let all = timer_all_mut();
 
         let timer: Option<*mut TimerObjectInternals> = 'brk: {
-            if timer_id_value.is_int32() {
+            if timer_id_value.is_number() {
+                // Node.js looks the id up by value (`knownTimersById[id]`): a double holding an
+                // integer names the same timer as the int32. Anything else clears nothing.
+                let Some(id) = Self::timer_id_from_number(timer_id_value) else {
+                    return Ok(());
+                };
                 // Immediates don't have numeric IDs in Node.js so we only have to look up timeouts and intervals
-                let Some(t) = all.remove_timer_by_id(timer_id_value.as_int32()) else {
+                let Some(t) = all.remove_timer_by_id(id) else {
                     return Ok(());
                 };
                 // SAFETY: t is a valid TimeoutObject pointer

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -47,6 +47,58 @@ describe("Bun.inspect", () => {
     expect(() => Bun.inspect({}, { depth: -1 })).toThrow();
     expect(() => Bun.inspect({}, { depth: -13210 })).toThrow();
   });
+
+  describe("depth is read by value, whichever way JSC boxes the number", () => {
+    // A Float64Array element is always a double-boxed JSValue, and -0 can only be one,
+    // even though each is === to the int32 it holds.
+    const asDouble = (n: number) => new Float64Array([n])[0];
+    const obj = { a: { b: { c: { d: 1 } } } };
+    const inspected = (depth: number) => {
+      try {
+        return Bun.inspect(obj, { depth });
+      } catch (e) {
+        return "threw: " + (e as Error).message;
+      }
+    };
+    const inspectedPositional = (depth: number) => {
+      try {
+        return Bun.inspect(obj, depth);
+      } catch (e) {
+        return "threw: " + (e as Error).message;
+      }
+    };
+
+    it("a double-boxed integer behaves like the int32", () => {
+      for (const depth of [0, 1, 2]) {
+        expect(asDouble(depth)).toBe(depth);
+        expect(inspected(asDouble(depth))).toBe(inspected(depth));
+        expect(inspectedPositional(asDouble(depth))).toBe(inspectedPositional(depth));
+      }
+      expect(inspected(asDouble(1))).toBe("{\n  a: {\n    b: [Object ...],\n  },\n}");
+    });
+
+    it("-0 is depth 0", () => {
+      expect(inspected(-0)).toBe(inspected(0));
+      expect(inspectedPositional(-0)).toBe(inspectedPositional(0));
+    });
+
+    it("an integer past int32 is clamped like a large int32", () => {
+      expect(inspected(2 ** 32)).toBe(inspected(0x0fff0000));
+      expect(inspected(Number.MAX_SAFE_INTEGER)).toBe(inspected(Infinity));
+    });
+
+    it("a negative double-boxed integer gets the same error as the int32", () => {
+      expect(inspected(asDouble(-1))).toBe("threw: expected depth to be greater than or equal to 0, got -1");
+      expect(inspected(asDouble(-1))).toBe(inspected(-1));
+      expect(inspectedPositional(asDouble(-1))).toBe(inspectedPositional(-1));
+    });
+
+    it("non-integers still throw", () => {
+      expect(inspected(1.5)).toBe("threw: expected depth to be an integer, got 1.5");
+      expect(inspected(NaN)).toBe("threw: expected depth to be an integer, got NaN");
+      expect(inspectedPositional(1.5)).toBe("threw: expected depth to be an integer, got 1.5");
+    });
+  });
   for (let base of [new Error("hi"), { a: "hi" }]) {
     it(`depth = Infinity works for ${base.constructor.name}`, () => {
       function createRecursiveObject(n: number): any {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1846,6 +1846,25 @@ test("a module whose evaluation times out is errored", async () => {
   expect(exitCode).toBe(0);
 }, 30_000);
 
+// The same timeout value reaches the native evaluate() either as an int32 or as a double (a
+// Float64Array element is always the latter). Only the value may decide whether the deadline is armed.
+test("SourceTextModule#evaluate() arms the timeout when the number is boxed as a double", async () => {
+  const code = `
+    const vm = require("node:vm");
+    const timeout = new Float64Array([20])[0];
+    // Spins far past the 20ms deadline, but not forever: without the deadline the body finishes
+    // and evaluate() resolves, so a timeout that is not armed fails this test instead of hanging it.
+    const m = new vm.SourceTextModule("for (const end = Date.now() + 2000; Date.now() < end;) {}", { context: vm.createContext({}) });
+    await m.link(() => { throw new Error("unreachable"); });
+    console.log(timeout === 20, await m.evaluate({ timeout }).then(() => "resolved", (e) => e.code), m.status);
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("true ERR_SCRIPT_EXECUTION_TIMEOUT errored\n");
+  expect(exitCode).toBe(0);
+});
+
 // A vm timeout that lands while a host function beneath the timed script is spinning a nested event-loop
 // wait (expect().resolves ticks the loop until its promise settles) must unwind to the run and surface as
 // ERR_SCRIPT_EXECUTION_TIMEOUT; the nested wait used to keep ticking over the pending termination (a hang).

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -70,6 +70,53 @@ it("clearTimeout", async () => {
   expect(called).toBe(false);
 });
 
+it("clearTimeout and clearInterval look a numeric id up by value, whichever way JSC boxes the number", async () => {
+  // The same integer as a double-boxed JSValue: a Float64Array element never
+  // comes back as an int32, and -0 cannot be one.
+  const asDouble = n => new Float64Array([n])[0];
+  const fired = [];
+
+  const timeoutViaClearTimeout = setTimeout(() => fired.push("timeoutViaClearTimeout"), 0);
+  const timeoutViaClearInterval = setTimeout(() => fired.push("timeoutViaClearInterval"), 0);
+  const intervalViaClearInterval = setInterval(() => fired.push("intervalViaClearInterval"), 1);
+  const intervalViaClearTimeout = setInterval(() => fired.push("intervalViaClearTimeout"), 1);
+  const kept = setTimeout(() => fired.push("kept"), 0);
+  const timers = [
+    timeoutViaClearTimeout,
+    timeoutViaClearInterval,
+    intervalViaClearInterval,
+    intervalViaClearTimeout,
+    kept,
+  ];
+
+  try {
+    expect(asDouble(+timeoutViaClearTimeout)).toBe(+timeoutViaClearTimeout);
+    clearTimeout(asDouble(+timeoutViaClearTimeout));
+    clearInterval(asDouble(+timeoutViaClearInterval));
+    clearInterval(asDouble(+intervalViaClearInterval));
+    clearTimeout(asDouble(+intervalViaClearTimeout));
+
+    // Numbers that do not name a timer clear nothing and do not throw. The last one
+    // would hit `kept` if the value were wrapped into an int32 (ToInt32) instead of compared.
+    clearTimeout(+kept + 0.5);
+    clearTimeout(-0);
+    clearTimeout(NaN);
+    clearTimeout(Infinity);
+    clearTimeout(2 ** 31);
+    clearTimeout(-(2 ** 31) - 1);
+    clearTimeout(+kept + 2 ** 32);
+
+    expect(timers.map(t => t._destroyed)).toEqual([true, true, true, true, false]);
+
+    // This timer is due after every timer above, so once it fires each cleared
+    // timer would have fired too had it still been armed.
+    await new Promise(resolve => setTimeout(resolve, 2));
+    expect(fired).toEqual(["kept"]);
+  } finally {
+    timers.forEach(t => clearTimeout(t));
+  }
+});
+
 it.todo("setImmediate runs after setTimeout cb", async () => {
   var ranFirst = -1;
   setTimeout(() => {


### PR DESCRIPTION
### Problem
- Three readers test how JSC boxes a Number, not its value. With an integer boxed as a double: `clearTimeout(id)` / `clearInterval(id)` clears nothing and the timer fires (`Timer.rs:318`, `is_int32()`). `SourceTextModule#evaluate({ timeout })` never arms the deadline (`NodeVMModule.cpp:547`, `isUInt32()`). `Bun.inspect(v, { depth })` throws `expected depth to be an integer, got 1`, also for `-0` (`ConsoleObject.rs:1289`, `:1321`).
- Such a value comes from a `Float64Array` read, `Math.sqrt()`, `-0` or a sum of fractions. It is `===` to the int32, so the bugs look intermittent. Node accepts all of these.

### Fix
- `clear_timer()` takes any Number whose value round-trips through `i32` as an id, like Node's `knownTimersById[id]`. Fractions, `NaN` and values outside int32 still clear nothing.
- `jsNodeVmModuleEvaluate()` reads the timeout with `isUInt32AsAnyInt()`. `vm.ts` already validated it by value, and its `-1` for "no timeout" still maps to none.
- The two copies of the depth reader become one `FormatOptions::set_depth()` that works on the value. Same messages. `-0` is depth 0. An integer past int32 is clamped to `u16::MAX`, as a large int32 was.
- Verified: seven new tests in `test/js/web/timers/setTimeout.test.js`, `test/js/node/vm/vm.test.ts` and `test/js/node/util/bun-inspect.test.ts`. Six fail on the unfixed build. The full files and Node's timer clear tests pass.

### Background
- A `JSValue` holds a Number as an int32 or as a double. Literals give the int32 form. Typed array reads, `Math` functions, `-0` and double arithmetic give the double form, even for an integer value.
- `isInt32()` / `isUInt32()` / `is_int32()` report the form. `as_number()` and `isUInt32AsAnyInt()` report the value in either form.
- Same class: #39977 (`node:crypto`), and open PRs #32274 (`dgram` port) and #38236 (`node:vm` offsets) for the two other known sites. #35289 edits the same depth blocks, so the second one to land needs a small rebase.

<details><summary>Notes</summary>

Probed on bun 1.4.0 with `Bun.inspect(obj, { depth: v })` as the detector. Double-boxed: `new Float64Array([1])[0]`, `DataView#getFloat64()`, `JSON.parse("[4294967296,1]")[1]`, `Math.sqrt(1)`, `-0`, `x = 0.5; x += 0.5`. Int32-boxed: a literal, `[1.5, 1][1]`, `JSON.parse("1.0")`, `Math.floor(1.5)`, `0.5 + 0.5` in one expression, `parseFloat("1")`. Node v26.3.0 accepts every double-boxed case at all three APIs.

Timer ids are `i32` (`All::last_id` wraps), so the int32 range is the whole id space. `timer_id_from_number()` uses the saturating `as i32` cast and checks that the result converts back to the same `f64`. That rejects `NaN` (the cast gives 0), fractions and anything outside int32 with one comparison. `-0` maps to id 0, as Node's `knownTimersById[-0]` reads `knownTimersById["0"]`.

`set_depth()` is unchanged for int32 inputs: the same two messages, the same `u16::MAX` clamp, and `Infinity` of either sign is unlimited, as before. Two double-only inputs change: a double-boxed negative now gets the "greater than or equal to 0" message instead of "an integer", and an integral double past int32 (`2**32`) is clamped instead of rejected.

The vm test spins for at most 2 seconds, so the unfixed build fails in about 2 seconds with "resolved evaluated" instead of hanging. The fixed build stops it at the 20 ms deadline. The seventh test ("non-integers still throw") passes on both builds by design.

A census of `isInt32` / `isUInt32` / `asInt32` / `is_int32` / `as_int32` / `isAnyInt` over `src/` found no other user-reachable site that decides by representation. The remaining tag checks are fast paths with a matching double path, or read values that internal code builds (`JSBundler.rs` loader ids, `#internalFlags` in `bun:sqlite`, subprocess exit codes, `$lazy` ids).

Suites run against the debug build: `vm.test.ts` (277 pass), `setTimeout.test.js`, `setInterval.test.js`, `bun/util/inspect.test.js`, `console/bun-inspect-table.test.ts`, `console/console-table.test.ts`, `node/util/bun-inspect.test.ts`, and Node's `test-timers-clear-null-does-not-throw-error`, `test-timers-clear-object-does-not-throw-error`, `test-timers-clear-timeout-interval-equivalent`, `test-timers-invalid-clear`, `test-timers-to-primitive`, `test-timers-destroyed`, `test-timers-timeout-to-interval`. The two RSS leak fixtures in `test/js/web/timers/` fail against a debug build with or without this change: they detect ASAN by the binary name (`bun-asan`), and their protected-Timeout checks pass. Reported separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts test/js/web/timers/setTimeout.test.js

<!-- robobun:evidence:end -->