### PR TITLE
install: path-scoped registry credentials, `install.allowedHosts`, `install.rewrite`

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -359,7 +359,16 @@ linker = "hoisted"
 # minimum age config
 minimumReleaseAge = 259200 # seconds
 minimumReleaseAgeExcludes = ["@types/node", "typescript"]
+
+# unset by default: when set, only these hosts (plus configured registries)
+# may serve manifests, tarballs and git repositories
+# allowedHosts = ["cdn.example.com"]
+
+# no rules by default: fetch-time URL prefix rewrites (bun.lock is unchanged)
+# rewrite = [{ from = "https://registry.npmjs.org/", to = "https://mirror.example.com/npm/" }]
 ```
+
+Registry credentials are scoped to the registry URL's host _and path_; see [Scopes and registries](/pm/scopes-registries#credential-scoping).
 
 ### Configuring with environment variables
 

--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -86,7 +86,7 @@ Bun supports the following options:
 - `_auth` (base64 encoded username:password, for example `btoa(username + ":" + password)`)
 - `email`
 
-Credentials apply to requests under the `//host/path/` they are written for. An entry whose `//host/path/` is a configured registry's URL becomes that registry's credentials; any other entry is still used for requests under its host and path — for example when a registry serves tarballs from a different path than its API, give each path its own line:
+Credentials apply to requests under the `//host/path/` they are written for. An entry whose `//host/path/` is a configured registry's URL becomes that registry's credentials; any other entry is still used for `https://` requests under its host and path (and for `http://` requests only when a configured registry uses plain http on that same host and port) — for example when a registry serves tarballs from a different path than its API, give each path its own line:
 
 ```ini .npmrc icon="npm"
 @myorg:registry=https://registry.example.com/api/packages/npm/

--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -13,7 +13,7 @@ Configuration is loaded in this order, with later sources overriding earlier one
 4. `BUN_CONFIG_REGISTRY` / `NPM_CONFIG_REGISTRY` and `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` environment variables
 5. Command-line flags such as `--registry`
 
-Bun matches credentials in `.npmrc` (`//<registry>/:_authToken`, etc.) to registries by host and path, even if you set the registry URL itself in `bunfig.toml`.
+Bun matches credentials in `.npmrc` (`//<registry>/:_authToken`, etc.) to registries by host and path, even if you set the registry URL itself in `bunfig.toml`. At request time those credentials are only sent to URLs under that registry's host _and path_ — see [credential scoping](/pm/scopes-registries#credential-scoping).
 
 Values may reference environment variables. Bun replaces `${NAME}` with the variable's value, or leaves it as-is if the variable is unset. `${NAME?}` becomes an empty string if unset.
 
@@ -85,6 +85,14 @@ Bun supports the following options:
 - `_password` (base64 encoded password)
 - `_auth` (base64 encoded username:password, for example `btoa(username + ":" + password)`)
 - `email`
+
+Credentials apply to requests under the `//host/path/` they are written for. An entry whose `//host/path/` is a configured registry's URL becomes that registry's credentials; any other entry is still used for requests under its host and path — for example when a registry serves tarballs from a different path than its API, give each path its own line:
+
+```ini .npmrc icon="npm"
+@myorg:registry=https://registry.example.com/api/packages/npm/
+//registry.example.com/api/packages/npm/:_authToken=${REGISTRY_TOKEN}
+//registry.example.com/api/projects/42/packages/npm/:_authToken=${REGISTRY_TOKEN}
+```
 
 The equivalent `bunfig.toml` option is to add a key in [`install.scopes`](/runtime/bunfig#install-scopes):
 

--- a/docs/pm/scopes-registries.mdx
+++ b/docs/pm/scopes-registries.mdx
@@ -30,6 +30,22 @@ To configure a private registry scoped to a particular organization:
 "@myorg3" = { token = "$npm_token", url = "https://registry.myorg.com/" }
 ```
 
+### Credential scoping
+
+Bun attaches a registry's credentials (token, or username and password) to a request only when the request URL is under the registry URL they were configured for: the same protocol, host and port, _and_ a path that starts with the registry URL's path, compared one path segment at a time. For a registry at the root of its host (such as `https://registry.npmjs.org/`) that is every URL on the host. For path-based multi-tenant registry hosts (e.g. Nexus, GitLab, Azure Artifacts, AWS CodeArtifact and similar products that serve many registries or feeds from one hostname) it means a token for one registry path is not sent to its siblings:
+
+| Registry URL                           | Request URL                                               | Credentials sent |
+| -------------------------------------- | --------------------------------------------------------- | ---------------- |
+| `https://registry.example.com/`        | `https://registry.example.com/any/path/pkg.tgz`           | yes              |
+| `https://host.example.com/npm/team-a/` | `https://host.example.com/npm/team-a/pkg/-/pkg-1.0.0.tgz` | yes              |
+| `https://host.example.com/npm/team-a/` | `https://host.example.com/npm/team-b/pkg/-/pkg-1.0.0.tgz` | no               |
+| `https://host.example.com/npm/team-a/` | `https://host.example.com/npm/team-ab/pkg.tgz`            | no               |
+| `https://host.example.com/npm/team-a/` | `https://cdn.example.com/npm/team-a/pkg.tgz`              | no               |
+
+This applies to package manifests and tarballs alike. A package's tarball URL comes from the registry's metadata, so this rule is what keeps a registry (or another tenant on a shared registry host) from directing your credentials somewhere else. It matches how npm scopes `//host/path/:_authToken` entries in `.npmrc`, and such [`.npmrc`](/pm/npmrc) entries are honoured the same way: a request not covered by its registry's credentials uses the `.npmrc` entry with the longest `//host/path/` that covers it, if any.
+
+To further restrict where `bun install` connects, see [`install.allowedHosts`](/runtime/bunfig#install-allowedhosts); to route requests through a mirror without changing `bun.lock`, see [`install.rewrite`](/runtime/bunfig#install-rewrite).
+
 ### `.npmrc`
 
 Bun also reads [`.npmrc`](/pm/npmrc) files.

--- a/docs/pm/scopes-registries.mdx
+++ b/docs/pm/scopes-registries.mdx
@@ -42,7 +42,7 @@ Bun attaches a registry's credentials (token, or username and password) to a req
 | `https://host.example.com/npm/team-a/` | `https://host.example.com/npm/team-ab/pkg.tgz`            | no               |
 | `https://host.example.com/npm/team-a/` | `https://cdn.example.com/npm/team-a/pkg.tgz`              | no               |
 
-This applies to package manifests and tarballs alike. A package's tarball URL comes from the registry's metadata, so this rule is what keeps a registry (or another tenant on a shared registry host) from directing your credentials somewhere else. It matches how npm scopes `//host/path/:_authToken` entries in `.npmrc`, and such [`.npmrc`](/pm/npmrc) entries are honoured the same way: a request not covered by its registry's credentials uses the `.npmrc` entry with the longest `//host/path/` that covers it, if any.
+This applies to package manifests and tarballs alike, and to each HTTP redirect they take: credentials are dropped on a hop that leaves the URL prefix they were issued for, even on the same host. A package's tarball URL comes from the registry's metadata, so this rule is what keeps a registry (or another tenant on a shared registry host) from directing your credentials somewhere else. It matches how npm scopes `//host/path/:_authToken` entries in `.npmrc`, and such [`.npmrc`](/pm/npmrc) entries are honoured the same way: a request not covered by its registry's credentials uses the `.npmrc` entry with the longest `//host/path/` that covers it, if any.
 
 To further restrict where `bun install` connects, see [`install.allowedHosts`](/runtime/bunfig#install-allowedhosts); to route requests through a mirror without changing `bun.lock`, see [`install.rewrite`](/runtime/bunfig#install-rewrite).
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -624,7 +624,7 @@ allowedHosts = []
 allowedHosts = ["cdn.example.com", "git.example.com:8443"]
 ```
 
-The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules, and again to every HTTP redirect before it is followed. A dependency on a refused host fails the install — an optional dependency included, so the allow-list never quietly changes what gets installed. For git dependencies the https and ssh forms of a specifier are checked separately, so `"git.example.com:22"` permits only the ssh transport.
+The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules, and again to every HTTP redirect before it is followed. A dependency on a refused host fails the install — an optional dependency included, so the allow-list never quietly changes what gets installed. Entries match by host and port, not by protocol. For git dependencies the https and ssh forms of a specifier are checked separately against their own ports, so `"git.example.com:22"` admits the ssh form (port 22) but not the https form (port 443), and `"git.example.com:443"` the reverse.
 
 ### `install.rewrite`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -624,7 +624,7 @@ allowedHosts = []
 allowedHosts = ["cdn.example.com", "git.example.com:8443"]
 ```
 
-The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules; HTTP redirects are followed as usual. A dependency on a refused host fails the install — an optional dependency included, so the allow-list never quietly changes what gets installed. For git dependencies the https and ssh forms of a specifier are checked separately, so `"git.example.com:22"` permits only the ssh transport.
+The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules, and again to every HTTP redirect before it is followed. A dependency on a refused host fails the install — an optional dependency included, so the allow-list never quietly changes what gets installed. For git dependencies the https and ssh forms of a specifier are checked separately, so `"git.example.com:22"` permits only the ssh transport.
 
 ### `install.rewrite`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -624,7 +624,7 @@ allowedHosts = []
 allowedHosts = ["cdn.example.com", "git.example.com:8443"]
 ```
 
-The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules; HTTP redirects are followed as usual.
+The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules; HTTP redirects are followed as usual. A required dependency on a refused host fails the install; an optional one is skipped with a warning. For git dependencies the https and ssh forms of a specifier are checked separately, so `"git.example.com:22"` permits only the ssh transport.
 
 ### `install.rewrite`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -624,7 +624,7 @@ allowedHosts = []
 allowedHosts = ["cdn.example.com", "git.example.com:8443"]
 ```
 
-The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules; HTTP redirects are followed as usual. A required dependency on a refused host fails the install; an optional one is skipped with a warning. For git dependencies the https and ssh forms of a specifier are checked separately, so `"git.example.com:22"` permits only the ssh transport.
+The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules; HTTP redirects are followed as usual. A dependency on a refused host fails the install — an optional dependency included, so the allow-list never quietly changes what gets installed. For git dependencies the https and ssh forms of a specifier are checked separately, so `"git.example.com:22"` permits only the ssh transport.
 
 ### `install.rewrite`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -605,6 +605,43 @@ myorg = { username = "myusername", password = "$npm_password", url = "https://re
 myorg = { token = "$npm_token", url = "https://registry.myorg.com/" }
 ```
 
+Registry credentials (a token, or a username and password) are only sent with requests under that registry's URL — the same origin _and_ path. A token configured for `https://registry.example.com/npm/team-a/` accompanies requests to `https://registry.example.com/npm/team-a/...`, but not to `https://registry.example.com/npm/team-b/...` or to another host a package's tarball URL points at. See [Scopes and registries](/pm/scopes-registries#credential-scoping).
+
+### `install.allowedHosts`
+
+Restrict which hosts `bun install` may download from. When this key is present — even as an empty array — Bun refuses to fetch a package manifest, tarball, or git repository from any host that is not either the host of a configured registry ([`install.registry`](#install-registry) and [`install.scopes`](#install-scopes), which are always allowed) or listed here. Entries are hostnames (any port) or `hostname:port`; they are not URLs. Unset by default, which allows any host.
+
+This matters because a package's tarball location comes from registry metadata (or a lockfile) rather than from your configuration: without an allow-list, a manifest can point the download anywhere.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+registry = "https://registry.example.com/npm/"
+
+# only the registry above ...
+allowedHosts = []
+
+# ... or the registry plus a CDN it redirects tarballs to and a git host
+allowedHosts = ["cdn.example.com", "git.example.com:8443"]
+```
+
+The check applies to the URL Bun requests, after any [`install.rewrite`](#install-rewrite) rules; HTTP redirects are followed as usual.
+
+### `install.rewrite`
+
+Rewrite the URLs `bun install` requests, without changing what is recorded in `bun.lock`. Each rule replaces a URL prefix; when several rules match, the longest `from` wins. Use this to send registry traffic through a mirror or proxy in one environment (CI, an office network) while keeping the lockfile portable.
+
+```toml title="bunfig.toml" icon="settings"
+[[install.rewrite]]
+from = "https://registry.npmjs.org/"
+to = "https://mirror.example.com/npm/"
+
+[[install.rewrite]]
+from = "https://registry.example.com/downloads/"
+to = "https://cache.internal.example.com/downloads/"
+```
+
+Rules apply to manifest and tarball requests. Registry credentials and [`install.allowedHosts`](#install-allowedhosts) are evaluated against the rewritten URL, so a rewritten request only carries a registry's token if it still points under that registry's URL.
+
 ### `install.ca` and `install.cafile`
 
 To configure a CA certificate, set `install.ca` to the certificate string or `install.cafile` to the path of a certificate file.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::collapsible_if, clippy::needless_return)]
 
 use bun_collections::VecExt;
+use bun_core::strings;
 use core::sync::atomic::Ordering;
 
 use bun_alloc::Arena as Bump;
@@ -34,6 +35,44 @@ pub(crate) struct Bunfig;
 #[inline]
 fn estring_to_owned(s: &E::EString, bump: &Bump) -> Box<[u8]> {
     Box::<[u8]>::from(s.string(bump).expect("OOM"))
+}
+
+/// `install.allowedHosts` entries are bare `hostname` or `hostname:port`
+/// (`[::1]:4873` for IPv6), never URLs or paths.
+fn is_valid_allowed_host(host: &[u8]) -> bool {
+    if host.is_empty()
+        || strings::contains_char(host, b'/')
+        || strings::contains_char(host, b'@')
+        || strings::contains_char(host, b' ')
+    {
+        return false;
+    }
+    let (name, port) = split_host_port(host);
+    !name.is_empty() && port.is_none_or(|p| !p.is_empty() && p.iter().all(u8::is_ascii_digit))
+}
+
+/// Split `host[:port]`, keeping a bracketed IPv6 literal intact.
+pub fn split_host_port(host: &[u8]) -> (&[u8], Option<&[u8]>) {
+    if strings::starts_with_char(host, b'[') {
+        return match strings::index_of_char(host, b']') {
+            Some(end) => {
+                let end = end as usize + 1;
+                let rest = &host[end..];
+                if rest.is_empty() {
+                    (&host[..end], None)
+                } else if rest[0] == b':' {
+                    (&host[..end], Some(&rest[1..]))
+                } else {
+                    (b"", None)
+                }
+            }
+            None => (b"", None),
+        };
+    }
+    match strings::last_index_of_char(host, b':') {
+        Some(colon) => (&host[..colon], Some(&host[colon + 1..])),
+        None => (host, None),
+    }
 }
 
 /// Macro-remap parsing (the `PackageJSON.parseMacrosJSON` shape),
@@ -1565,6 +1604,71 @@ impl<'a> Parser<'a> {
 
         if let Some(v) = install_obj.get(b"offline").and_then(|e| e.as_bool()) {
             install.offline = Some(v);
+        }
+
+        if let Some(hosts) = install_obj.get(b"allowedHosts") {
+            match &hosts.data {
+                ExprData::EArray(arr) => {
+                    let raw = arr.items.slice();
+                    // Present-but-empty is meaningful: only the configured
+                    // registries' hosts are allowed.
+                    let mut list: Vec<Box<[u8]>> = Vec::with_capacity(raw.len());
+                    for item in raw {
+                        self.expect_string(item)?;
+                        let host = item.as_string(self.bump).expect("infallible: type checked");
+                        if !is_valid_allowed_host(host) {
+                            self.add_error(
+                                item.loc,
+                                b"Expected a hostname or \"hostname:port\" (not a URL) in allowedHosts",
+                            )?;
+                        }
+                        list.push(host.into());
+                    }
+                    install.allowed_hosts = Some(list);
+                }
+                _ => {
+                    self.add_error(hosts.loc, b"Expected an array of strings for allowedHosts")?;
+                }
+            }
+        }
+
+        if let Some(rewrites) = install_obj.get(b"rewrite") {
+            match &rewrites.data {
+                ExprData::EArray(arr) => {
+                    let raw = arr.items.slice();
+                    let mut list: Vec<(Box<[u8]>, Box<[u8]>)> = Vec::with_capacity(raw.len());
+                    for item in raw {
+                        self.expect(item, ExprTag::EObject)?;
+                        let (Some(from), Some(to)) = (item.get(b"from"), item.get(b"to")) else {
+                            self.add_error(
+                                item.loc,
+                                b"Expected { from = \"<url prefix>\", to = \"<url prefix>\" } for rewrite",
+                            )?;
+                            continue;
+                        };
+                        self.expect_string(&from)?;
+                        self.expect_string(&to)?;
+                        let from = from.as_string(self.bump).expect("infallible: type checked");
+                        let to = to.as_string(self.bump).expect("infallible: type checked");
+                        for url in [from, to] {
+                            if !(url.starts_with(b"https://") || url.starts_with(b"http://")) {
+                                self.add_error(
+                                    item.loc,
+                                    b"Expected rewrite prefixes to be http:// or https:// URLs",
+                                )?;
+                            }
+                        }
+                        list.push((from.into(), to.into()));
+                    }
+                    install.url_rewrites = Some(list);
+                }
+                _ => {
+                    self.add_error(
+                        rewrites.loc,
+                        b"Expected an array of { from, to } tables for rewrite",
+                    )?;
+                }
+            }
         }
 
         Ok(())

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -166,6 +166,7 @@ fn make_client<'a>(
         // Note: DEFAULT_REDIRECT_COUNT (= 127) is crate-private in lib.rs;
         // duplicated as a literal here.
         remaining_redirect_count: 127,
+        redirect_policy: None,
         allow_retry: false,
         h2_retries: 0,
         redirect_type,

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -67,6 +67,10 @@ pub enum Error {
     UnsupportedRedirectProtocol,
     #[error("RedirectURLTooLong")]
     RedirectURLTooLong,
+    /// A caller-supplied [`RedirectPolicy`](crate::RedirectPolicy) refused the
+    /// redirect target (the package manager's `install.allowedHosts`).
+    #[error("RedirectHostNotAllowed")]
+    RedirectHostNotAllowed,
     #[error("RedirectURLInvalid")]
     RedirectURLInvalid,
     #[error("InvalidRedirectURL")]
@@ -293,6 +297,7 @@ impl Error {
             Self::RequestBodyNotReusable => "RequestBodyNotReusable",
             Self::UnsupportedRedirectProtocol => "UnsupportedRedirectProtocol",
             Self::RedirectURLTooLong => "RedirectURLTooLong",
+            Self::RedirectHostNotAllowed => "RedirectHostNotAllowed",
             Self::RedirectURLInvalid => "RedirectURLInvalid",
             Self::InvalidRedirectURL => "InvalidRedirectURL",
             Self::UnexpectedRedirect => "UnexpectedRedirect",

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -801,6 +801,9 @@ pub struct HTTPClient<'a> {
     // allocator param dropped — global mimalloc
     pub verbose: HTTPVerboseLevel,
     pub remaining_redirect_count: i8,
+    /// Caller-supplied rules re-applied to every redirect hop on top of
+    /// fetch's cross-origin header stripping (see [`RedirectPolicy`]).
+    pub redirect_policy: Option<RedirectPolicy>,
     pub(crate) allow_retry: bool,
     /// Transparent re-dispatch count for REFUSED_STREAM / graceful-GOAWAY,
     /// where the server promises the request was not processed. Capped by
@@ -1066,6 +1069,23 @@ bun_core::comptime_string_map! {
         b"content-location" => (),
         b"content-type" => (),
     };
+}
+
+/// Extra redirect rules for callers whose policy is stricter than fetch's
+/// same-origin header stripping — the package manager's `install.allowedHosts`
+/// and path-scoped registry credentials. Evaluated on the HTTP thread for each
+/// hop, against the resolved `Location` URL, before anything is sent to it.
+#[derive(Clone, Copy)]
+pub struct RedirectPolicy {
+    /// `false` refuses to follow the redirect; the request fails with
+    /// [`Error::RedirectHostNotAllowed`](crate::Error::RedirectHostNotAllowed).
+    pub target_allowed: fn(url: &[u8]) -> bool,
+    /// The request's `Authorization` header survives a hop only while this
+    /// returns `true` for `(target url, authorization_scope)`; otherwise it is
+    /// dropped even on a same-origin redirect.
+    pub keep_authorization: fn(url: &[u8], scope: &[u8]) -> bool,
+    /// The URL prefix the `Authorization` header was issued for.
+    pub authorization_scope: &'static [u8],
 }
 
 bun_core::comptime_string_map! {
@@ -5212,6 +5232,29 @@ impl<'a> HTTPClient<'a> {
                                 .get_ascii_case_insensitive(name)
                                 .is_some()
                             {
+                                let _ = self.header_entries.ordered_remove(i);
+                            } else {
+                                i += 1;
+                            }
+                        }
+                    }
+                }
+
+                // Caller policy (package manager): refuse hosts outside its
+                // allow-list, and drop credentials that were scoped to a URL
+                // prefix the target is no longer under — before fetch's own
+                // cross-origin stripping below.
+                if let Some(policy) = self.redirect_policy {
+                    if !(policy.target_allowed)(self.url.href) {
+                        return Err(crate::Error::RedirectHostNotAllowed);
+                    }
+                    if self.header_entries.len() > 0
+                        && !(policy.keep_authorization)(self.url.href, policy.authorization_scope)
+                    {
+                        let mut i = 0;
+                        while i < self.header_entries.len() {
+                            let name = self.header_str(self.header_entries.items_name()[i]);
+                            if name.eq_ignore_ascii_case(b"authorization") {
                                 let _ = self.header_entries.ordered_remove(i);
                             } else {
                                 i += 1;

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -122,7 +122,7 @@ bun_core::comptime_string_map! {
 
 pub use draft::{
     ConfigIterator, Parser, RegistryAuth, ScopeItem, ScopeIterator, ToStringFormatter,
-    apply_registry_auth, load_npmrc, load_npmrc_config,
+    apply_registry_auth, collect_registry_auth, load_npmrc, load_npmrc_config,
 };
 
 mod draft {
@@ -1301,6 +1301,44 @@ mod draft {
             ));
         }
         configs
+    }
+
+    /// Group every `//host/path/:key=value` entry by its `//host/path/` into an
+    /// `NpmRegistry` record (`url` = `host/path`, no scheme) carrying the merged
+    /// credentials. These back npm-style path-scoped ("nerf dart") credential
+    /// lookup for request URLs that a configured registry's own credentials do
+    /// not cover.
+    pub fn collect_registry_auth(auth: &[RegistryAuth]) -> Option<Vec<NpmRegistry>> {
+        if auth.is_empty() {
+            return None;
+        }
+        let mut out: Vec<NpmRegistry> = Vec::new();
+        for item in auth {
+            if matches!(item.credential, RegistryCredential::Email(_)) {
+                continue;
+            }
+            let existing = out.iter_mut().find(|r| {
+                let url = URL::parse(&r.url);
+                bun_core::without_trailing_slash(url.host) == &*item.host
+                    && bun_core::without_trailing_slash(url.pathname) == &*item.pathname
+            });
+            let registry = match existing {
+                Some(r) => r,
+                None => {
+                    let mut url = Vec::with_capacity(item.host.len() + item.pathname.len() + 1);
+                    url.extend_from_slice(&item.host);
+                    url.extend_from_slice(&item.pathname);
+                    url.push(b'/');
+                    out.push(NpmRegistry {
+                        url: url.into_boxed_slice(),
+                        ..Default::default()
+                    });
+                    out.last_mut().expect("just pushed")
+                }
+            };
+            item.apply_to(registry);
+        }
+        Some(out)
     }
 
     pub fn apply_registry_auth(install: &mut BunInstall, auth: &[RegistryAuth]) {

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -368,6 +368,14 @@ impl NetworkTask {
     }
 }
 
+/// Did this response fail because a redirect hop was refused by
+/// `install.allowedHosts` (`RedirectPolicy`)? That is policy, not
+/// availability: never retried, and an error even for an optional edge.
+#[inline]
+pub(crate) fn refused_by_policy(response: &bun_http::HTTPClientResult<'_>) -> bool {
+    response.fail == Some(bun_http::Error::RedirectHostNotAllowed)
+}
+
 #[derive(Clone, Copy)]
 pub enum Authorization {
     NoAuthorization,
@@ -598,28 +606,19 @@ impl NetworkTask {
             self.url_buf = rewritten.into_boxed_slice();
         }
 
+        // Fails closed like `for_tarball`: an error even for an optional edge,
+        // so the (terminal) reservation the caller records always comes with
+        // a failing install rather than a warning a required edge could inherit.
         if !pm.options.is_host_allowed(&self.url_buf) {
-            if !is_optional {
-                log.add_error_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Refusing to fetch manifest {} for package {}: host is not in install.allowedHosts",
-                        quote(&self.url_buf),
-                        quote(name),
-                    ),
-                );
-            } else {
-                log.add_warning_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Refusing to fetch manifest {} for package {}: host is not in install.allowedHosts",
-                        quote(&self.url_buf),
-                        quote(name),
-                    ),
-                );
-            }
+            log.add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Refusing to fetch manifest {} for package {}: host is not in install.allowedHosts",
+                    quote(&self.url_buf),
+                    quote(name),
+                ),
+            );
             return Err(ForManifestError::InvalidURL);
         }
 

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -726,6 +726,11 @@ impl NetworkTask {
             },
         ));
         self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+        // Redirect hops are held to the same rules as this request:
+        // `install.allowedHosts`, and credentials only while under their scope.
+        self.http_mut().client.redirect_policy = Some(
+            crate::package_manager::Options::redirect_policy(credentials),
+        );
 
         if PackageManager::verbose_install() {
             self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
@@ -926,6 +931,19 @@ impl NetworkTask {
             }
             _ => None,
         };
+        // What a redirect hop must stay under to keep the `Authorization`
+        // header: the registry / `.npmrc` prefix the credentials were issued
+        // for, or — for credentials that came embedded in the tarball URL —
+        // that URL's origin.
+        let credentials_scope: &[u8] = if url_authorization.is_some() {
+            URL::parse(&self.url_buf).origin
+        } else {
+            credentials.scope
+        };
+        let redirect_policy = crate::package_manager::Options::redirect_policy(Credentials {
+            scope: credentials_scope,
+            ..credentials
+        });
 
         let header_buf: &'static [u8] = if header_builder.header_count > 0 {
             header_builder.allocate()?;
@@ -998,6 +1016,9 @@ impl NetworkTask {
             http_options,
         ));
         self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+        // Redirect hops are held to the same rules as this request:
+        // `install.allowedHosts`, and credentials only while under their scope.
+        self.http_mut().client.redirect_policy = Some(redirect_policy);
         if PackageManager::verbose_install() {
             self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
         }

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -815,7 +815,6 @@ impl NetworkTask {
         tarball_: ExtractTarball,
         scope: &npm::registry::Scope,
         authorization: Authorization,
-        is_required: bool,
     ) -> Result<(), ForTarballError> {
         let pm = self.pm_mut();
 
@@ -878,31 +877,20 @@ impl NetworkTask {
         // connect* is concerned; with `install.allowedHosts` set, refuse hosts
         // the project did not opt into before any request is made. (Checked
         // after the userinfo split so the message never echoes credentials.)
-        // An optional dependency is skipped with a warning, like one whose
-        // download failed; a required one fails the install.
+        // This fails the install even for an optional dependency: the allow-
+        // list is a policy, and quietly producing a different tree is not what
+        // it asks for (nor can the install phase, which sees one tree slot per
+        // package, tell an optional edge from a required one).
         if !pm.options.is_host_allowed(&self.url_buf) {
-            let log = pm.log_mut();
-            if is_required {
-                log.add_error_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Refusing to download {} for package {}: host is not in install.allowedHosts",
-                        quote(&self.url_buf),
-                        quote(tarball.name.slice()),
-                    ),
-                );
-            } else {
-                log.add_warning_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Skipping optional package {}: {} is not in install.allowedHosts",
-                        quote(tarball.name.slice()),
-                        quote(&self.url_buf),
-                    ),
-                );
-            }
+            pm.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Refusing to download {} for package {}: host is not in install.allowedHosts",
+                    quote(&self.url_buf),
+                    quote(tarball.name.slice()),
+                ),
+            );
             return Err(ForTarballError::InvalidURL);
         }
 

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -15,6 +15,7 @@ use bun_url::URL;
 
 use crate::extract_tarball;
 use crate::npm::{self as npm, PackageManifest};
+use crate::package_manager::Options::Credentials;
 use crate::{ExtractTarball, PackageManager, PatchTask, TarballStream, Task};
 
 // Adapter so `StringOrTinyString::init_append_if_needed` can intern overflow
@@ -386,27 +387,27 @@ const DEFAULT_HEADERS_BUF: &str = concat!(
 );
 const EXTENDED_HEADERS_BUF: &str = concat!("Accept", "application/json, */*");
 
-fn append_auth(header_builder: &mut HeaderBuilder, scope: &npm::registry::Scope) {
+fn append_auth(header_builder: &mut HeaderBuilder, credentials: Credentials<'_>) {
     // Routing through `format_args!`/`BStr` Display would be
     // lossy for non-UTF-8 tokens (U+FFFD expands 1→3 bytes) and overrun the
     // exact byte count reserved by `count_auth`. Use raw-byte append.
-    if !scope.token.is_empty() {
-        header_builder.append_bytes_value("Authorization", b"Bearer ", &scope.token);
-    } else if !scope.auth.is_empty() {
-        header_builder.append_bytes_value("Authorization", b"Basic ", &scope.auth);
+    if !credentials.token.is_empty() {
+        header_builder.append_bytes_value("Authorization", b"Bearer ", credentials.token);
+    } else if !credentials.auth.is_empty() {
+        header_builder.append_bytes_value("Authorization", b"Basic ", credentials.auth);
     } else {
         return;
     }
     header_builder.append("npm-auth-type", "legacy");
 }
 
-fn count_auth(header_builder: &mut HeaderBuilder, scope: &npm::registry::Scope) {
-    if !scope.token.is_empty() {
+fn count_auth(header_builder: &mut HeaderBuilder, credentials: Credentials<'_>) {
+    if !credentials.token.is_empty() {
         header_builder.count("Authorization", "");
-        header_builder.content.cap += "Bearer ".len() + scope.token.len();
-    } else if !scope.auth.is_empty() {
+        header_builder.content.cap += "Bearer ".len() + credentials.token.len();
+    } else if !credentials.auth.is_empty() {
         header_builder.count("Authorization", "");
-        header_builder.content.cap += "Basic ".len() + scope.auth.len();
+        header_builder.content.cap += "Basic ".len() + credentials.auth.len();
     } else {
         return;
     }
@@ -590,6 +591,42 @@ impl NetworkTask {
             break 'blk url_bytes;
         };
 
+        // `install.rewrite` (mirror) rules apply to the request only; the auth
+        // and allow-list decisions below are made against the URL we actually
+        // connect to.
+        if let std::borrow::Cow::Owned(rewritten) = pm.options.rewrite_url(&self.url_buf) {
+            self.url_buf = rewritten.into_boxed_slice();
+        }
+
+        if !pm.options.is_host_allowed(&self.url_buf) {
+            if !is_optional {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Refusing to fetch manifest {} for package {}: host is not in install.allowedHosts",
+                        quote(&self.url_buf),
+                        quote(name),
+                    ),
+                );
+            } else {
+                log.add_warning_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Refusing to fetch manifest {} for package {}: host is not in install.allowedHosts",
+                        quote(&self.url_buf),
+                        quote(name),
+                    ),
+                );
+            }
+            return Err(ForManifestError::InvalidURL);
+        }
+
+        // Registry credentials are scoped to the registry URL's origin *and
+        // path*: see `Options::credentials_for`.
+        let credentials = pm.options.credentials_for(scope, &self.url_buf);
+
         let mut last_modified: &[u8] = b"";
         let mut etag: &[u8] = b"";
         if let Some(manifest) = loaded_manifest {
@@ -601,7 +638,7 @@ impl NetworkTask {
 
         let mut header_builder = HeaderBuilder::default();
 
-        count_auth(&mut header_builder, scope);
+        count_auth(&mut header_builder, credentials);
 
         if !etag.is_empty() {
             header_builder.count("If-None-Match", etag);
@@ -622,7 +659,7 @@ impl NetworkTask {
             }
             header_builder.allocate()?;
 
-            append_auth(&mut header_builder, scope);
+            append_auth(&mut header_builder, credentials);
 
             if !etag.is_empty() {
                 header_builder.append("If-None-Match", etag);
@@ -818,6 +855,13 @@ impl NetworkTask {
             return Err(ForTarballError::InvalidURL);
         }
 
+        // `install.rewrite` (mirror) rules: the lockfile/manifest keep the
+        // canonical URL, the request goes to the rewritten one, and the
+        // allow-list and credential checks below judge the rewritten URL.
+        if let std::borrow::Cow::Owned(rewritten) = pm.options.rewrite_url(&self.url_buf) {
+            self.url_buf = rewritten.into_boxed_slice();
+        }
+
         // Userinfo becomes a header and leaves the URL: `bun_url` keeps it in `origin`, which the redirect same-origin check compares.
         let url_authorization: Option<Vec<u8>> = match split_url_userinfo(&self.url_buf) {
             Some((userinfo, url_without_userinfo)) => {
@@ -829,36 +873,46 @@ impl NetworkTask {
             None => None,
         };
 
+        // `dist.tarball` is registry-controlled input as far as *where we
+        // connect* is concerned; with `install.allowedHosts` set, refuse hosts
+        // the project did not opt into before any request is made. (Checked
+        // after the userinfo split so the message never echoes credentials.)
+        if !pm.options.is_host_allowed(&self.url_buf) {
+            pm.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Refusing to download {} for package {}: host is not in install.allowedHosts",
+                    quote(&self.url_buf),
+                    quote(tarball.name.slice()),
+                ),
+            );
+            return Err(ForTarballError::InvalidURL);
+        }
+
         // Only attach the registry `Authorization` header when the tarball URL
-        // origin matches the configured registry scope origin. The npm manifest
-        // is registry-controlled, so a malicious registry could otherwise point
-        // the tarball at an attacker-controlled host and receive the scope
-        // credentials. The empty-`tarball_url` branch builds the URL from
-        // `scope.url.href()`, so its origin matches and authorized downloads
-        // keep working.
-        // Compare (protocol, hostname, effective port) rather than the raw
-        // `URL.origin` slice — `origin` is a borrowed prefix of the input
-        // string and is not normalized for default ports, so a tarball URL of
-        // `https://host:443/...` would not byte-match a `.npmrc` registry of
-        // `https://host/...` even though they are the same origin. Some
-        // registries emit `dist.tarball` URLs with the default port spelled
-        // out; without normalization those installs lose the `Authorization`
-        // header and fail with 401.
-        let send_auth = matches!(authorization, Authorization::AllowAuthorization) && {
-            let tarball = URL::parse(&self.url_buf);
-            let registry = scope.url.url();
-            tarball.protocol == registry.protocol
-                && tarball.hostname == registry.hostname
-                && tarball.get_port_auto() == registry.get_port_auto()
+        // is under the configured registry scope URL: same origin *and* path
+        // prefix (`Options::credentials_for`). The npm manifest is
+        // registry-controlled, so a malicious registry — or another tenant on
+        // a path-based multi-tenant registry host — could otherwise point the
+        // tarball somewhere that receives the scope credentials. The
+        // empty-`tarball_url` branch builds the URL from `scope.url.href()`, so
+        // it is always under the registry and authorized downloads keep
+        // working. Origins are compared as (protocol, hostname, effective
+        // port), so a `dist.tarball` that spells out the default port
+        // (`https://host:443/...`) still matches a registry of `https://host/`.
+        // A URL outside the registry can still be covered by an `.npmrc`
+        // `//host/path/:_authToken` entry written for it.
+        let credentials = match authorization {
+            Authorization::AllowAuthorization => pm.options.credentials_for(scope, &self.url_buf),
+            Authorization::NoAuthorization => Credentials::NONE,
         };
 
         self.response_buffer = MutableString::init_empty();
 
         let mut header_builder = HeaderBuilder::default();
 
-        if send_auth {
-            count_auth(&mut header_builder, scope);
-        }
+        count_auth(&mut header_builder, credentials);
 
         // Registry credentials win over URL userinfo, as in npm.
         let url_authorization = match url_authorization {
@@ -873,7 +927,7 @@ impl NetworkTask {
             header_builder.allocate()?;
             match &url_authorization {
                 Some(value) => header_builder.append("Authorization", value),
-                None => append_auth(&mut header_builder, scope),
+                None => append_auth(&mut header_builder, credentials),
             }
             debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
             self.header_buf = header_builder.content.move_to_slice();

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -815,6 +815,7 @@ impl NetworkTask {
         tarball_: ExtractTarball,
         scope: &npm::registry::Scope,
         authorization: Authorization,
+        is_required: bool,
     ) -> Result<(), ForTarballError> {
         let pm = self.pm_mut();
 
@@ -877,16 +878,31 @@ impl NetworkTask {
         // connect* is concerned; with `install.allowedHosts` set, refuse hosts
         // the project did not opt into before any request is made. (Checked
         // after the userinfo split so the message never echoes credentials.)
+        // An optional dependency is skipped with a warning, like one whose
+        // download failed; a required one fails the install.
         if !pm.options.is_host_allowed(&self.url_buf) {
-            pm.log_mut().add_error_fmt(
-                None,
-                bun_ast::Loc::EMPTY,
-                format_args!(
-                    "Refusing to download {} for package {}: host is not in install.allowedHosts",
-                    quote(&self.url_buf),
-                    quote(tarball.name.slice()),
-                ),
-            );
+            let log = pm.log_mut();
+            if is_required {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Refusing to download {} for package {}: host is not in install.allowedHosts",
+                        quote(&self.url_buf),
+                        quote(tarball.name.slice()),
+                    ),
+                );
+            } else {
+                log.add_warning_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Skipping optional package {}: {} is not in install.allowedHosts",
+                        quote(tarball.name.slice()),
+                        quote(&self.url_buf),
+                    ),
+                );
+            }
             return Err(ForTarballError::InvalidURL);
         }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1407,6 +1407,9 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        allowed_hosts,
+        url_rewrites,
+        npmrc_credentials,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1462,6 +1465,9 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        allowed_hosts,
+        url_rewrites,
+        npmrc_credentials,
     );
 }
 
@@ -1957,6 +1963,7 @@ pub fn init(
 
         ini::apply_registry_auth(&mut bunfig_install, &registry_auth);
         overlay_bunfig_install(&mut install, bunfig_install);
+        install.npmrc_credentials = ini::collect_registry_auth(&registry_auth);
         ctx.install = Some(Box::new(install));
     }
     let cpu_count: u32 = u32::from(bun_core::get_thread_count());

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -912,7 +912,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     let resolve_result = match resolve_result_ {
                         Ok(v) => v,
                         Err(err) => {
-                            if err == crate::Error::DistTagNotFound {
+                            if err == crate::Error::InvalidURL {
+                                // The package resolved but its tarball request
+                                // was refused (`NetworkTask::for_tarball` has
+                                // already logged why: unsupported scheme, or a
+                                // host outside `install.allowedHosts`). The
+                                // logged error fails the install; don't turn it
+                                // into an "internal error" on top.
+                                if let Some(fail) = fail_fn {
+                                    fail(this, dependency, id, err);
+                                }
+                                return Ok(());
+                            } else if err == crate::Error::DistTagNotFound {
                                 if dependency.behavior.is_required() {
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1320,14 +1320,22 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 
                                 let scope = this.scope_for_package_name(&name_str);
                                 // SAFETY: network_task points to a valid initialized NetworkTask slot
-                                unsafe {
+                                let prepared = unsafe {
                                     (*network_task).for_manifest(
                                         &name_str,
                                         scope,
                                         loaded_manifest.as_ref(),
                                         dependency.behavior.is_optional(),
                                         needs_extended_manifest,
-                                    )?;
+                                    )
+                                };
+                                if let Err(err) = prepared {
+                                    // Nothing was scheduled on the slot; return it.
+                                    // SAFETY: `write_init` made every field
+                                    // drop-safe and `for_manifest` fails before
+                                    // initializing `unsafe_http_client`.
+                                    unsafe { this.preallocated_network_tasks.put(network_task) };
+                                    return Err(err.into());
                                 }
                                 enqueue_network_task(this, network_task);
                             }
@@ -1563,8 +1571,13 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 None,
                 crate::network_task::Authorization::NoAuthorization,
             ) {
-                // --offline miss: already reported (if required) / skipped (if optional)
-                Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
+                // --offline miss, or a URL refused by `for_tarball` (scheme /
+                // `install.allowedHosts`): already reported (if required) /
+                // skipped (if optional)
+                Err(
+                    crate::network_task::ForTarballError::Offline
+                    | crate::network_task::ForTarballError::InvalidURL,
+                ) => return Ok(()),
                 other => other?,
             };
             if let Some(network_task) = generated {
@@ -1799,8 +1812,13 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             None,
                             crate::network_task::Authorization::NoAuthorization,
                         ) {
-                            // --offline miss: already reported / skipped
-                            Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
+                            // --offline miss, or a URL refused by `for_tarball`
+                            // (scheme / `install.allowedHosts`): already
+                            // reported / skipped
+                            Err(
+                                crate::network_task::ForTarballError::Offline
+                                | crate::network_task::ForTarballError::InvalidURL,
+                            ) => return Ok(()),
                             other => other?.map(std::ptr::from_mut::<NetworkTask>),
                         };
                     if let Some(network_task) = network_task {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -916,11 +916,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 // The package resolved but its tarball request
                                 // was refused (`NetworkTask::for_tarball` has
                                 // already logged why: unsupported scheme, or a
-                                // host outside `install.allowedHosts`). The
-                                // logged error fails the install; don't turn it
-                                // into an "internal error" on top.
-                                if let Some(fail) = fail_fn {
-                                    fail(this, dependency, id, err);
+                                // host outside `install.allowedHosts` — an
+                                // error for a required dependency, a warning
+                                // for an optional one). Don't turn it into an
+                                // "internal error" on top.
+                                if dependency.behavior.is_required() {
+                                    if let Some(fail) = fail_fn {
+                                        fail(this, dependency, id, err);
+                                    }
                                 }
                                 return Ok(());
                             } else if err == crate::Error::DistTagNotFound {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -915,15 +915,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             if err == crate::Error::InvalidURL {
                                 // The package resolved but its tarball request
                                 // was refused (`NetworkTask::for_tarball` has
-                                // already logged why: unsupported scheme, or a
-                                // host outside `install.allowedHosts` — an
-                                // error for a required dependency, a warning
-                                // for an optional one). Don't turn it into an
-                                // "internal error" on top.
-                                if dependency.behavior.is_required() {
-                                    if let Some(fail) = fail_fn {
-                                        fail(this, dependency, id, err);
-                                    }
+                                // already logged the error: unsupported scheme,
+                                // or a host outside `install.allowedHosts`).
+                                // That error fails the install; don't turn it
+                                // into an "internal error" on top.
+                                if let Some(fail) = fail_fn {
+                                    fail(this, dependency, id, err);
                                 }
                                 return Ok(());
                             } else if err == crate::Error::DistTagNotFound {
@@ -1330,11 +1327,16 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     )
                                 };
                                 if let Err(err) = prepared {
-                                    // Nothing was scheduled on the slot; return it.
+                                    // Nothing was scheduled on the slot; return it,
+                                    // and record the (already reported, deterministic)
+                                    // refusal on the reservation made above so later
+                                    // edges neither re-report it nor wait on a request
+                                    // that was never sent.
                                     // SAFETY: `write_init` made every field
                                     // drop-safe and `for_manifest` fails before
                                     // initializing `unsafe_http_client`.
                                     unsafe { this.preallocated_network_tasks.put(network_task) };
+                                    this.mark_network_task_failed(task_id);
                                     return Err(err.into());
                                 }
                                 enqueue_network_task(this, network_task);
@@ -1571,9 +1573,9 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 None,
                 crate::network_task::Authorization::NoAuthorization,
             ) {
-                // --offline miss, or a URL refused by `for_tarball` (scheme /
-                // `install.allowedHosts`): already reported (if required) /
-                // skipped (if optional)
+                // --offline miss (reported if required / skipped if optional),
+                // or a URL refused by `for_tarball` (scheme /
+                // `install.allowedHosts`; always reported as an error)
                 Err(
                     crate::network_task::ForTarballError::Offline
                     | crate::network_task::ForTarballError::InvalidURL,
@@ -1812,9 +1814,9 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             None,
                             crate::network_task::Authorization::NoAuthorization,
                         ) {
-                            // --offline miss, or a URL refused by `for_tarball`
-                            // (scheme / `install.allowedHosts`): already
-                            // reported / skipped
+                            // --offline miss (reported / skipped), or a URL
+                            // refused by `for_tarball` (scheme /
+                            // `install.allowedHosts`; already reported)
                             Err(
                                 crate::network_task::ForTarballError::Offline
                                 | crate::network_task::ForTarballError::InvalidURL,

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -317,12 +317,14 @@ impl Options {
             return Credentials {
                 token: &scope.token,
                 auth: &scope.auth,
+                scope: scope.url.href(),
             };
         }
         if let Some(found) = self.npmrc_credential_for(url) {
             return Credentials {
                 token: found.token,
                 auth: found.auth,
+                scope: found.scope,
             };
         }
         Credentials::NONE
@@ -400,6 +402,25 @@ impl Options {
     }
 }
 
+/// The redirect rules every package-manager request carries: a hop may not
+/// leave `install.allowedHosts`, and the `Authorization` header issued for
+/// `credentials.scope` is dropped as soon as a hop is no longer under it.
+pub fn redirect_policy(credentials: Credentials<'_>) -> bun_http::RedirectPolicy {
+    fn target_allowed(url: &[u8]) -> bool {
+        // Read-only after init; the HTTP thread may call this.
+        crate::PackageManager::get().options.is_host_allowed(url)
+    }
+    bun_http::RedirectPolicy {
+        target_allowed,
+        keep_authorization: url_under,
+        // SAFETY: lifetime extension only — every `Credentials::scope` is a
+        // leaked `'static` config string, a registry scope URL owned by the
+        // process-lifetime `Options`, or a slice of the requesting
+        // `NetworkTask`'s `url_buf`, which outlives its request.
+        authorization_scope: unsafe { bun_ptr::detach_lifetime(credentials.scope) },
+    }
+}
+
 /// One `install.allowedHosts` entry: a hostname, optionally pinned to a port.
 #[derive(Clone, Copy, Debug)]
 pub struct AllowedHost {
@@ -432,13 +453,22 @@ impl AllowedHost {
 pub struct Credentials<'a> {
     pub token: &'a [u8],
     pub auth: &'a [u8],
+    /// The URL prefix these credentials were issued for; a redirect hop keeps
+    /// them only while its target is still under it (`url_under`).
+    pub scope: &'a [u8],
 }
 
 impl Credentials<'_> {
     pub const NONE: Credentials<'static> = Credentials {
         token: b"",
         auth: b"",
+        scope: b"",
     };
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.token.is_empty() && self.auth.is_empty()
+    }
 }
 
 /// One `.npmrc` `//host[:port]/path/:<credential>` group, resolved to the
@@ -449,6 +479,9 @@ pub struct PathCredential {
     /// Only set when the `.npmrc` key spelled out a port.
     pub port: Option<u16>,
     pub pathname: &'static [u8],
+    /// `https://host[:port]/path/` — what a redirect target must stay under to
+    /// keep these credentials (see `Credentials::scope`).
+    pub scope: &'static [u8],
     pub token: &'static [u8],
     pub auth: &'static [u8],
 }
@@ -860,10 +893,14 @@ impl Options {
                     let Some(host) = AllowedHost::parse(&url[..slash]) else {
                         continue;
                     };
+                    let mut scope_url = Vec::with_capacity(b"https://".len() + url.len());
+                    scope_url.extend_from_slice(b"https://");
+                    scope_url.extend_from_slice(url);
                     creds.push(PathCredential {
                         hostname: host.hostname,
                         port: host.port,
                         pathname: &url[slash..],
+                        scope: bun_core::heap::release(scope_url.into_boxed_slice()),
                         token: leak_static(&scope.token),
                         auth: leak_static(&scope.auth),
                     });

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -319,16 +319,37 @@ impl Options {
                 auth: &scope.auth,
             };
         }
-        if !self.npmrc_credentials.is_empty() {
-            let parsed = bun_url::URL::parse(url);
-            if let Some(found) = self.npmrc_credentials.iter().find(|c| c.covers(&parsed)) {
-                return Credentials {
-                    token: found.token,
-                    auth: found.auth,
-                };
-            }
+        if let Some(found) = self.npmrc_credential_for(url) {
+            return Credentials {
+                token: found.token,
+                auth: found.auth,
+            };
         }
         Credentials::NONE
+    }
+
+    /// The `.npmrc` `//host/path/` credential covering `url`, if any. Such keys
+    /// carry no scheme, so to keep a manifest from downgrading a request to
+    /// plaintext and still collecting the token, they cover `https://` URLs,
+    /// and `http://` URLs only on an origin the configuration itself declares
+    /// as a plain-http registry (default or scoped).
+    fn npmrc_credential_for(&self, url: &[u8]) -> Option<&PathCredential> {
+        if self.npmrc_credentials.is_empty() {
+            return None;
+        }
+        let url = bun_url::URL::parse(url);
+        let scheme_ok = url.is_https()
+            || (url.is_http()
+                && self.registry_scopes().any(|scope| {
+                    let registry = scope.url.url();
+                    registry.is_http()
+                        && registry.hostname.eq_ignore_ascii_case(url.hostname)
+                        && registry.get_port_auto() == url.get_port_auto()
+                }));
+        if !scheme_ok {
+            return None;
+        }
+        self.npmrc_credentials.iter().find(|c| c.covers(&url))
     }
 
     /// `install.allowedHosts`: may bun connect to the host of `url` at all?
@@ -437,6 +458,7 @@ impl PathCredential {
     /// entry written without a port only covers URLs on their scheme's default
     /// port (npm derives the key from the parsed URL, which drops default
     /// ports); the path must be a segment-wise prefix with no dot-segments.
+    /// The scheme policy lives in `Options::npmrc_credential_for`.
     pub fn covers(&self, url: &bun_url::URL<'_>) -> bool {
         if url.hostname.is_empty() || !self.hostname.eq_ignore_ascii_case(url.hostname) {
             return false;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -541,19 +541,61 @@ pub fn url_under(url: &[u8], base: &[u8]) -> bool {
 }
 
 /// The path half of [`url_under`]: `path` starts with `base` segment-wise and
-/// carries no `.` / `..` (plain or percent-encoded) segment or backslash.
+/// carries nothing a server could resolve somewhere else: no `.` / `..`
+/// segment (plain or `%2e`-encoded), no backslash (plain or `%5c`, which
+/// http(s) URL parsers and some servers treat as a separator), and no
+/// `%2f`-encoded slash that would split a segment into pieces containing a
+/// dot segment (`..%2f..%2fother`). A plain `%2f` inside a name — the
+/// `@scope%2fpkg` form manifests are requested with — is fine.
 pub fn path_under(path: &[u8], base: &[u8]) -> bool {
-    if strings::contains_char(path, b'\\') {
+    if strings::contains_char(path, b'\\') || contains_percent_encoded(path, b'5', b'c') {
         return false;
     }
     let mut segments = strings::tokenize(path, b"/");
     for expected in strings::tokenize(base, b"/") {
         match segments.next() {
-            Some(segment) if segment == expected && !is_dot_segment(segment) => {}
+            Some(segment) if segment == expected && !is_unsafe_segment(segment) => {}
             _ => return false,
         }
     }
-    segments.all(|segment| !is_dot_segment(segment))
+    segments.all(|segment| !is_unsafe_segment(segment))
+}
+
+/// `%XY` (hex digit `y` matched case-insensitively) anywhere in `bytes`.
+fn contains_percent_encoded(bytes: &[u8], x: u8, y_lower: u8) -> bool {
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        if bytes[i] == b'%' && bytes[i + 1] == x && bytes[i + 2].eq_ignore_ascii_case(&y_lower) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// A dot segment, or a segment that an encoded `/` (`%2f`) splits into pieces
+/// one of which is a dot segment.
+fn is_unsafe_segment(segment: &[u8]) -> bool {
+    if !contains_percent_encoded(segment, b'2', b'f') {
+        return is_dot_segment(segment);
+    }
+    let mut start = 0;
+    let mut i = 0;
+    while i + 2 < segment.len() {
+        if segment[i] == b'%'
+            && segment[i + 1] == b'2'
+            && segment[i + 2].eq_ignore_ascii_case(&b'f')
+        {
+            if is_dot_segment(&segment[start..i]) {
+                return true;
+            }
+            i += 3;
+            start = i;
+        } else {
+            i += 1;
+        }
+    }
+    is_dot_segment(&segment[start..])
 }
 
 /// WHATWG "single-dot" / "double-dot" path segments, including the

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -320,11 +320,15 @@ impl Options {
                 scope: scope.url.href(),
             };
         }
-        if let Some(found) = self.npmrc_credential_for(url) {
+        if let Some((found, is_http)) = self.npmrc_credential_for(url) {
             return Credentials {
                 token: found.token,
                 auth: found.auth,
-                scope: found.scope,
+                scope: if is_http {
+                    found.scope_http
+                } else {
+                    found.scope_https
+                },
             };
         }
         Credentials::NONE
@@ -335,7 +339,7 @@ impl Options {
     /// plaintext and still collecting the token, they cover `https://` URLs,
     /// and `http://` URLs only on an origin the configuration itself declares
     /// as a plain-http registry (default or scoped).
-    fn npmrc_credential_for(&self, url: &[u8]) -> Option<&PathCredential> {
+    fn npmrc_credential_for(&self, url: &[u8]) -> Option<(&PathCredential, bool)> {
         if self.npmrc_credentials.is_empty() {
             return None;
         }
@@ -351,7 +355,10 @@ impl Options {
         if !scheme_ok {
             return None;
         }
-        self.npmrc_credentials.iter().find(|c| c.covers(&url))
+        self.npmrc_credentials
+            .iter()
+            .find(|c| c.covers(&url))
+            .map(|c| (c, url.is_http()))
     }
 
     /// `install.allowedHosts`: may bun connect to the host of `url` at all?
@@ -479,9 +486,11 @@ pub struct PathCredential {
     /// Only set when the `.npmrc` key spelled out a port.
     pub port: Option<u16>,
     pub pathname: &'static [u8],
-    /// `https://host[:port]/path/` — what a redirect target must stay under to
-    /// keep these credentials (see `Credentials::scope`).
-    pub scope: &'static [u8],
+    /// `https://host[:port]/path/` and `http://host[:port]/path/` — what a
+    /// redirect target must stay under to keep these credentials (see
+    /// `Credentials::scope`); the one matching the request's scheme is used.
+    pub scope_https: &'static [u8],
+    pub scope_http: &'static [u8],
     pub token: &'static [u8],
     pub auth: &'static [u8],
 }
@@ -893,14 +902,18 @@ impl Options {
                     let Some(host) = AllowedHost::parse(&url[..slash]) else {
                         continue;
                     };
-                    let mut scope_url = Vec::with_capacity(b"https://".len() + url.len());
-                    scope_url.extend_from_slice(b"https://");
-                    scope_url.extend_from_slice(url);
+                    let with_scheme = |scheme: &[u8]| -> &'static [u8] {
+                        let mut v = Vec::with_capacity(scheme.len() + url.len());
+                        v.extend_from_slice(scheme);
+                        v.extend_from_slice(url);
+                        bun_core::heap::release(v.into_boxed_slice())
+                    };
                     creds.push(PathCredential {
                         hostname: host.hostname,
                         port: host.port,
                         pathname: &url[slash..],
-                        scope: bun_core::heap::release(scope_url.into_boxed_slice()),
+                        scope_https: with_scheme(b"https://"),
+                        scope_http: with_scheme(b"http://"),
                         token: leak_static(&scope.token),
                         auth: leak_static(&scope.auth),
                     });

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -343,7 +343,8 @@ impl Options {
         if self.npmrc_credentials.is_empty() {
             return None;
         }
-        let url = bun_url::URL::parse(url);
+        let url = without_userinfo(url);
+        let url = bun_url::URL::parse(&url);
         let scheme_ok = url.is_https()
             || (url.is_http()
                 && self.registry_scopes().any(|scope| {
@@ -367,7 +368,8 @@ impl Options {
         let Some(allowed) = self.allowed_hosts else {
             return true;
         };
-        let url = bun_url::URL::parse(url);
+        let url = without_userinfo(url);
+        let url = bun_url::URL::parse(&url);
         if url.hostname.is_empty() {
             return false;
         }
@@ -515,6 +517,27 @@ impl PathCredential {
     }
 }
 
+/// `scheme://user[:pass]@host/…` → `scheme://host/…`. `bun_url::URL::parse`
+/// guesses whether `a@b:c` is `user@host:port` or `user:pass@host` and, for a
+/// password-less userinfo with an explicit port, folds the userinfo into the
+/// hostname; every host / prefix comparison here therefore looks at the URL
+/// with the userinfo removed (it never takes part in those decisions anyway).
+pub fn without_userinfo(url: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+    let Some(scheme_end) = strings::index_of(url, b"://") else {
+        return std::borrow::Cow::Borrowed(url);
+    };
+    let authority_start = scheme_end + b"://".len();
+    let rest = &url[authority_start..];
+    let authority = &rest[..strings::index_of_any(rest, b"/?#").unwrap_or(rest.len())];
+    let Some(at) = strings::last_index_of_char(authority, b'@') else {
+        return std::borrow::Cow::Borrowed(url);
+    };
+    let mut out = Vec::with_capacity(url.len() - (at + 1));
+    out.extend_from_slice(&url[..authority_start]);
+    out.extend_from_slice(&rest[at + 1..]);
+    std::borrow::Cow::Owned(out)
+}
+
 /// Is `url` at or under `base`? Same scheme, host (case-insensitive) and
 /// effective port, and `url`'s path starts with `base`'s path compared
 /// segment by segment (so `/npm/team-ab/x` is not under `/npm/team-a/`, and a
@@ -527,8 +550,10 @@ impl PathCredential {
 /// let `https://registry.example.com.evil.test/` pass for
 /// `https://registry.example.com` and `/npm/a/../b/` escape `/npm/a/`.
 pub fn url_under(url: &[u8], base: &[u8]) -> bool {
-    let url = bun_url::URL::parse(url);
-    let base = bun_url::URL::parse(base);
+    let url = without_userinfo(url);
+    let base = without_userinfo(base);
+    let url = bun_url::URL::parse(&url);
+    let base = bun_url::URL::parse(&base);
     if base.hostname.is_empty()
         || url.hostname.is_empty()
         || !url.protocol.eq_ignore_ascii_case(base.protocol)

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,6 +1,6 @@
 use crate::bun_schema::api as Api;
 use bun_core::ZStr;
-use bun_core::{Output, env_var};
+use bun_core::{Output, env_var, strings};
 use bun_paths::PathBuffer;
 
 use super::Subcommand;
@@ -113,6 +113,18 @@ pub struct Options {
     pub os: Npm::OperatingSystem,
 
     pub(crate) config_version: Option<ConfigVersion>,
+
+    /// `install.allowedHosts`: when `Some`, network requests (manifests,
+    /// tarballs, git) are refused unless the host is one of these or the host
+    /// of a configured registry. `None` (the default) allows any host.
+    pub allowed_hosts: Option<&'static [AllowedHost]>,
+    /// `install.rewrite`: `(from, to)` URL prefix rewrites applied at fetch time,
+    /// sorted longest `from` first so the most specific rule wins.
+    pub url_rewrites: &'static [(&'static [u8], &'static [u8])],
+    /// `.npmrc` `//host/path/:_authToken`-style credentials, longest path first.
+    /// Consulted for request URLs that the package's registry credentials do
+    /// not cover (see `credentials_for`).
+    pub npmrc_credentials: &'static [PathCredential],
 }
 
 impl Default for Options {
@@ -180,6 +192,9 @@ impl Default for Options {
             cpu: Npm::Architecture::CURRENT,
             os: Npm::OperatingSystem::CURRENT,
             config_version: None,
+            allowed_hosts: None,
+            url_rewrites: &[],
+            npmrc_credentials: &[],
         }
     }
 }
@@ -276,6 +291,214 @@ impl Options {
             _ => &self.scope,
         }
     }
+
+    /// Every configured registry: the default one plus each `@scope` registry.
+    pub fn registry_scopes(&self) -> impl Iterator<Item = &Npm::registry::Scope> + '_ {
+        core::iter::once(&self.scope).chain(self.registries.values())
+    }
+
+    /// Which credentials, if any, should accompany a registry request to `url`
+    /// made on behalf of a package whose registry is `scope`?
+    ///
+    /// Credentials are path-scoped: `scope`'s token / `_auth` /
+    /// username+password are used only when `url` is under the registry URL
+    /// they were configured for — same origin *and* path prefix
+    /// ([`url_under`]) — so a token for `https://host/npm/team-a/` is never
+    /// sent to `https://host/npm/team-b/`, nor to wherever else a manifest's
+    /// `dist.tarball` points. Failing that, an `.npmrc` `//host/path/:_authToken`
+    /// (or `_auth` / `username`+`_password`) entry whose `//host/path/` covers
+    /// `url` is used, longest path first, the way npm scopes such entries.
+    pub fn credentials_for<'a>(
+        &'a self,
+        scope: &'a Npm::registry::Scope,
+        url: &[u8],
+    ) -> Credentials<'a> {
+        if url_under(url, scope.url.href()) && (!scope.token.is_empty() || !scope.auth.is_empty()) {
+            return Credentials {
+                token: &scope.token,
+                auth: &scope.auth,
+            };
+        }
+        if !self.npmrc_credentials.is_empty() {
+            let parsed = bun_url::URL::parse(url);
+            if let Some(found) = self.npmrc_credentials.iter().find(|c| c.covers(&parsed)) {
+                return Credentials {
+                    token: found.token,
+                    auth: found.auth,
+                };
+            }
+        }
+        Credentials::NONE
+    }
+
+    /// `install.allowedHosts`: may bun connect to the host of `url` at all?
+    /// Always `true` when no allow-list is configured.
+    pub fn is_host_allowed(&self, url: &[u8]) -> bool {
+        let Some(allowed) = self.allowed_hosts else {
+            return true;
+        };
+        let url = bun_url::URL::parse(url);
+        if url.hostname.is_empty() {
+            return false;
+        }
+        // `get_port_auto` only knows http/https; give git's other transports
+        // their real defaults so `host:22`-style entries match ssh remotes.
+        let port = url.get_port().unwrap_or_else(|| {
+            let scheme = strings::trim_prefix(url.protocol, b"git+");
+            if scheme.eq_ignore_ascii_case(b"ssh") {
+                22
+            } else if scheme.eq_ignore_ascii_case(b"git") {
+                9418
+            } else {
+                url.get_port_auto()
+            }
+        });
+        allowed
+            .iter()
+            .any(|entry| entry.matches(url.hostname, port))
+            || self.registry_scopes().any(|scope| {
+                let registry = scope.url.url();
+                !registry.hostname.is_empty()
+                    && registry.hostname.eq_ignore_ascii_case(url.hostname)
+                    && registry.get_port_auto() == port
+            })
+    }
+
+    /// Apply `install.rewrite` prefix rules to a request URL (longest matching
+    /// `from` wins). Fetch-time only: the lockfile keeps the canonical URL.
+    pub fn rewrite_url<'a>(&self, url: &'a [u8]) -> std::borrow::Cow<'a, [u8]> {
+        for (from, to) in self.url_rewrites {
+            if url.starts_with(from) {
+                let mut out = Vec::with_capacity(to.len() + url.len() - from.len());
+                out.extend_from_slice(to);
+                out.extend_from_slice(&url[from.len()..]);
+                return std::borrow::Cow::Owned(out);
+            }
+        }
+        std::borrow::Cow::Borrowed(url)
+    }
+}
+
+/// One `install.allowedHosts` entry: a hostname, optionally pinned to a port.
+#[derive(Clone, Copy, Debug)]
+pub struct AllowedHost {
+    pub hostname: &'static [u8],
+    pub port: Option<u16>,
+}
+
+impl AllowedHost {
+    pub fn parse(entry: &'static [u8]) -> Option<AllowedHost> {
+        let (hostname, port) = bun_bunfig::bunfig::split_host_port(entry);
+        if hostname.is_empty() {
+            return None;
+        }
+        let port = match port {
+            None => None,
+            Some(p) => Some(bun_core::fmt::parse_int::<u16>(p, 10).ok()?),
+        };
+        Some(AllowedHost { hostname, port })
+    }
+
+    #[inline]
+    pub fn matches(&self, hostname: &[u8], port: u16) -> bool {
+        self.hostname.eq_ignore_ascii_case(hostname) && self.port.is_none_or(|p| p == port)
+    }
+}
+
+/// The `Authorization` material for one request: a bearer `token`, or basic
+/// `auth` (`base64(user:pass)`); both empty means send nothing.
+#[derive(Clone, Copy)]
+pub struct Credentials<'a> {
+    pub token: &'a [u8],
+    pub auth: &'a [u8],
+}
+
+impl Credentials<'_> {
+    pub const NONE: Credentials<'static> = Credentials {
+        token: b"",
+        auth: b"",
+    };
+}
+
+/// One `.npmrc` `//host[:port]/path/:<credential>` group, resolved to the
+/// token / basic-auth value it yields.
+#[derive(Clone, Copy)]
+pub struct PathCredential {
+    pub hostname: &'static [u8],
+    /// Only set when the `.npmrc` key spelled out a port.
+    pub port: Option<u16>,
+    pub pathname: &'static [u8],
+    pub token: &'static [u8],
+    pub auth: &'static [u8],
+}
+
+impl PathCredential {
+    /// Does this entry's `//host[:port]/path/` cover `url`? Host must match; an
+    /// entry written without a port only covers URLs on their scheme's default
+    /// port (npm derives the key from the parsed URL, which drops default
+    /// ports); the path must be a segment-wise prefix with no dot-segments.
+    pub fn covers(&self, url: &bun_url::URL<'_>) -> bool {
+        if url.hostname.is_empty() || !self.hostname.eq_ignore_ascii_case(url.hostname) {
+            return false;
+        }
+        let port_ok = match self.port {
+            Some(port) => url.get_port_auto() == port,
+            None => url
+                .get_port()
+                .is_none_or(|p| p == if url.is_https() { 443 } else { 80 }),
+        };
+        port_ok && path_under(url.pathname, self.pathname)
+    }
+}
+
+/// Is `url` at or under `base`? Same scheme, host (case-insensitive) and
+/// effective port, and `url`'s path starts with `base`'s path compared
+/// segment by segment (so `/npm/team-ab/x` is not under `/npm/team-a/`, and a
+/// trailing slash on `base` is optional). A `url` whose path contains `.` /
+/// `..` segments (plain or percent-encoded) or a backslash is never "under"
+/// anything: the server would resolve it somewhere we did not check.
+///
+/// This is the single predicate behind path-scoped registry credentials
+/// (`Options::credentials_for`); plain `starts_with` on the URL bytes would
+/// let `https://registry.example.com.evil.test/` pass for
+/// `https://registry.example.com` and `/npm/a/../b/` escape `/npm/a/`.
+pub fn url_under(url: &[u8], base: &[u8]) -> bool {
+    let url = bun_url::URL::parse(url);
+    let base = bun_url::URL::parse(base);
+    if base.hostname.is_empty()
+        || url.hostname.is_empty()
+        || !url.protocol.eq_ignore_ascii_case(base.protocol)
+        || !url.hostname.eq_ignore_ascii_case(base.hostname)
+        || url.get_port_auto() != base.get_port_auto()
+    {
+        return false;
+    }
+    path_under(url.pathname, base.pathname)
+}
+
+/// The path half of [`url_under`]: `path` starts with `base` segment-wise and
+/// carries no `.` / `..` (plain or percent-encoded) segment or backslash.
+pub fn path_under(path: &[u8], base: &[u8]) -> bool {
+    if strings::contains_char(path, b'\\') {
+        return false;
+    }
+    let mut segments = strings::tokenize(path, b"/");
+    for expected in strings::tokenize(base, b"/") {
+        match segments.next() {
+            Some(segment) if segment == expected && !is_dot_segment(segment) => {}
+            _ => return false,
+        }
+    }
+    segments.all(|segment| !is_dot_segment(segment))
+}
+
+/// WHATWG "single-dot" / "double-dot" path segments, including the
+/// percent-encoded spellings a server would normalize.
+fn is_dot_segment(segment: &[u8]) -> bool {
+    const DOT_SEGMENTS: [&[u8]; 6] = [b".", b"..", b"%2e", b"%2e.", b".%2e", b"%2e%2e"];
+    DOT_SEGMENTS
+        .iter()
+        .any(|dot| segment.eq_ignore_ascii_case(dot))
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
@@ -588,6 +811,54 @@ impl Options {
                 // equivalent), same as `leak_static` above.
                 self.minimum_release_age_excludes =
                     Some(&*bun_core::heap::release(leaked.into_boxed_slice()));
+            }
+
+            if let Some(hosts) = &config.allowed_hosts {
+                // Entries were validated by the bunfig parser; anything that
+                // still fails to parse is dropped rather than widening the list.
+                let parsed: Vec<AllowedHost> = hosts
+                    .iter()
+                    .filter_map(|h| AllowedHost::parse(leak_static(h)))
+                    .collect();
+                self.allowed_hosts = Some(&*bun_core::heap::release(parsed.into_boxed_slice()));
+            }
+
+            if let Some(entries) = &config.npmrc_credentials {
+                let mut creds: Vec<PathCredential> = Vec::with_capacity(entries.len());
+                for entry in entries {
+                    // `entry.url` is `host[:port]/path/` (no scheme). Reuse the
+                    // registry-scope conversion for `$ENV` expansion and
+                    // username:password → basic auth.
+                    let scope = Npm::registry::Scope::from_api(b"", entry.clone(), env)?;
+                    if scope.token.is_empty() && scope.auth.is_empty() {
+                        continue;
+                    }
+                    let url = leak_static(&entry.url);
+                    let slash = strings::index_of_char(url, b'/').map_or(url.len(), |i| i as usize);
+                    let Some(host) = AllowedHost::parse(&url[..slash]) else {
+                        continue;
+                    };
+                    creds.push(PathCredential {
+                        hostname: host.hostname,
+                        port: host.port,
+                        pathname: &url[slash..],
+                        token: leak_static(&scope.token),
+                        auth: leak_static(&scope.auth),
+                    });
+                }
+                // Longest (most specific) path first.
+                creds.sort_by_key(|c| core::cmp::Reverse(c.pathname.len()));
+                self.npmrc_credentials = &*bun_core::heap::release(creds.into_boxed_slice());
+            }
+
+            if let Some(rewrites) = &config.url_rewrites {
+                let mut leaked: Vec<(&'static [u8], &'static [u8])> = rewrites
+                    .iter()
+                    .map(|(from, to)| (leak_static(from), leak_static(to)))
+                    .collect();
+                // Longest `from` first so the most specific prefix wins.
+                leaked.sort_by_key(|rule| core::cmp::Reverse(rule.0.len()));
+                self.url_rewrites = &*bun_core::heap::release(leaked.into_boxed_slice());
             }
 
             // `PnpmMatcher` is move-only; `config` is `&` here so the matchers

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -82,13 +82,19 @@ fn start_manifest_task(
     let task = unsafe { &mut *net_ptr };
     // `scope` points into `manager.options` which is not mutated by
     // `for_manifest` (it only writes the pool slot and `manager.log`).
-    task.for_manifest(
+    if let Err(err) = task.for_manifest(
         pkg_name,
         scope.get(),
         None,
         !is_required,
         needs_extended_manifest,
-    )?;
+    ) {
+        // Nothing was scheduled on the slot; return it.
+        // SAFETY: `write_init` made every field drop-safe and `for_manifest`
+        // fails before initializing `unsafe_http_client`.
+        unsafe { manager.preallocated_network_tasks.put(net_ptr) };
+        return Err(err.into());
+    }
 
     enqueue::enqueue_network_task(manager, net_ptr);
     Ok(())

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -89,10 +89,13 @@ fn start_manifest_task(
         !is_required,
         needs_extended_manifest,
     ) {
-        // Nothing was scheduled on the slot; return it.
+        // Nothing was scheduled on the slot; return it, and record the (already
+        // reported) refusal on the reservation made above so later callers do
+        // not wait on a request that was never sent.
         // SAFETY: `write_init` made every field drop-safe and `for_manifest`
         // fails before initializing `unsafe_http_client`.
         unsafe { manager.preallocated_network_tasks.put(net_ptr) };
+        run_tasks::mark_network_task_failed(manager, task_id);
         return Err(err.into());
     }
 

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -2008,12 +2008,14 @@ pub fn generate_network_task_for_tarball<'a>(
         .expect("unreachable"),
     };
 
-    if let Err(err) = network_task.for_tarball(extract_tarball, scope, authorization) {
+    if let Err(err) = network_task.for_tarball(extract_tarball, scope, authorization, is_required) {
         if matches!(err, ForTarballError::InvalidURL) {
-            // The URL was refused before any request was made; record that on
-            // the dedupe entry so a later enqueue for the same tarball (e.g.
-            // from the install phase) fails fast with `AlreadyFailed` instead
-            // of waiting on a task that was never scheduled.
+            // The URL was refused before any request was made and that was
+            // reported (an error, or a warning for an optional dependency);
+            // record it on the dedupe entry — as a non-retryable HTTP status
+            // would be — so a later enqueue for the same tarball (e.g. from
+            // the install phase) fails fast with `AlreadyFailed` instead of
+            // reporting again or waiting on a task that was never scheduled.
             mark_network_task_failed(this, task_id);
         }
         return Err(err);

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -2018,6 +2018,12 @@ pub fn generate_network_task_for_tarball<'a>(
             // reporting again or waiting on a task that was never scheduled.
             mark_network_task_failed(this, task_id);
         }
+        // Hand the pool slot back: nothing was scheduled on it.
+        // SAFETY: `net_ptr` came from `get_network_task` above and `write_init`
+        // made every field drop-safe; `for_tarball` fails before it initializes
+        // `unsafe_http_client` (a `MaybeUninit`, no drop glue), so dropping the
+        // slot in place is sound and nothing else aliases it.
+        unsafe { this.preallocated_network_tasks.put(net_ptr) };
         return Err(err);
     }
 

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -2008,7 +2008,16 @@ pub fn generate_network_task_for_tarball<'a>(
         .expect("unreachable"),
     };
 
-    network_task.for_tarball(extract_tarball, scope, authorization)?;
+    if let Err(err) = network_task.for_tarball(extract_tarball, scope, authorization) {
+        if matches!(err, ForTarballError::InvalidURL) {
+            // The URL was refused before any request was made; record that on
+            // the dedupe entry so a later enqueue for the same tarball (e.g.
+            // from the install phase) fails fast with `AlreadyFailed` instead
+            // of waiting on a task that was never scheduled.
+            mark_network_task_failed(this, task_id);
+        }
+        return Err(err);
+    }
 
     if extract_tarball::uses_streaming_extraction() {
         // Pre-create the extract Task and streaming state here on the

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -2008,14 +2008,14 @@ pub fn generate_network_task_for_tarball<'a>(
         .expect("unreachable"),
     };
 
-    if let Err(err) = network_task.for_tarball(extract_tarball, scope, authorization, is_required) {
+    if let Err(err) = network_task.for_tarball(extract_tarball, scope, authorization) {
         if matches!(err, ForTarballError::InvalidURL) {
-            // The URL was refused before any request was made and that was
-            // reported (an error, or a warning for an optional dependency);
-            // record it on the dedupe entry — as a non-retryable HTTP status
-            // would be — so a later enqueue for the same tarball (e.g. from
-            // the install phase) fails fast with `AlreadyFailed` instead of
-            // reporting again or waiting on a task that was never scheduled.
+            // The URL was refused before any request was made and the error
+            // was logged; record it on the dedupe entry — as a non-retryable
+            // HTTP status would be — so a later enqueue for the same tarball
+            // (e.g. from the install phase) fails fast with `AlreadyFailed`
+            // instead of reporting again or waiting on a task that was never
+            // scheduled.
             mark_network_task_failed(this, task_id);
         }
         // Hand the pool slot back: nothing was scheduled on it.

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -480,16 +480,15 @@ fn run_tasks_erased(
                     throttle_after_network_error(manager, &mut has_network_error);
                 }
 
-                // Handle retry-able errors.
-                if download_failed
+                // Handle retry-able errors. (A redirect refused by
+                // `install.allowedHosts` is policy, not transient: not retried.)
+                if (download_failed
+                    && task.response.fail != Some(bun_http::Error::RedirectHostNotAllowed))
                     || task
                         .response
                         .metadata
                         .as_ref()
-                        .unwrap()
-                        .response
-                        .status_code
-                        > 499
+                        .is_some_and(|m| m.response.status_code > 499)
                 {
                     let err = task
                         .response
@@ -531,7 +530,12 @@ fn run_tasks_erased(
                         (cb.on_package_manifest_error)(extract_ctx, name, err, &task.url_buf);
                     } else {
                         let fmt_args = (err.name(), name);
-                        if manager.is_network_task_required(task.task_id) {
+                        // A redirect refused by `install.allowedHosts` is an
+                        // error even for an optional dependency (policy, not
+                        // availability).
+                        if manager.is_network_task_required(task.task_id)
+                            || task.response.fail == Some(bun_http::Error::RedirectHostNotAllowed)
+                        {
                             bun_ast::add_error_pretty!(
                                 manager.log_mut(),
                                 None,
@@ -754,15 +758,15 @@ fn run_tasks_erased(
                     throttle_after_network_error(manager, &mut has_network_error);
                 }
 
-                if download_failed
+                // (A redirect refused by `install.allowedHosts` is policy, not
+                // transient: not retried.)
+                if (download_failed
+                    && task.response.fail != Some(bun_http::Error::RedirectHostNotAllowed))
                     || task
                         .response
                         .metadata
                         .as_ref()
-                        .unwrap()
-                        .response
-                        .status_code
-                        > 499
+                        .is_some_and(|m| m.response.status_code > 499)
                 {
                     let err = task
                         .response
@@ -846,7 +850,11 @@ fn run_tasks_erased(
                         continue;
                     }
 
-                    if is_required {
+                    // A redirect refused by `install.allowedHosts` is an error
+                    // even for an optional dependency (policy, not availability).
+                    if is_required
+                        || task.response.fail == Some(bun_http::Error::RedirectHostNotAllowed)
+                    {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),
                             None,

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -26,7 +26,7 @@ use crate::dependency::Behavior;
 use crate::isolated_install::installer as store_installer;
 use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _};
 use crate::lifecycle_script_runner::InstallCtx;
-use crate::network_task::{Authorization, ForTarballError};
+use crate::network_task::{Authorization, ForTarballError, refused_by_policy};
 use crate::package_manifest_map::Value as ManifestEntry;
 use bun_core::fmt::PathSep;
 use bun_install::lockfile::Package;
@@ -482,8 +482,7 @@ fn run_tasks_erased(
 
                 // Handle retry-able errors. (A redirect refused by
                 // `install.allowedHosts` is policy, not transient: not retried.)
-                if (download_failed
-                    && task.response.fail != Some(bun_http::Error::RedirectHostNotAllowed))
+                if (download_failed && !refused_by_policy(&task.response))
                     || task
                         .response
                         .metadata
@@ -534,7 +533,7 @@ fn run_tasks_erased(
                         // error even for an optional dependency (policy, not
                         // availability).
                         if manager.is_network_task_required(task.task_id)
-                            || task.response.fail == Some(bun_http::Error::RedirectHostNotAllowed)
+                            || refused_by_policy(&task.response)
                         {
                             bun_ast::add_error_pretty!(
                                 manager.log_mut(),
@@ -564,6 +563,15 @@ fn run_tasks_erased(
                                     manager.options.do_.remove(Do::INSTALL_PACKAGES);
                                 }
                             }
+                        }
+                    }
+
+                    if refused_by_policy(&task.response) {
+                        // Terminal, like a refused tarball: later edges on this
+                        // package must neither re-request nor queue behind it.
+                        mark_network_task_failed(manager, task.task_id);
+                        if let Some(removed) = manager.task_queue.remove(&task.task_id) {
+                            drop(removed);
                         }
                     }
 
@@ -760,8 +768,7 @@ fn run_tasks_erased(
 
                 // (A redirect refused by `install.allowedHosts` is policy, not
                 // transient: not retried.)
-                if (download_failed
-                    && task.response.fail != Some(bun_http::Error::RedirectHostNotAllowed))
+                if (download_failed && !refused_by_policy(&task.response))
                     || task
                         .response
                         .metadata
@@ -852,9 +859,7 @@ fn run_tasks_erased(
 
                     // A redirect refused by `install.allowedHosts` is an error
                     // even for an optional dependency (policy, not availability).
-                    if is_required
-                        || task.response.fail == Some(bun_http::Error::RedirectHostNotAllowed)
-                    {
+                    if is_required || refused_by_policy(&task.response) {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),
                             None,

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -12,6 +12,7 @@ use bun_threading::thread_pool;
 use bun_wyhash::Wyhash11;
 
 use crate::npm;
+use crate::repository_real::git_host_refused;
 use crate::{
     DependencyID, ExtractData, ExtractTarball, NetworkTask, PackageManager, PatchTask, Repository,
     RepositoryExt as _, Resolution,
@@ -407,8 +408,62 @@ impl<'a> Task<'a> {
                     let url = req.url.slice();
                     let mut attempt: u8 = 1;
 
+                    // `install.allowedHosts`, decided per transport before `git`
+                    // is spawned (no clone, no fetch): the https and ssh forms
+                    // of one specifier differ in port, so `host:22` allows only
+                    // the ssh attempt and `host:443` only the https one. When
+                    // every candidate is refused, fail once naming the host
+                    // (never the URL — it may carry credentials).
+                    // SAFETY: see `manager` decl — `options` is read-only after init.
+                    let options = unsafe { &(*manager).options };
+                    // (owned copies: `try_https`/`try_ssh` return thread-local
+                    // buffers that the download calls below reuse)
+                    let (has_https, https_refused): (bool, Option<Box<[u8]>>) =
+                        match Repository::try_https(url) {
+                            Some(u) => (true, git_host_refused(options, u).map(Box::from)),
+                            None => (false, None),
+                        };
+                    let (has_ssh, ssh_refused): (bool, Option<Box<[u8]>>) =
+                        match Repository::try_ssh(url) {
+                            Some(u) => (true, git_host_refused(options, u).map(Box::from)),
+                            None => (false, None),
+                        };
+                    let skip_https = https_refused.is_some();
+                    let skip_ssh = ssh_refused.is_some();
+                    let all_refused: Option<Box<[u8]>> = if has_https || has_ssh {
+                        if (!has_https || skip_https) && (!has_ssh || skip_ssh) {
+                            https_refused.or(ssh_refused)
+                        } else {
+                            None
+                        }
+                    } else {
+                        git_host_refused(options, url).map(Box::from)
+                    };
+                    if let Some(host) = all_refused {
+                        this.log.add_error_fmt(
+                            None,
+                            Loc::EMPTY,
+                            format_args!(
+                                "Refusing to clone git dependency \"{}\" from \"{}\": host is not in install.allowedHosts",
+                                bstr::BStr::new(name),
+                                bstr::BStr::new(&host),
+                            ),
+                        );
+                        this.err = Some(crate::Error::HostNotAllowed);
+                        this.status = Status::Fail;
+                        this.data = Data {
+                            git_clone: ManuallyDrop::new(Fd::invalid()),
+                        };
+                        break 'body;
+                    }
+                    if skip_https || skip_ssh {
+                        // Only one transport will be tried; have `download`
+                        // report its failure instead of deferring to a retry.
+                        attempt += 1;
+                    }
+
                     let dir = 'brk: {
-                        if let Some(https) = Repository::try_https(url) {
+                        if !skip_https && let Some(https) = Repository::try_https(url) {
                             match Repository::download(
                                 req.env,
                                 &mut this.log,
@@ -422,11 +477,8 @@ impl<'a> Task<'a> {
                                 Ok(d) => break 'brk Some(d),
                                 Err(err) => {
                                     // Exit early if git checked and could
-                                    // not find the repository (or the host is
-                                    // not in `install.allowedHosts`), skip ssh
-                                    if err == crate::Error::RepositoryNotFound
-                                        || err == crate::Error::HostNotAllowed
-                                    {
+                                    // not find the repository, skip ssh
+                                    if err == crate::Error::RepositoryNotFound {
                                         this.err = Some(err);
                                         this.status = Status::Fail;
                                         this.data = Data {
@@ -451,7 +503,7 @@ impl<'a> Task<'a> {
                     let dir = match dir {
                         Some(d) => d,
                         None => {
-                            if let Some(ssh) = Repository::try_ssh(url) {
+                            if !skip_ssh && let Some(ssh) = Repository::try_ssh(url) {
                                 match Repository::download(
                                     req.env,
                                     &mut this.log,
@@ -472,7 +524,7 @@ impl<'a> Task<'a> {
                                         break 'body;
                                     }
                                 }
-                            } else if this.status != Status::Fail {
+                            } else if !has_https && !has_ssh && this.status != Status::Fail {
                                 // Neither matcher recognized the URL (`file://`,
                                 // `git://`, ...); clone with the URL as written
                                 // instead of finishing with zeroed task data.

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -422,8 +422,11 @@ impl<'a> Task<'a> {
                                 Ok(d) => break 'brk Some(d),
                                 Err(err) => {
                                     // Exit early if git checked and could
-                                    // not find the repository, skip ssh
-                                    if err == crate::Error::RepositoryNotFound {
+                                    // not find the repository (or the host is
+                                    // not in `install.allowedHosts`), skip ssh
+                                    if err == crate::Error::RepositoryNotFound
+                                        || err == crate::Error::HostNotAllowed
+                                    {
                                         this.err = Some(err);
                                         this.status = Status::Fail;
                                         this.data = Data {

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -150,6 +150,8 @@ pub enum Error {
     IntegrityCheckFailed,
     #[error("RepositoryNotFound")]
     RepositoryNotFound,
+    #[error("HostNotAllowed")]
+    HostNotAllowed,
     #[error("DebugTextLockfileRoundTrip")]
     DebugTextLockfileRoundTrip,
     #[error("NoPackage")]
@@ -320,6 +322,7 @@ impl Error {
             Self::Fail => "Fail",
             Self::IntegrityCheckFailed => "IntegrityCheckFailed",
             Self::RepositoryNotFound => "RepositoryNotFound",
+            Self::HostNotAllowed => "HostNotAllowed",
             Self::DebugTextLockfileRoundTrip => "DebugTextLockfileRoundTrip",
             Self::NoPackage => "NoPackage",
             Self::WriteFailed => "WriteFailed",

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -344,8 +344,12 @@ impl PatchTask {
                                 _ => Authorization::NoAuthorization,
                             },
                         ) {
-                            // --offline and not cached: already reported / skipped; nothing to patch
-                            Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
+                            // --offline and not cached, or the tarball URL was refused
+                            // (`install.allowedHosts`): already reported / skipped; nothing to patch
+                            Err(
+                                crate::network_task::ForTarballError::Offline
+                                | crate::network_task::ForTarballError::InvalidURL,
+                            ) => return Ok(()),
                             other => other?.unwrap_or_else(|| unreachable!()),
                         };
                     if manager.get_preinstall_state(pkg_meta_id) == PreinstallState::Extract {

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -361,6 +361,41 @@ pub trait RepositoryExt: Sized {
     ) -> Result<ExtractData, Error>;
 }
 
+/// `install.allowedHosts` check for a git remote. `url` is what we are about to
+/// hand to `git clone`: an `https://` / `ssh://` / `git://` URL, or an scp-like
+/// `[user@]host:path`. Returns the offending host when it is not allowed;
+/// local paths (no host) are always allowed.
+fn git_host_refused<'a>(
+    options: &crate::package_manager::Options::Options,
+    url: &'a [u8],
+) -> Option<&'a [u8]> {
+    // No allow-list configured: nothing is refused.
+    options.allowed_hosts?;
+    if strings::contains(url, b"://") {
+        if strings::has_prefix_comptime(url, b"file://") {
+            return None;
+        }
+        let host = bun_url::URL::parse(url).host;
+        return (!options.is_host_allowed(url)).then_some(host);
+    }
+    if Dependency::is_scp_like_path(url) {
+        // `[user@]host:path` — rebuild as a URL so the same matcher applies.
+        let colon = strings::index_of_char(url, b':')? as usize;
+        let authority = &url[..colon];
+        let host = match strings::last_index_of_char(authority, b'@') {
+            Some(at) => &authority[at + 1..],
+            None => authority,
+        };
+        let mut as_url = Vec::with_capacity(b"ssh://".len() + host.len() + 1);
+        as_url.extend_from_slice(b"ssh://");
+        as_url.extend_from_slice(host);
+        as_url.push(b'/');
+        return (!options.is_host_allowed(&as_url)).then_some(host);
+    }
+    // A filesystem path.
+    None
+}
+
 /// A module-level free fn because trait methods cannot be private; called only
 /// from this file's `download`/`find_commit`/`checkout`.
 fn exec(env: &bun_dotenv::Map, argv: &[&[u8]]) -> Result<Vec<u8>, Error> {
@@ -767,6 +802,23 @@ impl RepositoryExt for Repository {
         // we never own/close it — only the freshly-opened repo `Dir` is owned.
         bun_analytics::features::git_dependencies
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        // `install.allowedHosts`: a git dependency is fetched from wherever its
+        // specifier points; when the project restricts hosts, refuse anything
+        // not on the list before `git` is spawned (no clone, no fetch). Only
+        // the host is echoed — the URL may carry credentials.
+        if let Some(host) = git_host_refused(&PackageManager::get().options, url) {
+            log.add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Refusing to clone git dependency \"{}\" from \"{}\": host is not in install.allowedHosts",
+                    BStr::new(name),
+                    BStr::new(host),
+                ),
+            );
+            return Err(crate::Error::HostNotAllowed);
+        }
         // Per-field accessor — retags only `folder_name_buf`, leaving any live
         // shared borrow of `final_path_buf`/`ssh_path_buf` (the `url` argument
         // handed over by `try_https`/`try_ssh` callers) valid under Stacked

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -361,11 +361,13 @@ pub trait RepositoryExt: Sized {
     ) -> Result<ExtractData, Error>;
 }
 
-/// `install.allowedHosts` check for a git remote. `url` is what we are about to
-/// hand to `git clone`: an `https://` / `ssh://` / `git://` URL, or an scp-like
+/// `install.allowedHosts` check for a git remote. `url` is what would be handed
+/// to `git clone`: an `https://` / `ssh://` / `git://` URL, or an scp-like
 /// `[user@]host:path`. Returns the offending host when it is not allowed;
-/// local paths (no host) are always allowed.
-fn git_host_refused<'a>(
+/// local paths (no host) are always allowed. The clone task evaluates this per
+/// transport (the https and ssh forms of one specifier differ in port) before
+/// spawning `git`.
+pub(crate) fn git_host_refused<'a>(
     options: &crate::package_manager::Options::Options,
     url: &'a [u8],
 ) -> Option<&'a [u8]> {
@@ -802,23 +804,6 @@ impl RepositoryExt for Repository {
         // we never own/close it — only the freshly-opened repo `Dir` is owned.
         bun_analytics::features::git_dependencies
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-        // `install.allowedHosts`: a git dependency is fetched from wherever its
-        // specifier points; when the project restricts hosts, refuse anything
-        // not on the list before `git` is spawned (no clone, no fetch). Only
-        // the host is echoed — the URL may carry credentials.
-        if let Some(host) = git_host_refused(&PackageManager::get().options, url) {
-            log.add_error_fmt(
-                None,
-                bun_ast::Loc::EMPTY,
-                format_args!(
-                    "Refusing to clone git dependency \"{}\" from \"{}\": host is not in install.allowedHosts",
-                    BStr::new(name),
-                    BStr::new(host),
-                ),
-            );
-            return Err(crate::Error::HostNotAllowed);
-        }
         // Per-field accessor — retags only `folder_name_buf`, leaving any live
         // shared borrow of `final_path_buf`/`ssh_path_buf` (the `url` argument
         // handed over by `try_https`/`try_ssh` callers) valid under Stacked

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -377,8 +377,17 @@ pub(crate) fn git_host_refused<'a>(
         if strings::has_prefix_comptime(url, b"file://") {
             return None;
         }
-        let host = bun_url::URL::parse(url).host;
-        return (!options.is_host_allowed(url)).then_some(host);
+        // `is_host_allowed` ignores any `git@` userinfo; report `host[:port]`
+        // without it too.
+        if options.is_host_allowed(url) {
+            return None;
+        }
+        let rest = &url[strings::index_of(url, b"://").unwrap_or(0) + b"://".len()..];
+        let authority = &rest[..strings::index_of_any(rest, b"/?#").unwrap_or(rest.len())];
+        return Some(match strings::last_index_of_char(authority, b'@') {
+            Some(at) => &authority[at + 1..],
+            None => authority,
+        });
     }
     if Dependency::is_scp_like_path(url) {
         // `[user@]host:path` — rebuild as a URL so the same matcher applies.

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -260,6 +260,18 @@ pub mod api {
         pub hoist: Option<bool>,
         /// `offline = true`: `bun install` never touches the network.
         pub offline: Option<bool>,
+        /// `allowedHosts`: when present (even if empty), manifests, tarballs and
+        /// git repositories may only be fetched from the hosts of the configured
+        /// registries plus these `host` / `host:port` entries.
+        pub allowed_hosts: Option<Vec<Box<[u8]>>>,
+        /// `rewrite = [{ from, to }]`: URL prefix rewrites applied to registry
+        /// requests at fetch time only (the lockfile keeps the canonical URL).
+        pub url_rewrites: Option<Vec<(Box<[u8]>, Box<[u8]>)>>,
+        /// Every `.npmrc` `//host/path/:_authToken` (etc.) entry, keyed by the
+        /// `//host/path/` it was written for (`url` holds `host/path`). Used as
+        /// path-scoped credentials for requests that no configured registry's
+        /// own credentials cover — npm's "nerf dart" lookup.
+        pub npmrc_credentials: Option<Vec<NpmRegistry>>,
     }
 
     #[repr(u8)]

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -911,6 +911,9 @@ fn registry_get(
         http::FetchRedirect::Follow,
     );
     req.client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+    req.client.redirect_policy = Some(bun_install::package_manager::Options::redirect_policy(
+        credentials,
+    ));
     let res = match req.send_sync(&mut response_buf) {
         Ok(r) => r,
         Err(err) => {

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -857,20 +857,26 @@ fn registry_get(
     accept: &[u8],
     for_error: Option<(&[u8], &[u8])>,
 ) -> Result<MutableString, crate::Error> {
+    // Same fetch-time policy as `bun install`: `install.rewrite`, then `install.allowedHosts`.
+    let rewritten = pm.options.rewrite_url(url.href);
+    let url = match &rewritten {
+        std::borrow::Cow::Owned(href) => URL::parse(href),
+        std::borrow::Cow::Borrowed(_) => url,
+    };
+    if !pm.options.is_host_allowed(url.href) {
+        Status::clear();
+        Output::err_generic(
+            "Refusing to fetch {}: host is not in install.allowedHosts",
+            (BStr::new(url.href),),
+        );
+        Global::exit(1);
+    }
     let mut headers = http::HeaderBuilder::default();
     headers.count(b"Accept", accept);
-    // `dist.tarball` is registry-controlled; credentials only go back to the registry's own origin.
-    let same_origin = {
-        let registry = scope.url.url();
-        url.protocol == registry.protocol
-            && url.hostname == registry.hostname
-            && url.get_port_auto() == registry.get_port_auto()
-    };
-    let (token, auth): (&[u8], &[u8]) = if same_origin {
-        (&scope.token, &scope.auth)
-    } else {
-        (b"", b"")
-    };
+    // `dist.tarball` is registry-controlled; credentials only go back to URLs
+    // under the registry's own origin and path (`Options::credentials_for`).
+    let credentials = pm.options.credentials_for(scope, url.href);
+    let (token, auth): (&[u8], &[u8]) = (credentials.token, credentials.auth);
     if !token.is_empty() {
         headers.count(b"Authorization", b"");
         headers.content.cap += b"Bearer ".len() + token.len();

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -1,0 +1,521 @@
+import { spawn } from "bun";
+import { describe, expect, it } from "bun:test";
+import { rm } from "fs/promises";
+import { bunExe, bunEnv as env, tempDir } from "harness";
+import { join } from "path";
+
+// Covers three related `bun install` behaviours:
+//  1. registry credentials are scoped to the registry URL's origin *and path*
+//  2. `install.allowedHosts` refuses hosts the project did not list
+//  3. `install.rewrite` redirects requests at fetch time without touching bun.lock
+
+const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+const integrity = "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==";
+
+type Received = { path: string; authorization: string | null };
+
+/**
+ * A registry that serves the `no-deps@1.0.0` manifest under any path prefix
+ * (`<prefix>/no-deps`) and the tarball at any path ending in `.tgz`, records
+ * every request, and lets each test decide where the manifest's `dist.tarball`
+ * points.
+ */
+function serveRegistry(received: Received[], tarballUrl: (registryOrigin: string, manifestPath: string) => string) {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const url = new URL(req.url);
+      received.push({ path: url.pathname, authorization: req.headers.get("authorization") });
+      if (url.pathname.endsWith(".tgz")) {
+        return new Response(Bun.file(tgz));
+      }
+      if (url.pathname.endsWith("/no-deps")) {
+        return Response.json({
+          name: "no-deps",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "no-deps",
+              version: "1.0.0",
+              dist: { integrity, tarball: tarballUrl(`http://127.0.0.1:${server.port}`, url.pathname) },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return server;
+}
+
+/** A second host: serves the tarball to anyone, records what it was sent. */
+function serveElsewhere(received: Received[], status = 200) {
+  return Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      received.push({ path: new URL(req.url).pathname, authorization: req.headers.get("authorization") });
+      return status === 200 ? new Response(Bun.file(tgz)) : new Response("nope", { status });
+    },
+  });
+}
+
+async function install(cwd: string, ...args: string[]) {
+  await using proc = spawn({
+    cmd: [bunExe(), "install", ...args],
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+const packageJson = JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } });
+
+describe.concurrent("registry credentials are path-scoped", () => {
+  // The registry (with a token) lives at http://127.0.0.1:<port>/prefix-a/.
+  // Its manifest points the tarball at various places; only URLs under
+  // /prefix-a/ on that origin may carry the token.
+  it.each([
+    ["the registry path itself", (origin: string) => `${origin}/prefix-a/no-deps/-/no-deps-1.0.0.tgz`, "Bearer tok-a"],
+    [
+      "a deeper path under the registry",
+      (origin: string) => `${origin}/prefix-a/deep/er/no-deps-1.0.0.tgz`,
+      "Bearer tok-a",
+    ],
+    ["a sibling path on the same host", (origin: string) => `${origin}/prefix-b/no-deps/-/no-deps-1.0.0.tgz`, null],
+    ["a path that merely shares a string prefix", (origin: string) => `${origin}/prefix-ab/no-deps-1.0.0.tgz`, null],
+    ["the host root", (origin: string) => `${origin}/no-deps-1.0.0.tgz`, null],
+    ["a dot-segment escape", (origin: string) => `${origin}/prefix-a/../prefix-b/no-deps-1.0.0.tgz`, null],
+    ["an encoded dot-segment escape", (origin: string) => `${origin}/prefix-a/%2e%2e/prefix-b/no-deps-1.0.0.tgz`, null],
+  ])("tarball at %s", async (_, tarballUrl, expectedAuthorization) => {
+    const received: Received[] = [];
+    await using registry = serveRegistry(received, tarballUrl);
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/prefix-a/", token = "tok-a" }
+`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    const manifest = received.find(r => r.path === "/prefix-a/no-deps");
+    const tarball = received.find(r => r.path.endsWith(".tgz"));
+    expect(manifest?.authorization).toBe("Bearer tok-a");
+    expect(tarball).toBeDefined();
+    expect(tarball!.authorization).toBe(expectedAuthorization);
+  });
+
+  it("tarball on another host never receives the token", async () => {
+    const received: Received[] = [];
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    await using registry = serveRegistry(
+      received,
+      () => `http://127.0.0.1:${elsewhere.port}/prefix-a/no-deps/-/no-deps-1.0.0.tgz`,
+    );
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/prefix-a/", token = "tok-a" }
+`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received.find(r => r.path === "/prefix-a/no-deps")?.authorization).toBe("Bearer tok-a");
+    expect(elsewhereReceived).toEqual([{ path: "/prefix-a/no-deps/-/no-deps-1.0.0.tgz", authorization: null }]);
+  });
+
+  it("npmrc credentials for a path-based registry follow the same rule", async () => {
+    const received: Received[] = [];
+    await using registry = serveRegistry(received, origin => `${origin}/prefix-b/no-deps/-/no-deps-1.0.0.tgz`);
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+`,
+      ".npmrc": [
+        `registry=http://127.0.0.1:${registry.port}/prefix-a/`,
+        `//127.0.0.1:${registry.port}/prefix-a/:_authToken=tok-a`,
+        ``,
+      ].join("\n"),
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received.find(r => r.path === "/prefix-a/no-deps")?.authorization).toBe("Bearer tok-a");
+    expect(received.find(r => r.path === "/prefix-b/no-deps/-/no-deps-1.0.0.tgz")?.authorization).toBeNull();
+  });
+
+  // npm's "nerf dart" lookup: a `//host/path/:_authToken` line that no
+  // configured registry claims still supplies credentials for requests under
+  // that host and path. This is how a registry whose tarballs live under a
+  // sibling path is given a token for both.
+  it("an extra npmrc //host/path/ entry covers requests under that path", async () => {
+    const received: Received[] = [];
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    let tarballOnElsewhere = false;
+    await using registry = serveRegistry(received, origin =>
+      tarballOnElsewhere
+        ? `http://127.0.0.1:${elsewhere.port}/downloads/no-deps-1.0.0.tgz`
+        : `${origin}/prefix-b/no-deps/-/no-deps-1.0.0.tgz`,
+    );
+    const npmrc = [
+      `registry=http://127.0.0.1:${registry.port}/prefix-a/`,
+      `//127.0.0.1:${registry.port}/prefix-a/:_authToken=tok-a`,
+      `//127.0.0.1:${registry.port}/prefix-b/:_authToken=tok-b`,
+      `//127.0.0.1:${registry.port}/prefix-b/no-deps/:username=deep`,
+      `//127.0.0.1:${registry.port}/prefix-b/no-deps/:_password=${Buffer.from("secret").toString("base64")}`,
+      `//127.0.0.1:${elsewhere.port}/downloads/:_authToken=tok-elsewhere`,
+      ``,
+    ].join("\n");
+
+    {
+      using dir = tempDir("registry-path-scoped-auth", {
+        "package.json": packageJson,
+        "bunfig.toml": `[install]\ncache = false\n`,
+        ".npmrc": npmrc,
+      });
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+      expect(received).toEqual([
+        { path: "/prefix-a/no-deps", authorization: "Bearer tok-a" },
+        // the longest matching `//host/path/` wins: username + _password under /prefix-b/no-deps/
+        {
+          path: "/prefix-b/no-deps/-/no-deps-1.0.0.tgz",
+          authorization: `Basic ${Buffer.from("deep:secret").toString("base64")}`,
+        },
+      ]);
+    }
+
+    tarballOnElsewhere = true;
+    received.length = 0;
+    {
+      using dir = tempDir("registry-path-scoped-auth", {
+        "package.json": packageJson,
+        "bunfig.toml": `[install]\ncache = false\n`,
+        ".npmrc": npmrc,
+      });
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+      expect(received).toEqual([{ path: "/prefix-a/no-deps", authorization: "Bearer tok-a" }]);
+      expect(elsewhereReceived).toEqual([
+        { path: "/downloads/no-deps-1.0.0.tgz", authorization: "Bearer tok-elsewhere" },
+      ]);
+    }
+  });
+
+  it("an npmrc entry for a parent path covers a registry configured below it", async () => {
+    const received: Received[] = [];
+    await using registry = serveRegistry(received, origin => `${origin}/npm/team-a/no-deps/-/no-deps-1.0.0.tgz`);
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/npm/team-a/"
+`,
+      ".npmrc": `//127.0.0.1:${registry.port}/npm/:_authToken=npm-wide\n`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received).toEqual([
+      { path: "/npm/team-a/no-deps", authorization: "Bearer npm-wide" },
+      { path: "/npm/team-a/no-deps/-/no-deps-1.0.0.tgz", authorization: "Bearer npm-wide" },
+    ]);
+  });
+
+  it("an npmrc entry written without a port does not cover a non-default port", async () => {
+    const received: Received[] = [];
+    await using registry = serveRegistry(received, origin => `${origin}/prefix-b/no-deps-1.0.0.tgz`);
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/prefix-a/"
+`,
+      ".npmrc": `//127.0.0.1/prefix-b/:_authToken=portless\n`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received.map(r => r.authorization)).toEqual([null, null]);
+  });
+
+  it("a registry configured at the host root still authenticates every path on it", async () => {
+    const received: Received[] = [];
+    await using registry = serveRegistry(received, origin => `${origin}/some/where/else/no-deps-1.0.0.tgz`);
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}", token = "root-token" }
+`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received.map(r => r.authorization)).toEqual(["Bearer root-token", "Bearer root-token"]);
+  });
+});
+
+describe.concurrent("install.allowedHosts", () => {
+  it("refuses a tarball on a host that is not listed, without contacting it", async () => {
+    const received: Received[] = [];
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    const tarballUrl = `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.0.tgz`;
+    await using registry = serveRegistry(received, () => tarballUrl);
+    using dir = tempDir("allowed-hosts", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/"
+allowedHosts = []
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain(
+      `error: Refusing to download "${tarballUrl}" for package "no-deps": host is not in install.allowedHosts`,
+    );
+    expect(stderr).not.toContain("Saved lockfile");
+    expect(stderr).not.toContain("internal error");
+    expect(exitCode).toBe(1);
+    // the manifest came from the (implicitly allowed) registry host ...
+    expect(received.map(r => r.path)).toEqual(["/no-deps"]);
+    // ... and the foreign host was never contacted
+    expect(elsewhereReceived).toEqual([]);
+  });
+
+  it.each([
+    ["host:port", (port: number) => `["127.0.0.1:${port}"]`],
+    ["a bare hostname (any port)", () => `["127.0.0.1"]`],
+    ["one of several entries", (port: number) => `["registry.example.com", "127.0.0.1:${port}", "[::1]:1"]`],
+  ])("allows a tarball host listed as %s", async (_, entry) => {
+    const received: Received[] = [];
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    await using registry = serveRegistry(
+      received,
+      () => `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.0.tgz`,
+    );
+    using dir = tempDir("allowed-hosts", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://localhost:${registry.port}/", token = "registry-token" }
+allowedHosts = ${entry(elsewhere.port)}
+`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    // allowed to fetch, but being on the list does not earn the registry's token
+    expect(elsewhereReceived).toEqual([{ path: "/no-deps/-/no-deps-1.0.0.tgz", authorization: null }]);
+  });
+
+  it("does not match a listed host on a different port", async () => {
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    await using registry = serveRegistry([], () => `http://127.0.0.1:${elsewhere.port}/no-deps-1.0.0.tgz`);
+    using dir = tempDir("allowed-hosts", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:${registry.port}/"
+allowedHosts = ["127.0.0.1:${registry.port}"]
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("host is not in install.allowedHosts");
+    expect(exitCode).toBe(1);
+    expect(elsewhereReceived).toEqual([]);
+  });
+
+  it("is off when unset: tarballs may come from any host", async () => {
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    await using registry = serveRegistry([], () => `http://127.0.0.1:${elsewhere.port}/no-deps-1.0.0.tgz`);
+    using dir = tempDir("allowed-hosts", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:${registry.port}/"
+`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(elsewhereReceived.map(r => r.path)).toEqual(["/no-deps-1.0.0.tgz"]);
+  });
+
+  it("refuses git dependencies on hosts that are not listed", async () => {
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived, 404);
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { repo: `git+http://127.0.0.1:${elsewhere.port}/someone/repo.git` },
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:1/"
+allowedHosts = []
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain(
+      `error: Refusing to clone git dependency "repo" from "127.0.0.1:${elsewhere.port}": host is not in install.allowedHosts`,
+    );
+    expect(exitCode).toBe(1);
+    expect(elsewhereReceived).toEqual([]);
+  });
+
+  it("rejects entries that are not host[:port]", async () => {
+    using dir = tempDir("allowed-hosts", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+allowedHosts = ["https://registry.example.com/npm/"]
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain(`Expected a hostname or "hostname:port" (not a URL) in allowedHosts`);
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe.concurrent("install.rewrite", () => {
+  it("fetches tarballs from the rewritten URL but records the canonical URL in bun.lock", async () => {
+    // "canonical" is where the manifest (and therefore bun.lock) says the
+    // tarball lives; it must never be contacted. The mirror is a path on the
+    // registry server.
+    const canonicalReceived: Received[] = [];
+    await using canonical = serveElsewhere(canonicalReceived, 500);
+    const received: Received[] = [];
+    await using registry = serveRegistry(
+      received,
+      () => `http://127.0.0.1:${canonical.port}/no-deps/-/no-deps-1.0.0.tgz`,
+    );
+    using dir = tempDir("install-rewrite", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/", token = "mirror-token" }
+
+[[install.rewrite]]
+from = "http://127.0.0.1:${canonical.port}/"
+to = "http://127.0.0.1:${registry.port}/not-specific-enough/"
+
+[[install.rewrite]]
+from = "http://127.0.0.1:${canonical.port}/no-deps/"
+to = "http://127.0.0.1:${registry.port}/mirror/no-deps/"
+`,
+    });
+
+    {
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    }
+    // longest matching `from` wins; the rewritten URL is under the registry, so
+    // it carries the registry's credentials
+    expect(received.filter(r => r.path.endsWith(".tgz"))).toEqual([
+      { path: "/mirror/no-deps/-/no-deps-1.0.0.tgz", authorization: "Bearer mirror-token" },
+    ]);
+    expect(canonicalReceived).toEqual([]);
+
+    const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+    expect(lockfile).toContain(`http://127.0.0.1:${canonical.port}/no-deps/-/no-deps-1.0.0.tgz`);
+    expect(lockfile).not.toContain("/mirror/");
+
+    // a frozen install from that lockfile goes through the rewrite again
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    received.length = 0;
+    {
+      const { stdout, stderr, exitCode } = await install(String(dir), "--frozen-lockfile");
+      expect(stderr).not.toContain("error:");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    }
+    expect(received).toEqual([{ path: "/mirror/no-deps/-/no-deps-1.0.0.tgz", authorization: "Bearer mirror-token" }]);
+    expect(canonicalReceived).toEqual([]);
+    expect(await Bun.file(join(String(dir), "bun.lock")).text()).toBe(lockfile);
+  });
+
+  it("credentials and allowedHosts are judged against the rewritten URL", async () => {
+    // The registry (with a token) points tarballs at itself; the rewrite sends
+    // them to another host. That host is on the allow-list, so the download
+    // proceeds — but it is not under the registry URL, so no token.
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    const received: Received[] = [];
+    await using registry = serveRegistry(received, origin => `${origin}/no-deps/-/no-deps-1.0.0.tgz`);
+    using dir = tempDir("install-rewrite", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/", token = "registry-token" }
+allowedHosts = ["127.0.0.1:${elsewhere.port}"]
+rewrite = [
+  { from = "http://127.0.0.1:${registry.port}/no-deps/-/", to = "http://127.0.0.1:${elsewhere.port}/tarballs/" },
+]
+`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received).toEqual([{ path: "/no-deps", authorization: "Bearer registry-token" }]);
+    expect(elsewhereReceived).toEqual([{ path: "/tarballs/no-deps-1.0.0.tgz", authorization: null }]);
+  });
+});

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -309,6 +309,64 @@ cache = false
     }
   });
 
+  it("an npmrc entry used over plain http keeps covering a redirect under its path", async () => {
+    // The credential's scope follows the scheme it was honoured on: a hop that
+    // stays under //host/npm/ keeps the token, one that leaves it does not.
+    const received: Received[] = [];
+    await using registry = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        received.push({ path: url.pathname, authorization: req.headers.get("authorization") });
+        const origin = `http://127.0.0.1:${registry.port}`;
+        if (url.pathname === "/npm/team-a/no-deps") {
+          return Response.json({
+            name: "no-deps",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "no-deps",
+                version: "1.0.0",
+                dist: { integrity, tarball: `${origin}/npm/team-a/no-deps/-/no-deps-1.0.0.tgz` },
+              },
+            },
+          });
+        }
+        if (url.pathname === "/npm/team-a/no-deps/-/no-deps-1.0.0.tgz") {
+          return Response.redirect(`${origin}/npm/blobs/no-deps-1.0.0.tgz`, 307);
+        }
+        if (url.pathname === "/npm/blobs/no-deps-1.0.0.tgz") {
+          return Response.redirect(`${origin}/cdn/no-deps-1.0.0.tgz`, 307);
+        }
+        if (url.pathname === "/cdn/no-deps-1.0.0.tgz") {
+          return new Response(Bun.file(tgz));
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    using dir = tempDir("registry-path-scoped-auth", {
+      "package.json": packageJson,
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/npm/team-a/"
+`,
+      ".npmrc": `//127.0.0.1:${registry.port}/npm/:_authToken=npm-wide\n`,
+    });
+
+    const { stdout, stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(received).toEqual([
+      { path: "/npm/team-a/no-deps", authorization: "Bearer npm-wide" },
+      { path: "/npm/team-a/no-deps/-/no-deps-1.0.0.tgz", authorization: "Bearer npm-wide" },
+      { path: "/npm/blobs/no-deps-1.0.0.tgz", authorization: "Bearer npm-wide" },
+      { path: "/cdn/no-deps-1.0.0.tgz", authorization: null },
+    ]);
+  });
+
   it("an npmrc entry for a parent path covers a registry configured below it", async () => {
     const received: Received[] = [];
     await using registry = serveRegistry(received, origin => `${origin}/npm/team-a/no-deps/-/no-deps-1.0.0.tgz`);
@@ -647,6 +705,31 @@ allowedHosts = []
       `error: Refusing to download "${tarballUrl}" for package "no-deps": host is not in install.allowedHosts`,
     );
     expect(stderr).not.toContain("internal error");
+    expect(exitCode).toBe(1);
+    expect(elsewhereReceived).toEqual([]);
+  });
+
+  it("an optional dependency whose manifest host is not listed also fails the install", async () => {
+    // Only reachable through a rewrite (registries are implicitly allowed);
+    // must fail closed like the tarball case.
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    await using registry = serveRegistry([], origin => `${origin}/no-deps/-/no-deps-1.0.0.tgz`);
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", optionalDependencies: { "no-deps": "1.0.0" } }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/"
+allowedHosts = []
+rewrite = [{ from = "http://127.0.0.1:${registry.port}/", to = "http://127.0.0.1:${elsewhere.port}/" }]
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain(
+      `error: Refusing to fetch manifest "http://127.0.0.1:${elsewhere.port}/no-deps" for package "no-deps": host is not in install.allowedHosts`,
+    );
     expect(exitCode).toBe(1);
     expect(elsewhereReceived).toEqual([]);
   });

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -92,6 +92,17 @@ describe.concurrent("registry credentials are path-scoped", () => {
     ["the host root", (origin: string) => `${origin}/no-deps-1.0.0.tgz`, null],
     ["a dot-segment escape", (origin: string) => `${origin}/prefix-a/../prefix-b/no-deps-1.0.0.tgz`, null],
     ["an encoded dot-segment escape", (origin: string) => `${origin}/prefix-a/%2e%2e/prefix-b/no-deps-1.0.0.tgz`, null],
+    ["an encoded-backslash escape", (origin: string) => `${origin}/prefix-a/..%5Cprefix-b/no-deps-1.0.0.tgz`, null],
+    [
+      "an encoded-slash escape",
+      (origin: string) => `${origin}/prefix-a/x%2F..%2f..%2Fprefix-b/no-deps-1.0.0.tgz`,
+      null,
+    ],
+    [
+      "an encoded slash that is just part of a name",
+      (origin: string) => `${origin}/prefix-a/@scope%2fno-deps/-/no-deps-1.0.0.tgz`,
+      "Bearer tok-a",
+    ],
   ])("tarball at %s", (_, tarballUrl, expectedAuthorization) => {
     it(`is fetched with authorization ${expectedAuthorization}`, async () => {
       const received: Received[] = [];

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -460,7 +460,7 @@ allowedHosts = []
     expect(elsewhereReceived).toEqual([]);
   });
 
-  it("skips an optional dependency whose tarball host is not listed instead of failing", async () => {
+  it("an optional dependency whose tarball host is not listed also fails the install", async () => {
     const elsewhereReceived: Received[] = [];
     await using elsewhere = serveElsewhere(elsewhereReceived);
     const tarballUrl = `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.0.tgz`;
@@ -477,12 +477,81 @@ allowedHosts = []
 
     const { stderr, exitCode } = await install(String(dir));
     expect(stderr).toContain(
-      `warn: Skipping optional package "no-deps": "${tarballUrl}" is not in install.allowedHosts`,
+      `error: Refusing to download "${tarballUrl}" for package "no-deps": host is not in install.allowedHosts`,
     );
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("internal error");
+    expect(exitCode).toBe(1);
     expect(elsewhereReceived).toEqual([]);
     expect(existsSync(join(String(dir), "node_modules", "no-deps"))).toBeFalse();
+  });
+
+  it("a package that is optional for one dependent and required for another is refused once", async () => {
+    // Whichever edge is seen first, the refusal is one error and the install
+    // fails; the second edge must neither downgrade nor repeat it.
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    const pkgs = join(import.meta.dir, "registry", "packages");
+    await using registry = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        const origin = `http://127.0.0.1:${registry.port}`;
+        if (url.pathname === "/one-dep") {
+          // one-dep@1.0.0 depends on no-deps@1.0.1; its own tarball is on the registry
+          return Response.json({
+            name: "one-dep",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "one-dep",
+                version: "1.0.0",
+                dependencies: { "no-deps": "1.0.1" },
+                dist: { tarball: `${origin}/one-dep/-/one-dep-1.0.0.tgz` },
+              },
+            },
+          });
+        }
+        if (url.pathname === "/no-deps") {
+          return Response.json({
+            name: "no-deps",
+            "dist-tags": { latest: "1.0.1" },
+            versions: {
+              "1.0.1": {
+                name: "no-deps",
+                version: "1.0.1",
+                dist: { tarball: `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.1.tgz` },
+              },
+            },
+          });
+        }
+        if (url.pathname === "/one-dep/-/one-dep-1.0.0.tgz") {
+          return new Response(Bun.file(join(pkgs, "one-dep", "one-dep-1.0.0.tgz")));
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "one-dep": "1.0.0" },
+        optionalDependencies: { "no-deps": "1.0.1" },
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/"
+allowedHosts = []
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    const refusal = `error: Refusing to download "http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.1.tgz" for package "no-deps": host is not in install.allowedHosts`;
+    expect(stderr).toContain(refusal);
+    expect(stderr.split(refusal).length - 1).toBe(1);
+    expect(exitCode).toBe(1);
+    expect(elsewhereReceived).toEqual([]);
   });
 
   it("a host allowed only on the ssh port still gets the ssh attempt", async () => {
@@ -511,7 +580,7 @@ allowedHosts = ["git.example.invalid:22"]
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("Refusing to clone");
     expect(stderr).toContain(`"git clone" for "repo" failed`);
     expect(exitCode).toBe(1);

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -437,6 +437,29 @@ allowedHosts = []
     expect(elsewhereReceived).toEqual([]);
   });
 
+  it("refuses a tarball URL dependency on a host that is not listed", async () => {
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    const tarballUrl = `http://127.0.0.1:${elsewhere.port}/no-deps-1.0.0.tgz`;
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": tarballUrl } }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:1/"
+allowedHosts = []
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain(
+      `error: Refusing to download "${tarballUrl}" for package "no-deps": host is not in install.allowedHosts`,
+    );
+    expect(stderr).not.toContain("internal error");
+    expect(exitCode).toBe(1);
+    expect(elsewhereReceived).toEqual([]);
+  });
+
   it("skips an optional dependency whose tarball host is not listed instead of failing", async () => {
     const elsewhereReceived: Received[] = [];
     await using elsewhere = serveElsewhere(elsewhereReceived);

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -839,6 +839,57 @@ allowedHosts = []
     expect(elsewhereReceived).toEqual([]);
   });
 
+  it("matches a git dependency with userinfo and a port by host:port", async () => {
+    // `git+ssh://git@host:2222/…` (tried as `https://git@host:2222/…` first):
+    // the `git@` must not become part of the host the allow-list compares.
+    // Allowed here, so the (failing-fast) clone is attempted rather than refused.
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { repo: "git+ssh://git@git.example.invalid:2222/someone/repo.git" },
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:1/"
+allowedHosts = ["git.example.invalid:2222"]
+`,
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, GIT_SSH_COMMAND: "false", GIT_TERMINAL_PROMPT: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Refusing to clone");
+    expect(stderr).toContain(`"git clone" for "repo" failed`);
+    expect(exitCode).toBe(1);
+
+    // and the refusal names the bare host[:port] when it is not listed
+    using dir2 = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { repo: "git+ssh://git@git.example.invalid:2222/someone/repo.git" },
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:1/"
+allowedHosts = []
+`,
+    });
+    const refused = await install(String(dir2));
+    expect(refused.stderr).toContain(
+      `error: Refusing to clone git dependency "repo" from "git.example.invalid:2222": host is not in install.allowedHosts`,
+    );
+    expect(refused.exitCode).toBe(1);
+  });
+
   it("a host allowed only on the ssh port still gets the ssh attempt", async () => {
     // `git@host:path` is tried over https first (port 443, not allowed here)
     // and then over ssh (port 22, allowed). The https form must be skipped

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -80,7 +80,7 @@ describe.concurrent("registry credentials are path-scoped", () => {
   // The registry (with a token) lives at http://127.0.0.1:<port>/prefix-a/.
   // Its manifest points the tarball at various places; only URLs under
   // /prefix-a/ on that origin may carry the token.
-  it.each([
+  describe.each([
     ["the registry path itself", (origin: string) => `${origin}/prefix-a/no-deps/-/no-deps-1.0.0.tgz`, "Bearer tok-a"],
     [
       "a deeper path under the registry",
@@ -92,9 +92,69 @@ describe.concurrent("registry credentials are path-scoped", () => {
     ["the host root", (origin: string) => `${origin}/no-deps-1.0.0.tgz`, null],
     ["a dot-segment escape", (origin: string) => `${origin}/prefix-a/../prefix-b/no-deps-1.0.0.tgz`, null],
     ["an encoded dot-segment escape", (origin: string) => `${origin}/prefix-a/%2e%2e/prefix-b/no-deps-1.0.0.tgz`, null],
-  ])("tarball at %s", async (_, tarballUrl, expectedAuthorization) => {
+  ])("tarball at %s", (_, tarballUrl, expectedAuthorization) => {
+    it(`is fetched with authorization ${expectedAuthorization}`, async () => {
+      const received: Received[] = [];
+      await using registry = serveRegistry(received, tarballUrl);
+      using dir = tempDir("registry-path-scoped-auth", {
+        "package.json": packageJson,
+        "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/prefix-a/", token = "tok-a" }
+`,
+      });
+
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+
+      const manifest = received.find(r => r.path === "/prefix-a/no-deps");
+      const tarball = received.find(r => r.path.endsWith(".tgz"));
+      expect(manifest?.authorization).toBe("Bearer tok-a");
+      expect(tarball).toBeDefined();
+      expect(tarball!.authorization).toBe(expectedAuthorization);
+    });
+  });
+
+  // A redirect is held to the same rule as the request that produced it: the
+  // token issued for /prefix-a/ does not follow a hop to another path on the
+  // same origin (fetch's own rule only strips it cross-origin).
+  it("does not forward the token on a redirect that leaves the registry path", async () => {
     const received: Received[] = [];
-    await using registry = serveRegistry(received, tarballUrl);
+    await using registry = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        received.push({ path: url.pathname, authorization: req.headers.get("authorization") });
+        const origin = `http://127.0.0.1:${registry.port}`;
+        if (url.pathname === "/prefix-a/no-deps") {
+          return Response.redirect(`${origin}/mirror/no-deps`, 302);
+        }
+        if (url.pathname === "/mirror/no-deps") {
+          return Response.json({
+            name: "no-deps",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "no-deps",
+                version: "1.0.0",
+                dist: { integrity, tarball: `${origin}/prefix-a/no-deps/-/no-deps-1.0.0.tgz` },
+              },
+            },
+          });
+        }
+        if (url.pathname === "/prefix-a/no-deps/-/no-deps-1.0.0.tgz") {
+          return Response.redirect(`${origin}/prefix-b/no-deps-1.0.0.tgz`, 307);
+        }
+        if (url.pathname === "/prefix-b/no-deps-1.0.0.tgz") {
+          return new Response(Bun.file(tgz));
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
     using dir = tempDir("registry-path-scoped-auth", {
       "package.json": packageJson,
       "bunfig.toml": `
@@ -108,12 +168,12 @@ registry = { url = "http://127.0.0.1:${registry.port}/prefix-a/", token = "tok-a
     expect(stderr).toContain("Saved lockfile");
     expect(stdout).toContain("1 package installed");
     expect(exitCode).toBe(0);
-
-    const manifest = received.find(r => r.path === "/prefix-a/no-deps");
-    const tarball = received.find(r => r.path.endsWith(".tgz"));
-    expect(manifest?.authorization).toBe("Bearer tok-a");
-    expect(tarball).toBeDefined();
-    expect(tarball!.authorization).toBe(expectedAuthorization);
+    expect(received).toEqual([
+      { path: "/prefix-a/no-deps", authorization: "Bearer tok-a" },
+      { path: "/mirror/no-deps", authorization: null },
+      { path: "/prefix-a/no-deps/-/no-deps-1.0.0.tgz", authorization: "Bearer tok-a" },
+      { path: "/prefix-b/no-deps-1.0.0.tgz", authorization: null },
+    ]);
   });
 
   it("tarball on another host never receives the token", async () => {
@@ -342,34 +402,165 @@ allowedHosts = []
     expect(elsewhereReceived).toEqual([]);
   });
 
-  it.each([
+  describe.each([
     ["host:port", (port: number) => `["127.0.0.1:${port}"]`],
     ["a bare hostname (any port)", () => `["127.0.0.1"]`],
     ["one of several entries", (port: number) => `["registry.example.com", "127.0.0.1:${port}", "[::1]:1"]`],
-  ])("allows a tarball host listed as %s", async (_, entry) => {
-    const received: Received[] = [];
-    const elsewhereReceived: Received[] = [];
-    await using elsewhere = serveElsewhere(elsewhereReceived);
-    await using registry = serveRegistry(
-      received,
-      () => `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.0.tgz`,
-    );
-    using dir = tempDir("allowed-hosts", {
-      "package.json": packageJson,
-      "bunfig.toml": `
+  ])("a tarball host listed as %s", (_, entry) => {
+    it("is allowed", async () => {
+      const received: Received[] = [];
+      const elsewhereReceived: Received[] = [];
+      await using elsewhere = serveElsewhere(elsewhereReceived);
+      await using registry = serveRegistry(
+        received,
+        () => `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.0.tgz`,
+      );
+      using dir = tempDir("allowed-hosts", {
+        "package.json": packageJson,
+        "bunfig.toml": `
 [install]
 cache = false
 registry = { url = "http://localhost:${registry.port}/", token = "registry-token" }
 allowedHosts = ${entry(elsewhere.port)}
 `,
+      });
+
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+      // allowed to fetch, but being on the list does not earn the registry's token
+      expect(elsewhereReceived).toEqual([{ path: "/no-deps/-/no-deps-1.0.0.tgz", authorization: null }]);
+    });
+  });
+
+  // An allowed host must not be able to bounce the install to an unlisted one:
+  // the allow-list is re-applied to every redirect hop before it is followed.
+  describe.each(["manifest", "tarball"] as const)("a %s redirect to a host that is not listed", which => {
+    it("is refused without contacting it", async () => {
+      const elsewhereReceived: Received[] = [];
+      await using elsewhere = serveElsewhere(elsewhereReceived);
+      const received: Received[] = [];
+      await using registry = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          const url = new URL(req.url);
+          received.push({ path: url.pathname, authorization: req.headers.get("authorization") });
+          const origin = `http://127.0.0.1:${registry.port}`;
+          const elsewhereOrigin = `http://127.0.0.1:${elsewhere.port}`;
+          if (url.pathname === "/no-deps") {
+            if (which === "manifest") return Response.redirect(`${elsewhereOrigin}/no-deps`, 302);
+            return Response.json({
+              name: "no-deps",
+              "dist-tags": { latest: "1.0.0" },
+              versions: {
+                "1.0.0": {
+                  name: "no-deps",
+                  version: "1.0.0",
+                  dist: { integrity, tarball: `${origin}/no-deps/-/no-deps-1.0.0.tgz` },
+                },
+              },
+            });
+          }
+          if (url.pathname === "/no-deps/-/no-deps-1.0.0.tgz") {
+            return Response.redirect(`${elsewhereOrigin}/no-deps-1.0.0.tgz`, 302);
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      using dir = tempDir("allowed-hosts", {
+        "package.json": packageJson,
+        "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/", token = "registry-token" }
+allowedHosts = []
+`,
+      });
+
+      const { stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain(
+        which === "manifest"
+          ? "RedirectHostNotAllowed downloading package manifest no-deps"
+          : "RedirectHostNotAllowed downloading tarball no-deps@1.0.0",
+      );
+      expect(exitCode).toBe(1);
+      // one attempt, not retried, and the redirect target never contacted
+      expect(
+        received.filter(r => r.path === (which === "manifest" ? "/no-deps" : "/no-deps/-/no-deps-1.0.0.tgz")),
+      ).toHaveLength(1);
+      expect(elsewhereReceived).toEqual([]);
     });
 
-    const { stdout, stderr, exitCode } = await install(String(dir));
-    expect(stderr).toContain("Saved lockfile");
-    expect(stdout).toContain("1 package installed");
-    expect(exitCode).toBe(0);
-    // allowed to fetch, but being on the list does not earn the registry's token
-    expect(elsewhereReceived).toEqual([{ path: "/no-deps/-/no-deps-1.0.0.tgz", authorization: null }]);
+    it("is followed once the host is listed, without the registry's token", async () => {
+      const elsewhereReceived: Received[] = [];
+      await using elsewhere = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          const url = new URL(req.url);
+          elsewhereReceived.push({ path: url.pathname, authorization: req.headers.get("authorization") });
+          if (url.pathname === "/no-deps") {
+            return Response.json({
+              name: "no-deps",
+              "dist-tags": { latest: "1.0.0" },
+              versions: {
+                "1.0.0": {
+                  name: "no-deps",
+                  version: "1.0.0",
+                  dist: { integrity, tarball: `http://127.0.0.1:${elsewhere.port}/no-deps-1.0.0.tgz` },
+                },
+              },
+            });
+          }
+          return new Response(Bun.file(tgz));
+        },
+      });
+      await using registry = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          const url = new URL(req.url);
+          const origin = `http://127.0.0.1:${registry.port}`;
+          const elsewhereOrigin = `http://127.0.0.1:${elsewhere.port}`;
+          if (url.pathname === "/no-deps") {
+            if (which === "manifest") return Response.redirect(`${elsewhereOrigin}/no-deps`, 302);
+            return Response.json({
+              name: "no-deps",
+              "dist-tags": { latest: "1.0.0" },
+              versions: {
+                "1.0.0": {
+                  name: "no-deps",
+                  version: "1.0.0",
+                  dist: { integrity, tarball: `${origin}/no-deps/-/no-deps-1.0.0.tgz` },
+                },
+              },
+            });
+          }
+          if (url.pathname === "/no-deps/-/no-deps-1.0.0.tgz") {
+            return Response.redirect(`${elsewhereOrigin}/no-deps-1.0.0.tgz`, 302);
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      using dir = tempDir("allowed-hosts", {
+        "package.json": packageJson,
+        "bunfig.toml": `
+[install]
+cache = false
+registry = { url = "http://127.0.0.1:${registry.port}/", token = "registry-token" }
+allowedHosts = ["127.0.0.1:${elsewhere.port}"]
+`,
+      });
+
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+      expect(elsewhereReceived.length).toBeGreaterThan(0);
+      expect(elsewhereReceived.every(r => r.authorization === null)).toBeTrue();
+    });
   });
 
   it("does not match a listed host on a different port", async () => {

--- a/test/cli/install/bun-install-registry-scoping.test.ts
+++ b/test/cli/install/bun-install-registry-scoping.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
+import { existsSync } from "fs";
 import { rm } from "fs/promises";
 import { bunExe, bunEnv as env, tempDir } from "harness";
 import { join } from "path";
@@ -208,6 +209,10 @@ cache = false
       ]);
     }
 
+    // Over plain http an npmrc entry only covers an origin the configuration
+    // itself declares as an http registry (the entries carry no scheme, and a
+    // manifest must not be able to downgrade a request to cleartext and still
+    // collect the token) ...
     tarballOnElsewhere = true;
     received.length = 0;
     {
@@ -215,6 +220,23 @@ cache = false
         "package.json": packageJson,
         "bunfig.toml": `[install]\ncache = false\n`,
         ".npmrc": npmrc,
+      });
+      const { stdout, stderr, exitCode } = await install(String(dir));
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+      expect(received).toEqual([{ path: "/prefix-a/no-deps", authorization: "Bearer tok-a" }]);
+      expect(elsewhereReceived).toEqual([{ path: "/downloads/no-deps-1.0.0.tgz", authorization: null }]);
+    }
+
+    // ... such as a scoped registry on that origin.
+    received.length = 0;
+    elsewhereReceived.length = 0;
+    {
+      using dir = tempDir("registry-path-scoped-auth", {
+        "package.json": packageJson,
+        "bunfig.toml": `[install]\ncache = false\n`,
+        ".npmrc": npmrc + `@other:registry=http://127.0.0.1:${elsewhere.port}/\n`,
       });
       const { stdout, stderr, exitCode } = await install(String(dir));
       expect(stderr).toContain("Saved lockfile");
@@ -413,6 +435,63 @@ allowedHosts = []
     );
     expect(exitCode).toBe(1);
     expect(elsewhereReceived).toEqual([]);
+  });
+
+  it("skips an optional dependency whose tarball host is not listed instead of failing", async () => {
+    const elsewhereReceived: Received[] = [];
+    await using elsewhere = serveElsewhere(elsewhereReceived);
+    const tarballUrl = `http://127.0.0.1:${elsewhere.port}/no-deps/-/no-deps-1.0.0.tgz`;
+    await using registry = serveRegistry([], () => tarballUrl);
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", optionalDependencies: { "no-deps": "1.0.0" } }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://127.0.0.1:${registry.port}/"
+allowedHosts = []
+`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).toContain(
+      `warn: Skipping optional package "no-deps": "${tarballUrl}" is not in install.allowedHosts`,
+    );
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(elsewhereReceived).toEqual([]);
+    expect(existsSync(join(String(dir), "node_modules", "no-deps"))).toBeFalse();
+  });
+
+  it("a host allowed only on the ssh port still gets the ssh attempt", async () => {
+    // `git@host:path` is tried over https first (port 443, not allowed here)
+    // and then over ssh (port 22, allowed). The https form must be skipped
+    // quietly rather than failing the dependency; the ssh attempt is made to
+    // fail fast so no real connection is needed.
+    using dir = tempDir("allowed-hosts", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { repo: "git@git.example.invalid:someone/repo.git" },
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "http://localhost:1/"
+allowedHosts = ["git.example.invalid:22"]
+`,
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, GIT_SSH_COMMAND: "false", GIT_TERMINAL_PROMPT: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Refusing to clone");
+    expect(stderr).toContain(`"git clone" for "repo" failed`);
+    expect(exitCode).toBe(1);
   });
 
   it("rejects entries that are not host[:port]", async () => {


### PR DESCRIPTION
### What does this PR do?

Three related pieces of registry hardening for `bun install`, all backed by one predicate (`url_under(url, base)`: same scheme/host/effective port **and** `base`'s path is a segment-wise prefix of `url`'s path, with `.`/`..`/`%2e%2e` segments and backslashes rejected).

#### 1. Registry credentials are path-scoped, not just origin-scoped (behaviour change)

Today a registry's token / `_auth` / username+password is attached to any request whose *origin* matches the registry URL. Path-based multi-tenant registry hosts (e.g. Nexus, GitLab, Azure Artifacts, AWS CodeArtifact — many registries or feeds under one hostname, `https://host/npm/team-a/`, `https://host/npm/team-b/`, …) therefore receive a token configured for one path on every path of that host, including wherever a manifest's `dist.tarball` points on that host. Since `dist.tarball` is registry-controlled (or comes from a lockfile), another tenant on the same host can direct the credentials to themselves.

With this PR, credentials configured for a registry accompany a request only when the request URL is *under* the registry URL — origin and path. This matches how npm scopes `//host/path/:_authToken` ("nerf darts") and yarn berry's behaviour.

| Registry URL | Request URL | Before | After |
| --- | --- | --- | --- |
| `https://registry.npmjs.org/` | anything on `registry.npmjs.org` | sent | sent |
| `https://host/npm/team-a/` | `https://host/npm/team-a/pkg/-/pkg-1.0.0.tgz` | sent | sent |
| `https://host/npm/team-a/` | `https://host/npm/team-b/pkg/-/pkg-1.0.0.tgz` | sent | **not sent** |
| `https://host/npm/team-a/` | `https://host/npm/team-ab/x.tgz`, `https://host/npm/team-a/../team-b/x.tgz` | sent | **not sent** |
| `https://host/npm/team-a/` | `https://cdn.example.com/...` | not sent | not sent |

Registries configured at the root of their host (the common case, including the default registry) behave exactly as before. Default-port spelling (`https://host:443/` vs `https://host/`) is still normalized.

To keep configurations working where a registry legitimately serves tarballs from a *sibling* path (GitLab's instance-level endpoint returns project-level tarball URLs, for example), `.npmrc` `//host/path/:_authToken` / `_auth` / `username`+`_password` entries that no configured registry claims are now honoured as path-scoped credentials for requests under that `//host/path/` (longest path wins; an entry written without a port only covers the default port) — the same lookup npm performs, and the same two-line `.npmrc` those products already document for npm. Previously bun silently ignored such entries.

Redirects are held to the same rule: the HTTP client gained an optional per-request `RedirectPolicy` (set only by the package manager; `fetch()` is unchanged), evaluated on every hop, which drops the `Authorization` header as soon as the target is no longer under the URL prefix the credentials were issued for — even on a same-origin redirect to another path — on top of fetch's existing cross-origin stripping.

Also applied to `bun pm diff`'s registry requests, which had their own copy of the origin check.

#### 2. `install.allowedHosts`

```toml
[install]
registry = "https://registry.example.com/npm/"
allowedHosts = []                      # only the configured registries' hosts
# allowedHosts = ["cdn.example.com", "git.example.com:8443"]
```

When the key is present (even empty), `bun install` refuses to fetch a manifest, tarball (npm, GitHub, or URL) or git repository from any host that is not the host of a configured registry (default + scopes, implicitly allowed) or listed (`hostname` = any port, `hostname:port` = that port). The refusal happens before any request is made and names the URL and package; the install fails cleanly — for optional dependencies too, so the allow-list never quietly changes the installed tree. The check is re-applied to every HTTP redirect hop before it is followed (`RedirectHostNotAllowed`, not retried). For git dependencies the https and ssh forms of a specifier are checked separately (`host:22` permits only ssh). Unset (the default) keeps today's behaviour. Entries must be hosts, not URLs (validated with a bunfig error).

While here: a tarball URL refused during resolution (this new check, or the existing "must be http(s)" check) used to end with `error: An internal error occurred (InvalidURL)` after the real message; it now just fails the install with the logged error, and the dedupe entry is marked failed so the install phase does not wait on a task that was never scheduled.

#### 3. `[[install.rewrite]]`

```toml
[[install.rewrite]]
from = "https://registry.npmjs.org/"
to = "https://mirror.example.com/npm/"
```

Plain URL-prefix rewrites applied to manifest and tarball requests at fetch time; the longest matching `from` wins. `bun.lock` keeps the canonical URL, so the lockfile stays portable and the mirror is an environment concern. Credentials (1) and the allow-list (2) are evaluated against the *rewritten* URL.

Docs: `docs/runtime/bunfig.mdx` (both keys + a note under `install.scopes`), `docs/pm/scopes-registries.mdx` (new "Credential scoping" section), `docs/pm/npmrc.mdx`, `docs/pm/cli/install.mdx`.

Not changed / out of scope: `install.rewrite` rules are not applied to redirect targets (a redirect is the server's explicit instruction); registry URLs written with a path but no trailing slash keep resolving manifests the way they do today (WHATWG join), so their manifest requests are not under the registry path and no longer carry its token — write the trailing slash.

### How did you verify your code works?

New `test/cli/install/bun-install-registry-scoping.test.ts` (32 tests, local `Bun.serve` registries that record the path and `authorization` header of every request):

- token for `http://host:port/prefix-a/` is sent to `/prefix-a/no-deps` and `/prefix-a/.../no-deps-1.0.0.tgz`, not to `/prefix-b/…`, `/prefix-ab/…`, the host root, `/prefix-a/../prefix-b/…`, `/prefix-a/%2e%2e/prefix-b/…`, or another host; same via `.npmrc`; a root-configured registry (no trailing slash) still authenticates every path
- extra `.npmrc` `//host/prefix-b/:_authToken` / `username`+`_password` entries cover the sibling path (longest path wins), an entry for a parent path covers a registry below it, a port-less entry does not cover a non-default port
- `allowedHosts = []` refuses a foreign tarball host without contacting it (clean error, exit 1, no "internal error"); `host:port`, bare host and multi-entry lists allow it (and being allowed does not earn the registry's token); a listed host on another port is refused; unset = any host; git dependencies on unlisted hosts are refused before `git` runs; URL-shaped entries are a bunfig error
- rewrite: tarball fetched from the `to` prefix with the registry's token (longest `from` wins), the canonical host is never contacted, `bun.lock` records the canonical URL, and a `--frozen-lockfile` reinstall goes through the rewrite again with the lockfile unchanged; a rewrite to another (allow-listed) host carries no token
- redirects: a manifest or tarball 302 from the registry to an unlisted host is refused without contacting it (one attempt, no retries) and followed without the registry token once the host is listed; a same-origin redirect off the registry path does not carry the token
- `.npmrc` path credentials: an extra `//host/other-path/:_authToken` (or `username`/`_password`) entry covers requests under that path (longest wins), a parent-path entry covers a registry below it, a port-less entry does not cover a non-default port, and over plain http an entry only covers an origin that a configured registry declares as http
- optional dependency on a refused host fails the install; a package optional for one dependent and required for another is refused exactly once; git dependencies refused per transport (`host:22` still gets the ssh attempt)

Existing suites: `bun-install.test.ts`, `bun-install-registry.test.ts`, `npmrc.test.ts`, `config-precedence.test.ts`, `redacted-config-logs.test.ts`, `bun-pm-diff.test.ts`, `bun-workspaces.test.ts`, `isolated-install.test.ts`, `bun-lock.test.ts`, `test/internal/source-lints/` pass locally apart from pre-existing environment-dependent failures unrelated to this change (also failing on the base commit here).
