### PR TITLE
install: add --offline and --prefer-offline to bun install

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -186,7 +186,7 @@ With a warm cache, `bun install` can run without the network:
 # Use cached package metadata regardless of age; only fetch what is missing from the cache
 bun install --prefer-offline
 
-# Never touch the network; anything that is not already cached is an error
+# Never touch the network (registry, tarball URLs, git); a required dependency that is not cached is an error
 bun install --offline
 ```
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -190,7 +190,7 @@ bun install --prefer-offline
 bun install --offline
 ```
 
-`--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. Combined with `--frozen-lockfile` this makes CI installs from a restored cache fully deterministic and network-free.
+`--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. With a complete restored cache, `--offline --frozen-lockfile` makes a CI install fully deterministic and network-free; `--prefer-offline` still fetches whatever the cache is missing.
 
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -178,6 +178,20 @@ Bun does not enable `--frozen-lockfile` automatically in CI; pass the flag or us
 
 To validate the lockfile without installing, use `bun install --frozen-lockfile --dry-run`.
 
+### Offline installs
+
+With a warm cache, `bun install` can run without the network:
+
+```bash terminal icon="terminal"
+# Use cached package metadata regardless of age; only fetch what is missing from the cache
+bun install --prefer-offline
+
+# Never touch the network; anything that is not already cached is an error
+bun install --offline
+```
+
+`--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. Combined with `--frozen-lockfile` this makes CI installs from a restored cache fully deterministic and network-free.
+
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 
 ---

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -508,11 +508,11 @@ prefer = "online"
 
 Valid values are:
 
-| Value       | Description                                                                                        |
-| ----------- | -------------------------------------------------------------------------------------------------- |
-| `"online"`  | Default. Check the registry for stale packages as needed.                                          |
+| Value       | Description                                                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `"online"`  | Default. Check the registry for stale packages as needed.                                                                           |
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline` (also honoured by `bun install`). |
-| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
+| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                                                 |
 
 ### `install.offline`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -511,8 +511,17 @@ Valid values are:
 | Value       | Description                                                                                        |
 | ----------- | -------------------------------------------------------------------------------------------------- |
 | `"online"`  | Default. Check the registry for stale packages as needed.                                          |
-| `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
+| `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline` (also honoured by `bun install`). |
 | `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
+
+### `install.offline`
+
+When `true`, `bun install` never touches the network: package metadata and tarballs must already be in the cache, and anything missing is an error. Default `false`. Equivalent to `bun install --offline`. For the softer "use the cache when possible" behaviour see `install.prefer = "offline"` / `--prefer-offline`.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+offline = true
+```
 
 ### `install.frozenLockfile`
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1563,6 +1563,10 @@ impl<'a> Parser<'a> {
             install.hoist = Some(v);
         }
 
+        if let Some(v) = install_obj.get(b"offline").and_then(|e| e.as_bool()) {
+            install.offline = Some(v);
+        }
+
         Ok(())
     }
 

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -807,6 +807,20 @@ impl NetworkTask {
             return Err(ForTarballError::InvalidURL);
         }
 
+        // Only reached when the tarball is not already in the cache.
+        if pm.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
+            pm.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "--offline: {} is not in the cache (would fetch {})",
+                    quote(tarball.name.slice()),
+                    quote(&self.url_buf),
+                ),
+            );
+            return Err(ForTarballError::InvalidURL);
+        }
+
         // Userinfo becomes a header and leaves the URL: `bun_url` keeps it in `origin`, which the redirect same-origin check compares.
         let url_authorization: Option<Vec<u8>> = match split_url_userinfo(&self.url_buf) {
             Some((userinfo, url_without_userinfo)) => {

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -734,6 +734,10 @@ pub enum ForTarballError {
     OutOfMemory,
     #[error("InvalidURL")]
     InvalidURL,
+    /// `--offline` and the tarball is not in the cache. Already reported (once per
+    /// package); callers treat it like `AlreadyFailed`.
+    #[error("TarballFailedToDownload")]
+    Offline,
     /// Returned by `enqueue_*_for_download` when the dedupe map already records
     /// a terminal failure for this task id. Callers handle it silently (the
     /// original failure was already reported) and advance their own bookkeeping.
@@ -746,7 +750,9 @@ impl From<ForTarballError> for crate::Error {
         match e {
             ForTarballError::OutOfMemory => crate::Error::Alloc(bun_alloc::AllocError),
             ForTarballError::InvalidURL => crate::Error::InvalidURL,
-            ForTarballError::AlreadyFailed => crate::Error::TarballFailedToDownload,
+            ForTarballError::AlreadyFailed | ForTarballError::Offline => {
+                crate::Error::TarballFailedToDownload
+            }
         }
     }
 }
@@ -802,20 +808,6 @@ impl NetworkTask {
                     "Expected tarball URL to start with https:// or http://, got {} while fetching package {}",
                     quote(&self.url_buf),
                     quote(tarball.name.slice()),
-                ),
-            );
-            return Err(ForTarballError::InvalidURL);
-        }
-
-        // Only reached when the tarball is not already in the cache.
-        if pm.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
-            pm.log_mut().add_error_fmt(
-                None,
-                bun_ast::Loc::EMPTY,
-                format_args!(
-                    "--offline: {} is not in the cache (would fetch {})",
-                    quote(tarball.name.slice()),
-                    quote(&self.url_buf),
                 ),
             );
             return Err(ForTarballError::InvalidURL);

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1624,7 +1624,7 @@ impl<'a> PackageInstaller<'a> {
                             Err(ForTarballError::InvalidURL) => {
                                 self.fail_with_invalid_url(log_level, is_pending_package_install)
                             }
-                            Err(ForTarballError::AlreadyFailed) => self
+                            Err(ForTarballError::AlreadyFailed | ForTarballError::Offline) => self
                                 .increment_tree_install_count(
                                     !is_pending_package_install,
                                     self.current_tree_id,
@@ -1656,7 +1656,7 @@ impl<'a> PackageInstaller<'a> {
                             Err(ForTarballError::InvalidURL) => {
                                 self.fail_with_invalid_url(log_level, is_pending_package_install)
                             }
-                            Err(ForTarballError::AlreadyFailed) => self
+                            Err(ForTarballError::AlreadyFailed | ForTarballError::Offline) => self
                                 .increment_tree_install_count(
                                     !is_pending_package_install,
                                     self.current_tree_id,
@@ -1694,7 +1694,7 @@ impl<'a> PackageInstaller<'a> {
                             Err(ForTarballError::InvalidURL) => {
                                 self.fail_with_invalid_url(log_level, is_pending_package_install)
                             }
-                            Err(ForTarballError::AlreadyFailed) => self
+                            Err(ForTarballError::AlreadyFailed | ForTarballError::Offline) => self
                                 .increment_tree_install_count(
                                     !is_pending_package_install,
                                     self.current_tree_id,

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1599,14 +1599,21 @@ impl<'a> PackageInstaller<'a> {
                 };
                 match resolution.tag {
                     resolution::Tag::Git => {
-                        package_manager::enqueue_git_for_checkout(
+                        if package_manager::enqueue_git_for_checkout(
                             self.manager_mut(),
                             dependency_id,
                             alias.slice(string_buf!()),
                             resolution,
                             context,
                             download_patch_hash,
-                        );
+                        ) == package_manager::GitEnqueueResult::OfflineMiss
+                        {
+                            self.increment_tree_install_count(
+                                !is_pending_package_install,
+                                self.current_tree_id,
+                                log_level,
+                            );
+                        }
                     }
                     resolution::Tag::Github => {
                         let url = self.manager_mut().alloc_github_url(resolution.github());

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2248,6 +2248,11 @@ pub fn init(
                 == Some(bun_options_types::offline_mode::OfflineMode::Offline)
         {
             manager.options.offline = options::OfflineMode::PreferOffline;
+            // the manifest cache is the data source in this mode (see Options::load)
+            manager
+                .options
+                .enable
+                .set(options::Enable::MANIFEST_CACHE, true);
         }
 
         if let Some(config) = ctx.install.as_deref_mut() {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -216,12 +216,12 @@ pub use directories::{
 
 pub use self::package_manager_enqueue as enqueue;
 pub use enqueue::{
-    create_extract_task_for_streaming, enqueue_dependency_list, enqueue_dependency_to_root,
-    enqueue_dependency_with_main, enqueue_dependency_with_main_and_success_fn,
-    enqueue_extract_npm_package, enqueue_git_checkout, enqueue_git_for_checkout,
-    enqueue_network_task, enqueue_package_for_download, enqueue_parse_npm_package,
-    enqueue_patch_task, enqueue_patch_task_pre, enqueue_tarball_for_download,
-    enqueue_tarball_for_reading,
+    GitEnqueueResult, create_extract_task_for_streaming, enqueue_dependency_list,
+    enqueue_dependency_to_root, enqueue_dependency_with_main,
+    enqueue_dependency_with_main_and_success_fn, enqueue_extract_npm_package, enqueue_git_checkout,
+    enqueue_git_for_checkout, enqueue_network_task, enqueue_package_for_download,
+    enqueue_parse_npm_package, enqueue_patch_task, enqueue_patch_task_pre,
+    enqueue_tarball_for_download, enqueue_tarball_for_reading,
 };
 
 use self::package_manager_lifecycle as lifecycle;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1406,6 +1406,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         public_hoist_pattern,
         hoist_pattern,
         hoist,
+        offline,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1460,6 +1461,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         public_hoist_pattern,
         hoist_pattern,
         hoist,
+        offline,
     );
 }
 
@@ -2237,6 +2239,16 @@ pub fn init(
             ctx.install.as_deref(),
             subcommand,
         )?;
+
+        // `install.prefer = "offline"` in bunfig (also what `bun --prefer-offline` sets
+        // for the runtime's auto-install) means prefer-offline for `bun install` too,
+        // unless a flag already asked for more.
+        if manager.options.offline == options::OfflineMode::Online
+            && ctx.debug.offline_mode_setting
+                == Some(bun_options_types::offline_mode::OfflineMode::Offline)
+        {
+            manager.options.offline = options::OfflineMode::PreferOffline;
+        }
 
         if let Some(config) = ctx.install.as_deref_mut() {
             if let Some(p) = config.public_hoist_pattern.take() {

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -89,6 +89,12 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
         "--no-verify                           Skip verifying integrity of newly downloaded packages"
     ),
     clap::param!(
+        "--offline                             Never touch the network: resolve and install only from the local cache"
+    ),
+    clap::param!(
+        "--prefer-offline                      Use cached package metadata regardless of age; only fetch what is missing"
+    ),
+    clap::param!(
         "--ignore-scripts                      Skip lifecycle scripts in the project's package.json (dependency scripts are never run)"
     ),
     clap::param!(
@@ -520,6 +526,8 @@ pub struct CommandLineArguments {
     pub log_level: Options::LogLevel,
     pub(crate) no_progress: bool,
     pub(crate) no_verify: bool,
+    pub(crate) offline: bool,
+    pub(crate) prefer_offline: bool,
     pub(crate) ignore_scripts: bool,
     pub(crate) trusted: bool,
     pub(crate) no_summary: bool,
@@ -622,6 +630,8 @@ impl Default for CommandLineArguments {
             log_level: Options::LogLevel::default(),
             no_progress: false,
             no_verify: false,
+            offline: false,
+            prefer_offline: false,
             ignore_scripts: false,
             trusted: false,
             no_summary: false,
@@ -1288,6 +1298,8 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         cli.global = args.flag(b"--global");
         cli.force = args.flag(b"--force");
         cli.no_verify = args.flag(b"--no-verify");
+        cli.offline = args.flag(b"--offline");
+        cli.prefer_offline = args.flag(b"--prefer-offline");
         cli.no_cache = args.flag(b"--no-cache");
         // --silent checked first so `is_silent()` matches `--silent` exactly:
         // callers read it to suppress summaries/errors independently of verbose.

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -53,6 +53,7 @@ impl PackageManager {
             enable_manifest_cache_control: self.options.enable.manifest_cache_control(),
             cache_directory: enable_manifest_cache.then(|| get_cache_directory(self)),
             timestamp_for_manifest_cache_control: self.timestamp_for_manifest_cache_control,
+            accept_expired: self.options.offline != super::options::OfflineMode::Online,
         }
     }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -158,7 +158,7 @@ pub fn enqueue_tarball_for_download(
     if this.network_task_has_failed(task_id) {
         return Err(EnqueueTarballForDownloadError::AlreadyFailed);
     }
-    {
+    if this.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
         let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
             .behavior
             .is_required();
@@ -251,6 +251,16 @@ pub fn enqueue_tarball_for_reading(
     this.task_batch.push(ThreadPool::Batch::from(task));
 }
 
+/// Outcome of `enqueue_git_for_checkout`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum GitEnqueueResult {
+    /// a task was queued (or joined an existing one); completion arrives via the task queue
+    Queued,
+    /// `--offline` and the repository is not cached: nothing was queued (already reported
+    /// if required); the caller must count the package as failed/skipped itself
+    OfflineMiss,
+}
+
 pub fn enqueue_git_for_checkout(
     this: &mut PackageManager,
     dependency_id: DependencyID,
@@ -258,7 +268,7 @@ pub fn enqueue_git_for_checkout(
     resolution: &Resolution,
     task_context: TaskCallbackContext,
     patch_name_and_version_hash: Option<u64>,
-) {
+) -> GitEnqueueResult {
     // SAFETY: caller passes `resolution.tag == Git`; the `git` arm is the
     // active union field. Copy out so the value no longer borrows
     // `*resolution` while `*this` is mutably reborrowed below.
@@ -280,7 +290,7 @@ pub fn enqueue_git_for_checkout(
             .behavior
             .is_required();
         if offline_git_miss(this, clone_id, alias, is_required) {
-            return;
+            return GitEnqueueResult::OfflineMiss;
         }
     }
     let checkout_queue = this
@@ -294,7 +304,7 @@ pub fn enqueue_git_for_checkout(
     checkout_queue.value_ptr.push(task_context);
 
     if checkout_queue.found_existing {
-        return;
+        return GitEnqueueResult::Queued;
     }
 
     if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
@@ -320,13 +330,14 @@ pub fn enqueue_git_for_checkout(
             .push(TaskCallbackContext::Dependency(dependency_id));
 
         if clone_queue.found_existing {
-            return;
+            return GitEnqueueResult::Queued;
         }
 
         let dep = this.lockfile.buffers.dependencies[dependency_id as usize].clone();
         let task = enqueue_git_clone(this, clone_id, alias, &repository, &dep, resolution, None);
         this.task_batch.push(ThreadPool::Batch::from(task));
     }
+    GitEnqueueResult::Queued
 }
 
 /// Under `--offline`, an install-phase request for a package that is not in the cache
@@ -3155,7 +3166,7 @@ impl PackageManager {
         resolution: &Resolution,
         task_context: TaskCallbackContext,
         patch_name_and_version_hash: Option<u64>,
-    ) {
+    ) -> GitEnqueueResult {
         enqueue_git_for_checkout(
             self,
             dependency_id,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1128,12 +1128,30 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         }
 
                                         // Was it recent enough to just load it without the network call?
-                                        if this.options.enable.manifest_cache_control() && !expired
+                                        // `--prefer-offline` / `--offline` accept a cached manifest of
+                                        // any age.
+                                        if (this.options.enable.manifest_cache_control() && !expired)
+                                            || this.options.offline != crate::package_manager_real::options::OfflineMode::Online
                                         {
                                             let _ = this.network_dedupe_map.remove(&task_id);
                                             continue 'retry_from_manifests_ptr;
                                         }
                                     }
+                                }
+
+                                if this.options.offline
+                                    == crate::package_manager_real::options::OfflineMode::Offline
+                                {
+                                    let _ = this.network_dedupe_map.remove(&task_id);
+                                    let _ = this.log_mut().add_error_fmt(
+                                        None,
+                                        bun_ast::Loc::EMPTY,
+                                        format_args!(
+                                            "--offline: no cached manifest for \"{}\" (run once online, or use --prefer-offline)",
+                                            bstr::BStr::new(&name_str),
+                                        ),
+                                    );
+                                    return Ok(());
                                 }
 
                                 if verbose_install() {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -158,6 +158,18 @@ pub fn enqueue_tarball_for_download(
     if this.network_task_has_failed(task_id) {
         return Err(EnqueueTarballForDownloadError::AlreadyFailed);
     }
+    {
+        let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
+            .behavior
+            .is_required();
+        let name = this
+            .lockfile
+            .str(&this.lockfile.packages.get(package_id as usize).name)
+            .to_vec();
+        if offline_tarball_miss(this, task_id, &name, is_required) {
+            return Err(EnqueueTarballForDownloadError::Offline);
+        }
+    }
     let task_queue = this.task_queue.get_or_put(task_id)?;
     if !task_queue.found_existing {
         *task_queue.value_ptr = TaskCallbackList::default();
@@ -261,6 +273,16 @@ pub fn enqueue_git_for_checkout(
     let clone_id = Task::Id::for_git_clone(url);
     let resolved = this.lockfile.str_detached(&repository.resolved);
     let checkout_id = Task::Id::for_git_checkout(url, resolved);
+    // --offline: decide before any queue registration, so an optional miss leaves
+    // nothing behind and a later required edge still reaches the report
+    if this.git_repositories.get(&clone_id).is_none() {
+        let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
+            .behavior
+            .is_required();
+        if offline_git_miss(this, clone_id, alias, is_required) {
+            return;
+        }
+    }
     let checkout_queue = this
         .task_queue
         .get_or_put(checkout_id)
@@ -302,12 +324,37 @@ pub fn enqueue_git_for_checkout(
         }
 
         let dep = this.lockfile.buffers.dependencies[dependency_id as usize].clone();
-        if offline_git_miss(this, clone_id, alias, dep.behavior.is_required()) {
-            return;
-        }
         let task = enqueue_git_clone(this, clone_id, alias, &repository, &dep, resolution, None);
         this.task_batch.push(ThreadPool::Batch::from(task));
     }
+}
+
+/// Under `--offline`, an install-phase request for a package that is not in the cache
+/// (these helpers are only reached after the cache lookup missed): report it once if
+/// required, skip if optional, and never register a task nobody will complete.
+fn offline_tarball_miss(
+    this: &mut PackageManager,
+    task_id: Task::Id,
+    name: &[u8],
+    is_required: bool,
+) -> bool {
+    if this.options.offline != crate::package_manager_real::options::OfflineMode::Offline {
+        return false;
+    }
+    if is_required && !this.network_task_has_failed(task_id) {
+        // reserve + mark failed so later dependents take the already-failed path
+        let _ = this.has_created_network_task(task_id, true);
+        this.mark_network_task_failed(task_id);
+        let _ = this.log_mut().add_error_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "--offline: \"{}\" is not in the cache",
+                bstr::BStr::new(name)
+            ),
+        );
+    }
+    true
 }
 
 /// Under `--offline`, a git dependency whose clone is not already in the cache cannot
@@ -403,6 +450,14 @@ pub fn enqueue_package_for_download(
     let task_id = Task::Id::for_npm_package(name, version);
     if this.network_task_has_failed(task_id) {
         return Err(EnqueuePackageForDownloadError::AlreadyFailed);
+    }
+    {
+        let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
+            .behavior
+            .is_required();
+        if offline_tarball_miss(this, task_id, name, is_required) {
+            return Err(EnqueuePackageForDownloadError::Offline);
+        }
     }
     let task_queue = this.task_queue.get_or_put(task_id)?;
     if !task_queue.found_existing {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1146,15 +1146,19 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 if this.options.offline
                                     == crate::package_manager_real::options::OfflineMode::Offline
                                 {
-                                    let _ = this.network_dedupe_map.remove(&task_id);
-                                    let _ = this.log_mut().add_error_fmt(
-                                        None,
-                                        bun_ast::Loc::EMPTY,
-                                        format_args!(
-                                            "--offline: no cached manifest for \"{}\" (run once online, or use --prefer-offline)",
-                                            bstr::BStr::new(&name_str),
-                                        ),
-                                    );
+                                    // Keep the dedupe reservation so later edges to the same
+                                    // package do not report it again; optional/peer deps are
+                                    // skipped like any other unavailable optional dependency.
+                                    if dependency.behavior.is_required() {
+                                        let _ = this.log_mut().add_error_fmt(
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            format_args!(
+                                                "--offline: no cached manifest for \"{}\" (run once online, or use --prefer-offline)",
+                                                bstr::BStr::new(&name_str),
+                                            ),
+                                        );
+                                    }
                                     return Ok(());
                                 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -347,6 +347,9 @@ fn offline_git_miss(
                 bstr::BStr::new(name)
             ),
         );
+    } else {
+        // let a later required edge on the same repository report it
+        let _ = this.network_dedupe_map.remove(&clone_id);
     }
     true
 }
@@ -1461,7 +1464,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
             }
 
-            if let Some(network_task) = run_tasks::generate_network_task_for_tarball(
+            let generated = match run_tasks::generate_network_task_for_tarball(
                 this,
                 task_id,
                 &url,
@@ -1475,7 +1478,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 },
                 None,
                 crate::network_task::Authorization::NoAuthorization,
-            )? {
+            ) {
+                // --offline miss: already reported (if required) / skipped (if optional)
+                Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
+                other => other?,
+            };
+            if let Some(network_task) = generated {
                 // reshaped for borrowck — see `enqueue_tarball_for_download`.
                 let nt: *mut NetworkTask = network_task;
                 enqueue_network_task(this, nt);
@@ -1692,7 +1700,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     // immediately so the `&mut *this` borrow ends before
                     // `enqueue_network_task(this, …)` reborrows it (NLL).
                     let network_task: Option<*mut NetworkTask> =
-                        run_tasks::generate_network_task_for_tarball(
+                        match run_tasks::generate_network_task_for_tarball(
                             this,
                             task_id,
                             url,
@@ -1706,8 +1714,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             },
                             None,
                             crate::network_task::Authorization::NoAuthorization,
-                        )?
-                        .map(std::ptr::from_mut::<NetworkTask>);
+                        ) {
+                            // --offline miss: already reported / skipped
+                            Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
+                            other => other?.map(std::ptr::from_mut::<NetworkTask>),
+                        };
                     if let Some(network_task) = network_task {
                         enqueue_network_task(this, network_task);
                     }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -302,9 +302,53 @@ pub fn enqueue_git_for_checkout(
         }
 
         let dep = this.lockfile.buffers.dependencies[dependency_id as usize].clone();
+        if offline_git_miss(this, clone_id, alias, dep.behavior.is_required()) {
+            return;
+        }
         let task = enqueue_git_clone(this, clone_id, alias, &repository, &dep, resolution, None);
         this.task_batch.push(ThreadPool::Batch::from(task));
     }
+}
+
+/// Under `--offline`, a git dependency whose clone is not already in the cache cannot
+/// be installed: report it (once, and only if some edge requires it) instead of
+/// spawning `git`. Returns true when the clone must not be enqueued.
+fn offline_git_miss(
+    this: &mut PackageManager,
+    clone_id: Task::Id,
+    name: &[u8],
+    is_required: bool,
+) -> bool {
+    if this.options.offline != crate::package_manager_real::options::OfflineMode::Offline {
+        return false;
+    }
+    let mut folder = Vec::with_capacity(24);
+    {
+        use std::io::Write;
+        let _ = write!(
+            folder,
+            "{}.git",
+            bun_core::fmt::hex_int_lower::<16>(clone_id.get())
+        );
+    }
+    let cache_dir = package_manager_real::get_cache_directory(this);
+    let cached = bun_sys::directory_exists_at(cache_dir, &bun_core::ZBox::from_bytes(&folder))
+        .unwrap_or(false);
+    if cached {
+        return false;
+    }
+    if is_required {
+        this.mark_network_task_failed(clone_id);
+        let _ = this.log_mut().add_error_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "--offline: git repository for \"{}\" is not in the cache",
+                bstr::BStr::new(name)
+            ),
+        );
+    }
+    true
 }
 
 /// # Safety
@@ -1146,10 +1190,13 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 if this.options.offline
                                     == crate::package_manager_real::options::OfflineMode::Offline
                                 {
-                                    // Keep the dedupe reservation so later edges to the same
-                                    // package do not report it again; optional/peer deps are
-                                    // skipped like any other unavailable optional dependency.
+                                    // Optional/peer edges are skipped like any other unavailable
+                                    // optional dependency (and release the reservation so a later
+                                    // *required* edge on the same package still reports it); a
+                                    // required edge reports once and marks the task failed so
+                                    // later dependents take the already-failed path.
                                     if dependency.behavior.is_required() {
+                                        this.mark_network_task_failed(task_id);
                                         let _ = this.log_mut().add_error_fmt(
                                             None,
                                             bun_ast::Loc::EMPTY,
@@ -1158,6 +1205,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                 bstr::BStr::new(&name_str),
                                             ),
                                         );
+                                    } else {
+                                        let _ = this.network_dedupe_map.remove(&task_id);
                                     }
                                     return Ok(());
                                 }
@@ -1342,6 +1391,9 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
 
                 if this.has_created_network_task(clone_id, dependency.behavior.is_required()) {
+                    return Ok(());
+                }
+                if offline_git_miss(this, clone_id, alias, dependency.behavior.is_required()) {
                     return Ok(());
                 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -396,15 +396,19 @@ fn offline_git_miss(
         return false;
     }
     if is_required {
-        this.mark_network_task_failed(clone_id);
-        let _ = this.log_mut().add_error_fmt(
-            None,
-            bun_ast::Loc::EMPTY,
-            format_args!(
-                "--offline: git repository for \"{}\" is not in the cache",
-                bstr::BStr::new(name)
-            ),
-        );
+        if !this.network_task_has_failed(clone_id) {
+            // reserve + mark failed: reported once, later dependents see the failure
+            let _ = this.has_created_network_task(clone_id, true);
+            this.mark_network_task_failed(clone_id);
+            let _ = this.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "--offline: git repository for \"{}\" is not in the cache",
+                    bstr::BStr::new(name)
+                ),
+            );
+        }
     } else {
         // let a later required edge on the same repository report it
         let _ = this.network_dedupe_map.remove(&clone_id);

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1128,10 +1128,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         }
 
                                         // Was it recent enough to just load it without the network call?
-                                        // `--prefer-offline` / `--offline` accept a cached manifest of
-                                        // any age.
-                                        if (this.options.enable.manifest_cache_control() && !expired)
-                                            || this.options.offline != crate::package_manager_real::options::OfflineMode::Online
+                                        // (`--prefer-offline` / `--offline` load cached manifests as fresh
+                                        // regardless of age — see `DiskCacheCtx::accept_expired` — so they
+                                        // take this branch too; an entry still marked expired here needs
+                                        // the extended manifest and must be fetched.)
+                                        if !expired
+                                            && (this.options.enable.manifest_cache_control()
+                                                || this.options.offline
+                                                    != crate::package_manager_real::options::OfflineMode::Online)
                                         {
                                             let _ = this.network_dedupe_map.remove(&task_id);
                                             continue 'retry_from_manifests_ptr;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,4 +1,18 @@
 use crate::bun_schema::api as Api;
+
+/// Network policy for this install.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum OfflineMode {
+    /// Default: revalidate stale manifests, download what is missing.
+    #[default]
+    Online,
+    /// `--prefer-offline` / `install.prefer = "offline"`: a cached manifest of any age
+    /// satisfies resolution; only what is missing from the cache is fetched.
+    PreferOffline,
+    /// `--offline` / `install.offline = true`: never touch the network; anything not
+    /// in the cache is an error.
+    Offline,
+}
 use bun_core::ZStr;
 use bun_core::{Output, env_var};
 use bun_paths::PathBuffer;
@@ -81,6 +95,9 @@ pub struct Options {
     /// fallback (pnpm's `hoist=false`); takes precedence over `hoist_pattern`.
     pub(crate) hoist: bool,
 
+    /// `--offline` / `--prefer-offline` (or `install.offline` / `install.prefer = "offline"`).
+    pub offline: OfflineMode,
+
     // Security scanner module path
     pub security_scanner: Option<&'static [u8]>,
 
@@ -156,6 +173,7 @@ impl Default for Options {
             public_hoist_pattern: None,
             hoist_pattern: None,
             hoist: true,
+            offline: OfflineMode::Online,
             security_scanner: None,
             minimum_release_age_ms: None,
             minimum_release_age_excludes: None,
@@ -473,6 +491,10 @@ impl Options {
 
             if let Some(hoist) = config.hoist {
                 self.hoist = hoist;
+            }
+
+            if config.offline == Some(true) {
+                self.offline = OfflineMode::Offline;
             }
 
             if let Some(security_scanner) = config.security_scanner.as_deref() {
@@ -804,6 +826,11 @@ impl Options {
 
             if cli.no_verify {
                 self.do_.set(Do::VERIFY_INTEGRITY, false);
+            }
+            if cli.offline {
+                self.offline = OfflineMode::Offline;
+            } else if cli.prefer_offline && self.offline == OfflineMode::Online {
+                self.offline = OfflineMode::PreferOffline;
             }
 
             if cli.yarn {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -940,6 +940,11 @@ impl Options {
         if self.offline != OfflineMode::Online {
             self.enable.set(Enable::MANIFEST_CACHE, true);
         }
+        // Prefetching resolved tarballs is a latency optimisation for downloads; under
+        // --offline there is nothing to download and the install phase reports misses.
+        if self.offline == OfflineMode::Offline {
+            self.do_.set(Do::PREFETCH_RESOLVED_TARBALLS, false);
+        }
         Ok(())
     }
 }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,4 +1,12 @@
 use crate::bun_schema::api as Api;
+use bun_core::ZStr;
+use bun_core::{Output, env_var};
+use bun_paths::PathBuffer;
+
+use super::Subcommand;
+use super::command_line_arguments::{self, CommandLineArguments};
+use bun_dotenv::Loader as DotEnvLoader;
+use bun_install::{Features, Npm};
 
 /// Network policy for this install.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
@@ -13,14 +21,6 @@ pub enum OfflineMode {
     /// in the cache is an error.
     Offline,
 }
-use bun_core::ZStr;
-use bun_core::{Output, env_var};
-use bun_paths::PathBuffer;
-
-use super::Subcommand;
-use super::command_line_arguments::{self, CommandLineArguments};
-use bun_dotenv::Loader as DotEnvLoader;
-use bun_install::{Features, Npm};
 
 // `string` fields are `[]const u8` borrowed from CLI args / bunfig config,
 // which live for the process lifetime. There is no `deinit` on Options. Mapped to
@@ -935,6 +935,11 @@ impl Options {
         // moved from `defer { ... }` after scope assignment (see note above).
         self.did_override_default_scope = self.scope.url_hash != *Npm::registry::DEFAULT_URL_HASH;
 
+        // The manifest cache is the data source for --prefer-offline/--offline; keep it on
+        // even where it is otherwise bypassed (`bun update`, `--no-cache`, `--force`).
+        if self.offline != OfflineMode::Online {
+            self.enable.set(Enable::MANIFEST_CACHE, true);
+        }
         Ok(())
     }
 }

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -48,6 +48,10 @@ fn start_manifest_task(
     is_required: bool,
     needs_extended_manifest: bool,
 ) -> Result<(), StartManifestTaskError> {
+    // best-effort metadata backfill: nothing to do without the network
+    if manager.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
+        return Ok(());
+    }
     let task_id = Task::Id::for_manifest(pkg_name);
     if run_tasks::has_created_network_task(manager, task_id, is_required) {
         return Ok(());

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -57,7 +57,9 @@ pub fn install_with_manager(
 
     // Start resolving DNS for the default registry immediately.
     // Unless you're behind a proxy.
-    if !manager.env().has_http_proxy() {
+    if !manager.env().has_http_proxy()
+        && manager.options.offline != crate::package_manager_real::options::OfflineMode::Offline
+    {
         // And don't try to resolve DNS if it's an IP address.
         let scope_url = manager.options.scope.url.url();
         if !scope_url.hostname.is_empty() && !scope_url.is_ip_address() {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1897,6 +1897,8 @@ pub fn generate_network_task_for_tarball<'a>(
     // requires it — and let the caller treat it like an already-failed download.
     if this.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
         if is_required {
+            // reported once; later dependents see the failed dedupe entry
+            mark_network_task_failed(this, task_id);
             let name = this.lockfile.str(&package.name).to_vec();
             this.log_mut().add_error_fmt(
                 None,
@@ -1906,6 +1908,9 @@ pub fn generate_network_task_for_tarball<'a>(
                     bstr::BStr::new(&name)
                 ),
             );
+        } else {
+            // let a later required edge on the same package report it
+            let _ = this.network_dedupe_map.remove(&task_id);
         }
         return Err(ForTarballError::Offline);
     }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1891,6 +1891,24 @@ pub fn generate_network_task_for_tarball<'a>(
     if has_created_network_task(this, task_id, is_required) {
         return Ok(None);
     }
+    // Only reached when the tarball is not already extracted in the cache. Under
+    // --offline nothing can be fetched: report it once (the dedupe entry above stays,
+    // so later edges to the same package are quiet) — as an error only if some edge
+    // requires it — and let the caller treat it like an already-failed download.
+    if this.options.offline == crate::package_manager_real::options::OfflineMode::Offline {
+        if is_required {
+            let name = this.lockfile.str(&package.name).to_vec();
+            this.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "--offline: \"{}\" is not in the cache",
+                    bstr::BStr::new(&name)
+                ),
+            );
+        }
+        return Err(ForTarballError::Offline);
+    }
 
     // reshaped for borrowck —
     // all `&mut this` uses (patch-task alloc, cache/temp dir, pool slot) happen

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -47,6 +47,10 @@ pub struct DiskCacheCtx {
     /// branch that reads it is gated on that flag).
     pub(crate) cache_directory: Option<Fd>,
     pub(crate) timestamp_for_manifest_cache_control: u32,
+    /// `--prefer-offline` / `--offline`: a cached manifest of any age counts as fresh
+    /// (it is stored as `Value::Manifest`, never `Value::Expired`), so resolution can
+    /// use it without a revalidation request.
+    pub(crate) accept_expired: bool,
 }
 
 impl PackageManifestMap {
@@ -187,9 +191,10 @@ impl PackageManifestMap {
                             return None;
                         }
 
-                        if ctx.enable_manifest_cache_control
-                            && manifest.pkg.public_max_age
-                                > ctx.timestamp_for_manifest_cache_control
+                        if ctx.accept_expired
+                            || (ctx.enable_manifest_cache_control
+                                && manifest.pkg.public_max_age
+                                    > ctx.timestamp_for_manifest_cache_control)
                         {
                             let value_ptr = vac.insert(Value::Manifest(manifest));
                             let Value::Manifest(m) = value_ptr else {

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -47,9 +47,10 @@ pub struct DiskCacheCtx {
     /// branch that reads it is gated on that flag).
     pub(crate) cache_directory: Option<Fd>,
     pub(crate) timestamp_for_manifest_cache_control: u32,
-    /// `--prefer-offline` / `--offline`: a cached manifest of any age counts as fresh
-    /// (it is stored as `Value::Manifest`, never `Value::Expired`), so resolution can
-    /// use it without a revalidation request.
+    /// `--prefer-offline` / `--offline`: a cached manifest counts as fresh regardless of
+    /// its age (stored as `Value::Manifest`), so resolution can use it without a
+    /// revalidation request. It is still stored as `Value::Expired` when the caller needs
+    /// the extended manifest and the cached one lacks it — age is waived, content is not.
     pub(crate) accept_expired: bool,
 }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2426,7 +2426,10 @@ pub(crate) fn install_isolated_packages(
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     return Err(AllocError);
                                 }
-                                Err(crate::network_task::ForTarballError::AlreadyFailed) => {
+                                Err(
+                                    crate::network_task::ForTarballError::AlreadyFailed
+                                    | crate::network_task::ForTarballError::Offline,
+                                ) => {
                                     // .monotonic is okay because an error means the task isn't
                                     // running on another thread.
                                     entry_steps[entry_id.get() as usize]
@@ -2485,7 +2488,10 @@ pub(crate) fn install_isolated_packages(
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     bun_core::out_of_memory()
                                 }
-                                Err(crate::network_task::ForTarballError::AlreadyFailed) => {
+                                Err(
+                                    crate::network_task::ForTarballError::AlreadyFailed
+                                    | crate::network_task::ForTarballError::Offline,
+                                ) => {
                                     // .monotonic is okay because an error means the task isn't
                                     // running on another thread.
                                     entry_steps[entry_id.get() as usize]
@@ -2538,7 +2544,10 @@ pub(crate) fn install_isolated_packages(
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     bun_core::out_of_memory()
                                 }
-                                Err(crate::network_task::ForTarballError::AlreadyFailed) => {
+                                Err(
+                                    crate::network_task::ForTarballError::AlreadyFailed
+                                    | crate::network_task::ForTarballError::Offline,
+                                ) => {
                                     // .monotonic is okay because an error means the task isn't
                                     // running on another thread.
                                     entry_steps[entry_id.get() as usize]

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2463,13 +2463,21 @@ pub(crate) fn install_isolated_packages(
                             }
                         }
                         ResolutionTag::Git => {
-                            installer.manager_mut().enqueue_git_for_checkout(
+                            if installer.manager_mut().enqueue_git_for_checkout(
                                 dep_id,
                                 dep.name.slice(string_buf),
                                 &pkg_res,
                                 ctx,
                                 patch_info.name_and_version_hash(),
-                            );
+                            ) == crate::package_manager::GitEnqueueResult::OfflineMiss
+                            {
+                                // --offline and not cached: nothing was queued
+                                entry_steps[entry_id.get() as usize]
+                                    .store(installer::Step::Done as u32, Ordering::Relaxed);
+                                installer
+                                    .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                continue;
+                            }
                         }
                         ResolutionTag::Github => {
                             // The `.git()` accessor has a `debug_assert_eq!(tag, Git)` that

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -328,7 +328,7 @@ impl PatchTask {
                         .is_required();
                     let pkg_again: Package = *manager.lockfile.packages.get(pkg_id as usize);
                     let network_task: *mut crate::NetworkTask =
-                        package_manager::generate_network_task_for_tarball(
+                        match package_manager::generate_network_task_for_tarball(
                             manager,
                             // TODO: not just npm package
                             task_id,
@@ -343,8 +343,11 @@ impl PatchTask {
                                 }
                                 _ => Authorization::NoAuthorization,
                             },
-                        )?
-                        .unwrap_or_else(|| unreachable!());
+                        ) {
+                            // --offline and not cached: already reported / skipped; nothing to patch
+                            Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
+                            other => other?.unwrap_or_else(|| unreachable!()),
+                        };
                     if manager.get_preinstall_state(pkg_meta_id) == PreinstallState::Extract {
                         manager.set_preinstall_state(pkg_meta_id, PreinstallState::Extracting);
                         package_manager::enqueue_network_task(manager, network_task);

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -793,9 +793,11 @@ impl RepositoryExt for Repository {
                     &[folder_name.as_bytes()],
                 );
 
-                // --prefer-offline / --offline: use the cached clone as is
+                // --offline: use the cached clone as is (--prefer-offline still fetches:
+                // git dependencies pin exact commits, so a stale clone would fail to find a
+                // newly referenced one rather than "resolve older")
                 if PackageManager::get().options.offline
-                    == crate::package_manager_real::options::OfflineMode::Online
+                    != crate::package_manager_real::options::OfflineMode::Offline
                 {
                     if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"]) {
                         log.add_error_fmt(

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -793,19 +793,37 @@ impl RepositoryExt for Repository {
                     &[folder_name.as_bytes()],
                 );
 
-                if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"]) {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!("\"git fetch\" for \"{}\" failed", BStr::new(name)),
-                    );
-                    return Err(err);
+                // --prefer-offline / --offline: use the cached clone as is
+                if PackageManager::get().options.offline
+                    == crate::package_manager_real::options::OfflineMode::Online
+                {
+                    if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"]) {
+                        log.add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!("\"git fetch\" for \"{}\" failed", BStr::new(name)),
+                        );
+                        return Err(err);
+                    }
                 }
                 Ok(dir)
             }
             Err(not_found) => {
                 if not_found.get_errno() != bun_sys::E::ENOENT {
                     return Err(not_found.into());
+                }
+                if PackageManager::get().options.offline
+                    == crate::package_manager_real::options::OfflineMode::Offline
+                {
+                    log.add_error_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "--offline: git repository for \"{}\" is not in the cache",
+                            BStr::new(name)
+                        ),
+                    );
+                    return Err(crate::Error::InstallFailed);
                 }
 
                 let staging = CacheStaging::new(cache_dir)?;

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -258,6 +258,8 @@ pub mod api {
         pub public_hoist_pattern: Option<PnpmMatcher>,
         pub hoist_pattern: Option<PnpmMatcher>,
         pub hoist: Option<bool>,
+        /// `offline = true`: `bun install` never touches the network.
+        pub offline: Option<bool>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -16,13 +16,19 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-setDefaultTimeout(1000 * 60 * 5);
 
 let cache_dir: string;
+// temp dirs created by a test; removed after it
+let dirs: { [Symbol.dispose](): void }[] = [];
+function mkdtemp(): string {
+  const d = tempDir("offline", {});
+  dirs.push(d);
+  return String(d);
+}
 
 beforeEach(async () => {
   await dummyBeforeEach({ linker: "hoisted" });
-  cache_dir = tmpdirSync();
+  cache_dir = mkdtemp();
   // dummyBeforeEach disables the cache; these tests are about the cache
   await writeFile(
     join(package_dir, "bunfig.toml"),
@@ -31,7 +37,11 @@ beforeEach(async () => {
     }),
   );
 });
-afterEach(dummyAfterEach);
+afterEach(async () => {
+  await dummyAfterEach();
+  for (const d of dirs) d[Symbol.dispose]();
+  dirs = [];
+});
 
 async function install(cwd: string, args: string[]) {
   await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
@@ -39,12 +49,12 @@ async function install(cwd: string, args: string[]) {
   return { out, err, code };
 }
 
-async function newProject(deps: Record<string, string>) {
-  const dir = tmpdirSync();
+async function newProject(deps: Record<string, string>, cache = cache_dir) {
+  const dir = mkdtemp();
   await writeFile(
     join(dir, "bunfig.toml"),
     Bun.TOML.stringify({
-      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+      install: { cache: { dir: cache }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
     }),
   );
   await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
@@ -116,14 +126,15 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
 it("--prefer-offline and --offline use an expired cached manifest", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
-  );
-  expect((await install(package_dir, [])).code).toBe(0);
-  const before = urls.length;
   for (const flag of ["--prefer-offline", "--offline"]) {
-    const dir = await newProject({ baz: "^0.0.3" });
+    // each mode gets its own warmed cache so one cannot pre-fetch for the other
+    const cache = mkdtemp();
+    const warm = await newProject({ baz: "0.0.3" }, cache);
+    const w = await install(warm, []);
+    expect(w.err).not.toContain("error:");
+    expect(w.code).toBe(0);
+    const before = urls.length;
+    const dir = await newProject({ baz: "^0.0.3" }, cache);
     const r = await install(dir, ["--force", flag]);
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
@@ -140,9 +151,13 @@ it('install.prefer = "offline" and install.offline = true in bunfig.toml behave 
     join(package_dir, "package.json"),
     JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
   );
-  expect((await install(package_dir, [])).code).toBe(0);
+  {
+    const w = await install(package_dir, []);
+    expect(w.err).not.toContain("error:");
+    expect(w.code).toBe(0);
+  }
   const before = urls.length;
-  const dir2 = tmpdirSync();
+  const dir2 = mkdtemp();
   await writeFile(
     join(dir2, "bunfig.toml"),
     Bun.TOML.stringify({
@@ -155,7 +170,7 @@ it('install.prefer = "offline" and install.offline = true in bunfig.toml behave 
   expect(r.code).toBe(0);
   expect(urls.length).toBe(before);
 
-  const dir3 = tmpdirSync();
+  const dir3 = mkdtemp();
   await writeFile(
     join(dir3, "bunfig.toml"),
     Bun.TOML.stringify({

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -43,8 +43,18 @@ afterEach(async () => {
   dirs = [];
 });
 
+// the CI runner exports BUN_INSTALL_CACHE_DIR, which would override the per-project
+// bunfig cache dirs these tests populate and inspect
+const { BUN_INSTALL_CACHE_DIR: _ciCacheDir, ...installEnv } = env;
+
 async function install(cwd: string, args: string[]) {
-  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  await using proc = spawn({
+    cmd: [bunExe(), "install", ...args],
+    cwd,
+    env: installEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { out, err, code };
 }

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -298,55 +298,58 @@ const gitEnv = {
   GIT_COMMITTER_EMAIL: "test@example.com",
 };
 
-it("--offline installs a git dependency from the cached clone without touching the repository", async () => {
-  // a local bare repository with one package
-  const work = mkdtemp();
-  const bare = join(mkdtemp(), "repo.git");
-  await writeFile(join(work, "package.json"), JSON.stringify({ name: "gitpkg", version: "1.0.0" }));
-  await writeFile(join(work, "index.js"), "module.exports = 1;");
-  for (const cmd of [
-    ["init", "-q"],
-    ["add", "-A"],
-    ["commit", "-q", "-m", "init", "--no-gpg-sign"],
-    ["clone", "-q", "--bare", ".", bare],
-  ]) {
-    await using p = spawn({ cmd: ["git", ...cmd], cwd: work, env: gitEnv, stdout: "ignore", stderr: "pipe" });
-    const [gitErr, gitCode] = await Promise.all([p.stderr.text(), p.exited]);
-    expect(gitErr).not.toContain("fatal:");
-    expect(gitCode).toBe(0);
-  }
-  const url = `git+${pathToFileURL(bare)}`;
-  // online install populates the git cache
-  const warm = await newProject({ gitpkg: url });
-  const w = await install(warm, []);
-  expect(w.err).not.toContain("error:");
-  expect(w.code).toBe(0);
-  // the repository disappears; --offline must use the cached clone (no fetch) and succeed
-  await rm(bare, { recursive: true, force: true });
-  const dir = await newProject({ gitpkg: url });
-  const r = await install(dir, ["--offline"]);
-  expect(r.err).not.toContain("error:");
-  expect(r.code).toBe(0);
-  expect(await readdirSorted(join(dir, "node_modules", "gitpkg"))).toContain("index.js");
+it.skipIf(!Bun.which("git"))(
+  "--offline installs a git dependency from the cached clone without touching the repository",
+  async () => {
+    // a local bare repository with one package
+    const work = mkdtemp();
+    const bare = join(mkdtemp(), "repo.git");
+    await writeFile(join(work, "package.json"), JSON.stringify({ name: "gitpkg", version: "1.0.0" }));
+    await writeFile(join(work, "index.js"), "module.exports = 1;");
+    for (const cmd of [
+      ["init", "-q"],
+      ["add", "-A"],
+      ["commit", "-q", "-m", "init", "--no-gpg-sign"],
+      ["clone", "-q", "--bare", ".", bare],
+    ]) {
+      await using p = spawn({ cmd: ["git", ...cmd], cwd: work, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+      const [gitErr, gitCode] = await Promise.all([p.stderr.text(), p.exited]);
+      expect(gitErr).not.toContain("fatal:");
+      expect(gitCode).toBe(0);
+    }
+    const url = `git+${pathToFileURL(bare)}`;
+    // online install populates the git cache
+    const warm = await newProject({ gitpkg: url });
+    const w = await install(warm, []);
+    expect(w.err).not.toContain("error:");
+    expect(w.code).toBe(0);
+    // the repository disappears; --offline must use the cached clone (no fetch) and succeed
+    await rm(bare, { recursive: true, force: true });
+    const dir = await newProject({ gitpkg: url });
+    const r = await install(dir, ["--offline"]);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    expect(await readdirSorted(join(dir, "node_modules", "gitpkg"))).toContain("index.js");
 
-  // and from an existing lockfile with the git cache gone: a required one errors, an
-  // optional one is skipped — either way the install finishes (no queued-forever task)
-  for (const entry of await readdirSorted(cache_dir)) {
-    if (entry.endsWith(".git") || entry.startsWith("@G@"))
-      await rm(join(cache_dir, entry), { recursive: true, force: true });
-  }
-  await rm(join(dir, "node_modules"), { recursive: true, force: true });
-  const again = await install(dir, ["--offline"]);
-  expect(again.err).toContain("--offline");
-  expect(again.code).not.toBe(0);
-  const opt = mkdtemp();
-  await writeFile(join(opt, "bunfig.toml"), await Bun.file(join(dir, "bunfig.toml")).text());
-  await writeFile(
-    join(opt, "package.json"),
-    JSON.stringify({ name: "app", version: "1.0.0", optionalDependencies: { gitpkg: url } }),
-  );
-  await writeFile(join(opt, "bun.lock"), await Bun.file(join(dir, "bun.lock")).text());
-  const optr = await install(opt, ["--offline"]);
-  expect(optr.err).not.toContain("error:");
-  expect(optr.code).toBe(0);
-});
+    // and from an existing lockfile with the git cache gone: a required one errors, an
+    // optional one is skipped — either way the install finishes (no queued-forever task)
+    for (const entry of await readdirSorted(cache_dir)) {
+      if (entry.endsWith(".git") || entry.startsWith("@G@"))
+        await rm(join(cache_dir, entry), { recursive: true, force: true });
+    }
+    await rm(join(dir, "node_modules"), { recursive: true, force: true });
+    const again = await install(dir, ["--offline"]);
+    expect(again.err).toContain("--offline");
+    expect(again.code).not.toBe(0);
+    const opt = mkdtemp();
+    await writeFile(join(opt, "bunfig.toml"), await Bun.file(join(dir, "bunfig.toml")).text());
+    await writeFile(
+      join(opt, "package.json"),
+      JSON.stringify({ name: "app", version: "1.0.0", optionalDependencies: { gitpkg: url } }),
+    );
+    await writeFile(join(opt, "bun.lock"), await Bun.file(join(dir, "bun.lock")).text());
+    const optr = await install(opt, ["--offline"]);
+    expect(optr.err).not.toContain("error:");
+    expect(optr.code).toBe(0);
+  },
+);

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -197,6 +197,26 @@ it("--offline refuses an uncached git dependency without running git", async () 
   expect(r.err).toContain("--offline");
   expect(r.err).not.toContain('"git clone"');
   expect(r.code).not.toBe(0);
+
+  // …but an *optional* uncached git dependency is just skipped
+  const dir2 = mkdtemp();
+  await writeFile(
+    join(dir2, "bunfig.toml"),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
+  );
+  await writeFile(
+    join(dir2, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      optionalDependencies: { dep: "git+https://127.0.0.1:1/nobody/nothing.git#deadbeef" },
+    }),
+  );
+  const r2 = await install(dir2, ["--offline"]);
+  expect(r2.err).not.toContain("error:");
+  expect(r2.code).toBe(0);
 });
 
 it('install.prefer = "offline" and install.offline = true in bunfig.toml behave like the flags', async () => {

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -219,6 +219,33 @@ it("--offline refuses an uncached git dependency without running git", async () 
   expect(r2.code).toBe(0);
 });
 
+it("--offline reports an uncached tarball-URL / github dependency once, and skips optional ones", async () => {
+  const req = await newProject({ dep: `${root_url}/never-fetched-1.0.0.tgz` });
+  const r = await install(req, ["--offline"]);
+  expect(r.err).toContain("--offline");
+  expect(r.err).not.toContain("TarballFailedToDownload");
+  expect(r.code).not.toBe(0);
+
+  const opt = mkdtemp();
+  await writeFile(
+    join(opt, "bunfig.toml"),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
+  );
+  await writeFile(
+    join(opt, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      optionalDependencies: { dep: `${root_url}/never-fetched-1.0.0.tgz`, gh: "github:nobody-xyz/nothing#deadbeef" },
+    }),
+  );
+  const r2 = await install(opt, ["--offline"]);
+  expect(r2.err).not.toContain("error:");
+  expect(r2.code).toBe(0);
+});
+
 it('install.prefer = "offline" and install.offline = true in bunfig.toml behave like the flags', async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -101,6 +101,25 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
   expect(urls.length).toBe(before);
 });
 
+// Regression: with an *expired* cached manifest (here forced via --force, which turns off
+// the max-age check) --prefer-offline / --offline must still resolve from it, not spin.
+it("--prefer-offline and --offline use an expired cached manifest", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  expect((await install(package_dir, [])).code).toBe(0);
+  const before = urls.length;
+  for (const flag of ["--prefer-offline", "--offline"]) {
+    const dir = await newProject({ baz: "^0.0.3" });
+    const r = await install(dir, ["--force", flag]);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    // resolved the range from the cached manifest (0.0.5 is listed there too, but its
+    // tarball was never downloaded; 0.0.3's was) — no manifest request either way
+    expect(urls.slice(before).filter(u => !u.endsWith(".tgz"))).toEqual([]);
+  }
+});
+
 it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behave like the flags", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -1,0 +1,131 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+setDefaultTimeout(1000 * 60 * 5);
+
+let cache_dir: string;
+
+beforeEach(async () => {
+  await dummyBeforeEach({ linker: "hoisted" });
+  cache_dir = tmpdirSync();
+  // dummyBeforeEach disables the cache; these tests are about the cache
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+  );
+});
+afterEach(dummyAfterEach);
+
+async function install(cwd: string, args: string[]) {
+  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+async function newProject(deps: Record<string, string>) {
+  const dir = tmpdirSync();
+  await writeFile(
+    join(dir, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+  );
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
+  return dir;
+}
+
+it("--prefer-offline resolves from cached manifests without touching the network", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  // 1. online install populates the manifest + tarball cache
+  let r = await install(package_dir, []);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  const before = urls.length;
+  expect(before).toBeGreaterThan(0);
+
+  // 2. a fresh project without a lockfile: the (possibly stale) cached manifest satisfies
+  //    the range and the tarball comes from the cache: zero requests
+  const dir2 = await newProject({ baz: "<=0.0.3" });
+  r = await install(dir2, ["--prefer-offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.slice(before)).toEqual([]);
+  expect(await readdirSorted(join(dir2, "node_modules", "baz"))).toContain("package.json");
+});
+
+it("--offline never issues a request and fails cleanly on a cache miss", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  let r = await install(package_dir, []);
+  expect(r.code).toBe(0);
+  const before = urls.length;
+
+  // everything cached → works
+  const dir2 = await newProject({ baz: "0.0.3" });
+  r = await install(dir2, ["--offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.length).toBe(before);
+
+  // manifest for `bar` was never fetched → clean error, still no request
+  const dir3 = await newProject({ bar: "0.0.2" });
+  r = await install(dir3, ["--offline"]);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("--offline");
+  expect(urls.length).toBe(before);
+
+  // manifest cached but that version's tarball evicted → clean error, no request
+  for (const entry of await readdirSorted(cache_dir)) {
+    if (entry.startsWith("baz@0.0.3")) await rm(join(cache_dir, entry), { recursive: true, force: true });
+  }
+  const dir4 = await newProject({ baz: "0.0.3" });
+  r = await install(dir4, ["--offline"]);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("--offline");
+  expect(urls.length).toBe(before);
+});
+
+it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behave like the flags", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  expect((await install(package_dir, [])).code).toBe(0);
+  const before = urls.length;
+  const dir2 = tmpdirSync();
+  await writeFile(
+    join(dir2, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", prefer: "offline", linker: "hoisted" } }),
+  );
+  await writeFile(join(dir2, "package.json"), JSON.stringify({ name: "app", dependencies: { baz: "^0.0.3" } }));
+  let r = await install(dir2, []);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.length).toBe(before);
+
+  const dir3 = tmpdirSync();
+  await writeFile(
+    join(dir3, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", offline: true, linker: "hoisted" } }),
+  );
+  await writeFile(join(dir3, "package.json"), JSON.stringify({ name: "app", dependencies: { bar: "0.0.2" } }));
+  r = await install(dir3, []);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("--offline");
+  expect(urls.length).toBe(before);
+});

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { join } from "path";
@@ -116,8 +116,8 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
   // manifest for `bar` was never fetched → clean error, still no request
   const dir3 = await newProject({ bar: "0.0.2" });
   r = await install(dir3, ["--offline"]);
-  expect(r.code).not.toBe(0);
   expect(r.err).toContain("--offline");
+  expect(r.code).not.toBe(0);
   expect(urls.length).toBe(before);
 
   // manifest cached but that version's tarball evicted → clean error, no request
@@ -126,17 +126,17 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
   }
   const dir4 = await newProject({ baz: "0.0.3" });
   r = await install(dir4, ["--offline"]);
-  expect(r.code).not.toBe(0);
   expect(r.err).toContain("--offline");
+  expect(r.code).not.toBe(0);
   expect(urls.length).toBe(before);
 });
 
 // Regression: with an *expired* cached manifest (here forced via --force, which turns off
 // the max-age check) --prefer-offline / --offline must still resolve from it, not spin.
-it("--prefer-offline and --offline use an expired cached manifest", async () => {
-  const urls: string[] = [];
-  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  for (const flag of ["--prefer-offline", "--offline"]) {
+describe.each(["--prefer-offline", "--offline"])("%s with an expired cached manifest", flag => {
+  it("resolves a range from it instead of spinning", async () => {
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
     // each mode gets its own warmed cache so one cannot pre-fetch for the other
     const cache = mkdtemp();
     const warm = await newProject({ baz: "0.0.3" }, cache);
@@ -148,10 +148,55 @@ it("--prefer-offline and --offline use an expired cached manifest", async () => 
     const r = await install(dir, ["--force", flag]);
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
-    // resolved the range from the cached manifest (0.0.5 is listed there too, but its
-    // tarball was never downloaded; 0.0.3's was) — no manifest request either way
-    expect(urls.slice(before).filter(u => !u.endsWith(".tgz"))).toEqual([]);
-  }
+    if (flag === "--offline") {
+      // never any request
+      expect(urls.slice(before)).toEqual([]);
+    } else {
+      // resolved the range from the cached manifest: no *manifest* request (a missing
+      // tarball may still be fetched in this mode)
+      expect(urls.slice(before).filter(u => !u.endsWith(".tgz"))).toEqual([]);
+    }
+  });
+});
+
+it("--offline skips an optional dependency that is not in the cache", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+  const warm = await newProject({ baz: "0.0.3" });
+  const w = await install(warm, []);
+  expect(w.err).not.toContain("error:");
+  expect(w.code).toBe(0);
+  const before = urls.length;
+  // `bar` was never fetched: as an optionalDependency it is skipped, not an error
+  const dir = mkdtemp();
+  await writeFile(
+    join(dir, "bunfig.toml"),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
+  );
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { baz: "0.0.3" },
+      optionalDependencies: { bar: "0.0.2" },
+    }),
+  );
+  const r = await install(dir, ["--offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.slice(before)).toEqual([]);
+  expect(await readdirSorted(join(dir, "node_modules"))).toContain("baz");
+});
+
+it("--offline refuses an uncached git dependency without running git", async () => {
+  const dir = await newProject({ dep: "git+https://127.0.0.1:1/nobody/nothing.git#deadbeef" });
+  const r = await install(dir, ["--offline"]);
+  expect(r.err).toContain("--offline");
+  expect(r.err).not.toContain('"git clone"');
+  expect(r.code).not.toBe(0);
 });
 
 it('install.prefer = "offline" and install.offline = true in bunfig.toml behave like the flags', async () => {
@@ -189,7 +234,7 @@ it('install.prefer = "offline" and install.offline = true in bunfig.toml behave 
   );
   await writeFile(join(dir3, "package.json"), JSON.stringify({ name: "app", dependencies: { bar: "0.0.2" } }));
   r = await install(dir3, []);
-  expect(r.code).not.toBe(0);
   expect(r.err).toContain("--offline");
+  expect(r.code).not.toBe(0);
   expect(urls.length).toBe(before);
 });

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -26,7 +26,9 @@ beforeEach(async () => {
   // dummyBeforeEach disables the cache; these tests are about the cache
   await writeFile(
     join(package_dir, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
   );
 });
 afterEach(dummyAfterEach);
@@ -41,7 +43,9 @@ async function newProject(deps: Record<string, string>) {
   const dir = tmpdirSync();
   await writeFile(
     join(dir, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+    }),
   );
   await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
   return dir;
@@ -50,7 +54,10 @@ async function newProject(deps: Record<string, string>) {
 it("--prefer-offline resolves from cached manifests without touching the network", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   // 1. online install populates the manifest + tarball cache
   let r = await install(package_dir, []);
   expect(r.err).not.toContain("error:");
@@ -71,7 +78,10 @@ it("--prefer-offline resolves from cached manifests without touching the network
 it("--offline never issues a request and fails cleanly on a cache miss", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   let r = await install(package_dir, []);
   expect(r.code).toBe(0);
   const before = urls.length;
@@ -106,7 +116,10 @@ it("--offline never issues a request and fails cleanly on a cache miss", async (
 it("--prefer-offline and --offline use an expired cached manifest", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   expect((await install(package_dir, [])).code).toBe(0);
   const before = urls.length;
   for (const flag of ["--prefer-offline", "--offline"]) {
@@ -120,16 +133,21 @@ it("--prefer-offline and --offline use an expired cached manifest", async () => 
   }
 });
 
-it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behave like the flags", async () => {
+it('install.prefer = "offline" and install.offline = true in bunfig.toml behave like the flags', async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+  );
   expect((await install(package_dir, [])).code).toBe(0);
   const before = urls.length;
   const dir2 = tmpdirSync();
   await writeFile(
     join(dir2, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", prefer: "offline", linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", prefer: "offline", linker: "hoisted" },
+    }),
   );
   await writeFile(join(dir2, "package.json"), JSON.stringify({ name: "app", dependencies: { baz: "^0.0.3" } }));
   let r = await install(dir2, []);
@@ -140,7 +158,9 @@ it("install.prefer = \"offline\" and install.offline = true in bunfig.toml behav
   const dir3 = tmpdirSync();
   await writeFile(
     join(dir3, "bunfig.toml"),
-    Bun.TOML.stringify({ install: { cache: { dir: cache_dir }, registry: root_url + "/", offline: true, linker: "hoisted" } }),
+    Bun.TOML.stringify({
+      install: { cache: { dir: cache_dir }, registry: root_url + "/", offline: true, linker: "hoisted" },
+    }),
   );
   await writeFile(join(dir3, "package.json"), JSON.stringify({ name: "app", dependencies: { bar: "0.0.2" } }));
   r = await install(dir3, []);

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -3,6 +3,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { join } from "path";
+import { pathToFileURL } from "url";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -59,12 +60,12 @@ async function install(cwd: string, args: string[]) {
   return { out, err, code };
 }
 
-async function newProject(deps: Record<string, string>, cache = cache_dir) {
+async function newProject(deps: Record<string, string>, cache = cache_dir, linker: "hoisted" | "isolated" = "hoisted") {
   const dir = mkdtemp();
   await writeFile(
     join(dir, "bunfig.toml"),
     Bun.TOML.stringify({
-      install: { cache: { dir: cache }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
+      install: { cache: { dir: cache }, registry: root_url + "/", saveTextLockfile: true, linker },
     }),
   );
   await writeFile(join(dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: deps }));
@@ -95,40 +96,42 @@ it("--prefer-offline resolves from cached manifests without touching the network
   expect(await readdirSorted(join(dir2, "node_modules", "baz"))).toContain("package.json");
 });
 
-it("--offline never issues a request and fails cleanly on a cache miss", async () => {
-  const urls: string[] = [];
-  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
-  );
-  let r = await install(package_dir, []);
-  expect(r.code).toBe(0);
-  const before = urls.length;
+describe.each(["hoisted", "isolated"] as const)("--offline (%s linker)", linker => {
+  it("never issues a request and fails cleanly on a cache miss", async () => {
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+    );
+    let r = await install(package_dir, []);
+    expect(r.code).toBe(0);
+    const before = urls.length;
 
-  // everything cached → works
-  const dir2 = await newProject({ baz: "0.0.3" });
-  r = await install(dir2, ["--offline"]);
-  expect(r.err).not.toContain("error:");
-  expect(r.code).toBe(0);
-  expect(urls.length).toBe(before);
+    // everything cached → works
+    const dir2 = await newProject({ baz: "0.0.3" }, cache_dir, linker);
+    r = await install(dir2, ["--offline"]);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    expect(urls.length).toBe(before);
 
-  // manifest for `bar` was never fetched → clean error, still no request
-  const dir3 = await newProject({ bar: "0.0.2" });
-  r = await install(dir3, ["--offline"]);
-  expect(r.err).toContain("--offline");
-  expect(r.code).not.toBe(0);
-  expect(urls.length).toBe(before);
+    // manifest for `bar` was never fetched → clean error, still no request
+    const dir3 = await newProject({ bar: "0.0.2" }, cache_dir, linker);
+    r = await install(dir3, ["--offline"]);
+    expect(r.err).toContain("--offline");
+    expect(r.code).not.toBe(0);
+    expect(urls.length).toBe(before);
 
-  // manifest cached but that version's tarball evicted → clean error, no request
-  for (const entry of await readdirSorted(cache_dir)) {
-    if (entry.startsWith("baz@0.0.3")) await rm(join(cache_dir, entry), { recursive: true, force: true });
-  }
-  const dir4 = await newProject({ baz: "0.0.3" });
-  r = await install(dir4, ["--offline"]);
-  expect(r.err).toContain("--offline");
-  expect(r.code).not.toBe(0);
-  expect(urls.length).toBe(before);
+    // manifest cached but that version's tarball evicted → clean error, no request
+    for (const entry of await readdirSorted(cache_dir)) {
+      if (entry.startsWith("baz@0.0.3")) await rm(join(cache_dir, entry), { recursive: true, force: true });
+    }
+    const dir4 = await newProject({ baz: "0.0.3" }, cache_dir, linker);
+    r = await install(dir4, ["--offline"]);
+    expect(r.err).toContain("--offline");
+    expect(r.code).not.toBe(0);
+    expect(urls.length).toBe(before);
+  });
 });
 
 // Regression: with an *expired* cached manifest (here forced via --force, which turns off
@@ -192,7 +195,7 @@ it("--offline skips an optional dependency that is not in the cache", async () =
 });
 
 it("--offline refuses an uncached git dependency without running git", async () => {
-  const dir = await newProject({ dep: "git+https://127.0.0.1:1/nobody/nothing.git#deadbeef" });
+  const dir = await newProject({ dep: `git+${pathToFileURL(join(cache_dir, "no-such-repo.git"))}#deadbeef` });
   const r = await install(dir, ["--offline"]);
   expect(r.err).toContain("--offline");
   expect(r.err).not.toContain('"git clone"');
@@ -211,7 +214,7 @@ it("--offline refuses an uncached git dependency without running git", async () 
     JSON.stringify({
       name: "app",
       version: "1.0.0",
-      optionalDependencies: { dep: "git+https://127.0.0.1:1/nobody/nothing.git#deadbeef" },
+      optionalDependencies: { dep: `git+${pathToFileURL(join(cache_dir, "no-such-repo.git"))}#deadbeef` },
     }),
   );
   const r2 = await install(dir2, ["--offline"]);
@@ -284,4 +287,43 @@ it('install.prefer = "offline" and install.offline = true in bunfig.toml behave 
   expect(r.err).toContain("--offline");
   expect(r.code).not.toBe(0);
   expect(urls.length).toBe(before);
+});
+
+const gitEnv = {
+  ...installEnv,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+it("--offline installs a git dependency from the cached clone without touching the repository", async () => {
+  // a local bare repository with one package
+  const work = mkdtemp();
+  const bare = join(mkdtemp(), "repo.git");
+  await writeFile(join(work, "package.json"), JSON.stringify({ name: "gitpkg", version: "1.0.0" }));
+  await writeFile(join(work, "index.js"), "module.exports = 1;");
+  for (const cmd of [
+    ["init", "-q"],
+    ["add", "-A"],
+    ["commit", "-q", "-m", "init", "--no-gpg-sign"],
+    ["clone", "-q", "--bare", ".", bare],
+  ]) {
+    await using p = spawn({ cmd: ["git", ...cmd], cwd: work, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+    expect(await p.exited).toBe(0);
+  }
+  const url = `git+${pathToFileURL(bare)}`;
+  // online install populates the git cache
+  const warm = await newProject({ gitpkg: url });
+  const w = await install(warm, []);
+  expect(w.err).not.toContain("error:");
+  expect(w.code).toBe(0);
+  // the repository disappears; --offline must use the cached clone (no fetch) and succeed
+  await rm(bare, { recursive: true, force: true });
+  const dir = await newProject({ gitpkg: url });
+  const r = await install(dir, ["--offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(await readdirSorted(join(dir, "node_modules", "gitpkg"))).toContain("index.js");
 });

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -311,7 +311,9 @@ it("--offline installs a git dependency from the cached clone without touching t
     ["clone", "-q", "--bare", ".", bare],
   ]) {
     await using p = spawn({ cmd: ["git", ...cmd], cwd: work, env: gitEnv, stdout: "ignore", stderr: "pipe" });
-    expect(await p.exited).toBe(0);
+    const [gitErr, gitCode] = await Promise.all([p.stderr.text(), p.exited]);
+    expect(gitErr).not.toContain("fatal:");
+    expect(gitCode).toBe(0);
   }
   const url = `git+${pathToFileURL(bare)}`;
   // online install populates the git cache
@@ -326,4 +328,25 @@ it("--offline installs a git dependency from the cached clone without touching t
   expect(r.err).not.toContain("error:");
   expect(r.code).toBe(0);
   expect(await readdirSorted(join(dir, "node_modules", "gitpkg"))).toContain("index.js");
+
+  // and from an existing lockfile with the git cache gone: a required one errors, an
+  // optional one is skipped — either way the install finishes (no queued-forever task)
+  for (const entry of await readdirSorted(cache_dir)) {
+    if (entry.endsWith(".git") || entry.startsWith("@G@"))
+      await rm(join(cache_dir, entry), { recursive: true, force: true });
+  }
+  await rm(join(dir, "node_modules"), { recursive: true, force: true });
+  const again = await install(dir, ["--offline"]);
+  expect(again.err).toContain("--offline");
+  expect(again.code).not.toBe(0);
+  const opt = mkdtemp();
+  await writeFile(join(opt, "bunfig.toml"), await Bun.file(join(dir, "bunfig.toml")).text());
+  await writeFile(
+    join(opt, "package.json"),
+    JSON.stringify({ name: "app", version: "1.0.0", optionalDependencies: { gitpkg: url } }),
+  );
+  await writeFile(join(opt, "bun.lock"), await Bun.file(join(dir, "bun.lock")).text());
+  const optr = await install(opt, ["--offline"]);
+  expect(optr.err).not.toContain("error:");
+  expect(optr.code).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Adds two flags to `bun install` for cache-only workflows (CI with a restored cache, planes, flaky networks):

- `bun install --prefer-offline` — a cached manifest of **any age** satisfies resolution, so there are no revalidation requests; only manifests/tarballs that are genuinely missing from the cache are fetched. This is also what the existing `install.prefer = "offline"` bunfig setting now selects for `bun install` (previously that setting only affected the runtime's auto-install).
- `bun install --offline` (config: `install.offline = true`) — never touch the network: no registry requests, no tarball URLs, no `git clone`/`git fetch` (a cached clone is used as is), no registry DNS prefetch, no post-migration manifest backfill. A *required* dependency whose manifest, tarball or repository isn't in the cache is a clear error naming the package, reported once (`--offline: no cached manifest for "x"` / `--offline: "x" is not in the cache`); an uncached *optional* dependency is skipped like any other unavailable optional dependency. The manifest cache stays enabled in these modes even where it is normally bypassed (`bun update`, `--no-cache`, `--force`).

Implementation: a small `OfflineMode { Online, PreferOffline, Offline }` on the install `Options`; the manifest-cache freshness check in `PackageManagerEnqueue` accepts expired entries when not `Online`, refuses to enqueue a manifest download when `Offline`, and `NetworkTask::for_tarball` (only reached on a cache miss) refuses when `Offline`.

Docs: `docs/pm/cli/install.mdx` (new "Offline installs" section) and `docs/runtime/bunfig.mdx` (`install.offline`, note on `install.prefer`).

### How did you verify your code works?

New `test/cli/install/bun-install-offline.test.ts` (uses the existing dummy registry):
- warm the cache online, then a fresh project with `--prefer-offline` resolves and installs with **zero** registry requests;
- `--offline` with everything cached succeeds with zero requests; with an unknown package, and with a cached manifest but evicted tarball, it exits non-zero with the `--offline` message and still zero requests;
- `install.prefer = "offline"` and `install.offline = true` behave like the respective flags;
- an expired cached manifest (via `--force`) is still used by both modes (regression for a spin found in review);
- an uncached optionalDependency under `--offline` is skipped and the install succeeds; an uncached git dependency under `--offline` errors without spawning git.

Also ran `test/cli/install/bun-install.test.ts` locally.



Supersedes #39899 (same change, moved from a fork branch to a branch in this repository; the review discussion so far is on that PR and has been addressed here).

