### PR TITLE
install: return immediately when nothing that determines node_modules has changed

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -191,6 +191,9 @@ bun install --offline
 ```
 
 `--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. With a complete restored cache, `--offline --frozen-lockfile` makes a CI install fully deterministic and network-free; `--prefer-offline` still fetches whatever the cache is missing.
+### Repeat installs
+
+When nothing that affects `node_modules` has changed since the last successful install (lockfile, workspace manifests, config, flags, and the installed folders themselves), `bun install` detects this from a fingerprint kept in the cache directory and returns without re-verifying every package. On large workspaces this turns a repeat install into a few milliseconds. As with other package managers' equivalent optimisation, root lifecycle scripts do not re-run on such a no-op install; use `--force` (or set [`install.stateFile = false`](/runtime/bunfig#install-statefile)) to always do the full pass.
 
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -191,6 +191,7 @@ bun install --offline
 ```
 
 `--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. With a complete restored cache, `--offline --frozen-lockfile` makes a CI install fully deterministic and network-free; `--prefer-offline` still fetches whatever the cache is missing.
+
 ### Repeat installs
 
 When nothing that affects `node_modules` has changed since the last successful install (lockfile, workspace manifests, config, flags, and the installed folders themselves), `bun install` detects this from a fingerprint kept in the cache directory and returns without re-verifying every package. On large workspaces this turns a repeat install into a few milliseconds. As with other package managers' equivalent optimization, root lifecycle scripts do not re-run on such a no-op install; use `--force` (or set [`install.stateFile = false`](/runtime/bunfig#install-statefile)) to always do the full pass.

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -193,7 +193,7 @@ bun install --offline
 `--prefer-offline` is also what `install.prefer = "offline"` in `bunfig.toml` selects; `install.offline = true` is the config form of `--offline`. With a complete restored cache, `--offline --frozen-lockfile` makes a CI install fully deterministic and network-free; `--prefer-offline` still fetches whatever the cache is missing.
 ### Repeat installs
 
-When nothing that affects `node_modules` has changed since the last successful install (lockfile, workspace manifests, config, flags, and the installed folders themselves), `bun install` detects this from a fingerprint kept in the cache directory and returns without re-verifying every package. On large workspaces this turns a repeat install into a few milliseconds. As with other package managers' equivalent optimisation, root lifecycle scripts do not re-run on such a no-op install; use `--force` (or set [`install.stateFile = false`](/runtime/bunfig#install-statefile)) to always do the full pass.
+When nothing that affects `node_modules` has changed since the last successful install (lockfile, workspace manifests, config, flags, and the installed folders themselves), `bun install` detects this from a fingerprint kept in the cache directory and returns without re-verifying every package. On large workspaces this turns a repeat install into a few milliseconds. As with other package managers' equivalent optimization, root lifecycle scripts do not re-run on such a no-op install; use `--force` (or set [`install.stateFile = false`](/runtime/bunfig#install-statefile)) to always do the full pass.
 
 See [lockfile](/pm/lockfile) for more on `bun.lock`.
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -525,7 +525,7 @@ offline = true
 
 ### `install.stateFile`
 
-After a successful install, `bun install` records a fingerprint of everything that determines `node_modules` — the lockfile, every workspace `package.json`, `bunfig.toml` / `.npmrc`, patch files, install-relevant environment variables and flags, and the modification times of `node_modules` entries and of local `file:` / `link:` sources — under the cache directory. When nothing changed, the next plain `bun install` verifies the fingerprint and returns immediately instead of re-checking every installed package. `--force`, `bun add`/`remove`/`update`, or any change to those inputs takes the normal path. Default `true`; set to `false` to always do the full check.
+After a successful install, `bun install` records a fingerprint of everything that determines `node_modules` — the lockfile, every workspace `package.json`, `bunfig.toml` / `.npmrc`, patch files, install-relevant environment variables and flags, and the modification times of `node_modules` entries and of local `file:` sources — under the cache directory (projects with `bun link`-ed dependencies always take the normal path). When nothing changed, the next plain `bun install` verifies the fingerprint and returns immediately instead of re-checking every installed package. `--force`, `bun add`/`remove`/`update`, or any change to those inputs takes the normal path. Default `true`; set to `false` to always do the full check.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -523,6 +523,15 @@ When `true`, `bun install` never touches the network: package metadata and tarba
 offline = true
 ```
 
+### `install.stateFile`
+
+After a successful install, `bun install` records a fingerprint of everything that determines `node_modules` — the lockfile, every workspace `package.json`, `bunfig.toml` / `.npmrc`, patch files, install-relevant environment variables and flags, and the modification times of `node_modules` entries and of local `file:` / `link:` sources — under the cache directory. When nothing changed, the next plain `bun install` verifies the fingerprint and returns immediately instead of re-checking every installed package. `--force`, `bun add`/`remove`/`update`, or any change to those inputs takes the normal path. Default `true`; set to `false` to always do the full check.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+stateFile = false
+```
+
 ### `install.frozenLockfile`
 
 When `true`, `bun install` does not update `bun.lock`. Default `false`. If `package.json` and the existing `bun.lock` disagree, the install errors.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1566,6 +1566,9 @@ impl<'a> Parser<'a> {
         if let Some(v) = install_obj.get(b"offline").and_then(|e| e.as_bool()) {
             install.offline = Some(v);
         }
+        if let Some(v) = install_obj.get(b"stateFile").and_then(|e| e.as_bool()) {
+            install.install_state = Some(v);
+        }
 
         Ok(())
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1407,6 +1407,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        install_state,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1462,6 +1463,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        install_state,
     );
 }
 

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -44,6 +44,9 @@ pub struct Options {
     pub enable: Enable,
     pub do_: Do,
     pub positionals: &'static [&'static [u8]],
+    /// `-c/--config <path>` as given on the command line (the bunfig that was loaded
+    /// *instead of* ./bunfig.toml), so the install-state fingerprint can cover it.
+    pub explicit_config_path: Option<&'static [u8]>,
     pub(crate) update: DependencyGroup,
     pub dry_run: bool,
     pub check: bool,
@@ -134,6 +137,7 @@ impl Default for Options {
             enable: Enable::default(),
             do_: Do::default(),
             positionals: &[],
+            explicit_config_path: None,
             update: DependencyGroup::default(),
             dry_run: false,
             check: false,
@@ -729,6 +733,9 @@ impl Options {
             self.enable.set(Enable::MANIFEST_CACHE_CONTROL, false);
         }
 
+        if let Some(cli) = &maybe_cli {
+            self.explicit_config_path = cli.config;
+        }
         if let Some(cli) = maybe_cli {
             self.do_.set(Do::ANALYZE, cli.analyze);
             self.enable

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -97,6 +97,9 @@ pub struct Options {
 
     /// `--offline` / `--prefer-offline` (or `install.offline` / `install.prefer = "offline"`).
     pub offline: OfflineMode,
+    /// Record/consult the whole-install fingerprint (`install_state.rs`) so a repeat
+    /// `bun install` with nothing to do returns immediately. `install.stateFile`.
+    pub install_state: bool,
 
     // Security scanner module path
     pub security_scanner: Option<&'static [u8]>,
@@ -174,6 +177,7 @@ impl Default for Options {
             hoist_pattern: None,
             hoist: true,
             offline: OfflineMode::Online,
+            install_state: true,
             security_scanner: None,
             minimum_release_age_ms: None,
             minimum_release_age_excludes: None,
@@ -493,6 +497,9 @@ impl Options {
                 self.hoist = hoist;
             }
 
+            if let Some(v) = config.install_state {
+                self.install_state = v;
+            }
             if config.offline == Some(true) {
                 self.offline = OfflineMode::Offline;
             }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -55,6 +55,46 @@ pub fn install_with_manager(
 ) -> crate::Result<()> {
     let log_level = manager.options.log_level;
 
+    // Fast path: nothing that determines node_modules has changed since the last
+    // successful install (see install_state.rs) — skip lockfile parsing, hoisting and
+    // the per-package verification walk entirely.
+    let state_root: Vec<u8> = strings::without_trailing_slash(
+        crate::package_manager_real::FileSystem::instance().top_level_dir(),
+    )
+    .to_vec();
+    if crate::install_state::applicable(manager) {
+        if let Some(s) = crate::install_state::is_up_to_date(manager, &state_root) {
+            if manager.options.do_.summary() {
+                // Same wording as the regular no-op path so scripts/tests keying on it keep working.
+                bun_core::pretty!("\n");
+                if s.packages != s.entries {
+                    bun_core::pretty!(
+                        "Checked <green>{} install{}<r> across {} package{} <d>(no changes)<r> ",
+                        s.entries,
+                        if s.entries == 1 { "" } else { "s" },
+                        s.packages,
+                        if s.packages == 1 { "" } else { "s" },
+                    );
+                } else {
+                    bun_core::pretty!(
+                        "<r><green>Done<r>! Checked {} package{}<r> <d>(no changes)<r> ",
+                        s.entries,
+                        if s.entries == 1 { "" } else { "s" },
+                    );
+                }
+                Output::print_start_end_stdout(ctx.start_time, bun_core::time::nano_timestamp());
+                bun_core::pretty!("\n");
+                Output::flush();
+            }
+            return Ok(());
+        }
+        // We are about to do real work; never leave a stale "clean" marker behind if
+        // this install dies half way.
+        crate::install_state::invalidate(manager, &state_root);
+    } else if manager.subcommand != Subcommand::Install || !manager.update_requests.is_empty() {
+        crate::install_state::invalidate(manager, &state_root);
+    }
+
     // Start resolving DNS for the default registry immediately.
     // Unless you're behind a proxy.
     if !manager.env().has_http_proxy()
@@ -997,6 +1037,10 @@ pub fn install_with_manager(
 
     if install_summary.fail > 0 {
         manager.any_failed_to_install = true;
+    } else if !manager.log_mut().has_errors() {
+        let entries = u64::from(install_summary.success) + u64::from(install_summary.skipped);
+        let packages = manager.lockfile.packages.len() as u64;
+        crate::install_state::save(manager, &state_root, entries, packages);
     }
 
     Output::flush();

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -88,12 +88,10 @@ pub fn install_with_manager(
             }
             return Ok(());
         }
-        // We are about to do real work; never leave a stale "clean" marker behind if
-        // this install dies half way.
-        crate::install_state::invalidate(manager, &state_root);
-    } else if manager.subcommand != Subcommand::Install || !manager.update_requests.is_empty() {
-        crate::install_state::invalidate(manager, &state_root);
     }
+    // We are about to do real work (or were told to with --force / add / remove /
+    // update): never leave a stale "clean" marker behind if this install dies half way.
+    crate::install_state::invalidate(manager, &state_root);
 
     // Start resolving DNS for the default registry immediately.
     // Unless you're behind a proxy.

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -91,7 +91,10 @@ pub fn install_with_manager(
     }
     // We are about to do real work (or were told to with --force / add / remove /
     // update): never leave a stale "clean" marker behind if this install dies half way.
-    crate::install_state::invalidate(manager, &state_root);
+    // Runs that cannot touch node_modules (--dry-run, --lockfile-only) keep it.
+    if !manager.options.dry_run && !manager.options.lockfile_only {
+        crate::install_state::invalidate(manager, &state_root);
+    }
 
     // Start resolving DNS for the default registry immediately.
     // Unless you're behind a proxy.

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -28,6 +28,7 @@ use std::io::Write as _;
 
 use crate::lockfile::package::PackageColumns as _;
 use bun_paths::SEP;
+use bun_sys::Fd;
 
 use crate::PackageManager;
 use crate::package_manager_real::Subcommand;
@@ -38,27 +39,47 @@ fn h(bytes: &[u8]) -> u64 {
     bun_wyhash::hash(bytes)
 }
 
-fn hash_file(path: &[u8]) -> Option<u64> {
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
-    match std::fs::read(p) {
-        Ok(b) => Some(h(&b)),
-        Err(_) => None,
-    }
+fn zpath(path: &[u8]) -> bun_core::ZBox {
+    let mut v = Vec::with_capacity(path.len() + 1);
+    v.extend_from_slice(path);
+    v.push(0);
+    bun_core::ZBox::from_vec_with_nul(v)
 }
 
+fn read_file(path: &[u8]) -> Option<Vec<u8>> {
+    bun_sys::File::read_from(Fd::cwd(), path).ok()
+}
+
+fn hash_file(path: &[u8]) -> Option<u64> {
+    read_file(path).map(|b| h(&b))
+}
+
+fn mtime_ns(st: &bun_sys::Stat) -> u64 {
+    let t = bun_sys::stat_mtime(st);
+    (t.sec as u64)
+        .wrapping_mul(1_000_000_000)
+        .wrapping_add(t.nsec as u64)
+}
+
+/// mtime of `path` (following symlinks), None if it does not exist.
 fn dir_stamp(path: &[u8]) -> Option<u64> {
+    bun_sys::stat(&zpath(path)).ok().map(|st| mtime_ns(&st))
+}
+
+/// mtime of `path` itself (not following symlinks), None if it does not exist.
+fn lstat_stamp(path: &[u8]) -> Option<u64> {
+    bun_sys::lstat(&zpath(path)).ok().map(|st| mtime_ns(&st))
+}
+
+fn is_directory(path: &[u8]) -> bool {
+    matches!(bun_sys::stat(&zpath(path)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+}
+
+/// Iterate a directory with std's reader; the path bytes are ours.
+fn read_dir(path: &[u8]) -> Option<std::fs::ReadDir> {
+    // SAFETY: only hands our own path bytes to `read_dir`; never inspected as `str`.
     let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
-    let m = std::fs::metadata(p).ok()?;
-    let t = m
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?;
-    Some(
-        t.as_secs()
-            .wrapping_mul(1_000_000_000)
-            .wrapping_add(u64::from(t.subsec_nanos())),
-    )
+    std::fs::read_dir(p).ok()
 }
 
 fn join(root: &[u8], rel: &[u8]) -> Vec<u8> {
@@ -139,14 +160,12 @@ fn state_path(manager: &mut PackageManager, root: &[u8], create_dir: bool) -> Op
     } else {
         join(root, b"node_modules/.cache")
     };
-    if !std::path::Path::new(unsafe { std::str::from_utf8_unchecked(&cache_path) }).is_dir() {
+    if !is_directory(&cache_path) {
         return None;
     }
     let dir = join(&cache_path, b".install-state");
     if create_dir {
-        let _ = std::fs::create_dir_all(std::path::Path::new(unsafe {
-            std::str::from_utf8_unchecked(&dir)
-        }));
+        let _ = bun_sys::mkdir_recursive(&dir);
     }
     let mut name: Vec<u8> = Vec::with_capacity(20);
     let _ = write!(&mut name, "{:016x}", h(root));
@@ -186,10 +205,7 @@ fn parse(text: &[u8]) -> Option<Recorded> {
 /// `Some(summary)` when the recorded state exists and every input is unchanged.
 pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Summary> {
     let sp = state_path(manager, root_dir, false)?;
-    let text = std::fs::read(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&sp)
-    }))
-    .ok()?;
+    let text = read_file(&sp)?;
     let rec = parse(&text)?;
     if rec.lines.is_empty() {
         return None;
@@ -206,11 +222,7 @@ pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Su
             b'a' => hash_file(path).is_none(),
             b'd' => dir_stamp(path) == Some(*val),
             b'n' => dir_stamp(path).is_none(),
-            b'l' => {
-                lstat_stamp(std::path::Path::new(unsafe {
-                    std::str::from_utf8_unchecked(path)
-                })) == Some(*val)
-            }
+            b'l' => lstat_stamp(path) == Some(*val),
             b'p' => manifest_stamp(path) == *val,
             b'e' => {
                 saw_env = true;
@@ -365,9 +377,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     // manifest (`packages/*` → `packages/`), recorded even when it does not exist yet,
     // so creating the first workspace under it is noticed.
     let root_manifest_path = join(root_dir, b"package.json");
-    if let Ok(root_json) = std::fs::read(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&root_manifest_path)
-    })) {
+    if let Some(root_json) = read_file(&root_manifest_path) {
         if let Some(globs) = workspace_globs(&root_json) {
             for g in globs {
                 let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
@@ -376,7 +386,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                     .position(|c| matches!(*c, b'*' | b'?' | b'[' | b'{' | b'!'))
                     .unwrap_or(g.len());
                 let lit = &g[..literal_end];
-                let dir_end = lit.iter().rposition(|c| *c == b'/').map_or(0, |i| i);
+                let dir_end = lit.iter().rposition(|c| *c == b'/').unwrap_or(0);
                 let prefix = &lit[..dir_end];
                 let abs = if prefix.is_empty() {
                     root_dir.to_vec()
@@ -453,47 +463,21 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     );
     let _ = writeln!(out, "s {entries:016x} {packages}");
 
-    let sp_str = unsafe { std::str::from_utf8_unchecked(&sp) };
-    let tmp = format!("{sp_str}.tmp");
-    if std::fs::write(&tmp, &out).is_ok() {
-        let _ = std::fs::rename(&tmp, sp_str);
+    let mut tmp = sp.clone();
+    tmp.extend_from_slice(b".tmp");
+    if let Ok(f) = bun_sys::File::create(Fd::cwd(), &tmp, true) {
+        if f.write_all(&out).is_ok() {
+            let _ = bun_sys::renameat(Fd::cwd(), &zpath(&tmp), Fd::cwd(), &zpath(&sp));
+        }
     }
-}
-
-fn lstat_stamp(path: &std::path::Path) -> Option<u64> {
-    let m = std::fs::symlink_metadata(path).ok()?;
-    let t = m
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?;
-    Some(
-        t.as_secs()
-            .wrapping_mul(1_000_000_000)
-            .wrapping_add(u64::from(t.subsec_nanos())),
-    )
 }
 
 /// `<mtime ns> ^ <size>` of a package's package.json, following symlinks (so an
 /// isolated-linker entry is checked in the store it points at). 0 when missing.
 fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
     let pj = join(pkg_dir, b"package.json");
-    match std::fs::metadata(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&pj)
-    })) {
-        Ok(m) => {
-            let t = m
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| {
-                    d.as_secs()
-                        .wrapping_mul(1_000_000_000)
-                        .wrapping_add(u64::from(d.subsec_nanos()))
-                })
-                .unwrap_or(0);
-            (t ^ m.len().rotate_left(40)) | 1
-        }
+    match bun_sys::stat(&zpath(&pj)) {
+        Ok(st) => (mtime_ns(&st) ^ (st.st_size as u64).rotate_left(40)) | 1,
         Err(_) => 0,
     }
 }
@@ -502,12 +486,13 @@ fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
 /// package.json stamp (`p`). Scope dirs are descended one level; bookkeeping dirs
 /// (`.bin`, `.bun`, …) get only the `l` stamp.
 fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
-    let Some(stamp) = lstat_stamp(p) else { return };
+    let Some(stamp) = lstat_stamp(dir) else {
+        return;
+    };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let Ok(rd) = std::fs::read_dir(p) else { return };
+    let Some(rd) = read_dir(dir) else { return };
     for e in rd.flatten() {
         let name = e.file_name();
         let name = name.as_encoded_bytes();
@@ -519,9 +504,7 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
             stamp_tree(out, &child, depth + 1);
             continue;
         }
-        if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
-            std::str::from_utf8_unchecked(&child)
-        })) {
+        if let Some(stamp) = lstat_stamp(&child) {
             let _ = write!(out, "l {stamp:016x} ");
             out.extend_from_slice(&child);
             out.push(b'\n');
@@ -532,6 +515,10 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
             out.push(b'\n');
         }
     }
+}
+
+fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
+    bun_core::strings::index_of(hay, needle).is_some()
 }
 
 /// The `workspaces` glob patterns of a root package.json (`["a/*"]` or
@@ -565,21 +552,13 @@ fn workspace_globs(json_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
     Some(out)
 }
 
-fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
-    hay.windows(needle.len()).any(|w| w == needle)
-}
-
 /// Collect existing subdirectories of `dir` up to `depth` levels (bounded), skipping
 /// node_modules / dot dirs, into `out`.
 fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut usize) {
     if depth == 0 || *budget == 0 {
         return;
     }
-    let Ok(rd) = std::fs::read_dir(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(dir)
-    })) else {
-        return;
-    };
+    let Some(rd) = read_dir(dir) else { return };
     for e in rd.flatten() {
         if *budget == 0 {
             return;
@@ -605,14 +584,13 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules
 /// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
 fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
-    let Some(stamp) = lstat_stamp(p) else {
+    let Some(stamp) = lstat_stamp(dir) else {
         return false;
     };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let Ok(rd) = std::fs::read_dir(p) else {
+    let Some(rd) = read_dir(dir) else {
         return false;
     };
     for e in rd.flatten() {
@@ -631,9 +609,7 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
             if !stamp_source_tree(out, &child, budget) {
                 return false;
             }
-        } else if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
-            std::str::from_utf8_unchecked(&child)
-        })) {
+        } else if let Some(stamp) = lstat_stamp(&child) {
             let _ = write!(out, "l {stamp:016x} ");
             out.extend_from_slice(&child);
             out.push(b'\n');
@@ -648,7 +624,5 @@ pub fn invalidate(manager: &mut PackageManager, root_dir: &[u8]) {
     let Some(sp) = state_path(manager, root_dir, false) else {
         return;
     };
-    let _ = std::fs::remove_file(std::path::Path::new(unsafe {
-        std::str::from_utf8_unchecked(&sp)
-    }));
+    let _ = bun_sys::unlinkat(Fd::cwd(), &zpath(&sp));
 }

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -115,6 +115,18 @@ enum DirList {
     Unreadable,
 }
 
+impl DirList {
+    /// The entries, or — when there is nothing to walk — whether the walk still counts
+    /// as complete (`true` for an absent directory, `false` for an unreadable one).
+    fn into_entries(self) -> Result<Vec<(Vec<u8>, bool)>, bool> {
+        match self {
+            DirList::Entries(e) => Ok(e),
+            DirList::Absent => Err(true),
+            DirList::Unreadable => Err(false),
+        }
+    }
+}
+
 /// Directory entries as (name, is_directory); `.`/`..` are never returned by the
 /// iterator. An error part-way through is `Unreadable`, never a partial list.
 fn read_dir(path: &[u8]) -> DirList {
@@ -674,10 +686,10 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) -> bool {
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let rd = match read_dir(dir) {
-        DirList::Entries(rd) => rd,
-        DirList::Absent => return true,
-        DirList::Unreadable => return false,
+    let rd = match read_dir(dir).into_entries() {
+        Ok(rd) => rd,
+        // absent: nothing to stamp (fine); unreadable: refuse to record state
+        Err(complete) => return complete,
     };
     for (name, _) in &rd {
         let name = name.as_slice();
@@ -748,10 +760,10 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
     if depth == 0 {
         return true;
     }
-    let rd = match read_dir(dir) {
-        DirList::Entries(rd) => rd,
-        DirList::Absent => return true,
-        DirList::Unreadable => return false,
+    let rd = match read_dir(dir).into_entries() {
+        Ok(rd) => rd,
+        // absent: nothing to stamp (fine); unreadable: refuse to record state
+        Err(complete) => return complete,
     };
     for (name, is_dir) in &rd {
         if !is_dir {

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -85,12 +85,28 @@ fn lstat_stamp(path: &[u8]) -> Option<u64> {
     bun_sys::lstat(&zpath(path)).ok().map(|st| mtime_ns(&st))
 }
 
+enum Stamp {
+    At(u64),
+    Absent,
+    Unreadable,
+}
+
+/// `lstat_stamp`, but an existing path whose metadata cannot be read (EACCES, EIO, …)
+/// is reported separately so callers can refuse to record state over it.
+fn lstat_stamp_strict(path: &[u8]) -> Stamp {
+    match bun_sys::lstat(&zpath(path)) {
+        Ok(st) => Stamp::At(mtime_ns(&st)),
+        Err(e) if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) => {
+            Stamp::Absent
+        }
+        Err(_) => Stamp::Unreadable,
+    }
+}
+
 fn is_directory(path: &[u8]) -> bool {
     matches!(bun_sys::stat(&zpath(path)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
 }
 
-/// Directory entries as (name, is_directory); `.`/`..` are never returned by the
-/// iterator. None if the directory cannot be opened.
 enum DirList {
     Entries(Vec<(Vec<u8>, bool)>),
     /// ENOENT / ENOTDIR
@@ -160,6 +176,10 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
             k.starts_with(b"BUN_INSTALL")
                 || k.starts_with(b"BUN_CONFIG_")
                 || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
+                // where the global .npmrc / .bunfig.toml are looked up
+                || k == b"HOME"
+                || k == b"USERPROFILE"
+                || k == b"XDG_CONFIG_HOME"
         })
         .collect();
     keys.sort_unstable();
@@ -328,7 +348,14 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
         let buf = manager.lockfile.buffers.string_bytes.as_slice();
         let mut budget: usize = 20_000;
         let mut ok = true;
-        for r in manager.lockfile.packages.slice().items_resolution().iter() {
+        for (i, r) in manager
+            .lockfile
+            .packages
+            .slice()
+            .items_resolution()
+            .iter()
+            .enumerate()
+        {
             match r.tag {
                 Tag::Folder | Tag::Symlink => {
                     let rel = if r.tag == Tag::Folder {
@@ -353,6 +380,12 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                 }
                 Tag::LocalTarball => {
                     let rel = r.local_tarball().slice(buf);
+                    // A relative tarball path is stored as declared, i.e. relative to the
+                    // *declaring* package; only the root's can be resolved from here.
+                    if !bun_paths::is_absolute(rel) && !declared_by_root(&manager.lockfile, i) {
+                        ok = false;
+                        break;
+                    }
                     let path = if bun_paths::is_absolute(rel) {
                         rel.to_vec()
                     } else {
@@ -409,11 +442,19 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     file(&mut out, join(root_dir, b".npmrc"));
     // `-c <path>` is loaded instead of ./bunfig.toml; cover it too (its argv position is
     // already part of the env+argv hash, its contents are not)
-    if let Some(cfg) = manager.options.explicit_config_path {
+    if let Some(cfg) = manager.options.explicit_config_path
+        && !cfg.is_empty()
+    {
+        // `load_config` resolves a relative --config against the process cwd
+        let mut cwd_buf = bun_paths::PathBuffer::uninit();
+        let base: &[u8] = match bun_sys::getcwd(&mut cwd_buf.0) {
+            Ok(n) => &cwd_buf.0[..n],
+            Err(_) => root_dir,
+        };
         if bun_paths::is_absolute(cfg) {
             file(&mut out, cfg.to_vec());
         } else {
-            file(&mut out, join(root_dir, cfg));
+            file(&mut out, join(base, cfg));
         }
     }
     // global config, with the same precedence the loaders use: $XDG_CONFIG_HOME first
@@ -428,6 +469,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     }
     // workspaces: manifest hash + parent dir stamp
     let buf = manager.lockfile.buffers.string_bytes.as_slice();
+    let mut globs_incomplete = false;
     let mut parents: Vec<Vec<u8>> = Vec::new();
     for ws in manager.lockfile.workspace_paths.values() {
         let rel = ws.slice(buf);
@@ -464,12 +506,13 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                 // workspaces too — stamp existing dirs down to the glob's depth (2 for **)
                 let rest = &g[literal_end..];
                 let extra_depth = if strings_contains(rest, b"**") {
-                    2
+                    usize::MAX
                 } else {
                     bun_core::strings::count_char(rest, b'/')
                 };
-                if extra_depth > 0 {
-                    collect_dirs(&abs, extra_depth, &mut parents, &mut 2000);
+                if extra_depth > 0 && !collect_dirs(&abs, extra_depth, &mut parents, &mut 4000) {
+                    // too many candidate directories to watch cheaply: no fast path
+                    globs_incomplete = true;
                 }
                 if !parents.contains(&abs) {
                     parents.push(abs);
@@ -558,21 +601,29 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
             // an existing store we cannot enumerate makes the state unrecordable
             DirList::Unreadable => unreadable = true,
             DirList::Entries(entries) => {
-                for (name, is_dir) in entries {
-                    if !is_dir {
-                        continue;
-                    }
-                    let inner = join(&join(&store, &name), b"node_modules");
-                    if let Some(stamp) = lstat_stamp(&inner) {
-                        let _ = write!(out, "l {stamp:016x} ");
-                        out.extend_from_slice(&inner);
-                        out.push(b'\n');
+                for (name, _) in entries {
+                    // `.bun/node_modules` is the hidden hoist directory itself; every other
+                    // entry (a directory, or with a global store a symlink to one) holds
+                    // the package plus its dependency links under `<entry>/node_modules`
+                    let dir = if name == b"node_modules" {
+                        join(&store, &name)
+                    } else {
+                        join(&join(&store, &name), b"node_modules")
+                    };
+                    match lstat_stamp_strict(&dir) {
+                        Stamp::At(stamp) => {
+                            let _ = write!(out, "l {stamp:016x} ");
+                            out.extend_from_slice(&dir);
+                            out.push(b'\n');
+                        }
+                        Stamp::Absent => {}
+                        Stamp::Unreadable => unreadable = true,
                     }
                 }
             }
         }
     }
-    if unreadable {
+    if unreadable || globs_incomplete {
         return;
     }
     out.extend_from_slice(&local_lines);
@@ -608,8 +659,10 @@ fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
 /// package.json stamp (`p`). Scope dirs are descended one level; bookkeeping dirs
 /// (`.bin`, `.bun`, …) get only the `l` stamp.
 fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) -> bool {
-    let Some(stamp) = lstat_stamp(dir) else {
-        return true;
+    let stamp = match lstat_stamp_strict(dir) {
+        Stamp::At(s) => s,
+        Stamp::Absent => return true,
+        Stamp::Unreadable => return false,
     };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
@@ -682,18 +735,20 @@ fn workspace_globs(json_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
 
 /// Collect existing subdirectories of `dir` up to `depth` levels (bounded), skipping
 /// node_modules / dot dirs, into `out`.
-fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut usize) {
-    if depth == 0 || *budget == 0 {
-        return;
+/// Collect the directories up to `depth` levels below `dir` (skipping node_modules and
+/// dot dirs). Returns false if the walk could not be completed within `budget` or a
+/// directory could not be read — the caller must then not record state, since a
+/// workspace could later appear in a directory that was never stamped.
+fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut usize) -> bool {
+    if depth == 0 {
+        return true;
     }
-    // best effort: this only widens the set of directories that get an mtime stamp
-    let DirList::Entries(rd) = read_dir(dir) else {
-        return;
+    let rd = match read_dir(dir) {
+        DirList::Entries(rd) => rd,
+        DirList::Absent => return true,
+        DirList::Unreadable => return false,
     };
     for (name, is_dir) in &rd {
-        if *budget == 0 {
-            return;
-        }
         if !is_dir {
             continue;
         }
@@ -701,13 +756,19 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
         if name == b"node_modules" || name.starts_with(b".") {
             continue;
         }
+        if *budget == 0 {
+            return false;
+        }
         *budget -= 1;
         let child = join(dir, name);
-        collect_dirs(&child, depth - 1, out, budget);
+        if !collect_dirs(&child, depth - 1, out, budget) {
+            return false;
+        }
         if !out.contains(&child) {
             out.push(child);
         }
     }
+    true
 }
 
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules
@@ -743,6 +804,18 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
         }
     }
     true
+}
+
+/// Is package `pkg_id` a direct dependency of the root package? (Local paths are stored
+/// relative to the declaring package, so only those can be resolved from the root.)
+fn declared_by_root(lockfile: &crate::lockfile::Lockfile, pkg_id: usize) -> bool {
+    if lockfile.packages.len() == 0 {
+        return false;
+    }
+    let root_deps = lockfile.packages.items_dependencies()[0];
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+    (root_deps.off as usize..(root_deps.off + root_deps.len) as usize)
+        .any(|dep_id| resolutions.get(dep_id).copied() == Some(pkg_id as crate::PackageID))
 }
 
 /// Remove the state file (called before any install that will do real work, so a

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -611,8 +611,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
         }
     }
     // Nested node_modules folders (hoisted: `node_modules/a/node_modules`, from the
-    // lockfile's tree list) and each isolated store entry's own `node_modules`: one
-    // lstat each, so a deleted nested package, `.bin` or dependency link is noticed.
+    // lockfile's tree list) and each isolated store entry's own `node_modules` get the
+    // same per-entry stamps as the root tree, so a deleted or corrupted nested package,
+    // `.bin` or dependency link is noticed.
     {
         let lockfile = &*manager.lockfile;
         let mut iter = crate::lockfile::tree::Iterator::<
@@ -636,19 +637,6 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                         unreadable = true;
                     }
                 }
-            }
-            match lstat_stamp_strict(&join(&dir, b".bin")) {
-                Stamp::At(stamp) => {
-                    let _ = write!(out, "l {stamp:016x} ");
-                    out.extend_from_slice(&join(&dir, b".bin"));
-                    out.push(b'\n');
-                }
-                Stamp::Absent => {
-                    let _ = write!(out, "n {:016x} ", 0);
-                    out.extend_from_slice(&join(&dir, b".bin"));
-                    out.push(b'\n');
-                }
-                Stamp::Unreadable => unreadable = true,
             }
         }
         let store = join(&join(root_dir, b"node_modules"), b".bun");

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -46,12 +46,26 @@ fn zpath(path: &[u8]) -> bun_core::ZBox {
     bun_core::ZBox::from_vec_with_nul(v)
 }
 
-fn read_file(path: &[u8]) -> Option<Vec<u8>> {
-    bun_sys::File::read_from(Fd::cwd(), path).ok()
+enum FileHash {
+    Present(u64),
+    /// ENOENT / ENOTDIR — a legitimately missing input (recorded as such)
+    Absent,
+    /// exists but could not be read (EACCES, EIO, …): never treated as a valid state
+    Unreadable,
 }
 
-fn hash_file(path: &[u8]) -> Option<u64> {
-    read_file(path).map(|b| h(&b))
+fn read_file(path: &[u8]) -> Result<Vec<u8>, bun_sys::Error> {
+    bun_sys::File::read_from(Fd::cwd(), path)
+}
+
+fn hash_file(path: &[u8]) -> FileHash {
+    match read_file(path) {
+        Ok(b) => FileHash::Present(h(&b)),
+        Err(e) if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) => {
+            FileHash::Absent
+        }
+        Err(_) => FileHash::Unreadable,
+    }
 }
 
 fn mtime_ns(st: &bun_sys::Stat) -> u64 {
@@ -133,6 +147,7 @@ pub fn applicable(manager: &PackageManager) -> bool {
         && !manager.options.dry_run
         && !manager.options.enable.force_install()
         && manager.options.positionals.len() <= 1
+        && manager.options.filter_patterns.is_empty()
         && manager.update_requests.is_empty()
         && manager.options.do_.install_packages()
         && manager.options.do_.load_lockfile()
@@ -205,7 +220,7 @@ fn parse(text: &[u8]) -> Option<Recorded> {
 /// `Some(summary)` when the recorded state exists and every input is unchanged.
 pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Summary> {
     let sp = state_path(manager, root_dir, false)?;
-    let text = read_file(&sp)?;
+    let text = read_file(&sp).ok()?;
     let rec = parse(&text)?;
     if rec.lines.is_empty() {
         return None;
@@ -217,9 +232,12 @@ pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Su
     };
     for (kind, val, path) in &rec.lines {
         let ok = match kind {
-            b'f' => hash_file(path) == Some(*val),
+            b'f' => matches!(hash_file(path), FileHash::Present(v) if v == *val),
+            // the project root this state belongs to (guards against a hash collision
+            // between two projects sharing one cache directory)
+            b'r' => path.as_slice() == root_dir,
             // recorded as absent: must still be absent
-            b'a' => hash_file(path).is_none(),
+            b'a' => matches!(hash_file(path), FileHash::Absent),
             b'd' => dir_stamp(path) == Some(*val),
             b'n' => dir_stamp(path).is_none(),
             b'l' => lstat_stamp(path) == Some(*val),
@@ -301,12 +319,12 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                         join(root_dir, rel)
                     };
                     match hash_file(&path) {
-                        Some(v) => {
+                        FileHash::Present(v) => {
                             let _ = write!(local_lines, "f {v:016x} ");
                             local_lines.extend_from_slice(&path);
                             local_lines.push(b'\n');
                         }
-                        None => {
+                        _ => {
                             ok = false;
                             break;
                         }
@@ -325,17 +343,23 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     };
     let mut out: Vec<u8> = Vec::with_capacity(4096);
     let _ = writeln!(out, "{VERSION_LINE}");
-    let file = |out: &mut Vec<u8>, p: Vec<u8>| match hash_file(&p) {
-        Some(v) => {
+    let _ = write!(out, "r {:016x} ", 0);
+    out.extend_from_slice(root_dir);
+    out.push(b'\n');
+    // any input that exists but cannot be read makes the state unrecordable
+    let mut unreadable = false;
+    let mut file = |out: &mut Vec<u8>, p: Vec<u8>| match hash_file(&p) {
+        FileHash::Present(v) => {
             let _ = write!(out, "f {v:016x} ");
             out.extend_from_slice(&p);
             out.push(b'\n');
         }
-        None => {
+        FileHash::Absent => {
             let _ = write!(out, "a {:016x} ", 0);
             out.extend_from_slice(&p);
             out.push(b'\n');
         }
+        FileHash::Unreadable => unreadable = true,
     };
     // lockfiles (whichever exist; absence is recorded too)
     file(&mut out, join(root_dir, b"bun.lock"));
@@ -343,18 +367,15 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     file(&mut out, join(root_dir, b"package.json"));
     file(&mut out, join(root_dir, b"bunfig.toml"));
     file(&mut out, join(root_dir, b".npmrc"));
-    if let Some(home) = manager
-        .env()
-        .get(b"HOME")
-        .or_else(|| manager.env().get(b"USERPROFILE"))
-    {
+    // global config, with the same precedence the loaders use: $XDG_CONFIG_HOME first
+    // (its .npmrc wins when it exists), then $HOME (USERPROFILE on Windows)
+    if let Some(xdg) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+        file(&mut out, join(xdg, b".bunfig.toml"));
+        file(&mut out, join(xdg, b".npmrc"));
+    }
+    if let Some(home) = bun_core::env_var::HOME.get_not_empty() {
         file(&mut out, join(home, b".npmrc"));
         file(&mut out, join(home, b".bunfig.toml"));
-    }
-    if let Some(xdg) = manager.env().get(b"XDG_CONFIG_HOME") {
-        file(&mut out, join(xdg, b".bunfig.toml"));
-        // the npmrc loader prefers $XDG_CONFIG_HOME/.npmrc over ~/.npmrc when present
-        file(&mut out, join(xdg, b".npmrc"));
     }
     // workspaces: manifest hash + parent dir stamp
     let buf = manager.lockfile.buffers.string_bytes.as_slice();
@@ -377,7 +398,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     // manifest (`packages/*` → `packages/`), recorded even when it does not exist yet,
     // so creating the first workspace under it is noticed.
     let root_manifest_path = join(root_dir, b"package.json");
-    if let Some(root_json) = read_file(&root_manifest_path) {
+    if let Ok(root_json) = read_file(&root_manifest_path) {
         if let Some(globs) = workspace_globs(&root_json) {
             for g in globs {
                 let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
@@ -452,6 +473,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     for nm in nm_dirs {
         stamp_tree(&mut out, &nm, 0);
     }
+    if unreadable {
+        return;
+    }
     out.extend_from_slice(&local_lines);
     let _ = writeln!(
         out,
@@ -461,10 +485,12 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     let _ = writeln!(out, "s {entries:016x} {packages}");
 
     let mut tmp = sp.clone();
-    tmp.extend_from_slice(b".tmp");
+    let _ = write!(tmp, ".{}.tmp", std::process::id());
     if let Ok(f) = bun_sys::File::create(Fd::cwd(), &tmp, true) {
-        if f.write_all(&out).is_ok() {
-            let _ = bun_sys::renameat(Fd::cwd(), &zpath(&tmp), Fd::cwd(), &zpath(&sp));
+        let renamed = f.write_all(&out).is_ok()
+            && bun_sys::renameat(Fd::cwd(), &zpath(&tmp), Fd::cwd(), &zpath(&sp)).is_ok();
+        if !renamed {
+            let _ = bun_sys::unlinkat(Fd::cwd(), &zpath(&tmp));
         }
     }
 }

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -200,6 +200,7 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
                 || k.starts_with(b"BUN_CONFIG_")
                 || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
                 // where the global .npmrc / .bunfig.toml are looked up
+                || k == b"BUN_OPTIONS"
                 || k == b"HOME"
                 || k == b"USERPROFILE"
                 || k == b"XDG_CONFIG_HOME"
@@ -213,9 +214,14 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
         acc.push(0);
     }
     acc.push(1);
-    // argv[0] is the executable and argv[1] the subcommand token (`install`/`i`; the
-    // subcommand itself is part of `applicable()`), so start at the flags
-    for a in bun_core::argv().into_iter().skip(2) {
+    // argv[0] is the executable; the subcommand token (`install`/`i`) is skipped so both
+    // spellings share the fast path (the subcommand itself is part of `applicable()`).
+    // BUN_OPTIONS tokens are spliced into argv and are also covered by the env hash.
+    for a in bun_core::argv()
+        .into_iter()
+        .skip(1)
+        .filter(|a| !matches!(&a[..], b"install" | b"i" | b"add" | b"remove" | b"update"))
+    {
         acc.extend_from_slice(a);
         acc.push(0);
     }
@@ -363,7 +369,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     if !applicable(manager) {
         return;
     }
-    // Local sources (`file:` folders and tarballs, `link:`) are inputs too: their
+    // Local sources (`file:` folders and tarballs; `link:` deps disable the fast path) are inputs too: their
     // *contents* decide what gets materialized. Stamp them (recursive mtimes for
     // folders, content hash for tarballs); a project with enormous local sources just
     // doesn't get a state file.
@@ -805,6 +811,17 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules
 /// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
 fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
+    // a symlinked source (or subdirectory) would be walked through the link while only the
+    // link's own mtime is recorded: not trackable
+    match bun_sys::lstat(&zpath(dir)) {
+        Ok(st)
+            if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode)
+                == bun_sys::FileKind::SymLink =>
+        {
+            return false;
+        }
+        _ => {}
+    }
     let Some(stamp) = lstat_stamp(dir) else {
         return false;
     };

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -89,11 +89,25 @@ fn is_directory(path: &[u8]) -> bool {
     matches!(bun_sys::stat(&zpath(path)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
 }
 
-/// Iterate a directory with std's reader; the path bytes are ours.
-fn read_dir(path: &[u8]) -> Option<std::fs::ReadDir> {
-    // SAFETY: only hands our own path bytes to `read_dir`; never inspected as `str`.
-    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
-    std::fs::read_dir(p).ok()
+/// Directory entries as (name, is_directory); `.`/`..` are never returned by the
+/// iterator. None if the directory cannot be opened.
+fn read_dir(path: &[u8]) -> Option<Vec<(Vec<u8>, bool)>> {
+    let fd = bun_sys::open_dir_for_iteration(Fd::cwd(), path).ok()?;
+    let mut out = Vec::new();
+    let mut iter = bun_sys::iterate_dir(fd);
+    while let Ok(Some(entry)) = iter.next() {
+        let name = entry.name.slice_u8();
+        let is_dir = match entry.kind {
+            bun_sys::EntryKind::Directory => true,
+            // some filesystems do not report d_type; ask
+            bun_sys::EntryKind::Unknown => is_directory(&join(path, name)),
+            _ => false,
+        };
+        out.push((name.to_vec(), is_dir));
+    }
+    drop(iter);
+    let _ = bun_sys::close(fd);
+    Some(out)
 }
 
 fn join(root: &[u8], rel: &[u8]) -> Vec<u8> {
@@ -516,9 +530,8 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
     out.extend_from_slice(dir);
     out.push(b'\n');
     let Some(rd) = read_dir(dir) else { return };
-    for e in rd.flatten() {
-        let name = e.file_name();
-        let name = name.as_encoded_bytes();
+    for (name, _) in &rd {
+        let name = name.as_slice();
         if name == b".cache" || name == b".install-state" {
             continue;
         }
@@ -582,16 +595,14 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
         return;
     }
     let Some(rd) = read_dir(dir) else { return };
-    for e in rd.flatten() {
+    for (name, is_dir) in &rd {
         if *budget == 0 {
             return;
         }
-        let Ok(ft) = e.file_type() else { continue };
-        if !ft.is_dir() {
+        if !is_dir {
             continue;
         }
-        let name = e.file_name();
-        let name = name.as_encoded_bytes();
+        let name = name.as_slice();
         if name == b"node_modules" || name.starts_with(b".") {
             continue;
         }
@@ -616,19 +627,17 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
     let Some(rd) = read_dir(dir) else {
         return false;
     };
-    for e in rd.flatten() {
+    for (name, is_dir) in &rd {
         if *budget == 0 {
             return false;
         }
         *budget -= 1;
-        let name = e.file_name();
-        let name = name.as_encoded_bytes();
+        let name = name.as_slice();
         if name == b"node_modules" || name == b".git" {
             continue;
         }
         let child = join(dir, name);
-        let Ok(ft) = e.file_type() else { return false };
-        if ft.is_dir() {
+        if *is_dir {
             if !stamp_source_tree(out, &child, budget) {
                 return false;
             }

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -487,6 +487,49 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     for nm in nm_dirs {
         stamp_tree(&mut out, &nm, 0);
     }
+    // Nested node_modules folders (hoisted: `node_modules/a/node_modules`, from the
+    // lockfile's tree list) and each isolated store entry's own `node_modules`: one
+    // lstat each, so a deleted nested package, `.bin` or dependency link is noticed.
+    {
+        let lockfile = &*manager.lockfile;
+        let mut iter = crate::lockfile::tree::Iterator::<
+            { crate::lockfile::tree::IteratorPathStyle::NodeModules },
+        >::init(lockfile);
+        while let Some(nm) = iter.next(None) {
+            if nm.depth == 0 {
+                continue;
+            }
+            let dir = join(root_dir, nm.relative_path.as_bytes());
+            for d in [dir.clone(), join(&dir, b".bin")] {
+                match lstat_stamp(&d) {
+                    Some(stamp) => {
+                        let _ = write!(out, "l {stamp:016x} ");
+                        out.extend_from_slice(&d);
+                        out.push(b'\n');
+                    }
+                    None => {
+                        let _ = write!(out, "n {:016x} ", 0);
+                        out.extend_from_slice(&d);
+                        out.push(b'\n');
+                    }
+                }
+            }
+        }
+        let store = join(&join(root_dir, b"node_modules"), b".bun");
+        if let Some(entries) = read_dir(&store) {
+            for (name, is_dir) in entries {
+                if !is_dir {
+                    continue;
+                }
+                let inner = join(&join(&store, &name), b"node_modules");
+                if let Some(stamp) = lstat_stamp(&inner) {
+                    let _ = write!(out, "l {stamp:016x} ");
+                    out.extend_from_slice(&inner);
+                    out.push(b'\n');
+                }
+            }
+        }
+    }
     if unreadable {
         return;
     }

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -91,23 +91,49 @@ fn is_directory(path: &[u8]) -> bool {
 
 /// Directory entries as (name, is_directory); `.`/`..` are never returned by the
 /// iterator. None if the directory cannot be opened.
-fn read_dir(path: &[u8]) -> Option<Vec<(Vec<u8>, bool)>> {
-    let fd = bun_sys::open_dir_for_iteration(Fd::cwd(), path).ok()?;
+enum DirList {
+    Entries(Vec<(Vec<u8>, bool)>),
+    /// ENOENT / ENOTDIR
+    Absent,
+    /// exists but could not be (fully) enumerated
+    Unreadable,
+}
+
+/// Directory entries as (name, is_directory); `.`/`..` are never returned by the
+/// iterator. An error part-way through is `Unreadable`, never a partial list.
+fn read_dir(path: &[u8]) -> DirList {
+    let fd = match bun_sys::open_dir_for_iteration(Fd::cwd(), path) {
+        Ok(fd) => fd,
+        Err(e) if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) => {
+            return DirList::Absent;
+        }
+        Err(_) => return DirList::Unreadable,
+    };
     let mut out = Vec::new();
     let mut iter = bun_sys::iterate_dir(fd);
-    while let Ok(Some(entry)) = iter.next() {
-        let name = entry.name.slice_u8();
-        let is_dir = match entry.kind {
-            bun_sys::EntryKind::Directory => true,
-            // some filesystems do not report d_type; ask
-            bun_sys::EntryKind::Unknown => is_directory(&join(path, name)),
-            _ => false,
-        };
-        out.push((name.to_vec(), is_dir));
-    }
+    let complete = loop {
+        match iter.next() {
+            Ok(Some(entry)) => {
+                let name = entry.name.slice_u8();
+                let is_dir = match entry.kind {
+                    bun_sys::EntryKind::Directory => true,
+                    // some filesystems do not report d_type; ask
+                    bun_sys::EntryKind::Unknown => is_directory(&join(path, name)),
+                    _ => false,
+                };
+                out.push((name.to_vec(), is_dir));
+            }
+            Ok(None) => break true,
+            Err(_) => break false,
+        }
+    };
     drop(iter);
     let _ = bun_sys::close(fd);
-    Some(out)
+    if complete {
+        DirList::Entries(out)
+    } else {
+        DirList::Unreadable
+    }
 }
 
 fn join(root: &[u8], rel: &[u8]) -> Vec<u8> {
@@ -381,6 +407,15 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     file(&mut out, join(root_dir, b"package.json"));
     file(&mut out, join(root_dir, b"bunfig.toml"));
     file(&mut out, join(root_dir, b".npmrc"));
+    // `-c <path>` is loaded instead of ./bunfig.toml; cover it too (its argv position is
+    // already part of the env+argv hash, its contents are not)
+    if let Some(cfg) = manager.options.explicit_config_path {
+        if bun_paths::is_absolute(cfg) {
+            file(&mut out, cfg.to_vec());
+        } else {
+            file(&mut out, join(root_dir, cfg));
+        }
+    }
     // global config, with the same precedence the loaders use: $XDG_CONFIG_HOME first
     // (its .npmrc wins when it exists), then $HOME (USERPROFILE on Windows)
     if let Some(xdg) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
@@ -485,7 +520,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
         }
     }
     for nm in nm_dirs {
-        stamp_tree(&mut out, &nm, 0);
+        if !stamp_tree(&mut out, &nm, 0) {
+            unreadable = true;
+        }
     }
     // Nested node_modules folders (hoisted: `node_modules/a/node_modules`, from the
     // lockfile's tree list) and each isolated store entry's own `node_modules`: one
@@ -516,16 +553,21 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
             }
         }
         let store = join(&join(root_dir, b"node_modules"), b".bun");
-        if let Some(entries) = read_dir(&store) {
-            for (name, is_dir) in entries {
-                if !is_dir {
-                    continue;
-                }
-                let inner = join(&join(&store, &name), b"node_modules");
-                if let Some(stamp) = lstat_stamp(&inner) {
-                    let _ = write!(out, "l {stamp:016x} ");
-                    out.extend_from_slice(&inner);
-                    out.push(b'\n');
+        match read_dir(&store) {
+            DirList::Absent => {}
+            // an existing store we cannot enumerate makes the state unrecordable
+            DirList::Unreadable => unreadable = true,
+            DirList::Entries(entries) => {
+                for (name, is_dir) in entries {
+                    if !is_dir {
+                        continue;
+                    }
+                    let inner = join(&join(&store, &name), b"node_modules");
+                    if let Some(stamp) = lstat_stamp(&inner) {
+                        let _ = write!(out, "l {stamp:016x} ");
+                        out.extend_from_slice(&inner);
+                        out.push(b'\n');
+                    }
                 }
             }
         }
@@ -565,14 +607,18 @@ fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
 /// Record `dir`, and for each entry: its own lstat mtime (`l`) plus its
 /// package.json stamp (`p`). Scope dirs are descended one level; bookkeeping dirs
 /// (`.bin`, `.bun`, …) get only the `l` stamp.
-fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
+fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) -> bool {
     let Some(stamp) = lstat_stamp(dir) else {
-        return;
+        return true;
     };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let Some(rd) = read_dir(dir) else { return };
+    let rd = match read_dir(dir) {
+        DirList::Entries(rd) => rd,
+        DirList::Absent => return true,
+        DirList::Unreadable => return false,
+    };
     for (name, _) in &rd {
         let name = name.as_slice();
         if name == b".cache" || name == b".install-state" {
@@ -580,7 +626,9 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
         }
         let child = join(dir, name);
         if depth < 1 && name.first() == Some(&b'@') {
-            stamp_tree(out, &child, depth + 1);
+            if !stamp_tree(out, &child, depth + 1) {
+                return false;
+            }
             continue;
         }
         if let Some(stamp) = lstat_stamp(&child) {
@@ -594,6 +642,7 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
             out.push(b'\n');
         }
     }
+    true
 }
 
 fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
@@ -637,7 +686,10 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
     if depth == 0 || *budget == 0 {
         return;
     }
-    let Some(rd) = read_dir(dir) else { return };
+    // best effort: this only widens the set of directories that get an mtime stamp
+    let DirList::Entries(rd) = read_dir(dir) else {
+        return;
+    };
     for (name, is_dir) in &rd {
         if *budget == 0 {
             return;
@@ -667,7 +719,7 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
     out.push(b'\n');
-    let Some(rd) = read_dir(dir) else {
+    let DirList::Entries(rd) = read_dir(dir) else {
         return false;
     };
     for (name, is_dir) in &rd {

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -808,8 +808,6 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
     true
 }
 
-/// Recursively record `l` stamps for a local-source directory (skipping node_modules
-/// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
 /// `l`/`n`-stamp a nested or store `node_modules` directory, plus each `@scope`
 /// directory directly inside it (removing `@scope/pkg` only touches `@scope`'s mtime).
 /// Returns false when something that exists could not be read.
@@ -853,6 +851,8 @@ fn stamp_dir_and_scopes(out: &mut Vec<u8>, dir: &[u8], record_absent: bool) -> b
     }
 }
 
+/// Recursively record `l` stamps for a local-source directory (skipping node_modules
+/// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
 fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
     // a symlinked source (or entry inside it) would be walked through the link while only
     // the link's own mtime is recorded: not trackable

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -1,0 +1,654 @@
+//! Whole-install fingerprint: the "nothing changed" fast path.
+//!
+//! After a successful `bun install`, the inputs that determine what ends up in
+//! node_modules are hashed and recorded in `<cache>/.install-state/<project>`:
+//!   * the lockfile bytes (bun.lock / bun.lockb),
+//!   * root and every workspace `package.json`,
+//!   * config files that shape an install (./bunfig.toml, ./.npmrc, ~/.npmrc,
+//!     ~/.bunfig.toml), and every referenced patch file,
+//!   * the install-relevant environment (`BUN_INSTALL*`, `BUN_CONFIG_*`,
+//!     `NPM_CONFIG_*`) and the exact command line,
+//!   * bun's version,
+//!   * the mtime of each workspace directory's *parent* (so a workspace added
+//!     under `packages/*` is noticed even though no existing file changed).
+//! On the next plain `bun install`, if the file exists and every recorded input
+//! still hashes the same, there is provably nothing to do: we print the summary
+//! and return without parsing the lockfile, re-hoisting, or touching one
+//! `node_modules/*/package.json` — O(inputs) instead of O(packages) work, which
+//! is the difference between milliseconds and seconds on large monorepos and on
+//! Windows.
+//!
+//! Anything that mutates the inputs (add/remove/update/pm trust/patch, editing a
+//! package.json, switching branches) changes a hash and takes the normal path.
+//! `--force`, `--frozen-lockfile` off a mismatched file, or `install.stateFile =
+//! false` bypass it. Like yarn 4, root lifecycle scripts do not re-run on a
+//! no-op install.
+
+use std::io::Write as _;
+
+use crate::lockfile::package::PackageColumns as _;
+use bun_paths::SEP;
+
+use crate::PackageManager;
+use crate::package_manager_real::Subcommand;
+
+const VERSION_LINE: &str = "bun-install-state v2";
+
+fn h(bytes: &[u8]) -> u64 {
+    bun_wyhash::hash(bytes)
+}
+
+fn hash_file(path: &[u8]) -> Option<u64> {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
+    match std::fs::read(p) {
+        Ok(b) => Some(h(&b)),
+        Err(_) => None,
+    }
+}
+
+fn dir_stamp(path: &[u8]) -> Option<u64> {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(path) });
+    let m = std::fs::metadata(p).ok()?;
+    let t = m
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(
+        t.as_secs()
+            .wrapping_mul(1_000_000_000)
+            .wrapping_add(u64::from(t.subsec_nanos())),
+    )
+}
+
+fn join(root: &[u8], rel: &[u8]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(root.len() + rel.len() + 1);
+    v.extend_from_slice(root);
+    if !v.ends_with(&[SEP]) && !v.ends_with(b"/") {
+        v.push(SEP);
+    }
+    v.extend_from_slice(rel);
+    v
+}
+
+/// The install-relevant part of the environment + argv, hashed.
+fn env_and_argv_hash(manager: &PackageManager) -> u64 {
+    let mut acc: Vec<u8> = Vec::with_capacity(1024);
+    let mut keys: Vec<&[u8]> = manager
+        .env()
+        .map
+        .map
+        .keys()
+        .iter()
+        .map(|k| &**k)
+        .filter(|k| {
+            k.starts_with(b"BUN_INSTALL")
+                || k.starts_with(b"BUN_CONFIG_")
+                || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
+        })
+        .collect();
+    keys.sort_unstable();
+    for k in keys {
+        acc.extend_from_slice(k);
+        acc.push(b'=');
+        acc.extend_from_slice(manager.env().get(k).unwrap_or(b""));
+        acc.push(0);
+    }
+    acc.push(1);
+    for a in bun_core::argv().into_iter().skip(1) {
+        acc.extend_from_slice(a);
+        acc.push(0);
+    }
+    acc.push(2);
+    acc.extend_from_slice(bun_core::Global::package_json_version.as_bytes());
+    h(&acc)
+}
+
+/// May this invocation use / record the fast path at all?
+pub fn applicable(manager: &PackageManager) -> bool {
+    manager.subcommand == Subcommand::Install
+        && manager.options.install_state
+        && !manager.options.global
+        && !manager.options.dry_run
+        && !manager.options.enable.force_install()
+        && manager.options.positionals.len() <= 1
+        && manager.update_requests.is_empty()
+        && manager.options.do_.install_packages()
+        && manager.options.do_.load_lockfile()
+}
+
+struct Recorded {
+    lines: Vec<(u8, u64, Vec<u8>)>, // kind ('f' file hash / 'd' dir stamp / 'e' env), value, path
+}
+
+/// `<cache dir>/.install-state/<hash of project root>` — kept out of node_modules so
+/// directory listings are unchanged, and per project so a shared cache is fine.
+fn state_path(manager: &mut PackageManager, root: &[u8], create_dir: bool) -> Option<Vec<u8>> {
+    // Resolve the cache directory *path* without forcing the directory into
+    // existence (a workspaces-only install never creates it, and directory
+    // listings must not change because of the state file): the state lives only
+    // inside a cache directory that already exists.
+    let cache_path: Vec<u8> = if !manager.cache_directory_path.as_bytes().is_empty() {
+        manager.cache_directory_path.as_bytes().to_vec()
+    } else if manager.options.enable.cache() {
+        crate::package_manager_real::directories::fetch_cache_directory_path(
+            manager.env_mut(),
+            Some(&manager.options),
+        )
+        .path
+    } else {
+        join(root, b"node_modules/.cache")
+    };
+    if !std::path::Path::new(unsafe { std::str::from_utf8_unchecked(&cache_path) }).is_dir() {
+        return None;
+    }
+    let dir = join(&cache_path, b".install-state");
+    if create_dir {
+        let _ = std::fs::create_dir_all(std::path::Path::new(unsafe {
+            std::str::from_utf8_unchecked(&dir)
+        }));
+    }
+    let mut name: Vec<u8> = Vec::with_capacity(20);
+    let _ = write!(&mut name, "{:016x}", h(root));
+    Some(join(&dir, &name))
+}
+
+/// What the fast path prints (mirrors the normal "no changes" summary).
+pub struct Summary {
+    pub entries: u64,
+    pub packages: u64,
+}
+
+fn parse(text: &[u8]) -> Option<Recorded> {
+    let mut lines = text.split(|c| *c == b'\n');
+    if lines.next()? != VERSION_LINE.as_bytes() {
+        return None;
+    }
+    let mut out = Vec::new();
+    for l in lines {
+        if l.is_empty() {
+            continue;
+        }
+        let kind = l[0];
+        let rest = l.get(2..)?;
+        let sp = rest.iter().position(|c| *c == b' ').unwrap_or(rest.len());
+        let val = u64::from_str_radix(core::str::from_utf8(&rest[..sp]).ok()?, 16).ok()?;
+        let path = if sp < rest.len() {
+            rest[sp + 1..].to_vec()
+        } else {
+            Vec::new()
+        };
+        out.push((kind, val, path));
+    }
+    Some(Recorded { lines: out })
+}
+
+/// `Some(summary)` when the recorded state exists and every input is unchanged.
+pub fn is_up_to_date(manager: &mut PackageManager, root_dir: &[u8]) -> Option<Summary> {
+    let sp = state_path(manager, root_dir, false)?;
+    let text = std::fs::read(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&sp)
+    }))
+    .ok()?;
+    let rec = parse(&text)?;
+    if rec.lines.is_empty() {
+        return None;
+    }
+    let mut saw_env = false;
+    let mut summary = Summary {
+        entries: 0,
+        packages: 0,
+    };
+    for (kind, val, path) in &rec.lines {
+        let ok = match kind {
+            b'f' => hash_file(path) == Some(*val),
+            // recorded as absent: must still be absent
+            b'a' => hash_file(path).is_none(),
+            b'd' => dir_stamp(path) == Some(*val),
+            b'n' => dir_stamp(path).is_none(),
+            b'l' => {
+                lstat_stamp(std::path::Path::new(unsafe {
+                    std::str::from_utf8_unchecked(path)
+                })) == Some(*val)
+            }
+            b'p' => manifest_stamp(path) == *val,
+            b'e' => {
+                saw_env = true;
+                env_and_argv_hash(manager) == *val
+            }
+            b's' => {
+                summary.entries = *val;
+                summary.packages = core::str::from_utf8(path)
+                    .ok()
+                    .and_then(|s| s.trim().parse().ok())
+                    .unwrap_or(0);
+                true
+            }
+            _ => false,
+        };
+        if !ok {
+            bun_output::scoped_log!(
+                PackageManager,
+                "install state: {} changed",
+                bstr::BStr::new(path)
+            );
+            return None;
+        }
+    }
+    // node_modules itself must still be there
+    if saw_env && dir_stamp(&join(root_dir, b"node_modules")).is_some() {
+        Some(summary)
+    } else {
+        None
+    }
+}
+
+/// Record the state after a successful install. Best effort: failures are ignored.
+pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, packages: u64) {
+    if !applicable(manager) {
+        return;
+    }
+    // Local sources (`file:` folders and tarballs, `link:`) are inputs too: their
+    // *contents* decide what gets materialized. Stamp them (recursive mtimes for
+    // folders, content hash for tarballs); a project with enormous local sources just
+    // doesn't get a state file.
+    let mut local_lines: Vec<u8> = Vec::new();
+    {
+        use crate::resolution_real::Tag;
+        let buf = manager.lockfile.buffers.string_bytes.as_slice();
+        let mut budget: usize = 20_000;
+        let mut ok = true;
+        for r in manager.lockfile.packages.slice().items_resolution().iter() {
+            match r.tag {
+                Tag::Folder | Tag::Symlink => {
+                    let rel = if r.tag == Tag::Folder {
+                        r.folder().slice(buf)
+                    } else {
+                        r.symlink().slice(buf)
+                    };
+                    if rel.is_empty() || bun_paths::is_absolute(rel) && r.tag == Tag::Symlink {
+                        // global `bun link` targets: outside the project, not tracked
+                        ok = false;
+                        break;
+                    }
+                    let dir = if bun_paths::is_absolute(rel) {
+                        rel.to_vec()
+                    } else {
+                        join(root_dir, rel)
+                    };
+                    if !stamp_source_tree(&mut local_lines, &dir, &mut budget) {
+                        ok = false;
+                        break;
+                    }
+                }
+                Tag::LocalTarball => {
+                    let rel = r.local_tarball().slice(buf);
+                    let path = if bun_paths::is_absolute(rel) {
+                        rel.to_vec()
+                    } else {
+                        join(root_dir, rel)
+                    };
+                    match hash_file(&path) {
+                        Some(v) => {
+                            let _ = write!(local_lines, "f {v:016x} ");
+                            local_lines.extend_from_slice(&path);
+                            local_lines.push(b'\n');
+                        }
+                        None => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if !ok {
+            invalidate(manager, root_dir);
+            return;
+        }
+    }
+    let Some(sp) = state_path(manager, root_dir, true) else {
+        return;
+    };
+    let mut out: Vec<u8> = Vec::with_capacity(4096);
+    let _ = writeln!(out, "{VERSION_LINE}");
+    let file = |out: &mut Vec<u8>, p: Vec<u8>| match hash_file(&p) {
+        Some(v) => {
+            let _ = write!(out, "f {v:016x} ");
+            out.extend_from_slice(&p);
+            out.push(b'\n');
+        }
+        None => {
+            let _ = write!(out, "a {:016x} ", 0);
+            out.extend_from_slice(&p);
+            out.push(b'\n');
+        }
+    };
+    // lockfiles (whichever exist; absence is recorded too)
+    file(&mut out, join(root_dir, b"bun.lock"));
+    file(&mut out, join(root_dir, b"bun.lockb"));
+    file(&mut out, join(root_dir, b"package.json"));
+    file(&mut out, join(root_dir, b"bunfig.toml"));
+    file(&mut out, join(root_dir, b".npmrc"));
+    if let Some(home) = manager
+        .env()
+        .get(b"HOME")
+        .or_else(|| manager.env().get(b"USERPROFILE"))
+    {
+        file(&mut out, join(home, b".npmrc"));
+        file(&mut out, join(home, b".bunfig.toml"));
+    }
+    if let Some(xdg) = manager.env().get(b"XDG_CONFIG_HOME") {
+        file(&mut out, join(xdg, b".bunfig.toml"));
+        // the npmrc loader prefers $XDG_CONFIG_HOME/.npmrc over ~/.npmrc when present
+        file(&mut out, join(xdg, b".npmrc"));
+    }
+    // workspaces: manifest hash + parent dir stamp
+    let buf = manager.lockfile.buffers.string_bytes.as_slice();
+    let mut parents: Vec<Vec<u8>> = Vec::new();
+    for ws in manager.lockfile.workspace_paths.values() {
+        let rel = ws.slice(buf);
+        if rel.is_empty() {
+            continue;
+        }
+        let dir = join(root_dir, rel);
+        file(&mut out, join(&dir, b"package.json"));
+        if let Some(parent) = bun_paths::dirname(&dir) {
+            let parent = parent.to_vec();
+            if !parents.contains(&parent) {
+                parents.push(parent);
+            }
+        }
+    }
+    // …plus the literal directory prefix of every `workspaces` glob in the root
+    // manifest (`packages/*` → `packages/`), recorded even when it does not exist yet,
+    // so creating the first workspace under it is noticed.
+    let root_manifest_path = join(root_dir, b"package.json");
+    if let Ok(root_json) = std::fs::read(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&root_manifest_path)
+    })) {
+        if let Some(globs) = workspace_globs(&root_json) {
+            for g in globs {
+                let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
+                let literal_end = g
+                    .iter()
+                    .position(|c| matches!(*c, b'*' | b'?' | b'[' | b'{' | b'!'))
+                    .unwrap_or(g.len());
+                let lit = &g[..literal_end];
+                let dir_end = lit.iter().rposition(|c| *c == b'/').map_or(0, |i| i);
+                let prefix = &lit[..dir_end];
+                let abs = if prefix.is_empty() {
+                    root_dir.to_vec()
+                } else {
+                    join(root_dir, prefix)
+                };
+                // `a/*/*` or `a/**`: directories below the literal prefix can gain
+                // workspaces too — stamp existing dirs down to the glob's depth (2 for **)
+                let rest = &g[literal_end..];
+                let extra_depth = if strings_contains(rest, b"**") {
+                    2
+                } else {
+                    rest.iter().filter(|c| **c == b'/').count()
+                };
+                if extra_depth > 0 {
+                    collect_dirs(&abs, extra_depth, &mut parents, &mut 2000);
+                }
+                if !parents.contains(&abs) {
+                    parents.push(abs);
+                }
+                // a fully literal workspace path: its own dir + manifest matter too
+                if literal_end == g.len() && !g.is_empty() {
+                    let ws_dir = join(root_dir, g);
+                    if !parents.contains(&ws_dir) {
+                        parents.push(ws_dir);
+                    }
+                }
+            }
+        }
+    }
+    parents.sort();
+    for p in parents {
+        match dir_stamp(&p) {
+            Some(stamp) => {
+                let _ = write!(out, "d {stamp:016x} ");
+                out.extend_from_slice(&p);
+                out.push(b'\n');
+            }
+            None => {
+                // absent now; must stay absent
+                let _ = write!(out, "n {:016x} ", 0);
+                out.extend_from_slice(&p);
+                out.push(b'\n');
+            }
+        }
+    }
+    // patch files
+    for pd in manager.lockfile.patched_dependencies.values() {
+        let rel = pd.path.slice(buf);
+        if !rel.is_empty() {
+            file(&mut out, join(root_dir, rel));
+        }
+    }
+    // node_modules directories (root + workspaces): the dir itself and each top-level
+    // entry. Removing or replacing a package, or deleting a file directly inside one
+    // (its package.json, say), bumps one of these mtimes; that is the tampering the
+    // per-package verify pass used to catch, at the cost of an lstat instead of an
+    // open+read+parse per package.
+    let mut nm_dirs: Vec<Vec<u8>> = vec![join(root_dir, b"node_modules")];
+    for ws in manager.lockfile.workspace_paths.values() {
+        let rel = ws.slice(buf);
+        if !rel.is_empty() {
+            nm_dirs.push(join(&join(root_dir, rel), b"node_modules"));
+        }
+    }
+    for nm in nm_dirs {
+        stamp_tree(&mut out, &nm, 0);
+    }
+    out.extend_from_slice(&local_lines);
+    let _ = writeln!(
+        out,
+        "e {:016x} env+argv+version",
+        env_and_argv_hash(manager)
+    );
+    let _ = writeln!(out, "s {entries:016x} {packages}");
+
+    let sp_str = unsafe { std::str::from_utf8_unchecked(&sp) };
+    let tmp = format!("{sp_str}.tmp");
+    if std::fs::write(&tmp, &out).is_ok() {
+        let _ = std::fs::rename(&tmp, sp_str);
+    }
+}
+
+fn lstat_stamp(path: &std::path::Path) -> Option<u64> {
+    let m = std::fs::symlink_metadata(path).ok()?;
+    let t = m
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(
+        t.as_secs()
+            .wrapping_mul(1_000_000_000)
+            .wrapping_add(u64::from(t.subsec_nanos())),
+    )
+}
+
+/// `<mtime ns> ^ <size>` of a package's package.json, following symlinks (so an
+/// isolated-linker entry is checked in the store it points at). 0 when missing.
+fn manifest_stamp(pkg_dir: &[u8]) -> u64 {
+    let pj = join(pkg_dir, b"package.json");
+    match std::fs::metadata(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&pj)
+    })) {
+        Ok(m) => {
+            let t = m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| {
+                    d.as_secs()
+                        .wrapping_mul(1_000_000_000)
+                        .wrapping_add(u64::from(d.subsec_nanos()))
+                })
+                .unwrap_or(0);
+            (t ^ m.len().rotate_left(40)) | 1
+        }
+        Err(_) => 0,
+    }
+}
+
+/// Record `dir`, and for each entry: its own lstat mtime (`l`) plus its
+/// package.json stamp (`p`). Scope dirs are descended one level; bookkeeping dirs
+/// (`.bin`, `.bun`, …) get only the `l` stamp.
+fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
+    let Some(stamp) = lstat_stamp(p) else { return };
+    let _ = write!(out, "l {stamp:016x} ");
+    out.extend_from_slice(dir);
+    out.push(b'\n');
+    let Ok(rd) = std::fs::read_dir(p) else { return };
+    for e in rd.flatten() {
+        let name = e.file_name();
+        let name = name.as_encoded_bytes();
+        if name == b".cache" || name == b".install-state" {
+            continue;
+        }
+        let child = join(dir, name);
+        if depth < 1 && name.first() == Some(&b'@') {
+            stamp_tree(out, &child, depth + 1);
+            continue;
+        }
+        if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
+            std::str::from_utf8_unchecked(&child)
+        })) {
+            let _ = write!(out, "l {stamp:016x} ");
+            out.extend_from_slice(&child);
+            out.push(b'\n');
+        }
+        if name.first() != Some(&b'.') {
+            let _ = write!(out, "p {:016x} ", manifest_stamp(&child));
+            out.extend_from_slice(&child);
+            out.push(b'\n');
+        }
+    }
+}
+
+/// The `workspaces` glob patterns of a root package.json (`["a/*"]` or
+/// `{ "packages": [...] }` form).
+fn workspace_globs(json_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
+    let mut log = bun_ast::Log::init();
+    let arena = bun_alloc::Arena::new();
+    let source = bun_ast::Source::init_path_string(b"package.json", json_bytes);
+    let parsed = crate::bun_json::parse_package_json_utf8_with_opts(
+        crate::bun_json::JSONOptions {
+            json_warn_duplicate_keys: false,
+            ..crate::bun_json::PACKAGE_JSON_OPTS
+        },
+        &source,
+        &mut log,
+        &arena,
+    )
+    .ok()?;
+    let ws = parsed.root.get(b"workspaces")?;
+    let list = match ws.get(b"packages") {
+        Some(p) => p,
+        None => ws,
+    };
+    let mut items = list.as_array()?;
+    let mut out = Vec::new();
+    while let Some(item) = items.next() {
+        if let Some(s) = item.as_string(&arena) {
+            out.push(s.to_vec());
+        }
+    }
+    Some(out)
+}
+
+fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
+    hay.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Collect existing subdirectories of `dir` up to `depth` levels (bounded), skipping
+/// node_modules / dot dirs, into `out`.
+fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut usize) {
+    if depth == 0 || *budget == 0 {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(dir)
+    })) else {
+        return;
+    };
+    for e in rd.flatten() {
+        if *budget == 0 {
+            return;
+        }
+        let Ok(ft) = e.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let name = e.file_name();
+        let name = name.as_encoded_bytes();
+        if name == b"node_modules" || name.starts_with(b".") {
+            continue;
+        }
+        *budget -= 1;
+        let child = join(dir, name);
+        collect_dirs(&child, depth - 1, out, budget);
+        if !out.contains(&child) {
+            out.push(child);
+        }
+    }
+}
+
+/// Recursively record `l` stamps for a local-source directory (skipping node_modules
+/// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
+fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
+    let p = std::path::Path::new(unsafe { std::str::from_utf8_unchecked(dir) });
+    let Some(stamp) = lstat_stamp(p) else {
+        return false;
+    };
+    let _ = write!(out, "l {stamp:016x} ");
+    out.extend_from_slice(dir);
+    out.push(b'\n');
+    let Ok(rd) = std::fs::read_dir(p) else {
+        return false;
+    };
+    for e in rd.flatten() {
+        if *budget == 0 {
+            return false;
+        }
+        *budget -= 1;
+        let name = e.file_name();
+        let name = name.as_encoded_bytes();
+        if name == b"node_modules" || name == b".git" {
+            continue;
+        }
+        let child = join(dir, name);
+        let Ok(ft) = e.file_type() else { return false };
+        if ft.is_dir() {
+            if !stamp_source_tree(out, &child, budget) {
+                return false;
+            }
+        } else if let Some(stamp) = lstat_stamp(std::path::Path::new(unsafe {
+            std::str::from_utf8_unchecked(&child)
+        })) {
+            let _ = write!(out, "l {stamp:016x} ");
+            out.extend_from_slice(&child);
+            out.push(b'\n');
+        }
+    }
+    true
+}
+
+/// Remove the state file (called before any install that will do real work, so a
+/// crash mid-install can never leave a "clean" marker behind).
+pub fn invalidate(manager: &mut PackageManager, root_dir: &[u8]) {
+    let Some(sp) = state_path(manager, root_dir, false) else {
+        return;
+    };
+    let _ = std::fs::remove_file(std::path::Path::new(unsafe {
+        std::str::from_utf8_unchecked(&sp)
+    }));
+}

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -812,19 +812,17 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules
 /// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
 fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
-    // a symlinked source (or subdirectory) would be walked through the link while only the
-    // link's own mtime is recorded: not trackable
-    match bun_sys::lstat(&zpath(dir)) {
+    // a symlinked source (or entry inside it) would be walked through the link while only
+    // the link's own mtime is recorded: not trackable
+    let stamp = match bun_sys::lstat(&zpath(dir)) {
         Ok(st)
             if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode)
                 == bun_sys::FileKind::SymLink =>
         {
             return false;
         }
-        _ => {}
-    }
-    let Some(stamp) = lstat_stamp(dir) else {
-        return false;
+        Ok(st) => mtime_ns(&st),
+        Err(_) => return false,
     };
     let _ = write!(out, "l {stamp:016x} ");
     out.extend_from_slice(dir);
@@ -846,11 +844,17 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
             if !stamp_source_tree(out, &child, budget) {
                 return false;
             }
-        } else if matches!(bun_sys::lstat(&zpath(&child)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::SymLink)
-        {
+        } else if let Some(stamp) = match bun_sys::lstat(&zpath(&child)) {
             // a symlinked entry inside the source: not trackable (see above)
-            return false;
-        } else if let Some(stamp) = lstat_stamp(&child) {
+            Ok(st)
+                if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode)
+                    == bun_sys::FileKind::SymLink =>
+            {
+                return false;
+            }
+            Ok(st) => Some(mtime_ns(&st)),
+            Err(_) => None,
+        } {
             let _ = write!(out, "l {stamp:016x} ");
             out.extend_from_slice(&child);
             out.push(b'\n');

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -199,8 +199,9 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
             k.starts_with(b"BUN_INSTALL")
                 || k.starts_with(b"BUN_CONFIG_")
                 || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
-                // where the global .npmrc / .bunfig.toml are looked up
+                // spliced into argv (see below)
                 || k == b"BUN_OPTIONS"
+                // where the global .npmrc / .bunfig.toml are looked up
                 || k == b"HOME"
                 || k == b"USERPROFILE"
                 || k == b"XDG_CONFIG_HOME"
@@ -220,7 +221,7 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
     for a in bun_core::argv()
         .into_iter()
         .skip(1)
-        .filter(|a| !matches!(&a[..], b"install" | b"i" | b"add" | b"remove" | b"update"))
+        .filter(|a| !matches!(&a[..], b"install" | b"i" | b"ci"))
     {
         acc.extend_from_slice(a);
         acc.push(0);
@@ -845,6 +846,10 @@ fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool 
             if !stamp_source_tree(out, &child, budget) {
                 return false;
             }
+        } else if matches!(bun_sys::lstat(&zpath(&child)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::SymLink)
+        {
+            // a symlinked entry inside the source: not trackable (see above)
+            return false;
         } else if let Some(stamp) = lstat_stamp(&child) {
             let _ = write!(out, "l {stamp:016x} ");
             out.extend_from_slice(&child);

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -357,14 +357,20 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
             .enumerate()
         {
             match r.tag {
-                Tag::Folder | Tag::Symlink => {
-                    let rel = if r.tag == Tag::Folder {
-                        r.folder().slice(buf)
-                    } else {
-                        r.symlink().slice(buf)
-                    };
-                    if rel.is_empty() || bun_paths::is_absolute(rel) && r.tag == Tag::Symlink {
-                        // global `bun link` targets: outside the project, not tracked
+                // `bun link` packages live in the global link directory, outside the
+                // project: not tracked (no fast path for projects using them)
+                Tag::Symlink => {
+                    ok = false;
+                    break;
+                }
+                Tag::Folder => {
+                    let rel = r.folder().slice(buf);
+                    if rel.is_empty() {
+                        ok = false;
+                        break;
+                    }
+                    // stored relative to the declaring package (see LocalTarball below)
+                    if !bun_paths::is_absolute(rel) && !declared_by_root(&manager.lockfile, i) {
                         ok = false;
                         break;
                     }
@@ -503,7 +509,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                     join(root_dir, prefix)
                 };
                 // `a/*/*` or `a/**`: directories below the literal prefix can gain
-                // workspaces too — stamp existing dirs down to the glob's depth (2 for **)
+                // workspaces too — stamp existing dirs down to the glob's depth (all levels for **)
                 let rest = &g[literal_end..];
                 let extra_depth = if strings_contains(rest, b"**") {
                     usize::MAX
@@ -581,17 +587,18 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
             }
             let dir = join(root_dir, nm.relative_path.as_bytes());
             for d in [dir.clone(), join(&dir, b".bin")] {
-                match lstat_stamp(&d) {
-                    Some(stamp) => {
+                match lstat_stamp_strict(&d) {
+                    Stamp::At(stamp) => {
                         let _ = write!(out, "l {stamp:016x} ");
                         out.extend_from_slice(&d);
                         out.push(b'\n');
                     }
-                    None => {
+                    Stamp::Absent => {
                         let _ = write!(out, "n {:016x} ", 0);
                         out.extend_from_slice(&d);
                         out.push(b'\n');
                     }
+                    Stamp::Unreadable => unreadable = true,
                 }
             }
         }
@@ -733,8 +740,6 @@ fn workspace_globs(json_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
     Some(out)
 }
 
-/// Collect existing subdirectories of `dir` up to `depth` levels (bounded), skipping
-/// node_modules / dot dirs, into `out`.
 /// Collect the directories up to `depth` levels below `dir` (skipping node_modules and
 /// dot dirs). Returns false if the walk could not be completed within `budget` or a
 /// directory could not be read — the caller must then not record state, since a

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -80,6 +80,17 @@ fn dir_stamp(path: &[u8]) -> Option<u64> {
     bun_sys::stat(&zpath(path)).ok().map(|st| mtime_ns(&st))
 }
 
+/// `dir_stamp` (follows symlinks) distinguishing absent from unreadable.
+fn dir_stamp_strict(path: &[u8]) -> Stamp {
+    match bun_sys::stat(&zpath(path)) {
+        Ok(st) => Stamp::At(mtime_ns(&st)),
+        Err(e) if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) => {
+            Stamp::Absent
+        }
+        Err(_) => Stamp::Unreadable,
+    }
+}
+
 /// mtime of `path` itself (not following symlinks), None if it does not exist.
 fn lstat_stamp(path: &[u8]) -> Option<u64> {
     bun_sys::lstat(&zpath(path)).ok().map(|st| mtime_ns(&st))
@@ -202,7 +213,9 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
         acc.push(0);
     }
     acc.push(1);
-    for a in bun_core::argv().into_iter().skip(1) {
+    // argv[0] is the executable and argv[1] the subcommand token (`install`/`i`; the
+    // subcommand itself is part of `applicable()`), so start at the flags
+    for a in bun_core::argv().into_iter().skip(2) {
         acc.extend_from_slice(a);
         acc.push(0);
     }
@@ -464,9 +477,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
         && !cfg.is_empty()
     {
         // `load_config` resolves a relative --config against the process cwd
-        let mut cwd_buf = bun_paths::PathBuffer::uninit();
-        let base: &[u8] = match bun_sys::getcwd(&mut cwd_buf.0) {
-            Ok(n) => &cwd_buf.0[..n],
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
+        let base: &[u8] = match bun_sys::getcwd(&mut cwd_buf[..]) {
+            Ok(n) => &cwd_buf[..n],
             Err(_) => root_dir,
         };
         if bun_paths::is_absolute(cfg) {
@@ -547,18 +560,19 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
     }
     parents.sort();
     for p in parents {
-        match dir_stamp(&p) {
-            Some(stamp) => {
+        match dir_stamp_strict(&p) {
+            Stamp::At(stamp) => {
                 let _ = write!(out, "d {stamp:016x} ");
                 out.extend_from_slice(&p);
                 out.push(b'\n');
             }
-            None => {
+            Stamp::Absent => {
                 // absent now; must stay absent
                 let _ = write!(out, "n {:016x} ", 0);
                 out.extend_from_slice(&p);
                 out.push(b'\n');
             }
+            Stamp::Unreadable => globs_incomplete = true,
         }
     }
     // patch files

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -179,18 +179,18 @@ pub struct Summary {
 }
 
 fn parse(text: &[u8]) -> Option<Recorded> {
-    let mut lines = text.split(|c| *c == b'\n');
+    let mut lines = bun_core::strings::split(text, b"\n");
     if lines.next()? != VERSION_LINE.as_bytes() {
         return None;
     }
     let mut out = Vec::new();
-    for l in lines {
+    while let Some(l) = lines.next() {
         if l.is_empty() {
             continue;
         }
         let kind = l[0];
         let rest = l.get(2..)?;
-        let sp = rest.iter().position(|c| *c == b' ').unwrap_or(rest.len());
+        let sp = bun_core::strings::index_of_char_usize(rest, b' ').unwrap_or(rest.len());
         let val = u64::from_str_radix(core::str::from_utf8(&rest[..sp]).ok()?, 16).ok()?;
         let path = if sp < rest.len() {
             rest[sp + 1..].to_vec()
@@ -381,12 +381,9 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
         if let Some(globs) = workspace_globs(&root_json) {
             for g in globs {
                 let g: &[u8] = g.strip_prefix(b"./").unwrap_or(&g);
-                let literal_end = g
-                    .iter()
-                    .position(|c| matches!(*c, b'*' | b'?' | b'[' | b'{' | b'!'))
-                    .unwrap_or(g.len());
+                let literal_end = bun_core::strings::index_of_any(g, b"*?[{!").unwrap_or(g.len());
                 let lit = &g[..literal_end];
-                let dir_end = lit.iter().rposition(|c| *c == b'/').unwrap_or(0);
+                let dir_end = bun_core::strings::last_index_of_char(lit, b'/').unwrap_or(0);
                 let prefix = &lit[..dir_end];
                 let abs = if prefix.is_empty() {
                     root_dir.to_vec()
@@ -399,7 +396,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                 let extra_depth = if strings_contains(rest, b"**") {
                     2
                 } else {
-                    rest.iter().filter(|c| **c == b'/').count()
+                    bun_core::strings::count_char(rest, b'/')
                 };
                 if extra_depth > 0 {
                     collect_dirs(&abs, extra_depth, &mut parents, &mut 2000);

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -218,11 +218,15 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
     // argv[0] is the executable; the subcommand token (`install`/`i`) is skipped so both
     // spellings share the fast path (the subcommand itself is part of `applicable()`).
     // BUN_OPTIONS tokens are spliced into argv and are also covered by the env hash.
-    for a in bun_core::argv()
-        .into_iter()
-        .skip(1)
-        .filter(|a| !matches!(&a[..], b"install" | b"i" | b"ci"))
-    {
+    let mut skipped_subcommand = false;
+    for a in bun_core::argv().into_iter().skip(1).filter(|a| {
+        if !skipped_subcommand && matches!(&a[..], b"install" | b"i" | b"ci") {
+            skipped_subcommand = true;
+            false
+        } else {
+            true
+        }
+    }) {
         acc.extend_from_slice(a);
         acc.push(0);
     }
@@ -619,20 +623,21 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                 continue;
             }
             let dir = join(root_dir, nm.relative_path.as_bytes());
-            for d in [dir.clone(), join(&dir, b".bin")] {
-                match lstat_stamp_strict(&d) {
-                    Stamp::At(stamp) => {
-                        let _ = write!(out, "l {stamp:016x} ");
-                        out.extend_from_slice(&d);
-                        out.push(b'\n');
-                    }
-                    Stamp::Absent => {
-                        let _ = write!(out, "n {:016x} ", 0);
-                        out.extend_from_slice(&d);
-                        out.push(b'\n');
-                    }
-                    Stamp::Unreadable => unreadable = true,
+            if !stamp_dir_and_scopes(&mut out, &dir, true) {
+                unreadable = true;
+            }
+            match lstat_stamp_strict(&join(&dir, b".bin")) {
+                Stamp::At(stamp) => {
+                    let _ = write!(out, "l {stamp:016x} ");
+                    out.extend_from_slice(&join(&dir, b".bin"));
+                    out.push(b'\n');
                 }
+                Stamp::Absent => {
+                    let _ = write!(out, "n {:016x} ", 0);
+                    out.extend_from_slice(&join(&dir, b".bin"));
+                    out.push(b'\n');
+                }
+                Stamp::Unreadable => unreadable = true,
             }
         }
         let store = join(&join(root_dir, b"node_modules"), b".bun");
@@ -650,14 +655,8 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                     } else {
                         join(&join(&store, &name), b"node_modules")
                     };
-                    match lstat_stamp_strict(&dir) {
-                        Stamp::At(stamp) => {
-                            let _ = write!(out, "l {stamp:016x} ");
-                            out.extend_from_slice(&dir);
-                            out.push(b'\n');
-                        }
-                        Stamp::Absent => {}
-                        Stamp::Unreadable => unreadable = true,
+                    if !stamp_dir_and_scopes(&mut out, &dir, false) {
+                        unreadable = true;
                     }
                 }
             }
@@ -811,6 +810,49 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
 
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules
 /// and VCS dirs). Returns false if the walk exceeded `budget` entries or failed.
+/// `l`/`n`-stamp a nested or store `node_modules` directory, plus each `@scope`
+/// directory directly inside it (removing `@scope/pkg` only touches `@scope`'s mtime).
+/// Returns false when something that exists could not be read.
+fn stamp_dir_and_scopes(out: &mut Vec<u8>, dir: &[u8], record_absent: bool) -> bool {
+    match lstat_stamp_strict(dir) {
+        Stamp::At(stamp) => {
+            let _ = write!(out, "l {stamp:016x} ");
+            out.extend_from_slice(dir);
+            out.push(b'\n');
+        }
+        Stamp::Absent => {
+            if record_absent {
+                let _ = write!(out, "n {:016x} ", 0);
+                out.extend_from_slice(dir);
+                out.push(b'\n');
+            }
+            return true;
+        }
+        Stamp::Unreadable => return false,
+    }
+    match read_dir(dir) {
+        DirList::Absent => true,
+        DirList::Unreadable => false,
+        DirList::Entries(entries) => {
+            for (name, is_dir) in entries {
+                if is_dir && name.first() == Some(&b'@') {
+                    let scope = join(dir, &name);
+                    match lstat_stamp_strict(&scope) {
+                        Stamp::At(stamp) => {
+                            let _ = write!(out, "l {stamp:016x} ");
+                            out.extend_from_slice(&scope);
+                            out.push(b'\n');
+                        }
+                        Stamp::Absent => {}
+                        Stamp::Unreadable => return false,
+                    }
+                }
+            }
+            true
+        }
+    }
+}
+
 fn stamp_source_tree(out: &mut Vec<u8>, dir: &[u8], budget: &mut usize) -> bool {
     // a symlinked source (or entry inside it) would be walked through the link while only
     // the link's own mtime is recorded: not trackable

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -196,15 +196,15 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
         .iter()
         .map(|k| &**k)
         .filter(|k| {
-            k.starts_with(b"BUN_INSTALL")
-                || k.starts_with(b"BUN_CONFIG_")
+            starts_with_ci(k, b"BUN_INSTALL")
+                || starts_with_ci(k, b"BUN_CONFIG_")
                 || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
                 // spliced into argv (see below)
-                || k == b"BUN_OPTIONS"
+                || k.eq_ignore_ascii_case(b"BUN_OPTIONS")
                 // where the global .npmrc / .bunfig.toml are looked up
-                || k == b"HOME"
-                || k == b"USERPROFILE"
-                || k == b"XDG_CONFIG_HOME"
+                || k.eq_ignore_ascii_case(b"HOME")
+                || k.eq_ignore_ascii_case(b"USERPROFILE")
+                || k.eq_ignore_ascii_case(b"XDG_CONFIG_HOME")
         })
         .collect();
     keys.sort_unstable();
@@ -250,7 +250,7 @@ pub fn applicable(manager: &PackageManager) -> bool {
 }
 
 struct Recorded {
-    lines: Vec<(u8, u64, Vec<u8>)>, // kind ('f' file hash / 'd' dir stamp / 'e' env), value, path
+    lines: Vec<(u8, u64, Vec<u8>)>, // kind (one per record; kinds are matched in `is_up_to_date`), value, path
 }
 
 /// `<cache dir>/.install-state/<hash of project root>` — kept out of node_modules so
@@ -623,8 +623,19 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                 continue;
             }
             let dir = join(root_dir, nm.relative_path.as_bytes());
-            if !stamp_dir_and_scopes(&mut out, &dir, true) {
-                unreadable = true;
+            // same per-entry stamps as the root/workspace trees (entries, their
+            // package.json, @scope subdirectories); an absent nested dir must stay absent
+            match lstat_stamp_strict(&dir) {
+                Stamp::Absent => {
+                    let _ = write!(out, "n {:016x} ", 0);
+                    out.extend_from_slice(&dir);
+                    out.push(b'\n');
+                }
+                _ => {
+                    if !stamp_tree(&mut out, &dir, 0) {
+                        unreadable = true;
+                    }
+                }
             }
             match lstat_stamp_strict(&join(&dir, b".bin")) {
                 Stamp::At(stamp) => {
@@ -655,7 +666,7 @@ pub fn save(manager: &mut PackageManager, root_dir: &[u8], entries: u64, package
                     } else {
                         join(&join(&store, &name), b"node_modules")
                     };
-                    if !stamp_dir_and_scopes(&mut out, &dir, false) {
+                    if !stamp_tree(&mut out, &dir, 0) {
                         unreadable = true;
                     }
                 }
@@ -737,6 +748,12 @@ fn stamp_tree(out: &mut Vec<u8>, dir: &[u8], depth: u8) -> bool {
     true
 }
 
+/// ASCII-case-insensitive prefix test (env var names are case-insensitive on Windows,
+/// and the loader's map lookups are too).
+fn starts_with_ci(s: &[u8], prefix: &[u8]) -> bool {
+    s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix)
+}
+
 fn strings_contains(hay: &[u8], needle: &[u8]) -> bool {
     bun_core::strings::index_of(hay, needle).is_some()
 }
@@ -806,49 +823,6 @@ fn collect_dirs(dir: &[u8], depth: usize, out: &mut Vec<Vec<u8>>, budget: &mut u
         }
     }
     true
-}
-
-/// `l`/`n`-stamp a nested or store `node_modules` directory, plus each `@scope`
-/// directory directly inside it (removing `@scope/pkg` only touches `@scope`'s mtime).
-/// Returns false when something that exists could not be read.
-fn stamp_dir_and_scopes(out: &mut Vec<u8>, dir: &[u8], record_absent: bool) -> bool {
-    match lstat_stamp_strict(dir) {
-        Stamp::At(stamp) => {
-            let _ = write!(out, "l {stamp:016x} ");
-            out.extend_from_slice(dir);
-            out.push(b'\n');
-        }
-        Stamp::Absent => {
-            if record_absent {
-                let _ = write!(out, "n {:016x} ", 0);
-                out.extend_from_slice(dir);
-                out.push(b'\n');
-            }
-            return true;
-        }
-        Stamp::Unreadable => return false,
-    }
-    match read_dir(dir) {
-        DirList::Absent => true,
-        DirList::Unreadable => false,
-        DirList::Entries(entries) => {
-            for (name, is_dir) in entries {
-                if is_dir && name.first() == Some(&b'@') {
-                    let scope = join(dir, &name);
-                    match lstat_stamp_strict(&scope) {
-                        Stamp::At(stamp) => {
-                            let _ = write!(out, "l {stamp:016x} ");
-                            out.extend_from_slice(&scope);
-                            out.push(b'\n');
-                        }
-                        Stamp::Absent => {}
-                        Stamp::Unreadable => return false,
-                    }
-                }
-            }
-            true
-        }
-    }
 }
 
 /// Recursively record `l` stamps for a local-source directory (skipping node_modules

--- a/src/install/install_state.rs
+++ b/src/install/install_state.rs
@@ -198,7 +198,7 @@ fn env_and_argv_hash(manager: &PackageManager) -> u64 {
         .filter(|k| {
             starts_with_ci(k, b"BUN_INSTALL")
                 || starts_with_ci(k, b"BUN_CONFIG_")
-                || k.len() >= 11 && k[..11].eq_ignore_ascii_case(b"NPM_CONFIG_")
+                || starts_with_ci(k, b"NPM_CONFIG_")
                 // spliced into argv (see below)
                 || k.eq_ignore_ascii_case(b"BUN_OPTIONS")
                 // where the global .npmrc / .bunfig.toml are looked up

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -113,6 +113,7 @@ pub mod audit_fix;
 pub mod bin_real;
 pub mod dedupe;
 pub mod hoisted_install;
+pub mod install_state;
 pub mod isolated_install;
 pub mod lifecycle_script_runner;
 pub mod migration;

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -260,6 +260,8 @@ pub mod api {
         pub hoist: Option<bool>,
         /// `offline = true`: `bun install` never touches the network.
         pub offline: Option<bool>,
+        /// `stateFile = false` disables the whole-install fingerprint fast path.
+        pub install_state: Option<bool>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,7 @@ import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import { bunExe, bunEnv as env, readdirCacheSorted, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -1055,7 +1055,7 @@ it("should add dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -1470,7 +1470,7 @@ it("should add aliased dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
     "@GH@mishoo-UglifyJS-e219a9a@@@1",
     "uglify",
   ]);
@@ -1853,7 +1853,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
-  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
+  expect((await readdirCacheSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2214,7 +2214,7 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited1).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2275,7 +2275,7 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,16 @@ import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirCacheSorted, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import {
+  bunExe,
+  bunEnv as env,
+  readdirCacheSorted,
+  readdirSorted,
+  tmpdirSync,
+  toBeValidBin,
+  toBeWorkspaceLink,
+  toHaveBins,
+} from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -1055,7 +1064,9 @@ it("should add dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2214,7 +2225,9 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited1).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2275,7 +2288,9 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirCacheSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, readdirSync, readFileSync, statSync, utimesSync } from "fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
@@ -225,12 +225,15 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
 
     // find where @barn/moo actually lives (root node_modules for hoisted; the store entry's
     // node_modules for isolated) and remove it: only `@barn`'s mtime changes
-    const candidates = [join(package_dir, "node_modules", "@barn", "moo")];
+    // (store entries first, so the isolated arm exercises the store scan rather than the
+    // root node_modules symlink; a real directory, not a symlink into the store)
+    const candidates: string[] = [];
     const store = join(package_dir, "node_modules", ".bun");
     if (existsSync(store)) {
       for (const e of readdirSync(store)) candidates.push(join(store, e, "node_modules", "@barn", "moo"));
     }
-    const victim = candidates.find(p => existsSync(join(p, "package.json")));
+    candidates.push(join(package_dir, "node_modules", "@barn", "moo"));
+    const victim = candidates.find(p => existsSync(join(p, "package.json")) && lstatSync(p).isDirectory());
     expect(victim).toBeDefined();
     await rm(victim!, { recursive: true, force: true });
     // (a full pass that only re-links prints the same summary as the fast path, so assert

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -2,7 +2,7 @@ import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { existsSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -41,14 +41,29 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {} }));
     await writeFile(
       join(package_dir, "bunfig.toml"),
-      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker } }),
+      Bun.TOML.stringify({
+        install: {
+          cache: { dir: join(package_dir, ".cache") },
+          registry: root_url + "/",
+          saveTextLockfile: true,
+          linker,
+        },
+      }),
     );
     await mkdir(join(package_dir, "packages", "a"), { recursive: true });
     await writeFile(
       join(package_dir, "package.json"),
-      JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { bar: "0.0.2" }, devDependencies: { qux: "0.0.2" } }),
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: { bar: "0.0.2" },
+        devDependencies: { qux: "0.0.2" },
+      }),
     );
-    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.3" } }));
+    await writeFile(
+      join(package_dir, "packages", "a", "package.json"),
+      JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.3" } }),
+    );
   });
   afterEach(dummyAfterEach);
 
@@ -66,7 +81,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(urls.length).toBe(before);
 
     // 2. a workspace manifest edit is noticed
-    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }));
+    await writeFile(
+      join(package_dir, "packages", "a", "package.json"),
+      JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }),
+    );
     r = await install(package_dir);
     expect(r.code).toBe(0);
     expect(r.err).toContain("Saved lockfile");
@@ -74,7 +92,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
 
     // 3. a new workspace appearing under the glob is noticed
     await mkdir(join(package_dir, "packages", "b"), { recursive: true });
-    await writeFile(join(package_dir, "packages", "b", "package.json"), JSON.stringify({ name: "b", version: "1.0.0" }));
+    await writeFile(
+      join(package_dir, "packages", "b", "package.json"),
+      JSON.stringify({ name: "b", version: "1.0.0" }),
+    );
     r = await install(package_dir);
     expect(r.code).toBe(0);
     expect(r.err).toContain("Saved lockfile");
@@ -118,7 +139,15 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     //    here as node_modules damage being repaired without any recorded state)
     await writeFile(
       join(package_dir, "bunfig.toml"),
-      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker, stateFile: false } }),
+      Bun.TOML.stringify({
+        install: {
+          cache: { dir: join(package_dir, ".cache") },
+          registry: root_url + "/",
+          saveTextLockfile: true,
+          linker,
+          stateFile: false,
+        },
+      }),
     );
     expect((await install(package_dir)).code).toBe(0);
     await rm(join(package_dir, ".cache", ".install-state"), { recursive: true, force: true });
@@ -130,7 +159,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     await mkdir(join(package_dir, "local"), { recursive: true });
     await writeFile(join(package_dir, "local", "package.json"), JSON.stringify({ name: "local", version: "1.0.0" }));
     await writeFile(join(package_dir, "local", "index.js"), "module.exports = 1;");
-    await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "root", dependencies: { local: "file:./local", bar: "0.0.2" } }));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", dependencies: { local: "file:./local", bar: "0.0.2" } }),
+    );
 
     let r = await install(package_dir);
     expect(r.err).not.toContain("error:");

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
@@ -134,9 +134,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.code).toBe(0);
     expect(r.out).not.toMatch(noChanges);
 
-    // 8. install.stateFile = false disables the fast path (the classic per-package check
-    //    still reports "no changes", but only after verifying every package — observable
-    //    here as node_modules damage being repaired without any recorded state)
+    // 8. install.stateFile = false disables the fast path: no state is recorded, and the
+    //    classic per-package verification still repairs node_modules
     await writeFile(
       join(package_dir, "bunfig.toml"),
       Bun.TOML.stringify({
@@ -151,7 +150,10 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     );
     expect((await install(package_dir)).code).toBe(0);
     await rm(join(package_dir, ".cache", ".install-state"), { recursive: true, force: true });
-    expect((await install(package_dir)).code).toBe(0);
+    await rm(join(package_dir, "node_modules", "bar", "package.json"));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
     expect(existsSync(join(package_dir, ".cache", ".install-state"))).toBeFalse();
   });
 
@@ -171,8 +173,11 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.code).toBe(0);
     expect(r.out).toMatch(noChanges);
 
-    await Bun.sleep(10);
-    await writeFile(join(package_dir, "local", "index.js"), "module.exports = 2;");
+    const src = join(package_dir, "local", "index.js");
+    const before = statSync(src).mtimeMs;
+    await writeFile(src, "module.exports = 2;");
+    // make the edit observable regardless of timestamp granularity
+    utimesSync(src, new Date(before + 2000), new Date(before + 2000));
     r = await install(package_dir);
     expect(r.code).toBe(0);
     expect(r.out).not.toMatch(noChanges);

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -26,7 +26,15 @@ afterAll(dummyAfterAll);
 let urls: string[];
 
 async function install(cwd: string, args: string[] = []) {
-  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  // the CI runner exports BUN_INSTALL_CACHE_DIR, which would override the bunfig cache
+  // dir these tests inspect; pin it to the project's own cache
+  await using proc = spawn({
+    cmd: [bunExe(), "install", ...args],
+    cwd,
+    env: { ...env, BUN_INSTALL_CACHE_DIR: join(package_dir, ".cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { out, err, code };
 }

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -207,15 +207,20 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(existsSync(join(package_dir, ".cache", ".install-state"))).toBeFalse();
   });
 
-  it("removing a scoped package is noticed (only the @scope directory's mtime changes)", async () => {
-    setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {}, "0.1.0": {} }));
+  it("nested / store packages are verified like top-level ones (scoped removal, missing package.json)", async () => {
+    // `@barn/moo` is only a transitive dependency (of bar), so under the isolated linker it
+    // exists solely inside the store — no root node_modules entry covers it
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.2": { dependencies: { "@barn/moo": "0.1.0" } },
+        "0.0.3": {},
+        "0.0.5": {},
+        "0.1.0": {},
+      }),
+    );
     await writeFile(
       join(package_dir, "package.json"),
-      JSON.stringify({
-        name: "root",
-        workspaces: ["packages/*"],
-        dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2" },
-      }),
+      JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { bar: "0.0.2" } }),
     );
     let r = await install(package_dir);
     expect(r.err).not.toContain("error:");
@@ -223,25 +228,32 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     r = await install(package_dir);
     expect(r.out).toMatch(noChanges);
 
-    // find where @barn/moo actually lives (root node_modules for hoisted; the store entry's
-    // node_modules for isolated) and remove it: only `@barn`'s mtime changes
-    // (store entries first, so the isolated arm exercises the store scan rather than the
-    // root node_modules symlink; a real directory, not a symlink into the store)
-    const candidates: string[] = [];
+    // where the real @barn/moo directory lives: hoisted → root node_modules; isolated → its
+    // own store entry
     const store = join(package_dir, "node_modules", ".bun");
-    if (existsSync(store)) {
-      for (const e of readdirSync(store)) candidates.push(join(store, e, "node_modules", "@barn", "moo"));
-    }
-    candidates.push(join(package_dir, "node_modules", "@barn", "moo"));
-    const victim = candidates.find(p => existsSync(join(p, "package.json")) && lstatSync(p).isDirectory());
-    expect(victim).toBeDefined();
-    await rm(victim!, { recursive: true, force: true });
-    // (a full pass that only re-links prints the same summary as the fast path, so assert
-    // on the effect: the fast path would have left the package missing)
+    const real =
+      linker === "isolated"
+        ? join(store, readdirSync(store).find(e => e.startsWith("@barn+moo"))!, "node_modules", "@barn", "moo")
+        : join(package_dir, "node_modules", "@barn", "moo");
+    expect(lstatSync(real).isDirectory()).toBeTrue();
+
+    // 1. its package.json disappears (only the package dir's own mtime changes): repaired.
+    //    (A full pass that only re-links prints the same summary as the fast path, so
+    //    assert on the effect — the fast path would have left it missing.)
+    await rm(join(real, "package.json"));
     r = await install(package_dir);
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
-    expect(existsSync(join(victim!, "package.json"))).toBeTrue();
+    expect(existsSync(join(real, "package.json"))).toBeTrue();
+    r = await install(package_dir);
+    expect(r.out).toMatch(noChanges);
+
+    // 2. the whole scoped package directory disappears (only `@barn`'s mtime changes)
+    await rm(real, { recursive: true, force: true });
+    r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    expect(existsSync(join(real, "package.json"))).toBeTrue();
   });
 
   it("local file: dependencies: untouched is a no-op, an edited source re-installs", async () => {

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,5 +1,5 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
@@ -22,7 +22,6 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-setDefaultTimeout(1000 * 60 * 5);
 
 let urls: string[];
 

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -83,8 +83,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     // 1. nothing changed → no requests, same summary wording as the classic no-op
     const before = urls.length;
     r = await install(package_dir);
-    expect(r.code).toBe(0);
     expect(r.out).toMatch(noChanges);
+    expect(r.code).toBe(0);
     expect(urls.length).toBe(before);
 
     // 2. a workspace manifest edit is noticed
@@ -93,8 +93,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
       JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }),
     );
     r = await install(package_dir);
-    expect(r.code).toBe(0);
     expect(r.err).toContain("Saved lockfile");
+    expect(r.code).toBe(0);
     expect(await file(join(package_dir, "bun.lock")).text()).toContain("baz@0.0.5");
 
     // 3. a new workspace appearing under the glob is noticed
@@ -104,8 +104,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
       JSON.stringify({ name: "b", version: "1.0.0" }),
     );
     r = await install(package_dir);
-    expect(r.code).toBe(0);
     expect(r.err).toContain("Saved lockfile");
+    expect(r.code).toBe(0);
     expect(await file(join(package_dir, "bun.lock")).text()).toContain('"packages/b"');
 
     // 4. removing something from node_modules is noticed and repaired
@@ -125,7 +125,9 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     // 6. flags are part of the fingerprint: state recorded by an `--omit=dev` run is not
     //    valid for a plain run (and vice versa)
     const stateDir = join(package_dir, ".cache", ".install-state");
-    const stateFile = join(stateDir, (await Array.fromAsync(new Bun.Glob("*").scan(stateDir)))[0]);
+    const stateFiles = await Array.fromAsync(new Bun.Glob("*").scan(stateDir));
+    expect(stateFiles.length).toBe(1);
+    const stateFile = join(stateDir, stateFiles[0]);
     const envLine = async () => (await file(stateFile).text()).split("\n").find(l => l.startsWith("e "));
     const plainState = await envLine();
     r = await install(package_dir, ["--omit=dev"]);
@@ -138,10 +140,47 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
 
     // 7. --force always does the work
     r = await install(package_dir, ["--force"]);
-    expect(r.code).toBe(0);
     expect(r.out).not.toMatch(noChanges);
+    expect(r.code).toBe(0);
 
-    // 8. install.stateFile = false disables the fast path: no state is recorded, and the
+    // 8. `--config <file>`: the alternate config's contents are fingerprinted too. (A
+    //    full pass that finds nothing to do prints the same summary as the fast path, so
+    //    observe it through the state file: only a full pass rewrites it.)
+    const altConfig = (extra: object) =>
+      Bun.TOML.stringify({
+        install: {
+          cache: { dir: join(package_dir, ".cache") },
+          registry: root_url + "/",
+          saveTextLockfile: true,
+          linker,
+          ...extra,
+        },
+      });
+    const stateMtime = () => statSync(stateFile).mtimeMs;
+    await writeFile(join(package_dir, "alt.toml"), altConfig({}));
+    r = await install(package_dir, ["--config=alt.toml"]);
+    expect(r.code).toBe(0);
+    let m = stateMtime();
+    r = await install(package_dir, ["--config=alt.toml"]);
+    expect(r.out).toMatch(noChanges);
+    expect(r.code).toBe(0);
+    expect(stateMtime()).toBe(m);
+    await writeFile(join(package_dir, "alt.toml"), altConfig({ dev: false }));
+    r = await install(package_dir, ["--config=alt.toml"]);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    expect(stateMtime()).not.toBe(m);
+
+    // 9. --dry-run does not touch node_modules, so it leaves the marker alone
+    m = stateMtime();
+    r = await install(package_dir, ["--config=alt.toml", "--dry-run"]);
+    expect(r.code).toBe(0);
+    r = await install(package_dir, ["--config=alt.toml"]);
+    expect(r.out).toMatch(noChanges);
+    expect(r.code).toBe(0);
+    expect(stateMtime()).toBe(m);
+
+    // 10. install.stateFile = false disables the fast path: no state is recorded, and the
     //    classic per-package verification still repairs node_modules
     await writeFile(
       join(package_dir, "bunfig.toml"),
@@ -177,8 +216,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
     r = await install(package_dir);
-    expect(r.code).toBe(0);
     expect(r.out).toMatch(noChanges);
+    expect(r.code).toBe(0);
 
     const src = join(package_dir, "local", "index.js");
     const before = statSync(src).mtimeMs;
@@ -186,8 +225,8 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     // make the edit observable regardless of timestamp granularity
     utimesSync(src, new Date(before + 2000), new Date(before + 2000));
     r = await install(package_dir);
-    expect(r.code).toBe(0);
     expect(r.out).not.toMatch(noChanges);
+    expect(r.code).toBe(0);
     const installed =
       linker === "hoisted"
         ? join(package_dir, "node_modules", "local", "index.js")

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,0 +1,153 @@
+import { file, spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { existsSync } from "fs";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+// The install-state fast path: after a successful install bun records a fingerprint of
+// everything that determines node_modules; a repeat `bun install` with nothing changed
+// verifies it and returns without re-walking node_modules. These tests check that it
+// engages, and — more importantly — every kind of change that must invalidate it does.
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+setDefaultTimeout(1000 * 60 * 5);
+
+let urls: string[];
+
+async function install(cwd: string, args: string[] = []) {
+  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+const noChanges = /\(no changes\)/;
+
+describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => {
+  beforeEach(async () => {
+    await dummyBeforeEach({ linker });
+    urls = [];
+    setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {} }));
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker } }),
+    );
+    await mkdir(join(package_dir, "packages", "a"), { recursive: true });
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { bar: "0.0.2" }, devDependencies: { qux: "0.0.2" } }),
+    );
+    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.3" } }));
+  });
+  afterEach(dummyAfterEach);
+
+  it("a repeat install is a no-op, and every relevant change invalidates it", async () => {
+    let r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.err).toContain("Saved lockfile");
+    expect(r.code).toBe(0);
+
+    // 1. nothing changed → no requests, same summary wording as the classic no-op
+    const before = urls.length;
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(noChanges);
+    expect(urls.length).toBe(before);
+
+    // 2. a workspace manifest edit is noticed
+    await writeFile(join(package_dir, "packages", "a", "package.json"), JSON.stringify({ name: "a", version: "1.0.0", dependencies: { baz: "0.0.5" } }));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.err).toContain("Saved lockfile");
+    expect(await file(join(package_dir, "bun.lock")).text()).toContain("baz@0.0.5");
+
+    // 3. a new workspace appearing under the glob is noticed
+    await mkdir(join(package_dir, "packages", "b"), { recursive: true });
+    await writeFile(join(package_dir, "packages", "b", "package.json"), JSON.stringify({ name: "b", version: "1.0.0" }));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.err).toContain("Saved lockfile");
+    expect(await file(join(package_dir, "bun.lock")).text()).toContain('"packages/b"');
+
+    // 4. removing something from node_modules is noticed and repaired
+    await rm(join(package_dir, "node_modules", "bar"), { recursive: true, force: true });
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
+    // (and after the repair we are clean again)
+    expect((await install(package_dir)).out).toMatch(noChanges);
+
+    // 5. deleting a file *inside* an installed package is noticed and repaired
+    await rm(join(package_dir, "node_modules", "bar", "package.json"));
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
+
+    // 6. flags are part of the fingerprint: state recorded by an `--omit=dev` run is not
+    //    valid for a plain run (and vice versa)
+    const stateDir = join(package_dir, ".cache", ".install-state");
+    const stateFile = join(stateDir, (await Array.fromAsync(new Bun.Glob("*").scan(stateDir)))[0]);
+    const envLine = async () => (await file(stateFile).text()).split("\n").find(l => l.startsWith("e "));
+    const plainState = await envLine();
+    r = await install(package_dir, ["--omit=dev"]);
+    expect(r.code).toBe(0);
+    expect(await envLine()).not.toBe(plainState);
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(await envLine()).toBe(plainState);
+    expect((await install(package_dir)).out).toMatch(noChanges);
+
+    // 7. --force always does the work
+    r = await install(package_dir, ["--force"]);
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(noChanges);
+
+    // 8. install.stateFile = false disables the fast path (the classic per-package check
+    //    still reports "no changes", but only after verifying every package — observable
+    //    here as node_modules damage being repaired without any recorded state)
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      Bun.TOML.stringify({ install: { cache: { dir: join(package_dir, ".cache") }, registry: root_url + "/", saveTextLockfile: true, linker, stateFile: false } }),
+    );
+    expect((await install(package_dir)).code).toBe(0);
+    await rm(join(package_dir, ".cache", ".install-state"), { recursive: true, force: true });
+    expect((await install(package_dir)).code).toBe(0);
+    expect(existsSync(join(package_dir, ".cache", ".install-state"))).toBeFalse();
+  });
+
+  it("local file: dependencies: untouched is a no-op, an edited source re-installs", async () => {
+    await mkdir(join(package_dir, "local"), { recursive: true });
+    await writeFile(join(package_dir, "local", "package.json"), JSON.stringify({ name: "local", version: "1.0.0" }));
+    await writeFile(join(package_dir, "local", "index.js"), "module.exports = 1;");
+    await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "root", dependencies: { local: "file:./local", bar: "0.0.2" } }));
+
+    let r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(noChanges);
+
+    await Bun.sleep(10);
+    await writeFile(join(package_dir, "local", "index.js"), "module.exports = 2;");
+    r = await install(package_dir);
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(noChanges);
+    const installed =
+      linker === "hoisted"
+        ? join(package_dir, "node_modules", "local", "index.js")
+        : join(package_dir, "node_modules", ".bun", "local@file+local", "node_modules", "local", "index.js");
+    expect(await file(installed).text()).toBe("module.exports = 2;");
+  });
+});

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, statSync, utimesSync } from "fs";
+import { existsSync, readFileSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
@@ -156,29 +156,30 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
           ...extra,
         },
       });
-    const stateMtime = () => statSync(stateFile).mtimeMs;
+    // the file's env+argv line and stamps change whenever a full pass rewrites it
+    const stateText = () => readFileSync(stateFile, "utf8");
     await writeFile(join(package_dir, "alt.toml"), altConfig({}));
     r = await install(package_dir, ["--config=alt.toml"]);
     expect(r.code).toBe(0);
-    let m = stateMtime();
+    let m = stateText();
     r = await install(package_dir, ["--config=alt.toml"]);
     expect(r.out).toMatch(noChanges);
     expect(r.code).toBe(0);
-    expect(stateMtime()).toBe(m);
+    expect(stateText()).toBe(m);
     await writeFile(join(package_dir, "alt.toml"), altConfig({ dev: false }));
     r = await install(package_dir, ["--config=alt.toml"]);
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
-    expect(stateMtime()).not.toBe(m);
+    expect(stateText()).not.toBe(m);
 
     // 9. --dry-run does not touch node_modules, so it leaves the marker alone
-    m = stateMtime();
+    m = stateText();
     r = await install(package_dir, ["--config=alt.toml", "--dry-run"]);
     expect(r.code).toBe(0);
     r = await install(package_dir, ["--config=alt.toml"]);
     expect(r.out).toMatch(noChanges);
     expect(r.code).toBe(0);
-    expect(stateMtime()).toBe(m);
+    expect(stateText()).toBe(m);
 
     // 10. install.stateFile = false disables the fast path: no state is recorded, and the
     //    classic per-package verification still repairs node_modules

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, readFileSync, statSync, utimesSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync, utimesSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
@@ -205,6 +205,40 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.code).toBe(0);
     expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
     expect(existsSync(join(package_dir, ".cache", ".install-state"))).toBeFalse();
+  });
+
+  it("removing a scoped package is noticed (only the @scope directory's mtime changes)", async () => {
+    setHandler(dummyRegistry(urls, { "0.0.2": {}, "0.0.3": {}, "0.0.5": {}, "0.1.0": {} }));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2" },
+      }),
+    );
+    let r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    r = await install(package_dir);
+    expect(r.out).toMatch(noChanges);
+
+    // find where @barn/moo actually lives (root node_modules for hoisted; the store entry's
+    // node_modules for isolated) and remove it: only `@barn`'s mtime changes
+    const candidates = [join(package_dir, "node_modules", "@barn", "moo")];
+    const store = join(package_dir, "node_modules", ".bun");
+    if (existsSync(store)) {
+      for (const e of readdirSync(store)) candidates.push(join(store, e, "node_modules", "@barn", "moo"));
+    }
+    const victim = candidates.find(p => existsSync(join(p, "package.json")));
+    expect(victim).toBeDefined();
+    await rm(victim!, { recursive: true, force: true });
+    // (a full pass that only re-links prints the same summary as the fast path, so assert
+    // on the effect: the fast path would have left the package missing)
+    r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    expect(existsSync(join(victim!, "package.json"))).toBeTrue();
   });
 
   it("local file: dependencies: untouched is a no-op, an edited source re-installs", async () => {

--- a/test/cli/install/bun-install-state.test.ts
+++ b/test/cli/install/bun-install-state.test.ts
@@ -97,8 +97,11 @@ describe.each(["hoisted", "isolated"] as const)("install state (%s)", linker => 
     expect(r.code).toBe(0);
     expect(await file(join(package_dir, "bun.lock")).text()).toContain("baz@0.0.5");
 
-    // 3. a new workspace appearing under the glob is noticed
+    // 3. a new workspace appearing under the glob is noticed (bump the parent's mtime
+    //    explicitly so this does not depend on timestamp granularity)
     await mkdir(join(package_dir, "packages", "b"), { recursive: true });
+    const pk = join(package_dir, "packages");
+    utimesSync(pk, new Date(statSync(pk).mtimeMs + 2000), new Date(statSync(pk).mtimeMs + 2000));
     await writeFile(
       join(package_dir, "packages", "b", "package.json"),
       JSON.stringify({ name: "b", version: "1.0.0" }),

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9,6 +9,7 @@ import {
   isWindows,
   joinP,
   normalizeBunSnapshot,
+  readdirCacheSorted,
   readdirSorted,
   runBunInstall,
   tempDir,
@@ -4042,7 +4043,7 @@ describe.concurrent("bun-install", () => {
       expect(ctx.requested).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -4112,7 +4113,7 @@ describe.concurrent("bun-install", () => {
       expect(ctx.requested).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -4350,7 +4351,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -4482,7 +4483,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "@GH@mishoo-UglifyJS-e219a9a@@@1",
         "uglify",
       ]);
@@ -5443,7 +5444,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-js", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-js"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5506,7 +5507,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5567,7 +5568,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "9694c5fe9c41ad51.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);
@@ -5755,7 +5756,7 @@ describe.concurrent("bun-install", () => {
 
       expect(await install()).toMatchObject({ exitCode: 0 });
       expect(await readdirSorted(join(cache, `@G@${sha}`))).toEqual([".bun-tag", "package.json"]);
-      const mirror = (await readdirSorted(cache)).find(entry => entry.endsWith(".git"))!;
+      const mirror = (await readdirCacheSorted(cache)).find(entry => entry.endsWith(".git"))!;
 
       // `git log` during resolution does not need the tree object, but `git checkout` cannot unpack without it.
       const treeObject = join(cache, mirror, "objects", treeSha.slice(0, 2), treeSha.slice(2));
@@ -5766,7 +5767,7 @@ describe.concurrent("bun-install", () => {
       const failed = await install();
       expect(failed.err).toContain('"git checkout" for "checkout-fails" failed');
       expect(failed.exitCode).not.toBe(0);
-      expect(await readdirSorted(cache)).toEqual([mirror]);
+      expect(await readdirCacheSorted(cache)).toEqual([mirror]);
 
       await write(treeObject, treeBytes);
       expect(await install()).toMatchObject({ exitCode: 0 });
@@ -5949,7 +5950,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-hash", "bin", "uglifyjs"),
       );
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+      expect(await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
         "9694c5fe9c41ad51.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5444,7 +5444,9 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-js", "bin", "uglifyjs"),
       );
-      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe(
+        "9694c5fe9c41ad51.git",
+      );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-js"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5507,7 +5509,9 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
+      expect((await readdirCacheSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe(
+        "87d55589eb4217d2.git",
+      );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2038,6 +2038,14 @@ export async function readdirSorted(path: string): Promise<string[]> {
 }
 
 /**
+ * `readdirSorted` for bun's install cache directory: ignores bookkeeping entries that
+ * are not cached packages (currently the `.install-state` fingerprint dir).
+ */
+export async function readdirCacheSorted(path: string): Promise<string[]> {
+  return (await readdirSorted(path)).filter(e => e !== ".install-state");
+}
+
+/**
  * Helper function for making automatically lazily-executed promises.
  *
  * The difference is that the promise has not already started to be evaluated when it is created,


### PR DESCRIPTION
### What does this PR do?

Makes a repeat `bun install` with nothing to do close to free, without giving up correctness.

Today a no-op install still parses the lockfile, re-hoists, and walks `node_modules` opening and parsing every installed `package.json` to confirm name/version — O(packages) syscalls, which on large workspaces (and especially on Windows) is where almost all of the "no changes" time goes.

With this change, after a successful install bun records a fingerprint of the inputs that determine what ends up in `node_modules`, in `<cache>/.install-state/<hash of project root>`:

- content hashes of `bun.lock` / `bun.lockb`, the root and **every workspace** `package.json`, `./bunfig.toml`, `./.npmrc`, `~/.npmrc`, `~/.bunfig.toml`, `$XDG_CONFIG_HOME/{.bunfig.toml,.npmrc}`, and every referenced patch file (absence is recorded too);
- a hash of the install-relevant environment (`BUN_INSTALL*`, `BUN_CONFIG_*`, `NPM_CONFIG_*`), the exact argv, and bun's version (only the hash is stored);
- `lstat` stamps of each `node_modules` directory (root + workspaces), of its top-level entries and of each entry's `package.json` (through symlinks, so the isolated linker's store is covered);
- stamps of the parent directories of the `workspaces` globs — present *or absent*, and for nested globs the existing levels below the literal prefix — so a workspace added on a branch switch is noticed;
- for `file:` / local-tarball dependencies (projects using `bun link`-ed packages always take the normal path), recursive stamps of the source (bounded; a project with enormous local sources just doesn't get a state file).

The next plain `bun install` re-hashes those few files, checks the stamps and, if everything matches, prints the usual `Checked N installs across M packages (no changes)` and returns. Anything else — `bun add/remove/update`, `--force`, `--global`, dry runs, positional filters, `install.stateFile = false`, or any changed input — takes the normal path. The state file is deleted *before* an install that does real work, so a crash mid-install can't leave a "clean" marker behind. As with other package managers' equivalent optimisation, root lifecycle scripts don't re-run on a no-op install.

The state lives in the cache dir (not `node_modules`) so directory listings are unchanged; a new `readdirCacheSorted()` test helper hides the bookkeeping dir from the few tests that snapshot the *cache* directory.

Docs: `install.stateFile` in `docs/runtime/bunfig.mdx`, a short "Repeat installs" note in `docs/pm/cli/install.mdx`.

### How did you verify your code works?

- New `test/cli/install/bun-install-state.test.ts` (dummy registry, both `hoisted` and `isolated`): repeat install is a no-op with zero requests; then each of these invalidates it and is acted on — editing a workspace `package.json`, adding a workspace under the glob, removing a package dir from `node_modules`, deleting a file inside an installed package, running with different flags, `--force`, `stateFile = false`; plus a `file:` dependency whose untouched source is a no-op and whose edited source is re-installed.
- Ran `bun-install`, `bun-add`, `bun-install-registry`, `bun-workspaces`, `isolated-install`, `bun-link`, `bun-lock`, `bun-remove`, `bun-update`, `bun-pm` and `bun-install-lifecycle-scripts` suites locally.



Supersedes #39901 (same change, moved from a fork branch to a branch in this repository; the review discussion so far is on that PR and has been addressed here).

