### PR TITLE
node-fallbacks: fix the util polyfill and lint the polyfills for undeclared names

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -105,6 +105,25 @@
         // cache the value in a local instead.
         "bun/no-duplicate-conditional-property-access": "error"
       }
+    },
+    {
+      // Browser polyfills that `bun build --target=browser` inlines into the
+      // user's bundle. They are plain JS, not JSC builtins: a `$intrinsic` or
+      // any other undeclared name is a ReferenceError in the browser.
+      // `process` is not a browser global either. The polyfills read it behind
+      // `typeof process !== "undefined"` guards, which no-undef cannot see.
+      "files": ["src/node-fallbacks/*.js"],
+      "env": { "browser": true, "es2024": true },
+      "globals": { "process": "readonly" },
+      "rules": {
+        "no-undef": "error",
+        "no-unused-vars": "off",
+        "no-useless-rename": "off"
+      }
+    },
+    {
+      "files": ["src/node-fallbacks/stream.js"],
+      "env": { "commonjs": true }
     }
   ]
 }

--- a/oxlint.json
+++ b/oxlint.json
@@ -108,13 +108,11 @@
     },
     {
       // Browser polyfills that `bun build --target=browser` inlines into the
-      // user's bundle. They are plain JS, not JSC builtins: a `$intrinsic` or
-      // any other undeclared name is a ReferenceError in the browser.
-      // `process` is not a browser global either. The polyfills read it behind
-      // `typeof process !== "undefined"` guards, which no-undef cannot see.
+      // user's bundle. They are plain JS, not JSC builtins: a `$intrinsic`,
+      // a node global such as `process` or `Buffer`, or any other undeclared
+      // name is a ReferenceError in the browser. Read `globalThis.process`.
       "files": ["src/node-fallbacks/*.js"],
       "env": { "browser": true, "es2024": true },
-      "globals": { "process": "readonly" },
       "rules": {
         "no-undef": "error",
         "no-unused-vars": "off",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "fmt": "bun run prettier",
     "fmt:cpp": "bun run clang-format",
     "fmt:rust": "cargo fmt --all",
-    "lint": "oxlint --config=oxlint.json --format=github src/js",
+    "lint": "oxlint --config=oxlint.json --format=github src/js src/node-fallbacks",
     "lint:fix": "oxlint --config oxlint.json --fix",
     "test": "node scripts/runner.node.mjs --exec-path ./build/debug/bun-debug",
     "testleak": "BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=malloc_context_size=100:print_suppressions=1:suppressions=$npm_config_local_prefix/test/leaksan.supp ./build/debug/bun-debug",

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -16,13 +16,6 @@ for (const name of allFiles) {
 
 for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
   const name = allFiles[fileIndex];
-  const mod = basename(name, extname(name)).replaceAll(".", "/");
-  const file = allFiles.find(f => f.startsWith(mod));
-  const externals = [...builtins];
-  const i = externals.indexOf(name);
-  if (i !== -1) {
-    externals.splice(i, 1);
-  }
 
   // Build all files at once with specific options
   const externalModules = builtins
@@ -35,7 +28,7 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
     Bun.$`bun build --define=process.env.NODE_DEBUG:"false" --define=process.env.READABLE_STREAM="'enable'" --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
 
   commands.push(
-    buildCommand.then(async text => {
+    buildCommand.then(async () => {
       // This is very brittle. But that should be okay for our usecase
       let outfile = (await Bun.file(`${outdir}/${name}`).text())
         .replaceAll("__require(", "require(")

--- a/src/node-fallbacks/path.js
+++ b/src/node-fallbacks/path.js
@@ -116,7 +116,7 @@ export function resolve() {
     var path;
     if (i >= 0) path = arguments[i];
     else {
-      if (cwd === undefined) cwd = process.cwd();
+      if (cwd === undefined) cwd = globalThis.process?.cwd?.() ?? "/";
       path = cwd;
     }
 

--- a/src/node-fallbacks/util.js
+++ b/src/node-fallbacks/util.js
@@ -68,16 +68,17 @@ export function format(f, ...args) {
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
 export function deprecate(fn, msg) {
-  if (typeof process === "undefined" || process?.noDeprecation === true) {
+  var proc = globalThis.process;
+  if (proc == null || proc.noDeprecation === true) {
     return fn;
   }
 
   var warned = false;
   function deprecated(...args) {
     if (!warned) {
-      if (process.throwDeprecation) {
+      if (proc.throwDeprecation) {
         throw new Error(msg);
-      } else if (process.traceDeprecation) {
+      } else if (proc.traceDeprecation) {
         console.trace(msg);
       } else {
         console.error(msg);
@@ -91,18 +92,22 @@ export function deprecate(fn, msg) {
 }
 
 // This function has been edited to be tree-shakable and minifiable
-export const debuglog = /* @__PURE__ */ ((debugs = {}, debugEnvRegex = {}, debugEnv) => (
-  ((debugEnv = typeof process !== "undefined" && process.env.NODE_DEBUG) &&
-    (debugEnv = debugEnv
-      .replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
-      .replace(/\*/g, ".*")
-      .replace(/,/g, "$|^")
-      .toUpperCase()),
-  (debugEnvRegex = new RegExp("^" + debugEnv + "$", "i"))),
+export const debuglog = /* @__PURE__ */ ((debugs = {}, debugEnvRegex, debugEnv) => (
+  (debugEnv = globalThis.process?.env?.NODE_DEBUG) &&
+    (debugEnvRegex = new RegExp(
+      "^" +
+        debugEnv
+          .replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+          .replace(/\*/g, ".*")
+          .replace(/,/g, "$|^")
+          .toUpperCase() +
+        "$",
+      "i",
+    )),
   set => {
     set = set.toUpperCase();
     if (!debugs[set]) {
-      if (debugEnvRegex.test(set)) {
+      if (debugEnvRegex?.test(set)) {
         debugs[set] = function (...args) {
           console.error("%s: %s", set, format(...args));
         };
@@ -682,12 +687,32 @@ export function callbackify(original) {
 export const TextEncoder = /* @__PURE__ */ globalThis.TextEncoder;
 export const TextDecoder = /* @__PURE__ */ globalThis.TextDecoder;
 export default {
-  TextEncoder,
-  TextDecoder,
-  promisify,
+  format,
+  deprecate,
+  debuglog,
+  inspect,
+  types,
+  isArray,
+  isBoolean,
+  isNull,
+  isNullOrUndefined,
+  isNumber,
+  isString,
+  isSymbol,
+  isUndefined,
+  isRegExp,
+  isObject,
+  isDate,
+  isError,
+  isFunction,
+  isPrimitive,
+  isBuffer,
   log,
   inherits,
   _extend,
+  promisify,
   callbackifyOnRejected,
   callbackify,
+  TextEncoder,
+  TextDecoder,
 };

--- a/src/node-fallbacks/util.js
+++ b/src/node-fallbacks/util.js
@@ -498,8 +498,7 @@ export function isPrimitive(arg) {
   );
 }
 
-// There is no Buffer global in a browser. Detect the buffer polyfill by its
-// methods, the same way the npm `util` package does in its browser build.
+// Browsers have no Buffer global, so detect the buffer polyfill by its methods.
 export function isBuffer(arg) {
   return (
     typeof arg === "object" &&
@@ -663,9 +662,7 @@ export function callbackify(original) {
     var cb = function (...args) {
       return maybeCb.apply(self, args);
     };
-    // Node runs the callback on `nextTick` so that a throw inside it is an
-    // uncaught exception instead of a rejection of the promise. Browsers have
-    // no `process`, and `queueMicrotask` reports a throw the same way.
+    // Like process.nextTick in Node, a throw from the callback is an uncaught error, not a rejection.
     original.apply(this, args).then(
       function (ret) {
         queueMicrotask(cb.bind(null, null, ret));

--- a/src/node-fallbacks/util.js
+++ b/src/node-fallbacks/util.js
@@ -84,7 +84,7 @@ export function deprecate(fn, msg) {
       }
       warned = true;
     }
-    return fn.apply(this, ...args);
+    return fn.apply(this, args);
   }
 
   return deprecated;
@@ -104,7 +104,7 @@ export const debuglog = /* @__PURE__ */ ((debugs = {}, debugEnvRegex = {}, debug
     if (!debugs[set]) {
       if (debugEnvRegex.test(set)) {
         debugs[set] = function (...args) {
-          console.error("%s: %s", set, pid, format.apply(null, ...args));
+          console.error("%s: %s", set, format(...args));
         };
       } else {
         debugs[set] = function () {};
@@ -498,9 +498,16 @@ export function isPrimitive(arg) {
   );
 }
 
-// Compatibility with the buffer polyfill:
+// There is no Buffer global in a browser. Detect the buffer polyfill by its
+// methods, the same way the npm `util` package does in its browser build.
 export function isBuffer(arg) {
-  return arg instanceof Buffer;
+  return (
+    typeof arg === "object" &&
+    arg !== null &&
+    typeof arg.copy === "function" &&
+    typeof arg.fill === "function" &&
+    typeof arg.readUInt8 === "function"
+  );
 }
 
 function objectToString(o) {
@@ -568,11 +575,13 @@ function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-export const promisify = /* @__PURE__ */ (x => ((x.custom = Symbol.for("nodejs.util.promisify.custom")), x))(
+const kCustomPromisifiedSymbol = Symbol.for("nodejs.util.promisify.custom");
+
+export const promisify = /* @__PURE__ */ (x => ((x.custom = kCustomPromisifiedSymbol), x))(
   function promisify(original) {
     if (typeof original !== "function") throw new TypeError('The "original" argument must be of type Function');
 
-    if (kCustomPromisifiedSymbol && original[kCustomPromisifiedSymbol]) {
+    if (original[kCustomPromisifiedSymbol]) {
       var fn = original[kCustomPromisifiedSymbol];
 
       if (typeof fn !== "function") {
@@ -614,13 +623,12 @@ export const promisify = /* @__PURE__ */ (x => ((x.custom = Symbol.for("nodejs.u
 
     Object.setPrototypeOf(fn, Object.getPrototypeOf(original));
 
-    if (kCustomPromisifiedSymbol)
-      Object.defineProperty(fn, kCustomPromisifiedSymbol, {
-        value: fn,
-        enumerable: false,
-        writable: false,
-        configurable: true,
-      });
+    Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+      value: fn,
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    });
     return Object.defineProperties(fn, Object.getOwnPropertyDescriptors(original));
   },
 );
@@ -653,16 +661,17 @@ export function callbackify(original) {
     }
     var self = this;
     var cb = function (...args) {
-      return maybeCb.apply(self, ...args);
+      return maybeCb.apply(self, args);
     };
-    // In true node style we process the callback on `nextTick` with all the
-    // implications (stack, `uncaughtException`, `async_hooks`)
+    // Node runs the callback on `nextTick` so that a throw inside it is an
+    // uncaught exception instead of a rejection of the promise. Browsers have
+    // no `process`, and `queueMicrotask` reports a throw the same way.
     original.apply(this, args).then(
       function (ret) {
-        process.nextTick(cb.bind(null, null, ret));
+        queueMicrotask(cb.bind(null, null, ret));
       },
       function (rej) {
-        process.nextTick(callbackifyOnRejected.bind(null, rej, cb));
+        queueMicrotask(callbackifyOnRejected.bind(null, rej, cb));
       },
     );
   }

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -172,8 +172,22 @@ describe("bundler", () => {
   itBundled("browser/NodeUtilPolyfill", {
     files: {
       "/entry.js": /* js */ `
-        import { promisify, callbackify, deprecate, isBuffer, debuglog } from "node:util";
+        import util, { promisify, callbackify, deprecate, isBuffer, debuglog } from "node:util";
+        import * as utilNamespace from "node:util";
         import { Buffer } from "node:buffer";
+        import { resolve as resolvePath } from "node:path";
+
+        // A browser has none of these globals. The test runner has them all, so
+        // drop them before the polyfills run. Exit on an unhandled rejection so
+        // that a polyfill reaching for one of them fails fast instead of hanging.
+        const proc = globalThis.process;
+        proc.on("unhandledRejection", err => {
+          console.log("unhandledRejection: " + err.message);
+          proc.exit(1);
+        });
+        delete globalThis.process;
+        delete globalThis.Buffer;
+        delete globalThis.setImmediate;
         const results = [];
 
         results.push(await promisify((a, b, cb) => cb(null, a + b))(40, 2));
@@ -185,16 +199,29 @@ describe("bundler", () => {
         results.push(await new Promise(resolve => callbackify(async x => x * 2)(21, (err, value) => resolve(err + "," + value))));
         results.push(await new Promise(resolve => callbackify(async () => { throw new Error("rejected"); })(err => resolve(err.message))));
         results.push(await new Promise(resolve => callbackify(() => Promise.reject(null))(err => resolve(err.message + "," + err.reason))));
+        // As in node, a throw inside the callback is an uncaught exception, not a rejection.
+        const uncaught = new Promise(resolve => proc.once("uncaughtException", err => resolve("uncaughtException: " + err.message)));
+        callbackify(async () => 1)(() => { throw new Error("in callback"); });
+        results.push(await uncaught);
 
+        // Without a process there is no deprecation config: the function comes back as is.
+        const plain = () => {};
+        results.push(deprecate(plain, "old") === plain);
+        // With one, the wrapper warns once and forwards this and the arguments.
+        globalThis.process = proc;
         const warnings = [];
         const consoleError = console.error;
         console.error = msg => warnings.push(msg);
         const target = { base: 1, old: deprecate(function (a, b) { return this.base + a + b; }, "old is deprecated") };
         results.push(target.old(2, 3) + "," + target.old(4, 5) + "," + warnings.join("|"));
         console.error = consoleError;
+        delete globalThis.process;
 
         results.push([isBuffer(Buffer.from("x")), isBuffer(new Uint8Array(1)), isBuffer(null), isBuffer("str")].join(","));
         results.push(typeof debuglog("anything"));
+        results.push(resolvePath("relative/x"));
+        const missing = Object.keys(utilNamespace).filter(name => name !== "default" && util[name] !== utilNamespace[name]);
+        results.push("missing from default export: " + missing.join(","));
         console.log(results.join("\\n"));
       `,
     },
@@ -207,15 +234,14 @@ describe("bundler", () => {
         "null,42",
         "rejected",
         "Promise was rejected with a falsy value,null",
+        "uncaughtException: in callback",
+        "true",
         "6,10,old is deprecated",
         "true,false,false,false",
         "function",
+        "/relative/x",
+        "missing from default export: ",
       ].join("\n"),
-    },
-    onAfterBundle(api) {
-      // The test runs the bundle under bun, which has process.nextTick. A browser does not.
-      const out = api.readFile("/out.js");
-      assert(!out.includes("process.nextTick"), "util polyfill must not depend on process.nextTick");
     },
   });
   itBundled("browser/NodeUrlProtocolTablesIgnorePrototype", {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -212,6 +212,11 @@ describe("bundler", () => {
         "function",
       ].join("\n"),
     },
+    onAfterBundle(api) {
+      // The test runs the bundle under bun, which has process.nextTick. A browser does not.
+      const out = api.readFile("/out.js");
+      assert(!out.includes("process.nextTick"), "util polyfill must not depend on process.nextTick");
+    },
   });
   itBundled("browser/NodeUrlProtocolTablesIgnorePrototype", {
     files: {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -166,6 +166,53 @@ describe("bundler", () => {
       assert(!out.includes("$newPromiseCapability"), "events polyfill must not reference a JSC builtin intrinsic");
     },
   });
+  // The util polyfill is a hand conversion of the npm `util` package. Each of
+  // these exports had a bug from that conversion: an undeclared identifier, a
+  // spread into Function#apply, or a dependency on a Node-only global.
+  itBundled("browser/NodeUtilPolyfill", {
+    files: {
+      "/entry.js": /* js */ `
+        import { promisify, callbackify, deprecate, isBuffer, debuglog } from "node:util";
+        import { Buffer } from "node:buffer";
+        const results = [];
+
+        results.push(await promisify((a, b, cb) => cb(null, a + b))(40, 2));
+        results.push(await promisify(cb => cb(new Error("cb failed")))().then(() => "resolved", e => e.message));
+        const withCustom = () => {};
+        withCustom[promisify.custom] = () => Promise.resolve("custom");
+        results.push(promisify(withCustom) === withCustom[promisify.custom] ? await promisify(withCustom)() : "custom ignored");
+
+        results.push(await new Promise(resolve => callbackify(async x => x * 2)(21, (err, value) => resolve(err + "," + value))));
+        results.push(await new Promise(resolve => callbackify(async () => { throw new Error("rejected"); })(err => resolve(err.message))));
+        results.push(await new Promise(resolve => callbackify(() => Promise.reject(null))(err => resolve(err.message + "," + err.reason))));
+
+        const warnings = [];
+        const consoleError = console.error;
+        console.error = msg => warnings.push(msg);
+        const target = { base: 1, old: deprecate(function (a, b) { return this.base + a + b; }, "old is deprecated") };
+        results.push(target.old(2, 3) + "," + target.old(4, 5) + "," + warnings.join("|"));
+        console.error = consoleError;
+
+        results.push([isBuffer(Buffer.from("x")), isBuffer(new Uint8Array(1)), isBuffer(null), isBuffer("str")].join(","));
+        results.push(typeof debuglog("anything"));
+        console.log(results.join("\\n"));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: [
+        "42",
+        "cb failed",
+        "custom",
+        "null,42",
+        "rejected",
+        "Promise was rejected with a falsy value,null",
+        "6,10,old is deprecated",
+        "true,false,false,false",
+        "function",
+      ].join("\n"),
+    },
+  });
   itBundled("browser/NodeUrlProtocolTablesIgnorePrototype", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- `util.promisify()` from a `bun build --target=browser` bundle throws `ReferenceError: kCustomPromisifiedSymbol is not defined` (`src/node-fallbacks/util.js:582`). The polyfill is a hand conversion of the npm `util` package and the declaration was dropped.
- The same conversion broke more. `callbackify()` and `deprecate()` spread their arguments into `Function#apply`, so the callback gets no result and `deprecate(fn)(1, 2)` throws. `callbackify()` uses `process.nextTick` and `isBuffer()` uses `instanceof Buffer`. Browsers have neither. The default export lists 8 of 28 exports, so `util.format` is `undefined`.
- Nothing checked the polyfill sources for undeclared names. #40049 fixed the same class in `events.js`. Its self-review found this file.

### Fix
- `util.js`: declare the symbol, pass the arrays to `apply`, use `queueMicrotask`, duck-type the buffer polyfill in `isBuffer()` as upstream `util` does in its browser build, read `globalThis.process`, and complete the default export. `path.resolve()` falls back to `/` without `process.cwd()`.
- Lint `src/node-fallbacks/*.js` with `no-undef` under the browser environment (`oxlint.json` override, `lint` script). A node global or a JSC intrinsic in a polyfill source now fails CI. It flags the pre-#40049 `events.js`.
- Correct because the polyfill runs in the user's browser and can only use what a browser has. `queueMicrotask` keeps the node property that matters: a throw in the callback is an uncaught error, not a rejection.
- Verified: `test/bundler/bundler_browser.test.ts` (new `browser/NodeUtilPolyfill`, stock bun fails it). The test deletes `process`, `Buffer` and `setImmediate` before the bundle runs.

### Background
- `src/node-fallbacks/*.js` are browser polyfills for `node:*` modules. `bun build --target=browser` inlines them into the user's bundle.
- `promisify.custom` is `Symbol.for("nodejs.util.promisify.custom")`. A function can carry its own promisified form under it.

<details><summary>Notes</summary>

Repro with the released binary. Bundle this with `bun build --target=browser`, then run the output with `node` after `delete globalThis.process; delete globalThis.Buffer` to match a browser:

```js
import util, { promisify, callbackify, deprecate, isBuffer } from "node:util";
import { Buffer } from "node:buffer";
await promisify((a, cb) => cb(null, a * 2))(21);          // ReferenceError: kCustomPromisifiedSymbol
callbackify(async a => a + 1)(41, (err, v) => {});        // ReferenceError: process is not defined
deprecate((a, b) => a + b, "old")(1, 2);                  // TypeError: CreateListFromArrayLike called on non-object
isBuffer(Buffer.from("x"));                               // false, or ReferenceError without a Buffer global
typeof util.format;                                       // "undefined"
```

With the fix the same file prints `42`, `null,42`, `3`, `true`, `function`.

The test runs the bundle under bun, which has every node global. It saves `process`, deletes `process`, `Buffer` and `setImmediate` from `globalThis`, and exits on an unhandled rejection. With the debug build's polyfill output edited by hand, a `process.nextTick` revert fails with `unhandledRejection: process is not defined`, and a synchronous `cb(null, ret)` fails with `unhandledRejection: in callback` where the test expects `uncaughtException: in callback`.

The lint covers the hand-written sources only. The vendored packages that `assert.js`, `http.js`, `stream.js` and `zlib.js` bundle still reference `process` internally. #35484 covers the `process` shim for the stream polyfill.

Lint findings on main before this PR, with the new override and no `process` global: `util.js` `kCustomPromisifiedSymbol` (6), `pid` (1), `Buffer` (1), `process` (5), `path.js` `process` (1). Nothing else in the 20 polyfill sources. With the pre-#40049 `events.js` swapped in, the lint also reports `$newPromiseCapability`.

`debuglog()` reads `globalThis.process?.env?.NODE_DEBUG` at run time now. Before, `build-fallbacks.ts` defined `process.env.NODE_DEBUG` as `false` at build time, which also made the match regex `/^false$/`.

`build-fallbacks.ts` is linted with the base rules now. Its two `no-unused-vars` hits were dead locals (`mod`, `file`, `externals`, `i`, and the unused `text` parameter). Removed. Its output checks (string matches for a few known bad names) stay as they are.

Suites run: `test/bundler/bundler_browser.test.ts` (24 pass, 1 skip, 1 todo).
</details>

<!-- robobun:evidence:begin -->

---

**[decide:dep]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1620.55ms]
(pass) bundler > browser/NodeBuffer#12272 [828.03ms]
(pass) bundler > browser/NodeFS [357.81ms]
(pass) bundler > browser/NodeTTY [359.50ms]
(pass) bundler > browser/NodeEventsOnce [517.46ms]
1815 |           }
1816 |         } else if (!success) {
1817 |           if (run.exitCode) {
1818 |             expect([exitCode, signalCode]).toEqual([run.exitCode, undefined]);
1819 |           } else {
1820 |             throw new Error(prefix + "Runtime failed\n" + stdout!.toUnixString() + "\n" + stderr!.toUnixString());
                             ^
error: Runtime failed

364 |   return Object.prototype.hasOwnProperty.call(obj, prop);
365 | }
366 | var promisify = ((x) => (x.custom = Symbol.for("nodejs.util.promisify.custom"), x))(function(original) {
367 |   if (typeof original !== "function")
368 |     throw TypeError('The "original" argument must be of type Function');
369 |   if (kC
... (truncated)

release without fix: 2 skipped
bun test v1.4.1-canary.1 (aa455a21c)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [33.53ms]
(pass) bundler > browser/NodeBuffer#12272 [16.82ms]
(pass) bundler > browser/NodeFS [10.28ms]
(pass) bundler > browser/NodeTTY [10.85ms]
(pass) bundler > browser/NodeEventsOnce [13.49ms]
(pass) bundler > browser/NodeUtilPolyfill [21.86ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [14.34ms]
(pass) bundler > browser/NodePolyfills [149.10ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [12.59ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [13.26ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [9.69ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [13.77ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [5.38ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [4.87ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldOnlyAppliesToBrowserTarget [11.67ms]
(pass) bundler > browser/EntryPointDisabledByPackageMainBrowserField [5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1571.31ms]
(pass) bundler > browser/NodeBuffer#12272 [697.47ms]
(pass) bundler > browser/NodeFS [365.68ms]
(pass) bundler > browser/NodeTTY [349.38ms]
(pass) bundler > browser/NodeEventsOnce [524.67ms]
(pass) bundler > browser/NodeUtilPolyfill [1050.31ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [463.97ms]
(pass) bundler > browser/NodePolyfills [7825.42ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [436.23ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [719.04ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [387.81ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [472.16ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [227.19ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPo
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 648ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen node-fallbacks/*.js
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
oxlint.json                           | 17 ++++++
 package.json                          |  2 +-
 src/node-fallbacks/build-fallbacks.ts |  9 +---
 src/node-fallbacks/path.js            |  2 +-
 src/node-fallbacks/util.js            | 97 +++++++++++++++++++++++------------
 test/bundler/bundler_browser.test.ts  | 78 ++++++++++++++++++++++++++++
 6 files changed, 162 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
oxlint.json                                3      4      0
package.json                               0      0      0
src/node-fallbacks/build-fallbacks.ts      2      3      0
src/node-fallbacks/path.js                 1      1      0
src/node-fallbacks/util.js                 7     11      0
test/bundler/bundler_browser.test.ts       5      5      0
```

</details>

<!-- robobun:evidence:end -->