### PR TITLE
process: deliver exceptions reported against a node:vm context to uncaughtException

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1289,9 +1289,10 @@ extern "C" void Bun__logUnhandledException(JSC::EncodedJSValue exception);
 
 extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue exception, int isRejection)
 {
-    if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
-        return false;
-    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    // A node:vm context has no process object of its own: an exception reported
+    // against one goes to this thread's process, as promiseRejectionTrackerForNodeVM
+    // does for rejections.
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto* process = globalObject->processObject();
     auto& wrapped = process->wrapped();
     auto& vm = JSC::getVM(globalObject);
@@ -1337,14 +1338,14 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     auto capture = process->getUncaughtExceptionCaptureCallback();
     if (!capture.isEmpty() && !capture.isUndefinedOrNull()) {
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        (void)call(lexicalGlobalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
+        (void)call(globalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
         if (auto ex = scope.exception()) {
             (void)scope.tryClearException();
             if (vm.hasPendingTerminationException()) [[unlikely]]
                 return true;
             // if an exception is thrown in the uncaughtException handler, we abort
             Bun__logUnhandledException(JSValue::encode(JSValue(ex)));
-            Bun__Process__exit(lexicalGlobalObject, 1);
+            Bun__Process__exit(globalObject, 1);
         }
     } else if (wrapped.listenerCount(uncaughtExceptionIdent) > 0) {
         auto emitScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1289,9 +1289,7 @@ extern "C" void Bun__logUnhandledException(JSC::EncodedJSValue exception);
 
 extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue exception, int isRejection)
 {
-    // A node:vm context has no process object of its own: an exception reported
-    // against one goes to this thread's process, as promiseRejectionTrackerForNodeVM
-    // does for rejections.
+    // The exception may come from a node:vm context, which has no process of its own.
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto* process = globalObject->processObject();
     auto& wrapped = process->wrapped();

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -58,12 +58,6 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
     (void)scope.tryClearException();
     vm.clearLastException();
 
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
-    // if (auto* window = dynamicDowncast<JSDOMWindow>( globalObject)) {
-    //     if (!window->wrapped().isCurrentlyDisplayedInFrame())
-    //         return;
-    // }
-
     int lineNumber = 0;
     int columnNumber = 0;
     String exceptionSourceURL;
@@ -73,7 +67,8 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
     //     exceptionSourceURL = callFrame->sourceURL();
     // }
 
-    Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+    // The listener's realm may be a node:vm context, not a Zig::GlobalObject.
+    Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(lexicalGlobalObject, exception);
     RETURN_IF_EXCEPTION(scope, );
 
     if (exceptionDetails) {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1186,8 +1186,7 @@ fn on_unhandled_rejection(
         return;
     }
 
-    // The error is reported with the realm it was raised in, which may be a
-    // node:vm context; `WebWorker__dispatchError` needs the worker's own global.
+    // Not the realm the error was raised in: that may be a node:vm context.
     let global_object = vm.global();
 
     let mut error_instance = error_instance_or_exception

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1172,7 +1172,7 @@ impl WebWorker {
 
 fn on_unhandled_rejection(
     vm: &mut VirtualMachine,
-    global_object: &JSGlobalObject,
+    _: &JSGlobalObject,
     error_instance_or_exception: JSValue,
 ) {
     // Prevent recursion
@@ -1185,6 +1185,10 @@ fn on_unhandled_rejection(
     if !vm.script_allowed() {
         return;
     }
+
+    // The error is reported with the realm it was raised in, which may be a
+    // node:vm context; `WebWorker__dispatchError` needs the worker's own global.
+    let global_object = vm.global();
 
     let mut error_instance = error_instance_or_exception
         .to_error()

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1970,7 +1970,15 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
 // Node prints the same lines and exits 0 for each of these children.
 describe("an exception reported against a vm context reaches the process uncaughtException handlers", () => {
   const thrower = `vm.runInNewContext('(function () { throw new Error("thrown in vm context"); })')`;
+  const dispatchToListenerFromContext = `
+    const target = new EventTarget();
+    target.addEventListener("ping", ${thrower});
+    target.dispatchEvent(new Event("ping"));
+  `;
+  const listener = `process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));`;
 
+  // The monitor on the main thread's process doubles as the check that the worker children below do
+  // not report to the wrong thread.
   async function run(consumer: string, trigger: string) {
     const code = `
       const vm = require("node:vm");
@@ -1981,8 +1989,6 @@ describe("an exception reported against a vm context reaches the process uncaugh
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
     return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   }
-
-  const listener = `process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));`;
 
   test.concurrent.each([
     [
@@ -2002,14 +2008,7 @@ describe("an exception reported against a vm context reaches the process uncaugh
       `,
     ],
     ["a process 'exit' listener created in a context", `process.on("exit", ${thrower});`],
-    [
-      "an EventTarget listener created in a context",
-      `
-        const target = new EventTarget();
-        target.addEventListener("ping", ${thrower});
-        target.dispatchEvent(new Event("ping"));
-      `,
-    ],
+    ["an EventTarget listener created in a context", dispatchToListenerFromContext],
   ])("%s", async (_, trigger) => {
     const [stdout, stderr, exitCode] = await run(listener, trigger);
     expect(stderr).toBe("");
@@ -2022,14 +2021,42 @@ describe("an exception reported against a vm context reaches the process uncaugh
   test.concurrent("process.setUncaughtExceptionCaptureCallback() receives it too", async () => {
     const [stdout, stderr, exitCode] = await run(
       `process.setUncaughtExceptionCaptureCallback(err => console.log("captured:", err.message));`,
-      `
-        const target = new EventTarget();
-        target.addEventListener("ping", ${thrower});
-        target.dispatchEvent(new Event("ping"));
-      `,
+      dispatchToListenerFromContext,
     );
     expect(stderr).toBe("");
     expect(stdout).toBe("monitor: thrown in vm context uncaughtException\ncaptured: thrown in vm context\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // In a worker the exception belongs to the worker's process. Without a handler there it becomes the
+  // Worker's 'error' event, as in Node; that path used to crash on the context's global.
+  test.concurrent.each([
+    [
+      "the worker's uncaughtException handler",
+      `process.on("uncaughtException", (err, origin) => console.log("worker uncaughtException:", err.message, origin));`,
+      "worker uncaughtException: thrown in vm context uncaughtException\nworker exit: 0\n",
+    ],
+    [
+      "the Worker 'error' event when the worker has no handler",
+      "",
+      "worker error event: thrown in vm context\nworker exit: 1\n",
+    ],
+  ])("in a worker it reaches %s", async (_, workerConsumer, expected) => {
+    const [stdout, stderr, exitCode] = await run(
+      "",
+      `
+        const { Worker } = require("node:worker_threads");
+        const worker = new Worker(\`
+          const vm = require("node:vm");
+          ${workerConsumer}
+          ${dispatchToListenerFromContext}
+        \`, { eval: true });
+        worker.on("error", err => console.log("worker error event:", err.message));
+        worker.on("exit", code => console.log("worker exit:", code));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe(expected);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1963,3 +1963,73 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+// A vm context has no process object of its own, so an exception the runtime reports against one (the
+// realm of a FinalizationRegistry or of a listener function created in the context) goes to this thread's
+// process, as in Node. It used to be printed and set exit code 1 without running any of the handlers.
+// Node prints the same lines and exits 0 for each of these children.
+describe("an exception reported against a vm context reaches the process uncaughtException handlers", () => {
+  const thrower = `vm.runInNewContext('(function () { throw new Error("thrown in vm context"); })')`;
+
+  async function run(consumer: string, trigger: string) {
+    const code = `
+      const vm = require("node:vm");
+      process.on("uncaughtExceptionMonitor", (err, origin) => console.log("monitor:", err.message, origin));
+      ${consumer}
+      ${trigger}
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  const listener = `process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));`;
+
+  test.concurrent.each([
+    [
+      "a FinalizationRegistry created in the context",
+      `
+        let ran = false;
+        const context = vm.createContext({ markRan: () => { ran = true; } });
+        vm.runInContext(\`
+          globalThis.registry = new FinalizationRegistry(() => { markRan(); throw new Error("thrown in vm context"); });
+          registry.register({}, 1);
+        \`, context);
+        for (let i = 0; i < 1000 && !ran; i++) {
+          Bun.gc(true);
+          await Bun.sleep(1);
+        }
+        if (!ran) console.log("the cleanup callback never ran");
+      `,
+    ],
+    ["a process 'exit' listener created in a context", `process.on("exit", ${thrower});`],
+    [
+      "an EventTarget listener created in a context",
+      `
+        const target = new EventTarget();
+        target.addEventListener("ping", ${thrower});
+        target.dispatchEvent(new Event("ping"));
+      `,
+    ],
+  ])("%s", async (_, trigger) => {
+    const [stdout, stderr, exitCode] = await run(listener, trigger);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      "monitor: thrown in vm context uncaughtException\nuncaughtException: thrown in vm context uncaughtException\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("process.setUncaughtExceptionCaptureCallback() receives it too", async () => {
+    const [stdout, stderr, exitCode] = await run(
+      `process.setUncaughtExceptionCaptureCallback(err => console.log("captured:", err.message));`,
+      `
+        const target = new EventTarget();
+        target.addEventListener("ping", ${thrower});
+        target.dispatchEvent(new Event("ping"));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("monitor: thrown in vm context uncaughtException\ncaptured: thrown in vm context\n");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- An exception that bun reports against a `node:vm` context never reaches `process.on('uncaughtException')`, the monitor, or the capture callback. Bun prints it and exits 1. In a worker it crashes instead: `Segmentation fault at address 0x101` in `WebWorker__dispatchError` (`Worker.cpp:200`).
- Cause: `Bun__handleUncaughtException` (`src/jsc/bindings/BunProcess.cpp:1285`) returns false when its global is not a `Zig::GlobalObject`. A context's global is a `NodeVMGlobalObject`. The caller takes false as "no handler" and runs the fatal path, which in a worker reads `Zig::GlobalObject` fields from that global.
- On the `EventTarget` path, `reportException` (`src/jsc/bindings/JSDOMExceptionHandling.cpp:61`) downcasts the same global. Debug builds assert there.

### Fix
- `Bun__handleUncaughtException` maps its global through `defaultGlobalObject()`. A `Zig::GlobalObject` maps to itself, so the main realm, workers, and ShadowRealm behave as before. A `NodeVMGlobalObject` maps to the thread's default global, which owns `process`.
- The worker's fallback (`src/jsc/web_worker.rs`) dispatches on `vm.global()`, the global `WebWorker__dispatchError` expects, not on the realm it is handed.
- Correct because a context has no `process` of its own. The exception can only go to the process of the thread that runs the context. `promiseRejectionTrackerForNodeVM` (`NodeVM.cpp:955`) already routes a context's rejections this way. Matches node: every child in the new test prints the same lines and exit codes under node v26.
- Verified: `test/js/node/vm/vm.test.ts`, six new children, all fail on stock bun. The worker child without a handler still crashes with only the C++ part. Other suites in Notes.

### Background
- The main realm, a worker, and a ShadowRealm each get a `Zig::GlobalObject`, which holds the Bun state: `process`, the worker's event scope. `vm.createContext()` makes a `NodeVMGlobalObject`, a bare realm with none of that.
- `defaultGlobalObject(global)` (`ZigGlobalObject.h:914`) returns `global` if it is a `Zig::GlobalObject`, else the thread's default global. Bindings that a context can reach use it to find `process`.
- `VirtualMachine::uncaught_exception` is the one sink for uncaught exceptions. Reporting sites pass it the realm of the object that threw. It tries `Bun__handleUncaughtException`, then the thread's fallback: print and exit 1 on the main thread, the Worker's `'error'` event in a worker.

<details><summary>Notes</summary>

Repro from the report (release 1.4.0 prints the error, exits 1, `reported: 0`):

```js
import vm from "node:vm";
let reported = 0;
process.on("uncaughtException", () => { reported++; });
const context = vm.createContext({});
vm.runInContext(`
  globalThis.registry = new FinalizationRegistry(() => { throw new Error("cleanup"); });
  for (let i = 0; i < 3; i++) registry.register({}, i);
`, context);
Bun.gc(true);
await Bun.sleep(1);
console.log("reported:", reported);
```

Worker crash, release 1.4.0 (`panic: Segmentation fault at address 0x101`, the debug build reports the SEGV in `WebWorker__dispatchError` at `Worker.cpp:200`):

```js
const { Worker } = require("node:worker_threads");
new Worker(`
  const vm = require("node:vm");
  const t = new EventTarget();
  t.addEventListener("x", vm.runInNewContext('(function () { throw new Error("x"); })'));
  t.dispatchEvent(new Event("x"));
`, { eval: true }).on("error", e => console.log("error event:", e.message));
```

Affected reporting sites, each with a child in the new test: `JSCTaskScheduler::runPendingWork` (`JSCTaskScheduler.cpp:119`, FinalizationRegistry), `EventEmitter::innerInvokeEventListeners` (`EventEmitter.cpp:268`, a `process` listener created in a context, the test uses `'exit'`), `JSEventListener::handleEvent` through `reportException` (`JSEventListener.cpp:227`, an EventTarget listener created in a context, with both `on('uncaughtException')` and `setUncaughtExceptionCaptureCallback`). Two worker children: with a handler in the worker (handled there, worker exits 0) and without one (Worker `'error'` event, worker exits 1, the process exits 0). The `reportException` children fail on a stock debug build by the assertion, on a release build by the exit code. The worker children crash on stock bun.

The other consumers of the realm global in `uncaught_exception` were checked with a context global on the fixed debug build: the main-thread printer (prints, exit 1, as before), `Bun__Process__exit` (uses the VM only), and the `bun test` runner (the error is charged to the running test, as for a main-realm throw). `process._fatalException()` called from inside a context now works too, it used to return false.

Also checked on the fixed debug build, each matching node v26: a throwing `beforeExit` listener created in a context with a handler installed (handled, exit 0), `--unhandled-rejections=strict` with a promise rejected inside a context (delivered with origin `unhandledRejection`), and a ShadowRealm `FinalizationRegistry` throw (unchanged: printed, exit 1, see below).

Probed and not affected, they pass the main global already: `setTimeout(vmFn)` (the timer's global), `queueMicrotask(vmFn)`, `process.nextTick(vmFn)`.

`Bun__handleUnhandledRejection` and `Bun__emitHandledPromiseEvent` have the same guard and are left as they are. A context's rejections are mapped before they get there, by `promiseRejectionTrackerForNodeVM`, and `handleRejectedPromises` runs on the `Zig::GlobalObject` that holds the list.

Out of scope: a ShadowRealm gets a full `Zig::GlobalObject` and so a `process` object of its own. A throwing `FinalizationRegistry` callback in a ShadowRealm goes to that realm's process, which has no listeners, and exits 1 today. `defaultGlobalObject()` keeps that unchanged. Routing every realm to the thread's process would be a separate decision.

`NodeVMGlobalObject`'s method table entry for `reportUncaughtExceptionAtEventLoop` is JSC's default no-op. Bun reports through `Zig::GlobalObject::reportUncaughtExceptionAtEventLoop` directly, never through the table, and a context exposes no `queueMicrotask`, so the entry is not reachable and is not touched.

Suites run with the fixed debug build: `test/js/node/vm/`, `test/js/node/process/process.test.js`, `test/js/node/process/process-on.test.ts`, `test/js/web/abort/`, `test/js/node/events/`, `test/js/web/workers/worker.test.ts`, `worker-terminate-funnels.test.ts`, `worker-terminate-lifetime.test.ts`. Upstream files, all exit 0: the 25 `test-worker-*` files whose names mention uncaught, exit, error, unhandled, or exception, plus test-process-exit-code, test-emit-after-uncaught-exception, test-event-target, test-events-uncaught-exception-stack, test-eventtarget, test-process-exception-capture, test-process-exception-capture-errors, test-process-exception-capture-should-abort-on-uncaught, test-process-uncaught-exception-monitor, test-timers-uncaught-exception, test-uncaught-exception-handler-stack-overflow, test-vm-parse-abort-on-uncaught-exception, test-worker-nested-uncaught, test-worker-non-fatal-uncaught-exception, test-worker-uncaught-exception, test-worker-uncaught-exception-async, test-shadow-realm, test-shadow-realm-gc, test-whatwg-events-eventtarget-this-of-listener.

Local noise in this debug ASAN container, all reproduced without the worker change: `script-leak.test.ts` hits the 5 s default timeout (16 s for 10000 compiles), `process.test.js` fails once because the container has no `USER` variable, three timing tests in `worker.test.ts` (message flood, preload import, fs.readFile terminate) fail on worker startup time, and the c-ares terminate test in `worker-terminate-lifetime.test.ts` reports a LeakSanitizer leak of `node_fs_binding::Binding` after printing its `ok`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->