### PR TITLE
--hot: reload a replaced entrypoint even when its directory event came first (macOS)

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -415,9 +415,12 @@ pub struct MainFile {
     /// 4. New file gets created and written (a.js)
     /// 5. Parent directory gets NOTE_WRITE
     ///
-    /// To fix this: when the entrypoint gets NOTE_RENAME, we set this flag
-    /// and skip the reload. Then when the parent directory gets NOTE_WRITE,
-    /// we check if the file exists and trigger the reload.
+    /// To fix this: when the entrypoint gets NOTE_RENAME (or NOTE_DELETE:
+    /// XNU reports `unlink(2)` as `NOTE_DELETE | NOTE_LINK`) while its path is
+    /// empty, we set this flag and skip the reload. Then when the parent
+    /// directory gets NOTE_WRITE, we check if the file exists and trigger the
+    /// reload. Never armed once the file is back: its directory event may
+    /// already sit earlier in the same batch.
     pub(crate) is_waiting_for_dir_change: bool,
 }
 
@@ -454,6 +457,11 @@ impl MainFile {
         }
 
         main
+    }
+
+    /// Whether something sits at the entrypoint's path right now.
+    pub(crate) fn exists(&self) -> bool {
+        bun_sys::exists(self.file)
     }
 }
 
@@ -919,23 +927,17 @@ where
                         .intersects(WatchOp::WRITE | WatchOp::DELETE | WatchOp::RENAME)
                     {
                         record_changed_path(file_path);
-                        if IS_KQUEUE {
-                            if event.op.contains(WatchOp::RENAME) {
-                                // Special case for entrypoint: defer reload until we get
-                                // a directory write event confirming the file exists.
-                                // This handles vim's save process which renames the old file
-                                // before the new file is re-created with a different inode.
-                                if self.main.hash == current_hash && !RELOAD_IMMEDIATELY {
-                                    self.main.is_waiting_for_dir_change = true;
-                                    continue;
-                                }
-                            }
-
-                            // If we got a write event after rename, the file is back - proceed with reload
-                            if self.main.is_waiting_for_dir_change && self.main.hash == current_hash
+                        if IS_KQUEUE && self.main.hash == current_hash && !self.main.file.is_empty()
+                        {
+                            // See `MainFile::is_waiting_for_dir_change`.
+                            if !RELOAD_IMMEDIATELY
+                                && event.op.intersects(WatchOp::DELETE | WatchOp::RENAME)
+                                && !self.main.exists()
                             {
-                                self.main.is_waiting_for_dir_change = false;
+                                self.main.is_waiting_for_dir_change = true;
+                                continue;
                             }
+                            self.main.is_waiting_for_dir_change = false;
                         }
 
                         current_task.append(current_hash);
@@ -976,38 +978,14 @@ where
                                 }
 
                                 if event.op.contains(WatchOp::WRITE) {
-                                    // Check if the entrypoint now exists after an atomic save.
-                                    // If we previously got a NOTE_RENAME on the entrypoint (vim renamed
-                                    // the file), this directory write event signals that the new
-                                    // file has been re-created. Verify it exists and trigger reload.
+                                    // See `MainFile::is_waiting_for_dir_change`.
                                     if self.main.is_waiting_for_dir_change
                                         && self.main.dir_hash == current_hash
+                                        && self.main.exists()
                                     {
-                                        // `.is_ok()` only checks faccessat didn't
-                                        // error (it errs only on NAMETOOLONG), not
-                                        // that the file exists; harmless in
-                                        // practice (re-watching a missing
-                                        // entrypoint is a no-op downstream).
-                                        let mut name_buf = [0u8; 256];
-                                        let basename = bun_paths::basename(self.main.file);
-                                        let exists = if basename.len() < name_buf.len() {
-                                            name_buf[..basename.len()].copy_from_slice(basename);
-                                            name_buf[basename.len()] = 0;
-                                            // SAFETY: name_buf[..=basename.len()] is NUL-terminated.
-                                            let z = ZStr::from_buf(&name_buf[..], basename.len());
-                                            bun_sys::faccessat(
-                                                file_descriptors[event.index as usize],
-                                                z,
-                                            )
-                                            .is_ok()
-                                        } else {
-                                            false
-                                        };
-                                        if exists {
-                                            self.main.is_waiting_for_dir_change = false;
-                                            record_changed_path(self.main.file);
-                                            current_task.append(self.main.hash);
-                                        }
+                                        self.main.is_waiting_for_dir_change = false;
+                                        record_changed_path(self.main.file);
+                                        current_task.append(self.main.hash);
                                     }
                                 }
 
@@ -1098,20 +1076,7 @@ where
                                 if changed_name != main_basename {
                                     continue;
                                 }
-                                let main_exists = {
-                                    let mut zbuf = PathBuffer::uninit();
-                                    if self.main.file.len() >= zbuf.len() {
-                                        false
-                                    } else {
-                                        zbuf[..self.main.file.len()]
-                                            .copy_from_slice(self.main.file);
-                                        zbuf[self.main.file.len()] = 0;
-                                        // SAFETY: zbuf is NUL-terminated at len.
-                                        let z = ZStr::from_buf(&zbuf[..], self.main.file.len());
-                                        bun_sys::access(z, libc::F_OK).is_ok()
-                                    }
-                                };
-                                if main_exists {
+                                if self.main.exists() {
                                     record_changed_path(self.main.file);
                                     current_task.append(self.main.hash);
                                 }

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,8 +1,9 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
-import { join } from "path";
+import { copyFileSync, cpSync, existsSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isDebug, isMacOS, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { constants as osConstants } from "node:os";
+import { basename, join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
 const longTimeout = isDebug ? Infinity : 30_000;
@@ -507,6 +508,185 @@ it(
       runner?.unref?.();
       // @ts-ignore
       runner?.kill?.(9);
+    }
+  },
+  timeout,
+);
+
+// Helpers for the two tests below, which replace the --hot entrypoint in ways that depend on the
+// order in which the watcher thread receives the file system events.
+
+// Spawns `bun --hot run root` with the watcher trace enabled: one JSON line per delivered batch,
+// whose "files" keys are the watched paths in delivery order.
+function spawnHotWithTrace(root: string, traceFile: string) {
+  return spawn({
+    cmd: [bunExe(), "--hot", "run", root],
+    env: { ...bunEnv, BUN_WATCHER_TRACE: traceFile },
+    cwd,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+    killSignal: "SIGKILL",
+  });
+}
+
+function traceLines(traceFile: string) {
+  return existsSync(traceFile) ? readFileSync(traceFile, "utf-8").split("\n").filter(Boolean) : [];
+}
+
+// The paths of one trace line in delivery order. Scanned as text because a path can repeat within
+// a batch (split delivery), which JSON.parse would fold.
+function tracePaths(line: string) {
+  return [...line.matchAll(/"((?:[^"\\]|\\.)*)":\{"events"/g)].map(m => JSON.parse(`"${m[1]}"`) as string);
+}
+
+function namesEntrypoint(root: string) {
+  return (line: string) => tracePaths(line).some(p => p.endsWith("/" + basename(root)));
+}
+
+function deliveredEntrypointLast(root: string) {
+  return (line: string) => {
+    const paths = tracePaths(line);
+    return paths.length > 1 && paths.at(-1)!.endsWith("/" + basename(root));
+  };
+}
+
+// Yields the "[#!root] Reloaded: N" lines. A stalled --hot prints nothing at all, so each wait is
+// bounded and a stall is reported together with the batches the watcher received.
+function reloadReader(runner: ReturnType<typeof spawnHotWithTrace>, traceFile: string) {
+  async function* rootLines() {
+    let pending = "";
+    for await (const chunk of runner.stdout) {
+      pending += new TextDecoder().decode(chunk);
+      const lines = pending.split("\n");
+      pending = lines.pop()!;
+      for (const line of lines) if (line.includes("[#!root]")) yield line;
+    }
+  }
+  const lines = rootLines();
+  const STALLED = Symbol("stalled");
+  let reloadCounter = 0;
+  return async function nextReload(): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<typeof STALLED>(resolve => {
+      timer = setTimeout(resolve, 5_000, STALLED);
+    });
+    try {
+      const next = await Promise.race([lines.next(), deadline]);
+      if (next === STALLED || next.done) {
+        throw new Error(`no reload after the replace. delivered batches:\n${traceLines(traceFile).join("\n")}`);
+      }
+      reloadCounter++;
+      expect(next.value).toContain(`[#!root] Reloaded: ${reloadCounter}`);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+// Waits until a trace line past `since` satisfies `predicate` and returns the index after it. A batch
+// is traced before it is handled, and the next batch is traced only once the previous one was
+// handled, so a later line is the proof that an earlier batch has been fully processed.
+async function waitForTraceLine(traceFile: string, since: number, predicate: (line: string) => boolean) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const i = traceLines(traceFile).slice(since).findIndex(predicate);
+    if (i !== -1) return since + i + 1;
+    await Bun.sleep(5);
+  }
+  throw new Error(`the watcher never reported the batch. delivered batches:\n${traceLines(traceFile).join("\n")}`);
+}
+
+// Same rm + rename as above, but arranged so that the --hot process sees the directory's event
+// before the entry point's own event, with nothing after it. On macOS, unlink(2) of the entry point
+// is reported as NOTE_DELETE | NOTE_LINK, which --hot used to answer by waiting for the next
+// directory event; in this ordering that event was already consumed, so the reload never ran.
+// The process is stopped (no SIGSTOP on Windows) while the files change, so that its watcher
+// thread receives everything in one batch once it resumes. The trace tells whether a cycle produced
+// this ordering, and the test repeats the cycle if not.
+it.skipIf(isWindows)(
+  "should hot reload when the deleted and renamed entrypoint's event arrives after its directory's event",
+  async () => {
+    const root = hotRunnerRoot + ".tmp.js";
+    copyFileSync(hotRunnerRoot, root);
+    const traceFile = join(tmpdirSync(), "watcher-trace.log");
+    await using runner = spawnHotWithTrace(root, traceFile);
+    const nextReload = reloadReader(runner, traceFile);
+
+    // Signal numbers from node:os: a signal name is sent with its Linux number on every platform
+    // (#35296), and 19 is SIGCONT on macOS.
+    const { SIGSTOP, SIGCONT } = osConstants.signals;
+    let wakes = 0;
+    async function replaceEntrypointWhileStopped() {
+      const contents = readFileSync(root, "utf-8");
+      runner.kill(SIGSTOP);
+      try {
+        // A stopped process still completes a kevent() that is already waiting: the kernel hands the
+        // watcher thread this one directory event and parks the thread at the return to user space.
+        // Only a new directory entry posts to the directory, so the file name must be fresh each time.
+        // Nothing observable marks that moment, so give it time. A shorter wait cannot fail the test,
+        // it only lets the events below be split into two batches, which the trace check below sees.
+        writeFileSync(`${root}.wake${wakes++}`, "");
+        await Bun.sleep(100);
+        // From here on every event queues up until SIGCONT: the directory (temp file created), then
+        // the entry point (unlinked). The directory writes of the rm and the rename fold into the
+        // directory's queued event, so the entry point's event is the last one delivered.
+        writeFileSync(root + ".tmpfile", contents);
+        rmSync(root);
+        renameSync(root + ".tmpfile", root);
+      } finally {
+        runner.kill(SIGCONT);
+      }
+    }
+
+    // A cycle counts on macOS only if the trace shows the ordering under test. inotify reports the
+    // replace through the directory alone (the entry point is named in "changed"), so there every
+    // cycle counts.
+    const ordered = deliveredEntrypointLast(root);
+    function cycleCounts(since: number) {
+      return !isMacOS || traceLines(traceFile).slice(since).some(ordered);
+    }
+
+    await nextReload();
+    let countedCycles = 0;
+    for (let cycle = 0; cycle < 5 && countedCycles < 2; cycle++) {
+      const since = traceLines(traceFile).length;
+      await replaceEntrypointWhileStopped();
+      await nextReload();
+      if (cycleCounts(since)) countedCycles++;
+    }
+
+    expect(countedCycles, `delivered batches:\n${traceLines(traceFile).join("\n")}`).toBe(2);
+  },
+  timeout,
+);
+
+// The other half of the same wait: the entry point is removed, and the replacement is renamed into
+// place only after the watcher has handled the removal. The rm's own directory write arrives while
+// the path is still empty and must not end the wait, or the rename afterwards has nothing left to
+// trigger. Needs the kqueue event shape, so macOS only.
+it.skipIf(!isMacOS)(
+  "should hot reload when the entrypoint is renamed into place only after its removal was seen",
+  async () => {
+    const root = hotRunnerRoot + ".tmp.js";
+    copyFileSync(hotRunnerRoot, root);
+    const traceFile = join(tmpdirSync(), "watcher-trace.log");
+    await using runner = spawnHotWithTrace(root, traceFile);
+    const nextReload = reloadReader(runner, traceFile);
+
+    await nextReload();
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const contents = readFileSync(root, "utf-8");
+      writeFileSync(root + ".tmpfile", contents);
+      const since = traceLines(traceFile).length;
+      rmSync(root);
+      const afterRemoval = await waitForTraceLine(traceFile, since, namesEntrypoint(root));
+      // A harmless directory write: once its batch is traced, the removal's batch has been handled
+      // and the wait for the entry point is armed.
+      writeFileSync(`${root}.barrier${cycle}`, "");
+      await waitForTraceLine(traceFile, afterRemoval, () => true);
+      renameSync(root + ".tmpfile", root);
+      await nextReload();
     }
   },
   timeout,


### PR DESCRIPTION
### Problem
- On macOS, `bun --hot` can stop reloading after `rm entry.js && mv tmp entry.js`, with no error. This is the `hot.test.ts` "renamed() into place" flake (6 recent PR builds).
- XNU reports `unlink(2)` as `NOTE_DELETE | NOTE_LINK`, which Bun maps to `Op::RENAME`. So the `rm` arms `is_waiting_for_dir_change` (`src/jsc/hot_reloader.rs:928`, old) and waits for the next directory write event. That event is already spent: the temp file write activated the directory's knote first, and `EV_CLEAR` folded the `rm` and `mv` into it, so the batch is [directory, entry].
- The other side is wrong too: `bun_sys::faccessat` never errors, so its `.is_ok()` (old line 1004) was always true. Any directory write ended the wait, even while the entry was still missing.

### Fix
- Arm the flag only while the entry's path is empty (`MainFile::exists`), reload at once if the replacement is already there, and end the wait only when the path is populated again. The inotify recovery path uses the same helper.
- Correct because the path's state decides on both sides, not the event order. A replacement present at either check is reloaded. A missing one keeps the wait armed, and the write that brings it back always comes after the check.
- Verified: two new `hot.test.ts` cases, one per side, checked through the watcher trace. Without the fix the first stalls on darwin (build 103225), with it both pass there (build 103251 for the first). The whole file passes locally.

### Background
- `--hot` puts a kqueue knote on each loaded file and its directory. The watcher thread reads and handles events in batches, in order.
- With `EV_CLEAR`, a knote collects flags until read, so changes to one directory between two reads become one event, placed where the first change activated it.
- `is_waiting_for_dir_change` serves vim's save (rename `a.js` away, write a new `a.js`): the reload waits for the directory's write event that brings the file back.

<details><summary>Notes</summary>

Staged verification. The PR first holds only the test, so the darwin lanes run it against the unfixed code. The fix is pushed after that run.

- Test alone (unfixed), first version: build 103154 passed it on darwin aarch64 (sourdough-tart-15-1). That version only stopped the child around the three file operations. A stopped process still completes a `kevent()` that is already waiting: XNU's `kqueue_scan` sleeps with `THREAD_ABORTSAFE` and SIGSTOP only calls `task_suspend_internal` (no wait abort), so the first write woke the watcher thread, which harvested the queue at once and parked at the return to user space. Whether the rm and rename were already done at that instant decided the batch split, the same race as the original test.
- Test alone (unfixed), third version: build 103208 on darwin aarch64 (the macOS 26 mini) reloaded in all five cycles and the trace counted none of them as the ordering under test. The child was never stopped: `Subprocess.kill("SIGSTOP")` resolves the name through the Linux-numbered signal table (`bun_core::for_each_signal`, SIGSTOP = 19) and `Process::kill` passes that number to `kill(2)` unchanged. On macOS 19 is SIGCONT, and 18 ("SIGCONT") is SIGTSTP. This is #35296 (`Subprocess.kill` with a signal name, and `signalCode` reporting, use Linux numbers); #39970 fixes it. Not fixed here.
- Test alone (unfixed), fourth version (66471c7): signals sent by number from `node:os`. Build 103225, darwin aarch64 (darwin-aarch64-26.6.1-1), both attempts of the file failed after 5 s with `no reload after the replace. delivered batches:` followed by one line: the directory with `["write"]`, then the entry with `["delete","rename"]`. That is the ordering from the Problem section, the `rename` bit on a plain unlink included, and the old code never reloaded after it. Linux passed.
- Test plus fix (972bc1b): build 103251, darwin aarch64 (darwin-arm64-challah-tart-26-1, macOS 26.4 guest) and darwin x64 (darwin-x64-14.8.9-1): `hot.test.ts` 13 pass, 0 fail on both. The new test needs two cycles with the [directory, entry] ordering to pass, so the fixed code reloaded from that batch twice on each. The other red in that build is the pre-existing `bun-audit` snapshot break and flakes that passed on retry.

The test wakes the parked watcher once with a new file, waits 100 ms, then does the three operations. They queue as [directory, entry] with no harvest in between, because the thread is parked, not waiting. Each cycle is checked against the trace and repeated if the ordering did not occur. A stall is reported with the delivered batches.

XNU sources: `VNOP_REMOVE` in bsd/vfs/kpi_vfs.c posts `NOTE_DELETE | NOTE_LINK` to the file and `NOTE_WRITE` to the directory. `filt_vnode_common` in bsd/vfs/vfs_vnops.c does `if (kn->kn_sfflags & hint) kn->kn_fflags |= hint`, so the knote reports `NOTE_LINK` although Bun registers only `NOTE_WRITE | NOTE_RENAME | NOTE_DELETE`.

Why the existing test fails only on some machines: with a fast watcher wake-up, the first `kevent` returns the directory event from the temp file write alone. The 100 microsecond coalescing read in `watch_loop_cycle` then returns the entry's event followed by a second directory event (`VNOP_REMOVE` posts to the file before the directory), and that second directory event performs the reload. The stall needs the temp file write, the `rm`, and the `mv` to all land before the first read returns. The 6 occurrences (builds 101968, 102916, 102954, 102959, 102980, 102999) were all on darwin aarch64 tart guests running macOS 15, with `hot.test.ts` among the first 3 to 12 files of the run. The child printed nothing to stderr in any of them, which rules out a reload that ran and failed.

"should hot reload when a file is deleted and rewritten" does not hit this. Its first operation is the `rm`, which activates the entry's knote before the directory's, so the batch order is [entry, directory].

Linux can not show the failure. On inotify the entry's delete enqueues a reload at once, and the directory event that names the entry enqueues another one (the `!IS_KQUEUE` block in the directory arm). The new test passes there with and without the fix. It still runs there as coverage of batched delivery.

The completion half (directory arm): `bun_sys::faccessat` is documented "Never errors; any non-zero rc -> Ok(false)" (src/sys/lib.rs), so the old `.is_ok()` was a constant true and the in-code note called it harmless. It is not: with `rm entry` and a later `mv tmp entry`, the rm's own directory write ended the wait while the path was still empty, the reload failed with ENOENT, `add_main_to_watcher_if_needed` could not re-add a missing file, and the later `mv` triggered nothing. The second new test covers this: it removes the entry, waits until the trace shows the watcher handled the removal, then renames the replacement into place. This side is kqueue only, so that test is macOS only. Its pass-after run is build 103506 (head 3cf12e3, rebased onto main): `hot.test.ts` 14 pass, 0 fail on darwin aarch64 (macOS 15.7.7 guest) and darwin x64 (macOS 14.8). The other red in that build is a GitHub API 504 in `GHSA-pfwx-36v6-832x.test.ts` and flakes that passed on retry.

`MainFile::exists` is also evaluated for a bare `NOTE_DELETE`, which XNU posts to a file replaced by `rename(2)`. The replacement is in place when the event is posted, so that case still reloads at once. FreeBSD posts a bare `NOTE_DELETE` for `unlink(2)`, so there the check turns a failing immediate reload into a deferred one.

Ruled out before this fix: the `udata` rewrite in `flush_evictions`, fd ownership in the transpiler stores, `need_to_close_files`, and the deferred reload in `VirtualMachine::reload`.

Related, not overlapping: #36416 changes which flags the watcher registers, not how the entry's events are handled. #33073 (imported files deleted and recreated, inotify side) is the natural follow-up that could retire `is_waiting_for_dir_change` by routing the entry through the same recreate tracking.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->