### PR TITLE
net(windows): release the named-pipe context when an async connect fails

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -638,6 +638,15 @@ export const socketFaultInjection = {
   /** Disarm all fault rules. */
   clear: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsClearSocketFaults", 0) as () => void,
 };
+
+export const namedPipeInternals = {
+  /**
+   * Live native contexts behind sockets over Windows named pipes: one per
+   * connecting or connected `Bun.connect({ unix: "\\\\.\\pipe\\..." })` socket and
+   * one per accepted pipe client. Always 0 on other platforms.
+   */
+  liveCount: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsNamedPipeContextLiveCount", 0) as () => number,
+};
 type SerializationContext = "worker" | "window" | "postMessage" | "default";
 export const structuredCloneAdvanced: (
   value: any,

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -590,15 +590,16 @@ impl WindowsNamedPipe {
         }
 
         if let Some(err) = status.to_error(bun_sys::Tag::connect) {
-            // On async connect failure the
-            // leaked `Box<uv::Pipe>` was never adopted by `writer.source`
-            // (`start_with_pipe` only runs on the success branch below), so
-            // `on_error → close → writer.end()` is a no-op for it. Reclaim it
-            // here via `discard_unadopted_pipe` (which schedules `uv_close` and
-            // `Box::from_raw`s in the callback), mirroring the synchronous
-            // early-error paths in `connect`/`open`/`get_accepted_by`.
+            // The writer never adopted the pipe (`start_with_pipe` only runs on
+            // the success branch below), so `on_error → close → writer.end()`
+            // has no source to close: it neither frees the pipe nor reports
+            // `on_close`. Do both here. `discard_unadopted_pipe` schedules the
+            // `uv_close` that frees the `Box`, like the synchronous early-error
+            // paths in `connect`/`open`/`get_accepted_by`, and `on_close` is
+            // what makes the owner (`handlers.on_close`) release its ref.
             self.discard_unadopted_pipe();
             self.on_error(err);
+            self.on_close();
             self.deref();
             return;
         }

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -31,8 +31,10 @@ pub struct WindowsNamedPipeContext {
     // Intrusive refcount; on zero → `schedule_deinit` (deferred free), not
     // immediate `Box::from_raw`.
     ref_count: Cell<u32>,
-    // `socket` is deref'd manually in `Drop` before the `named_pipe` field
-    // drops — teardown order must stay socket.deref() then named_pipe deinit.
+    // Holds `create()`'s +1 on the wrapped socket while not `None`. `on_close`
+    // and `fail_connect` release it and clear this; anything still here is
+    // deref'd in `Drop` before the `named_pipe` field drops — teardown order
+    // must stay socket.deref() then named_pipe deinit.
     socket: SocketType,
     /// `pub(super)` so `WindowsNamedPipeListeningContext::on_client_connect`
     /// (sibling module) can call `get_accepted_by` on the freshly-created
@@ -261,12 +263,30 @@ impl WindowsNamedPipeContext {
                 s.handle_error(js_err)
             });
         } else {
-            match_socket!(socket, |s: NewSocket<SSL>| NewSocket::handle_connect_error(
-                s,
-                err.errno as i32,
-                0
-            ));
+            Self::fail_connect(this, err.errno as i32);
         }
+    }
+
+    /// `connectError` is the last event a socket whose connect failed receives:
+    /// `handle_connect_error` releases its connecting ref, and no `on_close`
+    /// follows for it. So this context is done with the socket too: release
+    /// `create()`'s +1 now and forget the socket, so that neither the pipe's
+    /// `on_close` (which still fires on the async failure path) nor `Drop`
+    /// touches it again.
+    fn fail_connect(this: *mut Self, errno: i32) {
+        // SAFETY: see `on_open`. Cleared before `connectError` runs JS, which may
+        // connect the same socket again through a new context.
+        let socket = unsafe {
+            let socket = (*this).socket;
+            (*this).socket = SocketType::None;
+            socket
+        };
+        match_socket!(socket, |s: NewSocket<SSL>| {
+            let failed = NewSocket::handle_connect_error(s, errno, 0);
+            // Release the +1 ref taken in `create()`.
+            s.get().deref();
+            failed
+        });
     }
 
     fn on_timeout(this: *mut Self) {
@@ -327,11 +347,7 @@ impl WindowsNamedPipeContext {
     /// errdefer shared by `open`/`connect`: fail the wrapped JS socket, then
     /// release the only ref `create()` handed us.
     fn fail_and_release(this: *mut Self) {
-        // SAFETY: `this` is live; `create()` returned it and no deref has fired yet.
-        // +1 ref held on the inner socket; live until `Self::deref` below.
-        match_socket!(unsafe { (*this).socket }, |s: NewSocket<SSL>| {
-            NewSocket::handle_connect_error(s, SystemErrno::ENOENT as i32, 0)
-        });
+        Self::fail_connect(this, SystemErrno::ENOENT as i32);
         // SAFETY: `this` was just returned from `create()` (refcount==1);
         // release the only ref on the errdefer path.
         unsafe { Self::deref(this) };

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -1,6 +1,7 @@
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::api::{TCPSocket, TLSSocket};
 use crate::socket::NewSocket;
@@ -18,6 +19,11 @@ use bun_sys::{self, Error as SysError, Fd, SystemErrno};
 use bun_uws::{self as uws, us_bun_verify_error_t};
 
 bun_output::declare_scope!(WindowsNamedPipeContext, visible);
+
+/// Live contexts, read by `bun:internal-for-testing` leak tests: `heapStats()`
+/// only sees the JS wrappers, and a failed connect lets those be collected
+/// while the context (and its ref on the native socket) stays behind.
+pub(crate) static LIVE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = schedule_deinit)]
@@ -403,6 +409,7 @@ impl WindowsNamedPipeContext {
                     .root
                     .set(ptr::addr_of_mut!((*this).named_pipe));
             }
+            LIVE_COUNT.fetch_add(1, Ordering::Relaxed);
 
             // Take a +1 intrusive ref so the wrapped JS socket outlives this context.
             match_socket!(socket, |s: NewSocket<SSL>| {
@@ -491,6 +498,7 @@ impl WindowsNamedPipeContext {
 impl Drop for WindowsNamedPipeContext {
     fn drop(&mut self) {
         bun_output::scoped_log!(WindowsNamedPipeContext, "deinit");
+        LIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
         // Deref the wrapped socket, then let `named_pipe` drop.
         match_socket!(
             core::mem::replace(&mut self.socket, SocketType::None),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5117,6 +5117,21 @@ pub mod testing_apis {
         Ok(JSValue::from(cfg!(socket_fault_injection)))
     }
 
+    /// Live `WindowsNamedPipeContext`s (one per connected or accepted socket
+    /// over a Windows named pipe); always 0 elsewhere.
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_named_pipe_context_live_count(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        #[cfg(windows)]
+        let count = crate::socket::windows_named_pipe_context::LIVE_COUNT
+            .load(core::sync::atomic::Ordering::Relaxed);
+        #[cfg(not(windows))]
+        let count = 0usize;
+        Ok(JSValue::js_number(count as f64))
+    }
+
     #[bun_jsc::host_fn]
     pub(crate) fn js_clear_socket_faults(
         global: &JSGlobalObject,

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1767,6 +1767,99 @@ describe.skipIf(!isWindows)("Bun.connect named-pipe client Handlers lifecycle", 
       signalCode: null,
     });
   });
+
+  // libuv reports a missing pipe from the connect callback, not from
+  // uv_pipe_connect itself. On that path the pipe was never handed to the
+  // writer, so closing the writer reported no close, and the native context
+  // (which holds a ref on the TCPSocket/TLSSocket, and for TLS the SSL_CTX)
+  // stayed alive once per failed attempt.
+  it.concurrent.each([
+    ["plain", "", 0],
+    ["tls", "tls: true,", 1],
+  ])(
+    "a connect that fails asynchronously (%s) releases the native context",
+    async (_name, tlsOption, sslCtxPerAttempt) => {
+      const attempts = 8;
+      const pipePrefix = "\\\\.\\pipe\\bun-test-missing-" + Math.random().toString(36).slice(2) + "-";
+      const src = /* js */ `
+        const { namedPipeInternals, sslCtxLiveCount } = require("bun:internal-for-testing");
+        const contextsBefore = namedPipeInternals.liveCount();
+        const sslCtxBefore = sslCtxLiveCount();
+
+        let connectErrors = 0;
+        let closes = 0;
+        let firstAttempt = null;
+        const outcomes = new Set();
+
+        for (let i = 0; i < ${attempts}; i++) {
+          try {
+            await Bun.connect({
+              unix: ${JSON.stringify(pipePrefix)} + i,
+              ${tlsOption}
+              socket: {
+                data() {},
+                open() {},
+                close() { closes++; },
+                error() {},
+                connectError(_socket, err) {
+                  connectErrors++;
+                  outcomes.add("connectError:" + err.code);
+                  // This attempt's context is still alive while it reports the failure.
+                  firstAttempt ??= {
+                    contexts: namedPipeInternals.liveCount() - contextsBefore,
+                    sslCtx: sslCtxLiveCount() - sslCtxBefore,
+                  };
+                },
+              },
+            });
+            outcomes.add("resolved");
+          } catch (err) {
+            outcomes.add("rejected:" + err.code);
+          }
+        }
+
+        // Finalizing the wrappers must not touch a socket its context already released.
+        Bun.gc(true);
+        // A context frees itself from a task it queues when its last ref drops.
+        for (let i = 0; i < 100 && namedPipeInternals.liveCount() > contextsBefore; i++) {
+          await new Promise(resolve => setImmediate(resolve));
+        }
+
+        console.log(JSON.stringify({
+          connectErrors,
+          closes,
+          outcomes: [...outcomes].sort(),
+          firstAttempt,
+          leaked: {
+            contexts: namedPipeInternals.liveCount() - contextsBefore,
+            sslCtx: sslCtxLiveCount() - sslCtxBefore,
+          },
+        }));
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // If the child died before reporting, the diff shows its raw output.
+      const result = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+      expect({ result, stderr, exitCode }).toEqual({
+        result: {
+          connectErrors: attempts,
+          closes: 0,
+          outcomes: ["connectError:ENOENT", "rejected:ENOENT"],
+          firstAttempt: { contexts: 1, sslCtx: sslCtxPerAttempt },
+          leaked: { contexts: 0, sslCtx: 0 },
+        },
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
 });
 
 it("reload() backs out cleanly when a handler getter closes the socket mid-reload", async () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1001,6 +1001,85 @@ it.if(isWindows)(
   20_000,
 );
 
+// The Windows counterpart of the synchronous-failure test below: a client
+// that polls for a daemon's pipe gets one asynchronous ENOENT per attempt,
+// and each failed attempt used to leave its native pipe context (and the
+// context's ref on the native socket) behind. Runs in a child so the context
+// count starts from zero: the test above leaves connections still closing.
+it.if(isWindows)("should not leak when connect({path}) fails asynchronously while polling for a pipe", async () => {
+  const script = /* js */ `
+    const { createServer, Socket } = require("node:net");
+    const { once } = require("node:events");
+    const { namedPipeInternals } = require("bun:internal-for-testing");
+    const path = "\\\\\\\\.\\\\pipe\\\\bun-test-polling-" + process.pid;
+    const events = [];
+    // Not events.once(): it rejects on the 'error' that precedes each 'close' here.
+    function watch(socket) {
+      socket.on("error", err => events.push("error:" + err.code));
+      socket.on("connect", () => events.push("connect"));
+      return new Promise(resolve => socket.on("close", hadError => (events.push("close:" + hadError), resolve())));
+    }
+
+    for (let i = 0; i < 4; i++) {
+      const socket = new Socket();
+      const closed = watch(socket);
+      socket.connect({ path });
+      await closed;
+    }
+
+    // The daemon shows up: the same path now connects, and that connection closes cleanly on both ends.
+    const serverSideClosed = Promise.withResolvers();
+    const server = createServer(socket => {
+      socket.on("close", serverSideClosed.resolve);
+      socket.end("ready");
+    });
+    server.listen(path);
+    await once(server, "listening");
+    const client = new Socket();
+    const clientClosed = watch(client);
+    client.setEncoding("utf8");
+    let received = "";
+    let contextsWhileConnected = -1;
+    client.on("data", chunk => {
+      received += chunk;
+      // Both ends of the live connection own a context; the failed attempts' contexts must be gone.
+      contextsWhileConnected = namedPipeInternals.liveCount();
+    });
+    client.connect({ path });
+    await clientClosed;
+    await serverSideClosed.promise;
+    server.close();
+
+    // Finalizing the handles must not touch a socket its context already released.
+    Bun.gc(true);
+    // A context frees itself from a task it queues once its pipe has closed.
+    for (let i = 0; i < 100 && namedPipeInternals.liveCount() > 0; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    console.log(JSON.stringify({ events, received, contextsWhileConnected, contextsAtEnd: namedPipeInternals.liveCount() }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // If the child died before reporting, the diff shows its raw output.
+  const result = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+  expect({ result, stderr, exitCode }).toEqual({
+    result: {
+      events: [...Array(4).fill(["error:ENOENT", "close:true"]).flat(), "connect", "close:false"],
+      received: "ready",
+      contextsWhileConnected: 2,
+      contextsAtEnd: 0,
+    },
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 // On Windows, unix paths route through the named-pipe codepath which reports
 // failure asynchronously; this test targets the synchronous-failure branch in
 // Listener.connectInner.


### PR DESCRIPTION
### Problem
- On Windows, a `Bun.connect({ unix: "\\\\.\\pipe\\..." })` or `net.connect(pipePath)` that fails leaks its `WindowsNamedPipeContext`, with the context's ref on the native socket and, for TLS, the `SSL_CTX`. About 1.6 KB per attempt for a client that polls for a daemon's pipe.
- libuv reports the failure from its connect callback. There `on_connect` (`src/runtime/socket/WindowsNamedPipe.rs:592`) runs `on_error`, which closes a writer that never adopted the pipe, so the writer reports no `on_close`. Only `on_close` releases the `create()` ref.

### Fix
- The failure branch of `on_connect` calls `self.on_close()`. That line is the fix.
- `fail_connect`, the context's connect failure path, releases the context's ref on the socket and forgets it. Otherwise the new `on_close` would reach `NewSocket::on_close` and release the socket's own ref a second time. With only the first change, the existing missing-pipe test segfaults at GC.
- Correct because `connectError` is the last event a failed socket gets, on TCP too. Only the context's own refs are left. This also repairs the double release when `start()` fails after a connect.
- Verified on Windows x64: the three new tests in `socket.test.ts` and `node-net.test.ts` fail without the fix (8, 8 and 4 leaked contexts) and pass with it, as do the suites in the notes.

### Background
- `WindowsNamedPipe` adapts a libuv pipe to the uSockets socket interface. Its owner, `WindowsNamedPipeContext`, is refcounted: one ref per connection (`create()` to `on_close`), one per pending connect or write. At zero a queued task frees it.
- The context also holds a ref on the native socket. Either `handle_connect_error` or `NewSocket::on_close` releases the socket's own connecting ref, never both.
- `namedPipeInternals.liveCount()` (`bun:internal-for-testing`) counts live contexts. `heapStats()` cannot see this leak: the JS wrapper of a failed socket is collectable.

<details><summary>Notes</summary>

- Repro on `1.4.0-canary.1+4448a2e21`: 20000 failed plain connects add 31 MB of RSS. With `sslCtxLiveCount()` from `bun:internal-for-testing`, 200 failed `tls: true` connects leave exactly 200 live `SSL_CTX`. The `BUN_DEBUG_WindowsNamedPipeContext=1` repro from the report prints no `deinit` line before the fix and prints `onClose`, `deinit` with it.
- The writer's early return is `BaseWindowsPipeWriter::close` (`src/io/PipeWriter.rs:1140`): with no source there is nothing to close and `on_close_source`, which reports `Parent::on_close`, is not reached. `start_with_pipe` only runs on the success branch of `on_connect`.
- `tls.connect({ path })` reaches the same native path as `Bun.connect({ unix, tls })`, which the `tls` case of the new `socket.test.ts` test covers. TLS does not change the analysis: `close()` calls `SSL_shutdown` on an SSL that never started a handshake, which returns 1 without a close callback (`vendor/boringssl/ssl/ssl_lib.cc:1028`).
- The synchronous failure paths (`FailAndRelease`) were already balanced. They go through `fail_connect` too, so the context releases its socket ref in one place. `Drop` still releases it for a context dropped before either event, such as a failed accept.
- The tests also assert the negative contract: `connectError` once per attempt with `ENOENT`, the promise rejected with `ENOENT`, the `close` handler never called. This is what a failed unix-socket connect does on POSIX. They sample the count while a context must be alive (during the first `connectError`, and while the final connection is established in the `node:net` test), so a hook that returned a constant fails them. The `Bun.gc(true)` before the final count runs the wrappers' finalizers, which is what catches a double release.
- The `node:net` test runs in a child. The named-pipe test before it leaves connections still closing, which moves an in-process baseline.
- Clause check on Windows (debug build): without `self.on_close()` the new tests report leaked contexts. Without `fail_connect` the new tests and the existing one exit with code 3 ("Segmentation fault at address 0xFFFFFFFFFFFFFFFF", debug builds poison freed blocks). With both, each new test passed 5 of 5 runs.
- Suites run on Windows with the fix (debug build): `test/js/bun/net/socket.test.ts` (87 pass, 9 skip), `test/js/node/net/node-net.test.ts` (80 pass, 4 skip), `node-net-server.test.ts`, `node-net-allowHalfOpen.test.js`, `named-pipe-listen-error.test.ts`, `node-tls-namedpipes.test.ts` (6 pass; its 400-handshake test needs a timeout above the 5 s default on a debug build, with and without this change, as #39983 also notes), `test/js/node/cluster.test.ts`. On Linux the new tests skip and `namedPipeInternals.liveCount()` returns 0. `cargo check -p bun_runtime` passes for the host and for `x86_64-pc-windows-msvc`.
- Related, not overlapping: #39983 keeps the context alive across read callbacks. Both PRs touch `WindowsNamedPipe.rs` in different functions and merge without conflicts. Its guard in `on_error` runs while this path still holds the connect ref, so the refs stay balanced with both applied. Checked on Windows x64 with both branches merged (debug build): the 6 named-pipe tests in `socket.test.ts` (2 from #39983, 2 from this PR, 2 existing) and the 2 pipe tests in `node-net.test.ts` pass. `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes on the merge too.
- Pre-existing and unchanged: when `start()` fails inside `WindowsNamedPipeContext::open` (for example `uv_read_start` on a write-only pipe fd), `open` still returns the `named_pipe` pointer and `Listener` stores it in a socket whose context has released itself. This change balances the refs on that path but does not touch the caller.

</details>
