### PR TITLE
yaml: escape unpaired surrogates in stringify and read them back in parse

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5518,7 +5518,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             }
             // YAML 1.2 is a JSON superset. JSON writes a supplementary code
             // point as a `\uD8xx\uDCxx` pair, and `JSON.parse` keeps an
-            // unpaired `\uXXXX` surrogate as a lone UTF-16 code unit. So does
+            // unpaired `\uHHHH` surrogate as a lone UTF-16 code unit. So does
             // this parser (js-yaml and eemeli/yaml do the same).
             if bun_core::strings::u16_is_lead(cp as u16) {
                 if let Some(trail) = self.peek_trail_surrogate_escape() {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5482,9 +5482,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         Ok(value)
     }
 
-    /// With the cursor on the last hex digit of a `\uD8xx` escape: the trail
-    /// surrogate named by an immediately following `\uDCxx` escape. Does not
-    /// move the cursor.
+    /// Cursor on the last hex digit of a `\uD8xx` escape. Does not advance.
     fn peek_trail_surrogate_escape(&self) -> Option<u16> {
         if Enc::wide(self.peek(1)) != 0x5C /* '\\' */ || Enc::wide(self.peek(2)) != 0x75
         /* 'u' */
@@ -5511,15 +5509,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         }
 
         if (0xD800..=0xDFFF).contains(&cp) {
-            // `\U` ([60] ns-esc-32-bit) names a Unicode character, and a
-            // surrogate code point is not one.
+            // `\U` names a Unicode character; a surrogate code point is not one.
             if !matches!(escape, Escape::LowerU) {
                 return Err(ParseError::UnexpectedCharacter);
             }
-            // YAML 1.2 is a JSON superset. JSON writes a supplementary code
-            // point as a `\uD8xx\uDCxx` pair, and `JSON.parse` keeps an
-            // unpaired `\uHHHH` surrogate as a lone UTF-16 code unit. So does
-            // this parser (js-yaml and eemeli/yaml do the same).
+            // Like `JSON.parse`: a `\uD8xx\uDCxx` pair is one code point and
+            // an unpaired surrogate stays a lone code unit.
             if bun_core::strings::u16_is_lead(cp as u16) {
                 if let Some(trail) = self.peek_trail_surrogate_escape() {
                     self.inc(2 + Escape::LowerU as usize);
@@ -5530,9 +5525,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         match Enc::KIND {
             EncodingKind::Utf8 => {
-                // WTF-8: a lone surrogate becomes `ED xx xx`, which the
-                // `E::String` → JS conversion (`wtf8_to_utf16_alloc`) turns
-                // back into the code unit it names.
+                // WTF-8: a lone surrogate stays `ED xx xx` until
+                // `wtf8_to_utf16_alloc` turns it back into a code unit for JS.
                 let mut buf = [0u8; 4];
                 let len = bun_core::strings::encode_wtf8_rune(&mut buf, cp);
                 for &b in &buf[..len] {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5482,6 +5482,23 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         Ok(value)
     }
 
+    /// With the cursor on the last hex digit of a `\uD8xx` escape: the trail
+    /// surrogate named by an immediately following `\uDCxx` escape. Does not
+    /// move the cursor.
+    fn peek_trail_surrogate_escape(&self) -> Option<u16> {
+        if Enc::wide(self.peek(1)) != 0x5C /* '\\' */ || Enc::wide(self.peek(2)) != 0x75
+        /* 'u' */
+        {
+            return None;
+        }
+        let mut value: u16 = 0;
+        for i in 0..Escape::LowerU as usize {
+            let digit = bun_core::fmt::hex_digit_value_u32(Enc::wide(self.peek(3 + i)))?;
+            value = value * 16 + u16::from(digit);
+        }
+        bun_core::strings::u16_is_trail(value).then_some(value)
+    }
+
     fn decode_hex_code_point(
         &mut self,
         escape: Escape,
@@ -5493,31 +5510,32 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             return Err(ParseError::UnexpectedCharacter);
         }
 
-        // JSON encodes supplementary code points as a `\uD8xx\uDCxx` surrogate
-        // pair; YAML 1.2 is a JSON superset. Lone surrogates remain an error.
         if (0xD800..=0xDFFF).contains(&cp) {
-            if !matches!(escape, Escape::LowerU)
-                || !bun_core::strings::u16_is_lead(cp as u16)
-                || Enc::wide(self.peek(1)) != 0x5C /* '\\' */
-                || Enc::wide(self.peek(2)) != 0x75
-            /* 'u' */
-            {
+            // `\U` ([60] ns-esc-32-bit) names a Unicode character, and a
+            // surrogate code point is not one.
+            if !matches!(escape, Escape::LowerU) {
                 return Err(ParseError::UnexpectedCharacter);
             }
-            self.inc(2);
-            let low = self.read_hex_digits(Escape::LowerU as u8)?;
-            if !bun_core::strings::u16_is_trail(low as u16) {
-                return Err(ParseError::UnexpectedCharacter);
+            // YAML 1.2 is a JSON superset. JSON writes a supplementary code
+            // point as a `\uD8xx\uDCxx` pair, and `JSON.parse` keeps an
+            // unpaired `\uXXXX` surrogate as a lone UTF-16 code unit. So does
+            // this parser (js-yaml and eemeli/yaml do the same).
+            if bun_core::strings::u16_is_lead(cp as u16) {
+                if let Some(trail) = self.peek_trail_surrogate_escape() {
+                    self.inc(2 + Escape::LowerU as usize);
+                    cp = bun_core::strings::u16_get_supplementary(cp as u16, trail);
+                }
             }
-            cp = bun_core::strings::u16_get_supplementary(cp as u16, low as u16);
         }
 
         match Enc::KIND {
             EncodingKind::Utf8 => {
-                let ch = char::from_u32(cp).ok_or(ParseError::UnexpectedCharacter)?;
+                // WTF-8: a lone surrogate becomes `ED xx xx`, which the
+                // `E::String` → JS conversion (`wtf8_to_utf16_alloc`) turns
+                // back into the code unit it names.
                 let mut buf = [0u8; 4];
-                let s = ch.encode_utf8(&mut buf);
-                for b in s.bytes() {
+                let len = bun_core::strings::encode_wtf8_rune(&mut buf, cp);
+                for &b in &buf[..len] {
                     text.push(Enc::ch(b));
                 }
             }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5513,8 +5513,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             if !matches!(escape, Escape::LowerU) {
                 return Err(ParseError::UnexpectedCharacter);
             }
-            // Like `JSON.parse`: a `\uD8xx\uDCxx` pair is one code point and
-            // an unpaired surrogate stays a lone code unit.
+            // Like `JSON.parse`: combine a lead+trail pair, keep a lone surrogate.
             if bun_core::strings::u16_is_lead(cp as u16) {
                 if let Some(trail) = self.peek_trail_surrogate_escape() {
                     self.inc(2 + Escape::LowerU as usize);
@@ -5525,8 +5524,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         match Enc::KIND {
             EncodingKind::Utf8 => {
-                // WTF-8: a lone surrogate stays `ED xx xx` until
-                // `wtf8_to_utf16_alloc` turns it back into a code unit for JS.
+                // WTF-8; `wtf8_to_utf16_alloc` restores a lone surrogate for JS.
                 let mut buf = [0u8; 4];
                 let len = bun_core::strings::encode_wtf8_rune(&mut buf, cp);
                 for &b in &buf[..len] {

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -652,8 +652,7 @@ impl Stringifier {
                 0x2028 => self.builder.append_latin1(b"\\L"), // line separator
                 0x2029 => self.builder.append_latin1(b"\\P"), // paragraph separator
 
-                // A pair is written as is; an unpaired surrogate as `\uHHHH`,
-                // like `JSON.stringify`.
+                // a pair as is; an unpaired surrogate as `\uHHHH` like JSON.stringify
                 0xd800..=0xdbff
                     if i < str.length() && bun_core::strings::u16_is_trail(str.char_at(i)) =>
                 {

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -653,7 +653,7 @@ impl Stringifier {
                 0x2029 => self.builder.append_latin1(b"\\P"), // paragraph separator
 
                 // A surrogate pair is written as is. An unpaired surrogate is
-                // not a Unicode character, so it is written as `\uXXXX`, the
+                // not a Unicode character, so it is written as `\uHHHH`, the
                 // way `JSON.stringify` writes it.
                 0xd800..=0xdbff
                     if i < str.length() && bun_core::strings::u16_is_trail(str.char_at(i)) =>
@@ -914,7 +914,7 @@ fn string_needs_quotes(str: &BunString) -> bool {
             | 0x2029 => return true,
 
             // A surrogate pair is a printable character. An unpaired surrogate
-            // is not, and has to be written as a `\uXXXX` escape.
+            // is not, and has to be written as a `\uHHHH` escape.
             0xd800..=0xdbff => {
                 if i + 1 < str.length() && bun_core::strings::u16_is_trail(str.char_at(i + 1)) {
                     i += 2;

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -606,8 +606,10 @@ impl Stringifier {
     fn append_double_quoted_string(&mut self, str: &BunString) {
         self.builder.append_lchar(b'"');
 
-        for i in 0..str.length() {
+        let mut i: usize = 0;
+        while i < str.length() {
             let c = str.char_at(i);
+            i += 1;
 
             match c {
                 0x00 => self.builder.append_latin1(b"\\0"),
@@ -650,13 +652,32 @@ impl Stringifier {
                 0x2028 => self.builder.append_latin1(b"\\L"), // line separator
                 0x2029 => self.builder.append_latin1(b"\\P"), // paragraph separator
 
+                // A surrogate pair is written as is. An unpaired surrogate is
+                // not a Unicode character, so it is written as `\uXXXX`, the
+                // way `JSON.stringify` writes it.
+                0xd800..=0xdbff
+                    if i < str.length() && bun_core::strings::u16_is_trail(str.char_at(i)) =>
+                {
+                    self.builder.append_uchar(c);
+                    self.builder.append_uchar(str.char_at(i));
+                    i += 1;
+                }
+                0xd800..=0xdfff => {
+                    self.builder.append_latin1(b"\\u");
+                    for shift in [12u8, 8, 4, 0] {
+                        self.builder
+                            .append_lchar(bun_core::fmt::hex_char_lower((c >> shift) as u8));
+                    }
+                }
+
                 0x20..=0x21
                 | 0x23..=0x5b
                 | 0x5d..=0x7e
                 | 0x80..=0x84
                 | 0x86..=0x9f
                 | 0xa1..=0x2027
-                | 0x202a..=u16::MAX => self.builder.append_uchar(c),
+                | 0x202a..=0xd7ff
+                | 0xe000..=u16::MAX => self.builder.append_uchar(c),
             }
         }
 
@@ -891,6 +912,17 @@ fn string_needs_quotes(str: &BunString) -> bool {
             | 0xa0
             | 0x2028
             | 0x2029 => return true,
+
+            // A surrogate pair is a printable character. An unpaired surrogate
+            // is not, and has to be written as a `\uXXXX` escape.
+            0xd800..=0xdbff => {
+                if i + 1 < str.length() && bun_core::strings::u16_is_trail(str.char_at(i + 1)) {
+                    i += 2;
+                } else {
+                    return true;
+                }
+            }
+            0xdc00..=0xdfff => return true,
 
             _ => {
                 i += 1;

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -652,9 +652,8 @@ impl Stringifier {
                 0x2028 => self.builder.append_latin1(b"\\L"), // line separator
                 0x2029 => self.builder.append_latin1(b"\\P"), // paragraph separator
 
-                // A surrogate pair is written as is. An unpaired surrogate is
-                // not a Unicode character, so it is written as `\uHHHH`, the
-                // way `JSON.stringify` writes it.
+                // A pair is written as is; an unpaired surrogate as `\uHHHH`,
+                // like `JSON.stringify`.
                 0xd800..=0xdbff
                     if i < str.length() && bun_core::strings::u16_is_trail(str.char_at(i)) =>
                 {
@@ -913,8 +912,7 @@ fn string_needs_quotes(str: &BunString) -> bool {
             | 0x2028
             | 0x2029 => return true,
 
-            // A surrogate pair is a printable character. An unpaired surrogate
-            // is not, and has to be written as a `\uHHHH` escape.
+            // an unpaired surrogate has to be escaped; a pair is printable
             0xd800..=0xdbff => {
                 if i + 1 < str.length() && bun_core::strings::u16_is_trail(str.char_at(i + 1)) {
                     i += 2;

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2116,19 +2116,41 @@ folded: >
           expect(YAML.parse(doc)).toEqual(JSON.parse(doc));
           // `\U` 32-bit escapes for the same code point still work.
           expect(YAML.parse('"\\U0001F600"')).toBe("😀");
-          // Lone or mis-ordered surrogates are rejected.
-          expect(() => YAML.parse('"\\uD83D"')).toThrow(SyntaxError);
-          expect(() => YAML.parse('"\\uD83Dx"')).toThrow(SyntaxError);
-          expect(() => YAML.parse('"\\uDE00"')).toThrow(SyntaxError);
-          expect(() => YAML.parse('"\\uDE00\\uD83D"')).toThrow(SyntaxError);
-          expect(() => YAML.parse('"\\uD83D\\uD83D"')).toThrow(SyntaxError);
-          expect(() => YAML.parse('"\\uD83D\\u0041"')).toThrow(SyntaxError);
-          expect(() => YAML.parse('"\\uD83D\\n"')).toThrow(SyntaxError);
           // `\U` ([60] ns-esc-32-bit) names a Unicode character; surrogate
           // code points are not characters and are never combined.
           expect(() => YAML.parse('"\\U0000D83D"')).toThrow(SyntaxError);
           expect(() => YAML.parse('"\\U0000D83D\\uDE00"')).toThrow(SyntaxError);
           expect(() => YAML.parse('"\\U0000D83D\\U0000DE00"')).toThrow(SyntaxError);
+        });
+
+        test("`\\uXXXX` unpaired surrogates are kept as lone code units, like JSON.parse", () => {
+          // JSON allows an unpaired `\uD83D` and `JSON.parse` keeps it as one
+          // UTF-16 code unit (RFC 8259 §8.2). js-yaml and eemeli/yaml do the
+          // same, and so does `YAML.stringify` when it writes such a string.
+          for (const doc of [
+            '"\\uD83D"',
+            '"\\uDE00"',
+            '"\\uD83Dx"',
+            '"\\uD83D\\u0041"',
+            '"\\uDE00\\uD83D"',
+            '"\\uD83D\\uD83D"',
+            '"\\uD83D\\uD83D\\uDE00"',
+            '"\\uD83D\\n"',
+            '"a\\ud800b"',
+            '{"a\\ud800b": 1, "a\\udc00b": 2, "a\\ufffdb": 3}',
+          ]) {
+            expect(YAML.parse(doc)).toEqual(JSON.parse(doc));
+          }
+          expect(YAML.parse('"\\uD83D"')).toHaveLength(1);
+          expect(YAML.parse('"\\uD83D\\uD83D\\uDE00"')).toBe("\uD83D😀");
+          expect(Object.keys(YAML.parse('{"a\\ud800b": 1, "a\\udc00b": 2, "a\\ufffdb": 3}'))).toEqual([
+            "a\uD800b",
+            "a\uDC00b",
+            "a\uFFFDb",
+          ]);
+          // The escape still needs four hex digits.
+          expect(() => YAML.parse('"\\uD83D\\uDE0"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uD83D\\uZZZZ"')).toThrow(SyntaxError);
         });
 
         test.todo("s-separate required after tag ([97] c-ns-tag-property)", () => {
@@ -2932,6 +2954,63 @@ config:
         expect(YAML.parse(YAML.stringify("\u2028"))).toBe("\u2028");
         expect(YAML.parse(YAML.stringify("\u2029"))).toBe("\u2029");
         expect(YAML.parse(YAML.stringify("a\u2028b\u2029c"))).toBe("a\u2028b\u2029c");
+      });
+
+      test("escapes unpaired surrogates as \\uXXXX, like JSON.stringify", () => {
+        // An unpaired surrogate is not a Unicode character. Written as is, it
+        // becomes U+FFFD at the next string to UTF-8 boundary (a file, stdout,
+        // or `YAML.parse` itself). A surrogate pair is a character and is
+        // written as is.
+        expect(YAML.stringify("\uD800")).toBe('"\\ud800"');
+        expect(YAML.stringify("\uDC00")).toBe('"\\udc00"');
+        expect(YAML.stringify("x\uD800y")).toBe('"x\\ud800y"');
+        expect(YAML.stringify("\uDC00\uD800")).toBe('"\\udc00\\ud800"');
+        expect(YAML.stringify("\uD83D\uD83D\uDE00")).toBe('"\\ud83d😀"');
+        expect(YAML.stringify("\uD83D\uDE00")).toBe("😀");
+        expect(YAML.stringify(["\uD800", "a\uD800", "\uD83D\uDE00"])).toBe('["\\ud800","a\\ud800",😀]');
+        expect(YAML.stringify({ ["a\uD800b"]: 1, ["a\uDC00b"]: 2, ["a\uFFFDb"]: 3 })).toBe(
+          '{"a\\ud800b": 1,"a\\udc00b": 2,a\uFFFDb: 3}',
+        );
+        expect(YAML.stringify({ ["a\uD800b"]: 1 }, null, 2)).toBe('"a\\ud800b": 1');
+      });
+
+      test("round-trips unpaired surrogates in values and keys", () => {
+        const obj = { ["a\uD800b"]: 1, ["a\uDC00b"]: 2, ["a\uFFFDb"]: 3 };
+        expect(YAML.parse(YAML.stringify(obj))).toEqual(obj);
+        expect(YAML.parse(YAML.stringify(obj, null, 2))).toEqual(obj);
+        expect(Object.keys(YAML.parse(YAML.stringify(obj)))).toEqual(Object.keys(JSON.parse(JSON.stringify(obj))));
+
+        const values = {
+          lead: "x\uD800y",
+          trail: "x\uDC00y",
+          reversed: "\uDC00\uD800",
+          pair: "\uD83D\uDE00",
+          leadThenPair: "\uD83D\uD83D\uDE00",
+          leadAtEnd: "abc\uDBFF",
+          trailAtStart: "\uDFFFabc",
+          list: ["\uD800", "\uDC00", "a\uD800"],
+        };
+        expect(YAML.parse(YAML.stringify(values))).toEqual(values);
+        expect(YAML.parse(YAML.stringify(values, null, 2))).toEqual(values);
+      });
+
+      test("round-trips every surrogate code unit", () => {
+        let all = "";
+        for (let cp = 0xd800; cp <= 0xdfff; cp++) {
+          // Separated so that no lead is followed by a trail.
+          all += String.fromCharCode(cp) + "|";
+        }
+        const back = YAML.parse(YAML.stringify(all));
+        expect(typeof back).toBe("string");
+        expect(back.length).toBe(all.length);
+        for (let i = 0; i < all.length; i++) {
+          if (back.charCodeAt(i) !== all.charCodeAt(i)) {
+            throw new Error(
+              `U+${all.charCodeAt(i).toString(16).padStart(4, "0")} did not round-trip: ` +
+                `got U+${back.charCodeAt(i).toString(16).padStart(4, "0")}`,
+            );
+          }
+        }
       });
 
       test("round-trips every non-surrogate BMP code point", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2123,7 +2123,7 @@ folded: >
           expect(() => YAML.parse('"\\U0000D83D\\U0000DE00"')).toThrow(SyntaxError);
         });
 
-        test("`\\uXXXX` unpaired surrogates are kept as lone code units, like JSON.parse", () => {
+        test("`\\uHHHH` unpaired surrogates are kept as lone code units, like JSON.parse", () => {
           // JSON allows an unpaired `\uD83D` and `JSON.parse` keeps it as one
           // UTF-16 code unit (RFC 8259 §8.2). js-yaml and eemeli/yaml do the
           // same, and so does `YAML.stringify` when it writes such a string.
@@ -2956,7 +2956,7 @@ config:
         expect(YAML.parse(YAML.stringify("a\u2028b\u2029c"))).toBe("a\u2028b\u2029c");
       });
 
-      test("escapes unpaired surrogates as \\uXXXX, like JSON.stringify", () => {
+      test("escapes unpaired surrogates as \\uHHHH, like JSON.stringify", () => {
         // An unpaired surrogate is not a Unicode character. Written as is, it
         // becomes U+FFFD at the next string to UTF-8 boundary (a file, stdout,
         // or `YAML.parse` itself). A surrogate pair is a character and is


### PR DESCRIPTION
### Problem
- `YAML.stringify` writes an unpaired surrogate code unit as is, in plain and in double-quoted scalars. The next string to UTF-8 conversion (a file, stdout, or the input of `YAML.parse`) turns it into U+FFFD. So `YAML.parse(YAML.stringify({"a\uD800b": 1, "a\uDC00b": 2, "a\uFFFDb": 3}))` returns one key, `{"a\uFFFDb": 3}`. The JSON round trip returns three.
- `string_needs_quotes` and `append_double_quoted_string` (`src/runtime/api/YAMLObject.rs`) have no rule for U+D800 to U+DFFF. `decode_hex_code_point` (`src/parsers/yaml.rs:5502`) rejects a lone `\uD800` escape, so a well-formed output could not be read back either.

### Fix
- `string_needs_quotes` forces the double-quoted style for a string with an unpaired surrogate. `append_double_quoted_string` writes it as `\uXXXX`, the way `JSON.stringify` does. A surrogate pair stays verbatim. The output is now the same as eemeli/yaml's (`"a\ud800b": 1`).
- `decode_hex_code_point` keeps an unpaired `\uXXXX` surrogate as a lone UTF-16 code unit instead of raising `SyntaxError`. In the UTF-8 parser the buffer holds it as WTF-8 (`ED xx xx`), which the existing `E::String` to JS conversion (`wtf8_to_utf16_alloc`) already decodes back to the code unit. A lead escape followed by a trail escape still combines. A `\U` escape that names a surrogate still fails.
- Correct because YAML 1.2 is a JSON superset and `"\ud800"` is a valid JSON text (RFC 8259 §8.2). `JSON.parse`, js-yaml and eemeli/yaml all return the lone code unit for it. `YAML.parse(doc)` now equals `JSON.parse(doc)` for every such document.
- Verified: `test/js/bun/yaml/yaml.test.ts` (4 new tests, all fail on 1.4.0). Also `test/js/bun/yaml/`, `test/js/bun/resolve/yaml/`, `test/bundler/bundler_loader.test.ts`.

### Background
- A JS string is a sequence of UTF-16 code units. A lead surrogate (D800 to DBFF) followed by a trail surrogate (DC00 to DFFF) encodes one supplementary character. Either unit on its own is an unpaired surrogate: it is not a Unicode character and has no UTF-8 encoding.
- Every conversion of a JS string to UTF-8 in bun replaces an unpaired surrogate with U+FFFD. That is why text that holds one cannot survive a file, a socket, or `YAML.parse` unless it is written as an ASCII escape.
- WTF-8 is UTF-8 plus 3-byte encodings of unpaired surrogates. The YAML parser works on bytes, so it needs WTF-8 to carry a lone code unit from a `\u` escape to the JS string.
- `string_needs_quotes` decides between a plain scalar (verbatim) and a double-quoted scalar (escapes). YAML has no escapes outside double quotes.

<details><summary>Notes</summary>

Reference behavior, checked live with `yaml@2` and `js-yaml@4`:

```
yaml     stringify({"a\uD800b":1,"a\uDC00b":2,"a\uFFFDb":3}) -> "a\ud800b": 1\n"a\udc00b": 2\na\uFFFDb: 3   (round trip: 3 keys)
js-yaml  same, uppercase hex
both     parse('"\\uD83D"') -> U+D83D, parse('"\\uD83D\\uD83D\\uDE00"') -> U+D83D U+1F600
both     parse('"\\U0000D83D"') -> U+D83D   (this PR keeps \U surrogates as an error, as before)
```

libyaml, go-yaml and serde_yaml reject lone surrogate escapes. The JS libraries and `JSON.parse` accept them. `Bun.YAML` is a JS API and its `stringify` now produces these escapes, so `parse` follows the JS libraries.

A raw unpaired surrogate in the string passed to `YAML.parse` (not an escape) is still replaced with U+FFFD. That is the string to UTF-8 conversion at the API boundary, the same as for every other bun API that takes text.

#32731 added the pair combining and chose to keep lone surrogates as an error. #35067 (JSON5) made the same stringify change for JSON5 and left YAML out because of that parser rule.

Probe output on this branch:

```
stringify: {"a\ud800b": 1,"a\udc00b": 2,a�b: 3}
round trip: 3 {"a\ud800b":1,"a\udc00b":2,"a�b":3}
values: {a: "x\ud800y",b: "x\udc00y",c: "\udc00\ud800",d: 😀,e: "\ud83d😀",f: "\ud800"}
all 2048 surrogate code units round-trip: true
```
</details>
