### PR TITLE
install: add a test harness flag that writes manifest cache entries before exit

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -277,6 +277,8 @@ pub mod feature_flag {
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});
+    // Set by the test harness: manifest cache entries are written before `save_async` returns.
+    new_feature_flag!(pub BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES, "BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN, "BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT, "BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_UV_STUB, "BUN_INTERNAL_SUPPRESS_CRASH_ON_UV_STUB", {});

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1257,6 +1257,16 @@ pub mod package_manifest {
                 Batch as PoolBatch, Node as PoolNode, Task as PoolTask,
             };
 
+            if bun_core::env_var::feature_flag::BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES
+                .get()
+                .unwrap_or(false)
+            {
+                if let Err(err) = Serializer::save(this, scope, tmpdir, cache_dir) {
+                    Self::warn_not_cached(this, err);
+                }
+                return;
+            }
+
             struct SaveTask {
                 manifest: PackageManifest,
                 // Owned: the thread-pool task can outlive the caller's borrow
@@ -1297,14 +1307,7 @@ pub mod package_manifest {
                         save_task.tmpdir,
                         save_task.cache_dir,
                     ) {
-                        if PackageManager::verbose_install() {
-                            bun_core::warn!(
-                                "Error caching manifest for {}: {}",
-                                bstr::BStr::new(save_task.manifest.name()),
-                                err.name(),
-                            );
-                            Output::flush();
-                        }
+                        Serializer::warn_not_cached(&save_task.manifest, err);
                     }
                 }
             }
@@ -1323,6 +1326,17 @@ pub mod package_manifest {
             // SAFETY: task is a valid Box-allocated SaveTask
             let batch = PoolBatch::from(unsafe { core::ptr::addr_of_mut!((*task).task) });
             PackageManager::get().thread_pool.schedule(batch);
+        }
+
+        fn warn_not_cached(manifest: &PackageManifest, err: Error) {
+            if PackageManager::verbose_install() {
+                bun_core::warn!(
+                    "Error caching manifest for {}: {}",
+                    bstr::BStr::new(manifest.name()),
+                    err.name(),
+                );
+                Output::flush();
+            }
         }
 
         fn manifest_file_name<'b>(

--- a/test/cli/install/bun-install-offline.test.ts
+++ b/test/cli/install/bun-install-offline.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "bun";
+import { npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
@@ -10,7 +11,6 @@ import {
   dummyBeforeAll,
   dummyBeforeEach,
   dummyRegistry,
-  package_dir,
   root_url,
   setHandler,
 } from "./dummy.registry";
@@ -30,13 +30,6 @@ function mkdtemp(): string {
 beforeEach(async () => {
   await dummyBeforeEach({ linker: "hoisted" });
   cache_dir = mkdtemp();
-  // dummyBeforeEach disables the cache; these tests are about the cache
-  await writeFile(
-    join(package_dir, "bunfig.toml"),
-    Bun.TOML.stringify({
-      install: { cache: { dir: cache_dir }, registry: root_url + "/", saveTextLockfile: true, linker: "hoisted" },
-    }),
-  );
 });
 afterEach(async () => {
   await dummyAfterEach();
@@ -48,11 +41,11 @@ afterEach(async () => {
 // bunfig cache dirs these tests populate and inspect
 const { BUN_INSTALL_CACHE_DIR: _ciCacheDir, ...installEnv } = env;
 
-async function install(cwd: string, args: string[]) {
+async function install(cwd: string, args: string[], installEnvironment = installEnv) {
   await using proc = spawn({
     cmd: [bunExe(), "install", ...args],
     cwd,
-    env: installEnv,
+    env: installEnvironment,
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -72,24 +65,68 @@ async function newProject(deps: Record<string, string>, cache = cache_dir, linke
   return dir;
 }
 
+// Online install of `deps` (one manifest each) that leaves their manifests and tarballs in
+// `cache`. The entries are on disk when the install exits because `bunEnv` sets
+// BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES (see test/harness.ts).
+async function warmCache(deps: Record<string, string>, cache = cache_dir) {
+  const r = await install(await newProject(deps, cache), []);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(await cachedManifests(cache)).toHaveLength(Object.keys(deps).length);
+}
+
+async function cachedManifests(cache: string) {
+  return (await readdirSorted(cache)).filter(name => name.endsWith(".npm"));
+}
+
+// Without the harness flag, the entry is written by a thread pool task that `bun install`
+// does not wait for before it exits (`save_async` in src/install/npm.rs). Hold the tarball
+// response until the entry exists so the install cannot finish first, then check that what
+// the task wrote is a manifest `--offline` resolves from.
+it("the manifest cache entry written from the thread pool is a usable manifest", async () => {
+  const urls: string[] = [];
+  const registry = dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} });
+  setHandler(async request => {
+    if (request.url.endsWith(".tgz")) {
+      const deadline = Date.now() + 10_000;
+      while ((await cachedManifests(cache_dir)).length === 0 && Date.now() < deadline) await Bun.sleep(10);
+    }
+    return registry(request);
+  });
+  const { BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES: _, ...threadPoolWriteEnv } = installEnv;
+  let r = await install(await newProject({ baz: "0.0.3" }), [], threadPoolWriteEnv);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.map(url => new URL(url).pathname)).toEqual(["/baz", "/baz-0.0.3.tgz"]);
+
+  const entries = await cachedManifests(cache_dir);
+  expect(entries).toHaveLength(1);
+  expect(npm_manifest_test_helpers.parseManifest(join(cache_dir, entries[0]), root_url + "/")).toEqual({
+    name: "baz",
+    versions: expect.arrayContaining(["0.0.3", "0.0.5"]),
+  });
+
+  const before = urls.length;
+  const dir2 = await newProject({ baz: "0.0.3" });
+  r = await install(dir2, ["--offline"]);
+  expect(r.err).not.toContain("error:");
+  expect(r.code).toBe(0);
+  expect(urls.length).toBe(before);
+  expect(await readdirSorted(join(dir2, "node_modules", "baz"))).toContain("package.json");
+});
+
 it("--prefer-offline resolves from cached manifests without touching the network", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
-  );
   // 1. online install populates the manifest + tarball cache
-  let r = await install(package_dir, []);
-  expect(r.err).not.toContain("error:");
-  expect(r.code).toBe(0);
+  await warmCache({ baz: "0.0.3" });
   const before = urls.length;
   expect(before).toBeGreaterThan(0);
 
   // 2. a fresh project without a lockfile: the (possibly stale) cached manifest satisfies
   //    the range and the tarball comes from the cache: zero requests
   const dir2 = await newProject({ baz: "<=0.0.3" });
-  r = await install(dir2, ["--prefer-offline"]);
+  const r = await install(dir2, ["--prefer-offline"]);
   expect(r.err).not.toContain("error:");
   expect(r.code).toBe(0);
   expect(urls.slice(before)).toEqual([]);
@@ -100,17 +137,12 @@ describe.each(["hoisted", "isolated"] as const)("--offline (%s linker)", linker 
   it("never issues a request and fails cleanly on a cache miss", async () => {
     const urls: string[] = [];
     setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-    await writeFile(
-      join(package_dir, "package.json"),
-      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
-    );
-    let r = await install(package_dir, []);
-    expect(r.code).toBe(0);
+    await warmCache({ baz: "0.0.3" });
     const before = urls.length;
 
     // everything cached → works
     const dir2 = await newProject({ baz: "0.0.3" }, cache_dir, linker);
-    r = await install(dir2, ["--offline"]);
+    let r = await install(dir2, ["--offline"]);
     expect(r.err).not.toContain("error:");
     expect(r.code).toBe(0);
     expect(urls.length).toBe(before);
@@ -142,10 +174,7 @@ describe.each(["--prefer-offline", "--offline"])("%s with an expired cached mani
     setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
     // each mode gets its own warmed cache so one cannot pre-fetch for the other
     const cache = mkdtemp();
-    const warm = await newProject({ baz: "0.0.3" }, cache);
-    const w = await install(warm, []);
-    expect(w.err).not.toContain("error:");
-    expect(w.code).toBe(0);
+    await warmCache({ baz: "0.0.3" }, cache);
     const before = urls.length;
     const dir = await newProject({ baz: "^0.0.3" }, cache);
     const r = await install(dir, ["--force", flag]);
@@ -165,10 +194,7 @@ describe.each(["--prefer-offline", "--offline"])("%s with an expired cached mani
 it("--offline skips an optional dependency that is not in the cache", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {} }));
-  const warm = await newProject({ baz: "0.0.3" });
-  const w = await install(warm, []);
-  expect(w.err).not.toContain("error:");
-  expect(w.code).toBe(0);
+  await warmCache({ baz: "0.0.3" });
   const before = urls.length;
   // `bar` was never fetched: as an optionalDependency it is skipped, not an error
   const dir = mkdtemp();
@@ -252,15 +278,7 @@ it("--offline reports an uncached tarball-URL / github dependency once, and skip
 it('install.prefer = "offline" and install.offline = true in bunfig.toml behave like the flags', async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
-  );
-  {
-    const w = await install(package_dir, []);
-    expect(w.err).not.toContain("error:");
-    expect(w.code).toBe(0);
-  }
+  await warmCache({ baz: "0.0.3" });
   const before = urls.length;
   const dir2 = mkdtemp();
   await writeFile(

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -82,6 +82,10 @@ export const bunEnv: NodeJS.Dict<string> = {
   // Tests drive `bun update --interactive` by writing keystrokes to a pipe;
   // the real command refuses on non-TTY stdin. Bypass that gate under test.
   BUN_INTERNAL_INTERACTIVE_ASSUME_TTY: "1",
+  // `bun install` writes each manifest cache entry from a thread pool task it
+  // does not wait for before exiting, so a test that installs again right away
+  // may not find the entry. Write it before the install exits instead.
+  BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES: "1",
   BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
   BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE: "1",
   BUN_DEBUG_linkerctx: "0",


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-install-offline.test.ts` (from #40010) flaked on the alpine 3.23 x64 lane of build 103389: `error: --offline: no cached manifest for "baz" (run once online, or use --prefer-offline)` at line 114.
- `Serializer::save_async` (src/install/npm.rs:1250) writes each manifest cache entry from a thread pool task that `bun install` never waits for, so under load an install exits first. #37203, #38580 and #39190 each patched one test around it.

### Fix
- A test-only flag, `BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES`, makes `save_async` write the entry inline: inside the tracked manifest task (200) or on the main thread (304), so it is on disk before the install goes on. `bunEnv` sets it for every install a test spawns.
- Production behavior is unchanged. Same shape as `BUN_DISABLE_SLOW_FILESYSTEM_WARNING`, and it keeps the #37203 decision: no exit-time wait in `bun install`.
- The offline tests share one `warmCache` helper. A new test installs with the flag unset and holds the tarball response until the thread pool entry exists, so the production path stays covered.
- Verified: `bun bd test test/cli/install/bun-install-offline.test.ts` (11 pass), `bun-install-registry -t manifest` and the `bun-lock` peer tests. Probe, one debug binary under load: flag unset loses 24 of 300 entries, flag set 0 of 150.

### Background
- Manifest cache: `bun install` serializes each fetched manifest to `<cache dir>/<hash>.npm`. `--offline` resolves from that file only and reports a miss as an error.
- `save_async` writes a temporary file and renames it into the cache directory from a thread pool task. The cache is optional, so nothing joins the task before exit.
- Feature flags (`src/bun_core/env_var.rs`) are env vars cached atomically, safe to read from a pool worker.

<details><summary>Notes</summary>

Probes. Each iteration: a fresh project against a local registry that serves `baz`, then `bun install`, then count `.npm` files in the cache directory after exit 0. 16 vCPUs, 48 busy loops alongside.

Release binary (1.4.0-canary.1, no flag support, unfixed):

| shape | installs that exited without the entry |
| --- | --- |
| cold cache: manifest, then tarball (the first step of each offline test) | 5 / 3000 |
| tarball already cached: the manifest is the last fetch | 746 / 3000 |

Debug binary from this branch, tarball already cached, 20,000-version manifest so the write takes longer:

| env | installs that exited without the entry |
| --- | --- |
| flag unset | 14 / 150, then 10 / 150 |
| `BUN_INTERNAL_SYNC_MANIFEST_CACHE_WRITES=1` | 0 / 150 |

No install failed in any run. Also run: `bun-add`, `bun-pm` and `lockfile-only`, all green.

Why both callers are covered: `get_package_metadata` (npm.rs:581) runs inside `PackageManagerTask` on a pool worker, and the main thread waits for that task, so an inline save there finishes before the task is marked done. The 304 path (runTasks.rs:674) is on the main thread.

Test proof: there is no build on which the unmodified tests fail deterministically. Without the flag the entry is usually on disk (the race needs load), and a test cannot observe the moment the install moves on precisely enough from outside the process (tried: a registry handler that checks for the entry when the tarball is requested; under the debug test runner the handler runs late and sees the entry 7 of 8 times). The probe above is the evidence.

Earlier shape of this PR: a per-file `warmCache` loop that reinstalled until the entry appeared, the same shape as #39190. A review pointed out that it was the fifth per-test patch around one root cause and that a harness flag with existing precedent covers all of them, so the loop was replaced with the flag. With the flag in `bunEnv`, #39190 and #38580 are no longer needed.

Follow-up for maintainers, not part of this PR: #37203 kept the write fire-and-forget because a missing entry only meant a refetch. Since #40010, `bun install --offline` reports a missing entry as an error after a successful online install, so a user can hit this race on a loaded machine. Whether `bun install` should join pending manifest writes at exit is a product decision.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-offline.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-install-offline.test.ts:
(pass) the manifest cache entry written from the thread pool is a usable manifest [469.43ms]
(pass) --prefer-offline resolves from cached manifests without touching the network [343.79ms]
(pass) --offline (hoisted linker) > never issues a request and fails cleanly on a cache miss [639.21ms]
(pass) --offline (isolated linker) > never issues a request and fails cleanly on a cache miss [595.25ms]
(pass) --prefer-offline with an expired cached manifest > resolves a range from it instead of spinning [344.21ms]
(pass) --offline with an expired cached manifest > resolves a range from it instead of spinning [333.32ms]
(pass) --offline skips an optional dependency that is not in the cache [344.85ms]
(pass) --offline refuses an uncached git dependency without running git [307.68ms]
(pass) --offline reports an uncached tarball-URL / github dependency once, and skips optional ones [295.33ms]
(pass) install.prefer = "offline" and 
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/bun-install-offline.test.ts:
(pass) the manifest cache entry written from the thread pool is a usable manifest [18.62ms]
(pass) --prefer-offline resolves from cached manifests without touching the network [11.27ms]
148 |     expect(urls.length).toBe(before);
149 | 
150 |     // manifest for `bar` was never fetched → clean error, still no request
151 |     const dir3 = await newProject({ bar: "0.0.2" }, cache_dir, linker);
152 |     r = await install(dir3, ["--offline"]);
153 |     expect(r.err).toContain("--offline");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "--offline"
Received: "Resolving dependencies\nResolved, downloaded and extracted [2]\nerror: No version matching \"0.0.2\" found for specifier \"bar\" (but package exists)\nerror: bar@0.0.2 failed to resolve\n"

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-offline.test.ts:153:19)
(fail) --offline (hoisted linker) > never issues a request and fails cleanly on a cache miss [15.29ms]
148 |     expect(urls.length).toBe(before);
149 | 
150 |     // manifest for `bar` was never fetched → 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-offline.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-install-offline.test.ts:
(pass) the manifest cache entry written from the thread pool is a usable manifest [450.93ms]
(pass) --prefer-offline resolves from cached manifests without touching the network [337.40ms]
(pass) --offline (hoisted linker) > never issues a request and fails cleanly on a cache miss [647.68ms]
(pass) --offline (isolated linker) > never issues a request and fails cleanly on a cache miss [595.52ms]
(pass) --prefer-offline with an expired cached manifest > resolves a range from it instead of spinning [337.88ms]
(pass) --offline with an expired cached manifest > resolves a range from it instead of spinning [336.31ms]
(pass) --offline skips an optional dependency that is not in the cache [364.02ms]
(pass) --offline refuses an uncached git dependency without running git [289.14ms]
(pass) --offline reports an uncached tarball-URL / github dependency once, and skips optional ones [291.63ms]
(pass) install.prefer = "offline" and 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 635ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/139] gen JS modules (bundle-modules)
Preprocess modules (7710ms)
Bundle modules (832ms)
Postprocesss modules (1060ms)
Bundle Functions (1121ms)
Generate Code (45ms)

[10.79s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[1/139] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_jsc_macros v0.0.0 (/workspace/bun/src/jsc_macros)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                      |   2 +
 src/install/npm.rs                           |  30 +++++---
 test/cli/install/bun-install-offline.test.ts | 102 ++++++++++++++++-----------
 test/harness.ts                              |   4 ++
 4 files changed, 88 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/bun_core/env_var.rs                           2      3      0
src/install/npm.rs                                3      7      0
test/cli/install/bun-install-offline.test.ts      4     19      0
test/harness.ts                                   1      1      0
```

</details>

<!-- robobun:evidence:end -->