### PR TITLE
test(serve): run the standard HTTP/3 fixture in-process in serve-http3.test.ts and tighten its assertions

### DIFF
--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -311,7 +311,9 @@ describe.concurrent("Bun.serve HTTP/3", () => {
     });
   });
 
-  test("http1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
+  // Serial: the TCP probe below must be refused, so no other fixture may bind
+  // this port number while it runs.
+  test.serial("http1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
     await using server = serveFixture(String(fixtureDir!), { http1: false });
     const port = server.port;
     const h3 = await fetchH3(port, "/hello");

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,5 +1,5 @@
 import type { ServerWebSocket } from "bun";
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHash, createPrivateKey, randomBytes } from "crypto";
 import { readFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
@@ -21,209 +21,217 @@ const fetchH3 = (port: number, path: string, init: RequestInit & { signal?: Abor
 // a live loopback server answers in well under this even on the ASAN lane.
 const DEAD_PORT_ABORT_MS = 1000;
 
-// Every fixture server in this file is torn down on stdin close so the client's
+// Every spawned fixture in this file is torn down on stdin close so the client's
 // pooled session sees CONNECTION_CLOSE and is dropped; otherwise a killed
 // process leaves the client retransmitting until lsquic's idle timeout, and if
 // the OS reuses that ephemeral UDP port a later test's request gets matched
 // onto the dead conn. us_quic_listen_socket_close() flushes CONNECTION_CLOSE
-// synchronously during stop(true); the trailing setTimeout gives the kernel a
-// tick to deliver the loopback datagram before the process exits.
-const STOP_ON_STDIN_END = `process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 100); });`;
+// synchronously during stop(true): the loopback datagram is queued on the
+// client's socket before stop(true) returns, so the process can exit at once.
+// (A fixture that is SIGKILLed instead makes a non-retryable POST to a
+// re-bound port time out every time; an immediate exit after stop(true) never
+// does.) withCustomServer() awaits that exit before the next case starts.
+const STOP_ON_STDIN_END = `process.stdin.on("end", () => { server.stop(true); process.exit(0); });`;
 
-const fixture = `
-import { serve } from "bun";
+const md5 = (b: Uint8Array | ArrayBuffer) => createHash("md5").update(Buffer.from(b)).digest("hex");
 
-const big = Buffer.alloc(512 * 1024, "abcdefghijklmnop");
-
-const server = serve({
-  port: 0,
-  tls: ${JSON.stringify(tls)},
-  http3: true,
-  http1: process.env.H3_ONLY !== "1",
-  routes: {
-    "/api/:id": req => new Response("id=" + req.params.id, { headers: { "x-route": "api" } }),
-    "/route-only": { POST: () => new Response("posted") },
-    "/lifetime/:id": async req => {
-      const before = req.params.id;
-      await Bun.sleep(0);
-      return new Response(before + "|" + req.params.id);
+/** The standard fixture: an in-process server with every route the
+ * request/response cases below use. `dir` holds big.bin (200 KB) and huge.bin
+ * (2 MB). */
+function serveFixture(dir: string, { http1 = true } = {}) {
+  const big = Buffer.alloc(512 * 1024, "abcdefghijklmnop");
+  const bigFile = join(dir, "big.bin");
+  const hugeFile = join(dir, "huge.bin");
+  return Bun.serve({
+    port: 0,
+    tls,
+    http3: true,
+    http1,
+    routes: {
+      "/api/:id": req => new Response("id=" + req.params.id, { headers: { "x-route": "api" } }),
+      "/route-only": { POST: () => new Response("posted") },
+      "/lifetime/:id": async req => {
+        const before = req.params.id;
+        await Bun.sleep(0);
+        return new Response(before + "|" + req.params.id);
+      },
+      "/static": new Response("from-static-route", {
+        headers: { "content-type": "text/plain", etag: '"v1"' },
+      }),
+      "/file-route": Bun.file(bigFile),
+      "/static-hop": new Response("hop", {
+        headers: { connection: "keep-alive", "keep-alive": "timeout=5", te: "gzip", "x-kept": "1" },
+      }),
+      "/file-hop": new Response(Bun.file(bigFile), { headers: { connection: "close", upgrade: "x", "x-kept": "1" } }),
     },
-    "/static": new Response("from-static-route", {
-      headers: { "content-type": "text/plain", etag: '"v1"' },
-    }),
-    "/file-route": Bun.file(process.env.BIG_FILE),
-    "/static-hop": new Response("hop", { headers: { connection: "keep-alive", "keep-alive": "timeout=5", te: "gzip", "x-kept": "1" } }),
-    "/file-hop": new Response(Bun.file(process.env.BIG_FILE), { headers: { connection: "close", upgrade: "x", "x-kept": "1" } }),
-  },
-  async fetch(req) {
-    const url = new URL(req.url);
-    if (url.pathname === "/hop-headers") {
-      return new Response("hi", { headers: { "transfer-encoding": "chunked", connection: "close", "keep-alive": "timeout=5", upgrade: "websocket", "proxy-connection": "x", te: "gzip", "x-kept": "1" } });
-    }
-    if (url.pathname === "/hello") {
-      return new Response("hello over h3", {
-        headers: { "x-proto": "h3", "content-type": "text/plain" },
-      });
-    }
-    if (url.pathname === "/echo") {
-      const body = await req.text();
-      return new Response(body, {
-        status: 201,
-        headers: {
-          "x-method": req.method,
-          "x-echo": req.headers.get("x-echo") ?? "",
-          "x-len": String(body.length),
-        },
-      });
-    }
-    if (url.pathname === "/echo-bytes") {
-      const body = await req.arrayBuffer();
-      return new Response(body, {
-        status: 200,
-        headers: { "x-len": String(body.byteLength) },
-      });
-    }
-    if (url.pathname === "/transform") {
-      const body = new Uint8Array(await req.arrayBuffer());
-      for (let i = 0; i < body.length; i++) body[i] = (body[i] + 1) & 0xff;
-      return new Response(body, { headers: { "x-len": String(body.length) } });
-    }
-    if (url.pathname === "/lifetime") {
-      const mode = url.searchParams.get("d");
-      const beforeUrl = req.url;
-      const beforeMethod = req.method;
-      const beforeHdr = req.headers.get("x-probe");
-      if (mode === "micro") await Promise.resolve();
-      else if (mode === "macro") await Bun.sleep(0);
-      else if (mode === "double") { await Promise.resolve(); await Bun.sleep(0); }
-      const afterUrl = req.url;
-      const afterMethod = req.method;
-      const afterHdr = req.headers.get("x-probe");
-      const all = {};
-      for (const [k, v] of req.headers) all[k] = v;
-      const body = await req.text();
-      return Response.json({
-        ok: beforeUrl === afterUrl && beforeMethod === afterMethod && beforeHdr === afterHdr,
-        url: afterUrl, method: afterMethod, probe: afterHdr,
-        headerCount: Object.keys(all).length, bodyLen: body.length,
-      });
-    }
-    if (url.pathname === "/spawn") {
-      const p = Bun.spawn({
-        cmd: [process.execPath, "-e", "for(let i=0;i<40;i++)process.stdout.write('x'.repeat(1000)+String.fromCharCode(10))"],
-        stdout: "pipe",
-      });
-      return new Response(p.stdout, { headers: { "content-type": "text/plain" } });
-    }
-    if (url.pathname === "/passthrough") {
-      return new Response(req.body, { status: 200, headers: { "x-passthrough": "1" } });
-    }
-    if (url.pathname === "/file-stream") {
-      return new Response(Bun.file(process.env.BIG_FILE).stream());
-    }
-    if (url.pathname === "/headers") {
-      const out = {};
-      for (const [k, v] of req.headers) out[k] = v;
-      return Response.json(out);
-    }
-    if (url.pathname === "/big") {
-      return new Response(big, { headers: { "content-type": "application/octet-stream" } });
-    }
-    if (url.pathname === "/status") {
-      return new Response(null, { status: 204 });
-    }
-    if (url.pathname === "/query") {
-      return new Response(url.searchParams.get("q") ?? "<none>");
-    }
-    if (url.pathname === "/slow") {
-      await new Promise(r => setTimeout(r, 50));
-      return new Response("late");
-    }
-    if (url.pathname === "/stream") {
-      return new Response(
-        new ReadableStream({
-          async start(ctrl) {
-            for (const c of ["one ", "two ", "three"]) {
-              ctrl.enqueue(new TextEncoder().encode(c));
-              await new Promise(r => setTimeout(r, 5));
-            }
-            ctrl.close();
+    async fetch(req, server) {
+      const url = new URL(req.url);
+      if (url.pathname === "/hop-headers") {
+        return new Response("hi", {
+          headers: {
+            "transfer-encoding": "chunked",
+            connection: "close",
+            "keep-alive": "timeout=5",
+            upgrade: "websocket",
+            "proxy-connection": "x",
+            te: "gzip",
+            "x-kept": "1",
           },
-        }),
-        { headers: { "content-type": "text/plain" } },
-      );
-    }
-    if (url.pathname === "/file") {
-      return new Response(Bun.file(process.env.BIG_FILE));
-    }
-    if (url.pathname === "/huge-file") {
-      return new Response(Bun.file(process.env.HUGE_FILE));
-    }
-    if (url.pathname === "/remote") {
-      return Response.json(server.requestIP(req));
-    }
-    return new Response("not found: " + url.pathname, { status: 404 });
-  },
-});
+        });
+      }
+      if (url.pathname === "/hello") {
+        return new Response("hello over h3", {
+          headers: { "x-proto": "h3", "content-type": "text/plain" },
+        });
+      }
+      if (url.pathname === "/echo") {
+        const body = await req.text();
+        return new Response(body, {
+          status: 201,
+          headers: {
+            "x-method": req.method,
+            "x-echo": req.headers.get("x-echo") ?? "",
+            "x-len": String(body.length),
+          },
+        });
+      }
+      if (url.pathname === "/echo-bytes") {
+        const body = await req.arrayBuffer();
+        return new Response(body, {
+          status: 200,
+          headers: { "x-len": String(body.byteLength) },
+        });
+      }
+      if (url.pathname === "/transform") {
+        const body = new Uint8Array(await req.arrayBuffer());
+        for (let i = 0; i < body.length; i++) body[i] = (body[i] + 1) & 0xff;
+        return new Response(body, { headers: { "x-len": String(body.length) } });
+      }
+      if (url.pathname === "/lifetime") {
+        const mode = url.searchParams.get("d");
+        const beforeUrl = req.url;
+        const beforeMethod = req.method;
+        const beforeHdr = req.headers.get("x-probe");
+        if (mode === "micro") await Promise.resolve();
+        else if (mode === "macro") await Bun.sleep(0);
+        else if (mode === "double") {
+          await Promise.resolve();
+          await Bun.sleep(0);
+        }
+        const afterUrl = req.url;
+        const afterMethod = req.method;
+        const afterHdr = req.headers.get("x-probe");
+        const all: Record<string, string> = {};
+        for (const [k, v] of req.headers) all[k] = v;
+        const body = await req.text();
+        return Response.json({
+          ok: beforeUrl === afterUrl && beforeMethod === afterMethod && beforeHdr === afterHdr,
+          url: afterUrl,
+          method: afterMethod,
+          probe: afterHdr,
+          headerCount: Object.keys(all).length,
+          bodyLen: body.length,
+        });
+      }
+      if (url.pathname === "/spawn") {
+        const p = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            "const line=Buffer.alloc(1000,'x').toString()+String.fromCharCode(10);for(let i=0;i<40;i++)process.stdout.write(line)",
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+        });
+        return new Response(p.stdout, { headers: { "content-type": "text/plain" } });
+      }
+      if (url.pathname === "/passthrough") {
+        return new Response(req.body, { status: 200, headers: { "x-passthrough": "1" } });
+      }
+      if (url.pathname === "/file-stream") {
+        return new Response(Bun.file(bigFile).stream());
+      }
+      if (url.pathname === "/headers") {
+        const out: Record<string, string> = {};
+        for (const [k, v] of req.headers) out[k] = v;
+        return Response.json(out);
+      }
+      if (url.pathname === "/big") {
+        return new Response(big, { headers: { "content-type": "application/octet-stream" } });
+      }
+      if (url.pathname === "/status") {
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname === "/query") {
+        return new Response(url.searchParams.get("q") ?? "<none>");
+      }
+      if (url.pathname === "/slow") {
+        // Only the client-abort case requests this; its 10 ms abort timer must
+        // win even when the concurrent group keeps the test's event loop busy.
+        await new Promise(r => setTimeout(r, 500));
+        return new Response("late");
+      }
+      if (url.pathname === "/stream") {
+        return new Response(
+          new ReadableStream({
+            async start(ctrl) {
+              for (const c of ["one ", "two ", "three"]) {
+                ctrl.enqueue(new TextEncoder().encode(c));
+                await new Promise(r => setTimeout(r, 5));
+              }
+              ctrl.close();
+            },
+          }),
+          { headers: { "content-type": "text/plain" } },
+        );
+      }
+      if (url.pathname === "/file") {
+        return new Response(Bun.file(bigFile));
+      }
+      if (url.pathname === "/huge-file") {
+        return new Response(Bun.file(hugeFile));
+      }
+      if (url.pathname === "/remote") {
+        return Response.json(server.requestIP(req));
+      }
+      return new Response("not found: " + url.pathname, { status: 404 });
+    },
+  });
+}
 
-console.error("PORT=" + server.port);
-process.stdin.on("data", () => {});
-${STOP_ON_STDIN_END}
-`;
-
-async function withServer(
-  fn: (port: number, dir: string) => Promise<void>,
-  env: Record<string, string> = {},
-): Promise<void> {
-  using dir = tempDir("serve-http3", {
-    "server.mjs": fixture,
+// The request/response cases share one standard fixture for the whole file.
+// stop(true) closes the client's still-pooled session with CONNECTION_CLOSE
+// instead of leaving it to lsquic's idle timeout.
+let fixtureDir: ReturnType<typeof tempDir>;
+let fixture: ReturnType<typeof serveFixture>;
+beforeAll(() => {
+  fixtureDir = tempDir("serve-http3", {
     "big.bin": Buffer.alloc(200 * 1024, "FILEfile"),
     "huge.bin": Buffer.alloc(2 * 1024 * 1024, "0123456789abcdef"),
   });
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "server.mjs"],
-    cwd: String(dir),
-    env: { ...bunEnv, ...env, BIG_FILE: join(String(dir), "big.bin"), HUGE_FILE: join(String(dir), "huge.bin") },
-    stdout: "inherit",
-    stderr: "pipe",
-    stdin: "pipe",
-  });
-  let port = 0;
-  const stderr = proc.stderr.getReader();
-  let buffered = "";
-  while (true) {
-    const { value, done } = await stderr.read();
-    if (done) break;
-    buffered += new TextDecoder().decode(value);
-    const m = buffered.match(/PORT=(\d+)/);
-    if (m) {
-      port = Number(m[1]);
-      break;
-    }
-  }
-  stderr.releaseLock();
-  // drain remaining stderr in background so the pipe doesn't fill
-  (async () => {
-    for await (const _ of proc.stderr) {
-    }
-  })();
-  expect(port).toBeGreaterThan(0);
-  try {
-    await fn(port, String(dir));
-  } finally {
-    proc.stdin?.end();
-    await Promise.race([proc.exited, Bun.sleep(2000)]);
-    proc.kill();
-    await proc.exited;
-  }
+  fixture = serveFixture(String(fixtureDir));
+});
+afterAll(async () => {
+  await fixture.stop(true);
+  fixtureDir[Symbol.dispose]();
+});
+
+async function withServer(fn: (port: number, dir: string) => Promise<void>): Promise<void> {
+  await fn(fixture.port, String(fixtureDir));
 }
 
-describe("Bun.serve HTTP/3", () => {
+// Concurrent: these cases send requests to the shared fixture (multiplexed over
+// the client's one pooled QUIC connection), start an in-process server of their
+// own, or spawn a process of their own. A case that probes a dead port is
+// test.serial so that no other fixture can bind that port while it probes it,
+// and a case that breaks the connection on purpose needs a server of its own.
+describe.concurrent("Bun.serve HTTP/3", () => {
   test("basic GET", async () => {
     await withServer(async port => {
       const res = await fetchH3(port, "/hello");
       expect(res.status).toBe(200);
       expect(res.headers.get("x-proto")).toBe("h3");
+      expect(res.headers.get("content-type")).toBe("text/plain");
       expect(await res.text()).toBe("hello over h3");
     });
   });
@@ -261,11 +269,13 @@ describe("Bun.serve HTTP/3", () => {
 
   test("large response body crosses multiple QUIC packets", async () => {
     await withServer(async port => {
-      const raw = await fetchH3(port, "/big").then(r => r.bytes());
+      const res = await fetchH3(port, "/big");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/octet-stream");
+      expect(res.headers.get("content-length")).toBe("524288");
+      const raw = await res.bytes();
       expect(raw.length).toBe(512 * 1024);
-      // verify content integrity at both ends
-      expect(new TextDecoder().decode(raw.subarray(0, 16))).toBe("abcdefghijklmnop");
-      expect(new TextDecoder().decode(raw.subarray(-16))).toBe("abcdefghijklmnop");
+      expect(md5(raw)).toBe(md5(Buffer.alloc(512 * 1024, "abcdefghijklmnop")));
     });
   });
 
@@ -281,30 +291,33 @@ describe("Bun.serve HTTP/3", () => {
   test("client abort mid-response does not crash the server", async () => {
     await withServer(async port => {
       // First request: tiny timeout forces abort during /slow
-      await expect(fetchH3(port, "/slow", { signal: AbortSignal.timeout(10) })).rejects.toThrow();
+      await expect(fetchH3(port, "/slow", { signal: AbortSignal.timeout(10) })).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
       // Server must still be alive for a follow-up
       const ok = await fetchH3(port, "/hello");
+      expect(ok.status).toBe(200);
+      expect(ok.headers.get("x-proto")).toBe("h3");
       expect(await ok.text()).toBe("hello over h3");
     });
   });
 
   test("http1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
-    await withServer(
-      async port => {
-        const h3 = await fetchH3(port, "/hello");
-        expect(await h3.text()).toBe("hello over h3");
-        // TCP listener should not be bound at all
-        await expect(
-          fetch(`https://127.0.0.1:${port}/hello`, { tls: { rejectUnauthorized: false } } as RequestInit),
-        ).rejects.toThrow();
-      },
-      { H3_ONLY: "1" },
-    );
+    await using server = serveFixture(String(fixtureDir), { http1: false });
+    const port = server.port;
+    const h3 = await fetchH3(port, "/hello");
+    expect(h3.status).toBe(200);
+    expect(h3.headers.get("x-proto")).toBe("h3");
+    expect(await h3.text()).toBe("hello over h3");
+    // TCP listener should not be bound at all
+    await expect(
+      fetch(`https://127.0.0.1:${port}/hello`, { tls: { rejectUnauthorized: false } } as RequestInit),
+    ).rejects.toMatchObject({ code: "ConnectionRefused" });
   });
 
   // With http1:false the TCP listen socket is never created, so server.url /
   // server.address / server.stop() must consult the QUIC listener.
-  test("http1: false — url/address/stop see the QUIC listener", async () => {
+  test.serial("http1: false — url/address/stop see the QUIC listener", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
@@ -367,6 +380,7 @@ describe("Bun.serve HTTP/3", () => {
         headers: { "content-type": "application/octet-stream" },
       });
       expect(res.status).toBe(413);
+      expect(await res.text()).toBe("");
     });
   });
 
@@ -390,9 +404,11 @@ describe("Bun.serve HTTP/3", () => {
   test("routes: per-method handler", async () => {
     await withServer(async port => {
       const post = await fetchH3(port, "/route-only", { method: "POST" });
+      expect(post.status).toBe(200);
       expect(await post.text()).toBe("posted");
       // GET falls through to fetch() since the route is POST-only
       const get = await fetchH3(port, "/route-only");
+      expect(get.status).toBe(404);
       expect(await get.text()).toBe("not found: /route-only");
     });
   });
@@ -420,16 +436,22 @@ describe("Bun.serve HTTP/3", () => {
 
   test("ReadableStream response body", async () => {
     await withServer(async port => {
-      expect(await fetchH3(port, "/stream").then(r => r.text())).toBe("one two three");
+      const res = await fetchH3(port, "/stream");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/plain");
+      expect(await res.text()).toBe("one two three");
     });
   });
 
   test("Bun.file response body", async () => {
     await withServer(async port => {
-      const raw = await fetchH3(port, "/file").then(r => r.bytes());
+      const res = await fetchH3(port, "/file");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/octet-stream");
+      expect(res.headers.get("content-length")).toBe("204800");
+      const raw = await res.bytes();
       expect(raw.length).toBe(200 * 1024);
-      expect(new TextDecoder().decode(raw.subarray(0, 8))).toBe("FILEfile");
-      expect(new TextDecoder().decode(raw.subarray(-8))).toBe("FILEfile");
+      expect(md5(raw)).toBe(md5(Buffer.alloc(200 * 1024, "FILEfile")));
     });
   });
 
@@ -465,20 +487,29 @@ describe("Bun.serve HTTP/3", () => {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("from-static-route");
       expect(res.headers.get("etag")).toBe('"v1"');
+      expect(res.headers.get("content-type")).toBe("text/plain");
       // If-None-Match -> 304 over H3
       const second = await fetchH3(port, "/static", { headers: { "if-none-match": '"v1"' } });
       expect(second.status).toBe(304);
+      expect(second.headers.get("etag")).toBe('"v1"');
+      expect(await second.text()).toBe("");
     });
   });
 
   test("file route (Bun.file value) streams over H3", async () => {
     await withServer(async port => {
-      const raw = await fetchH3(port, "/file-route").then(r => r.bytes());
+      const res = await fetchH3(port, "/file-route");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/octet-stream");
+      expect(res.headers.get("content-length")).toBe("204800");
+      const raw = await res.bytes();
       expect(raw.length).toBe(200 * 1024);
-      expect(Buffer.from(raw.subarray(0, 8)).toString()).toBe("FILEfile");
+      expect(md5(raw)).toBe(md5(Buffer.alloc(200 * 1024, "FILEfile")));
       // Range request over H3 hits the same FileResponseStream path
       const ranged = await fetchH3(port, "/file-route", { headers: { range: "bytes=4-11" } });
       expect(ranged.status).toBe(206);
+      expect(ranged.headers.get("content-range")).toBe("bytes 4-11/204800");
+      expect(ranged.headers.get("content-length")).toBe("8");
       expect(await ranged.text()).toBe("file" + "FILE");
     });
   });
@@ -516,11 +547,11 @@ describe("Bun.serve HTTP/3", () => {
   });
 });
 
-// Cases ported from h2o t/40http3 and aioquic interop. Each test gets its own
-// server (withServer) so they can run concurrently.
+// Cases ported from h2o t/40http3 and aioquic interop. They run one at a time
+// against the shared fixture: several of them flood the one pooled QUIC
+// connection on purpose (64 streams, an 8 MB body), and they should not
+// overlap.
 describe("Bun.serve HTTP/3 adversarial", () => {
-  const md5 = (b: Uint8Array | ArrayBuffer) => createHash("md5").update(Buffer.from(b)).digest("hex");
-
   test("64 concurrent streams on one connection", async () => {
     // h2o uses 1000; 64 stays inside lsquic's default initial-max-streams
     // and the debug-build 5s budget while still being 4× the existing
@@ -561,6 +592,8 @@ describe("Bun.serve HTTP/3 adversarial", () => {
         body: payload,
         headers: { "content-type": "application/octet-stream" },
       });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-len")).toBe(String(8 * 1024 * 1024));
       const raw = await res.bytes();
       expect(raw.length).toBe(payload.length);
       expect(md5(raw)).toBe(md5(payload));
@@ -601,6 +634,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
       const res = await fetchH3(port, "/big", { method: "HEAD" });
       expect(res.status).toBe(200);
       expect(res.headers.get("content-length")).toBe("524288");
+      expect(res.headers.get("content-type")).toBe("application/octet-stream");
       expect((await res.bytes()).length).toBe(0);
     });
   });
@@ -618,6 +652,8 @@ describe("Bun.serve HTTP/3 adversarial", () => {
         .then(r => r.text())
         .catch(() => {});
       const res = await fetchH3(port, "/hello");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-proto")).toBe("h3");
       expect(await res.text()).toBe("hello over h3");
     });
   });
@@ -636,6 +672,8 @@ describe("Bun.serve HTTP/3 adversarial", () => {
       });
       await p.catch(() => {});
       const res = await fetchH3(port, "/hello");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-proto")).toBe("h3");
       expect(await res.text()).toBe("hello over h3");
     });
   });
@@ -698,12 +736,13 @@ describe("Bun.serve HTTP/3 adversarial", () => {
 
   test("Response(subprocess.stdout) streams over H3", async () => {
     await withServer(async port => {
-      const raw = await fetchH3(port, "/spawn").then(r => r.bytes());
+      const res = await fetchH3(port, "/spawn");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/plain");
+      const raw = await res.bytes();
       expect(raw.length).toBe(40 * 1001);
-      const text = Buffer.from(raw).toString();
-      const lines = text.split("\n").filter(Boolean);
-      expect(lines.length).toBe(40);
-      expect(lines.every(l => l === Buffer.alloc(1000, "x").toString())).toBe(true);
+      const line = Buffer.alloc(1000, "x").toString() + "\n";
+      expect(Buffer.from(raw).toString()).toBe(Buffer.alloc(40 * 1001, line).toString());
     });
   });
 
@@ -761,11 +800,13 @@ describe("Bun.serve HTTP/3 adversarial", () => {
   });
 
   test("Response(Bun.file().stream()) goes through HTTPSResponseSink", async () => {
-    await withServer(async (port, dir) => {
-      const raw = await fetchH3(port, "/file-stream").then(r => r.bytes());
+    await withServer(async port => {
+      const res = await fetchH3(port, "/file-stream");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-length")).toBe("204800");
+      const raw = await res.bytes();
       expect(raw.length).toBe(200 * 1024);
-      const onDisk = await Bun.file(join(dir, "big.bin")).bytes();
-      expect(md5(raw)).toBe(md5(onDisk));
+      expect(md5(raw)).toBe(md5(Buffer.alloc(200 * 1024, "FILEfile")));
     });
   });
 
@@ -773,7 +814,10 @@ describe("Bun.serve HTTP/3 adversarial", () => {
   // has no socket fd. A 2 MB file is over the 1 MiB sendfile threshold.
   test("Bun.file >=1 MiB takes the reader path, not sendfile", async () => {
     await withServer(async port => {
-      const raw = await fetchH3(port, "/huge-file").then(r => r.bytes());
+      const res = await fetchH3(port, "/huge-file");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-length")).toBe("2097152");
+      const raw = await res.bytes();
       expect(raw.length).toBe(2 * 1024 * 1024);
       expect(md5(raw)).toBe(md5(Buffer.alloc(2 * 1024 * 1024, "0123456789abcdef")));
     });
@@ -866,19 +910,32 @@ async function withCustomServer(
   const send = (cmd: string) => proc.stdin!.write(cmd + "\n");
   try {
     await fn(port, send, waitForStderr);
-  } finally {
-    // Give the script a chance to server.stop(true) (CONNECTION_CLOSE) on
-    // stdin end before SIGKILL, so the client's pooled session is released
-    // and can't collide with a later test that reuses the same port.
-    proc.stdin?.end();
+  } catch (e) {
+    // The case already failed. Give the script a bounded chance to
+    // server.stop(true) (CONNECTION_CLOSE) on stdin end before SIGKILL, so the
+    // client's pooled session is released and can't collide with a later test
+    // that reuses the same port.
+    proc.stdin.end();
     await Promise.race([proc.exited, Bun.sleep(1000)]);
     proc.kill();
     await proc.exited;
     await drain.catch(() => {});
+    throw e;
   }
+  // Every script in this file stops its server and exits on stdin end, or has
+  // already exited on a command it was sent. Awaiting that exit, rather than
+  // racing it against a timer, keeps the next case from starting while this
+  // fixture still holds its port.
+  proc.stdin.end();
+  const exitCode = await proc.exited;
+  await drain;
+  expect(exitCode, `fixture exited with ${exitCode}; stderr:\n${buf}`).toBe(0);
 }
 
-describe("Bun.serve HTTP/3 lifecycle", () => {
+// Concurrent: every case here has its own fixture process. The cases that probe
+// a dead port are test.serial so that no other fixture can bind that port while
+// they probe it.
+describe.concurrent("Bun.serve HTTP/3 lifecycle", () => {
   // bughunt #2: server.reload() must clear the H3 router so removed routes
   // fall through to the fetch handler instead of dereferencing freed pointers.
   test("server.reload() clears stale H3 routes", async () => {
@@ -988,7 +1045,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
   // bughunt #3: server.stop() must not leave the lsquic engine pointing at a
   // freed listen-socket. The follow-up GET should cleanly fail to connect,
   // and the process must still be alive to exit 0 on its own.
-  test("server.stop() with live H3 connections does not UAF", async () => {
+  test.serial("server.stop() with live H3 connections does not UAF", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
@@ -1116,7 +1173,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
   // finish before the engine tears down. lsquic_engine_cooldown drops mini
   // (still-handshaking) conns immediately, so we wait until the server has
   // actually entered every handler before stopping — no arbitrary sleep.
-  test("graceful stop: in-flight H3 requests complete after server.stop()", async () => {
+  test.serial("graceful stop: in-flight H3 requests complete after server.stop()", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       let stopping = false, inflight = 0;
@@ -1208,7 +1265,8 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         async fetch(req) {
           const url = new URL(req.url);
           if (url.pathname === "/hang") {
-            req.signal.addEventListener("abort", () => { aborted++; });
+            req.signal.addEventListener("abort", () => { aborted++; console.error("ABORTED"); });
+            console.error("HANGING");
             await new Promise(r => req.signal.addEventListener("abort", r));
             return new Response("never");
           }
@@ -1220,29 +1278,26 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
       process.stdin.on("data", () => {});
       ${STOP_ON_STDIN_END}
     `;
-    await withCustomServer(script, async port => {
-      // Warm the QUIC connection so the /hang stream is actually bound
-      // (qstream != null) before we abort — otherwise abort() is a no-op
-      // and the server never sees STOP_SENDING.
-      await fetchH3(port, "/aborted").then(r => r.text());
+    await withCustomServer(script, async (port, _send, waitForStderr) => {
       const ac = new AbortController();
       const p = fetchH3(port, "/hang", { signal: ac.signal });
-      await Bun.sleep(200);
+      // Abort only once the handler runs: the /hang stream is then bound
+      // (qstream != null), so abort() sends STOP_SENDING instead of being a
+      // no-op on a request that is still queued behind the handshake.
+      await waitForStderr(/HANGING/);
       ac.abort();
-      await expect(p).rejects.toThrow();
+      await expect(p).rejects.toMatchObject({ name: "AbortError" });
       // The signal fires from on_stream_close, which runs on the next
       // process_conns tick after the RST lands.
-      let count = "0";
-      for (let i = 0; i < 60 && count === "0"; i++) {
-        count = await fetchH3(port, "/aborted").then(r => r.text());
-        if (count === "0") await Bun.sleep(50);
-      }
-      expect(Number(count)).toBeGreaterThan(0);
+      await waitForStderr(/ABORTED/);
+      expect(await fetchH3(port, "/aborted").then(r => r.text())).toBe("1");
     });
   });
 });
 
-describe("Bun.serve HTTP/3 production", () => {
+// Concurrent: the two cases on the shared fixture only send requests, and the
+// third has its own fixture process.
+describe.concurrent("Bun.serve HTTP/3 production", () => {
   // RFC 9110 §6.6.1: an origin server with a clock MUST send Date.
   // H1 writes it via HttpResponse::writeMark(); H3 must too.
   test("Date header is sent on every response shape", async () => {
@@ -1284,9 +1339,9 @@ describe("Bun.serve HTTP/3 production", () => {
       // headers from a different place; all three must advertise h3.
       for (const path of ["/hello", "/static", "/file-route"]) {
         const res = await fetch(`https://127.0.0.1:${port}${path}`, { tls: { rejectUnauthorized: false } });
+        await res.arrayBuffer();
         expect(res.status).toBe(200);
-        const alt = res.headers.get("alt-svc") ?? "";
-        expect(alt).toContain('h3=":' + port + '"');
+        expect(res.headers.get("alt-svc")).toBe(`h3=":${port}"; ma=86400`);
       }
     });
   });
@@ -1315,6 +1370,7 @@ describe("Bun.serve HTTP/3 production", () => {
     `;
     await withCustomServer(script, async port => {
       const res = await fetchH3(port, "/");
+      expect(res.status).toBe(200);
       expect(await res.text()).toBe("upgrade=false");
     });
   });

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -206,8 +206,8 @@ function serveFixture(dir: string, { http1 = true } = {}) {
 // The request/response cases share one standard fixture for the whole file.
 // stop(true) closes the client's still-pooled session with CONNECTION_CLOSE
 // instead of leaving it to lsquic's idle timeout.
-let fixtureDir: ReturnType<typeof tempDir>;
-let fixture: ReturnType<typeof serveFixture>;
+let fixtureDir: ReturnType<typeof tempDir> | undefined;
+let fixture: ReturnType<typeof serveFixture> | undefined;
 beforeAll(() => {
   fixtureDir = tempDir("serve-http3", {
     "big.bin": BIG_FILE_BYTES,
@@ -215,13 +215,18 @@ beforeAll(() => {
   });
   fixture = serveFixture(String(fixtureDir));
 });
+// Optional chaining: if beforeAll threw, the error it reported must stay the
+// only one, and the temp dir must still be removed.
 afterAll(async () => {
-  await fixture.stop(true);
-  fixtureDir[Symbol.dispose]();
+  try {
+    await fixture?.stop(true);
+  } finally {
+    fixtureDir?.[Symbol.dispose]();
+  }
 });
 
 async function withServer(fn: (port: number, dir: string) => Promise<void>): Promise<void> {
-  await fn(fixture.port, String(fixtureDir));
+  await fn(fixture!.port, String(fixtureDir!));
 }
 
 // Concurrent: these cases send requests to the shared fixture (multiplexed over
@@ -307,7 +312,7 @@ describe.concurrent("Bun.serve HTTP/3", () => {
   });
 
   test("http1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
-    await using server = serveFixture(String(fixtureDir), { http1: false });
+    await using server = serveFixture(String(fixtureDir!), { http1: false });
     const port = server.port;
     const h3 = await fetchH3(port, "/hello");
     expect(h3.status).toBe(200);

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -35,11 +35,15 @@ const STOP_ON_STDIN_END = `process.stdin.on("end", () => { server.stop(true); pr
 
 const md5 = (b: Uint8Array | ArrayBuffer) => createHash("md5").update(Buffer.from(b)).digest("hex");
 
+// Payloads the standard fixture serves; the cases compare against the same buffers.
+const BIG_BODY = Buffer.alloc(512 * 1024, "abcdefghijklmnop");
+const BIG_FILE_BYTES = Buffer.alloc(200 * 1024, "FILEfile");
+const HUGE_FILE_BYTES = Buffer.alloc(2 * 1024 * 1024, "0123456789abcdef");
+
 /** The standard fixture: an in-process server with every route the
- * request/response cases below use. `dir` holds big.bin (200 KB) and huge.bin
- * (2 MB). */
+ * request/response cases below use. `dir` holds big.bin (BIG_FILE_BYTES) and
+ * huge.bin (HUGE_FILE_BYTES). */
 function serveFixture(dir: string, { http1 = true } = {}) {
-  const big = Buffer.alloc(512 * 1024, "abcdefghijklmnop");
   const bigFile = join(dir, "big.bin");
   const hugeFile = join(dir, "huge.bin");
   return Bun.serve({
@@ -157,7 +161,7 @@ function serveFixture(dir: string, { http1 = true } = {}) {
         return Response.json(out);
       }
       if (url.pathname === "/big") {
-        return new Response(big, { headers: { "content-type": "application/octet-stream" } });
+        return new Response(BIG_BODY, { headers: { "content-type": "application/octet-stream" } });
       }
       if (url.pathname === "/status") {
         return new Response(null, { status: 204 });
@@ -206,8 +210,8 @@ let fixtureDir: ReturnType<typeof tempDir>;
 let fixture: ReturnType<typeof serveFixture>;
 beforeAll(() => {
   fixtureDir = tempDir("serve-http3", {
-    "big.bin": Buffer.alloc(200 * 1024, "FILEfile"),
-    "huge.bin": Buffer.alloc(2 * 1024 * 1024, "0123456789abcdef"),
+    "big.bin": BIG_FILE_BYTES,
+    "huge.bin": HUGE_FILE_BYTES,
   });
   fixture = serveFixture(String(fixtureDir));
 });
@@ -275,7 +279,7 @@ describe.concurrent("Bun.serve HTTP/3", () => {
       expect(res.headers.get("content-length")).toBe("524288");
       const raw = await res.bytes();
       expect(raw.length).toBe(512 * 1024);
-      expect(md5(raw)).toBe(md5(Buffer.alloc(512 * 1024, "abcdefghijklmnop")));
+      expect(md5(raw)).toBe(md5(BIG_BODY));
     });
   });
 
@@ -451,7 +455,7 @@ describe.concurrent("Bun.serve HTTP/3", () => {
       expect(res.headers.get("content-length")).toBe("204800");
       const raw = await res.bytes();
       expect(raw.length).toBe(200 * 1024);
-      expect(md5(raw)).toBe(md5(Buffer.alloc(200 * 1024, "FILEfile")));
+      expect(md5(raw)).toBe(md5(BIG_FILE_BYTES));
     });
   });
 
@@ -504,7 +508,7 @@ describe.concurrent("Bun.serve HTTP/3", () => {
       expect(res.headers.get("content-length")).toBe("204800");
       const raw = await res.bytes();
       expect(raw.length).toBe(200 * 1024);
-      expect(md5(raw)).toBe(md5(Buffer.alloc(200 * 1024, "FILEfile")));
+      expect(md5(raw)).toBe(md5(BIG_FILE_BYTES));
       // Range request over H3 hits the same FileResponseStream path
       const ranged = await fetchH3(port, "/file-route", { headers: { range: "bytes=4-11" } });
       expect(ranged.status).toBe(206);
@@ -806,7 +810,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
       expect(res.headers.get("content-length")).toBe("204800");
       const raw = await res.bytes();
       expect(raw.length).toBe(200 * 1024);
-      expect(md5(raw)).toBe(md5(Buffer.alloc(200 * 1024, "FILEfile")));
+      expect(md5(raw)).toBe(md5(BIG_FILE_BYTES));
     });
   });
 
@@ -819,7 +823,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
       expect(res.headers.get("content-length")).toBe("2097152");
       const raw = await res.bytes();
       expect(raw.length).toBe(2 * 1024 * 1024);
-      expect(md5(raw)).toBe(md5(Buffer.alloc(2 * 1024 * 1024, "0123456789abcdef")));
+      expect(md5(raw)).toBe(md5(HUGE_FILE_BYTES));
     });
   });
 


### PR DESCRIPTION
### Problem
- `test/js/bun/http/serve-http3.test.ts` takes 8 to 10 s on every release lane and 16 s on ASAN. The cost is fixed: 47 fixture processes, one per case, each paying bun startup plus a 100 ms `setTimeout` before `process.exit`, and three 1 s dead-port probes.

### Fix
- The standard fixture is now an in-process `Bun.serve` (`serveFixture`), started in `beforeAll` and stopped in `afterAll`, as `fetch-http3-client.test.ts` already does. `withServer(fn)` stays as a shim, so the case bodies do not move. The template string, its stdin protocol and the `PORT=` parsing are gone. 47 spawns become 13.
- The spawned custom fixtures exit right after `server.stop(true)`, which sends CONNECTION_CLOSE synchronously. A port-reuse stress passes 30/30 this way and fails 5/5 with SIGKILL (Notes). `withCustomServer` awaits that exit and asserts exit code 0.
- `describe.concurrent` on the basic, lifecycle and production blocks. The three dead-port probes are `test.serial`, so no other fixture can bind the port they probe. The adversarial block stays sequential on purpose: it floods one connection.
- Assertions check full responses (status, headers, exact bytes by md5) and rejection names. Same machine and build: release 9.9 s → 4.0 s, debug+ASAN 77 s → 20 s. 12 release and 10 ASAN runs green.

### Background
- A spawned fixture stops when its stdin closes: it runs `server.stop(true)`, which sends QUIC CONNECTION_CLOSE, so the test's pooled HTTP/3 session is dropped instead of retransmitting to a dead port a later fixture may get.
- A dead-port probe is a request that must fail. The QUIC client never fails fast on a dead UDP port, so the probe keeps its 1 s abort.

<details><summary>Notes</summary>

**Measurements** (this machine, release = `USE_SYSTEM_BUN=1 bun test`, debug = `bun bd test`, same build before and after):

| | before | after |
|---|---|---|
| release wall time | 9.9 s | 3.9 to 4.0 s (12 runs) |
| debug + ASAN wall time | 74 to 77 s | 19.5 to 19.8 s (10 runs) |
| fixture processes (release, ASAN case skipped) | 47 | 13 |
| fixture processes (debug) | 48 | 14 |
| CI, build 103647: linux release lanes (x64 and aarch64, glibc and musl) | 8 to 10 s | 3.8 to 3.9 s |
| CI, build 103647: darwin x64 and aarch64 | 8 to 10 s | 4.1 s and 3.9 s |
| CI, build 103647: windows 2019 x64 and windows 11 aarch64 | 8 to 10 s | 4.2 s and 4.5 s |
| CI, build 103647: debian 13 x64-asan | 16.0 s | 5.6 s |

Spawn counts come from a temporary copy of the file that wrapped `Bun.spawn` with a counter. After the change the 13 are: 9 `withCustomServer` scripts and 4 one-off `Bun.spawn` cases (3 validation, 1 natural exit). Debug adds the ASAN-only abort storm. The `/spawn` route's child process is not a fixture and is not counted (before, the fixture process spawned it; now the test process does).

Where the 9.9 s went before: 43 fixture-backed cases at about 140 ms each (about 100 ms of that is the `setTimeout(..., 100)` before `process.exit`, the rest bun startup and the `process.stdin` hookup), plus 3 × 1 s dead-port probes, plus a 200 ms sleep in `req.signal`. After: the three serial dead-port probes are 3.2 s of the 4.0 s. Everything else is about 0.7 s.

**In-process fixture.** `await server.stop(true)` with the client's pooled session still open resolves in 0.1 ms (release) and 0.9 ms (debug); a graceful `await server.stop()` resolves in 0.1 ms and 6 ms. The comment in `fetch-http3-client.test.ts:170` that says `stop(true)` would block on the pooled session draining does not match what the current server does. A native crash in the server now takes the test runner down instead of one fixture process; the crash output (or ASAN report) lands in the run's log under the case that was running, where before it went to a fixture stderr that nothing read. The `http1: false` case starts its own in-process `serveFixture(dir, { http1: false })`.

**Why the 100 ms exit delay can go.** Stress (`stop(true)` on stdin end, then a second fixture re-bound to the same port, then a non-retryable `ReadableStream` POST with a 3 s abort, 30 iterations): `process.exit(0)` right after `stop(true)`: 0/30 failures. Natural exit (no `process.exit`): 0/30, the fixture exits in 1 to 5 ms. Negative control, SIGKILL instead of stdin end: 5/5 time out, which shows the stress detects a missing CONNECTION_CLOSE. The existing `server.stop(true) sends CONNECTION_CLOSE on an idle H3 connection` case relies on the same property, and there `stop(true)` and the re-bind happen in the same tick with no delay at all.

**Concurrency.** `describe.concurrent` on "Bun.serve HTTP/3", "lifecycle" and "production". Hazard considered: a case that asserts a request to port P fails (a dead-port probe) while another case's fixture binds a random ephemeral port could, with probability about 1/28k per concurrent bind, see that fixture on P. The three probes (`url/address/stop`, `stop() ... does not UAF`, `graceful stop`) are therefore `test.serial`; the runner finishes the concurrent group before a serial case starts and starts the next group after it. The HTTP/3 client opens a second connection when the pooled one has no stream credit (`ClientContext::connect` → `has_headroom`), so concurrent cases on the shared fixture multiplex or spill over, they do not fail. The adversarial block is sequential because `64 concurrent streams on one connection` and the 8 MB POST are about one connection under load. A future case that breaks the connection on purpose (a QPACK or framing error that closes it) needs a server of its own, which the comment on the describe says.

`/slow` now sleeps 500 ms instead of 50 ms. The only case that requests it aborts at 10 ms, so the change costs nothing; it makes the abort timer win even if the concurrent group stalls the test's event loop for tens of milliseconds under ASAN. Three ASAN copies of the file run at once all passed, slowest case 2.4 s. `--randomize` (3 seeds) passes too.

**Sleeps that stay**: the 100 ms delayed-ACK wait and the 50 ms timer tick inside two lifecycle fixtures (they are the scenario), the 5 ms stream pacing and 20 ms client throttle in the stream cases, the 2 s abort on the post-restart POST, and the 1 s grace before SIGKILL that `withCustomServer` now uses only after a case has already failed.

**Assertion changes**: basic GET (content-type), large response (status, content-type, content-length, md5 of all 512 KB instead of two 16-byte samples), client abort (`TimeoutError`, full follow-up), http1:false (status, x-proto, `ConnectionRefused`), maxRequestBodySize (empty 413 body), per-method routes (200 and 404), ReadableStream body (status, content-type), Bun.file body and file route (status, content-type, content-length, md5, `content-range` and content-length on the 206), static route (content-type, etag and empty body on the 304), 8 MB POST (status, x-len), HEAD (content-type), lying content-length and client RST (full follow-up), subprocess stdout (status, content-type, exact 40040-byte body), Bun.file stream and 2 MB file (status, content-length, md5 of the expected pattern), Alt-Svc (exact `h3=":PORT"; ma=86400`), upgrade (status), `req.signal` (`AbortError`, exactly 1 abort, awaited `HANGING`/`ABORTED` lines instead of a 200 ms sleep and a 60 × 50 ms poll). Every custom fixture must now exit 0 on stdin end.

**Rebase onto #40137 (HTTP/2 support).** That commit added three routes to the standard fixture (`/hop-headers`, `/static-hop`, `/file-hop`), a `connection-specific response headers are dropped` case, and renamed `H3ResponseSink` to `HTTPSResponseSink` in comments and one case name. The routes are ported into `serveFixture` (`Bun.file(bigFile)` in place of `process.env.BIG_FILE`); the new case uses `withServer` unchanged and runs against the shared fixture. On a debug build of the rebased branch: 53 pass in 21 to 23 s, four runs.

**Relation to #39068.** That PR moves the spawned fixtures from `process.stdin` to `Bun.stdin.stream()` to cut about 1 s of debug-build startup per fixture, and keeps the 100 ms exit delay inside its new helper. The two PRs conflict on the `STOP_ON_STDIN_END` line and on the standard fixture template, which this PR deletes. Whichever lands second rebases: the `Bun.stdin.stream()` change still helps the 9 custom fixtures that remain spawned, and the 100 ms delay should stay dropped for the reason above.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 4 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-http3.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/http/serve-http3.test.ts:
(node:20983) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [131.57ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [132.33ms]
(pass) Bun.serve HTTP/3 > 204 with no body [163.78ms]
(pass) Bun.serve HTTP/3 > query string is preserved [155.14ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [66.93ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [46.19ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [165.09ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [56.18ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2356.78ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [47.28ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [51.81ms]
(pass) Bun.serve HTTP/3 > routes: per-method handler [72.96ms]
(pass) Bun.serve HTTP/3 > Bun.file response body [47.27ms]
(pass) Bun.serve HTTP/3 > ReadableStream response body [83.61ms]
(pass) Bun.serve HTTP/3 > static route (Response value) is mirrored onto H3 [25.02ms]
(pass) Bun.serve HTTP/3 > connection-specific response headers are dropped on fetch, static and file routes [62.76ms]
(pass) Bun.serve HTTP/3 > file route (Bun.file value) streams over H3 [50.89ms]
(pass) Bun.serve HTTP/3 > validation: http3 without tls throws [344.88ms]
(pass) Bun.serve HTTP/3 > validation: http1:false without http3 throws [348.46ms]
(pass) Bun.serve HTTP/3 > validation: http3 with unix socket warns and skips H3 listener [439.34ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [1
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/serve-http3.test.ts | 567 ++++++++++++++++++++---------------
 1 file changed, 317 insertions(+), 250 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
test/js/bun/http/serve-http3.test.ts     19     33      0
```

</details>

<!-- robobun:evidence:end -->