### PR TITLE
install: support path-style `link:./dir` dependencies (yarn/pnpm semantics)

### DIFF
--- a/docs/pm/cli/link.mdx
+++ b/docs/pm/cli/link.mdx
@@ -45,7 +45,7 @@ The `--save` flag also adds `cool-pkg` to the `dependencies` field of your app's
 
 ## Linking a directory by path
 
-`link:` also accepts a path, as written by Yarn and pnpm. A target that starts with `.` or is an absolute path is not looked up among the packages registered with `bun link`; it is resolved relative to the `package.json` that declares it and installed as a symlink to that directory:
+`link:` also accepts a filesystem path, as written by Yarn and pnpm. Any value that is not a package name — `link:./vendor/design-tokens`, `link:../shared`, `link:vendor/design-tokens`, or an absolute path — is not looked up among the packages registered with `bun link`; it is resolved relative to the `package.json` that declares it and installed as a symlink to that directory:
 
 ```json package.json icon="file-json"
 {
@@ -56,7 +56,9 @@ The `--save` flag also adds `cool-pkg` to the `dependencies` field of your app's
 }
 ```
 
-The directory does not need to be a workspace or to have been linked beforehand, and — like Yarn — it does not even need a `package.json` (it is then treated as a package with no dependencies of its own). Use `file:` instead when you want the directory's contents copied into `node_modules` rather than symlinked.
+The directory does not need to be a workspace or to have been linked beforehand, and — like Yarn — it does not even need a `package.json` (it is then treated as a package with no dependencies of its own). The directory itself must exist. Use `file:` instead when you want the directory's contents copied into `node_modules` rather than symlinked.
+
+As with `file:`, a path that leaves the project (`../` or an absolute path) is only allowed when the root `package.json`, a workspace, or a root `overrides`/`resolutions` entry declares it; a `link:` path declared by some other local dependency must stay inside the project.
 
 ## Unlinking
 

--- a/docs/pm/cli/link.mdx
+++ b/docs/pm/cli/link.mdx
@@ -43,6 +43,21 @@ The `--save` flag also adds `cool-pkg` to the `dependencies` field of your app's
 }
 ```
 
+## Linking a directory by path
+
+`link:` also accepts a path, as written by Yarn and pnpm. A target that starts with `.` or `/` is not looked up among the packages registered with `bun link`; it is resolved relative to the `package.json` that declares it and installed as a symlink to that directory:
+
+```json package.json icon="file-json"
+{
+  "dependencies": {
+    "design-tokens": "link:./vendor/design-tokens",
+    "shared": "link:../shared"
+  }
+}
+```
+
+The directory does not need to be a workspace or to have been linked beforehand, and — like Yarn — it does not even need a `package.json` (it is then treated as a package with no dependencies of its own). Use `file:` instead when you want the directory's contents copied into `node_modules` rather than symlinked.
+
 ## Unlinking
 
 Use `bun unlink` in the root directory to unregister a local package.

--- a/docs/pm/cli/link.mdx
+++ b/docs/pm/cli/link.mdx
@@ -58,7 +58,7 @@ The `--save` flag also adds `cool-pkg` to the `dependencies` field of your app's
 
 The directory does not need to be a workspace or to have been linked beforehand, and — like Yarn — it does not even need a `package.json` (it is then treated as a package with no dependencies of its own). The directory itself must exist. Use `file:` instead when you want the directory's contents copied into `node_modules` rather than symlinked.
 
-As with `file:`, a path that leaves the project (`../` or an absolute path) is only allowed when the root `package.json`, a workspace, or a root `overrides`/`resolutions` entry declares it; a `link:` path declared by some other local dependency must stay inside the project.
+As with `file:`, a path that leaves the project (`../` or an absolute path) is only allowed when the root `package.json` or a workspace declares it, or a root `overrides`/`resolutions` entry (plain or scoped to that dependency) supplies it; a `link:` path declared by some other local dependency must stay inside the project.
 
 ## Unlinking
 

--- a/docs/pm/cli/link.mdx
+++ b/docs/pm/cli/link.mdx
@@ -45,7 +45,7 @@ The `--save` flag also adds `cool-pkg` to the `dependencies` field of your app's
 
 ## Linking a directory by path
 
-`link:` also accepts a path, as written by Yarn and pnpm. A target that starts with `.` or `/` is not looked up among the packages registered with `bun link`; it is resolved relative to the `package.json` that declares it and installed as a symlink to that directory:
+`link:` also accepts a path, as written by Yarn and pnpm. A target that starts with `.` or is an absolute path is not looked up among the packages registered with `bun link`; it is resolved relative to the `package.json` that declares it and installed as a symlink to that directory:
 
 ```json package.json icon="file-json"
 {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1531,13 +1531,18 @@ impl<'a> PackageInstaller<'a> {
                 installer.cache_dir = Fd::cwd();
             }
             resolution::Tag::Symlink => {
-                let directory = package_manager::global_link_dir(self.manager_mut());
-
                 let folder_str = *resolution.symlink();
                 let folder = folder_str.slice(string_buf!());
 
                 if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                     installer.cache_dir_subpath = ZStr::from_static(b".\0");
+                    installer.cache_dir = Fd::cwd();
+                } else if crate::resolution::is_path_link(folder) {
+                    // `link:./dir`: the value is project-relative (see `is_path_link`)
+                    self.folder_path_buf[..folder.len()].copy_from_slice(folder);
+                    self.folder_path_buf[folder.len()] = 0;
+                    installer.cache_dir_subpath =
+                        ZStr::from_buf(&self.folder_path_buf, folder.len());
                     installer.cache_dir = Fd::cwd();
                 } else {
                     let global_link_dir = package_manager::global_link_dir_path(self.manager_mut());
@@ -1554,7 +1559,7 @@ impl<'a> PackageInstaller<'a> {
                     buf[len] = 0;
                     // SAFETY: buf[len] == 0 written above
                     installer.cache_dir_subpath = ZStr::from_buf(&self.folder_path_buf, len);
-                    installer.cache_dir = directory;
+                    installer.cache_dir = package_manager::global_link_dir(self.manager_mut());
                 }
             }
             _ => {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1537,14 +1537,34 @@ impl<'a> PackageInstaller<'a> {
                 if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                     installer.cache_dir_subpath = ZStr::from_static(b".\0");
                     installer.cache_dir = Fd::cwd();
-                } else if crate::resolution::is_path_link(folder) {
-                    // `link:./dir`: the value is project-relative (see `is_path_link`)
+                } else if crate::dependency::is_link_path(folder) {
+                    if folder.len() >= self.folder_path_buf.len()
+                        || !self
+                            .lockfile()
+                            .link_target_allowed_for_package(package_id, folder)
+                    {
+                        if log_level != Options::LogLevel::Silent {
+                            bun_core::pretty_errorln!(
+                                "<r><red>error<r>: refusing to link dependency <b>{}<r> to \"{}\": only the root package.json, a workspace, or an override may link to a path outside the project",
+                                bstr::BStr::new(pkg_name.slice(string_buf!())),
+                                bstr::BStr::new(folder),
+                            );
+                        }
+                        self.summary.fail += 1;
+                        self.increment_tree_install_count(
+                            !is_pending_package_install,
+                            self.current_tree_id,
+                            log_level,
+                        );
+                        return;
+                    }
                     self.folder_path_buf[..folder.len()].copy_from_slice(folder);
                     self.folder_path_buf[folder.len()] = 0;
                     installer.cache_dir_subpath =
                         ZStr::from_buf(&self.folder_path_buf, folder.len());
                     installer.cache_dir = Fd::cwd();
                 } else {
+                    let directory = package_manager::global_link_dir(self.manager_mut());
                     let global_link_dir = package_manager::global_link_dir_path(self.manager_mut());
                     let buf = self.folder_path_buf.as_mut_slice();
                     let mut len = 0usize;
@@ -1559,7 +1579,7 @@ impl<'a> PackageInstaller<'a> {
                     buf[len] = 0;
                     // SAFETY: buf[len] == 0 written above
                     installer.cache_dir_subpath = ZStr::from_buf(&self.folder_path_buf, len);
-                    installer.cache_dir = package_manager::global_link_dir(self.manager_mut());
+                    installer.cache_dir = directory;
                 }
             }
             _ => {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2182,6 +2182,7 @@ pub fn init(
             crate::resolvers::folder_resolver::hash(normalized),
             FolderResolutionEntry {
                 abs_path: Box::<[u8]>::from(&*normalized),
+                link: false,
                 resolution: FolderResolution::PackageId(0),
             },
         )?;

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -1021,19 +1021,19 @@ pub fn compute_cache_dir_and_subpath<'a>(
             if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                 cache_dir_subpath = z_static(b".\0");
                 cache_dir = Fd::cwd();
-            } else if crate::resolution::is_path_link(&folder) {
-                // `link:./dir`: the value is project-relative (see `is_path_link`)
-                folder_path_buf.0[..folder.len()].copy_from_slice(&folder);
-                folder_path_buf.0[folder.len()] = 0;
+            } else if crate::dependency::is_link_path(&folder) {
+                folder_path_buf[..folder.len()].copy_from_slice(&folder);
+                folder_path_buf[folder.len()] = 0;
                 cache_dir_subpath = ZStr::from_buf(folder_path_buf, folder.len());
                 cache_dir = Fd::cwd();
             } else {
-                let link_dir_path = global_link_dir_path(manager);
+                let directory = global_link_dir(manager);
+                let global_link_dir = global_link_dir_path(manager);
                 let ptr = &mut folder_path_buf.0[..];
                 let mut off = 0usize;
-                ptr[off..off + link_dir_path.len()].copy_from_slice(link_dir_path);
-                off += link_dir_path.len();
-                if link_dir_path[link_dir_path.len() - 1] != SEP {
+                ptr[off..off + global_link_dir.len()].copy_from_slice(global_link_dir);
+                off += global_link_dir.len();
+                if global_link_dir[global_link_dir.len() - 1] != SEP {
                     ptr[off] = SEP;
                     off += 1;
                 }
@@ -1042,7 +1042,7 @@ pub fn compute_cache_dir_and_subpath<'a>(
                 ptr[off] = 0;
                 let len = off;
                 cache_dir_subpath = ZStr::from_buf(folder_path_buf, len);
-                cache_dir = global_link_dir(manager);
+                cache_dir = directory;
             }
         }
         _ => {}

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -1010,8 +1010,6 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = Fd::cwd();
         }
         ResolutionTag::Symlink => {
-            let directory = global_link_dir(manager);
-
             // borrowck — `global_link_dir_path` below reborrows
             // `manager` mutably, so copy the symlink target out of the lockfile
             // string buffer first instead of holding a slice across that call.
@@ -1030,12 +1028,12 @@ pub fn compute_cache_dir_and_subpath<'a>(
                 cache_dir_subpath = ZStr::from_buf(folder_path_buf, folder.len());
                 cache_dir = Fd::cwd();
             } else {
-                let global_link_dir = global_link_dir_path(manager);
+                let link_dir_path = global_link_dir_path(manager);
                 let ptr = &mut folder_path_buf.0[..];
                 let mut off = 0usize;
-                ptr[off..off + global_link_dir.len()].copy_from_slice(global_link_dir);
-                off += global_link_dir.len();
-                if global_link_dir[global_link_dir.len() - 1] != SEP {
+                ptr[off..off + link_dir_path.len()].copy_from_slice(link_dir_path);
+                off += link_dir_path.len();
+                if link_dir_path[link_dir_path.len() - 1] != SEP {
                     ptr[off] = SEP;
                     off += 1;
                 }
@@ -1044,7 +1042,7 @@ pub fn compute_cache_dir_and_subpath<'a>(
                 ptr[off] = 0;
                 let len = off;
                 cache_dir_subpath = ZStr::from_buf(folder_path_buf, len);
-                cache_dir = directory;
+                cache_dir = global_link_dir(manager);
             }
         }
         _ => {}

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -1023,6 +1023,12 @@ pub fn compute_cache_dir_and_subpath<'a>(
             if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                 cache_dir_subpath = z_static(b".\0");
                 cache_dir = Fd::cwd();
+            } else if crate::resolution::is_path_link(&folder) {
+                // `link:./dir`: the value is project-relative (see `is_path_link`)
+                folder_path_buf.0[..folder.len()].copy_from_slice(&folder);
+                folder_path_buf.0[folder.len()] = 0;
+                cache_dir_subpath = ZStr::from_buf(folder_path_buf, folder.len());
+                cache_dir = Fd::cwd();
             } else {
                 let global_link_dir = global_link_dir_path(manager);
                 let ptr = &mut folder_path_buf.0[..];

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1635,17 +1635,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             quoted: true
                         },
                     );
-                } else if dependency_tag == dependency::version::Tag::Symlink
-                    && crate::resolution::is_path_link(this.lockfile.str(version.symlink()))
-                {
-                    bun_ast::add_error_pretty!(
-                        this.log_mut(),
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        "Could not resolve \"{}\": link target <b>{}<r> could not be read",
-                        bstr::BStr::new(this.lockfile.str(&name)),
-                        bstr::BStr::new(this.lockfile.str(version.symlink())),
-                    );
                 } else {
                     bun_ast::add_error_pretty!(
                         this.log_mut(),
@@ -1668,17 +1657,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             version,
                             quoted: true
                         },
-                    );
-                } else if dependency_tag == dependency::version::Tag::Symlink
-                    && crate::resolution::is_path_link(this.lockfile.str(version.symlink()))
-                {
-                    bun_ast::add_warning_pretty!(
-                        this.log_mut(),
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        "Could not resolve \"{}\": link target <b>{}<r> could not be read",
-                        bstr::BStr::new(this.lockfile.str(&name)),
-                        bstr::BStr::new(this.lockfile.str(version.symlink())),
                     );
                 } else {
                     bun_ast::add_warning_pretty!(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1635,6 +1635,17 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             quoted: true
                         },
                     );
+                } else if dependency_tag == dependency::version::Tag::Symlink
+                    && crate::resolution::is_path_link(this.lockfile.str(version.symlink()))
+                {
+                    bun_ast::add_error_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Could not resolve \"{}\": link target <b>{}<r> could not be read",
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                        bstr::BStr::new(this.lockfile.str(version.symlink())),
+                    );
                 } else {
                     bun_ast::add_error_pretty!(
                         this.log_mut(),
@@ -1657,6 +1668,17 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             version,
                             quoted: true
                         },
+                    );
+                } else if dependency_tag == dependency::version::Tag::Symlink
+                    && crate::resolution::is_path_link(this.lockfile.str(version.symlink()))
+                {
+                    bun_ast::add_warning_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Could not resolve \"{}\": link target <b>{}<r> could not be read",
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                        bstr::BStr::new(this.lockfile.str(version.symlink())),
                     );
                 } else {
                     bun_ast::add_warning_pretty!(
@@ -2968,12 +2990,22 @@ fn get_or_put_resolved_package(
             // `version.tag == Symlink`.
             let symlink_path = this.lockfile.str_detached(version.symlink());
             let res = if crate::resolution::is_path_link(symlink_path) {
-                // yarn/pnpm-style `link:./dir`: relative to the project, not to the
-                // global link directory
+                // yarn/pnpm-style `link:./dir`: relative to the project (already rebased
+                // to the root by Package.rs), not to the global link directory
+                let mut abs_buf = PathBuffer::uninit();
+                let link_path_abs = if bun_paths::is_absolute(symlink_path) {
+                    symlink_path
+                } else {
+                    Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                        FileSystem::instance().top_level_dir(),
+                        &mut abs_buf,
+                        &[symlink_path],
+                    )
+                };
                 FolderResolution::get_or_put(
                     GlobalOrRelative::Relative(dependency::version::Tag::Symlink),
                     version,
-                    symlink_path,
+                    link_path_abs,
                     this,
                 )
             } else {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1578,6 +1578,19 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             ) {
                 Ok(v) => v,
                 Err(crate::Error::MissingPackageJSON) => None,
+                Err(crate::Error::UnsafeLinkTarget) => {
+                    if dependency.behavior.is_required() {
+                        bun_ast::add_error_pretty!(
+                            this.log_mut(),
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            "Refusing to link dependency \"{}\" to \"{}\": only the root package.json, a workspace, or an override may link to a path outside the project\n\n",
+                            bstr::BStr::new(this.lockfile.str(&name)),
+                            bstr::BStr::new(this.lockfile.str(version.symlink())),
+                        );
+                    }
+                    return Ok(());
+                }
                 Err(err) => return Err(err),
             };
 
@@ -1635,6 +1648,15 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             quoted: true
                         },
                     );
+                } else if dependency::is_link_path(this.lockfile.str(version.symlink())) {
+                    bun_ast::add_error_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Could not find directory \"{}\" for linked dependency \"{}\"\n\n",
+                        bstr::BStr::new(this.lockfile.str(version.symlink())),
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                    );
                 } else {
                     bun_ast::add_error_pretty!(
                         this.log_mut(),
@@ -1657,6 +1679,15 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             version,
                             quoted: true
                         },
+                    );
+                } else if dependency::is_link_path(this.lockfile.str(version.symlink())) {
+                    bun_ast::add_warning_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Could not find directory \"{}\" for linked dependency \"{}\"\n\n",
+                        bstr::BStr::new(this.lockfile.str(version.symlink())),
+                        bstr::BStr::new(this.lockfile.str(&name)),
                     );
                 } else {
                     bun_ast::add_warning_pretty!(
@@ -2960,35 +2991,38 @@ fn get_or_put_resolved_package(
             // reshaped for borrowck — `link_dir` / `symlink_path`
             // borrow into `*this`; detach their lifetimes so the
             // `&mut PackageManager` reborrow for `get_or_put` does not
-            // conflict.
-            // SAFETY: `global_link_dir_path` returns a slice into the lazily-
-            // initialized `PackageManager.global_link_dir_path` (a `Box<[u8]>`
-            // set once and never freed); `get_or_put` copies `symlink_path`
-            // into the lockfile string buffer before any other mutation.
+            // conflict. `get_or_put` copies `symlink_path` into the lockfile
+            // string buffer before any other mutation.
             // `version.tag == Symlink`.
             let symlink_path = this.lockfile.str_detached(version.symlink());
-            let res = if crate::resolution::is_path_link(symlink_path) {
-                // yarn/pnpm-style `link:./dir`: relative to the project (already rebased
-                // to the root by Package.rs), not to the global link directory
-                let mut abs_buf = PathBuffer::uninit();
-                let link_path_abs = if bun_paths::is_absolute(symlink_path) {
-                    symlink_path
+            let res = if dependency::is_link_path(symlink_path) {
+                if !this
+                    .lockfile
+                    .link_target_allowed_for_dependency(dependency_id, symlink_path)
+                {
+                    FolderResolutionValue::Err(crate::Error::UnsafeLinkTarget)
                 } else {
-                    Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                        FileSystem::instance().top_level_dir(),
-                        &mut abs_buf,
-                        &[symlink_path],
+                    let mut buf2 = PathBuffer::uninit();
+                    let symlink_path_abs = if bun_paths::is_absolute(symlink_path) {
+                        symlink_path
+                    } else {
+                        Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                            FileSystem::instance().top_level_dir(),
+                            &mut buf2,
+                            &[symlink_path],
+                        )
+                    };
+                    FolderResolution::get_or_put(
+                        GlobalOrRelative::Relative(dependency::version::Tag::Symlink),
+                        version,
+                        symlink_path_abs,
+                        this,
                     )
-                };
-                FolderResolution::get_or_put(
-                    GlobalOrRelative::Relative(dependency::version::Tag::Symlink),
-                    version,
-                    link_path_abs,
-                    this,
-                )
+                }
             } else {
-                // SAFETY: see the note above — `global_link_dir_path` is set once and
-                // never freed; `get_or_put` copies what it needs before mutating.
+                // SAFETY: `global_link_dir_path` returns a slice into the
+                // lazily-initialized `PackageManager.global_link_dir_path`
+                // (a `Box<[u8]>` set once and never freed).
                 let link_dir =
                     unsafe { detach_lifetime(package_manager_real::global_link_dir_path(this)) };
                 FolderResolution::get_or_put(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2966,15 +2966,28 @@ fn get_or_put_resolved_package(
             // set once and never freed); `get_or_put` copies `symlink_path`
             // into the lockfile string buffer before any other mutation.
             // `version.tag == Symlink`.
-            let link_dir =
-                unsafe { detach_lifetime(package_manager_real::global_link_dir_path(this)) };
             let symlink_path = this.lockfile.str_detached(version.symlink());
-            let res = FolderResolution::get_or_put(
-                GlobalOrRelative::Global(link_dir),
-                version,
-                symlink_path,
-                this,
-            );
+            let res = if crate::resolution::is_path_link(symlink_path) {
+                // yarn/pnpm-style `link:./dir`: relative to the project, not to the
+                // global link directory
+                FolderResolution::get_or_put(
+                    GlobalOrRelative::Relative(dependency::version::Tag::Symlink),
+                    version,
+                    symlink_path,
+                    this,
+                )
+            } else {
+                // SAFETY: see the note above — `global_link_dir_path` is set once and
+                // never freed; `get_or_put` copies what it needs before mutating.
+                let link_dir =
+                    unsafe { detach_lifetime(package_manager_real::global_link_dir_path(this)) };
+                FolderResolution::get_or_put(
+                    GlobalOrRelative::Global(link_dir),
+                    version,
+                    symlink_path,
+                    this,
+                )
+            };
 
             resolved_folder_package(this, res, dependency_id, success_fn)
         }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1588,6 +1588,15 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             bstr::BStr::new(this.lockfile.str(&name)),
                             bstr::BStr::new(this.lockfile.str(version.symlink())),
                         );
+                    } else if this.options.log_level.is_verbose() {
+                        bun_ast::add_warning_pretty!(
+                            this.log_mut(),
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            "Refusing to link dependency \"{}\" to \"{}\": only the root package.json, a workspace, or an override may link to a path outside the project\n\n",
+                            bstr::BStr::new(this.lockfile.str(&name)),
+                            bstr::BStr::new(this.lockfile.str(version.symlink())),
+                        );
                     }
                     return Ok(());
                 }

--- a/src/install/PackageManager/add_remove_with_filter.rs
+++ b/src/install/PackageManager/add_remove_with_filter.rs
@@ -348,8 +348,11 @@ pub(crate) fn local_relative_path(request: &UpdateRequest) -> Option<(&'static [
         dependency::Tag::Symlink => (b"link:", literal.strip_prefix(b"link:")?),
         _ => return None,
     };
-    let is_path = path.starts_with(b".")
-        || (prefix != b"link:" && !path.is_empty() && !strings::contains(path, b"://"));
+    let is_path = if prefix == b"link:" {
+        dependency::is_link_path(path)
+    } else {
+        path.starts_with(b".") || (!path.is_empty() && !strings::contains(path, b"://"))
+    };
     (is_path && !path.starts_with(b"//") && !Platform::AUTO.is_absolute(path))
         .then_some((prefix, path))
 }

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -652,11 +652,12 @@ impl VersionExt for Version {
                     true,
                 ) || self.npm().eql(rhs.npm(), lhs_buf, rhs_buf)
             }
-            Tag::Folder | Tag::DistTag => self.literal.eql(rhs.literal, lhs_buf, rhs_buf),
+            Tag::Folder | Tag::DistTag | Tag::Symlink => {
+                self.literal.eql(rhs.literal, lhs_buf, rhs_buf)
+            }
             Tag::Git => Repository::eql(self.git(), rhs.git(), lhs_buf, rhs_buf),
             Tag::Github => Repository::eql(self.github(), rhs.github(), lhs_buf, rhs_buf),
             Tag::Tarball => self.tarball().eql(rhs.tarball(), lhs_buf, rhs_buf),
-            Tag::Symlink => self.symlink().eql(*rhs.symlink(), lhs_buf, rhs_buf),
             Tag::Workspace => self.workspace().eql(*rhs.workspace(), lhs_buf, rhs_buf),
             Tag::Catalog => self.catalog().eql(*rhs.catalog(), lhs_buf, rhs_buf),
             _ => true,
@@ -1034,6 +1035,46 @@ impl TagExt for Tag {
 // ──────────────────────────────────────────────────────────────────────────
 // Free functions: parse
 // ──────────────────────────────────────────────────────────────────────────
+
+/// A `link:` target is a path unless it is a package name (`bun link <name>`).
+/// Shared with the pnpm-lock.yaml migration so both agree on stored values.
+pub(crate) fn is_link_path(value: &[u8]) -> bool {
+    !value.is_empty() && !strings::is_npm_package_name(value)
+}
+
+/// Stored form of a path-form target (root-relative or absolute): `/`-separated
+/// and `./`-prefixed where needed, so `is_link_path` holds when read back.
+pub(crate) fn link_path_for_lockfile<'a>(
+    relative: &[u8],
+    buf: &'a mut bun_paths::PathBuffer,
+) -> Option<&'a [u8]> {
+    if relative.is_empty() || relative == b"." {
+        return Some(b".");
+    }
+    let already_shaped = relative == b".."
+        || relative.starts_with(b"./")
+        || relative.starts_with(b"../")
+        || (cfg!(windows) && (relative.starts_with(b".\\") || relative.starts_with(b"..\\")))
+        || bun_paths::is_absolute(relative);
+    let prefix_len = if already_shaped { 0 } else { 2 };
+    let total = prefix_len + relative.len();
+    if total > buf.len() {
+        return None;
+    }
+    if prefix_len != 0 {
+        buf[0] = b'.';
+        buf[1] = b'/';
+    }
+    buf[prefix_len..total].copy_from_slice(relative);
+    #[cfg(windows)]
+    bun_paths::dangerously_convert_path_to_posix_in_place::<u8>(&mut buf[..total]);
+    Some(&buf[..total])
+}
+
+/// Leaves the project root (`..` or absolute); same rule `file:` uses.
+pub(crate) fn link_path_escapes_root(stored: &[u8]) -> bool {
+    crate::bin::bin_target_escapes_package_dir(stored)
+}
 
 #[cfg(windows)]
 pub(crate) fn is_windows_abs_path_with_leading_slashes(dep: &[u8]) -> Option<&[u8]> {

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -60,6 +60,8 @@ pub enum Error {
     TooRecentVersion,
     #[error("MissingPackageJSON")]
     MissingPackageJSON,
+    #[error("UnsafeLinkTarget")]
+    UnsafeLinkTarget,
     #[error("InstallFailed")]
     InstallFailed,
     #[error("HTTPError")]
@@ -271,6 +273,7 @@ impl Error {
             Self::NoMatchingVersion => "NoMatchingVersion",
             Self::TooRecentVersion => "TooRecentVersion",
             Self::MissingPackageJSON => "MissingPackageJSON",
+            Self::UnsafeLinkTarget => "UnsafeLinkTarget",
             Self::InstallFailed => "InstallFailed",
             Self::HTTPError => "HTTPError",
             Self::Failed => "Failed",

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2087,18 +2087,37 @@ pub(crate) fn install_isolated_packages(
             task.installer = installer_backref;
         }
 
-        // `append_store_path` runs on worker threads via `&Installer` and
-        // can't take `&mut PackageManager` there, so ensure the
-        // global link dir once on the main thread before any `.symlink`
-        // resolution can be reached by a task. Guarded so installs without
-        // `link:` deps don't touch the global dir.
-        if pkg_resolutions.iter().any(|r| {
-            r.tag == ResolutionTag::Symlink
-                && !crate::resolution::is_path_link(r.symlink().slice(string_buf))
-        }) {
-            let _ = crate::package_manager_real::directories::global_link_dir_path(
-                installer.manager_mut(),
-            );
+        // Must precede the first `start_task`: workers symlink `link:` packages
+        // into dependents (`append_store_path`) and cannot create the global dir.
+        {
+            let mut needs_global_link_dir = false;
+            for (pkg_id, res) in pkg_resolutions.iter().enumerate() {
+                if res.tag != ResolutionTag::Symlink {
+                    continue;
+                }
+                let target = res.symlink().slice(string_buf);
+                if !crate::dependency::is_link_path(target) {
+                    needs_global_link_dir = true;
+                    continue;
+                }
+                let pkg_id = PackageID::try_from(pkg_id).expect("int cast");
+                if !lockfile_ro.link_target_allowed_for_package(pkg_id, target) {
+                    Output::err_generic(
+                        "refusing to link dependency <b>{}<r> to \"{}\": only the root package.json, a workspace, or an override may link to a path outside the project",
+                        (
+                            BStr::new(pkg_names[pkg_id as usize].slice(string_buf)),
+                            BStr::new(target),
+                        ),
+                    );
+                    Output::flush();
+                    Global::exit(1);
+                }
+            }
+            if needs_global_link_dir {
+                let _ = crate::package_manager_real::directories::global_link_dir_path(
+                    installer.manager_mut(),
+                );
+            }
         }
 
         // add the pending task count upfront

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2092,10 +2092,10 @@ pub(crate) fn install_isolated_packages(
         // global link dir once on the main thread before any `.symlink`
         // resolution can be reached by a task. Guarded so installs without
         // `link:` deps don't touch the global dir.
-        if pkg_resolutions
-            .iter()
-            .any(|r| r.tag == ResolutionTag::Symlink)
-        {
+        if pkg_resolutions.iter().any(|r| {
+            r.tag == ResolutionTag::Symlink
+                && !crate::resolution::is_path_link(r.symlink().slice(string_buf))
+        }) {
             let _ = crate::package_manager_real::directories::global_link_dir_path(
                 installer.manager_mut(),
             );

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2764,15 +2764,21 @@ impl<'a> Installer<'a> {
                 // threads, so the lazy init is hoisted to the main-thread caller
                 // (`isolated_install::install_packages`, before any `start_task`).
                 // Reading the cached field here is then equivalent.
-                let symlink_dir_path: &[u8] = &self.manager().global_link_dir_path;
-                debug_assert!(
-                    !symlink_dir_path.is_empty(),
-                    "global_link_dir_path must be ensured before tasks start",
-                );
+                let target = pkg_res.symlink().slice(string_buf);
+                if crate::resolution::is_path_link(target) {
+                    // `link:./dir`: project-relative (buf starts at the project root)
+                    buf.append(target);
+                } else {
+                    let symlink_dir_path: &[u8] = &self.manager().global_link_dir_path;
+                    debug_assert!(
+                        !symlink_dir_path.is_empty(),
+                        "global_link_dir_path must be ensured before tasks start",
+                    );
 
-                buf.clear();
-                buf.append(symlink_dir_path);
-                buf.append(pkg_res.symlink().slice(string_buf));
+                    buf.clear();
+                    buf.append(symlink_dir_path);
+                    buf.append(target);
+                }
             }
             _ => {
                 let pkg_name = pkg_names[pkg_id as usize];

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2758,17 +2758,19 @@ impl<'a> Installer<'a> {
                 buf.append(pkg_res.workspace().slice(string_buf));
             }
             ResolutionTag::Symlink => {
-                // Lazily ensuring the global link dir would mutate
-                // `*PackageManager`, but `append_store_path` is
-                // `&self` and may run on worker
-                // threads, so the lazy init is hoisted to the main-thread caller
-                // (`isolated_install::install_packages`, before any `start_task`).
-                // Reading the cached field here is then equivalent.
-                let target = pkg_res.symlink().slice(string_buf);
-                if crate::resolution::is_path_link(target) {
-                    // `link:./dir`: project-relative (buf starts at the project root)
-                    buf.append(target);
+                let symlink = pkg_res.symlink().slice(string_buf);
+                if crate::dependency::is_link_path(symlink) {
+                    if bun_paths::is_absolute(symlink) {
+                        buf.clear();
+                    }
+                    buf.append(symlink);
                 } else {
+                    // Lazily ensuring the global link dir would mutate
+                    // `*PackageManager`, but `append_store_path` is
+                    // `&self` and may run on worker
+                    // threads, so the lazy init is hoisted to the main-thread caller
+                    // (`isolated_install::install_packages`, before any `start_task`).
+                    // Reading the cached field here is then equivalent.
                     let symlink_dir_path: &[u8] = &self.manager().global_link_dir_path;
                     debug_assert!(
                         !symlink_dir_path.is_empty(),
@@ -2777,7 +2779,7 @@ impl<'a> Installer<'a> {
 
                     buf.clear();
                     buf.append(symlink_dir_path);
-                    buf.append(target);
+                    buf.append(symlink);
                 }
             }
             _ => {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -862,6 +862,10 @@ impl Lockfile {
 
     /// A path-form `link:` target may leave the project only if the root, a
     /// workspace, or a root override declared it; never a transitive package.
+    /// The override may be a plain `overrides`/`resolutions` entry or a scoped
+    /// one (`parent>name`, `name@range`, npm nested objects): what counts is
+    /// that the rule the root wrote applies to this particular edge, which is
+    /// what `OverrideMap::get` answers.
     pub fn link_target_allowed_for_dependency(&self, id: DependencyID, target: &[u8]) -> bool {
         if !dependency::link_path_escapes_root(target) {
             return true;
@@ -869,10 +873,8 @@ impl Lockfile {
         if self.is_workspace_dependency(id) {
             return true;
         }
-        let buf = self.buffers.string_bytes.as_slice();
         let dep = &self.buffers.dependencies[id as usize];
-        self.overrides
-            .contains_name(dep.name_hash, dep.name.slice(buf), buf)
+        self.overrides.get(self, id, dep.name_hash).is_some()
     }
 
     /// Installer-side check (installs from a lockfile skip resolution):

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -860,6 +860,40 @@ impl Lockfile {
         0
     }
 
+    /// A path-form `link:` target may leave the project only if the root, a
+    /// workspace, or a root override declared it; never a transitive package.
+    pub fn link_target_allowed_for_dependency(&self, id: DependencyID, target: &[u8]) -> bool {
+        if !dependency::link_path_escapes_root(target) {
+            return true;
+        }
+        if self.is_workspace_dependency(id) {
+            return true;
+        }
+        let buf = self.buffers.string_bytes.as_slice();
+        let dep = &self.buffers.dependencies[id as usize];
+        self.overrides
+            .contains_name(dep.name_hash, dep.name.slice(buf), buf)
+    }
+
+    /// Installer-side check (installs from a lockfile skip resolution):
+    /// allowed if any dependency resolving to the package is.
+    pub fn link_target_allowed_for_package(&self, pkg_id: PackageID, target: &[u8]) -> bool {
+        if !dependency::link_path_escapes_root(target) {
+            return true;
+        }
+        self.buffers
+            .resolutions
+            .iter()
+            .enumerate()
+            .filter(|(_, resolved)| **resolved == pkg_id)
+            .any(|(dep_id, _)| {
+                self.link_target_allowed_for_dependency(
+                    DependencyID::try_from(dep_id).expect("int cast"),
+                    target,
+                )
+            })
+    }
+
     /// Does this tree id belong to a workspace (including workspace root)?
     /// TODO(dylan-conway) fix!
     pub(crate) fn is_workspace_tree_id(&self, id: tree::Id) -> bool {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1873,6 +1873,45 @@ impl Package<u64> {
                 dependency_version.value.folder = string_builder
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
+            // yarn/pnpm-style `link:./dir` (a path, not the name of a package registered
+            // with `bun link`): like `file:` above, rebase it from the declaring package's
+            // directory to the project root so every consumer sees the same target. The
+            // stored value keeps a leading `./` so it stays recognisable as a path.
+            dependency::version::Tag::Symlink
+                if crate::resolution::is_path_link(dependency_version.symlink().slice(buf)) =>
+            {
+                let target = *dependency_version.symlink();
+                let mut link_buf = PathBuffer::uninit();
+                let Some(joined) = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
+                    FileSystem::instance().top_level_dir(),
+                    &mut link_buf.0,
+                    &[source.path.name().dir, target.slice(buf)],
+                ) else {
+                    log.add_error_fmt(
+                        source,
+                        value_loc_of(source, key_loc),
+                        format_args!(
+                            "Dependency \"{}\" has an unsafe link path",
+                            bstr::BStr::new(external_alias.slice(buf)),
+                        ),
+                    );
+                    return Err(crate::Error::InstallFailed);
+                };
+                let relative: &[u8] =
+                    resolve_path::relative(FileSystem::instance().top_level_dir(), joined);
+                let mut dotted = Vec::with_capacity(relative.len() + 2);
+                if relative.is_empty() {
+                    dotted.push(b'.');
+                } else {
+                    if !crate::resolution::is_path_link(relative) {
+                        dotted.extend_from_slice(b"./");
+                    }
+                    dotted.extend_from_slice(relative);
+                }
+                #[cfg(windows)]
+                path::dangerously_convert_path_to_posix_in_place::<u8>(&mut dotted);
+                dependency_version.value.symlink = string_builder.append::<String>(&dotted);
+            }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {
                     let satisfies =
@@ -2471,9 +2510,11 @@ impl Package<u64> {
                             string_builder.count(value);
 
                             // If it's a folder or workspace, pessimistically assume we will need a maximum path
+                            // (a path-like `link:` is rebased like a folder, so it too)
                             match dependency::version::Tag::infer(value) {
                                 dependency::version::Tag::Folder
-                                | dependency::version::Tag::Workspace => {
+                                | dependency::version::Tag::Workspace
+                                | dependency::version::Tag::Symlink => {
                                     string_builder.cap += MAX_PATH_BYTES;
                                 }
                                 _ => {}

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1873,44 +1873,45 @@ impl Package<u64> {
                 dependency_version.value.folder = string_builder
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
-            // yarn/pnpm-style `link:./dir` (a path, not the name of a package registered
-            // with `bun link`): like `file:` above, rebase it from the declaring package's
-            // directory to the project root so every consumer sees the same target. The
-            // stored value keeps a leading `./` so it stays recognisable as a path.
-            dependency::version::Tag::Symlink
-                if crate::resolution::is_path_link(dependency_version.symlink().slice(buf)) =>
-            {
-                let target = *dependency_version.symlink();
-                let mut link_buf = PathBuffer::uninit();
-                let Some(joined) = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
-                    &mut link_buf.0,
-                    &[source.path.name().dir, target.slice(buf)],
-                ) else {
-                    log.add_error_fmt(
-                        source,
-                        value_loc_of(source, key_loc),
-                        format_args!(
-                            "Dependency \"{}\" has an unsafe link path",
-                            bstr::BStr::new(external_alias.slice(buf)),
-                        ),
-                    );
-                    return Err(crate::Error::InstallFailed);
-                };
-                let relative: &[u8] =
-                    resolve_path::relative(FileSystem::instance().top_level_dir(), joined);
-                let mut dotted = Vec::with_capacity(relative.len() + 2);
-                if relative.is_empty() {
-                    dotted.push(b'.');
-                } else {
-                    if !crate::resolution::is_path_link(relative) {
-                        dotted.extend_from_slice(b"./");
-                    }
-                    dotted.extend_from_slice(relative);
+            dependency::version::Tag::Symlink => {
+                let symlink = *dependency_version.symlink();
+                if dependency::is_link_path(symlink.slice(buf)) {
+                    let mut symlink_buf = PathBuffer::uninit();
+                    let Some(joined) =
+                        resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
+                            FileSystem::instance().top_level_dir(),
+                            &mut symlink_buf.0,
+                            &[source.path.name().dir, symlink.slice(buf)],
+                        )
+                    else {
+                        log.add_error_fmt(
+                            source,
+                            value_loc_of(source, key_loc),
+                            format_args!(
+                                "Dependency \"{}\" has an unsafe folder path",
+                                bstr::BStr::new(external_alias.slice(buf)),
+                            ),
+                        );
+                        return Err(crate::Error::InstallFailed);
+                    };
+                    let relative =
+                        resolve_path::relative(FileSystem::instance().top_level_dir(), joined);
+                    let mut stored_buf = PathBuffer::uninit();
+                    let Some(stored) =
+                        dependency::link_path_for_lockfile(relative, &mut stored_buf)
+                    else {
+                        log.add_error_fmt(
+                            source,
+                            value_loc_of(source, key_loc),
+                            format_args!(
+                                "Dependency \"{}\" has an unsafe folder path",
+                                bstr::BStr::new(external_alias.slice(buf)),
+                            ),
+                        );
+                        return Err(crate::Error::InstallFailed);
+                    };
+                    dependency_version.value.symlink = string_builder.append::<String>(stored);
                 }
-                #[cfg(windows)]
-                path::dangerously_convert_path_to_posix_in_place::<u8>(&mut dotted);
-                dependency_version.value.symlink = string_builder.append::<String>(&dotted);
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {
@@ -2510,7 +2511,6 @@ impl Package<u64> {
                             string_builder.count(value);
 
                             // If it's a folder or workspace, pessimistically assume we will need a maximum path
-                            // (a path-like `link:` is rebased like a folder, so it too)
                             match dependency::version::Tag::infer(value) {
                                 dependency::version::Tag::Folder
                                 | dependency::version::Tag::Workspace

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -130,7 +130,7 @@ pub fn detect_and_load_other_lockfile<'a>(
                         }
                         MigratePnpmLockfileError::RelativeLinkDependency => {
                             bun_core::warn!(
-                                "Relative link dependencies aren't supported yet. Please follow along at <magenta>https://github.com/oven-sh/bun/issues/23026<r>",
+                                "pnpm-lock.yaml migration does not carry over relative link: dependencies; resolving fresh.",
                             );
                         }
                         MigratePnpmLockfileError::WorkspaceNameMissing => {

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -1033,15 +1033,6 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                                 );
                             }
 
-                            let mut pkg = lockfile::Package {
-                                name: dep.name,
-                                name_hash: dep.name_hash,
-                                resolution: Resolution::init_symlink(
-                                    sbuf!(lockfile).append(link_path)?,
-                                ),
-                                ..Default::default()
-                            };
-
                             let mut abs_link_path = bun_paths::AutoAbsPath::init_top_level_dir();
                             let _ = abs_link_path.join(&[workspace_path, link_path]); // path-buffer overflow unreachable for bounded inputs
 
@@ -1051,11 +1042,38 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                                 continue;
                             }
 
+                            // pnpm's value is importer-relative; the stored one is root-relative.
+                            let mut joined_buf = bun_paths::PathBuffer::uninit();
+                            let root_relative: &[u8] = if bun_paths::is_absolute(link_path) {
+                                link_path
+                            } else {
+                                bun_paths::resolve_path::join_string_buf::<
+                                    bun_paths::resolve_path::platform::Posix,
+                                >(
+                                    &mut joined_buf.0, &[workspace_path, link_path]
+                                )
+                            };
+                            let mut stored_buf = bun_paths::PathBuffer::uninit();
+                            let Some(stored) =
+                                dependency::link_path_for_lockfile(root_relative, &mut stored_buf)
+                            else {
+                                return Err(invalid_pnpm_lockfile());
+                            };
+
+                            let mut pkg = lockfile::Package {
+                                name: dep.name,
+                                name_hash: dep.name_hash,
+                                resolution: Resolution::init_symlink(
+                                    sbuf!(lockfile).append(stored)?,
+                                ),
+                                ..Default::default()
+                            };
+
                             *pkg_entry.value_ptr = lockfile.append_package_dedupe(&mut pkg)?;
                         }
                     }
                     dependency::VersionTag::Symlink => {
-                        if !strings::is_npm_package_name(
+                        if dependency::is_link_path(
                             dep.version.symlink().slice(string_bytes!(lockfile)),
                         ) {
                             log.add_warning_fmt(

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -58,7 +58,10 @@ impl Resolution {
 /// `Symlink` resolution stores that project-relative path instead of a name.
 #[inline]
 pub fn is_path_link(target: &[u8]) -> bool {
-    target.starts_with(b".") || target.starts_with(b"/")
+    target.starts_with(b".")
+        || target.starts_with(b"/")
+        // `link:C:\dir` / `link:\\server\share` on Windows
+        || (cfg!(windows) && bun_paths::is_absolute(target))
 }
 
 #[repr(C)]

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -52,18 +52,6 @@ impl Resolution {
     }
 }
 
-/// A `link:` dependency whose target is written as a path (`link:./vendor/x`,
-/// `link:../y`, `link:/abs`) rather than the name of a package registered with
-/// `bun link`. Such a link resolves relative to the declaring project and its
-/// `Symlink` resolution stores that project-relative path instead of a name.
-#[inline]
-pub fn is_path_link(target: &[u8]) -> bool {
-    target.starts_with(b".")
-        || target.starts_with(b"/")
-        // `link:C:\dir` / `link:\\server\share` on Windows
-        || (cfg!(windows) && bun_paths::is_absolute(target))
-}
-
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ResolutionType<SemverInt: VersionInt> {

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -52,6 +52,15 @@ impl Resolution {
     }
 }
 
+/// A `link:` dependency whose target is written as a path (`link:./vendor/x`,
+/// `link:../y`, `link:/abs`) rather than the name of a package registered with
+/// `bun link`. Such a link resolves relative to the declaring project and its
+/// `Symlink` resolution stores that project-relative path instead of a name.
+#[inline]
+pub fn is_path_link(target: &[u8]) -> bool {
+    target.starts_with(b".") || target.starts_with(b"/")
+}
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ResolutionType<SemverInt: VersionInt> {

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -83,9 +83,14 @@ impl<'a> fmt::Display for PackageWorkspaceSearchPathFormatter<'a> {
 /// Value stored in the folder-resolution map: the resolution plus the
 /// normalized absolute `package.json` path the key hash was computed from.
 /// Lookups compare the path, since a different path whose hash collides must
-/// not reuse this resolution.
+/// not reuse this resolution. `link` records whether the entry was resolved as
+/// a `link:` target (a `Symlink` resolution parsed with `Features::LINK`, i.e.
+/// without its dependencies) rather than as a folder/workspace: the same
+/// directory referenced both ways is two different packages, so it is part of
+/// the key (see `hash_for`) and of the equality check.
 pub struct Entry {
     pub(crate) abs_path: Box<[u8]>,
+    pub(crate) link: bool,
     pub(crate) resolution: FolderResolution,
 }
 
@@ -98,6 +103,14 @@ fn normalize(path: &[u8]) -> &[u8] {
 
 pub(crate) fn hash(normalized_path: &[u8]) -> u64 {
     bun_wyhash::hash(normalized_path)
+}
+
+/// Map key: the path hash, in a separate keyspace for `link:` entries so a
+/// `link:./x` and a `file:./x` (or workspace) naming the same directory do not
+/// share a resolution.
+fn hash_for(normalized_path: &[u8], link: bool) -> u64 {
+    let h = hash(normalized_path);
+    if link { h ^ 0x9E37_79B9_7F4A_7C15 } else { h }
 }
 
 // ── NewResolver ───────────────────────────────────────────────────────────
@@ -468,14 +481,23 @@ pub(crate) fn get_or_put(
             &rel_buf[..rel_len],
         )
     };
-    let abs_hash = hash(abs.as_bytes());
+    // `link:` targets (name-form under the global dir, or path-form) are parsed
+    // with `Features::LINK` into a `Symlink` resolution; the same directory as a
+    // `file:`/workspace target is a different package with its own dependencies.
+    let link = matches!(
+        global_or_relative,
+        GlobalOrRelative::Global(_) | GlobalOrRelative::Relative(dependency::version::Tag::Symlink)
+    );
+    let abs_hash = hash_for(abs.as_bytes(), link);
 
     // Check first, compute, then insert, because read_package_json_from_disk
-    // needs &mut manager. Compare the stored path, not just its hash: a
-    // different path whose hash collides must not reuse this resolution. On a
+    // needs &mut manager. Compare the stored path (and kind), not just its hash:
+    // a different path whose hash collides must not reuse this resolution. On a
     // collision, resolve fresh without caching so the first path's entry stays.
     let hash_collision = match manager.folders.get(&abs_hash) {
-        Some(existing) if *existing.abs_path == *abs.as_bytes() => return existing.resolution,
+        Some(existing) if existing.link == link && *existing.abs_path == *abs.as_bytes() => {
+            return existing.resolution;
+        }
         Some(_) => true,
         None => false,
     };
@@ -562,6 +584,7 @@ pub(crate) fn get_or_put(
                     abs_hash,
                     Entry {
                         abs_path: abs.as_bytes().into(),
+                        link,
                         resolution: stored,
                     },
                 );
@@ -575,6 +598,7 @@ pub(crate) fn get_or_put(
             abs_hash,
             Entry {
                 abs_path: abs.as_bytes().into(),
+                link,
                 resolution: FolderResolution::PackageId(package.meta.id),
             },
         );

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -164,9 +164,21 @@ impl ResolverContext for CacheFolderResolver {
 /// distinguishes the workspace resolver.
 trait FolderResolverImpl: ResolverContext {
     const IS_WORKSPACE: bool;
+
+    /// The stored (root-relative or absolute) target of a path-form `link:`
+    /// dependency, if that is what is being resolved. Such a target may be a
+    /// plain directory without a `package.json` (yarn/pnpm semantics).
+    fn link_path(&self) -> Option<&[u8]> {
+        None
+    }
 }
 impl<'a, const TAG: ResolutionTag> FolderResolverImpl for NewResolver<'a, TAG> {
     const IS_WORKSPACE: bool = matches!(TAG, ResolutionTag::Workspace);
+
+    fn link_path(&self) -> Option<&[u8]> {
+        (matches!(TAG, ResolutionTag::Symlink) && dependency::is_link_path(self.folder_path))
+            .then_some(self.folder_path)
+    }
 }
 impl FolderResolverImpl for CacheFolderResolver {
     const IS_WORKSPACE: bool = false;
@@ -328,40 +340,40 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
                         bun_sys::SizeHint::ProbablySmall,
                     )?;
                 }
-                Err(err) => {
-                    // yarn/pnpm `link:./dir` may point at a plain directory without a
-                    // package.json: treat it as an empty manifest named after the directory
-                    // (a lockfile package needs a name), with no dependencies. (If the
-                    // directory itself is missing, the link step reports that later.)
-                    let literal = version
-                        .literal
-                        .slice(manager.lockfile.buffers.string_bytes.as_slice());
-                    let dir = bun_paths::dirname(abs.as_bytes()).unwrap_or(b"");
-                    let is_path_link = literal
-                        .strip_prefix(b"link:")
-                        .is_some_and(crate::resolution::is_path_link);
+                // A path-form `link:` target may be a plain directory without a
+                // package.json: treat it as an empty manifest named after the
+                // directory (a lockfile package needs a name), with no dependencies.
+                // The directory itself must exist — neither linker opens the target
+                // when creating the symlink, so a missing one is reported here
+                // (before anything is written) rather than left dangling.
+                Err(err)
                     if matches!(err.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR)
-                        && is_path_link
-                    {
-                        body.list.extend_from_slice(b"{\"name\":\"");
-                        let start = body.list.len();
-                        for &c in bun_paths::basename(dir) {
-                            if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.') {
-                                body.list.push(c);
-                            }
-                        }
-                        if body.list.len() == start {
-                            // nothing usable in the directory name: a stable synthetic one
-                            use std::io::Write as _;
-                            // hash the literal as written (project-stable), not the absolute path
-                            let _ =
-                                write!(&mut body.list, "link-{:016x}", bun_wyhash::hash(literal));
-                        }
-                        body.list.extend_from_slice(b"\",\"version\":\"0.0.0\"}");
-                    } else {
-                        return Err(err.into());
+                        && resolver.link_path().is_some() =>
+                {
+                    let dir = bun_paths::dirname(abs.as_bytes()).unwrap_or(b"");
+                    if !matches!(
+                        bun_sys::directory_exists_at(Fd::cwd(), &bun_core::ZBox::from_bytes(dir)),
+                        Ok(true)
+                    ) {
+                        return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT));
                     }
+                    body.list.extend_from_slice(b"{\"name\":\"");
+                    let start = body.list.len();
+                    for &c in bun_paths::basename(dir) {
+                        if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.') {
+                            body.list.push(c);
+                        }
+                    }
+                    if body.list.len() == start {
+                        // nothing usable in the directory name: a stable synthetic one,
+                        // hashing the stored project-relative target (not the absolute path)
+                        use std::io::Write as _;
+                        let stored = resolver.link_path().unwrap_or(b"");
+                        let _ = write!(&mut body.list, "link-{:016x}", bun_wyhash::hash(stored));
+                    }
+                    body.list.extend_from_slice(b"\",\"version\":\"0.0.0\"}");
                 }
+                Err(err) => return Err(err.into()),
             }
 
             bun_ast::Source::init_path_string(abs.as_bytes(), body.list.as_slice())
@@ -504,19 +516,13 @@ pub(crate) fn get_or_put(
                     &mut resolver,
                 );
             }
-            // `link:./dir` — a path, not a globally registered name: recorded as a
-            // Symlink resolution whose value is the project-relative directory (see
-            // `resolution::is_path_link`), installed as a symlink to it.
-            dependency::version::Tag::Symlink => 'link: {
-                let mut dotted = Vec::with_capacity(rel.len() + 2);
-                if !crate::resolution::is_path_link(rel) {
-                    dotted.extend_from_slice(b"./");
-                }
-                dotted.extend_from_slice(rel);
-                let mut resolver: SymlinkResolver = NewResolver {
-                    folder_path: &dotted,
+            dependency::version::Tag::Symlink => 'symlink: {
+                let mut path = PathBuffer::uninit();
+                let Some(folder_path) = dependency::link_path_for_lockfile(rel, &mut path) else {
+                    break 'symlink Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
                 };
-                break 'link read_package_json_from_disk(
+                let mut resolver: SymlinkResolver = NewResolver { folder_path };
+                break 'symlink read_package_json_from_disk(
                     manager,
                     abs,
                     version,

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -344,15 +344,21 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
                         bun_sys::stat(&bun_core::ZBox::from_bytes(dir)),
                         Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory
                     );
-                    if err.get_errno() == bun_sys::E::ENOENT
-                        && literal.starts_with(b"link:")
-                        && is_dir
-                    {
+                    let is_path_link = literal
+                        .strip_prefix(b"link:")
+                        .is_some_and(crate::resolution::is_path_link);
+                    if err.get_errno() == bun_sys::E::ENOENT && is_path_link && is_dir {
                         body.list.extend_from_slice(b"{\"name\":\"");
+                        let start = body.list.len();
                         for &c in bun_paths::basename(dir) {
                             if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.') {
                                 body.list.push(c);
                             }
+                        }
+                        if body.list.len() == start {
+                            // nothing usable in the directory name: a stable synthetic one
+                            use std::io::Write as _;
+                            let _ = write!(&mut body.list, "link-{:016x}", bun_wyhash::hash(dir));
                         }
                         body.list.extend_from_slice(b"\",\"version\":\"0.0.0\"}");
                     } else {
@@ -506,7 +512,7 @@ pub(crate) fn get_or_put(
             // `resolution::is_path_link`), installed as a symlink to it.
             dependency::version::Tag::Symlink => 'link: {
                 let mut dotted = Vec::with_capacity(rel.len() + 2);
-                if !(rel.starts_with(b".") || rel.starts_with(b"/")) {
+                if !crate::resolution::is_path_link(rel) {
                     dotted.extend_from_slice(b"./");
                 }
                 dotted.extend_from_slice(rel);

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -330,9 +330,9 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
                 }
                 Err(err) => {
                     // yarn/pnpm `link:./dir` may point at a plain directory without a
-                    // package.json (or one that does not exist yet — the symlink is created
-                    // either way): treat it as an empty manifest named after the directory
-                    // (a lockfile package needs a name), with no dependencies.
+                    // package.json: treat it as an empty manifest named after the directory
+                    // (a lockfile package needs a name), with no dependencies. (If the
+                    // directory itself is missing, the link step reports that later.)
                     let literal = version
                         .literal
                         .slice(manager.lockfile.buffers.string_bytes.as_slice());

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -322,15 +322,11 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
             body.reset();
             match File::openat(Fd::cwd(), abs.as_bytes(), O::RDONLY, 0) {
                 Ok(file) => {
-                    // defer file.close()
-                    let read_result = file
-                        .read_to_end_with_array_list(
-                            &mut body.list,
-                            bun_sys::SizeHint::ProbablySmall,
-                        )
-                        .map(|_| ());
-                    let _ = file.close();
-                    read_result?;
+                    // closed on drop
+                    file.read_to_end_with_array_list(
+                        &mut body.list,
+                        bun_sys::SizeHint::ProbablySmall,
+                    )?;
                 }
                 Err(err) => {
                     // yarn/pnpm `link:./dir` may point at a plain directory without a
@@ -358,7 +354,9 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
                         if body.list.len() == start {
                             // nothing usable in the directory name: a stable synthetic one
                             use std::io::Write as _;
-                            let _ = write!(&mut body.list, "link-{:016x}", bun_wyhash::hash(dir));
+                            // hash the literal as written (project-stable), not the absolute path
+                            let _ =
+                                write!(&mut body.list, "link-{:016x}", bun_wyhash::hash(literal));
                         }
                         body.list.extend_from_slice(b"\",\"version\":\"0.0.0\"}");
                     } else {

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -319,13 +319,47 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
             bun_perf::trace(bun_perf::PerfEvent::FolderResolverReadPackageJSONFromDiskFolder);
 
         let source = {
-            let file = File::openat(Fd::cwd(), abs.as_bytes(), O::RDONLY, 0)?;
             body.reset();
-            let read_result = file
-                .read_to_end_with_array_list(&mut body.list, bun_sys::SizeHint::ProbablySmall)
-                .map(|_| ());
-            let _ = file.close();
-            read_result?;
+            match File::openat(Fd::cwd(), abs.as_bytes(), O::RDONLY, 0) {
+                Ok(file) => {
+                    // defer file.close()
+                    let read_result = file
+                        .read_to_end_with_array_list(
+                            &mut body.list,
+                            bun_sys::SizeHint::ProbablySmall,
+                        )
+                        .map(|_| ());
+                    let _ = file.close();
+                    read_result?;
+                }
+                Err(err) => {
+                    // yarn/pnpm `link:./dir` may point at a plain directory without a
+                    // package.json: treat it as an empty manifest named after the
+                    // directory (a lockfile package needs a name), with no dependencies.
+                    let literal = version
+                        .literal
+                        .slice(manager.lockfile.buffers.string_bytes.as_slice());
+                    let dir = bun_paths::dirname(abs.as_bytes()).unwrap_or(b"");
+                    let is_dir = matches!(
+                        bun_sys::stat(&bun_core::ZBox::from_bytes(dir)),
+                        Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory
+                    );
+                    if err.get_errno() == bun_sys::E::ENOENT
+                        && literal.starts_with(b"link:")
+                        && is_dir
+                    {
+                        body.list.extend_from_slice(b"{\"name\":\"");
+                        for &c in bun_paths::basename(dir) {
+                            if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.') {
+                                body.list.push(c);
+                            }
+                        }
+                        body.list.extend_from_slice(b"\",\"version\":\"0.0.0\"}");
+                    } else {
+                        return Err(err.into());
+                    }
+                }
+            }
 
             bun_ast::Source::init_path_string(abs.as_bytes(), body.list.as_slice())
         };
@@ -464,6 +498,26 @@ pub(crate) fn get_or_put(
                     abs,
                     version,
                     Features::WORKSPACE,
+                    &mut resolver,
+                );
+            }
+            // `link:./dir` — a path, not a globally registered name: recorded as a
+            // Symlink resolution whose value is the project-relative directory (see
+            // `resolution::is_path_link`), installed as a symlink to it.
+            dependency::version::Tag::Symlink => 'link: {
+                let mut dotted = Vec::with_capacity(rel.len() + 2);
+                if !(rel.starts_with(b".") || rel.starts_with(b"/")) {
+                    dotted.extend_from_slice(b"./");
+                }
+                dotted.extend_from_slice(rel);
+                let mut resolver: SymlinkResolver = NewResolver {
+                    folder_path: &dotted,
+                };
+                break 'link read_package_json_from_disk(
+                    manager,
+                    abs,
+                    version,
+                    Features::LINK,
                     &mut resolver,
                 );
             }

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -330,20 +330,19 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
                 }
                 Err(err) => {
                     // yarn/pnpm `link:./dir` may point at a plain directory without a
-                    // package.json: treat it as an empty manifest named after the
-                    // directory (a lockfile package needs a name), with no dependencies.
+                    // package.json (or one that does not exist yet — the symlink is created
+                    // either way): treat it as an empty manifest named after the directory
+                    // (a lockfile package needs a name), with no dependencies.
                     let literal = version
                         .literal
                         .slice(manager.lockfile.buffers.string_bytes.as_slice());
                     let dir = bun_paths::dirname(abs.as_bytes()).unwrap_or(b"");
-                    let is_dir = matches!(
-                        bun_sys::stat(&bun_core::ZBox::from_bytes(dir)),
-                        Ok(st) if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode) == bun_sys::FileKind::Directory
-                    );
                     let is_path_link = literal
                         .strip_prefix(b"link:")
                         .is_some_and(crate::resolution::is_path_link);
-                    if err.get_errno() == bun_sys::E::ENOENT && is_path_link && is_dir {
+                    if matches!(err.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR)
+                        && is_path_link
+                    {
                         body.list.extend_from_slice(b"{\"name\":\"");
                         let start = body.list.len();
                         for &c in bun_paths::basename(dir) {

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -1,6 +1,5 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { realpathSync } from "fs";
 import { chmod, exists, mkdir, rm } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import { join } from "path";
@@ -1979,23 +1978,40 @@ test.concurrent.each([
   expect(reinstall.exitCode).toBe(0);
 });
 
-// A `link:` *path* is re-spelled relative to the target workspace and installed as a
-// symlink to the directory (yarn/pnpm semantics), like the file: cases below.
-test.concurrent("a link: path is re-spelled relative to the target and linked", async () => {
+// A `link:` value that is not a package name is a path (see bun-link.test.ts): like `file:`, it is relative
+// to the cwd and re-spelled per target. A bare name still means a `bun link` registration and is left alone.
+test.concurrent.each([["link:./vendor/foo"], ["link:vendor/foo"]])(
+  "a link: path (%s) is re-spelled relative to the target",
+  async positional => {
+    const dir = await makeMonorepo();
+    await addVendorFoo(dir);
+    const before = await allPackageJsonTexts(dir);
+
+    const { stderr, exitCode } = await run(["add", positional, "--filter", "api"], dir, { linker: "hoisted" });
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    await expectAddedOnlyTo(dir, before, ["api"], "foo", "link:../../vendor/foo");
+    const { workspaces, packages } = await lockfileJson(dir);
+    expect(workspaces["packages/api"].dependencies).toStrictEqual({ foo: "link:../../vendor/foo" });
+    expect(packages.foo[0]).toBe("foo@link:./vendor/foo");
+    expect(await file(join(dir, "node_modules", "foo", "package.json")).json()).toStrictEqual(VENDOR_FOO);
+
+    const frozen = await run(["install", "--frozen-lockfile"], dir, { linker: "hoisted" });
+    expect(frozen.stderr).not.toContain("error:");
+    expect(frozen.exitCode).toBe(0);
+  },
+);
+
+test.concurrent("a link: path that does not exist fails with the per-target spelling and writes nothing", async () => {
   const dir = await makeMonorepo();
-  await addVendorFoo(dir);
   const before = await allPackageJsonTexts(dir);
 
-  const { stderr, exitCode } = await run(["add", "link:./vendor/foo", "--filter", "api"], dir, { linker: "hoisted" });
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain('"link:./vendor/foo"');
-  expect(exitCode).toBe(0);
+  const { stderr, exitCode } = await run(["add", "link:./vendor/foo", "--filter", "api"], dir);
+  expect(stderr).toContain('Could not find directory "./vendor/foo" for linked dependency "link:../../vendor/foo"');
+  expect(exitCode).toBe(1);
 
-  await expectAddedOnlyTo(dir, before, ["api"], "foo", "link:../../vendor/foo");
-  expect((await lockfileJson(dir)).workspaces["packages/api"].dependencies).toStrictEqual({
-    foo: "link:../../vendor/foo",
-  });
-  expect(realpathSync(join(dir, "node_modules", "foo"))).toBe(realpathSync(join(dir, "vendor", "foo")));
+  expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
 });
 
 test.concurrent.each([

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -1,5 +1,6 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
+import { realpathSync } from "fs";
 import { chmod, exists, mkdir, rm } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import { join } from "path";
@@ -1978,18 +1979,23 @@ test.concurrent.each([
   expect(reinstall.exitCode).toBe(0);
 });
 
-// `link:` resolves against the global link dir (same failure without --filter); the error shows the per-target spelling.
-test.concurrent("a link: path is re-spelled relative to the target before it is resolved", async () => {
+// A `link:` *path* is re-spelled relative to the target workspace and installed as a
+// symlink to the directory (yarn/pnpm semantics), like the file: cases below.
+test.concurrent("a link: path is re-spelled relative to the target and linked", async () => {
   const dir = await makeMonorepo();
   await addVendorFoo(dir);
   const before = await allPackageJsonTexts(dir);
 
-  const { stderr, exitCode } = await run(["add", "link:./vendor/foo", "--filter", "api"], dir);
-  expect(stderr).toContain('error: Package "link:../../vendor/foo" is not linked');
+  const { stderr, exitCode } = await run(["add", "link:./vendor/foo", "--filter", "api"], dir, { linker: "hoisted" });
+  expect(stderr).not.toContain("error:");
   expect(stderr).not.toContain('"link:./vendor/foo"');
-  expect(exitCode).toBe(1);
+  expect(exitCode).toBe(0);
 
-  expect(await allPackageJsonTexts(dir)).toStrictEqual(before);
+  await expectAddedOnlyTo(dir, before, ["api"], "foo", "link:../../vendor/foo");
+  expect((await lockfileJson(dir)).workspaces["packages/api"].dependencies).toStrictEqual({
+    foo: "link:../../vendor/foo",
+  });
+  expect(realpathSync(join(dir, "node_modules", "foo"))).toBe(realpathSync(join(dir, "vendor", "foo")));
 });
 
 test.concurrent.each([

--- a/test/cli/install/bun-install-link-path.test.ts
+++ b/test/cli/install/bun-install-link-path.test.ts
@@ -1,0 +1,65 @@
+import { spawn } from "bun";
+import { describe, expect, it } from "bun:test";
+import { lstatSync, readFileSync, realpathSync } from "fs";
+import { bunExe, bunEnv as env, tempDir } from "harness";
+import { join } from "path";
+
+// `link:./some/dir` (a path, as written by yarn and pnpm) is a folder dependency of the
+// declaring package, installed as a symlink — the target does not have to be registered
+// with `bun link` and does not even need a package.json. Bare `link:<name>` keeps its
+// meaning (a globally linked package) and is covered by bun-link.test.ts.
+
+async function install(cwd: string, args: string[] = []) {
+  await using proc = spawn({ cmd: [bunExe(), "install", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { out, err, code };
+}
+
+describe.each(["hoisted", "isolated"])("link:./path dependencies (%s linker)", linker => {
+  it("root and workspace link: paths resolve relative to the declaring package.json", async () => {
+    using dir = tempDir("link-path", {
+      "bunfig.toml": `[install]\nlinker = "${linker}"\n`,
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces: ["packages/*"],
+        dependencies: { "with-manifest": "link:./vendor/with-manifest", "no-manifest": "link:./vendor/no-manifest" },
+      }),
+      // a target with its own package.json (name comes from there)
+      "vendor/with-manifest/package.json": JSON.stringify({ name: "with-manifest", version: "1.2.3" }),
+      "vendor/with-manifest/index.js": "module.exports = 'with';",
+      // a plain directory without a package.json (yarn's link: allows this)
+      "vendor/no-manifest/index.js": "module.exports = 'without';",
+      // a workspace declaring a link: relative to *its* directory
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { local: "link:../../vendor/with-manifest" },
+      }),
+    });
+    const root = String(dir);
+    const r = await install(root);
+    expect(r.err).not.toContain("error:");
+    expect(r.err).toContain("Saved lockfile");
+    expect(r.code).toBe(0);
+
+    const nm = join(root, "node_modules");
+    expect(lstatSync(join(nm, "with-manifest")).isSymbolicLink()).toBeTrue();
+    expect(realpathSync(join(nm, "with-manifest"))).toBe(realpathSync(join(root, "vendor", "with-manifest")));
+    expect(readFileSync(join(nm, "no-manifest", "index.js"), "utf8")).toContain("without");
+    expect(realpathSync(join(nm, "no-manifest"))).toBe(realpathSync(join(root, "vendor", "no-manifest")));
+    // the workspace's link resolves relative to packages/app (not the root); with the
+    // hoisted linker it is hoisted to the root node_modules like any other dependency
+    const localLink = linker === "hoisted" ? join(nm, "local") : join(root, "packages", "app", "node_modules", "local");
+    expect(realpathSync(localLink)).toBe(realpathSync(join(root, "vendor", "with-manifest")));
+
+    const lock = await Bun.file(join(root, "bun.lock")).text();
+    expect(lock).toContain("link:./vendor/with-manifest");
+    expect(lock).toContain("link:../../vendor/with-manifest");
+
+    // a second install from the lockfile is stable
+    const again = await install(root, ["--frozen-lockfile"]);
+    expect(again.err).not.toContain("error:");
+    expect(again.code).toBe(0);
+  });
+});

--- a/test/cli/install/bun-install-link-path.test.ts
+++ b/test/cli/install/bun-install-link-path.test.ts
@@ -23,13 +23,19 @@ describe.each(["hoisted", "isolated"])("link:./path dependencies (%s linker)", l
         name: "root",
         private: true,
         workspaces: ["packages/*"],
-        dependencies: { "with-manifest": "link:./vendor/with-manifest", "no-manifest": "link:./vendor/no-manifest" },
+        dependencies: {
+          "with-manifest": "link:./vendor/with-manifest",
+          "no-manifest": "link:./vendor/no-manifest",
+          odd: "link:./vendor/~",
+        },
       }),
       // a target with its own package.json (name comes from there)
       "vendor/with-manifest/package.json": JSON.stringify({ name: "with-manifest", version: "1.2.3" }),
       "vendor/with-manifest/index.js": "module.exports = 'with';",
       // a plain directory without a package.json (yarn's link: allows this)
       "vendor/no-manifest/index.js": "module.exports = 'without';",
+      // …whose directory name has nothing usable for a package name
+      "vendor/~/index.js": "module.exports = 'tilde';",
       // a workspace declaring a link: relative to *its* directory
       "packages/app/package.json": JSON.stringify({
         name: "app",
@@ -48,6 +54,7 @@ describe.each(["hoisted", "isolated"])("link:./path dependencies (%s linker)", l
     expect(realpathSync(join(nm, "with-manifest"))).toBe(realpathSync(join(root, "vendor", "with-manifest")));
     expect(readFileSync(join(nm, "no-manifest", "index.js"), "utf8")).toContain("without");
     expect(realpathSync(join(nm, "no-manifest"))).toBe(realpathSync(join(root, "vendor", "no-manifest")));
+    expect(readFileSync(join(nm, "odd", "index.js"), "utf8")).toContain("tilde");
     // the workspace's link resolves relative to packages/app (not the root); with the
     // hoisted linker it is hoisted to the root node_modules like any other dependency
     const localLink = linker === "hoisted" ? join(nm, "local") : join(root, "packages", "app", "node_modules", "local");

--- a/test/cli/install/bun-install-link-path.test.ts
+++ b/test/cli/install/bun-install-link-path.test.ts
@@ -70,3 +70,13 @@ describe.each(["hoisted", "isolated"])("link:./path dependencies (%s linker)", l
     expect(again.code).toBe(0);
   });
 });
+
+it("a link: path whose target does not exist is reported when linking, not as an unknown package", async () => {
+  using dir = tempDir("link-path-missing", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { later: "link:./vendor/later" } }),
+  });
+  const r = await install(String(dir));
+  expect(r.err).not.toContain("is not linked");
+  expect(r.err).toContain("Saved lockfile");
+  expect(r.out + r.err).toContain("later");
+});

--- a/test/cli/install/bun-install-link-path.test.ts
+++ b/test/cli/install/bun-install-link-path.test.ts
@@ -76,7 +76,10 @@ it("a link: path whose target does not exist is reported when linking, not as an
     "package.json": JSON.stringify({ name: "root", dependencies: { later: "link:./vendor/later" } }),
   });
   const r = await install(String(dir));
+  // resolution succeeds (no "is not linked" / global-link hint) and the lockfile is written…
   expect(r.err).not.toContain("is not linked");
   expect(r.err).toContain("Saved lockfile");
-  expect(r.out + r.err).toContain("later");
+  // …but linking the missing directory fails and says which package
+  expect(r.out + r.err).toContain("failed linking dependency/workspace to node_modules for package later");
+  expect(r.out).toContain("Failed to install 1 package");
 });

--- a/test/cli/install/bun-install-link-path.test.ts
+++ b/test/cli/install/bun-install-link-path.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { lstatSync, readFileSync, realpathSync } from "fs";
+import { existsSync, lstatSync, readFileSync, realpathSync } from "fs";
 import { bunExe, bunEnv as env, tempDir } from "harness";
 import { join } from "path";
 
@@ -69,17 +69,21 @@ describe.each(["hoisted", "isolated"])("link:./path dependencies (%s linker)", l
     expect(again.err).not.toContain("error:");
     expect(again.code).toBe(0);
   });
-});
 
-it("a link: path whose target does not exist is reported when linking, not as an unknown package", async () => {
-  using dir = tempDir("link-path-missing", {
-    "package.json": JSON.stringify({ name: "root", dependencies: { later: "link:./vendor/later" } }),
+  it("a link: path whose target directory does not exist fails at resolve time and writes nothing", async () => {
+    using dir = tempDir("link-path-missing", {
+      "bunfig.toml": `[install]\nlinker = "${linker}"\n`,
+      "package.json": JSON.stringify({ name: "root", dependencies: { later: "link:./vendor/later" } }),
+    });
+    const root = String(dir);
+    const r = await install(root);
+    // reported as a missing directory (not as an unknown `bun link` registration)…
+    expect(r.err).toContain('error: Could not find directory "./vendor/later" for linked dependency "later"');
+    expect(r.err).not.toContain("is not linked");
+    expect(r.err).not.toContain("Saved lockfile");
+    expect(r.code).toBe(1);
+    // …before anything is written: no lockfile and no dangling symlink under either linker
+    expect(existsSync(join(root, "bun.lock"))).toBeFalse();
+    expect(existsSync(join(root, "node_modules"))).toBeFalse();
   });
-  const r = await install(String(dir));
-  // resolution succeeds (no "is not linked" / global-link hint) and the lockfile is written…
-  expect(r.err).not.toContain("is not linked");
-  expect(r.err).toContain("Saved lockfile");
-  // …but linking the missing directory fails and says which package
-  expect(r.out + r.err).toContain("failed linking dependency/workspace to node_modules for package later");
-  expect(r.out).toContain("Failed to install 1 package");
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -1,18 +1,20 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { access, mkdir, writeFile } from "fs/promises";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync } from "fs";
+import { access, mkdir, readlink, rm, writeFile } from "fs/promises";
 import {
   bunExe,
   bunEnv as env,
   isWindows,
   readdirSorted,
   runBunInstall,
+  tempDir,
   tmpdirSync,
   toBeValidBin,
   toHaveBins,
 } from "harness";
 import { basename, join } from "path";
-import { dummyAfterAll, dummyAfterEach, dummyBeforeAll, dummyBeforeEach, package_dir } from "./dummy.registry";
+import { dummyAfterAll, dummyAfterEach, dummyBeforeAll, dummyBeforeEach, getPort, package_dir } from "./dummy.registry";
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
@@ -470,4 +472,333 @@ it("should link dependency without crashing", async () => {
 
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
+});
+
+// https://github.com/oven-sh/bun/issues/4719
+describe.each(["hoisted", "isolated"])("link: with a filesystem path (%s)", linker => {
+  async function setLinker() {
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      `[install]\ncache = false\nregistry = "http://localhost:${getPort()}/"\nsaveTextLockfile = true\nlinker = "${linker}"\n`,
+    );
+  }
+
+  async function checkLink(dep: string, expected: { name: string; version: string }) {
+    await setLinker();
+    const { out, err } = await runBunInstall(env, package_dir);
+    expect(err).not.toContain("not linked");
+    if (linker === "hoisted") expect(out).toContain(`+ ${expected.name}@link:`);
+
+    const target = await readlink(join(package_dir, "node_modules", ...expected.name.split("/")));
+    expect(target.replaceAll("\\", "/")).toContain(basename(dep));
+    expect(await file(join(package_dir, "node_modules", expected.name, "package.json")).json()).toEqual(expected);
+
+    const second = await runBunInstall(env, package_dir, { frozenLockfile: true });
+    expect(second.err).not.toContain("Saved lockfile");
+  }
+
+  it("resolves a ./relative path", async () => {
+    await mkdir(join(package_dir, "lib", "mypkg"), { recursive: true });
+    await writeFile(
+      join(package_dir, "lib", "mypkg", "package.json"),
+      JSON.stringify({ name: "mypkg", version: "1.0.0" }),
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "root",
+        dependencies: { mypkg: "link:./lib/mypkg" },
+      }),
+    );
+    await checkLink("./lib/mypkg", { name: "mypkg", version: "1.0.0" });
+  });
+
+  it("treats a bare relative path (no ./) as a path, and stores it as ./", async () => {
+    await mkdir(join(package_dir, "lib", "bare"), { recursive: true });
+    await writeFile(
+      join(package_dir, "lib", "bare", "package.json"),
+      JSON.stringify({ name: "bare", version: "1.0.0" }),
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", dependencies: { bare: "link:lib/bare" } }),
+    );
+    await checkLink("lib/bare", { name: "bare", version: "1.0.0" });
+    expect(await file(join(package_dir, "bun.lock")).text()).toContain('"bare@link:./lib/bare"');
+  });
+
+  it("resolves a ../relative path", async () => {
+    await mkdir(join(link_dir, "sibling"), { recursive: true });
+    await writeFile(
+      join(link_dir, "sibling", "package.json"),
+      JSON.stringify({ name: "sibling-pkg", version: "2.0.0" }),
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "root",
+        dependencies: { "sibling-pkg": `link:${join("..", basename(link_dir), "sibling").replaceAll("\\", "/")}` },
+      }),
+    );
+    await checkLink("sibling", { name: "sibling-pkg", version: "2.0.0" });
+  });
+
+  it("resolves a scoped package path", async () => {
+    await mkdir(join(package_dir, "packages", "scoped"), { recursive: true });
+    await writeFile(
+      join(package_dir, "packages", "scoped", "package.json"),
+      JSON.stringify({ name: "@scope/pkg", version: "3.0.0" }),
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "root",
+        dependencies: { "@scope/pkg": "link:./packages/scoped" },
+      }),
+    );
+    await checkLink("./packages/scoped", { name: "@scope/pkg", version: "3.0.0" });
+  });
+
+  it("resolves an absolute path", async () => {
+    await mkdir(join(link_dir, "abspkg"), { recursive: true });
+    await writeFile(join(link_dir, "abspkg", "package.json"), JSON.stringify({ name: "abspkg", version: "4.0.0" }));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "root",
+        dependencies: { abspkg: `link:${join(link_dir, "abspkg").replaceAll("\\", "/")}` },
+      }),
+    );
+    await checkLink("abspkg", { name: "abspkg", version: "4.0.0" });
+  });
+
+  it("resolves relative to a workspace member", async () => {
+    await mkdir(join(package_dir, "packages", "foo", "local"), { recursive: true });
+    await writeFile(
+      join(package_dir, "packages", "foo", "local", "package.json"),
+      JSON.stringify({ name: "localpkg", version: "5.0.0" }),
+    );
+    await writeFile(
+      join(package_dir, "packages", "foo", "package.json"),
+      JSON.stringify({ name: "foo", dependencies: { localpkg: "link:./local" } }),
+    );
+    await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
+    await setLinker();
+    await runBunInstall(env, package_dir);
+
+    const linked =
+      linker === "hoisted"
+        ? join(package_dir, "node_modules", "localpkg")
+        : join(package_dir, "packages", "foo", "node_modules", "localpkg");
+    expect(await file(join(linked, "package.json")).json()).toEqual({ name: "localpkg", version: "5.0.0" });
+    expect((await readlink(linked)).replaceAll("\\", "/")).toContain("local");
+
+    const second = await runBunInstall(env, package_dir, { frozenLockfile: true });
+    expect(second.err).not.toContain("Saved lockfile");
+  });
+
+  it("errors at resolve time when the target directory does not exist", async () => {
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "root",
+        dependencies: { missing: "link:./does-not-exist" },
+      }),
+    );
+    await setLinker();
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [, stderr, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('Could not find directory "./does-not-exist" for linked dependency "missing"');
+    expect(stderr).not.toContain("is not linked");
+    expect(stderr).not.toContain("bun link my-pkg-name-from-package-json");
+    expect(stderr).not.toContain("Saved lockfile");
+    expect(exited).toBe(1);
+    // nothing is written: no lockfile, no dangling symlink
+    expect(existsSync(join(package_dir, "bun.lock"))).toBeFalse();
+    expect(existsSync(join(package_dir, "node_modules", "missing"))).toBeFalse();
+  });
+
+  it("accepts a target directory without a package.json", async () => {
+    await mkdir(join(package_dir, "vendor", "plain"), { recursive: true });
+    await writeFile(join(package_dir, "vendor", "plain", "index.js"), "module.exports = 'plain';");
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", dependencies: { plain: "link:vendor/plain" } }),
+    );
+    await setLinker();
+    const { err } = await runBunInstall(env, package_dir);
+    expect(err).not.toContain("error:");
+    expect(await file(join(package_dir, "node_modules", "plain", "index.js")).text()).toContain("plain");
+    expect(await file(join(package_dir, "bun.lock")).text()).toContain('"plain@link:./vendor/plain"');
+
+    const second = await runBunInstall(env, package_dir, { frozenLockfile: true });
+    expect(second.err).not.toContain("Saved lockfile");
+  });
+});
+
+// A path-form link: declared by a package that is not the root or a workspace
+// (here: a file: dependency of the project) may only point inside the project.
+// Same rule and same fixtures as the transitive file: tests in bun-install.test.ts.
+describe.each(["hoisted", "isolated"])("transitive path-form link: (%s)", linker => {
+  // Called inside each test: the dummy registry only exists after beforeAll.
+  const bunfig = () => `[install]\ncache = false\nregistry = "http://localhost:${getPort()}/"\nlinker = "${linker}"\n`;
+  const refusal = "only the root package.json, a workspace, or an override may link to a path outside the project";
+
+  // Every place either linker could have put the link (node_modules/<name>,
+  // a nested node_modules, or an isolated store entry), dangling links included.
+  function linksNamed(project: string, name: string): string[] {
+    const node_modules = join(project, "node_modules");
+    if (!existsSync(node_modules)) return [];
+    return Array.from(
+      new Bun.Glob(`**/${name}`).scanSync({ cwd: node_modules, onlyFiles: false, dot: true, followSymlinks: false }),
+    );
+  }
+
+  async function install(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  it("is refused when it escapes the project (resolve)", async () => {
+    using dir = tempDir("transitive-link-escape", {
+      "secret/package.json": JSON.stringify({ name: "loot", version: "1.0.0" }),
+      "project/bunfig.toml": bunfig(),
+      "project/package.json": JSON.stringify({ name: "my-app", dependencies: { evil: "file:./evil" } }),
+      "project/evil/package.json": JSON.stringify({
+        name: "evil",
+        version: "1.0.0",
+        dependencies: { loot: "link:../../secret" },
+      }),
+    });
+    const project = join(String(dir), "project");
+
+    const { err, exitCode } = await install(project);
+    expect(err).toContain(refusal);
+    expect(err).not.toContain("Could not find directory");
+    expect(exitCode).toBe(1);
+    expect(linksNamed(project, "loot")).toEqual([]);
+  });
+
+  it("is refused when it escapes the project (existing lockfile)", async () => {
+    // The lockfile already carries the escaping resolution, so resolution is
+    // skipped and the installer is what has to refuse it.
+    using dir = tempDir("transitive-link-escape-lock", {
+      "secret/package.json": JSON.stringify({ name: "loot", version: "1.0.0" }),
+      "project/bunfig.toml": bunfig(),
+      "project/package.json": JSON.stringify({ name: "my-app", dependencies: { evil: "file:./evil" } }),
+      "project/evil/package.json": JSON.stringify({
+        name: "evil",
+        version: "1.0.0",
+        dependencies: { loot: "link:../../secret" },
+      }),
+      "project/bun.lock": JSON.stringify({
+        lockfileVersion: 1,
+        workspaces: { "": { name: "my-app", dependencies: { evil: "file:./evil" } } },
+        packages: {
+          evil: ["evil@file:evil", { dependencies: { loot: "link:../../secret" } }],
+          loot: ["loot@link:../secret", {}],
+        },
+      }),
+    });
+    const project = join(String(dir), "project");
+
+    const { err, exitCode } = await install(project);
+    expect(err).toContain(refusal);
+    expect(exitCode).toBe(1);
+    expect(linksNamed(project, "loot")).toEqual([]);
+  });
+
+  it("is installed when it stays inside the project", async () => {
+    using dir = tempDir("transitive-link-inside", {
+      "bunfig.toml": bunfig(),
+      "package.json": JSON.stringify({ name: "my-app", dependencies: { lib: "file:./vendor/lib" } }),
+      "vendor/lib/package.json": JSON.stringify({
+        name: "lib",
+        version: "1.0.0",
+        main: "index.js",
+        dependencies: { nested: "link:../nested" },
+      }),
+      "vendor/lib/index.js": `module.exports = require("nested");`,
+      "vendor/nested/package.json": JSON.stringify({ name: "nested", version: "1.0.0", main: "index.js" }),
+      "vendor/nested/index.js": `module.exports = "it worked";`,
+    });
+    const project = String(dir);
+
+    for (const args of [[], ["--frozen-lockfile"]]) {
+      await rm(join(project, "node_modules"), { recursive: true, force: true });
+      const { err, exitCode } = await install(project, ...args);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      await using run = spawn({
+        cmd: [bunExe(), "-e", `console.log(require("lib"))`],
+        cwd: project,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect(runErr).toBe("");
+      expect(runOut.trim()).toBe("it worked");
+      expect(runExit).toBe(0);
+    }
+    // The declaring package's importer-relative target is stored root-relative.
+    expect(await file(join(project, "bun.lock")).text()).toContain('"nested@link:./vendor/nested"');
+  });
+
+  for (const field of ["overrides", "resolutions"]) {
+    it(`may escape the project when the target comes from root "${field}"`, async () => {
+      using dir = tempDir("transitive-link-override", {
+        "shared/package.json": JSON.stringify({ name: "shared", version: "1.0.0", main: "index.js" }),
+        "shared/index.js": `module.exports = "shared";`,
+        "project/bunfig.toml": bunfig(),
+        "project/package.json": JSON.stringify({
+          name: "my-app",
+          dependencies: { "pkg-a": "file:./pkg-a" },
+          [field]: { shared: "link:../shared" },
+        }),
+        "project/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+          main: "index.js",
+          dependencies: { shared: "1.0.0" },
+        }),
+        "project/pkg-a/index.js": `module.exports = require("shared");`,
+      });
+      const project = join(String(dir), "project");
+
+      for (const args of [[], ["--frozen-lockfile"]]) {
+        await rm(join(project, "node_modules"), { recursive: true, force: true });
+        const { err, exitCode } = await install(project, ...args);
+        expect(err).not.toContain(refusal);
+        expect(err).not.toContain("error:");
+        expect(exitCode).toBe(0);
+
+        await using run = spawn({
+          cmd: [bunExe(), "-e", `console.log(require("pkg-a"))`],
+          cwd: project,
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+        expect(runErr).toBe("");
+        expect(runOut.trim()).toBe("shared");
+        expect(runExit).toBe(0);
+      }
+    });
+  }
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -810,8 +810,15 @@ describe.each(["hoisted", "isolated"])("transitive path-form link: (%s)", linker
     expect(await file(join(project, "bun.lock")).text()).toContain('"nested@link:./vendor/nested"');
   });
 
-  for (const field of ["overrides", "resolutions"]) {
-    it(`may escape the project when the target comes from root "${field}"`, async () => {
+  // A root overrides/resolutions entry is root-authored, whether it is plain or
+  // scoped to the one edge it rewrites (pnpm `parent>name` / yarn `parent/name`).
+  for (const [field, key] of [
+    ["overrides", "shared"],
+    ["resolutions", "shared"],
+    ["overrides", "pkg-a>shared"],
+    ["resolutions", "pkg-a/shared"],
+  ]) {
+    it(`may escape the project when the target comes from root "${field}" ("${key}")`, async () => {
       using dir = tempDir("transitive-link-override", {
         "shared/package.json": JSON.stringify({ name: "shared", version: "1.0.0", main: "index.js" }),
         "shared/index.js": `module.exports = "shared";`,
@@ -819,7 +826,7 @@ describe.each(["hoisted", "isolated"])("transitive path-form link: (%s)", linker
         "project/package.json": JSON.stringify({
           name: "my-app",
           dependencies: { "pkg-a": "file:./pkg-a" },
-          [field]: { shared: "link:../shared" },
+          [field]: { [key]: "link:../shared" },
         }),
         "project/pkg-a/package.json": JSON.stringify({
           name: "pkg-a",

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -14,7 +14,17 @@ import {
   toHaveBins,
 } from "harness";
 import { basename, join } from "path";
-import { dummyAfterAll, dummyAfterEach, dummyBeforeAll, dummyBeforeEach, getPort, package_dir } from "./dummy.registry";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  getPort,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
@@ -595,6 +605,47 @@ describe.each(["hoisted", "isolated"])("link: with a filesystem path (%s)", link
 
     const second = await runBunInstall(env, package_dir, { frozenLockfile: true });
     expect(second.err).not.toContain("Saved lockfile");
+  });
+
+  it("the same directory as link: and file: is two packages (the file: one keeps its dependencies)", async () => {
+    // The folder-resolution cache is keyed on the target's package.json path; a
+    // link: entry (parsed without dependencies) must not be reused for file:.
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls));
+    await mkdir(join(package_dir, "vendor", "dual"), { recursive: true });
+    await writeFile(
+      join(package_dir, "vendor", "dual", "package.json"),
+      JSON.stringify({ name: "dual", version: "1.0.0", dependencies: { bar: "0.0.2" } }),
+    );
+    await mkdir(join(package_dir, "packages", "app"), { recursive: true });
+    await writeFile(
+      join(package_dir, "packages", "app", "package.json"),
+      JSON.stringify({ name: "app", version: "1.0.0", dependencies: { dual: "file:../../vendor/dual" } }),
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { dual: "link:./vendor/dual" } }),
+    );
+    await setLinker();
+
+    for (const args of [{}, { frozenLockfile: true }]) {
+      const { err } = await runBunInstall(env, package_dir, args);
+      expect(err).not.toContain("error:");
+      // root: a symlink to the directory, no dependencies installed for it
+      expect((await readlink(join(package_dir, "node_modules", "dual"))).replaceAll("\\", "/")).toContain(
+        "vendor/dual",
+      );
+      // workspace: the file: copy, whose dependency `bar` was resolved and installed
+      const bar =
+        linker === "hoisted"
+          ? join(package_dir, "node_modules", "bar")
+          : join(package_dir, "node_modules", ".bun", "dual@file+vendor+dual", "node_modules", "bar");
+      expect(await file(join(bar, "package.json")).json()).toEqual({ name: "bar", version: "0.0.2" });
+    }
+    expect(urls).toContain(`${root_url}/bar`);
+    const lock = await file(join(package_dir, "bun.lock")).text();
+    expect(lock).toContain('"dual@link:./vendor/dual"');
+    expect(lock).toContain('"dual@file:vendor/dual", { "dependencies": { "bar": "0.0.2" } }');
   });
 
   it("errors at resolve time when the target directory does not exist", async () => {

--- a/test/cli/install/migration/pnpm-lock-migration.test.ts
+++ b/test/cli/install/migration/pnpm-lock-migration.test.ts
@@ -261,6 +261,73 @@ snapshots:
     expect(packageJson).toMatchSnapshot("workspace-pnpm-migration-package-json");
   });
 
+  test("file: dependency of a workspace member is stored relative to the root", async () => {
+    // pnpm writes `link:../utils` relative to the importer; bun.lock stores it
+    // relative to the root, otherwise the install below looks for <root>/../utils.
+    await using tmpDir = tempDir("pnpm-migrate-importer-link", {
+      "package.json": JSON.stringify({ name: "root", private: true, workspaces: ["packages/app"] }),
+      "packages/app/package.json": JSON.stringify({ name: "app", dependencies: { utils: "file:../utils" } }),
+      "packages/utils/package.json": JSON.stringify({ name: "utils", version: "1.0.0", main: "index.js" }),
+      "packages/utils/index.js": `module.exports = "utils";`,
+      "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+  packages/app:
+    dependencies:
+      utils:
+        specifier: file:../utils
+        version: link:../utils
+`,
+    });
+
+    await using migrate = Bun.spawn({
+      cmd: [bunExe(), "pm", "migrate"],
+      cwd: tmpDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, migrateStderr, migrateExit] = await Promise.all([
+      migrate.stdout.text(),
+      migrate.stderr.text(),
+      migrate.exited,
+    ]);
+    expect(migrateStderr).toContain("migrated lockfile from pnpm-lock.yaml");
+    expect(migrateExit).toBe(0);
+
+    expect(fs.readFileSync(join(tmpDir, "bun.lock"), "utf8")).toContain('"utils@link:./packages/utils"');
+
+    await using install = Bun.spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: tmpDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, installStderr, installExit] = await Promise.all([
+      install.stdout.text(),
+      install.stderr.text(),
+      install.exited,
+    ]);
+    expect(installStderr).not.toContain("error:");
+    expect(installExit).toBe(0);
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log(require("utils"))`],
+      cwd: join(tmpDir, "packages", "app"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runErr).toBe("");
+    expect(runOut.trim()).toBe("utils");
+    expect(runExit).toBe(0);
+  });
+
   test("pnpm with npm protocol aliases", async () => {
     await using tmpDir = tempDir("pnpm-migrate-npm-aliases", {
       "package.json": JSON.stringify(


### PR DESCRIPTION
### What does this PR do?

Makes `bun install` understand **path-style `link:` dependencies** — `"dep": "link:./vendor/dep"`, `"dep": "link:../shared"` — the form Yarn and pnpm write, meaning "install a symlink to this directory, do not install its dependencies". Today bun only knows `link:<name>` (a package registered with `bun link`), so such manifests fail with `Package "dep" is not linked` (#4719, #5045).

- **Path vs. name.** A `link:` value is a path unless it is an npm package name (`dependency::is_link_path`): `link:./x`, `link:../x`, `link:lib/x`, `link:/abs` and Windows drive-absolute targets are paths; `link:foo` and `link:@scope/foo` keep meaning a `bun link` registration. This is the rule the pnpm-lock.yaml migration already used, and it now calls the shared helper, so the two writers of `bun.lock` agree. `bun add link:<path> --filter <ws>` (`add_remove_with_filter.rs::local_relative_path`) uses the same rule when it re-spells a local path relative to each target workspace.
- **Stored form.** `Package::parse_dependency` re-bases a path-form value from the declaring `package.json` onto the project root (as it already does for `file:`), and `link_path_for_lockfile` makes it `/`-separated and `./`-prefixed, so what is written always reads back as a path. The pnpm migration produces the same root-relative form from pnpm's importer-relative value.
- **Resolution.** A path-form value goes through the folder resolver as `GlobalOrRelative::Relative(Symlink)` (project-relative, `Features::LINK`) instead of a lookup under the global link directory; name-form is unchanged. The result is a `Symlink` resolution whose value is that root-relative path, and both linkers install it as a symlink to the directory: the hoisted `PackageInstaller`, `compute_cache_dir_and_subpath`, and the isolated `Installer` treat a path-form value as project-relative rather than `<global link dir>/<name>`; the isolated linker only pre-creates the global link dir when a name-form resolution exists. `Version::eql` for `Symlink` compares the literal (like `Folder`), since `bun.lock` round-trips the literal.
- **Manifest-less targets.** As with Yarn, the target directory does not need a `package.json`; it is then a leaf package named after the directory. The directory itself must exist: a missing target is reported at resolve time (`Could not find directory "<path>" for linked dependency "<name>"`) under both linkers, before a lockfile or any symlink is written — including for `bun add link:./missing --filter x`.
- **Containment, same rule as `file:`.** A target inside the project is always allowed, including one declared by a transitive `file:` package. One that leaves the project (`..` or absolute) is allowed only when the root or a workspace declared the dependency, or a root `overrides`/`resolutions` entry — plain, or scoped to that edge (`parent>name`, `name@range`, npm nested objects) — supplies it (`Lockfile::link_target_allowed_for_dependency` / `_for_package`, via `OverrideMap::get`). The folder-resolution cache is keyed on link-vs-folder as well as the path, so `link:./x` and `file:./x` naming the same directory stay two packages. Checked at resolve time and again in both installers, because an install driven by an existing lockfile never resolves (hoisted: per package in `PackageInstaller`; isolated: in the pass over resolutions that runs before any task is scheduled). Refusal is its own error (`UnsafeLinkTarget`, "refusing to link ...").
- Bare `link:<name>` and everything about `bun link` / `bun unlink` is unchanged; `file:` keeps its copy semantics.

**Lockfile note:** `bun.lock` entries of the form `x@link:../y` or `x@link:/abs` that main already writes (and then fails to install) start installing with this change, subject to the containment rule above. Name-form entries are unaffected. pnpm lockfiles whose importers carry `link:` targets now migrate to root-relative entries; ones migrated by older versions were never installable.

Docs: `docs/pm/cli/link.mdx` ("Linking a directory by path").

#### Relationship to #35461

#35461 (`farm/2cb823b1/link-protocol-path`) implemented the same feature earlier and more completely, and was closed in favour of this PR. Its implementation has been adopted here with a `Co-authored-by` trailer: the shared `is_link_path` / `link_path_for_lockfile` helpers, the containment rule and `UnsafeLinkTarget` error, the pnpm-lock.yaml re-basing, the `bun add --filter` re-spelling, `Version::eql` for `Symlink`, the resolve-time missing-target error, and its tests in `bun-link.test.ts`, `bun-add-filter.test.ts` and `pnpm-lock-migration.test.ts`. What this PR adds on top is the docs page and support for a target directory without a `package.json`.

### How did you verify your code works?

- `test/cli/install/bun-install-link-path.test.ts`, both linkers: a root package with `link:./vendor/with-manifest` (has a package.json), `link:./vendor/no-manifest` (plain directory) and a directory whose name has no usable characters, plus a workspace declaring `link:../../vendor/with-manifest`; asserts the symlinks, the lockfile literals and a stable `--frozen-lockfile` reinstall. A missing target directory fails at resolve time under both linkers and writes neither `bun.lock` nor `node_modules`.
- `test/cli/install/bun-link.test.ts`, both linkers with a `--frozen-lockfile` re-install each: `./`, bare `lib/x` (asserts the `./` stored form), `../`, absolute, scoped, workspace-member-relative, manifest-less directory, missing target. Containment block: a transitive escape is refused at resolve time and from an existing lockfile (nothing by that name anywhere under `node_modules`, isolated store included), a transitive in-project target installs, the `overrides`/`resolutions` exemption is honoured.
- `test/cli/install/bun-add-filter.test.ts`: `link:./vendor/foo` and `link:vendor/foo` are written to the target as `link:../../vendor/foo`, recorded as `foo@link:./vendor/foo`, install, and survive `--frozen-lockfile`; a missing target is refused naming the per-target spelling and writes nothing.
- `test/cli/install/migration/pnpm-lock-migration.test.ts`: a `file:` specifier from a non-root importer migrates to a root-relative target and installs.
- Also ran `bun-install` (the `file:` containment tests), `isolated-install`, `bun-workspaces`, `bun-pm`, the other pnpm migration suites and the source lints locally on Linux. Windows is covered by CI only.

Fixes #4719
Fixes #5045
