### PR TITLE
node:http2: do not write the client preface to a socket that is still connecting

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5712,13 +5712,8 @@ class ClientHttp2Session extends Http2Session {
     }
     const nativeSettings = { ...options, ...options?.settings };
     this.#localSettings = initialLocalSettings(nativeSettings);
-    // The parser serializes the connection preface as soon as it is constructed. A socket
-    // whose connect() is still in flight must not receive it: the kernel reports the
-    // pending connect error from that write and then forgets it, so a refused connect is
-    // reported as ECONNRESET. The parser queues the preface until #onConnect attaches the
-    // socket and flushes, which is what #Handlers.write already does for a JS transport.
+    // #onConnect attaches the native socket; frames written before that (the preface) queue.
     this.#parser = new H2FrameParser({
-      native: socket.connecting || socket.secureConnecting ? undefined : nativeSocket,
       context: this,
       settings: nativeSettings,
       handlers: ClientHttp2Session.#Handlers,

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5712,8 +5712,13 @@ class ClientHttp2Session extends Http2Session {
     }
     const nativeSettings = { ...options, ...options?.settings };
     this.#localSettings = initialLocalSettings(nativeSettings);
+    // The parser serializes the connection preface as soon as it is constructed. A socket
+    // whose connect() is still in flight must not receive it: the kernel reports the
+    // pending connect error from that write and then forgets it, so a refused connect is
+    // reported as ECONNRESET. The parser queues the preface until #onConnect attaches the
+    // socket and flushes, which is what #Handlers.write already does for a JS transport.
     this.#parser = new H2FrameParser({
-      native: nativeSocket,
+      native: socket.connecting || socket.secureConnecting ? undefined : nativeSocket,
       context: this,
       settings: nativeSettings,
       handlers: ClientHttp2Session.#Handlers,

--- a/test/js/node/http2/http2-connect-refused.fixture.js
+++ b/test/js/node/http2/http2-connect-refused.fixture.js
@@ -1,0 +1,30 @@
+// Connect an http2 client to a port nothing listens on and print the shape of the
+// session's 'error'. Run under Node.js and under Bun: the output must be identical.
+const http2 = require("node:http2");
+const net = require("node:net");
+
+const probe = net.createServer();
+probe.listen(0, "127.0.0.1", () => {
+  const port = probe.address().port;
+  probe.close(() => {
+    const client = http2.connect(`http://127.0.0.1:${port}`);
+    client.on("connect", () => {
+      console.log("FAIL: connected to a closed port");
+      client.destroy();
+      process.exitCode = 1;
+    });
+    client.on("error", err => {
+      console.log(
+        JSON.stringify({
+          code: err.code,
+          syscall: err.syscall,
+          address: err.address,
+          portMatches: err.port === port,
+          // errno is platform-specific (-111 on Linux, -61 on macOS), the name is not.
+          message: err.message.replaceAll(String(port), "<port>"),
+        }),
+      );
+      client.destroy();
+    });
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2648,6 +2648,39 @@ it("http2 connect supports various URL formats", async done => {
   });
 });
 
+// The client corks its connection preface before the socket has connected. A write on a
+// connecting socket consumes the kernel's pending connect error, and the refused connect
+// is then reported as ECONNRESET. The fixture prints the error shape; Node.js and Bun must
+// print the same line.
+it("http2 client reports ECONNREFUSED for a refused connect, like Node.js", async () => {
+  const fixture = path.join(import.meta.dir, "http2-connect-refused.fixture.js");
+  async function run(exe) {
+    await using proc = Bun.spawn({ cmd: [exe, fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+  const expected = {
+    code: "ECONNREFUSED",
+    syscall: "connect",
+    address: "127.0.0.1",
+    portMatches: true,
+    message: "connect ECONNREFUSED 127.0.0.1:<port>",
+  };
+
+  const bunRun = await run(bunExe());
+  expect(bunRun.stderr).toBe("");
+  expect(JSON.parse(bunRun.stdout)).toEqual(expected);
+  expect(bunRun.exitCode).toBe(0);
+
+  const node = nodeExe();
+  if (node) {
+    const nodeRun = await run(node);
+    expect(JSON.parse(nodeRun.stdout)).toEqual(expected);
+    expect(nodeRun.stdout).toBe(bunRun.stdout);
+    expect(nodeRun.exitCode).toBe(0);
+  }
+});
+
 it("http2 request.close() validates input and manages stream state", async done => {
   const { mustCall } = createCallCheckCtx(done);
   const server = http2.createServer();


### PR DESCRIPTION
### Problem
- `http2.connect("http://127.0.0.1:<closed port>")` emits `connect ECONNRESET` (`code: "ECONNRESET"`) on bun 1.4.x. Node v26.3.0 and bun 1.3.14 emit `connect ECONNREFUSED`. With no `'error'` listener on the session, bun 1.4.x swallows the failure entirely, where Node raises it.
- The cause is in `ClientHttp2Session`'s constructor (`src/js/node/http2.ts`). It handed `socket._handle` to `new H2FrameParser({ native })` while the socket's `connect()` was still in flight. The parser serializes the connection preface at construction and its auto flush wrote it to that handle, so the kernel got a `send()` on a connecting socket. Linux returns the pending connect error from that `send()` and clears `SO_ERROR`, so the connect completion read 0 and usockets reported ECONNRESET.

### Fix
- The client constructor no longer passes `native` to the parser. `#onConnect` is now the one place that attaches the native socket (`setNativeSocket()` then `flush()`), and every construction path reaches it: the `'connect'`/`'secureConnect'` listener for a connecting socket, a next-tick call for a `createConnection` socket that is already connected. Until then the preface, and any frame written before connect, stays queued in the parser and goes out first, in order. This is the path a JS transport (`createConnection` returning a Duplex) already took.
- Correct because nothing is written to a socket before Node would write to it: after `'connect'` for h2c, after `'secureConnect'` for h2.
- Verified: new test in `test/js/node/http2/node-http2.test.js` runs `http2-connect-refused.fixture.js` under Bun and under Node.js and requires the same `{code, syscall, address, port, message}`. It fails on stock bun (`ECONNRESET`) and passes with this change; the fixture passes on Node v26.3.0. `node-http2.test.js` (380 pass), the other `test/js/node/http2/` files, and 107 vendored `test-http2-{client,connect,session,settings,goaway,ping,window,tls,...}` tests pass.

### Background
- `H2FrameParser` (`src/runtime/api/bun/h2_frame_parser.rs`) is the native HTTP/2 framer behind `node:http2`. With a native socket attached it writes to the socket directly. Without one it hands bytes to the session's `write` handler, which returns -1 until the session is connected, and the parser keeps the bytes queued.
- usockets tracks a client socket whose `connect()` returned EINPROGRESS as a half-open socket and reads the real connect errno with `getsockopt(SO_ERROR)` when the poll reports an error. A `send()` on that socket consumes the pending error first, so the completion is blind.

<details><summary>Notes</summary>

Syscall sequence on stock 1.4.x for a refused h2c connect (LD_PRELOAD trace of `connect`/`send`/`getsockopt`):

```
connect(fd=7) = -1 EINPROGRESS
send(fd=7, PREFACE len=33) = -1 ECONNREFUSED
send(fd=7, PREFACE len=33) = -1 EPIPE
getsockopt(fd=7, SO_ERROR) -> 0
=> connect ECONNRESET
```

With this change:

```
connect(fd=8) = -1 EINPROGRESS
getsockopt(fd=8, SO_ERROR) -> 111 (Connection refused)
=> connect ECONNREFUSED
```

A successful h2c connect sends the preface once, after the connect completes, and a request round-trips.

Why 1.3.14 reported ECONNREFUSED: the half-open dispatch in `loop.c` passed a boolean to `us_internal_socket_after_open`, and the error path labeled every connect failure ECONNREFUSED without reading `SO_ERROR`. #32681 made the loop report the kernel's real errno, which exposed the consumed error.

The unobserved case: `ClientHttp2Session#onError` tears the session down quietly for an `ECONNRESET` that nobody listens for (an idle pooled connection dropped by the peer). The mislabeled refusal took that branch, so `http2.connect()` to a dead port with no `'error'` listener did nothing on 1.4.x. With the right code it raises, as Node does.

An earlier revision of this PR made the usockets write entry points refuse to `send()` on a half-open socket. Per review, the write should not be issued in the first place, so that change was dropped and the fix lives at the call site.

`test/js/third_party/grpc-js/test-client.test.ts` shows the same three debug-build timing failures (100 ms `waitForReady` deadline) with and without this change.
</details>
