### PR TITLE
test(bake): speed up bundle.test.ts and tighten its assertions

### DIFF
--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,11 +1,40 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
+//
+// Each dev server boot and each connected client costs about a second of wall
+// time, so small related cases share one dev server.
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { type Dev, devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
-devTest("import identifier doesnt get renamed", {
+/** A route whose bundle failed is served as the dev server's error page. */
+async function expectBuildFailed(dev: Dev, url: string) {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(500);
+  expect(await res.text()).toInclude("<title>Bun - Build Failed</title>");
+}
+
+/** The JS bundle the dev server currently serves for an html route. */
+async function fetchClientBundle(dev: Dev, route: string) {
+  const html = await dev.fetch(route).text();
+  const src = html.match(/src="([^"]+)" data-bun-dev-server-script/)?.[1];
+  if (!src) throw new Error("No dev server script tag in the html for " + route);
+  return dev.fetch(src).text();
+}
+
+/** Files of a package installed at `<dir>/node_modules/<name>`. */
+function inNodeModules(dir: string, name: string, files: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(files).map(([file, contents]) => [`${dir}/node_modules/${name}/${file}`, contents]),
+  );
+}
+
+const barrelPackageJson = (name: string) =>
+  JSON.stringify({ name, version: "1.0.0", main: "./index.js", sideEffects: false });
+
+devTest("import identifier: not renamed, no symbol collision, development condition", {
   framework: minimalFramework,
   files: {
     "db.ts": `export const abc = "123";`,
+    // The import identifier does not get renamed by the member accesses.
     "routes/index.ts": `
       import { abc } from '../db';
       export default function (req, meta) {
@@ -16,23 +45,9 @@ devTest("import identifier doesnt get renamed", {
         return new Response('Hello, ' + v2 + '!');
       }
     `,
-  },
-  async test(dev) {
-    await dev.fetch("/").equals("Hello, 123!");
-    await dev.write("db.ts", `export const abc = "456";`);
-    await dev.fetch("/").equals("Hello, 456!");
-    await dev.patch("routes/index.ts", {
-      find: "Hello",
-      replace: "Bun",
-    });
-    await dev.fetch("/").equals("Bun, 456!");
-  },
-});
-devTest("symbol collision with import identifier", {
-  framework: minimalFramework,
-  files: {
-    "db.ts": `export const abc = "123";`,
-    "routes/index.ts": `
+    // A local binding named like the generated import namespace does not
+    // collide with it.
+    "routes/collision.ts": `
       let import_db = 987;
       import { abc } from '../db';
       export default function (req, meta) {
@@ -43,16 +58,7 @@ devTest("symbol collision with import identifier", {
         return new Response('Hello, ' + v2 + ', ' + import_db + '!');
       }
     `,
-  },
-  async test(dev) {
-    await dev.fetch("/").equals("Hello, 123, 987!");
-    await dev.write("db.ts", `export const abc = "456";`);
-    await dev.fetch("/").equals("Hello, 456, 987!");
-  },
-});
-devTest('uses "development" condition', {
-  framework: minimalFramework,
-  files: {
+    // The dev server resolves the "development" export condition.
     "node_modules/example/package.json": JSON.stringify({
       name: "example",
       version: "1.0.0",
@@ -65,7 +71,7 @@ devTest('uses "development" condition', {
     }),
     "node_modules/example/development.js": `export default "development";`,
     "node_modules/example/production.js": `export default "production";`,
-    "routes/index.ts": `
+    "routes/condition.ts": `
       import environment from 'example';
       export default function (req, meta) {
         return new Response('Environment: ' + environment);
@@ -73,7 +79,23 @@ devTest('uses "development" condition', {
     `,
   },
   async test(dev) {
-    await dev.fetch("/").equals("Environment: development");
+    await dev.fetch("/").equals("Hello, 123!");
+    await dev.fetch("/collision").equals("Hello, 123, 987!");
+    await dev.fetch("/condition").equals("Environment: development");
+
+    // Both routes import db.ts, so one edit updates both.
+    await dev.write("db.ts", `export const abc = "456";`);
+    await dev.fetch("/").equals("Hello, 456!");
+    await dev.fetch("/collision").equals("Hello, 456, 987!");
+
+    // Editing one route leaves the others untouched.
+    await dev.patch("routes/index.ts", {
+      find: "Hello",
+      replace: "Bun",
+    });
+    await dev.fetch("/").equals("Bun, 456!");
+    await dev.fetch("/collision").equals("Hello, 456, 987!");
+    await dev.fetch("/condition").equals("Environment: development");
   },
 });
 devTest("importing a file before it is created", {
@@ -168,7 +190,7 @@ devTest("default export same-scope handling", {
   },
   async test(dev) {
     await using c = await dev.client("/", { storeHotChunks: true });
-    c.expectMessage(
+    await c.expectMessage(
       //
       "ONE",
       "TWO",
@@ -183,14 +205,17 @@ devTest("default export same-scope handling", {
       "ELEVEN",
     );
 
-    const filesExpectingMove = Object.entries(dev.options.files)
-      .filter(([, content]) => content.includes("MOVE"))
-      .map(([path]) => path);
-    for (const file of filesExpectingMove) {
-      await dev.writeNoChanges(file);
-      const chunk = await c.getMostRecentHmrChunk();
-      expect(chunk).toMatch(/default:\s*(function|class)\s*MOVE/);
+    // A self-accepting module keeps the declared name of its default export
+    // when it is re-bundled. Both files are rebuilt in one batch, so a single
+    // HMR chunk carries both modules.
+    {
+      await using _ = await dev.batchChanges();
+      await dev.writeNoChanges("fixture4.ts");
+      await dev.writeNoChanges("fixture8.ts");
     }
+    const moveChunk = await c.getMostRecentHmrChunk();
+    expect(moveChunk).toMatch(/default:\s*class\s+MOVE/);
+    expect(moveChunk).toMatch(/default:\s*function\s+MOVE/);
 
     await dev.writeNoChanges("fixture7.ts");
     const chunk = await c.getMostRecentHmrChunk();
@@ -198,7 +223,7 @@ devTest("default export same-scope handling", {
 
     // Since fixture7.ts is not marked as accepting, it will bubble the update
     // to `index.ts`, re-evaluate it and some of the dependencies.
-    c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
+    await c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
   },
 });
 devTest("directory cache bust case #17576", {
@@ -318,7 +343,7 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // and the client graph owns the key string for Comp.ts. Sibling.ts
     // fails to resolve './sibling-missing' under the browser target,
     // leaving a client-graph Dep on the components/ directory watch.
-    await dev.fetch("/");
+    await expectBuildFailed(dev, "/");
 
     // Re-bundle Comp.ts with a failing import while it is still a CCB.
     // With separateSSRGraph the re-parse runs under the browser target,
@@ -353,9 +378,10 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // a heap-use-after-free here and the dev server aborts.
     await dev.write("components/missing.ts", `export const value = "ok";`, { errors: null });
 
-    // The server must still be alive and responding.
+    // The server must still be alive. Sibling's import is still unresolved,
+    // so the route cannot render and answers with an error page.
     const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(500);
   },
 });
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
@@ -373,7 +399,7 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   },
   async test(dev) {
     // Initial bundle: both imports fail and attach deps to the sub/ watch.
-    await dev.fetch("/");
+    await expectBuildFailed(dev, "/");
 
     {
       await using _ = await dev.batchChanges({ errors: null });
@@ -388,9 +414,10 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
       await dev.write("sub/a.ts", `export {};`);
     }
 
-    // The server should still respond.
+    // The server still responds, and the rewritten page now bundles.
     const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toInclude('<script type="module" crossorigin src="/_bun/client/index-');
 
     // Test teardown sends graceful-exit, which calls DevServer.deinit.
     // Before the fix, deinit iterated every dependencies.items slot and
@@ -398,55 +425,36 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
     // AllocationScope's invalid-free panic.
   },
 });
-devTest("importing html file", {
+devTest("browser imports: html with the text loader works, html and bun builtins are errors", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import html from "./index.html";
-      console.log(html);
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ["index.ts:1:18: error: Browser builds cannot import HTML files."],
-    });
-  },
-});
-devTest("importing html file with text loader (#18154)", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
+    // Importing an html file with the text loader (#18154).
+    "text-loader.html": emptyHtmlFile({ scripts: ["text-loader.ts"] }),
+    "text-loader.ts": `
       import html from "./app.html" with { type: "text" };
       console.log(html);
     `,
     "app.html": "<div>hello world</div>",
-  },
-  htmlFiles: ["index.html"],
-  async test(dev) {
-    await using c = await dev.client("/", {});
-    await c.expectMessage("<div>hello world</div>");
-  },
-});
-devTest("importing bun on the client", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
+    // Importing an html file without a loader, and importing a Bun builtin,
+    // are both build errors in a browser bundle.
+    "errors.html": emptyHtmlFile({ scripts: ["errors.ts"] }),
+    "errors.ts": `
+      import html from "./errors.html";
       import bun from "bun";
-      console.log(bun);
+      console.log(html, bun);
     `,
   },
+  // app.html is an import target, not a page.
+  htmlFiles: ["text-loader.html", "errors.html"],
   async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ['index.ts:1:17: error: Browser build cannot import Bun builtin: "bun"'],
+    {
+      await using c = await dev.client("/text-loader");
+      await c.expectMessage("<div>hello world</div>");
+    }
+    await using c = await dev.client("/errors", {
+      errors: [
+        "errors.ts:1:18: error: Browser builds cannot import HTML files.",
+        'errors.ts:2:17: error: Browser build cannot import Bun builtin: "bun"',
+      ],
     });
   },
 });
@@ -475,102 +483,241 @@ devTest("import.meta.main", {
     await c.expectMessage(false);
   },
 });
+
+// Every way a module can reach its CommonJS `exports` object. Each form gets
+// its own file so one page load checks all of them, and one batched rebuild
+// swaps every file to the next form so the rebuild path re-detects each form.
+const cjsForms: Record<string, (value: string) => string> = {
+  "module-exports": v => `module.exports.field = ${v};`,
+  "exports": v => `exports.field = ${v};`,
+  "exports-alias": v => `let theExports = exports; theExports.field = ${v};`,
+  "module-alias": v => `let theModule = module; theModule.exports.field = ${v};`,
+  "let-destructure": v => `let { exports } = module; exports.field = ${v};`,
+  "var-destructure": v => `var { exports } = module; exports.field = ${v};`,
+  "module-exports-alias": v => `let theExports = module.exports; theExports.field = ${v};`,
+  "eval": v => `require; eval("module.exports.field = ${v}");`,
+};
+const cjsFormNames = Object.keys(cjsForms);
+const nextCjsForm = (i: number) => cjsFormNames[(i + 1) % cjsFormNames.length];
+
 devTest("commonjs forms", {
-  timeoutMultiplier: 2,
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import cjs from "./cjs.js";
-      console.log(cjs);
-    `,
-    "cjs.js": `
-      module.exports.field = {};
-    `,
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": [
+      ...cjsFormNames.map((name, i) => `import cjs${i} from "./${name}.js";`),
+      `console.log({ ${cjsFormNames.map((name, i) => `${JSON.stringify(name)}: cjs${i}`).join(", ")} });`,
+    ].join("\n"),
+    ...Object.fromEntries(cjsFormNames.map(name => [`${name}.js`, cjsForms[name](`'${name}'`)])),
   },
   async test(dev) {
-    console.log("Initial");
     await using c = await dev.client("/");
-    console.log("  expecting message");
-    await c.expectMessage({ field: {} });
-    console.log("  expecting reload");
+    await c.expectMessage(Object.fromEntries(cjsFormNames.map(name => [name, { field: name }])));
+
+    // None of the files accept hot updates, so the batch ends in a full reload.
     await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `exports.field = "1";`);
-      console.log("  now reloading");
+      await using _ = await dev.batchChanges();
+      for (let i = 0; i < cjsFormNames.length; i++) {
+        await dev.write(`${cjsFormNames[i]}.js`, cjsForms[nextCjsForm(i)](`'${nextCjsForm(i)}'`));
+      }
     });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "1" });
-    console.log("Second");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theExports = exports; theExports.field = "2";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "2" });
-    console.log("Third");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theModule = module; theModule.exports.field = "3";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "3" });
-    console.log("Fourth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let { exports } = module; exports.field = "4";`);
-    });
-    await c.expectMessage({ field: "4" });
-    console.log("Fifth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `var { exports } = module; exports.field = "4.5";`);
-    });
-    await c.expectMessage({ field: "4.5" });
-    console.log("Sixth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let theExports = module.exports; theExports.field = "5";`);
-    });
-    await c.expectMessage({ field: "5" });
-    console.log("Seventh");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `require; eval("module.exports.field = '6'");`);
-    });
-    await c.expectMessage({ field: "6" });
+    await c.expectMessage(Object.fromEntries(cjsFormNames.map((name, i) => [name, { field: nextCjsForm(i) }])));
   },
 });
 
 // --- Barrel optimization tests ---
 
-devTest("barrel optimization skips unused submodules", {
+// These cases only read the initial bundle, so they share one page. Each case
+// lives in its own directory with its own node_modules, so packages with the
+// same name do not collide, and logs a message prefixed with its directory.
+devTest("barrel optimization: initial bundle cases", {
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
     "index.ts": `
+      import "./skips-unused/index.ts";
+      import "./export-star/index.ts";
+      import "./two-export-blocks/index.ts";
+      import "./two-imports/index.ts";
+      import "./namespace-cycle/index.ts";
+    `,
+
+    // beta.js and gamma.js have syntax errors. If barrel optimization works,
+    // they are never parsed, so no error.
+    "skips-unused/index.ts": `
       import { Alpha } from 'barrel-lib';
-      console.log('got: ' + Alpha);
+      console.log('skips-unused: ' + Alpha);
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    ...inNodeModules("skips-unused", "barrel-lib", {
+      "package.json": barrelPackageJson("barrel-lib"),
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = <<<SYNTAX_ERROR>>>;`,
+      "gamma.js": `export const Gamma = <<<SYNTAX_ERROR>>>;`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
+
+    // Export star target not deferred (#27521). The user imports from
+    // consumer-lib, which is a non-barrel package that imports QueryClient
+    // from outer-lib.
+    "export-star/index.ts": `
+      import { useQuery } from 'consumer-lib';
+      console.log('export-star: ' + useQuery());
     `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = <<<SYNTAX_ERROR>>>;`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = <<<SYNTAX_ERROR>>>;`,
+    // consumer-lib is NOT a barrel — it has real code that uses
+    // QueryClient from outer-lib. This mirrors @refinedev/core
+    // importing QueryClient from @tanstack/react-query.
+    ...inNodeModules("export-star", "consumer-lib", {
+      "package.json": JSON.stringify({
+        name: "consumer-lib",
+        version: "1.0.0",
+        main: "./index.js",
+      }),
+      "index.js": `
+        import { QueryClient } from 'outer-lib';
+        export function useQuery() {
+          const client = new QueryClient();
+          return client instanceof QueryClient ? 'PASS' : 'FAIL';
+        }
+      `,
+    }),
+    // outer-lib is a barrel with sideEffects:false that re-exports
+    // everything from inner-lib via export *. Mirrors @tanstack/react-query.
+    ...inNodeModules("export-star", "outer-lib", {
+      "package.json": barrelPackageJson("outer-lib"),
+      "index.js": `
+        export * from 'inner-lib';
+        export { Unrelated } from './unrelated.js';
+      `,
+      "unrelated.js": `export const Unrelated = "UNRELATED";`,
+    }),
+    // inner-lib is a barrel with sideEffects:false that re-exports
+    // from submodules. Mirrors @tanstack/query-core. Without the fix,
+    // the barrel optimizer defers queryClient.js because it doesn't
+    // know inner-lib is an export-star target (source_index is not
+    // set in dev-server mode), so QueryClient becomes undefined.
+    ...inNodeModules("export-star", "inner-lib", {
+      "package.json": barrelPackageJson("inner-lib"),
+      "index.js": `
+        export { QueryClient } from './queryClient.js';
+        export { Other } from './other.js';
+      `,
+      "queryClient.js": `
+        export class QueryClient { constructor() { this.ready = true; } }
+      `,
+      "other.js": `export const Other = "OTHER";`,
+    }),
+
+    // Two export-from blocks pointing to the same source.
+    "two-export-blocks/index.ts": `
+      import { invariant } from 'barrel-lib';
+      console.log('two-export-blocks: ' + typeof invariant);
+    `,
+    ...inNodeModules("two-export-blocks", "barrel-lib", {
+      "package.json": barrelPackageJson("barrel-lib"),
+      "index.js": `
+        export {
+          createDataProperty,
+          defineProperty,
+        } from './utils.js';
+
+        export { unrelated } from './other.js';
+
+        export {
+          invariant,
+        } from './utils.js';
+      `,
+      "utils.js": `
+        export function createDataProperty() {}
+        export function defineProperty() {}
+        export function invariant(cond, msg) {
+          if (!cond) throw new Error(msg);
+        }
+      `,
+      "other.js": `export const unrelated = "UNRELATED";`,
+    }),
+
+    // Regression: #28886
+    // Consumer has TWO separate `import { X } from 'barrel'` statements for the
+    // same barrel. HMR deduplicates the second into the first; the second's
+    // import record is marked is_unused=true and never gets its path resolved.
+    // Barrel optimization then fails to see the named import from the dedup'd
+    // record and marks its target submodule as unused → submodule stays `{}` →
+    // the export is `undefined` at runtime.
+    "two-imports/index.ts": `
+      import { Alpha } from 'barrel-lib';
+      import { Beta } from 'barrel-lib';
+      console.log('two-imports: ' + Alpha() + ' ' + Beta());
+    `,
+    ...inNodeModules("two-imports", "barrel-lib", {
+      "package.json": barrelPackageJson("barrel-lib"),
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = () => "ALPHA";`,
+      "beta.js": `export const Beta = () => "BETA";`,
+      "gamma.js": `export const Gamma = () => "GAMMA";`,
+    }),
+
+    // Namespace re-export cycle through a star-exported module.
+    "namespace-cycle/index.ts": `
+      import { x, y, deepValue } from 'loop-lib';
+      import { keep } from 'loop-lib/w.js';
+      import { other } from 'loop-lib/g.js';
+      console.log('namespace-cycle: ' + typeof x + ' ' + y + ' ' + keep + ' ' + deepValue + ' ' + other);
+    `,
+    ...inNodeModules("namespace-cycle", "loop-lib", {
+      "package.json": barrelPackageJson("loop-lib"),
+      "index.js": `
+        export * from './t.js';
+      `,
+      "t.js": `
+        export { x } from './w.js';
+        export * from './r.js';
+        export * from './g.js';
+      `,
+      "w.js": `
+        import * as ns from './t.js';
+        export { ns as x };
+        export { keep } from './keep.js';
+      `,
+      "keep.js": `
+        export const keep = "KEEP";
+      `,
+      "r.js": `
+        export const y = "Y";
+      `,
+      "g.js": `
+        export { deepValue } from './deep.js';
+        export { other } from './other.js';
+      `,
+      "deep.js": `
+        export const deepValue = "DEEP";
+      `,
+      "other.js": `
+        export const other = "OTHER";
+      `,
+    }),
   },
   async test(dev) {
-    // Beta.js and Gamma.js have syntax errors.
-    // If barrel optimization works, they are never parsed, so no error.
     await using c = await dev.client("/");
-    await c.expectMessage("got: ALPHA");
+    await c.expectMessage(
+      "skips-unused: ALPHA",
+      "export-star: PASS",
+      "two-export-blocks: function",
+      "two-imports: ALPHA BETA",
+      "namespace-cycle: object Y KEEP DEEP OTHER",
+    );
+
+    // Submodules nothing imports are left out of the served bundle: Gamma in
+    // two-imports, Unrelated in export-star, and unrelated in two-export-blocks.
+    const bundle = await fetchClientBundle(dev, "/");
+    expect(bundle).toInclude('"ALPHA"');
+    expect(bundle).not.toInclude('"GAMMA"');
+    expect(bundle).not.toInclude('"UNRELATED"');
   },
 });
 
@@ -581,12 +728,7 @@ devTest("barrel optimization: adding a new import triggers reload", {
       import { Alpha } from 'barrel-lib';
       console.log('result: ' + Alpha);
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
+    "node_modules/barrel-lib/package.json": barrelPackageJson("barrel-lib"),
     "node_modules/barrel-lib/index.js": `
       export { Alpha } from './alpha.js';
       export { Beta } from './beta.js';
@@ -599,6 +741,10 @@ devTest("barrel optimization: adding a new import triggers reload", {
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("result: ALPHA");
+    let bundle = await fetchClientBundle(dev, "/");
+    expect(bundle).toInclude('"ALPHA"');
+    expect(bundle).not.toInclude('"BETA"');
+    expect(bundle).not.toInclude('"GAMMA"');
 
     // Add a second import from the barrel — Beta was previously deferred,
     // now needs to be loaded. The barrel file should be re-bundled with
@@ -613,6 +759,9 @@ devTest("barrel optimization: adding a new import triggers reload", {
       );
     });
     await c.expectMessage("result: ALPHA BETA");
+    bundle = await fetchClientBundle(dev, "/");
+    expect(bundle).toInclude('"BETA"');
+    expect(bundle).not.toInclude('"GAMMA"');
 
     // Add a third import
     await c.expectReload(async () => {
@@ -625,6 +774,7 @@ devTest("barrel optimization: adding a new import triggers reload", {
       );
     });
     await c.expectMessage("result: ALPHA BETA GAMMA");
+    expect(await fetchClientBundle(dev, "/")).toInclude('"GAMMA"');
   },
 });
 
@@ -640,12 +790,7 @@ devTest("barrel optimization: multi-file imports preserved across rebuilds", {
       import { Beta } from 'barrel-lib';
       export const value = Beta;
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
+    "node_modules/barrel-lib/package.json": barrelPackageJson("barrel-lib"),
     "node_modules/barrel-lib/index.js": `
       export { Alpha } from './alpha.js';
       export { Beta } from './beta.js';
@@ -658,6 +803,7 @@ devTest("barrel optimization: multi-file imports preserved across rebuilds", {
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("result: ALPHA BETA");
+    expect(await fetchClientBundle(dev, "/")).not.toInclude('"GAMMA"');
 
     // Edit only other.ts to also import Gamma. Alpha (from index.ts) must
     // still be available even though index.ts is not re-parsed.
@@ -671,197 +817,8 @@ devTest("barrel optimization: multi-file imports preserved across rebuilds", {
       );
     });
     await c.expectMessage("result: ALPHA BETA GAMMA");
-  },
-});
-
-devTest("barrel optimization: export star target not deferred (#27521)", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    // The user imports from consumer-lib, which is a non-barrel package
-    // that imports QueryClient from outer-lib.
-    "index.ts": `
-      import { useQuery } from 'consumer-lib';
-      console.log('result: ' + useQuery());
-    `,
-    // consumer-lib is NOT a barrel — it has real code that uses
-    // QueryClient from outer-lib. This mirrors @refinedev/core
-    // importing QueryClient from @tanstack/react-query.
-    "node_modules/consumer-lib/package.json": JSON.stringify({
-      name: "consumer-lib",
-      version: "1.0.0",
-      main: "./index.js",
-    }),
-    "node_modules/consumer-lib/index.js": `
-      import { QueryClient } from 'outer-lib';
-      export function useQuery() {
-        const client = new QueryClient();
-        return client instanceof QueryClient ? 'PASS' : 'FAIL';
-      }
-    `,
-    // outer-lib is a barrel with sideEffects:false that re-exports
-    // everything from inner-lib via export *. Mirrors @tanstack/react-query.
-    "node_modules/outer-lib/package.json": JSON.stringify({
-      name: "outer-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/outer-lib/index.js": `
-      export * from 'inner-lib';
-      export { Unrelated } from './unrelated.js';
-    `,
-    "node_modules/outer-lib/unrelated.js": `export const Unrelated = "X";`,
-    // inner-lib is a barrel with sideEffects:false that re-exports
-    // from submodules. Mirrors @tanstack/query-core. Without the fix,
-    // the barrel optimizer defers queryClient.js because it doesn't
-    // know inner-lib is an export-star target (source_index is not
-    // set in dev-server mode), so QueryClient becomes undefined.
-    "node_modules/inner-lib/package.json": JSON.stringify({
-      name: "inner-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/inner-lib/index.js": `
-      export { QueryClient } from './queryClient.js';
-      export { Other } from './other.js';
-    `,
-    "node_modules/inner-lib/queryClient.js": `
-      export class QueryClient { constructor() { this.ready = true; } }
-    `,
-    "node_modules/inner-lib/other.js": `export const Other = "OTHER";`,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: PASS");
-  },
-});
-
-devTest("barrel optimization: two export-from blocks pointing to the same source", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { invariant } from 'barrel-lib';
-      console.log('got: ' + typeof invariant);
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/barrel-lib/index.js": `
-      export {
-        createDataProperty,
-        defineProperty,
-      } from './utils.js';
-
-      export { unrelated } from './other.js';
-
-      export {
-        invariant,
-      } from './utils.js';
-    `,
-    "node_modules/barrel-lib/utils.js": `
-      export function createDataProperty() {}
-      export function defineProperty() {}
-      export function invariant(cond, msg) {
-        if (!cond) throw new Error(msg);
-      }
-    `,
-    "node_modules/barrel-lib/other.js": `export const unrelated = "OTHER";`,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("got: function");
-  },
-});
-
-// Regression: #28886
-// Consumer has TWO separate `import { X } from 'barrel'` statements for the
-// same barrel. HMR deduplicates the second into the first; the second's
-// import record is marked is_unused=true and never gets its path resolved.
-// Barrel optimization then fails to see the named import from the dedup'd
-// record and marks its target submodule as unused → submodule stays `{}` →
-// the export is `undefined` at runtime.
-devTest("barrel optimization: two import statements from the same barrel (#28886)", {
-  // Flakes on darwin in CI (timing); fix is platform-agnostic, coverage via linux/windows/alpine.
-  skip: ["darwin"],
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      import { Beta } from 'barrel-lib';
-      console.log('got: ' + Alpha() + ' ' + Beta());
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = () => "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = () => "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = () => "GAMMA";`,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("got: ALPHA BETA");
-  },
-});
-
-devTest("barrel optimization: namespace re-export cycle through a star-exported module", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { x, y, deepValue } from 'loop-lib';
-      import { keep } from 'loop-lib/w.js';
-      import { other } from 'loop-lib/g.js';
-      console.log('result: ' + typeof x + ' ' + y + ' ' + keep + ' ' + deepValue + ' ' + other);
-    `,
-    "node_modules/loop-lib/package.json": JSON.stringify({
-      name: "loop-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/loop-lib/index.js": `
-      export * from './t.js';
-    `,
-    "node_modules/loop-lib/t.js": `
-      export { x } from './w.js';
-      export * from './r.js';
-      export * from './g.js';
-    `,
-    "node_modules/loop-lib/w.js": `
-      import * as ns from './t.js';
-      export { ns as x };
-      export { keep } from './keep.js';
-    `,
-    "node_modules/loop-lib/keep.js": `
-      export const keep = "KEEP";
-    `,
-    "node_modules/loop-lib/r.js": `
-      export const y = "Y";
-    `,
-    "node_modules/loop-lib/g.js": `
-      export { deepValue } from './deep.js';
-      export { other } from './other.js';
-    `,
-    "node_modules/loop-lib/deep.js": `
-      export const deepValue = "DEEP";
-    `,
-    "node_modules/loop-lib/other.js": `
-      export const other = "OTHER";
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: object Y KEEP DEEP OTHER");
+    const bundle = await fetchClientBundle(dev, "/");
+    expect(bundle).toInclude('"ALPHA"');
+    expect(bundle).toInclude('"GAMMA"');
   },
 });

--- a/test/expected-durations.json
+++ b/test/expected-durations.json
@@ -28,10 +28,10 @@
     "windows": 16380
   },
   "bake/dev/bundle.test.ts": {
-    "default": 44320,
-    "asan": 47287,
-    "musl": 43410,
-    "windows": 41254
+    "default": 29700,
+    "asan": 31700,
+    "musl": 29100,
+    "windows": 27600
   },
   "bake/dev/css.test.ts": {
     "default": 52237,


### PR DESCRIPTION
### Problem
- `test/bake/dev/bundle.test.ts` takes 40 to 49s on every CI lane for 21 tests, ASAN no slower than release: the time is fixed waits.
- Each test boots its own dev server, and each client connection or client-observed edit runs `Client.expectErrorOverlay`, which polls 5 × `Bun.sleep(200)` when no overlay is expected: a fixed 1s per call, 32 calls here.

### Fix
- Related cases share a dev server: three framework routes, three browser-import cases, five read-only barrel cases. "commonjs forms" checks all 8 forms in one page load plus one batched rebuild, not seven reload rounds. 21 tests become 13. No assertion is dropped.
- Stronger assertions: status and the "Build Failed" page replace `toBeInstanceOf(Response)`. The served bundle proves a deferred barrel submodule is absent until imported. Two `expectMessage` calls are now awaited.
- Verified back to back on one machine. Debug+ASAN: 83.0s and 81.4s before, 55.0s and 55.2s after. Release: 41.8s and 42.2s before, 27.9s and 28.1s after. expect() calls: 44 to 52.
- `bake-harness.ts` is out of scope here. With its overlay poll cut to one check when no errors are expected, this file runs in 6.95s: the poll is about 21s of the remaining 28s.

### Background
- `devTest` boots one dev server per test and `dev.client()` spawns a node process with happy-dom. `dev.write()` waits for the rebuild and the client ack, then checks for an error overlay.
- A barrel is a `sideEffects: false` package that re-exports submodules. The dev server leaves out submodules nothing imports: the bundle has `var import_beta = {}` instead of `beta.js`.

<details><summary>Notes</summary>

**Per-test wall time, debug+ASAN, before**

| test | ms |
|---|---|
| import identifier doesnt get renamed | 2945 |
| symbol collision with import identifier | 2320 |
| uses "development" condition | 1999 |
| importing a file before it is created | 3373 |
| default export same-scope handling | 6566 |
| directory cache bust case #17576 | 5266 |
| deleting imported file shows error then recovers | 5407 |
| removing 'use client' from a component with a pending resolution failure | 2638 |
| deinit with a free-list slot in DirectoryWatchStore.dependencies | 1740 |
| importing html file | 1988 |
| importing html file with text loader (#18154) | 3006 |
| importing bun on the client | 1910 |
| import.meta.main | 4099 |
| commonjs forms | 11161 |
| barrel optimization skips unused submodules | 3043 |
| barrel optimization: adding a new import triggers reload | 5500 |
| barrel optimization: multi-file imports preserved across rebuilds | 4301 |
| barrel optimization: export star target not deferred (#27521) | 3073 |
| barrel optimization: two export-from blocks pointing to the same source | 3019 |
| barrel optimization: two import statements from the same barrel (#28886) | 3028 |
| barrel optimization: namespace re-export cycle through a star-exported module | 3034 |

A test with no client and no edit costs about 2s: 0.7s to boot the server, 0.3s for the first bundle, 0.8s for the graceful exit. A client without expected errors adds 1.2s (node spawn plus the 1s overlay poll). Each edit a client observes adds 1.2s, of which the rebuild is 30 to 60ms.

**Per-test wall time, debug+ASAN, after**

| test | ms |
|---|---|
| import identifier: not renamed, no symbol collision, development condition | 2489 |
| importing a file before it is created | 3217 |
| default export same-scope handling | 5482 |
| directory cache bust case #17576 | 5423 |
| deleting imported file shows error then recovers | 5689 |
| removing 'use client' from a component with a pending resolution failure | 2719 |
| deinit with a free-list slot in DirectoryWatchStore.dependencies | 1745 |
| browser imports: html with the text loader works, html and bun builtins are errors | 3948 |
| import.meta.main | 4186 |
| commonjs forms | 4240 |
| barrel optimization: initial bundle cases | 3145 |
| barrel optimization: adding a new import triggers reload | 5681 |
| barrel optimization: multi-file imports preserved across rebuilds | 4210 |

**Harness measurement.** The remaining time is dominated by `Client.expectErrorOverlay` in `test/bake/bake-harness.ts`. The new file makes 9 client connections and 12 client-observed edits, each with a 1s poll. With a local, uncommitted change that breaks out of the poll after the first check when `errors.length === 0`, the new file runs in 6.95s and the old file in 10.5s (release build). All tests still pass with that change. The client has already acked the update when the check runs, so an overlay that is going to appear is already visible at the first check. This PR does not touch the harness.

**Equivalence notes**

- "commonjs forms" used to test form 1 on the initial load and forms 2 to 8 through seven rebuild and reload rounds. CommonJS detection is per file at parse time and does not depend on whether the parse is part of the initial bundle or a rebuild. The new test checks all 8 forms on the initial load and all 8 again after one batched rebuild, so each form is now covered on both paths. The `console.log` tracing and `timeoutMultiplier: 2` were only needed for the seven rounds.
- The merged framework test shares `db.ts` between the two routes that import it. One edit updates both routes, and the `patch` of one route is asserted to leave the other two untouched.
- "two import statements from the same barrel (#28886)" was `skip: ["darwin"]` with the note "Flakes on darwin in CI (timing)". It is now a section of the shared barrel page, which has the same shape as the four barrel cases that already run on darwin. The skip is not carried over.
- In "default export same-scope handling", `fixture4.ts` and `fixture8.ts` are rebuilt in one batch. The single HMR chunk is checked for `default: class MOVE` and `default: function MOVE` instead of a shared `(function|class)` regex.
- The barrel bundle checks read the script the served HTML points at (`/_bun/client/index-<hash>.js`). `"GAMMA"` and `"UNRELATED"` are string literals from deferred submodules; the two unrelated values were renamed from `"X"` and `"OTHER"` so one check covers both cases.

**A dev server bug found while tightening the 'use client' test.** The original test only asserted `toBeInstanceOf(Response)` on the final fetch. The route is a 500 at that point, but not the "Build Failed" page: it is a runtime error page. The state after each step of the test's sequence:

1. initial: 500, Build Failed (Sibling's `./sibling-missing` does not resolve)
2. Comp.ts rebundled as a "use client" file with a failing import: 500, Build Failed
3. Comp.ts demoted (directive removed): 500, runtime error `Failed to load bundled module 'components/Sibling.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.`
4. `components/missing.ts` created: 500, runtime error `null is not an object (evaluating 'pageModule.streaming')`
5. `components/sibling-missing.ts` created: same as 4. The route never recovers.

Without step 2, or with Comp.ts kept as a client component in step 3, the route recovers and renders after step 5. So the demotion of a client component boundary that has a pending resolution failure breaks the server graph for a sibling client component. The final assertion in this PR checks `status === 500`, which holds in both the current and the fixed state. The bug is not addressed here.

**Other suites run:** `test/bake/dev/css.test.ts`, `hot.test.ts` and `esm.test.ts` are unaffected (no shared code changed). `test/expected-durations.json` is reseeded for this file with the measured ratio.
</details>
