### PR TITLE
docs: add nasm to the build dependency lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,26 +23,28 @@ Using your system's package manager, install Bun's dependencies:
 {% codetabs group="os" %}
 
 ```bash#macOS (Homebrew)
-$ brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool ninja pkg-config rustup-init ruby
+$ brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool nasm ninja pkg-config rustup-init ruby
 ```
 
 ```bash#Ubuntu/Debian
-$ sudo apt install curl wget lsb-release software-properties-common cmake git golang libtool ninja-build pkg-config ruby-full xz-utils
+$ sudo apt install curl wget lsb-release software-properties-common cmake git golang libtool nasm ninja-build pkg-config ruby-full xz-utils
 ```
 
 ```bash#Arch
-$ sudo pacman -S base-devel cmake git go libiconv libtool make ninja pkg-config python rustup sed unzip ruby
+$ sudo pacman -S base-devel cmake git go libiconv libtool make nasm ninja pkg-config python rustup sed unzip ruby
 ```
 
 ```bash#Fedora
-$ sudo dnf install clang21 llvm21 lld21 cmake git golang libtool ninja-build pkg-config ruby libatomic-static libstdc++-static sed unzip which libicu-devel 'perl(Math::BigInt)'
+$ sudo dnf install clang21 llvm21 lld21 cmake git golang libtool nasm ninja-build pkg-config ruby libatomic-static libstdc++-static sed unzip which libicu-devel 'perl(Math::BigInt)'
 ```
 
 ```bash#openSUSE Tumbleweed
-$ sudo zypper install go cmake ninja automake git icu rustup
+$ sudo zypper install go cmake nasm ninja automake git icu rustup
 ```
 
 {% /codetabs %}
+
+`nasm` assembles libjpeg-turbo's x86_64 SIMD kernels. Windows x64 builds also use it for BoringSSL's assembly.
 
 Bun is written in Rust and requires a specific nightly toolchain (pinned in [`rust-toolchain.toml`](/rust-toolchain.toml)). Install Rust via [rustup](https://rustup.rs) rather than your distro's `rust`/`cargo` packages — the build scripts use rustup to automatically install and update the pinned nightly:
 


### PR DESCRIPTION
### What does this PR do?

Adds `nasm` to the dependency lists in CONTRIBUTING.md for macOS, Ubuntu/Debian, Arch, Fedora, and openSUSE.

`nasm` assembles libjpeg-turbo's x86_64 SIMD kernels and BoringSSL's win-x64 assembly. `scripts/build/deps/libjpeg-turbo.ts` gates the `.asm` SIMD sources on `cfg.x64` and emits `-felf64` / `-fmacho64` / `-fwin64`, and `scripts/build/compile.ts` notes that clang cannot assemble NASM syntax. On any x86_64 host, a build with every currently-documented dependency installed fails at configure:

```
error: nasm not found in toolchain
  hint: Install nasm from your distro (apt/dnf/brew install nasm) or https://nasm.us
error: script "bd" exited with code 1
```

`scripts/bootstrap.sh` already installs `nasm` — under `brew` for macOS, and in the `linux` branch alongside `make`, `python3`, `libtool`, `ruby` and `perl`. CI machines are provisioned through that script, so they always have it. The gap only affects contributors setting up by hand from CONTRIBUTING.md.

### How did you verify your code works?

Reproduced the failure and confirmed the fix on a clean Ubuntu 24.04 x86_64 machine:

1. With every dependency CONTRIBUTING.md currently lists installed (plus LLVM 21.1.8), and no `nasm`, `bun bd` failed at configure with the error above.
2. `sudo apt install nasm`, then `bun bd` ran to completion and produced a working `build/debug/bun-debug` (`--version` reports `1.4.1-debug`).

Package names were cross-checked against `scripts/bootstrap.sh`, which installs `nasm` under both the `brew` branch and the Linux branch. I verified the `nasm` package name by execution on Ubuntu only; the other four are the standard name for those package managers and match what `bootstrap.sh` uses.

`bunx prettier --check CONTRIBUTING.md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
