### PR TITLE
test: cover a throwing export getter in the plugin object loader

### DIFF
--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -626,6 +626,87 @@ describe("object loader with a throwing exports getter", () => {
   });
 });
 
+describe("object loader with a throwing getter on an export", () => {
+  // The "exports" object itself is fine; one of its own properties is a getter
+  // that throws while the exports are copied into the module namespace. The
+  // error must reach the importer as-is, not become an `undefined` export.
+  const throwingExportResult = `
+    const exported = { before: 1 };
+    Object.defineProperty(exported, "boom", {
+      enumerable: true,
+      get() {
+        throw globalThis.sentinel;
+      },
+    });
+    exported.after = 2;
+    return { exports: exported, loader: "object" };
+  `;
+
+  async function expectSentinel(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `globalThis.sentinel = new Error("export getter threw");\n${code}`],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("failed with sentinel\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
+  const report = `
+    catch (e) {
+      console.log(e === globalThis.sentinel ? "failed with sentinel" : "failed with " + e);
+    }
+  `;
+
+  it.concurrent("rejects import() of a build.module result", async () => {
+    await expectSentinel(`
+      Bun.plugin({
+        name: "virt",
+        setup(build) {
+          build.module("virt-mod", () => { ${throwingExportResult} });
+        },
+      });
+      try {
+        const ns = await import("virt-mod");
+        console.log("imported boom=" + ns.boom);
+      } ${report}
+    `);
+  });
+
+  it.concurrent("throws from require() of a build.module result", async () => {
+    await expectSentinel(`
+      Bun.plugin({
+        name: "virt",
+        setup(build) {
+          build.module("virt-mod", () => { ${throwingExportResult} });
+        },
+      });
+      try {
+        const ns = require("virt-mod");
+        console.log("required boom=" + ns.boom);
+      } ${report}
+    `);
+  });
+
+  it.concurrent("rejects import() of a build.onLoad result", async () => {
+    await expectSentinel(`
+      Bun.plugin({
+        name: "virt",
+        setup(build) {
+          build.onResolve({ filter: /.*/, namespace: "virtns" }, args => ({ path: args.path, namespace: "virtns" }));
+          build.onLoad({ filter: /.*/, namespace: "virtns" }, () => { ${throwingExportResult} });
+        },
+      });
+      try {
+        const ns = await import("virtns:mod");
+        console.log("imported boom=" + ns.boom);
+      } ${report}
+    `);
+  });
+});
+
 it("require(...).default without __esModule", () => {
   {
     const { default: mod } = require("my-virtual-module-with-default");


### PR DESCRIPTION
### Problem
- #39804 (commit 025570f4b6) changed `generateObjectModuleSourceCode` (`src/jsc/modules/ObjectModule.cpp:25`). A throwing getter on the exports object of a `loader: "object"` result now fails the import. Before, the loader exported `undefined` for it.
- #39804 added tests for the `mock.module()` entry point only. Its description lists this change under "no repro", but a plugin reaches it: bun `1.4.0-canary.1+6e906e468` (before #39804) prints `boom=undefined` for the cases below.
- This replaces #33793. Its code change landed through #39804. Its plugin test did not.

### Fix
- Test only. Adds `describe("object loader with a throwing getter on an export")` to `test/js/bun/plugin/plugins.test.ts`, next to the #37026 block for a throwing getter on the result's `exports` property.
- Three cases: `import()` and `require()` of a `build.module()` result, and `import()` of a `build.onLoad()` result. Each checks that the caught error is the object the getter threw. The getter sits between two plain exports.
- Verified: all three fail with `USE_SYSTEM_BUN=1` (`1.4.0-canary.1+6e906e468`) and pass with a debug build of main at 40ef8113d9. The full file passes there (45 tests).

### Background
- A `loader: "object"` result becomes a synthetic module. `ModuleLoader.cpp:442` passes its `exports` object to `generateObjectModuleSourceCode`, which reads each own enumerable property once into the namespace. `require()` takes the same path after the `__esModule` check at `ModuleLoader.cpp:422`.
- `mock.module()` of a module that is not loaded yet uses the same generator. That is the entry point #39804 tests.
- #37026 covers the layer above: a getter on the `exports` property of the result object (`ModuleLoader.cpp:155`).

<details><summary>Notes</summary>

- Output on the old binary: `imported boom=undefined` for the two `import()` cases and `required boom=undefined` for the `require()` case.
- #33793's test ran `import()` and `require()` in one subprocess. This version mirrors the shape of the #37026 block: one subprocess per entry point, exact `stdout`, empty `stderr`, exit code 0.
- #33793's `mock.module()` test is not carried over. #39804 added two tests for that entry point in `test/js/bun/test/mock/mock-module.test.ts` (the import failure and the untouched namespace). Both of #33793's test cases pass on a debug build of main with no `src/` change. That is the basis for closing #33793.
- Commands: `bun bd test test/js/bun/plugin/plugins.test.ts` (45 pass) and `USE_SYSTEM_BUN=1 bun test test/js/bun/plugin/plugins.test.ts -t "throwing getter on an export"` (3 fail).
</details>
