### PR TITLE
test(perf): prime the cold C toolchain before the linker-order and ffi fixture compiles, and build the tracer fixtures once

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -11,7 +11,7 @@ import { heapStats } from "bun:jsc";
 import { beforeAll, describe, expect } from "bun:test";
 import { ChildProcess, execSync, fork } from "child_process";
 import { readdir, rm, writeFile } from "fs/promises";
-import fs, { closeSync, openSync, rmSync } from "node:fs";
+import fs, { closeSync, openSync, readSync, rmSync } from "node:fs";
 import os from "node:os";
 import { dirname, isAbsolute, join } from "path";
 
@@ -2247,7 +2247,28 @@ export function getPuppeteerInstallEnv(): Record<string, string> {
   return { PUPPETEER_CACHE_DIR: tmpdirSync("puppeteer-cache") };
 }
 
+/**
+ * Reads `files` through once, front to back, and keeps none of it. The first C
+ * compile on a fresh Windows CI VM otherwise demand-pages the toolchain in from
+ * the cloud disk one fault at a time: 7s for a 100 MB compiler on an Azure VM,
+ * against a second to read it through, after which the faults hit the disk's
+ * cache. Files that do not exist are skipped.
+ */
+export function primeToolchain(files: string[]) {
+  const buffer = Buffer.allocUnsafe(4 << 20);
+  for (const file of files) {
+    if (!fs.existsSync(file)) continue;
+    const fd = openSync(file, "r");
+    try {
+      while (readSync(fd, buffer, 0, buffer.length, null) > 0);
+    } finally {
+      closeSync(fd);
+    }
+  }
+}
+
 const compiledFixtures = new Map<string, string>();
+let primedFixtureCompiler = false;
 export function compileFixture(sourcePath: string, options: { flags?: string[] } = {}): string {
   const cacheKey = sourcePath + "\0" + (options.flags ?? []).join("\0");
   const cached = compiledFixtures.get(cacheKey);
@@ -2261,6 +2282,17 @@ export function compileFixture(sourcePath: string, options: { flags?: string[] }
 
   const cc = which("cc") || which("clang") || which("gcc");
   if (!cc) throw new Error("compileFixture: no C compiler (cc/clang/gcc) found in $PATH");
+  if (isWindows && !primedFixtureCompiler) {
+    // gcc runs these as separate programs, and cc1 is most of the bytes. clang
+    // is one binary: it answers with the bare names, which do not exist.
+    const programs = ["cc1", "as", "collect2", "ld"].map(name =>
+      spawnSync({ cmd: [cc, `-print-prog-name=${name}`], stdout: "pipe", stderr: "ignore", env: bunEnv })
+        .stdout.toString()
+        .trim(),
+    );
+    primeToolchain([cc, ...programs]);
+    primedFixtureCompiler = true;
+  }
 
   const cmd = isWindows
     ? [cc, sourcePath, "-shared", "-o", outPath, ...(options.flags ?? [])]

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isMusl, isWindows, nodeExe, tempDir } from "harness";
-import { closeSync, existsSync, openSync, readFileSync, readSync } from "node:fs";
+import { bunEnv, bunExe, isMusl, isWindows, nodeExe, primeToolchain, tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   mustGenerateOrderFile,
@@ -333,30 +333,12 @@ async function compileMsvc(cwd: string, source: string, out: string, link: strin
   if (exitCode !== 0) throw new Error(`${compiler} exited ${exitCode}:\n${stdout}${stderr}`);
 }
 
-/**
- * Nothing else in the suite runs the C toolchain, so on a CI lane (a fresh VM)
- * the first compile here pages the 100 MB compiler, 70 MB linker and 50 MB
- * static CRT in from a cold cloud disk one fault at a time: 7s, 3s and 4s on an
- * Azure VM, against a second each to read through first, which leaves the
- * faults to the disk's cache.
- */
-function primeMsvcToolchain() {
-  const libDirs = (process.env.LIB ?? "").split(";").filter(Boolean);
-  const files = [
-    compiler!,
-    join(dirname(compiler!), "lld-link.exe"),
-    ...["libcmt.lib", "libucrt.lib", "libvcruntime.lib"].flatMap(lib => libDirs.map(dir => join(dir, lib))),
-  ];
-  const buffer = Buffer.allocUnsafe(4 << 20);
-  for (const file of files.filter(file => existsSync(file))) {
-    const fd = openSync(file, "r");
-    try {
-      while (readSync(fd, buffer, 0, buffer.length, null) > 0);
-    } finally {
-      closeSync(fd);
-    }
-  }
-}
+/** The static CRT the fixtures link, wherever %LIB% (set by the VS shell) puts it. */
+const msvcCrt = () =>
+  (process.env.LIB ?? "")
+    .split(";")
+    .filter(Boolean)
+    .flatMap(dir => ["libcmt.lib", "libucrt.lib", "libvcruntime.lib"].map(lib => join(dir, lib)));
 
 /** The linker options that write a binary's two maps where the generator looks for them (see windows-symbols.ts). */
 const mapsFor = (exe: string): string[] => [`/map:${symbolMapFor(exe)}`, `/lldmap:${linkerMapFor(exe)}`];
@@ -723,7 +705,8 @@ describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
     tracer = join(root, "functrace.exe");
     const exe = (name: string) => join(root, `${name}.exe`);
 
-    primeMsvcToolchain();
+    // The compiler, the lld-link beside it that clang-cl links with, and the CRT: see primeToolchain.
+    primeToolchain([compiler!, join(dirname(compiler!), "lld-link.exe"), ...msvcCrt()]);
     await Promise.all([
       compileMsvc(root, join(orderfile, "functrace-windows.c"), tracer),
       // No folding: `after` has the same body as f1, and the trace is checked
@@ -748,7 +731,10 @@ describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
 
   afterAll(() => dir?.[Symbol.dispose]());
 
-  /** Runs `target` under the tracer, armed with its own starts unless told otherwise, and has it write `<name>.trace`. */
+  /**
+   * Runs `target` under the tracer, in `root`, armed with its own starts unless
+   * told otherwise, and has it write `<name>.trace`.
+   */
   async function trace(
     name: string,
     target: Built,
@@ -758,6 +744,7 @@ describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
     const out = join(root, `${name}.trace`);
     await using proc = Bun.spawn({
       cmd: [tracer, target.exe, ...args],
+      cwd: root,
       env: { ...bunEnv, ...env, BUN_FUNCTRACE_STARTS: starts, BUN_FUNCTRACE_OUT: out },
       stdin,
       stdout: "pipe",
@@ -788,13 +775,15 @@ describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
   });
 
   it.concurrent("reports the debuggee's exit code, and refuses a binary the starts are not for", async () => {
-    // Addresses far outside any code section: a starts file for some other binary.
-    const elsewhere = join(root, "elsewhere.starts");
-    await writeStarts(elsewhere, [0x7ff600000000, 0x7ff600000010]);
+    // Addresses far outside any code section: a starts file for some other
+    // binary. Named relative to the tracer's cwd: the message echoes the name,
+    // and the tracer prints it in the C locale, where a temp path under a
+    // non-ASCII user name would not survive.
+    await writeStarts(join(root, "elsewhere.starts"), [0x7ff600000000, 0x7ff600000010]);
 
     const [traced, refused] = await Promise.all([
       trace("exit", child, ["a", "b"]),
-      trace("refused", child, [], { starts: elsewhere }),
+      trace("refused", child, [], { starts: "elsewhere.starts" }),
     ]);
 
     // 43 is the child's argc + 40: both arguments reached it, and its exit code
@@ -807,7 +796,8 @@ describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
       traced: { stdout: "", stderr: "", exitCode: 43 },
       refused: {
         stdout: "",
-        stderr: `functrace: none of the 2 function starts in ${elsewhere} fall inside the command's code — is it the binary they were read from?\r\n`,
+        stderr:
+          "functrace: none of the 2 function starts in elsewhere.starts fall inside the command's code — is it the binary they were read from?\r\n",
         exitCode: 2,
       },
     });

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isMusl, isWindows, nodeExe, tempDir } from "harness";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { closeSync, existsSync, openSync, readFileSync, readSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
   mustGenerateOrderFile,
   orderFileEligible,
@@ -333,6 +333,31 @@ async function compileMsvc(cwd: string, source: string, out: string, link: strin
   if (exitCode !== 0) throw new Error(`${compiler} exited ${exitCode}:\n${stdout}${stderr}`);
 }
 
+/**
+ * Nothing else in the suite runs the C toolchain, so on a CI lane (a fresh VM)
+ * the first compile here pages the 100 MB compiler, 70 MB linker and 50 MB
+ * static CRT in from a cold cloud disk one fault at a time: 7s, 3s and 4s on an
+ * Azure VM, against a second each to read through first, which leaves the
+ * faults to the disk's cache.
+ */
+function primeMsvcToolchain() {
+  const libDirs = (process.env.LIB ?? "").split(";").filter(Boolean);
+  const files = [
+    compiler!,
+    join(dirname(compiler!), "lld-link.exe"),
+    ...["libcmt.lib", "libucrt.lib", "libvcruntime.lib"].flatMap(lib => libDirs.map(dir => join(dir, lib))),
+  ];
+  const buffer = Buffer.allocUnsafe(4 << 20);
+  for (const file of files.filter(file => existsSync(file))) {
+    const fd = openSync(file, "r");
+    try {
+      while (readSync(fd, buffer, 0, buffer.length, null) > 0);
+    } finally {
+      closeSync(fd);
+    }
+  }
+}
+
 /** The linker options that write a binary's two maps where the generator looks for them (see windows-symbols.ts). */
 const mapsFor = (exe: string): string[] => [`/map:${symbolMapFor(exe)}`, `/lldmap:${linkerMapFor(exe)}`];
 
@@ -345,10 +370,19 @@ async function writeStarts(path: string, addresses: Iterable<number | bigint>) {
   await Bun.write(path, new Uint8Array(words.buffer));
 }
 
-/** The trace's header: magic, version, slide, start count, entry count. */
-async function readTraceHeader(path: string) {
-  const [magic, version, , , entries] = new BigUint64Array(await Bun.file(path).slice(0, 40).arrayBuffer());
-  return { magic, version, entries: Number(entries) };
+/**
+ * The trace's entries, in the order they were recorded, and the names each one
+ * resolves to, the way generate.ts resolves them. Every entry was one of the
+ * starts handed in, so every one resolves.
+ */
+async function readTrace(path: string, symbols: Map<number, string[]>) {
+  const words = new BigUint64Array(await Bun.file(path).arrayBuffer());
+  // Layout: u64 magic, version, slide, start count, entry count, then the entries.
+  expect({ magic: words[0], version: words[1] }).toEqual({ magic: TRACE_MAGIC, version: 1n });
+  const entries = Array.from(words.subarray(5, 5 + Number(words[4])), address => Number(address));
+  const names = entries.flatMap(address => symbols.get(address) ?? [`unresolved ${address.toString(16)}`]);
+  expect(names.filter(name => name.startsWith("unresolved "))).toEqual([]);
+  return { entries, names };
 }
 
 describe("order file generator", () => {
@@ -591,22 +625,17 @@ describe.skipIf(!canTrace || isWindows)("pty runner", () => {
  * in a real trace are the hottest.
  */
 async function expectFixtureTrace(trace: string, symbols: Map<number, string[]>) {
-  const raw = await Bun.file(trace).arrayBuffer();
-  const words = new BigUint64Array(raw);
-  // Layout: u64 magic, version, slide, start count, entry count, then the entries.
-  expect({ magic: words[0], version: words[1] }).toEqual({ magic: TRACE_MAGIC, version: 1n });
-  const entries = Array.from(words.subarray(5, 5 + Number(words[4])), address => Number(address));
-
-  // Each entry resolves to the names at that address, the way generate.ts
-  // resolves them; macOS nm spells C functions with a leading underscore.
-  const names = entries.flatMap(address => symbols.get(address) ?? [`unresolved ${address.toString(16)}`]);
+  const { entries, names } = await readTrace(trace, symbols);
+  // macOS nm spells C functions with a leading underscore.
   const plain = names.map(name => (darwin ? name.replace(/^_/, "") : name));
-  const touched = plain.filter(name => /^f\d+$/.test(name));
 
-  expect(touched).toEqual(Array.from({ length: 32 }, (_, i) => `f${i}`));
-  expect(plain).toContain("main");
-  expect(plain).toContain("after");
-  expect(plain.indexOf("after")).toBeGreaterThan(plain.indexOf("f31"));
+  // The fixture's own functions, in the order it calls them, each entered once;
+  // the CRT's are whatever it ran on the way in and between them.
+  expect(plain.filter(name => /^(main|f\d+|after)$/.test(name))).toEqual([
+    "main",
+    ...Array.from({ length: 32 }, (_, i) => `f${i}`),
+    "after",
+  ]);
   expect(new Set(entries).size).toBe(entries.length);
 }
 
@@ -660,83 +689,18 @@ describe.skipIf(!canTrace || isWindows)("function tracer", () => {
  * linked with them, as the release is.
  */
 describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
-  it.concurrent("records exact entries out of the maps' functions, and leaves the child alone", async () => {
-    using dir = tempDir("functrace-windows", { "child.c": "int main(void) { return 0; }\n" });
-    const root = String(dir);
-    const tracer = join(root, "functrace.exe");
-    const fixture = join(root, "fixture.exe");
-    const child = join(root, "child.exe");
-    const starts = join(root, "starts.bin");
-    const trace = join(root, "trace.bin");
+  /** A binary the tracer runs: built once, its functions read from its maps once and written as its starts file. */
+  type Built = { exe: string; symbols: Map<number, string[]>; starts: string };
+  let dir: ReturnType<typeof tempDir> | undefined;
+  let root: string;
+  let tracer: string;
+  let fixture: Built, child: Built, probe: Built;
 
-    await Promise.all([
-      compileMsvc(root, join(orderfile, "functrace-windows.c"), tracer),
-      // No folding: `after` has the same body as f1, and the trace is checked
-      // for it being entered separately, after f31.
-      compileMsvc(root, join(import.meta.dir, "functrace-fixture.c"), fixture, [...mapsFor(fixture), "/opt:noicf"]),
-      compileMsvc(root, join(root, "child.c"), child),
-    ]);
-
-    const symbols = readTextSymbols(fixture);
-    expect(symbols.size).toBeGreaterThan(33); // the fixture's own functions, plus the static CRT's
-    // The static CRT is also where the labels come from that are not functions:
-    // its assembly routines name their internal labels (and, on arm64, their
-    // tables), so the listing always has more than the functions kept here. A
-    // breakpoint on one of those tables is what this test crashes on otherwise.
-    const listed = parseSymbolMap(readFileSync(symbolMapFor(fixture), "utf8")).symbols.length;
-    expect([...symbols.values()].flat().length).toBeLessThan(listed);
-    await writeStarts(starts, symbols.keys());
-
-    await using proc = Bun.spawn({
-      cmd: [tracer, fixture, child],
-      env: { ...bunEnv, BUN_FUNCTRACE_STARTS: starts, BUN_FUNCTRACE_OUT: trace },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // The fixture's stdout comes through the tracer's, and so does its exit code.
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "497", stderr: "", exitCode: 0 });
-
-    await expectFixtureTrace(trace, symbols);
-  });
-
-  it.concurrent("reports the debuggee's exit code, and refuses a binary the starts are not for", async () => {
-    using dir = tempDir("functrace-windows-exit", {
-      "exit.c": "int main(int argc, char **argv) { (void)argv; return argc + 40; }\n",
-    });
-    const root = String(dir);
-    const tracer = join(root, "functrace.exe");
-    const exit = join(root, "exit.exe");
-    const starts = join(root, "starts.bin");
-    await Promise.all([
-      compileMsvc(root, join(orderfile, "functrace-windows.c"), tracer),
-      compileMsvc(root, join(root, "exit.c"), exit, mapsFor(exit)),
-    ]);
-    const env = { ...bunEnv, BUN_FUNCTRACE_STARTS: starts, BUN_FUNCTRACE_OUT: join(root, "trace.bin") };
-
-    await writeStarts(starts, readTextSymbols(exit).keys());
-    await using traced = Bun.spawn({ cmd: [tracer, exit, "a", "b"], env, stdout: "pipe", stderr: "pipe" });
-    // Addresses far outside any code section: a starts file for some other binary.
-    await writeStarts(join(root, "elsewhere.bin"), [0x7ff600000000, 0x7ff600000010]);
-    await using refused = Bun.spawn({
-      cmd: [tracer, exit],
-      env: { ...env, BUN_FUNCTRACE_STARTS: join(root, "elsewhere.bin") },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [tracedErr, tracedExit, refusedErr, refusedExit] = await Promise.all([
-      traced.stderr.text(),
-      traced.exited,
-      refused.stderr.text(),
-      refused.exited,
-    ]);
-    expect({ tracedErr, tracedExit, refusedExit }).toEqual({ tracedErr: "", tracedExit: 43, refusedExit: 2 });
-    expect(refusedErr).toContain("none of the 2 function starts");
-  });
-
-  it.concurrent("puts the debuggee on a console when asked to, and types our stdin into it", async () => {
-    using dir = tempDir("functrace-console", {
+  beforeAll(async () => {
+    dir = tempDir("functrace-windows", {
+      // What the fixture runs: exits 0 with no arguments. With arguments it
+      // exits argc + 40, for the test of what comes back through the tracer.
+      "child.c": "int main(int argc, char **argv) { (void)argv; return argc > 1 ? argc + 40 : 0; }\n",
       // Reports whether its stdio is a console, how wide, and the line it was typed.
       "probe.c": [
         "#include <windows.h>",
@@ -747,55 +711,132 @@ describe.skipIf(!canTrace || !isWindows)("windows tracer", () => {
         "    CONSOLE_SCREEN_BUFFER_INFO screen;",
         "    int console = GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &mode) &&",
         "        GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &screen);",
-        "    char line[64];",
-        '    const char *typed = fgets(line, sizeof line, stdin) ? line : "nothing";',
-        '    line[strcspn(line, "\\r\\n")] = 0;',
-        '    printf("%s %d %s\\n", console ? "true" : "false", console ? (int)screen.dwSize.X : 0, typed);',
+        '    char line[64] = "nothing";',
+        '    if (fgets(line, sizeof line, stdin)) line[strcspn(line, "\\r\\n")] = 0;',
+        '    printf("%s %d %s\\n", console ? "true" : "false", console ? (int)screen.dwSize.X : 0, line);',
         "    return 0;",
         "}",
         "",
       ].join("\n"),
     });
-    const root = String(dir);
-    const tracer = join(root, "functrace.exe");
-    const probe = join(root, "probe.exe");
-    const starts = join(root, "starts.bin");
+    root = String(dir);
+    tracer = join(root, "functrace.exe");
+    const exe = (name: string) => join(root, `${name}.exe`);
+
+    primeMsvcToolchain();
     await Promise.all([
       compileMsvc(root, join(orderfile, "functrace-windows.c"), tracer),
-      compileMsvc(root, join(root, "probe.c"), probe, mapsFor(probe)),
+      // No folding: `after` has the same body as f1, and the trace is checked
+      // for it being entered separately, after f31.
+      compileMsvc(root, join(import.meta.dir, "functrace-fixture.c"), exe("fixture"), [
+        ...mapsFor(exe("fixture")),
+        "/opt:noicf",
+      ]),
+      compileMsvc(root, join(root, "child.c"), exe("child"), mapsFor(exe("child"))),
+      compileMsvc(root, join(root, "probe.c"), exe("probe"), mapsFor(exe("probe"))),
     ]);
-    await writeStarts(starts, readTextSymbols(probe).keys());
 
+    // The starts file the generator would write for each, from the same symbol reader.
+    async function built(name: string): Promise<Built> {
+      const symbols = readTextSymbols(exe(name));
+      const starts = join(root, `${name}.starts`);
+      await writeStarts(starts, symbols.keys());
+      return { exe: exe(name), symbols, starts };
+    }
+    [fixture, child, probe] = await Promise.all([built("fixture"), built("child"), built("probe")]);
+  });
+
+  afterAll(() => dir?.[Symbol.dispose]());
+
+  /** Runs `target` under the tracer, armed with its own starts unless told otherwise, and has it write `<name>.trace`. */
+  async function trace(
+    name: string,
+    target: Built,
+    args: string[],
+    { env = {}, stdin, starts = target.starts }: { env?: Record<string, string>; stdin?: Blob; starts?: string } = {},
+  ) {
+    const out = join(root, `${name}.trace`);
+    await using proc = Bun.spawn({
+      cmd: [tracer, target.exe, ...args],
+      env: { ...bunEnv, ...env, BUN_FUNCTRACE_STARTS: starts, BUN_FUNCTRACE_OUT: out },
+      stdin,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, trace: out };
+  }
+
+  it.concurrent("records exact entries out of the maps' functions, and leaves the child alone", async () => {
+    const { symbols } = fixture;
+    expect(symbols.size).toBeGreaterThan(33); // the fixture's own functions, plus the static CRT's
+    // The static CRT is also where the labels come from that are not functions:
+    // its assembly routines name their internal labels (and, on arm64, their
+    // tables), so the listing always has more than the functions kept here. A
+    // breakpoint on one of those tables is what this test crashes on otherwise.
+    const listed = parseSymbolMap(readFileSync(symbolMapFor(fixture.exe), "utf8")).symbols.length;
+    expect([...symbols.values()].flat().length).toBeLessThan(listed);
+
+    const run = await trace("fixture", fixture, [child.exe]);
+    // The fixture's stdout comes through the tracer's, and so does its exit code.
+    expect({ stdout: run.stdout.trim(), stderr: run.stderr, exitCode: run.exitCode }).toEqual({
+      stdout: "497",
+      stderr: "",
+      exitCode: 0,
+    });
+    await expectFixtureTrace(run.trace, symbols);
+  });
+
+  it.concurrent("reports the debuggee's exit code, and refuses a binary the starts are not for", async () => {
+    // Addresses far outside any code section: a starts file for some other binary.
+    const elsewhere = join(root, "elsewhere.starts");
+    await writeStarts(elsewhere, [0x7ff600000000, 0x7ff600000010]);
+
+    const [traced, refused] = await Promise.all([
+      trace("exit", child, ["a", "b"]),
+      trace("refused", child, [], { starts: elsewhere }),
+    ]);
+
+    // 43 is the child's argc + 40: both arguments reached it, and its exit code
+    // came back as the tracer's. The refusal is the tracer's own exit code, 2,
+    // and its one line of stderr (the CRT's, so \r\n).
+    expect({
+      traced: { stdout: traced.stdout, stderr: traced.stderr, exitCode: traced.exitCode },
+      refused: { stdout: refused.stdout, stderr: refused.stderr, exitCode: refused.exitCode },
+    }).toEqual({
+      traced: { stdout: "", stderr: "", exitCode: 43 },
+      refused: {
+        stdout: "",
+        stderr: `functrace: none of the 2 function starts in ${elsewhere} fall inside the command's code — is it the binary they were read from?\r\n`,
+        exitCode: 2,
+      },
+    });
+    // The exit code came out of a traced run; the refusal came before any trace was written.
+    expect((await readTrace(traced.trace, child.symbols)).names).toContain("main");
+    expect(existsSync(refused.trace)).toBe(false);
+  });
+
+  it.concurrent("puts the debuggee on a console when asked to, and types our stdin into it", async () => {
     async function type(name: string, env: Record<string, string>) {
-      const trace = join(root, `${name}.bin`);
-      await using proc = Bun.spawn({
-        cmd: [tracer, probe],
-        env: { ...bunEnv, ...env, BUN_FUNCTRACE_STARTS: starts, BUN_FUNCTRACE_OUT: trace },
-        stdin: new Blob(["hi\n"]),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const run = await trace(name, probe, [], { env, stdin: new Blob(["hi\n"]) });
       // A console's output is a terminal rendering — escape sequences, and the
       // typed line echoed back — so pick the probe's own line out of it.
-      const line = stdout
+      const line = run.stdout
         .replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)/g, "")
         .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
         .split(/[\x00-\x1f]+/)
         .map(text => text.trim())
         .find(text => /^(true|false) \d+ /.test(text));
-      return { line, stderr, exitCode, entries: (await readTraceHeader(trace)).entries };
+      const { names } = await readTrace(run.trace, probe.symbols);
+      return { line, stderr: run.stderr, exitCode: run.exitCode, tracedMain: names.includes("main") };
     }
 
     const [terminal, pipe] = await Promise.all([type("console", { BUN_FUNCTRACE_TTY: "1" }), type("pipe", {})]);
 
-    expect({ console: terminal.line, pipe: pipe.line, stderr: terminal.stderr + pipe.stderr }).toEqual({
-      console: "true 80 hi",
-      pipe: "false 0 hi",
-      stderr: "",
+    // Both runs were traced all the way into the probe's main, on either kind of stdio.
+    expect({ console: terminal, pipe }).toEqual({
+      console: { line: "true 80 hi", stderr: "", exitCode: 0, tracedMain: true },
+      pipe: { line: "false 0 hi", stderr: "", exitCode: 0, tracedMain: true },
     });
-    expect({ console: terminal.exitCode, pipe: pipe.exitCode }).toEqual({ console: 0, pipe: 0 });
-    // Both runs were traced: the probe's main, and the CRT on the way there.
-    expect(Math.min(terminal.entries, pipe.entries)).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
### Problem
- `test/js/bun/perf/linker-order.test.ts` is the slowest file on both windows lanes: 46s on 2019 x64, 31s on 11 aarch64 (build 103422). Run first and alone it takes 16.4s and 13.8s (build 99438). Warm, 0.9s.
- The cost is the first use of the C toolchain on a fresh VM, not the compiles (0.1 to 0.5s each, warm). `clang-cl.exe` (100 MB), `lld-link.exe` (70 MB) and the static CRT (50 MB) are demand-paged from the cold cloud disk: 7s, 3s and 4s on an Azure x64 VM. `ffi.test.js` pays the same through the harness's `compileFixture`: 7.9s for gcc's first `cc -shared`.

### Fix
- `primeToolchain(files)` in the harness reads the files through once, so the faults that follow hit the disk's cache. `compileFixture` calls it with the compiler's programs once per process on windows; linker-order with `clang-cl`, its `lld-link` and the CRT. On never-run copies of the binaries (x64): compile 7.1s to 1.1s, link 3.4s to 0.8s. The arm64 VM's disk cache helps less: 8.4s to 7.6s.
- linker-order builds its four binaries once in `beforeAll` (7 compiles across three tests before), reads each binary's maps once, shares one temp dir.
- Tighter assertions: the trace is exactly `main, f0..f31, after`, every entry resolves, each traced run reached `main`, a refused run writes no trace and prints exactly its `die` line.
- Verified: `bun bd test` of both files on windows x64 (debug, warm: 3.8s before and after), windows aarch64 and linux. CI build 103550: 6.5s and 6.3s first and alone, against 16.4s and 13.8s.

### Background
- `functrace-windows.c` is the debugger `scripts/orderfile/generate.ts` runs to find the functions bun enters at startup. The test compiles it with `clang-cl` and runs it on small fixtures.
- Demand paging: Windows reads each page of an executable the first time code touches it, one disk round trip per page. A sequential read is throughput-bound, and the disk's cache then serves the faults. The OS page cache cannot: these binaries have a PE `FileAlignment` of 512, not 4096.

<details><summary>Notes</summary>

Measurements, all on Azure VMs like the CI agents (Windows Server 2019 x64 and Windows 11 arm64, 16 vCPUs; the CI agents have 4 and run 3 other files at once).

- Instrumented run of the original file on a fresh arm64 VM: all 7 compiles finished between 13.0s and 13.5s, `readTextSymbols` took 5ms, the three tracer runs 136ms, 227ms and 443ms. Warm on the same VM: compiles 230ms to 650ms, file total 1.3s.
- x64, truly cold (never-run hardlink copies of the LLVM binaries, which share the cold blocks): `clang.exe -c trivial.c` 7.1s, second run 25ms. `clang++.exe` after one sequential read of the file (1.02s): 106ms. `lld.exe` cold link 3.35s. `ld.lld.exe` after a sequential read (0.70s): 98ms. Cold debug CRT libraries (`/MTd`, never touched): compile and link 4.5s against 0.11s warm. Cold mingw gcc (`cc -shared ffi-test.c`, what `compileFixture` runs in CI): 7.9s, then 0.33s, warm 0.08s. Its `cc1.exe` is 41 MB.
- x64, the new file against a never-run toolchain copy: 3.4s for the whole file (the original took 6.3s per test on the same VM when it was fresh). arm64, original file against a never-run copy: 8.4s, new file against another never-run copy: 7.6s. After a standby-list purge (OS page cache empty, disk cache warm) a compile and link costs 0.57s on arm64 and 0.5s on x64.
- Why the page cache cannot back the image: with `FileAlignment` 512 the file layout and the in-memory layout of the sections differ, so Windows cannot map the cached file pages as the image's pages and reads them again through paging I/O. Only a cache below the OS (the cloud disk's) sees the first read, and the arm64 VM's disk apparently caches less of a sequential read.
- The file runs in the parallel bucket, so its time is one of 3 or 4 slots, not the shard's wall-clock. The `compileFixture` half is in the serial phase, which is. Neither gain is measured in CI under bucket contention: a PR branch always runs its changed files first and alone. Build 99438 (the PR that added these tests, so it also ran the file first and alone) is the clean before: 16.40s x64, 13.78s arm64.
- Release build, warm, windows x64: 0.87s before and after. The compile sharing saves about 1.5s of CPU per run, which a 16 vCPU VM does not show in wall time.
- The child binary doubles as the exit-code binary: it exits `argc + 40` with arguments (43 with `a b`, as before) and 0 without, so the fixture's child run still passes.
- `Bun.file().arrayBuffer()` and `fs.readFile` of 220 MB take 0.6 to 1.2s under the debug build. A `readSync` loop into one 4 MB buffer takes 50ms, which is what `primeToolchain` uses.
- `bun test` runs `beforeAll` under the per-test timeout (90s in CI's parallel bucket), so the one-time build stays inside it.
- Compile flags stay `/O1 /Gy`: `/Od` did not compile measurably faster, and `/Gy` is what gives one chunk per function, which `windows-symbols.ts` depends on.
- The tracer prints the starts path with `%ls` in the C locale, which drops or truncates non-ASCII characters. The refused run therefore passes `elsewhere.starts` relative to the tracer's cwd (the shared temp dir), and the expected line is a constant.
- `compileFixture` on the CI images resolves `cc` to mingw's `cc.exe` (mingw is ahead of llvm in PATH); `-print-prog-name` gives gcc's real programs, and clang answers with bare names, which `primeToolchain` skips. The four probes cost about 150ms warm.
- Assertions in detail: `expectFixtureTrace` compares the filtered trace to `["main", "f0", ..., "f31", "after"]` instead of four separate checks. `readTrace` fails on any entry that does not resolve. The exit-code test compares `{stdout, stderr, exitCode}` of both runs in one `toEqual`, including the tracer's full `die` line, and checks `existsSync(refused.trace)` is false. The console test compares `{line, stderr, exitCode, tracedMain}` for both runs in one `toEqual`, replacing `Math.min(entries) > 1`. The probe's uninitialised `line` on an `fgets` failure is gone.
- The pty runner and function tracer describes (linux and macOS) have five distinct compiles and no repeats, so they are unchanged apart from the shared `expectFixtureTrace`. On linux they ran with `bun bd test` (debug) and with the release build. `ffi.test.js` on linux: 148 pass (its FTL test runs 4.6s against a 5s budget and flakes with or without this change).
- CI runs these tests with the release build. The debug build spends its extra time in module loading (2s) and map parsing, not in the compiles.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/perf/linker-order.test.ts

<!-- robobun:evidence:end -->