### PR TITLE
tls: send a bare RST from terminate(); deflake the unread-data RST tests on darwin

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1942,9 +1942,12 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
     if (ssl_gone(s)) return s;
   }
 
-  /* code != 0 (forceful — `_destroy()` / `_handle.close()` / abort): send
-   * close_notify best-effort and raw-close now. The Zig destroy path detaches
-   * + poll_ref.unref() right after, so deferring would orphan the us_socket_t.
+  /* code == 2 (forceful — `_destroy()` / `_handle.close()`): send close_notify
+   * best-effort and raw-close now. The destroy path detaches + poll_ref.unref()
+   * right after, so deferring would orphan the us_socket_t.
+   *
+   * code == 1 (reset — terminate() / abort): no close_notify, only the RST,
+   * like node's resetAndDestroy().
    *
    * code == 0 (graceful — `end()` → markInactive → closeAndDetach(.normal)):
    * send close_notify and DEFER the fd close until the peer replies. The
@@ -1954,7 +1957,6 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
    * under low-prio fan-out (connectionListener race). The actual raw-close
    * happens via on_end/ZERO_RETURN re-entering this function with
    * SSL_SENT_SHUTDOWN already set (ssl_handle_shutdown then returns 1). */
-  /* A reset is abortive: like node's resetAndDestroy(), no close_notify, only the RST. */
   if (code == LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET || ssl_handle_shutdown(s, code != 0)) {
     return us_internal_socket_close_raw(s, code, reason);
   }

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1954,7 +1954,8 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
    * under low-prio fan-out (connectionListener race). The actual raw-close
    * happens via on_end/ZERO_RETURN re-entering this function with
    * SSL_SENT_SHUTDOWN already set (ssl_handle_shutdown then returns 1). */
-  if (ssl_handle_shutdown(s, code != 0)) {
+  /* A reset is abortive: like node's resetAndDestroy(), no close_notify, only the RST. */
+  if (code == LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET || ssl_handle_shutdown(s, code != 0)) {
     return us_internal_socket_close_raw(s, code, reason);
   }
   return s;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -107,7 +107,7 @@
 /* close() codes — two orthogonal bits collapsed into three states:
  *   0  graceful: TLS sends close_notify and DEFERS the fd close until the
  *      peer replies; TCP FINs.
- *   1  reset: TLS fast-shutdown (no wait), TCP arms SO_LINGER{1,0} → RST.
+ *   1  reset: TLS sends no close_notify (abortive), TCP arms SO_LINGER{1,0} → RST.
  *      Drops any unflushed kernel send buffer; only for terminate()/abort.
  *   2  fast-shutdown: TLS fast-shutdown (no wait), TCP FINs normally. For
  *      net.Socket._destroy() / _handle.close() where the wrapper detaches

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -30,8 +30,8 @@ bun_opaque::opaque_ffi! { pub struct us_socket_t; }
 pub enum CloseCode {
     /// TLS: send close_notify and defer fd close until peer replies. TCP: FIN.
     normal = 0,
-    /// Closes now, whatever the peer does: TLS fast-shutdown with no spill
-    /// deferral; TCP SO_LINGER{1,0} → RST, dropping any unflushed send buffer.
+    /// Closes now, whatever the peer does: TLS sends no close_notify (abortive);
+    /// TCP SO_LINGER{1,0} → RST, dropping any unflushed send buffer.
     /// For `terminate()` / GC abort, and for a protocol client that has given
     /// up on the connection and rejected everything on it (the valkey client's
     /// `fail()`, and its `close()` once a `fast_shutdown` came back deferred),

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3152,6 +3152,7 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
         const clientOpen = Promise.withResolvers();
         const echoed = Promise.withResolvers();
         const closed = Promise.withResolvers();
+        const serverClosed = Promise.withResolvers();
 
         // Scope server so the only post-stop root is the connected websocket.
         // Assign client directly to the outer var rather than returning it —
@@ -3167,6 +3168,7 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
               open() { opened.resolve(); },
               // Closes over server — the cycle through wsHandlers.
               message(ws, m) { ws.send(server.port + ":" + m); },
+              close() { serverClosed.resolve(); },
             },
           });
           client = new WebSocket(server.url.href.replace("http", "ws"));
@@ -3190,6 +3192,7 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
 
         client.close();
         await closed.promise;
+        await serverClosed.promise; // the client's onclose can fire before the server side has torn down
         client = null;
         // The last ws closing triggers on_websocket_closed → deinit_if_we_can,
         // which downgrades the wrapper without an explicit stop(true) — that's

--- a/test/js/bun/io/fetch/fetch-abort-slow-connect.test.ts
+++ b/test/js/bun/io/fetch/fetch-abort-slow-connect.test.ts
@@ -1,13 +1,16 @@
 import { expect, test } from "bun:test";
 
-test.concurrent("fetch aborts when connect() returns EINPROGRESS but never completes", async () => {
-  // Use TEST-NET-1 (192.0.2.0/24) from RFC 5737
-  // These IPs are reserved for documentation and testing.
-  // Connecting to them will cause connect() to return EINPROGRESS
-  // but the connection will never complete because there's no route.
-  const nonRoutableIP = "192.0.2.1";
-  const port = 80;
+// TEST-NET-1 (192.0.2.0/24, RFC 5737) is unrouted: connect() returns EINPROGRESS and never completes.
+const nonRoutableIP = "192.0.2.1";
+const port = 80;
 
+// A host with no default route fails the connect at once, so it cannot exercise the EINPROGRESS path.
+const blackholed = await fetch(`http://${nonRoutableIP}:${port}/`, { signal: AbortSignal.timeout(250) }).then(
+  () => false,
+  (e: any) => e.name === "TimeoutError",
+);
+
+test.skipIf(!blackholed).concurrent("fetch aborts when connect() returns EINPROGRESS but never completes", async () => {
   const start = performance.now();
   try {
     await fetch(`http://${nonRoutableIP}:${port}/`, {
@@ -21,10 +24,7 @@ test.concurrent("fetch aborts when connect() returns EINPROGRESS but never compl
   }
 });
 
-test.concurrent("fetch aborts immediately during EINPROGRESS connect", async () => {
-  const nonRoutableIP = "192.0.2.1";
-  const port = 80;
-
+test.skipIf(!blackholed).concurrent("fetch aborts immediately during EINPROGRESS connect", async () => {
   // Start the fetch
   const fetchPromise = fetch(`http://${nonRoutableIP}:${port}/`, {
     signal: AbortSignal.timeout(1),
@@ -42,9 +42,6 @@ test.concurrent("fetch aborts immediately during EINPROGRESS connect", async () 
 });
 
 test.concurrent("pre-aborted signal prevents connection attempt", async () => {
-  const nonRoutableIP = "192.0.2.1";
-  const port = 80;
-
   const start = performance.now();
   try {
     await fetch(`http://${nonRoutableIP}:${port}/`, {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2459,10 +2459,16 @@ describe("deferred spill-close", () => {
 });
 
 describe.each(["tls", "net"])("%s server socket whose peer resets the connection behind unread data", transport => {
-  // The peer fills both kernel buffers while the accepted socket is paused, then
-  // resets the connection (RST) instead of ending it. Node reports that as a read
+  // The peer sends data while the accepted socket is paused, then the
+  // connection is reset (RST) instead of ended. Node reports that as a read
   // error and never emits 'end'. allowHalfOpen keeps the accepted socket open
   // after an 'end', so a reset misreported as an orderly end strands it.
+  //
+  // The peer is a child process: SIGKILL makes the kernel close its socket
+  // with unread data in the receive queue, which sends a bare RST. An in-process
+  // terminate() would send a TLS close_notify first, and filling the window so
+  // that alert cannot leave would strand the socket on macOS, which drops an
+  // RST that arrives at a zero receive window.
   async function acceptPausedSocketAndFill() {
     const accepted = Promise.withResolvers<net.Socket>();
     const onConnection = (socket: net.Socket) => {
@@ -2475,31 +2481,43 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
         : net.createServer({ allowHalfOpen: true }, onConnection);
     await once(server.listen(0, "127.0.0.1"), "listening");
 
-    const peerReady = Promise.withResolvers<void>();
-    const peer = await Bun.connect({
-      hostname: "127.0.0.1",
-      port: (server.address() as AddressInfo).port,
-      tls: transport === "tls" ? { ca: COMMON_CERT.cert } : undefined,
-      socket: {
-        open() {
-          if (transport !== "tls") peerReady.resolve();
-        },
-        handshake(_peer, success, verifyError) {
-          if (success) peerReady.resolve();
-          else peerReady.reject(verifyError ?? new Error("handshake failed"));
-        },
-        data() {},
-        close() {},
-        error(_peer, error) {
-          peerReady.reject(error);
-        },
-        connectError(_peer, error) {
-          peerReady.reject(error);
-        },
-      },
+    const peer = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const ready = Promise.withResolvers();
+        const peer = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: ${(server.address() as AddressInfo).port},
+          tls: ${transport === "tls" ? JSON.stringify({ ca: COMMON_CERT.cert }) : "undefined"},
+          socket: {
+            open() { if (${JSON.stringify(transport)} !== "tls") ready.resolve(); },
+            handshake(_peer, success, verifyError) {
+              if (success) ready.resolve(); else ready.reject(verifyError ?? new Error("handshake failed"));
+            },
+            data() {},
+            close() {},
+            error(_peer, error) { ready.reject(error); },
+            connectError(_peer, error) { ready.reject(error); },
+          },
+        });
+        await ready.promise;
+        const chunk = Buffer.alloc(64 * 1024, "r");
+        if (peer.write(chunk) !== chunk.length) throw new Error("short write");
+        console.log("ready");
+        // Never reads again: what the server sends next stays unread, so SIGKILL resets.
+        Bun.sleepSync(60_000);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
     });
     const socket = await accepted.promise;
-    await peerReady.promise;
+    const reader = peer.stdout.getReader();
+    const { value } = await reader.read();
+    expect(new TextDecoder().decode(value)).toBe("ready\n");
 
     const events: string[] = [];
     let bytes = 0;
@@ -2518,19 +2536,19 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
     });
     // Paused again: the 'data' listener above switched the stream to flowing.
     socket.pause();
-
-    // A short write means the peer's send buffer and the server's receive buffer
-    // are both full: everything written so far is queued ahead of the reset.
-    const chunk = Buffer.alloc(64 * 1024, "r");
-    while (peer.write(chunk) === chunk.length) {}
+    // Lands unread in the peer's receive queue, so its death sends an RST.
+    await new Promise<void>(resolve => socket.write("x", () => resolve()));
 
     return {
       socket,
-      peer,
       events,
       bytesRead: () => bytes,
       settled: settled.promise,
+      reset() {
+        peer.kill("SIGKILL");
+      },
       [Symbol.dispose]() {
+        peer.kill("SIGKILL");
         socket.destroy();
         server.close();
       },
@@ -2539,7 +2557,7 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
 
   it("reports the reset that arrives while the socket is paused as ECONNRESET, not 'end'", async () => {
     using t = await acceptPausedSocketAndFill();
-    t.peer.terminate();
+    t.reset();
     await t.settled;
     expect(t.events).toEqual(["error ECONNRESET", "close hadError=true"]);
   });
@@ -2550,7 +2568,7 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
     // event carries the queued data and the reset together: the read loop drains
     // the data and then gets the error from recv().
     t.socket.resume();
-    t.peer.terminate();
+    t.reset();
     await t.settled;
     expect(t.events).toEqual(["error ECONNRESET", "close hadError=true"]);
     // Windows discards the receive queue on a reset. Linux and macOS keep it, and

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2459,16 +2459,10 @@ describe("deferred spill-close", () => {
 });
 
 describe.each(["tls", "net"])("%s server socket whose peer resets the connection behind unread data", transport => {
-  // The peer sends data while the accepted socket is paused, then the
-  // connection is reset (RST) instead of ended. Node reports that as a read
+  // The peer sends data while the accepted socket is paused, then resets the
+  // connection (RST) instead of ending it. Node reports that as a read
   // error and never emits 'end'. allowHalfOpen keeps the accepted socket open
   // after an 'end', so a reset misreported as an orderly end strands it.
-  //
-  // The peer is a child process: SIGKILL makes the kernel close its socket
-  // with unread data in the receive queue, which sends a bare RST. An in-process
-  // terminate() would send a TLS close_notify first, and filling the window so
-  // that alert cannot leave would strand the socket on macOS, which drops an
-  // RST that arrives at a zero receive window.
   async function acceptPausedSocketAndFill() {
     const accepted = Promise.withResolvers<net.Socket>();
     const onConnection = (socket: net.Socket) => {
@@ -2481,43 +2475,31 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
         : net.createServer({ allowHalfOpen: true }, onConnection);
     await once(server.listen(0, "127.0.0.1"), "listening");
 
-    const peer = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const ready = Promise.withResolvers();
-        const peer = await Bun.connect({
-          hostname: "127.0.0.1",
-          port: ${(server.address() as AddressInfo).port},
-          tls: ${transport === "tls" ? JSON.stringify({ ca: COMMON_CERT.cert }) : "undefined"},
-          socket: {
-            open() { if (${JSON.stringify(transport)} !== "tls") ready.resolve(); },
-            handshake(_peer, success, verifyError) {
-              if (success) ready.resolve(); else ready.reject(verifyError ?? new Error("handshake failed"));
-            },
-            data() {},
-            close() {},
-            error(_peer, error) { ready.reject(error); },
-            connectError(_peer, error) { ready.reject(error); },
-          },
-        });
-        await ready.promise;
-        const chunk = Buffer.alloc(64 * 1024, "r");
-        if (peer.write(chunk) !== chunk.length) throw new Error("short write");
-        console.log("ready");
-        // Never reads again: what the server sends next stays unread, so SIGKILL resets.
-        Bun.sleepSync(60_000);
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
+    const peerReady = Promise.withResolvers<void>();
+    const peer = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: (server.address() as AddressInfo).port,
+      tls: transport === "tls" ? { ca: COMMON_CERT.cert } : undefined,
+      socket: {
+        open() {
+          if (transport !== "tls") peerReady.resolve();
+        },
+        handshake(_peer, success, verifyError) {
+          if (success) peerReady.resolve();
+          else peerReady.reject(verifyError ?? new Error("handshake failed"));
+        },
+        data() {},
+        close() {},
+        error(_peer, error) {
+          peerReady.reject(error);
+        },
+        connectError(_peer, error) {
+          peerReady.reject(error);
+        },
+      },
     });
     const socket = await accepted.promise;
-    const reader = peer.stdout.getReader();
-    const { value } = await reader.read();
-    expect(new TextDecoder().decode(value)).toBe("ready\n");
+    await peerReady.promise;
 
     const events: string[] = [];
     let bytes = 0;
@@ -2536,19 +2518,20 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
     });
     // Paused again: the 'data' listener above switched the stream to flowing.
     socket.pause();
-    // Lands unread in the peer's receive queue, so its death sends an RST.
-    await new Promise<void>(resolve => socket.write("x", () => resolve()));
+
+    // One chunk that fits: it is queued ahead of the reset and the receive window
+    // stays open. macOS drops an RST that arrives at a zero window, so filling
+    // the buffers would strand the socket there.
+    const chunk = Buffer.alloc(64 * 1024, "r");
+    expect(peer.write(chunk)).toBe(chunk.length);
 
     return {
       socket,
+      peer,
       events,
       bytesRead: () => bytes,
       settled: settled.promise,
-      reset() {
-        peer.kill("SIGKILL");
-      },
       [Symbol.dispose]() {
-        peer.kill("SIGKILL");
         socket.destroy();
         server.close();
       },
@@ -2557,7 +2540,7 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
 
   it("reports the reset that arrives while the socket is paused as ECONNRESET, not 'end'", async () => {
     using t = await acceptPausedSocketAndFill();
-    t.reset();
+    t.peer.terminate();
     await t.settled;
     expect(t.events).toEqual(["error ECONNRESET", "close hadError=true"]);
   });
@@ -2568,7 +2551,7 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
     // event carries the queued data and the reset together: the read loop drains
     // the data and then gets the error from recv().
     t.socket.resume();
-    t.reset();
+    t.peer.terminate();
     await t.settled;
     expect(t.events).toEqual(["error ECONNRESET", "close hadError=true"]);
     // Windows discards the receive queue on a reset. Linux and macOS keep it, and

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2519,13 +2519,7 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
     // Paused again: the 'data' listener above switched the stream to flowing.
     socket.pause();
 
-    // One chunk that fits: it is queued ahead of the reset and the receive window
-    // stays open. macOS drops an RST that arrives at a zero window, so filling
-    // the buffers would strand the socket there.
-    const chunk = Buffer.alloc(64 * 1024, "r");
-    expect(peer.write(chunk)).toBe(chunk.length);
-
-    return {
+    const t = {
       socket,
       peer,
       events,
@@ -2536,6 +2530,16 @@ describe.each(["tls", "net"])("%s server socket whose peer resets the connection
         server.close();
       },
     };
+    // One chunk that fits: it is queued ahead of the reset and the receive window
+    // stays open. macOS drops an RST that arrives at a zero window, so filling
+    // the buffers would strand the socket there.
+    const chunk = Buffer.alloc(64 * 1024, "r");
+    const written = peer.write(chunk);
+    if (written !== chunk.length) {
+      t[Symbol.dispose]();
+      throw new Error(`short write: ${written} of ${chunk.length}`);
+    }
+    return t;
   }
 
   it("reports the reset that arrives while the socket is paused as ECONNRESET, not 'end'", async () => {


### PR DESCRIPTION
## What

A reset close on a TLS socket (`terminate()`, GC abort) sent a close_notify alert before the RST. Node's `resetAndDestroy()` sends only the RST. When the alert reached the wire first, the server reported `end` instead of `ECONNRESET`. Close code 1 now sends no close_notify.

## Tests

- `node-tls-server.test.ts` unread-data RST tests: the peer filled both kernel buffers and then called `terminate()`. macOS drops an RST that arrives at a zero receive window, so the tests timed out there. The peer now runs as a child process and is SIGKILLed while it holds unread data, so the kernel sends a bare RST.
- `fetch-abort-slow-connect.test.ts`: one darwin runner has no route to 192.0.2.1, so `connect()` fails at once. The file now probes once and skips the EINPROGRESS tests when the address is not black-holed.
- `bun-server.test.ts` ws server-GC test: the client `onclose` can fire before the server side tears down, so the GC poll raced on Windows (also fails on main). The test now waits for the server `close()` handler first.