### PR TITLE
install: re-parse the root package.json after the pnpm migration rewrites it

### DIFF
--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -17,6 +17,7 @@ use crate::external_slice::ExternalSlice;
 use crate::integrity::Integrity;
 use crate::lockfile::{self, LoadResult, LoadResultOk, Lockfile};
 use crate::npm::{self};
+use crate::package_manager_real::update_package_json_and_install::print_package_json_into_cache_entry;
 use crate::repository::Repository;
 use crate::resolution::{self, Resolution, TaggedValue};
 use crate::{DependencyID, INVALID_PACKAGE_ID, PackageID, PackageManager};
@@ -2732,36 +2733,14 @@ fn update_package_json_after_migration(
     }
 
     if needs_update {
-        let mut buffer_writer = bun_js_printer::BufferWriter::init();
-        buffer_writer.append_newline = !root_pkg_json.source.contents().is_empty()
-            && root_pkg_json.source.contents()[root_pkg_json.source.contents().len() - 1] == b'\n';
-        let mut package_json_writer = bun_js_printer::BufferPrinter::init(buffer_writer);
-
-        if bun_js_printer::print_json(
-            &mut package_json_writer,
-            json,
-            &root_pkg_json.source,
-            bun_js_printer::PrintJsonOptions {
-                indent: root_pkg_json.indentation,
-                mangled_props: None,
-                ..Default::default()
-            },
-        )
-        .is_err()
-        {
-            return Ok(());
+        print_package_json_into_cache_entry(root_pkg_json, json);
+        // The edits above spliced `Store`-allocated nodes into the cached tree,
+        // and the next `initialize_store()` recycles them. Re-parse so the entry
+        // owns its tree again before `bun add` prints it after the install.
+        if let Err(err) = root_pkg_json.reparse_root(log) {
+            bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
+            bun_core::Global::crash();
         }
-
-        if package_json_writer.flush().is_err() {
-            return Err(AllocError);
-        }
-
-        root_pkg_json.source.contents = std::borrow::Cow::Owned(
-            package_json_writer
-                .ctx
-                .written_without_trailing_zero()
-                .to_vec(),
-        );
 
         // Write the updated package.json
         if sys::File::write_file(

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2773,6 +2773,119 @@ importers:
     expect(await bunLockOf(String(formatted))).toBe(await bunLockOf(String(plain)));
   });
 
+  // The migration edits the cached root package.json AST in place and then
+  // replaces its source text. `bun add` prints that same cache entry again
+  // after the install, so the entry has to be re-parsed after the migration
+  // or the second print reads freed memory.
+  test("bun add migrates pnpm-workspace.yaml and keeps the migrated fields", async () => {
+    const { packageDir } = await verdaccio.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({ name: "add-after-migration", private: true }),
+        "packages/a/package.json": JSON.stringify({ name: "a", private: true }),
+        "pnpm-workspace.yaml": `packages:
+  - 'packages/*'
+overrides:
+  pkg-x: 1.2.3
+catalog:
+  pkg-y: 2.0.0
+`,
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+  packages/a: {}
+`,
+      },
+    });
+
+    const { stderr, exitCode } = await run(packageDir, "add", "no-deps@1.0.0");
+
+    expect(stderr).toContain("moved pnpm-workspace.yaml to workspaces");
+    expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+    expect(stderr).not.toContain("error:");
+    expect(await Bun.file(join(packageDir, "package.json")).json()).toStrictEqual({
+      name: "add-after-migration",
+      private: true,
+      dependencies: { "no-deps": "1.0.0" },
+      workspaces: {
+        packages: ["packages/*"],
+        catalog: { "pkg-y": "2.0.0" },
+      },
+      overrides: { "pkg-x": "1.2.3" },
+    });
+    expect(exitCode).toBe(0);
+
+    const bunLock = await bunLockOf(packageDir);
+    expect(bunLock).toContain(`"no-deps": "1.0.0"`);
+    expect(bunLock).toContain(`"packages/a"`);
+  });
+
+  // #23694: `bun update -i` migrates once to list the outdated packages, edits
+  // package.json through the cache entry, and migrates again when it installs.
+  test("bun update -i as the first bun command in a pnpm workspace", async () => {
+    const { packageDir } = await verdaccio.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify({ name: "update-i-after-migration", dependencies: { "no-deps": "^1.0.0" } }),
+        "packages/a/package.json": JSON.stringify({ name: "a", private: true }),
+        "pnpm-workspace.yaml": `packages:
+  - 'packages/*'
+`,
+        "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+  packages/a: {}
+
+packages:
+
+  no-deps@1.0.0:
+    resolution: {integrity: ${NO_DEPS_1_0_0_INTEGRITY}}
+
+snapshots:
+
+  no-deps@1.0.0: {}
+`,
+      },
+    });
+
+    // `a` selects every offered row and `\r` confirms.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "update", "-i"],
+      cwd: packageDir,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write("a\r");
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain("no-deps");
+    expect(await Bun.file(join(packageDir, "package.json")).json()).toStrictEqual({
+      name: "update-i-after-migration",
+      dependencies: { "no-deps": "^1.1.0" },
+      workspaces: ["packages/*"],
+    });
+    expect(exitCode).toBe(0);
+
+    const bunLock = await bunLockOf(packageDir);
+    expect(bunLock).toContain(`"no-deps@1.1.0"`);
+    expect(bunLock).toContain(`"packages/a"`);
+  });
+
   describe("catalogs", () => {
     // pnpm/pnpm#10551: pruned Docker contexts ship the lockfile without pnpm-workspace.yaml
     test("lockfile catalogs: section is enough without pnpm-workspace.yaml", async () => {


### PR DESCRIPTION
### Problem
- `bun add` in a project that still has `pnpm-lock.yaml` and `pnpm-workspace.yaml` crashes or writes garbage into `package.json`. Sentry BUN-4NQS (1.4.0): `Segmentation fault at address 0xF3E9AD2800000000` in `extend_from_slice` under `EString::resolve_rope_if_needed`, `print_property`, `edit_after_resolve`. `bun update -i` hits the same bug (#23694).
- The cause is `update_package_json_after_migration` (`src/install/pnpm.rs:2334`). It edits the cached root `package.json` tree in place, replaces `entry.source.contents`, and returns. The tree now points into the freed contents, and its new nodes live in the thread-local AST `Store`, which the install resets (`src/install/lockfile/Package.rs:1676`) before the write-back prints the tree.

### Fix
- Print the edited tree into the cache entry and call `MapEntry::reparse_root`, as `store_entry` (`add_remove_with_filter.rs:280`) does. When the migration returns, the entry owns its tree again.
- A print or re-parse failure now crashes like the other editors do. Before, a print failure left the dangling tree in the cache.
- Verified: two new tests in `test/cli/install/migration/pnpm-lock-v9.test.ts` (`bun add`, and the `bun update -i` shape from #23694). Both fail on main with the debug build and with the 1.4.0 release. The other `pnpm-*` files pass.

### Background
- `WorkspacePackageJSONCache` keeps one `MapEntry` per `package.json`: the contents, a parsed tree, and the arena that owns the tree. `bun add` prints the root entry again after the install (`package_json_write_back.rs:63`).
- `Expr::init` allocates nodes in a thread-local `Store`. `initialize_store()` resets it before every `package.json` parse. `reparse_root` rebuilds the tree in an arena the entry owns.
- String nodes point into the entry's contents, so a writer that replaces the contents has to rebuild the tree.

<details><summary>Notes</summary>

- Repro without a registry: a `package.json`, a `pnpm-lock.yaml` with `lockfileVersion: '9.0'` and empty importers, a `pnpm-workspace.yaml` with a `packages:` list, then `bun add ./some-folder`. The 1.4.0 release writes `"\x00\x00\x00e"` in place of the `name` key, so `package.json` is no longer valid JSON. The debug build reports `heap-use-after-free` in `EString::eql_bytes` under `edit_after_resolve`, freed at `pnpm.rs:2759` (the `source.contents` assignment on main). Any yaml field the migration moves (`packages`, `catalog`, `overrides`, `patchedDependencies`) or a `pnpm.overrides` block triggers it, so every pnpm workspace does.
- Why the two builds differ: the debug `Store` reset poisons its blocks with `0xAA`, so the second print crashes every time. In release, the freed contents buffer gets a free-list pointer written over its first bytes (the `name` key), and the `Store` slots are reused by the install's parse of the root `package.json`, which gives the rope walk in the Sentry stack.
- Readers of the root entry's tree after the lockfile load, all covered by the one re-parse: the `bun add` / `bun update <name>` / `bun link` write-back and `sync_lockfile` (the Sentry crash), `bun update -i` (#23694), `bun update` with patches (`warn_orphaned_patches`), `bun dedupe` with an empty root, `bun audit --fix`, and the `--frozen-lockfile` error message (`overrides_field_name`). Plain `bun install` only reads `entry.source` after the migration, so it does not crash.
- The open #38775, #38754, and #38804 each add this same print and re-parse to `update_package_json_after_migration` as part of larger behavior changes (all three are in the fold branch #39403). None of them is in 1.4.0. This PR is only the crash fix, so it can land on its own. Whichever lands second gets a conflict in this block that resolves to the same code.
- Not changed here: the `patch --commit` branch in `update_package_json_and_install_with_manager_with_updates` (`updatePackageJSONAndInstall.rs:573`) replaces the root entry's contents the same way without a re-parse. Nothing reads that entry's tree afterwards today, and #38754 reworks that block. Also separate: `bun remove` during a pnpm migration writes its pre-install print back to disk and loses the fields the migration moved. That is a different bug and is tracked on its own.
- Suites run with the debug build: `pnpm-lock-v9` (84 pass), `pnpm-migration`, `pnpm-lock-migration`, `pnpm-comprehensive`, `pnpm-migration-complete` (the last one is a single test that sits near the 5 s default timeout when run next to other files, unrelated to this change). `complex-workspace` and `yarn-lock-migration` need network access and fail here with the release build too.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.1 (4448a2e21)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [372.39ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [531.51ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [188.78ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [164.22ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [227.90ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [170.19ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [258.83ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [214.16ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [445.93ms]
(pass) pnpm-lock.yaml
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [9.21ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [49.92ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [5.92ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [4.76ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [3.30ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [3.40ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [13.91ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [9.93ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [20.87ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at another registry is used for the tarballs [19.37ms]
(pass) pnpm-lock.yaml v9 > named registries > two packages from one unknown re
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.1 (4448a2e21)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [309.70ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [405.45ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [167.07ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [174.28ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [172.30ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [157.78ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [197.44ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [193.97ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [335.05ms]
(pass) pnpm-lock.yaml
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2a65176176
  features     baseline

23 deps, 129 codegen, 1172 objects in 1101ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[6/1243] gen bindgenv2
[7/1243] fetch zlib
[zlib] up to date
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/pnpm.rs                             |  37 ++------
 test/cli/install/migration/pnpm-lock-v9.test.ts | 113 ++++++++++++++++++++++++
 2 files changed, 121 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/install/pnpm.rs                                  4      3      0
test/cli/install/migration/pnpm-lock-v9.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->