### PR TITLE
inspect hooks: copy user options with putDirectMayBeIndex

### DIFF
--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -47,7 +47,6 @@
 
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
-#include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include "ScriptExecutionContext.h"
@@ -222,20 +221,11 @@ JSC_DEFINE_HOST_FUNCTION(jsURLSearchParamsPrototypeFunction_inspectCustom, (JSGl
         return JSValue::encode(jsNontrivialString(vm, "[Object]"_s));
     }
 
-    JSObject* opts = constructEmptyObject(lexicalGlobalObject);
+    JSObject* opts = Bun::WebStreams::copyInspectOptions(lexicalGlobalObject, optionsValue);
+    RETURN_IF_EXCEPTION(scope, {});
     JSValue childDepth = jsNull();
-    if (options) {
-        PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
-        options->getPropertyNames(lexicalGlobalObject, names, DontEnumPropertiesMode::Exclude);
-        RETURN_IF_EXCEPTION(scope, {});
-        for (size_t i = 0; i < names.size(); ++i) {
-            JSValue v = options->get(lexicalGlobalObject, names[i]);
-            RETURN_IF_EXCEPTION(scope, {});
-            opts->putDirect(vm, names[i], v, 0);
-        }
-        if (!depthValue.isUndefinedOrNull())
-            childDepth = jsNumber(depth - 1);
-    }
+    if (options && !depthValue.isUndefinedOrNull())
+        childDepth = jsNumber(depth - 1);
     opts->putDirect(vm, Identifier::fromString(vm, "depth"_s), childDepth, 0);
 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -31,19 +31,11 @@ EncodedJSValue customInspect(JSGlobalObject* lexicalGlobalObject, CallFrame* cal
     if (depth < 0)
         return JSValue::encode(thisValue);
 
-    JSObject* opts = constructEmptyObject(lexicalGlobalObject);
+    JSObject* opts = copyInspectOptions(lexicalGlobalObject, optionsValue);
+    RETURN_IF_EXCEPTION(scope, {});
     JSValue childDepth = jsNull();
     if (optionsValue.isObject()) {
-        JSObject* options = asObject(optionsValue);
-        PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
-        options->getPropertyNames(lexicalGlobalObject, names, DontEnumPropertiesMode::Exclude);
-        RETURN_IF_EXCEPTION(scope, {});
-        for (size_t i = 0; i < names.size(); ++i) {
-            JSValue v = options->get(lexicalGlobalObject, names[i]);
-            RETURN_IF_EXCEPTION(scope, {});
-            opts->putDirect(vm, names[i], v, 0);
-        }
-        JSValue optionsDepth = options->get(lexicalGlobalObject, Identifier::fromString(vm, "depth"_s));
+        JSValue optionsDepth = asObject(optionsValue)->get(lexicalGlobalObject, Identifier::fromString(vm, "depth"_s));
         RETURN_IF_EXCEPTION(scope, {});
         if (!optionsDepth.isUndefinedOrNull()) {
             double d = optionsDepth.toNumber(lexicalGlobalObject);
@@ -71,6 +63,28 @@ EncodedJSValue customInspect(JSGlobalObject* lexicalGlobalObject, CallFrame* cal
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsString(vm, makeString(name, " "_s, view.data)));
+}
+
+JSObject* copyInspectOptions(JSGlobalObject* lexicalGlobalObject, JSValue optionsValue)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* copy = constructEmptyObject(lexicalGlobalObject);
+    JSObject* options = optionsValue.getObject();
+    if (!options)
+        return copy;
+
+    PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+    options->methodTable()->getOwnPropertyNames(options, lexicalGlobalObject, names, DontEnumPropertiesMode::Exclude);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    for (const auto& name : names) {
+        JSValue value = options->get(lexicalGlobalObject, name);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        copy->putDirectMayBeIndex(lexicalGlobalObject, name, value);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+    return copy;
 }
 
 WTF::String constructorNameOf(JSGlobalObject* lexicalGlobalObject, JSValue thisValue, ASCIILiteral fallback)

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
@@ -15,9 +15,7 @@ namespace WebStreams {
 JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, JSC::JSObject* data);
 // Same, with a runtime-computed class name (subclass-aware inspectors).
 JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, const WTF::String& name, JSC::JSObject* data);
-// `{ ...options }` for a nested inspect call (empty when `options` is not an object).
-// util.inspect passes unknown user options through to hooks, so a key can be an array
-// index, which putDirect rejects. Returns nullptr with an exception pending.
+// `{ ...options }`: the options node's hooks pass to their nested inspect call.
 JSC::JSObject* copyInspectOptions(JSC::JSGlobalObject*, JSC::JSValue options);
 // getConstructorOf(obj).name (node lib/internal/util.js) with `fallback` when
 // no named constructor is found on the prototype chain.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
@@ -15,6 +15,10 @@ namespace WebStreams {
 JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, JSC::JSObject* data);
 // Same, with a runtime-computed class name (subclass-aware inspectors).
 JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, const WTF::String& name, JSC::JSObject* data);
+// `{ ...options }` for a nested inspect call (empty when `options` is not an object).
+// util.inspect passes unknown user options through to hooks, so a key can be an array
+// index, which putDirect rejects. Returns nullptr with an exception pending.
+JSC::JSObject* copyInspectOptions(JSC::JSGlobalObject*, JSC::JSValue options);
 // getConstructorOf(obj).name (node lib/internal/util.js) with `fallback` when
 // no named constructor is found on the prototype chain.
 WTF::String constructorNameOf(JSC::JSGlobalObject*, JSC::JSValue thisValue, ASCIILiteral fallback);

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -1,6 +1,7 @@
 // this file is compatible with jest to test node.js' util.inspect as well as bun's
 
 const util = require("util");
+const { bunEnv, bunExe } = process.versions.bun ? require("harness") : {};
 
 test("util.inspect.custom exists", () => {
   expect(util.inspect.custom).toEqual(Symbol.for("nodejs.util.inspect.custom"));
@@ -311,7 +312,6 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
   // unknown user options to the hooks as they are, and the native copy of the options
   // used to fail an assertion on an index key.
   test("accepts a user option whose key is an array index", async () => {
-    const { bunEnv, bunExe } = require("harness");
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -306,6 +306,44 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
     expect(rs[customSymbol](-1, {})).toBe(rs);
   });
 
+  // Like node's customInspect (lib/internal/webstreams/util.js), the hook passes
+  // `{ ...options }` to the inspect call it makes for its fields. util.inspect forwards
+  // unknown user options to the hooks as they are, and the native copy of the options
+  // used to fail an assertion on an index key.
+  test("accepts a user option whose key is an array index", async () => {
+    const { bunEnv, bunExe } = require("harness");
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { inspect } = require("node:util");
+         console.log(inspect(new ReadableStream(), { 0: 1 }));
+         console.log(inspect(new WritableStream(), { 0: 1 }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout:
+        "ReadableStream { locked: false, state: 'readable', supportsBYOB: false }\n" +
+        "WritableStream { locked: false, state: 'writable' }\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("copies the own enumerable options and not the inherited ones", () => {
+    const rs = new ReadableStream();
+    expect(rs[customSymbol](2, { colors: true })).toBe(
+      "ReadableStream { locked: \u001b[33mfalse\u001b[39m, state: \u001b[32m'readable'\u001b[39m, supportsBYOB: \u001b[33mfalse\u001b[39m }",
+    );
+    expect(rs[customSymbol](2, Object.create({ colors: true }))).toBe(
+      "ReadableStream { locked: false, state: 'readable', supportsBYOB: false }",
+    );
+  });
+
   test("wrong receiver returns the receiver (no infinite recursion)", () => {
     const o = {};
     expect(ReadableStream.prototype[customSymbol].call(o, 2, {})).toBe(o);

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -463,6 +463,48 @@ describe("url", () => {
   });
 });
 
+// Like node's, both hooks pass `{ ...options }` to the inspect call they make for their
+// contents. util.inspect forwards unknown user options to the hooks as they are.
+describe("URL and URLSearchParams [nodejs.util.inspect.custom] options", () => {
+  const oneLineUrl =
+    "URL { href: 'https://example.com/?a=1', origin: 'https://example.com', protocol: 'https:', username: '', password: '', host: 'example.com', hostname: 'example.com', port: '', pathname: '/', search: '?a=1', searchParams: URLSearchParams { 'a' => '1' }, hash: '' }";
+
+  // The native copy of the options used to fail an assertion on an index key. The URL
+  // case reaches the URLSearchParams hook a second time, through the nested inspect call.
+  test("accepts a user option whose key is an array index", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { inspect } = require("node:util");
+         console.log(inspect(new URLSearchParams("a=1&b=2"), { 0: 1 }));
+         console.log(inspect(new URL("https://example.com/?a=1"), { 0: 1, breakLength: Infinity }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: `URLSearchParams { 'a' => '1', 'b' => '2' }\n${oneLineUrl}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("copies the own enumerable options and not the inherited ones", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params[util.inspect.custom](2, { colors: true })).toBe(
+      "URLSearchParams { \u001b[32m'a'\u001b[39m => \u001b[32m'1'\u001b[39m }",
+    );
+    expect(params[util.inspect.custom](2, Object.create({ colors: true }))).toBe("URLSearchParams { 'a' => '1' }");
+
+    const url = new URL("https://example.com/?a=1");
+    expect(url[util.inspect.custom](2, { breakLength: Infinity })).toBe(oneLineUrl);
+    expect(url[util.inspect.custom](2, Object.create({ breakLength: Infinity }))).toBe(util.inspect(url));
+  });
+});
+
 describe("url.searchParams lazy href sync", () => {
   // The URLSearchParams update steps are applied lazily to the associated
   // URL's serialized string: each getter below must observe the change without


### PR DESCRIPTION
### Problem
- On a debug build, `util.inspect(new URLSearchParams("a=1"), { 0: 1 })` and `util.inspect(new ReadableStream(), { 0: 1 })` abort with `ASSERTION FAILED: !parseIndex(propertyName)` in `JSC::JSObject::putDirectInternal`. A release build stores `"0"` as a named property, where JSC never looks for an index key.
- The native hooks copy the options with `putDirect` (`src/jsc/bindings/webcore/JSURLSearchParams.cpp:234`, `src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp:44`). `util.inspect` forwards unknown user options to the hooks as they are, so a key can be an array index.
- The shared loop also serves `URL`, `CryptoKey` and the 17 web streams classes.

### Fix
- Add `Bun::WebStreams::copyInspectOptions`. It copies the own enumerable properties of the options with `putDirectMayBeIndex`. Both hooks call it in place of their own loops.
- `putDirectMayBeIndex` is what JSC uses in the slow path of `CopyDataProperties`, and what `JSDOMFormData`, `JSFetchHeaders` and `CookieMap` use for the same case.
- Own properties only: node builds these options with `{ ...options }` (`lib/internal/url.js`, `lib/internal/webstreams/util.js`). The old loops also copied inherited keys. `util.inspect`, `Bun.inspect` and `console.log` pass own properties, so their output does not change.
- Verified: two new tests each in `test/js/web/url/url.test.ts` and `test/js/node/util/custom-inspect.test.js`. All four fail before the fix. More suites in Notes.

### Background
- `util.inspect` calls a `[nodejs.util.inspect.custom]` hook as `hook(depth, options)`. `options` carries every user option that `util.inspect` does not know (`getUserOptions` in `src/js/internal/util/inspect.js`). The hooks copy it, set `depth`, and inspect their contents with it.
- JSC keeps a property whose name is an array index in the indexed storage of the object, never in its structure. `putDirect` writes to the structure, so it asserts on such a name. `putDirectMayBeIndex` picks the storage from the name.
- `WebStreamsInspectCustom.h` already holds the helpers these hooks share.

<details><summary>Notes</summary>

- `JSBroadcastChannel.cpp:200` has a third copy of the loop. #32240 (open) fixes that site, so this PR does not touch it. It can switch to the helper once either PR lands.
- The hooks landed in this order: BroadcastChannel (#19269), the shared web streams hook (#33830), URLSearchParams (#34660). Each copied the loop. The helper is there so the next hook does not copy it again.
- Repro: `bun bd -e 'const {inspect}=require("node:util"); console.log(inspect(new URLSearchParams("a=1"), {0:1})); console.log(inspect(new ReadableStream(), {0:1}))'`. `URL`, `WritableStream` and `TransformStream` abort the same way.
- Probed with `BUN_JSC_validateExceptionChecks=1`: index keys of several shapes (`0`, `4294967294`, `4294967295`, `"01"`), symbol keys, a null prototype options object, non-object options, a Proxy whose `ownKeys` throws, a getter that throws, a Proxy that lists index keys, and a cross-context value. No unchecked exception. Errors propagate as JS exceptions.
- In the new tests, the direct hook calls with `Object.create({ colors: true })` and `Object.create({ breakLength: Infinity })` fail on the unfixed build on every build type. The spawned cases fail on debug builds only (the assertion).
- Other suites run: `test/js/web/html/URLSearchParams.test.ts`, `test/js/bun/util/inspect.test.js`, `test/js/node/util/bun-inspect.test.ts`, `test/js/web/broadcastchannel/broadcast-channel.test.ts`, and the node tests `test-whatwg-url-custom-inspect.js`, `test-webstream-encoding-inspect.js`, `test-whatwg-webstreams-coverage.js`, `test-whatwg-readablebytestream.js`, `test-broadcastchannel-custom-inspect.js`. All pass.
- `test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js`: "no assertion failures 2" hits the 5 s timeout on this debug+ASAN container (7.3 s, 56 ms on a release build). It inspects none of the changed classes.
- Self-review of the own-properties change, per caller: `util.inspect` builds the hook options as an object literal (`getUserOptions`), `Bun.inspect` and `console.log` build them from a fixed structure (`createInspectOptionsObject` in `UtilInspect.cpp`). Both are own properties, so only direct hook calls with inherited keys change, and they now match node. An own `__proto__` data key stays a data key on the copy (spread semantics, not `Object.assign`). A getter that deletes a later key during the copy gives the same output as node.
- Follow-up commits: b6e40caa9c loads `harness` at module scope in `custom-inspect.test.js` (conditional on `process.versions.bun`, the file stays loadable under jest). 04b2fe309b cuts the helper comment to one line.
</details>

