### PR TITLE
bun:test: remove the dead toAsymmetricMatcher print hook for custom matchers

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2528,11 +2528,11 @@ impl ExpectArrayContaining {
 /// (but only created for *custom* matchers, as built-ins have their own classes)
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`. The only
 // field, `flags`, is set once at construction (`create()`) and never written
-// thereafter, so it stays a bare `Flags` (no `Cell` needed). Both host-fns
-// call into user JS (`execute_impl` → `execute_custom_matcher`, `custom_print`
-// → `matcher_fn.call`) which can re-enter on the same `m_ctx`; holding a
-// `noalias` `&mut Self` across that call is Stacked-Borrows UB even with no
-// field writes. The codegen shim emits `&*__this` for `&self` receivers.
+// thereafter, so it stays a bare `Flags` (no `Cell` needed). The host-fn
+// calls into user JS (`execute_impl` → `execute_custom_matcher`) which can
+// re-enter on the same `m_ctx`; holding a `noalias` `&mut Self` across that
+// call is Stacked-Borrows UB even with no field writes. The codegen shim
+// emits `&*__this` for `&self` receivers.
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct ExpectCustomAsymmetricMatcher {
     pub(crate) flags: Flags,
@@ -2637,65 +2637,6 @@ impl ExpectCustomAsymmetricMatcher {
         let matched = Self::execute_impl(self, callframe.this(), global_this, received_value)?;
         Ok(JSValue::from(matched))
     }
-
-    fn maybe_clear(global_this: &JSGlobalObject, err: JsError, dont_throw: bool) -> crate::Result<bool> {
-        if dont_throw {
-            global_this.clear_exception();
-            return Ok(false);
-        }
-        match err {
-            JsError::OutOfMemory => Err(crate::Error::Alloc(bun_alloc::AllocError)),
-            _ => Err(crate::Error::Unexpected),
-        }
-    }
-
-    /// Calls a custom implementation (if provided) to stringify this asymmetric matcher, and returns true if it was provided and it succeed
-    pub(crate) fn custom_print(
-        &self,
-        this_value: JSValue,
-        global_this: &JSGlobalObject,
-        writer: &mut (impl bun_io::Write + ?Sized),
-        dont_throw: bool,
-    ) -> crate::Result<bool> {
-        let Some(matcher_fn) = expect_custom_asymmetric_matcher_js::matcher_fn_get_cached(this_value) else { return Ok(false) };
-        let fn_value = match matcher_fn.get(global_this, "toAsymmetricMatcher") {
-            Ok(v) => v,
-            Err(e) => return Self::maybe_clear(global_this, e, dont_throw),
-        };
-        if let Some(fn_value) = fn_value {
-            if fn_value.js_type().is_function() {
-                let Some(captured_args) = expect_custom_asymmetric_matcher_js::captured_args_get_cached(this_value) else { return Ok(false) };
-                let args_len = match captured_args.get_length(global_this) {
-                    Ok(n) => n,
-                    Err(e) => return Self::maybe_clear(global_this, e, dont_throw),
-                };
-                let mut args: Vec<JSValue> = Vec::with_capacity(args_len as usize);
-                let mut iter = match captured_args.array_iterator(global_this) {
-                    Ok(it) => it,
-                    Err(e) => return Self::maybe_clear(global_this, e, dont_throw),
-                };
-                loop {
-                    match iter.next() {
-                        Ok(Some(arg)) => args.push(arg),
-                        Ok(None) => break,
-                        Err(e) => return Self::maybe_clear(global_this, e, dont_throw),
-                    }
-                }
-
-                let result = match matcher_fn.call(global_this, this_value, &args) {
-                    Ok(r) => r,
-                    Err(e) => return Self::maybe_clear(global_this, e, dont_throw),
-                };
-                let s = match result.to_bun_string(global_this) {
-                    Ok(s) => s,
-                    Err(e) => return Self::maybe_clear(global_this, e, dont_throw),
-                };
-                write!(writer, "{}", s)?;
-            }
-        }
-        Ok(false)
-    }
-
 }
 
 /// Reference: `MatcherContext` in https://github.com/jestjs/jest/blob/main/packages/expect/src/types.ts

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2888,37 +2888,26 @@ impl JestPrettyFormat {
             )?;
             *this.amf_quote_strings() = original_quote_strings;
         } else if let Some(instance) = value.as_class_ref::<expect::ExpectCustomAsymmetricMatcher>() {
-            let printed = expect::ExpectCustomAsymmetricMatcher::custom_print(
-                instance, value, this.amf_global_this(), &mut *writer.ctx, true,
-            )
-            .expect("unreachable");
-            if !printed {
-                // default print (non-overridden by user)
-                let flags = instance.flags;
-                let Some(args_value) =
-                    expect_js::custom::captured_args_get_cached(value)
-                else {
-                    return Ok(true);
-                };
-                let Some(matcher_fn) =
-                    expect_js::custom::matcher_fn_get_cached(value)
-                else {
-                    return Ok(true);
-                };
-                let matcher_name = matcher_fn.get_name(this.amf_global_this())?;
+            let flags = instance.flags;
+            let Some(args_value) = expect_js::custom::captured_args_get_cached(value) else {
+                return Ok(true);
+            };
+            let Some(matcher_fn) = expect_js::custom::matcher_fn_get_cached(value) else {
+                return Ok(true);
+            };
+            let matcher_name = matcher_fn.get_name(this.amf_global_this())?;
 
-                Self::print_asymmetric_matcher_promise_prefix(flags, this, writer);
-                if flags.not() {
-                    this.amf_add_for_new_line(b"not ".len());
-                    writer.write_all(b"not ");
-                }
-                this.amf_add_for_new_line(matcher_name.length() + 1);
-                writer.print(format_args!("{}", matcher_name));
-                writer.write_all(b" ");
-                this.amf_print_as::<ENABLE_ANSI_COLORS>(
-                    bun_jsc::FormatTag::Array, &mut *writer.ctx, args_value, JSType::Array,
-                )?;
+            Self::print_asymmetric_matcher_promise_prefix(flags, this, writer);
+            if flags.not() {
+                this.amf_add_for_new_line(b"not ".len());
+                writer.write_all(b"not ");
             }
+            this.amf_add_for_new_line(matcher_name.length() + 1);
+            writer.print(format_args!("{}", matcher_name));
+            writer.write_all(b" ");
+            this.amf_print_as::<ENABLE_ANSI_COLORS>(
+                bun_jsc::FormatTag::Array, &mut *writer.ctx, args_value, JSType::Array,
+            )?;
         } else {
             return Ok(false);
         }

--- a/test/js/bun/test/expect-extend-asymmetric-print.test.ts
+++ b/test/js/bun/test/expect-extend-asymmetric-print.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+
+// Like Jest, Bun ignores a `toAsymmetricMatcher` property on a matcher function
+// and prints the custom asymmetric matcher in the default `<name> [args]` form.
+test("ignores a toAsymmetricMatcher property on the matcher function", () => {
+  let hookCalls = 0;
+  function _toBeDivisibleByHooked(actual: unknown, divisor: number) {
+    return { pass: typeof actual === "number" && actual % divisor === 0, message: () => "" };
+  }
+  _toBeDivisibleByHooked.toAsymmetricMatcher = () => {
+    hookCalls++;
+    return "DivisibleBy<3>";
+  };
+  let stringified: string | undefined;
+  expect.extend({
+    _toBeDivisibleByHooked,
+    _stringifyActual(actual) {
+      stringified = this.utils.stringify(actual);
+      return { pass: true, message: () => "" };
+    },
+  });
+  const anyExpect = expect as any;
+
+  let message = "";
+  try {
+    expect({ n: 7 }).toEqual({ n: anyExpect._toBeDivisibleByHooked(3) });
+  } catch (err) {
+    message = Bun.stripANSI((err as Error).message);
+  }
+  expect(message).toContain('"n": _toBeDivisibleByHooked [');
+  expect(message).not.toContain("[object Object]");
+  expect(message).not.toContain("DivisibleBy<3>");
+
+  anyExpect(anyExpect.not._toBeDivisibleByHooked(3))._stringifyActual();
+  expect(stringified).toStartWith("not _toBeDivisibleByHooked [");
+  expect(stringified).not.toContain("[object Object]");
+  expect(hookCalls).toBe(0);
+});


### PR DESCRIPTION
### Problem
- When a matcher registered with `expect.extend` carries a `toAsymmetricMatcher` property, a failing `toEqual` prints the custom asymmetric matcher as `"n": [object Object]toBeDivisibleBy [ 3, ]`.
- `ExpectCustomAsymmetricMatcher::custom_print` (`src/runtime/test_runner/expect.rs:2681`, removed here) looked up that property, then called the matcher itself in its place. The matcher returns `{ pass, message }`, which stringifies to `[object Object]`. It then returned `false`, so the caller at `src/runtime/test_runner/pretty_format.rs:2911` printed the default `<name> [args]` form as well.
- The Zig original (`ExpectCustomAsymmetricMatcher.customPrint`, #7319) had the same two defects. The hook has never produced correct output, and it has no types, no docs, and no Jest or Vitest counterpart.

### Fix
- Delete `custom_print` and its helper `maybe_clear`. The formatter prints the default form directly. The diff line becomes `"n": toBeDivisibleBy [ 3, ]`, with the `not ` and promise prefixes intact.
- Correct because a `toAsymmetricMatcher` property on the matcher function is ignored in Jest too: Jest and Vitest put the print form on the matcher instance, and `expect.extend` offers no user hook for it. The hook is dead native code with no user-visible behavior to keep. The repo guidance asks new user-reachable surface to ship complete (types, docs) or not at all, and a review of the first version of this PR found that enabling the hook as written would print `expect.not.x(3)` and `expect.x(3)` identically.
- This also removes a user JS re-entry from inside the formatter and an `.expect("unreachable")` around it.
- Verified: `test/js/bun/test/expect-extend-asymmetric-print.test.ts` (new file, one test, fails on stock bun 1.4.0). Also ran `expect.test.js`, `jest-extended.test.js`, `expect-extend-*.test.ts`, `pretty-format-overflow.test.ts`, `expect/huge-failure-message.test.ts`, and the three `test/regression/issue` files that use `expect.extend`.

### Background
- An asymmetric matcher is a value like `expect.any(Number)` that `toEqual` matches by a predicate. `expect.toBeDivisibleBy(3)` creates one for a custom matcher. Bun stores the matcher function and the captured args on a native `ExpectCustomAsymmetricMatcher` instance.
- When a diff or `this.utils.stringify` prints such an instance, `pretty_format.rs` writes the promise prefix, `not ` if negated, the matcher name, and the captured args array.
- Jest prints a custom asymmetric matcher as `[not.]name<args>` from a `toAsymmetricMatcher()` method that Jest itself generates on the instance. Bun's default form is `[not ]name [args]`. This PR does not change that form.

<details><summary>Notes</summary>

- Repro on bun 1.4.0-canary.1 (4448a2e21) and on main at b30c6ff986:

  ```ts
  import { expect, test } from "bun:test";
  function toBeDivisibleBy(actual: unknown, divisor: number) {
    const pass = typeof actual === "number" && actual % divisor === 0;
    return { pass, message: () => `expected ${actual} to be divisible by ${divisor}` };
  }
  (toBeDivisibleBy as any).toAsymmetricMatcher = (divisor: number) => `DivisibleBy<${divisor}>`;
  expect.extend({ toBeDivisibleBy });
  test("x", () => { expect({ n: 7 }).toEqual({ n: (expect as any).toBeDivisibleBy(3) }); });
  ```

  Before: `-   "n": [object Object]toBeDivisibleBy [` / `-     3,` / `-   ],`. After: `-   "n": toBeDivisibleBy [` / `-     3,` / `-   ],`.
- The first version of this PR made the hook work (call `fn_value` instead of `matcher_fn`, return `true`). A self-review found that this enables an undocumented, untyped, Bun-only hook that nobody has asked for, and that the enabled form loses the `not` and promise flags, because `custom_print` never read them and the hook had no way to. Deleting the dead path is the smaller change and keeps no half-designed contract. If a maintainer wants a custom print form for `expect.extend` matchers, the complete version needs a `not`/promise decision, a `toAsymmetricMatcher?` member on `CustomMatcher` in `packages/bun-types/test.d.ts`, and a docs entry. That can be its own PR.
- `git show 90654143bb:src/bun.js/test/expect.zig` shows the Zig `customPrint` with the same call target (`matcher_fn.callWithThis`) and `return false`. The Zig instance-level `toAsymmetricMatcher` method was never exposed in `jest.classes.ts`, and the Rust port does not have it.
- `toAsymmetricMatcher` has zero hits in `docs/`, `packages/bun-types/`, and `src/js/`. No package in `test/node_modules` assigns the property to a matcher function.
- The test lives in its own Bun-only file, next to `expect-extend-asymmetric-match-throw.test.ts` and `expect-extend-matcher-utils-throw.test.ts`. `expect-extend.test.js` also runs under Jest and Vitest, where the default form differs, and its 10000-iteration GC test runs close to the 5 s limit on debug ASAN builds (#39359).
- Aligning Bun's default form with Jest's `[not.]name<args>` is a possible follow-up. It changes `.snap` files that hold custom property matchers, so it is out of scope here.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-extend-asymmetric-print.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-extend-asymmetric-print.test.ts:
25 |   try {
26 |     expect({ n: 7 }).toEqual({ n: anyExpect._toBeDivisibleByHooked(3) });
27 |   } catch (err) {
28 |     message = Bun.stripANSI((err as Error).message);
29 |   }
30 |   expect(message).toContain('"n": _toBeDivisibleByHooked [');
                       ^
error: expect(received).toContain(expected)

Expected to contain: "\"n\": _toBeDivisibleByHooked ["
Received: "expect(received).toEqual(expected)\n\n  {\n-   \"n\": [object Object]_toBeDivisibleByHooked [\n-     3,\n-   ],\n+   \"n\": 7,\n  }\n\n- Expected  - 3\n+ Received  + 1\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-extend-asymmetric-print.test.ts:30:19)
(fail) ignores a toAsymmetricMatcher property on the matcher function [49.77ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [2.32s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.1-canary.1 (35a7c23fa)

test/js/bun/test/expect-extend-asymmetric-print.test.ts:
(pass) ignores a toAsymmetricMatcher property on the matcher function [0.33ms]

 1 pass
 0 fail
 8 expect() calls
Ran 1 test across 1 file. [104.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-extend-asymmetric-print.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-extend-asymmetric-print.test.ts:
(pass) ignores a toAsymmetricMatcher property on the matcher function [95.95ms]

 1 pass
 0 fail
 8 expect() calls
Ran 1 test across 1 file. [2.15s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 786ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/37] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 243 extern-C blocks audited
[2/37] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/37] gen cpp.rs (cppbind)
[4/37] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect.rs                  | 69 ++--------------------
 src/runtime/test_runner/pretty_format.rs           | 49 ++++++---------
 .../test/expect-extend-asymmetric-print.test.ts    | 38 ++++++++++++
 3 files changed, 62 insertions(+), 94 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/runtime/test_runner/expect.rs                            6      3      0
src/runtime/test_runner/pretty_format.rs                     2      1      0
test/js/bun/test/expect-extend-asymmetric-print.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->
