### PR TITLE
node:fs: recursive readdir skips a subdirectory removed after it was opened

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6375,15 +6375,11 @@ impl NodeFS {
         Ok(())
     }
 
-    /// Whether an error on a subdirectory of a recursive readdir ends that
-    /// subdirectory instead of failing the whole call. The parent listed the
-    /// subdirectory a moment ago, so these errors mean it was removed or
-    /// replaced in the meantime, or that it cannot be entered at all. (Node
-    /// fails the whole call when the open of a subdirectory fails.) The same
-    /// check applies to the reads: Linux reports a directory removed after it
-    /// was opened as ENOENT from `getdents64`, which libc's readdir(3), and so
-    /// node, turn into the end of the directory. Errors on the root directory
-    /// are always returned.
+    /// A subdirectory that fails with one of these ends that subdirectory
+    /// instead of the whole call: its parent listed it a moment ago, so it was
+    /// removed or replaced since, or cannot be entered. This applies to the
+    /// reads too. `getdents64` reports a directory removed after it was opened
+    /// as ENOENT, which libc's readdir(3) reports as the end of the directory.
     fn readdir_recursive_skips_subdir(errno: E) -> bool {
         matches!(errno, E::ENOENT | E::ENOTDIR | E::EPERM)
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6376,13 +6376,14 @@ impl NodeFS {
     }
 
     /// Whether an error on a subdirectory of a recursive readdir ends that
-    /// subdirectory instead of the whole call. The parent listed the
+    /// subdirectory instead of failing the whole call. The parent listed the
     /// subdirectory a moment ago, so these errors mean it was removed or
-    /// replaced in the meantime, or that it cannot be entered at all. Node
-    /// fails the entire operation in these cases. Linux reports a directory
-    /// that was removed after it was opened as ENOENT from `getdents64`, so
-    /// the reads of a subdirectory get the same treatment as its open. Errors
-    /// on the root directory are always returned.
+    /// replaced in the meantime, or that it cannot be entered at all. (Node
+    /// fails the whole call when the open of a subdirectory fails.) The same
+    /// check applies to the reads: Linux reports a directory removed after it
+    /// was opened as ENOENT from `getdents64`, which libc's readdir(3), and so
+    /// node, turn into the end of the directory. Errors on the root directory
+    /// are always returned.
     fn readdir_recursive_skips_subdir(errno: E) -> bool {
         matches!(errno, E::ENOENT | E::ENOTDIR | E::EPERM)
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6376,7 +6376,7 @@ impl NodeFS {
     }
 
     /// Gone or not enterable since the parent listed it. Reading a gone directory gives ENOENT too.
-    fn readdir_recursive_skips_subdir(errno: E) -> bool {
+    fn readdir_skips_subdir(errno: E) -> bool {
         matches!(errno, E::ENOENT | E::ENOTDIR | E::EPERM)
     }
 
@@ -6421,7 +6421,7 @@ impl NodeFS {
         let fd = match open_res {
             Err(err) => {
                 if !is_root {
-                    if Self::readdir_recursive_skips_subdir(err.get_errno()) {
+                    if Self::readdir_skips_subdir(err.get_errno()) {
                         return Ok(());
                     }
                     if root_basename.len() + 1 + basename.as_bytes().len() + 1
@@ -6455,10 +6455,10 @@ impl NodeFS {
 
         loop {
             let current = match iterator.next() {
+                Ok(Some(ent)) => ent,
+                Ok(None) => break,
+                Err(err) if !is_root && Self::readdir_skips_subdir(err.get_errno()) => break,
                 Err(err) => {
-                    if !is_root && Self::readdir_recursive_skips_subdir(err.get_errno()) {
-                        break;
-                    }
                     dirent_path_prev.deref();
                     if !is_root
                         && root_basename.len() + 1 + basename.as_bytes().len() + 1
@@ -6472,8 +6472,6 @@ impl NodeFS {
                     }
                     return Err(err.with_path(root_basename));
                 }
-                Ok(None) => break,
-                Ok(Some(ent)) => ent,
             };
             let utf8_name = current.name.slice();
 
@@ -6626,7 +6624,7 @@ impl NodeFS {
                         return Err(err.with_path(args.path.slice()));
                     }
                     match err.get_errno() {
-                        errno if Self::readdir_recursive_skips_subdir(errno) => continue,
+                        errno if Self::readdir_skips_subdir(errno) => continue,
                         _ => {
                             // TODO: propagate file path (removed previously because it leaked the path)
                             return Err(err);
@@ -6649,15 +6647,13 @@ impl NodeFS {
 
             loop {
                 let current = match iterator.next() {
+                    Ok(Some(ent)) => ent,
+                    Ok(None) => break,
+                    Err(err) if !is_root && Self::readdir_skips_subdir(err.get_errno()) => break,
                     Err(err) => {
-                        if !is_root && Self::readdir_recursive_skips_subdir(err.get_errno()) {
-                            break;
-                        }
                         dirent_path_prev.deref();
                         return Err(err.with_path(args.path.slice()));
                     }
-                    Ok(None) => break,
-                    Ok(Some(ent)) => ent,
                 };
                 let utf8_name = current.name.slice();
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6375,9 +6375,7 @@ impl NodeFS {
         Ok(())
     }
 
-    /// The subdirectory went away, or cannot be entered, since its parent listed
-    /// it. Checked after its open and after each read: `getdents64` reports a
-    /// directory removed after it was opened as ENOENT.
+    /// Gone or not enterable since the parent listed it. Reading a gone directory gives ENOENT too.
     fn readdir_recursive_skips_subdir(errno: E) -> bool {
         matches!(errno, E::ENOENT | E::ENOTDIR | E::EPERM)
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6375,11 +6375,9 @@ impl NodeFS {
         Ok(())
     }
 
-    /// A subdirectory that fails with one of these ends that subdirectory
-    /// instead of the whole call: its parent listed it a moment ago, so it was
-    /// removed or replaced since, or cannot be entered. This applies to the
-    /// reads too. `getdents64` reports a directory removed after it was opened
-    /// as ENOENT, which libc's readdir(3) reports as the end of the directory.
+    /// The subdirectory went away, or cannot be entered, since its parent listed
+    /// it. Checked after its open and after each read: `getdents64` reports a
+    /// directory removed after it was opened as ENOENT.
     fn readdir_recursive_skips_subdir(errno: E) -> bool {
         matches!(errno, E::ENOENT | E::ENOTDIR | E::EPERM)
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6375,6 +6375,18 @@ impl NodeFS {
         Ok(())
     }
 
+    /// Whether an error on a subdirectory of a recursive readdir ends that
+    /// subdirectory instead of the whole call. The parent listed the
+    /// subdirectory a moment ago, so these errors mean it was removed or
+    /// replaced in the meantime, or that it cannot be entered at all. Node
+    /// fails the entire operation in these cases. Linux reports a directory
+    /// that was removed after it was opened as ENOENT from `getdents64`, so
+    /// the reads of a subdirectory get the same treatment as its open. Errors
+    /// on the root directory are always returned.
+    fn readdir_recursive_skips_subdir(errno: E) -> bool {
+        matches!(errno, E::ENOENT | E::ENOTDIR | E::EPERM)
+    }
+
     pub(crate) fn readdir_with_entries_recursive_async<T: ReaddirEntry>(
         buf: &mut PathBuffer,
         async_task: &mut AsyncReaddirRecursiveTask,
@@ -6416,13 +6428,8 @@ impl NodeFS {
         let fd = match open_res {
             Err(err) => {
                 if !is_root {
-                    match err.get_errno() {
-                        // These things can happen and there's nothing we can do about it.
-                        //
-                        // This is different than what Node does, at the time of writing.
-                        // Node doesn't gracefully handle errors like these. It fails the entire operation.
-                        E::ENOENT | E::ENOTDIR | E::EPERM => return Ok(()),
-                        _ => {}
+                    if Self::readdir_recursive_skips_subdir(err.get_errno()) {
+                        return Ok(());
                     }
                     if root_basename.len() + 1 + basename.as_bytes().len() + 1
                         < paths::MAX_PATH_BYTES
@@ -6456,6 +6463,9 @@ impl NodeFS {
         loop {
             let current = match iterator.next() {
                 Err(err) => {
+                    if !is_root && Self::readdir_recursive_skips_subdir(err.get_errno()) {
+                        break;
+                    }
                     dirent_path_prev.deref();
                     if !is_root
                         && root_basename.len() + 1 + basename.as_bytes().len() + 1
@@ -6623,11 +6633,7 @@ impl NodeFS {
                         return Err(err.with_path(args.path.slice()));
                     }
                     match err.get_errno() {
-                        // These things can happen and there's nothing we can do about it.
-                        //
-                        // This is different than what Node does, at the time of writing.
-                        // Node doesn't gracefully handle errors like these. It fails the entire operation.
-                        E::ENOENT | E::ENOTDIR | E::EPERM => continue,
+                        errno if Self::readdir_recursive_skips_subdir(errno) => continue,
                         _ => {
                             // TODO: propagate file path (removed previously because it leaked the path)
                             return Err(err);
@@ -6651,6 +6657,9 @@ impl NodeFS {
             loop {
                 let current = match iterator.next() {
                     Err(err) => {
+                        if !is_root && Self::readdir_recursive_skips_subdir(err.get_errno()) {
+                            break;
+                        }
                         dirent_path_prev.deref();
                         return Err(err.with_path(args.path.slice()));
                     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5703,6 +5703,171 @@ int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); re
   expect(proc.exitCode).toBe(0);
 });
 
+// A subdirectory can be removed between the moment the recursive walk lists it
+// in its parent and the moment the walk reads it. The walk skipped the
+// subdirectory when its open failed with ENOENT, but when the removal landed
+// after the open, the kernel reported ENOENT from getdents64(2) and the whole
+// call failed (readdirSync blamed the root). A concurrent deleter is not
+// deterministic, so LD_PRELOAD a shim that plays one from inside getdents64:
+// the marked directories are really removed and the kernel itself produces
+// the ENOENT. bun issues getdents64 through libc's syscall(), which is the
+// interposable symbol on this path. glibc-only, same as the statfs shim above.
+it.skipIf(!isGlibc || !cc)("recursive readdir skips a subdirectory that is removed after it was opened", async () => {
+  using dir = tempDir("readdir-vanishing-subdir", {
+    "shim.c": `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long (*next_syscall)(long, ...);
+
+long syscall(long nr, ...) {
+  va_list ap;
+  va_start(ap, nr);
+  long a1 = va_arg(ap, long), a2 = va_arg(ap, long), a3 = va_arg(ap, long);
+  long a4 = va_arg(ap, long), a5 = va_arg(ap, long), a6 = va_arg(ap, long);
+  va_end(ap);
+  if (!next_syscall) next_syscall = dlsym(RTLD_NEXT, "syscall");
+  if (nr == SYS_getdents64) {
+    int fd = (int)a1;
+    char link[64], target[PATH_MAX];
+    snprintf(link, sizeof link, "/proc/self/fd/%d", fd);
+    ssize_t n = readlink(link, target, sizeof target - 1);
+    if (n > 0) {
+      target[n] = 0;
+      const char *base = strrchr(target, '/');
+      base = base ? base + 1 : target;
+      if (strcmp(base, "vanish-before-read") == 0) {
+        // Removed before the first read: that read fails with ENOENT.
+        rmdir(target);
+      } else if (strcmp(base, "vanish-mid-read") == 0) {
+        // Removed once the first read handed out its entries: the read that
+        // would report the end of the directory fails with ENOENT instead.
+        // (After the rmdir the link reads "... (deleted)", so this branch
+        // is not taken again.)
+        long rc = next_syscall(nr, a1, a2, a3, a4, a5, a6);
+        if (rc > 0) {
+          unlinkat(fd, "inner.txt", 0);
+          rmdir(target);
+        }
+        return rc;
+      }
+    }
+  }
+  return next_syscall(nr, a1, a2, a3, a4, a5, a6);
+}
+`,
+    "child.js": `
+const fs = require("node:fs");
+const path = require("node:path");
+
+function makeTree(root) {
+  fs.mkdirSync(path.join(root, "keep", "deeper"), { recursive: true });
+  fs.writeFileSync(path.join(root, "keep", "deeper", "file.txt"), "x");
+  fs.mkdirSync(path.join(root, "vanish-before-read"));
+  fs.mkdirSync(path.join(root, "vanish-mid-read"));
+  fs.writeFileSync(path.join(root, "vanish-mid-read", "inner.txt"), "x");
+  return root;
+}
+function makeDoomedRoot(parent) {
+  const root = path.join(parent, "vanish-before-read");
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+const names = entries => entries.map(String).sort();
+const direntNames = (root, entries) =>
+  entries.map(d => path.relative(root, path.join(d.parentPath, d.name))).sort();
+const outcome = async fn => {
+  try {
+    return await fn();
+  } catch (e) {
+    return { code: e.code, path: e.path };
+  }
+};
+
+(async () => {
+  const out = {};
+  let root = makeTree("sync");
+  out.sync = await outcome(() => names(fs.readdirSync(root, { recursive: true })));
+  out.syncLeft = fs.readdirSync(root);
+
+  root = makeTree("sync-types");
+  out.syncTypes = await outcome(() => direntNames(root, fs.readdirSync(root, { recursive: true, withFileTypes: true })));
+  out.syncTypesLeft = fs.readdirSync(root);
+
+  root = makeTree("async");
+  out.async = await outcome(async () => names(await fs.promises.readdir(root, { recursive: true })));
+  out.asyncLeft = fs.readdirSync(root);
+
+  root = makeTree("async-types");
+  out.asyncTypes = await outcome(async () =>
+    direntNames(root, await fs.promises.readdir(root, { recursive: true, withFileTypes: true })),
+  );
+  out.asyncTypesLeft = fs.readdirSync(root);
+
+  // The root going away is still an error, recursive or not.
+  root = makeDoomedRoot("root-sync");
+  out.rootSync = await outcome(() => fs.readdirSync(root, { recursive: true }));
+  root = makeDoomedRoot("root-async");
+  out.rootAsync = await outcome(() => fs.promises.readdir(root, { recursive: true }));
+  root = makeDoomedRoot("root-plain");
+  out.rootPlain = await outcome(() => fs.readdirSync(root));
+  console.log(JSON.stringify(out));
+})();
+`,
+  });
+
+  const soPath = path.join(String(dir), "shim.so");
+  const compile = Bun.spawnSync({
+    cmd: [cc!, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+  });
+  if (compile.exitCode !== 0) {
+    throw new Error(`Failed to build readdir race shim:\n${compile.stderr.toString()}`);
+  }
+
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "child.js"],
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${soPath}:${existing}` : soPath },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+
+  const walked = [
+    "keep",
+    "keep/deeper",
+    "keep/deeper/file.txt",
+    "vanish-before-read",
+    "vanish-mid-read",
+    "vanish-mid-read/inner.txt",
+  ];
+  // The `*Left` lists prove that the shim removed both marked directories
+  // while the walk ran. If it did not interpose, they are still there.
+  expect(JSON.parse(stdout)).toEqual({
+    sync: walked,
+    syncLeft: ["keep"],
+    syncTypes: walked,
+    syncTypesLeft: ["keep"],
+    async: walked,
+    asyncLeft: ["keep"],
+    asyncTypes: walked,
+    asyncTypesLeft: ["keep"],
+    rootSync: { code: "ENOENT", path: path.join("root-sync", "vanish-before-read") },
+    rootAsync: { code: "ENOENT", path: path.join("root-async", "vanish-before-read") },
+    rootPlain: { code: "ENOENT", path: path.join("root-plain", "vanish-before-read") },
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("fs.Stat constructor", () => {
   expect(new Stats()).toMatchObject({
     "atimeMs": undefined,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5707,11 +5707,13 @@ int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); re
 // in its parent and the moment the walk reads it. The walk skipped the
 // subdirectory when its open failed with ENOENT, but when the removal landed
 // after the open, the kernel reported ENOENT from getdents64(2) and the whole
-// call failed (readdirSync blamed the root). A concurrent deleter is not
-// deterministic, so LD_PRELOAD a shim that plays one from inside getdents64:
-// the marked directories are really removed and the kernel itself produces
-// the ENOENT. bun issues getdents64 through libc's syscall(), which is the
-// interposable symbol on this path. glibc-only, same as the statfs shim above.
+// call failed (readdirSync blamed the root). libc's readdir(3), and so node,
+// report that ENOENT as the end of the directory; bun reads with the raw
+// syscall and sees it. A concurrent deleter is not deterministic, so
+// LD_PRELOAD a shim that plays one from inside getdents64: the marked
+// directories are really removed and the kernel itself produces the ENOENT.
+// bun issues getdents64 through libc's syscall(), which is the interposable
+// symbol on this path. glibc-only, same as the statfs shim above.
 it.skipIf(!isGlibc || !cc)("recursive readdir skips a subdirectory that is removed after it was opened", async () => {
   using dir = tempDir("readdir-vanishing-subdir", {
     "shim.c": `
@@ -5810,7 +5812,8 @@ const outcome = async fn => {
   );
   out.asyncTypesLeft = fs.readdirSync(root);
 
-  // The root going away is still an error, recursive or not.
+  // Only subdirectories are skipped. A read error on the root itself is still
+  // returned, recursive or not.
   root = makeDoomedRoot("root-sync");
   out.rootSync = await outcome(() => fs.readdirSync(root, { recursive: true }));
   root = makeDoomedRoot("root-async");


### PR DESCRIPTION
### Problem
- `fs.readdirSync(root, { recursive: true })` throws `ENOENT: no such file or directory, scandir '<root>'` when another process removes a subdirectory during the call. `root` still exists. `fs.promises.readdir` rejects too.
- The walk skips a subdirectory whose open fails with ENOENT, ENOTDIR or EPERM. A removal that lands after the open surfaces as ENOENT from `getdents64` instead. Both walkers in `src/runtime/node/node_fs.rs` returned that error.

### Fix
- One predicate, `readdir_skips_subdir`, now covers the open and the read of a subdirectory in both walkers. A tolerated read error ends that subdirectory. Root errors and other errnos are returned as before.
- Matches node for this race. libc's `readdir(3)` reports this ENOENT as the end of the directory, so node lists the subdirectory as empty and continues. bun reads with the raw syscall and saw the errno.
- The open arm is unchanged. Only timing decides which syscall sees the removal, so the read arm uses the same set.
- Verified: the new test in `test/js/node/fs/fs.test.ts`. Its four walk variants fail on bun 1.4.0. Other suites: see the notes.

### Background
- Each directory below the root is opened with `openat(root_fd, relative)` and read with `getdents64`, in one loop (sync) or in one subtask per directory (async). Any subtask error rejects the promise.
- On Linux, `getdents64` on a directory removed after its open fails with ENOENT (`IS_DEADDIR` in fs/readdir.c). glibc, and the FreeBSD arm of bun's iterator, turn this into end of directory. The Linux arm does not.
- The test preloads a shim on libc's `syscall()`, bun's route to `getdents64`. It really removes two marked directories during the walk, and the test checks that both are gone. glibc only.

<details><summary>Notes</summary>

- Origin: found while #39710 was verified. Recursive rm has the same gap on its own walk and is handled in that thread. The original observation: a root with 128 subdirectories, a second process unlinking their files and removing them, and `readdirSync(root, { recursive: true })` in a loop in the main process. It fired about once in a few hundred iterations.
- Repro without the race: the shim from the test, run against bun 1.4.0. Sync: `ENOENT scandir 'root-sync'`. Async: `ENOENT getdents64 'root-async/vanish-mid-read'`.
- Raw syscall against libc, same machine (kernel 6.17, glibc 2.41), directory opened and then removed: `getdents64` returns -1 with ENOENT on overlayfs and on tmpfs. glibc's `readdir(3)` on the same state returns NULL with errno 0, that is, end of directory. The kernel side is generic: `vfs_rmdir` sets `S_DEAD` on the inode, and `iterate_dir` returns ENOENT for it before any filesystem code runs. So the errno does not depend on the filesystem, only on whether the reader uses libc or the raw syscall. A probe through Python or any other libc reader shows an empty listing for this reason, not an error.
- Node, observed: `fs.opendirSync(dir)`, then `rmdirSync(dir)`, then `dir.readSync()` returns `null` (end of directory) on node v26.3.0. bun returns `ENOENT scandir` there before and after this change. That `opendir` path and a root removed after its open are the same libc difference, on a different consumer of the iterator. This change leaves them alone: it would mean a change to the Linux arm of the iterator, which every directory walker in bun shares (readdir, opendir, cp, rm, glob, the shell builtins). The rm side of that is in flight in #39710. That alignment is a separate change if wanted.
- Node with the subdirectory removed before node opens it (a shim on `scandir(3)`): `readdirSync` and `fs.promises.readdir` both throw `ENOENT scandir 'root/vanish-before-read'`. bun skips the subdirectory there, and did so before this change. This change does not widen that difference, it only makes the read step behave like the open step.
- The shim removes one directory before its first read (the read fails at once) and one after its first read handed out an entry (the end-of-directory read fails). The `withFileTypes` variants cover the `dirent_path_prev` release on the new `break` path. They pass under the ASAN debug build.
- Why the message named the root: `NodeFS::readdir` rebuilds every error of the sync form as `scandir` on the root argument. That is unchanged here and is what #38017 changes.
- Unchanged: EACCES, EINVAL, ELOOP, EIO and every other errno still fail the call, from the open and from the read. The root cases in the new test pass before and after this change on purpose. They pin that only subdirectories are skipped.
- Open PRs on the same lines, all independent of this one: #38017 (name the failing subdirectory), #37988 (syscall name of the async forms), #33432 (add ELOOP to the skipped set, which becomes a one-line change to the predicate). The test asserts `code` and `path` only, so #37988 and #38017 do not change its expectations.
- The walkers are shared by all platforms, so the predicate applies on macOS and Windows too. What those kernels report for a removed open directory was not checked here. The test runs on Linux glibc only.
- Suites run with the debug build: all of `test/js/node/fs/fs.test.ts`, `readdirSync-recursive-error-leak.test.ts`, `dir.test.ts`, `fs-path-length.test.ts`, node's `test-fs-readdir*.js`, regression tests 17793, 24007, 28159, 29585. `test/regression/issue/10139.test.ts` (a `bun build` of a 128 MB asset with a 5 s budget) times out in this container with the debug build. It does not use recursive readdir.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->
