### PR TITLE
util.inspect: drop the unused RegExpPrototypeTest primordial

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -97,7 +97,6 @@ const ReflectOwnKeys = Reflect.ownKeys;
 const RegExpPrototypeExec = uncurryThis(RegExp.prototype.exec);
 const RegExpPrototypeSymbolReplace = uncurryThis(RegExp.prototype[Symbol.replace]);
 const RegExpPrototypeSymbolSplit = uncurryThis(RegExp.prototype[Symbol.split]);
-const RegExpPrototypeTest = uncurryThis(RegExp.prototype.test);
 const RegExpPrototypeToString = uncurryThis(RegExp.prototype.toString);
 const SetPrototypeEntries = uncurryThis(Set.prototype.entries);
 const SetPrototypeValues = uncurryThis(Set.prototype.values);

--- a/test/internal/oxlint-plugin-bun.test.ts
+++ b/test/internal/oxlint-plugin-bun.test.ts
@@ -5,7 +5,7 @@
 // pointing oxlint at fixture files with a minimal config.
 
 import { describe, expect, test } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import path from "path";
 
@@ -18,11 +18,19 @@ const oxlintBin = path.join(root, "node_modules", "oxlint", "bin", "oxlint");
 const RULE = "bun(no-duplicate-conditional-property-access)";
 
 // oxlint ships a prebuilt NAPI binding that aborts when loaded under the
-// ASAN build; the rule is still enforced in CI by the Lint JavaScript
-// workflow (release bun), so skip here. Also skip if the repo's
-// devDependencies haven't been installed yet.
-const skip = isASAN || !existsSync(oxlintBin);
+// ASAN build. What is under test is the lint result, not the runtime that
+// hosts oxlint, so under ASAN run it with the release bun on PATH (CI agents
+// and dev machines have one) and skip only when there is none. Also skip if
+// the repo's devDependencies haven't been installed yet.
+const runtime = isASAN ? releaseBunOnPath() : bunExe();
+const skip = runtime === null || !existsSync(oxlintBin);
 const describeOxlint = skip ? describe.skip : describe;
+
+function releaseBunOnPath(): string | null {
+  const found = Bun.which("bun");
+  if (found === null || realpathSync(found) === realpathSync(bunExe())) return null;
+  return found;
+}
 
 async function runOxlint(files: Record<string, string>) {
   using dir = tempDir("oxlint-plugin-bun", {
@@ -36,7 +44,7 @@ async function runOxlint(files: Record<string, string>) {
     }),
   });
   await using proc = Bun.spawn({
-    cmd: [bunExe(), oxlintBin, "--config=oxlint.json", "--format=github", "."],
+    cmd: [runtime!, oxlintBin, "--config=oxlint.json", "--format=github", "."],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
@@ -220,7 +228,7 @@ describeOxlint("src/js lint", () => {
   // property into a local before the check; this guards against new ones.
   test("bun run lint is clean on src/js", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), oxlintBin, "--config=oxlint.json", "--format=github", "src/js"],
+      cmd: [runtime!, oxlintBin, "--config=oxlint.json", "--format=github", "src/js"],
       cwd: root,
       env: bunEnv,
       stdout: "pipe",


### PR DESCRIPTION
### Problem
- `bun run lint` fails on main since 06d0ae8ac1 (#39923): `src/js/internal/util/inspect.js:100` declares `RegExpPrototypeTest` and nothing uses it. The `Lint JavaScript` workflow and `test/internal/oxlint-plugin-bun.test.ts` ("bun run lint is clean on src/js") are red on every PR until this lands.
- Two merges crossed: a5e30c96d9 replaced one use of `RegExpPrototypeTest` in `inspect.js`, and #39923 deleted the JS `getOwnNonIndexProperties`, which held the other one. Each branch was lint clean on its own.

### Fix
- Remove the declaration. One line.
- `test/internal/oxlint-plugin-bun.test.ts` now runs on ASAN builds too. It was skipped there because oxlint's prebuilt NAPI binding aborts under ASAN. The lint result does not depend on the runtime that hosts oxlint, so under ASAN the test runs oxlint with the release bun on PATH (CI agents and dev machines have one through bootstrap) and skips only when there is none. Both the plugin fixture tests and the src/js lint test use it.
- Verified: on the debug (ASAN) build, "bun run lint is clean on src/js" fails with main's `inspect.js` (the `RegExpPrototypeTest` no-unused-vars diagnostic) and passes with this branch. `USE_SYSTEM_BUN=1 bun test` on the same file passes (non-ASAN path unchanged). `test/js/node/util/node-inspect-tests/internal-inspect.test.js` and `test/js/node/util/util.test.js` pass on the debug build.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/oxlint-plugin-bun.test.ts
bun test v1.4.1 (4448a2e21)

test/internal/oxlint-plugin-bun.test.ts:
(pass) bun/no-duplicate-conditional-property-access > flags re-reading the property inside the if body [257.64ms]
(pass) bun/no-duplicate-conditional-property-access > ignores destructured locals, different properties, nested functions, computed access, and method calls [245.16ms]
(pass) bun/no-duplicate-conditional-property-access > ignores bodies that write to the same property [207.96ms]
(pass) bun/no-duplicate-conditional-property-access > inline disable comment suppresses the diagnostic [176.41ms]
(pass) bun/no-duplicate-conditional-property-access > diagnostic message suggests destructuring the base object [161.57ms]
234 |       stdout: "pipe",
235 |       stderr: "pipe",
236 |     });
237 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
238 |     expect(stderr).not.toContain("Failed");
239 |     expect({ stdout, exitCode }).toEqual({ stdout: expect.stringC
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/internal/oxlint-plugin-bun.test.ts:
(pass) bun/no-duplicate-conditional-property-access > flags re-reading the property inside the if body [167.16ms]
(pass) bun/no-duplicate-conditional-property-access > ignores destructured locals, different properties, nested functions, computed access, and method calls [185.84ms]
(pass) bun/no-duplicate-conditional-property-access > ignores bodies that write to the same property [176.81ms]
(pass) bun/no-duplicate-conditional-property-access > inline disable comment suppresses the diagnostic [164.61ms]
(pass) bun/no-duplicate-conditional-property-access > diagnostic message suggests destructuring the base object [159.86ms]
234 |       stdout: "pipe",
235 |       stderr: "pipe",
236 |     });
237 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
238 |     expect(stderr).not.toContain("Failed");
239 |     expect({ stdout, exitCode }).toEqual({ stdout: expect.stringContaining("0 errors"), exitCode: 0 });
                                       ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stdout": Stri
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/oxlint-plugin-bun.test.ts
bun test v1.4.1 (4448a2e21)

test/internal/oxlint-plugin-bun.test.ts:
(pass) bun/no-duplicate-conditional-property-access > flags re-reading the property inside the if body [248.60ms]
(pass) bun/no-duplicate-conditional-property-access > ignores destructured locals, different properties, nested functions, computed access, and method calls [188.65ms]
(pass) bun/no-duplicate-conditional-property-access > ignores bodies that write to the same property [190.60ms]
(pass) bun/no-duplicate-conditional-property-access > inline disable comment suppresses the diagnostic [172.13ms]
(pass) bun/no-duplicate-conditional-property-access > diagnostic message suggests destructuring the base object [164.85ms]
(pass) src/js lint > bun run lint is clean on src/js [380.70ms]

 6 pass
 0 fail
 17 expect() calls
Ran 6 tests across 1 file. [4.08s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 677ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7797ms)
Bundle modules (47ms)
Postprocesss modules (216ms)
Bundle Functions (564ms)
Generate Code (32ms)

[8.68s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 51s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+7b1c0c9ec
[build] done
bun test v1.4.1-canary.1 (7b1c0c9ec)

test/internal/oxlint-plugin-bun.test.ts:
(pass) bun/no-duplicate-conditional-property-access > flags re-reading the property inside the if body [147.45ms]
(pass) bun/no-duplicate-conditional-property-access > ignores destructured lo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/util/inspect.js         |  1 -
 test/internal/oxlint-plugin-bun.test.ts | 22 +++++++++++++++-------
 2 files changed, 15 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/internal/util/inspect.js              1      2      0
test/internal/oxlint-plugin-bun.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->