### PR TITLE
bake: strip the source stylesheet tag from HTML bundled during a failed CSS build

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5388,6 +5388,13 @@ pub mod bv2_impl {
                                     (*parts_col.add(record.source_index.get() as usize)).len()
                                 } == 0
                                 {
+                                    // The CSS root failed to build. Disable the
+                                    // record so chunk generation treats it like a
+                                    // successful CSS import: the HTML scan removes
+                                    // the source tag (the stored HTML is reused on
+                                    // recovery, when only the CSS rebundles) and
+                                    // the HMR conversion skips the import.
+                                    record.path.is_disabled = true;
                                     record.source_index = Index::INVALID;
                                     continue;
                                 }

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -73,6 +73,11 @@ devTest("css file with initial syntax error gets recovered", {
       );
     });
     await c.style("body").color.expect.toBe("red");
+    // The recovered page reuses the HTML stored during the failed build. That
+    // HTML must not keep the source link tag next to the injected bundled one.
+    const html = await dev.fetch("/").text();
+    expect(html).toContain("/_bun/asset/");
+    expect(html).not.toContain('href="styles.css"');
     await dev.write(
       "styles.css",
       `


### PR DESCRIPTION
### Problem

- The dev server keeps the source `<link rel="stylesheet" href="styles.css">` tag after a failed CSS root recovers. The recovered page serves both the source tag and the injected `/_bun/asset/...css` link. A browser then requests `/styles.css`, gets the HTML fallback, and logs a MIME type error.
- The cause is `finish_from_bake_dev_server` (`src/bundler/bundle_v2.rs:5391`). When a CSS root fails to parse, it resets the importer's record to `source_index = INVALID`. The HTML rewrite (`generateCompileResultForHtmlChunk.rs:160`) then sees no loader and falls through to the keep-the-tag branch instead of `element.remove()`.

### Fix

- Also set `record.path.is_disabled = true` when the failed CSS root's record is invalidated. The HTML rewrite already removes disabled records, so the stored HTML matches what a successful build produces.
- This matters because the stored HTML outlives the failed build. A recovery edit rebundles only the CSS file, and the response path injects the new asset link into the stored HTML text.
- `is_disabled` on a CSS record is the existing idiom: the dev server sets it for cached CSS imports, and the HMR statement conversion sets it for every successful CSS import.
- Verified: tightened `test/bake/dev/css.test.ts` ("css file with initial syntax error gets recovered") to assert the recovered HTML has no `href="styles.css"`. Stock bun fails the new assertion. Also ran `test/bake/dev/{html,ecosystem,bundle,esm,hot,incremental-graph-edge-deletion}.test.ts`, all pass.

### Background

- A dev-server bundle proceeds even when a file fails. Failed files are filtered out by having zero parts, and routes with failures serve an error page.
- The HTML chunk's rewritten text and its script injection offset are stored per route (`DevServer.rs:4169`). The response path inserts the bundled CSS and JS tags at that offset on every request, so the stored text must not depend on whether the imported files built.
- On recovery, only the edited CSS file is re-enqueued. No HTML chunk is produced, so the stored text from the failed build is reused as is.

Fixes #40081

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/css.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/css.test.ts:
Dev server testing directory: /tmp/bun-dev-test-JcLVQT
[0;30mdev|[0m Started development server: http://localhost:33663
[0;30mdev|[0m [32mBundled page in 158ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-JcLVQT/css1/styles.css[0m[2m:[0m[33m4[0m[2m:[0m[33m1[0m
[0;30mdev|[0m [32mReloaded in 43ms[0m[2m:[0m styles.css
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 69ms[0m[2m:[0m styles.css
(pass)  DEV:css-1: css file with syntax error does not kill old styles [5945.56ms]
[0;30mdev|[0m Started development server: http://localhost:42339
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-JcLVQT/css2/styles.css[0m[2m:[0m[33m3[0m[2m:[0m[33m3[0m
[0;30mweb|[0m [I] [B
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (b565fb41c)

test/bake/dev/css.test.ts:
Dev server testing directory: /tmp/bun-dev-test-gqt9ji
[0;30mdev|[0m Started development server: http://localhost:35779
[0;30mdev|[0m [32mBundled page in 4ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-gqt9ji/css1/styles.css[0m[2m:[0m[33m4[0m[2m:[0m[33m1[0m
[0;30mdev|[0m [32mReloaded in 4ms[0m[2m:[0m styles.css
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 1ms[0m[2m:[0m styles.css
(pass)  DEV:css-1: css file with syntax error does not kill old styles [3654.79ms]
[0;30mdev|[0m Started development server: http://localhost:33229
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-gqt9ji/css2/styles.css[0m[2m:[0m[33m3[0m[2m:[0m[33m3[0m
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 1ms[0m[2m:[0m styles.css
[0;30mweb|[0m [I] [Bun] H
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/css.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/css.test.ts:
Dev server testing directory: /tmp/bun-dev-test-0D4k5r
[0;30mdev|[0m Started development server: http://localhost:45835
[0;30mdev|[0m [32mBundled page in 108ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-0D4k5r/css1/styles.css[0m[2m:[0m[33m4[0m[2m:[0m[33m1[0m
[0;30mdev|[0m [32mReloaded in 66ms[0m[2m:[0m styles.css
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 31ms[0m[2m:[0m styles.css
(pass)  DEV:css-1: css file with syntax error does not kill old styles [5817.18ms]
[0;30mdev|[0m Started development server: http://localhost:38569
[0;30mdev|[0m [39merror[0m[2m: [0m[1mUnexpected end of input[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-0D4k5r/css2/styles.css[0m[2m:[0m[33m3[0m[2m:[0m[33m3[0m
[0;30mweb|[0m [I] [B
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 620ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs  | 7 +++++++
 test/bake/dev/css.test.ts | 5 +++++
 2 files changed, 12 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                       reads  edits  tests
src/bundler/bundle_v2.rs       3      1      0
test/bake/dev/css.test.ts      1      1      0
```

</details>

**root cause** · written by the author bot

When a CSS root failed to parse, the dev server bundler invalidated the import record's source index but did not mark the record as disabled, unlike the successful path, so on recovery the HTML chunk was regenerated from that record and the rewriter lacked the signal it uses to strip the original link tag, leaving the source stylesheet reference alongside the injected bundled one. The fix sets is_disabled on the record at the same invalidation site, matching the state produced by successful CSS imports, so the rewriter removes the source tag and the HMR conversion skips the dead import. The…

<!-- robobun:evidence:end -->