### PR TITLE
S3: read an endpoint with a scheme exactly as new URL() does

### DIFF
--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -275,6 +275,26 @@ pub struct S3Endpoint {
     pub is_http: bool,
 }
 
+impl S3Endpoint {
+    /// `None` when `url` has no host: WTF::URL reads `localhost:9000` as the scheme `localhost`.
+    fn from_whatwg(url: &whatwg::URL) -> Option<Self> {
+        // `whatwg::URL::hostname` is the host with its port.
+        let host = url.hostname();
+        if host.is_empty() {
+            return None;
+        }
+        let is_http = url.protocol().eq_ascii(b"http");
+        let mut host_with_path = host.to_owned_slice();
+        let pathname = url.pathname();
+        let path = pathname.to_utf8();
+        host_with_path.extend_from_slice(strings::without_suffix_comptime(path.slice(), b"/"));
+        Some(Self {
+            host_with_path: host_with_path.into_boxed_slice(),
+            is_http,
+        })
+    }
+}
+
 impl<'a> URL<'a> {
     /// Detach the borrow-checker lifetime from a `URL`.
     ///
@@ -370,31 +390,26 @@ impl<'a> URL<'a> {
 
     /// `input` is `[scheme://]host[:port][/prefix]`, `https` by default. `None` when it has no host.
     pub fn parse_s3_endpoint(input: &[u8]) -> Option<S3Endpoint> {
+        // With a scheme, the endpoint is whatever `new URL(endpoint)` reads.
+        if let Some(endpoint) =
+            whatwg::Parsed::from_utf8(input).and_then(|url| S3Endpoint::from_whatwg(&url))
+        {
+            return Some(endpoint);
+        }
         let as_written = URL::parse(input);
         if as_written.host_with_path().is_empty() {
             return None;
         }
-        let normalized = if as_written.protocol.is_empty() {
+        let with_default_scheme = if as_written.protocol.is_empty() {
             whatwg::Parsed::from_utf8(&[b"https://".as_slice(), input].concat())
+                .and_then(|url| S3Endpoint::from_whatwg(&url))
         } else {
-            whatwg::Parsed::from_utf8(input)
+            None
         };
-        let Some(url) = normalized else {
-            return Some(S3Endpoint {
-                host_with_path: Box::from(as_written.host_with_path()),
-                is_http: as_written.is_http(),
-            });
-        };
-        let is_http = url.protocol().eq_ascii(b"http");
-        // `whatwg::URL::hostname` is the host with its port.
-        let mut host_with_path = url.hostname().to_owned_slice();
-        let pathname = url.pathname();
-        let path = pathname.to_utf8();
-        host_with_path.extend_from_slice(strings::without_suffix_comptime(path.slice(), b"/"));
-        Some(S3Endpoint {
-            host_with_path: host_with_path.into_boxed_slice(),
-            is_http,
-        })
+        Some(with_default_scheme.unwrap_or_else(|| S3Endpoint {
+            host_with_path: Box::from(as_written.host_with_path()),
+            is_http: as_written.is_http(),
+        }))
     }
 
     pub fn display_protocol(&self) -> &[u8] {

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -112,6 +112,10 @@ describe("S3Client endpoint option", () => {
     "http://127.1:1",
     "https://acct.supabase.co/storage/v1/s3",
     "https://[::1]:9000",
+    "http:/127.0.0.1:1",
+    "http:127.0.0.1:1",
+    "http:///127.0.0.1:1",
+    "  http://127.0.0.1:1  ",
   ])("signs for the origin and path that new URL(%j) names", endpoint => {
     const expected = new URL(endpoint);
     const presigned = new S3Client({ ...options, endpoint }).presign("key.txt");
@@ -120,9 +124,21 @@ describe("S3Client endpoint option", () => {
     expect(presigned.split("?")[0]).toBe(`${expected.origin}${expected.pathname.replace(/\/$/, "")}/bucket/key.txt`);
   });
 
-  it("defaults to https when the endpoint has no scheme", () => {
-    const presigned = new S3Client({ ...options, endpoint: "s3.example.com" }).presign("key.txt");
-    expect(presigned.split("?")[0]).toBe("https://s3.example.com/bucket/key.txt");
+  // new URL() reads these as a scheme (localhost:) or not at all.
+  it.each([
+    ["s3.example.com", "https://s3.example.com"],
+    ["localhost:9000", "https://localhost:9000"],
+    ["127.0.0.1:9000/prefix/", "https://127.0.0.1:9000/prefix"],
+    ["[::1]:9000", "https://[::1]:9000"],
+  ])("defaults %j to https", (endpoint, origin) => {
+    const presigned = new S3Client({ ...options, endpoint }).presign("key.txt");
+    expect(presigned.split("?")[0]).toBe(`${origin}/bucket/key.txt`);
+  });
+
+  it("rejects an endpoint without a host", () => {
+    expect(() => new S3Client({ ...options, endpoint: "//127.0.0.1:1" })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
   });
 
   it("applies the same parsing to S3_ENDPOINT", async () => {


### PR DESCRIPTION
### Problem
- After #39933, three endpoint spellings that `new URL()` accepts still go elsewhere. `http:/127.0.0.1:9` and `http:127.0.0.1:9` are read as the host `http` and fail with `DNSResolveFailed` after a resolver query. `  http://127.0.0.1:9  ` is rejected with `ERR_INVALID_ARG_TYPE`. `new URL()` reads all three as `127.0.0.1:9`. Same on 1.4.0.
- Cause: `URL::parse_s3_endpoint` (`src/url/lib.rs`) asks `URL::parse` first whether the endpoint has a scheme, and hands the string to WTF::URL only after that. `URL::parse` recognizes a scheme only as `scheme://`. With one slash or none it takes `http:` for the host, so `https://` is prepended and WTF::URL reads `http` as the host. Leading whitespace makes it find no host at all.

### Fix
- Give the string to WTF::URL first. When it parses with a host, that is the endpoint. Otherwise it is `host[:port][/prefix]` with `https` as the default, and `URL::parse` decides whether there is a host, as before.
- WTF::URL is the parser behind `new URL()`, so an endpoint with a scheme now means exactly what `new URL(endpoint)` says. A scheme-less endpoint (`localhost:9000`, `s3.example.com`, `[::1]:9000`) has no host to WTF::URL and takes the old path unchanged. An endpoint without a host (`//127.0.0.1:9`) is still rejected.
- Verified: `test/js/bun/s3/s3-list-encode-overflow.test.ts`, four new cases fail on main and on 1.4.0. The scheme-less and no-host cases are pinned as well. `test/js/bun/s3/`: 163 pass, 2 pre-existing flakes (notes).

### Background
- `S3Credentials.endpoint` stores `host[:port][/prefix]`. `sign_request` signs the part before the first `/` as the host and connects to it, so what `parse_s3_endpoint` stores decides where signed requests go.
- Bun has two URL parsers. WTF::URL (WebKit) is the WHATWG parser behind `new URL()`. `bun_url::URL::parse` slices an href that is already normalized, and it is the only one that accepts a scheme-less `host:port`.
- The error for a host-less endpoint still says `must be of type string. Received type string`. The code `ERR_INVALID_ARG_TYPE` is pinned by two tests in `s3.test.ts`, so this change leaves it alone.

<details><summary>Notes</summary>

Probe on main (`d95bc353ee`) and on release 1.4.0, presigned URL without the query:

```
"http:/127.0.0.1:1"        new URL host = 127.0.0.1:1   S3 -> https://http/127.0.0.1:1/b/k       (1.4.0: https://http:/127.0.0.1:1/b/k)
"http:127.0.0.1:1"         new URL host = 127.0.0.1:1   S3 -> https://http:127.0.0.1:1/b/k
"http:///127.0.0.1:1"      new URL host = 127.0.0.1:1   S3 -> ERR_INVALID_ARG_TYPE
"  http://127.0.0.1:1  "   new URL host = 127.0.0.1:1   S3 -> ERR_INVALID_ARG_TYPE
"//127.0.0.1:1"            new URL throws               S3 -> ERR_INVALID_ARG_TYPE
```

With the change the first four give `http://127.0.0.1:1/b/k`, the last one still throws. `localhost:9000`, `s3.example.com`, `bucket.test.r2.cloudflarestorage.com`, `[::1]:9000`, `127.0.0.1:9000/prefix/` and `s3://bucket` produce the same presigned URL before and after.

Why "parses with a host" and not "parses": WTF::URL reads `localhost:9000` as the scheme `localhost` with the opaque path `9000`, and `my-host:9000/x` the same way. Both have an empty host, so they fall through to the `https` default as before.

Why `https://` is still prepended only when `URL::parse` sees no scheme: an input such as `http://:9/x` fails in WTF::URL and has the scheme `http` to `URL::parse`. Prepending would turn it into `https://http://:9/x`, which WTF::URL reads as host `http`. Leaving the prepend out keeps the fallback at what `URL::parse` reads, as today.

`S3_ENDPOINT` and `AWS_ENDPOINT` go through the same function (`src/dotenv/env_loader.rs`) and are covered by the existing child-process test.

The two failures in the S3 suite run are not related: `s3-list-objects.test.ts` "Should fall back to NoSuchKey" hits its 5 s budget next to an 18 s test in the same `describe.concurrent` block under ASAN (passes alone), and `s3.test.ts` "uploads a fetch response body via the native ByteStream" lost a part's byte count to `received += (await ...)` in one of four runs (#37205 fixes that test).

Rebased over #40238 (`bun_core::String` owns its WTF ref) and #40374 (`eq_ascii`): `S3Endpoint::from_whatwg` calls the `whatwg::URL` getters directly and compares the scheme with `eq_ascii`, the same changes main made to the inline code this PR moves into the helper. No other conflict.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-list-encode-overflow.test.ts"
bun test v1.4.1 (861e9ae04)

test/js/bun/s3/s3-list-encode-overflow.test.ts:
(pass) S3Client.list() option encoding > should not panic when prefix is longer than 1024 bytes when encoded [8.53ms]
(pass) S3Client.list() option encoding > should not panic when delimiter is longer than 1024 bytes when encoded [2.27ms]
(pass) S3Client.list() option encoding > should not panic when continuationToken is longer than 1024 bytes when encoded [1.95ms]
(pass) S3Client.list() option encoding > should not panic when startAfter is longer than 1024 bytes when encoded [2.40ms]
(pass) S3 object keys containing '?' or '#' > includes the full object key in the presigned URL path [9.80ms]
(pass) S3Client region option > rejects the region us-east-1/other.example.com because it is not a valid host name component [6.05ms]
(pass) S3Client region option > rejects the region us-east-1?x because it is not a valid host name component [2.04ms]
(pass) S3Client region option > rejects the region us-east-1#x because it
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/s3/s3-list-encode-overflow.test.ts:
(pass) S3Client.list() option encoding > should not panic when prefix is longer than 1024 bytes when encoded [0.16ms]
(pass) S3Client.list() option encoding > should not panic when delimiter is longer than 1024 bytes when encoded [0.03ms]
(pass) S3Client.list() option encoding > should not panic when continuationToken is longer than 1024 bytes when encoded [0.02ms]
(pass) S3Client.list() option encoding > should not panic when startAfter is longer than 1024 bytes when encoded [0.01ms]
(pass) S3 object keys containing '?' or '#' > includes the full object key in the presigned URL path [0.22ms]
(pass) S3Client region option > rejects the region us-east-1/other.example.com because it is not a valid host name component [0.09ms]
(pass) S3Client region option > rejects the region us-east-1?x because it is not a valid host name component [0.01ms]
(pass) S3Client region option > rejects the region us-east-1#x because it is not a valid host name component
(pass) S3Client region option > rejects the region us east 1 because it is not a valid host name component
(pass) S3Client region option 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-list-encode-overflow.test.ts"
bun test v1.4.1 (861e9ae04)

test/js/bun/s3/s3-list-encode-overflow.test.ts:
(pass) S3Client.list() option encoding > should not panic when prefix is longer than 1024 bytes when encoded [8.31ms]
(pass) S3Client.list() option encoding > should not panic when delimiter is longer than 1024 bytes when encoded [2.28ms]
(pass) S3Client.list() option encoding > should not panic when continuationToken is longer than 1024 bytes when encoded [1.92ms]
(pass) S3Client.list() option encoding > should not panic when startAfter is longer than 1024 bytes when encoded [1.79ms]
(pass) S3 object keys containing '?' or '#' > includes the full object key in the presigned URL path [10.21ms]
(pass) S3Client region option > rejects the region us-east-1/other.example.com because it is not a valid host name component [6.40ms]
(pass) S3Client region option > rejects the region us-east-1?x because it is not a valid host name component [2.08ms]
(pass) S3Client region option > rejects the region us-east-1#x because i
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b3921981d9
  features     baseline

23 deps, 129 codegen, 1172 objects in 777ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [15.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [20.00ms]
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 13ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serv
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/url/lib.rs                                 | 51 +++++++++++++++++---------
 test/js/bun/s3/s3-list-encode-overflow.test.ts | 22 +++++++++--
 2 files changed, 52 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/url/lib.rs                                      7     13      0
test/js/bun/s3/s3-list-encode-overflow.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->


