### PR TITLE
test(bake): remove the fixed 1s overlay poll from the dev server harness

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -290,6 +290,8 @@ export class Dev extends EventEmitter {
     const initWait = this.#waitForSyncEvent(WatchSynchronization.Started);
     this.socket!.send("H");
     await initWait;
+    // An ack a client still owes for an earlier build must not count for this batch.
+    await Promise.all([...this.connectedClients].map(client => client.drainAcks()));
 
     let hasSeenFiles = true;
     let seenFiles: PromiseWithResolvers<void>;
@@ -488,8 +490,7 @@ export class Dev extends EventEmitter {
         // failure surfaces at the dev.write() call instead of timing out.
         const exitHandler = (code: number | string) => {
           cleanup();
-          const mapped = exitCodeMapStrings[code];
-          reject(new Error(`Client exited while applying hot update${mapped ? `: ${mapped}` : ` (${code})`}`));
+          reject(clientExitedWhile("applying hot update", code));
         };
         client.on("received-hmr-event", socketEventHandler);
         client.on("exit", exitHandler);
@@ -547,7 +548,7 @@ export class Dev extends EventEmitter {
       this.output.on("panic", onPanic);
       if (this.nodeEnv === "development") {
         try {
-          await client.output.waitForLine(hmrClientInitRegex);
+          await client.waitForPageLoad();
         } catch (e) {
           this.output.off("panic", onPanic);
           try {
@@ -818,6 +819,11 @@ expect(node, "test will fail if this is not node").not.toBe(process.execPath);
 
 const danglingProcesses = new Set<Subprocess>();
 
+function clientExitedWhile(activity: string, code: number | string): Error {
+  const reason = exitCodeMapStrings[code];
+  return new Error(`Client exited while ${activity}${reason ? `: ${reason}` : ` (${code})`}`);
+}
+
 /**
  * Controls a subprocess that uses happy-dom as a lightweight browser. It is
  * sandboxed in a separate process because happy-dom is a terrible mess to work
@@ -834,6 +840,8 @@ export class Client extends EventEmitter {
   expectingReload = false;
   hmr = false;
   webSocketMessagesAllowed = true;
+  /** Every `received-hmr-event` ack so far, counted before any listener runs. */
+  acksReceived = 0;
 
   constructor(
     url: string,
@@ -855,6 +863,7 @@ export class Client extends EventEmitter {
       env: bunEnv,
       serialization: "json",
       ipc: (message, subprocess) => {
+        if (message.type === "received-hmr-event") this.acksReceived++;
         this.emit(message.type, ...message.args);
       },
       onExit: (subprocess, exitCode, signalCode, error) => {
@@ -892,11 +901,109 @@ export class Client extends EventEmitter {
     return withAnnotatedStack(snapshotCallerLocation(), async () => {
       await maybeWaitInteractive("hard-reload");
       if (this.exited) throw new Error("Client is not running.");
+      if (!this.hmr) {
+        this.#proc.send({ type: "hard-reload" });
+        return;
+      }
+      await this.drainAcks();
+      const loaded = this.waitForPageLoad();
       this.#proc.send({ type: "hard-reload" });
+      await loaded;
+      await this.expectErrorOverlay(options.errors ?? []);
+    });
+  }
 
-      if (this.hmr) {
-        await this.output.waitForLine(hmrClientInitRegex);
-        await this.expectErrorOverlay(options.errors ?? []);
+  /**
+   * Resolves once the page that is loading has connected its HMR socket and
+   * the fixture has acked the load, which it does after every stylesheet is
+   * loaded. Register it before the load starts.
+   */
+  async waitForPageLoad(): Promise<void> {
+    const acked = this.#nextAck("loading the page", (isWindows ? 10_000 : 5_000) * WAIT_MULTIPLIER);
+    await Promise.all([this.output.waitForLine(hmrClientInitRegex), acked]);
+  }
+
+  /**
+   * Resolves once every ack the client still owes for builds that are already
+   * done has arrived, so none of them counts for the batch that starts next.
+   * The server also publishes to clients outside a batch: a fetch that
+   * re-bundles a failing route, or a page load that bundles a new route.
+   */
+  async drainAcks(): Promise<void> {
+    // A production page has no HMR socket and never acks.
+    if (!this.hmr) return;
+    // The fixture answers with every ack it has sent or still owes. Acks are
+    // counted as they arrive, so one that lands before this continuation runs
+    // is not lost.
+    const target = await this.#request<number>("ping", "pong", [], "draining its acks");
+    while (this.acksReceived < target) {
+      await this.#nextAck("draining its acks");
+    }
+  }
+
+  /** The next `received-hmr-event` ack. Rejects if the client exits or the timeout passes first. */
+  #nextAck(waitingFor: string, timeout = 2000 * WAIT_MULTIPLIER): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (this.exited) return reject(clientExitedWhile(waitingFor, this.exitCode ?? "unknown"));
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.off("received-hmr-event", onAck);
+        this.off("exit", onExit);
+      };
+      const onAck = () => {
+        cleanup();
+        resolve();
+      };
+      const onExit = (code: number | string) => {
+        cleanup();
+        reject(clientExitedWhile(waitingFor, code));
+      };
+      const timer = setTimeout(
+        () => {
+          cleanup();
+          reject(new Error(`Timeout waiting for the client's ack while ${waitingFor}`));
+        },
+        interactive ? interactive_timeout : timeout,
+      );
+      this.once("received-hmr-event", onAck);
+      this.once("exit", onExit);
+    });
+  }
+
+  /** Sends a request to client-fixture.mjs and returns its reply. Rejects if the client exits first. */
+  #request<T>(type: string, replyType: string, args: unknown[], waitingFor: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      if (this.exited) return reject(new Error("Client is not running."));
+      const messageId = Math.random().toString(36).slice(2);
+      const replyEvent = `${replyType}-${messageId}`;
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.off(replyEvent, onReply);
+        this.off("exit", onExit);
+      };
+      const onReply = (result: { value?: T; error?: string }) => {
+        cleanup();
+        if (result.error) reject(new Error(result.error));
+        else resolve(result.value as T);
+      };
+      const onExit = (code: number | string) => {
+        cleanup();
+        reject(clientExitedWhile(waitingFor, code));
+      };
+      const timer = setTimeout(
+        () => {
+          cleanup();
+          reject(new Error(`Timeout waiting for the client while ${waitingFor}`));
+        },
+        interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER,
+      );
+      this.once(replyEvent, onReply);
+      this.once("exit", onExit);
+      try {
+        this.#proc.send({ type, args: [messageId, ...args] });
+      } catch (e) {
+        cleanup();
+        reject(e);
       }
     });
   }
@@ -913,6 +1020,25 @@ export class Client extends EventEmitter {
     });
   }
 
+  /**
+   * Waits until the element's innerHTML is `text`. For DOM that a framework
+   * commits in a later task than the update the client acked.
+   */
+  expectElemText(selector: string, text: string): Promise<void> {
+    return withAnnotatedStack(snapshotCallerLocation(), async () => {
+      const last = await this.js<string | null>`
+        const deadline = Date.now() + ${interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER};
+        let last = document.querySelector(${selector})?.innerHTML ?? null;
+        while (last !== ${text} && Date.now() < deadline) {
+          await new Promise(resolve => setTimeout(resolve, 10));
+          last = document.querySelector(${selector})?.innerHTML ?? null;
+        }
+        return last;
+      `;
+      expect(last).toBe(text);
+    });
+  }
+
   elemsText(selector: string): Promise<string[]> {
     return withAnnotatedStack(snapshotCallerLocation(), async () => {
       const elems = await this.js<
@@ -926,11 +1052,15 @@ export class Client extends EventEmitter {
     if (activeClient === this) {
       activeClient = null;
     }
+    const wasRunning = this.#proc.exitCode === null && this.#proc.signalCode === null;
     try {
       this.#proc.send({ type: "exit" });
     } catch (e) {}
     await this.#proc.exited;
-    if (this.exitCode !== null && this.exitCode !== "0") {
+    // `exited` settles before `onExit` runs. Wait for it so `exitCode` is set
+    // and the `exit` listeners have removed this client from `connectedClients`.
+    if (!this.exited) await EventEmitter.once(this, "exit");
+    if (this.exitCode !== 0 && !(await this.#abortedInTeardown(wasRunning))) {
       let code;
       if (exitCodeMapStrings[this.exitCode]) {
         code = ": " + JSON.stringify(exitCodeMapStrings[this.exitCode]);
@@ -943,6 +1073,18 @@ export class Client extends EventEmitter {
       throw new Error(`Client sent ${this.messages.length} unread messages: ${JSON.stringify(this.messages, null, 2)}`);
     }
     this.output[Symbol.dispose]();
+  }
+
+  /**
+   * Node on Windows sometimes aborts inside its own teardown after the exit the
+   * harness requested (a `uv_async_send` on a closing handle). The fixture never
+   * exits with 3 or 9 itself, so that abort is a clean exit.
+   */
+  async #abortedInTeardown(exitWasRequested: boolean): Promise<boolean> {
+    if (!isWindows || !exitWasRequested || (this.exitCode !== 3 && this.exitCode !== 9)) return false;
+    // The assertion is on stderr; let both pipes drain before reading the lines.
+    if (this.output.closes < 2) await EventEmitter.once(this.output, "close");
+    return this.output.lines.some(line => line.includes("UV_HANDLE_CLOSING"));
   }
 
   expectReload(cb: () => Promise<void>) {
@@ -1046,59 +1188,37 @@ export class Client extends EventEmitter {
   expectErrorOverlay(errors: ErrorSpec[], caller: string | null = null) {
     return withAnnotatedStack(caller ?? snapshotCallerLocationMayFail(), async () => {
       this.suppressInteractivePrompt = true;
-      let retries = 0;
-      let hasVisibleModal = false;
-      while (retries < 5) {
-        hasVisibleModal = await this.js`document.querySelector("bun-hmr")?.style.display === "block"`;
-        if (hasVisibleModal) break;
-        await Bun.sleep(200);
-        retries++;
+      let hasVisibleModal: boolean;
+      try {
+        hasVisibleModal = await this.#hasVisibleErrorOverlay();
+        // A build error is on the page before the signals the harness awaits: the
+        // served HTML on a page load, or the "e" message that precedes the update
+        // ack. Only a runtime error reaches the overlay later (after a report
+        // round trip), so poll only while an expected error has not shown up yet.
+        const deadline = Date.now() + 1000 * WAIT_MULTIPLIER;
+        while (errors.length > 0 && !hasVisibleModal && Date.now() < deadline) {
+          await Bun.sleep(200);
+          hasVisibleModal = await this.#hasVisibleErrorOverlay();
+        }
+      } finally {
+        this.suppressInteractivePrompt = false;
       }
-      this.suppressInteractivePrompt = false;
-      if (errors && errors.length > 0) {
-        if (!hasVisibleModal) {
-          await maybeWaitInteractive("expectErrorOverlay");
-          throw new Error("Expected errors, but none found");
-        }
-
-        // Create unique message ID for this evaluation
-        const messageId = Math.random().toString(36).slice(2);
-
-        // Send the evaluation request and wait for response
-        this.#proc.send({
-          type: "get-errors",
-          args: [messageId],
-        });
-
-        const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
-
-        if (result.error) {
-          throw new Error(result.error);
-        }
-        const actualErrors = result.value;
-        const expectedErrors = [...errors].sort();
-        expect(actualErrors).toEqual(expectedErrors);
-      } else {
-        if (hasVisibleModal) {
-          // Create unique message ID for this evaluation
-          const messageId = Math.random().toString(36).slice(2);
-
-          // Send the evaluation request and wait for response
-          this.#proc.send({
-            type: "get-errors",
-            args: [messageId],
-          });
-
-          const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
-
-          if (result.error) {
-            throw new Error(result.error);
-          }
-          const actualErrors = result.value;
-          expect(actualErrors).toEqual([]);
-        }
+      if (!hasVisibleModal) {
+        if (errors.length === 0) return;
+        await maybeWaitInteractive("expectErrorOverlay");
+        throw new Error("Expected errors, but none found");
       }
+      expect(await this.readErrorOverlay()).toEqual([...errors].sort());
     });
+  }
+
+  #hasVisibleErrorOverlay(): Promise<boolean> {
+    return this.js<boolean>`document.querySelector("bun-hmr")?.style.display === "block"`;
+  }
+
+  /** The messages the error overlay shows, sorted. Empty when there is no overlay. */
+  readErrorOverlay(): Promise<string[]> {
+    return this.#request<string[]>("get-errors", "get-errors-result", [], "reading the error overlay");
   }
 
   getStringMessage(): Promise<string> {

--- a/test/bake/client-fixture.mjs
+++ b/test/bake/client-fixture.mjs
@@ -32,15 +32,17 @@ let expectingReload = false;
 let webSockets = [];
 let pendingReload = null;
 let pendingReloadTimer = null;
-let isUpdating = null;
+// Bumped when the current window is abandoned; acks captured by an older window are dropped.
+let windowGeneration = 0;
+// Acks the current window still owes the harness: builds it received and its page load.
+let pendingAcks = () => 0;
+// Every ack sent so far; with `pendingAcks()` it tells the harness how many acks to expect in total.
+let acksSent = 0;
 let objectURLRegistry = new Map();
 let internalAPIs;
 
 function reset() {
-  if (isUpdating !== null) {
-    clearImmediate(isUpdating);
-    isUpdating = null;
-  }
+  windowGeneration++;
   for (const ws of webSockets) {
     ws.onclose = () => {};
     ws.onerror = () => {};
@@ -71,16 +73,35 @@ function createWindow(windowUrl) {
     height: 768,
   });
 
+  // The harness counts one `received-hmr-event` per build per page. A page
+  // that reloads before its ack fires is abandoned, so the ack is dropped and
+  // the new window acks once it has loaded (see the socket-connected handler).
+  const generation = ++windowGeneration;
+  const ackToHarness = () => {
+    if (generation !== windowGeneration) return;
+    acksSent++;
+    process.send({ type: "received-hmr-event", args: [] });
+  };
+  let pageLoadAcked = false;
+  const ackPageLoad = () => {
+    if (pageLoadAcked) return;
+    pageLoadAcked = true;
+    ackToHarness();
+  };
+
   // The HMR runtime reads this symbol-keyed callback off `globalThis` (which is
   // `window` inside happy-dom's script context) and passes its internal hooks.
   let hmrEventHookInstalled = false;
-  let pendingHotUpdateAcks = 0;
-  let hmrScriptQueued = false;
-  const sendHmrAck = () => {
-    if (pendingHotUpdateAcks === 0) return;
-    pendingHotUpdateAcks--;
-    process.send({ type: "received-hmr-event", args: [] });
+  let pendingBuildAcks = 0;
+  // The update frame whose handlers are running. The HMR runtime appends a
+  // frame's script synchronously from its handler, so the flag lands on it.
+  let currentFrame = null;
+  const ackBuild = () => {
+    if (pendingBuildAcks === 0) return;
+    pendingBuildAcks--;
+    ackToHarness();
   };
+  pendingAcks = () => pendingBuildAcks + (pageLoadAcked ? 0 : 1);
   window[Symbol.for("bun testing api, may change at any time")] = internal => {
     window.internal = internal;
     if (typeof internal.onEvent === "function") {
@@ -88,9 +109,7 @@ function createWindow(windowUrl) {
       // Ack a hot update only once the new module code has actually run. Node's
       // Blob.arrayBuffer() resolves on a later macrotask than the WS listener's
       // setImmediate, so acking from the WS listener would race the eval.
-      // Full reloads are not acked here; the new window acks from the
-      // `[Bun] Hot-module-reloading socket connected` handler after loadPage.
-      internal.onEvent("bun:afterUpdate", sendHmrAck);
+      internal.onEvent("bun:afterUpdate", ackBuild);
     }
   };
 
@@ -110,25 +129,23 @@ function createWindow(windowUrl) {
       webSockets.push(this);
       this.addEventListener("message", event => {
         const data = new Uint8Array(event.data);
-        if (data[0] === "u".charCodeAt(0) && hmrEventHookInstalled) {
+        const kind = String.fromCharCode(data[0]);
+        // One ack per build, on the last frame the server sends this page for
+        // it: "u" for an HMR page (an "e" with the build's errors precedes it),
+        // "e" for the error page, which only subscribes to errors.
+        if (hmrEventHookInstalled ? kind === "u" : kind === "e" || kind === "u") {
           // JS updates queue a script tag and ack via bun:afterUpdate once it
           // evals; everything else (CSS, reloads, route reloads) acks here on
-          // the next tick when no script was queued.
-          pendingHotUpdateAcks++;
-          hmrScriptQueued = false;
-          isUpdating = setImmediate(() => {
-            isUpdating = null;
-            if (!hmrScriptQueued) sendHmrAck();
-          });
-        } else if (data[0] === "e".charCodeAt(0) || data[0] === "u".charCodeAt(0)) {
-          isUpdating = setImmediate(() => {
-            process.send({ type: "received-hmr-event", args: [] });
-            isUpdating = null;
+          // the next tick when this frame queued no script.
+          pendingBuildAcks++;
+          const frame = (currentFrame = { scriptQueued: false });
+          setImmediate(() => {
+            if (!frame.scriptQueued) ackBuild();
           });
         }
         if (!allowWebSocketMessages) {
           const allowedTypes = ["n", "r"];
-          if (allowedTypes.includes(String.fromCharCode(data[0]))) {
+          if (allowedTypes.includes(kind)) {
             return;
           }
           dumpWebSocketMessage("[E] WebSocket message received while messages are not allowed", data);
@@ -176,7 +193,7 @@ function createWindow(windowUrl) {
     value: function (element) {
       if (element instanceof ScriptTag) {
         assert(element.src.startsWith("blob:"));
-        hmrScriptQueued = true;
+        if (currentFrame) currentFrame.scriptQueued = true;
         const blob = objectURLRegistry.get(element.src);
         assert(blob);
         // Capture the window this script was appended to. Rapid HMR reloads
@@ -230,9 +247,7 @@ function createWindow(windowUrl) {
 
           // If no stylesheets of any kind, just emit the event
           if (styleLinks.length === 0 && styleTags.length === 0 && adoptedSheets.length === 0) {
-            process.nextTick(() => {
-              process.send({ type: "received-hmr-event", args: [] });
-            });
+            process.nextTick(ackPageLoad);
             return;
           }
 
@@ -270,9 +285,7 @@ function createWindow(windowUrl) {
             if (checkAttempts >= MAX_CHECK_ATTEMPTS && !allLoaded) {
               console.warn("[W] Reached maximum CSS load check attempts, proceeding anyway");
             }
-            process.nextTick(() => {
-              process.send({ type: "received-hmr-event", args: [] });
-            });
+            process.nextTick(ackPageLoad);
           } else {
             // Wait a bit and check again
             console.info(
@@ -430,6 +443,14 @@ process.on("message", async message => {
   }
   if (message.type === "set-allow-websocket-messages") {
     allowWebSocketMessages = message.args[0];
+  }
+  if (message.type === "ping") {
+    const [messageId] = message.args;
+    // Reply from the check phase: a frame received before this ping has then
+    // sent its ack, or is still counted in `pendingAcks`.
+    setImmediate(() => {
+      process.send({ type: `pong-${messageId}`, args: [{ value: acksSent + pendingAcks() }] });
+    });
   }
   if (message.type === "hard-reload") {
     expectingReload = true;

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -242,12 +242,12 @@ devTest("css url resolve error on hot reload is recoverable", {
           errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
         },
       );
-      expect((await dev.fetch("/")).status).toBe(500);
     }
-    // Recovery is checked without a connected client: when a failed CSS root
-    // recovers, the patch currently ships the HTML route as a JS module
-    // without the route-reload flag, which trips a client-side debug assert
-    // (tracked in https://github.com/oven-sh/bun/issues/31908).
+    // The failing route is fetched and recovered without a connected client: a
+    // fetch re-bundles the route, and both that and the recovery ship the HTML
+    // route as a JS module without the route-reload flag, which trips a
+    // client-side debug assert (tracked in https://github.com/oven-sh/bun/issues/31908).
+    expect((await dev.fetch("/")).status).toBe(500);
     await dev.write(
       "styles.css",
       `

--- a/test/bake/dev/harness.test.ts
+++ b/test/bake/dev/harness.test.ts
@@ -1,0 +1,84 @@
+// Tests for the behavior of bake-harness.ts and client-fixture.mjs themselves.
+import { expect } from "bun:test";
+import { devTest, emptyHtmlFile } from "../bake-harness";
+
+// Plain `await`, not `expect().rejects`: that matcher ticks the event loop from
+// inside the call and reorders exit handling.
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (err: any) {
+    return err.message;
+  }
+  throw new Error("Expected the promise to reject");
+}
+
+devTest("a write after a fetch of a failing route waits for the reloaded page", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: "<h1>Hello</h1>",
+    }),
+  },
+  async test(dev) {
+    await using c = await dev.client("/", {
+      errors: ['index.html: error: Could not resolve: "styles.css". Maybe you need to "bun install"?'],
+    });
+    // The fetch re-bundles the failing route and publishes its errors again.
+    // The client acks that build although no write is waiting for the ack.
+    expect((await dev.fetch("/")).status).toBe(500);
+    await c.expectReload(async () => {
+      await dev.write("styles.css", `h1 { color: red; }`);
+    });
+    // The write resolved on the reloaded page's ack, so its stylesheet is loaded.
+    await c.style("h1").color.expect.toBe("red");
+  },
+});
+
+devTest("expectElemText waits for a DOM update that lands after the ack", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: "<h1>Hello</h1>",
+    }),
+    "index.ts": `
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.js`
+      setTimeout(() => {
+        document.querySelector("h1").innerHTML = "Later";
+      }, 100);
+      return;
+    `;
+    await c.expectElemText("h1", "Later");
+    expect(await c.elemText("h1")).toBe("Later");
+  },
+});
+
+devTest("disposing a client reports an exit code it produces while it is being disposed", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: "<h1>Hello</h1>",
+    }),
+    "index.ts": `
+      console.log("loaded");
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    const c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    // The fixture is left expecting a reload, so the exit(0) that dispose
+    // requests becomes exitCodeMap.reloadNotCalled.
+    expect(await rejectionMessage(c.expectReload(() => Promise.reject(new Error("abort before reloading"))))).toBe(
+      "abort before reloading",
+    );
+
+    expect(await rejectionMessage(c[Symbol.asyncDispose]())).toBe('Client exited: "Reload not called"');
+  },
+});

--- a/test/bake/dev/ssg-pages-router.test.ts
+++ b/test/bake/dev/ssg-pages-router.test.ts
@@ -157,7 +157,8 @@ devTest("SSG pages router - hot reload on page changes", {
 
     // this %c%s%c is a react devtools thing and I don't know how to turn it off
     await c.expectMessage("%c%s%c updated load");
-    expect(await c.elemText("h1")).toBe("Updated Content");
+    // The log comes from the render; React commits the DOM in a later task.
+    await c.expectElemText("h1", "Updated Content");
   },
 });
 


### PR DESCRIPTION
### Problem
- `Client.expectErrorOverlay` in `test/bake/bake-harness.ts` polled 5 x 200ms before it decided that no overlay was visible. Every client connect, write and hard reload in 15 bake files paid that 1s. `test/bake/dev/css.test.ts` paid it 41 times: 41s of an 84s debug+ASAN run, 111s on the x64-asan lane.
- The poll hid races. `dev.client()` returned before the page-load ack. An ack for a build the harness did not start (a fetch re-bundles a failing route) could count for the next write. CI hit that on all 8 lanes of an earlier revision.

### Fix
- `expectErrorOverlay` checks once when no error is expected and polls only while an expected error has not shown up yet. A build error is on the page before the signals the harness awaits (Notes).
- `dev.client()` and `hardReload()` wait for the page-load ack. Before a batch listens for acks, `Client.drainAcks()` consumes every ack the fixture has sent or still owes. The fixture acks once per build per page and drops an ack from a window that reloaded first.
- `Client[Symbol.asyncDispose]` waits for the `exit` event, so its exit code check is live (it compared a number against `"0"` before). Node's Windows teardown abort after a requested exit counts as clean.
- Verified: css.test.ts 85.2s to 43.0s (debug+ASAN, same machine). All 25 test/bake files: 194 pass, 0 fail. `test/bake/dev/harness.test.ts` pins the protocol.

### Background
- `devTest` boots one dev server per case. `dev.client()` attaches a happy-dom page in a node process (`client-fixture.mjs`) that acks each build over IPC.
- `dev.write()` waits for the server's finish event and one ack per attached client, then checks each overlay.

<details><summary>Notes</summary>

- Scope. This is the harness half of #37866, re-extracted. #39488 carries an equivalent overlay change inside a 124-file consolidation that is conflicting with no landing date. Items for #39488 to reconcile on a rebase: the drain, the exit-event wait in dispose, the per-frame script attribution, the Windows teardown carve-out. An earlier revision of this PR also tightened css.test.ts (served-stylesheet snapshots, build-failed page checks, `errors: null` skips turned into real errors). #39488 rewrites that file wholesale with equivalent assertions, so that work is not in this PR. It is on the branch `farm/070f2cb5/css-assertions` for after #39488 lands. The two dev server bugs it surfaced are filed or known: #40081 (the served HTML keeps the source `<link>` tag after a failed CSS root recovers) and #31945 (a CSS root that fails after parsing loses its rules on the client).
- Why the single check is safe: the overlay is set synchronously before both signals. Initial build errors are embedded in the served 500 page and rendered by `hmr-runtime-error.ts` before it opens the socket. Hot-update errors arrive as the "e" message, which `finalize_bundle` publishes before the "u" message the fixture acks (`src/runtime/bake/DevServer.rs`). Only a runtime error reaches the overlay later, after a report round trip, and the wait for an expected error covers that (a deadline of `1000 * WAIT_MULTIPLIER`).
- The stray ack race, as build 103541 showed it on all 8 lanes: `dev.fetch()` of the failing route while the error-page client was attached re-bundled it, the server published an "e", the fixture acked it, and nothing waited for that ack. Measured locally, it reached the harness 23ms after the next write had registered its listeners. That write then resolved on the server's finish event alone, before the reloaded page existed, and `style("body")` found nothing.
- Why the drain counts instead of listening: the fixture sends the owed acks on the same IPC pipe right after the pong, so a listener registered after the pong resolves can miss them. The harness counts every ack in the `ipc` callback, before any listener runs, and the pong reports the fixture's total (sent plus owed). The pong is sent from the check phase, so a frame the fixture processed in the same turn as the ping is in that total either way.
- The harness change shifts every bake file, so `test/expected-durations.json` is left to its scheduled regeneration. The largest remaining cost on debug/ASAN is in product code: about 1.1s of each dev server's exit is `require("bun:internal-for-testing")` in `harness_start.ts` (19ms on release). A build id in the server's "e", "u" and "r" frames would let the harness match acks to builds and delete the drain; both are follow-ups.
- Sibling PR #40082 (bundle.test.ts) does not touch the harness.
- Suites run: every `test/bake/**/*.test.ts` with the final harness (25 files, 194 tests, 0 failures), css.test.ts 10 times, `harness.test.ts` also against main's harness (2 of 3 fail there, as intended).

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 5 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bake/dev/css.test.ts' 'test/bake/dev/harness.test.ts' 'test/bake/dev/ssg-pages-router.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bake/dev/css.test.ts test/bake/dev/harness.test.ts test/bake/dev/ssg-pages-router.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/css.test.ts:
Dev server testing directory: /tmp/bun-dev-test-l7i2xa
[0;30mdev|[0m Started development server: http://localhost:39591
[0;30mdev|[0m [32mBundled page in 106ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-l7i2xa/css1/styles.css[0m[2m:[0m[33m4[0m[2m:[0m[33m1[0m
[0;30mdev|[0m [32mReloaded in 48ms[0m[2m:[0m styles.css
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 31ms[0m[2m:[0m styles.css
(pass)  DEV:css-1: css file with syntax error does not kill old styles [2650.20ms]
[0;30mdev|[0m Started development server: http://localhost:38683
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-l7i2xa/css2/styles.css[0m[2m:[0m[33m3[0m[2m:[0m[33m3[0m
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 49ms[0m[2m:[0m styles.css
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 83ms[0m[2m:[0m styles.css
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-l7i2xa/css2/styles.css[0m[2m:[0m[33m3[0m[2m:[0m[33m3[0m
(pass)  DEV:css-2: css file with initial syntax error gets recovered [2352.61ms]
[0;30mdev|[0m Started development server: http://localhost:46683
[0;30mdev|[0m [32mBundled page in 109ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bake/bake-harness.ts              | 234 +++++++++++++++++++++++++--------
 test/bake/client-fixture.mjs           |  89 ++++++++-----
 test/bake/dev/css.test.ts              |  10 +-
 test/bake/dev/harness.test.ts          |  84 ++++++++++++
 test/bake/dev/ssg-pages-router.test.ts |   3 +-
 5 files changed, 323 insertions(+), 97 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
test/bake/bake-harness.ts                  13     23      0
test/bake/client-fixture.mjs                4     16      0
test/bake/dev/css.test.ts                   4     13      0
test/bake/dev/harness.test.ts               0      1      0
test/bake/dev/ssg-pages-router.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->