### PR TITLE
test(next-pages): wait for every request before the dev server is killed

### DIFF
--- a/test/integration/next-pages/test/dev-server-ssr-100.test.ts
+++ b/test/integration/next-pages/test/dev-server-ssr-100.test.ts
@@ -135,7 +135,6 @@ test(
   "ssr works for 100-ish requests",
   async () => {
     using devServer = await startDevServer();
-    const { resolve, reject, promise } = Promise.withResolvers();
     expect(dev_server).not.toBeUndefined();
     expect(baseUrl).not.toBeUndefined();
     const lockfile = parseLockfile(root);
@@ -145,6 +144,7 @@ test(
 
     // On an arm64 mac, it doesn't get faster if you increase it beyond 4 as of August, 2025.
     const queue = new PQueue({ concurrency: 4 });
+    let completed = 0;
 
     async function run(i: number) {
       const x = await fetch(`${baseUrl}/?i=${i}`, {
@@ -157,21 +157,24 @@ test(
       const text = await x.text();
       console.count("Completed request");
       expect(text).toContain(`>${Bun.version}</code>`);
+      completed++;
     }
 
+    const requests: Promise<void>[] = [];
     for (let i = 0; i < 100; i++) {
-      queue.add(
-        async () => {
-          await run(i);
-        },
-        { signal: controller.signal },
-      );
+      requests.push(queue.add(() => run(i), { signal: controller.signal }));
     }
-    queue.once("error", e => {
-      reject(e);
-    });
-    queue.onEmpty().then(resolve);
-    await promise;
+
+    // Every request must finish before `devServer` is disposed, which kills
+    // the dev server. `queue.onEmpty()` is not enough: it settles when the
+    // last job is dequeued while up to `concurrency` jobs are still running.
+    try {
+      await Promise.all(requests);
+    } catch (e) {
+      controller.abort(e);
+      throw e;
+    }
+    expect(completed).toBe(100);
   },
   timeout,
 );

--- a/test/integration/next-pages/test/dev-server-ssr-100.test.ts
+++ b/test/integration/next-pages/test/dev-server-ssr-100.test.ts
@@ -82,7 +82,7 @@ async function getDevServerURL() {
   readStream()
     .catch(e => reject(e))
     .finally(() => {
-      dev_server.unref?.();
+      dev_server?.unref?.();
     });
   await promise;
   return baseUrl;


### PR DESCRIPTION
### Problem
- `test/integration/next-pages/test/dev-server-ssr-100.test.ts` goes red on the Windows lanes with `Unhandled error between tests: TypeError: Unable to connect. Is the computer able to access the url?` (`code: "ConnectionRefused"`, `path: "http://localhost:NNNNN/?i=99"`) after the test itself passed. It took build 103222 down and is flaky on about 25% of recent builds.
- The test waits on `queue.onEmpty()` (line 173). That promise settles when the last job is dequeued, while up to `concurrency` (4) jobs still run. The test returns, `using devServer` disposes and kills `next dev`, and the in-flight fetches reject. Nothing awaits their `queue.add()` promises, so bun test reports them as unhandled errors.

### Fix
- Collect the `queue.add()` promises and `await Promise.all(...)`. The dev server is killed only after every request has finished. On a failure the test aborts the remaining requests through the existing `AbortController` and rethrows the real error.
- Assert `completed === 100`. The old wait let the test pass with 97 or 98 completed requests (198 or 200 `expect()` calls instead of 205) on every run I measured, on Linux and on Windows.
- This keeps the same code paths (100 SSR requests through `fetch` against `next dev` under `bun --bun`) and now checks all of them. The stdout reader's `finally` now uses `dev_server?.unref?.()`, as `dev-server.test.ts` does: `exited.finally()` clears `dev_server` before the stdout EOF when the exit is observed first.
- Verified: `bun bd test test/integration/next-pages/test/dev-server-ssr-100.test.ts` passes. On Windows, pinned to 2 CPUs, the old test reproduces the exact CI error (1 of 12 runs, same `ConnectionRefused` for `/?i=98` and `/?i=99`). The fixed test passes 32 of 32 runs on Windows with 100 completed requests each time.

### Background
- `p-queue`'s `onEmpty()` resolves when `queue.size === 0`. `onIdle()` is the one that also waits for `queue.pending === 0`. The test used the former.
- Bun's fetch reuses keep-alive connections. When a reused connection closes before the response arrives, the client retries once on a new connection. After the server dies, that retry fails with `ConnectionRefused`, which is the error in the annotation.
- bun test does not drain the event loop after the last test. Whether the rejection is processed before exit depends on timing, so the failure is intermittent and shows up on the slower 4 vCPU Windows agents.
- The `onEmpty()` wait dates from #21695. The Windows hit rate rose after #36175 removed the CPU pin from the test agents. No bun commit in the builds 103100 to 103238 separates clean from failing runs: every base commit in that range has both.

<details><summary>Notes</summary>

Measurements with the released canary (`USE_SYSTEM_BUN=1`) and the CI runner env (`BUN_GARBAGE_COLLECTOR_LEVEL=1`, `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1`, ...):

- Linux, old test: passes, 97 `Completed request` lines, 198 `expect()` calls. The server log shows 97 `GET /?i=` lines.
- Windows 16 vCPU, old test, 20 runs: 20 pass, 97 or 98 completed requests each.
- Windows pinned to 2 CPUs (`start /affinity 3`), old test, 12 runs: 1 fails with the CI signature (test passes, then two `Unhandled error between tests` with `ConnectionRefused` for `/?i=98` and `/?i=99`).
- Windows 16 vCPU, fixed test, 20 runs: 20 pass, 100 completed, 205 `expect()` calls.
- Windows pinned to 2 CPUs, fixed test, 12 runs: 12 pass, 100 completed each.
- Linux, `bun bd test` (debug, ASAN), fixed test: pass, 100 completed, 205 `expect()` calls.

Why the rejection is `ConnectionRefused` and not a reset: the last fetches reuse pooled keep-alive connections. The HTTP client marks a reused connection as retryable; when the dev server dies the reused socket closes with no response, the client retries on a fresh connection, and the fresh `connect()` is refused.

Onset data (Buildkite annotations, builds 83000 to 103238): the Windows lane failures start on 2026-07-29 with bases from `be5c92a8f1..e532ad91f3`, where #36175 (`be5c92a8f1`) dropped `cpuCount: 2, threadsPerCore: 1` from the test agents. Before that the same race hit macOS and Linux lanes at a low rate. One Windows hit on 2026-07-27 (build 83388) predates that change.

Related open PRs that edit this file:
- #35896 (bun test post-run drain) carries a `queue.onIdle()` hunk for the same line, inside the old `withResolvers` structure. `onIdle()` fixes the happy path only: the `queue.add()` promises stay unobserved, so a real failure still ends as an unhandled rejection. This PR supersedes that hunk. #35896 is in conflict with main and needs to drop it on rebase.
- #25599 does not touch the wait; it moves the fixture copy into `startDevServer()`.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/integration/next-pages/test/dev-server-ssr-100.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/integration/next-pages/test/dev-server-ssr-100.test.ts"
bun test v1.4.1 (4448a2e21)

test/integration/next-pages/test/dev-server-ssr-100.test.ts:
Copied to: /tmp/bun.test.HxU7Cl
bun install v1.4.1 (4448a2e21)

$ cd node_modules/puppeteer && bun install.mjs
**INFO** Skipping downloading browsers as instructed.

+ @types/node@25.0.0
+ @types/react@19.2.14
+ @types/react-dom@19.2.3
+ autoprefixer@10.4.21
+ bun-types@1.2.19
+ eslint@9.33.0
+ eslint-config-next@16.1.6
+ next@16.1.6
+ postcss@8.5.6
+ puppeteer@24.16.0
+ react@19.2.4
+ react-dom@19.2.4
+ tailwindcss@3.4.17
+ typescript@5.9.2

482 packages installed [4.46s]
Starting dev server
▲ Next.js 16.1.6 (Turbopack)

- Local:         http://localhost:35575

- Network:       http://172.19.0.37:35575



✓ Starting...

✓ Ready in 29.9s

○ Compiling / ...

Browserslist: browsers data (caniuse-lite) is 12 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
⚠ [next]/internal/font/google/inter_34fc90a6.module.css
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap

Import traces:
  Browser:
    [next]/internal/font/google/inter_34fc90a6.module.css
    [next]/internal/font/google/inter_34fc90a6.js
    ./src/pages/index.tsx

  SSR:
    [next]/internal/font/google/inter_34fc90a6.module.css
    [next]/internal/font/google/inter_34fc90a6.js
    ./src/pages/index.tsx


⚠ [next]/internal/font/google/inter_34fc90a6.module.css
next/font: warning:
Failed to download `Inter` from Google Fonts. Using fallback font instead.

Import traces:
  Browser:
    [next]/internal/font/google/inter_34fc90a6.module.css
    [next]/internal/font/google/inter_34fc90a6.js
    ./src/pages/index.tsx

  SSR:
    [next]/internal/font/google/inter_
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../next-pages/test/dev-server-ssr-100.test.ts     | 29 ++++++++++++----------
 1 file changed, 16 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…/integration/next-pages/test/dev-server-ssr-100.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->