### PR TITLE
watcher: issue the first ReadDirectoryChangesW before the watcher thread starts

### DIFF
--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -233,15 +233,13 @@ impl Watcher {
 
     pub fn start(&mut self) -> Result<(), crate::Error> {
         debug_assert!(!self.watchloop_handle.load());
-        // Windows reports no change made before the first ReadDirectoryChangesW
-        // on the handle. Issue it here, before the caller goes on to run the
-        // entry point, instead of on the watcher thread, which under load can
-        // get scheduled after the first write the user makes. inotify and
-        // kqueue queue events from the moment a file is added to the watchlist.
-        // `self` is the boxed watcher here, so the buffers the read writes into
-        // do not move.
+        // Windows records changes only while a read is outstanding, and the
+        // watcher thread can get scheduled after the user's first write.
         #[cfg(windows)]
-        self.platform.arm()?;
+        if let Err(err) = self.platform.arm() {
+            self.platform.stop();
+            return Err(err.into());
+        }
         self.watchloop_handle.store(true);
         // Watcher must be Send across the spawned thread boundary; we pass a
         // raw pointer (as usize) and uphold the safety contract manually.
@@ -267,9 +265,7 @@ impl Watcher {
             Ok(handle) => handle,
             Err(e) => {
                 self.watchloop_handle.store(false);
-                // No thread will ever take the read armed above. Retire it
-                // now: the caller frees `self` through `shutdown`'s no-thread
-                // path, and the read points into `self`.
+                // The read armed above points into `self`, which the caller frees.
                 #[cfg(windows)]
                 self.platform.stop();
                 // Windows: raw_os_error() is a Win32 GetLastError() code, so
@@ -382,9 +378,7 @@ impl Watcher {
                 running
             }
             Ok(()) => {
-                // `shutdown` handed the allocation to this thread and
-                // `thread_main` frees it next. The last cycle re-armed a read
-                // into it, so retire that read first.
+                // `thread_main` frees `self` next; the last cycle re-armed a read into it.
                 #[cfg(windows)]
                 self.platform.stop();
                 false

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -233,6 +233,15 @@ impl Watcher {
 
     pub fn start(&mut self) -> Result<(), crate::Error> {
         debug_assert!(!self.watchloop_handle.load());
+        // Windows reports no change made before the first ReadDirectoryChangesW
+        // on the handle. Issue it here, before the caller goes on to run the
+        // entry point, instead of on the watcher thread, which under load can
+        // get scheduled after the first write the user makes. inotify and
+        // kqueue queue events from the moment a file is added to the watchlist.
+        // `self` is the boxed watcher here, so the buffers the read writes into
+        // do not move.
+        #[cfg(windows)]
+        self.platform.arm()?;
         self.watchloop_handle.store(true);
         // Watcher must be Send across the spawned thread boundary; we pass a
         // raw pointer (as usize) and uphold the safety contract manually.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -263,23 +263,32 @@ impl Watcher {
             std::thread::sleep(std::time::Duration::from_millis(10));
             spawn().map_err(|_| first)
         });
-        self.thread = Some(handle.map_err(|e| {
-            self.watchloop_handle.store(false);
-            // Windows: raw_os_error() is a Win32 GetLastError() code, so
-            // route it through the u32 (Win32Error) mapper rather than
-            // from_errno's i64 discriminant-cast path.
-            #[cfg(windows)]
-            let errno = e
-                .raw_os_error()
-                .and_then(|c| bun_errno::SystemErrno::init(c as u32))
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            #[cfg(not(windows))]
-            let errno = e
-                .raw_os_error()
-                .map(bun_errno::from_errno)
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            crate::Error::Sys(errno)
-        })?);
+        let handle = match handle {
+            Ok(handle) => handle,
+            Err(e) => {
+                self.watchloop_handle.store(false);
+                // No thread will ever take the read armed above. Retire it
+                // now: the caller frees `self` through `shutdown`'s no-thread
+                // path, and the read points into `self`.
+                #[cfg(windows)]
+                self.platform.stop();
+                // Windows: raw_os_error() is a Win32 GetLastError() code, so
+                // route it through the u32 (Win32Error) mapper rather than
+                // from_errno's i64 discriminant-cast path.
+                #[cfg(windows)]
+                let errno = e
+                    .raw_os_error()
+                    .and_then(|c| bun_errno::SystemErrno::init(c as u32))
+                    .unwrap_or(bun_errno::SystemErrno::EAGAIN);
+                #[cfg(not(windows))]
+                let errno = e
+                    .raw_os_error()
+                    .map(bun_errno::from_errno)
+                    .unwrap_or(bun_errno::SystemErrno::EAGAIN);
+                return Err(crate::Error::Sys(errno));
+            }
+        };
+        self.thread = Some(handle);
         Ok(())
     }
 
@@ -372,7 +381,14 @@ impl Watcher {
                 }
                 running
             }
-            Ok(()) => false,
+            Ok(()) => {
+                // `shutdown` handed the allocation to this thread and
+                // `thread_main` frees it next. The last cycle re-armed a read
+                // into it, so retire that read first.
+                #[cfg(windows)]
+                self.platform.stop();
+                false
+            }
         };
 
         // deinit and close descriptors if needed

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -315,7 +315,8 @@ impl WindowsWatcher {
     /// thread is still being scheduled (for example right after the entry
     /// point's first evaluation under `--hot`) is not lost. Must only be
     /// called once `self` is at its final address: the outstanding read writes
-    /// into `watcher.buf` and `watcher.overlapped`.
+    /// into `watcher.buf` and `watcher.overlapped` until it completes or
+    /// [`Self::stop`] retires it, so `stop` has to run before `self` is freed.
     pub(crate) fn arm(&mut self) -> bun_sys::Result<()> {
         if self.read_pending {
             return Ok(());
@@ -409,14 +410,59 @@ impl WindowsWatcher {
         }
     }
 
+    /// Close the directory and the port. After this returns the kernel holds
+    /// no pointer into `self`, so the owner may free it.
     pub(crate) fn stop(&mut self) {
         // SAFETY: handles were opened in init() and are valid until stop() is called once.
         unsafe {
             w::CloseHandle(self.watcher.dir_handle);
+        }
+        if self.read_pending {
+            // Closing the directory retires the outstanding read, and its
+            // completion packet still arrives on the port. Take it, so that
+            // `buf` and `overlapped` are not written after the owner frees them.
+            let mut nbytes: w::DWORD = 0;
+            let mut key: w::ULONG_PTR = 0;
+            let mut overlapped: *mut w::OVERLAPPED = ptr::null_mut();
+            loop {
+                // SAFETY: iocp is a valid IOCP handle; out-params are valid stack locals.
+                let rc = unsafe {
+                    w::kernel32::GetQueuedCompletionStatus(
+                        self.iocp,
+                        &raw mut nbytes,
+                        &raw mut key,
+                        &raw mut overlapped,
+                        RETIRE_READ_TIMEOUT_MS,
+                    )
+                };
+                if overlapped == &raw mut self.watcher.overlapped {
+                    self.read_pending = false;
+                    break;
+                }
+                if rc == 0 && overlapped.is_null() {
+                    // Timed out, or the port itself is unusable.
+                    bun_core::scoped_log!(
+                        watcher,
+                        "stop(): no completion for the outstanding ReadDirectoryChangesW: {}",
+                        w::Win32Error::get().0
+                    );
+                    break;
+                }
+                // A packet for something else (spurious); keep waiting for ours.
+            }
+        }
+        // SAFETY: see above.
+        unsafe {
             w::CloseHandle(self.iocp);
         }
     }
 }
+
+/// How long `stop` waits for the read retired by closing the directory to
+/// report back. The file system completes it inside the close, so the packet
+/// is normally already queued; the bound only keeps a broken port from
+/// hanging shutdown.
+const RETIRE_READ_TIMEOUT_MS: w::DWORD = 1000;
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -22,6 +22,10 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
+    /// A `ReadDirectoryChangesW` is outstanding on `watcher.overlapped` and
+    /// `watcher.buf`. Set by [`Self::arm`], cleared when [`Self::next`]
+    /// dequeues its completion.
+    read_pending: bool,
 }
 
 impl Default for WindowsWatcher {
@@ -35,6 +39,7 @@ impl Default for WindowsWatcher {
             },
             buf: PathBuffer::uninit(),
             base_idx: 0,
+            read_pending: false,
         }
     }
 }
@@ -299,9 +304,30 @@ impl WindowsWatcher {
         Ok(())
     }
 
+    /// Issue the `ReadDirectoryChangesW` that [`Self::next`] waits on, unless
+    /// one is already outstanding.
+    ///
+    /// The kernel records changes to the directory only while a read has been
+    /// issued on the handle: changes made before the first call are never
+    /// reported, changes made between a completion and the next call are held
+    /// in the kernel's buffer. `Watcher::start` calls this on the starting
+    /// thread before the watcher thread exists, so a file written while that
+    /// thread is still being scheduled (for example right after the entry
+    /// point's first evaluation under `--hot`) is not lost. Must only be
+    /// called once `self` is at its final address: the outstanding read writes
+    /// into `watcher.buf` and `watcher.overlapped`.
+    pub(crate) fn arm(&mut self) -> bun_sys::Result<()> {
+        if self.read_pending {
+            return Ok(());
+        }
+        self.watcher.prepare()?;
+        self.read_pending = true;
+        Ok(())
+    }
+
     /// wait until new events are available
     fn next(&mut self, timeout: Timeout) -> bun_sys::Result<Option<EventIterator>> {
-        if let Err(err) = self.watcher.prepare() {
+        if let Err(err) = self.arm() {
             bun_core::scoped_log!(watcher, "prepare() returned error");
             return Err(err);
         }
@@ -320,6 +346,11 @@ impl WindowsWatcher {
                     timeout as w::DWORD,
                 )
             };
+            if overlapped == &raw mut self.watcher.overlapped {
+                // Our read completed (with or without an error); `buf` and
+                // `overlapped` are free to reuse.
+                self.read_pending = false;
+            }
             if rc == 0 {
                 let err = w::Win32Error::get();
                 // `WAIT_TIMEOUT` (258) — not yet a named const on `bun_sys::windows::Win32Error`.
@@ -339,7 +370,7 @@ impl WindowsWatcher {
 
             if !overlapped.is_null() {
                 // ignore possible spurious events
-                if overlapped != &mut self.watcher.overlapped as *mut w::OVERLAPPED {
+                if overlapped != &raw mut self.watcher.overlapped {
                     continue;
                 }
                 if nbytes == 0 {
@@ -356,9 +387,7 @@ impl WindowsWatcher {
                         watcher,
                         "ReadDirectoryChangesW buffer overflow (nbytes==0); re-arming"
                     );
-                    if let Err(err) = self.watcher.prepare() {
-                        return Err(err);
-                    }
+                    self.arm()?;
                     continue;
                 }
                 return Ok(Some(EventIterator {

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -22,9 +22,7 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
-    /// A `ReadDirectoryChangesW` is outstanding on `watcher.overlapped` and
-    /// `watcher.buf`. Set by [`Self::arm`], cleared when [`Self::next`]
-    /// dequeues its completion.
+    /// A `ReadDirectoryChangesW` into `watcher` is outstanding.
     read_pending: bool,
 }
 
@@ -304,19 +302,10 @@ impl WindowsWatcher {
         Ok(())
     }
 
-    /// Issue the `ReadDirectoryChangesW` that [`Self::next`] waits on, unless
-    /// one is already outstanding.
-    ///
-    /// The kernel records changes to the directory only while a read has been
-    /// issued on the handle: changes made before the first call are never
-    /// reported, changes made between a completion and the next call are held
-    /// in the kernel's buffer. `Watcher::start` calls this on the starting
-    /// thread before the watcher thread exists, so a file written while that
-    /// thread is still being scheduled (for example right after the entry
-    /// point's first evaluation under `--hot`) is not lost. Must only be
-    /// called once `self` is at its final address: the outstanding read writes
-    /// into `watcher.buf` and `watcher.overlapped` until it completes or
-    /// [`Self::stop`] retires it, so `stop` has to run before `self` is freed.
+    /// Issues the read that [`Self::next`] waits on, unless one is outstanding.
+    /// The kernel records changes only once the first read has been issued.
+    /// The read writes into `self`, so `self` must not move or be freed until
+    /// the read completes or [`Self::stop`] has run.
     pub(crate) fn arm(&mut self) -> bun_sys::Result<()> {
         if self.read_pending {
             return Ok(());
@@ -348,8 +337,7 @@ impl WindowsWatcher {
                 )
             };
             if overlapped == &raw mut self.watcher.overlapped {
-                // Our read completed (with or without an error); `buf` and
-                // `overlapped` are free to reuse.
+                // Completed, successfully or not.
                 self.read_pending = false;
             }
             if rc == 0 {
@@ -410,17 +398,15 @@ impl WindowsWatcher {
         }
     }
 
-    /// Close the directory and the port. After this returns the kernel holds
-    /// no pointer into `self`, so the owner may free it.
+    /// Closes the directory and the port. Once it returns, `self` can be freed.
     pub(crate) fn stop(&mut self) {
         // SAFETY: handles were opened in init() and are valid until stop() is called once.
         unsafe {
             w::CloseHandle(self.watcher.dir_handle);
         }
         if self.read_pending {
-            // Closing the directory retires the outstanding read, and its
-            // completion packet still arrives on the port. Take it, so that
-            // `buf` and `overlapped` are not written after the owner frees them.
+            // Closing the directory fails the read; its packet reaching the port
+            // is what proves the kernel is done with `buf` and `overlapped`.
             let mut nbytes: w::DWORD = 0;
             let mut key: w::ULONG_PTR = 0;
             let mut overlapped: *mut w::OVERLAPPED = ptr::null_mut();
@@ -432,7 +418,7 @@ impl WindowsWatcher {
                         &raw mut nbytes,
                         &raw mut key,
                         &raw mut overlapped,
-                        RETIRE_READ_TIMEOUT_MS,
+                        w::INFINITE,
                     )
                 };
                 if overlapped == &raw mut self.watcher.overlapped {
@@ -440,15 +426,14 @@ impl WindowsWatcher {
                     break;
                 }
                 if rc == 0 && overlapped.is_null() {
-                    // Timed out, or the port itself is unusable.
+                    // The port itself failed, so no packet can arrive.
                     bun_core::scoped_log!(
                         watcher,
-                        "stop(): no completion for the outstanding ReadDirectoryChangesW: {}",
+                        "stop(): GetQueuedCompletionStatus failed: {}",
                         w::Win32Error::get().0
                     );
                     break;
                 }
-                // A packet for something else (spurious); keep waiting for ours.
             }
         }
         // SAFETY: see above.
@@ -457,12 +442,6 @@ impl WindowsWatcher {
         }
     }
 }
-
-/// How long `stop` waits for the read retired by closing the directory to
-/// report back. The file system completes it inside the close, so the packet
-/// is normally already queued; the bound only keeps a broken port from
-/// hanging shutdown.
-const RETIRE_READ_TIMEOUT_MS: w::DWORD = 1000;
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -192,56 +192,48 @@ it(
   timeout,
 );
 
-// The watcher must already be recording changes when the entry point first
-// runs. On Windows the kernel records nothing until a ReadDirectoryChangesW is
-// outstanding, and that read used to be issued by the watcher thread, so a write
-// that landed before the thread got scheduled was never seen. A one-line entry
-// keeps the window between the first evaluation and the write as short as
-// possible, and the children run at the same time to put the thread start under
-// some load.
-it(
-  "should hot reload a file written as soon as the entry point first runs",
-  async () => {
-    async function reloadOnce(i: number) {
-      using dir = tempDir(`hot-first-write-${i}`, { "entry.js": `console.log("gen", 0);\n` });
-      const entry = join(String(dir), "entry.js");
-      await using runner = spawn({
-        cmd: [bunExe(), "--hot", "--no-clear-screen", entry],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        stdin: "ignore",
-      });
-      const stderr = runner.stderr.text();
-      const reader = runner.stdout.getReader();
-      const decoder = new TextDecoder();
-      let stdout = "";
-      async function waitForLine(line: string) {
-        while (!stdout.includes(line)) {
-          const { value, done } = await reader.read();
-          if (done) return false;
-          stdout += decoder.decode(value, { stream: true });
-        }
-        return true;
+// Regression test for the Windows watcher starting to record changes only once
+// its thread ran: the entry is one line so the write lands as early as possible,
+// and the children run at the same time so the thread start competes for CPU.
+it("should hot reload a file written as soon as the entry point first runs", async () => {
+  async function reloadOnce(i: number) {
+    using dir = tempDir(`hot-first-write-${i}`, { "entry.js": `console.log("gen", 0);\n` });
+    const entry = join(String(dir), "entry.js");
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "--no-clear-screen", entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const stderr = runner.stderr.text();
+    const reader = runner.stdout.getReader();
+    const decoder = new TextDecoder();
+    let stdout = "";
+    async function waitForLine(line: string) {
+      while (!stdout.includes(line)) {
+        const { value, done } = await reader.read();
+        if (done) return false;
+        stdout += decoder.decode(value, { stream: true });
       }
-      const seenFirst = await waitForLine("gen 0\n");
-      writeFileSync(entry, `console.log("gen", 1);\n`);
-      const reloaded = seenFirst && (await waitForLine("gen 1\n"));
-      runner.kill();
-      reader.releaseLock();
-      await runner.exited;
-      const stderrText = await stderr;
-      // stderr is only interesting when the reload did not happen.
-      return { i, reloaded, stderr: reloaded ? "" : stderrText };
+      return true;
     }
+    const seenFirst = await waitForLine("gen 0\n");
+    writeFileSync(entry, `console.log("gen", 1);\n`);
+    const reloaded = seenFirst && (await waitForLine("gen 1\n"));
+    runner.kill();
+    reader.releaseLock();
+    await runner.exited;
+    const stderrText = await stderr;
+    // stderr is only interesting when the reload did not happen.
+    return { i, reloaded, stderr: reloaded ? "" : stderrText };
+  }
 
-    const children = 6;
-    const results = await Promise.all(Array.from({ length: children }, (_, i) => reloadOnce(i)));
-    expect(results).toEqual(Array.from({ length: children }, (_, i) => ({ i, reloaded: true, stderr: "" })));
-  },
-  timeout,
-);
+  const children = 6;
+  const results = await Promise.all(Array.from({ length: children }, (_, i) => reloadOnce(i)));
+  expect(results).toEqual(Array.from({ length: children }, (_, i) => ({ i, reloaded: true, stderr: "" })));
+});
 
 it.each(["hot-file-loader.file", "hot-file-loader.css"])(
   "should hot reload when `%s` is overwritten",

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -188,6 +188,57 @@ it(
       // @ts-ignore
       runner?.kill?.(9);
     }
+  },
+  timeout,
+);
+
+// The watcher must already be recording changes when the entry point first
+// runs. On Windows the kernel records nothing until a ReadDirectoryChangesW is
+// outstanding, and that read used to be issued by the watcher thread, so a write
+// that landed before the thread got scheduled was never seen. A one-line entry
+// keeps the window between the first evaluation and the write as short as
+// possible, and the children run at the same time to put the thread start under
+// some load.
+it(
+  "should hot reload a file written as soon as the entry point first runs",
+  async () => {
+    async function reloadOnce(i: number) {
+      using dir = tempDir(`hot-first-write-${i}`, { "entry.js": `console.log("gen", 0);\n` });
+      const entry = join(String(dir), "entry.js");
+      await using runner = spawn({
+        cmd: [bunExe(), "--hot", "--no-clear-screen", entry],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+      const stderr = runner.stderr.text();
+      const reader = runner.stdout.getReader();
+      const decoder = new TextDecoder();
+      let stdout = "";
+      async function waitForLine(line: string) {
+        while (!stdout.includes(line)) {
+          const { value, done } = await reader.read();
+          if (done) return false;
+          stdout += decoder.decode(value, { stream: true });
+        }
+        return true;
+      }
+      const seenFirst = await waitForLine("gen 0\n");
+      writeFileSync(entry, `console.log("gen", 1);\n`);
+      const reloaded = seenFirst && (await waitForLine("gen 1\n"));
+      runner.kill();
+      reader.releaseLock();
+      await runner.exited;
+      const stderrText = await stderr;
+      // stderr is only interesting when the reload did not happen.
+      return { i, reloaded, stderr: reloaded ? "" : stderrText };
+    }
+
+    const children = 6;
+    const results = await Promise.all(Array.from({ length: children }, (_, i) => reloadOnce(i)));
+    expect(results).toEqual(Array.from({ length: children }, (_, i) => ({ i, reloaded: true, stderr: "" })));
   },
   timeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -192,9 +192,10 @@ it(
   timeout,
 );
 
-// Regression test for the Windows watcher starting to record changes only once
-// its thread ran: the entry is one line so the write lands as early as possible,
-// and the children run at the same time so the thread start competes for CPU.
+// A write that lands right after the first evaluation must still reload. The
+// Windows watcher used to record changes only once its thread had run, and on a
+// loaded machine (CI) this catches that too, hence the one-line entry. On an
+// idle machine the thread usually wins the race and the old code passes as well.
 it("should hot reload a file written as soon as the entry point first runs", async () => {
   async function reloadOnce(i: number) {
     using dir = tempDir(`hot-first-write-${i}`, { "entry.js": `console.log("gen", 0);\n` });


### PR DESCRIPTION
### Problem
- On Windows, `--hot`, `--watch` and the dev server miss a file change made right after the entry point first runs. `test/js/bun/resolve/bun-main-entry-point.test.ts` ("ServerEntryPoint regenerates cleanly across --hot reloads", `test timed out`) does that, and is retried in 284 of the last 377 CI builds (Notes).
- Windows records changes to a directory only after the first `ReadDirectoryChangesW` on its handle. The watcher thread issues that read (`src/watcher/WindowsWatcher.rs:309`). Under load it runs after the user's write, which is then never reported.

### Fix
- `Watcher::start` arms the first read on the calling thread, before it spawns the watcher thread and before the entry point runs. The watcher is boxed by then, so the buffer the read fills does not move.
- `next` used to issue a read on every call, so timed out waits left reads piling up on one buffer. `WindowsWatcher::arm` issues a read only when none is outstanding. One at a time is enough: changes made in between wait in the kernel's buffer. inotify and kqueue are unchanged.
- `WindowsWatcher::stop` waits for the packet of the read it retires, and runs on each path that frees the watcher with a read out: `start` failing, or the thread exiting on shutdown (Notes).
- Verified: `test/cli/hot/hot.test.ts`, new case "should hot reload a file written as soon as the entry point first runs". On a loaded 16 CPU Windows machine the unfixed debug build fails it 5 runs out of 8, the fixed one 0 out of 8. A probe of the same shape: 23 lost reloads out of 60 against 0 (Notes). In CI, `bun-main-entry-point.test.ts` was retried in 0 of this PR's 7 builds, against 20 of the 27 other builds that ran in the same hours (Notes).

### Background
- `bun_watcher` serves `--hot`, `--watch`, `bun build --watch` and the dev server. It owns the watchlist and a thread that waits for OS events and calls the hot reloader.
- On Windows it watches the project root with one overlapped `ReadDirectoryChangesW` into a 64 KiB buffer. Before the first read the kernel records nothing. After it, it holds changes in a buffer of the same size until the next read.
- The window closes when the new thread runs its first instruction. On a machine with free CPUs a test rarely hits it (Notes), so the new case fails on the old code under load, as `bun-main-entry-point.test.ts` does in CI, and never on the new code. On Linux and macOS it passes either way: there the watch is registered before the entry point runs.

<details><summary>Notes</summary>

Probe. A script spawns `bun --hot entry.mjs` (the entry prints `GEN 0`), writes `GEN 1` into the entry as soon as `GEN 0` arrives on stdout, and waits up to 15 s for `GEN 1`. Runs go 4 at a time, with 16 `bun -e 'while(...){}'` processes as load, on a 16 logical CPU Windows Server 2019 machine. `TEMP` points at a long form path: with the default 8.3 `TEMP` both builds watch nothing, which is #39832's bug, not this one.

| build | load | write | runs | never reloaded |
| --- | --- | --- | --- | --- |
| release 1.4.0 canary (unfixed) | 16 burners | at once | 60 | 21 |
| release 1.4.0 canary (unfixed) | 16 burners | 1 s later | 60 | 0 |
| debug, parent commit | 16 burners | at once | 60 | 23 |
| debug, this commit | 16 burners | at once | 60 | 0 |
| debug, parent commit | none, 16 runs at a time | at once | 96 | 3 |
| debug, parent commit | none, 8 runs at a time | at once | 96 | 0 |

In the unfixed build the runs that did reload had a median latency of 15 ms: the thread had started before the write. In the fixed build every run reloaded, with a median of about 2 s under this load: the change was recorded at once and reported when the thread got CPU time. The last two rows show that with free CPUs the window is hard to hit on purpose, which is why the new test is not a reliable fail-before on an idle machine. Under the same 16 burners, the new test run 8 times with each debug build: unfixed, 3 passes and 5 runs that never reloaded within 20 s; fixed, 8 passes. With the Linux debug build (`bun bd test`) and with the released Linux binary it passes, as expected.

CI after the change: builds 102938, 102948, 102955, 102965, 102992, 103007 and 103020 of this branch each have a flaky annotation (other tests), and none of them lists `bun-main-entry-point.test.ts`. Of the 30 most recent builds of other branches at the same time (102973 to 103105), 27 have annotations and 20 of them list it. The hot, watch and dev server suites pass on Windows with the final source change.

CI numbers: the `flaky` annotation (failed, then passed on retry) of the last 400 passed or failed builds of the bun pipeline, all from the last 18 hours. The test appears in 284 of the 377 builds that have annotations: 406 records, 385 of them from the parallel batch, 203 on Windows 2019 x64 and 203 on Windows 11 aarch64.

Suites run on Windows with the fixed debug build: `test/js/bun/resolve/bun-main-entry-point.test.ts`, `test/cli/hot/`, `test/cli/watch/`, `test/bake/dev/hot.test.ts`, `test/bake/deinitialization.test.ts`, `test/js/bun/http/bun-serve-html-hot-reload-drop.test.ts`, `test/cli/test/test-filter-lifecycle-snapshot.test.ts`, and the `--hot` case of `test/js/bun/cron/in-process-cron.test.ts`. All pass, on the first commit and again on the final one.

Shutdown. `stop` closes the directory first. That fails the outstanding read. The I/O manager then writes the status into `overlapped` and queues the packet, in that order, so taking the packet off the port is what proves the allocation is free to release. The wait has no bound: a failed read always produces its packet, and the only way out without one is the port itself failing, which the loop reports and gives up on. The pre-existing thread exit path (`thread_body` returning `Ok`) freed the allocation without this, with a read re-armed by the last cycle still pointing into it. This also applied to the reads the old code issued, so it is not new to this change, but the fix is the same call and it is included.

Overlap: #39820 adds a similar pending flag to `next` for a different bug (a panic in the batch loop). This change needs the flag so that the thread's first `next` does not double the read armed in `start`. Whichever of the two lands second rebases that hunk. #35596 restructures the same code for multiple roots. Each root it adds needs to be armed by the thread that adds it, for the same reason.

`cargo check -p bun_watcher --target x86_64-pc-windows-msvc` and `cargo fmt --check` pass. `cargo clippy` on that target reports 11 pre-existing findings in this crate after the change and 14 before (the three removed were on the rewritten lines).
</details>
