### PR TITLE
node:http: throw ERR_SERVER_ALREADY_LISTEN when listen() is called on a listening server

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -584,6 +584,12 @@ Server.prototype.listen = function () {
     this.once("listening", lastArg);
   }
 
+  // Each listen() creates a new native listener, so a second call on a server
+  // that already has one would leak the first (still accepting, never closed).
+  if (this[serverSymbol]) {
+    throw $ERR_SERVER_ALREADY_LISTEN();
+  }
+
   try {
     // listenInCluster
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -578,14 +578,14 @@ Server.prototype.listen = function () {
     }
   }
 
+  if (this[serverSymbol]) {
+    throw $ERR_SERVER_ALREADY_LISTEN();
+  }
+
   const lastArg = arguments[argc - 1];
   if ($isCallable(lastArg)) {
     // Before the bind, as in node, so a listen() retried from the 'error' handler still calls it.
     this.once("listening", lastArg);
-  }
-
-  if (this[serverSymbol]) {
-    throw $ERR_SERVER_ALREADY_LISTEN();
   }
 
   try {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -584,8 +584,6 @@ Server.prototype.listen = function () {
     this.once("listening", lastArg);
   }
 
-  // Each listen() creates a new native listener, so a second call on a server
-  // that already has one would leak the first (still accepting, never closed).
   if (this[serverSymbol]) {
     throw $ERR_SERVER_ALREADY_LISTEN();
   }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4366,3 +4366,68 @@ describe("response header values are written as latin-1 bytes", () => {
     ]);
   });
 });
+
+// Node's net.Server#listen throws while the server still has a handle, and http.Server inherits
+// that. Here every listen() builds a new native listener, so without the guard each extra call
+// leaked a listening socket that close() never reached and that kept the process alive.
+test("listen() while already listening throws ERR_SERVER_ALREADY_LISTEN", async () => {
+  const alreadyListening = expect.objectContaining({ code: "ERR_SERVER_ALREADY_LISTEN" });
+  const server = createServer((req, res) => res.end("ok"));
+  try {
+    server.listen(0, "127.0.0.1");
+    // Same tick, before 'listening' fired.
+    expect(() => server.listen(0, "127.0.0.1")).toThrow(alreadyListening);
+    await once(server, "listening");
+    expect(() => server.listen(0, "127.0.0.1")).toThrow(alreadyListening);
+    expect(() => server.listen()).toThrow(alreadyListening);
+
+    const { port } = server.address() as AddressInfo;
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(await res.text()).toBe("ok");
+
+    // close() releases the handle, so listen() is allowed again (test-net-server-call-listen-multiple-times).
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    expect(server.address()).toBeNull();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    expect(server.address()).not.toBeNull();
+    expect(() => server.listen(0, "127.0.0.1")).toThrow(alreadyListening);
+  } finally {
+    server.close();
+  }
+});
+
+test("repeated listen() does not leak listeners that outlive close()", async () => {
+  // Without the guard the 19 extra listeners kept serving after close() and the process never exited.
+  const script = `
+    const http = require("node:http");
+    const server = http.createServer((req, res) => res.end("ok"));
+    let rejected = 0;
+    for (let i = 0; i < 20; i++) {
+      try {
+        server.listen(0, "127.0.0.1");
+        if (i > 0) {
+          console.log("listen " + i + " did not throw");
+          process.exit(1);
+        }
+      } catch (e) {
+        if (e.code === "ERR_SERVER_ALREADY_LISTEN") rejected++;
+      }
+      await new Promise(r => setImmediate(r));
+    }
+    const { port } = server.address();
+    const res = await fetch("http://127.0.0.1:" + port + "/");
+    console.log("rejected:" + rejected + " served:" + (await res.text()));
+    server.close(() => console.log("closed:" + server.address()));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual(["rejected:19 served:ok", "closed:null"]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4380,6 +4380,11 @@ test("listen() while already listening throws ERR_SERVER_ALREADY_LISTEN", async 
     await once(server, "listening");
     expect(() => server.listen(0, "127.0.0.1")).toThrow(alreadyListening);
     expect(() => server.listen()).toThrow(alreadyListening);
+    // Node checks the handle before it registers the callback, so a rejected
+    // listen() leaves no 'listening' listener behind.
+    const rejectedCallback = mock(() => {});
+    expect(() => server.listen(0, "127.0.0.1", rejectedCallback)).toThrow(alreadyListening);
+    expect(server.listenerCount("listening")).toBe(1); // the server's own setupConnectionsTracking
 
     const { port } = server.address() as AddressInfo;
     const res = await fetch(`http://127.0.0.1:${port}/`);
@@ -4391,6 +4396,7 @@ test("listen() while already listening throws ERR_SERVER_ALREADY_LISTEN", async 
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     expect(server.address()).not.toBeNull();
+    expect(rejectedCallback).not.toHaveBeenCalled();
     expect(() => server.listen(0, "127.0.0.1")).toThrow(alreadyListening);
   } finally {
     server.close();

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -166,22 +166,21 @@ describe.each(["FormData", "Blob", "Buffer", "String", "URLSearchParams", "strea
 test("do not leak", async () => {
   await using server = createServer((req, res) => {
     res.end();
-  }).listen(0);
+  }).listen(0, "127.0.0.1");
   await once(server, "listening");
 
-  let url;
+  const url = new URL(`http://127.0.0.1:${server.address().port}`);
   let isDone = false;
-  server.listen(0, "127.0.0.1", function attack() {
+  (function attack() {
     if (isDone) {
       return;
     }
-    url ??= new URL(`http://127.0.0.1:${server.address().port}`);
     const controller = new AbortController();
     fetch(url, { signal: controller.signal })
       .then(res => res.arrayBuffer())
       .catch(() => {})
       .then(attack);
-  });
+  })();
 
   let prev = Infinity;
   let count = 0;


### PR DESCRIPTION
### Problem
- `server.listen()` on a `node:http` server that already listens creates a second listening socket and drops the reference to the first. Twenty `listen()` calls give twenty LISTEN sockets. `close()` stops only the last one. The other nineteen keep serving requests and keep the process alive. Node throws `ERR_SERVER_ALREADY_LISTEN` synchronously and keeps one socket.
- The cause is `Server.prototype.listen` in `src/js/node/_http_server.ts:531`. It calls `kRealListen`, which does `this[serverSymbol] = Bun.serve(...)` on every call (line 628). `net.Server#listen` has the guard (`net.ts:3801`, `if (this._handle) throw`). The http server never had it.

### Fix
- `Server.prototype.listen` throws `ERR_SERVER_ALREADY_LISTEN` when `this[serverSymbol]` is set, before it registers the `'listening'` callback and before it creates a native listener. The check sits before the `try` block, so the error is thrown, not emitted as `'error'`, and a rejected call leaves no listener behind. This is the order Node and `net.ts` use.
- `close()` and `closeAllConnections()` clear `this[serverSymbol]`, so `close()` then `listen()` still works. A `listen()` whose `Bun.serve` throws (EADDRINUSE) never sets the symbol, so a retry after `'error'` still works. `https.Server` is the same class.
- `test/js/web/fetch/fetch-leak.test.ts` called `listen()` a second time on a listening server to start its request loop. It now listens once and starts the loop directly.
- Verified: `test/js/node/http/node-http.test.ts` (two new tests, both fail on 1.4.0). Also `test/js/node/http/` and the cluster http tests in `test/js/node/test/parallel/`.

### Background
- `node:http`'s `Server` in Bun is not a `net.Server`. It is a facade over `Bun.serve`. `this[serverSymbol]` holds the `Bun.serve` instance and plays the role of Node's `_handle`.
- In Node, `listening` and the already-listening check both derive from `_handle`. A handle exists from the synchronous part of `listen()` until `close()`.

<details><summary>Notes</summary>

Repro against bun 1.4.0 (Linux, `ss -ltnp` counts sockets owned by the process):

```js
import http from "node:http";
const srv = http.createServer((q, r) => r.end("ok"));
for (let i = 0; i < 20; i++) {
  try { srv.listen(0, "127.0.0.1"); } catch {}
  await new Promise(r => setImmediate(r));
}
// bun 1.4.0: 20 LISTEN sockets, 0 errors. After close(): 19 sockets, process never exits.
// node v26.3.0: 1 LISTEN socket, 19 ERR_SERVER_ALREADY_LISTEN. After close(): 0, exits.
// this branch: same as node.
```

`test/js/node/http/` has three failures in this container that also fail on main with the same build: `request via http proxy, issue#4295` (the container resolves `localhost` to `::1` first, and Node fails the same way there), and two subprocess tests that hit their 5s timeout on the ASAN debug build (`node-http-connect.test.ts` "tests should run on bun", `node-http-syscall-fault.test.ts` "racing a queued drain").

A scan of `test/` for a second `.listen()` on one http server found only `fetch-leak.test.ts`.

#35498 is an earlier PR with the same guard. Its CI run hit build-agent expiry in July and it never got a new run. This PR supersedes it, with the test in the existing `node-http.test.ts` plus a subprocess test that proves the process exits after `close()`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch-leak.test.ts

<!-- robobun:evidence:end -->
