### PR TITLE
test(heapStats-mimalloc): read VM tags from the kernel instead of vmmap labels

### DIFF
--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -82,9 +82,9 @@ describe("heapStats() mimalloc integration", () => {
            mach_vm_region: { args: ["u32", "ptr", "ptr", "i32", "ptr", "ptr", "ptr"], returns: "i32" },
          }).symbols;
          const task = task_self_trap();
+         const VM_REGION_EXTENDED_INFO = 13, VM_REGION_EXTENDED_INFO_COUNT = 9; // sizeof(vm_region_extended_info_data_t) / 4
          const address = new BigUint64Array(1), size = new BigUint64Array(1);
-         const info = new Uint32Array(16), count = new Uint32Array(1), object = new Uint32Array(1);
-         const VM_REGION_EXTENDED_INFO = 13, VM_REGION_EXTENDED_INFO_COUNT = 10;
+         const info = new Uint32Array(VM_REGION_EXTENDED_INFO_COUNT), count = new Uint32Array(1), object = new Uint32Array(1);
          const bytesByTag = new Map();
          for (;;) {
            count[0] = VM_REGION_EXTENDED_INFO_COUNT;

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -66,19 +66,39 @@ describe("heapStats() mimalloc integration", () => {
 
   // mimalloc tags its arena mmaps with an app-reserved VM tag (240-255). The old default,
   // 100, is VM_MEMORY_IOACCELERATOR, so profilers reported Bun's heap as GPU memory.
+  // The tags are read back from the kernel (mach_vm_region's user_tag), not from vmmap's
+  // summary: vmmap's names for them change between releases (macOS 26 prints tag 240 as
+  // "Memory Tag 240", macOS 27 as "App-Specific Tag 1").
   test.skipIf(!isMacOS)("arena memory is tagged as application memory, not IOAccelerator", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `const keep = [];
+        `import { dlopen, ptr } from "bun:ffi";
+         const keep = [];
          for (let i = 0; i < 96; i++) keep.push(Buffer.alloc(1 << 20, i).toString("latin1"));
-         const summary = Bun.spawnSync({ cmd: ["vmmap", "--summary", String(process.pid)] }).stdout.toString();
-         const mb = name => summary.split("\\n").filter(l => l.startsWith(name)).reduce((n, l) => {
-           const m = l.slice(name.length).match(/([\\d.]+)([KMG])/);
-           return m ? n + parseFloat(m[1]) * { K: 1 / 1024, M: 1, G: 1024 }[m[2]] : n;
-         }, 0);
-         console.log(JSON.stringify({ ioaccelerator: mb("IOAccelerator"), appTag: mb("Memory Tag 24") + mb("Memory Tag 25"), kept: keep.length }));`,
+         const { task_self_trap, mach_vm_region } = dlopen("libSystem.B.dylib", {
+           task_self_trap: { args: [], returns: "u32" },
+           mach_vm_region: { args: ["u32", "ptr", "ptr", "i32", "ptr", "ptr", "ptr"], returns: "i32" },
+         }).symbols;
+         const task = task_self_trap();
+         const address = new BigUint64Array(1), size = new BigUint64Array(1);
+         const info = new Uint32Array(16), count = new Uint32Array(1), object = new Uint32Array(1);
+         const VM_REGION_EXTENDED_INFO = 13, VM_REGION_EXTENDED_INFO_COUNT = 10;
+         const bytesByTag = new Map();
+         for (;;) {
+           count[0] = VM_REGION_EXTENDED_INFO_COUNT;
+           if (mach_vm_region(task, ptr(address), ptr(size), VM_REGION_EXTENDED_INFO, ptr(info), ptr(count), ptr(object)) !== 0) break;
+           const tag = info[1]; // vm_region_extended_info.user_tag, after the protection field
+           bytesByTag.set(tag, (bytesByTag.get(tag) ?? 0) + Number(size[0]));
+           address[0] += size[0];
+         }
+         const mb = (from, to) => {
+           let bytes = 0;
+           for (let tag = from; tag <= to; tag++) bytes += bytesByTag.get(tag) ?? 0;
+           return bytes / (1 << 20);
+         };
+         console.log(JSON.stringify({ ioaccelerator: mb(100, 100), appTag: mb(240, 255), kept: keep.length }));`,
       ],
       env: bunEnv,
       stdout: "pipe",


### PR DESCRIPTION
### Problem
- `heapStats-mimalloc.test.ts` > `arena memory is tagged as application memory, not IOAccelerator` fails on macOS 27 beta (26A5416b): `expect(appTag).toBeGreaterThan(64)`, `Received: 0`. It passes on macOS 14, 15 and 26. Build 103104, lane `darwin 27 aarch64`.
- The test sums `vmmap --summary` lines that start with `Memory Tag 24` / `Memory Tag 25`. vmmap on macOS 27 prints tag 240 as `App-Specific Tag 1` (255 as `App-Specific Tag 16`), so nothing matches. The kernel still stores tag 240 on every mimalloc mapping. Bun has no regression.

### Fix
- The child reads the tags from the kernel with `mach_vm_region(VM_REGION_EXTENDED_INFO)` through `bun:ffi` and sums the region sizes per `user_tag`. `ioaccelerator` is the total for tag 100, `appTag` the total for tags 240 to 255. The assertions do not change.
- This is the same quantity as before (vmmap's VIRTUAL column is the sum of region sizes per tag), without the label table that Apple renames between releases.
- Verified on the macOS 27 box with bun 1.4.0: the same walk reports tag 240 at 1042.4 MB, tag 100 at 0 MB. On Linux the test is skipped. The other four tests in the file pass with `bun bd test`.

### Background
- A VM tag is an 8-bit label on each kernel map entry. On Darwin, `mmap` takes it in the `fd` argument as `VM_MAKE_TAG(tag)` when `MAP_ANON` is set. mimalloc passes 240 (`VM_MEMORY_APPLICATION_SPECIFIC_1`) since #36431. The old value, 100, is `VM_MEMORY_IOACCELERATOR`, so Instruments showed Bun's heap as GPU memory.
- `vmmap` turns tags into display names with a private table. `mach_vm_region` returns the raw tag in `vm_region_extended_info.user_tag`, the second 32-bit field of the struct.

Fixes #40037

<details><summary>Notes</summary>

Data from the macOS 27 box (`darwin-arm64-bingus`, xnu-13432.1.9~3), collected with a plain C probe and with the same probe through `bun:ffi` in bun 1.4.0.

Kernel view, one mapping per tag through `mmap(fd=VM_MAKE_TAG(tag))` and `mach_vm_allocate(VM_FLAGS_ANYWHERE | VM_MAKE_TAG(tag))`, read back with `mach_vm_region`:

```
mmap              requested=100  stored=100
mmap              requested=240  stored=240
mach_vm_allocate  requested=240  stored=240
...
mmap              requested=255  stored=255
```

vmmap labels on macOS 27 for the same mappings:

```
App-Specific Tag 1 .. 16   tags 240 .. 255   (macOS 26: "Memory Tag 240" ..)
Rosetta Tag 10             tag 239
VM_MEMORY_150              tag 150           (macOS 26: "Memory Tag 150")
Sanitizer                  tag 99
IOAccelerator              tag 100           (unchanged)
Untagged                   tag 0             (macOS 26: "VM_ALLOCATE")
```

bun 1.4.0 on macOS 27, `vmmap --summary` of the test's child (96 x 1 MiB latin1 strings kept alive):

```
App-Specific Tag 1               260.4M   146.9M   121.2M   ...   9
App-Specific Tag 1 (reserved)    768.0M       0K       0K   ...   1   reserved VM address space (unallocated)
```

The same process, kernel walk via `bun:ffi` (what the test now does):

```
tag 100: (absent)
tag 240: virtual=    1042.4M resident=   146.9M regions=17
```

bun 1.3.13 (before the tag change) on macOS 27 shows the arena as `IOAccelerator 132.3M` plus `IOAccelerator (reserved) 896.0M`, so the `ioaccelerator` assertion still catches the old default on 27.

macOS 27's vmmap also retitles the other rows (`Malloc Small`, `Stack Guard`, `Guard`, `OS Alloc Once`) and splits unallocated address space into `<label> (reserved)` rows. None of that matters once the test stops parsing the summary.

The gate cannot exercise this test: it is `skipIf(!isMacOS)` and there is no `src/` change. The darwin CI lanes run it on macOS 14, 15 and 26. The macOS 27 lane from #40019 runs it once that PR lands.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/heapStats-mimalloc.test.ts

<!-- robobun:evidence:end -->