### PR TITLE
pm: add `bun pm cache pack` / `bun pm cache unpack` (single-file cache snapshot for CI)

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -332,6 +332,19 @@ To clear Bun's global module cache:
 bun pm cache rm
 ```
 
+To snapshot the cache entries the current lockfile needs into a single file, and restore them elsewhere:
+
+```bash terminal icon="terminal"
+# after an install, with a warm cache
+bun pm cache pack .ci/bun-cache.pack
+
+# on another machine / CI runner, before installing
+bun pm cache unpack .ci/bun-cache.pack
+bun install --frozen-lockfile
+```
+
+This exists for CI caches: object-store caches move one large sequential file much faster than tens of thousands of small ones, and restoring a directory cache pays a create+write per file before `bun install` even starts. The pack is uncompressed (CI cache layers already compress) and contains only the packages referenced by `bun.lock` that are present locally (optional packages for other platforms are skipped). `unpack` recreates only the entries missing from the target cache, so it is cheap to run unconditionally, and it refuses entries with absolute or traversing paths.
+
 ## migrate
 
 To migrate another package manager's lockfile without installing anything:

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -343,7 +343,7 @@ bun pm cache unpack .ci/bun-cache.pack
 bun install --frozen-lockfile
 ```
 
-This exists for CI caches: object-store caches move one large sequential file much faster than tens of thousands of small ones, and restoring a directory cache pays a create+write per file before `bun install` even starts. The pack is uncompressed (CI cache layers already compress) and contains only the packages referenced by `bun.lock` that are present locally (optional packages for other platforms are skipped). `unpack` recreates only the entries missing from the target cache, so it is cheap to run unconditionally, and it refuses entries with absolute or traversing paths.
+This exists for CI caches: object-store caches move one large sequential file much faster than tens of thousands of small ones, and restoring a directory cache pays a create+write per file before `bun install` even starts. The pack is uncompressed (CI cache layers already compress) and contains every package referenced by `bun.lock` that is present in the local cache; a package that is missing locally is left out — with a warning, unless it is an optional package for another platform, which is expected to be absent. `unpack` recreates only the entries missing from the target cache, so it is cheap to run unconditionally, and it refuses entries with absolute or traversing paths.
 
 ## migrate
 

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -165,12 +165,14 @@ impl Write for FileWriter {
     }
 }
 
-/// The cache folder name for every fetchable package in the lockfile, and whether
-/// the package is expected on this platform (os/cpu/libc) — used only to decide
-/// whether a missing folder deserves a warning.
+/// The cache folder name for every fetchable package in the lockfile — computed the way
+/// the installer looks packages up (`compute_cache_dir_and_subpath`, including the
+/// `_patch_hash=…` folder for patched dependencies) — and whether the package is expected
+/// on this platform (os/cpu), which only decides if a missing folder deserves a warning.
 pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
     let mut out: Vec<(Vec<u8>, bool)> = Vec::new();
     let count = pm.lockfile.packages.len();
+    let mut path_buf = bun_paths::PathBuffer::uninit();
     for i in 0..count {
         let (name, resolution, expected) = {
             let pkgs = &pm.lockfile.packages;
@@ -181,41 +183,43 @@ pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
                 !meta.is_disabled(pm.options.cpu, pm.options.os),
             )
         };
-        let folder: Option<Vec<u8>> = match resolution.tag {
-            ResolutionTag::Npm => {
-                let name = pm.lockfile.str(&name).to_vec();
-                Some(
-                    directories::cached_npm_package_folder_name(
-                        pm,
-                        &name,
-                        resolution.npm().version,
-                        None,
-                    )
-                    .as_bytes()
-                    .to_vec(),
-                )
-            }
-            ResolutionTag::Git => Some(
-                directories::cached_git_folder_name(pm, resolution.git(), None)
-                    .as_bytes()
-                    .to_vec(),
-            ),
-            ResolutionTag::Github => Some(
-                directories::cached_github_folder_name(pm, resolution.github(), None)
-                    .as_bytes()
-                    .to_vec(),
-            ),
-            ResolutionTag::RemoteTarball => Some(
-                directories::cached_tarball_folder_name(pm, *resolution.remote_tarball(), None)
-                    .as_bytes()
-                    .to_vec(),
-            ),
-            _ => None,
+        if !matches!(
+            resolution.tag,
+            ResolutionTag::Npm
+                | ResolutionTag::Git
+                | ResolutionTag::Github
+                | ResolutionTag::LocalTarball
+                | ResolutionTag::RemoteTarball
+        ) {
+            continue;
+        }
+        let name = pm.lockfile.str(&name).to_vec();
+        // patched dependencies live in `<folder>_patch_hash=<hex>` (keyed by "name@version")
+        let patch_hash = if pm.lockfile.patched_dependencies.count() == 0 {
+            None
+        } else {
+            let buf = pm.lockfile.buffers.string_bytes.as_slice();
+            let key = format!(
+                "{}@{}",
+                bstr::BStr::new(&name),
+                resolution.fmt(buf, bun_core::fmt::PathSep::Posix)
+            );
+            let key_hash = bun_semver::string::Builder::string_hash(key.as_bytes());
+            pm.lockfile
+                .patched_dependencies
+                .get(&key_hash)
+                .and_then(|p| p.patchfile_hash())
         };
-        if let Some(f) = folder {
-            if !f.is_empty() {
-                out.push((f, expected));
-            }
+        let r = directories::compute_cache_dir_and_subpath(
+            pm,
+            &name,
+            &resolution,
+            &mut path_buf,
+            patch_hash,
+        );
+        let folder = r.cache_dir_subpath.as_bytes().to_vec();
+        if !folder.is_empty() {
+            out.push((folder, expected));
         }
     }
     // sorted for a deterministic pack; the same folder can back several lockfile
@@ -275,7 +279,7 @@ fn pack_dir(
             bun_sys::FileKind::SymLink => {
                 let mut buf = bun_paths::path_buffer_pool::get();
                 let n = bun_sys::readlink(&z(&abs), &mut buf[..]).map_err(sys_err)?;
-                if n >= buf.len() {
+                if n >= buf.len().min(4096) {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         format!("symlink target of {} is too long", bstr::BStr::new(&abs)),
@@ -343,22 +347,29 @@ pub fn pack(
     // written next to the destination under a temporary name, moved into place at the end
     let out_dir = parent(out_path).unwrap_or(b".");
     let out_dir_fd = bun_sys::open_dir_at(bun_sys::Fd::cwd(), out_dir).map_err(sys_err)?;
-    let mut tmpname_buf = [0u8; 256];
-    let tmpname =
-        bun_paths::fs::FileSystem::tmpname(b"pack", &mut tmpname_buf, bun_wyhash::hash(out_path))
-            .map_err(|_| std::io::Error::other("could not build a temporary file name"))?;
-    let mut tmpfile = bun_sys::Tmpfile::create(out_dir_fd, tmpname).map_err(sys_err)?;
-    // `bun_sys::FileWriter` borrows the fd; the Tmpfile keeps ownership.
-    let result = pack_impl(&folders, cache_dir, bun_sys::FileWriter(tmpfile.fd)).and_then(|s| {
-        let dest = z(bun_paths::basename(out_path));
-        tmpfile.finish(&dest).map_err(sys_err)?;
-        Ok(s)
-    });
-    if result.is_err() {
-        // never leave a partial temp file behind (ENOSPC, unreadable cache entry, …)
-        let _ = bun_sys::unlinkat(out_dir_fd, tmpname);
-    }
-    let _ = bun_sys::close(tmpfile.fd);
+    let result = (|| {
+        let mut tmpname_buf = [0u8; 256];
+        let tmpname = bun_paths::fs::FileSystem::tmpname(
+            b"pack",
+            &mut tmpname_buf,
+            bun_wyhash::hash(out_path),
+        )
+        .map_err(|_| std::io::Error::other("could not build a temporary file name"))?;
+        let mut tmpfile = bun_sys::Tmpfile::create(out_dir_fd, tmpname).map_err(sys_err)?;
+        // `bun_sys::FileWriter` borrows the fd; the Tmpfile keeps ownership.
+        let result =
+            pack_impl(&folders, cache_dir, bun_sys::FileWriter(tmpfile.fd)).and_then(|s| {
+                let dest = z(bun_paths::basename(out_path));
+                tmpfile.finish(&dest).map_err(sys_err)?;
+                Ok(s)
+            });
+        if result.is_err() {
+            // never leave a partial temp file behind (ENOSPC, unreadable cache entry, …)
+            let _ = bun_sys::unlinkat(out_dir_fd, tmpname);
+        }
+        let _ = bun_sys::close(tmpfile.fd);
+        result
+    })();
     let _ = bun_sys::close(out_dir_fd);
     result
 }
@@ -458,39 +469,73 @@ fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
 /// later file) out of the package, whatever order the records arrived in. Links whose
 /// target passes through another link are refused rather than resolved.
 fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io::Result<()> {
-    for (rel, target) in links.drain(..) {
-        let no_link_components = |base: &[u8], rel_path: &[u8]| -> std::io::Result<bool> {
-            let mut p = base.to_vec();
-            for comp in strings::split_any(rel_path, b"/\\").filter(|c| !c.is_empty()) {
-                match comp {
-                    b"." => continue,
-                    b".." => {
-                        // stays inside by construction (checked lexically); pop a component
-                        if let Some(parent) = parent(&p) {
-                            p = parent.to_vec();
-                        }
-                        continue;
-                    }
-                    _ => p = join(&p, comp),
+    // Normalised package-relative paths of every link about to be created. A link's
+    // own path and its target (resolved lexically from the link's directory) may not
+    // pass *through* any of them — checked against the whole set up front, so the
+    // record order cannot matter — nor through a symlink already on disk.
+    fn components(p: &[u8]) -> impl Iterator<Item = &[u8]> {
+        strings::split_any(p, b"/\\").filter(|c| !c.is_empty() && *c != b".")
+    }
+    let link_paths: Vec<Vec<Vec<u8>>> = links
+        .iter()
+        .map(|(rel, _)| components(rel).map(|c| c.to_vec()).collect())
+        .collect();
+    let passes_through_link = |start: &[Vec<u8>], rel_path: &[u8], own: Option<usize>| {
+        // walk `rel_path` from `start` (package-relative components), checking every
+        // proper prefix reached against the pending link paths
+        let mut cur: Vec<Vec<u8>> = start.to_vec();
+        let comps: Vec<&[u8]> = components(rel_path).collect();
+        for (idx, comp) in comps.iter().enumerate() {
+            if *comp == b".." {
+                cur.pop();
+                continue;
+            }
+            cur.push(comp.to_vec());
+            let is_last = idx + 1 == comps.len();
+            for (k, lp) in link_paths.iter().enumerate() {
+                // the link's own final component is itself, not a traversal
+                if is_last && Some(k) == own {
+                    continue;
                 }
-                if lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink) {
-                    return Ok(false);
+                if *lp == cur {
+                    return true;
                 }
             }
-            Ok(true)
+        }
+        false
+    };
+    for (k, (rel, target)) in links.iter().enumerate() {
+        let link_dir: Vec<Vec<u8>> = {
+            let mut c: Vec<Vec<u8>> = components(rel).map(|c| c.to_vec()).collect();
+            c.pop();
+            c
         };
-        let dest = join(staging, &rel);
-        let link_dir = parent(&dest).unwrap_or(staging).to_vec();
-        if !no_link_components(staging, &rel)? || !no_link_components(&link_dir, &target)? {
+        if passes_through_link(&[], rel, Some(k)) || passes_through_link(&link_dir, target, None) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
                     "pack entry {} -> {} passes through another symlink; delete the pack file and re-create it with `bun pm cache pack`",
-                    bstr::BStr::new(&rel),
-                    bstr::BStr::new(&target)
+                    bstr::BStr::new(rel),
+                    bstr::BStr::new(target)
                 ),
             ));
         }
+        // and nothing already on disk along the link's parent chain may be a symlink
+        let mut p = staging.to_vec();
+        for comp in components(rel) {
+            p = join(&p, comp);
+            if p.len() < join(staging, rel).len()
+                && lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink)
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("pack entry {} traverses a symlink", bstr::BStr::new(rel)),
+                ));
+            }
+        }
+    }
+    for (rel, target) in links.drain(..) {
+        let dest = join(staging, &rel);
         if let Some(dir) = parent(&dest) {
             mkdir_p(dir)?;
         }
@@ -661,28 +706,14 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 let (_, staging) = current.as_ref().unwrap();
                 let dest = join(staging, &path);
-                // refuse an entry placed under one of this package's (pending) symlinks …
+                // refuse an entry placed under one of this package's symlinks (they are
+                // created last, so on disk the parent chain here is plain directories)
                 if pending_links.iter().any(|(link, _)| {
                     path.len() > link.len()
                         && path.starts_with(link.as_slice())
                         && matches!(path[link.len()], b'/' | b'\\')
                 }) {
                     return Err(bad("pack entry traverses a symlink", record_no));
-                }
-                // … or under a symlink that already exists on disk
-                {
-                    let mut p = staging.clone();
-                    let comps: Vec<&[u8]> = strings::split_any(&path, b"/\\")
-                        .filter(|c| !c.is_empty())
-                        .collect();
-                    for (i, c) in comps.iter().enumerate() {
-                        p = join(&p, c);
-                        if lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink)
-                            && (i + 1 < comps.len() || kind[0] != 3)
-                        {
-                            return Err(bad("pack entry traverses a symlink", record_no));
-                        }
-                    }
                 }
                 match kind[0] {
                     4 => {

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -287,6 +287,12 @@ fn pack_dir(
                         format!("symlink target of {} is too long", bstr::BStr::new(&abs)),
                     ));
                 }
+                #[cfg(windows)]
+                for b in buf[..n].iter_mut() {
+                    if *b == b'\\' {
+                        *b = b'/';
+                    }
+                }
                 let target = &buf[..n];
                 // only links that stay inside the package can be restored; refuse to
                 // produce a pack that unpack would reject
@@ -422,10 +428,12 @@ fn bad(msg: &str) -> std::io::Error {
 fn safe_rel(path: &[u8]) -> bool {
     !path.is_empty()
         && path[0] != b'/'
-        && path[0] != b'\\'
+        // records always use `/`; a `\` would be a separator on Windows and a plain
+        // byte elsewhere, so lexical checks and the filesystem could disagree
+        && !strings::contains_char(path, b'\\')
         && !strings::contains_char(path, 0)
         && !strings::contains_char(path, b':')
-        && !strings::split_any(path, b"/\\").any(|seg| seg == b"..")
+        && !strings::split(path, b"/").any(|seg| seg == b"..")
 }
 
 /// May a symlink at package-relative `link_path` point at `target`? Relative targets
@@ -435,7 +443,7 @@ fn safe_rel(path: &[u8]) -> bool {
 fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
     if target.is_empty()
         || target[0] == b'/'
-        || target[0] == b'\\'
+        || strings::contains_char(target, b'\\')
         || strings::contains_char(target, 0)
         || strings::contains_char(target, b':')
     {
@@ -527,26 +535,69 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
                 ),
             ));
         }
-        // and nothing already on disk along the link's parent chain may be a symlink
+    }
+    // Create the links one at a time. Parents are created one level at a time and every
+    // existing component is lstat'ed, so nothing is ever created *through* a link made
+    // earlier (whatever the filesystem's own name matching — case-insensitive, Unicode
+    // normalising — considers "the same" component).
+    let traverses = |rel: &[u8]| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "pack entry {} passes through another symlink; delete the pack file and re-create it with `bun pm cache pack`",
+                bstr::BStr::new(rel)
+            ),
+        )
+    };
+    let created: Vec<(Vec<u8>, Vec<u8>)> = std::mem::take(links);
+    for (rel, target) in &created {
+        let comps: Vec<&[u8]> = components(rel).collect();
         let mut p = staging.to_vec();
-        for comp in components(rel) {
+        for (i, comp) in comps.iter().enumerate() {
             p = join(&p, comp);
-            if p.len() < join(staging, rel).len()
-                && lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink)
-            {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("pack entry {} traverses a symlink", bstr::BStr::new(rel)),
-                ));
+            if i + 1 == comps.len() {
+                break;
+            }
+            match lstat_kind(&p)? {
+                Some(bun_sys::FileKind::Directory) => {}
+                Some(_) => return Err(traverses(rel)),
+                None => bun_sys::mkdirat(bun_sys::Fd::cwd(), &z(&p), 0o755).map_err(sys_err)?,
             }
         }
+        // native separators for the link contents on Windows
+        let target_native: Vec<u8> = if cfg!(windows) {
+            target
+                .iter()
+                .map(|&b| if b == b'/' { b'\\' } else { b })
+                .collect()
+        } else {
+            target.clone()
+        };
+        bun_sys::symlinkat(&z(&target_native), bun_sys::Fd::cwd(), &z(&p)).map_err(sys_err)?;
     }
-    for (rel, target) in links.drain(..) {
-        let dest = join(staging, &rel);
-        if let Some(dir) = parent(&dest) {
-            mkdir_p(dir)?;
+    // Now that every link exists, resolve each target physically, one component at a
+    // time from the link's directory: an intermediate component that is a symlink on
+    // disk means the target routes through another link — refuse the package (staging is
+    // discarded by the caller, nothing was written outside it: symlink creation does not
+    // follow targets and parents were never created through links).
+    for (rel, target) in &created {
+        let mut p = parent(&join(staging, rel)).unwrap_or(staging).to_vec();
+        let comps: Vec<&[u8]> = strings::split(target, b"/")
+            .filter(|c| !c.is_empty() && *c != b".")
+            .collect();
+        for (i, comp) in comps.iter().enumerate() {
+            if *comp == b".." {
+                p = parent(&p).unwrap_or(staging).to_vec();
+                continue;
+            }
+            p = join(&p, comp);
+            if i + 1 == comps.len() {
+                break;
+            }
+            if lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink) {
+                return Err(traverses(rel));
+            }
         }
-        bun_sys::symlinkat(&z(&target), bun_sys::Fd::cwd(), &z(&dest)).map_err(sys_err)?;
     }
     Ok(())
 }

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -262,6 +262,7 @@ fn pack_dir(
     rel: &[u8],
     files: &mut u64,
     bytes: &mut u64,
+    links: &mut Vec<(Vec<u8>, Vec<u8>)>,
 ) -> std::io::Result<()> {
     let here = join(root, rel);
     let entries = list_dir(&here)?;
@@ -277,7 +278,7 @@ fn pack_dir(
         child_rel.extend_from_slice(&name);
         let abs = join(root, &child_rel);
         match kind {
-            bun_sys::FileKind::Directory => pack_dir(w, root, &child_rel, files, bytes)?,
+            bun_sys::FileKind::Directory => pack_dir(w, root, &child_rel, files, bytes, links)?,
             bun_sys::FileKind::SymLink => {
                 let mut buf = bun_paths::path_buffer_pool::get();
                 let n = bun_sys::readlink(&z(&abs), &mut buf[..]).map_err(sys_err)?;
@@ -307,6 +308,7 @@ fn pack_dir(
                     ));
                 }
                 write_record(w, 3, &child_rel, 0o777, target)?;
+                links.push((child_rel.clone(), target.to_vec()));
             }
             bun_sys::FileKind::File => {
                 let f = bun_sys::File::openat(bun_sys::Fd::cwd(), &abs, bun_sys::O::RDONLY, 0)
@@ -405,7 +407,28 @@ fn pack_impl(
             continue;
         }
         write_record(&mut w, 1, f, 0, &[])?;
-        pack_dir(&mut w, &dir, b"", &mut summary.files, &mut summary.bytes)?;
+        let mut links: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        pack_dir(
+            &mut w,
+            &dir,
+            b"",
+            &mut summary.files,
+            &mut summary.bytes,
+            &mut links,
+        )?;
+        // a link whose path or target passes *through* another link of the same package
+        // could not be restored; refuse to produce such a pack rather than one unpack rejects
+        if let Some((rel, target)) = link_through_link(&links) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "cache entry {} contains a symlink that passes through another symlink: {} -> {}",
+                    bstr::BStr::new(&dir),
+                    bstr::BStr::new(rel),
+                    bstr::BStr::new(target)
+                ),
+            ));
+        }
         summary.packages += 1;
     }
     write_record(&mut w, 0, b"", 0, &[])?;
@@ -433,7 +456,9 @@ fn safe_rel(path: &[u8]) -> bool {
         && !strings::contains_char(path, b'\\')
         && !strings::contains_char(path, 0)
         && !strings::contains_char(path, b':')
-        && !strings::split(path, b"/").any(|seg| seg == b"..")
+        // no `..`, and no `.` / empty components: the walks in `create_links` treat every
+        // component as a real name (pack_dir never emits others)
+        && !strings::split(path, b"/").any(|seg| seg == b".." || seg == b"." || seg.is_empty())
 }
 
 /// May a symlink at package-relative `link_path` point at `target`? Relative targets
@@ -450,14 +475,11 @@ fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
         return false;
     }
     // depth of the directory containing the link, relative to the package root
-    let mut depth: i64 = strings::split_any(link_path, b"/\\")
-        .filter(|c| !c.is_empty() && *c != b".")
-        .count() as i64
-        - 1;
+    let mut depth: i64 = components(link_path).count() as i64 - 1;
     if depth < 0 {
         return false;
     }
-    for comp in strings::split_any(target, b"/\\") {
+    for comp in strings::split(target, b"/") {
         match comp {
             b"" | b"." => {}
             b".." => {
@@ -472,23 +494,16 @@ fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
     true
 }
 
-/// Create a package's symlinks after all of its files and directories exist. Each
-/// link is re-checked against the tree as it now stands: no component of the link's
-/// own path, and no component of its target (resolved from the link's directory), may
-/// be a symlink — so one link can never be used to smuggle another link's target (or a
-/// later file) out of the package, whatever order the records arrived in. Links whose
-/// target passes through another link are refused rather than resolved.
-fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io::Result<()> {
-    // Normalised package-relative paths of every link about to be created. A link's
-    // own path and its target (resolved lexically from the link's directory) may not
-    // pass *through* any of them — checked against the whole set up front, so the
-    // record order cannot matter — nor through a symlink already on disk.
-    fn components(p: &[u8]) -> impl Iterator<Item = &[u8]> {
-        strings::split_any(p, b"/\\").filter(|c| !c.is_empty() && *c != b".")
-    }
-    // compared ASCII-case-insensitively: on case-insensitive filesystems `A/UP` and
-    // `a/up` are the same directory entry, and a legitimate package has no reason to
-    // contain entries that differ only in case along a symlink's path
+/// Package-relative path components (records use `/`; `.` and empty never occur).
+fn components(p: &[u8]) -> impl Iterator<Item = &[u8]> {
+    strings::split(p, b"/").filter(|c| !c.is_empty() && *c != b".")
+}
+
+/// Lexical check over a package's set of symlinks: does any link's own path, or its
+/// target resolved from the link's directory, pass *through* (not merely point at)
+/// another link of the set? Compared ASCII-case-insensitively (a cheap first pass; the
+/// physical checks in `create_links` are what actually holds). Returns the offender.
+fn link_through_link(links: &[(Vec<u8>, Vec<u8>)]) -> Option<(&[u8], &[u8])> {
     fn norm(c: &[u8]) -> Vec<u8> {
         c.to_ascii_lowercase()
     }
@@ -497,8 +512,6 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
         .map(|(rel, _)| components(rel).map(norm).collect())
         .collect();
     let passes_through_link = |start: &[Vec<u8>], rel_path: &[u8]| {
-        // walk `rel_path` from `start` (package-relative components), checking every
-        // proper prefix reached against the pending link paths
         let mut cur: Vec<Vec<u8>> = start.to_vec();
         let comps: Vec<&[u8]> = components(rel_path).collect();
         for (idx, comp) in comps.iter().enumerate() {
@@ -507,9 +520,7 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
                 continue;
             }
             cur.push(norm(comp));
-            // The final component may *be* a link (the link itself when checking its own
-            // path; another link when a target points at one — that link's own target is
-            // validated in its turn). Only passing *through* a link is refused.
+            // the final component may *be* a link; only passing through one is refused
             if idx + 1 == comps.len() {
                 break;
             }
@@ -519,36 +530,42 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
         }
         false
     };
-    for (rel, target) in links.iter() {
+    for (rel, target) in links {
         let link_dir: Vec<Vec<u8>> = {
             let mut c: Vec<Vec<u8>> = components(rel).map(norm).collect();
             c.pop();
             c
         };
         if passes_through_link(&[], rel) || passes_through_link(&link_dir, target) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "pack entry {} -> {} passes through another symlink; delete the pack file and re-create it with `bun pm cache pack`",
-                    bstr::BStr::new(rel),
-                    bstr::BStr::new(target)
-                ),
-            ));
+            return Some((rel.as_slice(), target.as_slice()));
         }
     }
-    // Create the links one at a time. Parents are created one level at a time and every
-    // existing component is lstat'ed, so nothing is ever created *through* a link made
-    // earlier (whatever the filesystem's own name matching — case-insensitive, Unicode
-    // normalising — considers "the same" component).
+    None
+}
+
+/// Create a package's symlinks after all of its files and directories exist, so that
+/// nothing can be smuggled out of the package through a link, whatever order the
+/// records arrived in and whatever the filesystem considers "the same" name:
+/// 1. lexically, no link may pass through another (`link_through_link`);
+/// 2. links are created one at a time; each parent chain is lstat'ed and created one
+///    directory at a time, never through an existing link;
+/// 3. once all exist, every target is walked on disk from the link's directory and an
+///    intermediate component that is a symlink refuses the package.
+/// The caller discards the staging directory on error; nothing outside it was touched
+/// (creating a symlink does not follow its target).
+fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io::Result<()> {
     let traverses = |rel: &[u8]| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
-                "pack entry {} passes through another symlink; delete the pack file and re-create it with `bun pm cache pack`",
+                "pack entry {} passes through another symlink; the pack is unusable",
                 bstr::BStr::new(rel)
             ),
         )
     };
+    if let Some((rel, _)) = link_through_link(links) {
+        return Err(traverses(rel));
+    }
     let created: Vec<(Vec<u8>, Vec<u8>)> = std::mem::take(links);
     for (rel, target) in &created {
         let comps: Vec<&[u8]> = components(rel).collect();
@@ -575,16 +592,14 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
         };
         bun_sys::symlinkat(&z(&target_native), bun_sys::Fd::cwd(), &z(&p)).map_err(sys_err)?;
     }
-    // Now that every link exists, resolve each target physically, one component at a
-    // time from the link's directory: an intermediate component that is a symlink on
-    // disk means the target routes through another link — refuse the package (staging is
-    // discarded by the caller, nothing was written outside it: symlink creation does not
-    // follow targets and parents were never created through links).
     for (rel, target) in &created {
-        let mut p = parent(&join(staging, rel)).unwrap_or(staging).to_vec();
-        let comps: Vec<&[u8]> = strings::split(target, b"/")
-            .filter(|c| !c.is_empty() && *c != b".")
-            .collect();
+        // the link's directory, built from the same components as the creation loop
+        let rel_comps: Vec<&[u8]> = components(rel).collect();
+        let mut p = staging.to_vec();
+        for comp in &rel_comps[..rel_comps.len().saturating_sub(1)] {
+            p = join(&p, comp);
+        }
+        let comps: Vec<&[u8]> = components(target).collect();
         for (i, comp) in comps.iter().enumerate() {
             if *comp == b".." {
                 p = parent(&p).unwrap_or(staging).to_vec();
@@ -769,7 +784,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 if pending_links.iter().any(|(link, _)| {
                     path.len() > link.len()
                         && path.starts_with(link.as_slice())
-                        && matches!(path[link.len()], b'/' | b'\\')
+                        && path[link.len()] == b'/'
                 }) {
                     return Err(bad("pack entry traverses a symlink", record_no));
                 }

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -581,16 +581,7 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
                 None => bun_sys::mkdirat(bun_sys::Fd::cwd(), &z(&p), 0o755).map_err(sys_err)?,
             }
         }
-        // native separators for the link contents on Windows
-        let target_native: Vec<u8> = if cfg!(windows) {
-            target
-                .iter()
-                .map(|&b| if b == b'/' { b'\\' } else { b })
-                .collect()
-        } else {
-            target.clone()
-        };
-        bun_sys::symlinkat(&z(&target_native), bun_sys::Fd::cwd(), &z(&p)).map_err(sys_err)?;
+        bun_sys::symlinkat(&z(target), bun_sys::Fd::cwd(), &z(&p)).map_err(sys_err)?;
     }
     for (rel, target) in &created {
         // the link's directory, built from the same components as the creation loop
@@ -619,7 +610,7 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
 
 /// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
 fn safe_folder_name(name: &[u8]) -> bool {
-    if !safe_rel(name) || strings::contains_char(name, b'\\') || name == b"." || name == b".." {
+    if !safe_rel(name) {
         return false;
     }
     let slashes = strings::count_char(name, b'/');
@@ -802,7 +793,12 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         if !symlink_target_stays_inside(&path, &target) {
                             return Err(bad("unsafe symlink target in pack", record_no));
                         }
-                        pending_links.push((path.clone(), target));
+                        // bun's tarball extraction does not create package symlinks on
+                        // Windows (cache entries never contain them there), so neither
+                        // does unpack; the record is validated and skipped
+                        if !cfg!(windows) {
+                            pending_links.push((path.clone(), target));
+                        }
                     }
                     _ => {
                         if let Some(parent) = parent(&dest) {

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -276,6 +276,17 @@ fn pack_dir(
             child_rel.push(b'/');
         }
         child_rel.extend_from_slice(&name);
+        // never emit a record this platform's unpack would refuse
+        if !safe_rel(&child_rel) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "cache entry {} contains a path that cannot be packed: {}",
+                    bstr::BStr::new(root),
+                    bstr::BStr::new(&child_rel)
+                ),
+            ));
+        }
         let abs = join(root, &child_rel);
         match kind {
             bun_sys::FileKind::Directory => pack_dir(w, root, &child_rel, files, bytes, links)?,
@@ -455,7 +466,9 @@ fn safe_rel(path: &[u8]) -> bool {
         // byte elsewhere, so lexical checks and the filesystem could disagree
         && !strings::contains_char(path, b'\\')
         && !strings::contains_char(path, 0)
-        && !strings::contains_char(path, b':')
+        // `:` is a drive/stream separator on Windows; elsewhere it is an ordinary byte that
+        // real package files (and IPv6-literal registry folder names) may contain
+        && !(cfg!(windows) && strings::contains_char(path, b':'))
         // no `..`, and no `.` / empty components: the walks in `create_links` treat every
         // component as a real name (pack_dir never emits others)
         && !strings::split(path, b"/").any(|seg| seg == b".." || seg == b"." || seg.is_empty())
@@ -470,7 +483,7 @@ fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
         || target[0] == b'/'
         || strings::contains_char(target, b'\\')
         || strings::contains_char(target, 0)
-        || strings::contains_char(target, b':')
+        || (cfg!(windows) && strings::contains_char(target, b':'))
     {
         return false;
     }
@@ -656,7 +669,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
-                "{msg} (record #{record_no}); delete the pack file and re-create it with `bun pm cache pack`"
+                "{msg} (record #{record_no}); the pack is corrupt or was produced on an incompatible platform"
             ),
         )
     };

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -291,7 +291,21 @@ pub fn pack(
     let folders = cache_folder_names(pm);
     let mut tmp = out_path.to_vec();
     let _ = write!(tmp, ".{}.tmp", std::process::id());
-    let file = bun_sys::File::create(bun_sys::Fd::cwd(), &tmp, true).map_err(sys_err)?;
+    let result = pack_impl(&folders, cache_dir, out_path, &tmp);
+    if result.is_err() {
+        // never leave a partial temp file behind (ENOSPC, unreadable cache entry, …)
+        let _ = bun_sys::unlinkat(bun_sys::Fd::cwd(), &z(&tmp));
+    }
+    result
+}
+
+fn pack_impl(
+    folders: &[(Vec<u8>, bool)],
+    cache_dir: &[u8],
+    out_path: &[u8],
+    tmp: &[u8],
+) -> std::io::Result<PackSummary> {
+    let file = bun_sys::File::create(bun_sys::Fd::cwd(), tmp, true).map_err(sys_err)?;
     let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
     w.write_all(MAGIC)?;
     let mut summary = PackSummary {
@@ -300,7 +314,7 @@ pub fn pack(
         bytes: 0,
         skipped_missing: 0,
     };
-    for (f, expected_here) in &folders {
+    for (f, expected_here) in folders {
         let dir = join(cache_dir, f);
         if folder_root_kind(&dir)?.is_none() {
             // optional binaries for other platforms are legitimately absent
@@ -316,10 +330,7 @@ pub fn pack(
     write_record(&mut w, 0, b"", 0, &[])?;
     w.flush()?;
     drop(w);
-    if let Err(e) = rename(&tmp, out_path) {
-        let _ = bun_sys::unlinkat(bun_sys::Fd::cwd(), &z(&tmp));
-        return Err(e);
-    }
+    rename(tmp, out_path)?;
     Ok(summary)
 }
 
@@ -341,6 +352,42 @@ fn safe_rel(path: &[u8]) -> bool {
         && !strings::contains_char(path, 0)
         && !strings::contains_char(path, b':')
         && !strings::split_any(path, b"/\\").any(|seg| seg == b"..")
+}
+
+/// May a symlink at package-relative `link_path` point at `target`? Relative targets
+/// are resolved against the link's own directory and must stay inside the package
+/// (`bin/cli -> ../lib/cli.js` is fine, `x -> ../../etc` is not); absolute targets,
+/// drive letters and NULs are refused. Mirrors the extractor's own rule for tarballs.
+fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
+    if target.is_empty()
+        || target[0] == b'/'
+        || target[0] == b'\\'
+        || strings::contains_char(target, 0)
+        || strings::contains_char(target, b':')
+    {
+        return false;
+    }
+    // depth of the directory containing the link, relative to the package root
+    let mut depth: i64 = strings::split_any(link_path, b"/\\")
+        .filter(|c| !c.is_empty() && *c != b".")
+        .count() as i64
+        - 1;
+    if depth < 0 {
+        return false;
+    }
+    for comp in strings::split_any(target, b"/\\") {
+        match comp {
+            b"" | b"." => {}
+            b".." => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            _ => depth += 1,
+        }
+    }
+    true
 }
 
 /// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
@@ -509,9 +556,8 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                             return Err(bad("symlink target too long", record_no));
                         }
                         let target = read_exact_vec(&mut r, size as usize)?;
-                        // links inside a package may only point within it (no `..`, not absolute)
-                        let t: &[u8] = target.strip_prefix(b"./").unwrap_or(&target);
-                        if !safe_rel(t) {
+                        // links inside a package may only point within it
+                        if !symlink_target_stays_inside(&path, &target) {
                             return Err(bad("unsafe symlink target in pack", record_no));
                         }
                         if let Some(parent) = parent(&dest) {

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -20,9 +20,9 @@
 //!     kind 0 = end of pack
 
 use std::io::{BufReader, BufWriter, Read, Write};
-use std::path::{Path, PathBuf};
 
 use bun_core::strings;
+use bun_paths::SEP;
 
 use crate::PackageManager;
 use crate::lockfile_real::package::PackageColumns as _;
@@ -45,64 +45,62 @@ pub struct UnpackSummary {
     pub bytes: u64,
 }
 
-/// `Path` view of path bytes. On POSIX any bytes are a valid `OsStr`; elsewhere the
-/// bytes must be UTF-8 and anything else is rejected as invalid data (archive-controlled
-/// names go through here too, so this is never unchecked).
-fn to_path(p: &[u8]) -> std::io::Result<PathBuf> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::ffi::OsStrExt;
-        Ok(PathBuf::from(std::ffi::OsStr::from_bytes(p)))
+// Paths in this module are plain byte strings (`Vec<u8>` / `&[u8]`), joined with the
+// platform separator and NUL-terminated only at the syscall boundary — no `std::path`
+// and no UTF-8 requirement on archive-controlled names.
+
+fn join(a: &[u8], b: &[u8]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(a.len() + 1 + b.len());
+    v.extend_from_slice(a);
+    if !a.is_empty() && !b.is_empty() && a[a.len() - 1] != SEP && a[a.len() - 1] != b'/' {
+        v.push(SEP);
     }
-    #[cfg(not(unix))]
-    {
-        std::str::from_utf8(p)
-            .map(PathBuf::from)
-            .map_err(|_| bad("path is not valid UTF-8"))
-    }
+    v.extend_from_slice(b);
+    v
 }
 
-fn zpath(p: &Path) -> bun_core::ZBox {
-    bun_core::ZBox::from_vec_with_nul({
-        let mut v = p.as_os_str().as_encoded_bytes().to_vec();
-        v.push(0);
-        v
-    })
+fn z(p: &[u8]) -> bun_core::ZBox {
+    let mut v = Vec::with_capacity(p.len() + 1);
+    v.extend_from_slice(p);
+    v.push(0);
+    bun_core::ZBox::from_vec_with_nul(v)
 }
 
-fn is_dir(p: &Path) -> bool {
-    matches!(bun_sys::stat(&zpath(p)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+fn parent(p: &[u8]) -> Option<&[u8]> {
+    bun_paths::dirname(p).filter(|d| !d.is_empty())
 }
 
-/// What sits at a cache-folder root: a real directory is packed, nothing is skipped,
-/// anything else (a symlink, a file, an unreadable entry) is an error rather than a
-/// silently incomplete pack.
-fn folder_root_kind(p: &Path) -> std::io::Result<Option<()>> {
-    match bun_sys::lstat(&zpath(p)) {
-        Ok(st) => match bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) {
-            bun_sys::FileKind::Directory => Ok(Some(())),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("cache entry {} is not a directory", p.display()),
-            )),
-        },
+/// Kind of `p` itself (not following symlinks); None if it does not exist.
+fn lstat_kind(p: &[u8]) -> std::io::Result<Option<bun_sys::FileKind>> {
+    match bun_sys::lstat(&z(p)) {
+        Ok(st) => Ok(Some(bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode))),
         Err(e) if e.get_errno() == bun_sys::E::ENOENT => Ok(None),
         Err(e) => Err(sys_err(e)),
     }
 }
 
-fn path_exists(p: &Path) -> bool {
-    bun_sys::lstat(&zpath(p)).is_ok()
+fn is_dir(p: &[u8]) -> bool {
+    matches!(bun_sys::stat(&z(p)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
 }
 
-fn pbytes(p: &Path) -> &[u8] {
-    p.as_os_str().as_encoded_bytes()
+/// What sits at a cache-folder root: a real directory is packed, nothing is skipped,
+/// anything else (a symlink, a file, an unreadable entry) is an error rather than a
+/// silently incomplete pack.
+fn folder_root_kind(p: &[u8]) -> std::io::Result<Option<()>> {
+    match lstat_kind(p)? {
+        Some(bun_sys::FileKind::Directory) => Ok(Some(())),
+        None => Ok(None),
+        Some(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("cache entry {} is not a directory", bstr::BStr::new(p)),
+        )),
+    }
 }
 
 /// (name, kind) for every entry of `dir`, sorted by name. `Unknown` d_type is resolved
 /// with an lstat so callers can rely on the kind.
-fn list_dir(dir: &Path) -> std::io::Result<Vec<(Vec<u8>, bun_sys::FileKind)>> {
-    let fd = bun_sys::open_dir_for_iteration(bun_sys::Fd::cwd(), pbytes(dir)).map_err(sys_err)?;
+fn list_dir(dir: &[u8]) -> std::io::Result<Vec<(Vec<u8>, bun_sys::FileKind)>> {
+    let fd = bun_sys::open_dir_for_iteration(bun_sys::Fd::cwd(), dir).map_err(sys_err)?;
     let mut out = Vec::new();
     let mut iter = bun_sys::iterate_dir(fd);
     loop {
@@ -110,8 +108,9 @@ fn list_dir(dir: &Path) -> std::io::Result<Vec<(Vec<u8>, bun_sys::FileKind)>> {
             Ok(Some(entry)) => {
                 let name = entry.name.slice_u8().to_vec();
                 let kind = match entry.kind {
-                    bun_sys::FileKind::Unknown => lstat_kind(&dir.join(to_path(&name)?))?
-                        .unwrap_or(bun_sys::FileKind::Unknown),
+                    bun_sys::FileKind::Unknown => {
+                        lstat_kind(&join(dir, &name))?.unwrap_or(bun_sys::FileKind::Unknown)
+                    }
                     k => k,
                 };
                 out.push((name, kind));
@@ -129,31 +128,16 @@ fn list_dir(dir: &Path) -> std::io::Result<Vec<(Vec<u8>, bun_sys::FileKind)>> {
     Ok(out)
 }
 
-/// Kind of `p` itself (not following symlinks); None if it does not exist.
-fn lstat_kind(p: &Path) -> std::io::Result<Option<bun_sys::FileKind>> {
-    match bun_sys::lstat(&zpath(p)) {
-        Ok(st) => Ok(Some(bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode))),
-        Err(e) if e.get_errno() == bun_sys::E::ENOENT => Ok(None),
-        Err(e) => Err(sys_err(e)),
-    }
+fn rename(from: &[u8], to: &[u8]) -> std::io::Result<()> {
+    bun_sys::renameat(bun_sys::Fd::cwd(), &z(from), bun_sys::Fd::cwd(), &z(to)).map_err(sys_err)
 }
 
-fn rename(from: &Path, to: &Path) -> std::io::Result<()> {
-    bun_sys::renameat(
-        bun_sys::Fd::cwd(),
-        &zpath(from),
-        bun_sys::Fd::cwd(),
-        &zpath(to),
-    )
-    .map_err(sys_err)
+fn mkdir_p(p: &[u8]) -> std::io::Result<()> {
+    bun_sys::mkdir_recursive(p).map_err(sys_err)
 }
 
-fn mkdir_p(p: &Path) -> std::io::Result<()> {
-    bun_sys::mkdir_recursive(p.as_os_str().as_encoded_bytes()).map_err(sys_err)
-}
-
-fn rm_rf(p: &Path) {
-    let _ = bun_sys::delete_tree_absolute(p.as_os_str().as_encoded_bytes());
+fn rm_rf(p: &[u8]) {
+    let _ = bun_sys::delete_tree_absolute(p);
 }
 
 #[allow(clippy::needless_pass_by_value)] // used as `.map_err(sys_err)`
@@ -254,31 +238,34 @@ fn write_record(
 
 fn pack_dir(
     w: &mut impl Write,
-    root: &Path,
-    rel: &Path,
+    root: &[u8],
+    rel: &[u8],
     files: &mut u64,
     bytes: &mut u64,
 ) -> std::io::Result<()> {
-    let here = root.join(rel);
+    let here = join(root, rel);
     let entries = list_dir(&here)?;
-    if entries.is_empty() && !rel.as_os_str().is_empty() {
-        write_record(w, 4, pbytes(rel), 0o755, &[])?;
+    if entries.is_empty() && !rel.is_empty() {
+        write_record(w, 4, rel, 0o755, &[])?;
     }
     for (name, kind) in entries {
-        let child_rel = rel.join(to_path(&name)?);
-        let relb = pbytes(&child_rel);
-        let abs = root.join(&child_rel);
+        // records always use `/` so a pack is portable
+        let mut child_rel = rel.to_vec();
+        if !child_rel.is_empty() {
+            child_rel.push(b'/');
+        }
+        child_rel.extend_from_slice(&name);
+        let abs = join(root, &child_rel);
         match kind {
             bun_sys::FileKind::Directory => pack_dir(w, root, &child_rel, files, bytes)?,
             bun_sys::FileKind::SymLink => {
                 let mut buf = [0u8; 4096];
-                let n = bun_sys::readlink(&zpath(&abs), &mut buf).map_err(sys_err)?;
-                write_record(w, 3, relb, 0o777, &buf[..n])?;
+                let n = bun_sys::readlink(&z(&abs), &mut buf).map_err(sys_err)?;
+                write_record(w, 3, &child_rel, 0o777, &buf[..n])?;
             }
             bun_sys::FileKind::File => {
-                let f =
-                    bun_sys::File::openat(bun_sys::Fd::cwd(), pbytes(&abs), bun_sys::O::RDONLY, 0)
-                        .map_err(sys_err)?;
+                let f = bun_sys::File::openat(bun_sys::Fd::cwd(), &abs, bun_sys::O::RDONLY, 0)
+                    .map_err(sys_err)?;
                 #[cfg(unix)]
                 let mode = bun_sys::fstat(f.handle()).map_err(sys_err)?.st_mode as u32;
                 #[cfg(not(unix))]
@@ -286,7 +273,7 @@ fn pack_dir(
                 let data = f.read_to_end().map_err(sys_err)?;
                 *files += 1;
                 *bytes += data.len() as u64;
-                write_record(w, 2, relb, mode, &data)?;
+                write_record(w, 2, &child_rel, mode, &data)?;
             }
             // sockets, fifos, devices: not part of a package
             _ => {}
@@ -302,11 +289,8 @@ pub fn pack(
     out_path: &[u8],
 ) -> std::io::Result<PackSummary> {
     let folders = cache_folder_names(pm);
-    let cache = to_path(cache_dir)?;
-    let out = to_path(out_path)?;
     let mut tmp = out_path.to_vec();
     let _ = write!(tmp, ".{}.tmp", std::process::id());
-    let tmp_path = to_path(&tmp)?;
     let file = bun_sys::File::create(bun_sys::Fd::cwd(), &tmp, true).map_err(sys_err)?;
     let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
     w.write_all(MAGIC)?;
@@ -317,7 +301,7 @@ pub fn pack(
         skipped_missing: 0,
     };
     for (f, expected_here) in &folders {
-        let dir = cache.join(to_path(f)?);
+        let dir = join(cache_dir, f);
         if folder_root_kind(&dir)?.is_none() {
             // optional binaries for other platforms are legitimately absent
             if *expected_here {
@@ -326,20 +310,14 @@ pub fn pack(
             continue;
         }
         write_record(&mut w, 1, f, 0, &[])?;
-        pack_dir(
-            &mut w,
-            &dir,
-            Path::new(""),
-            &mut summary.files,
-            &mut summary.bytes,
-        )?;
+        pack_dir(&mut w, &dir, b"", &mut summary.files, &mut summary.bytes)?;
         summary.packages += 1;
     }
     write_record(&mut w, 0, b"", 0, &[])?;
     w.flush()?;
     drop(w);
-    if let Err(e) = rename(&tmp_path, &out) {
-        let _ = bun_sys::unlinkat(bun_sys::Fd::cwd(), &zpath(&tmp_path));
+    if let Err(e) = rename(&tmp, out_path) {
+        let _ = bun_sys::unlinkat(bun_sys::Fd::cwd(), &z(&tmp));
         return Err(e);
     }
     Ok(summary)
@@ -380,15 +358,11 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
     let result = unpack_impl(cache_dir, pack_path);
     if result.is_err() {
         // don't leave a half-written staging dir behind
-        if let Ok(cache) = to_path(cache_dir)
-            && let Ok(entries) = list_dir(&cache)
-        {
+        if let Ok(entries) = list_dir(cache_dir) {
             let mine = format!(".unpack-{}-", std::process::id());
             for (name, _) in entries {
-                if name.starts_with(mine.as_bytes())
-                    && let Ok(n) = to_path(&name)
-                {
-                    rm_rf(&cache.join(n));
+                if name.starts_with(mine.as_bytes()) {
+                    rm_rf(&join(cache_dir, &name));
                 }
             }
         }
@@ -397,8 +371,7 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
 }
 
 fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
-    let cache = to_path(cache_dir)?;
-    mkdir_p(&cache)?;
+    mkdir_p(cache_dir)?;
     let file = bun_sys::File::openat(bun_sys::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)
         .map_err(sys_err)?;
     let mut r = BufReader::with_capacity(1 << 20, FileReader(file));
@@ -425,11 +398,11 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     // Staging directories are named `.unpack-<pid>-<n>`; only this process's own are
     // ever removed (on failure, by `unpack`), so a concurrent unpack is never disturbed.
     // current folder: (final path, staging path) — None while skipping an existing one
-    let mut current: Option<(PathBuf, PathBuf)> = None;
+    let mut current: Option<(Vec<u8>, Vec<u8>)> = None;
     let mut skipping = false;
     let pid = std::process::id();
 
-    let finish = |cur: &mut Option<(PathBuf, PathBuf)>,
+    let finish = |cur: &mut Option<(Vec<u8>, Vec<u8>)>,
                   summary: &mut UnpackSummary|
      -> std::io::Result<()> {
         if let Some((final_path, staging)) = cur.take() {
@@ -474,18 +447,21 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     return Err(bad("unsafe cache folder name in pack", record_no));
                 }
                 summary.packages += 1;
-                let final_path = cache.join(to_path(&path)?);
-                if path_exists(&final_path) {
+                let final_path = join(cache_dir, &path);
+                if lstat_kind(&final_path)?.is_some() {
                     skipping = true;
                     summary.already_present += 1;
                     current = None;
                 } else {
                     skipping = false;
-                    if let Some(parent) = final_path.parent() {
+                    if let Some(parent) = parent(&final_path) {
                         // `@scope/` directory for scoped packages
                         mkdir_p(parent)?;
                     }
-                    let staging = cache.join(format!(".unpack-{}-{}", pid, summary.packages));
+                    let staging = join(
+                        cache_dir,
+                        format!(".unpack-{}-{}", pid, summary.packages).as_bytes(),
+                    );
                     rm_rf(&staging);
                     mkdir_p(&staging)?;
                     current = Some((final_path, staging));
@@ -507,14 +483,15 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     return Err(bad("unsafe entry path in pack", record_no));
                 }
                 let (_, staging) = current.as_ref().unwrap();
-                let rel = to_path(&path)?;
-                let dest = staging.join(&rel);
+                let dest = join(staging, &path);
                 // refuse to traverse a symlink materialized earlier in this package
                 {
                     let mut p = staging.clone();
-                    let comps: Vec<_> = rel.components().collect();
+                    let comps: Vec<&[u8]> = strings::split_any(&path, b"/\\")
+                        .filter(|c| !c.is_empty())
+                        .collect();
                     for (i, c) in comps.iter().enumerate() {
-                        p.push(c);
+                        p = join(&p, c);
                         if lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink)
                             && (i + 1 < comps.len() || kind[0] != 3)
                         {
@@ -537,16 +514,12 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         if !safe_rel(t) {
                             return Err(bad("unsafe symlink target in pack", record_no));
                         }
-                        if let Some(parent) = dest.parent() {
+                        if let Some(parent) = parent(&dest) {
                             mkdir_p(parent)?;
                         }
                         #[cfg(unix)]
-                        bun_sys::symlinkat(
-                            &zpath(&to_path(&target)?),
-                            bun_sys::Fd::cwd(),
-                            &zpath(&dest),
-                        )
-                        .map_err(sys_err)?;
+                        bun_sys::symlinkat(&z(&target), bun_sys::Fd::cwd(), &z(&dest))
+                            .map_err(sys_err)?;
                         #[cfg(not(unix))]
                         {
                             let _ = (target, dest);
@@ -557,15 +530,11 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         }
                     }
                     _ => {
-                        if let Some(parent) = dest.parent() {
+                        if let Some(parent) = parent(&dest) {
                             mkdir_p(parent)?;
                         }
-                        let f = bun_sys::File::create(
-                            bun_sys::Fd::cwd(),
-                            dest.as_os_str().as_encoded_bytes(),
-                            true,
-                        )
-                        .map_err(sys_err)?;
+                        let f = bun_sys::File::create(bun_sys::Fd::cwd(), &dest, true)
+                            .map_err(sys_err)?;
                         #[cfg(unix)]
                         {
                             // keep the executable bit, never setuid/setgid/sticky or world-write

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -1,0 +1,431 @@
+//! `bun pm cache pack <file>` / `bun pm cache unpack <file>` — a single-file,
+//! uncompressed snapshot of exactly the cache entries the current lockfile
+//! needs.
+//!
+//! CI caches backed by object storage are dramatically faster at moving
+//! one large sequential file than tens of thousands of small ones, and the
+//! restore side of a directory cache pays a create+write per file *before*
+//! `bun install` even starts. With a pack, CI restores one file, `unpack`
+//! recreates only the missing cache folders (sequential reads, one rename per
+//! package), and `bun install --frozen-lockfile` then finds every tarball
+//! already extracted in the cache.
+//!
+//! Format (little endian, no compression — outer layers already zstd):
+//!   magic "BUNCACHEPACK\0v1\n"
+//!   repeated:  u8 kind | u32 path_len | path | u32 mode | u64 size | bytes
+//!     kind 1 = package folder start (path = cache folder name; size = 0)
+//!     kind 2 = regular file (path relative to the current folder)
+//!     kind 3 = symlink (bytes = link target)
+//!     kind 4 = directory (explicit, for empty dirs)
+//!     kind 0 = end of pack
+
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::PackageManager;
+use crate::lockfile_real::package::PackageColumns as _;
+use crate::package_manager_real::directories;
+use crate::resolution_real::Tag as ResolutionTag;
+
+const MAGIC: &[u8] = b"BUNCACHEPACK\0v1\n";
+
+pub struct PackSummary {
+    pub packages: u32,
+    pub files: u64,
+    pub bytes: u64,
+    pub skipped_missing: u32,
+}
+
+pub struct UnpackSummary {
+    pub packages: u32,
+    pub created: u32,
+    pub already_present: u32,
+    pub bytes: u64,
+}
+
+fn s(p: &[u8]) -> &str {
+    // cache folder names and package-relative paths are ASCII/UTF-8 by construction
+    unsafe { std::str::from_utf8_unchecked(p) }
+}
+
+/// The cache folder name for every fetchable package in the lockfile, and whether
+/// the package is expected on this platform (os/cpu/libc) — used only to decide
+/// whether a missing folder deserves a warning.
+pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
+    let mut out: Vec<(Vec<u8>, bool)> = Vec::new();
+    let count = pm.lockfile.packages.len();
+    for i in 0..count {
+        let (name, resolution, expected) = {
+            let pkgs = &pm.lockfile.packages;
+            let meta = &pkgs.items_meta()[i];
+            (
+                pkgs.items_name()[i],
+                pkgs.items_resolution()[i],
+                !meta.is_disabled(pm.options.cpu, pm.options.os),
+            )
+        };
+        let folder: Option<Vec<u8>> = match resolution.tag {
+            ResolutionTag::Npm => {
+                let name = pm.lockfile.str(&name).to_vec();
+                Some(
+                    directories::cached_npm_package_folder_name(
+                        pm,
+                        &name,
+                        resolution.npm().version,
+                        None,
+                    )
+                    .as_bytes()
+                    .to_vec(),
+                )
+            }
+            ResolutionTag::Git => Some(
+                directories::cached_git_folder_name(pm, resolution.git(), None)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            ResolutionTag::Github => Some(
+                directories::cached_github_folder_name(pm, resolution.github(), None)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            ResolutionTag::RemoteTarball => Some(
+                directories::cached_tarball_folder_name(pm, *resolution.remote_tarball(), None)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            _ => None,
+        };
+        if let Some(f) = folder {
+            if !f.is_empty() && !out.iter().any(|(e, _)| *e == f) {
+                out.push((f, expected));
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+fn write_record(
+    w: &mut impl Write,
+    kind: u8,
+    path: &[u8],
+    mode: u32,
+    data: &[u8],
+) -> std::io::Result<()> {
+    w.write_all(&[kind])?;
+    w.write_all(&(path.len() as u32).to_le_bytes())?;
+    w.write_all(path)?;
+    w.write_all(&mode.to_le_bytes())?;
+    w.write_all(&(data.len() as u64).to_le_bytes())?;
+    w.write_all(data)
+}
+
+fn pack_dir(
+    w: &mut impl Write,
+    root: &Path,
+    rel: &Path,
+    files: &mut u64,
+    bytes: &mut u64,
+) -> std::io::Result<()> {
+    let mut entries: Vec<std::fs::DirEntry> =
+        std::fs::read_dir(root.join(rel))?.flatten().collect();
+    entries.sort_by_key(|e| e.file_name());
+    if entries.is_empty() && !rel.as_os_str().is_empty() {
+        write_record(w, 4, rel.as_os_str().as_encoded_bytes(), 0o755, &[])?;
+    }
+    for e in entries {
+        let ft = e.file_type()?;
+        let child_rel = rel.join(e.file_name());
+        let relb = child_rel.as_os_str().as_encoded_bytes();
+        if ft.is_dir() {
+            pack_dir(w, root, &child_rel, files, bytes)?;
+        } else if ft.is_symlink() {
+            let target = std::fs::read_link(root.join(&child_rel))?;
+            write_record(w, 3, relb, 0o777, target.as_os_str().as_encoded_bytes())?;
+        } else if ft.is_file() {
+            let data = std::fs::read(root.join(&child_rel))?;
+            #[cfg(unix)]
+            let mode = {
+                use std::os::unix::fs::PermissionsExt;
+                e.metadata()?.permissions().mode()
+            };
+            #[cfg(not(unix))]
+            let mode = 0o644u32;
+            *files += 1;
+            *bytes += data.len() as u64;
+            write_record(w, 2, relb, mode, &data)?;
+        }
+    }
+    Ok(())
+}
+
+/// Write a pack of every cache folder the lockfile references that exists locally.
+pub fn pack(
+    pm: &mut PackageManager,
+    cache_dir: &[u8],
+    out_path: &[u8],
+) -> std::io::Result<PackSummary> {
+    let folders = cache_folder_names(pm);
+    let cache = PathBuf::from(s(cache_dir));
+    let tmp = format!("{}.tmp", s(out_path));
+    let file = std::fs::File::create(&tmp)?;
+    let mut w = BufWriter::with_capacity(1 << 20, file);
+    w.write_all(MAGIC)?;
+    let mut summary = PackSummary {
+        packages: 0,
+        files: 0,
+        bytes: 0,
+        skipped_missing: 0,
+    };
+    for (f, expected_here) in &folders {
+        let dir = cache.join(s(f));
+        if !dir.is_dir() {
+            // optional binaries for other platforms are legitimately absent
+            if *expected_here {
+                summary.skipped_missing += 1;
+            }
+            continue;
+        }
+        write_record(&mut w, 1, f, 0, &[])?;
+        pack_dir(
+            &mut w,
+            &dir,
+            Path::new(""),
+            &mut summary.files,
+            &mut summary.bytes,
+        )?;
+        summary.packages += 1;
+    }
+    write_record(&mut w, 0, b"", 0, &[])?;
+    w.flush()?;
+    drop(w);
+    std::fs::rename(&tmp, s(out_path))?;
+    Ok(summary)
+}
+
+fn read_exact_vec(r: &mut impl Read, n: usize) -> std::io::Result<Vec<u8>> {
+    let mut v = vec![0u8; n];
+    r.read_exact(&mut v)?;
+    Ok(v)
+}
+
+fn bad(msg: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg.to_string())
+}
+
+/// Reject anything that could write outside the folder being restored.
+fn safe_rel(path: &[u8]) -> bool {
+    !path.is_empty()
+        && path[0] != b'/'
+        && path[0] != b'\\'
+        && !path.contains(&0)
+        && !path.contains(&b':')
+        && !path
+            .split(|c| *c == b'/' || *c == b'\\')
+            .any(|seg| seg == b"..")
+}
+
+/// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
+fn safe_folder_name(name: &[u8]) -> bool {
+    if !safe_rel(name) || name.contains(&b'\\') || name == b"." || name == b".." {
+        return false;
+    }
+    let slashes = name.iter().filter(|c| **c == b'/').count();
+    slashes == 0 || (slashes == 1 && name[0] == b'@' && !name.ends_with(b"/"))
+}
+
+/// Restore missing cache folders from a pack. Existing folders are left untouched
+/// (their bytes are skipped without being written).
+pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
+    let result = unpack_impl(cache_dir, pack_path);
+    if result.is_err() {
+        // don't leave a half-written staging dir behind
+        let cache = PathBuf::from(s(cache_dir));
+        if let Ok(rd) = std::fs::read_dir(&cache) {
+            let mine = format!(".unpack-{}-", std::process::id());
+            for e in rd.flatten() {
+                if e.file_name()
+                    .as_encoded_bytes()
+                    .starts_with(mine.as_bytes())
+                {
+                    let _ = std::fs::remove_dir_all(e.path());
+                }
+            }
+        }
+    }
+    result
+}
+
+fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
+    let cache = PathBuf::from(s(cache_dir));
+    std::fs::create_dir_all(&cache)?;
+    let file = std::fs::File::open(s(pack_path))?;
+    let mut r = BufReader::with_capacity(1 << 20, file);
+    let magic = read_exact_vec(&mut r, MAGIC.len())?;
+    if magic != MAGIC {
+        return Err(bad("not a bun cache pack (bad magic)"));
+    }
+    let mut summary = UnpackSummary {
+        packages: 0,
+        created: 0,
+        already_present: 0,
+        bytes: 0,
+    };
+    // sweep staging dirs left by an earlier failed/killed unpack
+    if let Ok(rd) = std::fs::read_dir(&cache) {
+        for e in rd.flatten() {
+            if e.file_name().as_encoded_bytes().starts_with(b".unpack-") {
+                let _ = std::fs::remove_dir_all(e.path());
+            }
+        }
+    }
+    // current folder: (final path, staging path) — None while skipping an existing one
+    let mut current: Option<(PathBuf, PathBuf)> = None;
+    let mut skipping = false;
+    let pid = std::process::id();
+
+    let finish = |cur: &mut Option<(PathBuf, PathBuf)>,
+                  summary: &mut UnpackSummary|
+     -> std::io::Result<()> {
+        if let Some((final_path, staging)) = cur.take() {
+            match std::fs::rename(&staging, &final_path) {
+                Ok(()) => summary.created += 1,
+                Err(e) if final_path.is_dir() => {
+                    // lost a race with a concurrent unpack/install: theirs is as good as ours
+                    let _ = e;
+                    let _ = std::fs::remove_dir_all(&staging);
+                    summary.already_present += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    };
+
+    loop {
+        let mut kind = [0u8; 1];
+        r.read_exact(&mut kind)?;
+        let mut u32b = [0u8; 4];
+        r.read_exact(&mut u32b)?;
+        let path_len = u32::from_le_bytes(u32b) as usize;
+        if path_len > 4096 {
+            return Err(bad("path too long"));
+        }
+        let path = read_exact_vec(&mut r, path_len)?;
+        r.read_exact(&mut u32b)?;
+        let mode = u32::from_le_bytes(u32b);
+        let mut u64b = [0u8; 8];
+        r.read_exact(&mut u64b)?;
+        let size = u64::from_le_bytes(u64b);
+        match kind[0] {
+            0 => {
+                finish(&mut current, &mut summary)?;
+                break;
+            }
+            1 => {
+                finish(&mut current, &mut summary)?;
+                if !safe_folder_name(&path) {
+                    return Err(bad("unsafe cache folder name in pack"));
+                }
+                summary.packages += 1;
+                let final_path = cache.join(s(&path));
+                if final_path.exists() {
+                    skipping = true;
+                    summary.already_present += 1;
+                    current = None;
+                } else {
+                    skipping = false;
+                    if let Some(parent) = final_path.parent() {
+                        // `@scope/` directory for scoped packages
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    let staging = cache.join(format!(".unpack-{}-{}", pid, summary.packages));
+                    let _ = std::fs::remove_dir_all(&staging);
+                    std::fs::create_dir_all(&staging)?;
+                    current = Some((final_path, staging));
+                }
+                if size != 0 {
+                    return Err(bad("folder record with payload"));
+                }
+            }
+            2 | 3 | 4 => {
+                if size > (1u64 << 34) {
+                    return Err(bad("entry too large"));
+                }
+                if skipping || current.is_none() {
+                    // consume payload without writing
+                    std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
+                    continue;
+                }
+                if !safe_rel(&path) {
+                    return Err(bad("unsafe entry path in pack"));
+                }
+                let (_, staging) = current.as_ref().unwrap();
+                let dest = staging.join(s(&path));
+                // refuse to traverse a symlink materialized earlier in this package
+                {
+                    let mut p = staging.clone();
+                    let rel = std::path::Path::new(s(&path));
+                    let comps: Vec<_> = rel.components().collect();
+                    for (i, c) in comps.iter().enumerate() {
+                        p.push(c);
+                        if let Ok(m) = std::fs::symlink_metadata(&p) {
+                            if m.file_type().is_symlink() && (i + 1 < comps.len() || kind[0] != 3) {
+                                return Err(bad("pack entry traverses a symlink"));
+                            }
+                        }
+                    }
+                }
+                match kind[0] {
+                    4 => {
+                        std::fs::create_dir_all(&dest)?;
+                        std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
+                    }
+                    3 => {
+                        if size > 4096 {
+                            return Err(bad("symlink target too long"));
+                        }
+                        let target = read_exact_vec(&mut r, size as usize)?;
+                        // links inside a package may only point within it (no `..`, not absolute)
+                        let t: &[u8] = target.strip_prefix(b"./").unwrap_or(&target);
+                        if !safe_rel(t) {
+                            return Err(bad("unsafe symlink target in pack"));
+                        }
+                        if let Some(parent) = dest.parent() {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        #[cfg(unix)]
+                        std::os::unix::fs::symlink(s(&target), &dest)?;
+                        #[cfg(windows)]
+                        {
+                            // file symlinks need privileges on Windows; write a copy stub instead
+                            let _ = target;
+                        }
+                    }
+                    _ => {
+                        if let Some(parent) = dest.parent() {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        let mut f = std::fs::File::create(&dest)?;
+                        let copied = std::io::copy(&mut (&mut r).take(size), &mut f)?;
+                        if copied != size {
+                            return Err(bad("truncated pack"));
+                        }
+                        summary.bytes += size;
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            // keep the executable bit, never setuid/setgid/sticky or world-write
+                            let m = (mode & 0o755) | 0o600;
+                            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(m))?;
+                        }
+                        #[cfg(not(unix))]
+                        let _ = mode;
+                    }
+                }
+            }
+            _ => return Err(bad("unknown record kind")),
+        }
+    }
+    Ok(summary)
+}

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -44,8 +44,58 @@ pub struct UnpackSummary {
 }
 
 fn s(p: &[u8]) -> &str {
-    // cache folder names and package-relative paths are ASCII/UTF-8 by construction
+    // SAFETY: only used to build `Path`s / error text from cache folder names and
+    // package-relative paths, which are ASCII/UTF-8 by construction; the bytes are never
+    // inspected as `str` beyond that.
     unsafe { std::str::from_utf8_unchecked(p) }
+}
+
+fn zpath(p: &Path) -> bun_core::ZBox {
+    bun_core::ZBox::from_vec_with_nul({
+        let mut v = p.as_os_str().as_encoded_bytes().to_vec();
+        v.push(0);
+        v
+    })
+}
+
+fn is_dir(p: &Path) -> bool {
+    matches!(bun_sys::stat(&zpath(p)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+}
+
+fn path_exists(p: &Path) -> bool {
+    bun_sys::lstat(&zpath(p)).is_ok()
+}
+
+fn mkdir_p(p: &Path) -> std::io::Result<()> {
+    bun_sys::mkdir_recursive(p.as_os_str().as_encoded_bytes()).map_err(sys_err)
+}
+
+fn rm_rf(p: &Path) {
+    let _ = bun_sys::delete_tree_absolute(p.as_os_str().as_encoded_bytes());
+}
+
+#[allow(clippy::needless_pass_by_value)] // used as `.map_err(sys_err)`
+fn sys_err(e: bun_sys::Error) -> std::io::Error {
+    std::io::Error::from_raw_os_error(i32::from(e.errno))
+}
+
+/// `std::io::Read` over a `bun_sys::File`.
+struct FileReader(bun_sys::File);
+impl Read for FileReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf).map_err(sys_err)
+    }
+}
+/// `std::io::Write` over a `bun_sys::File`.
+struct FileWriter(bun_sys::File);
+impl Write for FileWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write_all(buf).map_err(sys_err)?;
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// The cache folder name for every fetchable package in the lockfile, and whether
@@ -143,7 +193,11 @@ fn pack_dir(
             let target = std::fs::read_link(root.join(&child_rel))?;
             write_record(w, 3, relb, 0o777, target.as_os_str().as_encoded_bytes())?;
         } else if ft.is_file() {
-            let data = std::fs::read(root.join(&child_rel))?;
+            let data = bun_sys::File::read_from(
+                bun_sys::Fd::cwd(),
+                root.join(&child_rel).as_os_str().as_encoded_bytes(),
+            )
+            .map_err(sys_err)?;
             #[cfg(unix)]
             let mode = {
                 use std::os::unix::fs::PermissionsExt;
@@ -168,8 +222,8 @@ pub fn pack(
     let folders = cache_folder_names(pm);
     let cache = PathBuf::from(s(cache_dir));
     let tmp = format!("{}.tmp", s(out_path));
-    let file = std::fs::File::create(&tmp)?;
-    let mut w = BufWriter::with_capacity(1 << 20, file);
+    let file = bun_sys::File::create(bun_sys::Fd::cwd(), tmp.as_bytes(), true).map_err(sys_err)?;
+    let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
     w.write_all(MAGIC)?;
     let mut summary = PackSummary {
         packages: 0,
@@ -179,7 +233,7 @@ pub fn pack(
     };
     for (f, expected_here) in &folders {
         let dir = cache.join(s(f));
-        if !dir.is_dir() {
+        if !is_dir(&dir) {
             // optional binaries for other platforms are legitimately absent
             if *expected_here {
                 summary.skipped_missing += 1;
@@ -248,7 +302,7 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
                     .as_encoded_bytes()
                     .starts_with(mine.as_bytes())
                 {
-                    let _ = std::fs::remove_dir_all(e.path());
+                    rm_rf(&e.path());
                 }
             }
         }
@@ -258,9 +312,10 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
 
 fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
     let cache = PathBuf::from(s(cache_dir));
-    std::fs::create_dir_all(&cache)?;
-    let file = std::fs::File::open(s(pack_path))?;
-    let mut r = BufReader::with_capacity(1 << 20, file);
+    mkdir_p(&cache)?;
+    let file = bun_sys::File::openat(bun_sys::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)
+        .map_err(sys_err)?;
+    let mut r = BufReader::with_capacity(1 << 20, FileReader(file));
     let magic = read_exact_vec(&mut r, MAGIC.len())?;
     if magic != MAGIC {
         return Err(bad("not a bun cache pack (bad magic)"));
@@ -275,7 +330,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     if let Ok(rd) = std::fs::read_dir(&cache) {
         for e in rd.flatten() {
             if e.file_name().as_encoded_bytes().starts_with(b".unpack-") {
-                let _ = std::fs::remove_dir_all(e.path());
+                rm_rf(&e.path());
             }
         }
     }
@@ -290,10 +345,10 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
         if let Some((final_path, staging)) = cur.take() {
             match std::fs::rename(&staging, &final_path) {
                 Ok(()) => summary.created += 1,
-                Err(e) if final_path.is_dir() => {
+                Err(e) if is_dir(&final_path) => {
                     // lost a race with a concurrent unpack/install: theirs is as good as ours
                     let _ = e;
-                    let _ = std::fs::remove_dir_all(&staging);
+                    rm_rf(&staging);
                     summary.already_present += 1;
                 }
                 Err(e) => return Err(e),
@@ -329,7 +384,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 summary.packages += 1;
                 let final_path = cache.join(s(&path));
-                if final_path.exists() {
+                if path_exists(&final_path) {
                     skipping = true;
                     summary.already_present += 1;
                     current = None;
@@ -337,18 +392,18 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     skipping = false;
                     if let Some(parent) = final_path.parent() {
                         // `@scope/` directory for scoped packages
-                        std::fs::create_dir_all(parent)?;
+                        mkdir_p(parent)?;
                     }
                     let staging = cache.join(format!(".unpack-{}-{}", pid, summary.packages));
-                    let _ = std::fs::remove_dir_all(&staging);
-                    std::fs::create_dir_all(&staging)?;
+                    rm_rf(&staging);
+                    mkdir_p(&staging)?;
                     current = Some((final_path, staging));
                 }
                 if size != 0 {
                     return Err(bad("folder record with payload"));
                 }
             }
-            2 | 3 | 4 => {
+            2..=4 => {
                 if size > (1u64 << 34) {
                     return Err(bad("entry too large"));
                 }
@@ -378,7 +433,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 match kind[0] {
                     4 => {
-                        std::fs::create_dir_all(&dest)?;
+                        mkdir_p(&dest)?;
                         std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
                     }
                     3 => {
@@ -392,7 +447,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                             return Err(bad("unsafe symlink target in pack"));
                         }
                         if let Some(parent) = dest.parent() {
-                            std::fs::create_dir_all(parent)?;
+                            mkdir_p(parent)?;
                         }
                         #[cfg(unix)]
                         std::os::unix::fs::symlink(s(&target), &dest)?;
@@ -404,23 +459,28 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     }
                     _ => {
                         if let Some(parent) = dest.parent() {
-                            std::fs::create_dir_all(parent)?;
+                            mkdir_p(parent)?;
                         }
-                        let mut f = std::fs::File::create(&dest)?;
-                        let copied = std::io::copy(&mut (&mut r).take(size), &mut f)?;
+                        let f = bun_sys::File::create(
+                            bun_sys::Fd::cwd(),
+                            dest.as_os_str().as_encoded_bytes(),
+                            true,
+                        )
+                        .map_err(sys_err)?;
+                        #[cfg(unix)]
+                        {
+                            // keep the executable bit, never setuid/setgid/sticky or world-write
+                            let m = (mode & 0o755) | 0o600;
+                            bun_sys::fchmod(f.handle(), m as bun_sys::Mode).map_err(sys_err)?;
+                        }
+                        #[cfg(not(unix))]
+                        let _ = mode;
+                        let mut w = FileWriter(f);
+                        let copied = std::io::copy(&mut (&mut r).take(size), &mut w)?;
                         if copied != size {
                             return Err(bad("truncated pack"));
                         }
                         summary.bytes += size;
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            // keep the executable bit, never setuid/setgid/sticky or world-write
-                            let m = (mode & 0o755) | 0o600;
-                            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(m))?;
-                        }
-                        #[cfg(not(unix))]
-                        let _ = mode;
                     }
                 }
             }

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -163,6 +163,19 @@ impl Write for FileWriter {
         Ok(())
     }
 }
+/// `std::io::Write` over a borrowed fd (the `Tmpfile` keeps ownership).
+struct FdWriter(bun_sys::Fd);
+impl Write for FdWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        bun_sys::File { handle: self.0 }
+            .write_all(buf)
+            .map_err(sys_err)
+            .map(|()| buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 /// The cache folder name for every fetchable package in the lockfile, and whether
 /// the package is expected on this platform (os/cpu/libc) — used only to decide
@@ -221,6 +234,20 @@ pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
     out
 }
 
+fn write_header(
+    w: &mut impl Write,
+    kind: u8,
+    path: &[u8],
+    mode: u32,
+    size: u64,
+) -> std::io::Result<()> {
+    w.write_all(&[kind])?;
+    w.write_all(&(path.len() as u32).to_le_bytes())?;
+    w.write_all(path)?;
+    w.write_all(&mode.to_le_bytes())?;
+    w.write_all(&size.to_le_bytes())
+}
+
 fn write_record(
     w: &mut impl Write,
     kind: u8,
@@ -228,11 +255,7 @@ fn write_record(
     mode: u32,
     data: &[u8],
 ) -> std::io::Result<()> {
-    w.write_all(&[kind])?;
-    w.write_all(&(path.len() as u32).to_le_bytes())?;
-    w.write_all(path)?;
-    w.write_all(&mode.to_le_bytes())?;
-    w.write_all(&(data.len() as u64).to_le_bytes())?;
+    write_header(w, kind, path, mode, data.len() as u64)?;
     w.write_all(data)
 }
 
@@ -261,19 +284,45 @@ fn pack_dir(
             bun_sys::FileKind::SymLink => {
                 let mut buf = [0u8; 4096];
                 let n = bun_sys::readlink(&z(&abs), &mut buf).map_err(sys_err)?;
-                write_record(w, 3, &child_rel, 0o777, &buf[..n])?;
+                let target = &buf[..n];
+                // only links that stay inside the package can be restored; refuse to
+                // produce a pack that unpack would reject
+                if !symlink_target_stays_inside(&child_rel, target) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "cache entry contains a symlink that points outside its package: {} -> {}",
+                            bstr::BStr::new(&abs),
+                            bstr::BStr::new(target)
+                        ),
+                    ));
+                }
+                write_record(w, 3, &child_rel, 0o777, target)?;
             }
             bun_sys::FileKind::File => {
                 let f = bun_sys::File::openat(bun_sys::Fd::cwd(), &abs, bun_sys::O::RDONLY, 0)
                     .map_err(sys_err)?;
+                let st = bun_sys::fstat(f.handle()).map_err(sys_err)?;
                 #[cfg(unix)]
-                let mode = bun_sys::fstat(f.handle()).map_err(sys_err)?.st_mode as u32;
+                let mode = st.st_mode as u32;
                 #[cfg(not(unix))]
                 let mode = 0o644u32;
-                let data = f.read_to_end().map_err(sys_err)?;
+                let size = u64::try_from(st.st_size).unwrap_or(0);
+                // header first (size from fstat), then stream the contents in chunks —
+                // peak memory is one buffer, not the largest file
+                write_header(w, 2, &child_rel, mode, size)?;
+                let copied = std::io::copy(&mut FileReader(f).take(size), w)?;
+                if copied != size {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "{} changed while it was being packed",
+                            bstr::BStr::new(&abs)
+                        ),
+                    ));
+                }
                 *files += 1;
-                *bytes += data.len() as u64;
-                write_record(w, 2, &child_rel, mode, &data)?;
+                *bytes += size;
             }
             // sockets, fifos, devices: not part of a package
             _ => {}
@@ -289,24 +338,34 @@ pub fn pack(
     out_path: &[u8],
 ) -> std::io::Result<PackSummary> {
     let folders = cache_folder_names(pm);
-    let mut tmp = out_path.to_vec();
-    let _ = write!(tmp, ".{}.tmp", std::process::id());
-    let result = pack_impl(&folders, cache_dir, out_path, &tmp);
+    // written next to the destination under a temporary name, moved into place at the end
+    let out_dir = parent(out_path).unwrap_or(b".");
+    let out_dir_fd = bun_sys::open_dir_at(bun_sys::Fd::cwd(), out_dir).map_err(sys_err)?;
+    let mut tmpname_buf = [0u8; 256];
+    let tmpname =
+        bun_paths::fs::FileSystem::tmpname(b"pack", &mut tmpname_buf, bun_wyhash::hash(out_path))
+            .map_err(|_| std::io::Error::other("could not build a temporary file name"))?;
+    let mut tmpfile = bun_sys::Tmpfile::create(out_dir_fd, tmpname).map_err(sys_err)?;
+    let result = pack_impl(&folders, cache_dir, FdWriter(tmpfile.fd)).and_then(|s| {
+        let dest = z(bun_paths::basename(out_path));
+        tmpfile.finish(&dest).map_err(sys_err)?;
+        Ok(s)
+    });
     if result.is_err() {
         // never leave a partial temp file behind (ENOSPC, unreadable cache entry, …)
-        let _ = bun_sys::unlinkat(bun_sys::Fd::cwd(), &z(&tmp));
+        let _ = bun_sys::unlinkat(out_dir_fd, tmpname);
     }
+    let _ = bun_sys::close(tmpfile.fd);
+    let _ = bun_sys::close(out_dir_fd);
     result
 }
 
 fn pack_impl(
     folders: &[(Vec<u8>, bool)],
     cache_dir: &[u8],
-    out_path: &[u8],
-    tmp: &[u8],
+    file: FdWriter,
 ) -> std::io::Result<PackSummary> {
-    let file = bun_sys::File::create(bun_sys::Fd::cwd(), tmp, true).map_err(sys_err)?;
-    let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
+    let mut w = BufWriter::with_capacity(1 << 20, file);
     w.write_all(MAGIC)?;
     let mut summary = PackSummary {
         packages: 0,
@@ -330,7 +389,6 @@ fn pack_impl(
     write_record(&mut w, 0, b"", 0, &[])?;
     w.flush()?;
     drop(w);
-    rename(tmp, out_path)?;
     Ok(summary)
 }
 
@@ -495,7 +553,17 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 summary.packages += 1;
                 let final_path = join(cache_dir, &path);
-                if lstat_kind(&final_path)?.is_some() {
+                let existing = lstat_kind(&final_path)?;
+                if existing.is_some() && existing != Some(bun_sys::FileKind::Directory) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "{} exists in the cache but is not a directory; remove it and retry",
+                            bstr::BStr::new(&final_path)
+                        ),
+                    ));
+                }
+                if existing.is_some() {
                     skipping = true;
                     summary.already_present += 1;
                     current = None;
@@ -505,10 +573,16 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         // `@scope/` directory for scoped packages
                         mkdir_p(parent)?;
                     }
-                    let staging = join(
-                        cache_dir,
-                        format!(".unpack-{}-{}", pid, summary.packages).as_bytes(),
-                    );
+                    let mut name_buf = [0u8; 256];
+                    let name = bun_paths::fs::FileSystem::tmpname(
+                        b"unpack",
+                        &mut name_buf,
+                        u64::from(summary.packages),
+                    )
+                    .map_err(|_| bad("could not build a staging directory name", record_no))?;
+                    let mut prefixed = format!(".unpack-{pid}-").into_bytes();
+                    prefixed.extend_from_slice(name.as_bytes());
+                    let staging = join(cache_dir, &prefixed);
                     rm_rf(&staging);
                     mkdir_p(&staging)?;
                     current = Some((final_path, staging));
@@ -563,17 +637,8 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         if let Some(parent) = parent(&dest) {
                             mkdir_p(parent)?;
                         }
-                        #[cfg(unix)]
                         bun_sys::symlinkat(&z(&target), bun_sys::Fd::cwd(), &z(&dest))
                             .map_err(sys_err)?;
-                        #[cfg(not(unix))]
-                        {
-                            let _ = (target, dest);
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::Unsupported,
-                                "this pack contains symbolic links, which `bun pm cache unpack` cannot restore on this platform yet",
-                            ));
-                        }
                     }
                     _ => {
                         if let Some(parent) = parent(&dest) {

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -567,6 +567,12 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
         return Err(traverses(rel));
     }
     let created: Vec<(Vec<u8>, Vec<u8>)> = std::mem::take(links);
+    // bun's tarball extraction does not create package symlinks on Windows (cache entries
+    // never contain them there), so neither does unpack: records were validated above and
+    // are otherwise skipped
+    if cfg!(windows) {
+        return Ok(());
+    }
     for (rel, target) in &created {
         let comps: Vec<&[u8]> = components(rel).collect();
         let mut p = staging.to_vec();
@@ -614,7 +620,7 @@ fn safe_folder_name(name: &[u8]) -> bool {
         return false;
     }
     let slashes = strings::count_char(name, b'/');
-    slashes == 0 || (slashes == 1 && name[0] == b'@' && !name.ends_with(b"/"))
+    slashes == 0 || (slashes == 1 && name[0] == b'@')
 }
 
 /// Restore missing cache folders from a pack. Existing folders are left untouched
@@ -793,12 +799,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         if !symlink_target_stays_inside(&path, &target) {
                             return Err(bad("unsafe symlink target in pack", record_no));
                         }
-                        // bun's tarball extraction does not create package symlinks on
-                        // Windows (cache entries never contain them there), so neither
-                        // does unpack; the record is validated and skipped
-                        if !cfg!(windows) {
-                            pending_links.push((path.clone(), target));
-                        }
+                        pending_links.push((path.clone(), target));
                     }
                     _ => {
                         if let Some(parent) = parent(&dest) {

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -95,6 +95,59 @@ fn path_exists(p: &Path) -> bool {
     bun_sys::lstat(&zpath(p)).is_ok()
 }
 
+fn pbytes(p: &Path) -> &[u8] {
+    p.as_os_str().as_encoded_bytes()
+}
+
+/// (name, kind) for every entry of `dir`, sorted by name. `Unknown` d_type is resolved
+/// with an lstat so callers can rely on the kind.
+fn list_dir(dir: &Path) -> std::io::Result<Vec<(Vec<u8>, bun_sys::FileKind)>> {
+    let fd = bun_sys::open_dir_for_iteration(bun_sys::Fd::cwd(), pbytes(dir)).map_err(sys_err)?;
+    let mut out = Vec::new();
+    let mut iter = bun_sys::iterate_dir(fd);
+    loop {
+        match iter.next() {
+            Ok(Some(entry)) => {
+                let name = entry.name.slice_u8().to_vec();
+                let kind = match entry.kind {
+                    bun_sys::FileKind::Unknown => lstat_kind(&dir.join(to_path(&name)?))?
+                        .unwrap_or(bun_sys::FileKind::Unknown),
+                    k => k,
+                };
+                out.push((name, kind));
+            }
+            Ok(None) => break,
+            Err(e) => {
+                let _ = bun_sys::close(fd);
+                return Err(sys_err(e));
+            }
+        }
+    }
+    drop(iter);
+    let _ = bun_sys::close(fd);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Kind of `p` itself (not following symlinks); None if it does not exist.
+fn lstat_kind(p: &Path) -> std::io::Result<Option<bun_sys::FileKind>> {
+    match bun_sys::lstat(&zpath(p)) {
+        Ok(st) => Ok(Some(bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode))),
+        Err(e) if e.get_errno() == bun_sys::E::ENOENT => Ok(None),
+        Err(e) => Err(sys_err(e)),
+    }
+}
+
+fn rename(from: &Path, to: &Path) -> std::io::Result<()> {
+    bun_sys::renameat(
+        bun_sys::Fd::cwd(),
+        &zpath(from),
+        bun_sys::Fd::cwd(),
+        &zpath(to),
+    )
+    .map_err(sys_err)
+}
+
 fn mkdir_p(p: &Path) -> std::io::Result<()> {
     bun_sys::mkdir_recursive(p.as_os_str().as_encoded_bytes()).map_err(sys_err)
 }
@@ -180,7 +233,7 @@ pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
             }
         }
     }
-    out.sort();
+    out.sort_by(|a, b| a.0.cmp(&b.0));
     out
 }
 
@@ -206,37 +259,37 @@ fn pack_dir(
     files: &mut u64,
     bytes: &mut u64,
 ) -> std::io::Result<()> {
-    let mut entries: Vec<std::fs::DirEntry> =
-        std::fs::read_dir(root.join(rel))?.collect::<std::io::Result<_>>()?;
-    entries.sort_by_key(|e| e.file_name());
+    let here = root.join(rel);
+    let entries = list_dir(&here)?;
     if entries.is_empty() && !rel.as_os_str().is_empty() {
-        write_record(w, 4, rel.as_os_str().as_encoded_bytes(), 0o755, &[])?;
+        write_record(w, 4, pbytes(rel), 0o755, &[])?;
     }
-    for e in entries {
-        let ft = e.file_type()?;
-        let child_rel = rel.join(e.file_name());
-        let relb = child_rel.as_os_str().as_encoded_bytes();
-        if ft.is_dir() {
-            pack_dir(w, root, &child_rel, files, bytes)?;
-        } else if ft.is_symlink() {
-            let target = std::fs::read_link(root.join(&child_rel))?;
-            write_record(w, 3, relb, 0o777, target.as_os_str().as_encoded_bytes())?;
-        } else if ft.is_file() {
-            let data = bun_sys::File::read_from(
-                bun_sys::Fd::cwd(),
-                root.join(&child_rel).as_os_str().as_encoded_bytes(),
-            )
-            .map_err(sys_err)?;
-            #[cfg(unix)]
-            let mode = {
-                use std::os::unix::fs::PermissionsExt;
-                e.metadata()?.permissions().mode()
-            };
-            #[cfg(not(unix))]
-            let mode = 0o644u32;
-            *files += 1;
-            *bytes += data.len() as u64;
-            write_record(w, 2, relb, mode, &data)?;
+    for (name, kind) in entries {
+        let child_rel = rel.join(to_path(&name)?);
+        let relb = pbytes(&child_rel);
+        let abs = root.join(&child_rel);
+        match kind {
+            bun_sys::FileKind::Directory => pack_dir(w, root, &child_rel, files, bytes)?,
+            bun_sys::FileKind::SymLink => {
+                let mut buf = [0u8; 4096];
+                let n = bun_sys::readlink(&zpath(&abs), &mut buf).map_err(sys_err)?;
+                write_record(w, 3, relb, 0o777, &buf[..n])?;
+            }
+            bun_sys::FileKind::File => {
+                let f =
+                    bun_sys::File::openat(bun_sys::Fd::cwd(), pbytes(&abs), bun_sys::O::RDONLY, 0)
+                        .map_err(sys_err)?;
+                #[cfg(unix)]
+                let mode = bun_sys::fstat(f.handle()).map_err(sys_err)?.st_mode as u32;
+                #[cfg(not(unix))]
+                let mode = 0o644u32;
+                let data = f.read_to_end().map_err(sys_err)?;
+                *files += 1;
+                *bytes += data.len() as u64;
+                write_record(w, 2, relb, mode, &data)?;
+            }
+            // sockets, fifos, devices: not part of a package
+            _ => {}
         }
     }
     Ok(())
@@ -285,8 +338,8 @@ pub fn pack(
     write_record(&mut w, 0, b"", 0, &[])?;
     w.flush()?;
     drop(w);
-    if let Err(e) = std::fs::rename(&tmp_path, &out) {
-        rm_rf(&tmp_path);
+    if let Err(e) = rename(&tmp_path, &out) {
+        let _ = bun_sys::unlinkat(bun_sys::Fd::cwd(), &zpath(&tmp_path));
         return Err(e);
     }
     Ok(summary)
@@ -328,15 +381,14 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
     if result.is_err() {
         // don't leave a half-written staging dir behind
         if let Ok(cache) = to_path(cache_dir)
-            && let Ok(rd) = std::fs::read_dir(&cache)
+            && let Ok(entries) = list_dir(&cache)
         {
             let mine = format!(".unpack-{}-", std::process::id());
-            for e in rd.flatten() {
-                if e.file_name()
-                    .as_encoded_bytes()
-                    .starts_with(mine.as_bytes())
+            for (name, _) in entries {
+                if name.starts_with(mine.as_bytes())
+                    && let Ok(n) = to_path(&name)
                 {
-                    rm_rf(&e.path());
+                    rm_rf(&cache.join(n));
                 }
             }
         }
@@ -381,7 +433,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                   summary: &mut UnpackSummary|
      -> std::io::Result<()> {
         if let Some((final_path, staging)) = cur.take() {
-            match std::fs::rename(&staging, &final_path) {
+            match rename(&staging, &final_path) {
                 Ok(()) => summary.created += 1,
                 Err(e) if is_dir(&final_path) => {
                     // lost a race with a concurrent unpack/install: theirs is as good as ours
@@ -463,10 +515,10 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     let comps: Vec<_> = rel.components().collect();
                     for (i, c) in comps.iter().enumerate() {
                         p.push(c);
-                        if let Ok(m) = std::fs::symlink_metadata(&p) {
-                            if m.file_type().is_symlink() && (i + 1 < comps.len() || kind[0] != 3) {
-                                return Err(bad("pack entry traverses a symlink", record_no));
-                            }
+                        if lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink)
+                            && (i + 1 < comps.len() || kind[0] != 3)
+                        {
+                            return Err(bad("pack entry traverses a symlink", record_no));
                         }
                     }
                 }
@@ -489,7 +541,12 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                             mkdir_p(parent)?;
                         }
                         #[cfg(unix)]
-                        std::os::unix::fs::symlink(to_path(&target)?, &dest)?;
+                        bun_sys::symlinkat(
+                            &zpath(&to_path(&target)?),
+                            bun_sys::Fd::cwd(),
+                            &zpath(&dest),
+                        )
+                        .map_err(sys_err)?;
                         #[cfg(not(unix))]
                         {
                             let _ = (target, dest);

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -30,6 +30,8 @@ use crate::package_manager_real::directories;
 use crate::resolution_real::Tag as ResolutionTag;
 
 const MAGIC: &[u8] = b"BUNCACHEPACK\0v1\n";
+/// Longest path (entry path, folder name, symlink target) a pack record may carry.
+const MAX_PACK_PATH_LEN: usize = 4096;
 
 pub struct PackSummary {
     pub packages: u32,
@@ -279,7 +281,7 @@ fn pack_dir(
             bun_sys::FileKind::SymLink => {
                 let mut buf = bun_paths::path_buffer_pool::get();
                 let n = bun_sys::readlink(&z(&abs), &mut buf[..]).map_err(sys_err)?;
-                if n >= buf.len().min(4096) {
+                if n >= buf.len().min(MAX_PACK_PATH_LEN) {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         format!("symlink target of {} is too long", bstr::BStr::new(&abs)),
@@ -476,11 +478,17 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
     fn components(p: &[u8]) -> impl Iterator<Item = &[u8]> {
         strings::split_any(p, b"/\\").filter(|c| !c.is_empty() && *c != b".")
     }
+    // compared ASCII-case-insensitively: on case-insensitive filesystems `A/UP` and
+    // `a/up` are the same directory entry, and a legitimate package has no reason to
+    // contain entries that differ only in case along a symlink's path
+    fn norm(c: &[u8]) -> Vec<u8> {
+        c.to_ascii_lowercase()
+    }
     let link_paths: Vec<Vec<Vec<u8>>> = links
         .iter()
-        .map(|(rel, _)| components(rel).map(|c| c.to_vec()).collect())
+        .map(|(rel, _)| components(rel).map(norm).collect())
         .collect();
-    let passes_through_link = |start: &[Vec<u8>], rel_path: &[u8], own: Option<usize>| {
+    let passes_through_link = |start: &[Vec<u8>], rel_path: &[u8]| {
         // walk `rel_path` from `start` (package-relative components), checking every
         // proper prefix reached against the pending link paths
         let mut cur: Vec<Vec<u8>> = start.to_vec();
@@ -490,27 +498,26 @@ fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io:
                 cur.pop();
                 continue;
             }
-            cur.push(comp.to_vec());
-            let is_last = idx + 1 == comps.len();
-            for (k, lp) in link_paths.iter().enumerate() {
-                // the link's own final component is itself, not a traversal
-                if is_last && Some(k) == own {
-                    continue;
-                }
-                if *lp == cur {
-                    return true;
-                }
+            cur.push(norm(comp));
+            // The final component may *be* a link (the link itself when checking its own
+            // path; another link when a target points at one — that link's own target is
+            // validated in its turn). Only passing *through* a link is refused.
+            if idx + 1 == comps.len() {
+                break;
+            }
+            if link_paths.contains(&cur) {
+                return true;
             }
         }
         false
     };
-    for (k, (rel, target)) in links.iter().enumerate() {
+    for (rel, target) in links.iter() {
         let link_dir: Vec<Vec<u8>> = {
-            let mut c: Vec<Vec<u8>> = components(rel).map(|c| c.to_vec()).collect();
+            let mut c: Vec<Vec<u8>> = components(rel).map(norm).collect();
             c.pop();
             c
         };
-        if passes_through_link(&[], rel, Some(k)) || passes_through_link(&link_dir, target, None) {
+        if passes_through_link(&[], rel) || passes_through_link(&link_dir, target) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
@@ -633,7 +640,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
         let mut u32b = [0u8; 4];
         r.read_exact(&mut u32b)?;
         let path_len = u32::from_le_bytes(u32b) as usize;
-        if path_len > 4096 {
+        if path_len > MAX_PACK_PATH_LEN {
             return Err(bad("path too long", record_no));
         }
         let path = read_exact_vec(&mut r, path_len)?;
@@ -721,7 +728,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         std::io::copy(&mut (&mut r).take(size), &mut std::io::sink())?;
                     }
                     3 => {
-                        if size > 4096 {
+                        if size > MAX_PACK_PATH_LEN as u64 {
                             return Err(bad("symlink target too long", record_no));
                         }
                         let target = read_exact_vec(&mut r, size as usize)?;

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -22,6 +22,8 @@
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
+use bun_core::strings;
+
 use crate::PackageManager;
 use crate::lockfile_real::package::PackageColumns as _;
 use crate::package_manager_real::directories;
@@ -43,11 +45,21 @@ pub struct UnpackSummary {
     pub bytes: u64,
 }
 
-fn s(p: &[u8]) -> &str {
-    // SAFETY: only used to build `Path`s / error text from cache folder names and
-    // package-relative paths, which are ASCII/UTF-8 by construction; the bytes are never
-    // inspected as `str` beyond that.
-    unsafe { std::str::from_utf8_unchecked(p) }
+/// `Path` view of path bytes. On POSIX any bytes are a valid `OsStr`; elsewhere the
+/// bytes must be UTF-8 and anything else is rejected as invalid data (archive-controlled
+/// names go through here too, so this is never unchecked).
+fn to_path(p: &[u8]) -> std::io::Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        Ok(PathBuf::from(std::ffi::OsStr::from_bytes(p)))
+    }
+    #[cfg(not(unix))]
+    {
+        std::str::from_utf8(p)
+            .map(PathBuf::from)
+            .map_err(|_| bad("path is not valid UTF-8"))
+    }
 }
 
 fn zpath(p: &Path) -> bun_core::ZBox {
@@ -60,6 +72,23 @@ fn zpath(p: &Path) -> bun_core::ZBox {
 
 fn is_dir(p: &Path) -> bool {
     matches!(bun_sys::stat(&zpath(p)), Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory)
+}
+
+/// What sits at a cache-folder root: a real directory is packed, nothing is skipped,
+/// anything else (a symlink, a file, an unreadable entry) is an error rather than a
+/// silently incomplete pack.
+fn folder_root_kind(p: &Path) -> std::io::Result<Option<()>> {
+    match bun_sys::lstat(&zpath(p)) {
+        Ok(st) => match bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) {
+            bun_sys::FileKind::Directory => Ok(Some(())),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("cache entry {} is not a directory", p.display()),
+            )),
+        },
+        Err(e) if e.get_errno() == bun_sys::E::ENOENT => Ok(None),
+        Err(e) => Err(sys_err(e)),
+    }
 }
 
 fn path_exists(p: &Path) -> bool {
@@ -178,7 +207,7 @@ fn pack_dir(
     bytes: &mut u64,
 ) -> std::io::Result<()> {
     let mut entries: Vec<std::fs::DirEntry> =
-        std::fs::read_dir(root.join(rel))?.flatten().collect();
+        std::fs::read_dir(root.join(rel))?.collect::<std::io::Result<_>>()?;
     entries.sort_by_key(|e| e.file_name());
     if entries.is_empty() && !rel.as_os_str().is_empty() {
         write_record(w, 4, rel.as_os_str().as_encoded_bytes(), 0o755, &[])?;
@@ -220,9 +249,12 @@ pub fn pack(
     out_path: &[u8],
 ) -> std::io::Result<PackSummary> {
     let folders = cache_folder_names(pm);
-    let cache = PathBuf::from(s(cache_dir));
-    let tmp = format!("{}.tmp", s(out_path));
-    let file = bun_sys::File::create(bun_sys::Fd::cwd(), tmp.as_bytes(), true).map_err(sys_err)?;
+    let cache = to_path(cache_dir)?;
+    let out = to_path(out_path)?;
+    let mut tmp = out_path.to_vec();
+    let _ = write!(tmp, ".{}.tmp", std::process::id());
+    let tmp_path = to_path(&tmp)?;
+    let file = bun_sys::File::create(bun_sys::Fd::cwd(), &tmp, true).map_err(sys_err)?;
     let mut w = BufWriter::with_capacity(1 << 20, FileWriter(file));
     w.write_all(MAGIC)?;
     let mut summary = PackSummary {
@@ -232,8 +264,8 @@ pub fn pack(
         skipped_missing: 0,
     };
     for (f, expected_here) in &folders {
-        let dir = cache.join(s(f));
-        if !is_dir(&dir) {
+        let dir = cache.join(to_path(f)?);
+        if folder_root_kind(&dir)?.is_none() {
             // optional binaries for other platforms are legitimately absent
             if *expected_here {
                 summary.skipped_missing += 1;
@@ -253,7 +285,10 @@ pub fn pack(
     write_record(&mut w, 0, b"", 0, &[])?;
     w.flush()?;
     drop(w);
-    std::fs::rename(&tmp, s(out_path))?;
+    if let Err(e) = std::fs::rename(&tmp_path, &out) {
+        rm_rf(&tmp_path);
+        return Err(e);
+    }
     Ok(summary)
 }
 
@@ -272,19 +307,17 @@ fn safe_rel(path: &[u8]) -> bool {
     !path.is_empty()
         && path[0] != b'/'
         && path[0] != b'\\'
-        && !path.contains(&0)
-        && !path.contains(&b':')
-        && !path
-            .split(|c| *c == b'/' || *c == b'\\')
-            .any(|seg| seg == b"..")
+        && !strings::contains_char(path, 0)
+        && !strings::contains_char(path, b':')
+        && !strings::split_any(path, b"/\\").any(|seg| seg == b"..")
 }
 
 /// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
 fn safe_folder_name(name: &[u8]) -> bool {
-    if !safe_rel(name) || name.contains(&b'\\') || name == b"." || name == b".." {
+    if !safe_rel(name) || strings::contains_char(name, b'\\') || name == b"." || name == b".." {
         return false;
     }
-    let slashes = name.iter().filter(|c| **c == b'/').count();
+    let slashes = strings::count_char(name, b'/');
     slashes == 0 || (slashes == 1 && name[0] == b'@' && !name.ends_with(b"/"))
 }
 
@@ -294,8 +327,9 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
     let result = unpack_impl(cache_dir, pack_path);
     if result.is_err() {
         // don't leave a half-written staging dir behind
-        let cache = PathBuf::from(s(cache_dir));
-        if let Ok(rd) = std::fs::read_dir(&cache) {
+        if let Ok(cache) = to_path(cache_dir)
+            && let Ok(rd) = std::fs::read_dir(&cache)
+        {
             let mine = format!(".unpack-{}-", std::process::id());
             for e in rd.flatten() {
                 if e.file_name()
@@ -311,7 +345,7 @@ pub fn unpack(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumma
 }
 
 fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSummary> {
-    let cache = PathBuf::from(s(cache_dir));
+    let cache = to_path(cache_dir)?;
     mkdir_p(&cache)?;
     let file = bun_sys::File::openat(bun_sys::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)
         .map_err(sys_err)?;
@@ -320,20 +354,24 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     if magic != MAGIC {
         return Err(bad("not a bun cache pack (bad magic)"));
     }
+    let mut record_no: u64 = 0;
+    // errors name the record so a corrupt pack can be identified and regenerated
+    let bad = |msg: &str, record_no: u64| -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{msg} (record #{record_no}); delete the pack file and re-create it with `bun pm cache pack`"
+            ),
+        )
+    };
     let mut summary = UnpackSummary {
         packages: 0,
         created: 0,
         already_present: 0,
         bytes: 0,
     };
-    // sweep staging dirs left by an earlier failed/killed unpack
-    if let Ok(rd) = std::fs::read_dir(&cache) {
-        for e in rd.flatten() {
-            if e.file_name().as_encoded_bytes().starts_with(b".unpack-") {
-                rm_rf(&e.path());
-            }
-        }
-    }
+    // Staging directories are named `.unpack-<pid>-<n>`; only this process's own are
+    // ever removed (on failure, by `unpack`), so a concurrent unpack is never disturbed.
     // current folder: (final path, staging path) — None while skipping an existing one
     let mut current: Option<(PathBuf, PathBuf)> = None;
     let mut skipping = false;
@@ -358,13 +396,14 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     };
 
     loop {
+        record_no += 1;
         let mut kind = [0u8; 1];
         r.read_exact(&mut kind)?;
         let mut u32b = [0u8; 4];
         r.read_exact(&mut u32b)?;
         let path_len = u32::from_le_bytes(u32b) as usize;
         if path_len > 4096 {
-            return Err(bad("path too long"));
+            return Err(bad("path too long", record_no));
         }
         let path = read_exact_vec(&mut r, path_len)?;
         r.read_exact(&mut u32b)?;
@@ -380,10 +419,10 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
             1 => {
                 finish(&mut current, &mut summary)?;
                 if !safe_folder_name(&path) {
-                    return Err(bad("unsafe cache folder name in pack"));
+                    return Err(bad("unsafe cache folder name in pack", record_no));
                 }
                 summary.packages += 1;
-                let final_path = cache.join(s(&path));
+                let final_path = cache.join(to_path(&path)?);
                 if path_exists(&final_path) {
                     skipping = true;
                     summary.already_present += 1;
@@ -400,12 +439,12 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     current = Some((final_path, staging));
                 }
                 if size != 0 {
-                    return Err(bad("folder record with payload"));
+                    return Err(bad("folder record with payload", record_no));
                 }
             }
             2..=4 => {
                 if size > (1u64 << 34) {
-                    return Err(bad("entry too large"));
+                    return Err(bad("entry too large", record_no));
                 }
                 if skipping || current.is_none() {
                     // consume payload without writing
@@ -413,20 +452,20 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     continue;
                 }
                 if !safe_rel(&path) {
-                    return Err(bad("unsafe entry path in pack"));
+                    return Err(bad("unsafe entry path in pack", record_no));
                 }
                 let (_, staging) = current.as_ref().unwrap();
-                let dest = staging.join(s(&path));
+                let rel = to_path(&path)?;
+                let dest = staging.join(&rel);
                 // refuse to traverse a symlink materialized earlier in this package
                 {
                     let mut p = staging.clone();
-                    let rel = std::path::Path::new(s(&path));
                     let comps: Vec<_> = rel.components().collect();
                     for (i, c) in comps.iter().enumerate() {
                         p.push(c);
                         if let Ok(m) = std::fs::symlink_metadata(&p) {
                             if m.file_type().is_symlink() && (i + 1 < comps.len() || kind[0] != 3) {
-                                return Err(bad("pack entry traverses a symlink"));
+                                return Err(bad("pack entry traverses a symlink", record_no));
                             }
                         }
                     }
@@ -438,23 +477,26 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                     }
                     3 => {
                         if size > 4096 {
-                            return Err(bad("symlink target too long"));
+                            return Err(bad("symlink target too long", record_no));
                         }
                         let target = read_exact_vec(&mut r, size as usize)?;
                         // links inside a package may only point within it (no `..`, not absolute)
                         let t: &[u8] = target.strip_prefix(b"./").unwrap_or(&target);
                         if !safe_rel(t) {
-                            return Err(bad("unsafe symlink target in pack"));
+                            return Err(bad("unsafe symlink target in pack", record_no));
                         }
                         if let Some(parent) = dest.parent() {
                             mkdir_p(parent)?;
                         }
                         #[cfg(unix)]
-                        std::os::unix::fs::symlink(s(&target), &dest)?;
-                        #[cfg(windows)]
+                        std::os::unix::fs::symlink(to_path(&target)?, &dest)?;
+                        #[cfg(not(unix))]
                         {
-                            // file symlinks need privileges on Windows; write a copy stub instead
-                            let _ = target;
+                            let _ = (target, dest);
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Unsupported,
+                                "this pack contains symbolic links, which `bun pm cache unpack` cannot restore on this platform yet",
+                            ));
                         }
                     }
                     _ => {
@@ -478,13 +520,13 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         let mut w = FileWriter(f);
                         let copied = std::io::copy(&mut (&mut r).take(size), &mut w)?;
                         if copied != size {
-                            return Err(bad("truncated pack"));
+                            return Err(bad("truncated pack", record_no));
                         }
                         summary.bytes += size;
                     }
                 }
             }
-            _ => return Err(bad("unknown record kind")),
+            _ => return Err(bad("unknown record kind", record_no)),
         }
     }
     Ok(summary)

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -103,27 +103,26 @@ fn list_dir(dir: &[u8]) -> std::io::Result<Vec<(Vec<u8>, bun_sys::FileKind)>> {
     let fd = bun_sys::open_dir_for_iteration(bun_sys::Fd::cwd(), dir).map_err(sys_err)?;
     let mut out = Vec::new();
     let mut iter = bun_sys::iterate_dir(fd);
-    loop {
+    let result: std::io::Result<()> = loop {
         match iter.next() {
             Ok(Some(entry)) => {
                 let name = entry.name.slice_u8().to_vec();
                 let kind = match entry.kind {
-                    bun_sys::FileKind::Unknown => {
-                        lstat_kind(&join(dir, &name))?.unwrap_or(bun_sys::FileKind::Unknown)
-                    }
+                    bun_sys::FileKind::Unknown => match lstat_kind(&join(dir, &name)) {
+                        Ok(k) => k.unwrap_or(bun_sys::FileKind::Unknown),
+                        Err(e) => break Err(e),
+                    },
                     k => k,
                 };
                 out.push((name, kind));
             }
-            Ok(None) => break,
-            Err(e) => {
-                let _ = bun_sys::close(fd);
-                return Err(sys_err(e));
-            }
+            Ok(None) => break Ok(()),
+            Err(e) => break Err(sys_err(e)),
         }
-    }
+    };
     drop(iter);
     let _ = bun_sys::close(fd);
+    result?;
     out.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(out)
 }
@@ -142,7 +141,9 @@ fn rm_rf(p: &[u8]) {
 
 #[allow(clippy::needless_pass_by_value)] // used as `.map_err(sys_err)`
 fn sys_err(e: bun_sys::Error) -> std::io::Error {
-    std::io::Error::from_raw_os_error(i32::from(e.errno))
+    // keep the syscall + path in the message, and the errno as the kind
+    let kind = std::io::Error::from_raw_os_error(i32::from(e.errno)).kind();
+    std::io::Error::new(kind, format!("{e}"))
 }
 
 /// `std::io::Read` over a `bun_sys::File`.
@@ -158,19 +159,6 @@ impl Write for FileWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.0.write_all(buf).map_err(sys_err)?;
         Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-/// `std::io::Write` over a borrowed fd (the `Tmpfile` keeps ownership).
-struct FdWriter(bun_sys::Fd);
-impl Write for FdWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        bun_sys::File { handle: self.0 }
-            .write_all(buf)
-            .map_err(sys_err)
-            .map(|()| buf.len())
     }
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
@@ -307,7 +295,12 @@ fn pack_dir(
                 let mode = st.st_mode as u32;
                 #[cfg(not(unix))]
                 let mode = 0o644u32;
-                let size = u64::try_from(st.st_size).unwrap_or(0);
+                let size = u64::try_from(st.st_size).map_err(|_| {
+                    std::io::Error::other(format!(
+                        "{} reports a negative size",
+                        bstr::BStr::new(&abs)
+                    ))
+                })?;
                 // header first (size from fstat), then stream the contents in chunks —
                 // peak memory is one buffer, not the largest file
                 write_header(w, 2, &child_rel, mode, size)?;
@@ -346,7 +339,8 @@ pub fn pack(
         bun_paths::fs::FileSystem::tmpname(b"pack", &mut tmpname_buf, bun_wyhash::hash(out_path))
             .map_err(|_| std::io::Error::other("could not build a temporary file name"))?;
     let mut tmpfile = bun_sys::Tmpfile::create(out_dir_fd, tmpname).map_err(sys_err)?;
-    let result = pack_impl(&folders, cache_dir, FdWriter(tmpfile.fd)).and_then(|s| {
+    // `bun_sys::FileWriter` borrows the fd; the Tmpfile keeps ownership.
+    let result = pack_impl(&folders, cache_dir, bun_sys::FileWriter(tmpfile.fd)).and_then(|s| {
         let dest = z(bun_paths::basename(out_path));
         tmpfile.finish(&dest).map_err(sys_err)?;
         Ok(s)
@@ -363,7 +357,7 @@ pub fn pack(
 fn pack_impl(
     folders: &[(Vec<u8>, bool)],
     cache_dir: &[u8],
-    file: FdWriter,
+    file: bun_sys::FileWriter,
 ) -> std::io::Result<PackSummary> {
     let mut w = BufWriter::with_capacity(1 << 20, file);
     w.write_all(MAGIC)?;
@@ -448,6 +442,54 @@ fn symlink_target_stays_inside(link_path: &[u8], target: &[u8]) -> bool {
     true
 }
 
+/// Create a package's symlinks after all of its files and directories exist. Each
+/// link is re-checked against the tree as it now stands: no component of the link's
+/// own path, and no component of its target (resolved from the link's directory), may
+/// be a symlink — so one link can never be used to smuggle another link's target (or a
+/// later file) out of the package, whatever order the records arrived in. Links whose
+/// target passes through another link are refused rather than resolved.
+fn create_links(staging: &[u8], links: &mut Vec<(Vec<u8>, Vec<u8>)>) -> std::io::Result<()> {
+    for (rel, target) in links.drain(..) {
+        let no_link_components = |base: &[u8], rel_path: &[u8]| -> std::io::Result<bool> {
+            let mut p = base.to_vec();
+            for comp in strings::split_any(rel_path, b"/\\").filter(|c| !c.is_empty()) {
+                match comp {
+                    b"." => continue,
+                    b".." => {
+                        // stays inside by construction (checked lexically); pop a component
+                        if let Some(parent) = parent(&p) {
+                            p = parent.to_vec();
+                        }
+                        continue;
+                    }
+                    _ => p = join(&p, comp),
+                }
+                if lstat_kind(&p)? == Some(bun_sys::FileKind::SymLink) {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        };
+        let dest = join(staging, &rel);
+        let link_dir = parent(&dest).unwrap_or(staging).to_vec();
+        if !no_link_components(staging, &rel)? || !no_link_components(&link_dir, &target)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "pack entry {} -> {} passes through another symlink; delete the pack file and re-create it with `bun pm cache pack`",
+                    bstr::BStr::new(&rel),
+                    bstr::BStr::new(&target)
+                ),
+            ));
+        }
+        if let Some(dir) = parent(&dest) {
+            mkdir_p(dir)?;
+        }
+        bun_sys::symlinkat(&z(&target), bun_sys::Fd::cwd(), &z(&dest)).map_err(sys_err)?;
+    }
+    Ok(())
+}
+
 /// A cache folder name is either `name@ver…` or `@scope/name@ver…` (one slash).
 fn safe_folder_name(name: &[u8]) -> bool {
     if !safe_rel(name) || strings::contains_char(name, b'\\') || name == b"." || name == b".." {
@@ -504,13 +546,18 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     // ever removed (on failure, by `unpack`), so a concurrent unpack is never disturbed.
     // current folder: (final path, staging path) — None while skipping an existing one
     let mut current: Option<(Vec<u8>, Vec<u8>)> = None;
+    // symlink records of the current package, created only once every other entry of
+    // the package exists (see `create_links`)
+    let mut pending_links: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
     let mut skipping = false;
     let pid = std::process::id();
 
     let finish = |cur: &mut Option<(Vec<u8>, Vec<u8>)>,
+                  pending_links: &mut Vec<(Vec<u8>, Vec<u8>)>,
                   summary: &mut UnpackSummary|
      -> std::io::Result<()> {
         if let Some((final_path, staging)) = cur.take() {
+            create_links(&staging, pending_links)?;
             match rename(&staging, &final_path) {
                 Ok(()) => summary.created += 1,
                 Err(e) if is_dir(&final_path) => {
@@ -543,11 +590,11 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
         let size = u64::from_le_bytes(u64b);
         match kind[0] {
             0 => {
-                finish(&mut current, &mut summary)?;
+                finish(&mut current, &mut pending_links, &mut summary)?;
                 break;
             }
             1 => {
-                finish(&mut current, &mut summary)?;
+                finish(&mut current, &mut pending_links, &mut summary)?;
                 if !safe_folder_name(&path) {
                     return Err(bad("unsafe cache folder name in pack", record_no));
                 }
@@ -605,7 +652,15 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                 }
                 let (_, staging) = current.as_ref().unwrap();
                 let dest = join(staging, &path);
-                // refuse to traverse a symlink materialized earlier in this package
+                // refuse an entry placed under one of this package's (pending) symlinks …
+                if pending_links.iter().any(|(link, _)| {
+                    path.len() > link.len()
+                        && path.starts_with(link.as_slice())
+                        && matches!(path[link.len()], b'/' | b'\\')
+                }) {
+                    return Err(bad("pack entry traverses a symlink", record_no));
+                }
+                // … or under a symlink that already exists on disk
                 {
                     let mut p = staging.clone();
                     let comps: Vec<&[u8]> = strings::split_any(&path, b"/\\")
@@ -634,11 +689,7 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
                         if !symlink_target_stays_inside(&path, &target) {
                             return Err(bad("unsafe symlink target in pack", record_no));
                         }
-                        if let Some(parent) = parent(&dest) {
-                            mkdir_p(parent)?;
-                        }
-                        bun_sys::symlinkat(&z(&target), bun_sys::Fd::cwd(), &z(&dest))
-                            .map_err(sys_err)?;
+                        pending_links.push((path.clone(), target));
                     }
                     _ => {
                         if let Some(parent) = parent(&dest) {

--- a/src/install/cache_pack.rs
+++ b/src/install/cache_pack.rs
@@ -213,12 +213,15 @@ pub fn cache_folder_names(pm: &mut PackageManager) -> Vec<(Vec<u8>, bool)> {
             _ => None,
         };
         if let Some(f) = folder {
-            if !f.is_empty() && !out.iter().any(|(e, _)| *e == f) {
+            if !f.is_empty() {
                 out.push((f, expected));
             }
         }
     }
-    out.sort_by(|a, b| a.0.cmp(&b.0));
+    // sorted for a deterministic pack; the same folder can back several lockfile
+    // entries (e.g. aliases), keep one — "expected" if any of them is
+    out.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    out.dedup_by(|a, b| a.0 == b.0);
     out
 }
 
@@ -270,8 +273,14 @@ fn pack_dir(
         match kind {
             bun_sys::FileKind::Directory => pack_dir(w, root, &child_rel, files, bytes)?,
             bun_sys::FileKind::SymLink => {
-                let mut buf = [0u8; 4096];
-                let n = bun_sys::readlink(&z(&abs), &mut buf).map_err(sys_err)?;
+                let mut buf = bun_paths::path_buffer_pool::get();
+                let n = bun_sys::readlink(&z(&abs), &mut buf[..]).map_err(sys_err)?;
+                if n >= buf.len() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("symlink target of {} is too long", bstr::BStr::new(&abs)),
+                    ));
+                }
                 let target = &buf[..n];
                 // only links that stay inside the package can be restored; refuse to
                 // produce a pack that unpack would reject
@@ -522,9 +531,9 @@ fn unpack_impl(cache_dir: &[u8], pack_path: &[u8]) -> std::io::Result<UnpackSumm
     let file = bun_sys::File::openat(bun_sys::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)
         .map_err(sys_err)?;
     let mut r = BufReader::with_capacity(1 << 20, FileReader(file));
-    let magic = read_exact_vec(&mut r, MAGIC.len())?;
-    if magic != MAGIC {
-        return Err(bad("not a bun cache pack (bad magic)"));
+    match read_exact_vec(&mut r, MAGIC.len()) {
+        Ok(magic) if magic == MAGIC => {}
+        _ => return Err(bad("not a bun cache pack (bad magic)")),
     }
     let mut record_no: u64 = 0;
     // errors name the record so a corrupt pack can be identified and regenerated

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -111,6 +111,7 @@ pub use lockfile_real::{DEFAULT_TRUSTED_DEPENDENCIES_LIST, default_trusted_depen
 pub mod audit_fix;
 #[path = "bin.rs"]
 pub mod bin_real;
+pub mod cache_pack;
 pub mod dedupe;
 pub mod hoisted_install;
 pub mod isolated_install;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -217,6 +217,8 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile\n\
   <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder\n\
   <b><green>bun pm<r> <blue>cache rm<r>             clear the cache\n\
+  <b><green>bun pm<r> <blue>cache pack<r> <d>file<r>      write the cache entries this lockfile needs into one file (for CI caches)\n\
+  <b><green>bun pm<r> <blue>cache unpack<r> <d>file<r>    restore cache entries from a pack\n\
   <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything\n\
   <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts\n\
   <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`\n\
@@ -433,6 +435,77 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"cache") {
             if pm.options.positionals.len() > 1
+                && (strings::eql_comptime(pm.options.positionals[1], b"pack")
+                    || strings::eql_comptime(pm.options.positionals[1], b"unpack"))
+            {
+                let is_pack = strings::eql_comptime(pm.options.positionals[1], b"pack");
+                let Some(file) = pm.options.positionals.get(2).copied() else {
+                    Output::err_generic(
+                        "usage: bun pm cache {} <file>",
+                        (if is_pack { "pack" } else { "unpack" },),
+                    );
+                    Global::exit(1);
+                };
+                let mut process_env = bun_dotenv::Loader::init();
+                process_env.load_process()?;
+                let cache_dir = fetch_cache_directory_path(&mut process_env, Some(&pm.options));
+                let start = std::time::Instant::now();
+                if is_pack {
+                    let log_level = pm.options.log_level;
+                    let load_lockfile = pm.load_lockfile_from_cwd::<true>();
+                    Self::handle_load_lockfile_errors_for(&load_lockfile, log_level, "cache pack");
+                    // SAFETY: pm_ptr is the unique owner; lockfile borrow released above.
+                    let pm = unsafe { &mut *pm_ptr };
+                    match bun_install::cache_pack::pack(pm, &cache_dir.path, file) {
+                        Ok(s) => {
+                            bun_core::prettyln!(
+                                "<green>Packed<r> {} package{} ({} files, {}) into <b>{}<r> <d>[{} ms]<r>",
+                                s.packages,
+                                if s.packages == 1 { "" } else { "s" },
+                                s.files,
+                                bun_core::fmt::size(s.bytes as usize, Default::default()),
+                                bstr::BStr::new(file),
+                                start.elapsed().as_millis(),
+                            );
+                            if s.skipped_missing > 0 {
+                                bun_core::prettyln!(
+                                    "<yellow>warn<r>: {} package{} not in the local cache were left out (run bun install first)",
+                                    s.skipped_missing,
+                                    if s.skipped_missing == 1 {
+                                        " was"
+                                    } else {
+                                        "s were"
+                                    },
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            Output::err_generic("cache pack failed: {}", (e,));
+                            Global::exit(1);
+                        }
+                    }
+                } else {
+                    match bun_install::cache_pack::unpack(&cache_dir.path, file) {
+                        Ok(s) => {
+                            bun_core::prettyln!(
+                                "<green>Unpacked<r> {} package{} ({} new, {} already cached, {}) <d>[{} ms]<r>",
+                                s.packages,
+                                if s.packages == 1 { "" } else { "s" },
+                                s.created,
+                                s.already_present,
+                                bun_core::fmt::size(s.bytes as usize, Default::default()),
+                                start.elapsed().as_millis(),
+                            );
+                        }
+                        Err(e) => {
+                            Output::err_generic("cache unpack failed: {}", (e,));
+                            Global::exit(1);
+                        }
+                    }
+                }
+                Output::flush();
+                Global::exit(0);
+            } else if pm.options.positionals.len() > 1
                 && strings::eql_comptime(pm.options.positionals[1], b"rm")
             {
                 let mut had_err = false;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -439,12 +439,16 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                     || strings::eql_comptime(pm.options.positionals[1], b"unpack"))
             {
                 let is_pack = strings::eql_comptime(pm.options.positionals[1], b"pack");
-                let Some(file) = pm.options.positionals.get(2).copied() else {
-                    Output::err_generic(
-                        "usage: bun pm cache {} <file>",
-                        (if is_pack { "pack" } else { "unpack" },),
-                    );
-                    Global::exit(1);
+                // exactly one non-empty <file>
+                let file = match pm.options.positionals.get(2..).unwrap_or(&[]) {
+                    [file] if !file.is_empty() => *file,
+                    rest => {
+                        Output::err_generic(
+                            "expected exactly one \\<file\\> argument, got {}\n  usage: bun pm cache {} \\<file\\>",
+                            (rest.len(), if is_pack { "pack" } else { "unpack" }),
+                        );
+                        Global::exit(1);
+                    }
                 };
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -472,13 +472,14 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                                 start.elapsed().as_millis(),
                             );
                             if s.skipped_missing > 0 {
-                                bun_core::prettyln!(
-                                    "<yellow>warn<r>: {} package{} not in the local cache were left out (run bun install first)",
+                                bun_core::pretty_errorln!(
+                                    "<yellow>warn<r>: {} package{} not in the local cache and {} left out (run bun install first)",
                                     s.skipped_missing,
+                                    if s.skipped_missing == 1 { "" } else { "s" },
                                     if s.skipped_missing == 1 {
-                                        " was"
+                                        "was"
                                     } else {
-                                        "s were"
+                                        "were"
                                     },
                                 );
                             }

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -443,10 +443,17 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let file = match pm.options.positionals.get(2..).unwrap_or(&[]) {
                     [file] if !file.is_empty() => *file,
                     rest => {
-                        Output::err_generic(
-                            "expected exactly one \\<file\\> argument, got {}\n  usage: bun pm cache {} \\<file\\>",
-                            (rest.len(), if is_pack { "pack" } else { "unpack" }),
-                        );
+                        if matches!(rest, [_]) {
+                            Output::err_generic(
+                                "the \\<file\\> argument must not be empty\n  usage: bun pm cache {} \\<file\\>",
+                                (if is_pack { "pack" } else { "unpack" },),
+                            );
+                        } else {
+                            Output::err_generic(
+                                "expected exactly one \\<file\\> argument, got {}\n  usage: bun pm cache {} \\<file\\>",
+                                (rest.len(), if is_pack { "pack" } else { "unpack" }),
+                            );
+                        }
                         Global::exit(1);
                     }
                 };

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -61,7 +61,14 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   const cache1 = tmpdirSync();
   const cache2 = tmpdirSync();
   await writeFile(join(package_dir, "bunfig.toml"), bunfig());
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2", baz: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2", baz: "0.0.3" },
+    }),
+  );
 
   let r = await run(["install"], package_dir, cache1);
   expect(r.err).not.toContain("error:");
@@ -88,7 +95,9 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   expect(r.err).not.toContain("error:");
   expect(r.code).toBe(0);
   expect(urls.filter(u => u.endsWith(".tgz")).length).toBe(before);
-  expect(await Bun.file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toMatchObject({ name: "@barn/moo" });
+  expect(await Bun.file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toMatchObject({
+    name: "@barn/moo",
+  });
   expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
 
   // idempotent
@@ -112,9 +121,19 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   const rel = "./../../" + require("path").basename(victim);
   await writeFile(
     join(dir, "escape.pack"),
-    Buffer.concat([MAGIC, rec(1, "evil@1.0.0", 0, ""), rec(3, "esc", 0o777, rel), rec(2, "esc/pwned", 0o644, "owned"), rec(0, "", 0, "")]),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "evil@1.0.0", 0, ""),
+      rec(3, "esc", 0o777, rel),
+      rec(2, "esc/pwned", 0o644, "owned"),
+      rec(0, "", 0, ""),
+    ]),
   );
-  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", require("path").basename(cache)));
+  r = await run(
+    ["pm", "cache", "unpack", join(dir, "escape.pack")],
+    dir,
+    join(victim, "..", require("path").basename(cache)),
+  );
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
   expect(existsSync(join(victim, "pwned"))).toBeFalse();
@@ -122,7 +141,10 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
 
   // an absurd symlink target length
-  await writeFile(join(dir, "long.pack"), Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]));
+  await writeFile(
+    join(dir, "long.pack"),
+    Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]),
+  );
   r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
   expect(r.code).not.toBe(0);
 

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, lstatSync, readFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, isWindows, readdirSorted, tempDir } from "harness";
 import { basename, join } from "path";
@@ -115,6 +115,9 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   r = await run(["pm", "cache", "unpack", pack, "extra"], package_dir, cache2);
   expect(r.err).toContain("expected exactly one <file>");
   expect(r.code).toBe(1);
+  r = await run(["pm", "cache", "pack", ""], package_dir, cache2);
+  expect(r.err).toContain("expected exactly one <file>");
+  expect(r.code).toBe(1);
 });
 
 it("bun pm cache unpack refuses hostile packs", async () => {
@@ -197,6 +200,9 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   r = await run(["pm", "cache", "unpack", join(dir, "links.pack")], dir, cache);
   expect(r.err).not.toContain("error:");
   expect(r.code).toBe(0);
+  const linkEntry = (await readdirSorted(cache)).find(n => n.startsWith("links@1.0.0"))!;
+  expect(lstatSync(join(cache, linkEntry, "bin", "cli")).isSymbolicLink()).toBeTrue();
+  expect(readFileSync(join(cache, linkEntry, "bin", "cli"), "utf8")).toBe("x");
   await writeFile(
     join(dir, "climb.pack"),
     Buffer.concat([MAGIC, rec(1, "climb@1.0.0", 0, ""), rec(3, "bin/cli", 0o777, "../../victim"), rec(0, "", 0, "")]),

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -1,0 +1,133 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { existsSync } from "fs";
+import { rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+setDefaultTimeout(1000 * 60 * 5);
+
+let urls: string[];
+beforeEach(async () => {
+  await dummyBeforeEach({ linker: "hoisted" });
+  urls = [];
+  setHandler(dummyRegistry(urls, { "0.1.0": {}, "0.0.2": {}, "0.0.3": {}, latest: "0.0.3" }));
+});
+afterEach(dummyAfterEach);
+
+async function run(args: string[], cwd: string, cacheDir: string) {
+  await using proc = spawn({
+    cmd: [bunExe(), ...args],
+    cwd,
+    env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+function bunfig() {
+  return Bun.TOML.stringify({ install: { registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" } });
+}
+
+// length-prefixed record, mirroring the pack format
+function rec(kind: number, path: string, mode: number, data: string | Buffer) {
+  const p = Buffer.from(path);
+  const d = Buffer.from(data);
+  const h = Buffer.alloc(1 + 4 + p.length + 4 + 8);
+  h[0] = kind;
+  h.writeUInt32LE(p.length, 1);
+  p.copy(h, 5);
+  h.writeUInt32LE(mode, 5 + p.length);
+  h.writeBigUInt64LE(BigInt(d.length), 9 + p.length);
+  return Buffer.concat([h, d]);
+}
+const MAGIC = Buffer.from("BUNCACHEPACK\0v1\n");
+
+it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile needs", async () => {
+  const cache1 = tmpdirSync();
+  const cache2 = tmpdirSync();
+  await writeFile(join(package_dir, "bunfig.toml"), bunfig());
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "@barn/moo": "0.1.0", bar: "0.0.2", baz: "0.0.3" } }));
+
+  let r = await run(["install"], package_dir, cache1);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+
+  const pack = join(package_dir, "cache.pack");
+  r = await run(["pm", "cache", "pack", pack], package_dir, cache1);
+  expect(r.err).not.toContain("error:");
+  expect(r.out).toContain("Packed 3 packages");
+  expect(existsSync(pack)).toBeTrue();
+
+  // restore into an empty cache dir …
+  r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
+  expect(r.err).not.toContain("error:");
+  expect(r.out).toContain("3 new");
+  const names = await readdirSorted(cache2);
+  expect(names.some(n => n.startsWith("bar@0.0.2"))).toBeTrue();
+  expect(existsSync(join(cache2, "@barn"))).toBeTrue();
+
+  // … and install from it: no tarball is downloaded again
+  await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+  const before = urls.filter(u => u.endsWith(".tgz")).length;
+  r = await run(["install", "--frozen-lockfile"], package_dir, cache2);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.filter(u => u.endsWith(".tgz")).length).toBe(before);
+  expect(await Bun.file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toMatchObject({ name: "@barn/moo" });
+  expect(existsSync(join(package_dir, "node_modules", "bar", "package.json"))).toBeTrue();
+
+  // idempotent
+  r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
+  expect(r.out).toContain("0 new, 3 already cached");
+});
+
+it("bun pm cache unpack refuses hostile packs", async () => {
+  const cache = tmpdirSync();
+  const victim = tmpdirSync();
+  const dir = tmpdirSync();
+  await writeFile(join(dir, "package.json"), "{}");
+
+  // a folder name that tries to escape the cache dir
+  await writeFile(join(dir, "traversal.pack"), Buffer.concat([MAGIC, rec(1, "../xx", 0, ""), rec(0, "", 0, "")]));
+  let r = await run(["pm", "cache", "unpack", join(dir, "traversal.pack")], dir, cache);
+  expect(r.code).not.toBe(0);
+  expect(r.err).toContain("unsafe");
+
+  // a symlink out of the package followed by a file written through it
+  const rel = "./../../" + require("path").basename(victim);
+  await writeFile(
+    join(dir, "escape.pack"),
+    Buffer.concat([MAGIC, rec(1, "evil@1.0.0", 0, ""), rec(3, "esc", 0o777, rel), rec(2, "esc/pwned", 0o644, "owned"), rec(0, "", 0, "")]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", require("path").basename(cache)));
+  expect(r.code).not.toBe(0);
+  expect(r.err).toMatch(/unsafe|traverses/);
+  expect(existsSync(join(victim, "pwned"))).toBeFalse();
+  // no staging directory is left behind after a failed unpack
+  expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
+
+  // an absurd symlink target length
+  await writeFile(join(dir, "long.pack"), Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]));
+  r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
+  expect(r.code).not.toBe(0);
+
+  // not a pack at all
+  await writeFile(join(dir, "junk.pack"), "hello");
+  r = await run(["pm", "cache", "unpack", join(dir, "junk.pack")], dir, cache);
+  expect(r.code).not.toBe(0);
+});

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -248,6 +248,41 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect(r.code).not.toBe(0);
   expect((await readdirSorted(cache)).filter(n => n.startsWith("chain2"))).toEqual([]);
 
+  // …and with the second link spelled in a different case (same entry on
+  // case-insensitive filesystems)
+  await writeFile(
+    join(dir, "chain3.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "chain3@1.0.0", 0, ""),
+      rec(4, "a", 0o755, ""),
+      rec(3, "a/up", 0o777, ".."),
+      rec(3, "A/UP/A/UP/out", 0o777, "../../../.."),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "chain3.pack")], dir, cacheViaVictim);
+  expect(r.err).toContain("passes through another symlink");
+  expect(r.code).not.toBe(0);
+
+  // a link that points *at* another link (not through it) is fine: bin/cli -> ../index.js -> ./lib/impl.js
+  await writeFile(
+    join(dir, "links2.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "links2@1.0.0", 0, ""),
+      rec(2, "lib/impl.js", 0o644, "y"),
+      rec(3, "index.js", 0o777, "./lib/impl.js"),
+      rec(3, "bin/cli", 0o777, "../index.js"),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "links2.pack")], dir, cache);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  const links2 = (await readdirSorted(cache)).find(n => n.startsWith("links2@1.0.0"))!;
+  expect(readFileSync(join(cache, links2, "bin", "cli"), "utf8")).toBe("y");
+
   // an absurd symlink target length
   await writeFile(
     join(dir, "long.pack"),

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -159,11 +159,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
       rec(0, "", 0, ""),
     ]),
   );
-  r = await run(
-    ["pm", "cache", "unpack", join(dir, "escape.pack")],
-    dir,
-    join(victim, "..", basename(cache)),
-  );
+  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", basename(cache)));
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
   expect(existsSync(join(victim, "pwned"))).toBeFalse();

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, isMacOS, isWindows, readdirSorted, tempDir } from "harness";
+import { bunExe, bunEnv as env, isWindows, readdirSorted, tempDir } from "harness";
 import { basename, dirname, join } from "path";
 import {
   dummyAfterAll,
@@ -203,27 +203,25 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   // no staging directory is left behind after a failed unpack
   expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
 
-  // (symlink records are validated but not materialised on Windows, matching tarball
-  // extraction there, so the scenarios that read through created links are POSIX-only)
-  if (!isWindows) {
-    // a file written *through* a symlink created earlier in the same package: the link
-    // itself is legal (points inside the package), the write through it is not
-    await writeFile(
-      join(dir, "through.pack"),
-      Buffer.concat([
-        MAGIC,
-        rec(1, "through@1.0.0", 0, ""),
-        rec(4, "real", 0o755, ""),
-        rec(3, "esc", 0o777, "real"),
-        rec(2, "esc/pwned", 0o644, "owned"),
-        rec(0, "", 0, ""),
-      ]),
-    );
-    r = await run(["pm", "cache", "unpack", join(dir, "through.pack")], dir, cache);
-    expect(r.err).toContain("traverses");
-    expect(r.code).not.toBe(0);
-  }
-  // intra-package relative links are fine (bin/cli -> ../lib/cli.js), climbing out is not
+  // a file written *through* a symlink created earlier in the same package: the link
+  // itself is legal (points inside the package), the write through it is not
+  await writeFile(
+    join(dir, "through.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "through@1.0.0", 0, ""),
+      rec(4, "real", 0o755, ""),
+      rec(3, "esc", 0o777, "real"),
+      rec(2, "esc/pwned", 0o644, "owned"),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "through.pack")], dir, cache);
+  expect(r.err).toContain("traverses");
+  expect(r.code).not.toBe(0);
+  // intra-package relative links are fine (bin/cli -> ../lib/cli.js), climbing out is not.
+  // (symlink records are validated everywhere but only materialised on POSIX, matching
+  // tarball extraction, so the scenarios that read through created links are POSIX-only)
   if (!isWindows) {
     await writeFile(
       join(dir, "links.pack"),
@@ -321,9 +319,11 @@ it("bun pm cache unpack refuses hostile packs", async () => {
     expect(readFileSync(join(cache, links2, "bin", "cli"), "utf8")).toBe("y");
   }
   // a non-ASCII pair that only a case-insensitive/normalising filesystem equates: the
-  // lexical check cannot see it, the physical parent-chain walk must (macOS; APFS is
-  // case-insensitive by default)
-  if (isMacOS) {
+  // lexical check cannot see it, the physical walks must. Only meaningful where the
+  // filesystem actually folds `ä`/`Ä` (default APFS; not ext4 or case-sensitive APFS).
+  await writeFile(join(dir, "ä-probe"), "");
+  const folds = !isWindows && existsSync(join(dir, "Ä-probe"));
+  if (folds) {
     await writeFile(
       join(dir, "chain4.pack"),
       Buffer.concat([

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -116,7 +116,7 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   expect(r.err).toContain("expected exactly one <file>");
   expect(r.code).toBe(1);
   r = await run(["pm", "cache", "pack", ""], package_dir, cache2);
-  expect(r.err).toContain("expected exactly one <file>");
+  expect(r.err).toContain("must not be empty");
   expect(r.code).toBe(1);
 });
 
@@ -210,6 +210,23 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   r = await run(["pm", "cache", "unpack", join(dir, "climb.pack")], dir, cache);
   expect(r.err).toContain("unsafe symlink target");
   expect(r.code).not.toBe(0);
+
+  // a target that only escapes by passing *through* another (self-referential) link:
+  // lexically inside, physically outside — must be refused
+  await writeFile(
+    join(dir, "chain.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "chain@1.0.0", 0, ""),
+      rec(3, "same", 0o777, "."),
+      rec(3, "x", 0o777, "same/same/../../" + basename(victim)),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "chain.pack")], dir, join(victim, "..", basename(cache)));
+  expect(r.err).toContain("passes through another symlink");
+  expect(r.code).not.toBe(0);
+  expect((await readdirSorted(join(victim, "..", basename(cache)))).filter(n => n.startsWith("chain"))).toEqual([]);
 
   // an absurd symlink target length
   await writeFile(

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -166,6 +166,45 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   // no staging directory is left behind after a failed unpack
   expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
 
+  // a file written *through* a symlink created earlier in the same package: the link
+  // itself is legal (points inside the package), the write through it is not
+  await writeFile(
+    join(dir, "through.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "through@1.0.0", 0, ""),
+      rec(4, "real", 0o755, ""),
+      rec(3, "esc", 0o777, "real"),
+      rec(2, "esc/pwned", 0o644, "owned"),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "through.pack")], dir, cache);
+  expect(r.err).toContain("traverses");
+  expect(r.code).not.toBe(0);
+
+  // intra-package relative links are fine (bin/cli -> ../lib/cli.js), climbing out is not
+  await writeFile(
+    join(dir, "links.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "links@1.0.0", 0, ""),
+      rec(2, "lib/cli.js", 0o644, "x"),
+      rec(3, "bin/cli", 0o777, "../lib/cli.js"),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "links.pack")], dir, cache);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  await writeFile(
+    join(dir, "climb.pack"),
+    Buffer.concat([MAGIC, rec(1, "climb@1.0.0", 0, ""), rec(3, "bin/cli", 0o777, "../../victim"), rec(0, "", 0, "")]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "climb.pack")], dir, cache);
+  expect(r.err).toContain("unsafe symlink target");
+  expect(r.code).not.toBe(0);
+
   // an absurd symlink target length
   await writeFile(
     join(dir, "long.pack"),

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test
 import { existsSync, lstatSync, readFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, isWindows, readdirSorted, tempDir } from "harness";
-import { basename, join } from "path";
+import { basename, dirname, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -150,7 +150,10 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect(existsSync(join(victim, "x"))).toBeFalse();
   expect((await readdirSorted(cache)).filter(n => !n.startsWith("."))).toEqual([]);
 
-  // a symlink out of the package followed by a file written through it
+  // a symlink out of the package followed by a file written through it (victim and the
+  // cache dir are siblings under the same temp root; the escape path relies on that)
+  expect(dirname(victim)).toBe(dirname(cache));
+  const cacheViaVictim = join(victim, "..", basename(cache));
   const rel = "./../../" + basename(victim);
   await writeFile(
     join(dir, "escape.pack"),
@@ -162,7 +165,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
       rec(0, "", 0, ""),
     ]),
   );
-  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, join(victim, "..", basename(cache)));
+  r = await run(["pm", "cache", "unpack", join(dir, "escape.pack")], dir, cacheViaVictim);
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
   expect(existsSync(join(victim, "pwned"))).toBeFalse();
@@ -223,10 +226,10 @@ it("bun pm cache unpack refuses hostile packs", async () => {
       rec(0, "", 0, ""),
     ]),
   );
-  r = await run(["pm", "cache", "unpack", join(dir, "chain.pack")], dir, join(victim, "..", basename(cache)));
+  r = await run(["pm", "cache", "unpack", join(dir, "chain.pack")], dir, cacheViaVictim);
   expect(r.err).toContain("passes through another symlink");
   expect(r.code).not.toBe(0);
-  expect((await readdirSorted(join(victim, "..", basename(cache)))).filter(n => n.startsWith("chain"))).toEqual([]);
+  expect((await readdirSorted(cache)).filter(n => n.startsWith("chain"))).toEqual([]);
 
   // an absurd symlink target length
   await writeFile(
@@ -234,10 +237,12 @@ it("bun pm cache unpack refuses hostile packs", async () => {
     Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, Buffer.alloc(10_000, "a")), rec(0, "", 0, "")]),
   );
   r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
+  expect(r.err).toContain("symlink target too long");
   expect(r.code).not.toBe(0);
 
   // not a pack at all
   await writeFile(join(dir, "junk.pack"), "hello");
   r = await run(["pm", "cache", "unpack", join(dir, "junk.pack")], dir, cache);
+  expect(r.err).toContain("not a bun cache pack");
   expect(r.code).not.toBe(0);
 });

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -187,40 +187,45 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   // no staging directory is left behind after a failed unpack
   expect((await readdirSorted(cache)).filter(n => n.startsWith(".unpack-"))).toEqual([]);
 
-  // a file written *through* a symlink created earlier in the same package: the link
-  // itself is legal (points inside the package), the write through it is not
-  await writeFile(
-    join(dir, "through.pack"),
-    Buffer.concat([
-      MAGIC,
-      rec(1, "through@1.0.0", 0, ""),
-      rec(4, "real", 0o755, ""),
-      rec(3, "esc", 0o777, "real"),
-      rec(2, "esc/pwned", 0o644, "owned"),
-      rec(0, "", 0, ""),
-    ]),
-  );
-  r = await run(["pm", "cache", "unpack", join(dir, "through.pack")], dir, cache);
-  expect(r.err).toContain("traverses");
-  expect(r.code).not.toBe(0);
-
+  // (symlink records are validated but not materialised on Windows, matching tarball
+  // extraction there, so the scenarios that read through created links are POSIX-only)
+  if (!isWindows) {
+    // a file written *through* a symlink created earlier in the same package: the link
+    // itself is legal (points inside the package), the write through it is not
+    await writeFile(
+      join(dir, "through.pack"),
+      Buffer.concat([
+        MAGIC,
+        rec(1, "through@1.0.0", 0, ""),
+        rec(4, "real", 0o755, ""),
+        rec(3, "esc", 0o777, "real"),
+        rec(2, "esc/pwned", 0o644, "owned"),
+        rec(0, "", 0, ""),
+      ]),
+    );
+    r = await run(["pm", "cache", "unpack", join(dir, "through.pack")], dir, cache);
+    expect(r.err).toContain("traverses");
+    expect(r.code).not.toBe(0);
+  }
   // intra-package relative links are fine (bin/cli -> ../lib/cli.js), climbing out is not
-  await writeFile(
-    join(dir, "links.pack"),
-    Buffer.concat([
-      MAGIC,
-      rec(1, "links@1.0.0", 0, ""),
-      rec(2, "lib/cli.js", 0o644, "x"),
-      rec(3, "bin/cli", 0o777, "../lib/cli.js"),
-      rec(0, "", 0, ""),
-    ]),
-  );
-  r = await run(["pm", "cache", "unpack", join(dir, "links.pack")], dir, cache);
-  expect(r.err).not.toContain("error:");
-  expect(r.code).toBe(0);
-  const linkEntry = (await readdirSorted(cache)).find(n => n.startsWith("links@1.0.0"))!;
-  expect(lstatSync(join(cache, linkEntry, "bin", "cli")).isSymbolicLink()).toBeTrue();
-  expect(readFileSync(join(cache, linkEntry, "bin", "cli"), "utf8")).toBe("x");
+  if (!isWindows) {
+    await writeFile(
+      join(dir, "links.pack"),
+      Buffer.concat([
+        MAGIC,
+        rec(1, "links@1.0.0", 0, ""),
+        rec(2, "lib/cli.js", 0o644, "x"),
+        rec(3, "bin/cli", 0o777, "../lib/cli.js"),
+        rec(0, "", 0, ""),
+      ]),
+    );
+    r = await run(["pm", "cache", "unpack", join(dir, "links.pack")], dir, cache);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    const linkEntry = (await readdirSorted(cache)).find(n => n.startsWith("links@1.0.0"))!;
+    expect(lstatSync(join(cache, linkEntry, "bin", "cli")).isSymbolicLink()).toBeTrue();
+    expect(readFileSync(join(cache, linkEntry, "bin", "cli"), "utf8")).toBe("x");
+  }
   await writeFile(
     join(dir, "climb.pack"),
     Buffer.concat([MAGIC, rec(1, "climb@1.0.0", 0, ""), rec(3, "bin/cli", 0o777, "../../victim"), rec(0, "", 0, "")]),
@@ -280,27 +285,29 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect(r.err).toContain("passes through another symlink");
   expect(r.code).not.toBe(0);
 
-  // a link that points *at* another link (not through it) is fine: bin/cli -> ../index.js -> ./lib/impl.js
-  await writeFile(
-    join(dir, "links2.pack"),
-    Buffer.concat([
-      MAGIC,
-      rec(1, "links2@1.0.0", 0, ""),
-      rec(2, "lib/impl.js", 0o644, "y"),
-      rec(3, "index.js", 0o777, "./lib/impl.js"),
-      rec(3, "bin/cli", 0o777, "../index.js"),
-      rec(0, "", 0, ""),
-    ]),
-  );
-  r = await run(["pm", "cache", "unpack", join(dir, "links2.pack")], dir, cache);
-  expect(r.err).not.toContain("error:");
-  expect(r.code).toBe(0);
-  const links2 = (await readdirSorted(cache)).find(n => n.startsWith("links2@1.0.0"))!;
-  expect(readFileSync(join(cache, links2, "bin", "cli"), "utf8")).toBe("y");
-
+  if (!isWindows) {
+    // a link that points *at* another link (not through it) is fine: bin/cli -> ../index.js -> ./lib/impl.js
+    await writeFile(
+      join(dir, "links2.pack"),
+      Buffer.concat([
+        MAGIC,
+        rec(1, "links2@1.0.0", 0, ""),
+        rec(2, "lib/impl.js", 0o644, "y"),
+        rec(3, "index.js", 0o777, "./lib/impl.js"),
+        rec(3, "bin/cli", 0o777, "../index.js"),
+        rec(0, "", 0, ""),
+      ]),
+    );
+    r = await run(["pm", "cache", "unpack", join(dir, "links2.pack")], dir, cache);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    const links2 = (await readdirSorted(cache)).find(n => n.startsWith("links2@1.0.0"))!;
+    expect(readFileSync(join(cache, links2, "bin", "cli"), "utf8")).toBe("y");
+  }
   // a non-ASCII pair that only a case-insensitive/normalising filesystem equates: the
-  // lexical check cannot see it, the physical parent-chain walk must (macOS/Windows)
-  if (isMacOS || isWindows) {
+  // lexical check cannot see it, the physical parent-chain walk must (macOS; APFS is
+  // case-insensitive by default)
+  if (isMacOS) {
     await writeFile(
       join(dir, "chain4.pack"),
       Buffer.concat([
@@ -316,6 +323,24 @@ it("bun pm cache unpack refuses hostile packs", async () => {
     expect(r.err).toContain("passes through another symlink");
     expect(r.code).not.toBe(0);
     expect((await readdirSorted(cache)).filter(n => n.startsWith("chain4"))).toEqual([]);
+
+    // and a single-component link whose *target* routes through the differently-cased
+    // link: only the post-creation target walk can see this one
+    await writeFile(
+      join(dir, "chain5.pack"),
+      Buffer.concat([
+        MAGIC,
+        rec(1, "chain5@1.0.0", 0, ""),
+        rec(4, "ä", 0o755, ""),
+        rec(3, "ä/up", 0o777, ".."),
+        rec(3, "x", 0o777, "Ä/up/Ä/up/../victim"),
+        rec(0, "", 0, ""),
+      ]),
+    );
+    r = await run(["pm", "cache", "unpack", join(dir, "chain5.pack")], dir, cacheViaVictim);
+    expect(r.err).toContain("passes through another symlink");
+    expect(r.code).not.toBe(0);
+    expect((await readdirSorted(cache)).filter(n => n.startsWith("chain5"))).toEqual([]);
   }
 
   // an absurd symlink target length

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -231,6 +231,23 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect(r.code).not.toBe(0);
   expect((await readdirSorted(cache)).filter(n => n.startsWith("chain"))).toEqual([]);
 
+  // same attack with the records in the opposite order (the escaping link first)
+  await writeFile(
+    join(dir, "chain2.pack"),
+    Buffer.concat([
+      MAGIC,
+      rec(1, "chain2@1.0.0", 0, ""),
+      rec(4, "a", 0o755, ""),
+      rec(3, "out", 0o777, "a/up/../.."),
+      rec(3, "a/up", 0o777, ".."),
+      rec(0, "", 0, ""),
+    ]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "chain2.pack")], dir, cacheViaVictim);
+  expect(r.err).toContain("passes through another symlink");
+  expect(r.code).not.toBe(0);
+  expect((await readdirSorted(cache)).filter(n => n.startsWith("chain2"))).toEqual([]);
+
   // an absurd symlink target length
   await writeFile(
     join(dir, "long.pack"),

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -108,6 +108,22 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   expect(r.out).toContain("0 new, 3 already cached");
   expect(r.code).toBe(0);
 
+  // a file name containing `:` (legal on POSIX) round-trips
+  if (!isWindows) {
+    const barDir = join(cache1, (await readdirSorted(cache1)).find(n => n.startsWith("bar@0.0.2"))!);
+    await writeFile(join(barDir, "a:b.js"), "colon");
+    using cache3Dir = tempDir("cache-pack-c", {});
+    r = await run(["pm", "cache", "pack", join(package_dir, "colon.pack")], package_dir, cache1);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    r = await run(["pm", "cache", "unpack", join(package_dir, "colon.pack")], package_dir, String(cache3Dir));
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    const bar3 = (await readdirSorted(String(cache3Dir))).find(n => n.startsWith("bar@0.0.2"))!;
+    expect(readFileSync(join(String(cache3Dir), bar3, "a:b.js"), "utf8")).toBe("colon");
+    rmSync(join(barDir, "a:b.js"));
+  }
+
   // a cache entry containing a link that passes *through* another link cannot be
   // restored, so pack refuses it up front instead of producing a pack unpack rejects
   if (!isWindows) {

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -1,9 +1,9 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { existsSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
-import { join } from "path";
+import { bunExe, bunEnv as env, isWindows, readdirSorted, tempDir } from "harness";
+import { basename, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -17,7 +17,6 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-setDefaultTimeout(1000 * 60 * 5);
 
 let urls: string[];
 beforeEach(async () => {
@@ -58,8 +57,10 @@ function rec(kind: number, path: string, mode: number, data: string | Buffer) {
 const MAGIC = Buffer.from("BUNCACHEPACK\0v1\n");
 
 it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile needs", async () => {
-  const cache1 = tmpdirSync();
-  const cache2 = tmpdirSync();
+  using cache1Dir = tempDir("cache-pack-a", {});
+  using cache2Dir = tempDir("cache-pack-b", {});
+  const cache1 = String(cache1Dir);
+  const cache2 = String(cache2Dir);
   await writeFile(join(package_dir, "bunfig.toml"), bunfig());
   await writeFile(
     join(package_dir, "package.json"),
@@ -78,12 +79,14 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   r = await run(["pm", "cache", "pack", pack], package_dir, cache1);
   expect(r.err).not.toContain("error:");
   expect(r.out).toContain("Packed 3 packages");
+  expect(r.code).toBe(0);
   expect(existsSync(pack)).toBeTrue();
 
   // restore into an empty cache dir …
   r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
   expect(r.err).not.toContain("error:");
   expect(r.out).toContain("3 new");
+  expect(r.code).toBe(0);
   const names = await readdirSorted(cache2);
   expect(names.some(n => n.startsWith("bar@0.0.2"))).toBeTrue();
   expect(existsSync(join(cache2, "@barn"))).toBeTrue();
@@ -103,22 +106,49 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   // idempotent
   r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
   expect(r.out).toContain("0 new, 3 already cached");
+  expect(r.code).toBe(0);
+
+  // argument validation
+  r = await run(["pm", "cache", "pack"], package_dir, cache2);
+  expect(r.err).toContain("expected exactly one <file>");
+  expect(r.code).toBe(1);
+  r = await run(["pm", "cache", "unpack", pack, "extra"], package_dir, cache2);
+  expect(r.err).toContain("expected exactly one <file>");
+  expect(r.code).toBe(1);
 });
 
 it("bun pm cache unpack refuses hostile packs", async () => {
-  const cache = tmpdirSync();
-  const victim = tmpdirSync();
-  const dir = tmpdirSync();
-  await writeFile(join(dir, "package.json"), "{}");
+  using cacheDir = tempDir("cache-pack-c", {});
+  using victimDir = tempDir("cache-pack-v", {});
+  using dirDir = tempDir("cache-pack-d", { "package.json": "{}" });
+  const cache = String(cacheDir);
+  const victim = String(victimDir);
+  const dir = String(dirDir);
 
   // a folder name that tries to escape the cache dir
   await writeFile(join(dir, "traversal.pack"), Buffer.concat([MAGIC, rec(1, "../xx", 0, ""), rec(0, "", 0, "")]));
   let r = await run(["pm", "cache", "unpack", join(dir, "traversal.pack")], dir, cache);
-  expect(r.code).not.toBe(0);
   expect(r.err).toContain("unsafe");
+  expect(r.code).not.toBe(0);
+
+  // absolute folder name / absolute entry path
+  const abs = isWindows ? "C:\\evil" : "/tmp/evil";
+  await writeFile(join(dir, "absdir.pack"), Buffer.concat([MAGIC, rec(1, abs, 0, ""), rec(0, "", 0, "")]));
+  r = await run(["pm", "cache", "unpack", join(dir, "absdir.pack")], dir, cache);
+  expect(r.err).toContain("unsafe");
+  expect(r.code).not.toBe(0);
+  await writeFile(
+    join(dir, "absentry.pack"),
+    Buffer.concat([MAGIC, rec(1, "abs@1.0.0", 0, ""), rec(2, join(victim, "x"), 0o644, "x"), rec(0, "", 0, "")]),
+  );
+  r = await run(["pm", "cache", "unpack", join(dir, "absentry.pack")], dir, cache);
+  expect(r.err).toContain("unsafe");
+  expect(r.code).not.toBe(0);
+  expect(existsSync(join(victim, "x"))).toBeFalse();
+  expect((await readdirSorted(cache)).filter(n => !n.startsWith("."))).toEqual([]);
 
   // a symlink out of the package followed by a file written through it
-  const rel = "./../../" + require("path").basename(victim);
+  const rel = "./../../" + basename(victim);
   await writeFile(
     join(dir, "escape.pack"),
     Buffer.concat([
@@ -132,7 +162,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   r = await run(
     ["pm", "cache", "unpack", join(dir, "escape.pack")],
     dir,
-    join(victim, "..", require("path").basename(cache)),
+    join(victim, "..", basename(cache)),
   );
   expect(r.code).not.toBe(0);
   expect(r.err).toMatch(/unsafe|traverses/);
@@ -143,7 +173,7 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   // an absurd symlink target length
   await writeFile(
     join(dir, "long.pack"),
-    Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, "a".repeat(10000)), rec(0, "", 0, "")]),
+    Buffer.concat([MAGIC, rec(1, "x@1.0.0", 0, ""), rec(3, "l", 0o777, Buffer.alloc(10_000, "a")), rec(0, "", 0, "")]),
   );
   r = await run(["pm", "cache", "unpack", join(dir, "long.pack")], dir, cache);
   expect(r.code).not.toBe(0);

--- a/test/cli/install/bun-pm-cache-pack.test.ts
+++ b/test/cli/install/bun-pm-cache-pack.test.ts
@@ -1,8 +1,8 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { existsSync, lstatSync, readFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, isWindows, readdirSorted, tempDir } from "harness";
+import { bunExe, bunEnv as env, isMacOS, isWindows, readdirSorted, tempDir } from "harness";
 import { basename, dirname, join } from "path";
 import {
   dummyAfterAll,
@@ -107,6 +107,21 @@ it("bun pm cache pack / unpack round-trips exactly the cache entries a lockfile 
   r = await run(["pm", "cache", "unpack", pack], package_dir, cache2);
   expect(r.out).toContain("0 new, 3 already cached");
   expect(r.code).toBe(0);
+
+  // a cache entry containing a link that passes *through* another link cannot be
+  // restored, so pack refuses it up front instead of producing a pack unpack rejects
+  if (!isWindows) {
+    const barDir = join(cache1, (await readdirSorted(cache1)).find(n => n.startsWith("bar@0.0.2"))!);
+    mkdirSync(join(barDir, "real"), { recursive: true });
+    symlinkSync("real", join(barDir, "lnk"));
+    symlinkSync("lnk/inner", join(barDir, "through"));
+    r = await run(["pm", "cache", "pack", join(package_dir, "bad.pack")], package_dir, cache1);
+    expect(r.err).toContain("passes through another symlink");
+    expect(r.code).not.toBe(0);
+    expect(existsSync(join(package_dir, "bad.pack"))).toBeFalse();
+    rmSync(join(barDir, "through"));
+    rmSync(join(barDir, "lnk"));
+  }
 
   // argument validation
   r = await run(["pm", "cache", "pack"], package_dir, cache2);
@@ -282,6 +297,26 @@ it("bun pm cache unpack refuses hostile packs", async () => {
   expect(r.code).toBe(0);
   const links2 = (await readdirSorted(cache)).find(n => n.startsWith("links2@1.0.0"))!;
   expect(readFileSync(join(cache, links2, "bin", "cli"), "utf8")).toBe("y");
+
+  // a non-ASCII pair that only a case-insensitive/normalising filesystem equates: the
+  // lexical check cannot see it, the physical parent-chain walk must (macOS/Windows)
+  if (isMacOS || isWindows) {
+    await writeFile(
+      join(dir, "chain4.pack"),
+      Buffer.concat([
+        MAGIC,
+        rec(1, "chain4@1.0.0", 0, ""),
+        rec(4, "ä", 0o755, ""),
+        rec(3, "ä/up", 0o777, ".."),
+        rec(3, "Ä/UP/Ä/UP/out", 0o777, "../../../.."),
+        rec(0, "", 0, ""),
+      ]),
+    );
+    r = await run(["pm", "cache", "unpack", join(dir, "chain4.pack")], dir, cacheViaVictim);
+    expect(r.err).toContain("passes through another symlink");
+    expect(r.code).not.toBe(0);
+    expect((await readdirSorted(cache)).filter(n => n.startsWith("chain4"))).toEqual([]);
+  }
 
   // an absurd symlink target length
   await writeFile(


### PR DESCRIPTION
### What does this PR do?

Adds two subcommands for CI cache workflows:

```sh
bun pm cache pack   <file>   # snapshot the cache entries this lockfile needs into one file
bun pm cache unpack <file>   # restore the missing ones into the cache dir
```

**Why:** the usual advice is to cache bun's install cache directory between CI runs. Object-store backed caches move one large sequential file far faster than tens of thousands of small ones, and restoring a directory cache pays a `create + write` per file before `bun install` even starts. A pack is a single uncompressed stream (the CI cache layer already compresses), and `unpack` recreates only the folders that are missing, so it is cheap to run unconditionally before `bun install --frozen-lockfile`.

Details:
- `pack` walks the lockfile's packages (npm / git / github / remote tarball resolutions), maps them to their cache folder names, and writes `magic | (kind, path, mode, size, bytes)*` records — folder-start, file, symlink, dir. Optional packages for other os/cpu that were never downloaded are silently skipped; anything else missing from the local cache is counted and reported.
- `unpack` writes each package under `.unpack-<pid>-<n>` in the cache dir and renames it into place (an existing folder wins, so concurrent unpacks/installs are fine). It refuses: folder names that aren't `name@…` / `@scope/name@…`, entry paths that are absolute / contain `..` / drive letters / NUL, symlink targets that escape the package or exceed 4 KiB, and any file/dir entry that would be written *through* a symlink materialised earlier in the same package. Modes are masked to `0755` (no setuid/setgid), and a failed unpack removes its own staging dirs (staging dirs are per-process, so a concurrent unpack is never disturbed; another process's leftovers are not touched). Relative symlink targets are resolved against the link's directory and may point anywhere inside the package (`bin/cli → ../lib/cli.js`), never outside it.

Docs: `docs/pm/cli/pm.mdx` (`## cache`).

### How did you verify your code works?

New `test/cli/install/bun-pm-cache-pack.test.ts` (dummy registry):
- install (incl. a scoped package) with cache dir A → `pack` → `unpack` into empty cache dir B → `rm -rf node_modules` → `bun install --frozen-lockfile` against B downloads **no** tarballs and produces the same tree; a second `unpack` reports everything already cached.
- hostile packs: traversing folder name, `esc -> ./../../<dir>` symlink followed by a file entry `esc/pwned`, a 10 000-byte symlink target, and a non-pack file are all rejected, nothing is written outside the cache, and no staging dir is left behind.
- `test/cli/install/bun-pm.test.ts` still passes.



Supersedes #39904 (same change, moved from a fork branch to a branch in this repository; the review discussion so far is on that PR and has been addressed here).

