### PR TITLE
spawnSync: throw EMFILE when the isolated event loop cannot open its fds

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -241,7 +241,22 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
     loop->fd = kqueue();
 #endif
 
-    us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
+    /* EMFILE/ENFILE: hand the errno back to the caller instead of running
+     * with fd -1. */
+    if (loop->fd < 0) {
+        int saved_errno = errno;
+        us_free(loop);
+        errno = saved_errno;
+        return 0;
+    }
+
+    if (us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb)) {
+        int saved_errno = errno;
+        close(loop->fd);
+        us_free(loop);
+        errno = saved_errno;
+        return 0;
+    }
     return loop;
 }
 
@@ -786,10 +801,12 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
 
     int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (efd == -1) {
-        // eventfd only fails on EMFILE/ENFILE — the loop is unusable without
-        // wakeup_async, and the sole caller doesn't NULL-check. Crash loudly
-        // rather than NULL-deref or store -1 as a poll fd.
-        BUN_PANIC("eventfd() failed during loop init (out of file descriptors?)");
+        /* EMFILE/ENFILE. The poll was created with fallthrough, so it never
+         * counted in loop->num_polls: free it directly. */
+        int saved_errno = errno;
+        us_free(p);
+        errno = saved_errno;
+        return 0;
     }
     us_poll_init(p, efd, POLL_TYPE_CALLBACK);
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -180,10 +180,12 @@ void us_internal_group_maybe_unlink(struct us_socket_group_t *group);
  * SSL path calls _raw once it's actually time to drop the fd. */
 struct us_socket_t *us_internal_socket_close_raw(us_socket_r s, int code, void *reason);
 struct us_socket_t *us_internal_ssl_close(us_socket_r s, int code, void *reason);
-void us_internal_loop_data_init(struct us_loop_t *loop,
-                                void (*wakeup_cb)(us_loop_r loop),
-                                void (*pre_cb)(us_loop_r loop),
-                                void (*post_cb)(us_loop_r loop));
+/* Returns 0, or -1 with errno set when the wakeup async could not get its fd
+ * (EMFILE/ENFILE). Nothing stays allocated on failure. */
+int us_internal_loop_data_init(struct us_loop_t *loop,
+                               void (*wakeup_cb)(us_loop_r loop),
+                               void (*pre_cb)(us_loop_r loop),
+                               void (*post_cb)(us_loop_r loop));
 void us_internal_loop_data_free(us_loop_r loop);
 void us_internal_loop_pre(us_loop_r loop);
 void us_internal_loop_post(us_loop_r loop);
@@ -195,7 +197,8 @@ void us_nq_loop_drain(struct us_loop_t *loop);
 void us_nq_loop_register(struct us_loop_t *loop, struct us_nq_driver_s *d, void *owner);
 void us_nq_loop_unregister(struct us_loop_t *loop, struct us_nq_driver_s *d);
 
-/* Asyncs (old) */
+/* Asyncs (old). Returns 0 with errno set when the eventfd cannot be created
+ * (epoll only: EMFILE/ENFILE). */
 struct us_internal_async *us_internal_create_async(struct us_loop_t *loop,
                                                    int fallthrough,
                                                    unsigned int ext_size);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -575,7 +575,9 @@ void *us_ssl_get_session_sink_owner(struct ssl_st *ssl);
 
 /* Public interfaces for loops */
 
-/* Returns a new event loop with user data extension */
+/* Returns a new event loop with user data extension. On epoll/kqueue the loop
+ * needs one or two fds; returns NULL with errno set (EMFILE/ENFILE) when the
+ * process cannot open them. */
 struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(us_loop_r loop),
     void (*pre_cb)(us_loop_r loop), void (*post_cb)(us_loop_r loop), unsigned int ext_size);
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -121,7 +121,7 @@ void us_internal_sweep_if_due(struct us_loop_t *loop) {
 #endif
 
 
-void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
+int us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
     void (*pre_cb)(struct us_loop_t *loop), void (*post_cb)(struct us_loop_t *loop)) {
     // We allocate with calloc, so we only need to initialize the specific fields in use.
 #ifdef LIBUS_USE_LIBUV
@@ -138,12 +138,23 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     loop->data.pre_cb = pre_cb;
     loop->data.post_cb = post_cb;
     loop->data.wakeup_async = us_internal_create_async(loop, 1, 0);
+    if (!loop->data.wakeup_async) {
+        int saved_errno = errno;
+        us_free(loop->data.recv_buf);
+        us_free(loop->data.send_buf);
+#ifdef LIBUS_USE_LIBUV
+        us_timer_close(loop->data.sweep_timer, 0);
+#endif
+        errno = saved_errno;
+        return -1;
+    }
     us_internal_async_set(loop->data.wakeup_async, (void (*)(struct us_internal_async *)) wakeup_cb);
 #if ASSERT_ENABLED
     if (Bun__lock__size != sizeof(loop->data.mutex)) {
         BUN_PANIC("The size of the mutex must match the size of the lock");
     }
 #endif
+    return 0;
 }
 
 void us_internal_loop_data_free(struct us_loop_t *loop) {

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -26,6 +26,7 @@
 #include "AsyncSocket.h"
 
 extern "C" int bun_is_exiting();
+extern "C" void __attribute__((__noreturn__)) Bun__panic(const char *message, size_t length);
 
 namespace uWS {
 struct Loop {
@@ -83,8 +84,13 @@ private:
     }
 
     static Loop *create(void *hint) {
-        Loop *loop = ((Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData)))->init();
-        return loop;
+        us_loop_t *raw = us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData));
+        if (!raw) {
+            /* The thread's main loop: nothing can run on this thread without it. */
+            static const char message[] = "Failed to create the event loop (out of file descriptors?)";
+            Bun__panic(message, sizeof(message) - 1);
+        }
+        return ((Loop *) raw)->init();
     }
 
     /* What to do with loops created with existingNativeLoop? */

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -146,15 +146,22 @@ impl SpawnSyncEventLoop {
     // below, so `Self` MUST NOT move after `init` returns (no-move invariant
     // upheld by the caller). The caller provides uninitialized storage, hence
     // `MaybeUninit<Self>` (out-param ctor exception).
+    //
+    // Fails with the errno of the fd the loop could not open (EMFILE/ENFILE:
+    // the epoll/kqueue fd, or the eventfd on Linux). Nothing is written to
+    // `this` in that case.
     pub fn init(
         this: &mut core::mem::MaybeUninit<Self>,
         vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
-    ) {
-        // `uws::Loop::create` takes a `LoopHandler` impl with associated-const fn ptrs.
-        let loop_ = uws::Loop::create::<handler::Handler>();
-
-        let loop_ =
-            NonNull::new(loop_).expect("uws::Loop::create never returns null (asserts on OOM)");
+    ) -> bun_sys::Result<()> {
+        // `uws::Loop::try_create` takes a `LoopHandler` impl with associated-const fn ptrs.
+        let Some(loop_) = uws::Loop::try_create::<handler::Handler>() else {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            let tag = bun_sys::Tag::eventfd;
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
+            let tag = bun_sys::Tag::kqueue;
+            return Err(bun_sys::Error::from_code_int(bun_sys::last_errno(), tag));
+        };
 
         // Initialize the JSC EventLoop with empty state.
         // CRITICAL: On Windows, the impl stores our isolated loop pointer in `uws_loop`.
@@ -182,6 +189,7 @@ impl SpawnSyncEventLoop {
         let loop_data = &mut this.uws_loop_mut().internal_loop_data;
         loop_data.set_parent_raw(tag, ptr);
         loop_data.jsc_vm = core::ptr::null();
+        Ok(())
     }
 
     /// Erased `*mut bun_jsc::event_loop::EventLoop` (heap-owned via

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -731,7 +731,13 @@ impl RareData {
             .push(CleanupHook::from(global_this, ctx, func));
     }
 
-    pub fn spawn_sync_event_loop(&mut self, vm: &mut VirtualMachine) -> &mut SpawnSyncEventLoop {
+    /// Lazily creates the isolated spawnSync loop. The first call can fail
+    /// with EMFILE/ENFILE when the loop cannot open its fds; nothing is cached
+    /// then, so a later call retries.
+    pub fn spawn_sync_event_loop(
+        &mut self,
+        vm: &mut VirtualMachine,
+    ) -> bun_sys::Result<&mut SpawnSyncEventLoop> {
         if self.spawn_sync_event_loop_.is_none() {
             // In-place out-param init: `event_loop` inside captures the
             // `self` address, so the value must not move after init; allocate
@@ -740,11 +746,11 @@ impl RareData {
             SpawnSyncEventLoop::init(
                 &mut *boxed,
                 core::ptr::from_mut::<VirtualMachine>(vm).cast::<()>(),
-            );
+            )?;
             // SAFETY: `init` fully initialised the slot.
             self.spawn_sync_event_loop_ = Some(unsafe { boxed.assume_init() });
         }
-        self.spawn_sync_event_loop_.as_mut().unwrap()
+        Ok(self.spawn_sync_event_loop_.as_mut().unwrap())
     }
 
     // ── watch-mode listen sockets ─────────────────────────────────────────

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1094,9 +1094,14 @@ fn spawn_maybe_sync(
         // SAFETY: see note above; `spawn_sync_event_loop` re-borrows the
         // same VM via the raw pointer for its `vm` arg.
         unsafe {
-            let sync_loop = (*jsc_vm_ptr)
+            let sync_loop = match (*jsc_vm_ptr)
                 .rare_data()
-                .spawn_sync_event_loop(&mut *jsc_vm_ptr);
+                .spawn_sync_event_loop(&mut *jsc_vm_ptr)
+            {
+                Ok(sync_loop) => sync_loop,
+                // EMFILE/ENFILE: the isolated loop could not open its fds.
+                Err(err) => return Err(global_this.throw_value(err.to_js(global_this))),
+            };
             sync_loop.prepare(jsc_vm_ptr.cast());
             // `SpawnSyncEventLoop.event_loop` is type-erased to `*mut ()`
             // (bun_event_loop is below bun_jsc); the accessor returns the
@@ -1123,6 +1128,7 @@ fn spawn_maybe_sync(
                 (*jsc_vm_ptr_cleanup)
                     .rare_data()
                     .spawn_sync_event_loop(&mut *jsc_vm_ptr_cleanup)
+                    .expect("the spawn-sync loop was created before this guard was armed")
                     .cleanup(jsc_vm_ptr_cleanup.cast(), main_loop.cast());
             }
         }
@@ -1940,7 +1946,8 @@ fn spawn_maybe_sync(
         // SAFETY: jsc_vm_ptr is the live thread VM; re-borrowed for the nested arg.
         let sync_loop = unsafe { &mut *jsc_vm_ptr }
             .rare_data()
-            .spawn_sync_event_loop(unsafe { &mut *jsc_vm_ptr });
+            .spawn_sync_event_loop(unsafe { &mut *jsc_vm_ptr })
+            .expect("the spawn-sync loop was created before the process was spawned");
 
         while subprocess.compute_has_pending_activity() {
             // Re-evaluate this at each iteration of the loop since it may change between iterations.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1393,6 +1393,10 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    /// `eventfd(2)`. Also covers the `epoll_create1(2)` fd that a
+    /// `us_create_loop` needs right before it: C reports only "the loop
+    /// could not open its fds".
+    pub const eventfd: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1400,7 +1404,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1510,6 +1514,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "eventfd",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -9121,7 +9126,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
 pub fn eventfd(initval: u32, flags: i32) -> Maybe<Fd> {
     let rc = safe_libc::eventfd(initval, flags);
     if rc < 0 {
-        return Err(err_with(Tag::open));
+        return Err(err_with(Tag::eventfd));
     }
     Ok(Fd::from_native(rc))
 }

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -229,13 +229,15 @@ impl PosixLoop {
         unsafe { c::us_quic_loop_flush_if_pending(self) };
     }
 
-    pub fn create<H: LoopHandler>() -> *mut Loop {
+    /// Creates a new loop. The loop owns one epoll/kqueue fd plus, on Linux, an
+    /// eventfd for wakeups. Returns `None` with errno set (EMFILE/ENFILE) when
+    /// the process cannot open them.
+    pub fn try_create<H: LoopHandler>() -> Option<core::ptr::NonNull<Loop>> {
         // SAFETY: us_create_loop allocates and returns a new loop; null hint is valid
         let p = unsafe {
             c::us_create_loop(core::ptr::null_mut(), Some(H::WAKEUP), H::PRE, H::POST, 0)
         };
-        assert!(!p.is_null(), "us_create_loop returned null");
-        p
+        core::ptr::NonNull::new(p)
     }
 
     pub fn wakeup(&mut self) {
@@ -450,13 +452,14 @@ impl WindowsLoop {
         unsafe { c::us_quic_loop_flush_if_pending(self) };
     }
 
-    pub fn create<H: LoopHandler>() -> *mut WindowsLoop {
+    /// Creates a new loop on top of a fresh `uv_loop_t`. Returns `None` with
+    /// errno set if the loop could not be created.
+    pub fn try_create<H: LoopHandler>() -> Option<core::ptr::NonNull<WindowsLoop>> {
         // SAFETY: us_create_loop allocates and returns a new loop; null hint is valid
         let p = unsafe {
             c::us_create_loop(core::ptr::null_mut(), Some(H::WAKEUP), H::PRE, H::POST, 0)
         };
-        assert!(!p.is_null(), "us_create_loop returned null");
-        p
+        core::ptr::NonNull::new(p)
     }
 
     pub fn run(&mut self) {

--- a/test/js/bun/spawn/spawnsync-emfile.test.ts
+++ b/test/js/bun/spawn/spawnsync-emfile.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// The first spawnSync in a process creates its own isolated event loop. That
+// loop needs fds of its own (epoll + eventfd on Linux, kqueue on macOS). When
+// the process is at RLIMIT_NOFILE, loop creation used to abort the whole
+// process with "panic: eventfd() failed during loop init". An async Bun.spawn
+// at the same point already returned a plain EMFILE.
+//
+// The fixture walks the spare-fd count up from 0: every attempt must finish as
+// a thrown EMFILE or a clean exit, and the first attempt (zero spare fds) must
+// fail at the loop's own fd.
+test.skipIf(isWindows)("Bun.spawnSync at the fd limit throws EMFILE instead of aborting the process", async () => {
+  const fixture = `
+const fs = require("fs");
+const held = [];
+for (;;) {
+  try {
+    held.push(fs.openSync("/dev/null", "r"));
+  } catch {
+    break;
+  }
+}
+for (let spare = 0; spare <= 8; spare++) {
+  if (spare > 0) fs.closeSync(held.pop());
+  let result;
+  try {
+    const r = Bun.spawnSync(["/bin/echo", "hi"]);
+    result = "ok " + r.exitCode + " " + JSON.stringify(r.stdout.toString());
+  } catch (e) {
+    result = "err " + e.code + " " + e.syscall;
+  }
+  console.log(spare + ": " + result);
+}
+`;
+
+  await using proc = Bun.spawn({
+    cmd: ["/bin/sh", "-c", 'ulimit -n 64 && exec "$@"', "sh", bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines).toHaveLength(9);
+  expect(lines[0]).toMatch(/^0: err EMFILE (eventfd|kqueue)$/);
+  expect(lines.at(-1)).toBe('8: ok 0 "hi\\n"');
+  for (const line of lines) {
+    expect(line).toMatch(/^\d: (err EMFILE (eventfd|kqueue|socketpair|posix_spawn|pidfd_open)|ok 0 "hi\\n")$/);
+  }
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- The first `Bun.spawnSync` (or `child_process.execSync`/`spawnSync`) in a process that is at its fd limit aborts the whole process: `panic: eventfd() failed during loop init (out of file descriptors?)` plus the crash banner. An async `Bun.spawn` at the same point returns a plain `EMFILE`.
- `spawnSync` runs the child on an isolated uSockets loop. `us_create_loop` (`packages/bun-usockets/src/eventing/epoll_kqueue.c:222`) did not check `epoll_create1`, and `us_internal_create_async` called `BUN_PANIC` when `eventfd` failed.

### Fix
- `us_create_loop` returns NULL with errno set when the epoll/kqueue fd or the eventfd cannot be opened. It frees what it allocated. `us_internal_loop_data_init` and `us_internal_create_async` report the failure instead of panicking.
- `uws::Loop::try_create` replaces `create` and returns `Option`. `SpawnSyncEventLoop::init` and `RareData::spawn_sync_event_loop` return `bun_sys::Result`. `spawn_maybe_sync` throws the error, so JS sees `EMFILE: too many open files, eventfd` (`kqueue` on macOS). Nothing is cached on failure, so a later spawnSync retries.
- The thread's main loop (`uWS::Loop::create`) still panics when it cannot be created, now with a message that names the cause. Nothing can run on a thread without its loop.
- Verified: `test/js/bun/spawn/spawnsync-emfile.test.ts` (the fixture runs under `ulimit -n 64` and walks the spare-fd count from 0 to 8; stock bun aborts at 0 and 1). Also `spawnSync.test.ts`, `spawnsync-isolated-event-loop.test.ts`, `spawnsync-no-microtask-drain.test.ts`, `spawn-cgroup.test.ts`.

### Background
- uSockets (`packages/bun-usockets`) is the C event loop under Bun's sockets and subprocess pipes. A loop is an epoll or kqueue fd plus a wakeup mechanism: on Linux an eventfd, on kqueue a user event that needs no fd.
- spawnSync must not run JS timers or the main loop's callbacks while it blocks, so it creates a second loop once per process (`SpawnSyncEventLoop`) and swaps it in for the duration of the call.
- `bun_sys::Tag` is the frozen, append-only table of syscall names that become `err.syscall` in JS. This adds `eventfd` (108). The existing `bun_sys::eventfd` wrapper used `open` for its errors and now uses the new tag.

<details><summary>Notes</summary>

Repro (stock bun 1.4.0), from the resource-exhaustion fuzz ledger:

```sh
bash -c 'ulimit -n 64; exec bun -e "
const fs=require(\"fs\"); for(;;){try{fs.openSync(\"/dev/null\")}catch{break}}
require(\"child_process\").execSync(\"echo hi\")"'   # rc 134, panic: eventfd() failed during loop init
```

Sweep with the fix (Linux, debug build), spare fds from 0 to 8 with `Bun.spawnSync(["/bin/echo", "hi"])`:

```
0: err EMFILE eventfd
1: err EMFILE eventfd
2: err EMFILE socketpair
3: err EMFILE socketpair
4: err EMFILE socketpair
5: err EMFILE socketpair
6: err EMFILE posix_spawn
7: ok 0 "hi\n"
8: ok 0 "hi\n"
```

At 0 spare fds the failing call is `epoll_create1`, not `eventfd`. C hands back only "the loop could not open its fds", so both are reported under the `eventfd` tag. The `watch` tag folds `inotify_init1` and `inotify_add_watch` the same way.

Before this change `us_create_loop` stored `-1` as the epoll fd when `epoll_create1` failed and went on to the eventfd. The panic message named eventfd even when epoll was the first failure.

The libuv (Windows) `us_create_loop` is unchanged. Its `us_internal_create_async` never returns NULL, so the new `-1` branch in `us_internal_loop_data_init` is dead there.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawnsync-emfile.test.ts

<!-- robobun:evidence:end -->