### PR TITLE
test(install): update pm ls and prune snapshots to the new count wording

### DIFF
--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -600,7 +600,7 @@ it.each([
   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls");
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
-    "<dir> node_modules (5)
+    "<dir> node_modules (5 installed)
     ├── bar@0.0.2
     ├── bar-alias@0.0.2
     ├── ws-once@workspace:packages/ws-once
@@ -622,7 +622,7 @@ it("should list a trusted workspace the root also depends on once with --trusted
   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls", "--trusted");
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
-    "<dir> node_modules (5)
+    "<dir> node_modules (5 installed)
     └── ws-once@workspace:packages/ws-once"
   `);
   expect(exitCode).toBe(0);
@@ -670,7 +670,7 @@ it("should list a root optional peer that a dependency provides", async () => {
   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls");
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
-    "<dir> node_modules (2)
+    "<dir> node_modules (2 installed)
     ├── bar@0.0.2
     └── moo@moo"
   `);

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -658,7 +658,7 @@ test.concurrent("isolated linker: --verbose does not print the store build timin
 
     - no-deps@1.0.1
     - one-dep@1.0.0
-    2 packages removed (checked 5)"
+    2 packages removed (checked 5 installed packages)"
   `);
   expect(stderr).not.toContain("Resolved peers");
   expect(stderr).not.toContain("Created store");


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-pm.test.ts` and `test/cli/install/bun-prune.test.ts` fail on every lane on main since 3b3687e55f (#38952). Four `toMatchInlineSnapshot` calls mismatch by one line: `- "<dir> node_modules (5)` / `+ "<dir> node_modules (5 installed)` and `- 2 packages removed (checked 5)` / `+ 2 packages removed (checked 5 installed packages)`.
- #38952 renamed the summary counts on purpose (`src/install/prune.rs`, `src/runtime/cli/package_manager_command.rs`) and updated the snapshots it knew about. Two PRs merged before it kept the old text: #39962 added the three `bun pm ls` snapshots (`bun-pm.test.ts:603`, `:625`, `:673`) and #39157 added the prune snapshot (`bun-prune.test.ts:661`). Neither branch saw the other.

### Fix
- Update the four inline snapshots to the wording #38952 ships. No `src/` change.
- The new wording is the intended behavior. #38952 documents it in its body and in `docs/pm/cli/{prune,pm}.mdx`. The neighboring prune test at `bun-prune.test.ts:626` already asserts `(checked 9 installed packages)`.
- The tests still exercise the same paths: full `bun pm ls` and `bun prune --production --verbose` output, compared line by line.
- Verified: `bun bd test test/cli/install/bun-pm.test.ts` (22 pass, 4 fail before) and `bun bd test test/cli/install/bun-prune.test.ts` (110 pass, 1 fail before). Also `bun-pm-licenses.test.ts`, `bun-dedupe.test.ts` and `isolated-relink.test.ts`, the other files #38952 touched, all green.

### Background
- `bun pm ls` prints a header line `<dir> node_modules (N installed)` followed by a tree of the installed packages. `N` counts node_modules entries.
- `bun prune` ends with `N packages removed (checked M installed packages)`. `M` counts the installed entries it compared against the lockfile.
- #38952 named the unit in each count so the numbers from `dedupe` (lockfile entries), `prune` (installed entries) and `pm ls` (tree positions) no longer look contradictory.

<details><summary>Notes</summary>

- Main build 103285 (299bc9a3da) and the reporting build 103286 show the same failures on all 10 test lanes for both files.
- I grepped `test/` and `docs/` for every wording #38952 changed (`node_modules (N)`, `(checked N)`, `can be removed (checked`, `No duplicates`, `nothing to prune`, `across N licenses`). The only stale matches are the four lines in this PR. The `(checked N)` lines in `bun-audit.test.ts` belong to `bun audit --fix`, which #38952 did not change.
- #40045 (a feature PR for `--json` output) carries the same four snapshot updates inside a much larger diff. Main needs the fix on its own.

</details>
