### PR TITLE
node:net, node:http: emit listen() results on the next tick, not from a 1 ms timer

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -487,6 +487,7 @@ Server.prototype.close = function (optionalCallback?) {
   if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
   this.listening = false;
   server.closeIdleConnections();
+  // stop() queues the task that emits 'close', which holds the loop one more turn, as node's uv_close() does.
   server.stop();
   return this;
 };
@@ -534,7 +535,7 @@ Server.prototype.address = function () {
 
 Server.prototype.listen = function () {
   const server = this;
-  let port, host, onListen;
+  let port, host;
   let socketPath;
   let tls = this[tlsSymbol];
 
@@ -580,14 +581,15 @@ Server.prototype.listen = function () {
 
   const lastArg = arguments[argc - 1];
   if ($isCallable(lastArg)) {
-    onListen = lastArg;
+    // Before the bind, as in node, so a listen() retried from the 'error' handler still calls it.
+    this.once("listening", lastArg);
   }
 
   try {
     // listenInCluster
 
     if (isPrimary) {
-      server[kRealListen](tls, port, host, socketPath, false, onListen);
+      server[kRealListen](tls, port, host, socketPath, false);
       return this;
     }
 
@@ -611,7 +613,7 @@ Server.prototype.listen = function () {
       process.send(message, undefined, kInternalSendOptions);
     });
 
-    server[kRealListen](tls, port, host, socketPath, true, onListen);
+    server[kRealListen](tls, port, host, socketPath, true);
   } catch (err) {
     process.nextTick(emitListenErrorNextTick, server, err);
   }
@@ -619,7 +621,7 @@ Server.prototype.listen = function () {
   return this;
 };
 
-Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort, onListen) {
+Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort) {
   {
     const ResponseClass = this[optionsSymbol].ServerResponse || ServerResponse;
     const RequestClass = this[optionsSymbol].IncomingMessage || IncomingMessage;
@@ -1062,10 +1064,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 
     if (this?._unref) {
       this[serverSymbol]?.unref?.();
-    }
-
-    if ($isCallable(onListen)) {
-      this.once("listening", onListen);
     }
 
     // A tick, not a timer, as in node: a timer never fires on its own under jest.useFakeTimers().

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -231,6 +231,10 @@ function emitListeningNextTick(self, hostname, port) {
   }
 }
 
+function emitListenErrorNextTick(self, err) {
+  self.emit("error", err);
+}
+
 // Node.js only requests a client certificate when `requestCert: true`.
 // The uSockets SSL context treats `ca` alone as "verify peer", so without
 // these two flags an `https.Server({ ca })` would reject every client that
@@ -609,7 +613,7 @@ Server.prototype.listen = function () {
 
     server[kRealListen](tls, port, host, socketPath, true, onListen);
   } catch (err) {
-    setTimeout(() => server.emit("error", err), 1);
+    process.nextTick(emitListenErrorNextTick, server, err);
   }
 
   return this;
@@ -1064,7 +1068,9 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       this.once("listening", onListen);
     }
 
-    setTimeout(emitListeningNextTick, 1, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
+    // A tick, not a timer, as in node. A timer here sits in the bun:test fake timer heap while
+    // jest.useFakeTimers() is active and never fires on its own.
+    process.nextTick(emitListeningNextTick, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
   }
 };
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -224,11 +224,10 @@ function onNodeHTTPServerSocketTimeout() {
 }
 
 function emitListeningNextTick(self, hostname, port) {
-  if ((self.listening = !!self[serverSymbol])) {
-    // TODO: remove the arguments
-    // Note does not pass any arguments.
-    self.emit("listening", null, hostname, port);
-  }
+  // Nothing to announce if close() ran in the same tick as listen().
+  if (!self[serverSymbol]) return;
+  // Node passes no arguments. The extra ones are a Bun extension.
+  self.emit("listening", null, hostname, port);
 }
 
 function emitListenErrorNextTick(self, err) {
@@ -1059,6 +1058,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       },
     });
 
+    // Bun.serve() has bound and listened by now, so the flag is true at once, as node's getter is.
+    this.listening = true;
     getBunServerAllClosedPromise(this[serverSymbol]).$then(emitCloseNTServer.bind(this));
     applyServerCustomOptions(this);
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1068,8 +1068,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       this.once("listening", onListen);
     }
 
-    // A tick, not a timer, as in node. A timer here sits in the bun:test fake timer heap while
-    // jest.useFakeTimers() is active and never fires on its own.
+    // A tick, not a timer, as in node: a timer never fires on its own under jest.useFakeTimers().
     process.nextTick(emitListeningNextTick, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
   }
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3864,7 +3864,11 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
     );
   } catch (err) {
     const isUnix = path != null;
-    setTimeout(emitErrorNextTick, 1, this, formatListenError(err, isUnix ? path : hostname, isUnix ? undefined : port));
+    process.nextTick(
+      emitErrorNextTick,
+      this,
+      formatListenError(err, isUnix ? path : hostname, isUnix ? undefined : port),
+    );
   }
   return this;
 };
@@ -4154,7 +4158,7 @@ function listenInCluster(
         server[kClusterUnixPath] = undefined;
         handle[kClusterOwner] = null;
         handle.close();
-        setTimeout(emitErrorNextTick, 1, server, err);
+        process.nextTick(emitErrorNextTick, server, err);
       }
       return;
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3578,6 +3578,8 @@ Server.prototype.close = function close(callback) {
   if (this._handle) {
     if (typeof this._handle.stop === "function") {
       this._handle.stop(false);
+      // Node's uv_close() keeps the loop alive for one more turn (test-process-beforeexit); so does this.
+      setImmediate(noop);
       // Released here, not on 'close': https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2434-L2437
       const clusterHandle = this[kClusterHandle];
       if (clusterHandle) {
@@ -3966,14 +3968,8 @@ Server.prototype[kRealListen] = function (
   // Unref the handle if the server was unref'ed prior to listening
   if (this._unref) this.unref();
 
-  // We must schedule the emitListeningNextTick() only after the next run of
-  // the event loop's IO queue. Otherwise, the server may not actually be listening
-  // when the 'listening' event is emitted.
-  //
-  // That leads to all sorts of confusion.
-  //
-  // process.nextTick() is not sufficient because it will run before the IO queue.
-  setTimeout(emitListeningNextTick, 1, this);
+  // A tick, not a timer, so a close() from 'listening' runs before the loop accepts anything (as in Node).
+  process.nextTick(emitListeningNextTick, this);
 };
 
 Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, sock) {
@@ -4182,7 +4178,7 @@ Server.prototype[kClusterFauxListen] = function (handle, backlog, path) {
   handle[kClusterOwner] = this;
   handle.listen(backlog || 511);
   if (this._unref) this.unref();
-  setTimeout(emitListeningNextTick, 1, this);
+  process.nextTick(emitListeningNextTick, this);
 };
 
 function onClusterConnection(err, clientHandle) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3578,8 +3578,7 @@ Server.prototype.close = function close(callback) {
   if (this._handle) {
     if (typeof this._handle.stop === "function") {
       this._handle.stop(false);
-      // Node's uv_close() keeps the loop alive for one more turn (test-process-beforeexit). The native
-      // listener unrefs at once (Listener::do_stop), unlike sockets (KeepAlive::unref_on_next_tick), so hold it here.
+      // Listener::do_stop unrefs the loop at once; hold it one turn like node's uv_close() (test-process-beforeexit).
       setImmediate(noop);
       // Released here, not on 'close': https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2434-L2437
       const clusterHandle = this[kClusterHandle];

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3578,7 +3578,8 @@ Server.prototype.close = function close(callback) {
   if (this._handle) {
     if (typeof this._handle.stop === "function") {
       this._handle.stop(false);
-      // Node's uv_close() keeps the loop alive for one more turn (test-process-beforeexit); so does this.
+      // Node's uv_close() keeps the loop alive for one more turn (test-process-beforeexit). The native
+      // listener unrefs at once (Listener::do_stop), unlike sockets (KeepAlive::unref_on_next_tick), so hold it here.
       setImmediate(noop);
       // Released here, not on 'close': https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2434-L2437
       const clusterHandle = this[kClusterHandle];

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,4 +1,7 @@
 import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
 import path from "node:path";
 
 test("we can go back in time", () => {
@@ -113,4 +116,53 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
   // null => exited on its own; non-null => killed by the spawn timeout (spun).
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
+});
+
+describe.each([
+  ["net", () => net.createServer()],
+  ["http", () => http.createServer()],
+])("%s.Server#listen() while fake timers are active", (_, createServer) => {
+  test("emits 'listening' without fake time being advanced", async () => {
+    jest.useFakeTimers();
+    try {
+      const server = createServer();
+      try {
+        const listening = once(server, "listening");
+        server.listen(0, "127.0.0.1");
+        // The deferred emit must not be a timer, or it would sit in the fake heap.
+        expect(jest.getTimerCount()).toBe(0);
+        await listening;
+        expect(server.listening).toBe(true);
+        expect(server.address()).toMatchObject({ address: "127.0.0.1", port: expect.any(Number) });
+      } finally {
+        server.close();
+      }
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("emits 'error' for a port that is in use without fake time being advanced", async () => {
+    const holder = createServer();
+    try {
+      holder.listen(0, "127.0.0.1");
+      await once(holder, "listening");
+      const { port } = holder.address() as net.AddressInfo;
+
+      jest.useFakeTimers();
+      try {
+        const server = createServer();
+        const errored = once(server, "error");
+        server.listen(port, "127.0.0.1");
+        expect(jest.getTimerCount()).toBe(0);
+        const [err] = await errored;
+        expect(err).toMatchObject({ code: "EADDRINUSE" });
+        expect(server.listening).toBe(false);
+      } finally {
+        jest.useRealTimers();
+      }
+    } finally {
+      holder.close();
+    }
+  });
 });

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -62,6 +62,130 @@ process.on('message', (m, server) => {
     });
   });
 
+  // The receiver's first poll of the adopted descriptor accepts everything queued in its backlog, so
+  // the 'message' listener has to hold the server before that poll. The server is emitted from its
+  // 'listening' event; while that was a 1ms timer, the poll ran first and the connections landed on a
+  // server nobody was listening on.
+  test.concurrent(
+    "connections queued before a net.Server handoff reach the receiver's 'connection' listener",
+    async () => {
+      using dir = tempDir("ipc-handle-server-backlog", {
+        "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const N = 20;
+const child = fork('child.js');
+const server = net.createServer();
+let served = 0;
+let report;
+
+function finish(extra) {
+  console.log(JSON.stringify({ served, ...report, ...extra }));
+  child.kill();
+  process.exit(0);
+}
+
+child.on('exit', code => finish({ childExit: code }));
+child.on('message', m => {
+  report = m;
+  // A connection accepted before the child held the server is never served: stop waiting for it.
+  if (m.acceptedBeforeDelivery !== 0 || served === N) finish();
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address();
+  child.send('srv', server);
+  // send() duplicated the descriptor, so the socket keeps listening after the parent closes its own
+  // copy: the connections below queue up in the backlog and only the child can accept them.
+  server.close();
+  for (let i = 0; i < N; i++) {
+    const client = net.connect(port, '127.0.0.1');
+    client.setEncoding('utf8');
+    let data = '';
+    client.on('data', c => (data += c));
+    client.on('end', () => {
+      if (data === 'C') served++;
+      if (served === N && report) finish();
+    });
+    client.on('error', e => finish({ clientError: e.message }));
+  }
+});
+`,
+        "child.js": `
+process.on('message', (m, server) => {
+  server.on('connection', s => s.end('C'));
+  process.send({ acceptedBeforeDelivery: server._connections });
+});
+`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "parent.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+        out: { served: 20, acceptedBeforeDelivery: 0 },
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  // A plain message sent after a handle is only written once the handle is acked, so the receiver
+  // has to emit the handle before it reads that message. A received net.Server is emitted from its
+  // 'listening' event; while that was a 1ms timer, it fired after the message behind it had been read.
+  test.concurrent("a net.Server handle is delivered before the message sent after it", async () => {
+    using dir = tempDir("ipc-handle-send-order", {
+      "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const child = fork('child.js');
+let report;
+child.on('message', m => { report = m; });
+child.on('close', code => console.log(JSON.stringify({ ...report, code })));
+const server = net.createServer().listen(0, '127.0.0.1', () => {
+  child.send('srv', server, () => server.close());
+  child.send('after-handle');
+});
+`,
+      "child.js": `
+const order = [];
+function record(event) {
+  order.push(event);
+  if (order.length === 3) {
+    process.send({ order });
+    process.disconnect();
+  }
+}
+process.on('message', (m, server) => {
+  if (server) {
+    server.close();
+    record('handle:' + m);
+    return;
+  }
+  record(m);
+  setImmediate(() => record('immediate'));
+});
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { order: ["handle:srv", "after-handle", "immediate"], code: 0 },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test
     .skipIf(!node)
     .concurrent("bun parent -> node child: the user message survives the NODE_HANDLE envelope", async () => {
@@ -608,10 +732,11 @@ process.on('disconnect', () => process.exit(sawQueued ? 0 : 3));
   );
 
   // The child sends a server and disconnects at once. node: process.connected drops immediately, a
-  // second disconnect() errors, and the parent still receives the server (its adoption completes a
-  // loop turn later, which must not lose it) as well as the message queued behind it. Order is not
-  // pinned: bun currently emits the late-adopted handle after 'disconnect', node before it.
-  test.concurrent("a handle sent right before the child's disconnect() is still delivered", async () => {
+  // second disconnect() errors, and the parent receives the server, then the message queued behind
+  // it (the child only sends it once the handle is acked), then 'disconnect'. The parent reports on
+  // 'close', which a fork()ed child reaches only after 'exit', the IPC 'disconnect' and the end of
+  // the stderr pipe; 'exit' alone can run before the other two.
+  test.concurrent("a handle sent right before the child's disconnect() is delivered, in send order", async () => {
     using dir = tempDir("ipc-handle-then-disconnect", {
       "parent.js": `
 const { fork } = require('node:child_process');
@@ -621,7 +746,7 @@ let childReport = '';
 child.stderr.on('data', d => { childReport += d; });
 child.on('message', (m, h) => { got.push(h ? 'handle:' + m : m); if (h) h.close(); });
 child.on('disconnect', () => got.push('disconnect'));
-child.on('exit', code => console.log(JSON.stringify({ got: got.sort(), code, child: JSON.parse(childReport) })));
+child.on('close', code => console.log(JSON.stringify({ got, code, child: JSON.parse(childReport) })));
 `,
       "child.js": `
 const net = require('node:net');
@@ -647,7 +772,7 @@ const server = net.createServer().listen(0, '127.0.0.1', () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
       out: {
-        got: ["after-handle", "disconnect", "handle:srv"],
+        got: ["handle:srv", "after-handle", "disconnect"],
         code: 0,
         child: { connectedAfterDisconnect: false, secondDisconnect: "ERR_IPC_DISCONNECTED" },
       },

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -661,6 +661,52 @@ test.each(["net", "http"])("cluster 'listening' reports the address a %s server 
   }
 });
 
+// Node registers the listen() callback before the worker's own 'listening' listener that notifies
+// the primary. So the callback still sees worker.state 'online', and the primary receives what the
+// callback sends before cluster emits 'listening'.
+const listenCallbackOrderFixture = `
+const cluster = require("node:cluster");
+
+if (cluster.isPrimary) {
+  const order = [];
+  const worker = cluster.fork();
+  const done = () => {
+    if (order.length < 2) return;
+    console.log(JSON.stringify(order));
+    worker.kill();
+    process.exit(0);
+  };
+  worker.on("message", message => {
+    order.push("callback:" + message.state);
+    done();
+  });
+  cluster.on("listening", () => {
+    order.push("cluster:listening");
+    done();
+  });
+  worker.on("exit", (code, signal) => {
+    console.error("worker exited before it finished listening (" + code + ", " + signal + ")");
+    process.exit(1);
+  });
+} else {
+  const { createServer } = require("node:" + process.env.MODULE);
+  createServer(() => {}).listen(0, () => process.send({ state: cluster.worker.state }));
+}
+`;
+
+test.each(["net", "http"])(
+  "a %s server's listen() callback runs before the worker reports 'listening'",
+  async moduleName => {
+    const dir = tempDirWithFiles("cluster-listen-callback", { "fixture.js": listenCallbackOrderFixture });
+    const { stdout, stderr, exitCode } = await bunRun(joinP(dir, "fixture.js"), { MODULE: moduleName });
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify(["callback:online", "cluster:listening"]),
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
+
 test("round-robin worker connection socket has connecting=false and remoteAddress synchronously", async () => {
   const dir = tempDirWithFiles("bun-test", {
     "main.ts": `

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -160,6 +160,37 @@ describe("node:http", () => {
       server.close();
     });
 
+    // Like net.Server, http.Server reports the listen() result from process.nextTick, not a timer.
+    // No host argument: with one, Node resolves it through dns.lookup first, which adds a tick.
+    it("emits 'listening' on the next tick, before the event loop polls", async () => {
+      const server = createServer();
+      const order: string[] = [];
+      server.on("listening", () => order.push("listening"));
+      server.listen(0);
+      process.nextTick(() => order.push("nextTick"));
+      await once(server, "listening");
+      server.close();
+      await once(server, "close");
+      expect(order).toEqual(["listening", "nextTick"]);
+    });
+
+    it("emits a listen() error on the next tick, before the event loop polls", async () => {
+      const occupant = createServer();
+      occupant.listen(0);
+      await once(occupant, "listening");
+      const { port } = occupant.address() as AddressInfo;
+
+      const server = createServer();
+      const order: string[] = [];
+      server.on("error", (err: NodeJS.ErrnoException) => order.push("error:" + err.code));
+      server.listen(port);
+      process.nextTick(() => order.push("nextTick"));
+      await once(server, "error");
+      occupant.close();
+      await once(occupant, "close");
+      expect(order).toEqual(["error:EADDRINUSE", "nextTick"]);
+    });
+
     it("should use the provided port", async () => {
       while (true) {
         try {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -167,11 +167,13 @@ describe("node:http", () => {
       const order: string[] = [];
       server.on("listening", () => order.push("listening"));
       server.listen(0);
+      // The socket is bound when listen() returns, so the flag does not wait for the event.
+      const listeningAtOnce = server.listening;
       process.nextTick(() => order.push("nextTick"));
       await once(server, "listening");
       server.close();
       await once(server, "close");
-      expect(order).toEqual(["listening", "nextTick"]);
+      expect({ order, listeningAtOnce }).toEqual({ order: ["listening", "nextTick"], listeningAtOnce: true });
     });
 
     it("emits a listen() error on the next tick, before the event loop polls", async () => {
@@ -184,11 +186,16 @@ describe("node:http", () => {
       const order: string[] = [];
       server.on("error", (err: NodeJS.ErrnoException) => order.push("error:" + err.code));
       server.listen(port);
+      const listeningAtOnce = server.listening;
       process.nextTick(() => order.push("nextTick"));
       await once(server, "error");
       occupant.close();
       await once(occupant, "close");
-      expect(order).toEqual(["error:EADDRINUSE", "nextTick"]);
+      expect({ order, listeningAtOnce, listening: server.listening }).toEqual({
+        order: ["error:EADDRINUSE", "nextTick"],
+        listeningAtOnce: false,
+        listening: false,
+      });
     });
 
     // vite's port auto-increment (#27406): the callback of the failed listen() belongs to the

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -250,11 +250,7 @@ describe("node:http", () => {
           stderr: "pipe",
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        // stderr only matters on failure: debug builds may print benign warnings.
-        expect({ stdout, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
-          stdout: "beforeExit again\n",
-          failureDetail: "",
-        });
+        expect({ stdout, stderr }).toEqual({ stdout: "beforeExit again\n", stderr: "" });
         expect(exitCode).toBe(0);
       });
     });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -191,6 +191,74 @@ describe("node:http", () => {
       expect(order).toEqual(["error:EADDRINUSE", "nextTick"]);
     });
 
+    // vite's port auto-increment (#27406): the callback of the failed listen() belongs to the
+    // server, not to that attempt, so the retry from the 'error' handler calls it.
+    it("calls the listen() callback after a retry from the EADDRINUSE 'error' handler", async () => {
+      const occupant = createServer();
+      occupant.listen(0);
+      await once(occupant, "listening");
+      const { port } = occupant.address() as AddressInfo;
+
+      const server = createServer();
+      const events: string[] = [];
+      server.on("error", (err: NodeJS.ErrnoException) => {
+        events.push("error:" + err.code);
+        server.listen(0);
+      });
+      // Not events.once(): it would reject on the expected 'error'.
+      const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+      server.listen(port, () => events.push("callback"));
+      server.on("listening", () => onListening());
+      await listening;
+      const address = server.address() as AddressInfo;
+      server.close();
+      occupant.close();
+      await Promise.all([once(server, "close"), once(occupant, "close")]);
+      expect({ events, retriedPort: address.port !== port }).toEqual({
+        events: ["error:EADDRINUSE", "callback"],
+        retriedPort: true,
+      });
+    });
+
+    // Node's server.close() completes the handle's uv_close() on the next loop turn, so a server
+    // listened and closed from a 'beforeExit' handler revives the loop once and 'beforeExit' fires
+    // again (upstream test-process-beforeexit, with net). 'listening' is a nextTick now, so the turn
+    // has to come from close() itself.
+    describe.each([
+      ["http", {}],
+      ["https", { key: tlsCert.key, cert: tlsCert.cert }],
+    ])("%s: closing a server listened from 'beforeExit'", (mod, options) => {
+      it("re-emits 'beforeExit'", async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
+              const { createServer } = require(${JSON.stringify(mod)});
+              process.once("beforeExit", () => {
+                createServer(${JSON.stringify(options)})
+                  .listen(0)
+                  .on("listening", function () {
+                    this.close();
+                    process.once("beforeExit", () => console.log("beforeExit again"));
+                  });
+              });
+            `,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        // stderr only matters on failure: debug builds may print benign warnings.
+        expect({ stdout, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
+          stdout: "beforeExit again\n",
+          failureDetail: "",
+        });
+        expect(exitCode).toBe(0);
+      });
+    });
+
     it("should use the provided port", async () => {
       while (true) {
         try {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -241,16 +241,17 @@ describe("net.createServer listen", () => {
   });
 
   // The error twin of the test above: a listen() that fails reports on the same tick as one that succeeds.
+  // No host argument: with one, Node resolves it through dns.lookup first, which adds a tick.
   it("emits a listen() error on the next tick, before the event loop polls", async () => {
     const occupant: Server = createServer();
-    occupant.listen(0, "127.0.0.1");
+    occupant.listen(0);
     await once(occupant, "listening");
     const { port } = occupant.address() as AddressInfo;
 
     const server: Server = createServer();
     const order: string[] = [];
     server.on("error", (err: NodeJS.ErrnoException) => order.push("error:" + err.code));
-    server.listen(port, "127.0.0.1");
+    server.listen(port);
     process.nextTick(() => order.push("nextTick"));
     await once(server, "error");
     occupant.close();

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -321,11 +321,7 @@ describe("net.createServer listen", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // stderr only matters on failure: debug builds may print benign warnings.
-    expect({ stdout, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
-      stdout: "beforeExit again\n",
-      failureDetail: "",
-    });
+    expect({ stdout, stderr }).toEqual({ stdout: "beforeExit again\n", stderr: "" });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -303,11 +303,11 @@ describe("net.createServer listen", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // stderr only matters on failure: debug builds may print benign warnings.
-    expect({ stdout, exitCode, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
+    expect({ stdout, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
       stdout: "beforeExit again\n",
-      exitCode: 0,
       failureDetail: "",
     });
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -240,6 +240,24 @@ describe("net.createServer listen", () => {
     expect(order).toEqual(["listening", "nextTick"]);
   });
 
+  // The error twin of the test above: a listen() that fails reports on the same tick as one that succeeds.
+  it("emits a listen() error on the next tick, before the event loop polls", async () => {
+    const occupant: Server = createServer();
+    occupant.listen(0, "127.0.0.1");
+    await once(occupant, "listening");
+    const { port } = occupant.address() as AddressInfo;
+
+    const server: Server = createServer();
+    const order: string[] = [];
+    server.on("error", (err: NodeJS.ErrnoException) => order.push("error:" + err.code));
+    server.listen(port, "127.0.0.1");
+    process.nextTick(() => order.push("nextTick"));
+    await once(server, "error");
+    occupant.close();
+    await once(occupant, "close");
+    expect(order).toEqual(["error:EADDRINUSE", "nextTick"]);
+  });
+
   // How vite, get-port and friends probe for a free port: listen, then close()
   // from the 'listening' handler. A peer that connects in between must be reset
   // by the kernel when the listening fd closes, not accepted into the closing

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -227,6 +227,88 @@ describe("net.createServer listen", () => {
       }),
     );
   });
+
+  it("emits 'listening' on the next tick, before the event loop polls", async () => {
+    const server: Server = createServer();
+    const order: string[] = [];
+    server.on("listening", () => order.push("listening"));
+    server.listen(0);
+    process.nextTick(() => order.push("nextTick"));
+    await once(server, "listening");
+    server.close();
+    await once(server, "close");
+    expect(order).toEqual(["listening", "nextTick"]);
+  });
+
+  // How vite, get-port and friends probe for a free port: listen, then close()
+  // from the 'listening' handler. A peer that connects in between must be reset
+  // by the kernel when the listening fd closes, not accepted into the closing
+  // server, whose close() would then wait on a connection nobody is reading.
+  it("close() from 'listening' does not accept a peer that connected in between", async () => {
+    const server: Server = createServer();
+    let accepted = 0;
+    server.on("connection", () => accepted++);
+    const { promise: closed, resolve: onClosed, reject } = Promise.withResolvers<void>();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1");
+
+    // Bun.connect() issues connect(2) synchronously, so the peer is already
+    // sitting in the listen backlog when the 'listening' handler runs.
+    const { port } = server.address() as AddressInfo;
+    const peer = Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data() {},
+        error() {},
+        connectError() {},
+      },
+    }).catch(() => null);
+
+    server.once("listening", () => {
+      server.close(() => onClosed());
+      peer.then(socket => socket?.end());
+    });
+
+    await closed;
+    expect(accepted).toBe(0);
+  });
+
+  // Node's server.close() completes the handle's uv_close() on the next loop
+  // turn, so a server listened and closed from a 'beforeExit' handler brings
+  // the loop back to life once more and 'beforeExit' fires again
+  // (upstream test-process-beforeexit). 'listening' itself is only a nextTick
+  // now, so close() has to hold the loop for that turn on its own.
+  it("closing a server listened from 'beforeExit' re-emits 'beforeExit'", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          process.once("beforeExit", () => {
+            net
+              .createServer()
+              .listen(0)
+              .on("listening", function () {
+                this.close();
+                process.once("beforeExit", () => console.log("beforeExit again"));
+              });
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr only matters on failure: debug builds may print benign warnings.
+    expect({ stdout, exitCode, failureDetail: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: "beforeExit again\n",
+      exitCode: 0,
+      failureDetail: "",
+    });
+  });
 });
 
 describe("net.createServer events", () => {


### PR DESCRIPTION
### Problem
- `child_process_ipc_handle.test.ts` > "a handle sent right before the child's disconnect() is still delivered" is red on main (darwin aarch64, builds 103063 and 102999): the parent never gets the `net.Server`.
- Cause: `net.Server` emits `'listening'` from a 1 ms timer (`net.ts:3976`). A received server is emitted from that event (`Ipc.ts:58`), so it arrives one I/O poll late: after the next message, with its backlog already accepted. A `close()` from `'listening'` can inherit a connection, which hangs vite's port probe (#39114).
- `http.Server` has the same timer (`_http_server.ts:1067`). Under `jest.useFakeTimers()` it never fires, so `listen(0, cb)` never calls `cb` (#37959). http also registered `cb` only after a successful bind, so a `listen(0)` retried from the EADDRINUSE `'error'` handler never called it: vite's port auto-increment hangs (#27406).

### Fix
- Both servers emit `'listening'`, and a failed `listen()` its `'error'`, with `process.nextTick`, as node does. `Bun.listen()` and `Bun.serve()` have called `listen(2)` when they return, so the event is not early. A tick runs before the next I/O poll and is not a timer.
- http registers the `listen()` callback before the bind and sets `server.listening` as soon as `Bun.serve()` returns, as node and `net.Server` do.
- `net.Server.close()` queues a no-op `setImmediate` so the loop lives one more turn, as node's `uv_close()` does. The timer provided that turn by accident. http gets it from the `Bun.serve` stop task.
- Verified: eighteen new or pinned tests in five files, fourteen fail on the unfixed build (notes). The net, tls, http, cluster, IPC, third-party and 54 upstream suites match main.

Adopts #39114. Includes the http hunk and tests of #37959. Fixes #27406. Supersedes #37802 and #39242.

### Background
- Handle passing: `process.send(msg, server)` sends the socket's descriptor with the message. The receiver wraps it in a new `net.Server` and emits `'message'` from its `'listening'`. Later messages wait for the receiver's ack.
- Accept backlog: connections wait in the kernel until a holder of the listening socket accepts them. bun accepts the whole backlog on the first readable poll.
- Fake timers: `jest.useFakeTimers()` puts every new `setTimeout`, even one made by a built-in module, into a heap that only `jest.advanceTimersByTime()` drains. `process.nextTick` is never diverted.

<details><summary>Notes</summary>

Tests (thirteen fail on the unfixed build): `node-net-server.test.ts`: `'listening'` before a later `nextTick`, a listen `'error'` before a later `nextTick`, no accept before a `close()` from the `'listening'` handler, `'beforeExit'` re-emitted (passes on main, fails with the nextTick change alone, which is why `close()` holds the loop). `node-http.test.ts`: the same two order tests for http (they also assert `server.listening` right after `listen()`: true after a bind, false after EADDRINUSE), the retry shape of #27406 (the callback runs once after the retry, fails on main), and http and https twins of the `'beforeExit'` test (pass on main too: the 1 ms timer gave the turn by accident, now the task that emits `'close'` gives it). `cluster.test.ts`: a worker's `listen()` callback runs before the worker reports `'listening'` to the primary, for net and http (http fails on main: the callback used to be registered after the notifier). `child_process_ipc_handle.test.ts`: backlog served after a handoff (`acceptedBeforeDelivery: 20, served: 0` on the released bun), a handle before the message sent after it, and the disconnect test pinned to node's order and reporting on `'close'`. `test-timers.test.ts`: `'listening'` and EADDRINUSE `'error'` under fake timers for net and http (`jest.getTimerCount()` is 1 right after `listen()` on main).

Earlier shape of this PR: emit the received server right after `listen({ fd })` returns, with `Ipc.ts` the only runtime change. A review pointed out that this patches the consumer around the stale timer, duplicates the open root fix #39114, and diverges from node once that lands (the received server would emit `'listening'` after `'message'`). This PR now carries the root fix. All three IPC tests pass with the nextTick `'listening'` and the unchanged `Ipc.ts`.

#27406 ("`http.Server.listen()` hangs when called again after EADDRINUSE") was closed as not reproducible on 1.3.13. It reproduces on 1.4.0 with a dynamic port: `http.Server.listen` passed the callback into `kRealListen`, which registered it as `once('listening')` only after `Bun.serve()` returned. On EADDRINUSE `Bun.serve()` throws first, so the callback was dropped and the retry's `'listening'` had no listener for it. node (`Server.prototype.listen`: `if (cb !== null) this.once('listening', cb)` before `listenInCluster`) and `net.ts:3807` register it before the bind. The review of this PR found it in the hunk being changed; the fix is the same three lines in `Server.prototype.listen`, and `kRealListen` loses its `onListen` argument. In a cluster worker the user callback now runs before the `act: 'listening'` notification to the primary, as in node (node v26.3.0: `callback:online, cluster:listening` for net and http), and `cluster.worker.state` is still `'online'` inside it.

`server.listening` on http was set to true only by the deferred emit, so it lagged `address()` by a tick (by 1 ms before this PR). Node's `listening` is a getter on `_handle`, true as soon as `listen()` returns for the host-less form (with a host, both runtimes report false for one tick: node because of `dns.lookup`, bun because the flag was set by the emit; now bun reports true at once in both forms). `kRealListen` sets the flag right after `Bun.serve()` returns; `close()` and `closeAllConnections()` already clear it, and `emitListeningNextTick` only guards on the handle now, as `net.ts` does.

#37959 made the same four `net.ts` changes for the fake-timer symptom and also moved the two `_http_server.ts` emits. Its http hunk and its four tests are folded in here (commit "node:http: emit listen() results on the next tick too"), and #37959 is closed in favor of this PR. The http path was checked like net: a server listened from `'beforeExit'` and closed from `'listening'` prints `beforeExit, listening, nextTick, closeCb, close, beforeExit again` on the debug build. Node prints the same order, except that it emits `'close'` before the `close()` callback, a pre-existing difference not touched here. `http.Server.close()` goes through the `Bun.serve` stop, whose all-connections-closed task (`ServerAllConnectionsClosedTask`, an event-loop task, not a microtask) keeps the loop alive for that turn and then emits `'close'`, so http needs no `setImmediate`; the http and https `'beforeExit'` tests pin that turn.

Node's `listen(port, host)` resolves `host` through `dns.lookup` before it binds, and `dns.lookup` defers even an IP literal to a `process.nextTick`. So in node, `listen(port, "127.0.0.1")` emits one tick later than `listen(port)`. bun binds an IP literal synchronously in both cases. The order tests therefore call `listen()` without a host, where node v26.3.0 and bun agree tick for tick: `listening, nextTick` and `error:EADDRINUSE, nextTick`. `node-http.test.ts` requires its tests to pass in node.

Measurements with the fixture of the disconnect test, 16 at a time:

- bun 1.4.0 (unfixed, report on `'exit'`, 200 runs): 175 deliver the server after `'disconnect'`, 13 between the message and `'disconnect'`, 11 have no server at `'exit'` (the CI shape), 1 has node's order.
- bun 1.4.0 (unfixed, report on `'close'`, 200 runs): 199 have the wrong order, 1 of them has no server even at `'close'`.
- node v26.3.0, 50 runs: all `handle:srv, after-handle, disconnect`.
- debug build with this change, report on `'close'`, 150 runs: all `handle:srv, after-handle, disconnect`.

Why `'close'`: `fork()` counts the IPC channel as a channel to close (`child_process.ts:1468`), and `#onDisconnect` emits `'disconnect'` one tick before it counts the close (`child_process.ts:1555`). The stderr pipe counts too (`child_process.ts:1258`), so the child's report is complete at `'close'`. On `'exit'` neither is guaranteed: the IPC EOF is a deferred task, so `'disconnect'` can follow `'exit'`. With the fix and the report on `'exit'`, 18 of 100 runs still had no `'disconnect'`.

Why the order is send order: once a message with a handle is fully written, the sender moves it to `waiting_for_ack` and writes nothing but an ack or nack until the receiver's ack arrives (`ipc.rs:1487`, `ipc.rs:1550`). So the message behind a handle never shares a read buffer with it. On the receiver, `PosixSocket::on_data` (`ipc.rs:2436`) and `WindowsNamedPipe::on_read` (`ipc.rs:2515`) decode a whole read buffer inside one event-loop scope, and the nextTick queue drains with the microtasks when that outer scope exits (`event_loop.rs:313`), before the next I/O poll and so before the ack'd follow-up message is read. The scope inside the handle arm (`ipc.rs:2169`) is nested and does not drain on its own. With the 1 ms timer, the follow-up message was read by a poll that ran before the timer expired, so it overtook the handle.

Why the timer was there: 25097cd632 (2023-03-18, "[node:net] Fix issue with `listen` callback firing before it's listening") replaced the `process.nextTick` of #2337 with `setTimeout(..., 1)`, with no test and no linked issue, and kept the error path on `nextTick`. The error path moved to the timer in 6baedd27bc (tls.Server, #2552) and #31829 copied it for the cluster path. Whatever the symptom was then, the socket is listening when `listen()` returns today: `Bun.listen()` runs `us_socket_group_listen` -> `bsd_create_listen_socket` -> `bind(2)` and `listen(2)` before it returns (`packages/bun-usockets/src/context.c:388`, `bsd.c:1328`, `bsd.c:1067`), and `kRealListen` already depends on that: it reads the bound address with `getsockname` right after `Bun.listen()` returns (`net.ts:3952`) and chmods the unix socket file (`net.ts:3906`). `Bun.serve()` binds and listens in `Server::listen` (`src/runtime/server/mod.rs`) before it returns, and `_http_server.ts` reads `this[serverSymbol].port` right after. The `'listening'` tests and the upstream files are the evidence that nothing needs the delay.

#39628 (deferred module init in `node:net`) is not a factor: bun 1.4.0 has #31829 but not #39628 and reproduces the failure.

Not changed: the `dgram.Socket` arm of `parseHandle` emits from `bind()`'s callback, which resolves in the microtask drain of the same read. `http.Server`'s `connectionsCheckingInterval` (a 30 s `setInterval` made on `'listening'`) still lands in the fake heap once `'listening'` fires under fake timers; #37987 covers built-in timers under fake timers in general. #37831 (close the descriptor when `listen({ fd })` refuses it) stays independent. #34659 adds a `nextTickListening` flag to `kRealListen` for cluster-adopted descriptors and deflakes the disconnect test by reporting at process exit with `got.sort()`; both hunks become unnecessary with this change.

Suites run with the debug build, same results as main: `test/js/node/net` (the 10 `localhost` failures of `node-net.test.ts` fail on the released bun too), `test/js/node/tls` (1 `ECONNREFUSED` test on a `localhost` bind, same on the released bun), `test/js/node/http` (`node-http.test.ts`: 146 pass, the proxy test fails on `localhost` on the released bun too; `node-http-connect.test.ts`: one 5 s spawn timeout under the debug build, same without the http change), `test/js/node/http2`, `test/js/bun/net` (the `localhost` failures, same on the released bun), `cluster.test.ts` (32 pass), `child_process_ipc.test.js`, `child_process_send_cb.test.js`, `child_process_ipc_large_disconnect.test.js`, `spawn.ipc*.test.ts`, `bun-ipc-inherit.test.ts` (55 pass with cluster), `test/js/third_party/express`, `@fastify`, `socket.io` (308 pass, the same 2 timeouts without the http change). Upstream, all pass: `test-net-listen-*` (9), `test-net-server-listen-*` (4), `test-net-server-close*` (3), `test-net-server-unref*` (2), `test-net-listening`, `test-net-pingpong`, `test-process-beforeexit`, `test-child-process-fork-net-server`, `fork-net-socket`, `send-keep-open`, `test-cluster-basic`, `dgram-1`, `dgram-2`, `eaddrinuse`, `listening-port`, `message`, `net-send`, `server-restart-none`, `server-restart-rr`, `shared-handle-bind-error`, `test-cluster-http-pipe`, `test-http-listening`, `test-http-server-close-all`, `test-http-server-close-destroy-timeout`, `test-http-server-close-idle`, `test-http-server-close-idle-wait-response`, `test-http-server-consumed-timeout`, `test-http-server-options-incoming-message`, `test-http-server-options-server-response`, `test-https-server-close-all`, `test-https-server-close-destroy-timeout`, `test-https-server-close-idle`, `test-http-bind-twice`, `test-http-server-stale-close`, `test-http-server-keepalive-end`, `test-http-server-multiheaders`, `test-http-server-keep-alive-timeout`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net-server.test.ts, test/js/node/cluster.test.ts, test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->
