### PR TITLE
Let JSC's DeferredWorkTimer own the deferred-work tickets so a collection cancels a dead realm's work (WebKit bump)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,11 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c4ddc0cf5255ec9cc209e6369292739b78e3ca80";
+// Preview of oven-sh/WebKit#487: DeferredWorkTimer keeps the embedder's tickets in
+// m_pendingTickets, so the end of a collection cancels the tickets of a dead realm before the
+// embedder runs their tasks. It sits on top of c4ddc0cf, the pin here before this change. Swap
+// in the merged sha once that PR lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-487-b5c71022";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/JSCScheduler.rs
+++ b/src/jsc/JSCScheduler.rs
@@ -11,7 +11,8 @@ bun_opaque::opaque_ffi! {
 impl Taskable for JSCDeferredWorkTask {
     const TAG: TaskTag = task_tag::JSCDeferredWorkTask;
     /// A cross-thread Atomics.notify / Wasm / FinalizationRegistry completion:
-    /// delete the C++ job (its `Ref<Ticket>` drops before ~VM).
+    /// release the C++ job unrun (it takes its ticket out of the DeferredWorkTimer
+    /// and gives the event loop ref back; its `Ref<Ticket>` drops before ~VM).
     unsafe fn release_unrun(this: *mut Self) {
         // SAFETY: fn contract; heap-allocated by JSCTaskScheduler::onScheduleWorkSoon.
         unsafe { Bun__deleteDeferredWorkTask(this) }
@@ -24,17 +25,19 @@ unsafe extern "C" {
     // C++ side consuming it is interior to the opaque cell.
     safe fn Bun__runDeferredWork(task: &mut JSCDeferredWorkTask);
     fn Bun__deleteDeferredWorkTask(task: *mut JSCDeferredWorkTask);
+    fn Bun__discardDeferredWorkTask(task: *mut JSCDeferredWorkTask);
 }
 
 impl JSCDeferredWorkTask {
-    /// Delete the C++ job without running it (its ticket is cancelled with the
-    /// DeferredWorkTimer at VM teardown).
+    /// Delete the C++ job the closed VM handle refused, on whatever thread posted
+    /// it. Nothing is balanced here: the ticket stays pending and is cancelled
+    /// with the VM.
     ///
     /// # Safety
     /// `this` is the job handed over by `onScheduleWorkSoon`, not yet run.
     pub unsafe fn destroy(this: *mut Self) {
         // SAFETY: fn contract.
-        unsafe { Bun__deleteDeferredWorkTask(this) };
+        unsafe { Bun__discardDeferredWorkTask(this) };
     }
 
     /// The C++ side reports what a job throws at its own boundary; what can

--- a/src/jsc/JSCScheduler.rs
+++ b/src/jsc/JSCScheduler.rs
@@ -64,8 +64,8 @@ unsafe extern "C" fn Bun__queueJSCDeferredWorkTaskConcurrently(
     let ct = ConcurrentTask::create_from(task);
     if let crate::vm_handle::Posted::Refused(ct) = handle.post(kind, ct) {
         // SAFETY: refused ⇒ we own the ConcurrentTask box; the C++ job's ticket
-        // was already cancelled by the VM teardown (DeferredWorkTimer is shut
-        // down before ~VM), so dropping the job pointer here loses nothing.
+        // stays pending in the DeferredWorkTimer, which cancels it with the VM,
+        // so dropping the job pointer here loses nothing.
         drop(unsafe { bun_core::heap::take(ct.as_ptr()) });
         // SAFETY: `task` is the C++ job handed over for exactly one run/destroy.
         unsafe { JSCDeferredWorkTask::destroy(task) };

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -529,6 +529,13 @@ pub extern "C" fn Bun__VM__currentLoopKind(vm: &VirtualMachine) -> LoopKind {
     vm.current_loop_kind()
 }
 
+/// Any thread: whether the calling thread is the one `vm` runs on. Compares
+/// the thread's own VM slot to `vm`, which is not dereferenced.
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__VM__isCurrentThread(vm: *const VirtualMachine) -> bool {
+    VirtualMachine::get_or_null().is_some_and(|current| core::ptr::eq(current, vm))
+}
+
 // ── Test suite only: deterministic late completions ───────────────────────
 //
 // `BUN_DEBUG_TEST_WORKER_TEARDOWN_GATE` (first-level worker VMs; builds with

--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -53,7 +53,8 @@ JSHeapData::~JSHeapData() = default;
 #define CLIENT_ISO_SUBSPACE_INIT(subspace) subspace(m_heapData->subspace)
 
 JSVMClientData::JSVMClientData(VM& vm, RefPtr<JSC::SourceProvider> sourceProvider)
-    : m_builtinNames(vm)
+    : deferredWorkTimer(vm)
+    , m_builtinNames(vm)
     , m_builtinFunctions(makeUnique<JSBuiltinFunctions>(vm, sourceProvider, m_builtinNames))
     , m_heapData(JSHeapData::ensureHeapData(vm.heap))
     , CLIENT_ISO_SUBSPACE_INIT(m_domConstructorSpace)
@@ -115,8 +116,8 @@ void JSVMClientData::create(VM* vm, void* bunVM, WorkerMessagingProxy* worker)
     clientData->m_isNodeWorkerVM = worker && worker->options().kind == WorkerOptions::Kind::Node;
     clientData->vmHandle = Bun__VmHandle__retain(bunVM);
     clientData->vmHandleState = Bun__VmHandle__stateAddress(clientData->vmHandle);
-    vm->deferredWorkTimer->onAddPendingWork = [clientData](Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::WorkType kind) -> void {
-        Bun::JSCTaskScheduler::onAddPendingWork(clientData, WTF::move(ticket), kind);
+    vm->deferredWorkTimer->onAddPendingWork = [clientData](JSC::DeferredWorkTimer::Ticket& ticket) -> void {
+        Bun::JSCTaskScheduler::onAddPendingWork(clientData, ticket);
     };
     vm->deferredWorkTimer->onScheduleWorkSoon = [clientData](Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::Task&& task) -> void {
         Bun::JSCTaskScheduler::onScheduleWorkSoon(clientData, WTF::move(ticket), WTF::move(task));

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -41,6 +41,8 @@ inline bool Bun__VmHandle__scriptAllowedInline(const unsigned char* state)
 }
 // JS thread only: adjust the keep-alive of the VM this thread runs.
 extern "C" void Bun__eventLoop__refKeepAlive(void* bunVM, int delta);
+// Any thread: whether the calling thread is the one `bunVM` runs on.
+extern "C" bool Bun__VM__isCurrentThread(const void* bunVM);
 
 namespace WebCore {
 

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -114,11 +114,24 @@ extern "C" void Bun__runDeferredWork(Bun::JSCDeferredWorkTask* job)
     runPendingWork(job);
 }
 
-// Reclaim a queued-but-never-dispatched job during shutdown. Called while the
-// JSC VM is still alive, so ~Ref<Ticket> and the captured Task lambda may
-// safely touch TZone-allocated / JSC-owned state. The ticket itself stays
-// pending; the VM's teardown cancels or releases it.
+// Release a queued job unrun during the teardown, on the VM's thread while the
+// JSC VM is alive and the VM handle still takes refs. The job is consumed like a
+// run one: the ticket leaves the pending set and gives its event loop ref back
+// here, where the ref still lands. Left for ~JSGlobalObject, the release would
+// come after the handle closed and be dropped.
 extern "C" void Bun__deleteDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
+{
+    auto* clientData = job->clientData;
+    Ticket& ticket = job->ticket.get();
+    if (clientData->deferredWorkTimer.vm().deferredWorkTimer->takePendingWork(ticket))
+        releaseEventLoopRef(clientData, ticket);
+    delete job;
+}
+
+// Drop a job the VM handle refused because it had already closed. Any thread.
+// Nothing is left to balance: the loop the ref held open is gone, and the
+// ticket is cancelled with the VM.
+extern "C" void Bun__discardDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
 {
     delete job;
 }

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -48,20 +48,24 @@ static bool tookEventLoopRef(Ticket& ticket)
     return ticket.embedderData() & holdsEventLoopRef;
 }
 
-// VM thread only: the ref goes back the way onAddPendingWork took it, so it
-// lands whatever state the VM handle is in. Other threads go through the handle.
-static void releaseEventLoopRefOnVMThread(WebCore::JSVMClientData* clientData, Ticket& ticket)
+// Any thread. The VM's own thread gives the ref back the way onAddPendingWork
+// took it, which lands in any state of the VM handle (the teardown cancels
+// what is still pending after the handle has closed). Another thread, such as
+// a collector thread at the end of a collection, goes through the handle.
+static void releaseEventLoopRef(WebCore::JSVMClientData* clientData, Ticket& ticket)
 {
-    if (tookEventLoopRef(ticket))
+    if (!tookEventLoopRef(ticket))
+        return;
+    if (Bun__VM__isCurrentThread(clientData->bunVM))
         Bun__eventLoop__refKeepAlive(clientData->bunVM, -1);
+    else
+        Bun__VmHandle__refKeepAlive(clientData->vmHandle, loopKindOf(ticket), -1);
 }
 
 void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
 {
     uint8_t data = static_cast<uint8_t>(Bun__VM__currentLoopKind(clientData->bunVM));
-    // Past the event loop's last tick nothing runs any more, and the release below
-    // would be dropped once the VM handle closes, so no ref is taken.
-    if (ticket.type() == DeferredWorkTimer::WorkType::ImminentlyScheduled && !clientData->deferredWorkTimer.isShuttingDown()) {
+    if (ticket.type() == DeferredWorkTimer::WorkType::ImminentlyScheduled) {
         Bun__eventLoop__refKeepAlive(clientData->bunVM, 1);
         data |= holdsEventLoopRef;
     }
@@ -71,18 +75,11 @@ void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Tic
 // The ticket stops being pending here or in runPendingWork, never both.
 void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
 {
-    if (tookEventLoopRef(ticket))
-        Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
+    releaseEventLoopRef(clientData, ticket);
 }
 
 void JSCTaskScheduler::onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<Ticket>&& ticket, Task&& task)
 {
-    // Past the event loop's last tick nothing runs any more; the ticket stays pending
-    // until the VM tears the timer down. A post that still races the shutdown lands
-    // on the VM handle, which either queues it for the teardown to release unrun or
-    // refuses it and runs the job's release path.
-    if (clientData->deferredWorkTimer.isShuttingDown()) [[unlikely]]
-        return;
     BunLoopKind loopKind = loopKindOf(ticket.get());
     auto* job = new JSCDeferredWorkTask(clientData, WTF::move(ticket), WTF::move(task));
     Bun__queueJSCDeferredWorkTaskConcurrently(clientData->vmHandle, job, loopKind);
@@ -97,7 +94,7 @@ static void runPendingWork(JSCDeferredWorkTask* job)
     // False once a collection found the ticket's realm dead, or once an earlier job
     // for the same ticket ran. Nothing the ticket points at may be read then.
     if (vm.deferredWorkTimer->takePendingWork(ticket)) {
-        releaseEventLoopRefOnVMThread(clientData, ticket);
+        releaseEventLoopRef(clientData, ticket);
 
         // Deferred work runs script (FinalizationRegistry callbacks, wasm
         // completions); not once the VM's stop was requested. Like any other
@@ -123,22 +120,18 @@ extern "C" void Bun__runDeferredWork(Bun::JSCDeferredWorkTask* job)
 }
 
 // Release a queued job unrun during the teardown, on the VM's thread while the
-// JSC VM and its event loop are alive. The job is consumed like a run one: the
-// ticket leaves the pending set and gives its event loop ref back. The VM handle
-// may already be closed here (the last pass after Closed), which is why the ref
-// does not go through it.
+// JSC VM and its event loop are alive. The job is consumed like a run one.
 extern "C" void Bun__deleteDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
 {
     auto* clientData = job->clientData;
     Ticket& ticket = job->ticket.get();
     if (clientData->deferredWorkTimer.vm().deferredWorkTimer->takePendingWork(ticket))
-        releaseEventLoopRefOnVMThread(clientData, ticket);
+        releaseEventLoopRef(clientData, ticket);
     delete job;
 }
 
 // Drop a job the VM handle refused because it had already closed. Any thread.
-// Nothing is left to balance: the loop the ref held open is gone, and the
-// ticket is cancelled with the VM.
+// The ticket stays pending, and the teardown cancels it with the VM.
 extern "C" void Bun__discardDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
 {
     delete job;

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -43,10 +43,17 @@ static BunLoopKind loopKindOf(Ticket& ticket)
     return static_cast<BunLoopKind>(ticket.embedderData() & loopKindMask);
 }
 
-static void releaseEventLoopRef(WebCore::JSVMClientData* clientData, Ticket& ticket)
+static bool tookEventLoopRef(Ticket& ticket)
 {
-    if (ticket.embedderData() & holdsEventLoopRef)
-        Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
+    return ticket.embedderData() & holdsEventLoopRef;
+}
+
+// VM thread only: the ref goes back the way onAddPendingWork took it, so it
+// lands whatever state the VM handle is in. Other threads go through the handle.
+static void releaseEventLoopRefOnVMThread(WebCore::JSVMClientData* clientData, Ticket& ticket)
+{
+    if (tookEventLoopRef(ticket))
+        Bun__eventLoop__refKeepAlive(clientData->bunVM, -1);
 }
 
 void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
@@ -64,7 +71,8 @@ void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Tic
 // The ticket stops being pending here or in runPendingWork, never both.
 void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
 {
-    releaseEventLoopRef(clientData, ticket);
+    if (tookEventLoopRef(ticket))
+        Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
 }
 
 void JSCTaskScheduler::onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<Ticket>&& ticket, Task&& task)
@@ -89,7 +97,7 @@ static void runPendingWork(JSCDeferredWorkTask* job)
     // False once a collection found the ticket's realm dead, or once an earlier job
     // for the same ticket ran. Nothing the ticket points at may be read then.
     if (vm.deferredWorkTimer->takePendingWork(ticket)) {
-        releaseEventLoopRef(clientData, ticket);
+        releaseEventLoopRefOnVMThread(clientData, ticket);
 
         // Deferred work runs script (FinalizationRegistry callbacks, wasm
         // completions); not once the VM's stop was requested. Like any other
@@ -115,16 +123,16 @@ extern "C" void Bun__runDeferredWork(Bun::JSCDeferredWorkTask* job)
 }
 
 // Release a queued job unrun during the teardown, on the VM's thread while the
-// JSC VM is alive and the VM handle still takes refs. The job is consumed like a
-// run one: the ticket leaves the pending set and gives its event loop ref back
-// here, where the ref still lands. Left for ~JSGlobalObject, the release would
-// come after the handle closed and be dropped.
+// JSC VM and its event loop are alive. The job is consumed like a run one: the
+// ticket leaves the pending set and gives its event loop ref back. The VM handle
+// may already be closed here (the last pass after Closed), which is why the ref
+// does not go through it.
 extern "C" void Bun__deleteDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
 {
     auto* clientData = job->clientData;
     Ticket& ticket = job->ticket.get();
     if (clientData->deferredWorkTimer.vm().deferredWorkTimer->takePendingWork(ticket))
-        releaseEventLoopRef(clientData, ticket);
+        releaseEventLoopRefOnVMThread(clientData, ticket);
     delete job;
 }
 

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -16,116 +16,84 @@ extern "C" void Bun__queueJSCDeferredWorkTaskConcurrently(const ::BunVmHandleRef
 
 class JSCDeferredWorkTask {
 public:
-    JSCDeferredWorkTask(Ref<Ticket> ticket, Task&& task)
-        : ticket(WTF::move(ticket))
+    JSCDeferredWorkTask(WebCore::JSVMClientData* clientData, Ref<Ticket> ticket, Task&& task)
+        : clientData(clientData)
+        , ticket(WTF::move(ticket))
         , task(WTF::move(task))
     {
     }
 
+    // The ticket's realm can be dead by the time the job runs; the VM comes from
+    // here, not from the ticket.
+    WebCore::JSVMClientData* clientData;
     Ref<Ticket> ticket;
     Task task;
-    ~JSCDeferredWorkTask()
-    {
-    }
-
-    JSC::VM& vm() const { return ticket->scriptExecutionOwner()->vm(); }
 
     WTF_MAKE_TZONE_ALLOCATED(JSCDeferredWorkTask);
 };
 
-// Drop `ticket` from whichever pending set holds it. Caller holds m_lock; the
-// event-loop ref is balanced after the caller releases the lock.
-static bool dropPendingTicketLocked(Bun::JSCTaskScheduler& scheduler, Ticket* ticket) WTF_REQUIRES_LOCK(scheduler.m_lock)
+static bool holdsEventLoopOpen(Ticket& ticket)
 {
-    bool isKeepingEventLoopAlive = scheduler.m_pendingTicketsKeepingEventLoopAlive.removeIf([ticket](auto& pendingTicket) {
-        return pendingTicket.key.ptr() == ticket;
-    });
-    // -- At this point, ticket may be an invalid pointer.
-    if (!isKeepingEventLoopAlive) {
-        scheduler.m_pendingTicketsOther.removeIf([ticket](auto& pendingTicket) {
-            return pendingTicket.key.ptr() == ticket;
-        });
-    }
-    return isKeepingEventLoopAlive;
+    return ticket.type() == DeferredWorkTimer::WorkType::ImminentlyScheduled;
 }
 
-void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Ref<Ticket>&& ticket, JSC::DeferredWorkTimer::WorkType kind)
+// The loop that was current when JSC registered the work; its completion is posted there.
+static BunLoopKind loopKindOf(Ticket& ticket)
 {
-    auto& scheduler = clientData->deferredWorkTimer;
-    BunLoopKind loopKind = Bun__VM__currentLoopKind(clientData->bunVM);
-    Locker<Lock> holder { scheduler.m_lock };
-    if (scheduler.m_isShuttingDown) [[unlikely]]
-        return;
-    if (kind == DeferredWorkTimer::WorkType::ImminentlyScheduled) {
-        Bun__eventLoop__refKeepAlive(clientData->bunVM, 1);
-        scheduler.m_pendingTicketsKeepingEventLoopAlive.add(WTF::move(ticket), loopKind);
-    } else {
-        scheduler.m_pendingTicketsOther.add(WTF::move(ticket), loopKind);
-    }
+    return static_cast<BunLoopKind>(ticket.embedderData());
 }
+
+void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
+{
+    ticket.setEmbedderData(static_cast<uint8_t>(Bun__VM__currentLoopKind(clientData->bunVM)));
+    if (holdsEventLoopOpen(ticket))
+        Bun__eventLoop__refKeepAlive(clientData->bunVM, 1);
+}
+
+// The ticket stops being pending here or in runPendingWork, never both.
+void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
+{
+    if (holdsEventLoopOpen(ticket))
+        Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
+}
+
 void JSCTaskScheduler::onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<Ticket>&& ticket, Task&& task)
 {
-    auto& scheduler = clientData->deferredWorkTimer;
-    BunLoopKind loopKind = BunLoopKind::Regular;
-    {
-        Locker<Lock> holder { scheduler.m_lock };
-        // The event loop is past its last tick: don't bother posting. Reached from
-        // ~VM -> WaiterListManager::unregister -> Waiter::cancelAndClear for every
-        // outstanding Atomics.waitAsync on a terminating worker, and from
-        // collectNow -> JSFinalizationRegistry::finalizeUnconditionally. Balance
-        // onAddPendingWork so the ticket-set entry and event-loop ref are released.
-        if (scheduler.m_isShuttingDown) [[unlikely]] {
-            bool wasKeepingAlive = dropPendingTicketLocked(scheduler, ticket.ptr());
-            holder.unlockEarly();
-            if (wasKeepingAlive)
-                Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
-            return;
-        }
-        auto it = scheduler.m_pendingTicketsKeepingEventLoopAlive.find(ticket.ptr());
-        loopKind = it != scheduler.m_pendingTicketsKeepingEventLoopAlive.end() ? it->value : scheduler.m_pendingTicketsOther.get(ticket.ptr());
-    }
-    // Outside m_lock (markShuttingDown, on the VM's thread, needs it): a post that
-    // still races the shutdown lands on the VM handle, which either queues it for
-    // the teardown to release unrun or refuses it and runs the job's release path.
-    auto* job = new JSCDeferredWorkTask(WTF::move(ticket), WTF::move(task));
+    // Past the event loop's last tick nothing runs any more; the ticket stays pending
+    // until the VM tears the timer down. A post that still races the shutdown lands
+    // on the VM handle, which either queues it for the teardown to release unrun or
+    // refuses it and runs the job's release path.
+    if (clientData->deferredWorkTimer.isShuttingDown()) [[unlikely]]
+        return;
+    BunLoopKind loopKind = loopKindOf(ticket.get());
+    auto* job = new JSCDeferredWorkTask(clientData, WTF::move(ticket), WTF::move(task));
     Bun__queueJSCDeferredWorkTaskConcurrently(clientData->vmHandle, job, loopKind);
 }
 
-void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
+static void runPendingWork(JSCDeferredWorkTask* job)
 {
-    auto* vmHandle = clientData->vmHandle;
-    auto& scheduler = clientData->deferredWorkTimer;
+    auto* clientData = job->clientData;
+    auto& vm = clientData->deferredWorkTimer.vm();
+    Ticket& ticket = job->ticket.get();
 
-    Locker<Lock> holder { scheduler.m_lock };
-    bool wasKeepingAlive = dropPendingTicketLocked(scheduler, &ticket);
-    holder.unlockEarly();
-    if (wasKeepingAlive)
-        Bun__VmHandle__refKeepAlive(vmHandle, BunLoopKind::Regular, -1);
-}
+    // False once a collection found the ticket's realm dead, or once an earlier job
+    // for the same ticket ran. Nothing the ticket points at may be read then.
+    if (vm.deferredWorkTimer->takePendingWork(ticket)) {
+        if (holdsEventLoopOpen(ticket))
+            Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
 
-static void runPendingWork(const ::BunVmHandleRef* vmHandle, Bun::JSCTaskScheduler& scheduler, JSCDeferredWorkTask* job)
-{
-    Locker<Lock> holder { scheduler.m_lock };
-    bool wasPending = scheduler.m_pendingTicketsKeepingEventLoopAlive.remove(job->ticket.ptr());
-    if (!wasPending) {
-        wasPending = scheduler.m_pendingTicketsOther.remove(job->ticket.ptr());
-    } else {
-        Bun__VmHandle__refKeepAlive(vmHandle, BunLoopKind::Regular, -1);
-    }
-    holder.unlockEarly();
-
-    // Deferred work runs script (FinalizationRegistry callbacks, wasm
-    // completions); not once the VM's stop was requested. Like any other
-    // event-loop callback boundary, an exception a task lets escape is
-    // reported as uncaught here rather than left on the VM for the next entry.
-    if (wasPending && !job->ticket->isCancelled() && Bun__VmHandle__scriptAllowed(vmHandle)) {
-        auto& vm = job->vm();
-        auto* globalObject = job->ticket->target()->globalObject();
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        job->task(job->ticket.get());
-        if (auto* exception = scope.exception(); exception && !vm.hasPendingTerminationException()) {
-            scope.clearException();
-            Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        // Deferred work runs script (FinalizationRegistry callbacks, wasm
+        // completions); not once the VM's stop was requested. Like any other
+        // event-loop callback boundary, an exception a task lets escape is
+        // reported as uncaught here rather than left on the VM for the next entry.
+        if (Bun__VmHandle__scriptAllowed(clientData->vmHandle)) {
+            auto* globalObject = ticket.target()->globalObject();
+            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            job->task(ticket);
+            if (auto* exception = scope.exception(); exception && !vm.hasPendingTerminationException()) {
+                scope.clearException();
+                Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            }
         }
     }
 
@@ -134,26 +102,15 @@ static void runPendingWork(const ::BunVmHandleRef* vmHandle, Bun::JSCTaskSchedul
 
 extern "C" void Bun__runDeferredWork(Bun::JSCDeferredWorkTask* job)
 {
-    auto& vm = job->vm();
-    auto clientData = WebCore::clientData(vm);
-
-    runPendingWork(clientData->vmHandle, clientData->deferredWorkTimer, job);
+    runPendingWork(job);
 }
 
 // Reclaim a queued-but-never-dispatched job during shutdown. Called while the
 // JSC VM is still alive, so ~Ref<Ticket> and the captured Task lambda may
-// safely touch TZone-allocated / JSC-owned state. Mirrors runPendingWork's
-// ticket take() so the pending set and event-loop ref stay balanced.
+// safely touch TZone-allocated / JSC-owned state. The ticket itself stays
+// pending; the VM's teardown cancels or releases it.
 extern "C" void Bun__deleteDeferredWorkTask(Bun::JSCDeferredWorkTask* job)
 {
-    if (auto* clientData = WebCore::clientData(job->vm())) {
-        auto& scheduler = clientData->deferredWorkTimer;
-        Locker<Lock> holder { scheduler.m_lock };
-        bool wasKeepingAlive = dropPendingTicketLocked(scheduler, job->ticket.ptr());
-        holder.unlockEarly();
-        if (wasKeepingAlive)
-            Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
-    }
     delete job;
 }
 

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -32,29 +32,39 @@ public:
     WTF_MAKE_TZONE_ALLOCATED(JSCDeferredWorkTask);
 };
 
-static bool holdsEventLoopOpen(Ticket& ticket)
-{
-    return ticket.type() == DeferredWorkTimer::WorkType::ImminentlyScheduled;
-}
+// Ticket::embedderData(): the loop that was current when JSC registered the work,
+// which its completion is posted to, and whether the ticket took an event loop ref.
+static constexpr uint8_t loopKindMask = 0x1;
+static constexpr uint8_t holdsEventLoopRef = 0x2;
+static_assert(static_cast<uint8_t>(BunLoopKind::Macro) <= loopKindMask);
 
-// The loop that was current when JSC registered the work; its completion is posted there.
 static BunLoopKind loopKindOf(Ticket& ticket)
 {
-    return static_cast<BunLoopKind>(ticket.embedderData());
+    return static_cast<BunLoopKind>(ticket.embedderData() & loopKindMask);
+}
+
+static void releaseEventLoopRef(WebCore::JSVMClientData* clientData, Ticket& ticket)
+{
+    if (ticket.embedderData() & holdsEventLoopRef)
+        Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
 }
 
 void JSCTaskScheduler::onAddPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
 {
-    ticket.setEmbedderData(static_cast<uint8_t>(Bun__VM__currentLoopKind(clientData->bunVM)));
-    if (holdsEventLoopOpen(ticket))
+    uint8_t data = static_cast<uint8_t>(Bun__VM__currentLoopKind(clientData->bunVM));
+    // Past the event loop's last tick nothing runs any more, and the release below
+    // would be dropped once the VM handle closes, so no ref is taken.
+    if (ticket.type() == DeferredWorkTimer::WorkType::ImminentlyScheduled && !clientData->deferredWorkTimer.isShuttingDown()) {
         Bun__eventLoop__refKeepAlive(clientData->bunVM, 1);
+        data |= holdsEventLoopRef;
+    }
+    ticket.setEmbedderData(data);
 }
 
 // The ticket stops being pending here or in runPendingWork, never both.
 void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, Ticket& ticket)
 {
-    if (holdsEventLoopOpen(ticket))
-        Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
+    releaseEventLoopRef(clientData, ticket);
 }
 
 void JSCTaskScheduler::onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<Ticket>&& ticket, Task&& task)
@@ -79,8 +89,7 @@ static void runPendingWork(JSCDeferredWorkTask* job)
     // False once a collection found the ticket's realm dead, or once an earlier job
     // for the same ticket ran. Nothing the ticket points at may be read then.
     if (vm.deferredWorkTimer->takePendingWork(ticket)) {
-        if (holdsEventLoopOpen(ticket))
-            Bun__VmHandle__refKeepAlive(clientData->vmHandle, BunLoopKind::Regular, -1);
+        releaseEventLoopRef(clientData, ticket);
 
         // Deferred work runs script (FinalizationRegistry callbacks, wasm
         // completions); not once the VM's stop was requested. Like any other

--- a/src/jsc/bindings/JSCTaskScheduler.h
+++ b/src/jsc/bindings/JSCTaskScheduler.h
@@ -6,14 +6,15 @@ class JSVMClientData;
 
 #include <JavaScriptCore/DeferredWorkTimer.h>
 #include "BunLoopKind.h"
-#include <atomic>
 
 namespace Bun {
 
 // Bun's side of JSC's DeferredWorkTimer (the hook contract is described in
 // DeferredWorkTimer.h): each task runs from the event loop that was current
 // when its work was registered, and a pending ImminentlyScheduled ticket holds
-// the event loop open.
+// the event loop open. The VM handle decides what becomes of a posted task
+// (run, released unrun by the teardown, or refused once the VM has closed), so
+// there is no state here.
 class JSCTaskScheduler {
     WTF_MAKE_NONCOPYABLE(JSCTaskScheduler);
 
@@ -29,17 +30,8 @@ public:
     static void onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::Task&& task);
     static void onCancelPendingWork(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket& ticket);
 
-    // Set once the owning VM's event loop has taken its last tick. After this,
-    // onScheduleWorkSoon drops the task up front instead of posting it (~VM ->
-    // WaiterListManager::unregister reaches it for every still-pending
-    // Atomics.waitAsync ticket). An early-out, not a fence: a post that races
-    // this is handled by the VM handle (released unrun by the teardown, or refused).
-    void markShuttingDown() { m_isShuttingDown.store(true, std::memory_order_relaxed); }
-    bool isShuttingDown() const { return m_isShuttingDown.load(std::memory_order_relaxed); }
-
 private:
     JSC::VM& m_vm;
-    std::atomic<bool> m_isShuttingDown { false };
 };
 
 }

--- a/src/jsc/bindings/JSCTaskScheduler.h
+++ b/src/jsc/bindings/JSCTaskScheduler.h
@@ -6,18 +6,26 @@ class JSVMClientData;
 
 #include <JavaScriptCore/DeferredWorkTimer.h>
 #include "BunLoopKind.h"
+#include <atomic>
 
 namespace Bun {
 
+// Bun's side of JSC's DeferredWorkTimer (the hook contract is described in
+// DeferredWorkTimer.h): each task runs from the event loop that was current
+// when its work was registered, and a pending ImminentlyScheduled ticket holds
+// the event loop open.
 class JSCTaskScheduler {
+    WTF_MAKE_NONCOPYABLE(JSCTaskScheduler);
+
 public:
-    JSCTaskScheduler()
-        : m_pendingTicketsKeepingEventLoopAlive()
-        , m_pendingTicketsOther()
+    explicit JSCTaskScheduler(JSC::VM& vm)
+        : m_vm(vm)
     {
     }
 
-    static void onAddPendingWork(WebCore::JSVMClientData* clientData, Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::WorkType kind);
+    JSC::VM& vm() const { return m_vm; }
+
+    static void onAddPendingWork(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket& ticket);
     static void onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::Task&& task);
     static void onCancelPendingWork(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket& ticket);
 
@@ -26,18 +34,12 @@ public:
     // WaiterListManager::unregister reaches it for every still-pending
     // Atomics.waitAsync ticket). An early-out, not a fence: a post that races
     // this is handled by the VM handle (released unrun by the teardown, or refused).
-    void markShuttingDown()
-    {
-        Locker<Lock> holder { m_lock };
-        m_isShuttingDown = true;
-    }
+    void markShuttingDown() { m_isShuttingDown.store(true, std::memory_order_relaxed); }
+    bool isShuttingDown() const { return m_isShuttingDown.load(std::memory_order_relaxed); }
 
-public:
-    Lock m_lock;
-    bool m_isShuttingDown WTF_GUARDED_BY_LOCK(m_lock) { false };
-    // Value: the loop that was current when JSC registered the work; its completion is posted there.
-    UncheckedKeyHashMap<Ref<JSC::DeferredWorkTimer::Ticket>, BunLoopKind> m_pendingTicketsKeepingEventLoopAlive;
-    UncheckedKeyHashMap<Ref<JSC::DeferredWorkTimer::Ticket>, BunLoopKind> m_pendingTicketsOther;
+private:
+    JSC::VM& m_vm;
+    std::atomic<bool> m_isShuttingDown { false };
 };
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4296,10 +4296,8 @@ void GlobalObject::prepareForDestruction()
         nextTickQueue->discard(vm);
 
     // Tell cross-thread posters not to bother from here (what still lands is queued and released
-    // unrun by the teardown, or refused once the VM handle closes). DeferredWorkTimer is fenced
-    // separately because finalizers during the final collection and ~VM both reach scheduleWorkSoon().
+    // unrun by the teardown, or refused once the VM handle closes).
     context->markTerminating();
-    WebCore::clientData(vm)->deferredWorkTimer.markShuttingDown();
 
     // WorkerOrWorkletGlobalScope::prepareForDestruction(): stop every ActiveDOMObject (workers are
     // asked to terminate, ports/channels/sockets close without dispatching) and strip listeners,

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -2039,13 +2039,11 @@ describe("deferred work of a context that is collected while the work is pending
   async function run(code: string) {
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-    return stdout;
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
   }
 
   test.concurrent("a FinalizationRegistry cleanup job queued before the collection does not run", async () => {
-    const stdout = await run(
+    await run(
       fixture(`
         function setup() {
           const context = createContext({});
@@ -2060,11 +2058,10 @@ describe("deferred work of a context that is collected while the work is pending
         function afterRound() {}
       `),
     );
-    expect(stdout).toBe("done\n");
   });
 
   test.concurrent("a notify for the collected context's Atomics.waitAsync does not run its wake-up", async () => {
-    const stdout = await run(
+    await run(
       fixture(`
         const i32 = new Int32Array(new SharedArrayBuffer(4));
         let wakeUps = 0;
@@ -2084,6 +2081,5 @@ describe("deferred work of a context that is collected while the work is pending
         }
       `),
     );
-    expect(stdout).toBe("done\n");
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1997,11 +1997,13 @@ describe("deferred work of a context that is collected while the work is pending
       const keep = [];
       for (let i = 0; i < 8; i++) keep.push(vm.createContext({}));
 
-      let contextsCollected = 0;
-      const observer = new FinalizationRegistry(() => contextsCollected++);
+      // Which rounds' sandboxes have died, so that a round only looks at its own context.
+      const collectedRounds = new Set();
+      const observer = new FinalizationRegistry(round => collectedRounds.add(round));
 
+      let round = 0;
       function createContext(sandbox) {
-        observer.register(sandbox, null);
+        observer.register(sandbox, round);
         return vm.createContext(sandbox);
       }
 
@@ -2015,7 +2017,7 @@ describe("deferred work of a context that is collected while the work is pending
 
       ${body}
 
-      for (let round = 0; round < 5; round++) {
+      for (round = 0; round < 5; round++) {
         deep(500, setup);
         // The structure shared by every context roots the most recently created one.
         vm.createContext({});
@@ -2025,12 +2027,11 @@ describe("deferred work of a context that is collected while the work is pending
         fullGC();
         afterCollection();
         // The next tick runs whatever was queued, then the observer's job for this round's sandbox.
-        const before = contextsCollected;
-        for (let i = 0; contextsCollected === before && i < 50; i++) await Bun.sleep(1);
-        afterRound(contextsCollected > before);
+        for (let i = 0; !collectedRounds.has(round) && i < 50; i++) await Bun.sleep(1);
+        afterRound(collectedRounds.has(round));
       }
       // A round whose context survived the collection exercised nothing.
-      if (contextsCollected === 0) throw new Error("no round collected its context");
+      if (collectedRounds.size === 0) throw new Error("no round collected its context");
       console.log("done");
     `;
   }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1974,3 +1974,92 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+// FinalizationRegistry cleanup and Atomics.waitAsync wake-ups reach script through JSC's DeferredWorkTimer,
+// which Bun drives from its own event loop. The end of the collection that kills a context cancels the
+// context's pending work. Bun's tickets used to be kept where that cancellation could not see them, so the
+// work still ran once the context was dead: the cleanup job read a destructed registry (BUN-4NCK) or called
+// into the dead context (BUN-4M46), and a notify resolved a destructed promise. The context has to die
+// without its destructor running first (that cancels the work too), so the fixtures keep it out of the
+// eagerly swept cells. In a child because the failure mode is a segfault.
+describe("deferred work of a context that is collected while the work is pending", () => {
+  function fixture(body: string) {
+    return `
+      const vm = require("node:vm");
+      const { fullGC, releaseWeakRefs } = require("bun:jsc");
+
+      // The first 8 cells of a subspace are swept, and so destructed, as soon as the collection that kills
+      // them ends. With 8 contexts kept alive, every context below lands in a block, which is swept lazily.
+      // The registry inside a context is among the first 8 cells of its own subspace, so it is destructed
+      // by the time fullGC() returns.
+      const keep = [];
+      for (let i = 0; i < 8; i++) keep.push(vm.createContext({}));
+
+      let contextsCollected = 0;
+      const observer = new FinalizationRegistry(() => contextsCollected++);
+
+      function createContext(sandbox) {
+        observer.register(sandbox, null);
+        return vm.createContext(sandbox);
+      }
+
+      for (let round = 0; round < 3; round++) {
+        ${body}
+        // The structure shared by every context roots the most recently created one.
+        vm.createContext({});
+        // createContext() also tracks the sandbox in a WeakRef, which roots it until the end of the turn.
+        releaseWeakRefs();
+        // The context dies here. Nothing is swept synchronously, so its destructor does not run yet.
+        fullGC();
+        afterCollection();
+        // The next tick runs whatever was queued, then the observer's job for this round's sandbox.
+        for (let i = 0; contextsCollected <= round && i < 100; i++) await Bun.sleep(1);
+        if (contextsCollected <= round) throw new Error("round " + round + ": the context was not collected");
+      }
+      console.log("done", contextsCollected);
+    `;
+  }
+
+  async function run(code: string) {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test.concurrent("a FinalizationRegistry cleanup job queued before the collection does not run", async () => {
+    const stdout = await run(
+      fixture(`
+        {
+          const context = createContext({});
+          vm.runInContext(
+            "globalThis.registry = new FinalizationRegistry(() => {}); for (let i = 0; i < 4; i++) registry.register({}, i);",
+            context,
+          );
+          // The targets are dead and the registry is alive: this queues the registry's cleanup job.
+          Bun.gc(true);
+        }
+        function afterCollection() {}
+      `),
+    );
+    expect(stdout).toBe("done 3\n");
+  });
+
+  test.concurrent("a notify for the collected context's Atomics.waitAsync does not run its wake-up", async () => {
+    const stdout = await run(
+      fixture(`
+        const i32 = new Int32Array(new SharedArrayBuffer(4));
+        {
+          const context = createContext({ i32 });
+          vm.runInContext("Atomics.waitAsync(i32, 0, 0).value.then(() => { throw new Error('woken in a dead context'); })", context);
+        }
+        function afterCollection() {
+          // The wake-up would resolve the dead context's promise on the next tick.
+          Atomics.notify(i32, 0);
+        }
+      `),
+    );
+    expect(stdout).toBe("done 3\n");
+  });
+});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1983,6 +1983,8 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
 // without its destructor running first (that cancels the work too), so the fixtures keep it out of the
 // eagerly swept cells. In a child because the failure mode is a segfault.
 describe("deferred work of a context that is collected while the work is pending", () => {
+  // `body` declares setup(), which creates the context and queues the work, afterCollection(), and
+  // afterRound(collected), which says whether this round's context died.
   function fixture(body: string) {
     return `
       const vm = require("node:vm");
@@ -2003,8 +2005,18 @@ describe("deferred work of a context that is collected while the work is pending
         return vm.createContext(sandbox);
       }
 
-      for (let round = 0; round < 3; round++) {
-        ${body}
+      // Runs fn at the bottom of a deep stack. The slots that held pointers to what fn created then lie
+      // below everything the collections scan, so they cannot keep the context alive. Not a tail call.
+      function deep(depth, fn) {
+        if (depth === 0) return fn();
+        const r = deep(depth - 1, fn);
+        return r;
+      }
+
+      ${body}
+
+      for (let round = 0; round < 5; round++) {
+        deep(500, setup);
         // The structure shared by every context roots the most recently created one.
         vm.createContext({});
         // createContext() also tracks the sandbox in a WeakRef, which roots it until the end of the turn.
@@ -2013,10 +2025,13 @@ describe("deferred work of a context that is collected while the work is pending
         fullGC();
         afterCollection();
         // The next tick runs whatever was queued, then the observer's job for this round's sandbox.
-        for (let i = 0; contextsCollected <= round && i < 100; i++) await Bun.sleep(1);
-        if (contextsCollected <= round) throw new Error("round " + round + ": the context was not collected");
+        const before = contextsCollected;
+        for (let i = 0; contextsCollected === before && i < 50; i++) await Bun.sleep(1);
+        afterRound(contextsCollected > before);
       }
-      console.log("done", contextsCollected);
+      // A round whose context survived the collection exercised nothing.
+      if (contextsCollected === 0) throw new Error("no round collected its context");
+      console.log("done");
     `;
   }
 
@@ -2031,7 +2046,7 @@ describe("deferred work of a context that is collected while the work is pending
   test.concurrent("a FinalizationRegistry cleanup job queued before the collection does not run", async () => {
     const stdout = await run(
       fixture(`
-        {
+        function setup() {
           const context = createContext({});
           vm.runInContext(
             "globalThis.registry = new FinalizationRegistry(() => {}); for (let i = 0; i < 4; i++) registry.register({}, i);",
@@ -2041,25 +2056,33 @@ describe("deferred work of a context that is collected while the work is pending
           Bun.gc(true);
         }
         function afterCollection() {}
+        function afterRound() {}
       `),
     );
-    expect(stdout).toBe("done 3\n");
+    expect(stdout).toBe("done\n");
   });
 
   test.concurrent("a notify for the collected context's Atomics.waitAsync does not run its wake-up", async () => {
     const stdout = await run(
       fixture(`
         const i32 = new Int32Array(new SharedArrayBuffer(4));
-        {
-          const context = createContext({ i32 });
-          vm.runInContext("Atomics.waitAsync(i32, 0, 0).value.then(() => { throw new Error('woken in a dead context'); })", context);
+        let wakeUps = 0;
+        const wake = () => wakeUps++;
+        function setup() {
+          const context = createContext({ i32, wake });
+          vm.runInContext("Atomics.waitAsync(i32, 0, 0).value.then(wake)", context);
         }
+        let wakeUpsBefore = 0;
         function afterCollection() {
-          // The wake-up would resolve the dead context's promise on the next tick.
+          wakeUpsBefore = wakeUps;
+          // The wake-up resolves the context's promise on the next tick, if the waiter is still there.
           Atomics.notify(i32, 0);
+        }
+        function afterRound(collected) {
+          if (collected && wakeUps !== wakeUpsBefore) throw new Error("the wake-up ran in a collected context");
         }
       `),
     );
-    expect(stdout).toBe("done 3\n");
+    expect(stdout).toBe("done\n");
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -2107,22 +2107,32 @@ describe("deferred work of a context that is collected while the work is pending
     );
   });
 
-  // The other owner a ticket can belong to. A ShadowRealm's global is larger than
-  // MarkedSpace::largeCutoff, so it is a precise allocation and its destructor runs in the epilogue
-  // of the collection that kills it. That destructor cancels the realm's pending work, which is why
-  // the fixture above cannot reach this owner: it has to be a collection the loop did not ask for.
+  // The other owner a ticket can belong to. A ShadowRealm's global is larger than MarkedSpace::largeCutoff,
+  // so it is a precise allocation, destructed as soon as the collection that kills it finalizes, and the
+  // destructor cancels the realm's pending work. A synchronous fullGC() finalizes before it returns, which
+  // is why the fixture above cannot reach this owner: the realms have to die in collections the loop did
+  // not ask for.
   test.concurrent("a WebAssembly.instantiate completion does not run in a collected ShadowRealm", async () => {
     await run(`
-      const glue =
-        "const bytes = new Uint8Array([0,97,115,109,1,0,0,0,5,3,1,0,1,7,5,1,1,109,2,0]);" +
-        "WebAssembly.instantiate(bytes).then(r => { globalThis.byteLength = r.instance.exports.m.buffer.byteLength; });" +
-        "undefined";
-      for (let i = 0; i < 400; i++) {
-        new ShadowRealm().evaluate(glue);
+      // A realm that died before its completion ran had work pending when it was collected. That is the
+      // case under test, so the loop has to produce at least one.
+      const died = new Set();
+      const completed = new Set();
+      const realms = new FinalizationRegistry(i => died.add(i));
+      const instantiate =
+        "(done) => { const bytes = new Uint8Array([0,97,115,109,1,0,0,0,5,3,1,0,1,7,5,1,1,109,2,0]);" +
+        " WebAssembly.instantiate(bytes).then(r => done(r.instance.exports.m.buffer.byteLength)); }";
+      for (let i = 0; i < 150; i++) {
+        const realm = new ShadowRealm();
+        realms.register(realm, i);
+        realm.evaluate(instantiate)(() => { completed.add(i); });
         // Hand the queued completions a turn, so the realms die while their work is pending
         // instead of only growing the queue.
         if (i % 100 === 99) await Bun.sleep(0);
       }
+      const diedWithWorkPending = () => [...died].some(i => !completed.has(i));
+      for (let i = 0; i < 50 && !diedWithWorkPending(); i++) await Bun.sleep(1);
+      if (!diedWithWorkPending()) throw new Error("no ShadowRealm was collected while its completion was pending");
       console.log("done");
     `);
   });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -2082,4 +2082,28 @@ describe("deferred work of a context that is collected while the work is pending
       `),
     );
   });
+
+  // A third ticket source, and a different completion: JSWebAssembly.cpp's task casts the ticket's
+  // target to a JSPromise and reads its realm, where the registry's task reads the registry.
+  test.concurrent("a WebAssembly.instantiate completion queued before the collection does not run", async () => {
+    await run(
+      fixture(`
+        // An empty module with one exported memory. Small enough that the compile finishes
+        // within the round, so the completion is queued before the collection.
+        const bytes = [0, 97, 115, 109, 1, 0, 0, 0, 5, 3, 1, 0, 1, 7, 5, 1, 1, 109, 2, 0];
+        const completedRounds = new Set();
+        function setup() {
+          const thisRound = round;
+          const context = createContext({ bytes, ran: () => completedRounds.add(thisRound) });
+          vm.runInContext("WebAssembly.instantiate(new Uint8Array(bytes)).then(ran, ran)", context);
+        }
+        function afterCollection() {}
+        function afterRound(collected) {
+          if (collected && completedRounds.has(round)) {
+            throw new Error("the wasm completion ran in a collected context");
+          }
+        }
+      `),
+    );
+  });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -2106,4 +2106,24 @@ describe("deferred work of a context that is collected while the work is pending
       `),
     );
   });
+
+  // The other owner a ticket can belong to. A ShadowRealm's global is larger than
+  // MarkedSpace::largeCutoff, so it is a precise allocation and its destructor runs in the epilogue
+  // of the collection that kills it. That destructor cancels the realm's pending work, which is why
+  // the fixture above cannot reach this owner: it has to be a collection the loop did not ask for.
+  test.concurrent("a WebAssembly.instantiate completion does not run in a collected ShadowRealm", async () => {
+    await run(`
+      const glue =
+        "const bytes = new Uint8Array([0,97,115,109,1,0,0,0,5,3,1,0,1,7,5,1,1,109,2,0]);" +
+        "WebAssembly.instantiate(bytes).then(r => { globalThis.byteLength = r.instance.exports.m.buffer.byteLength; });" +
+        "undefined";
+      for (let i = 0; i < 400; i++) {
+        new ShadowRealm().evaluate(glue);
+        // Hand the queued completions a turn, so the realms die while their work is pending
+        // instead of only growing the queue.
+        if (i % 100 === 99) await Bun.sleep(0);
+      }
+      console.log("done");
+    `);
+  });
 });


### PR DESCRIPTION
### Problem
- Segfault in `WTF::Vector::takeLast` under `JSFinalizationRegistry::takeDeadHoldingsValue`, from `Bun::runPendingWork` (Sentry BUN-4NCK, BUN-4M46). A `node:vm` context died with a cleanup job posted, and the job ran on its destructed registry.
- Cause: `addPendingWork` handed each ticket to `JSCTaskScheduler`'s own sets, so `DeferredWorkTimer::cancelPendingWork(VM&)`, which cancels dead realms' tickets after each collection, found none.
- The same gap lets `Atomics.notify` wake a dead context's `Atomics.waitAsync`.

### Fix
- oven-sh/WebKit#487 (built against its preview until it lands): the timer keeps every ticket in `m_pendingTickets`, the hooks become notifications, and the embedder calls `takePendingWork()` before it runs a task. Upstream's cancellation applies unchanged.
- Here: `JSCTaskScheduler` loses its sets, lock and shutdown flag. The hooks count the event loop ref of `ImminentlyScheduled` tickets, and `runPendingWork` runs a task only if `takePendingWork()` returns true.
- The ticket's embedder byte records its loop (#39905) and whether it took a ref. A release on the VM's thread goes through the VM, so it lands after the handle has closed. The job reaches the VM through its `JSVMClientData`, not the dead realm.
- Verified: four new `test/js/node/vm/vm.test.ts` tests (registry cleanup, `Atomics.waitAsync` and `WebAssembly.instantiate` in a vm context, `WebAssembly.instantiate` in a ShadowRealm), each segfaults or misfires without the fix.

### Background
- `DeferredWorkTimer` carries native completions (FinalizationRegistry cleanup, wasm compilation, `Atomics.waitAsync`) to the JS thread, one ticket each. Bun's hooks run its tasks from Bun's event loop, not `doWork`.
- Only the realm marks a ticket's target. Upstream cancels the ticket when a collection finds the realm dead, before the sweep destructs the target.
- `~JSGlobalObject` cancels it too, but a `NodeVMGlobalObject` sits in a lazily swept block, so that came after the job ran.

<details><summary>Notes</summary>

The preview sits on the fork's main at c4ddc0cf, which is the pin main already uses (#40677 bumped it), plus the two #487 commits. The three source files #487 touches did not change in any of the pin moves since the first preview (#40276, #40417, #40507, #40570, #40270, #40643, #40681, #40677), so each rebase was a clean cherry-pick. Earlier previews sat on the previous pins (b7f217b4 could not be built: its Dockerfiles still fetched LLVM from apt.llvm.org, which oven-sh/WebKit#480 replaced because it fails).

Rebased onto #39905, which made the scheduler's sets maps from ticket to `BunLoopKind`. That value now lives in the ticket itself (`Ticket::embedderData()`, one byte, added in oven-sh/WebKit#487): `onAddPendingWork` writes it on the JS thread, `onScheduleWorkSoon` reads it on whatever thread schedules the work, and a release from another thread goes through `Bun__VmHandle__refKeepAlive` on that loop. The macro routing tests (`test/regression/issue/39900.test.ts`, `macro-test.test.ts` event loop routing block) pass against the preview.

The first version of this PR kept Bun's sets and walked them from a `HeapObserver` at the end of each collection. That duplicated upstream's walk on Bun's side and needed an extra `WaiterListManager::unregister` step. It was rejected in review. This version fixes the divergence in the fork instead.

The fixture has to get around three things that otherwise hide the bug:

- The first 8 cells of an `IsoSubspace` are precise allocations and are destructed in the epilogue of the collection that kills them. The fixture keeps 8 contexts alive so the context under test lands in a block. The registry inside the context is one of those first cells, so it is destructed as soon as `fullGC()` returns, while its context is not.
- `vm.createContext()` stores the sandbox in a `WeakRef`, which pins it until the turn ends. `releaseWeakRefs()` from `bun:jsc` clears that.
- The structure shared by all `NodeVMGlobalObject`s roots the most recently created one. The fixture creates one more context. Filed separately as #39990. The `uncaughtException` routing of errors reported against a vm context is #39992.

Sizes and tiers: `JSGlobalObject` 3976 bytes, `NodeVMGlobalObject` 4016, `Zig::GlobalObject` 10656, `MarkedSpace::largeCutoff` 8032. Every `Zig::GlobalObject` (the main realm, ShadowRealm, `--isolate` realms) is a precise allocation. A synchronous collection sweeps it, and so runs its `~JSGlobalObject`, before it returns, so `fullGC()` never leaves work queued against a dead realm of that kind. A collection the mutator did not ask for finalizes later, at the mutator's next safepoint, which can come after the queued job ran: the fourth fixture lets allocation pressure collect ShadowRealms with a wasm completion pending, and segfaults at 0xfffffffffffffff9 without the fix.

`Bun.gc(true)` is `collectNow(Sync)`, which sweeps everything before it returns, so the realm's destructor cancels the ticket in time. `fullGC()` from `bun:jsc` is `collectSync`, which does not sweep. `Bun.gc(false)` is `collectAsync`.

Crash addresses on 1.4.0: the registry test faults at 0x18 (4 dead holdings: a destructed `Vector` keeps its size and nulls its buffer, which gives the 0x8 with 2 holdings in BUN-4NCK). The waitAsync test faults at 0xfffffffffffffff9. An unfixed debug build reproduces the BUN-4NCK stack exactly and fails the waitAsync test with `ASSERTION FAILED: !isCancelled() && isTargetObject()`.

With the fork change, a dead context's waiter stays on its list until the context is swept, and a notify in between consumes it without scheduling anything, as in upstream. The fork change relaxes the `WaiterList::takeFirst` assertion that required the waiter's ticket to still be alive. Upstream has the same window after `doWork` purges a cancelled ticket.

Event loop ref accounting: `addPendingWork` adds the ticket to the set and calls `onAddPendingWork` (+1 for `ImminentlyScheduled`, recorded in the ticket's embedder byte, which the release checks, so the two sides always match). The ticket leaves the set exactly once: through a cancellation path, which calls `onCancelPendingWork` only for a ticket that was still in the set, or through `takePendingWork` (`runPendingWork`, or `Bun__deleteDeferredWorkTask` when the teardown releases a queued job unrun). Each of those gives the ref back through `releaseEventLoopRef`, which picks its path by thread: the VM's own thread goes through `Bun__eventLoop__refKeepAlive`, which folds into the platform loop at once and works in any state of the VM handle, so the cancellations `~JSGlobalObject` runs after the handle has closed balance their tickets too. Another thread (a collector thread at the end of a collection) goes through the VM handle on the ticket's loop, which drops the release only once the handle is Closed, and by then the collector thread is gone. That is why the scheduler needs no shutdown flag: a ticket added after the last tick is cancelled with the VM, on its thread, and a post after the last tick is queued and released unrun, or refused (`Bun__discardDeferredWorkTask`, which only frees the job: the ticket stays pending and is cancelled with the VM). A second job posted for the same ticket (`StreamingCompiler` posts an empty one from its destructor) finds the ticket gone and does nothing. `Atomics.waitAsync` tickets are `AtSomePoint` and take no ref.

The gate's fail-before run cannot show this one: the fix lives in the WebKit dependency, which is outside `src/`, and the old scheduler does not compile against the new hook signature. The fail-before evidence is the run against 1.4.0 above.

Suites run against the preview build: `test/js/node/vm/`, `test/js/web/atomics.test.ts`, `test/regression/issue/atomics-waitasync-wtftimer-uaf.test.ts`, `test/js/web/timers/timer-heap-race.test.ts`, `test/js/web/workers/worker-terminate-funnels.test.ts`, `test/js/node/worker_threads/worker_threads.test.ts`, `test/js/web/fetch/wasm-streaming.test.ts`, `test/js/bun/wasm/`, `test/js/bun/jsc/bun-jsc.test.ts`, `test/js/bun/jsc/shadow.test.js`, `test/regression/issue/29519.test.ts`, `test/cli/test/isolation.test.ts`, `test/js/node/test/parallel/test-finalization-registry-shutdown.js`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 13 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->














