### PR TITLE
test: update bun-pm.test.ts `pm ls` snapshots for #38952's header; name prune's HoistedTree::init flags

### DIFF
--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -666,8 +666,17 @@ enum Installed {
     OtherVersion,
 }
 
+#[derive(Clone, Copy)]
+struct HoistedTreeInit {
+    /// suppress per-package progress output
+    quiet: bool,
+    /// restrict to `--filter`-selected workspaces
+    filtered: bool,
+}
+
 impl<'a> HoistedTree<'a> {
-    fn init(lockfile: &'a Lockfile, quiet: bool, filtered: bool) -> HoistedTree<'a> {
+    fn init(lockfile: &'a Lockfile, opts: HoistedTreeInit) -> HoistedTree<'a> {
+        let HoistedTreeInit { quiet, filtered } = opts;
         let trees = lockfile.buffers.trees.as_slice();
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
@@ -960,7 +969,7 @@ fn plan_hoisted(
         || !features.optional_dependencies
         || !features.peer_dependencies;
     let lockfile: &Lockfile = &manager.lockfile;
-    let hoisted = HoistedTree::init(lockfile, quiet, filtered);
+    let hoisted = HoistedTree::init(lockfile, HoistedTreeInit { quiet, filtered });
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
     let trees = lockfile.buffers.trees.as_slice();
@@ -1144,8 +1153,20 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
         return;
     }
     let quiet = manager.options.log_level == LogLevel::Silent;
-    let old = HoistedTree::init(before, true, false);
-    let new = HoistedTree::init(after, quiet, false);
+    let old = HoistedTree::init(
+        before,
+        HoistedTreeInit {
+            quiet: true,
+            filtered: false,
+        },
+    );
+    let new = HoistedTree::init(
+        after,
+        HoistedTreeInit {
+            quiet,
+            filtered: false,
+        },
+    );
     let targets = manager.filtered_link_targets.as_ref();
     let selected: Option<Vec<PackageID>> = targets.map(|targets| targets.package_ids(before));
     let importers = selected.as_ref().map(|_| tree_importers(before));

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -670,7 +670,7 @@ enum Installed {
 struct HoistedTreeInit {
     /// suppress per-package progress output
     quiet: bool,
-    /// restrict to `--filter`-selected workspaces
+    /// the expected tree excludes dev/optional/peer dependencies (`--production` / `--omit`)
     filtered: bool,
 }
 

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -600,7 +600,7 @@ it.each([
   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls");
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
-    "<dir> node_modules (5)
+    "<dir> node_modules (5 installed)
     ├── bar@0.0.2
     ├── bar-alias@0.0.2
     ├── ws-once@workspace:packages/ws-once
@@ -622,7 +622,7 @@ it("should list a trusted workspace the root also depends on once with --trusted
   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls", "--trusted");
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
-    "<dir> node_modules (5)
+    "<dir> node_modules (5 installed)
     └── ws-once@workspace:packages/ws-once"
   `);
   expect(exitCode).toBe(0);
@@ -670,7 +670,7 @@ it("should list a root optional peer that a dependency provides", async () => {
   const [stdout, stderr, exitCode] = await spawnAndCollect("pm", "ls");
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout, package_dir)).toMatchInlineSnapshot(`
-    "<dir> node_modules (2)
+    "<dir> node_modules (2 installed)
     ├── bar@0.0.2
     └── moo@moo"
   `);

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -658,7 +658,7 @@ test.concurrent("isolated linker: --verbose does not print the store build timin
 
     - no-deps@1.0.1
     - one-dep@1.0.0
-    2 packages removed (checked 5)"
+    2 packages removed (checked 5 installed packages)"
   `);
   expect(stderr).not.toContain("Resolved peers");
   expect(stderr).not.toContain("Created store");


### PR DESCRIPTION
### What does this PR do?

Two small fixes for things currently red on `main` for any PR that touches `bun_install`:

1. **`test/cli/install/bun-pm.test.ts`** — #39962 added three `bun pm ls` inline snapshots using the old `node_modules (N)` header, and #38952 (merged around the same time) changed that header to `node_modules (N installed)`. The two crossed, so those three snapshots fail on `main`. Updated them to the current wording. Same for one `bun-prune.test.ts` `--verbose` snapshot that predates #38952's `checked N installed packages` wording.
2. **`src/install/prune.rs`** — the mordant `bare_bool_args` lint flags `HoistedTree::init(before, true, false)` (0 recorded in the baseline for that file), which fails the `rust-lints / mordant` job on PRs touching the crate (seen on #40011 and #40053, neither of which touches `prune.rs`). `init` now takes a small named options struct.

No behaviour change.

### How did you verify your code works?

`bun test test/cli/install/bun-pm.test.ts` passes locally (was 3 failures on `main`); `cargo clippy -p bun_install` clean; `bun-prune.test.ts` unchanged.

