### PR TITLE
bun-types: keep generic process.removeListener and off signatures visible with @types/node 24

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -116,6 +116,14 @@ declare global {
       prependOnceListener(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
       emit(event: "memoryPressure", level: "warning" | "critical"): boolean;
 
+      // @types/node <= 24 does not declare `off`/`removeListener` directly on
+      // `Process` (they are only inherited from EventEmitter), so the
+      // `memoryPressure` overloads above would hide the inherited generic
+      // signatures and reject every other event name (#40003). Re-declare the
+      // generic signatures so both stay visible.
+      off(event: string | symbol, listener: (...args: any[]) => void): this;
+      removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
       binding(m: "constants"): {
         os: typeof import("node:os").constants;
         fs: typeof import("node:fs").constants;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -524,6 +524,59 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds: spawned tsc over a single file, like the
+  // Bun.mmap check above. @types/node@24 declares `off`/`removeListener` only
+  // on EventEmitter, not on `Process`, so the `memoryPressure` overloads in
+  // overrides.d.ts used to hide the inherited signatures and reject every
+  // other event name (#40003). @types/node >= 26 declares them on `Process`
+  // directly, which masks the bug, so this check pins @types/node@24 instead
+  // of reusing the base fixture.
+  describe("process event methods with @types/node@24", () => {
+    test("removeListener and off accept other event names", async () => {
+      const checkDir = join(TEMP_DIR, "types-node-24-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["index.ts"];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "package.json": JSON.stringify({ name: "types-node-24-check", private: true }),
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "index.ts": `process.removeListener("SIGINT", () => {});
+           process.off("unhandledRejection", () => {});
+           process.removeListener("memoryPressure", () => {});
+           process.on("memoryPressure", level => {
+             level satisfies "warning" | "critical";
+           });`,
+      });
+      await $`cd ${checkDir} && bun add @types/node@24`.quiet();
+      await cp(join(BASE_FIXTURE_DIR, "node_modules", "bun-types"), join(checkDir, "node_modules", "bun-types"), {
+        recursive: true,
+      });
+      await cp(
+        join(BASE_FIXTURE_DIR, "node_modules", "@types", "bun"),
+        join(checkDir, "node_modules", "@types", "bun"),
+        { recursive: true },
+      );
+
+      // Guard against resolution drift silently checking the wrong major.
+      const nodeTypesPkg = await Bun.file(join(checkDir, "node_modules", "@types", "node", "package.json")).json();
+      expect(nodeTypesPkg.version).toStartWith("24.");
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;


### PR DESCRIPTION
### Problem
- With `@types/node@24` installed, tsc rejects `process.removeListener("SIGINT", fn)` and `process.off(...)` with `error TS2345: Argument of type '"SIGINT"' is not assignable to parameter of type '"memoryPressure"'` (#40003).
- The cause is `packages/bun-types/overrides.d.ts:112-114`. It declares `off` and `removeListener` overloads for the `memoryPressure` event on `NodeJS.Process`. `@types/node@24` does not declare these two methods on `Process`, it only inherits them from `EventEmitter`. A method declared on a derived interface hides the inherited overloads, so `memoryPressure` became the only accepted event name.

### Fix
- Re-declare the generic `(event: string | symbol, listener: (...args: any[]) => void): this` signatures for `off` and `removeListener` next to the `memoryPressure` overloads.
- This restores exactly what `EventEmitter` provides on `@types/node@24`. On `@types/node@26`, which declares the same generic signatures on `Process` directly, the merge adds an identical overload and nothing changes.
- The other overridden methods (`on`, `once`, `addListener`, `prependListener`, `prependOnceListener`, `emit`) are declared on `Process` by `@types/node@24`, so declaration merging keeps them visible and they need no change.
- Verified: new case in `test/integration/bun-types/bun-types.test.ts` pins `@types/node@24` and runs tsc over `removeListener`/`off`/`memoryPressure` calls. It fails on main with the exact error above. The full bun-types integration suite passes (16/16).

### Background
- `bun-types` augments `NodeJS.Process` in `overrides.d.ts` to type the Bun-only `memoryPressure` event (#32594).
- TypeScript merges same-name interface declarations, so overloads added to `Process` coexist with the ones `@types/node` declares there. Hiding only happens for methods the base interface (`EventEmitter`) declares and the derived interface (`Process`) does not.
- The existing bun-types fixture resolves `@types/node@latest` (currently 26), which masks the bug. That is why #39807 was closed as unreproducible. The new test pins major 24 and asserts the installed major so resolution drift cannot make it vacuous.
- #37790 touches the same declarations with a `ProcessEventMap` approach, bundled with unrelated scripts/build typecheck fixes. This PR is the minimal fix for the reported break on the current `@types/node` LTS.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/26] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/26] gen cpp.rs (cppbind)
[3/26] gen JS modules (bundle-modules)
Preprocess modules (7475ms)
Bundle modules (60ms)
Postprocesss modules (199ms)
Bundle Functions (490ms)
Generate Code (35ms)

[8.27s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/8] cargo bun_runtime → libbun_runtime.a
[4/8] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar -
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (7e07e7a89)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [0.10ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.34ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [2875.25ms]
(pass) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts [553.59ms]
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [48.09ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [49.86ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [0.79ms]
(pass) @types/bun integration test > Event and EventTarget > lib.dom's composedPath() declaration wins when lib.dom is loaded [78.63ms]
(pass) @types/bun integration test > Event and EventTarget > the Node-style composedPath() tuple applies without lib.dom [51.17ms]
570 |       });
571 | 
572 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.1 (d578a8c70)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.04ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [5.88ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [745.09ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [682.14ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [38.91ms]
(pass) @types/bun integration test > Event and EventTarget > lib.dom's composedPath() declaration wins when lib.dom is loaded [718.69ms]
(pass) @types/bun integration test > Event and EventTarget > the Node-style composedPath() tuple appl
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 773ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7439ms)
Bundle modules (34ms)
Postprocesss modules (40ms)
Bundle Functions (439ms)
Generate Code (23ms)

[7.98s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/ca
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/overrides.d.ts            |  8 +++++
 test/integration/bun-types/bun-types.test.ts | 53 ++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/overrides.d.ts                 1      1      0
test/integration/bun-types/bun-types.test.ts      4      5      0
```

</details>

**root cause** · written by the author bot

The bug was that the memoryPressure overloads for removeListener and off in overrides.d.ts were the only declarations of those methods on the NodeJS.Process interface under @types/node@24, where Process inherits them solely from EventEmitter; since re-declared methods in a derived interface hide inherited overloads rather than merging with them, the memoryPressure signature became the only one visible, rejecting any other event name. The fix re-declares the generic (eventName: string | symbol, listener: (...args: any[]) => void) overload alongside the memoryPressure overloads, so both the t…

<!-- robobun:evidence:end -->