### PR TITLE
shell: open FIFO redirect targets on the work pool instead of the event-loop thread

### DIFF
--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -109,6 +109,7 @@ pub mod task_tag {
         ShellMkdirTask,
         ShellMvBatchedTask,
         ShellMvCheckTargetTask,
+        ShellRedirectOpenTask,
         ShellRmDirTask,
         ShellRmTask,
         ShellTouchTask,

--- a/src/io/openForWriting.rs
+++ b/src/io/openForWriting.rs
@@ -81,7 +81,7 @@ where
     )
 }
 
-pub fn open_for_writing_impl<P, C>(
+pub fn open_for_writing_impl<P, C, F>(
     dir: Fd,
     input_path: &P,
     input_flags: i32,
@@ -93,10 +93,11 @@ pub fn open_for_writing_impl<P, C>(
     ctx: C,
     on_force_sync_or_isa_tty: fn(C),
     is_pollable: fn(mode: Mode) -> bool,
-    openat: fn(dir: Fd, path: &ZStr, flags: i32, mode: Mode) -> bun_sys::Result<Fd>,
+    openat: F,
 ) -> bun_sys::Result<Fd>
 where
     P: OpenForWritingInput,
+    F: Fn(Fd, &ZStr, i32, Mode) -> bun_sys::Result<Fd>,
 {
     #[cfg(windows)]
     {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -74,7 +74,9 @@ use crate::shell::builtins::{
     touch::ShellTouchTask,
     yes::YesTask as ShellYesTask,
 };
-use crate::shell::dispatch_tasks::{ShellCondExprStatTask, ShellGlobTask, ShellRmDirTask};
+use crate::shell::dispatch_tasks::{
+    ShellCondExprStatTask, ShellGlobTask, ShellRedirectOpenTask, ShellRmDirTask,
+};
 use crate::shell::interpreter::ShellTask;
 #[cfg(not(windows))]
 use crate::shell::io_writer::Poll as ShellBufferedWriterPoll;
@@ -327,6 +329,7 @@ pub(crate) fn run_task(
         | task_tag::ShellLsTask
         | task_tag::ShellMvBatchedTask
         | task_tag::ShellMvCheckTargetTask
+        | task_tag::ShellRedirectOpenTask
         | task_tag::ShellRmTask
         | task_tag::ShellRmDirTask
         | task_tag::ShellGlobTask
@@ -556,6 +559,7 @@ fn run_task_cold(task: Task) {
         task_tag::ShellLsTask => shell_dispatch!(ShellLsTask),
         task_tag::ShellMvBatchedTask => shell_dispatch!(ShellMvBatchedTask),
         task_tag::ShellMvCheckTargetTask => shell_dispatch!(ShellMvCheckTargetTask),
+        task_tag::ShellRedirectOpenTask => shell_dispatch!(ShellRedirectOpenTask),
         task_tag::ShellRmTask => shell_dispatch!(ShellRmTask),
         task_tag::ShellRmDirTask => {
             let t = cast_ptr!(ShellRmDirTask);
@@ -589,7 +593,7 @@ fn run_task_cold(task: Task) {
 /// `release_task_unrun` track `bun_event_loop::task_tag::COUNT`. Bump when
 /// adding a variant — and give it an arm in both.
 const _: () = assert!(
-    task_tag::COUNT == 61,
+    task_tag::COUNT == 62,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1279,6 +1283,7 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::ShellMkdirTask => release!(ShellMkdirTask),
         task_tag::ShellMvBatchedTask => release!(ShellMvBatchedTask),
         task_tag::ShellMvCheckTargetTask => release!(ShellMvCheckTargetTask),
+        task_tag::ShellRedirectOpenTask => release!(ShellRedirectOpenTask),
         task_tag::ShellRmDirTask => release!(ShellRmDirTask),
         task_tag::ShellRmTask => release!(ShellRmTask),
         task_tag::ShellTouchTask => release!(ShellTouchTask),

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{
-    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode, shell_openat,
+    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode,
 };
 use crate::shell::io::{InKind, OutFd, OutKind};
 use crate::shell::io_reader::IOReader;
@@ -585,8 +585,11 @@ impl Builtin {
                 let mut is_socket = false;
                 let mut is_nonblocking = false;
 
+                let open = |dir, path: &bun_core::ZStr, flags, perm| {
+                    Cmd::open_redirect_target(interp, cmd, dir, path, flags, perm)
+                };
                 let redirfd: bun_sys::Fd = if redirect.stdin() {
-                    match shell_openat(cwd_fd, path, redirect.to_flags(), perm) {
+                    match open(cwd_fd, path, redirect.to_flags(), perm) {
                         Err(e) => {
                             let sys = e.to_shell_system_error();
                             return Some(Self::cmd_write_failing_error(
@@ -614,7 +617,7 @@ impl Builtin {
                         (),
                         |_| {},
                         is_pollable_from_mode,
-                        shell_openat,
+                        open,
                     );
                     match result {
                         Err(e) => {

--- a/src/runtime/shell/dispatch_tasks.rs
+++ b/src/runtime/shell/dispatch_tasks.rs
@@ -56,12 +56,9 @@ impl ShellCondExprStatTask {
     }
 }
 
-/// Opens a file redirect target (`> path`, `< path`, ...) on the work pool.
-///
-/// `open(2)` on a FIFO blocks until the other end is opened. Done on the
-/// event-loop thread that stalls the whole process, including the timer or
-/// stream in the same script that would have opened the other end. Regular
-/// files keep the inline open in `Cmd`; only a FIFO comes here.
+/// Opens a FIFO redirect target on the work pool, where its `open(2)` can
+/// wait for the other end without stalling the event loop
+/// (`Cmd::open_redirect_on_pool`).
 #[repr(C)]
 pub(crate) struct ShellRedirectOpenTask {
     pub task: ShellTask,

--- a/src/runtime/shell/dispatch_tasks.rs
+++ b/src/runtime/shell/dispatch_tasks.rs
@@ -56,6 +56,88 @@ impl ShellCondExprStatTask {
     }
 }
 
+/// Opens a file redirect target (`> path`, `< path`, ...) on the work pool.
+///
+/// `open(2)` on a FIFO blocks until the other end is opened. Done on the
+/// event-loop thread that stalls the whole process, including the timer or
+/// stream in the same script that would have opened the other end. Regular
+/// files keep the inline open in `Cmd`; only a FIFO comes here.
+#[repr(C)]
+pub(crate) struct ShellRedirectOpenTask {
+    pub task: ShellTask,
+    pub cmd: NodeId,
+    pub cwd_fd: bun_sys::Fd,
+    /// NUL-terminated.
+    pub path: Vec<u8>,
+    pub flags: i32,
+    pub perm: bun_sys::Mode,
+    pub result: bun_sys::Result<bun_sys::Fd>,
+}
+
+impl ShellRedirectOpenTask {
+    /// Heap-allocate the task for `cmd` and hand it to the work pool; the
+    /// allocation is freed in `run_from_main_thread`.
+    pub(crate) fn create_and_schedule(
+        interp: &Interpreter,
+        cmd: NodeId,
+        cwd_fd: bun_sys::Fd,
+        path: Vec<u8>,
+        flags: i32,
+        perm: bun_sys::Mode,
+    ) {
+        debug_assert!(path.last() == Some(&0));
+        let mut task = ShellTask::new(interp.event_loop);
+        task.interp = interp.as_ctx_ptr();
+        let this = bun_core::heap::alloc(ShellRedirectOpenTask {
+            task,
+            cmd,
+            cwd_fd,
+            path,
+            flags,
+            perm,
+            // Placeholder, overwritten by `run_from_thread_pool` before the
+            // main thread reads it.
+            result: Err(Default::default()),
+        });
+        // SAFETY: `this` is a fresh heap allocation embedding `ShellTask` at
+        // `TASK_OFFSET`; freed in `run_from_main_thread`.
+        unsafe { ShellTask::schedule::<ShellRedirectOpenTask>(this) };
+    }
+}
+
+impl bun_event_loop::Taskable for ShellRedirectOpenTask {
+    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellRedirectOpenTask;
+    /// A pool completion that will not run: close the fd it opened, drop the
+    /// keep-alive and the box.
+    unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: fn contract — the box `create_and_schedule` scheduled.
+        unsafe {
+            let mut me = bun_core::heap::take(this);
+            me.task.unref_unrun();
+            if let Ok(fd) = me.result {
+                crate::shell::interpreter::closefd(fd);
+            }
+        }
+    }
+}
+
+impl crate::shell::interpreter::ShellTaskCtx for ShellRedirectOpenTask {
+    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
+    fn run_from_thread_pool(this: &mut Self) {
+        let z = bun_core::ZStr::from_buf(&this.path, this.path.len() - 1);
+        this.result =
+            crate::shell::interpreter::shell_openat(this.cwd_fd, z, this.flags, this.perm);
+    }
+    // Dispatch trampoline: `this` validity is guaranteed by the `run_task`
+    // contract; signature is fixed by the `ShellTaskCtx` trait.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
+        // SAFETY: paired with `heap::alloc` in `create_and_schedule`.
+        let me = unsafe { bun_core::heap::take(this) };
+        crate::shell::states::cmd::Cmd::on_redirect_open_done(interp, me.cmd, me.result);
+    }
+}
+
 /// Error result of a glob-expansion task.
 pub enum ShellGlobErr {
     Syscall(bun_sys::Error),

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -25,8 +25,8 @@ pub struct Cmd {
     pub args: Vec<Vec<u8>>,
     pub(crate) redirection_file: Vec<u8>,
     pub(crate) redirection_fd: Option<*mut CowFd>,
-    /// Result of the work-pool `open` of `redirection_file`
-    /// (`CmdState::OpeningRedirect`); consumed by `open_redirect_target`.
+    /// Result of the work-pool open of `redirection_file`, taken by
+    /// `open_redirect_target`.
     pub(crate) opened_redirect: Option<bun_sys::Result<bun_sys::Fd>>,
     pub(crate) exec: Exec,
     pub(crate) exit_code: Option<ExitCode>,
@@ -418,10 +418,9 @@ impl Cmd {
         Yield::Next(this)
     }
 
-    /// `open(2)` on a FIFO blocks until the other end is opened, so a
-    /// `> fifo` / `< fifo` redirect is opened on the work pool instead of the
-    /// event-loop thread. Returns `Some(suspended)` once the task is out, or
-    /// `None` when the target opens inline (`transition_to_exec`).
+    /// `open(2)` on a FIFO blocks until the other end is opened, so a FIFO
+    /// redirect target is opened on the work pool. `None`: the target opens
+    /// inline in `transition_to_exec`.
     fn open_redirect_on_pool(interp: &Interpreter, this: NodeId) -> Option<Yield> {
         // Windows has no FIFO that `open` waits on.
         if cfg!(windows) {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -25,6 +25,9 @@ pub struct Cmd {
     pub args: Vec<Vec<u8>>,
     pub(crate) redirection_file: Vec<u8>,
     pub(crate) redirection_fd: Option<*mut CowFd>,
+    /// Result of the work-pool `open` of `redirection_file`
+    /// (`CmdState::OpeningRedirect`); consumed by `open_redirect_target`.
+    pub(crate) opened_redirect: Option<bun_sys::Result<bun_sys::Fd>>,
     pub(crate) exec: Exec,
     pub(crate) exit_code: Option<ExitCode>,
 }
@@ -40,6 +43,9 @@ pub enum CmdState {
     ExpandingRedirect {
         idx: u32,
     },
+    /// The redirect target is a FIFO: its `open(2)` runs on the work pool
+    /// (`ShellRedirectOpenTask`) and resumes at `Exec`.
+    OpeningRedirect,
     Exec,
     WaitingWriteErr,
     Done,
@@ -214,6 +220,7 @@ impl Cmd {
             args: Vec::new(),
             redirection_file: Vec::new(),
             redirection_fd: None,
+            opened_redirect: None,
             exec: Exec::None,
             exit_code: None,
         }))
@@ -274,9 +281,14 @@ impl Cmd {
                     return Expansion::start(interp, child);
                 }
                 CmdState::Exec => {
+                    if let Some(y) = Self::open_redirect_on_pool(interp, this) {
+                        return y;
+                    }
                     return Self::transition_to_exec(interp, this);
                 }
-                CmdState::WaitingWriteErr => return Yield::suspended(),
+                CmdState::OpeningRedirect | CmdState::WaitingWriteErr => {
+                    return Yield::suspended();
+                }
                 CmdState::Done => {
                     let exit = interp.as_cmd(this).exit_code.unwrap_or(0);
                     let parent = interp.as_cmd(this).base.parent;
@@ -404,6 +416,77 @@ impl Cmd {
         }
         interp.deinit_node(child);
         Yield::Next(this)
+    }
+
+    /// `open(2)` on a FIFO blocks until the other end is opened, so a
+    /// `> fifo` / `< fifo` redirect is opened on the work pool instead of the
+    /// event-loop thread. Returns `Some(suspended)` once the task is out, or
+    /// `None` when the target opens inline (`transition_to_exec`).
+    fn open_redirect_on_pool(interp: &Interpreter, this: NodeId) -> Option<Yield> {
+        // Windows has no FIFO that `open` waits on.
+        if cfg!(windows) {
+            return None;
+        }
+        let (cwd_fd, path, flags) = {
+            let me = interp.as_cmd(this);
+            if me.opened_redirect.is_some()
+                || !matches!(me.ast_node().redirect_file, Some(ast::Redirect::Atom(_)))
+            {
+                return None;
+            }
+            // Empty after expansion: `init_*_redirections` reports the
+            // ambiguous redirect.
+            let path_len = me.redirection_file.len().checked_sub(1)?;
+            let path = bun_core::ZStr::from_buf(&me.redirection_file, path_len);
+            let cwd_fd = me.base.shell().cwd_fd;
+            match bun_sys::fstatat(cwd_fd, path) {
+                Ok(st) if bun_sys::S::ISFIFO(st.st_mode as bun_sys::Mode) => {}
+                _ => return None,
+            }
+            (
+                cwd_fd,
+                me.redirection_file.clone(),
+                me.ast_node().redirect.to_flags(),
+            )
+        };
+        interp.as_cmd_mut(this).state = CmdState::OpeningRedirect;
+        crate::shell::dispatch_tasks::ShellRedirectOpenTask::create_and_schedule(
+            interp, this, cwd_fd, path, flags, 0o666,
+        );
+        Some(Yield::suspended())
+    }
+
+    /// Main-thread re-entry for [`Self::open_redirect_on_pool`]: stash the
+    /// result for `open_redirect_target` and continue to `Exec`.
+    pub(crate) fn on_redirect_open_done(
+        interp: &Interpreter,
+        this: NodeId,
+        result: bun_sys::Result<bun_sys::Fd>,
+    ) {
+        debug_assert!(matches!(
+            interp.as_cmd(this).state,
+            CmdState::OpeningRedirect
+        ));
+        let me = interp.as_cmd_mut(this);
+        me.opened_redirect = Some(result);
+        me.state = CmdState::Exec;
+        Yield::Next(this).run(interp);
+    }
+
+    /// Open the expanded file redirect target, or take the fd the work pool
+    /// already opened for it.
+    pub(crate) fn open_redirect_target(
+        interp: &Interpreter,
+        this: NodeId,
+        dir: bun_sys::Fd,
+        path: &bun_core::ZStr,
+        flags: i32,
+        perm: bun_sys::Mode,
+    ) -> bun_sys::Result<bun_sys::Fd> {
+        match interp.as_cmd_mut(this).opened_redirect.take() {
+            Some(result) => result,
+            None => crate::shell::interpreter::shell_openat(dir, path, flags, perm),
+        }
     }
 
     /// Resolves argv[0] to a builtin or falls through to subprocess spawn
@@ -812,7 +895,9 @@ impl Cmd {
                 let path = bun_core::ZStr::from_buf(&path_buf, path_buf.len() - 1);
                 log!("Expanded Redirect: {}\n", bstr::BStr::new(path.as_bytes()));
                 let cwd_fd = interp.as_cmd(this).base.shell().cwd_fd;
-                let redirfd = match crate::shell::interpreter::shell_openat(
+                let redirfd = match Self::open_redirect_target(
+                    interp,
+                    this,
                     cwd_fd,
                     path,
                     flags.to_flags(),
@@ -879,6 +964,10 @@ impl Cmd {
             if let Some(fd) = me.redirection_fd.take() {
                 // SAFETY: `fd` is the +1 ref held in `me.redirection_fd`.
                 CowFd::deref(fd);
+            }
+            // `$(true) > fifo` expands to no argv, so nothing took the fd.
+            if let Some(Ok(fd)) = me.opened_redirect.take() {
+                crate::shell::interpreter::closefd(fd);
             }
             core::mem::take(&mut me.exec)
         };

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isPosix, tempDir } from "harness";
 import * as fs from "node:fs";
 import { join } from "node:path";
 import { createTestBuilder } from "./test_builder";
@@ -174,7 +174,12 @@ describe("IOWriter file output redirection", () => {
         console.log(JSON.stringify(result));
       `;
 
-      for (const mode of ["builtin >", "external >", "builtin <", "external <"]) {
+      // macOS reports no kqueue or poll readiness when the last writer of a
+      // FIFO closes, so the builtin `cat` never sees EOF there (node's
+      // process.stdin has the same gap). The external `cat` blocks in read(2)
+      // and does.
+      const modes = ["builtin >", "external >", "external <", ...(isLinux ? ["builtin <"] : [])];
+      for (const mode of modes) {
         test.concurrent(
           mode,
           async () => {
@@ -193,7 +198,10 @@ describe("IOWriter file output redirection", () => {
             });
             // A blocked open never returns on its own: the child's main thread
             // sits in open(2) and no partner ever arrives. Bound the wait.
-            const exited = await Promise.race([proc.exited, Bun.sleep(30_000).then(() => "hung" as const)]);
+            const hang = Promise.withResolvers<"hung">();
+            const deadline = setTimeout(() => hang.resolve("hung"), 30_000);
+            const exited = await Promise.race([proc.exited, hang.promise]);
+            clearTimeout(deadline);
             if (exited === "hung") {
               proc.kill(9);
               await proc.exited;
@@ -207,7 +215,7 @@ describe("IOWriter file output redirection", () => {
             }
             expect({ parsed, stderr, exited }).toEqual({
               parsed: { text: "hello\n", exitCode: 0, stderr: "" },
-              stderr: expect.any(String),
+              stderr: "",
               exited: 0,
             });
           },

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -125,6 +125,96 @@ describe("IOWriter file output redirection", () => {
         fs.closeSync(holder);
       }
     });
+
+    // open(2) on a FIFO blocks until the other end is opened. The redirect
+    // target must not be opened on the event-loop thread, or the whole process
+    // freezes until some other process shows up. Each fixture opens the other
+    // end from its own event loop, which can only happen if that loop is
+    // still running while the shell waits for the partner.
+    describe.skipIf(!isPosix)("redirect to a FIFO does not block the event loop", () => {
+      const fixture = /* ts */ `
+        import { $ } from "bun";
+        import * as fs from "node:fs";
+        const fifo = process.env.FIFO!;
+        const mode = process.env.MODE!;
+        const echo = Bun.which("echo")!;
+        const cat = Bun.which("cat")!;
+        // .then() starts the shell; the redirect open now waits for a partner.
+        let result;
+        switch (mode) {
+          case "builtin >": {
+            const pending = $\`echo hello > \${fifo}\`.quiet().nothrow().then(r => r);
+            const text = await fs.promises.readFile(fifo, "utf8");
+            const r = await pending;
+            result = { text, exitCode: r.exitCode, stderr: r.stderr.toString() };
+            break;
+          }
+          case "external >": {
+            const pending = $\`\${echo} hello > \${fifo}\`.quiet().nothrow().then(r => r);
+            const text = await fs.promises.readFile(fifo, "utf8");
+            const r = await pending;
+            result = { text, exitCode: r.exitCode, stderr: r.stderr.toString() };
+            break;
+          }
+          case "builtin <": {
+            const pending = $\`cat < \${fifo}\`.quiet().nothrow().then(r => r);
+            await fs.promises.writeFile(fifo, "hello\\n");
+            const r = await pending;
+            result = { text: r.stdout.toString(), exitCode: r.exitCode, stderr: r.stderr.toString() };
+            break;
+          }
+          case "external <": {
+            const pending = $\`\${cat} < \${fifo}\`.quiet().nothrow().then(r => r);
+            await fs.promises.writeFile(fifo, "hello\\n");
+            const r = await pending;
+            result = { text: r.stdout.toString(), exitCode: r.exitCode, stderr: r.stderr.toString() };
+            break;
+          }
+        }
+        console.log(JSON.stringify(result));
+      `;
+
+      for (const mode of ["builtin >", "external >", "builtin <", "external <"]) {
+        test.concurrent(
+          mode,
+          async () => {
+            using dir = tempDir("shell-fifo-open", { "fixture.ts": fixture });
+            const fifo = join(String(dir), "target.fifo");
+            await using mk = Bun.spawn({ cmd: [Bun.which("mkfifo")!, fifo], env: bunEnv });
+            expect(await mk.exited).toBe(0);
+
+            await using proc = Bun.spawn({
+              cmd: [bunExe(), "fixture.ts"],
+              cwd: String(dir),
+              env: { ...bunEnv, FIFO: fifo, MODE: mode },
+              stdout: "pipe",
+              stderr: "pipe",
+            });
+            // A blocked open never returns on its own: the child's main thread
+            // sits in open(2) and no partner ever arrives. Bound the wait.
+            const exited = await Promise.race([proc.exited, Bun.sleep(30_000).then(() => "hung" as const)]);
+            if (exited === "hung") {
+              proc.kill(9);
+              await proc.exited;
+            }
+            const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(stdout.trim().split("\n").pop() ?? "");
+            } catch {
+              parsed = stdout;
+            }
+            expect({ parsed, stderr, exited }).toEqual({
+              parsed: { text: "hello\n", exitCode: 0, stderr: "" },
+              stderr: expect.any(String),
+              exited: 0,
+            });
+          },
+          // Debug/ASAN child startup plus the 30s hang-detection race above.
+          60_000,
+        );
+      }
+    });
   });
 
   describe("writer queue and bump behavior", () => {

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -186,7 +186,8 @@ describe("IOWriter file output redirection", () => {
             await using proc = Bun.spawn({
               cmd: [bunExe(), "fixture.ts"],
               cwd: String(dir),
-              env: { ...bunEnv, FIFO: fifo, MODE: mode },
+              // `cat` is only a builtin on POSIX behind this flag.
+              env: { ...bunEnv, FIFO: fifo, MODE: mode, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
               stdout: "pipe",
               stderr: "pipe",
             });

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -139,47 +139,49 @@ describe("IOWriter file output redirection", () => {
         const mode = process.env.MODE!;
         const echo = Bun.which("echo")!;
         const cat = Bun.which("cat")!;
+        const read = () => fs.promises.readFile(fifo, "utf8");
+        const write = () => fs.promises.writeFile(fifo, "hello\\n").then(() => "");
+        const none = async () => "";
         // .then() starts the shell; the redirect open now waits for a partner.
-        let result;
+        let pending, partner;
         switch (mode) {
-          case "builtin >": {
-            const pending = $\`echo hello > \${fifo}\`.quiet().nothrow().then(r => r);
-            const text = await fs.promises.readFile(fifo, "utf8");
-            const r = await pending;
-            result = { text, exitCode: r.exitCode, stderr: r.stderr.toString() };
-            break;
-          }
-          case "external >": {
-            const pending = $\`\${echo} hello > \${fifo}\`.quiet().nothrow().then(r => r);
-            const text = await fs.promises.readFile(fifo, "utf8");
-            const r = await pending;
-            result = { text, exitCode: r.exitCode, stderr: r.stderr.toString() };
-            break;
-          }
-          case "builtin <": {
-            const pending = $\`cat < \${fifo}\`.quiet().nothrow().then(r => r);
-            await fs.promises.writeFile(fifo, "hello\\n");
-            const r = await pending;
-            result = { text: r.stdout.toString(), exitCode: r.exitCode, stderr: r.stderr.toString() };
-            break;
-          }
-          case "external <": {
-            const pending = $\`\${cat} < \${fifo}\`.quiet().nothrow().then(r => r);
-            await fs.promises.writeFile(fifo, "hello\\n");
-            const r = await pending;
-            result = { text: r.stdout.toString(), exitCode: r.exitCode, stderr: r.stderr.toString() };
-            break;
-          }
+          case "builtin >": pending = $\`echo hello > \${fifo}\`.quiet().nothrow().then(r => r); partner = read; break;
+          case "external >": pending = $\`\${echo} hello > \${fifo}\`.quiet().nothrow().then(r => r); partner = read; break;
+          case "builtin <": pending = $\`cat < \${fifo}\`.quiet().nothrow().then(r => r); partner = write; break;
+          case "external <": pending = $\`\${cat} < \${fifo}\`.quiet().nothrow().then(r => r); partner = write; break;
+          // The redirect is opened, then nothing uses it: the reader gets EOF.
+          case "no argv": pending = $\`$(true) > \${fifo}\`.quiet().nothrow().then(r => r); partner = read; break;
+          case "command not found": pending = $\`nosuchcmd_17261 > \${fifo}\`.quiet().nothrow().then(r => r); partner = read; break;
+          // The FIFO has mode 000: the pool open fails and the error is reported like an inline one.
+          case "open error": pending = $\`echo hello > \${fifo}\`.quiet().nothrow().then(r => r); partner = none; break;
         }
-        console.log(JSON.stringify(result));
+        const [text, r] = await Promise.all([partner(), pending]);
+        console.log(JSON.stringify({
+          text: mode.endsWith("<") ? r.stdout.toString() : text,
+          exitCode: r.exitCode,
+          stderr: r.stderr.toString(),
+        }));
       `;
 
-      // macOS reports no kqueue or poll readiness when the last writer of a
-      // FIFO closes, so the builtin `cat` never sees EOF there (node's
-      // process.stdin has the same gap). The external `cat` blocks in read(2)
-      // and does.
-      const modes = ["builtin >", "external >", "external <", ...(isLinux ? ["builtin <"] : [])];
-      for (const mode of modes) {
+      const ok = { text: "hello\n", exitCode: 0, stderr: "" };
+      const isRoot = process.getuid?.() === 0;
+      const cases: Record<string, { text: string; exitCode: number; stderr: string | ((fifo: string) => string) }> = {
+        "builtin >": ok,
+        "external >": ok,
+        "external <": ok,
+        // macOS reports no kqueue or poll readiness when the last writer of a
+        // FIFO closes, so the builtin `cat` never sees EOF there (node's
+        // process.stdin has the same gap). The external `cat` blocks in
+        // read(2) and does.
+        ...(isLinux ? { "builtin <": ok } : {}),
+        "no argv": { text: "", exitCode: 0, stderr: "" },
+        "command not found": { text: "", exitCode: 1, stderr: "bun: command not found: nosuchcmd_17261\n" },
+        // root opens a mode 000 FIFO without an error.
+        ...(isRoot
+          ? {}
+          : { "open error": { text: "", exitCode: 1, stderr: fifo => `bun: Permission denied: ${fifo}` } }),
+      };
+      for (const [mode, want] of Object.entries(cases)) {
         test.concurrent(
           mode,
           async () => {
@@ -187,6 +189,7 @@ describe("IOWriter file output redirection", () => {
             const fifo = join(String(dir), "target.fifo");
             await using mk = Bun.spawn({ cmd: [Bun.which("mkfifo")!, fifo], env: bunEnv });
             expect(await mk.exited).toBe(0);
+            if (mode === "open error") fs.chmodSync(fifo, 0o000);
 
             await using proc = Bun.spawn({
               cmd: [bunExe(), "fixture.ts"],
@@ -214,7 +217,7 @@ describe("IOWriter file output redirection", () => {
               parsed = stdout;
             }
             expect({ parsed, stderr, exited }).toEqual({
-              parsed: { text: "hello\n", exitCode: 0, stderr: "" },
+              parsed: { ...want, stderr: typeof want.stderr === "function" ? want.stderr(fifo) : want.stderr },
               stderr: "",
               exited: 0,
             });


### PR DESCRIPTION
### Problem
- `Bun.$` opens every file redirect target (`> path`, `>> path`, `2> path`, `< path`, `> ${Bun.file(path)}`) on the event-loop thread. `open(2)` on a FIFO blocks until the other end is opened, so `$\`echo x > fifo\`` freezes the whole process until another process opens the FIFO.
- The two sites are `Builtin::init_redirections` (`src/runtime/shell/Builtin.rs:589`) and `Cmd::init_subproc_redirections` (`src/runtime/shell/states/Cmd.rs:815`).
- Not changed here: the builtin `cat` opens its operands inline (`src/runtime/shell/builtin/cat.rs:200`), so `$\`cat fifo\`` still freezes. It is off on POSIX without `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`, and #35337, #39198 and #37743 rewrite that block. Follow-up once those land.

### Fix
- `Cmd` stats the expanded target before exec. A FIFO is opened by a new `ShellRedirectOpenTask` on the work pool. The state machine parks in `CmdState::OpeningRedirect` and resumes at `Exec` with the result in `Cmd::opened_redirect`.
- Both sites call `Cmd::open_redirect_target`, which returns that fd or does the inline `shell_openat` for every other target.
- The shell waits for the peer like bash. The sibling PRs for synchronous APIs fail fast instead: #37641 gives `Bun.spawn` stdio `ENXIO`, #37937 makes `cp` refuse a FIFO. A redirect is already asynchronous, so the wait fits.
- Verified: `test/js/bun/shell/file-io.test.ts`, `redirect to a FIFO does not block the event loop`: four rendezvous cases (hang on stock bun), the pool open failing with `EACCES`, and the fd going unused (`$(true) > fifo`, command not found). Also the rest of `test/js/bun/shell`.

### Background
- The shell interpreter is a state machine on the JS thread. A node returns `Yield::suspended()` to hand control to the event loop, and a callback resumes it with `Yield::Next(id).run(interp)`.
- `ShellTask` is the shell's thread-pool wrapper: `run_from_thread_pool` runs on a worker, then a `ConcurrentTask` brings `run_from_main_thread` back to the JS thread. `ShellCondExprStatTask` (the `[[ -f x ]]` stat) has the same shape.
- The poster a `ShellTask` takes is a VM `Ticket`. Teardown waits for every ticket and releases a late completion through `release_unrun`, so the task cannot reach a freed interpreter.

<details><summary>Notes</summary>

- Repro: `mkfifo /tmp/f && bun -e 'setInterval(() => console.log("tick"), 250); setTimeout(() => process.exit(0), 2000); Bun.$\`echo x > /tmp/f\`.quiet().nothrow().then(() => console.log("done"))'`. Stock 1.4.0: no output, the main thread sits in `openat(..., O_WRONLY|O_CREAT|O_TRUNC)` (kernel `fifo_open -> wait_for_partner`). Fixed: ticks, exit at 2 s.
- All seven redirect forms listed in the report go through the same two sites. `> ${Bun.file(path)}` is turned into a plain path by the template tag (`shell_body.rs:409`), so it is the `Atom` redirect.
- Why stat first instead of `O_NONBLOCK`: a write-side `O_NONBLOCK` open of a FIFO with no reader fails with `ENXIO`, and there is nothing to poll for a reader to appear. A read-side `O_NONBLOCK` open returns at once and the first `read` reports EOF before any writer shows up, which breaks `cat < fifo`. A blocking open on the pool keeps bash semantics. The extra `fstatat` is one syscall per file redirect.
- A FIFO open that never gets a peer holds its ticket, so `worker.terminate()` or a `BUN_DESTRUCT_VM_ON_EXIT=1` exit waits for it, the same as `fs.promises.readFile(fifo)` today. The default exit path does not wait. Before this change the same script could not reach `process.exit` at all.
- `ShellPromise` starts the script on `.then()`, not on construction. The test fixtures start the shell first and then open the other end from the same event loop (`fs.promises.readFile` / `writeFile`), which can only complete if that loop is still running.
- The `builtin <` case (`cat < fifo` with the experimental builtin) runs on Linux only. macOS reports no kqueue or poll readiness when the last writer of a FIFO closes, so the builtin `cat` never sees EOF there. Stock bun has the same hang, and so does `process.stdin` in node 26.3.0 on macOS. Tracked separately.
- The `open error` case is skipped as root, which opens a mode 000 FIFO without an error. Checked by hand as an unprivileged user: the pool error prints `bun: Permission denied: <fifo>`, the same text as the inline open of a file in an unwritable directory.
- `bun exec 'echo x > fifo'` (mini event loop) was checked by hand: works, the pool task posts back through the mini loop.
- Checked: `cargo check` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, `cargo clippy` and `cargo fmt` on the touched crates, `test/internal/source-lints`.
- Unrelated local failures with the debug build: `leak.test.ts` `memleak_Blob_*` (each iteration takes 1.5 s under ASAN, 100 iterations hit the 100 s timeout) and `ls` permission tests (the container runs as root). Both use in-memory Blob redirects or no redirect at all.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/file-io.test.ts

<!-- robobun:evidence:end -->