### PR TITLE
node: tls v26 compat: engine validation, keepalive delay units, reinitialize handle, setMaxSendFragment, cleared timer _idleTimeout (+7 tests)

### DIFF
--- a/src/js/internal/test/binding.ts
+++ b/src/js/internal/test/binding.ts
@@ -92,13 +92,10 @@ function internalBinding(name: string) {
       return { TCP: TestTCPWrap, constants: { SOCKET: 0, SERVER: 1 } };
     case "util":
       return { isInsideNodeModules };
-    // Vendored tls engine tests construct binding.SecureContext (or replace it)
-    // before requiring node:tls; Bun's SecureContext class is the equivalent
-    // native surface.
+    // The engine tests construct or replace binding.SecureContext before requiring node:tls.
     case "crypto":
       return { SecureContext: require("node:tls").SecureContext };
-    // BoringSSL does not compile in OpenSSL's SSL_trace(), so a Node built
-    // against it reports HAVE_SSL_TRACE = false; --trace-tls tests skip.
+    // BoringSSL has no SSL_trace(), the same as a node built without it.
     case "tls_wrap":
       return { HAVE_SSL_TRACE: false };
     case "cares_wrap":

--- a/src/js/internal/test/binding.ts
+++ b/src/js/internal/test/binding.ts
@@ -92,6 +92,15 @@ function internalBinding(name: string) {
       return { TCP: TestTCPWrap, constants: { SOCKET: 0, SERVER: 1 } };
     case "util":
       return { isInsideNodeModules };
+    // Vendored tls engine tests construct binding.SecureContext (or replace it)
+    // before requiring node:tls; Bun's SecureContext class is the equivalent
+    // native surface.
+    case "crypto":
+      return { SecureContext: require("node:tls").SecureContext };
+    // BoringSSL does not compile in OpenSSL's SSL_trace(), so a Node built
+    // against it reports HAVE_SSL_TRACE = false; --trace-tls tests skip.
+    case "tls_wrap":
+      return { HAVE_SSL_TRACE: false };
     case "cares_wrap":
       // Only the pure IP-normalizer the vendored tls/dns tests reach for; the
       // resolver surface lives in node:dns.

--- a/src/js/internal/timers.ts
+++ b/src/js/internal/timers.ts
@@ -23,6 +23,7 @@ function getTimerDuration(msecs, name) {
 }
 
 export default {
+  TIMEOUT_MAX,
   // For hiding Timeouts on other internals. A registered symbol so the node
   // test harness's --expose-internals shim ("internal/timers" virtual module
   // in test/js/node/test/common/index.js) can hand the same symbol to ported

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -140,6 +140,13 @@ const kSetTOS = Symbol("kSetTOS");
 const kSetKeepAlive = Symbol("kSetKeepAlive");
 const kSyncWriteFd = Symbol("kSyncWriteFd");
 const kSetKeepAliveInitialDelay = Symbol("kSetKeepAliveInitialDelay");
+
+// The keepalive delay is stored in whole seconds, as node does for libuv. Bun's
+// native setKeepAlive takes an int32 of milliseconds, so convert at the call
+// and clamp: node never rejects a large delay, it passes the seconds on.
+function keepAliveDelayMs(seconds) {
+  return MathMin(seconds * 1000, 2147483647);
+}
 const kConnectOptions = Symbol("connect-options");
 const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
@@ -503,7 +510,7 @@ const SocketHandlers: SocketHandler = {
     }
 
     if (self[kSetKeepAlive]) {
-      socket.setKeepAlive(true, self[kSetKeepAliveInitialDelay] * 1000);
+      socket.setKeepAlive(true, keepAliveDelayMs(self[kSetKeepAliveInitialDelay]));
     }
 
     // A TOS value set before the connection existed (setTypeOfService before
@@ -1216,7 +1223,7 @@ function onconnection(err, clientHandle) {
   if (self.keepAlive && clientHandle.setKeepAlive) {
     _socket[kSetKeepAlive] = true;
     _socket[kSetKeepAliveInitialDelay] = self.keepAliveInitialDelay;
-    clientHandle.setKeepAlive(true, self.keepAliveInitialDelay * 1000);
+    clientHandle.setKeepAlive(true, keepAliveDelayMs(self.keepAliveInitialDelay));
   }
 
   self._connections++;
@@ -1585,8 +1592,8 @@ function Socket(options?) {
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
-  // Node stores whole seconds here (libuv's unit); call sites convert back to
-  // milliseconds for Bun's native _handle.setKeepAlive.
+  // Node stores whole seconds here (libuv's unit); keepAliveDelayMs converts
+  // for Bun's native _handle.setKeepAlive.
   this[kSetKeepAliveInitialDelay] = MathMax(0, ~~(keepAliveInitialDelay / 1000));
 
   this[khandlers] = SocketHandlers2;
@@ -1873,7 +1880,7 @@ Socket.prototype[kAttach] = function (port, socket) {
   }
 
   if (this[kSetKeepAlive]) {
-    socket.setKeepAlive(true, this[kSetKeepAliveInitialDelay] * 1000);
+    socket.setKeepAlive(true, keepAliveDelayMs(this[kSetKeepAliveInitialDelay]));
   }
 
   if (!this[kupgraded]) {
@@ -2596,8 +2603,8 @@ Socket.prototype.resetAndDestroy = function resetAndDestroy() {
 Socket.prototype.setKeepAlive = function setKeepAlive(enable = false, initialDelayMsecs = 0) {
   enable = Boolean(enable);
   // Node truncates to whole seconds (libuv's TCP_KEEPIDLE unit) and stores
-  // seconds in kSetKeepAliveInitialDelay; Bun's native setKeepAlive takes
-  // milliseconds, so call sites convert back with * 1000.
+  // seconds in kSetKeepAliveInitialDelay; keepAliveDelayMs converts for the
+  // native call.
   const initialDelay = MathMax(0, ~~(initialDelayMsecs / 1000));
 
   if (!this._handle) {
@@ -2611,7 +2618,7 @@ Socket.prototype.setKeepAlive = function setKeepAlive(enable = false, initialDel
   if (enable !== this[kSetKeepAlive] || (enable && this[kSetKeepAliveInitialDelay] !== initialDelay)) {
     this[kSetKeepAlive] = enable;
     this[kSetKeepAliveInitialDelay] = initialDelay;
-    this._handle.setKeepAlive(enable, initialDelay * 1000);
+    this._handle.setKeepAlive(enable, keepAliveDelayMs(initialDelay));
   }
   return this;
 };
@@ -3382,7 +3389,7 @@ function afterConnect(status, handle, req, readable, writable) {
     }
 
     if (self[kSetKeepAlive] && self._handle.setKeepAlive) {
-      self._handle.setKeepAlive(true, self[kSetKeepAliveInitialDelay] * 1000);
+      self._handle.setKeepAlive(true, keepAliveDelayMs(self[kSetKeepAliveInitialDelay]));
     }
 
     self.emit("connect");

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -503,7 +503,7 @@ const SocketHandlers: SocketHandler = {
     }
 
     if (self[kSetKeepAlive]) {
-      socket.setKeepAlive(true, self[kSetKeepAliveInitialDelay]);
+      socket.setKeepAlive(true, self[kSetKeepAliveInitialDelay] * 1000);
     }
 
     // A TOS value set before the connection existed (setTypeOfService before
@@ -1216,7 +1216,7 @@ function onconnection(err, clientHandle) {
   if (self.keepAlive && clientHandle.setKeepAlive) {
     _socket[kSetKeepAlive] = true;
     _socket[kSetKeepAliveInitialDelay] = self.keepAliveInitialDelay;
-    clientHandle.setKeepAlive(true, self.keepAliveInitialDelay);
+    clientHandle.setKeepAlive(true, self.keepAliveInitialDelay * 1000);
   }
 
   self._connections++;
@@ -1585,9 +1585,9 @@ function Socket(options?) {
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
-  // Bun's native _handle.setKeepAlive takes milliseconds (it is the public
-  // Bun.Socket), so store ms here. Node stores seconds because libuv does.
-  this[kSetKeepAliveInitialDelay] = MathMax(0, ~~keepAliveInitialDelay);
+  // Node stores whole seconds here (libuv's unit); call sites convert back to
+  // milliseconds for Bun's native _handle.setKeepAlive.
+  this[kSetKeepAliveInitialDelay] = MathMax(0, ~~(keepAliveInitialDelay / 1000));
 
   this[khandlers] = SocketHandlers2;
   this.bytesRead = 0;
@@ -1873,7 +1873,7 @@ Socket.prototype[kAttach] = function (port, socket) {
   }
 
   if (this[kSetKeepAlive]) {
-    socket.setKeepAlive(true, this[kSetKeepAliveInitialDelay]);
+    socket.setKeepAlive(true, this[kSetKeepAliveInitialDelay] * 1000);
   }
 
   if (!this[kupgraded]) {
@@ -2149,7 +2149,10 @@ Socket.prototype.connect = function connect(...args) {
 Socket.prototype[kReinitializeHandle] = function reinitializeHandle(handle) {
   this._handle?.close();
 
-  this._handle = handle;
+  // Node's TLSSocket override creates the replacement handle itself when none
+  // is passed (net.Socket's version requires one); Bun's TLS sockets share
+  // this method, so default it here for both flavors.
+  this._handle = handle ?? newDetachedSocket(typeof this[bunTlsSymbol] === "function");
   this._handle[owner_symbol] = this;
 
   initSocketHandle(this);
@@ -2592,10 +2595,10 @@ Socket.prototype.resetAndDestroy = function resetAndDestroy() {
 
 Socket.prototype.setKeepAlive = function setKeepAlive(enable = false, initialDelayMsecs = 0) {
   enable = Boolean(enable);
-  // Bun's native _handle.setKeepAlive takes milliseconds; the ms→seconds
-  // conversion for TCP_KEEPIDLE lives in the native binding. Clamp to 0 so
-  // negatives and ~~ overflow match Node's no-validate behavior.
-  const initialDelay = MathMax(0, ~~initialDelayMsecs);
+  // Node truncates to whole seconds (libuv's TCP_KEEPIDLE unit) and stores
+  // seconds in kSetKeepAliveInitialDelay; Bun's native setKeepAlive takes
+  // milliseconds, so call sites convert back with * 1000.
+  const initialDelay = MathMax(0, ~~(initialDelayMsecs / 1000));
 
   if (!this._handle) {
     this[kSetKeepAlive] = enable;
@@ -2608,7 +2611,7 @@ Socket.prototype.setKeepAlive = function setKeepAlive(enable = false, initialDel
   if (enable !== this[kSetKeepAlive] || (enable && this[kSetKeepAliveInitialDelay] !== initialDelay)) {
     this[kSetKeepAlive] = enable;
     this[kSetKeepAliveInitialDelay] = initialDelay;
-    this._handle.setKeepAlive(enable, initialDelay);
+    this._handle.setKeepAlive(enable, initialDelay * 1000);
   }
   return this;
 };
@@ -3379,7 +3382,7 @@ function afterConnect(status, handle, req, readable, writable) {
     }
 
     if (self[kSetKeepAlive] && self._handle.setKeepAlive) {
-      self._handle.setKeepAlive(true, self[kSetKeepAliveInitialDelay]);
+      self._handle.setKeepAlive(true, self[kSetKeepAliveInitialDelay] * 1000);
     }
 
     self.emit("connect");
@@ -3522,7 +3525,7 @@ function Server(options?, connectionListener?) {
   // https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/net.js#L1880
   this.allowHalfOpen = allowHalfOpen;
   this.keepAlive = Boolean(keepAlive);
-  this.keepAliveInitialDelay = MathMax(0, ~~keepAliveInitialDelay);
+  this.keepAliveInitialDelay = MathMax(0, ~~(keepAliveInitialDelay / 1000));
   this.highWaterMark = highWaterMark;
   this.pauseOnConnect = Boolean(pauseOnConnect);
   this.noDelay = Boolean(noDelay);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -141,9 +141,7 @@ const kSetKeepAlive = Symbol("kSetKeepAlive");
 const kSyncWriteFd = Symbol("kSyncWriteFd");
 const kSetKeepAliveInitialDelay = Symbol("kSetKeepAliveInitialDelay");
 
-// The keepalive delay is stored in whole seconds, as node does for libuv. Bun's
-// native setKeepAlive takes an int32 of milliseconds, so convert at the call
-// and clamp: node never rejects a large delay, it passes the seconds on.
+// The delay is stored in whole seconds like node; the native handle takes int32 milliseconds.
 function keepAliveDelayMs(seconds) {
   return MathMin(seconds * 1000, 2147483647);
 }
@@ -1592,8 +1590,7 @@ function Socket(options?) {
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
-  // Node stores whole seconds here (libuv's unit); keepAliveDelayMs converts
-  // for Bun's native _handle.setKeepAlive.
+  // Whole seconds, as in node.
   this[kSetKeepAliveInitialDelay] = MathMax(0, ~~(keepAliveInitialDelay / 1000));
 
   this[khandlers] = SocketHandlers2;
@@ -2156,9 +2153,7 @@ Socket.prototype.connect = function connect(...args) {
 Socket.prototype[kReinitializeHandle] = function reinitializeHandle(handle) {
   this._handle?.close();
 
-  // Node's TLSSocket override creates the replacement handle itself when none
-  // is passed (net.Socket's version requires one); Bun's TLS sockets share
-  // this method, so default it here for both flavors.
+  // node's TLSSocket override creates the handle itself; Bun's TLS sockets share this method.
   this._handle = handle ?? newDetachedSocket(typeof this[bunTlsSymbol] === "function");
   this._handle[owner_symbol] = this;
 
@@ -2602,9 +2597,7 @@ Socket.prototype.resetAndDestroy = function resetAndDestroy() {
 
 Socket.prototype.setKeepAlive = function setKeepAlive(enable = false, initialDelayMsecs = 0) {
   enable = Boolean(enable);
-  // Node truncates to whole seconds (libuv's TCP_KEEPIDLE unit) and stores
-  // seconds in kSetKeepAliveInitialDelay; keepAliveDelayMs converts for the
-  // native call.
+  // Whole seconds, as in node.
   const initialDelay = MathMax(0, ~~(initialDelayMsecs / 1000));
 
   if (!this._handle) {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -200,10 +200,13 @@ const SUPPORTED_ECDH_GROUPS = new Set([
 function validateSecureContextOptions(options) {
   const {
     ciphers,
+    key,
     passphrase,
     ecdhCurve,
     minVersion,
     maxVersion,
+    privateKeyIdentifier,
+    privateKeyEngine,
     sessionTimeout,
     sigalgs,
     ticketKeys,
@@ -217,6 +220,30 @@ function validateSecureContextOptions(options) {
   if (sigalgs !== undefined && sigalgs !== null) {
     validateString(sigalgs, "options.sigalgs");
     if (sigalgs === "") throw $ERR_INVALID_ARG_VALUE("options.sigalgs", sigalgs);
+  }
+  // BoringSSL has no OpenSSL ENGINE support, so engine-backed keys fail like Node's
+  // no-engine builds; validation ordering matches Node:
+  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L221
+  if (privateKeyIdentifier !== undefined && privateKeyIdentifier !== null) {
+    if (privateKeyEngine === undefined || privateKeyEngine === null) {
+      // Engine is required when privateKeyIdentifier is present
+      throw $ERR_INVALID_ARG_VALUE("options.privateKeyEngine", privateKeyEngine);
+    }
+    if (key) {
+      // Both data key and engine key can't be set at the same time
+      throw $ERR_INVALID_ARG_VALUE("options.privateKeyIdentifier", privateKeyIdentifier);
+    }
+    if (typeof privateKeyIdentifier === "string" && typeof privateKeyEngine === "string") {
+      throw $ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED("Custom engines not supported by this OpenSSL");
+    } else if (typeof privateKeyIdentifier !== "string") {
+      throw $ERR_INVALID_ARG_TYPE(
+        "options.privateKeyIdentifier",
+        ["string", "null", "undefined"],
+        privateKeyIdentifier,
+      );
+    } else {
+      throw $ERR_INVALID_ARG_TYPE("options.privateKeyEngine", ["string", "null", "undefined"], privateKeyEngine);
+    }
   }
   if (ecdhCurve !== undefined) {
     validateString(ecdhCurve, "options.ecdhCurve");

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -665,20 +665,6 @@ var InternalSecureContext = class SecureContext {
         throw new TypeError("servername argument must be an string");
       if (options.secureOptions != null && typeof options.secureOptions !== "number")
         throw new TypeError("secureOptions argument must be an number");
-      const privateKeyIdentifier = options.privateKeyIdentifier;
-      if (!$isUndefinedOrNull(privateKeyIdentifier)) {
-        const privateKeyEngine = options.privateKeyEngine;
-        if ($isUndefinedOrNull(privateKeyEngine))
-          throw $ERR_INVALID_ARG_VALUE("options.privateKeyEngine", privateKeyEngine);
-        if (typeof privateKeyEngine !== "string")
-          throw $ERR_INVALID_ARG_TYPE("options.privateKeyEngine", ["string", "null", "undefined"], privateKeyEngine);
-        if (typeof privateKeyIdentifier !== "string")
-          throw $ERR_INVALID_ARG_TYPE(
-            "options.privateKeyIdentifier",
-            ["string", "null", "undefined"],
-            privateKeyIdentifier,
-          );
-      }
     }
     const requestedCiphers = options?.ciphers;
     if (requestedCiphers && StringPrototypeIncludes.$call(requestedCiphers, "TLS_")) {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -221,8 +221,7 @@ function validateSecureContextOptions(options) {
     validateString(sigalgs, "options.sigalgs");
     if (sigalgs === "") throw $ERR_INVALID_ARG_VALUE("options.sigalgs", sigalgs);
   }
-  // BoringSSL has no ENGINE support; same checks and order as node's no-engine build:
-  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L221
+  // BoringSSL has no ENGINE support; same checks and order as node's no-engine build (lib/internal/tls/secure-context.js).
   if (privateKeyIdentifier !== undefined && privateKeyIdentifier !== null) {
     if (privateKeyEngine === undefined || privateKeyEngine === null) {
       // Engine is required when privateKeyIdentifier is present

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -221,8 +221,7 @@ function validateSecureContextOptions(options) {
     validateString(sigalgs, "options.sigalgs");
     if (sigalgs === "") throw $ERR_INVALID_ARG_VALUE("options.sigalgs", sigalgs);
   }
-  // BoringSSL has no OpenSSL ENGINE support, so engine-backed keys fail like Node's
-  // no-engine builds; validation ordering matches Node:
+  // BoringSSL has no ENGINE support; same checks and order as node's no-engine build:
   // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L221
   if (privateKeyIdentifier !== undefined && privateKeyIdentifier !== null) {
     if (privateKeyEngine === undefined || privateKeyEngine === null) {

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -423,13 +423,16 @@ pub(super) fn set_max_send_fragment(
         return Err(global.throw(format_args!("Expected size to be a number")));
     }
     let size = arg.coerce_to_int64(global)?;
-    if !(512..=16384).contains(&size) {
+    if size < 0 {
         return Ok(JSValue::FALSE);
     }
 
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::FALSE);
     };
+    // No range gate here: Node returns SSL_set_max_send_fragment's own verdict,
+    // and BoringSSL clamps out-of-range sizes into [512, 16384] and reports
+    // success (vendor/boringssl/ssl/ssl_lib.cc, SSL_set_max_send_fragment).
     Ok(JSValue::from(
         ffi::SSL_set_max_send_fragment(
             boringssl::SSL::opaque_ref(ssl_ptr),

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -430,9 +430,7 @@ pub(super) fn set_max_send_fragment(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::FALSE);
     };
-    // No range gate here: Node returns SSL_set_max_send_fragment's own verdict,
-    // and BoringSSL clamps out-of-range sizes into [512, 16384] and reports
-    // success (vendor/boringssl/ssl/ssl_lib.cc, SSL_set_max_send_fragment).
+    // Like node, return SSL_set_max_send_fragment's own verdict (BoringSSL clamps the size).
     Ok(JSValue::from(
         ffi::SSL_set_max_send_fragment(
             boringssl::SSL::opaque_ref(ssl_ptr),

--- a/src/runtime/timer/ImmediateObject.rs
+++ b/src/runtime/timer/ImmediateObject.rs
@@ -11,8 +11,7 @@ use super::{Kind, TimerObjectInternals};
 super::impl_timer_object!(ImmediateObject, ImmediateObject, "Immediate");
 
 impl ImmediateObject {
-    /// Hook called by the `dispose` host function `impl_timer_object!` generates.
-    /// An Immediate has no `_idleTimeout`, so there is nothing to record.
+    /// `impl_timer_object!`'s `dispose` hook; an Immediate has no `_idleTimeout`.
     #[inline]
     pub(crate) fn before_explicit_cancel(&self, _global: &JSGlobalObject, _this_value: JSValue) {}
 

--- a/src/runtime/timer/ImmediateObject.rs
+++ b/src/runtime/timer/ImmediateObject.rs
@@ -11,6 +11,11 @@ use super::{Kind, TimerObjectInternals};
 super::impl_timer_object!(ImmediateObject, ImmediateObject, "Immediate");
 
 impl ImmediateObject {
+    /// Hook called by the `dispose` host function `impl_timer_object!` generates.
+    /// An Immediate has no `_idleTimeout`, so there is nothing to record.
+    #[inline]
+    pub(crate) fn before_explicit_cancel(&self, _global: &JSGlobalObject, _this_value: JSValue) {}
+
     pub(crate) fn init(
         global: &JSGlobalObject,
         id: i32,

--- a/src/runtime/timer/TimeoutObject.rs
+++ b/src/runtime/timer/TimeoutObject.rs
@@ -32,8 +32,21 @@ impl TimeoutObject {
 
     #[bun_jsc::host_fn(method)]
     pub fn close(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        this.before_explicit_cancel(global, frame.this());
         this.internals.cancel(global.bun_vm_ptr());
         Ok(frame.this())
+    }
+
+    /// Node's `unenroll`: a timer cancelled by `clearTimeout`/`clearInterval`,
+    /// `close()` or `[Symbol.dispose]` reads back `_idleTimeout === -1`. Not for
+    /// the natural-fire path, where a fired timer keeps its duration.
+    pub(crate) fn mark_unenrolled(this_value: JSValue, global: &JSGlobalObject) {
+        js::idle_timeout_set_cached(this_value, global, JSValue::js_number(-1.0));
+    }
+
+    /// Hook called by the `dispose` host function `impl_timer_object!` generates.
+    pub(crate) fn before_explicit_cancel(&self, global: &JSGlobalObject, this_value: JSValue) {
+        Self::mark_unenrolled(this_value, global);
     }
 
     // Cached-property getters/setters — codegen passes `this_value` (the JS

--- a/src/runtime/timer/TimeoutObject.rs
+++ b/src/runtime/timer/TimeoutObject.rs
@@ -37,14 +37,12 @@ impl TimeoutObject {
         Ok(frame.this())
     }
 
-    /// Node's `unenroll`: a timer cancelled by `clearTimeout`/`clearInterval`,
-    /// `close()` or `[Symbol.dispose]` reads back `_idleTimeout === -1`. Not for
-    /// the natural-fire path, where a fired timer keeps its duration.
+    /// Node's `unenroll`: an explicitly cancelled timer reads back `_idleTimeout === -1`.
     pub(crate) fn mark_unenrolled(this_value: JSValue, global: &JSGlobalObject) {
         js::idle_timeout_set_cached(this_value, global, JSValue::js_number(-1.0));
     }
 
-    /// Hook called by the `dispose` host function `impl_timer_object!` generates.
+    /// `impl_timer_object!`'s `dispose` hook.
     pub(crate) fn before_explicit_cancel(&self, global: &JSGlobalObject, this_value: JSValue) {
         Self::mark_unenrolled(this_value, global);
     }

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -398,6 +398,18 @@ impl All {
         };
 
         let Some(timer) = timer else { return Ok(()) };
+        // Node's unenroll: a timer cleared by clearTimeout/clearInterval reads
+        // back `_idleTimeout === -1` (a naturally fired one keeps its duration).
+        if kind != Kind::SetImmediate
+            // SAFETY: timer points to a live TimerObjectInternals
+            && let Some(js_timer) = unsafe { (*timer).this_value.get().try_get() }
+        {
+            crate::jsc::generated::JSTimeout::idle_timeout_set_cached(
+                js_timer,
+                global_this,
+                JSValue::js_number(-1.0),
+            );
+        }
         // SAFETY: timer points to a live TimerObjectInternals
         unsafe { (*timer).cancel(vm) };
         Ok(())

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -398,17 +398,11 @@ impl All {
         };
 
         let Some(timer) = timer else { return Ok(()) };
-        // Node's unenroll: a timer cleared by clearTimeout/clearInterval reads
-        // back `_idleTimeout === -1` (a naturally fired one keeps its duration).
         if kind != Kind::SetImmediate
             // SAFETY: timer points to a live TimerObjectInternals
             && let Some(js_timer) = unsafe { (*timer).this_value.get().try_get() }
         {
-            crate::jsc::generated::JSTimeout::idle_timeout_set_cached(
-                js_timer,
-                global_this,
-                JSValue::js_number(-1.0),
-            );
+            TimeoutObject::mark_unenrolled(js_timer, global_this);
         }
         // SAFETY: timer points to a live TimerObjectInternals
         unsafe { (*timer).cancel(vm) };

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -249,8 +249,9 @@ macro_rules! impl_timer_object {
             pub fn dispose(
                 this: &Self,
                 global: &::bun_jsc::JSGlobalObject,
-                _frame: &::bun_jsc::CallFrame,
+                frame: &::bun_jsc::CallFrame,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
+                this.before_explicit_cancel(global, frame.this());
                 this.internals.cancel(global.bun_vm_ptr());
                 Ok(::bun_jsc::JSValue::UNDEFINED)
             }

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { AddressInfo, createServer, Server, Socket } from "net";
+import { AddressInfo, connect, createServer, Server, Socket } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
 import { tmpdir } from "os";
@@ -661,4 +661,31 @@ it("server.unref() on a pipe/unix-socket listener lets the process exit", async 
   expect(stdout).toBe("");
   expect(exitCode === 0 ? "" : stderr).toBe("");
   expect(exitCode).toBe(0);
+});
+
+describe("keepAlive initial delay", () => {
+  // node stores the delay in whole seconds and passes it on to libuv without a
+  // ceiling; the native handle takes int32 milliseconds, so the conversion
+  // back must clamp instead of throwing inside the connection callbacks.
+  it("a delay above int32 milliseconds is stored in seconds and does not throw", async () => {
+    const delay = 3_000_000_000;
+    await using server = createServer({ keepAlive: true, keepAliveInitialDelay: delay });
+    expect(server.keepAliveInitialDelay).toBe(delay / 1000);
+    server.on("connection", socket => socket.end("ok"));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const client = connect({ port: (server.address() as AddressInfo).port, host: "127.0.0.1" });
+    await once(client, "connect");
+    expect(client.setKeepAlive(true, delay)).toBe(client);
+    const [data] = await once(client, "data");
+    expect(String(data)).toBe("ok");
+    await once(client, "close");
+  });
+
+  it("sub-second delays truncate to whole seconds like node", async () => {
+    await using server = createServer({ keepAlive: true, keepAliveInitialDelay: 1999 });
+    expect(server.keepAliveInitialDelay).toBe(1);
+    expect(createServer({ keepAliveInitialDelay: 999 }).keepAliveInitialDelay).toBe(0);
+  });
 });

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -1494,7 +1494,23 @@ function installBunExposeInternalsShim() {
         const normalizedArgsSymbol = Object.getOwnPropertySymbols(probe).find(
           s => s.description === "normalizedArgs",
         );
-        return { loader: "object", exports: { normalizedArgsSymbol } };
+        // The per-socket option symbols are module-private in Bun's node:net,
+        // like normalizedArgsSymbol; recover the real ones from a probe
+        // socket (the constructor always sets them) and the prototype.
+        const socketProbe = new net.Socket();
+        const bySymbolName = name =>
+          Object.getOwnPropertySymbols(socketProbe).find(s => s.description === name) ??
+          Object.getOwnPropertySymbols(net.Socket.prototype).find(s => s.description === name);
+        return {
+          loader: "object",
+          exports: {
+            normalizedArgsSymbol,
+            kSetNoDelay: bySymbolName("kSetNoDelay"),
+            kSetKeepAlive: bySymbolName("kSetKeepAlive"),
+            kSetKeepAliveInitialDelay: bySymbolName("kSetKeepAliveInitialDelay"),
+            kReinitializeHandle: bySymbolName("kReinitializeHandle"),
+          },
+        };
       });
       // node's internal/options: map the few CLI options vendored http tests ask
       // about onto the equivalent runtime values. Unknown options return undefined.

--- a/test/js/node/test/parallel/test-tls-clientcertengine-unsupported.js
+++ b/test/js/node/test/parallel/test-tls-clientcertengine-unsupported.js
@@ -1,0 +1,30 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+// Monkey-patch SecureContext
+const { internalBinding } = require('internal/test/binding');
+const binding = internalBinding('crypto');
+const NativeSecureContext = binding.SecureContext;
+
+binding.SecureContext = function() {
+  const rv = new NativeSecureContext();
+  rv.setClientCertEngine = undefined;
+  return rv;
+};
+
+const tls = require('tls');
+
+{
+  assert.throws(
+    () => { tls.createSecureContext({ clientCertEngine: 'Cannonmouth' }); },
+    {
+      code: 'ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
+      message: 'Custom engines not supported by this OpenSSL'
+    }
+  );
+}

--- a/test/js/node/test/parallel/test-tls-connect-keepalive-nodelay.js
+++ b/test/js/node/test/parallel/test-tls-connect-keepalive-nodelay.js
@@ -1,0 +1,65 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+// This test verifies that tls.connect() forwards keepAlive,
+// keepAliveInitialDelay, and noDelay options to the underlying socket.
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const {
+  kSetNoDelay,
+  kSetKeepAlive,
+  kSetKeepAliveInitialDelay,
+} = require('internal/net');
+
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+
+// Test: keepAlive, keepAliveInitialDelay, and noDelay
+{
+  const server = tls.createServer({ key, cert }, (socket) => {
+    socket.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false,
+      keepAlive: true,
+      keepAliveInitialDelay: 1000,
+      noDelay: true,
+    }, common.mustCall(() => {
+      assert.strictEqual(socket[kSetKeepAlive], true);
+      assert.strictEqual(socket[kSetKeepAliveInitialDelay], 1);
+      assert.strictEqual(socket[kSetNoDelay], true);
+      socket.destroy();
+      server.close();
+    }));
+  }));
+}
+
+// Test: defaults (options not set)
+{
+  const server = tls.createServer({ key, cert }, (socket) => {
+    socket.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false,
+    }, common.mustCall(() => {
+      assert.strictEqual(socket[kSetKeepAlive], false);
+      assert.strictEqual(socket[kSetKeepAliveInitialDelay], 0);
+      assert.strictEqual(socket[kSetNoDelay], false);
+      socket.destroy();
+      server.close();
+    }));
+  }));
+}

--- a/test/js/node/test/parallel/test-tls-enable-trace-cli.js
+++ b/test/js/node/test/parallel/test-tls-enable-trace-cli.js
@@ -1,0 +1,68 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
+
+// Test --trace-tls CLI flag.
+
+const assert = require('assert');
+const { fork } = require('child_process');
+
+if (process.argv[2] === 'test')
+  return test();
+
+const binding = require('internal/test/binding').internalBinding;
+
+if (!binding('tls_wrap').HAVE_SSL_TRACE)
+  return common.skip('no SSL_trace() compiled into openssl');
+
+const child = fork(__filename, ['test'], {
+  silent: true,
+  execArgv: ['--trace-tls']
+});
+
+let stdout = '';
+let stderr = '';
+child.stdout.setEncoding('utf8');
+child.stderr.setEncoding('utf8');
+child.stdout.on('data', (data) => stdout += data);
+child.stderr.on('data', (data) => stderr += data);
+child.on('close', common.mustCall((code, signal) => {
+  // For debugging and observation of actual trace output.
+  console.log(stderr);
+
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(stdout.trim(), '');
+  assert.match(stderr, /Warning: Enabling --trace-tls can expose sensitive/);
+  assert.match(stderr, /Sent (?:TLS )?Record/);
+}));
+
+function test() {
+  const {
+    connect, keys
+  } = require(fixtures.path('tls-connect'));
+
+  connect({
+    client: {
+      checkServerIdentity: (servername, cert) => { },
+      ca: `${keys.agent1.cert}\n${keys.agent6.ca}`,
+    },
+    server: {
+      cert: keys.agent6.cert,
+      key: keys.agent6.key
+    },
+  }, common.mustCall((err, pair, cleanup) => {
+    if (pair.server.err) {
+      console.trace('server', pair.server.err);
+    }
+    if (pair.client.err) {
+      console.trace('client', pair.client.err);
+    }
+    assert.ifError(pair.server.err);
+    assert.ifError(pair.client.err);
+
+    return cleanup();
+  }));
+}

--- a/test/js/node/test/parallel/test-tls-enable-trace.js
+++ b/test/js/node/test/parallel/test-tls-enable-trace.js
@@ -1,0 +1,58 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
+
+// Test enableTrace: option for TLS.
+
+const assert = require('assert');
+const { fork } = require('child_process');
+
+if (process.argv[2] === 'test')
+  return test();
+
+const binding = require('internal/test/binding').internalBinding;
+
+if (!binding('tls_wrap').HAVE_SSL_TRACE)
+  return common.skip('no SSL_trace() compiled into openssl');
+
+const child = fork(__filename, ['test'], { silent: true });
+
+let stderr = '';
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', (data) => stderr += data);
+child.on('close', common.mustCall(() => {
+  assert.match(stderr, /Received (?:TLS )?Record/);
+  assert.match(stderr, /ClientHello/);
+}));
+
+// For debugging and observation of actual trace output.
+child.stderr.pipe(process.stderr);
+child.stdout.pipe(process.stdout);
+
+child.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 0);
+}));
+
+function test() {
+  const {
+    connect, keys
+  } = require(fixtures.path('tls-connect'));
+
+  connect({
+    client: {
+      checkServerIdentity: (servername, cert) => { },
+      ca: `${keys.agent1.cert}\n${keys.agent6.ca}`,
+    },
+    server: {
+      cert: keys.agent6.cert,
+      key: keys.agent6.key,
+      enableTrace: true,
+    },
+  }, common.mustCall((err, pair, cleanup) => {
+    pair.client.conn.enableTrace();
+
+    return cleanup();
+  }));
+}

--- a/test/js/node/test/parallel/test-tls-keyengine-unsupported.js
+++ b/test/js/node/test/parallel/test-tls-keyengine-unsupported.js
@@ -1,0 +1,35 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+// Monkey-patch SecureContext
+const { internalBinding } = require('internal/test/binding');
+const binding = internalBinding('crypto');
+const NativeSecureContext = binding.SecureContext;
+
+binding.SecureContext = function() {
+  const rv = new NativeSecureContext();
+  rv.setEngineKey = undefined;
+  return rv;
+};
+
+const tls = require('tls');
+
+{
+  assert.throws(
+    () => {
+      tls.createSecureContext({
+        privateKeyEngine: 'engine',
+        privateKeyIdentifier: 'key'
+      });
+    },
+    {
+      code: 'ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
+      message: 'Custom engines not supported by this OpenSSL'
+    }
+  );
+}

--- a/test/js/node/test/parallel/test-tls-reinitialize-listeners.js
+++ b/test/js/node/test/parallel/test-tls-reinitialize-listeners.js
@@ -1,0 +1,42 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const events = require('events');
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+const { kReinitializeHandle } = require('internal/net');
+
+// Test that repeated calls to kReinitializeHandle() do not result in repeatedly
+// adding new listeners on the socket (i.e. no MaxListenersExceededWarnings)
+
+process.on('warning', common.mustNotCall());
+
+const server = tls.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+});
+
+server.listen(0, common.mustCall(function() {
+  const socket = tls.connect({
+    port: this.address().port,
+    rejectUnauthorized: false
+  });
+
+  socket.on('secureConnect', common.mustCall(function() {
+    for (let i = 0; i < events.defaultMaxListeners + 1; i++) {
+      socket[kReinitializeHandle]();
+    }
+
+    socket.destroy();
+  }));
+
+  socket.on('close', function() {
+    server.close();
+  });
+}));

--- a/test/js/node/test/parallel/test-tls-wrap-timeout.js
+++ b/test/js/node/test/parallel/test-tls-wrap-timeout.js
@@ -1,0 +1,53 @@
+// Flags: --expose-internals
+
+'use strict';
+const common = require('../common');
+const { kTimeout, TIMEOUT_MAX } = require('internal/timers');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const net = require('net');
+const fixtures = require('../common/fixtures');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+const server = tls.createServer(options, common.mustCall((c) => {
+  setImmediate(() => {
+    c.write('hello', () => {
+      setImmediate(() => {
+        c.destroy();
+        server.close();
+      });
+    });
+  });
+}));
+
+let socket;
+let lastIdleStart;
+
+server.listen(0, common.mustCall(() => {
+  socket = net.connect(server.address().port, common.mustCall(() => {
+    const s = socket.setTimeout(TIMEOUT_MAX, common.mustNotCall('timeout'));
+    assert.ok(s instanceof net.Socket);
+
+    assert.notStrictEqual(socket[kTimeout]._idleTimeout, -1);
+    lastIdleStart = socket[kTimeout]._idleStart;
+
+    const tsocket = tls.connect({
+      socket: socket,
+      rejectUnauthorized: false
+    });
+    tsocket.resume();
+  }));
+}));
+
+process.on('exit', () => {
+  assert.strictEqual(socket[kTimeout]._idleTimeout, -1);
+  assert(lastIdleStart < socket[kTimeout]._idleStart);
+});

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -220,6 +220,40 @@ describe("clear", () => {
   });
 });
 
+describe("_idleTimeout", () => {
+  const idleTimeoutOf = (timer: object) => (timer as { _idleTimeout: number })._idleTimeout;
+
+  // node's unenroll() sets _idleTimeout to -1 on every explicit cancel path.
+  it.each([
+    ["clearTimeout", (t: NodeJS.Timeout) => void clearTimeout(t)],
+    ["clearInterval", (t: NodeJS.Timeout) => void clearInterval(t)],
+    ["close()", (t: NodeJS.Timeout) => void t.close()],
+    ["Symbol.dispose", (t: NodeJS.Timeout) => t[Symbol.dispose]()],
+  ])("%s sets it to -1", (_, cancel) => {
+    const timeout = setTimeout(() => {
+      throw new Error("timeout not cleared");
+    }, 1000);
+    expect(idleTimeoutOf(timeout)).toBe(1000);
+    cancel(timeout);
+    expect(idleTimeoutOf(timeout)).toBe(-1);
+  });
+
+  it("a timer that fired keeps its duration", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const timeout = setTimeout(resolve, 1);
+    await promise;
+    expect(idleTimeoutOf(timeout)).toBe(1);
+  });
+
+  it("an immediate has none, and disposing it does not add one", () => {
+    const immediate = setImmediate(() => {
+      throw new Error("immediate not cleared");
+    });
+    immediate[Symbol.dispose]();
+    expect("_idleTimeout" in immediate).toBe(false);
+  });
+});
+
 describe("_idleStart", () => {
   // https://github.com/oven-sh/bun/issues/26508
   // Next.js 16 Cache Components writes `t2._idleStart = t1._idleStart` so two

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -170,10 +170,13 @@ it("initializes authorizationError to null in the TLSSocket constructor", () => 
   socket.destroy();
 });
 
-it("setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing", async () => {
-  // Node returns whatever SSL_set_max_send_fragment returns: OpenSSL rejects a
-  // size outside [512, 16384] with 0 (-> false). BoringSSL clamps and always
-  // returns 1, so bun enforces the same contract in the native binding.
+it("setMaxSendFragment returns BoringSSL's verdict (clamps out-of-range sizes, reports success)", async () => {
+  // Node returns whatever SSL_set_max_send_fragment returns. Bun links
+  // BoringSSL, which clamps out-of-range sizes into [512, 16384] and reports
+  // success; upstream test-tls-max-send-fragment.js pins exactly this for
+  // process.features.openssl_is_boringssl builds. Negative sizes stay false
+  // (Node's C++ binding would CHECK-crash on a non-Uint32; Bun refuses
+  // gracefully).
   const server = tls.createServer(COMMON_CERT_, s => s.on("data", () => {}));
   await once(server.listen(0, "127.0.0.1"), "listening");
   const connected = Promise.withResolvers<void>();
@@ -186,12 +189,12 @@ it("setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwin
     await connected.promise;
     const results = [0, -1, 511, 512, 16384, 16385].map(size => [size, client.setMaxSendFragment(size)]);
     expect(results).toEqual([
-      [0, false],
+      [0, true],
       [-1, false],
-      [511, false],
+      [511, true],
       [512, true],
       [16384, true],
-      [16385, false],
+      [16385, true],
     ]);
   } finally {
     client.destroy();


### PR DESCRIPTION
Split out of #35483 (TLS part). Stacked on nothing, based on main.

### Fixes
- `tls.createSecureContext` validates `privateKeyEngine`/`privateKeyIdentifier` in Node's order, then throws `ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED` (BoringSSL has no ENGINE support): src/js/node/tls.ts:227
- `net.Socket`/`net.Server` store the keepalive initial delay in whole seconds like Node; native call sites convert back to ms: src/js/node/net.ts:1590, :2601, :3528
- `Socket[kReinitializeHandle]()` creates the replacement handle when none is passed, like Node's TLSSocket override: src/js/node/net.ts:2155
- `setMaxSendFragment()` returns BoringSSL's own verdict instead of an OpenSSL-style range gate; negative sizes still return false: src/runtime/socket/tls_socket_functions.rs:426
- `clearTimeout`/`clearInterval` set `_idleTimeout` to -1 like Node's unenroll. The fix is in the timers code; the vendored test needing it is a tls test: src/runtime/timer/Timer.rs:401
- The stored seconds are converted back with a clamp, so a delay above int32 milliseconds no longer throws from the native validator (also inside the connection callbacks): src/js/node/net.ts keepAliveDelayMs
- `close()` and `[Symbol.dispose]` record the unenroll like `clearTimeout` does (`_idleTimeout` reads back -1 on every explicit cancel path): src/runtime/timer/TimeoutObject.rs
- Removed: the `privateKeyIdentifier` checks in the `InternalSecureContext` constructor, unreachable once `validateSecureContextOptions` throws first
- Test support: `internal/timers` exports `TIMEOUT_MAX` (src/js/internal/timers.ts:26), `internalBinding` gains `crypto` and `tls_wrap` (src/js/internal/test/binding.ts:98), the harness `internal/net` shim exports the real socket option symbols (test/js/node/test/common/index.js:1511)

### Tests
Vendored upstream files, byte-identical to Node v26.3.0 as in #35483, under test/js/node/test/parallel/:
- test-tls-clientcertengine-unsupported.js
- test-tls-connect-keepalive-nodelay.js
- test-tls-enable-trace-cli.js and test-tls-enable-trace.js (skip, as on a Node built without SSL_trace)
- test-tls-keyengine-unsupported.js
- test-tls-reinitialize-listeners.js
- test-tls-wrap-timeout.js

Bun test changed: test/js/node/tls/node-tls-connect.test.ts (setMaxSendFragment expectations follow BoringSSL).

Bun tests added: keepalive delay cases in test/js/node/net/node-net-server.test.ts, `_idleTimeout` cases in test/js/node/timers/node-timers.test.ts.

### Verified
Linux x64 debug build: the 7 vendored tests exit 0 here and all fail on main. The existing engine/keepalive/timeout vendored tests and the node-tls-connect, node-net-server, server.spec and node-timers suites pass. node-tls-server, node-net, web timers and bun socket have the same failures on a main build (sandbox localhost resolution, RSS thresholds on an ASAN debug build).

