### PR TITLE
Add missing exception checks found by the validator; re-enable it for 12 test files

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -740,9 +740,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     env->filename = filename_cstr;
 
     auto encoded = reinterpret_cast<EncodedJSValue>(napi_register_module_v1(env.ptr(), reinterpret_cast<napi_value>(exportsValue)));
-    if (env->throwPendingException()) {
-        return {};
-    }
+    env->throwPendingException();
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue resultValue = encoded == 0 ? exports : JSValue::decode(encoded);
 

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -376,9 +376,12 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
         return {};
     }
     WTF::String on_before_parse_symbol = on_before_parse_symbol_js.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     // The dlopen *void handle is attached to the node_addon as a NapiExternal
-    Bun::NapiExternal* napi_external = dynamicDowncast<Bun::NapiExternal>(node_addon.getObject()->get(globalObject, WebCore::builtinNames(vm).napiDlopenHandlePrivateName()));
+    JSValue napiDlopenHandle = node_addon.getObject()->get(globalObject, WebCore::builtinNames(vm).napiDlopenHandlePrivateName());
+    RETURN_IF_EXCEPTION(scope, {});
+    Bun::NapiExternal* napi_external = dynamicDowncast<Bun::NapiExternal>(napiDlopenHandle);
     if (!napi_external) [[unlikely]] {
         Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "Expected node_addon (2nd argument) to have a napiDlopenHandle property"_s);
         return {};

--- a/src/jsc/bindings/NapiClass.cpp
+++ b/src/jsc/bindings/NapiClass.cpp
@@ -67,9 +67,7 @@ JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue NapiClass_ConstructorFunction(JSC::
 
     JSValue ret = toJS(napi->constructor()(napi->env(), frame.toNapi()));
     napi_set_last_error(napi->env(), napi_ok);
-    if (napi->env()->throwPendingException()) {
-        return {};
-    }
+    napi->env()->throwPendingException();
     RETURN_IF_EXCEPTION(scope, {});
     if (ret.isEmpty()) {
         ret = jsUndefined();

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1428,7 +1428,9 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
     MarkedArgumentBuffer parameters;
     JSValue paramsArg = callFrame->argument(1);
     if (paramsArg && !paramsArg.isUndefined()) {
-        if (!paramsArg.isObject() || !isArray(globalObject, paramsArg)) {
+        bool paramsIsArray = paramsArg.isObject() && isArray(globalObject, paramsArg);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!paramsIsArray) {
             return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "params"_s, "Array"_s, paramsArg);
         }
 
@@ -1483,7 +1485,9 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
     // Process contextExtensions if they exist
     JSScope* functionScope = options.parsingContext ? options.parsingContext : globalObject;
 
-    if (!options.contextExtensions.isUndefinedOrNull() && !options.contextExtensions.isEmpty() && options.contextExtensions.isObject() && isArray(globalObject, options.contextExtensions)) {
+    bool hasContextExtensions = !options.contextExtensions.isUndefinedOrNull() && !options.contextExtensions.isEmpty() && options.contextExtensions.isObject() && isArray(globalObject, options.contextExtensions);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (hasContextExtensions) {
         auto* contextExtensionsArray = dynamicDowncast<JSArray>(options.contextExtensions);
         unsigned length = contextExtensionsArray ? contextExtensionsArray->length() : 0;
 
@@ -1990,7 +1994,9 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
                 return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
 
             if (auto* contextExtensionsObject = asObject(contextExtensionsValue)) {
-                if (!isArray(globalObject, contextExtensionsObject))
+                bool contextExtensionsIsArray = isArray(globalObject, contextExtensionsObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (!contextExtensionsIsArray)
                     return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
 
                 // Validate that all items in the array are objects

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -337,7 +337,7 @@ void NAPICallFrame::extract(size_t* argc, napi_value* argv, napi_value* this_arg
     }
 }
 
-napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ThrowScope& scope)
+napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ExceptionScope& scope)
 {
     Zig::GlobalObject* globalObject = env->globalObject();
     JSC::VM& vm = JSC::getVM(globalObject);
@@ -370,18 +370,24 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
     if (property.getter != nullptr || property.setter != nullptr) {
         if (property.getter) {
             auto name = makeString("get "_s, propertyName.isSymbol() ? String() : propertyName.string());
-            descriptor.setGetter(NapiClass::create(vm, env, name, property.getter, dataPtr, 0, nullptr));
+            auto* getter = NapiClass::create(vm, env, name, property.getter, dataPtr, 0, nullptr);
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
+            descriptor.setGetter(getter);
         }
         if (property.setter) {
             auto name = makeString("set "_s, propertyName.isSymbol() ? String() : propertyName.string());
-            descriptor.setSetter(NapiClass::create(vm, env, name, property.setter, dataPtr, 0, nullptr));
+            auto* setter = NapiClass::create(vm, env, name, property.setter, dataPtr, 0, nullptr);
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
+            descriptor.setSetter(setter);
         }
     } else if (property.method != nullptr) {
         WTF::String name;
         if (!propertyName.isSymbol()) {
             name = propertyName.string();
         }
-        descriptor.setValue(NapiClass::create(vm, env, name, property.method, dataPtr, 0, nullptr));
+        auto* method = NapiClass::create(vm, env, name, property.method, dataPtr, 0, nullptr);
+        RETURN_IF_EXCEPTION(scope, napi_pending_exception);
+        descriptor.setValue(method);
         descriptor.setWritable(writable);
         failureStatus = napi_generic_failure;
     } else {
@@ -980,6 +986,7 @@ extern "C" napi_status napi_create_function(napi_env env, const char* utf8name,
     }
 
     auto function = NapiClass::create(vm, env, name, cb, data, 0, nullptr);
+    NAPI_RETURN_IF_EXCEPTION(env);
 
     ASSERT(function->isCallable());
     *result = toNapi(JSValue(function), globalObject);
@@ -1010,29 +1017,24 @@ extern "C" napi_status
 napi_define_properties(napi_env env, napi_value object, size_t property_count,
     const napi_property_descriptor* properties)
 {
-    NAPI_PREAMBLE_NO_THROW_SCOPE(env);
-    Zig::GlobalObject* globalObject = toJS(env);
-    JSC::VM& vm = JSC::getVM(globalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, throwScope);
+    NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, object);
     NAPI_RETURN_EARLY_IF_FALSE(env, properties || property_count == 0, napi_invalid_arg);
+    Zig::GlobalObject* globalObject = toJS(env);
 
     JSValue objectValue = toJS(object);
     JSC::JSObject* objectObject = objectValue.toObject(globalObject);
-    RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_object_expected));
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error(env, napi_object_expected));
 
     for (size_t i = 0; i < property_count; i++) {
-        napi_status status = Napi::defineProperty(env, objectObject, properties[i], throwScope);
-
-        RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_pending_exception));
+        napi_status status = Napi::defineProperty(env, objectObject, properties[i], napi_preamble_throw_scope__);
+        NAPI_RETURN_IF_EXCEPTION(env);
         if (status != napi_ok) {
             return napi_set_last_error(env, status);
         }
     }
 
-    throwScope.release();
-    return napi_set_last_error(env, napi_ok);
+    NAPI_RETURN_SUCCESS(env);
 }
 
 static JSC::ErrorInstance* createErrorWithCode(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const WTF::String& code, const WTF::String& message, JSC::ErrorType type)

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -116,7 +116,7 @@ private:
 
 using HookSet = std::unordered_set<EitherCleanupHook, EitherCleanupHook::Hash>;
 
-napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ThrowScope& scope);
+napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_descriptor& property, JSC::ExceptionScope& scope);
 }
 
 // Owned by the addon: allocated by napi_add_async_cleanup_hook and freed only

--- a/src/jsc/bindings/webcore/JSURLPatternResult.cpp
+++ b/src/jsc/bindings/webcore/JSURLPatternResult.cpp
@@ -65,7 +65,7 @@ static JSC::JSValue convertURLPatternInputToJS(JSC::JSGlobalObject& lexicalGloba
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    return WTF::switchOn(input, [&](const String& str) -> JSValue { return toJS<IDLUSVString>(lexicalGlobalObject, throwScope, str); }, [&](const URLPatternInit& init) -> JSValue { return convertDictionaryToJS(lexicalGlobalObject, globalObject, init); });
+    RELEASE_AND_RETURN(throwScope, WTF::switchOn(input, [&](const String& str) -> JSValue { return toJS<IDLUSVString>(lexicalGlobalObject, throwScope, str); }, [&](const URLPatternInit& init) -> JSValue { return convertDictionaryToJS(lexicalGlobalObject, globalObject, init); }));
 }
 
 JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const URLPatternComponentResult& dictionary)

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -168,6 +168,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor,
 
         if (index != WTF::notFound) {
             dirname = JSC::jsSubstring(globalObject, idString, 0, index);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
@@ -220,7 +221,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionWrap, (JSC::JSGlobalObject * globalObject, JS
             "(function (exports, require, module, __filename, __dirname) { "_s));
     JSString* suffix = jsString(vm, String("\n});"_s));
 
-    return JSValue::encode(jsString(globalObject, prefix, code, suffix));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(globalObject, prefix, code, suffix)));
 }
 extern "C" void Bun__Node__Path_joinWTF(BunString* lhs, const char* rhs,
     size_t len, BunString* result);
@@ -349,7 +350,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
         // If paths are provided, use Bun__resolveSyncWithPaths
         if (!pathsValue.isUndefinedOrNull()) {
             // Node.js requires options.paths to be an array
-            if (!JSC::isArray(globalObject, pathsValue)) {
+            bool pathsIsArray = JSC::isArray(globalObject, pathsValue);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!pathsIsArray) {
                 Bun::throwError(globalObject, scope,
                     Bun::ErrorCode::ERR_INVALID_ARG_TYPE,
                     "options.paths must be an array"_s);

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -4,17 +4,12 @@
 test/bake/dev/production.test.ts
 test/cli/install/bun-install-lifecycle-scripts.test.ts
 test/integration/vite-build/vite-build.test.ts
-test/js/bun/resolve/import-meta.test.js
-test/js/bun/resolve/resolve.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
 test/js/bun/util/BunObject.test.ts
 test/js/bun/util/fuzzy-wuzzy.test.ts
-test/js/node/module/module-resolve-filename-paths.test.js
 test/js/node/module/node-module-module.test.js
 test/js/node/test/parallel/test-vm-module-referrer-realm.mjs
 test/js/third_party/astro/astro-post.test.js
-test/js/web/websocket/websocket.test.js
-test/regression/issue/ctrl-c.test.ts
 
 # hit a debug assert
 test/bundler/bundler_compile.test.ts
@@ -79,13 +74,9 @@ test/napi/node-napi-tests/test/node-api/test_env_teardown_gc/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
 
 # normalizeCryptoAlgorithmParameters
-test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts
 test/js/deno/crypto/webcrypto.test.ts
 test/js/node/crypto/node-crypto.test.js
-test/js/node/test/parallel/test-crypto-webcrypto-aes-decrypt-tag-too-small.js
-test/js/node/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
 test/js/third_party/pg/pg.test.ts
-test/js/web/crypto/web-crypto.test.ts
 vendor/elysia/test/aot/response.test.ts
 vendor/elysia/test/cookie/response.test.ts
 vendor/elysia/test/cookie/signature.test.ts
@@ -95,23 +86,13 @@ vendor/elysia/test/validator/body.test.ts
 vendor/elysia/test/ws/message.test.ts
 
 
-# TODO: WebCore fixes
-test/js/web/urlpattern/urlpattern.test.ts
-
 # TODO: jsc
 test/js/bun/jsonl/jsonl-parse.test.ts
-test/regression/issue/isArray-proxy-crash.test.ts
 
 # Third-party SDK with unchecked exception path in JSArray pushInline
 test/js/third_party/@azure/service-bus/azure-service-bus.test.ts
 
-# The napi addon fixture's Init() calls napi_create_function then
-# napi_set_named_property without checking the status in between, like most
-# real addons. Under validateExceptionChecks every scope simulates a throw, so
-# the second call trips the assertion at the napi boundary.
-test/bundler/native-plugin.test.ts
-# `bun run build` in the react templates loads bun-plugin-tailwind's napi
-# addon, same Init() pattern.
+# `bun run build` in the react templates loads bun-plugin-tailwind's napi addon.
 test/cli/init/init.test.ts
 
 # JSC JSONP fast path (Interpreter::executeProgram doGet lambda) does an


### PR DESCRIPTION
### What does this PR do?

`test/no-validate-exceptions.txt` lists files that run without `BUN_JSC_validateExceptionChecks` on the ASAN lane because something on their path leaves a JS exception unchecked. Running those files under the validator on a debug build gives the exact site; this fixes the ones that are in Bun's code and removes the corresponding entries, plus seven entries that already pass clean on main.

Fixes:
- **napi**: `Napi::defineProperty` / `napi_create_function` now check after each `NapiClass::create()` (its `finishCreation` declares a ThrowScope) — this was the "every `.node` load trips it" case. `napi_define_properties` uses the `NAPI_PREAMBLE` scope like every other entry point instead of a `ThrowScope` that simulates a throw into addon code. The NapiClass constructor and `process.dlopen` check `env->throwPendingException()` through their scope instead of `if (…) return {}`.
- **vm.compileFunction / new vm.Script**: check after `isArray()` (a Proxy can throw) before building `ERR_INVALID_ARG_INSTANCE`.
- **node:module**: check after `jsSubstring` in `new Module(id)`; `RELEASE_AND_RETURN` the rope in `Module.wrap`; check after `isArray()` in `_resolveFilename({ paths })`.
- **URLPattern**: `RELEASE_AND_RETURN` around the scoped dictionary conversion in `convertURLPatternInputToJS` (tripped on every `exec()` with a dictionary input).
- **JSBundlerPlugin `onBeforeParse`**: check after `toWTFString` and the dlopen-handle `get()`.

Re-enabled: `module-resolve-filename-paths`, `urlpattern`, `isArray-proxy-crash`, `native-plugin`, `ctrl-c` (fixed here); `import-meta`, `resolve`, `websocket`, `web-crypto.test`, `wpt-webcrypto.generateKey`, and the two node-parallel webcrypto scripts (already clean).

Still excluded, with reasons unchanged: the static-property `PropertyCallback` builders (`BunObject.test`, `node-module-module`, …), two JSC-internal sites (`LiteralParser`, `Completion.cpp`), third-party napi addons, `napi.test.ts`/`require-cache` (not verified locally).

### How did you verify your code works?

Ran each re-enabled file under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` on a debug build: no validator output, tests pass (`ctrl-c`'s vite cases time out on a debug build with or without the validator).