### PR TITLE
spawn: kill and reap the child when pidfd_open fails instead of blocking the JS thread

### DIFF
--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -549,22 +549,13 @@ impl PosixSpawnResult {
                     // Until we switch to CLONE_PIDFD, this needs to be handled separately.
                     bun_sys::E::ESRCH => {}
 
-                    // For all other cases, ensure we don't leak the child process on error
-                    // That would cause Zombie processes to accumulate.
+                    // The spawn fails below. Kill first: a child that waits on a pipe this process holds would block wait4 forever.
                     _ => {
-                        loop {
-                            let mut status: i32 = 0;
-                            // SAFETY: libc wait4
-                            let rc = unsafe {
-                                libc::wait4(self.pid, &raw mut status, 0, core::ptr::null_mut())
-                            };
-                            match bun_sys::get_errno(rc as isize) {
-                                bun_sys::E::SUCCESS => {}
-                                bun_sys::E::EINTR => continue,
-                                _ => {}
-                            }
-                            break;
+                        // SAFETY: `self.pid` is the un-reaped child posix_spawn just returned.
+                        unsafe {
+                            libc::kill(self.pid, libc::SIGKILL);
                         }
+                        let _ = posix_spawn::wait4(self.pid, 0, None);
                     }
                 }
                 Err(err)

--- a/test/js/bun/spawn/spawn-pidfd-emfile.test.ts
+++ b/test/js/bun/spawn/spawn-pidfd-emfile.test.ts
@@ -57,3 +57,60 @@ for (let spare = 1; spare <= 6; spare++) {
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
+
+// With every stdio slot inherited, nothing allocates an fd before posix_spawn,
+// so at zero free fds pidfd_open is the first call that fails. The fixture's
+// stdin is a pipe whose write end this test keeps open, so a blocked wait4 on
+// `cat` would never return. node:child_process reaches the same arm and must
+// report the failure as an "error" event, as node does at its fd limit.
+test.skipIf(!isLinux)(
+  "Bun.spawn with inherited stdio at zero free fds fails with EMFILE instead of blocking in wait4",
+  async () => {
+    const fixture = `
+const fs = require("fs");
+const { spawn } = require("child_process");
+// Run the deferred "error" path once while fds are still free: a debug build
+// reads the builtins it lazily requires (process.nextTick's queue) from disk.
+await new Promise(resolve => spawn("/nonexistent", { stdio: "ignore" }).once("error", resolve));
+const held = [];
+for (;;) {
+  try {
+    held.push(fs.openSync("/dev/null", "r"));
+  } catch {
+    break;
+  }
+}
+try {
+  const p = Bun.spawn(["/bin/cat"], { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+  p.kill();
+  console.log("Bun.spawn: ok");
+} catch (e) {
+  console.log("Bun.spawn: err " + e.code + " " + e.syscall);
+}
+const child = spawn("/bin/cat", { stdio: "inherit" });
+const result = await new Promise(resolve => {
+  child.once("error", e => resolve("err " + e.code + " " + e.syscall));
+  child.once("spawn", () => {
+    child.kill();
+    resolve("ok");
+  });
+});
+console.log("child_process.spawn: " + result);
+// LeakSanitizer reads /proc/self/task at exit, which needs a free fd.
+for (const fd of held) fs.closeSync(fd);
+`;
+
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", 'ulimit -n 64 && exec "$@"', "sh", bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("Bun.spawn: err EMFILE pidfd_open\nchild_process.spawn: err EMFILE spawn /bin/cat\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/spawn/spawn-pidfd-emfile.test.ts
+++ b/test/js/bun/spawn/spawn-pidfd-emfile.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+
+// On Linux, Bun.spawn opens a pidfd after posix_spawn so the event loop can
+// observe the child's exit. When the process is at its RLIMIT_NOFILE, the
+// socketpairs for stdin/stdout can succeed and pidfd_open can still fail with
+// EMFILE. That arm used to block the JS thread in wait4() until the child
+// exited on its own. A child that reads its stdin (cat) never exits, because
+// the write end of that pipe belongs to the blocked parent: a deadlock with
+// no timers firing.
+//
+// The fixture walks the spare-fd count up from 1 so the exact boundary does not
+// matter: every attempt must finish, as a thrown EMFILE or a clean exit.
+test.skipIf(!isLinux)("Bun.spawn at the fd limit fails with EMFILE instead of blocking in wait4", async () => {
+  const fixture = `
+const fs = require("fs");
+const held = [];
+for (;;) {
+  try {
+    held.push(fs.openSync("/dev/null", "r"));
+  } catch {
+    break;
+  }
+}
+for (let spare = 1; spare <= 6; spare++) {
+  fs.closeSync(held.pop());
+  let result;
+  try {
+    const p = Bun.spawn(["/bin/cat"], { stdin: "pipe", stdout: "pipe", stderr: "inherit" });
+    p.stdin.end();
+    const [text, code] = await Promise.all([p.stdout.text(), p.exited]);
+    result = "ok " + code + " " + JSON.stringify(text);
+  } catch (e) {
+    result = "err " + e.code + " " + e.syscall;
+  }
+  console.log(spare + ": " + result);
+}
+`;
+
+  await using proc = Bun.spawn({
+    cmd: ["/bin/sh", "-c", 'ulimit -n 64 && exec "$@"', "sh", bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // Without the fix the fixture blocks forever inside Bun.spawn at the
+  // pidfd_open boundary and this test times out.
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines).toHaveLength(6);
+  expect(lines.filter(l => l.includes("err EMFILE pidfd_open"))).toHaveLength(1);
+  expect(lines.at(-1)).toBe('6: ok 0 ""');
+  for (const line of lines) {
+    expect(line).toMatch(/^\d: (err EMFILE (socketpair|pidfd_open)|ok 0 "")$/);
+  }
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- At the fd limit, `Bun.spawn(["/bin/cat"], { stdin: "pipe", stdout: "pipe" })` freezes the whole process. The stdio socketpairs take the last free fds, then `pidfd_open` fails with `EMFILE`.
- The error arm in `PosixSpawnResult::pifd_from_pid` (`src/spawn_sys/spawn_process.rs:554`) reaped the child with a blocking `wait4(pid, 0)` on the JS thread. `cat` waits on a pipe the blocked parent holds. `node:child_process` and `Bun.$` share the path.
- Fuzz-found, Linux only, no field report.

### Fix
- Send `SIGKILL` to the child before the reap. The reap returns at once and the spawn fails with `EMFILE: too many open files, pidfd_open`. No zombie, no leaked child.
- Policy: after `posix_spawn` returns, a failed pidfd acquisition kills the child and fails the spawn with that errno. One fd earlier, `socketpair` fails the same way. Node behaves the same: `EMFILE`, and no child runs.
- Verified: `test/js/bun/spawn/spawn-pidfd-emfile.test.ts`. Test 1 walks the spare-fd count from 1 to 6 under `ulimit -n 64`. Test 2: inherited stdio at zero free fds, plus the `node:child_process` `error` event. Both hang on stock bun.

### Background
- A pidfd is a file descriptor that refers to a process. Bun polls it to learn when a child exits.
- `pidfd_open` runs after `posix_spawn`, the one fd acquisition after the child exists. `ENOSYS`/`EPERM` (seccomp) mean it never works and switch to the waiter thread. Other errnos land in this arm.
- Supersedes #35924 (closed, unmerged). It tracked the child with a per-process waiter thread, which needs an eventfd, also unavailable here, so it fell back to a synchronous wait. Test 2 is its inherited-stdio probe.

<details><summary>Notes</summary>

Also run with the debug build: `spawn.test.ts`, `spawnSync.test.ts`, `pidfd-exit-nested-tick.test.ts`, `child_process.test.ts`, `child-process-stdio.test.js`.

Repro (stock bun 1.4.0), from the resource-exhaustion fuzz ledger:

```js
// bash -c 'ulimit -n 64; exec bun spcat.js'
const fs = require("fs"); const held = [];
for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
for (let i = 0; i < 4; i++) fs.closeSync(held.pop());
setInterval(() => console.error("tick"), 1000).unref();   // never prints
const p = Bun.spawn(["/bin/cat"], { stdin: "pipe", stdout: "pipe" }); // never returns
p.stdin.end(); await p.exited;
```

Boundary measured here: 3 spare fds gives `EMFILE socketpair`, 4 spare hangs, 5 spare works. With this change, 4 spare gives `EMFILE pidfd_open`.

The two probes from #35924, run against this branch: piped stdio with room for the socketpairs but not for `pidfd_open` (`sleep 1`), and inherited stdio at zero free fds (`sleep 0.1`, `sleep 30`). Each returns in about 3 ms with `EMFILE pidfd_open`. On stock bun the same probes block for the child's whole lifetime (1001 ms, 2002 ms, and past an 8 s timeout for `sleep 30`).

`wait4` after `SIGKILL` still blocks until the kernel has torn the child down. For a child that posix_spawn returned microseconds ago that is far below a millisecond. `kill` cannot fail for this pid: the child is not reaped yet, so it exists, and it was created by this process with this process's real uid.

`ENOMEM` stays in this arm on purpose. It is transient, and the policy arm flips a process-wide flag that routes every later spawn through the waiter thread.

The structural fix is `CLONE_PIDFD`, which makes the kernel hand out the pidfd in the same call that creates the child, so this arm becomes unreachable. That is a larger change to `bun_clone3_vfork` and is not part of this PR.

Test 2 runs one `child_process.spawn("/nonexistent")` before it exhausts the fd table. A debug build reads lazily required builtins (the `process.nextTick` queue) from disk, and that read needs a free fd.

In this container two tests in `child_process.test.ts` fail with and without the change: "should allow us to spawn in the default shell" (`$SHELL` is unset here) and "extra stdio pipes are not double-closed on GC" (20 nested debug-build startups take about 5 s, the test timeout). Neither reaches the changed arm. `spawn_waiter_thread.test.ts` also fails here with and without the change (the debug build uses about 1.04s of CPU in its 1s budget).
</details>
