### PR TITLE
test: run the control-character check in bun-pm-licenses.test.ts with --no-summary

### DIFF
--- a/test/cli/install/bun-pm-licenses.test.ts
+++ b/test/cli/install/bun-pm-licenses.test.ts
@@ -846,7 +846,9 @@ describe("bun pm licenses", () => {
       patchInstalledManifest(dir, "one-dep", { license: "ISC\nGPL-3.0" });
       patchInstalledManifest(dir, "no-deps", { license: "BSD\t2" });
 
-      const stdout = await licensesText(dir, "--long");
+      // --no-summary drops the "bun pm licenses v<version> (<short sha>)" banner. A short sha can be all
+      // digits, and the banner would then pass the group-header filter below.
+      const stdout = await licensesText(dir, "--long", "--no-summary");
       expect(stdout).not.toContain("\u001b");
       expect(stdout).not.toContain("\r");
       expect(stdout).not.toContain("\t");


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-pm-licenses.test.ts`, test "control characters from package.json are stripped in text output but preserved in --json", fails on every lane for some commits. The received array has one extra first element: `"bun pm licenses v1.4.1-canary.1 (169084272)"`.
- The test collects the license group headers (`MIT (2)`) with `stdout.split("\n").filter(line => / \(\d+\)$/.test(line))`. The first output line is the banner `bun pm licenses v<version> (<short sha>)`, printed at `src/runtime/cli/pm_licenses_command.rs:158`. When the short sha is all digits, the banner matches the regex too. About 1.5% of commits have a 9-digit short sha, so the failure depends on the commit, not on the run.

### Fix
- Run the command with `--no-summary`. That flag drops the banner and the trailing summary line, so the filter sees only the group headers. A comment above the call says why the flag is there.
- This is correct because the test checks the listing body: the group headers, the tree rows, and the `--long` detail lines. `--no-summary` does not change those lines or the control-character stripping they go through. The banner mode with `--long` stays covered by the inline snapshots elsewhere in the file, and `--no-summary` has its own test.
- A fix in `bun pm licenses` is not wanted. The banner has the same `v<version> (<short sha>)` format as `bun install` and the other pm commands.
- Verified: `bun bd test test/cli/install/bun-pm-licenses.test.ts` (80 pass). The failure needs a build whose short sha is all digits, so the fail-before is shown with a stubbed output in the Notes.

### Background
- `bun pm licenses --long` prints a banner, one group per license (`<license> (<count>)` followed by a tree of packages), and a summary line. `--no-summary` prints only the groups.
- The banner text comes from `Global::package_json_version_with_sha`, the same value that `Bun.version_with_sha` exposes.

<details><summary>Notes</summary>

Seen in Buildkite build 103435 on PR #40064 (commit 16908427257a001b1cbb7871d3e8872223b7e4fd, short sha `169084272`). The PR does not touch `bun pm` or this test. 7 lanes failed with the same diff (debian 13 x64, x64-asan, aarch64, ubuntu 25.04 x64, aarch64, alpine 3.23 x64, aarch64):

```
[
+   "bun pm licenses v1.4.1-canary.1 (169084272)",
    "BSD2 (1)",
    "ISCGPL-3.0 (1)",
    "MIT (2)",
    "MIT[31mEVIL (1)",
    "Unknown (1)",
]
```

Probe of the filter on a stubbed output with that banner, with and without the banner line:

```
with banner:    ["bun pm licenses v1.4.1-canary.1 (169084272)","BSD2 (1)","MIT (2)","Unknown (1)"]
without banner: ["BSD2 (1)","MIT (2)","Unknown (1)"]
```

`grep -rn '\\(\\d+\\)' test/cli/install/*.test.ts` finds no other test that filters lines with this pattern. The `checked \d+ packages` regexes match the summary line, which the banner cannot match.

The first version of this PR split the banner off as the first line and asserted it against `HEADER` with `normalizeBunSnapshot`. A self-review pointed out that `--no-summary` removes the colliding line at the source and leaves the original filter unchanged, so the PR now does that instead.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-pm-licenses.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-pm-licenses.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-pm-licenses.test.ts:
(pass) bun pm licenses > text output groups packages by license, Unknown last, dev-only packages marked [154.43ms]
(pass) bun pm licenses > --json shape [165.72ms]
(pass) bun pm licenses > legacy license shapes [377.41ms]
(pass) bun pm licenses > `license` array and legacy `name` key [374.10ms]
(pass) bun pm licenses > empty `license` falls through to `licenses`; `license` wins when both are present [358.23ms]
(pass) bun pm licenses > groups are ordered case-insensitively, ignoring a leading parenthesis, Unknown last [535.97ms]
(pass) bun pm licenses > non-string license shapes are Unknown; entries with non-string type are skipped [448.08ms]
(pass) bun pm licenses > repeated legacy entries are not deduplicated [356.35ms]
(pass) bun pm licenses > --json `license` follows each version's group; an empty description is omitted [346.07ms]
(pass) bun pm licenses > one package with two versions: per-license grouping, metadata from the newest version [506.64ms]
(pass) bun pm licenses > versions are ordered by semver, names bytewise [475.18ms]
(pass) bun pm licenses > (dev) propagates through a devDependency's subtree; --dev lists that subtree [586.60ms]
(pass) bun pm licenses > --dev cannot be combined with --prod [378.74ms]
(pass) bun pm licenses > (dev) marks packages only reachable through devDependencies [812.88ms]
(pass) bun pm licenses > --prod omits devDependencies (--json) [125.17ms]
(pass) bun pm licenses > --dev in a workspace [575.17ms]
(pass) bun pm licenses > --production omits devDependencies (--json) [128.58ms]
(pass) bun pm licenses > -p omits devDependencies (--json) [134.12ms]
(pass) bun pm licenses > -P omits devDependencies (--json) [121.95ms]
(pass) bun pm licenses > --prod omits devDependencies (text) [125.08ms]
(pass) bun pm licenses > --dev lists the 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/bun-pm-licenses.test.ts | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/cli/install/bun-pm-licenses.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->