### PR TITLE
inspector: build the debugger VM from a copy of the debuggee's environment

### DIFF
--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -174,7 +174,8 @@ unsafe extern "C" {
 static FUTEX_ATOMIC: AtomicU32 = AtomicU32::new(0);
 static HAS_CREATED_DEBUGGER: AtomicBool = AtomicBool::new(false);
 
-/// What the debugger thread takes from the debuggee VM's thread.
+/// What [`Debugger::start`] takes from the debuggee VM's thread. The copy of
+/// the debuggee's environment travels next to it and is used up by the VM setup.
 struct DebuggerThreadInit {
     debuggee: crate::VmHandle,
     ctx_id: u32,
@@ -395,6 +396,9 @@ impl Debugger {
             this_ref.as_mut().has_started_debugger = true;
             // Everything the debugger thread needs from this VM, copied here;
             // it reaches back only through the (uncounted) handle to wake us.
+            // That includes the environment: the debugger VM builds its
+            // `process.env` from this copy, not from this thread's loader.
+            let env_map = this_ref.env_loader().map.clone_with_allocator()?;
             let init = DebuggerThreadInit {
                 debuggee: this_ref.handle(),
                 ctx_id: dbg.script_execution_context_id,
@@ -409,7 +413,7 @@ impl Debugger {
             std::thread::Builder::new()
                 .name("Debugger".to_string())
                 .stack_size(16 * 1024 * 1024)
-                .spawn(move || Debugger::start_js_debugger_thread(init))
+                .spawn(move || Debugger::start_js_debugger_thread(env_map, init))
                 .map_err(|_| crate::CrateError::ThreadSpawnFailed)?;
             // The `JoinHandle` is dropped here, detaching the thread.
         }
@@ -424,17 +428,24 @@ impl Debugger {
         Ok(())
     }
 
-    /// Debugger-thread entry: build a second `VirtualMachine`, hold the API
-    /// lock, and run [`Debugger::start`] inside it.
-    fn start_js_debugger_thread(init: DebuggerThreadInit) {
-        // The global allocator is mimalloc and `InitOptions` does not carry
-        // `allocator`/`env_loader` (those are wired by
-        // `RuntimeHooks::init_runtime_state`).
+    /// Debugger-thread entry: build a second `VirtualMachine` on the
+    /// debuggee's copied environment, hold the API lock, and run
+    /// [`Debugger::start`] inside it.
+    ///
+    /// The VM only evaluates built-in modules, so `env_map` is the whole of
+    /// its environment setup: `Transpiler::configure_defines` is not run here.
+    /// It would reload the `.env` files and JSON-parse `NODE_ENV`, and its
+    /// failure (say a stray `\r` in `NODE_ENV`) would abort the debuggee.
+    fn start_js_debugger_thread(env_map: bun_dotenv::Map, init: DebuggerThreadInit) {
         bun_core::Output::Source::configure_named_thread(bun_core::zstr!("Debugger"));
         bun_core::scoped_log!(debugger, "startJSDebuggerThread");
         jsc::mark_binding();
 
         let vm_ptr = VirtualMachine::init(crate::virtual_machine::InitOptions {
+            // Lives as long as the VM, which this thread never tears down.
+            env_loader: Some(bun_core::heap::alloc_nn(bun_dotenv::Loader::init_with_map(
+                env_map,
+            ))),
             is_main_thread: false,
             ..Default::default()
         })
@@ -442,10 +453,6 @@ impl Debugger {
         let _ = vm_ptr;
         // `init` installs the freshly-boxed VM as this thread's singleton.
         let vm = VirtualMachine::get().as_mut();
-
-        vm.transpiler
-            .configure_defines()
-            .unwrap_or_else(|_| panic!("Failed to configure defines"));
         vm.is_main_thread = false;
         vm.event_loop_mut().ensure_waker();
 

--- a/test/regression/issue/test_env_loader_threading.test.ts
+++ b/test/regression/issue/test_env_loader_threading.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 test("env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO", async () => {
   await using dir = tempDir("env-loader-threading", {
@@ -56,3 +57,162 @@ test("env_loader should not have allocator threading issues with BUN_INSPECT_CON
   expect(inspectorStderr).not.toContain("thread");
   expect(inspectorStderr).not.toContain("assertion failed");
 }, 10000); // 10 second timeout for potential debugger connection attempts
+
+// The debugger thread's VM (start_js_debugger_thread in src/jsc/Debugger.rs) must take the main VM's
+// environment as it is: not parse it again (the define setup JSON-parses NODE_ENV and fails on a value
+// that is not valid JSON) and not load .env files of its own into the process.
+//
+// Once that VM is up, the debugger thread connects to BUN_INSPECT_NOTIFY (src/js/internal/debugger.ts)
+// through its own process.env. The fixtures wait for stdin, which is closed after that notification,
+// so what they print was observed after the debugger thread finished its setup. A debugger thread
+// that aborts takes the process down before the notification instead.
+async function runUnderInspector(cmd: string[], cwd: string, env: Record<string, string | undefined>) {
+  const { promise: notified, resolve: onNotified } = Promise.withResolvers<string>();
+  using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data: (_socket, payload) => onNotified(payload.toString()),
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...cmd],
+    cwd,
+    env: { ...bunEnv, ...env, BUN_INSPECT_NOTIFY: `tcp://127.0.0.1:${listener.port}` },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = Promise.all([proc.stdout.text(), proc.stderr.text()]);
+
+  const notifiedOrExited = await Promise.race([notified, proc.exited]);
+  proc.stdin.end();
+  const [stdout, stderr] = await output;
+  const exitCode = await proc.exited;
+  return {
+    notification: typeof notifiedOrExited === "string" ? notifiedOrExited : null,
+    // Only the fixture itself prints JSON; `bun test` adds its own report around it.
+    report: stdout
+      .split("\n")
+      .filter(line => line.startsWith("{"))
+      .map(line => JSON.parse(line)),
+    exitCode,
+    signalCode: proc.signalCode,
+    stderrIfFailed: exitCode === 0 ? "" : stderr,
+  };
+}
+
+// Neither value survives being wrapped in double quotes and parsed as JSON. The first one is what a
+// CRLF env file leaves behind when the tool that launched bun does not strip the \r.
+const invalidNodeEnvs: [variable: string, value: string][] = [
+  ["NODE_ENV", "development\r"],
+  ["BUN_ENV", "test\\"],
+];
+
+test.concurrent.each(invalidNodeEnvs)(
+  "--inspect starts when %s holds a value that is not valid JSON",
+  async (variable, value) => {
+    using dir = tempDir("debugger-thread-invalid-node-env", {
+      "fixture.ts": `
+        await Bun.stdin.text();
+        console.log(JSON.stringify({ [${JSON.stringify(variable)}]: process.env[${JSON.stringify(variable)}] }));
+      `,
+    });
+
+    const result = await runUnderInspector(["--inspect=127.0.0.1:0", "fixture.ts"], String(dir), {
+      NODE_ENV: undefined,
+      BUN_ENV: undefined,
+      [variable]: value,
+    });
+    expect(result).toEqual({
+      notification: "1",
+      report: [{ [variable]: value }],
+      exitCode: 0,
+      signalCode: null,
+      stderrIfFailed: "",
+    });
+  },
+);
+
+test.concurrent.each(invalidNodeEnvs)(
+  "inspector.open() starts when %s holds a value that is not valid JSON",
+  async (variable, value) => {
+    using dir = tempDir("debugger-thread-invalid-node-env-open", {
+      "fixture.ts": `
+        import inspector from "node:inspector";
+        // Returns once the debugger thread reports its server as listening.
+        inspector.open(0, "127.0.0.1");
+        console.log(JSON.stringify({ url: typeof inspector.url(), [${JSON.stringify(variable)}]: process.env[${JSON.stringify(variable)}] }));
+        inspector.close();
+      `,
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, [variable]: value },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode, signalCode: proc.signalCode, stderrIfFailed: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: JSON.stringify({ url: "string", [variable]: value }) + "\n",
+      exitCode: 0,
+      signalCode: null,
+      stderrIfFailed: "",
+    });
+    expect(stderr).toContain("Debugger listening on ws://127.0.0.1:");
+  },
+);
+
+// `bun test` loads .env.test* and .env, never .env.local or .env.development, whatever NODE_ENV says.
+// A debugger thread that picks .env files from NODE_ENV=development on its own adds the other two.
+// Children get their environment from the env map (Bun.spawn), not from the process.env object, so
+// the grandchild shows the map's state no matter when process.env was materialized.
+test.concurrent("the debugger thread does not load .env files into a bun test process", async () => {
+  const keys = ["FROM_ENV", "FROM_ENV_LOCAL", "FROM_ENV_DEVELOPMENT"];
+  using dir = tempDir("debugger-thread-bun-test-dotenv", {
+    "project/.env": "FROM_ENV=1\n",
+    "project/.env.local": "FROM_ENV_LOCAL=1\n",
+    "project/.env.development": "FROM_ENV_DEVELOPMENT=1\n",
+    "project/env.test.ts": `
+      import { test } from "bun:test";
+      import { dirname } from "node:path";
+
+      const keys = ${JSON.stringify(keys)};
+      const pick = (env: Record<string, string | undefined>) =>
+        Object.fromEntries(keys.map(key => [key, env[key] ?? null]));
+
+      test("report the environment", async () => {
+        await Bun.stdin.text();
+        // The parent directory holds no .env files, so the child can only inherit these.
+        const child = Bun.spawnSync({
+          cmd: [process.execPath, "-e", "console.log(JSON.stringify(process.env))"],
+          cwd: dirname(import.meta.dir),
+        });
+        console.log(
+          JSON.stringify({ processEnv: pick(process.env), childEnv: pick(JSON.parse(child.stdout.toString())) }),
+        );
+      });
+    `,
+  });
+
+  const result = await runUnderInspector(
+    ["test", "--inspect=127.0.0.1:0", "./env.test.ts"],
+    join(String(dir), "project"),
+    {
+      NODE_ENV: "development",
+      BUN_ENV: undefined,
+      ...Object.fromEntries(keys.map(key => [key, undefined])),
+    },
+  );
+  const loadedByBunTest = { FROM_ENV: "1", FROM_ENV_LOCAL: null, FROM_ENV_DEVELOPMENT: null };
+  expect(result).toEqual({
+    notification: "1",
+    report: [{ processEnv: loadedByBunTest, childEnv: loadedByBunTest }],
+    exitCode: 0,
+    signalCode: null,
+    stderrIfFailed: "",
+  });
+});


### PR DESCRIPTION
### Problem
- With the inspector on, a `NODE_ENV` or `BUN_ENV` value that is not valid JSON once quoted (a stray `\r`, say) aborts the process: `panic: Failed to configure defines` on the debugger thread (Sentry BUN-4NKY, 1.4.0, `bun test` on macOS).
- Cause: `start_js_debugger_thread` (`src/jsc/Debugger.rs:446`) ran `configure_defines()` on the debugger VM's transpiler. With that transpiler's bundler defaults, `load_defines` JSON-parses the quoted `NODE_ENV` (`src/bundler/options.rs:888`). The main VM uses `LoadAllWithoutInlining`, which skips that parse.
- The debugger VM also shared the main VM's env loader, so the same call loaded `.env` files into the main VM. With `NODE_ENV=development`, `bun test --inspect` gets `.env.local` into `process.env` and into its children.

### Fix
- `Debugger::create` copies the main VM's env map. The debugger thread builds its VM on a `Loader` holding that copy, as worker VMs do, and skips `configure_defines()`.
- Correct because that VM only evaluates precompiled built-in modules, which never use the define table. Its one environment read, `BUN_INSPECT_NOTIFY`, comes from the copy.
- The panic site is gone. The copy can only fail on allocation, which takes the existing `create()` error path.
- Verified: `test/regression/issue/test_env_loader_threading.test.ts`, 5 new cases, all failing unfixed (4 abort, 1 shows the leaked variables). Also `test/js/node/inspector/` and `test/cli/inspect/`.

### Background
- Debugger thread: the inspector server runs on a second `VirtualMachine` on its own thread.
- Env loader: a VM's map of environment variables, from the process environment plus `.env` files. `process.env` and `Bun.spawn` read it. A VM created without one shares the main VM's.
- `configure_defines()` fills that map and builds the define table, which includes a JSON-parsed `process.env.NODE_ENV` unless the env behavior is `LoadAllWithoutInlining`.

<details><summary>Notes</summary>

Repro on the release binary, either of:

```
NODE_ENV=$'development\r' bun --inspect=127.0.0.1:0 script.ts
BUN_ENV='test\' bun -e 'require("node:inspector").open(0, "127.0.0.1")'
```

Entry points: `--inspect` and friends, `BUN_INSPECT` / `BUN_INSPECT_CONNECT_TO`, and `inspector.open()` all start the thread through `Debugger::create`, so one site covers them. The new tests run `--inspect` and `inspector.open()`. The existing test in the file runs `BUN_INSPECT_CONNECT_TO`.

Relation to #37775: that PR gives the debugger VM a fresh loader in `disable` mode and keeps the `configure_defines()` call. `disable` skips `copy_env_for_define` but still reaches the `NODE_ENV` parse (`options.rs:887`). Proof on the release binary, which uses `disable` for `Bun.Transpiler`: `NODE_ENV=$'development\r' bun -e 'new Bun.Transpiler()'` throws `SyntaxError Failed to load define`. So the debugger thread in #37775 still aborts on these values. This PR supersedes it and also covers what it fixed: the debugger thread opens no `.env` file, so an unreadable one cannot abort it, and `--env-file` exclusions hold because the copy is taken after the main VM finished its own loading. One difference: the debugger VM sees everything the main VM loaded, `.env` files included, instead of `environ` read again on the debugger thread. Nothing reads `environ` or the cwd from the debugger thread any more.

The copy is taken on the debuggee thread, the only thread that writes that map, so it needs no lock. `DebuggerThreadInit` already exists for this purpose: everything the thread needs is copied before it starts. The loader is never freed, like the debugger VM itself and the per-VM `Log` that `VirtualMachine::init` allocates.

Modules the debugger VM loads: `internal/debugger`, `internal/inspector/cdp`, `node:path`, `node:url`. All come from the internal module registry.

Leak repro on the release binary: a directory with `.env.local` holding `X=1`, a test that prints `process.env.X`, then `NODE_ENV=development bun test --inspect=127.0.0.1:0`. Prints `1`. Without `--inspect` it prints `undefined`. `bun test` picks the `.env.test*` set through `rewrite_jest_for_tests`. The debugger VM's transpiler picked its set from `NODE_ENV`, so it added `.env.local` and `.env.development`.

History: #22206 gave the Zig debugger thread a fresh loader of its own. The Rust port fell back to the shared one. Both ran `configure_defines` on it, so the `NODE_ENV` abort predates the port.

Consumers of the skipped step: `defines_loaded` is read by `configure_defines` itself and by `BundleOptions::for_worker` (bundler parse workers, reached only from a build, which the debugger VM never runs). `from_api` leaves `options.define` as a valid empty table.

Test notes: the fixtures wait on stdin, and the test closes it once the debugger thread has connected to `BUN_INSPECT_NOTIFY`, so the order is fixed without timers. The notification itself checks that the copied environment reaches the debugger VM's `process.env`. The grandchild in the `bun test` case gets its environment from the env map through `Bun.spawn`, so it shows the map no matter when `process.env` was materialized. 5 runs in a row at 6/6, about 4.8 s per run on a debug ASAN build.

`test/cli/inspect/inspect.test.ts`: the 16 `websocket > bun --inspect...localhost` cases fail in this container with the unmodified release binary as well (localhost resolution). The other 31 tests in the directory pass.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/regression/issue/test_env_loader_threading.test.ts
bun test v1.4.0 (6e906e468)

test/regression/issue/test_env_loader_threading.test.ts:
(pass) env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO [589.82ms]
206 |       BUN_ENV: undefined,
207 |       ...Object.fromEntries(keys.map(key => [key, undefined])),
208 |     },
209 |   );
210 |   const loadedByBunTest = { FROM_ENV: "1", FROM_ENV_LOCAL: null, FROM_ENV_DEVELOPMENT: null };
211 |   expect(result).toEqual({
                       ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "notification": "1",
    "report": [
      {
        "childEnv": {
          "FROM_ENV": "1",
-         "FROM_ENV_DEVELOPMENT": null,
-         "FROM_ENV_LOCAL": null,
+         "FROM_ENV_DEVELOPMENT": "1",
+         "FROM_ENV_LOCAL": "1",
        },
        "processEnv": {
          "FROM_ENV": "1",
-         "FROM_ENV_DEVELOPMENT": null,
-         "FROM_ENV_LOCAL": null,
+         "FROM_ENV_DEVELOPMENT": "1",
+         "FROM_ENV_LOCAL": "1",
      
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/regression/issue/test_env_loader_threading.test.ts:
(pass) env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO [14.29ms]
206 |       BUN_ENV: undefined,
207 |       ...Object.fromEntries(keys.map(key => [key, undefined])),
208 |     },
209 |   );
210 |   const loadedByBunTest = { FROM_ENV: "1", FROM_ENV_LOCAL: null, FROM_ENV_DEVELOPMENT: null };
211 |   expect(result).toEqual({
                       ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "notification": "1",
    "report": [
      {
        "childEnv": {
          "FROM_ENV": "1",
-         "FROM_ENV_DEVELOPMENT": null,
-         "FROM_ENV_LOCAL": null,
+         "FROM_ENV_DEVELOPMENT": "1",
+         "FROM_ENV_LOCAL": "1",
        },
        "processEnv": {
          "FROM_ENV": "1",
-         "FROM_ENV_DEVELOPMENT": null,
-         "FROM_ENV_LOCAL": null,
+         "FROM_ENV_DEVELOPMENT": "1",
+         "FROM_ENV_LOCAL": "1",
        },
      },
    ],
    "signalCode": null,
    "stderrIfFailed": "",
  }

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/regression/issue/test_env_load
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/regression/issue/test_env_loader_threading.test.ts
bun test v1.4.0 (6e906e468)

test/regression/issue/test_env_loader_threading.test.ts:
(pass) env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO [623.97ms]
(pass) --inspect starts when NODE_ENV holds a value that is not valid JSON [529.71ms]
(pass) --inspect starts when BUN_ENV holds a value that is not valid JSON [506.57ms]
(pass) the debugger thread does not load .env files into a bun test process [922.03ms]
(pass) inspector.open() starts when BUN_ENV holds a value that is not valid JSON [1708.59ms]
(pass) inspector.open() starts when NODE_ENV holds a value that is not valid JSON [2153.57ms]

 6 pass
 0 fail
 15 expect() calls
Ran 6 tests across 1 file. [5.17s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     22ea939793
  features     baseline

23 deps, 129 codegen, 1172 objects in 863ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [3.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[5/1244] gen bindgenv2
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] esbuild bun-error

  ../../build/release/codegen/bun-error/index.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/Debugger.rs                                |  31 ++--
 .../issue/test_env_loader_threading.test.ts        | 162 ++++++++++++++++++++-
 2 files changed, 180 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/Debugger.rs                                          7      7      0
test/regression/issue/test_env_loader_threading.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->