### PR TITLE
install: support `packageExtensions` (yarn/pnpm compatibility)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -223,6 +223,7 @@
               "/pm/lifecycle",
               "/pm/scopes-registries",
               "/pm/overrides",
+              "/pm/package-extensions",
               "/pm/security-scanner-api",
               "/pm/npmrc"
             ]

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -136,7 +136,7 @@ Bun supports npm's `"overrides"` and Yarn's `"resolutions"` in `package.json`. B
 
 ## Package extensions
 
-Bun supports pnpm's and Yarn's `"packageExtensions"` in `package.json` (and `bunfig.toml`) for adding `dependencies` / `peerDependencies` that a third-party package forgot to declare — most often needed with [isolated installs](/pm/isolated-installs). See [package extensions](/pm/package-extensions).
+Bun supports pnpm's and Yarn's `"packageExtensions"` in `package.json` (and `bunfig.toml`) for adding `dependencies`, `optionalDependencies`, `peerDependencies` and `peerDependenciesMeta` entries that a third-party package forgot to declare — most often needed with [isolated installs](/pm/isolated-installs). See [package extensions](/pm/package-extensions).
 
 {/* prettier-ignore */}
 ```json package.json icon="file-json"

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -134,6 +134,28 @@ Bun supports npm's `"overrides"` and Yarn's `"resolutions"` in `package.json`. B
 
 ---
 
+## Package extensions
+
+Bun supports pnpm's and Yarn's `"packageExtensions"` in `package.json` (and `bunfig.toml`) for adding `dependencies` / `peerDependencies` that a third-party package forgot to declare — most often needed with [isolated installs](/pm/isolated-installs). See [package extensions](/pm/package-extensions).
+
+{/* prettier-ignore */}
+```json package.json icon="file-json"
+{
+  "name": "my-app",
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-redux": "^7.0.0"
+  },
+  "packageExtensions": { // [!code ++]
+    "react-redux@7": { // [!code ++]
+      "peerDependencies": { "react": "*" } // [!code ++]
+    } // [!code ++]
+  } // [!code ++]
+}
+```
+
+---
+
 ## Global packages
 
 To install a package globally, use the `-g`/`--global` flag. Use it to install command-line tools.
@@ -600,6 +622,7 @@ Bun preserves dependencies that use pnpm's `catalog:` protocol:
 Bun migrates the following pnpm configuration from both `pnpm-lock.yaml` and `pnpm-workspace.yaml`:
 
 - **Overrides**: Moved from `pnpm.overrides` to root-level `overrides` in `package.json`
+- **Package Extensions**: Moved from `pnpm.packageExtensions` to root-level `packageExtensions` in `package.json`
 - **Patched Dependencies**: Moved from `pnpm.patchedDependencies` to root-level `patchedDependencies` in `package.json`
 - **Workspace Overrides**: Applied from `pnpm-workspace.yaml` to root `package.json`
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -622,7 +622,7 @@ Bun preserves dependencies that use pnpm's `catalog:` protocol:
 Bun migrates the following pnpm configuration from both `pnpm-lock.yaml` and `pnpm-workspace.yaml`:
 
 - **Overrides**: Moved from `pnpm.overrides` to root-level `overrides` in `package.json`
-- **Package Extensions**: Moved from `pnpm.packageExtensions` to root-level `packageExtensions` in `package.json`
+- **Package Extensions**: Moved from `pnpm.packageExtensions` in the root `package.json` and `packageExtensions` in `pnpm-workspace.yaml` to root-level `packageExtensions` in `package.json`
 - **Patched Dependencies**: Moved from `pnpm.patchedDependencies` to root-level `patchedDependencies` in `package.json`
 - **Workspace Overrides**: Applied from `pnpm-workspace.yaml` to root `package.json`
 

--- a/docs/pm/package-extensions.mdx
+++ b/docs/pm/package-extensions.mdx
@@ -37,7 +37,7 @@ Extensions only ever _add_ entries. If the package already declares a dependency
 
 ## Where to configure it
 
-Bun reads `packageExtensions` from the root `package.json`, either at the top level (shown above) or under the `pnpm` key, so an existing pnpm configuration keeps working:
+Bun reads `packageExtensions` from the root `package.json`, both at the top level (shown above) and under the `pnpm` key, so an existing pnpm configuration keeps working:
 
 ```json package.json icon="file-json"
 {

--- a/docs/pm/package-extensions.mdx
+++ b/docs/pm/package-extensions.mdx
@@ -1,0 +1,72 @@
+---
+title: "Package extensions"
+description: "Add missing dependencies and peerDependencies to third-party packages with packageExtensions"
+---
+
+Some packages forget to declare a package they `require()`, or a peer dependency they expect the consumer to provide. With hoisted `node_modules` this often goes unnoticed because the missing package happens to be installed nearby, but with [isolated installs](/pm/isolated-installs) a package can only access what it declares, so the import fails.
+
+`packageExtensions` lets the root project patch the _declared dependencies_ of any package in the dependency tree without forking or patching it. It is the same feature (and the same shape) as pnpm's `pnpm.packageExtensions` and Yarn's `packageExtensions`.
+
+{/* prettier-ignore */}
+```json package.json icon="file-json"
+{
+  "name": "my-app",
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-redux": "^7.0.0",
+    "legacy-plugin": "^2.0.0"
+  },
+  "packageExtensions": { // [!code ++]
+    "react-redux@7": { // [!code ++]
+      "peerDependencies": { "react": "*" } // [!code ++]
+    }, // [!code ++]
+    "legacy-plugin": { // [!code ++]
+      "dependencies": { "lodash": "^4.17.21" }, // [!code ++]
+      "peerDependencies": { "webpack": "*" }, // [!code ++]
+      "peerDependenciesMeta": { "webpack": { "optional": true } } // [!code ++]
+    } // [!code ++]
+  } // [!code ++]
+}
+```
+
+Each key is a package name, optionally followed by `@` and a semver range (`react-redux@7`, `@scope/pkg@^1.2`). Without a range the extension applies to every version of the package; with one it only applies to resolved versions that satisfy it.
+
+Each value may contain `dependencies`, `optionalDependencies`, `peerDependencies` and `peerDependenciesMeta`, with exactly the meaning they have in a `package.json`. When `bun install` resolves a matching package, the listed entries are added to that package's own dependency list and are then resolved, installed and written to `bun.lock` like any dependency the package declared itself. A `peerDependenciesMeta` entry with `"optional": true` makes the corresponding peer optional.
+
+Extensions only ever _add_ entries. If the package already declares a dependency with the same name — in any of its dependency groups — the package's own declaration wins and the extension entry is ignored. To change the version of a dependency a package already declares, use [`overrides`](/pm/overrides) instead.
+
+## Where to configure it
+
+Bun reads `packageExtensions` from the root `package.json`, either at the top level (shown above) or under the `pnpm` key, so an existing pnpm configuration keeps working:
+
+```json package.json icon="file-json"
+{
+  "pnpm": {
+    "packageExtensions": {
+      "react-redux@7": { "peerDependencies": { "react": "*" } }
+    }
+  }
+}
+```
+
+When migrating from a `pnpm-lock.yaml`, `pnpm.packageExtensions` and the `packageExtensions` field of `pnpm-workspace.yaml` are moved to the top level of `package.json` automatically.
+
+It can also be set in [`bunfig.toml`](/runtime/bunfig#install-packageextensions), which is merged with the `package.json` entries:
+
+```toml bunfig.toml icon="settings"
+[install.packageExtensions."react-redux@7"]
+peerDependencies = { react = "*" }
+
+[install.packageExtensions.legacy-plugin]
+dependencies = { lodash = "^4.17.21" }
+peerDependencies = { webpack = "*" }
+peerDependenciesMeta = { webpack = { optional = true } }
+```
+
+## Lockfile behavior
+
+The added entries are recorded in `bun.lock` as part of the extended package's metadata, so installs from the lockfile (including `bun install --frozen-lockfile`) reproduce them without consulting the configuration again.
+
+Adding an extension to an existing project does not re-resolve the rest of the tree: on the next `bun install`, packages already in the lockfile that match the new extension get the new entries appended and only those are resolved. Because the lockfile does not distinguish injected entries from declared ones, _removing_ an extension takes effect the next time the affected package is re-resolved (for example by `bun update <pkg>`, or by deleting `bun.lock`).
+
+Extensions apply to packages resolved from a registry. Workspace packages and `file:`, `link:`, git and tarball dependencies are not extended — edit their `package.json` directly.

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -774,6 +774,22 @@ minimumReleaseAge = 259200
 minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
 ```
 
+### `install.packageExtensions`
+
+Add `dependencies`, `optionalDependencies` or `peerDependencies` (with `peerDependenciesMeta`) to third-party packages that forgot to declare them. One table per package, keyed by the package name optionally followed by `@` and a semver range. Merged with the `packageExtensions` field of the root `package.json`. Default: none.
+
+```toml title="bunfig.toml" icon="settings"
+[install.packageExtensions."react-redux@7"]
+peerDependencies = { react = "*" }
+
+[install.packageExtensions.legacy-plugin]
+dependencies = { lodash = "^4.17.21" }
+peerDependencies = { webpack = "*" }
+peerDependenciesMeta = { webpack = { optional = true } }
+```
+
+See [Package extensions](/pm/package-extensions).
+
 ## `bun run`
 
 The `[run]` section configures the `bun run` command. These settings also apply to the `bun` command when running a file, script, or executable.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1567,6 +1567,20 @@ impl<'a> Parser<'a> {
             install.offline = Some(v);
         }
 
+        if let Some(package_extensions_expr) = install_obj.get(b"packageExtensions") {
+            // [install.packageExtensions."react-redux@1"]
+            // peerDependencies = { react = "*" }
+            let list = install.package_extensions.get_or_insert_with(Vec::new);
+            bun_install_types::PackageExtensions::parse_from_expr(
+                list,
+                &package_extensions_expr,
+                self.log,
+                self.source,
+                bun_install_types::PackageExtensions::Strictness::Error,
+            )
+            .map_err(remap)?;
+        }
+
         Ok(())
     }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1407,6 +1407,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        package_extensions,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1462,6 +1463,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        package_extensions,
     );
 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2328,6 +2328,32 @@ fn get_or_put_resolved_package_with_find_result(
     )?)?;
 
     debug_assert!(package.meta.id != invalid_package_id);
+    // packageExtensions: graft the configured extra edges onto the package
+    // just created (its dependency slice is the buffer tail, so this is an
+    // in-place extend), then re-read it so the caller walks the full list.
+    let package = if this.options.package_extensions.is_empty() {
+        package
+    } else {
+        let log = this.log_mut();
+        // Moved out for the call so the list is not borrowed through `this`.
+        let extensions = core::mem::take(&mut this.options.package_extensions);
+        // SAFETY: same disjoint split as `from_npm` above — through `pm` the
+        // extension pass only reaches `known_npm_aliases` (via
+        // `Dependency::parse`), never `lockfile`.
+        let added = unsafe { &mut *(*this_ptr).lockfile }.apply_package_extensions_to(
+            unsafe { &mut *this_ptr },
+            log,
+            &extensions,
+            package.meta.id,
+            None,
+        );
+        this.options.package_extensions = extensions;
+        if added? > 0 {
+            *this.lockfile.packages.get(package.meta.id as usize)
+        } else {
+            package
+        }
+    };
     // Record exact-version pins so `Lockfile::get_package_id`'s
     // order-independence guard can tell them apart from range-resolved
     // entries (which it treats as network-order artefacts).

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -107,6 +107,12 @@ pub struct Options {
     // Packages to exclude from minimum release age checking
     pub minimum_release_age_excludes: Option<&'static [&'static [u8]]>,
 
+    /// `packageExtensions` from bunfig and the root package.json, merged
+    /// (see `Lockfile::apply_package_extensions`). The first
+    /// `package_extensions_from_bunfig` entries are bunfig's.
+    pub package_extensions: Vec<Api::PackageExtension>,
+    pub(crate) package_extensions_from_bunfig: usize,
+
     /// Override CPU architecture for optional dependencies filtering
     pub cpu: Npm::Architecture,
     /// Override OS for optional dependencies filtering
@@ -177,6 +183,8 @@ impl Default for Options {
             security_scanner: None,
             minimum_release_age_ms: None,
             minimum_release_age_excludes: None,
+            package_extensions: Vec::new(),
+            package_extensions_from_bunfig: 0,
             cpu: Npm::Architecture::CURRENT,
             os: Npm::OperatingSystem::CURRENT,
             config_version: None,
@@ -588,6 +596,12 @@ impl Options {
                 // equivalent), same as `leak_static` above.
                 self.minimum_release_age_excludes =
                     Some(&*bun_core::heap::release(leaked.into_boxed_slice()));
+            }
+
+            if let Some(package_extensions) = &config.package_extensions {
+                self.package_extensions
+                    .extend(package_extensions.iter().cloned());
+                self.package_extensions_from_bunfig = self.package_extensions.len();
             }
 
             // `PnpmMatcher` is move-only; `config` is `&` here so the matchers

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -91,6 +91,32 @@ pub fn install_with_manager(
 
     update_lockfile_if_needed(manager, &load_result)?;
 
+    // packageExtensions: read the root package.json's entries (after the load,
+    // which may have migrated them out of a pnpm config), then make every
+    // loaded package carry the configured extra edges. New ones have no
+    // resolution yet; they are enqueued below once the differ has run
+    // (`package_extension_edges`).
+    manager.load_package_extensions_from_package_json(root_package_json_path.as_bytes())?;
+    let package_extension_edges: Vec<DependencyID> = match &load_result {
+        lockfile::LoadResult::Ok(_) if !manager.options.package_extensions.is_empty() => {
+            // Moved out for the call so the list is not borrowed through `manager`.
+            let extensions = core::mem::take(&mut manager.options.package_extensions);
+            let mgr: *mut PackageManager = manager;
+            // SAFETY: `mgr` is the sole provenance root; `lockfile` and `*log`
+            // are disjoint storage, and through `&mut *mgr` the pass only
+            // touches `known_npm_aliases` (same split as `load_from_cwd` above).
+            let edges = unsafe {
+                let log = (*mgr).log;
+                (*mgr)
+                    .lockfile
+                    .apply_package_extensions(&mut *mgr, &mut *log, &extensions)
+            };
+            manager.options.package_extensions = extensions;
+            edges?
+        }
+        _ => Vec::new(),
+    };
+
     // Snapshot the loaded-from-lockfile package count so
     // `Lockfile::get_package_id` can tell loaded pins apart from packages
     // appended by manifest fetches in this resolve session.
@@ -640,6 +666,30 @@ pub fn install_with_manager(
                 let task = PatchTask::new_calc_patch_hash(manager, key, None);
                 enqueue_patch_task_pre(manager, task);
             }
+        }
+        // packageExtensions edges injected into already-locked packages this
+        // run: their owners are not new, so nothing above walked their
+        // dependency lists — enqueue the still-unresolved ones explicitly.
+        if !package_extension_edges.is_empty() {
+            for &dependency_id in &package_extension_edges {
+                if manager.lockfile.buffers.resolutions[dependency_id as usize]
+                    != invalid_package_id
+                {
+                    continue;
+                }
+                let dependency =
+                    manager.lockfile.buffers.dependencies[dependency_id as usize].clone();
+                if let Err(err) = enqueue_dependency_with_main(
+                    manager,
+                    dependency_id,
+                    &dependency,
+                    invalid_package_id,
+                    false,
+                ) {
+                    add_dependency_error(manager, &dependency, err);
+                }
+            }
+            had_any_diffs = true;
         }
         // Anything that needs to be downloaded from an update needs to be scheduled here
         manager.drain_dependency_list();

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -63,6 +63,8 @@ pub mod override_map;
 pub(crate) mod override_selector;
 #[path = "lockfile/Package.rs"]
 pub mod package;
+#[path = "lockfile/package_extensions.rs"]
+pub(crate) mod package_extensions;
 #[path = "lockfile/pruned_workspaces.rs"]
 pub(crate) mod pruned_workspaces;
 #[path = "lockfile/reachable.rs"]

--- a/src/install/lockfile/package_extensions.rs
+++ b/src/install/lockfile/package_extensions.rs
@@ -116,7 +116,9 @@ impl Lockfile {
         // Which edges to add: matching extensions, minus names the package (or
         // an earlier extension) already declares. `to_add` borrows from
         // `extensions`, not from `self`, so the lockfile can be mutated below.
-        let mut to_add: Vec<(&[u8], &[u8], Behavior)> = Vec::new();
+        let mut to_add: Vec<(&[u8], &[u8], Behavior, u64)> = Vec::new();
+        // For diagnostics; borrowed from the matching extension, not `self`.
+        let mut package_name: &[u8] = b"";
         {
             let buf = self.buffers.string_bytes.as_slice();
             let name = self.packages.items_name()[idx].slice(buf);
@@ -126,14 +128,15 @@ impl Lockfile {
                 if *extension.name != *name || !range_matches(&extension.range, version, buf) {
                     continue;
                 }
+                package_name = &extension.name;
                 for dep in &extension.dependencies {
                     let hash = semver::string::Builder::string_hash(&dep.name);
                     if existing.iter().any(|d| d.name_hash == hash)
-                        || to_add.iter().any(|(n, _, _)| *n == &*dep.name)
+                        || to_add.iter().any(|(_, _, _, h)| *h == hash)
                     {
                         continue;
                     }
-                    to_add.push((&dep.name, &dep.version, dep.behavior));
+                    to_add.push((&dep.name, &dep.version, dep.behavior, hash));
                 }
             }
         }
@@ -142,37 +145,54 @@ impl Lockfile {
         }
 
         // Strings first (count -> allocate -> append), then the `Dependency`
-        // values, parsed exactly like a manifest entry in `Package::from_npm`.
+        // values, parsed like a manifest entry in `Package::from_npm` (except
+        // that an unparseable version is warned about and the edge skipped).
         let mut new_deps: Vec<Dependency> = Vec::with_capacity(to_add.len());
         {
             let mut builder = crate::string_builder!(self);
-            for (name, version, _) in &to_add {
+            for (name, version, _, _) in &to_add {
                 builder.count(name);
                 builder.count(version);
             }
             builder.allocate()?;
-            for (name, version, behavior) in &to_add {
-                let name: ExternalString = builder.append::<ExternalString>(name);
-                let version: SemverString = builder.append::<SemverString>(version);
+            for (name_text, version_text, behavior, hash) in &to_add {
+                let name: ExternalString =
+                    builder.append_with_hash::<ExternalString>(name_text, *hash);
+                let version: SemverString = builder.append::<SemverString>(version_text);
                 let sliced = version.sliced(builder.string_bytes.as_slice());
+                let Some(version) = Dependency::parse(
+                    name.value,
+                    Some(name.hash),
+                    sliced.slice,
+                    &sliced,
+                    Some(&mut *log),
+                    Some(&mut *pm),
+                ) else {
+                    log.add_warning_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "packageExtensions: ignoring \"{}\": \"{}\" for {}, invalid dependency version",
+                            bstr::BStr::new(name_text),
+                            bstr::BStr::new(version_text),
+                            bstr::BStr::new(package_name),
+                        ),
+                    );
+                    continue;
+                };
                 let mut dependency = Dependency {
                     name: name.value,
                     name_hash: name.hash,
                     behavior: *behavior,
-                    version: Dependency::parse(
-                        name.value,
-                        Some(name.hash),
-                        sliced.slice,
-                        &sliced,
-                        Some(&mut *log),
-                        Some(&mut *pm),
-                    )
-                    .unwrap_or_default(),
+                    version,
                 };
                 lockfile::CatalogMap::strip_reference(&mut dependency);
                 new_deps.push(dependency);
             }
             builder.clamp();
+        }
+        if new_deps.is_empty() {
+            return Ok(0);
         }
 
         // Splice into the package's dependency slice. When the slice is the
@@ -233,16 +253,14 @@ impl Lockfile {
         self.packages.items_resolutions_mut()[idx] = PackageIDSlice::new(new_off, new_len);
 
         if let Some(ids) = added_ids {
-            let injected = |d: &Dependency| {
-                to_add
-                    .iter()
-                    .any(|(n, _, _)| semver::string::Builder::string_hash(n) == d.name_hash)
-            };
             for (i, dependency) in deps[new_off as usize..(new_off + new_len) as usize]
                 .iter()
                 .enumerate()
             {
-                if injected(dependency) {
+                if to_add
+                    .iter()
+                    .any(|(_, _, _, hash)| *hash == dependency.name_hash)
+                {
                     ids.push(new_off + u32::try_from(i).expect("int cast"));
                 }
             }

--- a/src/install/lockfile/package_extensions.rs
+++ b/src/install/lockfile/package_extensions.rs
@@ -33,19 +33,19 @@ use bun_install_types::PackageExtensions::{
 };
 
 /// Does `range` (extension key suffix, `""`/`"*"` = any) admit `version`?
+/// `parse_from_expr` already rejected keys whose range does not parse.
 fn range_matches(range: &[u8], version: semver::Version, version_buf: &[u8]) -> bool {
     if range.is_empty() || range == b"*" {
         return true;
     }
-    match semver::query::parse(range, semver::SlicedString::init(range, range)) {
-        Ok(query) => !query.is_empty() && query.satisfies(version, range, version_buf),
-        Err(_) => false,
-    }
+    let query = semver::query::parse(range, semver::SlicedString::init(range, range))
+        .unwrap_or_else(|_| bun_core::out_of_memory());
+    !query.is_empty() && query.satisfies(version, range, version_buf)
 }
 
 impl PackageManager {
-    /// Append the root `package.json`'s `packageExtensions` (or, pnpm-style,
-    /// `pnpm.packageExtensions`) to `options.package_extensions`, after the
+    /// Append the root `package.json`'s `packageExtensions` and, pnpm-style,
+    /// `pnpm.packageExtensions` to `options.package_extensions`, after the
     /// ones bunfig contributed (replacing any read by an earlier call).
     /// Malformed entries warn and are skipped.
     pub(crate) fn load_package_extensions_from_package_json(
@@ -69,24 +69,29 @@ impl PackageManager {
             return Ok(());
         };
         scratch_log.append_to_maybe_recycled(log, &entry.source);
-        let Some(expr) = entry.root.get(b"packageExtensions").or_else(|| {
+        // Top-level first, then pnpm's namespaced field; both are read.
+        let sources = [
+            entry.root.get(b"packageExtensions"),
             entry
                 .root
                 .get(b"pnpm")
-                .and_then(|pnpm| pnpm.get(b"packageExtensions"))
-        }) else {
-            return Ok(());
-        };
-        match parse_package_extensions(
-            &mut self.options.package_extensions,
-            &expr,
-            log,
-            &entry.source,
-            Strictness::Warn,
-        ) {
-            Ok(()) | Err(FromExprError::UnexpectedExpr) => Ok(()),
-            Err(FromExprError::OutOfMemory) => Err(crate::Error::Alloc(bun_alloc::AllocError)),
+                .and_then(|pnpm| pnpm.get(b"packageExtensions")),
+        ];
+        for expr in sources.into_iter().flatten() {
+            match parse_package_extensions(
+                &mut self.options.package_extensions,
+                &expr,
+                log,
+                &entry.source,
+                Strictness::Warn,
+            ) {
+                Ok(()) | Err(FromExprError::UnexpectedExpr) => {}
+                Err(FromExprError::OutOfMemory) => {
+                    return Err(crate::Error::Alloc(bun_alloc::AllocError));
+                }
+            }
         }
+        Ok(())
     }
 }
 

--- a/src/install/lockfile/package_extensions.rs
+++ b/src/install/lockfile/package_extensions.rs
@@ -1,0 +1,279 @@
+//! `packageExtensions`: graft extra dependency edges onto registry packages
+//! whose own manifest is missing them (the yarn / pnpm feature of the same
+//! name; parsed shape lives in `bun_install_types::PackageExtensions`).
+//!
+//! Applied to npm-resolved packages in two places so the lockfile always
+//! carries the configured edges:
+//!
+//! - right after a package is created from a registry manifest
+//!   (`Package::from_npm` -> `apply_package_extensions_to`), and
+//! - to every package of a lockfile that was just loaded from disk
+//!   (`apply_package_extensions`), so adding an extension to the config takes
+//!   effect on the next install without re-resolving anything else.
+//!
+//! An injected edge is an ordinary `Dependency` in the package's dependency
+//! list with no resolution yet; it is resolved, installed and written to
+//! `bun.lock` exactly like a dependency the package declared itself. Edges the
+//! package already declares are never touched (declared wins), which is also
+//! what makes a lockfile that already recorded the injected edges stable under
+//! `--frozen-lockfile`.
+
+use bun_semver::{self as semver, ExternalString, String as SemverString};
+
+use crate::bun_schema::api::PackageExtension;
+use crate::dependency::{Behavior, DependencyExt as _};
+use crate::lockfile_real::package::PackageColumns as _;
+use crate::lockfile_real::{self as lockfile, DependencySlice, Lockfile, PackageIDSlice};
+use crate::package_manager_real::workspace_package_json_cache::GetResult as WorkspacePackageJsonCacheResult;
+use crate::resolution_real::Tag as ResolutionTag;
+use crate::{Dependency, DependencyID, PackageID, PackageManager, invalid_package_id};
+use bun_install_types::NodeLinker::FromExprError;
+use bun_install_types::PackageExtensions::{
+    Strictness, parse_from_expr as parse_package_extensions,
+};
+
+/// Does `range` (extension key suffix, `""`/`"*"` = any) admit `version`?
+fn range_matches(range: &[u8], version: semver::Version, version_buf: &[u8]) -> bool {
+    if range.is_empty() || range == b"*" {
+        return true;
+    }
+    match semver::query::parse(range, semver::SlicedString::init(range, range)) {
+        Ok(query) => !query.is_empty() && query.satisfies(version, range, version_buf),
+        Err(_) => false,
+    }
+}
+
+impl PackageManager {
+    /// Append the root `package.json`'s `packageExtensions` (or, pnpm-style,
+    /// `pnpm.packageExtensions`) to `options.package_extensions`, after the
+    /// ones bunfig contributed (replacing any read by an earlier call).
+    /// Malformed entries warn and are skipped.
+    pub(crate) fn load_package_extensions_from_package_json(
+        &mut self,
+        root_package_json_path: &[u8],
+    ) -> crate::Result<()> {
+        self.options
+            .package_extensions
+            .truncate(self.options.package_extensions_from_bunfig);
+        let log = self.log_mut();
+        // This runs before the paths that report a missing/unparsable root
+        // package.json (and exit). A failed read is not cached, so those paths
+        // read it again: parse into a scratch log and only keep its messages
+        // when the read succeeds, otherwise the parse error would print twice.
+        let mut scratch_log = bun_ast::Log::init();
+        scratch_log.level = log.level;
+        let WorkspacePackageJsonCacheResult::Entry(entry) = self
+            .workspace_package_json_cache
+            .get_with_path(&mut scratch_log, root_package_json_path, Default::default())
+        else {
+            return Ok(());
+        };
+        scratch_log.append_to_maybe_recycled(log, &entry.source);
+        let Some(expr) = entry.root.get(b"packageExtensions").or_else(|| {
+            entry
+                .root
+                .get(b"pnpm")
+                .and_then(|pnpm| pnpm.get(b"packageExtensions"))
+        }) else {
+            return Ok(());
+        };
+        match parse_package_extensions(
+            &mut self.options.package_extensions,
+            &expr,
+            log,
+            &entry.source,
+            Strictness::Warn,
+        ) {
+            Ok(()) | Err(FromExprError::UnexpectedExpr) => Ok(()),
+            Err(FromExprError::OutOfMemory) => Err(crate::Error::Alloc(bun_alloc::AllocError)),
+        }
+    }
+}
+
+impl Lockfile {
+    /// Append the edges of every extension matching `package_id` (an
+    /// npm-resolved package) that the package does not already declare.
+    /// Returns how many edges were added; their ids are pushed to `added_ids`
+    /// when given.
+    pub(crate) fn apply_package_extensions_to(
+        &mut self,
+        pm: &mut PackageManager,
+        log: &mut bun_ast::Log,
+        extensions: &[PackageExtension],
+        package_id: PackageID,
+        added_ids: Option<&mut Vec<DependencyID>>,
+    ) -> crate::Result<u32> {
+        if extensions.is_empty() {
+            return Ok(0);
+        }
+        let idx = package_id as usize;
+        let resolution = self.packages.items_resolution()[idx];
+        if resolution.tag != ResolutionTag::Npm {
+            return Ok(0);
+        }
+        let version = resolution.npm().version;
+
+        // Which edges to add: matching extensions, minus names the package (or
+        // an earlier extension) already declares. `to_add` borrows from
+        // `extensions`, not from `self`, so the lockfile can be mutated below.
+        let mut to_add: Vec<(&[u8], &[u8], Behavior)> = Vec::new();
+        {
+            let buf = self.buffers.string_bytes.as_slice();
+            let name = self.packages.items_name()[idx].slice(buf);
+            let existing: &[Dependency] =
+                self.packages.items_dependencies()[idx].get(self.buffers.dependencies.as_slice());
+            for extension in extensions {
+                if *extension.name != *name || !range_matches(&extension.range, version, buf) {
+                    continue;
+                }
+                for dep in &extension.dependencies {
+                    let hash = semver::string::Builder::string_hash(&dep.name);
+                    if existing.iter().any(|d| d.name_hash == hash)
+                        || to_add.iter().any(|(n, _, _)| *n == &*dep.name)
+                    {
+                        continue;
+                    }
+                    to_add.push((&dep.name, &dep.version, dep.behavior));
+                }
+            }
+        }
+        if to_add.is_empty() {
+            return Ok(0);
+        }
+
+        // Strings first (count -> allocate -> append), then the `Dependency`
+        // values, parsed exactly like a manifest entry in `Package::from_npm`.
+        let mut new_deps: Vec<Dependency> = Vec::with_capacity(to_add.len());
+        {
+            let mut builder = crate::string_builder!(self);
+            for (name, version, _) in &to_add {
+                builder.count(name);
+                builder.count(version);
+            }
+            builder.allocate()?;
+            for (name, version, behavior) in &to_add {
+                let name: ExternalString = builder.append::<ExternalString>(name);
+                let version: SemverString = builder.append::<SemverString>(version);
+                let sliced = version.sliced(builder.string_bytes.as_slice());
+                let mut dependency = Dependency {
+                    name: name.value,
+                    name_hash: name.hash,
+                    behavior: *behavior,
+                    version: Dependency::parse(
+                        name.value,
+                        Some(name.hash),
+                        sliced.slice,
+                        &sliced,
+                        Some(&mut *log),
+                        Some(&mut *pm),
+                    )
+                    .unwrap_or_default(),
+                };
+                lockfile::CatalogMap::strip_reference(&mut dependency);
+                new_deps.push(dependency);
+            }
+            builder.clamp();
+        }
+
+        // Splice into the package's dependency slice. When the slice is the
+        // tail of the buffer (a package that was just appended) this is an
+        // in-place extend; otherwise the slice is first relocated to the end
+        // (the old rows become unreferenced garbage that `clean()` drops, the
+        // same thing the root package's re-layout in `install_with_manager`
+        // does). Each edge is appended to the end of its own group so the list
+        // keeps the `dependencies, optionalDependencies, peerDependencies`
+        // order `from_npm` produces and a reload from `bun.lock` reproduces.
+        let DependencySlice { off, len, .. } = self.packages.items_dependencies()[idx];
+        let (off, len) = (off as usize, len as usize);
+        let deps = &mut self.buffers.dependencies;
+        let ress = &mut self.buffers.resolutions;
+        debug_assert_eq!(deps.len(), ress.len());
+        let new_off = if off + len == deps.len() {
+            off
+        } else {
+            let start = deps.len();
+            deps.extend_from_within(off..off + len);
+            ress.extend_from_within(off..off + len);
+            start
+        };
+        let group = |d: &Dependency| -> u8 {
+            if d.behavior.is_peer() {
+                2
+            } else if d.behavior.is_optional() {
+                1
+            } else {
+                0
+            }
+        };
+        // Insertion points (relative to `new_off`): the end of the prod group
+        // and the end of the optional group. Peers are simply pushed.
+        let existing = &deps[new_off..new_off + len];
+        let mut group_end = [
+            existing.iter().filter(|d| group(d) == 0).count(),
+            existing.iter().filter(|d| group(d) <= 1).count(),
+        ];
+        let added = new_deps.len();
+        for dependency in new_deps {
+            let g = group(&dependency) as usize;
+            if g == 2 {
+                deps.push(dependency);
+                ress.push(invalid_package_id);
+                continue;
+            }
+            let at = new_off + group_end[g];
+            deps.insert(at, dependency);
+            ress.insert(at, invalid_package_id);
+            for end in &mut group_end[g..] {
+                *end += 1;
+            }
+        }
+        let new_len = u32::try_from(len + added).expect("int cast");
+        let new_off = u32::try_from(new_off).expect("int cast");
+        self.packages.items_dependencies_mut()[idx] = DependencySlice::new(new_off, new_len);
+        self.packages.items_resolutions_mut()[idx] = PackageIDSlice::new(new_off, new_len);
+
+        if let Some(ids) = added_ids {
+            let injected = |d: &Dependency| {
+                to_add
+                    .iter()
+                    .any(|(n, _, _)| semver::string::Builder::string_hash(n) == d.name_hash)
+            };
+            for (i, dependency) in deps[new_off as usize..(new_off + new_len) as usize]
+                .iter()
+                .enumerate()
+            {
+                if injected(dependency) {
+                    ids.push(new_off + u32::try_from(i).expect("int cast"));
+                }
+            }
+        }
+        Ok(u32::try_from(added).expect("int cast"))
+    }
+
+    /// Apply `extensions` to every package currently in the lockfile (right
+    /// after it was loaded from disk). Returns the ids of the injected,
+    /// still-unresolved edges so the caller can enqueue them: their owners are
+    /// not new packages, so nothing else would walk their dependency lists.
+    pub(crate) fn apply_package_extensions(
+        &mut self,
+        pm: &mut PackageManager,
+        log: &mut bun_ast::Log,
+        extensions: &[PackageExtension],
+    ) -> crate::Result<Vec<DependencyID>> {
+        let mut added_ids: Vec<DependencyID> = Vec::new();
+        if extensions.is_empty() {
+            return Ok(added_ids);
+        }
+        let len = u32::try_from(self.packages.len()).expect("int cast");
+        for package_id in 0..len {
+            self.apply_package_extensions_to(
+                pm,
+                log,
+                extensions,
+                package_id,
+                Some(&mut added_ids),
+            )?;
+        }
+        Ok(added_ids)
+    }
+}

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2368,6 +2368,7 @@ fn update_package_json_after_migration(
     let mut needs_update = false;
     let mut moved_overrides = false;
     let mut moved_patched_deps = false;
+    let mut moved_package_extensions = false;
     let mut moved: Vec<&'static str> = Vec::new();
 
     if let Some(mut pnpm_prop) = json.as_property(b"pnpm") {
@@ -2433,7 +2434,21 @@ fn update_package_json_after_migration(
                 }
             }
 
-            if moved_overrides || moved_patched_deps {
+            if let Some(extensions_field) = pnpm_obj.get(b"packageExtensions") {
+                if is_non_empty_object(&extensions_field) {
+                    merge_object_into_root(
+                        &mut json,
+                        &bump,
+                        b"packageExtensions",
+                        extensions_field,
+                    )?;
+                    moved_package_extensions = true;
+                    needs_update = true;
+                    moved.push("pnpm.packageExtensions to packageExtensions");
+                }
+            }
+
+            if moved_overrides || moved_patched_deps || moved_package_extensions {
                 let mut remaining_count: usize = 0;
                 for prop in pnpm_obj.properties.slice() {
                     let Some(key) = as_string(prop.key.as_ref().expect("infallible: prop has key"))
@@ -2445,6 +2460,9 @@ fn update_package_json_after_migration(
                         continue;
                     }
                     if moved_patched_deps && key == b"patchedDependencies" {
+                        continue;
+                    }
+                    if moved_package_extensions && key == b"packageExtensions" {
                         continue;
                     }
                     remaining_count += 1;
@@ -2493,6 +2511,9 @@ fn update_package_json_after_migration(
                         if moved_patched_deps && key == b"patchedDependencies" {
                             continue;
                         }
+                        if moved_package_extensions && key == b"packageExtensions" {
+                            continue;
+                        }
                         VecExt::append(&mut new_pnpm_props, shallow_clone_prop(prop));
                     }
 
@@ -2511,6 +2532,7 @@ fn update_package_json_after_migration(
     let mut catalogs_obj: Option<Expr> = None;
     let mut workspace_overrides_obj: Option<Expr> = None;
     let mut workspace_patched_deps_obj: Option<Expr> = None;
+    let mut workspace_package_extensions_obj: Option<Expr> = None;
 
     match sys::File::read_from(Fd::cwd(), b"pnpm-workspace.yaml") {
         Ok(contents) => 'read_pnpm_workspace_yaml: {
@@ -2559,6 +2581,9 @@ fn update_package_json_after_migration(
             workspace_patched_deps_obj = ws_root
                 .get_object(b"patchedDependencies")
                 .filter(is_non_empty_object);
+            workspace_package_extensions_obj = ws_root
+                .get_object(b"packageExtensions")
+                .filter(is_non_empty_object);
 
             // These subtrees escape this arm (into `json` and the cached
             // package.json tree) while `arena` drops with it, so their
@@ -2568,6 +2593,7 @@ fn update_package_json_after_migration(
                 &mut catalogs_obj,
                 &mut workspace_overrides_obj,
                 &mut workspace_patched_deps_obj,
+                &mut workspace_package_extensions_obj,
             ]
             .into_iter()
             .flatten()
@@ -2732,6 +2758,13 @@ fn update_package_json_after_migration(
         }
     }
 
+    // Handle packageExtensions from pnpm-workspace.yaml
+    if let Some(ws_extensions) = workspace_package_extensions_obj {
+        merge_object_into_root(&mut json, &bump, b"packageExtensions", ws_extensions)?;
+        needs_update = true;
+        moved.push("pnpm-workspace.yaml packageExtensions to packageExtensions");
+    }
+
     if needs_update {
         print_package_json_into_cache_entry(root_pkg_json, json);
         // The edits above spliced `Store`-allocated nodes into the cached tree,
@@ -2757,6 +2790,30 @@ fn update_package_json_after_migration(
     }
 
     Ok(())
+}
+
+/// Copy every property of `obj` into the root-level object `field` of `json`,
+/// creating `field` when the root does not have it yet (later keys win).
+fn merge_object_into_root(
+    json: &mut Expr,
+    bump: &bun_alloc::Arena,
+    field: &'static [u8],
+    obj: Expr,
+) -> Result<(), AllocError> {
+    if let Some(mut existing_prop) = json.as_property(field) {
+        if existing_prop.expr.is_object() {
+            let existing = e_object_mut(&mut existing_prop.expr);
+            for prop in e_object(&obj).properties.slice() {
+                let Some(key) = as_string(prop.key.as_ref().expect("infallible: prop has key"))
+                else {
+                    continue;
+                };
+                existing.put(bump, key, prop.value.expect("infallible: prop has value"))?;
+            }
+            return Ok(());
+        }
+    }
+    e_object_mut(json).put(bump, field, obj)
 }
 
 fn is_non_empty_object(expr: &Expr) -> bool {

--- a/src/install_types/PackageExtensions.rs
+++ b/src/install_types/PackageExtensions.rs
@@ -168,9 +168,13 @@ pub fn parse_from_expr(
                     };
                     // Same name in two groups: like a manifest,
                     // `optionalDependencies` overrides `dependencies` and a
-                    // duplicate `peerDependencies` entry is ignored.
+                    // duplicate `peerDependencies` entry (optional or not) is
+                    // ignored. (`is_optional()` is already false for optional
+                    // peers; the peer check just makes that explicit.)
                     match extension.dependencies.iter_mut().find(|d| *d.name == *dep_name) {
-                        Some(existing) if behavior.is_optional() => *existing = dependency,
+                        Some(existing) if behavior.is_optional() && !behavior.is_peer() => {
+                            *existing = dependency
+                        }
                         Some(_) => {}
                         None => extension.dependencies.push(dependency),
                     }

--- a/src/install_types/PackageExtensions.rs
+++ b/src/install_types/PackageExtensions.rs
@@ -114,6 +114,14 @@ pub fn parse_from_expr(
         if name.is_empty() {
             return report(log, key_loc, b"Expected a package name");
         }
+        // `name@<range>`: reject a range that parses to nothing here, once,
+        // rather than letting the extension silently never match.
+        if !range.is_empty() && range != b"*" {
+            let query = bun_semver::query::parse(range, bun_semver::SlicedString::init(range, range))?;
+            if query.is_empty() {
+                return report(log, key_loc, b"Expected a semver range after \"@\" in the package name");
+            }
+        }
         if !value.is_object() {
             return report(
                 log,

--- a/src/install_types/PackageExtensions.rs
+++ b/src/install_types/PackageExtensions.rs
@@ -1,0 +1,200 @@
+//! `packageExtensions`: extra `dependencies` / `optionalDependencies` /
+//! `peerDependencies` (+ `peerDependenciesMeta`) grafted onto third-party
+//! packages whose own manifest forgot to declare them. Same shape as pnpm's
+//! `package.json#pnpm.packageExtensions` and yarn's
+//! `.yarnrc.yml#packageExtensions`:
+//!
+//! ```json
+//! { "react-redux@1": { "peerDependencies": { "react": "*" } } }
+//! ```
+//!
+//! Only the parsed representation lives here so that both `bun_bunfig`
+//! (`[install.packageExtensions]`) and `bun_install` (root `package.json`)
+//! can build it; applying it to the lockfile is `bun_install`'s job.
+
+use bun_alloc::Arena;
+use bun_ast as ast;
+use bun_core::strings;
+
+use crate::NodeLinker::FromExprError;
+use crate::resolver_hooks::Behavior;
+
+/// One dependency edge an extension adds.
+#[derive(Clone)]
+pub struct PackageExtensionDependency {
+    pub name: Box<[u8]>,
+    /// Version specifier text, exactly as written (`"^1"`, `"*"`, `"npm:foo@1"`, ...).
+    pub version: Box<[u8]>,
+    /// `PROD`, `OPTIONAL`, `PEER` or `PEER | OPTIONAL`.
+    pub behavior: Behavior,
+}
+
+/// One `"<name>[@<range>]": { ... }` entry.
+#[derive(Clone)]
+pub struct PackageExtension {
+    /// Package name the extension applies to.
+    pub name: Box<[u8]>,
+    /// Semver range text scoping which resolved versions of `name` it applies
+    /// to; empty means any version.
+    pub range: Box<[u8]>,
+    pub dependencies: Vec<PackageExtensionDependency>,
+}
+
+/// How parse problems are reported: bunfig is strict (an error fails config
+/// loading), package.json is lenient (a warning, the entry is skipped).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Strictness {
+    Error,
+    Warn,
+}
+
+/// `"name@range"` -> (`name`, `range`); a leading `@` is part of a scoped
+/// name, not a separator. No range -> (`key`, `""`).
+pub fn split_name_and_range(key: &[u8]) -> (&[u8], &[u8]) {
+    let from = usize::from(strings::starts_with(key, b"@"));
+    match strings::index_of_char_pos(key, b'@', from) {
+        Some(at) => (&key[..at], &key[at + 1..]),
+        None => (key, b""),
+    }
+}
+
+const GROUPS: [(&[u8], Behavior); 3] = [
+    (b"dependencies", Behavior::PROD),
+    (b"optionalDependencies", Behavior::OPTIONAL),
+    (b"peerDependencies", Behavior::PEER),
+];
+
+/// Parse a `packageExtensions` object expression (TOML table or JSON object)
+/// and append every well-formed entry to `out`.
+///
+/// With [`Strictness::Error`] the first malformed value logs an error and
+/// returns `Err(UnexpectedExpr)`; with [`Strictness::Warn`] it logs a warning
+/// and that value is skipped.
+pub fn parse_from_expr(
+    out: &mut Vec<PackageExtension>,
+    expr: &ast::Expr,
+    log: &mut bun_ast::Log,
+    source: &bun_ast::Source,
+    strictness: Strictness,
+) -> Result<(), FromExprError> {
+    // Scratch arena for `as_string_cloned` (TOML strings may be UTF-16 in the
+    // AST); every slice is copied into a `Box` before this returns.
+    let arena = Arena::new();
+
+    let report = |log: &mut bun_ast::Log, loc: ast::Loc, text: &'static [u8]| match strictness {
+        Strictness::Error => {
+            log.add_error_opts(
+                text,
+                bun_ast::AddErrorOptions {
+                    loc,
+                    redact_sensitive_information: true,
+                    source: Some(source),
+                    ..Default::default()
+                },
+            );
+            Err(FromExprError::UnexpectedExpr)
+        }
+        Strictness::Warn => {
+            log.add_warning(Some(source), loc, text);
+            Ok(())
+        }
+    };
+
+    if !expr.is_object() {
+        return report(
+            log,
+            expr.loc,
+            b"Expected \"packageExtensions\" to be an object",
+        );
+    }
+
+    out.reserve(expr.property_count());
+    expr.try_for_each_property(|key, key_loc, value| -> Result<(), FromExprError> {
+        let (name, range) = split_name_and_range(key);
+        if name.is_empty() {
+            return report(log, key_loc, b"Expected a package name");
+        }
+        if !value.is_object() {
+            return report(
+                log,
+                value.loc,
+                b"Expected an object with \"dependencies\", \"optionalDependencies\", \"peerDependencies\" and/or \"peerDependenciesMeta\"",
+            );
+        }
+
+        let mut extension = PackageExtension {
+            name: Box::from(name),
+            range: Box::from(range),
+            dependencies: Vec::new(),
+        };
+
+        // `peerDependenciesMeta: { "<name>": { optional: true } }`
+        let mut optional_peers: Vec<Box<[u8]>> = Vec::new();
+        if let Some(meta) = value.get(b"peerDependenciesMeta") {
+            if !meta.is_object() {
+                report(log, meta.loc, b"Expected \"peerDependenciesMeta\" to be an object")?;
+            }
+            meta.for_each_property(|peer, _, peer_meta| {
+                if peer_meta.get(b"optional").and_then(|e| e.as_bool()) == Some(true) {
+                    optional_peers.push(Box::from(peer));
+                }
+            });
+        }
+
+        for (field, behavior) in GROUPS {
+            let Some(group) = value.get(field) else {
+                continue;
+            };
+            if !group.is_object() {
+                report(log, group.loc, b"Expected an object of \"name\": \"version range\"")?;
+                continue;
+            }
+            group.try_for_each_property(
+                |dep_name, dep_loc, dep_version| -> Result<(), FromExprError> {
+                    if dep_name.is_empty() {
+                        return report(log, dep_loc, b"Expected a dependency name");
+                    }
+                    let Some(version) = dep_version.as_string_cloned(&arena)? else {
+                        return report(log, dep_version.loc, b"Expected a version range string");
+                    };
+                    let mut behavior = behavior;
+                    if behavior.is_peer() && optional_peers.iter().any(|p| **p == *dep_name) {
+                        behavior.insert(Behavior::OPTIONAL);
+                    }
+                    let dependency = PackageExtensionDependency {
+                        name: Box::from(dep_name),
+                        version: Box::from(version),
+                        behavior,
+                    };
+                    // Same name in two groups: like a manifest,
+                    // `optionalDependencies` overrides `dependencies` and a
+                    // duplicate `peerDependencies` entry is ignored.
+                    match extension.dependencies.iter_mut().find(|d| *d.name == *dep_name) {
+                        Some(existing) if behavior.is_optional() => *existing = dependency,
+                        Some(_) => {}
+                        None => extension.dependencies.push(dependency),
+                    }
+                    Ok(())
+                },
+            )?;
+        }
+
+        // A `peerDependenciesMeta` entry with no matching `peerDependencies`
+        // entry declares an optional peer on any version (yarn/npm behaviour).
+        for peer in optional_peers {
+            if extension.dependencies.iter().any(|d| d.name == peer) {
+                continue;
+            }
+            extension.dependencies.push(PackageExtensionDependency {
+                name: peer,
+                version: Box::from(&b"*"[..]),
+                behavior: Behavior::PEER | Behavior::OPTIONAL,
+            });
+        }
+
+        if !extension.dependencies.is_empty() {
+            out.push(extension);
+        }
+        Ok(())
+    })
+}

--- a/src/install_types/PackageExtensions.rs
+++ b/src/install_types/PackageExtensions.rs
@@ -114,8 +114,16 @@ pub fn parse_from_expr(
         if name.is_empty() {
             return report(log, key_loc, b"Expected a package name");
         }
-        // `name@<range>`: reject a range that parses to nothing here, once,
-        // rather than letting the extension silently never match.
+        // `name@<range>`: reject a range that is missing (`name@`) or parses
+        // to nothing here, once, rather than letting the extension silently
+        // match everything / nothing.
+        if range.is_empty() && key.last() == Some(&b'@') {
+            return report(
+                log,
+                key_loc,
+                b"Expected a semver range after \"@\" in the package name",
+            );
+        }
         if !range.is_empty() && range != b"*" {
             let query = bun_semver::query::parse(range, bun_semver::SlicedString::init(range, range))?;
             if query.is_empty() {

--- a/src/install_types/lib.rs
+++ b/src/install_types/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
 pub mod NodeLinker;
+pub mod PackageExtensions;
 pub mod resolver_hooks;
 
 pub use resolver_hooks::{

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -196,6 +196,8 @@ pub mod api {
     /// `BunInstall.hoist_pattern` and `bun_ini`'s callers all name the
     /// same type.
     pub use bun_install_types::NodeLinker::{NodeLinker, PnpmMatcher};
+    /// Parsed `packageExtensions` entries; canonical in `bun_install_types`.
+    pub use bun_install_types::PackageExtensions::PackageExtension;
 
     /// Full field set.
     /// `Default` is every field `None`/empty.
@@ -260,6 +262,8 @@ pub mod api {
         pub hoist: Option<bool>,
         /// `offline = true`: `bun install` never touches the network.
         pub offline: Option<bool>,
+        /// `[install.packageExtensions."<name>@<range>"]`
+        pub package_extensions: Option<Vec<PackageExtension>>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/bun-install-package-extensions.test.ts
+++ b/test/cli/install/bun-install-package-extensions.test.ts
@@ -242,6 +242,8 @@ optionalDependencies = { left-pad = "1.0.0" }
       JSON.stringify({
         name: "app",
         dependencies: { "a-dep": "1.0.6", "peer-no-deps": "2.0.0" },
+        // top-level and pnpm-namespaced entries are both read
+        packageExtensions: { "a-dep": { optionalDependencies: { bar: "0.0.7" } } },
         pnpm: { packageExtensions: { "a-dep@*": { peerDependencies: { "peer-no-deps": "*" } } } },
       }),
     );
@@ -249,6 +251,7 @@ optionalDependencies = { left-pad = "1.0.0" }
     await runBunInstall(bunEnv, packageDir);
     expect(await lockfileEntry(packageDir, "a-dep")).toEqual({
       dependencies: { "no-deps": "1.0.1" },
+      optionalDependencies: { bar: "0.0.7" },
       peerDependencies: { "peer-no-deps": "*" },
     });
     expect(await lockfileEntry(packageDir, "peer-no-deps")).toEqual({
@@ -269,6 +272,7 @@ test("malformed package.json packageExtensions entries warn and are skipped", as
       packageExtensions: {
         "a-dep": { dependencies: { "no-deps": 1 } },
         "no-deps": "not an object",
+        "a-dep@not a range": { dependencies: { "no-deps": "1.0.0" } },
       },
     }),
   );
@@ -283,6 +287,7 @@ test("malformed package.json packageExtensions entries warn and are skipped", as
   const [_, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(err).toContain("warn: Expected a version range string");
   expect(err).toContain("warn: Expected an object with");
+  expect(err).toContain('warn: Expected a semver range after "@" in the package name');
   expect(err).not.toContain("error:");
   expect(exitCode).toBe(0);
   expect(await lockfileEntry(packageDir, "a-dep")).toEqual({});

--- a/test/cli/install/bun-install-package-extensions.test.ts
+++ b/test/cli/install/bun-install-package-extensions.test.ts
@@ -273,6 +273,7 @@ test("malformed package.json packageExtensions entries warn and are skipped", as
         "a-dep": { dependencies: { "no-deps": 1 } },
         "no-deps": "not an object",
         "a-dep@not a range": { dependencies: { "no-deps": "1.0.0" } },
+        "a-dep@": { dependencies: { "no-deps": "1.0.1" } },
       },
     }),
   );
@@ -284,11 +285,14 @@ test("malformed package.json packageExtensions entries warn and are skipped", as
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [_, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(err).toContain("warn: Expected a version range string");
   expect(err).toContain("warn: Expected an object with");
-  expect(err).toContain('warn: Expected a semver range after "@" in the package name');
+  expect(err.match(/warn: Expected a semver range after "@" in the package name/g)).toHaveLength(2);
   expect(err).not.toContain("error:");
+  // only a-dep itself: every extension entry was rejected
+  expect(out).toContain("+ a-dep@1.0.7");
+  expect(out).toContain("1 package installed");
   expect(exitCode).toBe(0);
   expect(await lockfileEntry(packageDir, "a-dep")).toEqual({});
 });
@@ -337,7 +341,8 @@ test("malformed bunfig.toml packageExtensions is a config error", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [_, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(err).toContain(`Expected "packageExtensions" to be an object`);
+  expect(out).not.toContain("installed");
   expect(exitCode).not.toBe(0);
 });

--- a/test/cli/install/bun-install-package-extensions.test.ts
+++ b/test/cli/install/bun-install-package-extensions.test.ts
@@ -1,0 +1,309 @@
+import { file, spawn, write } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { rm } from "fs/promises";
+import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall } from "harness";
+import { join } from "path";
+
+// `packageExtensions` lets the root project add dependencies / peerDependencies
+// that a third-party package forgot to declare. These tests use registry
+// fixtures that declare nothing themselves (`a-dep`, `no-deps`, `peer-no-deps`)
+// and graft edges onto them from the root package.json / bunfig.toml.
+
+const registry = new VerdaccioRegistry();
+
+beforeAll(async () => {
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+/** bun.lock is JSONC with trailing commas; good enough for these fixtures. */
+async function readLockfile(dir: string): Promise<any> {
+  const text = await file(join(dir, "bun.lock")).text();
+  return JSON.parse(text.replace(/,(\s*[}\]])/g, "$1"));
+}
+
+/** The info object (`{ dependencies, peerDependencies, optionalPeers, ... }`) bun.lock records for `name`. */
+async function lockfileEntry(dir: string, name: string): Promise<Record<string, any>> {
+  const lock = await readLockfile(dir);
+  const entry = lock.packages[name];
+  expect(entry).toBeArray();
+  return entry[2];
+}
+
+async function installedVersion(dir: string, linker: "hoisted" | "isolated", name: string, version: string) {
+  const pkgJson =
+    linker === "hoisted"
+      ? join(dir, "node_modules", name, "package.json")
+      : join(dir, "node_modules", ".bun", `${name}@${version}`, "node_modules", name, "package.json");
+  return (await file(pkgJson).json()).version;
+}
+
+function isInstalled(dir: string, linker: "hoisted" | "isolated", name: string, version: string) {
+  return linker === "hoisted"
+    ? existsSync(join(dir, "node_modules", name))
+    : existsSync(join(dir, "node_modules", ".bun", `${name}@${version}`));
+}
+
+function bunfigWithExtensions(linker: "hoisted" | "isolated", dir: string, extra: string) {
+  return `[install]
+cache = "${join(dir, ".bun-cache").replaceAll("\\", "\\\\")}"
+registry = "${registry.registryUrl()}"
+linker = "${linker}"
+${extra}
+`;
+}
+
+describe.each(["hoisted", "isolated"] as const)("packageExtensions (%s linker)", linker => {
+  test("adds a missing dependency, records it in bun.lock, and is stable under --frozen-lockfile", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "a-dep": "1.0.5" },
+        packageExtensions: {
+          "a-dep": { dependencies: { "no-deps": "^1.0.0" } },
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    // `no-deps` is only reachable through the extension
+    expect(await installedVersion(packageDir, linker, "no-deps", "1.1.0")).toBe("1.1.0");
+    if (linker === "isolated") {
+      // and it is linked as a dependency of a-dep, not just present in the store
+      expect(existsSync(join(packageDir, "node_modules", ".bun", "a-dep@1.0.5", "node_modules", "no-deps"))).toBeTrue();
+    }
+    expect(await lockfileEntry(packageDir, "a-dep")).toEqual({ dependencies: { "no-deps": "^1.0.0" } });
+
+    // a second install has nothing to do
+    const second = await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+
+    // reinstalling from the lockfile alone reproduces the injected edge
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await runBunInstall(bunEnv, packageDir, { frozenLockfile: true });
+    expect(await installedVersion(packageDir, linker, "no-deps", "1.1.0")).toBe("1.1.0");
+  });
+
+  test("name@range keys only apply to matching versions", async () => {
+    const extensions = {
+      "no-deps@^2": { dependencies: { "a-dep": "1.0.1" } },
+    };
+    // no-deps@1.0.0 does not match ^2
+    {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({ name: "app", dependencies: { "no-deps": "1.0.0" }, packageExtensions: extensions }),
+      );
+      await runBunInstall(bunEnv, packageDir);
+      expect(isInstalled(packageDir, linker, "a-dep", "1.0.1")).toBeFalse();
+      expect(await lockfileEntry(packageDir, "no-deps")).toEqual({});
+    }
+    // no-deps@2.0.0 does
+    {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({ name: "app", dependencies: { "no-deps": "2.0.0" }, packageExtensions: extensions }),
+      );
+      await runBunInstall(bunEnv, packageDir);
+      expect(await installedVersion(packageDir, linker, "a-dep", "1.0.1")).toBe("1.0.1");
+      expect(await lockfileEntry(packageDir, "no-deps")).toEqual({ dependencies: { "a-dep": "1.0.1" } });
+    }
+  });
+
+  test("peerDependencies and peerDependenciesMeta.optional", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "app",
+        dependencies: { "a-dep": "1.0.3", "peer-no-deps": "1.0.1" },
+        packageExtensions: {
+          "a-dep@1": {
+            peerDependencies: { "peer-no-deps": "^1.0.0", "left-pad": "*" },
+            peerDependenciesMeta: { "left-pad": { optional: true } },
+          },
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    expect(await lockfileEntry(packageDir, "a-dep")).toEqual({
+      peerDependencies: { "peer-no-deps": "^1.0.0", "left-pad": "*" },
+      optionalPeers: ["left-pad"],
+    });
+    // the required peer resolves to what the root provides; the optional peer
+    // that nobody provides is not installed
+    const lock = await readLockfile(packageDir);
+    expect(lock.packages["peer-no-deps"][0]).toBe("peer-no-deps@1.0.1");
+    expect(lock.packages["left-pad"]).toBeUndefined();
+    if (linker === "isolated") {
+      const storeEntries = (await readdirSorted(join(packageDir, "node_modules", ".bun"))).filter(entry =>
+        entry.startsWith("a-dep@1.0.3"),
+      );
+      expect(storeEntries).toHaveLength(1);
+      expect(
+        existsSync(join(packageDir, "node_modules", ".bun", storeEntries[0], "node_modules", "peer-no-deps")),
+      ).toBeTrue();
+      expect(
+        existsSync(join(packageDir, "node_modules", ".bun", storeEntries[0], "node_modules", "left-pad")),
+      ).toBeFalse();
+    } else {
+      expect(existsSync(join(packageDir, "node_modules", "left-pad"))).toBeFalse();
+    }
+  });
+
+  test("does not override a dependency the package already declares", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "app",
+        // one-fixed-dep@1.0.0 declares `"no-deps": "1.0.0"` itself
+        dependencies: { "one-fixed-dep": "1.0.0" },
+        packageExtensions: {
+          "one-fixed-dep": { dependencies: { "no-deps": "2.0.0", "a-dep": "1.0.2" } },
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    expect(await lockfileEntry(packageDir, "one-fixed-dep")).toEqual({
+      dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.2" },
+    });
+    expect(await installedVersion(packageDir, linker, "no-deps", "1.0.0")).toBe("1.0.0");
+    expect((await readLockfile(packageDir)).packages["no-deps"][0]).toBe("no-deps@1.0.0");
+    expect(await installedVersion(packageDir, linker, "a-dep", "1.0.2")).toBe("1.0.2");
+  });
+
+  test("an extension added after the first install is applied to the existing lockfile", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(packageJson, JSON.stringify({ name: "app", dependencies: { "a-dep": "1.0.4", "no-deps": "2.0.0" } }));
+    await runBunInstall(bunEnv, packageDir);
+    expect(await lockfileEntry(packageDir, "a-dep")).toEqual({});
+    expect(isInstalled(packageDir, linker, "peer-no-deps", "2.0.0")).toBeFalse();
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "app",
+        dependencies: { "a-dep": "1.0.4", "no-deps": "2.0.0" },
+        packageExtensions: {
+          "a-dep": {
+            dependencies: { "peer-no-deps": "2.0.0" },
+            peerDependencies: { "no-deps": "*" },
+          },
+        },
+      }),
+    );
+    // the lockfile gains the new edges (and the new package) without re-resolving the rest
+    await runBunInstall(bunEnv, packageDir);
+    expect(await lockfileEntry(packageDir, "a-dep")).toEqual({
+      dependencies: { "peer-no-deps": "2.0.0" },
+      peerDependencies: { "no-deps": "*" },
+    });
+    expect(await installedVersion(packageDir, linker, "peer-no-deps", "2.0.0")).toBe("2.0.0");
+    const lock = await readLockfile(packageDir);
+    expect(lock.packages["a-dep"][0]).toBe("a-dep@1.0.4");
+    expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
+
+    // and from here on the lockfile is stable
+    await runBunInstall(bunEnv, packageDir, { frozenLockfile: true });
+    const again = await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(again.err).not.toContain("Saved lockfile");
+  });
+
+  test("bunfig.toml [install.packageExtensions] and package.json pnpm.packageExtensions", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(
+      join(packageDir, "bunfig.toml"),
+      bunfigWithExtensions(
+        linker,
+        packageDir,
+        `
+[install.packageExtensions.a-dep]
+dependencies = { no-deps = "1.0.1" }
+
+[install.packageExtensions."peer-no-deps@2"]
+optionalDependencies = { left-pad = "1.0.0" }
+`,
+      ),
+    );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "app",
+        dependencies: { "a-dep": "1.0.6", "peer-no-deps": "2.0.0" },
+        pnpm: { packageExtensions: { "a-dep@*": { peerDependencies: { "peer-no-deps": "*" } } } },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    expect(await lockfileEntry(packageDir, "a-dep")).toEqual({
+      dependencies: { "no-deps": "1.0.1" },
+      peerDependencies: { "peer-no-deps": "*" },
+    });
+    expect(await lockfileEntry(packageDir, "peer-no-deps")).toEqual({
+      optionalDependencies: { "left-pad": "1.0.0" },
+    });
+    expect(await installedVersion(packageDir, linker, "no-deps", "1.0.1")).toBe("1.0.1");
+    expect(await installedVersion(packageDir, linker, "left-pad", "1.0.0")).toBe("1.0.0");
+  });
+});
+
+test("malformed package.json packageExtensions entries warn and are skipped", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" } });
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "app",
+      dependencies: { "a-dep": "1.0.7" },
+      packageExtensions: {
+        "a-dep": { dependencies: { "no-deps": 1 } },
+        "no-deps": "not an object",
+      },
+    }),
+  );
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(err).toContain("warn: Expected a version range string");
+  expect(err).toContain("warn: Expected an object with");
+  expect(err).not.toContain("error:");
+  expect(await lockfileEntry(packageDir, "a-dep")).toEqual({});
+  expect(exitCode).toBe(0);
+});
+
+test("malformed bunfig.toml packageExtensions is a config error", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" } });
+  await write(
+    join(packageDir, "bunfig.toml"),
+    bunfigWithExtensions("hoisted", packageDir, `packageExtensions = "nope"`),
+  );
+  await write(packageJson, JSON.stringify({ name: "app", dependencies: { "a-dep": "1.0.8" } }));
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(err).toContain(`Expected "packageExtensions" to be an object`);
+  expect(exitCode).not.toBe(0);
+});

--- a/test/cli/install/bun-install-package-extensions.test.ts
+++ b/test/cli/install/bun-install-package-extensions.test.ts
@@ -280,12 +280,41 @@ test("malformed package.json packageExtensions entries warn and are skipped", as
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [_, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(err).toContain("warn: Expected a version range string");
   expect(err).toContain("warn: Expected an object with");
   expect(err).not.toContain("error:");
-  expect(await lockfileEntry(packageDir, "a-dep")).toEqual({});
   expect(exitCode).toBe(0);
+  expect(await lockfileEntry(packageDir, "a-dep")).toEqual({});
+});
+
+test("the same name in several groups follows package.json rules", async () => {
+  // optionalDependencies overrides dependencies; a peerDependencies entry for a
+  // name that is already a (optional) dependency is ignored, optional or not.
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" } });
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "app",
+      dependencies: { "a-dep": "1.0.9" },
+      packageExtensions: {
+        "a-dep": {
+          dependencies: { "no-deps": "1.0.0", "peer-no-deps": "1.0.0" },
+          optionalDependencies: { "no-deps": "1.0.1" },
+          peerDependencies: { "no-deps": "*", "peer-no-deps": "*" },
+          peerDependenciesMeta: { "peer-no-deps": { optional: true } },
+        },
+      },
+    }),
+  );
+
+  await runBunInstall(bunEnv, packageDir);
+  expect(await lockfileEntry(packageDir, "a-dep")).toEqual({
+    dependencies: { "peer-no-deps": "1.0.0" },
+    optionalDependencies: { "no-deps": "1.0.1" },
+  });
+  expect(await installedVersion(packageDir, "hoisted", "no-deps", "1.0.1")).toBe("1.0.1");
+  expect(await installedVersion(packageDir, "hoisted", "peer-no-deps", "1.0.0")).toBe("1.0.0");
 });
 
 test("malformed bunfig.toml packageExtensions is a config error", async () => {
@@ -303,7 +332,7 @@ test("malformed bunfig.toml packageExtensions is a config error", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [_, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(err).toContain(`Expected "packageExtensions" to be an object`);
   expect(exitCode).not.toBe(0);
 });

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2721,6 +2721,106 @@ importers:
     });
   });
 
+  // packageExtensions live in `pnpm.packageExtensions` (package.json) or in
+  // pnpm-workspace.yaml; both move to the root `packageExtensions` bun reads.
+  // pnpm already wrote the injected edges into its lockfile snapshots, so the
+  // migrated bun.lock carries them as-is.
+  test.concurrent("packageExtensions move to the root of package.json", async () => {
+    using dir = tempDir("pnpm-v9-package-extensions", {
+      "package.json": JSON.stringify({
+        name: "package-extensions",
+        dependencies: { "is-even": "1.0.0" },
+        pnpm: { packageExtensions: { "is-even@1": { dependencies: { "is-buffer": "^1.1.5" } } } },
+      }),
+      "pnpm-workspace.yaml": `packageExtensions:
+  is-odd:
+    peerDependencies:
+      is-number: '*'
+`,
+      "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+packageExtensionsChecksum: sha256-x
+
+importers:
+
+  .:
+    dependencies:
+      is-even:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-even@1.0.0:
+    resolution: {integrity: sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@3.0.0:
+    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@0.1.2:
+    resolution: {integrity: sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      is-number: '*'
+
+  kind-of@3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-buffer@1.1.6: {}
+
+  is-even@1.0.0:
+    dependencies:
+      is-buffer: 1.1.6
+      is-odd: 0.1.2(is-number@3.0.0)
+
+  is-number@3.0.0:
+    dependencies:
+      kind-of: 3.2.2
+
+  is-odd@0.1.2(is-number@3.0.0):
+    dependencies:
+      is-number: 3.0.0
+
+  kind-of@3.2.2:
+    dependencies:
+      is-buffer: 1.1.6
+`,
+    });
+
+    const { stderr, exitCode } = await migrate(String(dir));
+
+    expect(stderr).not.toContain("error:");
+    expect(stderr).toContain("moved pnpm.packageExtensions to packageExtensions");
+    expect(stderr).toContain("pnpm-workspace.yaml packageExtensions to packageExtensions");
+    expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+    expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
+      name: "package-extensions",
+      dependencies: { "is-even": "1.0.0" },
+      packageExtensions: {
+        "is-even@1": { dependencies: { "is-buffer": "^1.1.5" } },
+        "is-odd": { peerDependencies: { "is-number": "*" } },
+      },
+    });
+    const bunLock = await bunLockOf(String(dir));
+    expect(bunLock).toMatch(
+      /"is-even": \["is-even@1\.0\.0", "[^"]*", \{ "dependencies": \{ "is-buffer": "1\.1\.6", "is-odd": "0\.1\.2" \} \}/,
+    );
+    expect(bunLock).toMatch(/"is-odd": \["is-odd@0\.1\.2", "[^"]*", \{ "peerDependencies": \{ "is-number": "\*" \} \}/);
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("link: version with a semver specifier resolves to the workspace (pnpm/pnpm#7712)", async () => {
     // save-workspace-protocol=false / link-workspace-packages shape
     using dir = fixture("v9-link-semver-specifier");

--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -2805,6 +2805,7 @@ snapshots:
     expect(stderr).toContain("moved pnpm.packageExtensions to packageExtensions");
     expect(stderr).toContain("pnpm-workspace.yaml packageExtensions to packageExtensions");
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+    expect(exitCode).toBe(0);
     expect(await Bun.file(join(String(dir), "package.json")).json()).toStrictEqual({
       name: "package-extensions",
       dependencies: { "is-even": "1.0.0" },
@@ -2818,7 +2819,6 @@ snapshots:
       /"is-even": \["is-even@1\.0\.0", "[^"]*", \{ "dependencies": \{ "is-buffer": "1\.1\.6", "is-odd": "0\.1\.2" \} \}/,
     );
     expect(bunLock).toMatch(/"is-odd": \["is-odd@0\.1\.2", "[^"]*", \{ "peerDependencies": \{ "is-number": "\*" \} \}/);
-    expect(exitCode).toBe(0);
   });
 
   test.concurrent("link: version with a semver specifier resolves to the workspace (pnpm/pnpm#7712)", async () => {


### PR DESCRIPTION
### What does this PR do?

Adds `packageExtensions` to `bun install`: the yarn (`.yarnrc.yml#packageExtensions`) / pnpm (`package.json#pnpm.packageExtensions`) feature for patching the *declared dependencies* of third-party packages — typically to add a `dependencies` / `peerDependencies` entry a package forgot to declare, so it resolves under the isolated linker. Projects that rely on it today have no equivalent when migrating to bun.

#### Configuration

Root `package.json`, either top-level or under `pnpm` (same object shape as pnpm/yarn):

```json
{
  "dependencies": { "react": "^18", "react-redux": "^7", "legacy-plugin": "^2" },
  "packageExtensions": {
    "react-redux@7": { "peerDependencies": { "react": "*" } },
    "legacy-plugin": {
      "dependencies": { "lodash": "^4.17.21" },
      "peerDependencies": { "webpack": "*" },
      "peerDependenciesMeta": { "webpack": { "optional": true } }
    }
  }
}
```

and/or `bunfig.toml` (merged with the package.json entries):

```toml
[install.packageExtensions."react-redux@7"]
peerDependencies = { react = "*" }

[install.packageExtensions.legacy-plugin]
dependencies = { lodash = "^4.17.21" }
peerDependencies = { webpack = "*" }
peerDependenciesMeta = { webpack = { optional = true } }
```

Keys are `<name>` or `<name>@<semver range>`; the range scopes the extension to resolved versions of that package that satisfy it. Values accept `dependencies`, `optionalDependencies`, `peerDependencies` and `peerDependenciesMeta` (`optional: true` → optional peer).

The pnpm lockfile migration now also moves `pnpm.packageExtensions` and `pnpm-workspace.yaml#packageExtensions` to the root `packageExtensions` of package.json, next to the existing `overrides` / `patchedDependencies` moves.

#### Semantics

- When an npm-resolved package `name@version` matching an extension is added to the lockfile (`Package::from_npm`), the extension's entries are appended to that package's dependency list with the corresponding behavior (prod / optional / peer / optional peer). From there they are ordinary edges: resolved and installed through the normal path and written to `bun.lock` as part of the package's `dependencies` / `peerDependencies` / `optionalPeers`, so installs from the lockfile — including `--frozen-lockfile` — reproduce them without consulting the config again.
- **Declared deps win**: an entry the package already declares (in any group) is left alone; extensions only add, they never change a version. (Use `overrides` for that.)
- The same pass runs over every package of a lockfile that was just loaded from disk, so adding an extension to an existing project takes effect on the next `bun install`: matching locked packages get the new edges appended and only those edges are enqueued for resolution — nothing else is re-resolved. Since these owners are not new packages, the injected still-unresolved edges are enqueued explicitly after the diff pass (otherwise nothing would walk their dependency lists).
- Only registry (npm) resolutions are extended; workspace / folder / git / tarball packages are not.
- Removing an extension takes effect when the affected package is next re-resolved (the lockfile does not distinguish injected from declared edges) — documented.
- Malformed entries in package.json warn and are skipped (like `overrides`); malformed bunfig is a config error.

#### Implementation

- `src/install_types/PackageExtensions.rs`: the parsed representation (`PackageExtension { name, range, dependencies: [{ name, version, behavior }] }`) and a shared `parse_from_expr` used by both bunfig (`[install.packageExtensions]` → `Api::BunInstall.package_extensions`) and the root package.json reader. Lives in `bun_install_types` so `bun_bunfig` does not depend on the package manager.
- `src/install/lockfile/package_extensions.rs`: `Lockfile::apply_package_extensions_to(package_id)` (splices the new `Dependency` rows into the package's dependency slice — in place when the slice is the buffer tail, i.e. the `from_npm` case, otherwise relocating the slice to the end like the root package re-layout already does; each edge goes at the end of its own group so the order matches what a `bun.lock` reload produces) and `Lockfile::apply_package_extensions()` for the post-load pass, which returns the injected dependency ids. `PackageManager::load_package_extensions_from_package_json` reads the root package.json entries after the lockfile load (so a pnpm migration has already moved them).
- Hooks: `PackageManagerEnqueue.rs` right after `append_package(from_npm(..))` (re-reading the package so the caller walks the extended list), and `install_with_manager.rs` after `load_from_cwd` + an explicit enqueue of the injected edges before `drain_dependency_list`.
- Docs: new `docs/pm/package-extensions.mdx`, a section in `docs/pm/cli/install.mdx`, and `install.packageExtensions` in `docs/runtime/bunfig.mdx`.

### How did you verify your code works?

New tests in `test/cli/install/bun-install-package-extensions.test.ts` (verdaccio fixtures, `describe.each(["hoisted", "isolated"])`):

- an extension adding a missing `dependencies` entry → the dep is installed (hoisted: in `node_modules`; isolated: linked inside the extended package's store entry), recorded in `bun.lock` under the extended package, a second install is a no-op, and `rm -rf node_modules && bun install --frozen-lockfile` reproduces it
- `name@range` scoping: applies to a matching resolved version, not to a non-matching one
- `peerDependencies` + `peerDependenciesMeta.optional`: required peer resolves to what the root provides, optional peer is recorded in `optionalPeers` and not installed
- an entry the package already declares is not overridden (version stays the package's), while a sibling new entry is added
- adding an extension after the first install updates the existing lockfile on the next `bun install` (existing resolutions untouched) and is stable under `--frozen-lockfile` afterwards
- bunfig `[install.packageExtensions]` and package.json `pnpm.packageExtensions` forms, merged
- malformed package.json entries warn and are skipped; malformed bunfig errors

Plus a `bun pm migrate` case in `test/cli/install/migration/pnpm-lock-v9.test.ts` for moving `pnpm.packageExtensions` / `pnpm-workspace.yaml#packageExtensions` into package.json.

Also ran `bun-install.test.ts`, `bun-install-registry.test.ts`, `isolated-install.test.ts`, `bun-lock.test.ts`, `bun-workspaces.test.ts`, the pnpm migration tests and `test/internal/source-lints/` locally; `cargo clippy -p bun_install -p bun_install_types -p bun_bunfig -p bun_options_types --no-deps` is clean.
