### PR TITLE
test: cover terminate() on a TLS socket sending a bare RST

### DIFF
--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4479,9 +4479,8 @@ describe.concurrent("close() error after the peer resets the connection", () => 
   describe.each(["tcp", "tls"] as const)("%s", transport => {
     // The peer lives in a child process that is killed while data it never read sits
     // in its receive buffer: the kernel then closes its socket with an RST, and
-    // nothing (no FIN, and for TLS no close_notify) is queued ahead of the reset. An
-    // in-process terminate() is not usable for the TLS case: it writes a close_notify
-    // first, and on POSIX the reading side consumes that as a clean end.
+    // nothing (no FIN, and for TLS no close_notify) is queued ahead of the reset.
+    // The second test resets from inside this process with terminate() instead.
     const peerSource = `
       await Bun.connect({
         hostname: "127.0.0.1",
@@ -4545,45 +4544,56 @@ describe.concurrent("close() error after the peer resets the connection", () => 
 
       expect(closeErrorShape(await closedWith.promise)).toEqual(readReset);
     });
-  });
 
-  it("a connected socket reports the reset the same way (tcp)", async () => {
-    // Plain TCP terminate() queues nothing ahead of the RST, so the server side of
-    // the same process can reset the connection.
-    const accepted = Promise.withResolvers<Socket>();
-    using listener = Bun.listen({
-      hostname: "127.0.0.1",
-      port: 0,
-      socket: {
-        open(socket) {
-          accepted.resolve(socket);
-          socket.write("greeting");
+    it("a connected socket reports the accepted socket's terminate() the same way", async () => {
+      // terminate() queues nothing ahead of the RST. For tls that means no close_notify:
+      // a reading peer takes a close_notify as a clean end (close() without an error),
+      // and on POSIX the queued alert is delivered before the reset behind it.
+      const accepted = Promise.withResolvers<Socket>();
+      const greet = (socket: Socket) => {
+        accepted.resolve(socket);
+        socket.write("greeting");
+      };
+      using listener = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: transport === "tls" ? tls : undefined,
+        socket: {
+          open(socket) {
+            if (transport === "tcp") greet(socket);
+          },
+          handshake(socket, success, authorizationError) {
+            if (success) greet(socket);
+            else accepted.reject(authorizationError ?? new Error("server handshake failed"));
+          },
+          data() {},
+          close() {},
         },
-        data() {},
-        close() {},
-      },
-    });
+      });
 
-    const greeted = Promise.withResolvers<void>();
-    const closedWith = Promise.withResolvers<CloseError>();
-    await Bun.connect({
-      hostname: "127.0.0.1",
-      port: listener.port,
-      socket: {
-        data: () => greeted.resolve(),
-        connectError: (_socket, error) => greeted.reject(error),
-        close(_socket, error) {
-          greeted.reject(new Error("the connected socket closed before the greeting arrived"));
-          closedWith.resolve(error as CloseError);
+      const greeted = Promise.withResolvers<void>();
+      const closedWith = Promise.withResolvers<CloseError>();
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: listener.port,
+        tls: transport === "tls" ? { ca: tls.cert } : undefined,
+        socket: {
+          data: () => greeted.resolve(),
+          error: (_socket, error) => greeted.reject(error),
+          connectError: (_socket, error) => greeted.reject(error),
+          close(_socket, error) {
+            greeted.reject(new Error("the connected socket closed before the greeting arrived"));
+            closedWith.resolve(error as CloseError);
+          },
         },
-      },
+      });
+
+      const server = await accepted.promise;
+      await greeted.promise;
+      server.terminate();
+
+      expect(closeErrorShape(await closedWith.promise)).toEqual(readReset);
     });
-
-    const server = await accepted.promise;
-    await greeted.promise;
-    server.terminate();
-
-    expect(closeErrorShape(await closedWith.promise)).toEqual(readReset);
   });
 });
 


### PR DESCRIPTION
### Problem
- #39632 made `terminate()` on a TLS socket send only an RST, with no close_notify. No test in the tree fails when that change is reverted: the tls reset tests in `node-tls-server.test.ts` and `socket.test.ts` pass either way on Linux.
- #40006 is the branch #39632 was merged from, plus one commit. Its tests pass on main because the fix is on main. The rest of that commit is covered by #39893 (merged) and #39903 (open).

### Fix
- `test/js/bun/net/socket.test.ts`: the in-process `terminate()` case in "close() error after the peer resets the connection" now runs for tls as well as tcp. The accepted TLS socket calls `terminate()`, and the connected peer must get `close(socket, error)` with `read ECONNRESET`.
- Before #39632 the peer got a clean close: the close_notify queued ahead of the RST was consumed as an end of stream. The comment that said an in-process TLS `terminate()` is not usable here was stale and is removed.
- Verified: a debug build of main with only the `LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET` check at `packages/bun-usockets/src/crypto/openssl.c:1960` reverted fails the tls case (`reported: false`, no code). The same build with the line restored passes 5 of 5 runs. Also `bun test` with bun 1.3.13 fails 20 of 20, and the 1.4.0 canary passes 20 of 20.

### Background
- `terminate()` closes with code 1 (`CloseCode::failure`): `SO_LINGER{1,0}` so the kernel sends an RST. For TLS, `us_internal_ssl_close` used to run `SSL_shutdown` first for every non-zero code, which wrote a close_notify alert before the RST.
- A peer that reads a close_notify gets `SSL_ERROR_ZERO_RETURN` and closes cleanly. Only a bare RST reaches it as a read error, which is what node's `resetAndDestroy()` produces.

<details><summary>Notes</summary>

- This PR has no `src/` or `packages/` change. The fix is on main (4199361edf). The test is the missing proof for it.
- Local revert used for the fail-before run: `if (ssl_handle_shutdown(s, code != 0))` in place of `if (code == LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET || ssl_handle_shutdown(s, code != 0))`. The tcp case and the two child-process cases pass both ways.
- Whole file on the debug build: 86 pass, 6 skip, 9 fail. The same 9 fail on main in this container (`socket` block, `localhost` resolution and external network), as noted in #39615.
- #39653 rewrites the same comment lines in `socket.test.ts` and adds no test. Whichever lands second has a one-hunk merge.
- Windows: the kernel discards the receive queue on a reset, so the tls case passes there with or without #39632. The proof is the Linux run above.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->