### PR TITLE
worker_threads: keep a markAsUntransferable() ArrayBuffer attached

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -103,6 +103,8 @@ using WasmMemoryHandleArray = Vector<RefPtr<JSC::SharedArrayBufferContents>>;
 #endif
 
 // worker_threads.markAsUncloneable() / markAsUntransferable(): create() rejects a tagged object.
+// These set the tag and nothing else. The worker_threads host function in Worker.cpp also pins an
+// ArrayBuffer; napi's external buffers carry the tag alone and stay detachable.
 void markAsUncloneable(JSC::VM&, JSC::JSObject&);
 void markAsUntransferable(JSC::VM&, JSC::JSObject&);
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -51,6 +51,7 @@
 #include "JSBroadcastChannel.h"
 #include "JSStructuredSerializeOptions.h"
 #include "BunClientData.h"
+#include <JavaScriptCore/JSArrayBuffer.h>
 
 namespace WebCore {
 
@@ -258,10 +259,22 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionMarkAsUncloneable, (JSGlobalObject * lexicalG
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
+// Node also gives an ArrayBuffer a detach key here, so that nothing can detach it afterwards:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/buffer.js#L1078-L1086
+// JSC has no detach key; the permanent pin is the closest thing. With isDetachable() false,
+// transferTo() copies instead of detaching (see pinStorage in bindings.cpp) and a BYOB read throws.
+// Only this entry point pins: napi.cpp marks its external buffers with markAsUntransferable() alone,
+// because Node keeps those detachable.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionMarkAsUntransferable, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    if (auto* object = callFrame->argument(0).getObject())
-        markAsUntransferable(lexicalGlobalObject->vm(), *object);
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    JSValue value = callFrame->argument(0);
+    auto* object = value.getObject();
+    if (!object)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    markAsUntransferable(vm, *object);
+    if (auto* arrayBuffer = JSC::toUnsharedArrayBuffer(vm, value))
+        arrayBuffer->pinAndLock();
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -138,6 +138,126 @@ test("markAsUncloneable and markAsUntransferable markers are private, unforgeabl
   expectDataCloneError(() => structuredClone(unmarkAttempt));
 });
 
+// Node also gives a marked ArrayBuffer a detach key (lib/internal/buffer.js markAsUntransferable), so
+// transfer() throws a TypeError there. JSC has no detach key; bun pins the buffer instead. The buffer
+// stays attached on every detach path either way. What the caller gets back differs in one place:
+// JSC answers transfer() on a pinned buffer with a copy. The byte stream's TransferArrayBuffer step
+// throws a TypeError as in Node, and the transfer list keeps throwing DataCloneError.
+test("markAsUntransferable keeps an ArrayBuffer attached on every detach path", async () => {
+  const bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+  const attached = { detached: false, byteLength: 8, bytes, marked: true };
+  const markedBuffer = (options?: { maxByteLength: number }) => {
+    const ab = new ArrayBuffer(8, options);
+    new Uint8Array(ab).set(bytes);
+    markAsUntransferable(ab);
+    return ab;
+  };
+  const state = (ab: ArrayBuffer) => ({
+    detached: ab.detached,
+    byteLength: ab.byteLength,
+    bytes: ab.detached ? null : Array.from(new Uint8Array(ab)),
+    marked: wt.isMarkedAsUntransferable(ab),
+  });
+  const outcome = (attempt: () => ArrayBuffer) => {
+    try {
+      return { returned: Array.from(new Uint8Array(attempt())) };
+    } catch (e: any) {
+      return { threw: e.name };
+    }
+  };
+
+  const transfers: Record<string, (ab: ArrayBuffer) => ArrayBuffer> = {
+    "transfer()": ab => ab.transfer(),
+    "transfer(4)": ab => ab.transfer(4),
+    "transferToFixedLength()": ab => ab.transferToFixedLength(),
+  };
+  const results = Object.fromEntries(
+    Object.entries(transfers).map(([name, transfer]) => {
+      const ab = markedBuffer();
+      return [name, { result: outcome(() => transfer(ab)), source: state(ab) }];
+    }),
+  );
+  expect(results).toEqual({
+    "transfer()": { result: { returned: bytes }, source: attached },
+    "transfer(4)": { result: { returned: [1, 2, 3, 4] }, source: attached },
+    "transferToFixedLength()": { result: { returned: bytes }, source: attached },
+  });
+
+  // The returned buffer is a copy with its own storage.
+  {
+    const ab = markedBuffer();
+    new Uint8Array(ab.transfer()).fill(0xff);
+    expect(state(ab)).toEqual(attached);
+  }
+
+  // A resizable buffer stays attached and resizable. Its transfer() reports a RangeError: the copy
+  // JSC makes of a pinned buffer is fixed-length, so the resizability cannot be carried over.
+  {
+    const rab = markedBuffer({ maxByteLength: 16 });
+    expect(outcome(() => rab.transfer())).toEqual({ threw: "RangeError" });
+    expect(outcome(() => rab.transferToFixedLength())).toEqual({ returned: bytes });
+    expect(state(rab)).toEqual(attached);
+    rab.resize(16);
+    expect(rab.byteLength).toBe(16);
+    expect(rab.resizable).toBe(true);
+  }
+
+  // A byte stream transfers the buffer behind every chunk it is handed, on enqueue() and on a BYOB
+  // read. Both refuse a marked buffer.
+  {
+    const enqueued = markedBuffer();
+    const read = markedBuffer();
+    const thrown = (error: unknown) => ({
+      TypeError: error instanceof TypeError,
+      message: error instanceof Error ? error.message : error,
+    });
+    const refused = { TypeError: true, message: "Cannot transfer an ArrayBuffer that is not detachable" };
+    let enqueueError: unknown;
+    const reader = new ReadableStream({
+      type: "bytes",
+      start(controller) {
+        try {
+          controller.enqueue(new Uint8Array(enqueued));
+        } catch (e) {
+          enqueueError = e;
+        }
+      },
+    }).getReader({ mode: "byob" });
+    expect(thrown(enqueueError)).toEqual(refused);
+    expect(state(enqueued)).toEqual(attached);
+
+    let readError: unknown;
+    try {
+      await reader.read(new Uint8Array(read));
+    } catch (e) {
+      readError = e;
+    }
+    expect(thrown(readError)).toEqual(refused);
+    expect(state(read)).toEqual(attached);
+    reader.releaseLock();
+  }
+
+  // The transfer list rejects the mark itself; cloning without a transfer still copies the bytes.
+  {
+    const ab = markedBuffer();
+    expect(outcome(() => structuredClone(ab, { transfer: [ab] }))).toEqual({ threw: "DataCloneError" });
+    expect(outcome(() => structuredClone(ab))).toEqual({ returned: bytes });
+    expect(outcome(() => ab.slice(0))).toEqual({ returned: bytes });
+    expect(state(ab)).toEqual(attached);
+  }
+
+  // Only an ArrayBuffer is pinned. Marking a view marks the view alone, and its buffer stays
+  // detachable, as in Node.
+  {
+    const view = new Uint8Array(bytes);
+    markAsUntransferable(view);
+    const buffer = view.buffer as ArrayBuffer;
+    expect(wt.isMarkedAsUntransferable(view)).toBe(true);
+    expect(outcome(() => buffer.transfer())).toEqual({ returned: bytes });
+    expect(state(buffer)).toEqual({ detached: true, byteLength: 0, bytes: null, marked: false });
+  }
+});
+
 test("all worker_threads worker instance properties are present", async () => {
   const worker = new Worker(new URL("./worker.js", import.meta.url));
   expect(worker).toHaveProperty("threadId");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -2008,6 +2008,37 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
         "napi_detach_arraybuffer=19 napi_is_detached_arraybuffer=0 is_detached=false napi_get_arraybuffer_info=1 length=0",
       ]);
     });
+
+    // The two ways a buffer becomes untransferable differ in Node. An external buffer only
+    // carries the mark and stays detachable. worker_threads.markAsUntransferable() also sets a
+    // detach key, which bun represents by pinning the buffer.
+    it("still detaches an external buffer, which is marked untransferable", async () => {
+      const output = await checkSameOutput(
+        "test_detach_arraybuffer",
+        "[tests.create_external_arraybuffer_for_transfer(8), tests.create_external_buffer_for_transfer(8).buffer]",
+      );
+      expect(output.split(/\r?\n/)).toEqual([
+        "napi_detach_arraybuffer=0 napi_is_detached_arraybuffer=0 is_detached=true napi_get_arraybuffer_info=0 length=0",
+        "napi_detach_arraybuffer=0 napi_is_detached_arraybuffer=0 is_detached=true napi_get_arraybuffer_info=0 length=0",
+      ]);
+    });
+    it("refuses a buffer that worker_threads.markAsUntransferable() marked", async () => {
+      // Not checkSameOutput: Node aborts here ("v8::FromJust Maybe value is Nothing" inside
+      // napi_detach_arraybuffer, from the detach key's TypeError). Bun reports
+      // napi_detachable_arraybuffer_expected (20) and leaves the buffer attached.
+      const output = (
+        await runOn(
+          bunExe(),
+          "test_detach_arraybuffer",
+          '(() => { const ab = new ArrayBuffer(8); require("node:worker_threads").markAsUntransferable(ab); return [ab]; })()',
+        )
+      )
+        .replaceAll(/^\[\w+\].+$/gm, "")
+        .trim();
+      expect(output).toBe(
+        "napi_detach_arraybuffer=20 napi_is_detached_arraybuffer=0 is_detached=false napi_get_arraybuffer_info=0 length=8",
+      );
+    });
   });
 
   describe("error handling", () => {


### PR DESCRIPTION
### Problem
- `worker_threads.markAsUntransferable(ab)` only sets the private name that the transfer list reads (`SerializedScriptValue.cpp:4321`). `ab.transfer()`, `transferToFixedLength()`, a byte stream `enqueue()` and a BYOB `read()` still detach the marked buffer.
- Node also sets a detach key ([`lib/internal/buffer.js`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/buffer.js#L1078-L1086)). All four calls throw a `TypeError` there.

### Fix
- The host function behind `markAsUntransferable()` (`Worker.cpp`) also calls `ArrayBuffer::pinAndLock()` on a non-shared `ArrayBuffer`. The shared mark helper is unchanged, so the napi external buffers from #39973 stay detachable, as in Node.
- Correct because the pin is JSC's one "must not be detached" flag, and every detach path reads it: `transferTo()` copies instead of detaching, the streams' TransferArrayBuffer step throws a `TypeError`, `napi_detach_arraybuffer` returns `napi_detachable_arraybuffer_expected`. That is the detach key's job in V8. `pinAndLock()` is the permanent, idempotent form of the pin.
- One difference remains: `transfer()` returns a copy instead of throwing. A throw needs a change inside JSC. The test documents this.
- Verified: `test/js/node/worker_threads/worker_threads.test.ts` and `test/napi/napi.test.ts`, both red on main. Also the rest of both files, the upstream `mark-as-*` tests and the structured clone suites.

### Background
- A detach moves the bytes out of an `ArrayBuffer` and leaves it empty. `transfer()`, transfer lists and byte streams all detach.
- The spec's [[ArrayBufferDetachKey]] makes a detach fail unless the caller presents the key. V8 exposes it as `SetDetachKey`. JSC has it only for `WebAssembly.Memory`.
- `ArrayBuffer::pin()` is a counter that native code raises while it reads the bytes off-thread. `pinAndLock()` sets a sticky bit in that counter, as JSC does for `SharedArrayBuffer`. Both clear `isDetachable()`. #33349 documents that `transferTo()` then copies.

<details><summary>Notes</summary>

Repro, run under Node v26.3.0 and bun 1.4.0:

```js
const { markAsUntransferable } = require("node:worker_threads");
const ab = new ArrayBuffer(4);
markAsUntransferable(ab);
try { ab.transfer(); console.log("transfer ok, detached:", ab.detached); } catch (e) { console.log(e.name); }
```

Node prints `TypeError` (message: "ArrayBuffer is not detachable and could not be cloned."). Bun prints `transfer ok, detached: true`. A byte stream `controller.enqueue(new Uint8Array(ab))` and a BYOB `reader.read(new Uint8Array(ab))` behave the same way: Node throws a `TypeError`, bun detaches `ab`.

Matrix with this change (Node in parentheses). The marked buffer stays attached in every row.

- `ab.transfer()`, `ab.transfer(n)`, `ab.transferToFixedLength()`: return a copy (TypeError).
- resizable `rab.transfer()`: `RangeError` from JSC, because the copy of a pinned buffer is fixed-length and cannot be resized (TypeError). `rab.transferToFixedLength()` returns a copy. `rab.resize()` still works (same in Node).
- byte stream `enqueue()` and BYOB `read()`: `TypeError` "Cannot transfer an ArrayBuffer that is not detachable" (TypeError).
- transfer list: `DataCloneError` code 25, unchanged (same).
- `structuredClone(ab)`, `ab.slice()`, views, `isMarkedAsUntransferable`, own keys: unchanged (same).
- `markAsUntransferable(view)`: marks the view only, `view.buffer` stays detachable (same).
- `SharedArrayBuffer`, a detached buffer, a wasm memory buffer: `pinAndLock()` is already set or has no effect. The code skips shared buffers explicitly, like Node's `isArrayBuffer()` check.
- `napi_detach_arraybuffer` on a marked buffer: bun returns status 20 and leaves it attached. Node aborts the process here (`v8::FromJust Maybe value is Nothing` inside `napi_detach_arraybuffer`), so that test is bun only. External buffers from `napi_create_external_arraybuffer` and `napi_create_external_buffer` still detach, and that test is compared against Node.

Alternatives considered:

- Replace `ArrayBuffer.prototype.transfer` and `transferToFixedLength` on every global object with bun functions that throw for a marked buffer. That duplicates or wraps engine code, adds a call to a path that user streams hit per chunk, has to cover every realm (workers, `node:vm`), and still leaves the stream paths to the pin. The pin covers every path with one flag. A throw from `transfer()` on a locked buffer is a small change in `arrayBufferProtoFuncTransferImpl` in the WebKit fork. It would give marked buffers Node's TypeError with no further change here.
- `pin()` instead of `pinAndLock()`: a counter meant to be balanced by `unpin()`, and a second mark would count twice. The lock bit is what JSC itself uses for buffers that must never be detached.
- Pinning inside the shared `WebCore::markAsUntransferable()`: this would pin napi's external buffers too. #39973 rejected that because Node keeps them detachable (`napi_detach_arraybuffer` and BYOB reads work on them). The new napi test checks this against Node.

Suites run with the debug build: all of `worker_threads.test.ts` (138 pass), all of `test/napi/napi.test.ts` (185 pass), `test-worker-message-transfer-port-mark-as-untransferable.js`, `test-worker-message-mark-as-uncloneable.js`, `test/js/web/workers/structured-clone.test.ts`, `worker-postmessage-transfer.test.ts`, `message-channel.test.ts`, `structured-clone-shared-array-buffer.test.ts`, `structured-clone-fastpath.test.ts`.

Found while comparing the mark with Node's after #39973. The gap predates #39973.
</details>
