### PR TITLE
shell(ls): decide operand errors with lstat, not the O_DIRECTORY errno

### DIFF
--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -9,7 +9,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, ShellTask,
-    shell_openat,
+    shell_lstatat, shell_openat, shell_statat,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -457,20 +457,8 @@ impl ShellLsTask {
         }
 
         let fd = match shell_openat(this.cwd, this.path.as_zstr(), O::RDONLY | O::DIRECTORY, 0) {
-            Err(e) => {
-                match e.get_errno() {
-                    E::ENOENT => {
-                        this.err = Some(this.error_with_path(&e));
-                    }
-                    E::ENOTDIR => {
-                        // Clone the path to dodge the &mut/& borrow overlap.
-                        let p = ZBox::from_bytes(this.path.as_bytes());
-                        this.add_entry(p.as_bytes(), this.cwd);
-                    }
-                    _ => {
-                        this.err = Some(this.error_with_path(&e));
-                    }
-                }
+            Err(open_err) => {
+                this.list_non_directory_operand(open_err);
                 return;
             }
             Ok(fd) => fd,
@@ -522,6 +510,35 @@ impl ShellLsTask {
         this.output.push(b'\n');
     }
 
+    /// coreutils operand rule: `stat`, and on ENOENT or ELOOP `lstat` so a symlink is itself.
+    fn list_non_directory_operand(&mut self, open_err: bun_sys::Error) {
+        match shell_statat(self.cwd, self.path.as_zstr()) {
+            // A directory that would not open: report the open error.
+            Ok(stat) if S::ISDIR(stat.st_mode as _) => {
+                self.err = Some(self.error_with_path(&open_err));
+                return;
+            }
+            Ok(_) => {}
+            Err(e) if matches!(e.get_errno(), E::ENOENT | E::ELOOP) => {}
+            Err(e) => {
+                self.err = Some(self.error_with_path(&e));
+                return;
+            }
+        }
+        match shell_lstatat(self.cwd, self.path.as_zstr()) {
+            Ok(stat) => {
+                // An operand is never subject to the -a/-A filter.
+                let name = ZBox::from_bytes(self.path.as_bytes());
+                if self.opts.long_listing {
+                    self.add_entry_long_from_stat(name.as_bytes(), &stat);
+                } else {
+                    self.add_entry_short(name.as_bytes());
+                }
+            }
+            Err(e) => self.err = Some(self.error_with_path(&e)),
+        }
+    }
+
     fn should_skip_entry(&self, name: &[u8]) -> bool {
         match self.opts.dotfiles {
             DotfileMode::All => false,
@@ -538,27 +555,32 @@ impl ShellLsTask {
         if self.opts.long_listing {
             self.add_entry_long(name, dir_fd);
         } else {
-            self.output.reserve(name.len() + 1);
-            self.output.extend_from_slice(name);
-            self.output.push(b'\n');
+            self.add_entry_short(name);
         }
+    }
+
+    fn add_entry_short(&mut self, name: &[u8]) {
+        self.output.reserve(name.len() + 1);
+        self.output.extend_from_slice(name);
+        self.output.push(b'\n');
     }
 
     fn add_entry_long(&mut self, name: &[u8], dir_fd: bun_sys::Fd) {
         // Use lstatat to not follow symlinks (so symlinks show as 'l' type).
         let name_z = ZBox::from_bytes(name);
-        let stat = match bun_sys::lstatat(dir_fd, name_z.as_zstr()) {
+        match bun_sys::lstatat(dir_fd, name_z.as_zstr()) {
             Err(_) => {
                 // If stat fails, just output the name with placeholders.
                 self.output
                     .extend_from_slice(b"?????????? ? ? ? ?            ? ");
                 self.output.extend_from_slice(name);
                 self.output.push(b'\n');
-                return;
             }
-            Ok(s) => s,
-        };
+            Ok(stat) => self.add_entry_long_from_stat(name, &stat),
+        }
+    }
 
+    fn add_entry_long_from_stat(&mut self, name: &[u8], stat: &bun_sys::Stat) {
         // File type and permissions.
         let mode: u32 = stat.st_mode as u32;
         let file_type = get_file_type_char(mode);
@@ -575,7 +597,7 @@ impl ShellLsTask {
         let size: i64 = stat.st_size as i64;
 
         // Modification time.
-        let mtime = bun_sys::stat_mtime(&stat);
+        let mtime = bun_sys::stat_mtime(stat);
         let time_str = format_time(mtime.sec, self.now_secs);
 
         // SAFETY: `format_permissions` only writes ASCII bytes (`r`/`w`/`x`/`s`/`S`/`t`/`T`/`-`).

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -458,7 +458,7 @@ impl ShellLsTask {
 
         let fd = match shell_openat(this.cwd, this.path.as_zstr(), O::RDONLY | O::DIRECTORY, 0) {
             Err(open_err) => {
-                this.list_non_directory_operand(open_err);
+                this.list_non_directory_operand(&open_err);
                 return;
             }
             Ok(fd) => fd,
@@ -511,11 +511,11 @@ impl ShellLsTask {
     }
 
     /// coreutils operand rule: `stat`, and on ENOENT or ELOOP `lstat` so a symlink is itself.
-    fn list_non_directory_operand(&mut self, open_err: bun_sys::Error) {
+    fn list_non_directory_operand(&mut self, open_err: &bun_sys::Error) {
         match shell_statat(self.cwd, self.path.as_zstr()) {
             // A directory that would not open: report the open error.
             Ok(stat) if S::ISDIR(stat.st_mode as _) => {
-                self.err = Some(self.error_with_path(&open_err));
+                self.err = Some(self.error_with_path(open_err));
                 return;
             }
             Ok(_) => {}

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2226,7 +2226,7 @@ fn shell_get_path<'a>(
 /// Windows: rewrite the path via `shell_get_path` then `bun_sys::stat`, tagging
 /// the error with the *original* `path_` (not the rewritten one). POSIX: plain
 /// `bun_sys::fstatat(dir, path_)`.
-// consumed by states/CondExpr (`[[ -e/-f/-d ... ]]`)
+// consumed by states/CondExpr (`[[ -e/-f/-d ... ]]`) and the `ls` builtin
 pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<bun_sys::Stat> {
     #[cfg(windows)]
     {
@@ -2237,6 +2237,20 @@ pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<b
     #[cfg(not(windows))]
     {
         bun_sys::fstatat(dir, path_)
+    }
+}
+
+/// `shell_statat` without following a final symlink.
+pub(crate) fn shell_lstatat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<bun_sys::Stat> {
+    #[cfg(windows)]
+    {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let p = shell_get_path(dir, path_, &mut buf)?;
+        return bun_sys::lstat(p).map_err(|e| e.with_path(path_.as_bytes()));
+    }
+    #[cfg(not(windows))]
+    {
+        bun_sys::lstatat(dir, path_)
     }
 }
 

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -411,6 +411,12 @@ describe.concurrent("bunshell ls", () => {
         .stderr(notADirectory("f/x"))
         .setTempdir(String(tempdir))
         .run();
+      await TestBuilder.command`ls -d f/x`
+        .exitCode(1)
+        .stdout("")
+        .stderr(notADirectory("f/x"))
+        .setTempdir(String(tempdir))
+        .run();
       await TestBuilder.command`ls f/x/y/z`
         .exitCode(1)
         .stdout("")
@@ -421,6 +427,12 @@ describe.concurrent("bunshell ls", () => {
       await TestBuilder.command`ls sub f/x`
         .exitCode(1)
         .stdout(s => expect(sortedLsOutput(s)).toEqual(["a", "sub:"]))
+        .stderr(notADirectory("f/x"))
+        .setTempdir(String(tempdir))
+        .run();
+      await TestBuilder.command`ls f f/x`
+        .exitCode(1)
+        .stdout("f\n")
         .stderr(notADirectory("f/x"))
         .setTempdir(String(tempdir))
         .run();

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -303,10 +303,21 @@ describe.concurrent("bunshell ls", () => {
 
     test.if(isPosix)("permission denied directory", async () => {
       await using tempdir = tempDir("ls-permission", {});
-      await $`mkdir restricted; chmod 000 restricted`.quiet().throws(true).cwd(tempdir);
+      await $`mkdir restricted; chmod 000 restricted; ln -s restricted link-to-restricted`
+        .quiet()
+        .throws(true)
+        .cwd(tempdir);
       await TestBuilder.command`ls restricted`
         .setTempdir(tempdir)
         .exitCode(1)
+        .stderr(s => expect(s).toContain("Permission denied"))
+        .run();
+      // A symlink to a directory that cannot be opened reports the open
+      // error. It is not listed by name like a symlink to a file.
+      await TestBuilder.command`ls link-to-restricted`
+        .setTempdir(tempdir)
+        .exitCode(1)
+        .stdout("")
         .stderr(s => expect(s).toContain("Permission denied"))
         .run();
       await $`chmod 755 restricted`.quiet().throws(true).cwd(tempdir); // cleanup
@@ -336,12 +347,25 @@ describe.concurrent("bunshell ls", () => {
       await $`chmod 755 level1/level2`.quiet().throws(true).cwd(tempdir); // cleanup
     });
 
+    // A dangling symlink named on the command line is listed by name, like
+    // GNU and BSD ls. Only `ls` of a nonexistent path is an error.
     test.if(isPosix)("broken symlink file", async () => {
       await using tempdir = tempDir("ls-broken-symlink", {});
       await $`touch will-remove; ln -s will-remove broken-link; rm will-remove`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls broken-link`
-        .exitCode(1)
-        .stderr("ls: broken-link: No such file or directory\n")
+        .exitCode(0)
+        .stdout("broken-link\n")
+        .stderr("")
+        .setTempdir(tempdir)
+        .run();
+      await TestBuilder.command`ls -l broken-link`
+        .exitCode(0)
+        .stdout(s => {
+          // symlink perms differ between Linux (0777) and macOS (0755)
+          expect(s).toStartWith("lrwx");
+          expect(s).toEndWith(" broken-link\n");
+        })
+        .stderr("")
         .setTempdir(tempdir)
         .run();
     });
@@ -350,9 +374,78 @@ describe.concurrent("bunshell ls", () => {
       await using tempdir = tempDir("ls-broken-symlink", {});
       await $`mkdir will-remove; ln -s will-remove broken-link; rm -rf will-remove`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls broken-link`
-        .exitCode(1)
-        .stderr("ls: broken-link: No such file or directory\n")
+        .exitCode(0)
+        .stdout("broken-link\n")
+        .stderr("")
         .setTempdir(tempdir)
+        .run();
+    });
+
+    test.if(isPosix)("symlink loop", async () => {
+      await using tempdir = tempDir("ls-symlink-loop", {});
+      await $`ln -s loop loop`.quiet().throws(true).cwd(tempdir);
+      await TestBuilder.command`ls loop`.exitCode(0).stdout("loop\n").stderr("").setTempdir(tempdir).run();
+      await TestBuilder.command`ls loop/x`
+        .exitCode(1)
+        .stdout("")
+        .stderr("ls: loop/x: Too many levels of symbolic links\n")
+        .setTempdir(tempdir)
+        .run();
+    });
+
+    test("operand whose path goes through a regular file", async () => {
+      using tempdir = tempDir("ls-enotdir", { "f": "hello", "sub/a": "" });
+      const notADirectory = (operand: string) => (s: string) => {
+        expect(s).toStartWith(`ls: ${operand}: `);
+        if (isPosix) expect(s).toBe(`ls: ${operand}: Not a directory\n`);
+      };
+      await TestBuilder.command`ls f/x`
+        .exitCode(1)
+        .stdout("")
+        .stderr(notADirectory("f/x"))
+        .setTempdir(String(tempdir))
+        .run();
+      await TestBuilder.command`ls -l f/x`
+        .exitCode(1)
+        .stdout("")
+        .stderr(notADirectory("f/x"))
+        .setTempdir(String(tempdir))
+        .run();
+      await TestBuilder.command`ls f/x/y/z`
+        .exitCode(1)
+        .stdout("")
+        .stderr(notADirectory("f/x/y/z"))
+        .setTempdir(String(tempdir))
+        .run();
+      // The other operands are still listed.
+      await TestBuilder.command`ls sub f/x`
+        .exitCode(1)
+        .stdout(s => expect(sortedLsOutput(s)).toEqual(["a", "sub:"]))
+        .stderr(notADirectory("f/x"))
+        .setTempdir(String(tempdir))
+        .run();
+    });
+
+    test("operand starting with a dot is not hidden", async () => {
+      using tempdir = tempDir("ls-dot-operand", { ".hidden": "", "f": "hello" });
+      await TestBuilder.command`ls .hidden`
+        .exitCode(0)
+        .stdout(".hidden\n")
+        .stderr("")
+        .setTempdir(String(tempdir))
+        .run();
+      await TestBuilder.command`ls -d .hidden`
+        .exitCode(0)
+        .stdout(".hidden\n")
+        .stderr("")
+        .setTempdir(String(tempdir))
+        .run();
+      await TestBuilder.command`ls ./f`.exitCode(0).stdout("./f\n").stderr("").setTempdir(String(tempdir)).run();
+      await TestBuilder.command`ls -l ./f`
+        .exitCode(0)
+        .stdout(s => expect(s).toEndWith(" ./f\n"))
+        .stderr("")
+        .setTempdir(String(tempdir))
         .run();
     });
 


### PR DESCRIPTION
### Problem
- The `ls` builtin opens each operand with `O_DIRECTORY` and reads `ENOTDIR` as "the operand is a file". The kernel also returns `ENOTDIR` when a path component is a file, so `ls f/x` prints `f/x` and exits 0, and `ls -l f/x` prints a row of `?`. coreutils: `ls: cannot access 'f/x': Not a directory`, exit 2.
- Every other open error is fatal, so a dangling or self-referencing symlink operand (`ENOENT`, `ELOOP`) is reported as an error. GNU and BSD ls list the link by name, exit 0.
- The operand went through the `-a`/`-A` dotfile filter, so `ls .hidden` and `ls ./f` print nothing, exit 0.
- Cause for all three: `ShellLsTask::run_from_thread_pool`, `src/runtime/shell/builtin/ls.rs:459`.

### Fix
- When the open fails, apply the rule coreutils uses for a command-line operand: `stat` it, and on `ENOENT` or `ELOOP` fall back to `lstat`. A directory that would not open keeps the open error (`EACCES`, also through a symlink). A failed `stat` is the error to report (`f/x`, `nx`). Anything else that exists is a non-directory and is listed by name. `lstat` describes it, so `-l` shows a symlink as a link.
- Operands bypass the dotfile filter, which only applies to directory entries.
- `shell_lstatat` in `interpreter.rs` mirrors `shell_statat` so Windows operands get the same path rewrite as the open above.
- Verified: `test/js/bun/shell/commands/ls.test.ts` (5 new or updated tests fail on the release build, plus a symlink case in the permission test). The `f/x` test also carries the `ls -d f/x` and `ls f f/x` cases from #39725. Also `bunshell.test.ts`.

Supersedes #39725, which only fixes the `f/x` case. Its `stat` check sits inside the `ENOTDIR` arm, so it cannot list a dangling link, and it keeps the dotfile filter on operands. Its four test cases pass on this branch. The two this branch did not already have are folded in.

### Background
- The `ls` builtin runs one `ShellLsTask` per operand on the thread pool. A task either lists a directory's entries or appends the operand itself to its output. A task that sets `err` makes the builtin print `ls: <path>: <strerror>` and exit 1.
- `lstat` reports a symlink as itself, `stat` reports its target. A dangling link exists for `lstat` and does not exist for `stat`.

<details><summary>Notes</summary>

Cells from the conformance matrix, release 1.4.0 vs this branch vs `bash -c`, run as a non-root user. `f` is a regular file, `dl -> nonexist`, `loop -> loop`, `sub` is a directory, `restricted` is a mode 000 directory, `symrestricted -> restricted`.

| command | 1.4.0 | this branch | coreutils 8.32 |
|---|---|---|---|
| `ls f/x` | 0 `f/x` | 1 `ls: f/x: Not a directory` | 2 `cannot access 'f/x': Not a directory` |
| `ls -l f/x` | 0 `?????????? ? ? ? ? ? f/x` | 1 same error | 2 same error |
| `ls f/x/y/z` | 0 `f/x/y/z` | 1 `Not a directory` | 2 `Not a directory` |
| `ls dl` | 1 `No such file or directory` | 0 `dl` | 0 `dl` |
| `ls -l dl` | 1 | 0 `lrwxrwxrwx ... dl` | 0 `lrwxrwxrwx ... dl -> nonexist` |
| `ls loop` | 1 `Too many levels of symbolic links` | 0 `loop` | 0 `loop` |
| `ls loop/x` | 1 ELOOP | 1 ELOOP | 2 ELOOP |
| `ls .hidden` | 0 (empty) | 0 `.hidden` | 0 `.hidden` |
| `ls ./f` | 0 (empty) | 0 `./f` | 0 `./f` |
| `ls sub f/x` | 0 `sub:\na\nf/x` | 1 `sub:\na` + error | 2 same |
| `ls restricted`, `ls symrestricted`, `ls restricted/x` | 1 `Permission denied` | 1 `Permission denied` | 2 `Permission denied` |
| `ls f`, `ls symf`, `ls symdir`, `ls nx`, `ls -d f` | unchanged | unchanged | match |

The first version of this branch decided with `lstat` alone. Review caught that a symlink to an unreadable directory then passed as "exists, not a directory" and swallowed the `EACCES`. The `stat` first, `lstat` on `ENOENT`/`ELOOP` order is what coreutils does (`gobble_file`, `DEREF_COMMAND_LINE_SYMLINK_TO_DIR`), and the permission test now covers the symlink.

Not changed here:
- The exit code stays 1. The builtin uses 1 for every error, coreutils uses 2 for a failed operand and 1 for a failed entry.
- `-l` does not print ` -> target` for symlinks.
- `ls -l symdir` and `ls -d symdir` still follow a command-line symlink to a directory. coreutils does not with `-l` or `-d`.

The two existing `broken symlink` tests expected the error. They came in with #20531 (a memory refactor) and pinned the behavior of the time. They now expect the coreutils output.

The chmod based `permission denied` tests fail in any environment that runs as root, with or without this change (#39232). They pass here as `nobody`.

`cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/commands/ls.test.ts

<!-- robobun:evidence:end -->
