### PR TITLE
Remove leftover Zig defer comments

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6981,8 +6981,6 @@ pub mod bv2_impl {
                     .push(core::mem::take(&mut parse_result.external));
             }
 
-            // defer bun.default_allocator.destroy(parse_result) — caller owns Box and drops at end
-
             let mut diff: i32 = -1;
             // The pending-items adjustment is
             // hoisted to tail position (see end of fn) so a deferred closure doesn't

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -219,7 +219,6 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
 
     // Iterate through all files in chunks to collect unique source indices
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
-    // defer seen_sources.deinit() — handled by Drop
 
     // Mark all files that appear in chunks
     for chunk in chunks.iter() {
@@ -763,7 +762,6 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
         Ok(v) => v,
         Err(_) => return Err(crate::Error::InvalidJSON),
     };
-    // defer parsed.deinit() — handled by Drop
 
     let JsonValue::Object(root_obj) = &root else {
         return Err(crate::Error::InvalidJSON);
@@ -814,7 +812,6 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
     // Build a map of module path -> bytesInOutput (bytes contributed to output)
     // This aggregates from all outputs since a module may appear in multiple chunks
     let mut bytes_in_output: StringHashMap<u64> = StringHashMap::default();
-    // defer bytes_in_output.deinit() — handled by Drop
 
     // First pass through outputs to collect bytesInOutput for each module
     for (_, out_value) in outputs_obj.iter() {
@@ -848,7 +845,6 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
     let mut input_files: Vec<InputFileInfo> = Vec::new();
 
     let mut imported_by: StringHashMap<Vec<&[u8]>> = StringHashMap::default();
-    // defer { ... imported_by.deinit() } — handled by Drop (Vec values drop automatically)
 
     // Second pass: collect all input file info and build reverse dependency map
     for (path, input) in inputs_obj.iter() {

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -28,7 +28,6 @@ pub(crate) fn compute_cross_chunk_dependencies(
             dynamic_imports: ArrayHashMap::<IndexInt, ()>::default(),
         })
         .collect();
-    // defer { meta.*.deinit(); free(chunk_metas) } — handled by Drop
 
     {
         // Constructed on the stack and dropped at scope end.
@@ -443,7 +442,6 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
     {
         debug_assert!(chunk_metas.len() == chunks.len());
         let mut r = renamer::ExportRenamer::init();
-        // defer r.deinit() — handled by Drop
         debug!("Generating cross-chunk exports");
 
         let mut stable_ref_list: Vec<StableRef> = Vec::new();
@@ -536,7 +534,6 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
     {
         debug!("Generating cross-chunk imports");
         let mut list: Vec<CrossChunkImport> = Vec::new();
-        // defer list.deinit() — handled by Drop
         // We move the per-chunk fields we
         // mutate (`imports_from_other_chunks`, `cross_chunk_imports`) out via `take`, drop
         // the `chunk` borrow, hand the whole `chunks` slice to `sorted_cross_chunk_imports`

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -625,7 +625,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         cache: bun_collections::ArrayHashMap::default(),
         visited: AutoBitSet::init_empty(c.graph.files.len()).expect("oom"),
     };
-    // defer static_route_visitor.deinit() — handled by Drop
 
     // For standalone mode, resolve JS/CSS chunks so we can inline their content into HTML.
     // Closing tag escaping (</script → <\\/script, </style → <\\/style) is handled during

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -884,7 +884,6 @@ impl<'a> PackageInstall<'a> {
             .node_modules
             .open_file(root_node_modules_dir, package_json_path)
             .ok()?;
-        // defer package_json_file.close()
 
         // Heuristic: most package.jsons will be less than 2048 bytes.
         read = package_json_file.read(&mut mutable.list[total..]).ok()?;

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -517,7 +517,6 @@ pub mod entry {
         let entry_parents = store.entries.items_parents();
 
         let mut parents: ArrayHashMap<Id, ()> = ArrayHashMap::default();
-        // defer parents.deinit(bun.default_allocator);
 
         for &parent_id in entry_parents[entry_id.get() as usize].as_slice() {
             if parent_id == Id::INVALID {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -703,7 +703,6 @@ impl Package<u64> {
         string_builder.count(manifest.str(&package_version_ptr.tarball_url));
 
         string_builder.allocate()?;
-        // defer string_builder.clamp(); — handled at end of scope
         let extern_strings_list = &mut lockfile.buffers.extern_strings;
         let dependencies_list = &mut lockfile.buffers.dependencies;
         let resolutions_list = &mut lockfile.buffers.resolutions;
@@ -1416,7 +1415,6 @@ impl Diff {
                 }
                 continue;
             }
-            // defer to_i += 1; — applied at end of iteration body
             let cur_to_i = to_i;
             to_i += 1;
 
@@ -1458,7 +1456,6 @@ impl Diff {
                         };
 
                         let mut package_json_path: AutoAbsPath = AutoAbsPath::init_top_level_dir();
-                        // defer package_json_path.deinit(); — Drop handles it
 
                         let _ = package_json_path.append(
                             workspace_path.slice(to_lockfile.buffers.string_bytes.as_slice()),
@@ -2291,7 +2288,6 @@ impl Package<u64> {
         };
 
         let mut workspace_names = workspace_map::WorkspaceMap::init();
-        // defer workspace_names.deinit(); — Drop handles it
 
         // pnpm/yarn synthesise an implicit `"*"` optional peer for entries
         // that appear in `peerDependenciesMeta` but not in
@@ -2303,7 +2299,6 @@ impl Package<u64> {
             &[u8],
             bun_collections::identity_context::U64,
         > = ArrayHashMap::default();
-        // defer optional_peer_dependencies.deinit(); — Drop handles it
 
         if FEATURES.peer_dependencies {
             if let Some(peer_dependencies_meta) = json.as_property(b"peerDependenciesMeta") {
@@ -2715,7 +2710,6 @@ impl Package<u64> {
         }
 
         let mut bundled_deps = StringSet::init();
-        // defer bundled_deps.deinit(); — Drop handles it
         let mut bundle_all_deps = false;
         if !resolver.is_void() && resolver.check_bundled_dependencies() {
             if let Some(bundled_deps_expr) = json
@@ -2749,7 +2743,6 @@ impl Package<u64> {
                     (),
                     ArrayIdentityContext,
                 > = ArrayHashMap::default();
-                // defer seen_workspace_names.deinit(allocator); — Drop handles it
                 for (entry, path_) in workspace_names
                     .values()
                     .iter()
@@ -3231,7 +3224,6 @@ pub mod serializer {
         if migrate_from_v2 {
             type OldPackageV2 = Package<u32>;
             let mut list_for_migrating_from_v2 = <List<u32>>::default();
-            // defer list_for_migrating_from_v2.deinit(allocator); — Drop handles it
 
             list_for_migrating_from_v2.ensure_total_capacity(list_len as usize)?;
             // SAFETY: capacity reserved above; `load_fields` writes every column.

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -375,7 +375,6 @@ pub mod registry {
                 'outer: {
                     if registry.password.is_empty() {
                         let mut pathname: &[u8] = url.pathname;
-                        // defer { url.pathname = pathname; url.path = pathname; } — applied below
                         let mut needs_to_check_slash = true;
                         while let Some(colon) = strings::last_index_of_char(pathname, b':') {
                             let mut segment = &pathname[colon + 1..];

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -265,7 +265,6 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
     resolver: &mut R,
 ) -> crate::Result<LockfilePackage> {
     let mut body = npm::Registry::BodyPool::get();
-    // defer Npm.Registry.BodyPool.release(body) — handled by PoolGuard Drop
 
     let mut package: LockfilePackage = Default::default();
 
@@ -321,7 +320,6 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
 
         let source = {
             let file = File::openat(Fd::cwd(), abs.as_bytes(), O::RDONLY, 0)?;
-            // defer file.close()
             body.reset();
             let read_result = file
                 .read_to_end_with_array_list(&mut body.list, bun_sys::SizeHint::ProbablySmall)

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -768,14 +768,6 @@ impl<'a> Parser<'a> {
         p.binary_expression_stack = BumpVec::with_capacity_in(41, p.arena);
         p.binary_expression_simplify_stack = BumpVec::with_capacity_in(47, p.arena);
 
-        // defer {
-        //     if (p.allocated_names_pool) |pool| {
-        //         pool.data = p.allocated_names;
-        //         pool.release();
-        //         p.allocated_names_pool = null;
-        //     }
-        // }
-
         // Consume a leading hashbang comment
         let mut hashbang: &[u8] = b"";
         if p.lexer.token == js_lexer::T::THashbang {

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -99,7 +99,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             value: Some(value),
                             ..Default::default()
                         });
-                        i += 1; // defer i += 1
+                        i += 1;
                     }
                     T::TOpenBrace => {
                         // This arm must increment `i` once before exiting.
@@ -206,7 +206,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         p.lexer.next_inside_jsx_element()?;
-                        i += 1; // defer i += 1
+                        i += 1;
                     }
                     _ => {
                         break 'parse_attributes;

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -841,8 +841,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         {
             self.push_scope_for_visit_pass(ScopeKind::ClassBody, class.body_loc)
                 .expect("unreachable");
-            // defer { p.pop_scope(); p.enclosing_class_keyword = old_enclosing_class_keyword; }
-            // — manual restore at block end below; no early returns in this block.
 
             let mut constructor_function: Option<bun_ast::StoreRef<E::Function>> = None;
             let properties: &mut [G::Property] = class.properties.slice_mut();
@@ -898,13 +896,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 // Make it an error to use "arguments" in a class body
                 self.vis_scope().forbid_arguments = true;
-                // defer p.current_scope.forbid_arguments = false;
 
                 // The value of "this" is shadowed inside property values
                 let old_is_this_captured = self.fn_only_data_visit.is_this_nested;
                 self.fn_only_data_visit.is_this_nested = true;
-                // defer p.fn_only_data_visit.is_this_nested = old_is_this_captured;
-                // — manual restore at end of loop body; no `continue` after this point.
 
                 // We need to explicitly assign the name to the property initializer if it
                 // will be transformed such that it is no longer an inline initializer.

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1014,9 +1014,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             if p.current_scope == p.module_scope {
-                // defer-vs-drop-scope — restore hook_ctx_storage/is_control_flow_dead
-                // before propagating Err so the stack-local `react_hook_data` ptr is never left in
-                // p.react_refresh on the OOM path.
+                // Restore hook_ctx_storage/is_control_flow_dead before propagating Err so the
+                // stack-local `react_hook_data` ptr is never left in p.react_refresh on the OOM path.
                 rr = p.handle_react_refresh_register(
                     stmts,
                     original_name,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7468,8 +7468,6 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         no_op_renamer.to_renamer()
     };
 
-    // defer: if minify_identifiers { renamer.deinit() } — Drop handles.
-
     // `is_bun_platform = ascii_only` for printAst.
     type PrinterType<'a, W, const A: bool, const G: bool> =
         Printer<'a, W, A, /*IS_BUN_PLATFORM=*/ A, false, G>;
@@ -7560,7 +7558,6 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     } else {
         None
     };
-    // defer: if let Some(chunk) = &mut source_maps_chunk { chunk.deinit() } — Drop handles.
 
     if let Some(cache) = printer.options.runtime_transpiler_cache {
         let mut srlz_res: Vec<u8> = Vec::new();
@@ -7748,7 +7745,6 @@ pub(crate) fn print_with_writer_and_platform<
         printer.module_info = printer.options.module_info.take();
     }
     printer.binary_expression_stack = Vec::new();
-    // defer: temporary_bindings.deinit / writer.* = printer.writer.* — handled by move-out below.
 
     // `Index::is_runtime` ⇔ `index.value == 0`.
     if module_type == bundle_opts::Format::InternalBakeDev && source.index.0 != 0 {

--- a/src/jsc/btjs.rs
+++ b/src/jsc/btjs.rs
@@ -221,7 +221,6 @@ fn print_source_at_address(
         }
         Err(e) => return Err(e),
     };
-    // defer free(sl.file_name) — handled by Drop on SourceLocation.file_name: Box<[u8]>
 
     // jsc_llint_begin/end are link-time symbols; `&raw const` avoids creating a reference to extern static
     let llint_begin = (&raw const jsc_llint_begin) as usize;
@@ -390,7 +389,6 @@ fn print_line_from_file_any_os(
         0,
     )
     .map_err(Into::<Error>::into)?;
-    // defer f.close() — handled by Drop
     // TODO fstat and make sure that the file has the correct size
 
     let mut buf = [0u8; 4096];

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1365,7 +1365,6 @@ impl Archiver {
                         else {
                             continue 'loop_;
                         };
-                        // defer opened.close()
                         let _close_guard = scopeguard::guard(opened, |fd| fd.close());
                         let stat_size = bun_sys::get_file_size(opened)?;
 

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5227,7 +5227,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     }
 
     fn scan_literal_scalar(&mut self) -> Result<Token<Enc>, ParseError> {
-        // defer self.whitespace_buf.clearRetainingCapacity();
         let start = self.pos;
         let line = self.line;
 

--- a/src/resolver/data_url.rs
+++ b/src/resolver/data_url.rs
@@ -173,7 +173,6 @@ impl<'a> DataURL<'a> {
     /// Decodes the data from the data URL. Always returns an owned slice.
     pub fn decode_data(&self) -> Result<Vec<u8>, DecodeDataError> {
         let percent_decoded_owned: Option<Vec<u8>> = PercentEncoding::decode_unstrict(self.data)?;
-        // defer: `percent_decoded_owned` drops at scope exit
         let percent_decoded: &[u8] = percent_decoded_owned.as_deref().unwrap_or(self.data);
 
         if self.is_base64 {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1382,10 +1382,6 @@ impl<'a> Resolver<'a> {
                 .unwrap_or_else(|_| panic!("Failed to query CWD"));
         };
 
-        // r.mutex.lock();
-        // defer r.mutex.unlock();
-        // errdefer (r.flushDebugLogs(.fail) catch {}) — handled at each error return below
-
         // A path with a null byte cannot exist on the filesystem. Continuing
         // anyways would cause assertion failures.
         if strings::index_of_char(import_path, 0).is_some() {
@@ -4454,7 +4450,6 @@ impl<'a> Resolver<'a> {
             let (qt_unsafe_path, qt_safe_path) = (queue_top.unsafe_path, queue_top.safe_path);
             let queue_top_unsafe_path: &[u8] = qt_unsafe_path.slice();
             let queue_top_safe_path: &[u8] = qt_safe_path.slice();
-            // defer top_parent = queue_top.result — done at end of loop body
             queue_slice_len -= 1;
 
             let open_dir: FD = if queue_top.fd.is_valid() {
@@ -5187,7 +5182,6 @@ impl<'a> Resolver<'a> {
             debug.increase_indent();
         }
 
-        // defer { debug.decreaseIndent() } — handled at returns
         macro_rules! dec_ret {
             ($e:expr) => {{
                 if let Some(d) = self.debug_logs.as_mut() {
@@ -5576,7 +5570,6 @@ impl<'a> Resolver<'a> {
             ));
             debug.increase_indent();
         }
-        // defer if (r.debug_logs) |*debug| debug.decreaseIndent();
         macro_rules! dec_ret {
             ($e:expr) => {{
                 if let Some(d) = self.debug_logs.as_mut() {

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -332,7 +332,6 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
             include_value: true,
         },
     )?;
-    // defer iter.deinit() — handled by Drop
 
     while let Some(key) = iter.next()? {
         let value = iter.value;
@@ -343,11 +342,9 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
         // Get the key as a null-terminated string
         let key_slice = key.to_utf8();
         let key_str = ZBox::from_vec_with_nul(key_slice.slice().to_vec());
-        // defer free(key_str)/key_slice.deinit() — handled by Drop
 
         // Get data - use view for Blob/ArrayBuffer, convert for strings
         let data_slice = get_entry_data(global, value)?;
-        // defer data_slice.deinit() — handled by Drop
 
         // Write entry to archive
         let data = data_slice.slice();

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -549,7 +549,6 @@ impl Config {
                 // SAFETY: `replace_obj` is non-null (just returned by get_object()).
                 let replace_obj_ref = unsafe { &*replace_obj };
                 let mut iter = JSPropertyIterator::init(global, replace_obj_ref, PROP_ITER_OPTS)?;
-                // defer iter.deinit() → Drop
 
                 if iter.len > 0 {
                     bun_core::handle_oom(replacements.ensure_unused_capacity(iter.len));
@@ -1290,7 +1289,6 @@ impl JSTranspiler {
         // SAFETY: bun_vm() returns the live VM singleton on this thread.
         let vm = global.bun_vm();
         let mut args = ArgumentsSlice::init(vm, callframe.arguments());
-        // defer args.deinit() → Drop
         let Some(code_arg) = args.next() else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
@@ -1298,7 +1296,6 @@ impl JSTranspiler {
         let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
-        // defer code_holder.deinit() → Drop
         let code = code_holder.slice();
         args.eat();
 
@@ -1316,7 +1313,6 @@ impl JSTranspiler {
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
-        // defer log.deinit() → Drop
         // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
         // `_restore` (declared after `arena`/`log`, so dropped first) restores
         // `prev_arena` and `&self.config.log` before either local drops.
@@ -1380,7 +1376,6 @@ impl JSTranspiler {
         // SAFETY: bun_vm() returns the live VM singleton on this thread.
         let vm = global.bun_vm();
         let mut args = ArgumentsSlice::init(vm, callframe.arguments());
-        // defer args.arena.deinit() → Drop
         let Some(code_arg) = args.next() else {
             return Err(global.throw_invalid_argument_type(
                 "transform",
@@ -1446,7 +1441,6 @@ impl JSTranspiler {
         // SAFETY: bun_vm() returns the live VM singleton on this thread.
         let vm = global.bun_vm();
         let mut args = ArgumentsSlice::init(vm, arguments);
-        // defer args.arena.deinit() → Drop
         let Some(code_arg) = args.next() else {
             return Err(global.throw_invalid_argument_type(
                 "transformSync",
@@ -1463,7 +1457,6 @@ impl JSTranspiler {
                 "string or Uint8Array",
             ));
         };
-        // defer code_holder.deinit() → Drop
         let code = code_holder.slice();
         arguments[0].ensure_still_alive();
         let _keep0 = bun_jsc::EnsureStillAlive(arguments[0]);
@@ -1555,9 +1548,6 @@ impl JSTranspiler {
             bun_core::handle_oom(writer.buffer.grow_if_needed(code.len()));
             writer
         });
-
-        // defer { this.buffer_writer = buffer_writer } — only the print-error and tail
-        // paths reach past this point; both write `Some(..)` back explicitly.
 
         buffer_writer.reset();
         let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
@@ -1657,7 +1647,6 @@ impl JSTranspiler {
         // SAFETY: bun_vm() returns the live VM singleton on this thread.
         let vm = global.bun_vm();
         let mut args = ArgumentsSlice::init(vm, callframe.arguments());
-        // defer args.deinit() → Drop
 
         let Some(code_arg) = args.next() else {
             return Err(global.throw_invalid_argument_type(
@@ -1681,7 +1670,6 @@ impl JSTranspiler {
             }
         };
         args.eat();
-        // defer code_holder.deinit() → Drop
         let code = code_holder.slice();
 
         let mut loader: Loader = self.config.get().default_loader;
@@ -1700,7 +1688,6 @@ impl JSTranspiler {
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
-        // defer log.deinit() → Drop
         // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
         // `_restore` (declared after `arena`/`log`, so dropped first) restores
         // `prev_arena` and `&self.config.log` before either local drops.

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1477,7 +1477,6 @@ impl Terminal {
                 "write() argument must be a string or ArrayBuffer"
             )));
         };
-        // defer string_or_buffer.deinit() — Drop handles it.
 
         let bytes = string_or_buffer.slice();
         let input_len = bytes.len();

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1558,7 +1558,6 @@ impl Stream {
             }
         };
 
-        // defer block from Zig (only when the full frame was flushed)
         if let Some(_frame) = owned_frame {
             // only call the callback + free the frame if we write to the socket the full frame
             client

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -112,7 +112,6 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // SAFETY: `init_bake` returns a freshly-allocated VM owned by this thread;
     // unique access for the rest of this function.
     let vm = unsafe { &mut *vm_ptr };
-    // defer vm.deinit() — handled by `vm.destroy()` on the unwind path below.
     // Note: pass `vm_ptr` by value into the guard so the drop closure does
     // not borrow the local (`defer!` would capture `&vm_ptr`, which under
     // edition-2024 disjoint-capture rules collides with the `&mut *vm_ptr`
@@ -972,7 +971,6 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
 
     let mut params_buf: Vec<&[u8]> = Vec::new();
     for (nav_index, &route_index) in navigatable_routes.iter().enumerate() {
-        // defer params_buf.clearRetainingCapacity()
         let mut params_guard = scopeguard::guard(&mut params_buf, |b| b.clear());
         let params_buf = &mut **params_guard;
 

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -181,7 +181,6 @@ impl ReplCommand {
     fn dump_build_error(vm: &VirtualMachine) {
         Output::flush();
         let writer = Output::error_writer_buffered();
-        // defer Output.flush()
         let _flush = Output::flush_guard();
         if let Some(log) = vm.log {
             // SAFETY: log is a valid NonNull<Log> for the VM lifetime.

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -197,7 +197,6 @@ impl UpgradeCommand {
             },
         };
         header_entries.append(accept).expect("oom");
-        // defer if SILENT header_entries.deinit() — Drop handles this
 
         // Incase they're using a GitHub proxy in e.g. China
         let mut github_api_domain: &[u8] = b"api.github.com";

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -715,7 +715,6 @@ fn js_password_object_hash_sync(
             "string or TypedArray",
         ));
     };
-    // defer string_or_buffer.deinit() — Drop at scope exit.
 
     if string_or_buffer.slice().is_empty() {
         return Err(
@@ -870,8 +869,6 @@ fn js_password_object_verify_sync(
     if let StringOrBuffer::Buffer(buffer) = &mut password {
         buffer.buffer = ArrayBuffer::from_typed_array(global_object, buffer.buffer.value);
     }
-
-    // defer password.deinit() / hash_.deinit() — Drop at scope exit.
 
     if hash_.slice().is_empty() {
         return Ok(JSValue::FALSE);

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -712,7 +712,6 @@ impl NodeHTTPResponse {
 
     fn mark_request_as_done(&self) {
         scoped_log!(NodeHTTPResponse, "markRequestAsDone()");
-        // defer this.deref(); — moved to end of fn body.
         self.update_flags(|f| f.remove(Flags::IS_REQUEST_PENDING));
 
         // The async path (`on_node_http_request_with_upgrade_ctx`) stashes the
@@ -1255,9 +1254,6 @@ pub enum AbortEvent {
 
 impl NodeHTTPResponse {
     fn handle_abort_or_timeout<const EVENT: AbortEvent>(&self, js_value: JSValue) {
-        // defer { if event == abort, raw_response = None }
-        // The deferred null is moved to explicit tail positions.
-
         if self.flags.get().contains(Flags::REQUEST_HAS_COMPLETED) {
             if EVENT == AbortEvent::Abort {
                 // The socket is gone — no further uws callback will arrive to
@@ -1285,8 +1281,6 @@ impl NodeHTTPResponse {
         }
 
         self.ref_();
-        // defer this.deref();
-        // defer if (event == .abort) this.markRequestAsDoneIfNecessary();
 
         let js_this: JSValue = if js_value.is_empty() {
             self.get_this_value()
@@ -1487,7 +1481,6 @@ fn node_http_request_on_resolve(global_object: &JSGlobalObject, callframe: &Call
         p.deinit();
         had
     });
-    // defer this.deref(); — moved to tail.
     this.maybe_stop_reading_body(bun_vm_mut(global_object), arguments[1]);
 
     let flags = this.flags.get();
@@ -1532,8 +1525,6 @@ fn node_http_request_on_reject(global_object: &JSGlobalObject, callframe: &CallF
         had
     });
     this.maybe_stop_reading_body(bun_vm_mut(global_object), arguments[1]);
-
-    // defer this.deref(); — moved to tail.
 
     let flags = this.flags.get();
     if !flags.contains(Flags::REQUEST_HAS_COMPLETED)
@@ -1680,8 +1671,6 @@ impl NodeHTTPResponse {
             self.body_read_state.set(BodyReadState::Done);
         }
 
-        // defer { if last { ... } } — moved to tail.
-
         // "Armed" means a callable is cached — the slot holds an explicit
         // `undefined` between the dispatch reset and the reader's _read() arming
         // it, and a body arriving in that window used to be dropped outright.
@@ -1820,7 +1809,6 @@ impl NodeHTTPResponse {
     fn on_drain_corked(&self, offset: u64) {
         scoped_log!(NodeHTTPResponse, "onDrainCorked({})", offset);
         self.ref_();
-        // defer this.deref(); — moved to tail.
 
         let this_value = self.get_this_value();
         let Some(on_writable) = js::on_writable_get_cached(this_value) else {
@@ -2297,7 +2285,6 @@ impl NodeHTTPResponse {
         {
             js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
             self.armed_this_value.set(JSValue::ZERO);
-            // defer { if body_read_ref.has { unref } } — moved to tail of this branch.
             match self.body_read_state.get() {
                 BodyReadState::Pending | BodyReadState::Done => {
                     if !flags.contains(Flags::REQUEST_HAS_COMPLETED)
@@ -2349,7 +2336,6 @@ impl NodeHTTPResponse {
     }
 
     fn on_auto_flush(&self) -> bool {
-        // defer this.deref(); — moved to tail.
         let flags = self.flags.get();
         if !flags.contains(Flags::SOCKET_CLOSED) && !flags.contains(Flags::UPGRADED) {
             if let Some(raw_response) = self.raw_response.get() {
@@ -2534,7 +2520,6 @@ impl NodeHTTPResponse {
         // BACKREF: `this` is the live `m_ctx` heap payload; `ref_()` keeps it
         // alive across re-entry.
         this.ref_();
-        // defer this.deref(); — moved to tail.
 
         // Snapshot before re-entry; `raw_response` is `Copy`.
         let raw_response = this.raw_response.get();

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -183,9 +183,7 @@ impl ParsedShellScript {
             // on OOM).
             let slice = value_str.to_owned_slice();
             let keyref = EnvStr::init_ref_counted(keyslice.into_boxed_slice());
-            // defer keyref.deref() — done below (insert refs again).
             let valueref = EnvStr::init_ref_counted(slice.into_boxed_slice());
-            // defer valueref.deref() — done below.
 
             env.insert(keyref, valueref);
             keyref.deref();

--- a/src/runtime/test_runner/expect/toBeWithin.rs
+++ b/src/runtime/test_runner/expect/toBeWithin.rs
@@ -61,7 +61,6 @@ impl Expect {
         let mut formatter = super::make_formatter(global);
         let mut formatter2 = super::make_formatter(global);
         let mut formatter3 = super::make_formatter(global);
-        // defer formatter.deinit(); — handled by Drop
         let start_fmt = start_value.to_fmt(&mut formatter);
         let end_fmt = end_value.to_fmt(&mut formatter2);
         let received_fmt = value.to_fmt(&mut formatter3);

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -68,7 +68,6 @@ pub(crate) fn to_have_nth_returned_with(
     // Handle failure
     let mut formatter = super::make_formatter(global);
     let mut formatter2 = super::make_formatter(global);
-    // defer formatter.deinit() — handled by Drop
 
     let signature = get_signature("toHaveNthReturnedWith", "<green>n<r>, <green>expected<r>", false);
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -394,7 +394,6 @@ impl PendingValue {
                         Action::GetBlob => global_this.readable_stream_to_blob(readable.value),
                         Action::GetFormData(form_data) => 'brk: {
                             let fd = form_data.take().unwrap();
-                            // defer: form_data already taken; action.getFormData = None handled by take()
                             let encoding_js = match &fd.encoding {
                                 bun_core::form_data::Encoding::Multipart(multipart) => {
                                     BunString::init(&multipart[..]).to_js(global_this)?

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -149,7 +149,7 @@ impl ByteBlobLoader {
             // SAFETY: `StoreRef` deref is `&Store`; `to_any_blob` needs `&mut` to move bytes out.
             // We hold the only outstanding ref (just detached) so exclusive access is sound.
             if let Some(blob) = unsafe { (*store.as_ptr()).to_any_blob() } {
-                drop(store); // defer store.deref()
+                drop(store);
                 return Some(blob);
             }
         }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -492,7 +492,6 @@ impl ReadableStream {
         recommended_chunk_size: webcore::blob::SizeType,
     ) -> JsResult<JSValue> {
         let blob = Blob::init(bytes.into(), global_this);
-        // defer blob.deinit() → handled by Drop
         Self::from_blob_copy_ref(global_this, &blob, recommended_chunk_size)
     }
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -365,7 +365,6 @@ impl CopyFile {
         let src_fd = self.source_fd;
         let dest_fd = self.destination_fd;
 
-        // defer { this.read_len = @truncate(total_written); }
         let read_len_slot: *mut SizeType = &raw mut self.read_len;
         let total_written_slot: *const u64 = core::ptr::addr_of!(total_written);
         scopeguard::defer! {
@@ -626,8 +625,6 @@ impl CopyFile {
         }
         #[cfg(not(windows))]
         {
-            // defer task.onFinish();
-
             #[cfg(target_os = "macos")]
             let mut stat_: Option<Stat> = None;
             #[cfg(not(target_os = "macos"))]

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1150,7 +1150,6 @@ impl FetchTasklet {
 
         let tracker = self.tracker;
         tracker.will_dispatch(&global_this);
-        // defer block:
         let dispatch_cleanup = |_this: &mut FetchTasklet| {
             bun_output::scoped_log!(FetchTasklet, "onProgressUpdate: promise_value is not null");
             tracker.did_dispatch(&global_this);

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -798,7 +798,6 @@ impl S3Credentials {
         // `authorization` (Box<[u8]>) drops on `?`.
 
         if sign_query {
-            // defer free(host); defer free(amz_date); — drop at scope exit.
             // SignResult implements Drop, so struct-update `..default()`
             // is forbidden; mutate a default in place instead.
             let mut r = SignResult::default();

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -428,7 +428,6 @@ pub(crate) fn get_source_map_impl<P: SourceProvider + ?Sized>(
         if load_hint != SourceMapLoadHint::IsExternalMap {
             'try_inline: {
                 let source = provider.get_source_slice();
-                // defer source.deref() → Drop on bun_core::String
                 debug_assert!(source.tag() == bun_core::Tag::ZigString);
 
                 let maybe_found_url = if source.is_8bit() {
@@ -440,7 +439,6 @@ pub(crate) fn get_source_map_impl<P: SourceProvider + ?Sized>(
                 let Some(found_url) = maybe_found_url else {
                     break 'try_inline;
                 };
-                // defer found_url.deinit() → Drop
 
                 match parse_url(&arena, found_url.slice(), result) {
                     Ok(parsed) => break 'parsed (SourceMapLoadHint::IsInlineMap, parsed),

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1818,10 +1818,6 @@ mod spawn_process_body {
 
         let mut uv_files_to_close: Vec<uv::uv_file> = Vec::new();
 
-        // defer: close uv_files_to_close — handled at each return site below
-        // via explicit cleanup calls at each error return; no
-        // `failed` flag is needed.
-
         if let Some(hpcon) = options.pseudoconsole {
             uv_process_options.pseudoconsole = hpcon;
         }
@@ -2068,8 +2064,6 @@ mod spawn_process_body {
             exit_handler: ProcessExitHandler::default(),
         }));
 
-        // defer if failed: process.close(); process.deref(); — handled at error sites
-
         // SAFETY: process is freshly allocated
         unsafe {
             // SAFETY: all-zero is valid uv::Process
@@ -2082,7 +2076,6 @@ mod spawn_process_body {
             uv_proc.data = process.cast::<c_void>();
         }
 
-        // defer dup_fds cleanup — handled below at each exit
         let cleanup_dup = |failed: bool| {
             if dup_src.is_some() {
                 debug_assert!(dup_src.is_some() && dup_tgt.is_some());
@@ -3171,8 +3164,6 @@ mod spawn_process_body {
                 process.stderr.unwrap_or(Fd::INVALID),
             ];
             let mut success = false;
-            // defer cleanup — handled at end / via guards below; error returns
-            // run their cleanup manually
 
             let mut out_fds_to_wait_for: [Fd; 2] = [
                 process.stdout.unwrap_or(Fd::INVALID),

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -635,10 +635,8 @@ pub unsafe fn spawn_process_posix(
 ) -> crate::Result<bun_sys::Result<PosixSpawnResult>> {
     bun_analytics::features::spawn.fetch_add(1, Ordering::Relaxed);
     let mut actions = PosixSpawnActions::init()?;
-    // defer actions.deinit() — Drop
 
     let mut attr = PosixSpawnAttr::init()?;
-    // defer attr.deinit() — Drop
 
     // libc 0.2.x exposes the `POSIX_SPAWN_SETSIG*` flags for glibc/musl/macOS
     // but not for Android. Bionic's `<spawn.h>` uses the same values as glibc

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -713,8 +713,6 @@ impl JSMySQLConnection {
         };
         on_close.ensure_still_alive();
         let loop_ = self.event_loop();
-        // loop.enter();
-        // defer loop.exit();
         self.ensure_js_value_is_alive();
         let mut js_error = value.to_error().unwrap_or(value);
         if js_error.is_empty() {
@@ -793,7 +791,6 @@ impl JSMySQLConnection {
             bigint: request.is_bigint_supported(),
             values: Box::default(),
         };
-        // defer row.deinit(allocator) — Drop on ResultSet::Row
         if let Err(e) = row.decode(reader) {
             if e == AnyMySQLErrorT::ShortRead {
                 return Err(OnResultRowError::ShortRead);

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -215,7 +215,6 @@ fn parse_array(
                 | types::Tag::date_array => {
                     let date_str = &slice[1..current_idx];
                     let mut str = BunString::init(date_str);
-                    // defer str.deref() → Drop on BunString
                     array.push(SQLDataCell::date(
                         crate::jsc::bun_string_jsc::parse_date(&mut str, global_object)
                             .map_err(crate::jsc::js_error_to_postgres)?,

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1420,7 +1420,6 @@ pub(crate) fn inject<'a>(
 
         #[cfg(not(windows))]
         {
-            // defer self_fd.close()
             let _self_fd_guard = Syscall::CloseOnDrop::new(self_fd);
 
             if let Err(e) = bun_sys::copy_file(self_fd, fd) {
@@ -1802,7 +1801,6 @@ pub(crate) fn download_to_path(
         let mut tarball_bytes: Vec<u8> = Vec::new();
         {
             refresher.refresh();
-            // defer compressed_archive_bytes.list.deinit(allocator) — handled by Drop
 
             if compressed_archive_bytes.list.is_empty() {
                 // Return error without printing - let caller handle the messaging
@@ -1831,7 +1829,6 @@ pub(crate) fn download_to_path(
 
             {
                 refresher.start(b"Extracting", 0);
-                // defer node.end() — see explicit calls below
 
                 let mut tmpname_buf = [0u8; 1024];
                 let tempdir_name: &ZStr =

--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -532,7 +532,6 @@ impl<'a> ValkeyReader<'a> {
 
                 // First element is the push type
                 let push_type = self.read_value_with_depth(depth + 1)?;
-                // defer push_type.deinit() — drops at scope end
                 let push_type_str: &[u8] = match &push_type {
                     RESPValue::SimpleString(str) => str,
                     RESPValue::BulkString(maybe_str) => {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -397,7 +397,6 @@ impl Watcher {
             "flush_evictions: caller must hold self.mutex (platform watcher holds it around on_file_update)",
         );
         let evict_list_i = self.evict_list_i as usize;
-        // defer this.evict_list_i = 0 — set at end of fn
 
         // swapRemove messes up the order
         // But, it only messes up the order if any elements in the list appear after the item being removed

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -370,7 +370,6 @@ impl<'a> ZlibReaderArrayList<'a> {
             Ok(())
         })();
 
-        // defer epilogue (runs unconditionally):
         let total_out = self.zlib.total_out as usize;
         if self.list_ptr.len() > total_out {
             self.list_ptr.truncate(total_out);


### PR DESCRIPTION
Deletes the `// defer ... — handled by Drop` style comments left behind by the Zig to Rust port. They describe what Drop already does and carry no information.

Comment-only change. No behavior change.