### PR TITLE
napi: do not tear down the envs on process.exit() or a fatal error on the main thread

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -217,7 +217,8 @@ pub struct VirtualMachine {
     pub(crate) hide_bun_stackframes: bool,
 
     pub is_shutting_down: bool,
-    /// Set once `on_exit()` has finished draining `RareData::cleanup_hooks`.
+    /// Set once `on_exit()` has finished draining `RareData::cleanup_hooks`, or
+    /// decided not to run them (`exit_tears_down_napi_envs`).
     /// After this point the cleanup-hook list is never iterated again, so
     /// pushing to it (e.g. from a deferred N-API finalizer scheduled during
     /// the final `collectNow()` in `Zig__GlobalObject__destructOnExit`) would
@@ -553,6 +554,11 @@ pub struct ExitHandler {
     pub exit_code: u8,
     /// `bun test` sets this at the end of a run unless `node:test` APIs were used: jest and vitest never fire a test file's `process.on('exit')` listeners.
     pub skip_exit_listeners: bool,
+    /// The exit was asked for (`process.exit()`, or an uncaught error that ended
+    /// the run) rather than the event loop running dry. Decides whether
+    /// `on_exit()` tears the Node-API envs down
+    /// (`VirtualMachine::exit_tears_down_napi_envs`).
+    pub requested: bool,
 }
 
 impl ExitHandler {
@@ -1707,12 +1713,42 @@ impl VirtualMachine {
 
         self.is_shutting_down = true;
 
-        // Make sure we run new cleanup hooks introduced by running cleanup
-        // hooks.
-        // Note: each iteration re-fetches `rare_data` so the FFI hook
-        // bodies (which may re-enter `VirtualMachine` and push more hooks) do
-        // not run while a `&mut RareData` is live — the borrow ends after
-        // `mem::take` returns the owned `Vec`.
+        if self.exit_tears_down_napi_envs() {
+            self.run_cleanup_hooks();
+        }
+        // Drained, or left unrun for good: either way the list is never walked again.
+        self.has_run_cleanup_hooks = true;
+
+        // Persist the Node compile cache (NODE_COMPILE_CACHE /
+        // module.enableCompileCache()) after user exit handlers ran.
+        if self.is_main_thread() {
+            crate::node_compile_cache::persist_at_exit();
+        }
+    }
+
+    /// Whether `on_exit()` runs `RareData::cleanup_hooks`, which tear down the
+    /// Node-API envs loaded into this VM (`NapiEnv::cleanup`: the addon's cleanup
+    /// hooks, then the finalizers of everything it still has alive).
+    ///
+    /// Node tears the envs down when it frees the environment. A worker's is freed
+    /// however the worker stopped. The main thread's is freed only once its event
+    /// loop ran dry: `process.exit()` and a fatal error call `exit()` instead, so on
+    /// those paths Node never calls back into an addon, and neither do we. Under
+    /// `BUN_DESTRUCT_VM_ON_EXIT` the main thread's VM is destroyed like a worker's,
+    /// and that teardown only ever runs after the envs are gone, so they go first
+    /// there too.
+    fn exit_tears_down_napi_envs(&self) -> bool {
+        !self.is_main_thread()
+            || !self.exit_handler.requested
+            || self.should_destruct_main_thread_on_exit()
+    }
+
+    /// Runs `RareData::cleanup_hooks` until the hooks stop pushing more (an env
+    /// cleanup defers finalizers onto this same list once shutdown has begun).
+    /// Each iteration re-fetches `rare_data` so the FFI hook bodies, which may
+    /// re-enter `VirtualMachine` and push more hooks, do not run while a
+    /// `&mut RareData` is live: the borrow ends once `mem::take` returns the `Vec`.
+    fn run_cleanup_hooks(&mut self) {
         loop {
             let hooks = match self.rare_data.as_deref_mut() {
                 Some(rare) if !rare.cleanup_hooks.is_empty() => {
@@ -1730,14 +1766,6 @@ impl VirtualMachine {
                     let _ = crate::task::report_error_or_terminate(global, crate::JsError::Thrown);
                 }
             }
-        }
-        // `mem::take` above leaves an empty `Vec` (capacity already freed by drop).
-        self.has_run_cleanup_hooks = true;
-
-        // Persist the Node compile cache (NODE_COMPILE_CACHE /
-        // module.enableCompileCache()) after user exit handlers ran.
-        if self.is_main_thread() {
-            crate::node_compile_cache::persist_at_exit();
         }
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -217,12 +217,9 @@ pub struct VirtualMachine {
     pub(crate) hide_bun_stackframes: bool,
 
     pub is_shutting_down: bool,
-    /// Set once `on_exit()` has finished draining `RareData::cleanup_hooks`, or
-    /// decided not to run them (`exit_tears_down_napi_envs`).
-    /// After this point the cleanup-hook list is never iterated again, so
-    /// pushing to it (e.g. from a deferred N-API finalizer scheduled during
-    /// the final `collectNow()` in `Zig__GlobalObject__destructOnExit`) would
-    /// only leak the hook's `ctx` allocation.
+    /// Set once `on_exit()` is past `RareData::cleanup_hooks`, run or not
+    /// (`exit_tears_down_napi_envs`). The list is never walked again, so a hook
+    /// pushed after this (a finalizer deferred from the final collection) would only leak.
     pub(crate) has_run_cleanup_hooks: bool,
     pub plugin_runner: Option<crate::plugin_runner::PluginRunner>,
     pub is_main_thread: bool,
@@ -554,10 +551,8 @@ pub struct ExitHandler {
     pub exit_code: u8,
     /// `bun test` sets this at the end of a run unless `node:test` APIs were used: jest and vitest never fire a test file's `process.on('exit')` listeners.
     pub skip_exit_listeners: bool,
-    /// The exit was asked for (`process.exit()`, or an uncaught error that ended
-    /// the run) rather than the event loop running dry. Decides whether
-    /// `on_exit()` tears the Node-API envs down
-    /// (`VirtualMachine::exit_tears_down_napi_envs`).
+    /// `process.exit()` or a fatal error, as opposed to the event loop running dry.
+    /// See `VirtualMachine::exit_tears_down_napi_envs`.
     pub requested: bool,
 }
 
@@ -1716,7 +1711,6 @@ impl VirtualMachine {
         if self.exit_tears_down_napi_envs() {
             self.run_cleanup_hooks();
         }
-        // Drained, or left unrun for good: either way the list is never walked again.
         self.has_run_cleanup_hooks = true;
 
         // Persist the Node compile cache (NODE_COMPILE_CACHE /
@@ -1726,28 +1720,21 @@ impl VirtualMachine {
         }
     }
 
-    /// Whether `on_exit()` runs `RareData::cleanup_hooks`, which tear down the
-    /// Node-API envs loaded into this VM (`NapiEnv::cleanup`: the addon's cleanup
-    /// hooks, then the finalizers of everything it still has alive).
-    ///
-    /// Node tears the envs down when it frees the environment. A worker's is freed
-    /// however the worker stopped. The main thread's is freed only once its event
-    /// loop ran dry: `process.exit()` and a fatal error call `exit()` instead, so on
-    /// those paths Node never calls back into an addon, and neither do we. Under
-    /// `BUN_DESTRUCT_VM_ON_EXIT` the main thread's VM is destroyed like a worker's,
-    /// and that teardown only ever runs after the envs are gone, so they go first
-    /// there too.
+    /// Whether `on_exit()` runs `RareData::cleanup_hooks`, i.e. `NapiEnv::cleanup` for
+    /// each addon. Node does this when it frees an environment: a worker's on any exit,
+    /// the main thread's only once its loop ran dry (`process.exit()` and a fatal error
+    /// call `exit()` instead). `BUN_DESTRUCT_VM_ON_EXIT` destroys the main thread's VM
+    /// like a worker's, and that teardown expects the envs to be gone, so it tears them
+    /// down on every exit too.
     fn exit_tears_down_napi_envs(&self) -> bool {
         !self.is_main_thread()
             || !self.exit_handler.requested
             || self.should_destruct_main_thread_on_exit()
     }
 
-    /// Runs `RareData::cleanup_hooks` until the hooks stop pushing more (an env
-    /// cleanup defers finalizers onto this same list once shutdown has begun).
-    /// Each iteration re-fetches `rare_data` so the FFI hook bodies, which may
-    /// re-enter `VirtualMachine` and push more hooks, do not run while a
-    /// `&mut RareData` is live: the borrow ends once `mem::take` returns the `Vec`.
+    /// Drains `RareData::cleanup_hooks`, repeating while the hooks push more (an env's
+    /// cleanup defers finalizers onto this list once shutdown has begun). The `Vec` is
+    /// taken out of `rare_data` before the hooks run: they re-enter the VM.
     fn run_cleanup_hooks(&mut self) {
         loop {
             let hooks = match self.rare_data.as_deref_mut() {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1546,6 +1546,11 @@ impl Run<'_> {
 
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
         let _ = vm.global().handle_rejected_promises();
+        // An uncaught error stops the loop (`is_event_loop_alive`) and brings us
+        // here: Node's fatal-exception exit, not a drain.
+        if vm.unhandled_error_counter > 0 {
+            vm.exit_handler.requested = true;
+        }
         vm.on_exit();
 
         if ANY_UNHANDLED.load(Ordering::Relaxed) {
@@ -1615,6 +1620,7 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 )]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
+    vm.exit_handler.requested = true;
     vm.on_exit();
     if ANY_UNHANDLED.load(Ordering::Relaxed) {
         bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1546,8 +1546,7 @@ impl Run<'_> {
 
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
         let _ = vm.global().handle_rejected_promises();
-        // An uncaught error stops the loop (`is_event_loop_alive`) and brings us
-        // here: Node's fatal-exception exit, not a drain.
+        // The loop stopped on an uncaught error: Node's fatal-exception exit, not a drain.
         if vm.unhandled_error_counter > 0 {
             vm.exit_handler.requested = true;
         }

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -84,6 +84,7 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
             bun_core::Output::flush();
             bun_core::reload_process(should_clear_terminal, false);
         }
+        vm.exit_handler.requested = true;
         vm.on_exit();
         vm.global_exit();
     }

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1416,6 +1416,18 @@ nativeTests.test_cleanup_hook_order = () => {
   addon.test();
 };
 
+// Node tears an addon's env down (its cleanup hooks, then the finalizers of
+// whatever it still has alive) only when the main thread's event loop runs dry.
+// process.exit() skips all of it, so only the two lines printed by test() are
+// expected here: no "hookN executed" lines and no "finalize order" line.
+nativeTests.test_env_teardown_skipped_by_process_exit = () => {
+  const hooks = require("./build/Debug/test_cleanup_hook_order.node");
+  const wraps = require("./build/Debug/test_wrap_cleanup_order.node");
+  hooks.test();
+  globalThis.keep = wraps.createParentAndChildren(1);
+  process.exit(0);
+};
+
 nativeTests.test_cleanup_hook_remove_nonexistent = () => {
   const addon = require("./build/Debug/test_cleanup_hook_remove_nonexistent.node");
   addon.test();

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1751,7 +1751,14 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     // test() prints these two lines when called; each hook prints a line when it
     // runs. createParentAndChildren() prints "finalize order: ..." from the
     // parent's napi_wrap finalizer.
-    const setupOutput = "Added hooks in order: 1, 2, 3\nThey should execute in reverse order: 3, 2, 1\n";
+    const setupLines = ["Added hooks in order: 1, 2, 3", "They should execute in reverse order: 3, 2, 1"];
+    const teardownLines = [
+      ...setupLines,
+      "hook3 executed at position 0",
+      "hook2 executed at position 1",
+      "hook1 executed at position 2",
+      "finalize order: 1 0",
+    ];
     const setup = `
       const hooks = require(${JSON.stringify(hooksAddon)});
       const wraps = require(${JSON.stringify(wrapsAddon)});
@@ -1759,6 +1766,9 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
       globalThis.keep = wraps.createParentAndChildren(1);
     `;
 
+    // Returns stdout as a sorted list of lines. The addons print with printf(),
+    // which on Windows ends lines with \r\n and buffers each addon's output in
+    // its own CRT until exit, so only the set of lines is stable there.
     async function run(code: string, env: Record<string, string>) {
       await using proc = spawn({
         cmd: [bunExe(), "-e", code],
@@ -1767,7 +1777,7 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout, stderr, exitCode };
+      return { lines: stdout.split(/\r?\n/).filter(Boolean).sort(), stderr, exitCode };
     }
 
     it("process.exit() skips it, like Node", async () => {
@@ -1775,39 +1785,33 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
 
     it("an uncaught exception while the entry point runs skips it", async () => {
-      const { stdout, stderr, exitCode } = await run(`${setup}; throw new Error("fatal");`, noDestruct);
+      const { lines, stderr, exitCode } = await run(`${setup}; throw new Error("fatal");`, noDestruct);
       expect(stderr).toContain("fatal");
-      expect(stdout).toBe(setupOutput);
+      expect(lines).toEqual(setupLines.toSorted());
       expect(exitCode).toBe(1);
     });
 
     it("an uncaught exception from the event loop skips it", async () => {
-      const { stdout, stderr, exitCode } = await run(
+      const { lines, stderr, exitCode } = await run(
         `${setup}; setTimeout(() => { throw new Error("fatal"); }, 1);`,
         noDestruct,
       );
       expect(stderr).toContain("fatal");
-      expect(stdout).toBe(setupOutput);
+      expect(lines).toEqual(setupLines.toSorted());
       expect(exitCode).toBe(1);
     });
 
     it("an event loop that runs dry tears it down", async () => {
-      const { stdout, stderr, exitCode } = await run(setup, noDestruct);
+      const { lines, stderr, exitCode } = await run(setup, noDestruct);
       expect(stderr).toBe("");
-      expect(stdout).toBe(
-        setupOutput +
-          "hook3 executed at position 0\nhook2 executed at position 1\nhook1 executed at position 2\nfinalize order: 1 0\n",
-      );
+      expect(lines).toEqual(teardownLines.toSorted());
       expect(exitCode).toBe(0);
     });
 
     it("process.exit() still tears it down when the VM is destroyed on exit", async () => {
-      const { stdout, stderr, exitCode } = await run(`${setup}; process.exit(0);`, { BUN_DESTRUCT_VM_ON_EXIT: "1" });
+      const { lines, stderr, exitCode } = await run(`${setup}; process.exit(0);`, { BUN_DESTRUCT_VM_ON_EXIT: "1" });
       expect(stderr).toBe("");
-      expect(stdout).toBe(
-        setupOutput +
-          "hook3 executed at position 0\nhook2 executed at position 1\nhook1 executed at position 2\nfinalize order: 1 0\n",
-      );
+      expect(lines).toEqual(teardownLines.toSorted());
       expect(exitCode).toBe(0);
     });
   });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1732,6 +1732,86 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  // Node frees the main thread's environment, which is what runs an addon's
+  // cleanup hooks and the finalizers of everything it still has alive, only
+  // after the event loop runs dry. process.exit() and a fatal error call exit()
+  // instead, so an addon's teardown code never runs on those paths (Node
+  // v26.3.0). Bun used to run it on every exit, calling into addons where Node
+  // does not. Under BUN_DESTRUCT_VM_ON_EXIT (the sanitizer lanes set it for
+  // every child) the main thread's VM is destroyed like a worker's, and the envs
+  // are still torn down first, so these children opt out of it and of the leak
+  // check that goes with it.
+  describe.concurrent("env teardown on the main thread", () => {
+    const noDestruct = {
+      BUN_DESTRUCT_VM_ON_EXIT: "0",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    };
+    const hooksAddon = join(__dirname, "napi-app/build/Debug/test_cleanup_hook_order.node");
+    const wrapsAddon = join(__dirname, "napi-app/build/Debug/test_wrap_cleanup_order.node");
+    // test() prints these two lines when called; each hook prints a line when it
+    // runs. createParentAndChildren() prints "finalize order: ..." from the
+    // parent's napi_wrap finalizer.
+    const setupOutput = "Added hooks in order: 1, 2, 3\nThey should execute in reverse order: 3, 2, 1\n";
+    const setup = `
+      const hooks = require(${JSON.stringify(hooksAddon)});
+      const wraps = require(${JSON.stringify(wrapsAddon)});
+      hooks.test();
+      globalThis.keep = wraps.createParentAndChildren(1);
+    `;
+
+    async function run(code: string, env: Record<string, string>) {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", code],
+        env: { ...bunEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    it("process.exit() skips it, like Node", async () => {
+      await checkSameOutput("test_env_teardown_skipped_by_process_exit", [], noDestruct);
+    });
+
+    it("an uncaught exception while the entry point runs skips it", async () => {
+      const { stdout, stderr, exitCode } = await run(`${setup}; throw new Error("fatal");`, noDestruct);
+      expect(stderr).toContain("fatal");
+      expect(stdout).toBe(setupOutput);
+      expect(exitCode).toBe(1);
+    });
+
+    it("an uncaught exception from the event loop skips it", async () => {
+      const { stdout, stderr, exitCode } = await run(
+        `${setup}; setTimeout(() => { throw new Error("fatal"); }, 1);`,
+        noDestruct,
+      );
+      expect(stderr).toContain("fatal");
+      expect(stdout).toBe(setupOutput);
+      expect(exitCode).toBe(1);
+    });
+
+    it("an event loop that runs dry tears it down", async () => {
+      const { stdout, stderr, exitCode } = await run(setup, noDestruct);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        setupOutput +
+          "hook3 executed at position 0\nhook2 executed at position 1\nhook1 executed at position 2\nfinalize order: 1 0\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    it("process.exit() still tears it down when the VM is destroyed on exit", async () => {
+      const { stdout, stderr, exitCode } = await run(`${setup}; process.exit(0);`, { BUN_DESTRUCT_VM_ON_EXIT: "1" });
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        setupOutput +
+          "hook3 executed at position 0\nhook2 executed at position 1\nhook1 executed at position 2\nfinalize order: 1 0\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("napi_strict_equals", () => {
     it("should match JavaScript === operator behavior", async () => {
       const output = await checkSameOutput("test_napi_strict_equals", []);


### PR DESCRIPTION
### Problem
- BUN-4NMY: `Segmentation fault at address 0x8` in an addon's `napi_wrap` finalizer, from `NapiEnv::cleanup` (napi.h:241) <- `VirtualMachine::on_exit` <- `Bun__Process__exit`. The script called `process.exit()`. The fault itself is the addon's.
- Node never calls that finalizer there. It frees the main thread's environment (addon cleanup hooks, then the remaining finalizers) only after the event loop runs dry. `process.exit()` and a fatal error call `exit()` instead. Bun ran `NapiEnv::cleanup` on every exit.

### Fix
- `ExitHandler::requested` marks an exit that was asked for: `Bun__Process__exit`, an entry point that threw, a loop stopped by an uncaught error. On the main thread `on_exit()` then leaves `cleanup_hooks` unrun.
- A natural exit and a Worker are unchanged: Node frees a Worker's environment however it stopped. `BUN_DESTRUCT_VM_ON_EXIT` still tears the envs down, since that VM teardown has only ever run after them.
- Correct because the main thread now matches Node on every path: a C addon that logs each teardown callback prints the same lines under Node 26.3.0 and this build on nine exit paths (Notes).
- Verified: `test/napi/napi.test.ts` "env teardown on the main thread" (3 of 5 fail on 1.4.0). Also the rest of `test/napi`, Node's teardown suites, `process.test.js`.

### Background
- A `NapiEnv` is Bun's per addon state. Its constructor registers `NapiEnv::cleanup` in `RareData::cleanup_hooks`.
- `on_exit()` drains that list on every exit of a VM: `bun run` ending, `process.exit()`, `bun test`, a Worker's shutdown. Only the first and the last correspond to Node freeing an environment.
- `BUN_DESTRUCT_VM_ON_EXIT` makes the main thread destroy its JSC VM at exit, as a Worker does. The sanitizer lanes set it for every child, so the tests that expect no teardown set it to 0 and turn the leak check off.

<details><summary>Notes</summary>

Probe results. Inside one env the order on a normal exit matched Node before this change. Node 26.3.0 on the main thread prints nothing from the addon for `process.exit()` at top level, from a timer, after a top-level await, from an `'exit'` listener, `reallyExit()`, a sync uncaught exception and an async one. On a normal exit it prints: external buffer finalizers, cleanup hooks LIFO, threadsafe function finalizer, reference finalizers LIFO, instance data. Bun 1.4.0 printed the normal exit list on every one of those paths. This build prints what Node prints on each, and a Worker still tears down on every path in both.

The `Bun__Process__exit` cases are `process.exit()`, `reallyExit()`, and the fatal exception paths that go through it. Node's suites run: `node-api` test_cleanup_hook, test_async_cleanup_hook, test_env_teardown_gc, test_instance_data, test_general, test_fatal, test_fatal_exception, test_worker_terminate, test_worker_terminate_finalization, test_worker_buffer_callback, test_threadsafe_function; `js-native-api` test_reference, test_reference_double_free, test_cannot_run_js, test_finalizer, test_general, test_instance_data, 6_object_wrap, 7_factory_wrap, 8_passing_wrapped.

Other differences from Node the probe showed, left alone here:

- Node runs teardown finalizers with JS disabled: `napi_get_named_property` and `napi_call_function` return status 10 from a finalizer at exit. Bun runs them with JS enabled (status 0, the JS callback runs after `'exit'`). The gate exists (`NAPI_PREAMBLE` checks `isStoppingOrStopped`), but the main thread's natural exit does not arm it.
- Node runs `napi_add_finalizer` and `napi_create_external` finalizers at teardown. Bun does not (#32912 is open for this).
- Node runs external buffer and external arraybuffer finalizers before every cleanup hook, whatever the registration order. Bun runs them after the hooks, with the other bound finalizers.
- With two addons, Node runs all cleanup hooks of all addons first, then the finalizers. Bun tears the envs down one at a time in load order, so the first addon's finalizers run before the second addon's cleanup hooks.
- The `napi_module_register` tag in the report is only set by the static constructor registration path, so the addon was built against headers that predate the `napi_register_module_v1` form of `NAPI_MODULE`. #32569 (BUN-390H) is the sibling crash class from the same kind of addon, in libc `exit()` after this teardown.
- #39656 adds the same `ExitHandler::requested` field for a narrower purpose (not waiting for async cleanup hooks on these exits). Whichever lands second drops its copy.
- `test_reference/test.js`, `test_instance_data/test.js` and `test_finalizer/test_fatal_finalize.js` from Node's suite exceed the 5 s per test timeout in this ASAN debug build. Run directly they exit 0 (24 s, 6 s, 7 s). `process.test.js` has one failure because `USER` is unset in this container.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->