### PR TITLE
node-fallbacks: build the once() promise without $newPromiseCapability

### DIFF
--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -68,7 +68,8 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
       if (
         outfile.includes("$isObject(") ||
         outfile.includes("$isPromise(") ||
-        outfile.includes("$isUndefinedOrNull(")
+        outfile.includes("$isUndefinedOrNull(") ||
+        outfile.includes("$newPromiseCapability(")
       ) {
         throw new Error("Unsupported function in " + name);
       }

--- a/src/node-fallbacks/events.js
+++ b/src/node-fallbacks/events.js
@@ -323,39 +323,38 @@ function once(emitter, type, options) {
   if (signal?.aborted) {
     throw new AbortError(undefined, { cause: signal?.reason });
   }
-  const { resolve, reject, promise } = $newPromiseCapability(Promise);
-  const errorListener = err => {
-    emitter.removeListener(type, resolver);
+  return new Promise((resolve, reject) => {
+    const errorListener = err => {
+      emitter.removeListener(type, resolver);
+      if (signal != null) {
+        eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
+      }
+      reject(err);
+    };
+    const resolver = (...args) => {
+      if (typeof emitter.removeListener === "function") {
+        emitter.removeListener("error", errorListener);
+      }
+      if (signal != null) {
+        eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
+      }
+      resolve(args);
+    };
+    eventTargetAgnosticAddListener(emitter, type, resolver, { once: true });
+    if (type !== "error" && typeof emitter.once === "function") {
+      // EventTarget does not have `error` event semantics like Node
+      // EventEmitters, we listen to `error` events only on EventEmitters.
+      emitter.once("error", errorListener);
+    }
+    function abortListener() {
+      eventTargetAgnosticRemoveListener(emitter, type, resolver);
+      eventTargetAgnosticRemoveListener(emitter, "error", errorListener);
+      reject(new AbortError(undefined, { cause: signal?.reason }));
+    }
     if (signal != null) {
-      eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
+      eventTargetAgnosticAddListener(signal, "abort", abortListener, { once: true });
     }
-    reject(err);
-  };
-  const resolver = (...args) => {
-    if (typeof emitter.removeListener === "function") {
-      emitter.removeListener("error", errorListener);
-    }
-    if (signal != null) {
-      eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
-    }
-    resolve(args);
-  };
-  eventTargetAgnosticAddListener(emitter, type, resolver, { once: true });
-  if (type !== "error" && typeof emitter.once === "function") {
-    // EventTarget does not have `error` event semantics like Node
-    // EventEmitters, we listen to `error` events only on EventEmitters.
-    emitter.once("error", errorListener);
-  }
-  function abortListener() {
-    eventTargetAgnosticRemoveListener(emitter, type, resolver);
-    eventTargetAgnosticRemoveListener(emitter, "error", errorListener);
-    reject(new AbortError(undefined, { cause: signal?.reason }));
-  }
-  if (signal != null) {
-    eventTargetAgnosticAddListener(signal, "abort", abortListener, { once: true });
-  }
-
-  return promise;
+  });
 }
 
 function getEventListeners(emitter, type) {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -118,6 +118,54 @@ describe("bundler", () => {
       api.expectFile("out.js").not.toInclude("import ");
     },
   });
+  // The polyfill is plain JS bundled into the user's output, so it cannot use
+  // JSC builtin intrinsics ($newPromiseCapability and friends). Those are
+  // only rewritten inside src/js; in a browser bundle they are bare globals.
+  itBundled("browser/NodeEventsOnce", {
+    files: {
+      "/entry.js": /* js */ `
+        import { once, EventEmitter } from "node:events";
+        const results = [];
+        {
+          const e = new EventEmitter();
+          const p = once(e, "hello");
+          e.emit("hello", 1, "two");
+          results.push(JSON.stringify(await p));
+        }
+        {
+          const e = new EventEmitter();
+          const p = once(e, "never");
+          e.emit("error", new Error("boom"));
+          results.push(await p.then(() => "resolved", err => "rejected:" + err.message));
+          results.push(e.listenerCount("never") + "," + e.listenerCount("error"));
+        }
+        {
+          const e = new EventEmitter();
+          const ac = new AbortController();
+          const p = once(e, "never", { signal: ac.signal });
+          ac.abort();
+          results.push(await p.then(() => "resolved", err => err.name + ":" + err.code));
+          results.push(e.listenerCount("never") + "," + e.listenerCount("error"));
+        }
+        {
+          const et = new EventTarget();
+          const p = once(et, "ping");
+          et.dispatchEvent(new Event("ping"));
+          const [ev] = await p;
+          results.push(ev.type);
+        }
+        console.log(results.join("\\n"));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: '[1,"two"]\nrejected:boom\n0,0\nAbortError:ABORT_ERR\n0,0\nping',
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      assert(!out.includes("$newPromiseCapability"), "events polyfill must not reference a JSC builtin intrinsic");
+    },
+  });
   itBundled("browser/NodeUrlProtocolTablesIgnorePrototype", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- `events.once()` from a `bun build --target=browser` bundle throws `ReferenceError: $newPromiseCapability is not defined`. Any code that awaits an event through the polyfill fails.
- The cause is `src/node-fallbacks/events.js:326`. It calls `$newPromiseCapability(Promise)`. That name is a JSC builtin intrinsic. Only the runtime builtins in `src/js/` get it rewritten. The browser polyfill is bundled as plain JS into the user's output, so the call is a lookup of a global that does not exist.

### Fix
- `once()` now returns `new Promise((resolve, reject) => { ... })` and sets up the listeners inside the executor. This is the same shape node uses for its own `once()`.
- Correct because the polyfill runs in the user's browser, not inside JSC builtins. Only standard JS is available there. The listener logic is unchanged. Only the promise creation moves into a standard executor.
- `build-fallbacks.ts` already rejects a few `$` intrinsics at codegen time. `$newPromiseCapability(` is now on that list so the build fails before the intrinsic can reach a bundle again.
- Verified: `test/bundler/bundler_browser.test.ts` (new `browser/NodeEventsOnce`, stock bun fails it). The whole file passes. The bundle output also runs correctly under `node`.

### Background
- `src/node-fallbacks/*.js` are browser polyfills for `node:*` modules. `bun build --target=browser` inlines them into the user's bundle. The runtime never loads them.
- `src/js/` holds the runtime builtins. Their `$name` identifiers are rewritten to JSC `@name` intrinsics at build time. That rewrite does not run on `node-fallbacks`.
- `$newPromiseCapability(Promise)` is the JSC helper that returns `{ promise, resolve, reject }`. Upstream WebKit removed it. The runtime copies in `src/js/node/*.ts` are handled in the WebKit upgrade. This PR only covers the browser polyfill.

<details><summary>Notes</summary>

Repro with the released binary:

```sh
cat > entry.js <<'EOF'
import { once, EventEmitter } from "events";
const e = new EventEmitter();
once(e, "x").then(console.log);
e.emit("x", 1);
EOF
bun build --target=browser entry.js --outfile=dist/out.js
grep -c newPromiseCapability dist/out.js   # 1
node dist/out.js   # ReferenceError: $newPromiseCapability is not defined
bun dist/out.js    # same ReferenceError
```

The new test exercises every path that used `resolve` or `reject` from the old capability object: resolve with the emitted args, reject from an `error` event, reject from an `AbortSignal`, and the `EventTarget` path through `addEventListener`. It checks that the listeners are removed after the error and abort paths. It also asserts the bundle text does not contain `$newPromiseCapability`.

Alternative considered: `Promise.withResolvers()`. It is a one-line change but it needs Chrome 119, Firefox 121, or Safari 17.4. The `new Promise` executor has no browser floor and matches node's implementation.

Validation throws (`validateAbortSignal`, an already aborted signal) stay synchronous, as they were before this change. Node's `once` is an `async function`, so those surface as rejections there. That difference predates this PR and is out of scope here.

Suites run: `test/bundler/bundler_browser.test.ts` (23 pass, 1 skip, 1 todo).
</details>
