### PR TITLE
test: keep audit fixture advisory range clear of Bun.version

### DIFF
--- a/test/cli/install/__snapshots__/bun-audit.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-audit.test.ts.snap
@@ -37,7 +37,7 @@ fresh@0.3.0
 
 mime@1.3.4
   express > send > mime
-  high: mime Regular Expression Denial of Service when MIME lookup performed on untrusted user input (<1.4.1) - https://github.com/advisories/GHSA-wrvr-8mpx-r7pp
+  high: mime Regular Expression Denial of Service when MIME lookup performed on untrusted user input (<1.3.5) - https://github.com/advisories/GHSA-wrvr-8mpx-r7pp
 
 minimist@0.0.8
   express > mkdirp > minimist
@@ -261,7 +261,7 @@ exports[`\`bun audit\` should print valid JSON and exit 1 when --json is passed 
       "severity": "high",
       "title": "mime Regular Expression Denial of Service when MIME lookup performed on untrusted user input",
       "url": "https://github.com/advisories/GHSA-wrvr-8mpx-r7pp",
-      "vulnerable_versions": "<1.4.1",
+      "vulnerable_versions": "<1.3.5",
     },
   ],
   "minimist": [

--- a/test/cli/install/registry/fixtures/audit/audit-fixtures.json
+++ b/test/cli/install/registry/fixtures/audit/audit-fixtures.json
@@ -243,7 +243,7 @@
 				"url": "https://github.com/advisories/GHSA-wrvr-8mpx-r7pp",
 				"title": "mime Regular Expression Denial of Service when MIME lookup performed on untrusted user input",
 				"severity": "high",
-				"vulnerable_versions": "<1.4.1",
+				"vulnerable_versions": "<1.3.5",
 				"cwe": [
 					"CWE-400"
 				],


### PR DESCRIPTION
normalizeBunSnapshot replaces the current Bun version string. The mime advisory fixture used `<1.4.1`, which collided once Bun became 1.4.1 and broke the `bun-audit.test.ts` snapshot on every platform. Moved the range to `<1.3.5` (mime@1.3.4 still matches).