### PR TITLE
install: treat a tarball/manifest body cut short by the connection as a failed download

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -207,7 +207,12 @@ impl NetworkTask {
             // main thread and later chunk callbacks can see it.
             if let Some(m) = result.metadata.take() {
                 // SAFETY: `stream` is the live heap-allocated `TarballStream`.
-                unsafe { (*stream).status_code = m.response.status_code };
+                unsafe {
+                    (*stream).status_code = m.response.status_code;
+                    if let http::BodySize::ContentLength(len) = result.body_size {
+                        (*stream).content_length = Some(len);
+                    }
+                }
                 // New attempt's headers arrived — drop any bytes buffered from
                 // a prior failed attempt (pre-refactor `HTTPClient::start()`
                 // did this via `body_out_str.reset()`).
@@ -245,11 +250,11 @@ impl NetworkTask {
                         // runs at most once at a time, releases the
                         // worker on ARCHIVE_RETRY, and is re-enqueued by
                         // the next chunk. Pending-task accounting stays
-                        // balanced: this NetworkTask is never pushed to
-                        // `async_network_task_queue` once committed, so
-                        // its `increment_pending_tasks()` is satisfied by
-                        // the extract Task that `TarballStream.finish()`
-                        // publishes to `resolve_tasks`.
+                        // balanced: `TarballStream.finish()` publishes
+                        // exactly one of the extract Task (to
+                        // `resolve_tasks`) or, when the connection failed
+                        // mid-body, this NetworkTask (to
+                        // `async_network_task_queue`).
                         // SAFETY: `this` is live; the HTTP thread is its sole writer here.
                         unsafe { (*this).streaming_committed = true };
                         // SAFETY: `stream` is the live heap-allocated
@@ -960,13 +965,24 @@ impl NetworkTask {
         }
     }
 
-    /// Prepare this task for another HTTP attempt (used by retry logic when
-    /// streaming extraction never started). Keeps the stream allocation so the
-    /// retry can still benefit from streaming.
+    /// Prepare this task for another HTTP attempt. A stream that never ran is
+    /// reused; one consumed by a download that failed mid-body (released in
+    /// `TarballStream::finish`) is replaced, keeping the same extract Task.
     pub(crate) fn reset_streaming_for_retry(&mut self) {
         debug_assert!(!self.streaming_committed);
         if let Some(stream) = self.tarball_stream.as_deref_mut() {
             stream.reset_for_retry();
+        } else if !self.streaming_extract_task.is_null() {
+            let manager = self.package_manager.as_mut_ptr();
+            let this: *mut NetworkTask = self;
+            // SAFETY: `init` returns a fresh heap allocation owned here.
+            self.tarball_stream = Some(unsafe {
+                bun_core::heap::take(TarballStream::init(
+                    self.streaming_extract_task,
+                    this,
+                    manager,
+                ))
+            });
         }
         self.response = HTTPClientResult::default();
     }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -469,18 +469,19 @@ fn run_tasks_erased(
                     }
                 }
 
-                if !has_network_error && task.response.metadata.is_none() {
-                    has_network_error = true;
-                    let min = manager.options.min_simultaneous_requests;
-                    let max = AsyncHTTP::max_simultaneous_requests().load(Ordering::Relaxed);
-                    if max > min {
-                        AsyncHTTP::max_simultaneous_requests()
-                            .store(min.max(max / 2), Ordering::Relaxed);
-                    }
+                // Headers can arrive and the connection still die before the
+                // body does; for a 2xx/3xx that is a failed download too (an
+                // error status keeps its own handling below).
+                let download_failed = match &task.response.metadata {
+                    None => true,
+                    Some(m) => task.response.fail.is_some() && m.response.status_code < 400,
+                };
+                if download_failed {
+                    throttle_after_network_error(manager, &mut has_network_error);
                 }
 
                 // Handle retry-able errors.
-                if task.response.metadata.is_none()
+                if download_failed
                     || task
                         .response
                         .metadata
@@ -517,7 +518,8 @@ fn run_tasks_erased(
                     }
                 }
 
-                let Some(metadata) = task.response.metadata.as_ref() else {
+                let Some(metadata) = task.response.metadata.as_ref().filter(|_| !download_failed)
+                else {
                     // Handle non-retry-able errors.
                     let err = task
                         .response
@@ -738,24 +740,21 @@ fn run_tasks_erased(
                 // touch `task.callback` (see `NetworkTask::reset_streaming_*`
                 // / `discard_unused_streaming_state`).
                 let extract = unsafe { &mut *extract_ptr };
-                // Streaming extraction never pushes its NetworkTask to
-                // `async_network_task_queue` once committed — the
-                // extract Task published by `TarballStream.finish()`
-                // owns its lifetime — so every `.extract` task that
-                // arrives here is taking the buffered path.
+                // A committed stream publishes its result through the extract
+                // Task, except when the connection failed mid-body:
+                // `TarballStream::finish()` then un-commits and sends the
+                // NetworkTask back here to be retried like any failed download.
                 debug_assert!(!task.streaming_committed);
 
-                if !has_network_error && task.response.metadata.is_none() {
-                    has_network_error = true;
-                    let min = manager.options.min_simultaneous_requests;
-                    let max = AsyncHTTP::max_simultaneous_requests().load(Ordering::Relaxed);
-                    if max > min {
-                        AsyncHTTP::max_simultaneous_requests()
-                            .store(min.max(max / 2), Ordering::Relaxed);
-                    }
+                let download_failed = match &task.response.metadata {
+                    None => true,
+                    Some(m) => task.response.fail.is_some() && m.response.status_code < 400,
+                };
+                if download_failed {
+                    throttle_after_network_error(manager, &mut has_network_error);
                 }
 
-                if task.response.metadata.is_none()
+                if download_failed
                     || task
                         .response
                         .metadata
@@ -773,9 +772,6 @@ fn run_tasks_erased(
 
                     if task.retried < manager.options.max_retry_count {
                         task.retried += 1;
-                        // Streaming never committed (asserted above), so
-                        // the pre-allocated stream is safe to reuse for
-                        // the retry attempt.
                         task.reset_streaming_for_retry();
                         enqueue::enqueue_network_task(manager, task_ptr);
 
@@ -784,7 +780,7 @@ fn run_tasks_erased(
                                 manager.log_mut(),
                                 None,
                                 bun_ast::Loc::EMPTY,
-                                "<r><yellow>warn:<r> {} downloading tarball <b>{}@{}<r>. Retrying {}/{}...",
+                                "{} downloading tarball <b>{}@{}<r>. Retrying {}/{}...",
                                 bstr::BStr::new(err.name().as_bytes()),
                                 bstr::BStr::new(extract.name.slice()),
                                 extract
@@ -806,7 +802,8 @@ fn run_tasks_erased(
                 // path below allocates its own Task.
                 task.discard_unused_streaming_state(manager);
 
-                let Some(metadata) = task.response.metadata.as_ref() else {
+                let Some(metadata) = task.response.metadata.as_ref().filter(|_| !download_failed)
+                else {
                     let err = task
                         .response
                         .fail
@@ -1876,6 +1873,19 @@ pub(crate) fn network_task_has_failed(this: &PackageManager, task_id: Task::Id) 
     this.network_dedupe_map
         .get(&task_id)
         .is_some_and(|e| e.failed)
+}
+
+/// The first failed download in a `run_tasks` pass halves the number of
+/// concurrent requests (down to the configured minimum).
+fn throttle_after_network_error(manager: &PackageManager, has_network_error: &mut bool) {
+    if core::mem::replace(has_network_error, true) {
+        return;
+    }
+    let min = manager.options.min_simultaneous_requests;
+    let max = AsyncHTTP::max_simultaneous_requests().load(Ordering::Relaxed);
+    if max > min {
+        AsyncHTTP::max_simultaneous_requests().store(min.max(max / 2), Ordering::Relaxed);
+    }
 }
 
 pub fn generate_network_task_for_tarball<'a>(

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -44,8 +44,6 @@ use crate::package_manager_real::PackageManager;
 // materialise a `&'static` borrow of the inner `Request` lifetime.
 type Task = crate::package_manager_task::Task<'static>;
 
-bun_output::declare_scope!(TarballStream, hidden);
-
 type OSPathZ<'a> = &'a OSPathSliceZ;
 type OSPathZMut<'a> = &'a mut OSPathSliceZ;
 
@@ -79,8 +77,10 @@ pub struct TarballStream {
     /// True once the HTTP thread has delivered the final chunk (or an error).
     closed: bool,
 
-    /// Non-null if the HTTP request failed mid-stream; surfaced to the user
-    /// instead of whatever libarchive would otherwise report.
+    /// Set if the HTTP request failed mid-stream. Unless libarchive still
+    /// reached end-of-archive and the digest verifies, this — not
+    /// libarchive's truncation error — is the failure, and `finish()` hands
+    /// the NetworkTask back to be retried as a failed download.
     http_err: Option<crate::Error>,
 
     /// Cached response status (metadata only arrives on the first callback).
@@ -150,8 +150,14 @@ pub struct TarballStream {
     deferred_symlinks: Vec<bun_libarchive::DeferredSymlink>,
 
     bytes_received: usize,
+    /// Compressed bytes handed to libarchive by the read callback so far.
+    bytes_consumed: usize,
+    /// `Content-Length` of the response, when the server sent one.
+    pub(crate) content_length: Option<usize>,
     entry_count: u32,
     fail: Option<crate::Error>,
+    /// libarchive's error string for `fail == Some(Fail)`.
+    fail_detail: Vec<u8>,
     invalid_name: bool,
 
     /// Thread-pool task that runs `drain`. Re-enqueued whenever new data
@@ -261,8 +267,11 @@ impl TarballStream {
             #[cfg(unix)]
             deferred_symlinks: Vec::new(),
             bytes_received: 0,
+            bytes_consumed: 0,
+            content_length: None,
             entry_count: 0,
             fail: None,
+            fail_detail: Vec::new(),
             invalid_name: false,
             drain_task: thread_pool::Task {
                 node: thread_pool::Node::default(),
@@ -371,7 +380,16 @@ impl TarballStream {
                     let more = Self::take_pending(this);
 
                     if let Err(err) = Self::step(this) {
-                        (*this).fail = Some(err);
+                        // If the body was cut short by a transport error,
+                        // that is the failure; libarchive's complaint about
+                        // the truncated input is just its symptom.
+                        (*this).mutex.lock();
+                        let http_err = (*this).http_err;
+                        (*this).mutex.unlock();
+                        (*this).fail = Some(match (err, http_err) {
+                            (crate::Error::Fail, Some(http_err)) => http_err,
+                            (err, _) => err,
+                        });
                         (*this).close_output_file();
                     }
 
@@ -417,18 +435,7 @@ impl TarballStream {
                 // next `notify` dereference a dead pointer.
                 (*this).pending.clear();
                 let closed = (*this).closed;
-                let http_err = (*this).http_err;
                 (*this).mutex.unlock();
-                // A transport error that arrives *after* libarchive reached
-                // EOF (e.g. the server RSTs the connection once the last
-                // byte is on the wire) must not override a successful
-                // extraction; the integrity check in `populate_result()` is
-                // the sole arbiter of correctness once `Done` is reached.
-                if let Some(e) = http_err {
-                    if (*this).fail.is_none() && (*this).phase != Phase::Done {
-                        (*this).fail = Some(e);
-                    }
-                }
                 if closed {
                     Self::finish(this);
                     // `this` is freed; nothing below may touch it.
@@ -564,12 +571,7 @@ impl TarballStream {
                                 (*this).begin_entry(&mut *entry)?;
                             }
                             lib::Result::Failed | lib::Result::Fatal => {
-                                let msg = archive.error_string();
-                                bun_output::scoped_log!(
-                                    TarballStream,
-                                    "readNextHeader: {}",
-                                    bstr::BStr::new(msg)
-                                );
+                                (*this).fail_detail = archive.error_string().to_vec();
                                 return Err(crate::Error::Fail);
                             }
                         }
@@ -590,12 +592,7 @@ impl TarballStream {
                                 }
                             }
                             _ => {
-                                let msg = archive.error_string();
-                                bun_output::scoped_log!(
-                                    TarballStream,
-                                    "read_data_block: {}",
-                                    bstr::BStr::new(msg)
-                                );
+                                (*this).fail_detail = archive.error_string().to_vec();
                                 return Err(crate::Error::Fail);
                             }
                         }
@@ -671,11 +668,8 @@ impl TarballStream {
                 return Ok(());
             }
             _ => {
-                bun_output::scoped_log!(
-                    TarballStream,
-                    "archive_read_open: {}",
-                    bstr::BStr::new(archive.error_string())
-                );
+                // SAFETY: see fn-level # Safety — raw-ptr field write.
+                unsafe { (*this).fail_detail = archive.error_string().to_vec() };
                 return Err(crate::Error::Fail);
             }
         }
@@ -1007,11 +1001,15 @@ impl TarballStream {
             // SAFETY: see comment above; network_task is live until published below.
             (*network).response_buffer = Default::default();
 
+            // The HTTP thread delivered its final chunk before `closed` was
+            // set, so `http_err` is stable without the lock.
+            let http_err = (*this).http_err;
+
             // SAFETY: `task` is live until pushed onto `resolve_tasks` below.
             // `(*this).extract_task` is a raw `*mut Task` (not `&mut`), so this
             // is the only writer — no aliasing with a stored reference.
             // `populate_result` does not touch `(*this).extract_task`.
-            (*this).populate_result(task);
+            (*this).populate_result(task, http_err);
 
             // Temp-dir cleanup must happen before we release the stream or
             // publish the task: both `(*this).tmpname` and
@@ -1031,6 +1029,24 @@ impl TarballStream {
                 // `ManuallyDrop` → `ExtractRequest` deref.
                 let _ = Dir::borrow(&(&(*task).request.extract).tarball.temp_dir)
                     .delete_tree((*this).tmpname.as_bytes());
+            }
+
+            if let Some(crate::Error::Http(err)) = (*task).err
+                && (*task).status != TaskStatus::Success
+            {
+                // The connection died before the body was complete: a failed
+                // download, not a failed extraction. Hand the NetworkTask back
+                // to `run_tasks` the way `notify()` does for one that failed
+                // before the body started, so it is retried/reported there. The
+                // extract Task stays with the NetworkTask for the next attempt.
+                (*network).response.fail = Some(err);
+                (*network).streaming_committed = false;
+                drop((*network).tarball_stream.take());
+                (*manager)
+                    .async_network_task_queue
+                    .push(core::ptr::NonNull::new_unchecked(network));
+                PackageManager::wake_raw(manager);
+                return;
             }
 
             // The `Box<TarballStream>` lives in `(*network).tarball_stream`
@@ -1073,7 +1089,7 @@ impl TarballStream {
     // The `&(&(*task).request.extract)` wrapper below sidesteps
     // `dangerous_implicit_autorefs`; `needless_borrow` is wrong here.
     #[allow(clippy::needless_borrow)]
-    unsafe fn populate_result(&mut self, task: *mut Task) {
+    unsafe fn populate_result(&mut self, task: *mut Task, http_err: Option<crate::Error>) {
         // SAFETY: see fn-level # Safety — `task` is live and exclusively
         // owned by this drain; union field `extract` is the active variant
         // for streaming tarballs (set by `enqueue_extract_npm_package`).
@@ -1082,9 +1098,12 @@ impl TarballStream {
             (*task).data = TaskData {
                 extract: ManuallyDrop::new(Default::default()),
             };
+            (*task).err = None;
 
             if let Some(err) = self.fail {
-                if self.invalid_name {
+                if matches!(err, crate::Error::Http(_)) {
+                    // Reported (or retried) by `run_tasks`; see `finish()`.
+                } else if self.invalid_name {
                     (*task).log.add_error_fmt(
                         None,
                         bun_ast::Loc::EMPTY,
@@ -1098,9 +1117,19 @@ impl TarballStream {
                         None,
                         bun_ast::Loc::EMPTY,
                         format_args!(
-                            "{} extracting tarball for \"{}\"",
+                            "{} extracting tarball for \"{}\"{}{} (at byte {} of {})",
                             err.name(),
                             bstr::BStr::new(tarball.name.slice()),
+                            if self.fail_detail.is_empty() {
+                                ""
+                            } else {
+                                ": "
+                            },
+                            bstr::BStr::new(&self.fail_detail),
+                            self.bytes_consumed,
+                            self.content_length
+                                .as_ref()
+                                .map_or(&"unknown" as &dyn core::fmt::Display, |n| n),
                         ),
                     );
                 }
@@ -1111,6 +1140,14 @@ impl TarballStream {
 
             if !tarball.skip_verify && tarball.integrity.tag.is_supported() {
                 if !self.hasher.verify() {
+                    if let Some(http_err) = http_err {
+                        // libarchive found the end-of-archive marker but the
+                        // body still ended early (gzip trailer, tar padding):
+                        // the same failed download as above.
+                        (*task).err = Some(http_err);
+                        (*task).status = TaskStatus::Fail;
+                        return;
+                    }
                     (*task).log.add_error_fmt(
                         None,
                         bun_ast::Loc::EMPTY,
@@ -1208,6 +1245,7 @@ impl TarballStream {
         self.http_err = None;
         self.status_code = 0;
         self.bytes_received = 0;
+        self.content_length = None;
         self.mutex.unlock();
     }
 }
@@ -1276,6 +1314,7 @@ extern "C" fn archive_read_callback(
         if !remaining.is_empty() {
             *out_buffer = remaining.as_ptr().cast();
             (*this).read_pos = (*this).reading.len();
+            (*this).bytes_consumed += remaining.len();
             (*this).archive_holds_reading = true;
             return lib::la_ssize_t::try_from(remaining.len()).expect("int cast");
         }
@@ -1311,6 +1350,7 @@ extern "C" fn archive_read_callback(
             if !again.is_empty() {
                 *out_buffer = again.as_ptr().cast();
                 (*this).read_pos = (*this).reading.len();
+                (*this).bytes_consumed += again.len();
                 (*this).archive_holds_reading = true;
                 return lib::la_ssize_t::try_from(again.len()).expect("int cast");
             }

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -439,6 +439,11 @@ impl Batch {
     /// Create a batch from a single task.
     pub fn from(task: *mut Task) -> Batch {
         let task = NonNull::new(task);
+        if let Some(task) = task {
+            // A rescheduled task may still carry the link from its last batch.
+            // SAFETY: caller passes a live Task that is not currently queued.
+            unsafe { (*Task::node_of(task).as_ptr()).next = ptr::null_mut() };
+        }
         Batch {
             len: 1,
             head: task,

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -492,9 +492,11 @@ describe("streaming tarball extraction", () => {
       using dir = tempDir("streaming-extract-drop-retry", {
         "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "stream-pkg": "1.0.0" } }),
         "bunfig.toml": Bun.TOML.stringify({ install: { registry: reg.url } }),
+        "tmp/.keep": "",
       });
+      const tmp = join(String(dir), "tmp");
 
-      const { stderr, exitCode } = await runInstall(String(dir), env);
+      const { stderr, exitCode } = await runInstall(String(dir), { ...env, BUN_TMPDIR: tmp, TMPDIR: tmp });
       expect(stderr).not.toContain("error:");
       expect(stderr).not.toContain("extracting tarball");
       expect(stderr.match(/ConnectionClosed downloading tarball stream-pkg@1\.0\.0\. Retrying/g)).toHaveLength(2);
@@ -510,7 +512,7 @@ describe("streaming tarball extraction", () => {
         expect([path, got.equals(body)]).toEqual([path, true]);
       }
       // Extraction temp dirs from the failed attempts are removed.
-      expect(readdirSync(join(String(dir), ".cache")).filter(f => f.endsWith(".stream-pkg"))).toEqual([]);
+      expect(readdirSync(tmp).filter(f => f.endsWith(".stream-pkg"))).toEqual([]);
       expect(exitCode).toBe(0);
     });
 

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -137,33 +137,64 @@ function makeEntries(): Entry[] {
 // the BUN_INSTALL_STREAMING_MIN_SIZE gate.
 // -------------------------------------------------------------------
 
-async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number) {
+type Faults = {
+  /** Pick the size of each body write (default: fixed `chunkBytes`). */
+  chunker?: (offset: number) => number;
+  /** Milliseconds to wait between writes (default: none, `setImmediate`). */
+  delayMs?: (offset: number) => number;
+  /** Destroy the tarball connection after this many body bytes... */
+  dropTarballAt?: number;
+  /** ...for the first N tarball requests (default: every request). */
+  dropTarballTimes?: number;
+  /** Destroy the first N manifest connections half-way through the body. */
+  dropManifestTimes?: number;
+};
+
+async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number, faults: Faults = {}) {
   let tarballHits = 0;
+  let manifestHits = 0;
+  let tarballDropsLeft = faults.dropTarballTimes ?? Infinity;
+  let manifestDropsLeft = faults.dropManifestTimes ?? 0;
   const server: Server = createServer((req, res) => {
     const url = new URL(req.url!, "http://x");
-    if (url.pathname.endsWith("/stream-pkg")) {
+    // `stream-pkg`, plus `stream-pkg-<n>` aliases of the same tarball so a
+    // single install can run several streams at once.
+    const manifest = url.pathname.match(/^\/(stream-pkg(?:-\d+)?)$/);
+    if (manifest) {
+      manifestHits++;
+      const name = manifest[1];
       const body = JSON.stringify({
-        name: "stream-pkg",
+        name,
         "dist-tags": { latest: "1.0.0" },
         versions: {
           "1.0.0": {
-            name: "stream-pkg",
+            name,
             version: "1.0.0",
             dist: {
               shasum,
               integrity,
-              tarball: `http://127.0.0.1:${port}/stream-pkg/-/stream-pkg-1.0.0.tgz`,
+              tarball: `http://127.0.0.1:${port}/${name}/-/${name}-1.0.0.tgz`,
             },
           },
         },
       });
       res.setHeader("content-type", "application/json");
+      if (manifestDropsLeft > 0) {
+        manifestDropsLeft--;
+        // Promise a body twice as long as what is sent, then hang up.
+        const padded = body + " ".repeat(body.length);
+        res.setHeader("content-length", String(Buffer.byteLength(padded)));
+        res.write(padded.slice(0, body.length + 1), () => req.socket.destroy());
+        return;
+      }
       res.setHeader("content-length", String(Buffer.byteLength(body)));
       res.end(body);
       return;
     }
-    if (url.pathname.endsWith("/stream-pkg-1.0.0.tgz")) {
+    if (/\/stream-pkg(-\d+)?-1\.0\.0\.tgz$/.test(url.pathname)) {
       tarballHits++;
+      const dropAt = faults.dropTarballAt !== undefined && tarballDropsLeft > 0 ? faults.dropTarballAt : -1;
+      if (dropAt >= 0) tarballDropsLeft--;
       res.setHeader("content-type", "application/octet-stream");
       res.setHeader("content-length", String(tgz.length));
       // Prevent Nagle coalescing so each write() is its own packet.
@@ -174,9 +205,16 @@ async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chun
           res.end();
           return;
         }
-        res.write(tgz.subarray(i, Math.min(i + chunkBytes, tgz.length)));
-        i += chunkBytes;
-        setImmediate(step);
+        if (dropAt >= 0 && i >= dropAt) {
+          req.socket.destroy();
+          return;
+        }
+        const n = faults.chunker ? Math.max(1, faults.chunker(i)) : chunkBytes;
+        res.write(tgz.subarray(i, Math.min(i + n, tgz.length)));
+        i += n;
+        const delay = faults.delayMs ? faults.delayMs(i) : 0;
+        if (delay > 0) setTimeout(step, delay);
+        else setImmediate(step);
       };
       step();
       return;
@@ -190,6 +228,9 @@ async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chun
     url: `http://127.0.0.1:${port}/`,
     get tarballHits() {
       return tarballHits;
+    },
+    get manifestHits() {
+      return manifestHits;
     },
     [Symbol.asyncDispose]: () => new Promise<void>(resolve => server.close(() => resolve())),
   };
@@ -434,6 +475,141 @@ describe("streaming tarball extraction", () => {
     expect(stderr).toContain("Integrity check failed");
     expect(exitCode).not.toBe(0);
   });
+
+  // A connection that dies part-way through the body is a failed download,
+  // whichever extractor is consuming it: report the transport error, retry
+  // like any other failed download, and never hand the truncated body to
+  // libarchive (streaming) or the integrity check (buffered).
+  describe.each([
+    ["streaming", {}],
+    ["buffered", { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" }],
+  ] as const)("tarball connection dropped mid-body (%s)", (label, env) => {
+    test.concurrent("is retried and then succeeds", async () => {
+      await using reg = await makeRegistry(tgz, shasum, integrity, 64 * 1024, {
+        dropTarballAt: tgz.length >> 1,
+        dropTarballTimes: 2,
+      });
+      using dir = tempDir("streaming-extract-drop-retry", {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "stream-pkg": "1.0.0" } }),
+        "bunfig.toml": Bun.TOML.stringify({ install: { registry: reg.url } }),
+      });
+
+      const { stderr, exitCode } = await runInstall(String(dir), env);
+      expect(stderr).not.toContain("error:");
+      expect(stderr).not.toContain("extracting tarball");
+      expect(stderr.match(/ConnectionClosed downloading tarball stream-pkg@1\.0\.0\. Retrying/g)).toHaveLength(2);
+      if (label === "streaming") {
+        expect(stderr).toContain("Streamed ");
+      } else {
+        expect(stderr).not.toContain("Streamed ");
+      }
+      expect(reg.tarballHits).toBe(3);
+      const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+      for (const { path, body } of entries) {
+        const got = readFileSync(join(pkgRoot, path));
+        expect([path, got.equals(body)]).toEqual([path, true]);
+      }
+      // Extraction temp dirs from the failed attempts are removed.
+      expect(readdirSync(join(String(dir), ".cache")).filter(f => f.endsWith(".stream-pkg"))).toEqual([]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("is reported as a download error once retries are exhausted", async () => {
+      await using reg = await makeRegistry(tgz, shasum, integrity, 64 * 1024, { dropTarballAt: tgz.length >> 1 });
+      using dir = tempDir("streaming-extract-drop-fail", {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "stream-pkg": "1.0.0" } }),
+        "bunfig.toml": Bun.TOML.stringify({ install: { registry: reg.url } }),
+      });
+
+      const { stderr, exitCode } = await runInstall(String(dir), { ...env, BUN_CONFIG_HTTP_RETRY_COUNT: "2" });
+      expect(stderr).not.toContain("extracting tarball");
+      expect(stderr).not.toContain("Integrity check failed");
+      expect(stderr).toContain("error: ConnectionClosed downloading tarball stream-pkg@1.0.0");
+      expect(reg.tarballHits).toBe(3);
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  test.concurrent("manifest connection dropped mid-body is retried", async () => {
+    await using reg = await makeRegistry(tgz, shasum, integrity, 64 * 1024, { dropManifestTimes: 1 });
+    using dir = tempDir("streaming-extract-manifest-drop", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "stream-pkg": "1.0.0" } }),
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry: reg.url } }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(stderr).toContain("ConnectionClosed downloading package manifest stream-pkg. Retry 1/");
+    expect(reg.manifestHits).toBe(2);
+    expect(reg.tarballHits).toBe(1);
+    expect(exitCode).toBe(0);
+  });
+
+  // A body that arrives in full but is not a valid archive is an extraction
+  // failure: not retried, and the message carries libarchive's reason and
+  // the offset it gave up at.
+  test.concurrent("streaming reports libarchive's error for a corrupt tarball", async () => {
+    const corrupt = Buffer.from(tgz);
+    corrupt.fill(0x55, corrupt.length >> 1, (corrupt.length >> 1) + 4096);
+    const corruptIntegrity = "sha512-" + createHash("sha512").update(corrupt).digest("base64");
+    const corruptShasum = createHash("sha1").update(corrupt).digest("hex");
+    await using reg = await makeRegistry(corrupt, corruptShasum, corruptIntegrity, 64 * 1024);
+    using dir = tempDir("streaming-extract-corrupt", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "stream-pkg": "1.0.0" } }),
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry: reg.url } }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+    expect(stderr).toMatch(
+      /error: Fail extracting tarball for "stream-pkg": [^\n]*(gzip decompression failed|[Tt]runcated|[Dd]amaged)[^\n]* \(at byte \d+ of \d+\)/,
+    );
+    expect(reg.tarballHits).toBe(1);
+    expect(exitCode).toBe(1);
+  });
+
+  // Chunk boundaries land at arbitrary points in the gzip/tar stream and the
+  // extractor yields its worker at each one. Sweep delivery patterns (tiny
+  // writes, MSS-sized, TLS-record-sized, bursts larger than the socket
+  // buffer, random) with several tarballs in flight at once so drains
+  // interleave across pool threads, and require byte-identical output.
+  {
+    let seed = 0x9e3779b9;
+    const rand = () => {
+      seed = (Math.imul(seed, 1103515245) + 12345) >>> 0;
+      return seed / 0x100000000;
+    };
+    const patterns: [string, Faults][] = [
+      // Tiny writes for the first 64 KB (gzip header, first tar headers),
+      // then sub-MSS writes so the debug build finishes in seconds.
+      ["tiny", { chunker: o => (o < 65536 ? 1 + Math.floor(rand() * 48) : 500 + Math.floor(rand() * 900)) }],
+      ["mss", { chunker: () => 1200 + Math.floor(rand() * 260), delayMs: () => (rand() < 0.02 ? 1 : 0) }],
+      ["16k", { chunker: () => 16384, delayMs: () => (rand() < 0.05 ? 2 : 0) }],
+      ["burst", { chunker: () => 512 * 1024 + Math.floor(rand() * 512 * 1024) }],
+      ["random", { chunker: () => 1 + Math.floor(rand() * 70000), delayMs: () => (rand() < 0.1 ? 1 : 0) }],
+      ["whole", { chunker: () => tgz.length }],
+    ];
+    const streams = 4;
+    test.concurrent.each(patterns)("streams concurrent tarballs correctly (%s chunks)", async (label, faults) => {
+      await using reg = await makeRegistry(tgz, shasum, integrity, chunkBytes, faults);
+      const dependencies: Record<string, string> = {};
+      for (let i = 0; i < streams; i++) dependencies[`stream-pkg-${i}`] = "1.0.0";
+      using dir = tempDir("streaming-extract-stress", {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies }),
+        "bunfig.toml": Bun.TOML.stringify({ install: { registry: reg.url } }),
+      });
+      const { stderr, exitCode } = await runInstall(String(dir), { BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: "1" });
+      expect([label, stderr.match(/^error:.*$/m)?.[0] ?? null]).toEqual([label, null]);
+      expect([label, stderr.match(/Streamed /g)?.length]).toEqual([label, streams]);
+      for (let i = 0; i < streams; i++) {
+        const pkgRoot = join(String(dir), "node_modules", `stream-pkg-${i}`);
+        for (const { path, body } of entries) {
+          const got = readFileSync(join(pkgRoot, path));
+          expect([label, i, path, got.equals(body)]).toEqual([label, i, path, true]);
+        }
+      }
+      expect(exitCode).toBe(0);
+    });
+  }
 
   // Below the threshold no drain is scheduled, so nothing lands in the
   // extraction temp dir; crossing it schedules one drain that writes


### PR DESCRIPTION
### What was wrong

A tarball or manifest response whose connection dies after the headers but before `Content-Length` bytes have arrived is a failed download. `bun install` treated it as a successful one in three places, each producing a different misleading error and none of them retrying:

| path | what the user saw |
|---|---|
| streaming extractor (tarballs ≥ 2 MB) | `error: Fail extracting tarball for "effect"` — the stream fed libarchive an EOF, libarchive said "truncated archive", and `TarballStream` reported its own `Fail` instead of the HTTP client's `ConnectionClosed` (the code comment said the opposite of what the code did) |
| buffered extractor | `error: Integrity check failed for tarball: effect` |
| manifest | `error: No version matching "4.0.0-rc.111" found for specifier "effect" (but package exists)` |

The HTTP client already reports the truncation (`result.fail = ConnectionClosed`, `Timeout`, …). The install side only consulted `fail` when the response had *no* metadata, so a truncated 200 fell through to the extractor / manifest parser. The retry gate had the same hole, so a failure that `npm`/`pnpm` retry transparently was terminal in bun — while a connection that failed one packet earlier (before headers) was retried up to 5 times.

Reproduces deterministically with a registry that closes the socket mid-body (see tests); reproduces the exact output in #39972 / #39716 / #34821.

### Fix

- `run_tasks`: a 2xx/3xx response with `fail` set is a failed download in both the manifest and tarball arms — same retry policy and same `"{err} downloading tarball"` reporting as a response with no headers.
- `TarballStream`: when the HTTP thread closes the stream with an error and libarchive did not reach a verified end-of-archive, the transport error (not libarchive's "truncated input" symptom) is the failure, and `finish()` hands the `NetworkTask` back through `async_network_task_queue` — the same path `notify()` uses for a request that failed before the body — so the existing network-loop retry re-arms a fresh stream around the same extract Task. No new retry policy; the streaming path just stops bypassing the one that exists. Extraction temp dirs from failed attempts are removed as before.
- Genuine extraction failures (complete body, libarchive rejects it) are unchanged: terminal, not retried — but the message now carries libarchive's error string and the byte offset it stopped at, e.g. `Fail extracting tarball for "effect": gzip decompression failed (at byte 1182901 of 2365802)`, so the next report of this class says which layer failed and where.

### #39972 root cause (from the reporter's strace)

The reporter captured a failing run with `strace -e trace=network,...`. The `@effect/tsgo-linux-arm64` tarball is 49,581,368 bytes; its socket received 7,804,766 bytes over 3m14s (~40 KB/s under contention) and then `recvfrom(...) = 0` — the peer closed the connection ~16% into the body. 23 ms later the extractor tore down its temp dir and bun printed `Fail extracting tarball`. That is exactly the path fixed here; with this change the run retries the download and, under `--verbose`, says `ConnectionClosed downloading tarball ... Retrying 1/5`.

Separately, I could not make the streaming extractor mis-handle a *complete* body on Linux x64 (~1,250 cold real-registry installs on debug+ASAN and release, 320 under `rr record --chaos`, local-registry sweeps over chunk size / TLS / concurrency / trickle-vs-burst / first-chunk boundaries, the reporter's Dockerfile under `tc netem`, and an ASAN libarchive replay harness over every stride/offset on the `effect` and `next` tarballs — all byte-identical). If an extractor bug does exist somewhere, the new error text names libarchive's complaint and the byte offset instead of `Fail`.

### Tests

`test/cli/install/bun-install-streaming-extract.test.ts`:
- tarball connection dropped mid-body, streaming and buffered: retried then succeeds (3 requests, byte-identical tree, temp dirs cleaned); reported as `ConnectionClosed downloading tarball` once retries are exhausted
- manifest connection dropped mid-body: retried
- corrupt-but-complete tarball: not retried, message includes libarchive's reason and offset
- concurrent streams across chunking patterns (tiny / MSS / 16 K / >512 K bursts / random / whole-body) produce byte-identical output

All six new fault tests fail on 1.4.0 and pass here; existing streaming, retry and integrity suites pass.

Closes #39972
Closes #39716
