### PR TITLE
install: keep versions already pinned in the lockfile installable under minimum-release-age

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1076,6 +1076,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                         && Npm::PackageManifest::is_package_version_too_recent(
                                                             find_result.package, min_age_ms,
                                                         )
+                                                        // minimum-release-age gates new
+                                                        // resolution only: a version the
+                                                        // loaded lockfile already pins
+                                                        // stays installable.
+                                                        && locked_version_in_lockfile(
+                                                            this, name_hash, &version,
+                                                        )
+                                                        .is_none()
                                                     {
                                                         let package_name = this.lockfile.str(&name);
                                                         let min_age_seconds = min_age_ms / MS_PER_S;
@@ -2564,7 +2572,17 @@ fn get_or_put_resolved_package(
                 Npm::FindVersionResult::Err(err_type) => match err_type {
                     Npm::FindVersionError::TooRecent
                     | Npm::FindVersionError::AllVersionsTooRecent => {
-                        return Err(crate::Error::TooRecentVersion);
+                        // minimum-release-age gates new resolution only. A
+                        // version the loaded lockfile already pins for this
+                        // range stays installable (ranges get this through
+                        // `get_package_id`'s satisfies-dedupe, which this
+                        // error path would otherwise never reach).
+                        match locked_version_in_lockfile(this, name_hash, version)
+                            .and_then(|(locked, _)| manifest.find_by_version(locked))
+                        {
+                            Some(locked_result) => Some(locked_result),
+                            None => return Err(crate::Error::TooRecentVersion),
+                        }
                     }
                     Npm::FindVersionError::NotFound => None, // Handle below with existing logic
                 },

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1990,6 +1990,171 @@ describe("minimum-release-age", () => {
       const lockfile = await Bun.file(`${dir}/bun.lock`).text();
       expect(lockfile).toContain("regular-package@2.1.0");
     });
+
+    // https://github.com/oven-sh/bun/issues/40031
+    test("frozen lockfile installs a pinned too-recent version after a catalog: specifier swap", async () => {
+      using dir = tempDir("frozen-catalog-pin", {
+        // The lockfile is created while the dependency is a literal version
+        // (`bun add pkg@x.y.z` rewrites `catalog:` to the literal), then the
+        // user restores `catalog:` in package.json. The specifier mismatch
+        // forces a re-resolution on the next install.
+        "package.json": JSON.stringify({
+          name: "repro",
+          workspaces: { catalog: { "regular-package": "3.0.0" } },
+          dependencies: { "regular-package": "3.0.0" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      let proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-verify"],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/cache-first` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toContain("regular-package@3.0.0");
+
+      await Bun.write(
+        `${dir}/package.json`,
+        JSON.stringify({
+          name: "repro",
+          workspaces: { catalog: { "regular-package": "3.0.0" } },
+          dependencies: { "regular-package": "catalog:" },
+        }),
+      );
+
+      // A cold cache makes the re-resolution fetch the manifest with publish
+      // timestamps, so the age filter sees the pinned version.
+      proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "install",
+          "--frozen-lockfile",
+          "--minimum-release-age",
+          `${5 * SECONDS_PER_DAY}`,
+          "--no-verify",
+        ],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/cache-second` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await proc.stderr.text();
+      expect(stderr).not.toContain("minimum-release-age");
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toContain("regular-package@3.0.0");
+    });
+
+    // https://github.com/oven-sh/bun/issues/40031
+    test("expired cached manifest keeps a pinned too-recent version installable", async () => {
+      using dir = tempDir("expired-manifest-pin", {
+        "package.json": JSON.stringify({
+          name: "repro",
+          workspaces: { catalog: { "regular-package": "3.0.0" } },
+          dependencies: { "regular-package": "3.0.0" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      // A 1 second age gate filters nothing (every version is at least a day
+      // old) but caches the manifest with publish timestamps.
+      let proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", "1", "--no-verify"],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/cache` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toContain("regular-package@3.0.0");
+
+      await Bun.write(
+        `${dir}/package.json`,
+        JSON.stringify({
+          name: "repro",
+          workspaces: { catalog: { "regular-package": "3.0.0" } },
+          dependencies: { "regular-package": "catalog:" },
+        }),
+      );
+
+      // --force disables manifest cache control, so the cached manifest loads
+      // as expired. That takes the exact-version fast path in
+      // enqueue_dependency instead of the manifest resolution path.
+      proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "install",
+          "--frozen-lockfile",
+          "--force",
+          "--minimum-release-age",
+          `${5 * SECONDS_PER_DAY}`,
+          "--no-verify",
+        ],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/cache` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await proc.stderr.text();
+      expect(stderr).not.toContain("minimum release age");
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toContain("regular-package@3.0.0");
+    });
+
+    // https://github.com/oven-sh/bun/issues/40031
+    test("re-resolution keeps a pinned too-recent version when the range still allows it", async () => {
+      using dir = tempDir("range-catalog-pin", {
+        // Same catalog: specifier swap as above, but with a range. Every
+        // version the range accepts is too recent, and 3.0.0 is already
+        // pinned in the lockfile.
+        "package.json": JSON.stringify({
+          name: "repro",
+          workspaces: { catalog: { "regular-package": "^3.0.0" } },
+          dependencies: { "regular-package": "^3.0.0" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      let proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-verify"],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/cache-first` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toContain("regular-package@3.0.0");
+
+      await Bun.write(
+        `${dir}/package.json`,
+        JSON.stringify({
+          name: "repro",
+          workspaces: { catalog: { "regular-package": "^3.0.0" } },
+          dependencies: { "regular-package": "catalog:" },
+        }),
+      );
+
+      proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "install",
+          "--frozen-lockfile",
+          "--minimum-release-age",
+          `${5 * SECONDS_PER_DAY}`,
+          "--no-verify",
+        ],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${dir}/cache-second` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await proc.stderr.text();
+      expect(stderr).not.toContain("minimum-release-age");
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(`${dir}/bun.lock`).text()).toContain("regular-package@3.0.0");
+    });
   });
 
   describe("monorepo with linker modes", () => {


### PR DESCRIPTION
### Problem

- `bun ci` fails with `No version matching "@types/bun" found for specifier "1.4.0" (blocked by minimum-release-age: 1209600 seconds)` even though bun.lock pins `@types/bun@1.4.0` exactly. Fixes #40031.
- The trigger is a specifier mismatch between package.json and bun.lock. In the issue, `bun add pkg@x.y.z` rewrote a `catalog:` reference to the literal version, and the user restored `catalog:`. The mismatch forces a re-resolution, and the age filter in `find_best_version_with_filter` rejects the pinned version (`PackageManagerEnqueue.rs:2564`).
- A second site fails the same way: the exact-version fast path that reads an expired cached manifest (`PackageManagerEnqueue.rs:1067`, `was published within minimum release age`).

### Fix

- When the age filter rejects every candidate (`TooRecent` or `AllVersionsTooRecent`), fall back to a lockfile-loaded version that satisfies the range (`locked_version_in_lockfile`). The same guard skips the error on the exact-version fast path.
- This matches the documented behavior: `minimumReleaseAge` gates new resolution only, and packages already in bun.lock stay unchanged.
- It also matches what ranges already do. A re-resolved range binds to a satisfying lockfile entry through `get_package_id`'s satisfies-dedupe. The error paths bailed out before that check could run.
- Verified: 3 new tests in `test/cli/install/minimum-release-age.test.ts`. All three fail on unfixed bun. The full file (52 tests) plus the catalogs, dedupe, update-transitive, frozen-lockfile, and bun-lock suites pass.

### Background

- `minimumReleaseAge` blocks versions published more recently than N seconds, as protection against fresh malicious releases. `minimumReleaseAgeExcludes` exempts whole packages.
- A `catalog:` specifier resolves through the workspace catalog map to a real version, then resolves like a normal npm dependency.
- The outcome depends on the manifest cache. The filter needs publish timestamps, which only the extended manifest has. The new tests pin `BUN_INSTALL_CACHE_DIR` so each install sees a known cache state.

<details><summary>Notes</summary>

- Reproduction: with a lockfile whose root specifier is the literal version and a package.json that says `catalog:`, `bun ci` re-resolves the dependency. With a cold cache it fetches the extended manifest and fails in `find_best_version_with_filter`. With a warm but expired cached manifest it fails in the exact-version fast path. With a warm abbreviated cached manifest it succeeds, because the abbreviated manifest has no timestamps. That cache dependence is why the tests set explicit cache dirs.
- A widened range (for example `3.0.0` to `^3.0.0`) does not trigger the bug: `Diff::generate` keeps the resolution mapping when the new specifier still satisfies the old resolution, so no re-resolution happens. The range test goes through the catalog swap instead.
- The third test uses `--force` to disable manifest cache control, which is the deterministic way to load the cached manifest as expired and reach the fast-path site.
- `locked_version_in_lockfile` only considers packages loaded from the lockfile (`id < loaded_package_count`), so a fresh resolve session gets no exemption. An install without a lockfile still fails on a too-recent exact version (covered by the existing "handles exact version requests" test).
- Not addressed here: `bun add pkg@version` rewrites a `catalog:` specifier in package.json to the literal version instead of updating the catalog entry. That is the step that creates the mismatch in the first place, and it deserves its own issue.
- Suites run: `minimum-release-age.test.ts` (52), `bun-update-transitive`, `bun-dedupe`, `catalogs`, `bun-add-catalog`, `frozen-lockfile-missing-workspace`, `frozen-lockfile-pruned` (590 together), `bun-lock` (40). The original issue reproduction (`@types/bun@1.4.0` through a catalog with a 14 day gate) installs correctly with the fix, including the transitive `bun-types@1.4.0` pin.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/minimum-release-age.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [278.81ms]
(pass) minimum-release-age > basic filtering > respects float values for days [157.51ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [161.24ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [200.52ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [159.80ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [204.71ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [215.31ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [165.25ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [167.73ms]
(pass) minimum-release-
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [28.83ms]
(pass) minimum-release-age > basic filtering > respects float values for days [14.12ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [13.83ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [24.70ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [6.11ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [31.83ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [12.49ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [18.78ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [12.87ms]
(pass) minimum-release-age > 7-day give-up threshold > stops searching after 7 days beyond minimum age [18.55ms]
(pass) minimum-release-age > 7-day give-up threshold > with daily releases, gets the late
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/minimum-release-age.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [259.91ms]
(pass) minimum-release-age > basic filtering > respects float values for days [154.49ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [162.13ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [197.53ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [164.22ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [192.78ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [181.87ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [157.88ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [167.04ms]
(pass) minimum-release-
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 644ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/79] gen ErrorCode+*.h
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (8990ms)
Bundle modules (39ms)
Postprocesss modules (39ms)
Bundle Functions (699ms)
Generate Code (25ms)

[9.81s] Bundled "src/js" for production
  2621 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[3/7] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semv
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerEnqueue.rs        |  20 ++-
 test/cli/install/minimum-release-age.test.ts       | 165 +++++++++++++++++++++
 2 files changed, 184 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager/PackageManagerEnqueue.rs      3      2      0
test/cli/install/minimum-release-age.test.ts             2      3      0
```

</details>

**root cause** · written by the author bot

The root cause was that when a specifier mismatch between package.json and bun.lock forced re-resolution of a dependency, the minimum-release-age filter was applied even though the exact version was already pinned in the committed lockfile, blocking it at two sites: the TooRecent error path in resolution and the exact-version fast path reading an expired cached manifest. The fix makes both sites fall back to a version already loaded from the lockfile that satisfies the requested range, restoring the documented contract that minimumReleaseAge gates new resolution only. The fallback is scoped…

<!-- robobun:evidence:end -->