### PR TITLE
ci: say what the beta lane's soft_fail does and does not cover

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -849,7 +849,12 @@ function getTestBunStep(platform, options, testOptions = {}) {
     // never starts is not something soft_fail can convert.
     retry: platform.tier === "beta" ? { manual: { permit_on_passed: true }, automatic: false } : getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    // One beta box: one shard, and it cannot block a merge.
+    // One beta box: one shard. soft_fail keeps a failing run from
+    // failing the build, and the lane is never added on the merge queue
+    // (see betaDarwinTestPlatforms). One window stays open: the box was
+    // connected at upload but drops off during the build wait, so the
+    // step sits `scheduled` with nobody to take it. That holds only this
+    // PR's own build, and a cancel clears it.
     parallelism: platform.tier === "beta" ? 1 : os === "darwin" ? 2 : os === "windows" ? 8 : 20,
     ...(platform.tier === "beta" ? { soft_fail: true } : {}),
     timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,


### PR DESCRIPTION
Follow-up to #40019, from its last review thread.

The comment on the beta test step said it "cannot block a merge". Two of three cases hold: a failing run cannot fail the build (`soft_fail`), and the lane is never added on the merge queue. The third does not: if the beta box is connected at upload but drops off during the darwin build wait, the step goes `scheduled` with no agent and holds that one PR build until someone cancels it. No automatic retry and no timeout applies to a job that never starts. The comment now says so instead of overstating the guarantee.

Comment-only; no behaviour change.