### PR TITLE
Read iterator results through their structure instead of [[Get]]

### DIFF
--- a/src/jsc/bindings/ObjectBindings.h
+++ b/src/jsc/bindings/ObjectBindings.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "root.h"
 #include <JavaScriptCore/IteratorOperations.h>
+#include <utility>
 
 namespace Bun {
 
@@ -33,54 +34,21 @@ ALWAYS_INLINE JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::
 JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name);
 
 /**
- * True when `object` has the realm's iteratorResultObjectStructure: `{ value, done }` as two
- * plain data properties at iteratorResultObjectValuePropertyOffset and
- * iteratorResultObjectDonePropertyOffset. createIteratorResultObject, the `{ value, done }`
- * literals of the generator and Array/Map/Set/String iterator builtins, and the DFG/FTL
- * inlined next() all produce it. Any mutation of such an object (a getter, a deleted
- * property, a prototype change, freezing) transitions it to another structure, so a match
- * means no user code can observe the read.
+ * `{ done, value }` of an iterator result object.
+ *
+ * When `result` has the realm's iteratorResultObjectStructure, both are plain data properties
+ * at iteratorResultObjectDonePropertyOffset / iteratorResultObjectValuePropertyOffset and the
+ * two slots are read directly. createIteratorResultObject, the `{ value, done }` literals of the
+ * generator and Array/Map/Set/String iterator builtins, and the DFG-inlined next() all produce
+ * that structure. Any mutation (a getter, a delete, a prototype change, a freeze) transitions the
+ * object to another structure, so on a match no user code can observe the read.
+ *
+ * Otherwise this is `get(done)` then `get(value)`. If either throws, both values are empty and
+ * the exception is pending on the VM.
  */
-ALWAYS_INLINE bool isIteratorResultObject(JSC::JSGlobalObject* globalObject, JSC::JSObject* object)
+ALWAYS_INLINE std::pair<JSC::JSValue, JSC::JSValue> getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
 {
-    return object->structureID() == globalObject->iteratorResultObjectStructure()->id();
-}
-
-/**
- * `result.value` with the iteratorResultObjectStructure slot read as the fast path.
- * Equivalent to `result->get(globalObject, vm.propertyNames->value)`.
- */
-ALWAYS_INLINE JSC::JSValue getIteratorResultValue(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
-{
-    if (isIteratorResultObject(globalObject, result)) [[likely]]
-        return result->getDirect(JSC::iteratorResultObjectValuePropertyOffset);
-    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->value);
-}
-
-/**
- * `result.done` with the iteratorResultObjectStructure slot read as the fast path.
- * Equivalent to `result->get(globalObject, vm.propertyNames->done)`.
- */
-ALWAYS_INLINE JSC::JSValue getIteratorResultDone(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
-{
-    if (isIteratorResultObject(globalObject, result)) [[likely]]
-        return result->getDirect(JSC::iteratorResultObjectDonePropertyOffset);
-    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->done);
-}
-
-struct IteratorResult {
-    JSC::JSValue done;
-    JSC::JSValue value;
-};
-
-/**
- * Both fields of an iterator result with one structure check. Off the fast path this is
- * `get(done)` then `get(value)` (the IteratorComplete, IteratorValue order); if either
- * throws, the returned fields are empty and the exception is pending on the VM.
- */
-ALWAYS_INLINE IteratorResult getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
-{
-    if (isIteratorResultObject(globalObject, result)) [[likely]]
+    if (result->structureID() == globalObject->iteratorResultObjectStructure()->id()) [[likely]]
         return { result->getDirect(JSC::iteratorResultObjectDonePropertyOffset), result->getDirect(JSC::iteratorResultObjectValuePropertyOffset) };
 
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ObjectBindings.h
+++ b/src/jsc/bindings/ObjectBindings.h
@@ -33,8 +33,14 @@ ALWAYS_INLINE JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::
  */
 JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name);
 
+// Whether `getIteratorResult` runs `get(value)` on a result whose `done` is true. IteratorStepValue never does.
+enum class IteratorDoneValue : uint8_t {
+    Read,
+    Skip,
+};
+
 // `{ done, value }` of an iterator result: the inline slots when `result` has the realm's iteratorResultObjectStructure, else `get(done)` then `get(value)` (both empty if either throws).
-ALWAYS_INLINE std::pair<JSC::JSValue, JSC::JSValue> getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
+ALWAYS_INLINE std::pair<JSC::JSValue, JSC::JSValue> getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result, IteratorDoneValue doneValue = IteratorDoneValue::Read)
 {
     if (result->structureID() == globalObject->iteratorResultObjectStructure()->id()) [[likely]]
         return { result->getDirect(JSC::iteratorResultObjectDonePropertyOffset), result->getDirect(JSC::iteratorResultObjectValuePropertyOffset) };
@@ -43,6 +49,8 @@ ALWAYS_INLINE std::pair<JSC::JSValue, JSC::JSValue> getIteratorResult(JSC::JSGlo
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue done = result->get(globalObject, vm.propertyNames->done);
     RETURN_IF_EXCEPTION(scope, {});
+    if (doneValue == IteratorDoneValue::Skip && done.toBoolean(globalObject))
+        return { done, JSC::jsUndefined() };
     JSC::JSValue value = result->get(globalObject, vm.propertyNames->value);
     RETURN_IF_EXCEPTION(scope, {});
     return { done, value };

--- a/src/jsc/bindings/ObjectBindings.h
+++ b/src/jsc/bindings/ObjectBindings.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "root.h"
+#include <JavaScriptCore/IteratorOperations.h>
 
 namespace Bun {
 
@@ -30,5 +31,65 @@ ALWAYS_INLINE JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::
  * This is the strictest form of property access - use for security-critical options.
  */
 JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name);
+
+/**
+ * True when `object` has the realm's iteratorResultObjectStructure: `{ value, done }` as two
+ * plain data properties at iteratorResultObjectValuePropertyOffset and
+ * iteratorResultObjectDonePropertyOffset. createIteratorResultObject, the `{ value, done }`
+ * literals of the generator and Array/Map/Set/String iterator builtins, and the DFG/FTL
+ * inlined next() all produce it. Any mutation of such an object (a getter, a deleted
+ * property, a prototype change, freezing) transitions it to another structure, so a match
+ * means no user code can observe the read.
+ */
+ALWAYS_INLINE bool isIteratorResultObject(JSC::JSGlobalObject* globalObject, JSC::JSObject* object)
+{
+    return object->structureID() == globalObject->iteratorResultObjectStructure()->id();
+}
+
+/**
+ * `result.value` with the iteratorResultObjectStructure slot read as the fast path.
+ * Equivalent to `result->get(globalObject, vm.propertyNames->value)`.
+ */
+ALWAYS_INLINE JSC::JSValue getIteratorResultValue(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
+{
+    if (isIteratorResultObject(globalObject, result)) [[likely]]
+        return result->getDirect(JSC::iteratorResultObjectValuePropertyOffset);
+    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->value);
+}
+
+/**
+ * `result.done` with the iteratorResultObjectStructure slot read as the fast path.
+ * Equivalent to `result->get(globalObject, vm.propertyNames->done)`.
+ */
+ALWAYS_INLINE JSC::JSValue getIteratorResultDone(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
+{
+    if (isIteratorResultObject(globalObject, result)) [[likely]]
+        return result->getDirect(JSC::iteratorResultObjectDonePropertyOffset);
+    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->done);
+}
+
+struct IteratorResult {
+    JSC::JSValue done;
+    JSC::JSValue value;
+};
+
+/**
+ * Both fields of an iterator result with one structure check. Off the fast path this is
+ * `get(done)` then `get(value)` (the IteratorComplete, IteratorValue order); if either
+ * throws, the returned fields are empty and the exception is pending on the VM.
+ */
+ALWAYS_INLINE IteratorResult getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
+{
+    if (isIteratorResultObject(globalObject, result)) [[likely]]
+        return { result->getDirect(JSC::iteratorResultObjectDonePropertyOffset), result->getDirect(JSC::iteratorResultObjectValuePropertyOffset) };
+
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSValue done = result->get(globalObject, vm.propertyNames->done);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSValue value = result->get(globalObject, vm.propertyNames->value);
+    RETURN_IF_EXCEPTION(scope, {});
+    return { done, value };
+}
 
 }

--- a/src/jsc/bindings/ObjectBindings.h
+++ b/src/jsc/bindings/ObjectBindings.h
@@ -33,9 +33,7 @@ ALWAYS_INLINE JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::
  */
 JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name);
 
-// `{ done, value }` of an iterator result. An object with the realm's iteratorResultObjectStructure
-// holds both as data properties at fixed inline offsets (any mutation transitions it away), so the
-// slots are read directly. Otherwise `get(done)` then `get(value)`; both empty if either throws.
+// `{ done, value }` of an iterator result: the inline slots when `result` has the realm's iteratorResultObjectStructure, else `get(done)` then `get(value)` (both empty if either throws).
 ALWAYS_INLINE std::pair<JSC::JSValue, JSC::JSValue> getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
 {
     if (result->structureID() == globalObject->iteratorResultObjectStructure()->id()) [[likely]]

--- a/src/jsc/bindings/ObjectBindings.h
+++ b/src/jsc/bindings/ObjectBindings.h
@@ -33,19 +33,9 @@ ALWAYS_INLINE JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::
  */
 JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name);
 
-/**
- * `{ done, value }` of an iterator result object.
- *
- * When `result` has the realm's iteratorResultObjectStructure, both are plain data properties
- * at iteratorResultObjectDonePropertyOffset / iteratorResultObjectValuePropertyOffset and the
- * two slots are read directly. createIteratorResultObject, the `{ value, done }` literals of the
- * generator and Array/Map/Set/String iterator builtins, and the DFG-inlined next() all produce
- * that structure. Any mutation (a getter, a delete, a prototype change, a freeze) transitions the
- * object to another structure, so on a match no user code can observe the read.
- *
- * Otherwise this is `get(done)` then `get(value)`. If either throws, both values are empty and
- * the exception is pending on the VM.
- */
+// `{ done, value }` of an iterator result. An object with the realm's iteratorResultObjectStructure
+// holds both as data properties at fixed inline offsets (any mutation transitions it away), so the
+// slots are read directly. Otherwise `get(done)` then `get(value)`; both empty if either throws.
 ALWAYS_INLINE std::pair<JSC::JSValue, JSC::JSValue> getIteratorResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result)
 {
     if (result->structureID() == globalObject->iteratorResultObjectStructure()->id()) [[likely]]

--- a/src/jsc/bindings/webcore/JSStructuredSerializeOptions.cpp
+++ b/src/jsc/bindings/webcore/JSStructuredSerializeOptions.cpp
@@ -67,12 +67,10 @@ Vector<JSC::Strong<JSC::JSObject>> convertTransferList(JSGlobalObject& lexicalGl
         RETURN_IF_EXCEPTION(throwScope, {});
         if (!step.isObject())
             return notIterable();
-        JSValue done = Bun::getIteratorResultDone(&lexicalGlobalObject, asObject(step));
+        auto [done, element] = Bun::getIteratorResult(&lexicalGlobalObject, asObject(step));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (done.toBoolean(&lexicalGlobalObject))
             break;
-        JSValue element = Bun::getIteratorResultValue(&lexicalGlobalObject, asObject(step));
-        RETURN_IF_EXCEPTION(throwScope, {});
         // The arg IS iterable, so a bad *element* is not a "must be an iterable" error.
         // node: DataCloneError from port.postMessage(), TypeError from structuredClone().
         if (!element.isObject()) {

--- a/src/jsc/bindings/webcore/JSStructuredSerializeOptions.cpp
+++ b/src/jsc/bindings/webcore/JSStructuredSerializeOptions.cpp
@@ -25,6 +25,7 @@
 #include "ErrorCode.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMException.h"
+#include "ObjectBindings.h"
 #include "ZigGlobalObject.h"
 #include "JSDOMConvertSequences.h"
 #include <JavaScriptCore/JSArray.h>
@@ -66,11 +67,11 @@ Vector<JSC::Strong<JSC::JSObject>> convertTransferList(JSGlobalObject& lexicalGl
         RETURN_IF_EXCEPTION(throwScope, {});
         if (!step.isObject())
             return notIterable();
-        JSValue done = step.get(&lexicalGlobalObject, vm.propertyNames->done);
+        JSValue done = Bun::getIteratorResultDone(&lexicalGlobalObject, asObject(step));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (done.toBoolean(&lexicalGlobalObject))
             break;
-        JSValue element = step.get(&lexicalGlobalObject, vm.propertyNames->value);
+        JSValue element = Bun::getIteratorResultValue(&lexicalGlobalObject, asObject(step));
         RETURN_IF_EXCEPTION(throwScope, {});
         // The arg IS iterable, so a bad *element* is not a "must be an iterable" error.
         // node: DataCloneError from port.postMessage(), TypeError from structuredClone().

--- a/src/jsc/bindings/webcore/JSStructuredSerializeOptions.cpp
+++ b/src/jsc/bindings/webcore/JSStructuredSerializeOptions.cpp
@@ -67,7 +67,7 @@ Vector<JSC::Strong<JSC::JSObject>> convertTransferList(JSGlobalObject& lexicalGl
         RETURN_IF_EXCEPTION(throwScope, {});
         if (!step.isObject())
             return notIterable();
-        auto [done, element] = Bun::getIteratorResult(&lexicalGlobalObject, asObject(step));
+        auto [done, element] = Bun::getIteratorResult(&lexicalGlobalObject, asObject(step), Bun::IteratorDoneValue::Skip);
         RETURN_IF_EXCEPTION(throwScope, {});
         if (done.toBoolean(&lexicalGlobalObject))
             break;

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -12,6 +12,7 @@
 #include "JSDOMWrapperCache.h"
 #include "JSReadableStream.h"
 #include "JSStreamsRuntime.h"
+#include "ObjectBindings.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
@@ -226,9 +227,7 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
         throwTypeError(globalObject, scope, "Async iterator result is not an object"_s);
         return NextStep::Finished;
     }
-    JSValue doneValue = result.get(globalObject, vm.propertyNames->done);
-    RETURN_IF_EXCEPTION(scope, NextStep::Finished);
-    JSValue value = result.get(globalObject, vm.propertyNames->value);
+    auto [doneValue, value] = Bun::getIteratorResult(globalObject, asObject(result));
     RETURN_IF_EXCEPTION(scope, NextStep::Finished);
 
     if (doneValue.toBoolean(globalObject))

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -792,9 +792,7 @@ static JSValue intoArrayLoop(JSC::VM& vm, JSGlobalObject* globalObject, WebCore:
             throwTypeError(globalObject, scope, "readMany() did not return an object"_s);
             return {};
         }
-        JSValue doneValue = runtime->readManyResultDone(globalObject, result);
-        RETURN_IF_EXCEPTION(scope, {});
-        JSValue value = runtime->readManyResultValue(globalObject, result);
+        auto [doneValue, value] = runtime->readManyResult(globalObject, result);
         RETURN_IF_EXCEPTION(scope, {});
         if (auto* valueArray = dynamicDowncast<JSArray>(value)) {
             unsigned valueLength = valueArray->length();
@@ -1621,7 +1619,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectConsumeLoopReadFulfilled, (
     auto* context = uncheckedDowncast<InternalFieldTuple>(callFrame->uncheckedArgument(1));
     bool done = false;
     if (JSObject* result = callFrame->argument(0).getObject()) {
-        JSValue doneValue = Bun::getIteratorResultDone(globalObject, result);
+        JSValue doneValue = Bun::getIteratorResult(globalObject, result).first;
         RETURN_IF_EXCEPTION(scope, {});
         done = doneValue.toBoolean(globalObject);
     }

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -18,6 +18,7 @@
 #include "JSReadableStream.h"
 #include "JSReadableStreamDefaultReader.h"
 #include "JSStreamsRuntime.h"
+#include "ObjectBindings.h"
 #include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
@@ -777,10 +778,10 @@ static JSValue intoArrayLoop(JSC::VM& vm, JSGlobalObject* globalObject, WebCore:
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* domGlobalObject = defaultGlobalObject(globalObject);
+    auto* runtime = JSStreamsRuntime::from(globalObject);
     JSValue many = manyResult;
     while (true) {
         if (auto* manyPromise = dynamicDowncast<JSPromise>(many)) {
-            auto* runtime = JSStreamsRuntime::from(globalObject);
             auto* context = InternalFieldTuple::create(vm, domGlobalObject->internalFieldTupleStructure(), reader, chunks);
             auto* derived = JSPromise::create(vm, globalObject->promiseStructure());
             manyPromise->performPromiseThenWithContext(vm, globalObject, runtime->onIntoArrayReadManyFulfilled(), runtime->onIntoArrayReadManyRejected(), derived, context);
@@ -791,9 +792,9 @@ static JSValue intoArrayLoop(JSC::VM& vm, JSGlobalObject* globalObject, WebCore:
             throwTypeError(globalObject, scope, "readMany() did not return an object"_s);
             return {};
         }
-        JSValue doneValue = result->get(globalObject, vm.propertyNames->done);
+        JSValue doneValue = runtime->readManyResultDone(globalObject, result);
         RETURN_IF_EXCEPTION(scope, {});
-        JSValue value = result->get(globalObject, vm.propertyNames->value);
+        JSValue value = runtime->readManyResultValue(globalObject, result);
         RETURN_IF_EXCEPTION(scope, {});
         if (auto* valueArray = dynamicDowncast<JSArray>(value)) {
             unsigned valueLength = valueArray->length();
@@ -1555,9 +1556,7 @@ static bool intoArrayStep(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableS
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!readResult.isObject()) [[unlikely]]
         return true;
-    JSValue done = asObject(readResult)->get(globalObject, vm.propertyNames->done);
-    RETURN_IF_EXCEPTION(scope, true);
-    JSValue value = asObject(readResult)->get(globalObject, vm.propertyNames->value);
+    auto [done, value] = Bun::getIteratorResult(globalObject, asObject(readResult));
     RETURN_IF_EXCEPTION(scope, true);
     if (done.toBoolean(globalObject))
         return true;
@@ -1622,7 +1621,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectConsumeLoopReadFulfilled, (
     auto* context = uncheckedDowncast<InternalFieldTuple>(callFrame->uncheckedArgument(1));
     bool done = false;
     if (JSObject* result = callFrame->argument(0).getObject()) {
-        JSValue doneValue = result->get(globalObject, vm.propertyNames->done);
+        JSValue doneValue = Bun::getIteratorResultDone(globalObject, result);
         RETURN_IF_EXCEPTION(scope, {});
         done = doneValue.toBoolean(globalObject);
     }

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1121,8 +1121,7 @@ static void rsisContinueWithMany(JSC::VM& vm, JSGlobalObject* globalObject, JSRe
         throwTypeError(globalObject, scope, "readMany() returned an invalid result"_s);
         return;
     }
-    auto* runtime = WebCore::JSStreamsRuntime::from(globalObject);
-    JSValue done = runtime->readManyResultDone(globalObject, manyObject);
+    auto [done, valuesValue] = WebCore::JSStreamsRuntime::from(globalObject)->readManyResult(globalObject, manyObject);
     RETURN_IF_EXCEPTION(scope, );
     bool isDone = done.toBoolean(globalObject);
     RETURN_IF_EXCEPTION(scope, );
@@ -1133,8 +1132,6 @@ static void rsisContinueWithMany(JSC::VM& vm, JSGlobalObject* globalObject, JSRe
         rsisRegisterAndStart(vm, globalObject, op);
         RETURN_IF_EXCEPTION(scope, );
     }
-    JSValue valuesValue = runtime->readManyResultValue(globalObject, manyObject);
-    RETURN_IF_EXCEPTION(scope, );
     JSObject* values = valuesValue.getObject();
     unsigned length = 0;
     if (auto* valuesArray = dynamicDowncast<JSArray>(values)) {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1121,7 +1121,8 @@ static void rsisContinueWithMany(JSC::VM& vm, JSGlobalObject* globalObject, JSRe
         throwTypeError(globalObject, scope, "readMany() returned an invalid result"_s);
         return;
     }
-    JSValue done = manyObject->get(globalObject, vm.propertyNames->done);
+    auto* runtime = WebCore::JSStreamsRuntime::from(globalObject);
+    JSValue done = runtime->readManyResultDone(globalObject, manyObject);
     RETURN_IF_EXCEPTION(scope, );
     bool isDone = done.toBoolean(globalObject);
     RETURN_IF_EXCEPTION(scope, );
@@ -1132,11 +1133,13 @@ static void rsisContinueWithMany(JSC::VM& vm, JSGlobalObject* globalObject, JSRe
         rsisRegisterAndStart(vm, globalObject, op);
         RETURN_IF_EXCEPTION(scope, );
     }
-    JSValue valuesValue = manyObject->get(globalObject, vm.propertyNames->value);
+    JSValue valuesValue = runtime->readManyResultValue(globalObject, manyObject);
     RETURN_IF_EXCEPTION(scope, );
     JSObject* values = valuesValue.getObject();
     unsigned length = 0;
-    if (values) {
+    if (auto* valuesArray = dynamicDowncast<JSArray>(values)) {
+        length = valuesArray->length();
+    } else if (values) {
         JSValue lengthValue = values->get(globalObject, vm.propertyNames->length);
         RETURN_IF_EXCEPTION(scope, );
         length = lengthValue.toUInt32(globalObject);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -16,6 +16,7 @@
 #include "JSReadableStream.h"
 #include "JSReadableStreamDefaultController.h"
 #include "JSStreamsRuntime.h"
+#include "ObjectBindings.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInspectCustom.h"
@@ -172,9 +173,9 @@ static JSObject* createReadManyResult(JSC::VM& vm, JSGlobalObject* globalObject,
 {
     auto* structure = JSStreamsRuntime::from(globalObject)->readManyResultStructure(defaultGlobalObject(globalObject));
     auto* result = constructEmptyObject(vm, structure);
-    result->putDirectOffset(vm, 0, value);
-    result->putDirectOffset(vm, 1, jsNumber(size));
-    result->putDirectOffset(vm, 2, jsBoolean(done));
+    result->putDirectOffset(vm, JSStreamsRuntime::readManyResultValueOffset, value);
+    result->putDirectOffset(vm, JSStreamsRuntime::readManyResultSizeOffset, jsNumber(size));
+    result->putDirectOffset(vm, JSStreamsRuntime::readManyResultDoneOffset, jsBoolean(done));
     return result;
 }
 
@@ -318,9 +319,7 @@ static JSValue readManyAfterPull(JSC::VM& vm, JSGlobalObject* globalObject, JSRe
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!result.isObject()) [[unlikely]]
         RELEASE_AND_RETURN(scope, emptyDoneReadManyResult(vm, globalObject));
-    JSValue chunk = asObject(result)->get(globalObject, vm.propertyNames->value);
-    RETURN_IF_EXCEPTION(scope, {});
-    JSValue done = asObject(result)->get(globalObject, vm.propertyNames->done);
+    auto [done, chunk] = Bun::getIteratorResult(globalObject, asObject(result));
     RETURN_IF_EXCEPTION(scope, {});
     if (done.toBoolean(globalObject)) {
         auto* values = constructEmptyArray(globalObject, nullptr, chunk.toBoolean(globalObject) ? 1 : 0);
@@ -350,9 +349,7 @@ static JSValue readManyAfterDirectPull(JSC::VM& vm, JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!result.isObject()) [[unlikely]]
         RELEASE_AND_RETURN(scope, emptyDoneReadManyResult(vm, globalObject));
-    JSValue chunk = asObject(result)->get(globalObject, vm.propertyNames->value);
-    RETURN_IF_EXCEPTION(scope, {});
-    JSValue done = asObject(result)->get(globalObject, vm.propertyNames->done);
+    auto [done, chunk] = Bun::getIteratorResult(globalObject, asObject(result));
     RETURN_IF_EXCEPTION(scope, {});
     bool isDone = done.toBoolean(globalObject);
     bool hasChunk = isDone ? chunk.toBoolean(globalObject) : true;

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
@@ -98,11 +98,11 @@ void JSStreamsRuntime::initialize(Zig::GlobalObject* globalObject)
         auto* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), 3);
         JSC::PropertyOffset offset;
         structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->value, 0, offset);
-        RELEASE_ASSERT(offset == 0);
+        RELEASE_ASSERT(offset == readManyResultValueOffset);
         structure = Structure::addPropertyTransition(vm, structure, WebCore::builtinNames(vm).sizePublicName(), 0, offset);
-        RELEASE_ASSERT(offset == 1);
+        RELEASE_ASSERT(offset == readManyResultSizeOffset);
         structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->done, 0, offset);
-        RELEASE_ASSERT(offset == 2);
+        RELEASE_ASSERT(offset == readManyResultDoneOffset);
         init.set(structure);
     });
 }

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -385,8 +385,7 @@ public:
     static constexpr JSC::PropertyOffset readManyResultSizeOffset = 1;
     static constexpr JSC::PropertyOffset readManyResultDoneOffset = 2;
 
-    // `{ done, value }` of a readMany() result: the slots while `result` still has
-    // readManyResultStructure, else `get(done)` then `get(value)` (both empty if either throws).
+    // `{ done, value }` of a readMany() result: the slots while `result` has readManyResultStructure, else `get(done)` then `get(value)` (both empty if either throws).
     std::pair<JSC::JSValue, JSC::JSValue> readManyResult(JSC::JSGlobalObject*, JSC::JSObject* result) const;
 
 private:

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -380,8 +380,22 @@ public:
     // The readMany `{value, size, done}` result shape, so results are built with
     // putDirectOffset instead of three transitioning putDirects.
     JSC::Structure* readManyResultStructure(const Zig::GlobalObject*);
+    static constexpr JSC::PropertyOffset readManyResultValueOffset = 0;
+    static constexpr JSC::PropertyOffset readManyResultSizeOffset = 1;
+    static constexpr JSC::PropertyOffset readManyResultDoneOffset = 2;
+
+    // `result.done` / `result.value` of a readMany() result. While `result` still has
+    // readManyResultStructure (three plain data properties) the slot is read directly; a
+    // mutated result or a foreign object takes the ordinary [[Get]].
+    JSC::JSValue readManyResultDone(JSC::JSGlobalObject*, JSC::JSObject* result) const;
+    JSC::JSValue readManyResultValue(JSC::JSGlobalObject*, JSC::JSObject* result) const;
 
 private:
+    bool isReadManyResult(JSC::JSObject* object) const
+    {
+        return object->structureID() == m_readManyResultStructure.getInitializedOnMainThread(m_globalObject)->id();
+    }
+
     JSC::JSGlobalObject* m_globalObject { nullptr };
 
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction> m_handlers[static_cast<size_t>(Handler::Count)];
@@ -392,5 +406,19 @@ private:
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure> m_internalStructures[static_cast<size_t>(InternalStructure::Count)];
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure> m_readManyResultStructure;
 };
+
+inline JSC::JSValue JSStreamsRuntime::readManyResultDone(JSC::JSGlobalObject* globalObject, JSC::JSObject* result) const
+{
+    if (isReadManyResult(result)) [[likely]]
+        return result->getDirect(readManyResultDoneOffset);
+    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->done);
+}
+
+inline JSC::JSValue JSStreamsRuntime::readManyResultValue(JSC::JSGlobalObject* globalObject, JSC::JSObject* result) const
+{
+    if (isReadManyResult(result)) [[likely]]
+        return result->getDirect(readManyResultValueOffset);
+    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->value);
+}
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/Structure.h>
+#include <utility>
 
 namespace WebCore {
 
@@ -384,18 +385,12 @@ public:
     static constexpr JSC::PropertyOffset readManyResultSizeOffset = 1;
     static constexpr JSC::PropertyOffset readManyResultDoneOffset = 2;
 
-    // `result.done` / `result.value` of a readMany() result. While `result` still has
-    // readManyResultStructure (three plain data properties) the slot is read directly; a
-    // mutated result or a foreign object takes the ordinary [[Get]].
-    JSC::JSValue readManyResultDone(JSC::JSGlobalObject*, JSC::JSObject* result) const;
-    JSC::JSValue readManyResultValue(JSC::JSGlobalObject*, JSC::JSObject* result) const;
+    // `{ done, value }` of a readMany() result. While `result` still has readManyResultStructure
+    // (three plain data properties) both slots are read directly; a mutated result or a foreign
+    // object takes `get(done)` then `get(value)`, and both are empty if either throws.
+    std::pair<JSC::JSValue, JSC::JSValue> readManyResult(JSC::JSGlobalObject*, JSC::JSObject* result) const;
 
 private:
-    bool isReadManyResult(JSC::JSObject* object) const
-    {
-        return object->structureID() == m_readManyResultStructure.getInitializedOnMainThread(m_globalObject)->id();
-    }
-
     JSC::JSGlobalObject* m_globalObject { nullptr };
 
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction> m_handlers[static_cast<size_t>(Handler::Count)];
@@ -407,18 +402,18 @@ private:
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure> m_readManyResultStructure;
 };
 
-inline JSC::JSValue JSStreamsRuntime::readManyResultDone(JSC::JSGlobalObject* globalObject, JSC::JSObject* result) const
+inline std::pair<JSC::JSValue, JSC::JSValue> JSStreamsRuntime::readManyResult(JSC::JSGlobalObject* globalObject, JSC::JSObject* result) const
 {
-    if (isReadManyResult(result)) [[likely]]
-        return result->getDirect(readManyResultDoneOffset);
-    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->done);
-}
+    if (result->structureID() == m_readManyResultStructure.getInitializedOnMainThread(m_globalObject)->id()) [[likely]]
+        return { result->getDirect(readManyResultDoneOffset), result->getDirect(readManyResultValueOffset) };
 
-inline JSC::JSValue JSStreamsRuntime::readManyResultValue(JSC::JSGlobalObject* globalObject, JSC::JSObject* result) const
-{
-    if (isReadManyResult(result)) [[likely]]
-        return result->getDirect(readManyResultValueOffset);
-    return result->get(globalObject, JSC::getVM(globalObject).propertyNames->value);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSValue done = result->get(globalObject, vm.propertyNames->done);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSValue value = result->get(globalObject, vm.propertyNames->value);
+    RETURN_IF_EXCEPTION(scope, {});
+    return { done, value };
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -385,9 +385,8 @@ public:
     static constexpr JSC::PropertyOffset readManyResultSizeOffset = 1;
     static constexpr JSC::PropertyOffset readManyResultDoneOffset = 2;
 
-    // `{ done, value }` of a readMany() result. While `result` still has readManyResultStructure
-    // (three plain data properties) both slots are read directly; a mutated result or a foreign
-    // object takes `get(done)` then `get(value)`, and both are empty if either throws.
+    // `{ done, value }` of a readMany() result: the slots while `result` still has
+    // readManyResultStructure, else `get(done)` then `get(value)` (both empty if either throws).
     std::pair<JSC::JSValue, JSC::JSValue> readManyResult(JSC::JSGlobalObject*, JSC::JSObject* result) const;
 
 private:

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -941,7 +941,7 @@ static EncodedJSValue fromIterablePullFulfilled(JSGlobalObject* globalObject, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!iterResult.isObject())
         return throwVMTypeError(globalObject, scope, "The promise returned by the async iterator's next() method must fulfill with an object"_s);
-    auto [doneValue, value] = Bun::getIteratorResult(globalObject, asObject(iterResult));
+    auto [doneValue, value] = Bun::getIteratorResult(globalObject, asObject(iterResult), Bun::IteratorDoneValue::Skip);
     RETURN_IF_EXCEPTION(scope, {});
     if (doneValue.toBoolean(globalObject)) {
         readableStreamDefaultControllerClose(globalObject, controller);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -941,17 +941,13 @@ static EncodedJSValue fromIterablePullFulfilled(JSGlobalObject* globalObject, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!iterResult.isObject())
         return throwVMTypeError(globalObject, scope, "The promise returned by the async iterator's next() method must fulfill with an object"_s);
-    JSValue doneValue = Bun::getIteratorResultDone(globalObject, asObject(iterResult));
+    auto [doneValue, value] = Bun::getIteratorResult(globalObject, asObject(iterResult));
     RETURN_IF_EXCEPTION(scope, {});
-    bool done = doneValue.toBoolean(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (done) {
+    if (doneValue.toBoolean(globalObject)) {
         readableStreamDefaultControllerClose(globalObject, controller);
         RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsUndefined());
     }
-    JSValue value = Bun::getIteratorResultValue(globalObject, asObject(iterResult));
-    RETURN_IF_EXCEPTION(scope, {});
     readableStreamDefaultControllerEnqueue(globalObject, controller, value);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -22,6 +22,7 @@
 #include "JSStreamsRuntime.h"
 #include "JSWritableStream.h"
 #include "JSWritableStreamDefaultWriter.h"
+#include "ObjectBindings.h"
 #include "ZigGlobalObject.h"
 
 #include <JavaScriptCore/InternalFieldTuple.h>
@@ -940,14 +941,16 @@ static EncodedJSValue fromIterablePullFulfilled(JSGlobalObject* globalObject, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!iterResult.isObject())
         return throwVMTypeError(globalObject, scope, "The promise returned by the async iterator's next() method must fulfill with an object"_s);
-    bool done = iteratorCompleteExported(globalObject, iterResult);
+    JSValue doneValue = Bun::getIteratorResultDone(globalObject, asObject(iterResult));
+    RETURN_IF_EXCEPTION(scope, {});
+    bool done = doneValue.toBoolean(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (done) {
         readableStreamDefaultControllerClose(globalObject, controller);
         RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsUndefined());
     }
-    JSValue value = iteratorValue(globalObject, iterResult);
+    JSValue value = Bun::getIteratorResultValue(globalObject, asObject(iterResult));
     RETURN_IF_EXCEPTION(scope, {});
     readableStreamDefaultControllerEnqueue(globalObject, controller, value);
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2832,3 +2832,217 @@ describe("ReadableStream async iterator reentrancy", () => {
     expect(await it.next()).toEqual({ value: undefined, done: true });
   });
 });
+
+// Every native consumer of an iterator result ({value, done} from read()/next()) or of a
+// readMany() result ({value, size, done}). Results Bun itself produced, and the ones from
+// generators and the built-in iterators, are plain data objects; a custom next() can hand back
+// accessors instead, and those must run exactly as often and in the same order as before.
+describe("iterator result consumers", () => {
+  const decode = chunks => chunks.map(c => (typeof c === "string" ? c : new TextDecoder().decode(c)));
+
+  test("readMany() continuing a pending read", async () => {
+    let controller;
+    const stream = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const reader = stream.getReader();
+    const pending = reader.readMany();
+    controller.enqueue("a");
+    controller.enqueue("b");
+    const first = await pending;
+    controller.close();
+    const last = await reader.readMany();
+    expect({ first: { value: first.value, done: first.done }, last }).toEqual({
+      first: { value: ["a", "b"], done: false },
+      last: { value: [], size: 0, done: true },
+    });
+  });
+
+  test("readMany() on a direct stream", async () => {
+    const stream = new ReadableStream({
+      type: "direct",
+      async pull(c) {
+        c.write("x");
+        await Bun.sleep(1);
+        c.write("y");
+        c.close();
+      },
+    });
+    const reader = stream.getReader();
+    const first = await reader.readMany();
+    const second = await reader.readMany();
+    expect({ first: decode(first.value), firstDone: first.done, second: decode(second.value) }).toEqual({
+      first: ["x"],
+      firstDone: false,
+      second: ["y"],
+    });
+  });
+
+  test("readableStreamToArray over pending reads and over a direct stream", async () => {
+    let controller;
+    const queued = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const queuedPromise = readableStreamToArray(queued);
+    controller.enqueue(1);
+    await Bun.sleep(0);
+    controller.enqueue(2);
+    controller.close();
+
+    const direct = new ReadableStream({
+      type: "direct",
+      async pull(c) {
+        c.write("1");
+        await Bun.sleep(1);
+        c.write("2");
+        c.close();
+      },
+    });
+    expect({ queued: await queuedPromise, direct: decode(await readableStreamToArray(direct)) }).toEqual({
+      queued: [1, 2],
+      direct: ["1", "2"],
+    });
+  });
+
+  test("readableStreamToText over a direct stream", async () => {
+    const stream = new ReadableStream({
+      type: "direct",
+      async pull(c) {
+        c.write("he");
+        await Bun.sleep(1);
+        c.write("llo");
+        c.close();
+      },
+    });
+    expect(await readableStreamToText(stream)).toBe("hello");
+  });
+
+  test("Response body from an async generator", async () => {
+    async function* gen() {
+      yield "g1";
+      yield "g2";
+    }
+    expect(await new Response(gen()).text()).toBe("g1g2");
+  });
+
+  test("Response body from an async iterator whose results have accessors", async () => {
+    const reads = [];
+    let i = 0;
+    const iterable = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            const n = i++;
+            return Promise.resolve({
+              get done() {
+                reads.push(`done${n}`);
+                return n >= 2;
+              },
+              get value() {
+                reads.push(`value${n}`);
+                return n >= 2 ? undefined : `chunk${n}`;
+              },
+            });
+          },
+        };
+      },
+    };
+    const text = await new Response(iterable).text();
+    expect({ text, reads }).toEqual({
+      text: "chunk0chunk1",
+      reads: ["done0", "value0", "done1", "value1", "done2", "value2"],
+    });
+  });
+
+  test("Response body from a {value, done} result given a done accessor afterwards", async () => {
+    let i = 0;
+    const iterable = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            const n = i++;
+            const result = { value: `m${n}`, done: false };
+            Object.defineProperty(result, "done", { get: () => n >= 1 });
+            return Promise.resolve(result);
+          },
+        };
+      },
+    };
+    // A final result that is done still carries its value, like `return v` in a generator.
+    expect(await new Response(iterable).text()).toBe("m0m1");
+  });
+
+  test("ReadableStream.from over generators", async () => {
+    async function* asyncGen() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+    function* syncGen() {
+      yield "s1";
+      yield "s2";
+    }
+    expect({
+      async: await readableStreamToArray(ReadableStream.from(asyncGen())),
+      sync: await readableStreamToArray(ReadableStream.from(syncGen())),
+    }).toEqual({ async: [1, 2, 3], sync: ["s1", "s2"] });
+  });
+
+  test("ReadableStream.from over an async iterator whose results have accessors", async () => {
+    const reads = [];
+    let i = 0;
+    const iterable = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            const n = i++;
+            return Promise.resolve({
+              get done() {
+                reads.push(`done${n}`);
+                return n >= 3;
+              },
+              get value() {
+                reads.push(`value${n}`);
+                return n * 10;
+              },
+            });
+          },
+        };
+      },
+    };
+    const chunks = await readableStreamToArray(ReadableStream.from(iterable));
+    expect({ chunks, reads }).toEqual({
+      chunks: [0, 10, 20],
+      // value is not read once done is true
+      reads: ["done0", "value0", "done1", "value1", "done2", "value2", "done3"],
+    });
+  });
+
+  test("a ReadableStream response body is pumped into the HTTP sink", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        let controller;
+        const stream = new ReadableStream({
+          start(c) {
+            controller = c;
+          },
+        });
+        (async () => {
+          controller.enqueue("part1-");
+          await Bun.sleep(1);
+          controller.enqueue("part2-");
+          controller.enqueue("part3");
+          await Bun.sleep(1);
+          controller.close();
+        })();
+        return new Response(stream);
+      },
+    });
+    expect(await (await fetch(server.url)).text()).toBe("part1-part2-part3");
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2836,7 +2836,7 @@ describe("ReadableStream async iterator reentrancy", () => {
 // Every native consumer of an iterator result ({value, done} from read()/next()) or of a
 // readMany() result ({value, size, done}). Results Bun itself produced, and the ones from
 // generators and the built-in iterators, are plain data objects; a custom next() can hand back
-// accessors instead, and those must still run, done before value, on every result.
+// accessors instead, and those must still run exactly as often and in the same order as before.
 describe("iterator result consumers", () => {
   const decode = chunks => chunks.map(c => (typeof c === "string" ? c : new TextDecoder().decode(c)));
 
@@ -3018,6 +3018,8 @@ describe("iterator result consumers", () => {
               },
               get value() {
                 reads.push(`value${n}`);
+                // IteratorStepValue: the value of a done result is never read.
+                if (n >= 3) throw new Error("value read on a done result");
                 return n * 10;
               },
             });
@@ -3028,7 +3030,7 @@ describe("iterator result consumers", () => {
     const chunks = await readableStreamToArray(ReadableStream.from(iterable));
     expect({ chunks, reads }).toEqual({
       chunks: [0, 10, 20],
-      reads: ["done0", "value0", "done1", "value1", "done2", "value2", "done3", "value3"],
+      reads: ["done0", "value0", "done1", "value1", "done2", "value2", "done3"],
     });
   });
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2836,7 +2836,7 @@ describe("ReadableStream async iterator reentrancy", () => {
 // Every native consumer of an iterator result ({value, done} from read()/next()) or of a
 // readMany() result ({value, size, done}). Results Bun itself produced, and the ones from
 // generators and the built-in iterators, are plain data objects; a custom next() can hand back
-// accessors instead, and those must run exactly as often and in the same order as before.
+// accessors instead, and those must still run, done before value, on every result.
 describe("iterator result consumers", () => {
   const decode = chunks => chunks.map(c => (typeof c === "string" ? c : new TextDecoder().decode(c)));
 
@@ -3017,8 +3017,7 @@ describe("iterator result consumers", () => {
     const chunks = await readableStreamToArray(ReadableStream.from(iterable));
     expect({ chunks, reads }).toEqual({
       chunks: [0, 10, 20],
-      // value is not read once done is true
-      reads: ["done0", "value0", "done1", "value1", "done2", "value2", "done3"],
+      reads: ["done0", "value0", "done1", "value1", "done2", "value2", "done3", "value3"],
     });
   });
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2861,49 +2861,61 @@ describe("iterator result consumers", () => {
   });
 
   test("readMany() on a direct stream", async () => {
+    // The second write waits for the first readMany() to settle, so each call sees one chunk.
+    const secondWrite = Promise.withResolvers();
     const stream = new ReadableStream({
       type: "direct",
       async pull(c) {
         c.write("x");
-        await Bun.sleep(1);
+        await secondWrite.promise;
         c.write("y");
         c.close();
       },
     });
     const reader = stream.getReader();
     const first = await reader.readMany();
+    secondWrite.resolve();
     const second = await reader.readMany();
-    expect({ first: decode(first.value), firstDone: first.done, second: decode(second.value) }).toEqual({
+    const last = await reader.readMany();
+    expect({
+      first: decode(first.value),
+      firstDone: first.done,
+      second: decode(second.value),
+      secondDone: second.done,
+      last: { value: last.value, done: last.done },
+    }).toEqual({
       first: ["x"],
       firstDone: false,
       second: ["y"],
+      secondDone: false,
+      last: { value: [], done: true },
     });
   });
 
   test("readableStreamToArray over pending reads and over a direct stream", async () => {
-    let controller;
+    // Each pull() runs when the consumer's pending read drained the queue.
+    let pulls = 0;
     const queued = new ReadableStream({
-      start(c) {
-        controller = c;
+      pull(c) {
+        if (++pulls <= 2) c.enqueue(pulls);
+        else c.close();
       },
     });
-    const queuedPromise = readableStreamToArray(queued);
-    controller.enqueue(1);
-    await Bun.sleep(0);
-    controller.enqueue(2);
-    controller.close();
-
     const direct = new ReadableStream({
       type: "direct",
-      async pull(c) {
+      pull(c) {
         c.write("1");
-        await Bun.sleep(1);
         c.write("2");
         c.close();
       },
     });
-    expect({ queued: await queuedPromise, direct: decode(await readableStreamToArray(direct)) }).toEqual({
+    expect({
+      queued: await readableStreamToArray(queued),
+      pulls,
+      direct: decode(await readableStreamToArray(direct)),
+    }).toEqual({
       queued: [1, 2],
+      pulls: 3,
       direct: ["1", "2"],
     });
   });
@@ -2911,9 +2923,8 @@ describe("iterator result consumers", () => {
   test("readableStreamToText over a direct stream", async () => {
     const stream = new ReadableStream({
       type: "direct",
-      async pull(c) {
+      pull(c) {
         c.write("he");
-        await Bun.sleep(1);
         c.write("llo");
         c.close();
       },
@@ -3022,26 +3033,27 @@ describe("iterator result consumers", () => {
   });
 
   test("a ReadableStream response body is pumped into the HTTP sink", async () => {
+    // Each pull() runs when the sink drained the queue, so the body arrives in three batches.
+    let pulls = 0;
     using server = Bun.serve({
       port: 0,
       fetch() {
-        let controller;
         const stream = new ReadableStream({
           start(c) {
-            controller = c;
+            c.enqueue("part1-");
+          },
+          pull(c) {
+            if (++pulls === 1) {
+              c.enqueue("part2-");
+              c.enqueue("part3");
+            } else {
+              c.close();
+            }
           },
         });
-        (async () => {
-          controller.enqueue("part1-");
-          await Bun.sleep(1);
-          controller.enqueue("part2-");
-          controller.enqueue("part3");
-          await Bun.sleep(1);
-          controller.close();
-        })();
         return new Response(stream);
       },
     });
-    expect(await (await fetch(server.url)).text()).toBe("part1-part2-part3");
+    expect({ text: await (await fetch(server.url)).text(), pulls }).toEqual({ text: "part1-part2-part3", pulls: 2 });
   });
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -965,7 +965,7 @@ describe("options.transfer iterator error propagation", () => {
 
 // The transfer list is read through the iterator protocol. A Set iterator hands back plain
 // {value, done} objects; a custom next() can return anything, including accessors, and those
-// must still run in IteratorComplete, IteratorValue order.
+// must still run, done before value, on every result.
 describe("options.transfer iterator results", () => {
   test("a Set of buffers is transferred", () => {
     const a = new ArrayBuffer(4);
@@ -1008,8 +1008,7 @@ describe("options.transfer iterator results", () => {
     }).toEqual({
       clonedLengths: [4, 8],
       originalLengths: [0, 0],
-      // value is not read once done is true
-      reads: ["done0", "value0", "done1", "value1", "done2"],
+      reads: ["done0", "value0", "done1", "value1", "done2", "value2"],
     });
   });
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -965,7 +965,7 @@ describe("options.transfer iterator error propagation", () => {
 
 // The transfer list is read through the iterator protocol. A Set iterator hands back plain
 // {value, done} objects; a custom next() can return anything, including accessors, and those
-// must still run, done before value, on every result.
+// must still run in IteratorComplete, IteratorValue order.
 describe("options.transfer iterator results", () => {
   test("a Set of buffers is transferred", () => {
     const a = new ArrayBuffer(4);
@@ -993,6 +993,8 @@ describe("options.transfer iterator results", () => {
               },
               get value() {
                 reads.push(`value${n}`);
+                // IteratorStepValue: the value of a done result is never read.
+                if (n >= buffers.length) throw new Error("value read on a done result");
                 return buffers[n];
               },
             };
@@ -1008,7 +1010,7 @@ describe("options.transfer iterator results", () => {
     }).toEqual({
       clonedLengths: [4, 8],
       originalLengths: [0, 0],
-      reads: ["done0", "value0", "done1", "value1", "done2", "value2"],
+      reads: ["done0", "value0", "done1", "value1", "done2"],
     });
   });
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -963,6 +963,76 @@ describe("options.transfer iterator error propagation", () => {
   });
 });
 
+// The transfer list is read through the iterator protocol. A Set iterator hands back plain
+// {value, done} objects; a custom next() can return anything, including accessors, and those
+// must still run in IteratorComplete, IteratorValue order.
+describe("options.transfer iterator results", () => {
+  test("a Set of buffers is transferred", () => {
+    const a = new ArrayBuffer(4);
+    const b = new ArrayBuffer(8);
+    const cloned = structuredClone([a, b], { transfer: new Set([a, b]) } as any);
+    expect({
+      clonedLengths: cloned.map((x: ArrayBuffer) => x.byteLength),
+      originalLengths: [a.byteLength, b.byteLength],
+    }).toEqual({ clonedLengths: [4, 8], originalLengths: [0, 0] });
+  });
+
+  test("done and value accessors on a custom iterator result are honored", () => {
+    const buffers = [new ArrayBuffer(4), new ArrayBuffer(8)];
+    const reads: string[] = [];
+    let i = 0;
+    const transfer = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            const n = i++;
+            return {
+              get done() {
+                reads.push(`done${n}`);
+                return n >= buffers.length;
+              },
+              get value() {
+                reads.push(`value${n}`);
+                return buffers[n];
+              },
+            };
+          },
+        };
+      },
+    };
+    const cloned = structuredClone(buffers, { transfer } as any);
+    expect({
+      clonedLengths: cloned.map((x: ArrayBuffer) => x.byteLength),
+      originalLengths: buffers.map(x => x.byteLength),
+      reads,
+    }).toEqual({
+      clonedLengths: [4, 8],
+      originalLengths: [0, 0],
+      // value is not read once done is true
+      reads: ["done0", "value0", "done1", "value1", "done2"],
+    });
+  });
+
+  test("a {value, done} result given a done accessor afterwards uses the accessor", () => {
+    const buffer = new ArrayBuffer(4);
+    let i = 0;
+    const transfer = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            const n = i++;
+            const result = { value: buffer, done: false };
+            Object.defineProperty(result, "done", { get: () => n >= 1 });
+            return result;
+          },
+        };
+      },
+    };
+    const cloned = structuredClone(buffer, { transfer } as any);
+    expect([cloned.byteLength, buffer.byteLength]).toEqual([4, 0]);
+  });
+});
+
 describe("truncated Set/Map payloads are rejected without hanging", () => {
   // Wire header + tag bytes derived from a real serialize() so a CurrentVersion
   // bump doesn't invalidate the crafted payloads.


### PR DESCRIPTION
### Problem
- Every native consumer of an iterator result read `done` and `value` with `JSObject::get`: a structure lookup, the prototype walk, and a `PropertySlot` per field, on every chunk. The sites are the stream consumers (`readableStreamTo*`), the `readMany()` continuations, the async-iterable `Response` body source, `ReadableStream.from`, and the `postMessage` transfer list.
- Bun already has the fast shape for `process.cpuUsage(prev)` (`BunProcess.cpp`: compare the structure ID, then `getDirect`). Nothing else used it.

### Fix
- `ObjectBindings.h` adds `Bun::getIteratorResult`, which returns `std::pair<JSValue, JSValue>` (done, value). It compares the object's structure ID with the realm's `iteratorResultObjectStructure` once and on a match reads both inline slots (`iteratorResultObjectDonePropertyOffset`, `iteratorResultObjectValuePropertyOffset`). Otherwise it runs `get(done)` then `get(value)`. `IteratorDoneValue::Skip` leaves `value` unread when `done` is true, for the two sites the spec defines with IteratorStepValue (`ReadableStream.from`, the transfer list).
- `JSStreamsRuntime::readManyResult` does the same for the `{value, size, done}` shape of `readMany()`, whose offsets are now named constants.
- Correct because a structure match proves both properties are plain data properties at the known offsets. A getter, a Proxy, a deleted property, a frozen object, or a changed prototype each transitions the object to a different structure, so they always take the `get()` path. The readMany `value` array uses `JSArray::length()` instead of `get("length")` for the same reason.
- Verified: `test/js/web/streams/streams.test.js` ("iterator result consumers") and `test/js/web/workers/structured-clone.test.ts` ("options.transfer iterator results"). Also the WPT streams suite, the `body*`, `fetch.stream`, `async-iterator-stream`, `serve-direct-readable-stream`, `direct-readable-stream`, `stream-fast-path`, and `sync-pull-fast-path` suites, and `test-webstream-readable-from.js`.

### Background
- JSC gives every realm one `iteratorResultObjectStructure`: `value` at inline offset 0, `done` at offset 1. `createIteratorResultObject` uses it, and so does every `{ value, done }` literal with that property order, because object literals start from the same `emptyObjectStructureForPrototype(objectPrototype, 2)` and follow the same transitions. That covers generators, async generators, `AsyncFromSyncIterator`, and the Array/Map/Set/String iterators.
- A `Structure` is the hidden class of a JSC object. Two objects with the same structure ID have the same properties, attributes, and slot layout. `getDirect(offset)` reads a slot without any lookup.
- A structure check is what the DFG emits when it inlines `next()`, so this fast path matches the JIT's own assumptions.

<details><summary>Notes</summary>

Verification of the fast path: a temporary counter in the structure checks was run against a script that exercises each changed site. Every Bun-produced result, async generator result, `AsyncFromSyncIterator` result, Set iterator result, and readMany result took the fast path. Custom `next()` results with accessors and a `{value, done}` literal later given a `done` accessor took the slow path, and the accessor call counts matched bun 1.4.0.

Slow-path read order is `done` then `value` at every site. The two sites that previously read `value` first (`readManyAfterPull`, `readManyAfterDirectPull`) only ever see Bun-created results, which take the fast path. The two spec-governed sites keep IteratorStepValue: a done result's `value` accessor is never run, and the tests make that accessor throw to prove it.

Property order matters for the literal case: `{ done, value }` (done first) produces a different structure and takes the slow path. That is correct, only slower.

Remaining `get()` calls in the bindings (about 430) read user option dictionaries, where no structure can be predicted.

`fetch.stream.test.ts` "Content-Length response works (multiple parts)" exceeds its 5 s budget in this container's debug build both with and without this change. Each of those tests passes when run alone.

JSC's own `iteratorValue` and `iteratorComplete` in `IteratorOperations.cpp` still use a plain `get()`. They back `forEachInIterable`, which the sequence conversions and `new Map(iterable)` use. The same check there is a WebKit change, not done here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->