### PR TITLE
test(serve-body-leak): cut the request volume and tighten the assertions

### DIFF
--- a/test/js/bun/http/body-leak-test-fixture.ts
+++ b/test/js/bun/http/body-leak-test-fixture.ts
@@ -1,39 +1,44 @@
-// RSS on darwin keeps freed-but-mapped (MADV_FREE_REUSABLE) pages, so it only reports
-// the high-water mark; memoryFootprint() is what the process actually retains.
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+import { rss, tls } from "harness";
 
-async function memoryUsage() {
-  Bun.gc(true);
-  await Bun.sleep(50);
-  return rss();
+// RSS only drops once the allocators hand freed pages back to the OS. Bun.gc(true) sweeps
+// the JS heap but leaves that to background scavengers that run tens to hundreds of ms
+// later, so a sample taken right after it still counts the previous batch's garbage.
+// Bun.shrink() queues a full GC plus a synchronous scavenge for the moment the VM goes
+// idle; yielding to the event loop runs it. Repeat until the reading stops falling.
+// Bun.shrink() also deletes all compiled code, so this belongs in a measurement fixture
+// like this one and not in the test runner's own VM.
+async function settledMemoryUsage(): Promise<number> {
+  let previous = Infinity;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    Bun.gc(true);
+    Bun.shrink();
+    await new Promise(resolve => setImmediate(resolve));
+    const current = rss();
+    if (current > previous - 1024 * 1024) {
+      return Math.min(current, previous);
+    }
+    previous = current;
+  }
+  return previous;
 }
+
+// Positive control for the test's leak detection: /retain keeps every body alive.
+const retainedBodies: Uint8Array[] = [];
 
 const http2 = process.argv.includes("--http2");
 const server = Bun.serve({
   port: 0,
   idleTimeout: 0,
-  ...(http2 ? { tls: require("harness").tls, http2: true } : {}),
+  ...(http2 ? { tls, http2: true } : {}),
   async fetch(req: Request) {
     const url = req.url;
     if (url.endsWith("/report")) {
-      return new Response(JSON.stringify(await memoryUsage()), {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      return Response.json(await settledMemoryUsage());
     } else if (url.endsWith("/heap-snapshot")) {
-      Bun.gc(true);
-      await Bun.sleep(10);
+      await settledMemoryUsage();
       require("v8").writeHeapSnapshot("/tmp/heap.heapsnapshot");
       console.log("Wrote heap snapshot to /tmp/heap.heapsnapshot");
-      return new Response(JSON.stringify(await memoryUsage()), {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      return Response.json(await settledMemoryUsage());
     }
     if (url.endsWith("/json-buffering")) {
       await req.json();
@@ -43,33 +48,34 @@ const server = Bun.serve({
       req.body;
       await req.text();
     } else if (url.endsWith("/streaming")) {
-      const reader = req.body.getReader();
-      while (reader) {
-        const { done, value } = await reader?.read();
+      const reader = req.body!.getReader();
+      while (true) {
+        const { done } = await reader.read();
         if (done) {
           break;
         }
       }
     } else if (url.endsWith("/incomplete-streaming")) {
-      const reader = req.body?.getReader();
-      await reader?.read();
+      await req.body!.getReader().read();
     } else if (url.endsWith("/streaming-echo")) {
       return new Response(req.body, {
         headers: {
           "Content-Type": "application/octet-stream",
         },
       });
+    } else if (url.endsWith("/retain")) {
+      retainedBodies.push(await req.bytes());
     }
     return new Response("Ok");
   },
 });
 console.log(server.url.href);
-process?.send?.(server.url.href);
+process.send?.(server.url.href);
 
+// Run directly (no IPC channel) to watch the server while driving it by hand.
 if (!process.send) {
-  setInterval(() => {
-    Bun.gc(true);
-    const rssMB = (rss() / 1024 / 1024) | 0;
+  setInterval(async () => {
+    const rssMB = ((await settledMemoryUsage()) / 1024 / 1024) | 0;
     console.log("RSS", rssMB, "MB");
     console.log("Active requests", server.pendingRequests);
 

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -4,150 +4,119 @@ import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { join } from "path";
 
 const payload = Buffer.alloc(512 * 1024, "1").toString("utf-8"); // decent size payload to test memory leak
-const batchSize = 40;
-// A leaked 512 KB body × totalCount would grow RSS by gigabytes; the assertions
-// below compare against O(100 MB), so the slower ASAN/debug lanes keep the same
-// margin with fewer iterations (each request is ~2-10× slower there).
-const baseCount = isASAN || isDebug ? 3_000 : 10_000;
-// The HTTP/2 pass repeats every scenario; 40% keeps the file inside its CI
-// budget while a leaked 512 KB body per request would still be gigabytes.
-let totalCount = baseCount;
 const zeroCopyPayload = new Blob([payload]);
 const zeroCopyJSONPayload = new Blob([JSON.stringify({ bun: payload })]);
 
-let fetchOptions: { protocol?: "http2"; tls?: { rejectUnauthorized: boolean } } = {};
-const fetch = (url: string | URL, init: RequestInit = {}) => globalThis.fetch(url, { ...fetchOptions, ...init });
+const concurrency = 40;
+// Each scenario sends requestCount requests and samples the fixture's settled RSS at
+// `checkpoints` evenly spaced points. Growth is measured from the first checkpoint, so it
+// covers the last 3/4 of the requests. Sizing: a retained 512 KB body per request grows RSS
+// by 360 MB (release) or 120 MB (ASAN/debug), and a retained 64 KB chunk per request by
+// 46 MB on release, where requests are cheap enough to afford the larger count.
+const requestCount = isASAN || isDebug ? 320 : 960;
+const checkpoints = 4;
+// Warmup requests per route: enough to JIT the handlers, grow the heap to its steady state
+// and, under ASAN, fill the free-memory quarantine before anything is measured.
+const warmupCount = 80;
+// Leak-free settled samples stay within a few MB when the fixture's scavenge reaches every
+// allocator: release builds link JSC against Bun's mimalloc, and ASAN builds get a 32 MB
+// quarantine below. A debug build without ASAN links JSC against libpas instead, so
+// Bun.shrink() cannot purge Bun-native mimalloc frees; those wait for the allocator's
+// 100 ms background purge, and a sample can still hold a batch of freed body buffers.
+const maxGrowthMB = isDebug && !isASAN ? 64 : 32;
+// Absolute bound on the settled RSS after a scenario: the release fixture sits near 50 MB,
+// the debug one near 110 MB and the ASAN one near 410 MB.
+const maxRssMB = isASAN ? 512 : 256;
 
-async function getMemoryUsage(url: URL): Promise<number> {
-  return (await fetch(`${url.origin}/report`).then(res => res.json())) as number;
-}
-
-async function warmup(url: URL) {
-  var remaining = totalCount;
-
-  while (remaining > 0) {
-    const batch = new Array(batchSize);
-    for (let j = 0; j < batchSize; j++) {
-      // warmup the server with streaming requests, because is the most memory intensive
-      batch[j] = fetch(`${url.origin}/streaming`, {
-        method: "POST",
-        body: zeroCopyPayload,
-      }).then(res => res.text());
-    }
-    await Promise.all(batch);
-    remaining -= batchSize;
-  }
-  // clean up memory before first test
-  await getMemoryUsage(url);
-}
-
-async function callBuffering(url: URL) {
-  const result = await fetch(`${url.origin}/buffering`, {
-    method: "POST",
-    body: zeroCopyPayload,
-  }).then(res => res.text());
-  expect(result).toBe("Ok");
-}
-async function callJSONBuffering(url: URL) {
-  const result = await fetch(`${url.origin}/json-buffering`, {
-    method: "POST",
+type Scenario = { name: string; path: string; body: Blob; expected: string };
+const scenarios: Scenario[] = [
+  { name: "#10265 should not leak memory when ignoring the body", path: "/", body: zeroCopyPayload, expected: "Ok" },
+  { name: "should not leak memory when buffering the body", path: "/buffering", body: zeroCopyPayload, expected: "Ok" },
+  {
+    name: "should not leak memory when buffering a JSON body",
+    path: "/json-buffering",
     body: zeroCopyJSONPayload,
-  }).then(res => res.text());
-  expect(result).toBe("Ok");
+    expected: "Ok",
+  },
+  {
+    name: "should not leak memory when buffering the body and accessing req.body",
+    path: "/buffering+body-getter",
+    body: zeroCopyPayload,
+    expected: "Ok",
+  },
+  { name: "should not leak memory when streaming the body", path: "/streaming", body: zeroCopyPayload, expected: "Ok" },
+  {
+    name: "should not leak memory when streaming the body incompletely",
+    path: "/incomplete-streaming",
+    body: zeroCopyPayload,
+    expected: "Ok",
+  },
+  {
+    name: "should not leak memory when streaming the body and echoing it back",
+    path: "/streaming-echo",
+    body: zeroCopyPayload,
+    expected: payload,
+  },
+];
+
+// The fixture server plus the fetch options that reach it (HTTP/2 runs over TLS with the
+// harness's self-signed certificate).
+type Target = { url: URL; fetchInit: RequestInit };
+
+async function getMemoryUsage({ url, fetchInit }: Target): Promise<number> {
+  const res = await fetch(new URL("/report", url), fetchInit);
+  expect(res.status).toBe(200);
+  return (await res.json()) as number;
 }
 
-async function callBufferingBodyGetter(url: URL) {
-  const result = await fetch(`${url.origin}/buffering+body-getter`, {
-    method: "POST",
-    body: zeroCopyPayload,
-  }).then(res => res.text());
-  expect(result).toBe("Ok");
-}
-async function callStreaming(url: URL) {
-  const result = await fetch(`${url.origin}/streaming`, {
-    method: "POST",
-    body: zeroCopyPayload,
-  }).then(res => res.text());
-  expect(result).toBe("Ok");
-}
-async function callIncompleteStreaming(url: URL) {
-  const result = await fetch(`${url.origin}/incomplete-streaming`, {
-    method: "POST",
-    body: zeroCopyPayload,
-  }).then(res => res.text());
-  expect(result).toBe("Ok");
-}
-async function callStreamingEcho(url: URL) {
-  const result = await fetch(`${url.origin}/streaming-echo`, {
-    method: "POST",
-    body: zeroCopyPayload,
-  }).then(res => res.text());
-  expect(result).toBe(payload);
-}
-async function callIgnore(url: URL) {
-  const result = await fetch(url, {
-    method: "POST",
-    body: zeroCopyPayload,
-  }).then(res => res.text());
-  expect(result).toBe("Ok");
-}
-
-async function calculateMemoryLeak(fn: (url: URL) => Promise<void>, url: URL) {
-  const start_memory = await getMemoryUsage(url);
-  const memory_examples: Array<number> = [];
-  let peak_memory = start_memory;
-
-  var remaining = totalCount;
-  while (remaining > 0) {
-    const batch = new Array(batchSize);
-    for (let j = 0; j < batchSize; j++) {
-      batch[j] = fn(url);
+async function sendRequests({ url, fetchInit }: Target, { path, body, expected }: Scenario, count: number) {
+  for (let remaining = count; remaining > 0; remaining -= concurrency) {
+    const batch = new Array(Math.min(concurrency, remaining));
+    for (let i = 0; i < batch.length; i++) {
+      batch[i] = fetch(new URL(path, url), { ...fetchInit, method: "POST", body }).then(async res => {
+        const text = await res.text();
+        expect(res.status).toBe(200);
+        expect(text.length).toBe(expected.length);
+        expect(text).toBe(expected);
+      });
     }
     await Promise.all(batch);
-    remaining -= batchSize;
-
-    // garbage collect and check memory usage every 1000 requests
-    if (remaining > 0 && remaining % 1000 === 0) {
-      const report = await getMemoryUsage(url);
-      if (report > peak_memory) {
-        peak_memory = report;
-      }
-      memory_examples.push(report);
-    }
   }
-
-  // wait for the last memory usage to be stable
-  const end_memory = await getMemoryUsage(url);
-  if (end_memory > peak_memory) {
-    peak_memory = end_memory;
-  }
-  // use first example as a reference if is a memory leak this should keep increasing and not be stable
-  const consumption = end_memory - memory_examples[0];
-  // memory leak in MB
-  const leak = Math.floor(consumption > 0 ? consumption / 1024 / 1024 : 0);
-  return { leak, start_memory, peak_memory, end_memory, memory_examples };
 }
 
-// Since the payload size is 512 KB
-// If it was leaking the body, the memory usage would be at least 512 KB * totalCount = multiple GB
-// If it ends up around 280 MB, it's probably not leaking the body.
-//
-// One fixture subprocess serves every scenario below: spawning a fresh one per
-// test (and re-running the 10k-request warmup each time) was the dominant cost
-// on ASAN. Sequential reuse keeps the RSS assertions meaningful because a real
-// body leak compounds across scenarios instead of being hidden by a restart.
+const toMB = (bytes: number) => Math.round(bytes / 1024 / 1024);
+
+async function measureMemoryGrowth(target: Target, scenario: Scenario, count: number) {
+  const startMB = toMB(await getMemoryUsage(target));
+  const samplesMB: number[] = [];
+  for (let i = 0; i < checkpoints; i++) {
+    await sendRequests(target, scenario, count / checkpoints);
+    samplesMB.push(toMB(await getMemoryUsage(target)));
+  }
+  // The first checkpoint is the baseline so that a one-time step (heap growth, allocator
+  // arenas, the ASAN quarantine) while the scenario ramps up is not mistaken for a leak.
+  // A per-request leak keeps every later checkpoint above it.
+  const growthMB = Math.max(...samplesMB.slice(1)) - samplesMB[0];
+  return { growthMB, startMB, endMB: samplesMB[samplesMB.length - 1], samplesMB };
+}
+
+// One fixture subprocess serves every scenario: a real body leak compounds across them
+// instead of being hidden by a restart, and the warmup runs once.
 describe.each([false, true])("request body leak (http2: %p)", http2 => {
   let fixture: Subprocess;
-  let url: URL;
+  let target: Target;
 
   beforeAll(async () => {
-    fetchOptions = http2 ? { protocol: "http2", tls: { rejectUnauthorized: false } } : {};
-    totalCount = http2 ? baseCount * 0.4 : baseCount;
     const defer = Promise.withResolvers<string>();
     fixture = Bun.spawn(
       [bunExe(), "--smol", join(import.meta.dirname, "body-leak-test-fixture.ts"), ...(http2 ? ["--http2"] : [])],
       {
-        env: bunEnv,
+        env: {
+          ...bunEnv,
+          // ASAN parks freed allocations in a 256 MB quarantine, so the fixture's RSS would
+          // track the quarantine instead of live memory. Cap it like fetch-leak.test.ts does.
+          ...(isASAN && { ASAN_OPTIONS: `${bunEnv.ASAN_OPTIONS ?? ""}:quarantine_size_mb=32`.replace(/^:/, "") }),
+        },
         stdout: "inherit",
         stderr: "inherit",
         stdin: "ignore",
@@ -157,8 +126,13 @@ describe.each([false, true])("request body leak (http2: %p)", http2 => {
       },
     );
     fixture.exited.then(code => defer.reject(new Error(`body-leak fixture exited (${code}) before sending its URL`)));
-    url = new URL(await defer.promise);
-    await warmup(url);
+    target = {
+      url: new URL(await defer.promise),
+      fetchInit: http2 ? { protocol: "http2", tls: { rejectUnauthorized: false } } : {},
+    };
+    for (const scenario of scenarios) {
+      await sendRequests(target, scenario, warmupCount);
+    }
   }, 60_000);
 
   afterAll(async () => {
@@ -166,38 +140,36 @@ describe.each([false, true])("request body leak (http2: %p)", http2 => {
     await fixture?.exited;
   });
 
-  for (const test_info of [
-    ["#10265 should not leak memory when ignoring the body", callIgnore, 64],
-    ["should not leak memory when buffering the body", callBuffering, 64],
-    ["should not leak memory when buffering a JSON body", callJSONBuffering, 64],
-    ["should not leak memory when buffering the body and accessing req.body", callBufferingBodyGetter, 64],
-    ["should not leak memory when streaming the body", callStreaming, 64],
-    ["should not leak memory when streaming the body incompletely", callIncompleteStreaming, 64],
-    ["should not leak memory when streaming the body and echoing it back", callStreamingEcho, 64],
-  ] as const) {
-    const [testName, fn, maxMemoryGrowth] = test_info;
+  for (const scenario of scenarios) {
     it(
-      testName,
+      scenario.name,
       async () => {
         // fail fast with the exit code instead of a ConnectionRefused cascade if a prior scenario crashed the fixture
         expect(fixture.exitCode ?? fixture.signalCode).toBeNull();
-        const report = await calculateMemoryLeak(fn, url);
-        console.log(report);
-        // Samples are taken between batches, so up to one batch of in-flight bodies plus
-        // not-yet-purged garbage may be counted; a leaked 512 KB body per request would blow
-        // past this by an order of magnitude.
-        expect(report.peak_memory - report.start_memory).toBeLessThan(256 * 1024 * 1024);
-        // acceptable memory leak
-        expect(report.leak).toBeLessThanOrEqual(maxMemoryGrowth);
-        // ASAN quarantine + debug-assertions instrumentation inflate RSS;
-        // give the asan lane more headroom than a plain release build. The
-        // http2 variant also runs TLS, which adds ~200 MB of baseline under ASAN.
-        const ceilingMB = (isASAN ? 768 : 512) + (http2 ? 256 : 0);
-        expect(report.end_memory).toBeLessThanOrEqual(ceilingMB * 1024 * 1024);
+        const report = await measureMemoryGrowth(target, scenario, requestCount);
+        console.log(scenario.path, report);
+        expect(report.growthMB).toBeLessThanOrEqual(maxGrowthMB);
+        expect(report.endMB).toBeLessThanOrEqual(maxRssMB);
       },
-      isDebug || isASAN ? 60_000 : 40_000,
+      isDebug || isASAN ? 60_000 : 30_000,
     );
   }
+
+  // Positive control: the fixture keeps every body it receives on this route, which is the
+  // leak the scenarios above guard against, so the same measurement must flag it. 360 bodies
+  // are retained after the first checkpoint (180 MB). It runs last because they stay
+  // resident until the fixture exits.
+  it(
+    "detects a retained body",
+    async () => {
+      expect(fixture.exitCode ?? fixture.signalCode).toBeNull();
+      const scenario = { name: "retain", path: "/retain", body: zeroCopyPayload, expected: "Ok" };
+      const report = await measureMemoryGrowth(target, scenario, 480);
+      console.log(scenario.path, report);
+      expect(report.growthMB).toBeGreaterThan(maxGrowthMB);
+    },
+    isDebug || isASAN ? 60_000 : 30_000,
+  );
 });
 
 // A client disconnecting while a direct response stream is suspended inside pull() must not


### PR DESCRIPTION
### Problem
- `serve-body-leak.test.ts` took 55 s on Windows 11 aarch64 and 26 to 47 s elsewhere (build #103422): 80,000 requests of 512 KB. #40137 then added an HTTP/2 pass, and main now takes 46 s on Linux release and 190 s on debug+ASAN here.
- The volume hides a noisy measurement. The fixture read RSS 50 ms after `Bun.gc(true)`, but freed memory leaves RSS only when background scavengers run, 100 ms or more later. Leak-free samples swung by 50 MB, and scenarios fail from that noise alone (streaming: leak 66 and 70 on Linux; incomplete-streaming: leak 75 on Linux, 84 on Windows).

### Fix
- The fixture reports a settled RSS: `Bun.gc(true)` plus `Bun.shrink()`, repeated until the reading stops falling. Under ASAN the fixture gets a 32 MB quarantine, as `fetch-leak.test.ts` does. Leak-free samples now stay within 3 MB on every build.
- Each scenario sends 960 requests (320 on ASAN/debug) with 4 checkpoints, growth measured from the first. A retained 512 KB body per request grows RSS by 360 MB (120 MB on ASAN/debug) against a 32 MB threshold. On release a retained 64 KB chunk per request (46 MB) trips it too. The HTTP/2 pass runs the same scenarios with the same counts.
- Every response is checked for status 200 and the exact body. A positive control route, `/retain`, keeps every body alive and asserts the same measurement flags it (180 MB on every build, over both protocols).
- Verified on this machine, both passes: Linux release 45.8 s to 6.8 s, `bun bd test test/js/bun/http/serve-body-leak.test.ts` 189.8 s to 53.7 s. Before the HTTP/2 pass existed: Windows x64 41.7 s to 3.3 s, Windows 11 aarch64 54.8 s to 3.8 s, release-asan 33.5 s to 9.5 s. Supersedes #35265.

### Background
- RSS counts freed memory until the allocator returns the pages to the OS. Bun's mimalloc does that from a background thread after a 100 ms purge delay. JSC's allocator has its own scavenger thread.
- `Bun.shrink()` is JSC's `shrinkFootprintWhenIdle`: once the running JS returns to the event loop it runs a full GC, deletes compiled code, and scavenges synchronously. Release builds link JSC against Bun's mimalloc, so the scavenge reaches every freed page.
- ASAN parks freed memory in a 256 MB quarantine that drains to 90% when full, so RSS moves by about 26 MB with no leak.

<details><summary>Notes</summary>

**Why the old samples were noisy.** Probing the fixture after a batch with `Bun.gc(true)` and polling RSS every 5 ms: the drop arrives anywhere between 10 and 100+ ms later, and sometimes not within 150 ms (incomplete-streaming settled at 72 MB vs 40 MB). With `Bun.shrink()` and one event-loop yield, the drop is in the first poll every time. `Bun.gc(true)` calls `mi_collect(false)` before the collection, so the memory that collection frees is left to the 100 ms purge delay of the mimalloc scavenger thread (`vendor/mimalloc/src/scavenger.c`); JSC-side memory waits for bmalloc's scavenger. `VM::shrinkFootprintWhenIdle` (`vendor/WebKit/Source/JavaScriptCore/runtime/VM.cpp`) runs `deleteAllCode`, `collectNow(Sync, Full)` and `WTF::releaseFastMallocFreeMemory()` once the outermost entry scope pops, which the `setImmediate` yield in the fixture guarantees. The release WebKit prebuilt is built with `USE_MIMALLOC` and `USE_EXTERNAL_MIMALLOC`, so that scavenge is `mi_collect(true)` on Bun's own mimalloc and purges Bun-native frees as well. The debug and ASAN prebuilts use libpas, so there it reaches the JSC side only.

**Why the helper stays in the fixture.** `Bun.shrink()` deletes all compiled code, so it is for a measurement child, not the test runner's VM. The fixture comment says so.

**Baseline runs before the rebase (main without the HTTP/2 pass, this machine).** Linux release `USE_SYSTEM_BUN=1`: 36.7 s, 7 pass 1 fail (incomplete-streaming, leak 75 > 64, samples `[52, 80, 82, 103, 60, 66, 72, 56, 146]` MB). Linux debug+ASAN `bun bd test`: 99.7 s, 8 pass, end_memory up to 753 MB against the 768 MB bound. Linux release-asan: 33.5 s, 7 pass 1 fail (streaming, leak 70). Windows x64 release (canary 1.4.1): 41.7 s, 7 pass 1 fail (incomplete-streaming, leak 84). Windows 11 aarch64 release (canary 1.4.1): 54.8 s, 8 pass.

**Runs after the rebase onto #40137 (HTTP/1.1 and HTTP/2 passes, 17 tests).** Main on this machine: Linux release 45.8 s with the streaming scenario failing at leak 66, debug+ASAN 189.8 s. This PR: Linux release 6.73 to 6.89 s over 3 runs, growth between -5 and 3 MB, controls 179 to 183 MB; debug+ASAN 53.7 s, growth between -21 and 7 MB, controls 185 MB (HTTP/1.1) and 169 MB (HTTP/2). The HTTP/2 fixture settles near 450 MB under debug+ASAN.

**Runs before the rebase (HTTP/1.1 pass only, 9 tests).** Linux release: 3.02 to 3.17 s over 5 runs, per-scenario growth between -1 and 2 MB, control 180 to 181 MB. Linux debug+ASAN: 25.5 s, growth between -1 and 10 MB, control 186 MB, RSS 408 to 415 MB. Linux release-asan: 9.5 s over 2 runs, growth between -2 and 5 MB, control 185 MB, RSS near 297 MB. Linux debug without ASAN (`bun bd --asan=off`): 15.8 s over 2 runs, growth between -6 and 3 MB (one earlier run read 18 MB on one sample, see below), control 183 MB. Windows x64: 3.21 to 3.38 s over 3 runs, growth 0 to 1 MB, control 181 MB. Windows 11 aarch64: 3.73 to 3.85 s over 3 runs, growth 0 to 1 MB, control 180 MB.

**Leaks each scenario guards.** #10268 (issue #10265) fixed a server that kept the whole body of a request the handler never read, and added the ignore, buffering, streaming, incomplete-streaming and echo scenarios. #13704 fixed a leak of the body buffered through `req.body` before `req.text()` and added the body-getter scenario. #14191 added the `req.json()` scenario. All of these are body-sized (512 KB per request) leaks; the `/retain` control reproduces that class and measures 180 MB on every build, 1:1 with the retained bytes.

**ASAN.** With the default 256 MB quarantine the settled readings oscillated by up to 27 MB (the quarantine recycles down to 90% when it fills) and a retained body showed up as 0.6 to 0.9 of its size while freed regions were released on the allocator's 5 s interval; the fixture plateaued near 600 MB. With `quarantine_size_mb=32` (the cap `test/js/web/fetch/fetch-leak.test.ts` already uses for its fixtures) the readings stay within 3 MB, the control reads 185 MB, and the plateau is 300 MB (release-asan) or 410 MB (debug). The cap only shortens how long freed memory is held for use-after-free detection; the scenarios still run under ASAN.

**Debug without ASAN.** JSC uses libpas there, so `Bun.shrink()` does not purge Bun-native mimalloc frees and a sample can include up to a batch of freed body buffers (one run read +18 MB on one checkpoint). That build gets a 64 MB growth threshold. `MIMALLOC_PURGE_DELAY=0` for the fixture would remove the effect but costs about 24% of the fixture's throughput on release, where it is not needed, so it was not used.

**Scenarios.** All seven routes exercise distinct body consumption paths (ignored, `text()`, `json()`, `body` getter then `text()`, reader drain, partial read, pipe to a Response), so none is a subset of another and none was dropped. Running scenarios concurrently would mix their RSS, and two fixtures only cut 10% (release) to 36% (debug) of the request time in a probe, so they stay sequential on one fixture. Batch size 16 to 80 made no difference to throughput.

**Unchanged.** The direct-stream abort test keeps its `Bun.sleep(20)` before exit: it is a one-time 20 ms in a child whose measurement is LeakSanitizer's exit report (50 ms on release, 4 to 5 s on ASAN for two child processes).

**Relation to #35265 and #39660.** #35265 moves the warmup to incomplete-streaming and baselines against the median sample to absorb the same noise. This PR removes the noise at the source, warms every route, and rewrites the same lines, so the two conflict and this one supersedes it. #39660 appends LSan cases to this test file and merges clean with this PR.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-body-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-body-leak.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/serve-body-leak.test.ts:
http://localhost:39569/
/ {
  growthMB: 1,
  startMB: 401,
  endMB: 402,
  samplesMB: [ 401, 402, 402, 402 ],
}
(pass) request body leak (http2: false) > #10265 should not leak memory when ignoring the body [1528.09ms]
/buffering {
  growthMB: 6,
  startMB: 402,
  endMB: 413,
  samplesMB: [ 407, 407, 409, 413 ],
}
(pass) request body leak (http2: false) > should not leak memory when buffering the body [1946.95ms]
/json-buffering {
  growthMB: -5,
  startMB: 413,
  endMB: 413,
  samplesMB: [ 419, 414, 413, 413 ],
}
(pass) request body leak (http2: false) > should not leak memory when buffering a JSON body [4870.99ms]
/buffering+body-getter {
  growthMB: 2,
  startMB: 415,
  endMB: 403,
  samplesMB: [ 405, 407, 403, 403 ],
}
(pass) request body leak (http2: false) > should not leak memory when buffering the body and accessing req.body [2142.39ms]
/streaming {
  growthMB: 3,
  startMB: 403,
  endMB: 407,
  samplesMB: [ 404, 405, 404, 407 ],
}
(pass) request body leak (http2: false) > should not leak memory when streaming the body [2357.00ms]
/incomplete-streaming {
  growthMB: 0,
  startMB: 407,
  endMB: 405,
  samplesMB: [ 407, 407, 405, 405 ],
}
(pass) request body leak (http2: false) > should not leak memory when streaming the body incompletely [2115.83ms]
/streaming-echo {
  growthMB: 1,
  startMB: 405,
  endMB: 406,
  samplesMB: [ 405, 405, 406, 406 ],
}
(pass) request body leak (http2: false) > should not leak memory when streaming the body and echoing it back [1548.10ms]
/retain {
  growthMB: 183,
  startMB: 406,
  endMB: 636,
  samplesMB: [ 453, 513, 575, 636 ],
}
(pass) request body leak (http2: false) > detects a retained body [1826.49ms]
https://localhost:46231/
/ {
  growthMB: 1,
  startMB: 452,
  endMB: 451,
  samplesMB: [ 450, 450, 450, 451 ],
}
(pass) req
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/body-leak-test-fixture.ts |  70 ++++----
 test/js/bun/http/serve-body-leak.test.ts   | 266 +++++++++++++----------------
 2 files changed, 157 insertions(+), 179 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/js/bun/http/body-leak-test-fixture.ts      1      4      0
test/js/bun/http/serve-body-leak.test.ts        6      7      0
```

</details>

<!-- robobun:evidence:end -->
