### PR TITLE
Bun.serve: reject a WebSocket idleTimeout outside 0..960 instead of truncating it to 16 bits

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -275,7 +275,7 @@ The `.send(message)` method of `ServerWebSocket` returns a `number` indicating t
 
 ### Timeouts and limits
 
-By default, Bun closes a WebSocket connection that has been idle for 120 seconds. Configure this with the `idleTimeout` parameter. The maximum value is `960`, and `0` disables the timeout entirely.
+By default, Bun closes a WebSocket connection that has been idle for 120 seconds. Configure this with the `idleTimeout` parameter. It takes a whole number of seconds from `0` to `960`. `0` disables the timeout entirely, and values from `1` to `7` are rounded up to `8`.
 
 ```ts
 Bun.serve({

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -275,7 +275,7 @@ The `.send(message)` method of `ServerWebSocket` returns a `number` indicating t
 
 ### Timeouts and limits
 
-By default, Bun closes a WebSocket connection that has been idle for 120 seconds. Configure this with the `idleTimeout` parameter.
+By default, Bun closes a WebSocket connection that has been idle for 120 seconds. Configure this with the `idleTimeout` parameter. The maximum value is `960`, and `0` disables the timeout entirely.
 
 ```ts
 Bun.serve({

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -494,6 +494,8 @@ declare module "bun" {
      * Sets the number of seconds to wait before timing out a connection
      * due to no messages or pings.
      *
+     * The maximum value is `960`. `0` disables the timeout.
+     *
      * @default 120
      */
     idleTimeout?: number;

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -494,7 +494,8 @@ declare module "bun" {
      * Sets the number of seconds to wait before timing out a connection
      * due to no messages or pings.
      *
-     * The maximum value is `960`. `0` disables the timeout.
+     * The maximum value is `960`. `0` disables the timeout. Values from
+     * `1` to `7` are rounded up to `8`.
      *
      * @default 120
      */

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -331,18 +331,16 @@ pub(crate) fn on_create(
                 )));
             }
 
-            let mut idle_timeout: u16 = value.to_int64().max(0) as u16;
-            if idle_timeout > 960 {
+            let seconds = value.to_int64();
+            if !(0..=960).contains(&seconds) {
                 return Err(global_object.throw_invalid_arguments(format_args!(
-                    "websocket expects idleTimeout to be 960 or less"
+                    "websocket expects idleTimeout to be between 0 and 960"
                 )));
-            } else if idle_timeout > 0 {
-                // uws does not allow idleTimeout to be between (0, 8),
-                // since its timer is not that accurate, therefore round up.
-                idle_timeout = idle_timeout.max(8);
             }
 
-            server.idle_timeout = idle_timeout;
+            // uws does not allow idleTimeout to be between (0, 8),
+            // since its timer is not that accurate, therefore round up.
+            server.idle_timeout = if seconds > 0 { (seconds as u16).max(8) } else { 0 };
         }
     }
     if let Some(value) = object.get(global_object, "backpressureLimit")? {

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -340,7 +340,11 @@ pub(crate) fn on_create(
 
             // uws does not allow idleTimeout to be between (0, 8),
             // since its timer is not that accurate, therefore round up.
-            server.idle_timeout = if seconds > 0 { (seconds as u16).max(8) } else { 0 };
+            server.idle_timeout = if seconds > 0 {
+                (seconds as u16).max(8)
+            } else {
+                0
+            };
         }
     }
     if let Some(value) = object.get(global_object, "backpressureLimit")? {

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -338,8 +338,7 @@ pub(crate) fn on_create(
                 )));
             }
 
-            // uws does not allow idleTimeout to be between (0, 8),
-            // since its timer is not that accurate, therefore round up.
+            // uws::App::ws terminates on an idleTimeout in 1..8 or above 960.
             server.idle_timeout = if seconds > 0 {
                 (seconds as u16).max(8)
             } else {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -201,6 +201,41 @@ describe("Bun.serve websocket options", () => {
     server.stop();
   });
 
+  // idleTimeout was narrowed to 16 bits before the range check, so 65537
+  // became 1 second and 2 ** 31 became 0 (no timeout at all).
+  test("websocket idleTimeout outside 0..960 throws", () => {
+    for (const idleTimeout of [65537, 2 ** 31, 961, -1]) {
+      expect(() =>
+        serve({
+          port: 0,
+          websocket: {
+            message(ws, message) {},
+            idleTimeout,
+          },
+          fetch() {
+            return new Response("ok");
+          },
+        }),
+      ).toThrow("websocket expects idleTimeout to be between 0 and 960");
+    }
+  });
+
+  test("websocket idleTimeout accepts 0 and 960", () => {
+    for (const idleTimeout of [0, 960]) {
+      using server = serve({
+        port: 0,
+        websocket: {
+          message(ws, message) {},
+          idleTimeout,
+        },
+        fetch() {
+          return new Response("ok");
+        },
+      });
+      server.stop();
+    }
+  });
+
   test("websocket with compression options", () => {
     using server = serve({
       port: 0,


### PR DESCRIPTION
### Problem
- `Bun.serve({ websocket: { idleTimeout } })` cast the value to `u16` before the range check, so `idleTimeout: 65537` (18 hours) was accepted and the server closed idle clients after 8 seconds with `WebSocket timed out from inactivity`. `idleTimeout: 2 ** 31` became `0` and disabled the idle timeout. `-1` was accepted as `0`.
- The cause is `src/runtime/server/WebSocketServerContext.rs:334`: `value.to_int64().max(0) as u16` ran before `if idle_timeout > 960`. The HTTP `idleTimeout` on the same constructor already rejects out-of-range values.

### Fix
- Keep the value as an `i64` and reject anything outside `0..=960` with `websocket expects idleTimeout to be between 0 and 960`. The narrowing to `u16` happens after the check. In-range values behave as before, including the round-up of 1..7 to 8 seconds.
- The maximum is now documented on the type and in the WebSocket docs.
- Verified: `test/js/bun/http/bun-serve-args.test.ts` (two new tests; stock bun 1.4.0 fails the first). Also `test/js/bun/websocket/websocket-server.test.ts` and `test/integration/bun-types/bun-types.test.ts`.

### Background
- `idleTimeout` is the number of seconds a WebSocket connection may stay silent before uWebSockets closes it. uWS stores it as `unsigned short` and Bun caps it at 960 seconds (16 minutes), the most its 4-second sweep timer can track per socket.
- Bun's validation for this option runs once at `Bun.serve()` time in `WebSocketServerContext::on_create`, which builds the `uws::WebSocketBehavior` passed to uWS.

<details><summary>Notes</summary>

Reproduced on bun 1.4.0 with a raw loopback client that finishes the upgrade and stays silent:

```js
const s = Bun.serve({ port: 0, fetch(r, srv) { srv.upgrade(r); }, websocket: { idleTimeout: 65537, message() {},
  close(ws, code, why) { console.log(((performance.now() - t0) / 1e3).toFixed(1) + "s", code, why); process.exit(0); } } });
const t0 = performance.now();
const c = require("net").connect(s.port, "127.0.0.1", () => c.write("GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"));
// 1.4.0: "8.0s 1006 WebSocket timed out from inactivity" (configured: 65537 s)
```

With this change the same script throws at `Bun.serve()`. `-1`, `65537`, `2 ** 31` and `961` all throw; `0` and `960` are accepted.

Negative values used to map to `0` (timeout disabled). They now throw. The docs only ever described `0` as the way to disable the timeout.

`maxPayloadLength` and `backpressureLimit` in the same function narrow with `as u32` without a range check. They are not timeouts and are left alone here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-args.test.ts

<!-- robobun:evidence:end -->