### PR TITLE
ci: an opportunistic macOS beta test lane on PR builds

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1481,24 +1481,41 @@ async function darwinBetaQueueIdle() {
         headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(10_000),
       });
-      return res.ok ? res.json() : undefined;
+      return res.ok ? res : undefined;
     };
 
     // No connected agent: a step added now would sit `scheduled` until
     // the box comes back, and soft_fail does nothing for a job that
-    // never starts.
-    const agents = await api("agents?per_page=100");
-    if (!agents?.some(({ meta_data = [] }) => meta_data.includes(`queue=${darwinBetaQueue}`))) {
+    // never starts. The org has a few hundred agents and the list pages
+    // at 100, so follow `Link: rel="next"`; `stopping` does not count.
+    let connected = false;
+    let next = "agents?per_page=100";
+    for (let page = 0; next && page < 10 && !connected; page++) {
+      const res = await api(next);
+      if (!res) {
+        return false;
+      }
+      const agents = await res.json();
+      connected = agents.some(
+        ({ connection_state, meta_data = [] }) =>
+          connection_state === "connected" && meta_data.includes(`queue=${darwinBetaQueue}`),
+      );
+      const link = res.headers.get("link") ?? "";
+      const match = link.match(/<https:\/\/api\.buildkite\.com\/v2\/organizations\/bun\/([^>]+)>;\s*rel="next"/);
+      next = match?.[1];
+    }
+    if (!connected) {
       return false;
     }
 
     // Builds in `failing` and `canceling` still carry live jobs.
-    const builds = await api(
+    const res = await api(
       "pipelines/bun/builds?state%5B%5D=running&state%5B%5D=scheduled&state%5B%5D=failing&state%5B%5D=canceling&per_page=100",
     );
-    if (!builds) {
+    if (!res) {
       return false;
     }
+    const builds = await res.json();
     const terminal = new Set(["passed", "failed", "canceled", "skipped", "timed_out", "expired", "broken", "finished"]);
     const busy = builds.some(({ jobs = [] }) =>
       jobs.some(

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -36,7 +36,7 @@ import {
  * @typedef {"aarch64" | "x64"} Arch
  * @typedef {"musl" | "android"} Abi
  * @typedef {"debian" | "ubuntu" | "alpine" | "amazonlinux"} Distro
- * @typedef {"latest" | "previous" | "oldest" | "eol"} Tier
+ * @typedef {"latest" | "previous" | "oldest" | "eol" | "beta"} Tier
  * @typedef {"release" | "assert" | "debug" | "asan"} Profile
  */
 
@@ -1455,17 +1455,14 @@ async function getPipelineOptions() {
 }
 
 /**
- * @param {PipelineOptions} [options]
- * @returns {Promise<Pipeline | undefined>}
- */
-/**
- * True when no running or scheduled job in the pipeline targets the darwin
- * beta queue, so one more PR can be given the beta lane without queueing
- * behind another. Reads the cluster secret `CI_QUEUE_PROBE_TOKEN` (a REST
- * token with read_builds only); without it, or on any error, the answer
- * is false and the lane is simply not added.
- * Two uploads a few seconds apart can both see "idle"; a queue of two is
- * the worst case, never a backlog.
+ * True when the darwin beta queue can take one more job right now: an
+ * agent is connected to it, and no live build has a job targeting it in
+ * any non-terminal state (`waiting` counts: the beta test step waits on
+ * the darwin build for tens of minutes before it is ever `scheduled`).
+ * Reads the cluster secret `CI_QUEUE_PROBE_TOKEN` (a REST token with
+ * read_builds and read_agents only); without it, or on any error, the
+ * answer is false and the lane is simply not added. Two uploads a few
+ * seconds apart can both see "idle"; a queue of two is the worst case.
  * @returns {Promise<boolean>}
  */
 async function darwinBetaQueueIdle() {
@@ -1479,19 +1476,34 @@ async function darwinBetaQueueIdle() {
     if (!token) {
       return false;
     }
-    const res = await fetch(
-      "https://api.buildkite.com/v2/organizations/bun/pipelines/bun/builds?state%5B%5D=running&state%5B%5D=scheduled&per_page=100",
-      { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(10_000) },
-    );
-    if (!res.ok) {
+    const api = async path => {
+      const res = await fetch(`https://api.buildkite.com/v2/organizations/bun/${path}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      return res.ok ? res.json() : undefined;
+    };
+
+    // No connected agent: a step added now would sit `scheduled` until
+    // the box comes back, and soft_fail does nothing for a job that
+    // never starts.
+    const agents = await api("agents?per_page=100");
+    if (!agents?.some(({ meta_data = [] }) => meta_data.includes(`queue=${darwinBetaQueue}`))) {
       return false;
     }
-    const builds = await res.json();
+
+    // Builds in `failing` and `canceling` still carry live jobs.
+    const builds = await api(
+      "pipelines/bun/builds?state%5B%5D=running&state%5B%5D=scheduled&state%5B%5D=failing&state%5B%5D=canceling&per_page=100",
+    );
+    if (!builds) {
+      return false;
+    }
+    const terminal = new Set(["passed", "failed", "canceled", "skipped", "timed_out", "expired", "broken", "finished"]);
     const busy = builds.some(({ jobs = [] }) =>
       jobs.some(
         ({ state, agent_query_rules = [] }) =>
-          (state === "running" || state === "scheduled" || state === "assigned" || state === "accepted") &&
-          agent_query_rules.includes(`queue=${darwinBetaQueue}`),
+          !terminal.has(state) && agent_query_rules.includes(`queue=${darwinBetaQueue}`),
       ),
     );
     return !busy;
@@ -1502,6 +1514,10 @@ async function darwinBetaQueueIdle() {
 
 const darwinBetaQueue = "test-darwin-beta";
 
+/**
+ * @param {PipelineOptions} [options]
+ * @returns {Promise<Pipeline | undefined>}
+ */
 async function getPipeline(options = {}) {
   const priority = getPriority();
 
@@ -1631,9 +1647,12 @@ async function getPipeline(options = {}) {
   // its own queue, soft-fail. PR builds get it only when that queue is
   // idle at upload time, so it is always busy while PRs flow and never
   // has a backlog: a PR that misses it loses nothing.
-  const betaDarwinTestPlatforms = (await darwinBetaQueueIdle())
-    ? [{ os: "darwin", arch: "aarch64", release: "27", tier: "beta" }]
-    : [];
+  // Never on the merge queue: a step that cannot start (box offline) would
+  // hold the required check open and stall the queue.
+  const betaDarwinTestPlatforms =
+    !darwinTestsEnabled && !isMergeQueue() && (await darwinBetaQueueIdle())
+      ? [{ os: "darwin", arch: "aarch64", release: "27", tier: "beta" }]
+      : [];
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
   )

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1461,15 +1461,19 @@ async function getPipelineOptions() {
 /**
  * True when no running or scheduled job in the pipeline targets the darwin
  * beta queue, so one more PR can be given the beta lane without queueing
- * behind another. Needs a REST token (`BUILDKITE_API_TOKEN`); without one,
- * or on any error, the answer is false and the lane is simply not added.
+ * behind another. Reads the cluster secret `BUILDKITE_READ_TOKEN` (a REST
+ * token with read_builds only); without it, or on any error, the answer
+ * is false and the lane is simply not added.
  * Two uploads a few seconds apart can both see "idle"; a queue of two is
  * the worst case, never a backlog.
  * @returns {Promise<boolean>}
  */
 async function darwinBetaQueueIdle() {
-  const token = getEnv("BUILDKITE_API_TOKEN", false);
-  if (!token || !isBuildkite) {
+  if (!isBuildkite) {
+    return false;
+  }
+  const token = getSecret("BUILDKITE_READ_TOKEN", { required: false });
+  if (!token) {
     return false;
   }
   try {

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -844,7 +844,10 @@ function getTestBunStep(platform, options, testOptions = {}) {
     depends_on: depends,
     agents: getTestAgent(platform, options),
 
-    retry: getRetry(),
+    // No automatic retry on the beta tier: agent loss would re-queue the
+    // job onto a single-box queue with nobody to take it, and a job that
+    // never starts is not something soft_fail can convert.
+    retry: platform.tier === "beta" ? { manual: { permit_on_passed: true }, automatic: false } : getRetry(),
     cancel_on_build_failing: isMergeQueue(),
     // One beta box: one shard, and it cannot block a merge.
     parallelism: platform.tier === "beta" ? 1 : os === "darwin" ? 2 : os === "windows" ? 8 : 20,
@@ -1516,7 +1519,19 @@ async function darwinBetaQueueIdle() {
       return false;
     }
     const builds = await res.json();
-    const terminal = new Set(["passed", "failed", "canceled", "skipped", "timed_out", "expired", "broken", "finished"]);
+    const terminal = new Set([
+      "passed",
+      "failed",
+      "canceled",
+      "skipped",
+      "timed_out",
+      "expired",
+      "broken",
+      "finished",
+      "waiting_failed",
+      "blocked_failed",
+      "unblocked_failed",
+    ]);
     const busy = builds.some(({ jobs = [] }) =>
       jobs.some(
         ({ state, agent_query_rules = [] }) =>

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1461,7 +1461,7 @@ async function getPipelineOptions() {
 /**
  * True when no running or scheduled job in the pipeline targets the darwin
  * beta queue, so one more PR can be given the beta lane without queueing
- * behind another. Reads the cluster secret `BUILDKITE_READ_TOKEN` (a REST
+ * behind another. Reads the cluster secret `CI_QUEUE_PROBE_TOKEN` (a REST
  * token with read_builds only); without it, or on any error, the answer
  * is false and the lane is simply not added.
  * Two uploads a few seconds apart can both see "idle"; a queue of two is
@@ -1472,7 +1472,7 @@ async function darwinBetaQueueIdle() {
   if (!isBuildkite) {
     return false;
   }
-  const token = getSecret("BUILDKITE_READ_TOKEN", { required: false });
+  const token = getSecret("CI_QUEUE_PROBE_TOKEN", { required: false });
   if (!token) {
     return false;
   }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -408,7 +408,7 @@ function getTestAgent(platform, options) {
     // box — because the tier split bottlenecked the smaller pool and Intel
     // can't run latest anyway.
     return {
-      queue: `test-${os}`,
+      queue: tier === "beta" ? darwinBetaQueue : `test-${os}`,
       os,
       arch,
       ...(arch === "aarch64" && tier ? { "release-tier": tier } : {}),
@@ -829,7 +829,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
   // The untiered darwin lane PR builds get (see prDarwinTestPlatforms) skips
   // the ~1% of files that take 10s or more; they are ~60% of a shard's wall
   // time and still run on every other PR lane and on main's darwin lanes.
-  if (os === "darwin" && !platform.tier) {
+  if (os === "darwin" && (!platform.tier || platform.tier === "beta")) {
     args.push("--skip-slower-than=10000");
   }
 
@@ -843,9 +843,12 @@ function getTestBunStep(platform, options, testOptions = {}) {
     label: `${getPlatformLabel(platform)} - test-bun`,
     depends_on: depends,
     agents: getTestAgent(platform, options),
+
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    parallelism: os === "darwin" ? 2 : os === "windows" ? 8 : 20,
+    // One beta box: one shard, and it cannot block a merge.
+    parallelism: platform.tier === "beta" ? 1 : os === "darwin" ? 2 : os === "windows" ? 8 : 20,
+    ...(platform.tier === "beta" ? { soft_fail: true } : {}),
     timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
@@ -1455,6 +1458,44 @@ async function getPipelineOptions() {
  * @param {PipelineOptions} [options]
  * @returns {Promise<Pipeline | undefined>}
  */
+/**
+ * True when no running or scheduled job in the pipeline targets the darwin
+ * beta queue, so one more PR can be given the beta lane without queueing
+ * behind another. Needs a REST token (`BUILDKITE_API_TOKEN`); without one,
+ * or on any error, the answer is false and the lane is simply not added.
+ * Two uploads a few seconds apart can both see "idle"; a queue of two is
+ * the worst case, never a backlog.
+ * @returns {Promise<boolean>}
+ */
+async function darwinBetaQueueIdle() {
+  const token = getEnv("BUILDKITE_API_TOKEN", false);
+  if (!token || !isBuildkite) {
+    return false;
+  }
+  try {
+    const res = await fetch(
+      "https://api.buildkite.com/v2/organizations/bun/pipelines/bun/builds?state%5B%5D=running&state%5B%5D=scheduled&per_page=100",
+      { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(10_000) },
+    );
+    if (!res.ok) {
+      return false;
+    }
+    const builds = await res.json();
+    const busy = builds.some(({ jobs = [] }) =>
+      jobs.some(
+        ({ state, agent_query_rules = [] }) =>
+          (state === "running" || state === "scheduled" || state === "assigned" || state === "accepted") &&
+          agent_query_rules.includes(`queue=${darwinBetaQueue}`),
+      ),
+    );
+    return !busy;
+  } catch {
+    return false;
+  }
+}
+
+const darwinBetaQueue = "test-darwin-beta";
+
 async function getPipeline(options = {}) {
   const priority = getPriority();
 
@@ -1580,11 +1621,19 @@ async function getPipeline(options = {}) {
     { os: "darwin", arch: "x64", release: "any" },
   ];
   const darwinTestsEnabled = isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
+  // The macOS beta lane: a single home-hosted mini on the next macOS,
+  // its own queue, soft-fail. PR builds get it only when that queue is
+  // idle at upload time, so it is always busy while PRs flow and never
+  // has a backlog: a PR that misses it loses nothing.
+  const betaDarwinTestPlatforms = (await darwinBetaQueueIdle())
+    ? [{ os: "darwin", arch: "aarch64", release: "27", tier: "beta" }]
+    : [];
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
   )
     .filter(({ os }) => os !== "darwin" || darwinTestsEnabled)
-    .concat(darwinTestsEnabled ? [] : prDarwinTestPlatforms);
+    .concat(darwinTestsEnabled ? [] : prDarwinTestPlatforms)
+    .concat(darwinTestsEnabled ? [] : betaDarwinTestPlatforms);
   /** @type {string[]} */
   const testStepKeys = [];
   {

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1472,11 +1472,13 @@ async function darwinBetaQueueIdle() {
   if (!isBuildkite) {
     return false;
   }
-  const token = getSecret("CI_QUEUE_PROBE_TOKEN", { required: false });
-  if (!token) {
-    return false;
-  }
   try {
+    // getSecret throws on Buildkite when the secret is absent; the probe
+    // must never take the pipeline down with it.
+    const token = getSecret("CI_QUEUE_PROBE_TOKEN", { required: false });
+    if (!token) {
+      return false;
+    }
     const res = await fetch(
       "https://api.buildkite.com/v2/organizations/bun/pipelines/bun/builds?state%5B%5D=running&state%5B%5D=scheduled&per_page=100",
       { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(10_000) },

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -38,7 +38,8 @@ const AZURE_KEYVAULT = "bun-ci";
 const AZURE_TOKEN_SECRET = "buildkite-agent-token";
 
 // macOS major-version thresholds for the `release-tier` agent tag.
-//   >= LATEST   -> "latest"   (current macOS; arm64-only in practice)
+//   >  LATEST   -> "beta"     (next macOS, pre-release; its own queue)
+//   == LATEST   -> "latest"   (current macOS; arm64-only in practice)
 //   >= PREVIOUS -> "previous" (recent-but-not-current; 14/15 today)
 //   else        -> "oldest"   (min-supported; 13 today)
 // Bump LATEST when a new macOS ships and the first runner on it is online.
@@ -48,6 +49,7 @@ const PREVIOUS_DARWIN_RELEASE = 14;
 
 function darwinReleaseTier(distroVersion) {
   const major = parseInt(distroVersion?.split(".")[0] || "0");
+  if (major > LATEST_DARWIN_RELEASE) return "beta";
   if (major >= LATEST_DARWIN_RELEASE) return "latest";
   if (major >= PREVIOUS_DARWIN_RELEASE) return "previous";
   return "oldest";

--- a/scripts/darwin-ci/lib/config.ts
+++ b/scripts/darwin-ci/lib/config.ts
@@ -19,7 +19,9 @@ export const config = {
 
 export const toolchain = ["bun", "node", "cmake", "ninja", "ccache", "cargo", "go", "clang-21"];
 
-export function releaseTier(release: number): "latest" | "previous" | "oldest" {
+// Keep in step with darwinReleaseTier in scripts/agent.mjs.
+export function releaseTier(release: number): "beta" | "latest" | "previous" | "oldest" {
+  if (release > 26) return "beta";
   if (release >= 26) return "latest";
   if (release >= 14) return "previous";
   return "oldest";


### PR DESCRIPTION
A home-hosted M2 mini (bingus) now runs **macOS 27.0 developer beta** (`26A5416b`) on its own cluster queue, `test-darwin-beta`, tagged `release-tier=beta`.

**Shape.** A PR build adds a `darwin 27 aarch64 - test-bun` step only when that queue has no running or scheduled job at pipeline-upload time (`darwinBetaQueueIdle()`, one REST call listing live builds and checking their jobs' `agent_query_rules`). So the box is always working while PRs flow, never has a queue, and a PR that doesn't get the lane loses nothing. The step is `soft_fail` with `parallelism: 1`: a beta OS can't block a merge; its result is advisory and shows up in annotations. Without `BUILDKITE_API_TOKEN`, or on any API error, the lane is not added. `main` is unchanged.

Two uploads seconds apart can both see "idle"; a queue of two is the worst case.

**agent.mjs.** A macOS newer than `LATEST_DARWIN_RELEASE` now tags itself `release-tier=beta` (was `latest`), so a beta box can never match the current release's lane even if it ended up on the main queue.

`--dry-run`: PR without a token → the two existing `any` lanes only; `main` → unchanged. The positive path runs in this PR's own build (the agent env has the token and the beta queue is idle), so expect a `darwin 27 aarch64 - test-bun` step on it.