### PR TITLE
Upgrade WebKit to baf4a9a7ec0b

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "aea1f010b69783c0fc1ff24ff663691abe642c16";
+export const WEBKIT_VERSION = "autobuild-preview-pr-488-d0fae3b3";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -123,6 +123,16 @@ declare function $resolvePromise<T>(promise: Promise<T>, value: NoInfer<T>): voi
  * Reject a promise with a value
  */
 declare function $rejectPromise(promise: Promise<unknown>, value: unknown): void;
+/**
+ * A new pending promise with the intrinsic %Promise.prototype%. Settle it with the
+ * `$resolvePromise` / `$rejectPromise` family. `$resolvePromise` and `$rejectPromise`
+ * require the promise to still be pending; the `...WithFirstResolvingFunctionCallCheck`
+ * variants behave like the resolving functions handed to a Promise executor and ignore
+ * every call after the first one.
+ */
+declare function $newPromise<T = unknown>(): Promise<T>;
+declare function $resolvePromiseWithFirstResolvingFunctionCallCheck<T>(promise: Promise<T>, value: NoInfer<T>): void;
+declare function $rejectPromiseWithFirstResolvingFunctionCallCheck(promise: Promise<unknown>, value: unknown): void;
 
 declare function $loadEsmIntoCjs(...args: any[]): TODO;
 declare function $getProxyInternalField(): TODO;
@@ -296,7 +306,6 @@ declare function $overridableRequire(this: JSCommonJSModule, id: string): any;
 declare function $toLength(length: number): number;
 declare function $isTypedArrayView(obj: unknown): obj is ArrayBufferView | DataView | Uint8Array;
 declare function $setStateToMax(target: any, state: number): void;
-declare function $newPromiseCapability(C: PromiseConstructor): TODO;
 /** @deprecated, use new TypeError instead */
 declare function $makeTypeError(message: string): TypeError;
 

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -123,14 +123,9 @@ declare function $resolvePromise<T>(promise: Promise<T>, value: NoInfer<T>): voi
  * Reject a promise with a value
  */
 declare function $rejectPromise(promise: Promise<unknown>, value: unknown): void;
-/**
- * A new pending promise with the intrinsic %Promise.prototype%. Settle it with the
- * `$resolvePromise` / `$rejectPromise` family. `$resolvePromise` and `$rejectPromise`
- * require the promise to still be pending; the `...WithFirstResolvingFunctionCallCheck`
- * variants behave like the resolving functions handed to a Promise executor and ignore
- * every call after the first one.
- */
+/** A new pending promise. `$resolvePromise` / `$rejectPromise` require it to still be pending. */
 declare function $newPromise<T = unknown>(): Promise<T>;
+/** Like the resolving functions of a Promise executor: calls after the first one are ignored. */
 declare function $resolvePromiseWithFirstResolvingFunctionCallCheck<T>(promise: Promise<T>, value: NoInfer<T>): void;
 declare function $rejectPromiseWithFirstResolvingFunctionCallCheck(promise: Promise<unknown>, value: unknown): void;
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1328,8 +1328,6 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
 }
-// 'close' listener for a handed-off CONNECT/Upgrade socket: settles the promise
-// that keeps the native request callback open.
 function resolveHandoffPromise(promise) {
   $resolvePromise(promise, undefined);
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -752,7 +752,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // Attach the internal close listener after the user's "connect"
             // handler ran: Node.js hands the socket over with no listeners and
             // tests assert socket.listenerCount("close") === 0 there.
-            socket.once("close", () => $resolvePromise(promise, undefined));
+            socket.once("close", resolveHandoffPromise.bind(undefined, promise));
             return promise;
           } else {
             // Node.js will close the socket and will NOT respond with 400 Bad Request
@@ -992,7 +992,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           // machinery; hold the native callback open until the raw socket
           // closes.
           const upgradePromise = $newPromise();
-          socket.once("close", () => $resolvePromise(upgradePromise, undefined));
+          socket.once("close", resolveHandoffPromise.bind(undefined, upgradePromise));
           return upgradePromise;
         } else if (
           server.requireHostHeader &&
@@ -1327,6 +1327,11 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("error", socketOnError);
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
+}
+// 'close' listener for a handed-off CONNECT/Upgrade socket: settles the promise
+// that keeps the native request callback open.
+function resolveHandoffPromise(promise) {
+  $resolvePromise(promise, undefined);
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -740,7 +740,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // The parser is detached: the socket is handed over with only
             // net.Socket's 'end' listener left, like Node.js.
             detachSocketListenersForHandoff(socket);
-            const { promise, resolve } = $newPromiseCapability(Promise);
+            const promise = $newPromise();
             // Pass the pipelined data (head buffer) if any was received with the CONNECT request
             const head = connectHead ? connectHead : kEmptyBuffer;
             // Node.js's parserOnIncoming: req.upgrade is true for CONNECT
@@ -752,7 +752,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // Attach the internal close listener after the user's "connect"
             // handler ran: Node.js hands the socket over with no listeners and
             // tests assert socket.listenerCount("close") === 0 there.
-            socket.once("close", resolve);
+            socket.once("close", () => $resolvePromise(promise, undefined));
             return promise;
           } else {
             // Node.js will close the socket and will NOT respond with 400 Bad Request
@@ -831,7 +831,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
         drainMicrotasks();
 
-        let resolveFunction;
+        let pendingPromise: Promise<void> | undefined;
         let didFinish = false;
 
         const isRequestsLimitSet = typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0;
@@ -921,7 +921,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
         function onClose() {
           didFinish = true;
-          if (resolveFunction) resolveFunction();
+          if (pendingPromise) $resolvePromiseWithFirstResolvingFunctionCallCheck(pendingPromise, undefined);
         }
 
         if (!isPipelined) {
@@ -991,8 +991,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           // Like CONNECT: the connection is detached from the HTTP request
           // machinery; hold the native callback open until the raw socket
           // closes.
-          const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
-          socket.once("close", resolveUpgrade);
+          const upgradePromise = $newPromise();
+          socket.once("close", () => $resolvePromise(upgradePromise, undefined));
           return upgradePromise;
         } else if (
           server.requireHostHeader &&
@@ -1051,10 +1051,9 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           return;
         }
 
-        const { resolve, promise } = $newPromiseCapability(Promise);
-        resolveFunction = resolve;
+        pendingPromise = $newPromise();
 
-        return promise;
+        return pendingPromise;
       },
     });
 

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -1160,12 +1160,12 @@ Socket.prototype[SymbolAsyncDispose] = async function () {
   if (!this[kStateSymbol].handle) {
     return;
   }
-  const { promise, resolve, reject } = $newPromiseCapability(Promise);
+  const promise = $newPromise();
   this.close(err => {
     if (err) {
-      reject(err);
+      $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
     } else {
-      resolve();
+      $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
     }
   });
 

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -1161,7 +1161,7 @@ Socket.prototype[SymbolAsyncDispose] = async function () {
     return;
   }
   const promise = $newPromise();
-  this.close(onAsyncDisposeClosed.bind(undefined, promise));
+  this.close(FunctionPrototypeBind.$call(onAsyncDisposeClosed, undefined, promise));
 
   return promise;
 };

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -1161,16 +1161,18 @@ Socket.prototype[SymbolAsyncDispose] = async function () {
     return;
   }
   const promise = $newPromise();
-  this.close(err => {
-    if (err) {
-      $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
-    } else {
-      $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
-    }
-  });
+  this.close(onAsyncDisposeClosed.bind(undefined, promise));
 
   return promise;
 };
+
+function onAsyncDisposeClosed(promise, err) {
+  if (err) {
+    $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
+  } else {
+    $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
+  }
+}
 
 function socketCloseNT(self) {
   self.emit("close");

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -564,13 +564,13 @@ async function once(emitter, type, options = kEmptyObject) {
   if (signal?.aborted) {
     throw $makeAbortError(undefined, { cause: signal?.reason });
   }
-  const { resolve, reject, promise } = $newPromiseCapability(Promise);
+  const promise = $newPromise();
   const errorListener = err => {
     emitter.removeListener(type, resolver);
     if (signal != null) {
       eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
     }
-    reject(err);
+    $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
   };
   const resolver = (...args) => {
     if (typeof emitter.removeListener === "function") {
@@ -579,7 +579,7 @@ async function once(emitter, type, options = kEmptyObject) {
     if (signal != null) {
       eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
     }
-    resolve(args);
+    $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, args);
   };
   const opts = resistStopPropagation({ __proto__: null, once: true });
   eventTargetAgnosticAddListener(emitter, type, resolver, opts);
@@ -591,7 +591,7 @@ async function once(emitter, type, options = kEmptyObject) {
   function abortListener() {
     eventTargetAgnosticRemoveListener(emitter, type, resolver);
     eventTargetAgnosticRemoveListener(emitter, "error", errorListener);
-    reject($makeAbortError(undefined, { cause: signal?.reason }));
+    $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, $makeAbortError(undefined, { cause: signal?.reason }));
   }
   if (signal != null) {
     eventTargetAgnosticAddListener(signal, "abort", abortListener, opts);

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -620,8 +620,10 @@ function convertProcessSignalToExitCode(signalCode) {
 
 let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
-  unregisterToken: (...args: any[]) => void;
+  listener: (...args: any[]) => void;
 }>;
+// The promise is also the FinalizationRegistry unregister token: once the
+// signal aborts, the resource no longer needs its listener removed on GC.
 function onAbortedCallback(promise: Promise<void>) {
   lazyAbortedRegistry.unregister(promise);
 
@@ -642,19 +644,19 @@ function aborted(signal: AbortSignal, resource: object) {
   }
 
   const promise = $newPromise();
-  const unregisterToken = onAbortedCallback.bind(undefined, promise);
+  const listener = onAbortedCallback.bind(undefined, promise);
   signal.addEventListener(
     "abort",
     // Do not leak the current scope into the listener.
     // Instead, create a new function.
-    unregisterToken,
+    listener,
     resistStopPropagation({ __proto__: null, once: true }),
   );
 
   if (!lazyAbortedRegistry) {
-    lazyAbortedRegistry = new FinalizationRegistry(({ ref, unregisterToken }) => {
+    lazyAbortedRegistry = new FinalizationRegistry(({ ref, listener }) => {
       const signal = ref.deref();
-      if (signal) signal.removeEventListener("abort", unregisterToken);
+      if (signal) signal.removeEventListener("abort", listener);
     });
   }
 
@@ -665,9 +667,9 @@ function aborted(signal: AbortSignal, resource: object) {
     resource,
     {
       ref: new WeakRef(signal),
-      unregisterToken,
+      listener,
     },
-    unregisterToken,
+    promise,
   );
 
   return promise;

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -622,10 +622,10 @@ let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
   unregisterToken: (...args: any[]) => void;
 }>;
-function onAbortedCallback(resolveFn: Function) {
-  lazyAbortedRegistry.unregister(resolveFn);
+function onAbortedCallback(promise: Promise<void>) {
+  lazyAbortedRegistry.unregister(promise);
 
-  resolveFn();
+  $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
 }
 
 function aborted(signal: AbortSignal, resource: object) {
@@ -641,8 +641,8 @@ function aborted(signal: AbortSignal, resource: object) {
     return Promise.$resolve();
   }
 
-  const { promise, resolve } = $newPromiseCapability(Promise);
-  const unregisterToken = onAbortedCallback.bind(undefined, resolve);
+  const promise = $newPromise();
+  const unregisterToken = onAbortedCallback.bind(undefined, promise);
   signal.addEventListener(
     "abort",
     // Do not leak the current scope into the listener.

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -622,8 +622,6 @@ let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
   listener: (...args: any[]) => void;
 }>;
-// The promise is also the FinalizationRegistry unregister token: once the
-// signal aborts, the resource no longer needs its listener removed on GC.
 function onAbortedCallback(promise: Promise<void>) {
   lazyAbortedRegistry.unregister(promise);
 

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -66,7 +66,7 @@ test("node:dgram Symbol.asyncDispose closes the socket and resolves after 'close
   expect(events).toEqual(["close", "disposed"]);
   // The handle is gone, so disposing again resolves without touching the socket.
   await expect(socket[Symbol.asyncDispose]()).resolves.toBeUndefined();
-  expect(() => socket.address()).toThrow();
+  expect(() => socket.address()).toThrow(expect.objectContaining({ code: "ERR_SOCKET_DGRAM_NOT_RUNNING" }));
 });
 
 describe.skipIf(!isIPv6())("node:dgram", () => {

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -56,6 +56,19 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
   expect(exitCode).toBe(0);
 });
 
+test("node:dgram Symbol.asyncDispose closes the socket and resolves after 'close'", async () => {
+  const socket = dgram.createSocket("udp4");
+  await new Promise(resolve => socket.bind(0, "127.0.0.1", resolve));
+  const events = [];
+  socket.on("close", () => events.push("close"));
+  await socket[Symbol.asyncDispose]();
+  events.push("disposed");
+  expect(events).toEqual(["close", "disposed"]);
+  // The handle is gone, so disposing again resolves without touching the socket.
+  await expect(socket[Symbol.asyncDispose]()).resolves.toBeUndefined();
+  expect(() => socket.address()).toThrow();
+});
+
 describe.skipIf(!isIPv6())("node:dgram", () => {
   it("adds membership successfully (IPv6)", () => {
     const socket = makeSocket6();

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -102,6 +102,35 @@ describe("node:events", () => {
     expect(p).toBeInstanceOf(Promise);
     await expect(p).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
   });
+
+  test("once rejects with the value emitted on 'error' and removes both listeners", async () => {
+    const emitter = new EventEmitter();
+    const p = EventEmitter.once(emitter, "hey");
+    const err = new Error("boom");
+    emitter.emit("error", err);
+    await expect(p).rejects.toBe(err);
+    expect([emitter.listenerCount("hey"), emitter.listenerCount("error")]).toEqual([0, 0]);
+  });
+
+  test("once settles once when the event fires and the signal aborts afterwards", async () => {
+    const emitter = new EventEmitter();
+    const controller = new AbortController();
+    const p = EventEmitter.once(emitter, "hey", { signal: controller.signal });
+    emitter.emit("hey", 42);
+    controller.abort();
+    expect(await p).toEqual([42]);
+    expect([emitter.listenerCount("hey"), emitter.listenerCount("error")]).toEqual([0, 0]);
+  });
+
+  test("once resolves with the Event dispatched on an EventTarget and ignores later events", async () => {
+    const target = new EventTarget();
+    const p = EventEmitter.once(target, "ping");
+    const event = new Event("ping");
+    target.dispatchEvent(event);
+    target.dispatchEvent(new Event("ping"));
+    const [received] = await p;
+    expect(received).toBe(event);
+  });
 });
 
 describe("EventEmitter", () => {

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -93,3 +93,16 @@ test("fails if not provided a resource", async () => {
     await expect(() => aborted(ac.signal, resource)).toThrow();
   }
 });
+
+test("aborted resolves every waiter on the same signal with undefined", async () => {
+  const ac = new AbortController();
+  const first = aborted(ac.signal, {});
+  const second = aborted(ac.signal, {});
+  expect([first, second]).toEqual([expect.any(Promise), expect.any(Promise)]);
+  expect(getEventListeners(ac.signal, "abort")).toHaveLength(2);
+  ac.abort();
+  // A second abort() is a no-op; the already-settled promises must not be touched.
+  ac.abort();
+  expect(await Promise.all([first, second])).toEqual([undefined, undefined]);
+  expect(getEventListeners(ac.signal, "abort")).toHaveLength(0);
+});


### PR DESCRIPTION
### Problem
- Bun's WebKit is pinned to the fork's `aea1f010b6`. Upstream WebKit main has moved 387 commits since the fork's merge base `47f7250137c6`, 82 of them in JavaScriptCore, WTF or bmalloc.
- Upstream removed the `@newPromiseCapability` private builtin (WebKit/WebKit 38027ff0ec). Six call sites in Bun's bundled modules use it, so those modules would fail to compile against the new engine.

### Fix
- `WEBKIT_VERSION` points at the oven-sh/WebKit#488 build (`autobuild-preview-pr-488-d0fae3b3`), which merges upstream `baf4a9a7ec0b` into the fork on top of the fork's current main (including #330, the Buffer accessor nodes that Bun main needs). The conflict resolutions and the per-commit changelog are in that PR. That tag is the preview build of the open fork PR. Before this PR merges, `WEBKIT_VERSION` has to move to the `autobuild-<sha>` release that the fork's main produces once oven-sh/WebKit#488 lands.
- `node:events` (`once`), `node:util` (`aborted`), `node:dgram` (`Symbol.asyncDispose`) and the HTTP server (CONNECT, Upgrade, the per-request completion promise) create their promise with `$newPromise()` and settle it with `$resolvePromise` / `$rejectPromise` or the `...WithFirstResolvingFunctionCallCheck` variants where a second settle is possible. This is what upstream's own builtins moved to: no capability record, no property lookups.
- `builtins.d.ts` declares the three intrinsics and drops `$newPromiseCapability`. `util.aborted` also registers and unregisters its FinalizationRegistry entry with the same token (the promise); before, the abort path unregistered with a different object, so the entry lived until the resource was collected.
- New tests cover the ported settlement paths: `events.once` rejecting on `error`, settling once when the event and an abort race, and resolving for an `EventTarget`; `util.aborted` resolving every waiter once; `dgram` `Symbol.asyncDispose` resolving after `close`. Without the port these files fail at load against the new engine (`Private symbol not found: newPromiseCapability`).
- Verified: a debug build against the merged WebKit runs `test/js/node/events`, `test/js/node/util`, `test/js/node/dgram`, `test/js/node/http/node-http-connect.test.ts`, `test/js/bun/jsc`, `test/js/node/vm`, `test/js/node/module`, `test/js/bun/resolve`, `test/js/node/worker_threads`, `test/js/bun/wasm`, `test/js/web/url`, `test/js/web/atomics.test.ts`, `test/js/node/async_hooks`, `test/js/node/string_decoder` with no failures beyond the ones the current pin produces on the same machine (5 s timeouts under debug+ASAN, IPv6 multicast `ENODEV`, a Valkey `debug_assert` in `fuzzy-wuzzy.test.ts`).

### Background
- Bun builds against a prebuilt JavaScriptCore from oven-sh/WebKit releases. `scripts/build/deps/webkit.ts` names the release tag; CI downloads the matching tarball per platform.
- Bun's built-in JavaScript modules (`src/js/`) are compiled by JavaScriptCore's builtin compiler. A `$name` call becomes the private name `@name`, which has to exist in the engine. `@newPromise` is a bytecode intrinsic and `@resolvePromise` / `@rejectPromise` are link-time constants, so they are always available.
- `$resolvePromise` and `$rejectPromise` require a pending promise (they assert on it in debug builds). The `...WithFirstResolvingFunctionCallCheck` variants behave like the functions a Promise executor receives: the first call settles, later calls are ignored.

<details><summary>Notes</summary>

- Every push to oven-sh/WebKit#488 produces a new preview tag (`autobuild-preview-pr-488-<first 8 of the head sha>`), and this PR's `WEBKIT_VERSION` follows it. CI lanes that fetch the prebuilt fail on the download until that tag's Actions run has published the release.
- Behavior changes in this upstream range that are visible from JavaScript: `Promise.try` follows the updated spec (`PromiseResolve` instead of `NewPromiseCapability`); the module map no longer caches fetch failures, so a second `import()` of a specifier whose load failed re-runs Bun's module loader instead of rejecting with the cached error; `Uint8Array.prototype.setFromBase64` on a zero-length target returns `{ read: 0, written: 0 }` without validating the input; `WebAssembly.Module.imports()/exports()` descriptors drop the non-standard `type` field; re-exported imported Wasm globals and tags keep object identity.
- Performance changes of note: `JSON.parse` allocates arrays once at their final size; `TypedArray.prototype.sort()` without a comparator uses a radix sort for 2/4/8-byte element types; `Map`/`Set` `forEach` is inlined in the DFG and FTL; the bytecode cache emits `CodeForConstruct` for class constructors so cached programs stop reparsing them; `RegExp` cells shrink from 96 to 80 bytes.
- The upstream change to Linux thread scheduling (per-QOS `sched_setattr` on every WTF thread, `SCHED_BATCH` compiler threads on hosts with 4 or fewer cores) is gated off for Bun in the fork: Bun's threads keep inheriting the process scheduling attributes. See oven-sh/WebKit#488 for the reasoning and how to drop that hunk.
- The fork's #262 (`setFetchError` for a non-`ErrorInstance` fetch rejection) is superseded by upstream's module map change. Its repro (import a file with a parse error, then import a file that statically imports it) completes on this build.
- `test/js/bun/util/fuzzy-wuzzy.test.ts` aborts with `panic: assertion failed: self.is_subscriber()` in the Valkey client on both the current pin and this build. Reported separately.
- The `$newPromiseCapability` call in `src/node-fallbacks/events.js` (the browser polyfill, not a JSC builtin) is a pre-existing bug and is reported separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dgram/node-dgram.test.js

<!-- robobun:evidence:end -->

