### PR TITLE
websocket client: remove the remaining unsafe from the module

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -181,8 +181,6 @@ impl<const SSL: bool> WebSocket<SSL> {
             // SAFETY: `tunnel` holds a live ref until the `deref` below.
             let tunnel = unsafe { ThisPtr::new(tunnel_ptr) };
             tunnel.clear_connected_web_socket();
-            // `shutdown` may synchronously fire SSLWrapper callbacks that
-            // re-enter the tunnel allocation (see WebSocketProxyTunnel::shutdown).
             WebSocketProxyTunnel::shutdown(tunnel);
             // SAFETY: `tunnel` (NonNull) held a live intrusive ref; release it.
             unsafe { WebSocketProxyTunnel::deref(tunnel_ptr) };
@@ -898,8 +896,6 @@ impl<const SSL: bool> WebSocket<SSL> {
     fn enqueue_encoded_bytes(&self, bytes: &[u8]) -> bool {
         // For tunnel mode, write through the tunnel instead of direct socket
         if let Some(tunnel) = self.proxy_tunnel.get() {
-            // `write_data()` may fire `write_encrypted(ctx)` which re-enters
-            // the tunnel allocation; `write` never holds a `&mut` across it.
             // SAFETY: `proxy_tunnel` holds a live ref on `tunnel`.
             let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
             let wrote = match WebSocketProxyTunnel::write(tunnel, bytes) {
@@ -1065,9 +1061,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             debug_assert!(!out_buf.is_empty());
             if let Some(tunnel) = self.proxy_tunnel.get() {
                 // In tunnel mode, route through the tunnel's TLS layer
-                // instead of the detached raw socket. `write_data()` may fire
-                // `write_encrypted(ctx)` which re-enters the tunnel; `write`
-                // never holds a `&mut WebSocketProxyTunnel` across that dispatch.
+                // instead of the detached raw socket.
                 // SAFETY: `proxy_tunnel` holds a live ref on `tunnel`.
                 let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
                 match WebSocketProxyTunnel::write(tunnel, out_buf) {

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -178,14 +178,12 @@ impl<const SSL: bool> WebSocket<SSL> {
         // Detach the tunnel first so its shutdown callbacks cannot re-enter this path.
         if let Some(tunnel) = self.proxy_tunnel.take() {
             let tunnel_ptr = tunnel.as_ptr();
-            // SAFETY: `tunnel` holds a live ref; field-scoped raw write, no
-            // borrow of the tunnel is formed.
-            unsafe { WebSocketProxyTunnel::clear_connected_web_socket(tunnel_ptr) };
-            // SAFETY: `tunnel` holds a live ref. `shutdown` may synchronously
-            // fire SSLWrapper callbacks that re-enter the tunnel allocation,
-            // so call the raw-ptr overload which never holds a `&mut Self`
-            // across the dispatch (see WebSocketProxyTunnel::shutdown).
-            unsafe { WebSocketProxyTunnel::shutdown(tunnel_ptr) };
+            // SAFETY: `tunnel` holds a live ref until the `deref` below.
+            let tunnel = unsafe { ThisPtr::new(tunnel_ptr) };
+            tunnel.clear_connected_web_socket();
+            // `shutdown` may synchronously fire SSLWrapper callbacks that
+            // re-enter the tunnel allocation (see WebSocketProxyTunnel::shutdown).
+            WebSocketProxyTunnel::shutdown(tunnel);
             // SAFETY: `tunnel` (NonNull) held a live intrusive ref; release it.
             unsafe { WebSocketProxyTunnel::deref(tunnel_ptr) };
             // Release the I/O-layer ref taken in init_with_tunnel() — the
@@ -900,11 +898,11 @@ impl<const SSL: bool> WebSocket<SSL> {
     fn enqueue_encoded_bytes(&self, bytes: &[u8]) -> bool {
         // For tunnel mode, write through the tunnel instead of direct socket
         if let Some(tunnel) = self.proxy_tunnel.get() {
-            // SAFETY: `tunnel` holds a live ref (RefPtr has no `Deref`).
-            // `write_data()` may fire `write_encrypted(ctx)` which reborrows
-            // the tunnel allocation, so call the raw-ptr overload that never
-            // holds a `&mut WebSocketProxyTunnel` across the dispatch.
-            let wrote = match unsafe { WebSocketProxyTunnel::write(tunnel.as_ptr(), bytes) } {
+            // `write_data()` may fire `write_encrypted(ctx)` which re-enters
+            // the tunnel allocation; `write` never holds a `&mut` across it.
+            // SAFETY: `proxy_tunnel` holds a live ref on `tunnel`.
+            let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
+            let wrote = match WebSocketProxyTunnel::write(tunnel, bytes) {
                 Ok(w) => w,
                 Err(_) => {
                     self.terminate(ErrorCode::FailedToWrite);
@@ -1067,12 +1065,12 @@ impl<const SSL: bool> WebSocket<SSL> {
             debug_assert!(!out_buf.is_empty());
             if let Some(tunnel) = self.proxy_tunnel.get() {
                 // In tunnel mode, route through the tunnel's TLS layer
-                // instead of the detached raw socket.
-                // SAFETY: `tunnel` holds a live ref (RefPtr has no `Deref`).
-                // Use the raw-ptr `write` overload — `write_data()` may fire
-                // `write_encrypted(ctx)` which reborrows the tunnel; never
-                // hold a `&mut WebSocketProxyTunnel` across that dispatch.
-                match unsafe { WebSocketProxyTunnel::write(tunnel.as_ptr(), out_buf) } {
+                // instead of the detached raw socket. `write_data()` may fire
+                // `write_encrypted(ctx)` which re-enters the tunnel; `write`
+                // never holds a `&mut WebSocketProxyTunnel` across that dispatch.
+                // SAFETY: `proxy_tunnel` holds a live ref on `tunnel`.
+                let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
+                match WebSocketProxyTunnel::write(tunnel, out_buf) {
                     Ok(w) => Ok(w),
                     Err(_) => Err(true),
                 }

--- a/src/http_jsc/websocket_client/WebSocketProxy.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxy.rs
@@ -1,5 +1,7 @@
 use core::ptr::NonNull;
 
+use bun_ptr::ThisPtr;
+
 use super::WebSocketProxyTunnel;
 
 /// WebSocketProxy encapsulates proxy state for WebSocket connections through HTTP/HTTPS proxies.
@@ -69,7 +71,7 @@ impl Drop for WebSocketProxy {
             // SAFETY: tunnel is a live intrusive-refcounted pointer; we hold one ref
             // until deref() below releases it.
             unsafe {
-                WebSocketProxyTunnel::shutdown(tunnel.as_ptr());
+                WebSocketProxyTunnel::shutdown(ThisPtr::new(tunnel.as_ptr()));
                 WebSocketProxyTunnel::deref(tunnel.as_ptr());
             }
         }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -20,8 +20,6 @@
 //! `wrapper` is a write-once `OnceCell` set in `start()` before it is first
 //! driven, so every access — from a driving entry or from a re-entered
 //! callback — is a short shared borrow; no `&mut Self` is ever formed.
-//! Callbacks never touch `wrapper`; the `*mut SSL` needed by `on_handshake` is
-//! snapshotted into `self.ssl` in `start()`.
 //!
 //! `*WebSocketProxyTunnel` is freely aliased across callbacks.
 
@@ -115,12 +113,6 @@ pub struct WebSocketProxyTunnel {
     socket: SocketUnion,
     /// Write buffer for encrypted data (maintains TLS record ordering)
     write_buffer: JsCell<StreamBuffer>,
-    /// Snapshot of `wrapper.ssl` taken in `start()`.
-    ///
-    /// Callbacks fired from inside `SslWrapper::{start,receive_data,...}` run while
-    /// the caller holds a live `&SslWrapper`. Snapshotting the `*mut SSL` here
-    /// lets `on_handshake` read it without touching `wrapper` at all.
-    ssl: Cell<Option<NonNull<boringssl::c::SSL>>>,
     /// Hostname for SNI (Server Name Indication)
     sni_hostname: Option<Box<[u8]>>,
     /// Whether to reject unauthorized certificates
@@ -162,7 +154,6 @@ impl WebSocketProxyTunnel {
             wrapper: OnceCell::new(),
             socket,
             write_buffer: JsCell::new(StreamBuffer::default()),
-            ssl: Cell::new(None),
             sni_hostname: Some(Box::<[u8]>::from(sni_hostname)),
             reject_unauthorized,
         });
@@ -210,12 +201,9 @@ impl WebSocketProxyTunnel {
         )
         .map_err(|_| crate::Error::InvalidOptions)?;
 
+        debug_assert!(this.wrapper.get().is_none(), "start() called twice");
+        let wrapper = this.wrapper.get_or_init(|| wrapper);
         let ssl = wrapper.ssl.get();
-
-        if this.wrapper.set(wrapper).is_err() {
-            return Err(crate::Error::InvalidOptions);
-        }
-        this.ssl.set(ssl);
 
         // Configure SNI with hostname.
         //
@@ -247,15 +235,11 @@ impl WebSocketProxyTunnel {
         }
 
         // `start*()` synchronously fires `on_open(ctx)` / `write_encrypted(ctx)`
-        // / etc. Those callbacks never touch `wrapper` and mutate only
-        // `Cell`/`JsCell` fields, so the `&SslWrapper` formed here is never
-        // invalidated.
-        if let Some(w) = this.wrapper.get() {
-            if !initial_data.is_empty() {
-                w.start_with_payload(initial_data);
-            } else {
-                w.start();
-            }
+        // / etc.; those callbacks mutate only `Cell`/`JsCell` fields.
+        if !initial_data.is_empty() {
+            wrapper.start_with_payload(initial_data);
+        } else {
+            wrapper.start();
         }
         Ok(())
     }
@@ -266,10 +250,7 @@ impl WebSocketProxyTunnel {
         let this = unsafe { ThisPtr::new(this) };
         let _guard = this.ref_guard();
         bun_core::scoped_log!(WebSocketProxyTunnel, "onOpen");
-        // SNI configuration is done in `start()` before the wrapper is driven;
-        // see the note there. This callback intentionally does not touch
-        // `this.wrapper` — the caller (`SslWrapper::start`) holds `&self`
-        // over those bytes.
+        // SNI configuration is done in `start()` before the wrapper is driven.
     }
 
     /// SSLWrapper callback: Called with decrypted data from the network
@@ -339,10 +320,9 @@ impl WebSocketProxyTunnel {
                 return;
             }
 
-            // Verify server identity via the `ssl` snapshot + `sni_hostname`;
-            // this path deliberately does not touch `wrapper` (the
-            // `receive_data()` frame holds `&SslWrapper`).
-            let failed_identity = match (this.ssl.get(), this.sni_hostname.as_deref()) {
+            // Verify server identity.
+            let ssl = this.wrapper.get().and_then(|w| w.ssl.get());
+            let failed_identity = match (ssl, this.sni_hostname.as_deref()) {
                 (Some(ssl_ptr), Some(hostname)) => {
                     // SAFETY: ssl_ptr is a live `*mut SSL` owned by the wrapper
                     // (heap-allocated by BoringSSL; disjoint from the tunnel struct).
@@ -458,27 +438,29 @@ impl WebSocketProxyTunnel {
             let _ = w.flush();
         }
 
-        // Send buffered encrypted data. `write_encrypted` above may have
-        // mutated `write_buffer`, so read it fresh; lend it out for the socket
-        // write so no borrow of the cell spans that call.
-        if this.write_buffer.get().is_not_empty() {
-            let mut buf = this.write_buffer.replace(StreamBuffer::default());
-            let to_send_len = buf.slice().len();
-            let written = this.socket.write(buf.slice());
+        // Send buffered encrypted data (`write_encrypted` above may have
+        // appended to it). A raw uws socket write does not re-enter the tunnel.
+        let still_backpressured = this.write_buffer.with_mut(|buf| {
+            let to_send = buf.slice();
+            if to_send.is_empty() {
+                return false;
+            }
+            let to_send_len = to_send.len();
+            let written = this.socket.write(to_send);
             if written < 0 {
-                this.write_buffer.set(buf);
-                return;
+                return true;
             }
-
-            let written_usize = usize::try_from(written).expect("int cast");
-            if written_usize == to_send_len {
+            let written = usize::try_from(written).expect("int cast");
+            if written == to_send_len {
                 buf.reset();
-                this.write_buffer.set(buf);
+                false
             } else {
-                buf.cursor += written_usize;
-                this.write_buffer.set(buf);
-                return; // still have backpressure
+                buf.wrote(written);
+                true
             }
+        });
+        if still_backpressured {
+            return;
         }
 
         // Tunnel drained - let the connected WebSocket flush its send_buffer.
@@ -510,6 +492,9 @@ impl WebSocketProxyTunnel {
     /// Takes `ThisPtr<Self>` because `write_data()` fires `write_encrypted(ctx)`
     /// and may fire `on_handshake(ctx)`/`on_close(ctx)`.
     pub(crate) fn write(this: ThisPtr<Self>, data: &[u8]) -> crate::Result<usize> {
+        // The caller's ref (the client's `proxy`/`proxy_tunnel` field) can be
+        // released from inside `write_data` via `on_close`; keep `w` alive.
+        let _guard = this.ref_guard();
         if let Some(w) = this.wrapper.get() {
             return w
                 .write_data(data)
@@ -523,6 +508,7 @@ impl WebSocketProxyTunnel {
     /// Takes `ThisPtr<Self>` because `shutdown()` may fire
     /// `on_close(ctx)`/`write_encrypted(ctx)`.
     pub(crate) fn shutdown(this: ThisPtr<Self>) {
+        let _guard = this.ref_guard();
         if let Some(w) = this.wrapper.get() {
             let _ = w.shutdown(true); // Fast shutdown
         }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -16,27 +16,22 @@
 //! synchronously re-enters this struct through the `ctx` backref via
 //! `on_open`/`on_data`/`on_handshake`/`on_close`/`write_encrypted`.
 //!
-//! To stay sound under Stacked Borrows:
-//! - Driving entries take `*mut Self` and project to `wrapper` via
-//!   `ptr::addr_of_mut!` so the `&mut` covers only that field's bytes.
-//! - Callbacks **never** form `&Self`/`&mut Self` (whole-struct) and **never** read
-//!   `(*ctx).wrapper` — either would touch `wrapper`'s bytes through the
-//!   Box-provenance `ctx` and alias the caller's shared `&SslWrapper` (harmless — no Unique tag to pop, since every `SslWrapper` method is `&self`).
-//!   They access only disjoint fields (`ref_count`, `ssl`, `sni_hostname`,
-//!   `write_buffer`, `socket`, `upgrade_client`, `connected_websocket`) via
-//!   `(*ctx).field` raw projections.
-//! - The `*mut SSL` needed by `on_handshake` is snapshotted into `self.ssl` in
-//!   `start()` so it can be read without going through `wrapper`.
+//! All state mutated after construction lives in `Cell`/`JsCell` fields, and
+//! `wrapper` is a write-once `OnceCell` set in `start()` before it is first
+//! driven, so every access — from a driving entry or from a re-entered
+//! callback — is a short shared borrow; no `&mut Self` is ever formed.
+//! Callbacks never touch `wrapper`; the `*mut SSL` needed by `on_handshake` is
+//! snapshotted into `self.ssl` in `start()`.
 //!
 //! `*WebSocketProxyTunnel` is freely aliased across callbacks.
 
-use core::cell::Cell;
+use core::cell::{Cell, OnceCell};
 use core::ptr;
 use core::ptr::NonNull;
 
 use bun_boringssl as boringssl;
 use bun_io::StreamBuffer;
-use bun_ptr::ThisPtr;
+use bun_ptr::{JsCell, ThisPtr};
 use bun_uws::ssl_wrapper::{Handlers as SslHandlers, SslWrapper};
 use bun_uws::{NewSocketHandler, us_bun_verify_error_t};
 
@@ -111,23 +106,21 @@ type WebSocketClient = crate::websocket_client::WebSocket<false>;
 pub struct WebSocketProxyTunnel {
     ref_count: Cell<u32>,
     /// Reference to the upgrade client (WebSocketUpgradeClient) - used during handshake phase
-    upgrade_client: UpgradeClientUnion,
+    upgrade_client: Cell<UpgradeClientUnion>,
     /// Reference to the connected WebSocket client - used after successful upgrade
-    connected_websocket: *mut WebSocketClient,
-    /// SSL wrapper for TLS inside tunnel
-    wrapper: Option<SslWrapperType>,
+    connected_websocket: Cell<*mut WebSocketClient>,
+    /// SSL wrapper for TLS inside tunnel; set once in `start()`.
+    wrapper: OnceCell<SslWrapperType>,
     /// Socket reference (the proxy connection)
     socket: SocketUnion,
     /// Write buffer for encrypted data (maintains TLS record ordering)
-    write_buffer: StreamBuffer,
+    write_buffer: JsCell<StreamBuffer>,
     /// Snapshot of `wrapper.ssl` taken in `start()`.
     ///
     /// Callbacks fired from inside `SslWrapper::{start,receive_data,...}` run while
-    /// the caller holds a live `&SslWrapper` (all its methods are `&self`, so a
-    /// shared read of `wrapper` is harmless; only a whole-struct `&mut *ctx` in a
-    /// callback would overlap it). Snapshotting the `*mut SSL` here — the field is a
-    /// `Cell` — lets `on_handshake` read it without touching `wrapper` at all.
-    ssl: Option<NonNull<boringssl::c::SSL>>,
+    /// the caller holds a live `&SslWrapper`. Snapshotting the `*mut SSL` here
+    /// lets `on_handshake` read it without touching `wrapper` at all.
+    ssl: Cell<Option<NonNull<boringssl::c::SSL>>>,
     /// Hostname for SNI (Server Name Indication)
     sni_hostname: Option<Box<[u8]>>,
     /// Whether to reject unauthorized certificates
@@ -164,12 +157,12 @@ impl WebSocketProxyTunnel {
 
         let boxed = Box::new(WebSocketProxyTunnel {
             ref_count: Cell::new(1),
-            upgrade_client,
-            connected_websocket: ptr::null_mut(),
-            wrapper: None,
+            upgrade_client: Cell::new(upgrade_client),
+            connected_websocket: Cell::new(ptr::null_mut()),
+            wrapper: OnceCell::new(),
             socket,
-            write_buffer: StreamBuffer::default(),
-            ssl: None,
+            write_buffer: JsCell::new(StreamBuffer::default()),
+            ssl: Cell::new(None),
             sni_hostname: Some(Box::<[u8]>::from(sni_hostname)),
             reject_unauthorized,
         });
@@ -181,13 +174,11 @@ impl WebSocketProxyTunnel {
     /// Start TLS handshake inside the tunnel
     /// The ssl_options should contain all TLS configuration including CA certificates.
     ///
-    /// # Safety
-    /// `this` must be the Box-provenance pointer returned from `init` /
-    /// `IntrusiveRc::as_ptr` and must be live for the duration of the call.
-    /// `start*()` synchronously invokes `on_open(ctx)`, so this function must
-    /// not hold a `&mut Self` across that call.
-    pub(crate) unsafe fn start(
-        this: *mut Self,
+    /// Takes `ThisPtr<Self>` because `start*()` synchronously invokes
+    /// `on_open(ctx)` / `on_handshake(ctx)`, which may terminate the upgrade
+    /// client.
+    pub(crate) fn start(
+        this: ThisPtr<Self>,
         ssl_options: &SslConfig,
         initial_data: &[u8],
     ) -> crate::Result<()> {
@@ -205,7 +196,7 @@ impl WebSocketProxyTunnel {
             SslHandlers {
                 // Store the Box-provenance pointer directly so callback derefs
                 // remain valid regardless of intervening reborrows.
-                ctx: this,
+                ctx: this.as_ptr(),
                 on_open: Self::on_open,
                 on_data: Self::on_data,
                 on_handshake: Self::on_handshake,
@@ -221,24 +212,21 @@ impl WebSocketProxyTunnel {
 
         let ssl = wrapper.ssl.get();
 
-        // SAFETY: caller contract — `this` is live. Short-lived raw derefs to assign
-        // fields; no `&mut Self` is bound across the re-entrant `start*()` below.
-        unsafe {
-            (*this).ssl = ssl;
-            (*this).wrapper = Some(wrapper);
+        this.ssl.set(ssl);
+        if this.wrapper.set(wrapper).is_err() {
+            return Err(crate::Error::InvalidOptions);
         }
 
         // Configure SNI with hostname.
         //
         // This could live inside `onOpen`, which `SslWrapper::start()`
-        // invokes immediately before `handle_traffic()`. We hoist it here because
-        // `start()` holds `&SslWrapper` across the `on_open` dispatch, and any
-        // read of `(*ctx).wrapper` from inside the callback would invalidate that
-        // borrow under Stacked Borrows. The observable order vs BoringSSL is
-        // identical: SNI is set on the `SSL*` before the handshake is driven.
+        // invokes immediately before `handle_traffic()`. We hoist it here so
+        // the callback never has to read `wrapper` while `start()` holds
+        // `&SslWrapper` across the `on_open` dispatch. The observable order vs
+        // BoringSSL is identical: SNI is set on the `SSL*` before the handshake
+        // is driven.
         if let Some(ssl_ptr) = ssl {
-            // SAFETY: `this` is live; field projection covers only `sni_hostname`.
-            if let Some(hostname) = unsafe { (*this).sni_hostname.as_deref() } {
+            if let Some(hostname) = this.sni_hostname.as_deref() {
                 if !bun_core::ip_address::is_ip_address(hostname) {
                     // Set SNI hostname
                     let hostname_z = bun_core::ZBox::from_vec_with_nul(hostname.to_vec());
@@ -258,23 +246,15 @@ impl WebSocketProxyTunnel {
             }
         }
 
-        // SAFETY: raw field projection; `start*()` synchronously fires `on_open(ctx)`
-        // / `write_encrypted(ctx)` / etc. Those callbacks touch only fields disjoint
-        // from `wrapper` (`ref_count`, `ssl`, `sni_hostname`, `write_buffer`,
-        // `socket`, …), so the `&SslWrapper` formed here — which covers only
-        // the `wrapper` field bytes — is never aliased.
-        let wrapper_ptr = unsafe { ptr::addr_of_mut!((*this).wrapper) };
-        if !initial_data.is_empty() {
-            // SAFETY: deref of field projection; `this` is live.
-            unsafe {
-                (*wrapper_ptr)
-                    .as_ref()
-                    .unwrap()
-                    .start_with_payload(initial_data)
-            };
-        } else {
-            // SAFETY: deref of field projection; `this` is live.
-            unsafe { (*wrapper_ptr).as_ref().unwrap().start() };
+        // `start*()` synchronously fires `on_open(ctx)` / `write_encrypted(ctx)`
+        // / etc. Those callbacks touch only `Cell`/`JsCell` fields disjoint from
+        // `wrapper`, so the `&SslWrapper` formed here is never invalidated.
+        if let Some(w) = this.wrapper.get() {
+            if !initial_data.is_empty() {
+                w.start_with_payload(initial_data);
+            } else {
+                w.start();
+            }
         }
         Ok(())
     }
@@ -282,19 +262,20 @@ impl WebSocketProxyTunnel {
     /// SSLWrapper callback: Called before TLS handshake starts
     fn on_open(this: *mut WebSocketProxyTunnel) {
         // SAFETY: ctx pointer set in `start`; SSLWrapper guarantees it is live during callbacks.
-        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+        let this = unsafe { ThisPtr::new(this) };
+        let _guard = this.ref_guard();
         bun_core::scoped_log!(WebSocketProxyTunnel, "onOpen");
         // SNI configuration is done in `start()` before the wrapper is driven;
         // see the note there. This callback intentionally does not touch
-        // `(*this).wrapper` — the caller (`SslWrapper::start`) holds `&self`
+        // `this.wrapper` — the caller (`SslWrapper::start`) holds `&self`
         // over those bytes.
-        let _ = this;
     }
 
     /// SSLWrapper callback: Called with decrypted data from the network
     fn on_data(this: *mut WebSocketProxyTunnel, decrypted_data: &[u8]) {
         // SAFETY: ctx pointer set in `start`; SSLWrapper guarantees it is live during callbacks.
-        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+        let this = unsafe { ThisPtr::new(this) };
+        let _guard = this.ref_guard();
 
         bun_core::scoped_log!(
             WebSocketProxyTunnel,
@@ -305,12 +286,11 @@ impl WebSocketProxyTunnel {
             return;
         }
 
-        // Snapshot backref pointers via short raw-ptr reads; the dispatch below may
-        // re-enter `tunnel.write/shutdown/clear_connected_web_socket/detach_upgrade_client`,
-        // so no `&Self`/`&mut Self` may be live across it.
-        // SAFETY: ScopedRef guard holds a ref; `this` is live. Reads of `Copy` fields.
+        // Snapshot backref pointers; the dispatch below may re-enter
+        // `tunnel.write/shutdown/clear_connected_web_socket/detach_upgrade_client`,
+        // so no borrow of `*this` may be live across it.
         let (connected_websocket, upgrade_client) =
-            unsafe { ((*this).connected_websocket, (*this).upgrade_client) };
+            (this.connected_websocket.get(), this.upgrade_client.get());
 
         // If we have a connected WebSocket client, forward data to it
         if !connected_websocket.is_null() {
@@ -331,16 +311,16 @@ impl WebSocketProxyTunnel {
         ssl_error: us_bun_verify_error_t,
     ) {
         // SAFETY: ctx pointer set in `start`; SSLWrapper guarantees it is live during callbacks.
-        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+        let this = unsafe { ThisPtr::new(this) };
+        let _guard = this.ref_guard();
 
         bun_core::scoped_log!(WebSocketProxyTunnel, "onHandshake: success={}", success);
 
         // Snapshot the fields we need; `terminate()` / `on_proxy_tls_handshake_complete()`
         // re-enter `tunnel.detach_upgrade_client()` / `tunnel.write()`, so no borrow of
         // `*this` may span the dispatch.
-        // SAFETY: ScopedRef guard holds a ref; `this` is live. Reads of `Copy` fields.
         let (upgrade_client, reject_unauthorized) =
-            unsafe { ((*this).upgrade_client, (*this).reject_unauthorized) };
+            (this.upgrade_client.get(), this.reject_unauthorized);
 
         if upgrade_client.is_none() {
             return;
@@ -358,22 +338,16 @@ impl WebSocketProxyTunnel {
                 return;
             }
 
-            // Verify server identity. Read the `ssl` snapshot + `sni_hostname` via
-            // raw field projections; a shared read overlapping `wrapper` would be
-            // harmless (the `receive_data()` frame holds only `&SslWrapper`), but
-            // this path deliberately touches neither `wrapper` nor a whole-struct
-            // borrow, so no exclusive access is ever formed under that frame.
-            // SAFETY: ScopedRef guard holds a ref; `this` is live. `ssl` is `Copy`;
-            // `sni_hostname` autoref covers only that field's bytes.
-            let failed_identity = unsafe {
-                match ((*this).ssl, (*this).sni_hostname.as_deref()) {
-                    (Some(ssl_ptr), Some(hostname)) => {
-                        // SAFETY: ssl_ptr is a live `*mut SSL` owned by the wrapper
-                        // (heap-allocated by BoringSSL; disjoint from the tunnel struct).
-                        !boringssl::check_server_identity(&mut *ssl_ptr.as_ptr(), hostname)
-                    }
-                    _ => false,
+            // Verify server identity via the `ssl` snapshot + `sni_hostname`;
+            // this path deliberately does not touch `wrapper` (the
+            // `receive_data()` frame holds `&SslWrapper`).
+            let failed_identity = match (this.ssl.get(), this.sni_hostname.as_deref()) {
+                (Some(ssl_ptr), Some(hostname)) => {
+                    // SAFETY: ssl_ptr is a live `*mut SSL` owned by the wrapper
+                    // (heap-allocated by BoringSSL; disjoint from the tunnel struct).
+                    !boringssl::check_server_identity(unsafe { &mut *ssl_ptr.as_ptr() }, hostname)
                 }
+                _ => false,
             };
             if failed_identity {
                 upgrade_client.terminate(ErrorCode::TlsHandshakeFailed);
@@ -388,16 +362,16 @@ impl WebSocketProxyTunnel {
     /// SSLWrapper callback: Called when connection is closing
     fn on_close(this: *mut WebSocketProxyTunnel) {
         // SAFETY: ctx pointer set in `start`; SSLWrapper guarantees it is live during callbacks.
-        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+        let this = unsafe { ThisPtr::new(this) };
+        let _guard = this.ref_guard();
 
         bun_core::scoped_log!(WebSocketProxyTunnel, "onClose");
 
         // Snapshot backref pointers; `fail()`/`terminate()` re-enter
         // `tunnel.clear_connected_web_socket()` / `tunnel.shutdown()` /
         // `tunnel.detach_upgrade_client()`, so no borrow of `*this` may span them.
-        // SAFETY: ScopedRef guard holds a ref; `this` is live. Reads of `Copy` fields.
         let (connected_websocket, upgrade_client) =
-            unsafe { ((*this).connected_websocket, (*this).upgrade_client) };
+            (this.connected_websocket.get(), this.upgrade_client.get());
 
         // If we have a connected WebSocket client, notify it of the close
         if !connected_websocket.is_null() {
@@ -422,39 +396,23 @@ impl WebSocketProxyTunnel {
     /// a clean close so the tunnel's onClose callback doesn't dispatch a spurious
     /// abrupt close (1006) after the WebSocket has already sent a clean close frame.
     ///
-    /// # Safety
-    /// `this` must point to a live tunnel. Takes `*mut Self` (not `&mut self`)
-    /// because it can be reached from inside an SSLWrapper callback while the
-    /// driving frame holds `&SslWrapper`; the raw write covers only this field.
-    pub(crate) unsafe fn clear_connected_web_socket(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; raw place write, field-scoped.
-        unsafe { (*this).connected_websocket = ptr::null_mut() };
+    /// Can be reached from inside an SSLWrapper callback while the driving
+    /// frame holds `&SslWrapper`; the `Cell` write covers only this field.
+    pub(crate) fn clear_connected_web_socket(&self) {
+        self.connected_websocket.set(ptr::null_mut());
     }
 
     /// Clear the upgrade client reference. Called before tunnel shutdown during
     /// cleanup so that the SSLWrapper's synchronous onHandshake/onClose callbacks
     /// do not re-enter the upgrade client's terminate/clearData path.
-    ///
-    /// # Safety
-    /// Same contract as [`Self::clear_connected_web_socket`].
-    pub(crate) unsafe fn detach_upgrade_client(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; raw place write, field-scoped.
-        unsafe { (*this).upgrade_client = UpgradeClientUnion::None };
+    pub(crate) fn detach_upgrade_client(&self) {
+        self.upgrade_client.set(UpgradeClientUnion::None);
     }
 
     /// SSLWrapper callback: Called with encrypted data to send to network
     fn write_encrypted(this: *mut WebSocketProxyTunnel, encrypted_data: &[u8]) {
-        // SAFETY: ctx pointer set in `start`; SSLWrapper guarantees it is live during
-        // callbacks. The driving frame (`receive`/`on_writable`/`write`/`shutdown`/
-        // `start`) holds a live `&SslWrapper` derived from `(*this).wrapper`, so
-        // a whole-struct `&mut *this` here would alias it (Stacked Borrows UB).
-        // Project to the disjoint `write_buffer`/`socket` fields only.
-        let (write_buffer, socket) = unsafe {
-            (
-                &mut *ptr::addr_of_mut!((*this).write_buffer),
-                &*ptr::addr_of!((*this).socket),
-            )
-        };
+        // SAFETY: ctx pointer set in `start`; SSLWrapper guarantees it is live during callbacks.
+        let this = unsafe { ThisPtr::new(this) };
         bun_core::scoped_log!(
             WebSocketProxyTunnel,
             "writeEncrypted: {} bytes",
@@ -462,75 +420,70 @@ impl WebSocketProxyTunnel {
         );
 
         // If data is already buffered, queue this to maintain TLS record ordering
-        if write_buffer.is_not_empty() {
-            bun_core::handle_oom(write_buffer.write(encrypted_data));
+        if this.write_buffer.get().is_not_empty() {
+            bun_core::handle_oom(this.write_buffer.with_mut(|b| b.write(encrypted_data)));
             return;
         }
 
         // Try direct write to socket
-        let written = socket.write(encrypted_data);
+        let written = this.socket.write(encrypted_data);
         if written < 0 {
             // Write failed - buffer data for retry when socket becomes writable
-            bun_core::handle_oom(write_buffer.write(encrypted_data));
+            bun_core::handle_oom(this.write_buffer.with_mut(|b| b.write(encrypted_data)));
             return;
         }
 
         // Buffer remaining data
         let written_usize = usize::try_from(written).expect("int cast");
         if written_usize < encrypted_data.len() {
-            bun_core::handle_oom(write_buffer.write(&encrypted_data[written_usize..]));
+            bun_core::handle_oom(
+                this.write_buffer
+                    .with_mut(|b| b.write(&encrypted_data[written_usize..])),
+            );
         }
     }
 
     /// Called when the socket becomes writable - flush buffered encrypted data
     ///
-    /// # Safety
-    /// `this` must point to a live tunnel. `flush()` fires `write_encrypted(ctx)`
-    /// and `handle_tunnel_writable()` re-enters `tunnel.write()`, so this function
-    /// operates on `*mut Self` end-to-end and never binds a whole-struct `&mut`.
-    pub(crate) unsafe fn on_writable(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live.
-        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+    /// Takes `ThisPtr<Self>` because `flush()` fires `write_encrypted(ctx)` and
+    /// `handle_tunnel_writable()` re-enters `tunnel.write()`, either of which
+    /// can reach a close path that drops a ref on the tunnel.
+    pub(crate) fn on_writable(this: ThisPtr<Self>) {
+        let _guard = this.ref_guard();
 
-        // Flush the SSL state machine via raw field projection so no `&mut Self`
-        // spans the synchronous `write_encrypted` re-entry.
-        // SAFETY: `this` is live; projection covers only `wrapper`.
-        let wrapper_ptr = unsafe { ptr::addr_of_mut!((*this).wrapper) };
-        // SAFETY: deref of field projection; `write_encrypted`'s `&mut *ctx` derives
-        // from the Box-provenance `ctx`, not from this borrow.
-        if let Some(w) = unsafe { (*wrapper_ptr).as_ref() } {
+        // Flush the SSL state machine; no borrow of `*this` other than
+        // `wrapper` spans the synchronous `write_encrypted` re-entry.
+        if let Some(w) = this.wrapper.get() {
             let _ = w.flush();
         }
 
-        // Send buffered encrypted data. Fresh raw-ptr field accesses — `write_encrypted`
-        // above may have mutated `write_buffer`, so we must not reuse any earlier borrow.
-        // SAFETY: `this` is live; short-lived borrows that do not span re-entrant calls
-        // (`socket.write` is a uws send, `write_buffer` ops are local).
-        unsafe {
-            let to_send = (*this).write_buffer.slice();
-            if !to_send.is_empty() {
-                // reshaped for borrowck — capture len before re-borrowing write_buffer
-                let to_send_len = to_send.len();
-                let written = (*this).socket.write(to_send);
-                if written < 0 {
-                    return;
-                }
+        // Send buffered encrypted data. `write_encrypted` above may have
+        // mutated `write_buffer`, so read it fresh; lend it out for the socket
+        // write so no borrow of the cell spans that call.
+        if this.write_buffer.get().is_not_empty() {
+            let mut buf = this.write_buffer.replace(StreamBuffer::default());
+            let to_send_len = buf.slice().len();
+            let written = this.socket.write(buf.slice());
+            if written < 0 {
+                this.write_buffer.set(buf);
+                return;
+            }
 
-                let written_usize = usize::try_from(written).expect("int cast");
-                if written_usize == to_send_len {
-                    (*this).write_buffer.reset();
-                } else {
-                    (*this).write_buffer.cursor += written_usize;
-                    return; // still have backpressure
-                }
+            let written_usize = usize::try_from(written).expect("int cast");
+            if written_usize == to_send_len {
+                buf.reset();
+                this.write_buffer.set(buf);
+            } else {
+                buf.cursor += written_usize;
+                this.write_buffer.set(buf);
+                return; // still have backpressure
             }
         }
 
         // Tunnel drained - let the connected WebSocket flush its send_buffer.
         // `handle_tunnel_writable()` re-enters `tunnel.write()`; snapshot the pointer
-        // into a local so no `&Self` borrow is active across the dispatch.
-        // SAFETY: `this` is live; read of `Copy` field.
-        let connected_websocket = unsafe { (*this).connected_websocket };
+        // into a local so no borrow of `*this` is active across the dispatch.
+        let connected_websocket = this.connected_websocket.get();
         if !connected_websocket.is_null() {
             // SAFETY: BACKREF — WebSocket owns tunnel via ref(); cleared before WebSocket frees.
             // No `&`/`&mut WebSocket` is live in this frame across the call.
@@ -540,36 +493,23 @@ impl WebSocketProxyTunnel {
 
     /// Feed encrypted data from the network to the SSL wrapper for decryption
     ///
-    /// # Safety
-    /// `this` must point to a live tunnel. `receive_data()` synchronously dispatches
-    /// `on_data`/`on_handshake`/`on_close`/`write_encrypted`, each of which derefs
-    /// `ctx` back into this allocation; this function therefore never holds a
-    /// `&mut Self` across the call.
-    pub(crate) unsafe fn receive(this: *mut Self, data: &[u8]) {
-        // SAFETY: caller contract — `this` is live.
-        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+    /// Takes `ThisPtr<Self>` because `receive_data()` synchronously dispatches
+    /// `on_data`/`on_handshake`/`on_close`/`write_encrypted`, which can reach a
+    /// close path that drops a ref on the tunnel.
+    pub(crate) fn receive(this: ThisPtr<Self>, data: &[u8]) {
+        let _guard = this.ref_guard();
 
-        // SAFETY: raw field projection; the `&mut Option<SslWrapper>` covers only
-        // `wrapper`, and the re-entrant callbacks access tunnel fields via the
-        // Box-provenance `ctx`, not through this borrow.
-        let wrapper_ptr = unsafe { ptr::addr_of_mut!((*this).wrapper) };
-        // SAFETY: deref of field projection; `this` is live.
-        if let Some(w) = unsafe { (*wrapper_ptr).as_ref() } {
+        if let Some(w) = this.wrapper.get() {
             w.receive_data(data);
         }
     }
 
     /// Write application data through the tunnel (will be encrypted)
     ///
-    /// # Safety
-    /// `this` must point to a live tunnel. `write_data()` fires `write_encrypted(ctx)`
-    /// which forms `&mut *ctx`; this function therefore accesses `wrapper` via raw
-    /// projection and never holds a `&mut Self` across the call.
-    pub(crate) unsafe fn write(this: *mut Self, data: &[u8]) -> crate::Result<usize> {
-        // SAFETY: caller contract — `this` is live; projection covers only `wrapper`.
-        let wrapper_ptr = unsafe { ptr::addr_of_mut!((*this).wrapper) };
-        // SAFETY: deref of field projection; `this` is live.
-        if let Some(w) = unsafe { (*wrapper_ptr).as_ref() } {
+    /// Takes `ThisPtr<Self>` because `write_data()` fires `write_encrypted(ctx)`
+    /// and may fire `on_handshake(ctx)`/`on_close(ctx)`.
+    pub(crate) fn write(this: ThisPtr<Self>, data: &[u8]) -> crate::Result<usize> {
+        if let Some(w) = this.wrapper.get() {
             return w
                 .write_data(data)
                 .map_err(|_| crate::Error::ConnectionClosed);
@@ -579,28 +519,23 @@ impl WebSocketProxyTunnel {
 
     /// Gracefully shutdown the TLS connection
     ///
-    /// # Safety
-    /// `this` must point to a live tunnel. `shutdown()` may fire
-    /// `on_close(ctx)`/`write_encrypted(ctx)`; this function therefore accesses
-    /// `wrapper` via raw projection and never holds a `&mut Self` across the call.
-    pub(crate) unsafe fn shutdown(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; projection covers only `wrapper`.
-        let wrapper_ptr = unsafe { ptr::addr_of_mut!((*this).wrapper) };
-        // SAFETY: deref of field projection; `this` is live.
-        if let Some(w) = unsafe { (*wrapper_ptr).as_ref() } {
+    /// Takes `ThisPtr<Self>` because `shutdown()` may fire
+    /// `on_close(ctx)`/`write_encrypted(ctx)`.
+    pub(crate) fn shutdown(this: ThisPtr<Self>) {
+        if let Some(w) = this.wrapper.get() {
             let _ = w.shutdown(true); // Fast shutdown
         }
     }
 
     /// Check if the tunnel has backpressure
     pub(crate) fn has_backpressure(&self) -> bool {
-        self.write_buffer.is_not_empty()
+        self.write_buffer.get().is_not_empty()
     }
 }
 
 impl Drop for WebSocketProxyTunnel {
     fn drop(&mut self) {
-        // Field cleanup is automatic: wrapper (Option<SslWrapper>), write_buffer (StreamBuffer),
+        // Field cleanup is automatic: wrapper (OnceCell<SslWrapper>), write_buffer (StreamBuffer),
         // sni_hostname (Option<Box<[u8]>>) all impl Drop. Deallocation
         // is handled by IntrusiveRc / `deref()` via heap::take.
     }
@@ -616,11 +551,9 @@ extern "C" fn WebSocketProxyTunnel__setConnectedWebSocket(
     ws: *mut WebSocketClient,
 ) {
     bun_core::scoped_log!(WebSocketProxyTunnel, "setConnectedWebSocket");
-    // SAFETY: C++ guarantees a live, non-null tunnel pointer; raw field-scoped
-    // writes, nothing re-enters.
-    unsafe {
-        (*tunnel).connected_websocket = ws;
-        // Clear the upgrade client reference since we're now in connected phase
-        (*tunnel).upgrade_client = UpgradeClientUnion::None;
-    }
+    // SAFETY: C++ guarantees a live, non-null tunnel pointer.
+    let tunnel = unsafe { ThisPtr::new(tunnel) };
+    tunnel.connected_websocket.set(ws);
+    // Clear the upgrade client reference since we're now in connected phase
+    tunnel.upgrade_client.set(UpgradeClientUnion::None);
 }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -212,10 +212,10 @@ impl WebSocketProxyTunnel {
 
         let ssl = wrapper.ssl.get();
 
-        this.ssl.set(ssl);
         if this.wrapper.set(wrapper).is_err() {
             return Err(crate::Error::InvalidOptions);
         }
+        this.ssl.set(ssl);
 
         // Configure SNI with hostname.
         //
@@ -247,8 +247,9 @@ impl WebSocketProxyTunnel {
         }
 
         // `start*()` synchronously fires `on_open(ctx)` / `write_encrypted(ctx)`
-        // / etc. Those callbacks touch only `Cell`/`JsCell` fields disjoint from
-        // `wrapper`, so the `&SslWrapper` formed here is never invalidated.
+        // / etc. Those callbacks never touch `wrapper` and mutate only
+        // `Cell`/`JsCell` fields, so the `&SslWrapper` formed here is never
+        // invalidated.
         if let Some(w) = this.wrapper.get() {
             if !initial_data.is_empty() {
                 w.start_with_payload(initial_data);

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -595,9 +595,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // cannot re-enter clear_data() while the proxy is still reachable.
         if let Some(proxy) = self.proxy.replace(None) {
             if let Some(tunnel) = proxy.get_tunnel() {
-                // SAFETY: `proxy` holds a live ref on `tunnel`; field-scoped
-                // raw write, no borrow of the tunnel is formed.
-                unsafe { WebSocketProxyTunnel::detach_upgrade_client(tunnel.as_ptr()) };
+                // SAFETY: `proxy` holds a live ref on `tunnel`.
+                unsafe { ThisPtr::new(tunnel.as_ptr()) }.detach_upgrade_client();
             }
             drop(proxy);
         }
@@ -875,13 +874,12 @@ impl<const SSL: bool> HTTPClient<SSL> {
         if this.state.get() == State::Done {
             let tunnel = this.proxy.get().as_ref().and_then(|p| p.get_tunnel());
             if let Some(tunnel) = tunnel {
-                let tp = tunnel.as_ptr();
+                // SAFETY: `proxy` holds a live ref on `tunnel`.
+                let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
                 // Ref the tunnel to keep it alive during this call
                 // (in case the WebSocket client closes during processing)
-                // SAFETY: `proxy` holds a live ref on `tunnel`.
-                let _g = unsafe { bun_ptr::ScopedRef::new(tp) };
-                // SAFETY: ref guard above keeps the tunnel live.
-                unsafe { WebSocketProxyTunnel::receive(tp, data) };
+                let _g = tunnel.ref_guard();
+                WebSocketProxyTunnel::receive(tunnel, data);
             }
             return;
         }
@@ -912,7 +910,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             let tunnel = this.proxy.get().as_ref().and_then(|p| p.get_tunnel());
             if let Some(tunnel) = tunnel {
                 // SAFETY: `proxy` holds a live ref on `tunnel`.
-                unsafe { WebSocketProxyTunnel::receive(tunnel.as_ptr(), data) };
+                WebSocketProxyTunnel::receive(unsafe { ThisPtr::new(tunnel.as_ptr()) }, data);
                 return;
             }
         }
@@ -1096,9 +1094,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         // Start TLS handshake
         // SAFETY: `tunnel` was just allocated by `init` (live, ref_count == 1).
-        if unsafe { WebSocketProxyTunnel::start(tunnel.as_ptr(), &ssl_options, initial_data) }
-            .is_err()
-        {
+        let tunnel_this = unsafe { ThisPtr::new(tunnel.as_ptr()) };
+        if WebSocketProxyTunnel::start(tunnel_this, &ssl_options, initial_data).is_err() {
             // SAFETY: release the ref taken by `init`.
             unsafe { WebSocketProxyTunnel::deref(tunnel.as_ptr()) };
             Self::terminate(this, ErrorCode::ProxyTunnelFailed);
@@ -1159,10 +1156,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
             Self::terminate(this, ErrorCode::ProxyTunnelFailed);
             return;
         };
-        Self::write_pending(this, |buf| {
-            // SAFETY: `proxy` holds a live ref on `tunnel`.
-            unsafe { WebSocketProxyTunnel::write(tunnel.as_ptr(), buf) }.ok()
-        });
+        // SAFETY: `proxy` holds a live ref on `tunnel`.
+        let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
+        Self::write_pending(this, |buf| WebSocketProxyTunnel::write(tunnel, buf).ok());
     }
 
     /// Called by WebSocketProxyTunnel with decrypted data from the TLS tunnel
@@ -1609,7 +1605,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let tunnel = this.proxy.get().as_ref().and_then(|p| p.get_tunnel());
         if let Some(tunnel) = tunnel {
             // SAFETY: `proxy` holds a live ref on `tunnel`.
-            unsafe { WebSocketProxyTunnel::on_writable(tunnel.as_ptr()) };
+            let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
+            WebSocketProxyTunnel::on_writable(tunnel);
             // In .done state (after WebSocket upgrade), just handle tunnel writes
             if this.state.get() == State::Done {
                 return;
@@ -1619,10 +1616,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             if this.to_send_len.get() == 0 {
                 return;
             }
-            Self::write_pending(this, |buf| {
-                // SAFETY: `proxy` holds a live ref on `tunnel`.
-                unsafe { WebSocketProxyTunnel::write(tunnel.as_ptr(), buf) }.ok()
-            });
+            Self::write_pending(this, |buf| WebSocketProxyTunnel::write(tunnel, buf).ok());
             return;
         }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -875,11 +875,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             let tunnel = this.proxy.get().as_ref().and_then(|p| p.get_tunnel());
             if let Some(tunnel) = tunnel {
                 // SAFETY: `proxy` holds a live ref on `tunnel`.
-                let tunnel = unsafe { ThisPtr::new(tunnel.as_ptr()) };
-                // Ref the tunnel to keep it alive during this call
-                // (in case the WebSocket client closes during processing)
-                let _g = tunnel.ref_guard();
-                WebSocketProxyTunnel::receive(tunnel, data);
+                WebSocketProxyTunnel::receive(unsafe { ThisPtr::new(tunnel.as_ptr()) }, data);
             }
             return;
         }


### PR DESCRIPTION
### What

Follow-up to #40002. Takes the whole websocket client module — `websocket_client.rs`, `WebSocketUpgradeClient.rs`, `WebSocketProxyTunnel.rs`, `WebSocketProxy.rs`, `CppWebSocket.rs` — from 55 / 71 / 44 / 1 / 9 `unsafe` sites to **zero** (the one remaining `unsafe` keyword is the `unsafe extern "C" {` block declaring the C++ imports, all of which are now `safe fn`). Rather than annotate call sites, this fixes the layers underneath:

- **Ownership.** The refs held on behalf of the socket's userdata pointer and of C++'s `m_upgradeClient`/`m_connectedWebSocket` are `RefPtr<Self>` fields, released with `RefPtr::deref`; no more hand-paired `Self::deref(ptr)`. Custom `deinit` destructors become `Drop`.
- **Back-references.** Tunnel ↔ client links are `BackRef<_, Mut>` built from the dispatch-time `ThisPtr` and cleared by the pointee before it can be freed; the tunnel dispatches into either transport via `UpgradeClientRef`. `SslWrapper` handlers are typed `ThisPtr<WebSocketProxyTunnel>` (the wrapper was already generic over its ctx).
- **C++ boundary.** Every `Bun__WebSocket*` entry point is a plain `HOST_EXPORT` fn; `generate-host-exports.ts` now scans `src/http_jsc`, and learns `&[T]` (C passes `ptr, len`) and `ThisPtr<T>` params. C++ passes the header arrays as `(ptr, len)` pairs, the handshake-overflow bytes as one opaque `InitialData` box, the custom `SSL_CTX` as `Option<OwnedSslCtx>`, and `setConnectedWebSocket` passes `nullptr` once the open handler has closed the client. The `WebSocket__*` imports are `safe fn`s over a new by-value `bun_core::ffi::FfiSlice<'a, T>` (`{ptr,len}` with the borrow's lifetime).
- **Initial-data microtask.** `JSGlobalObject::queue_microtask_boxed<T: MicrotaskCallback>` owns the trampoline; the task and the client hold detachable back-references to each other, and the C++ pending-activity ref is still released at VM shutdown if the queue never drains.
- **Small safe accessors** replacing per-site raw handling: `Socket::ssl_mut()` (and `ssl()` no longer returns the connecting-socket sentinel), `Socket::take_ext_owner`, `SSL::servername()`, `VirtualMachine::{default_client_ssl_ctx, ssl_ctx_cache_get_or_create}` (the `RuntimeHooks` entries are now safe fns returning `OwnedSslCtx`), `RefPtr::from_this`, `BackRef<_, Mut>::this_ptr`.

Also from the earlier commit on this branch: `WebSocketProxyTunnel::write/shutdown` hold a ref across the SslWrapper call (its `on_close` can release the caller's ref mid-call).

### Testing

Debug+ASAN: all 22 `test/js/web/websocket/*.test.ts` files (178 tests incl. proxy, proxy re-entrancy/leak, deflate, autobahn) pass; hand-driven ws/wss echo, wss verify-rejection, close-during-connect/handshake, non-101; `BUN_DEBUG_alloc` shows 50/50 `new`/`destroy` for both `HTTPClient` and `WebSocket` over 50 connections.