### PR TITLE
io: wait for a named pipe's EOF with select(2) on macOS

### DIFF
--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -277,7 +277,10 @@ impl Drop for SpawnSyncEventLoop {
         // Destroy the event loop before the uws loop.
         __bun_spawn_sync_destroy_event_loop(self.event_loop);
         // SAFETY: uws_loop was returned by `us_create_loop` in `init` and not yet freed.
-        unsafe { uws::Loop::destroy(self.uws_loop.as_ptr()) };
+        unsafe {
+            bun_io::loop_closing(self.uws_loop.as_ptr());
+            uws::Loop::destroy(self.uws_loop.as_ptr());
+        }
     }
 }
 

--- a/src/io/fifo_select.rs
+++ b/src/io/fifo_select.rs
@@ -1,43 +1,33 @@
 //! macOS: readiness of a named pipe (FIFO), which kqueue cannot report.
 //!
-//! XNU attaches a FIFO's `EVFILT_READ` knote to the vnode (`vn_kqfilter`), and
-//! `filt_vnode_common` activates it only while bytes are buffered. The last
-//! writer closing never wakes it, and `poll(2)` is built on the same filter, so
-//! a reader parked in a kqueue after draining the pipe never learns about EOF.
-//! `select(2)` goes through the FIFO's socket (`fifo_select` -> `soo_select`),
-//! whose readable test includes `SS_CANTRCVMORE`: it wakes for data and for the
-//! last writer's close. `pipe(2)` pipes are not affected (their own filter
-//! reports `EV_EOF`); they `fstat` with `st_dev == 0`, a named pipe with the
-//! device of the filesystem it lives on.
+//! XNU's `EVFILT_READ` filter for a FIFO vnode (`filt_vnode_common`) fires only
+//! while bytes are buffered, and `poll(2)` is built on it; the last writer's
+//! close wakes neither. `select(2)` goes through the FIFO's socket and does
+//! wake for it (`soreadable()` includes `SS_CANTRCVMORE`). `pipe(2)` pipes have
+//! their own filter, which reports `EV_EOF`.
 //!
-//! One thread per process blocks in `select` on every armed FIFO. A FIFO that
-//! becomes readable is disarmed (one-shot, like the `EV_ONESHOT`/`EV_DISPATCH`
-//! knote it stands in for) and its poll is delivered into the owning kqueue as
-//! an `EVFILT_USER` event with the poll's `udata`, so it reaches that kqueue's
-//! dispatch like any other readiness event. The owner disarms before it closes
-//! the fd; that removal and the delivery take the same lock, so a poll that is
-//! gone is never delivered.
+//! One thread per process blocks in `select` on every armed FIFO. A readable one
+//! is disarmed (one-shot) and delivered into the owning kqueue as an
+//! `EVFILT_USER` event carrying the poll's `udata`, so that kqueue dispatches it
+//! like any other event. Delivery and `disarm` take the same lock.
 
 use bun_sys::{self as sys, Fd, FdExt as _};
 use bun_threading::{Guarded, Mutex};
 
-/// User flag (low 24 bits of `fflags`) on a delivered `EVFILT_USER` event: the
-/// fd is readable or at EOF.
+/// Set in the low 24 `fflags` bits of a delivered event.
 pub(crate) const NOTE_FIFO_READABLE: u32 = 0x1;
 
 struct Armed {
     fd: Fd,
-    /// The kqueue the owner waits in.
     kqueue: Fd,
-    /// The `udata` that kqueue's dispatch decodes into the poll.
     udata: u64,
     generation: u64,
 }
 
 struct Watcher {
     armed: Guarded<Vec<Armed>>,
-    /// Self-pipe. `arm`/`disarm` write a byte so the thread leaves `select`
-    /// and rebuilds its set.
+    /// Self-pipe: a byte written here makes the thread leave `select` and
+    /// rebuild its set.
     wake_read: Fd,
     wake_write: Fd,
 }
@@ -60,8 +50,6 @@ fn watcher() -> sys::Result<&'static Watcher> {
     if let Some(watcher) = WATCHER.get() {
         return Ok(watcher);
     }
-    // Owning raw pointer first, shared view second: the spawn error arm
-    // reclaims through `watcher_ptr`, which must not come from a shared reference.
     let watcher_ptr = bun_core::heap::into_raw(Box::new(Watcher::init()?));
     // SAFETY: just allocated and exclusively owned; published only on Ok.
     let watcher: &'static Watcher = unsafe { &*watcher_ptr };
@@ -112,15 +100,14 @@ impl Watcher {
     fn deliver(&self, fd: Fd) {
         let mut armed = self.armed.lock();
         while let Some(index) = armed.iter().position(|a| a.fd == fd) {
-            let entry = armed.swap_remove(index);
-            // Still under the lock: an owner that unregisters after this has
-            // the knote to delete, one that did so before took the entry away.
-            entry.deliver();
+            // Under the lock, so an owner that unregisters afterwards finds the
+            // knote to delete.
+            armed.swap_remove(index).deliver();
         }
     }
 
-    /// Drops every registration of `fd` without delivering, the way a kqueue
-    /// drops a knote whose fd was closed. Returns whether there was one.
+    /// Drops every registration of `fd` without delivering, as a kqueue drops
+    /// the knote of a closed fd. Returns whether there was one.
     fn forget(&self, fd: Fd) -> bool {
         let mut armed = self.armed.lock();
         let before = armed.len();
@@ -163,11 +150,9 @@ impl Armed {
     }
 }
 
-/// Waits for `fd` (a named pipe) to be readable or at EOF on behalf of the
-/// poll behind `udata`; the result arrives in `kqueue` as an `EVFILT_USER`
-/// event with `ident == fd` and `NOTE_FIFO_READABLE` in `fflags`. Arming an fd
-/// that `kqueue` already has armed replaces that registration, as kqueue does
-/// for one `ident`.
+/// Waits for `fd` to be readable or at EOF; the result arrives in `kqueue` as
+/// an `EVFILT_USER` event with `ident == fd`, `udata`, and `NOTE_FIFO_READABLE`
+/// in `fflags`. Arming again replaces the registration, as kqueue does.
 pub(crate) fn arm(kqueue: Fd, fd: Fd, udata: u64, generation: u64) -> sys::Result<()> {
     let watcher = watcher()?;
     {
@@ -187,9 +172,7 @@ pub(crate) fn arm(kqueue: Fd, fd: Fd, udata: u64, generation: u64) -> sys::Resul
     Ok(())
 }
 
-/// Stops waiting on `fd` for `kqueue`. Call before the fd is closed: a close
-/// on XNU wakes a `select` that includes the fd, and the thread must not put
-/// it back.
+/// Stops waiting on `fd` for `kqueue`. Call before the fd is closed.
 pub(crate) fn disarm(kqueue: Fd, fd: Fd) {
     let Some(watcher) = WATCHER.get() else {
         return;
@@ -249,13 +232,9 @@ fn run(watcher: &'static Watcher) {
                         "fifo_select: select failed: {}",
                         <&'static str>::from(errno)
                     );
-                    // An fd closed behind its owner's back is the one way a set
-                    // of live registrations fails. Forget those, as a kqueue
-                    // forgets the knote of a closed fd; never deliver an fd
-                    // that is not readable, since the owner's read on a
-                    // blocking FIFO would then block its loop. With nothing to
-                    // forget, back off instead of spinning on a failure we
-                    // cannot explain.
+                    // An fd closed behind its owner's back. A live fd is never
+                    // delivered without readiness: a blocking read would stall
+                    // the owner's loop.
                     let mut forgot = false;
                     for fd in &fds[1..] {
                         if sys::get_fcntl_flags(*fd).is_err() {

--- a/src/io/fifo_select.rs
+++ b/src/io/fifo_select.rs
@@ -115,12 +115,12 @@ impl Watcher {
         }
     }
 
-    /// Drops every registration of `fd` without delivering, as a kqueue drops
-    /// the knote of a closed fd. Returns whether there was one.
-    fn forget(&self, fd: Fd) -> bool {
+    /// Drops every registration that `keep` rejects without delivering, as a
+    /// kqueue drops the knotes of a closed fd. Returns whether there was one.
+    fn forget(&self, keep: impl Fn(&Armed) -> bool) -> bool {
         let mut armed = self.armed.lock();
         let before = armed.entries.len();
-        armed.entries.retain(|a| a.fd != fd);
+        armed.entries.retain(keep);
         armed.entries.len() != before
     }
 }
@@ -186,6 +186,17 @@ pub(crate) fn arm(kqueue: Fd, fd: Fd, udata: u64, generation: u64) -> sys::Resul
     }
     watcher.wake();
     Ok(())
+}
+
+/// Drops every registration that would deliver into `kqueue`. Call before the
+/// kqueue is closed, so nothing is ever delivered into a reused descriptor.
+pub(crate) fn forget_kqueue(kqueue: Fd) {
+    let Some(watcher) = WATCHER.get() else {
+        return;
+    };
+    if watcher.forget(|a| a.kqueue != kqueue) {
+        watcher.wake();
+    }
 }
 
 /// Stops waiting on `fd` for `kqueue`. Call before the fd is closed.
@@ -260,7 +271,7 @@ fn run(watcher: &'static Watcher) {
                     let mut forgot = false;
                     for (fd, _) in &watched {
                         if sys::get_fcntl_flags(*fd).is_err() {
-                            forgot |= watcher.forget(*fd);
+                            forgot |= watcher.forget(|a| a.fd != *fd);
                         }
                     }
                     if !forgot {

--- a/src/io/fifo_select.rs
+++ b/src/io/fifo_select.rs
@@ -1,0 +1,272 @@
+//! macOS: readiness of a named pipe (FIFO), which kqueue cannot report.
+//!
+//! XNU attaches a FIFO's `EVFILT_READ` knote to the vnode (`vn_kqfilter`), and
+//! `filt_vnode_common` activates it only while bytes are buffered. The last
+//! writer closing never wakes it, and `poll(2)` is built on the same filter, so
+//! a reader parked in the loop's kqueue after draining the pipe never learns
+//! about EOF. `select(2)` goes through the FIFO's socket (`fifo_select` ->
+//! `soo_select`), whose readable test includes `SS_CANTRCVMORE`: it wakes for
+//! data and for the last writer's close. `pipe(2)` pipes are not affected
+//! (their own filter reports `EV_EOF`); they `fstat` with `st_dev == 0`, a
+//! named pipe with the device of the filesystem it lives on.
+//!
+//! One thread per process blocks in `select` on every armed FIFO. A FIFO that
+//! becomes readable is disarmed (one-shot, like the `EV_DISPATCH` kqueue
+//! registration it stands in for) and its `FilePoll` is delivered into the
+//! owning loop's kqueue as an `EVFILT_USER` event, so it reaches
+//! `FilePoll::on_kqueue_event` like any other readiness event. `unregister`
+//! removes the armed entry before the owner closes the fd; that removal and the
+//! delivery take the same lock, so a poll that is gone is never delivered.
+
+use bun_sys::{self as sys, Fd, FdExt as _};
+use bun_threading::{Guarded, Mutex};
+
+struct Armed {
+    fd: Fd,
+    /// The owning loop's kqueue.
+    kqueue: Fd,
+    /// `Pollable::init(poll).ptr()`: the `udata` the loop dispatches on.
+    udata: u64,
+    generation: u64,
+}
+
+struct Watcher {
+    armed: Guarded<Vec<Armed>>,
+    /// Self-pipe. `arm`/`disarm` write a byte so the thread leaves `select`
+    /// and rebuilds its set.
+    wake_read: Fd,
+    wake_write: Fd,
+}
+
+impl Drop for Watcher {
+    fn drop(&mut self) {
+        self.wake_read.close();
+        self.wake_write.close();
+    }
+}
+
+static WATCHER: std::sync::OnceLock<&'static Watcher> = std::sync::OnceLock::new();
+static INIT: Mutex = Mutex::new();
+
+fn watcher() -> sys::Result<&'static Watcher> {
+    if let Some(watcher) = WATCHER.get() {
+        return Ok(watcher);
+    }
+    let _init = INIT.lock_guard();
+    if let Some(watcher) = WATCHER.get() {
+        return Ok(watcher);
+    }
+    // Owning raw pointer first, shared view second: the spawn error arm
+    // reclaims through `watcher_ptr`, which must not come from a shared reference.
+    let watcher_ptr = bun_core::heap::into_raw(Box::new(Watcher::init()?));
+    // SAFETY: just allocated and exclusively owned; published only on Ok.
+    let watcher: &'static Watcher = unsafe { &*watcher_ptr };
+    let spawned = std::thread::Builder::new()
+        .stack_size(1024 * 1024)
+        .spawn(move || run(watcher));
+    if spawned.is_err() {
+        // SAFETY: the thread never started and the watcher was never published.
+        drop(unsafe { bun_core::heap::take(watcher_ptr) });
+        return Err(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::select));
+    }
+    let _ = WATCHER.set(watcher);
+    Ok(watcher)
+}
+
+impl Watcher {
+    fn init() -> sys::Result<Watcher> {
+        let [wake_read, wake_write] = sys::pipe()?;
+        for fd in [wake_read, wake_write] {
+            if let Err(err) = sys::set_close_on_exec(fd).and_then(|()| sys::set_nonblocking(fd)) {
+                wake_read.close();
+                wake_write.close();
+                return Err(err);
+            }
+        }
+        Ok(Watcher {
+            armed: Guarded::new(Vec::new()),
+            wake_read,
+            wake_write,
+        })
+    }
+
+    fn wake(&self) {
+        // A byte already in the pipe (EAGAIN) wakes the thread just as well.
+        let _ = sys::write(self.wake_write, &[0u8]);
+    }
+
+    fn drain_wake(&self) {
+        let mut buf = [0u8; 64];
+        while let Ok(n) = sys::read(self.wake_read, &mut buf) {
+            if n < buf.len() {
+                break;
+            }
+        }
+    }
+
+    /// Disarms every registration of `fd` and delivers each to its loop.
+    /// Returns whether there was one.
+    fn deliver(&self, fd: Fd) -> bool {
+        let mut armed = self.armed.lock();
+        let mut delivered = false;
+        while let Some(index) = armed.iter().position(|a| a.fd == fd) {
+            let entry = armed.swap_remove(index);
+            // Still under the lock: an `unregister` that runs after this has
+            // the knote to delete, one that ran before took the entry away.
+            entry.deliver();
+            delivered = true;
+        }
+        delivered
+    }
+}
+
+impl Armed {
+    fn deliver(&self) {
+        use sys::darwin::{EV, EVFILT, NOTE, kevent64, kevent64_s};
+        let change = kevent64_s {
+            ident: u64::try_from(self.fd.native()).expect("int cast"),
+            filter: EVFILT::USER,
+            flags: EV::ADD | EV::ONESHOT,
+            fflags: NOTE::TRIGGER,
+            data: 0,
+            udata: self.udata,
+            ext: [self.generation, 0],
+        };
+        // SAFETY: FFI syscall; `change` is a stack-local valid for the call,
+        // and with no eventlist the call does not wait.
+        let rc = unsafe {
+            kevent64(
+                self.kqueue.native(),
+                &raw const change,
+                1,
+                core::ptr::null_mut(),
+                0,
+                0,
+                core::ptr::null(),
+            )
+        };
+        sys::syslog!(
+            "fifo_select: deliver({}) to kqueue {} = {}",
+            self.fd,
+            self.kqueue,
+            rc
+        );
+    }
+}
+
+/// Waits for `fd` (a named pipe) to be readable or at EOF on behalf of the
+/// `FilePoll` behind `udata`; the result arrives in `kqueue` as an
+/// `EVFILT_USER` event with `ident == fd`. Arming an fd that `kqueue` already
+/// has armed replaces that registration, as kqueue does for one `ident`.
+pub(crate) fn arm(kqueue: Fd, fd: Fd, udata: u64, generation: u64) -> sys::Result<()> {
+    let watcher = watcher()?;
+    {
+        let mut armed = watcher.armed.lock();
+        let entry = Armed {
+            fd,
+            kqueue,
+            udata,
+            generation,
+        };
+        match armed.iter_mut().find(|a| a.fd == fd && a.kqueue == kqueue) {
+            Some(existing) => *existing = entry,
+            None => armed.push(entry),
+        }
+    }
+    watcher.wake();
+    Ok(())
+}
+
+/// Stops waiting on `fd` for `kqueue`. Call before the fd is closed: a close
+/// on XNU wakes a `select` that includes the fd, and the thread must not put
+/// it back.
+pub(crate) fn disarm(kqueue: Fd, fd: Fd) {
+    let Some(watcher) = WATCHER.get() else {
+        return;
+    };
+    let removed = {
+        let mut armed = watcher.armed.lock();
+        match armed.iter().position(|a| a.fd == fd && a.kqueue == kqueue) {
+            Some(index) => {
+                armed.swap_remove(index);
+                true
+            }
+            None => false,
+        }
+    };
+    if removed {
+        watcher.wake();
+    }
+}
+
+fn set_bit(set: &mut [u32], fd: Fd) {
+    let index = fd.native() as usize;
+    set[index / 32] |= 1 << (index % 32);
+}
+
+fn is_set(set: &[u32], fd: Fd) -> bool {
+    let index = fd.native() as usize;
+    set[index / 32] & (1 << (index % 32)) != 0
+}
+
+fn run(watcher: &'static Watcher) {
+    bun_core::Output::Source::configure_named_thread(bun_core::ZStr::from_static(
+        b"FIFO Watcher\0",
+    ));
+    let mut fds: Vec<Fd> = Vec::new();
+    let mut set: Vec<u32> = Vec::new();
+    loop {
+        fds.clear();
+        fds.push(watcher.wake_read);
+        for entry in watcher.armed.lock().iter() {
+            if !fds.contains(&entry.fd) {
+                fds.push(entry.fd);
+            }
+        }
+        let max_fd = fds.iter().map(|fd| fd.native()).max().unwrap_or(0) as usize;
+        set.clear();
+        set.resize(max_fd / 32 + 1, 0);
+        for fd in &fds {
+            set_bit(&mut set, *fd);
+        }
+
+        match sys::select_readable(&mut set) {
+            Ok(_) => {}
+            Err(err) => match err.get_errno() {
+                sys::E::EINTR | sys::E::EAGAIN => continue,
+                errno => {
+                    sys::syslog!(
+                        "fifo_select: select failed: {}",
+                        <&'static str>::from(errno)
+                    );
+                    // An fd closed behind its owner's back is the one way a set
+                    // of live registrations fails. Deliver those, so the
+                    // owner's read reports the error instead of waiting
+                    // forever; never deliver a live fd that is not readable,
+                    // since the owner's read on a blocking FIFO would then
+                    // block the loop. With nothing to deliver, back off
+                    // instead of spinning on a failure we cannot explain.
+                    let mut delivered = false;
+                    for fd in &fds[1..] {
+                        if sys::get_fcntl_flags(*fd).is_err() {
+                            delivered |= watcher.deliver(*fd);
+                        }
+                    }
+                    if !delivered {
+                        std::thread::sleep(core::time::Duration::from_millis(10));
+                    }
+                    continue;
+                }
+            },
+        }
+
+        if is_set(&set, watcher.wake_read) {
+            watcher.drain_wake();
+        }
+        for fd in &fds[1..] {
+            if is_set(&set, *fd) {
+                watcher.deliver(*fd);
+            }
+        }
+    }
+}

--- a/src/io/fifo_select.rs
+++ b/src/io/fifo_select.rs
@@ -18,14 +18,23 @@ use bun_threading::{Guarded, Mutex};
 pub(crate) const NOTE_FIFO_READABLE: u32 = 0x1;
 
 struct Armed {
+    /// Unique per registration: a delivery is for the registration `select`
+    /// observed, not for whatever owns the fd number by the time it runs.
+    id: u64,
     fd: Fd,
     kqueue: Fd,
     udata: u64,
     generation: u64,
 }
 
+#[derive(Default)]
+struct Registry {
+    entries: Vec<Armed>,
+    next_id: u64,
+}
+
 struct Watcher {
-    armed: Guarded<Vec<Armed>>,
+    armed: Guarded<Registry>,
     /// Self-pipe: a byte written here makes the thread leave `select` and
     /// rebuild its set.
     wake_read: Fd,
@@ -76,7 +85,7 @@ impl Watcher {
             }
         }
         Ok(Watcher {
-            armed: Guarded::new(Vec::new()),
+            armed: Guarded::new(Registry::default()),
             wake_read,
             wake_write,
         })
@@ -96,13 +105,13 @@ impl Watcher {
         }
     }
 
-    /// Disarms every registration of `fd` and delivers each to its kqueue.
-    fn deliver(&self, fd: Fd) {
+    /// Disarms registration `id`, if it is still there, and delivers it.
+    fn deliver(&self, id: u64) {
         let mut armed = self.armed.lock();
-        while let Some(index) = armed.iter().position(|a| a.fd == fd) {
+        if let Some(index) = armed.entries.iter().position(|a| a.id == id) {
             // Under the lock, so an owner that unregisters afterwards finds the
             // knote to delete.
-            armed.swap_remove(index).deliver();
+            armed.entries.swap_remove(index).deliver();
         }
     }
 
@@ -110,9 +119,9 @@ impl Watcher {
     /// the knote of a closed fd. Returns whether there was one.
     fn forget(&self, fd: Fd) -> bool {
         let mut armed = self.armed.lock();
-        let before = armed.len();
-        armed.retain(|a| a.fd != fd);
-        armed.len() != before
+        let before = armed.entries.len();
+        armed.entries.retain(|a| a.fd != fd);
+        armed.entries.len() != before
     }
 }
 
@@ -157,15 +166,22 @@ pub(crate) fn arm(kqueue: Fd, fd: Fd, udata: u64, generation: u64) -> sys::Resul
     let watcher = watcher()?;
     {
         let mut armed = watcher.armed.lock();
+        let id = armed.next_id;
+        armed.next_id += 1;
         let entry = Armed {
+            id,
             fd,
             kqueue,
             udata,
             generation,
         };
-        match armed.iter_mut().find(|a| a.fd == fd && a.kqueue == kqueue) {
+        match armed
+            .entries
+            .iter_mut()
+            .find(|a| a.fd == fd && a.kqueue == kqueue)
+        {
             Some(existing) => *existing = entry,
-            None => armed.push(entry),
+            None => armed.entries.push(entry),
         }
     }
     watcher.wake();
@@ -179,9 +195,13 @@ pub(crate) fn disarm(kqueue: Fd, fd: Fd) {
     };
     let removed = {
         let mut armed = watcher.armed.lock();
-        match armed.iter().position(|a| a.fd == fd && a.kqueue == kqueue) {
+        match armed
+            .entries
+            .iter()
+            .position(|a| a.fd == fd && a.kqueue == kqueue)
+        {
             Some(index) => {
-                armed.swap_remove(index);
+                armed.entries.swap_remove(index);
                 true
             }
             None => false,
@@ -206,20 +226,22 @@ fn run(watcher: &'static Watcher) {
     bun_core::Output::Source::configure_named_thread(bun_core::ZStr::from_static(
         b"FIFO Watcher\0",
     ));
-    let mut fds: Vec<Fd> = Vec::new();
+    // The registrations this round waits for, as (fd, id).
+    let mut watched: Vec<(Fd, u64)> = Vec::new();
     let mut set: Vec<u32> = Vec::new();
     loop {
-        fds.clear();
-        fds.push(watcher.wake_read);
-        for entry in watcher.armed.lock().iter() {
-            if !fds.contains(&entry.fd) {
-                fds.push(entry.fd);
-            }
-        }
-        let max_fd = fds.iter().map(|fd| fd.native()).max().unwrap_or(0) as usize;
+        watched.clear();
+        watched.extend(watcher.armed.lock().entries.iter().map(|a| (a.fd, a.id)));
+        let max_fd = watched
+            .iter()
+            .map(|(fd, _)| fd.native())
+            .max()
+            .unwrap_or(0)
+            .max(watcher.wake_read.native()) as usize;
         set.clear();
         set.resize(max_fd / 32 + 1, 0);
-        for fd in &fds {
+        set_bit(&mut set, watcher.wake_read);
+        for (fd, _) in &watched {
             set_bit(&mut set, *fd);
         }
 
@@ -236,7 +258,7 @@ fn run(watcher: &'static Watcher) {
                     // delivered without readiness: a blocking read would stall
                     // the owner's loop.
                     let mut forgot = false;
-                    for fd in &fds[1..] {
+                    for (fd, _) in &watched {
                         if sys::get_fcntl_flags(*fd).is_err() {
                             forgot |= watcher.forget(*fd);
                         }
@@ -252,9 +274,9 @@ fn run(watcher: &'static Watcher) {
         if is_set(&set, watcher.wake_read) {
             watcher.drain_wake();
         }
-        for fd in &fds[1..] {
+        for (fd, id) in &watched {
             if is_set(&set, *fd) {
-                watcher.deliver(*fd);
+                watcher.deliver(*id);
             }
         }
     }

--- a/src/io/fifo_select.rs
+++ b/src/io/fifo_select.rs
@@ -3,29 +3,33 @@
 //! XNU attaches a FIFO's `EVFILT_READ` knote to the vnode (`vn_kqfilter`), and
 //! `filt_vnode_common` activates it only while bytes are buffered. The last
 //! writer closing never wakes it, and `poll(2)` is built on the same filter, so
-//! a reader parked in the loop's kqueue after draining the pipe never learns
-//! about EOF. `select(2)` goes through the FIFO's socket (`fifo_select` ->
-//! `soo_select`), whose readable test includes `SS_CANTRCVMORE`: it wakes for
-//! data and for the last writer's close. `pipe(2)` pipes are not affected
-//! (their own filter reports `EV_EOF`); they `fstat` with `st_dev == 0`, a
-//! named pipe with the device of the filesystem it lives on.
+//! a reader parked in a kqueue after draining the pipe never learns about EOF.
+//! `select(2)` goes through the FIFO's socket (`fifo_select` -> `soo_select`),
+//! whose readable test includes `SS_CANTRCVMORE`: it wakes for data and for the
+//! last writer's close. `pipe(2)` pipes are not affected (their own filter
+//! reports `EV_EOF`); they `fstat` with `st_dev == 0`, a named pipe with the
+//! device of the filesystem it lives on.
 //!
 //! One thread per process blocks in `select` on every armed FIFO. A FIFO that
-//! becomes readable is disarmed (one-shot, like the `EV_DISPATCH` kqueue
-//! registration it stands in for) and its `FilePoll` is delivered into the
-//! owning loop's kqueue as an `EVFILT_USER` event, so it reaches
-//! `FilePoll::on_kqueue_event` like any other readiness event. `unregister`
-//! removes the armed entry before the owner closes the fd; that removal and the
-//! delivery take the same lock, so a poll that is gone is never delivered.
+//! becomes readable is disarmed (one-shot, like the `EV_ONESHOT`/`EV_DISPATCH`
+//! knote it stands in for) and its poll is delivered into the owning kqueue as
+//! an `EVFILT_USER` event with the poll's `udata`, so it reaches that kqueue's
+//! dispatch like any other readiness event. The owner disarms before it closes
+//! the fd; that removal and the delivery take the same lock, so a poll that is
+//! gone is never delivered.
 
 use bun_sys::{self as sys, Fd, FdExt as _};
 use bun_threading::{Guarded, Mutex};
 
+/// User flag (low 24 bits of `fflags`) on a delivered `EVFILT_USER` event: the
+/// fd is readable or at EOF.
+pub(crate) const NOTE_FIFO_READABLE: u32 = 0x1;
+
 struct Armed {
     fd: Fd,
-    /// The owning loop's kqueue.
+    /// The kqueue the owner waits in.
     kqueue: Fd,
-    /// `Pollable::init(poll).ptr()`: the `udata` the loop dispatches on.
+    /// The `udata` that kqueue's dispatch decodes into the poll.
     udata: u64,
     generation: u64,
 }
@@ -104,19 +108,24 @@ impl Watcher {
         }
     }
 
-    /// Disarms every registration of `fd` and delivers each to its loop.
-    /// Returns whether there was one.
-    fn deliver(&self, fd: Fd) -> bool {
+    /// Disarms every registration of `fd` and delivers each to its kqueue.
+    fn deliver(&self, fd: Fd) {
         let mut armed = self.armed.lock();
-        let mut delivered = false;
         while let Some(index) = armed.iter().position(|a| a.fd == fd) {
             let entry = armed.swap_remove(index);
-            // Still under the lock: an `unregister` that runs after this has
-            // the knote to delete, one that ran before took the entry away.
+            // Still under the lock: an owner that unregisters after this has
+            // the knote to delete, one that did so before took the entry away.
             entry.deliver();
-            delivered = true;
         }
-        delivered
+    }
+
+    /// Drops every registration of `fd` without delivering, the way a kqueue
+    /// drops a knote whose fd was closed. Returns whether there was one.
+    fn forget(&self, fd: Fd) -> bool {
+        let mut armed = self.armed.lock();
+        let before = armed.len();
+        armed.retain(|a| a.fd != fd);
+        armed.len() != before
     }
 }
 
@@ -127,7 +136,7 @@ impl Armed {
             ident: u64::try_from(self.fd.native()).expect("int cast"),
             filter: EVFILT::USER,
             flags: EV::ADD | EV::ONESHOT,
-            fflags: NOTE::TRIGGER,
+            fflags: NOTE::TRIGGER | NOTE_FIFO_READABLE,
             data: 0,
             udata: self.udata,
             ext: [self.generation, 0],
@@ -155,9 +164,10 @@ impl Armed {
 }
 
 /// Waits for `fd` (a named pipe) to be readable or at EOF on behalf of the
-/// `FilePoll` behind `udata`; the result arrives in `kqueue` as an
-/// `EVFILT_USER` event with `ident == fd`. Arming an fd that `kqueue` already
-/// has armed replaces that registration, as kqueue does for one `ident`.
+/// poll behind `udata`; the result arrives in `kqueue` as an `EVFILT_USER`
+/// event with `ident == fd` and `NOTE_FIFO_READABLE` in `fflags`. Arming an fd
+/// that `kqueue` already has armed replaces that registration, as kqueue does
+/// for one `ident`.
 pub(crate) fn arm(kqueue: Fd, fd: Fd, udata: u64, generation: u64) -> sys::Result<()> {
     let watcher = watcher()?;
     {
@@ -240,19 +250,19 @@ fn run(watcher: &'static Watcher) {
                         <&'static str>::from(errno)
                     );
                     // An fd closed behind its owner's back is the one way a set
-                    // of live registrations fails. Deliver those, so the
-                    // owner's read reports the error instead of waiting
-                    // forever; never deliver a live fd that is not readable,
-                    // since the owner's read on a blocking FIFO would then
-                    // block the loop. With nothing to deliver, back off
-                    // instead of spinning on a failure we cannot explain.
-                    let mut delivered = false;
+                    // of live registrations fails. Forget those, as a kqueue
+                    // forgets the knote of a closed fd; never deliver an fd
+                    // that is not readable, since the owner's read on a
+                    // blocking FIFO would then block its loop. With nothing to
+                    // forget, back off instead of spinning on a failure we
+                    // cannot explain.
+                    let mut forgot = false;
                     for fd in &fds[1..] {
                         if sys::get_fcntl_flags(*fd).is_err() {
-                            delivered |= watcher.deliver(*fd);
+                            forgot |= watcher.forget(*fd);
                         }
                     }
-                    if !delivered {
+                    if !forgot {
                         std::thread::sleep(core::time::Duration::from_millis(10));
                     }
                     continue;

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -40,6 +40,8 @@ pub mod windows_event_loop;
 mod keep_alive;
 pub mod posix_event_loop;
 pub use keep_alive::KeepAlive;
+#[cfg(target_os = "macos")]
+mod fifo_select;
 
 // ParentDeathWatchdog: POSIX uses `PR_SET_PDEATHSIG` / `EVFILT_PROC` plus an
 // exit-time descendant SIGKILL walk. Windows does both halves via Win32:

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1131,8 +1131,6 @@ impl IoRequestLoop {
                         Action::Readable(readable) => {
                             #[cfg(target_os = "macos")]
                             if readable.poll.flags.contains(Flags::NamedFifo) {
-                                // kqueue never reports a named pipe's EOF; the
-                                // watcher delivers an EVFILT_USER event here instead.
                                 let udata =
                                     Pollable::init(readable.tag, &raw mut *readable.poll).ptr();
                                 match fifo_select::arm(self.pollfd(), readable.fd, udata, 0) {
@@ -1165,8 +1163,6 @@ impl IoRequestLoop {
                             if close.poll.flags.contains(Flags::NamedFifo)
                                 && close.poll.flags.contains(Flags::PollReadable)
                             {
-                                // Before `on_done` closes the fd; the EV_DELETE
-                                // below removes a delivery that raced this.
                                 fifo_select::disarm(self.pollfd(), close.fd);
                             }
                             if close.poll.flags.contains(Flags::PollReadable)
@@ -1510,9 +1506,7 @@ pub enum Flags {
 
     Registered,
 
-    /// macOS: the fd is a named pipe, so a readable wait goes through
-    /// `fifo_select` instead of an `EVFILT_READ` knote (kqueue never reports
-    /// its EOF). Set by the owner, which has the `fstat`.
+    /// macOS: readable waits go through `fifo_select`, not a knote.
     NamedFifo,
 }
 
@@ -1562,8 +1556,6 @@ impl Poll {
             ApplyAction::Writable => (libc::EVFILT_WRITE, libc::EV_ADD | one_shot_flag, owner),
             ApplyAction::Cancel => {
                 if poll.flags.contains(Flags::PollReadable) {
-                    // A named pipe's readable wait is an EVFILT_USER knote (see
-                    // `fifo_select`), keyed by the same ident.
                     let filter = if poll.flags.contains(Flags::NamedFifo) {
                         libc::EVFILT_USER
                     } else {

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -300,6 +300,19 @@ pub fn uws_to_native(uws: *mut bun_uws_sys::Loop) -> *mut Loop {
     }
 }
 
+/// Call before a uws loop is freed: drops the named-pipe waits that would
+/// otherwise deliver into its kqueue after the descriptor is closed (macOS).
+///
+/// # Safety
+/// `uws` is a live loop.
+pub unsafe fn loop_closing(uws: *mut bun_uws_sys::Loop) {
+    #[cfg(target_os = "macos")]
+    // SAFETY: fn contract.
+    fifo_select::forget_kqueue(Fd::from_native(unsafe { (*uws).fd }));
+    #[cfg(not(target_os = "macos"))]
+    let _ = uws;
+}
+
 pub use posix_event_loop::{AllocatorType, Owner, PollTag, get_vm_ctx, js_vm_ctx};
 
 pub type OpaqueCallback = unsafe extern "C" fn(*mut core::ffi::c_void);

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1129,6 +1129,20 @@ impl IoRequestLoop {
                     request.scheduled = false;
                     match (request.callback)(request) {
                         Action::Readable(readable) => {
+                            #[cfg(target_os = "macos")]
+                            if readable.poll.flags.contains(Flags::NamedFifo) {
+                                // kqueue never reports a named pipe's EOF; the
+                                // watcher delivers an EVFILT_USER event here instead.
+                                let udata =
+                                    Pollable::init(readable.tag, &raw mut *readable.poll).ptr();
+                                match fifo_select::arm(self.pollfd(), readable.fd, udata, 0) {
+                                    Ok(()) => {
+                                        readable.poll.flags.insert(Flags::PollReadable);
+                                    }
+                                    Err(err) => (readable.on_error)(readable.ctx, &err),
+                                }
+                                continue;
+                            }
                             Poll::apply_kqueue(
                                 ApplyAction::Readable,
                                 readable.tag,
@@ -1147,6 +1161,14 @@ impl IoRequestLoop {
                             );
                         }
                         Action::Close(close) => {
+                            #[cfg(target_os = "macos")]
+                            if close.poll.flags.contains(Flags::NamedFifo)
+                                && close.poll.flags.contains(Flags::PollReadable)
+                            {
+                                // Before `on_done` closes the fd; the EV_DELETE
+                                // below removes a delivery that raced this.
+                                fifo_select::disarm(self.pollfd(), close.fd);
+                            }
                             if close.poll.flags.contains(Flags::PollReadable)
                                 || close.poll.flags.contains(Flags::PollWritable)
                             {
@@ -1487,6 +1509,11 @@ pub enum Flags {
     WasEverRegistered,
 
     Registered,
+
+    /// macOS: the fd is a named pipe, so a readable wait goes through
+    /// `fifo_select` instead of an `EVFILT_READ` knote (kqueue never reports
+    /// its EOF). Set by the owner, which has the `fstat`.
+    NamedFifo,
 }
 
 pub type FlagsSet = enumset::EnumSet<Flags>;
@@ -1535,7 +1562,14 @@ impl Poll {
             ApplyAction::Writable => (libc::EVFILT_WRITE, libc::EV_ADD | one_shot_flag, owner),
             ApplyAction::Cancel => {
                 if poll.flags.contains(Flags::PollReadable) {
-                    (libc::EVFILT_READ, libc::EV_DELETE, 0)
+                    // A named pipe's readable wait is an EVFILT_USER knote (see
+                    // `fifo_select`), keyed by the same ident.
+                    let filter = if poll.flags.contains(Flags::NamedFifo) {
+                        libc::EVFILT_USER
+                    } else {
+                        libc::EVFILT_READ
+                    };
+                    (filter, libc::EV_DELETE, 0)
                 } else if poll.flags.contains(Flags::PollWritable) {
                     (libc::EVFILT_WRITE, libc::EV_DELETE, 0)
                 } else {

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -333,10 +333,7 @@ impl FilePoll {
     fn is_named_fifo(&mut self, fd: Fd) -> bool {
         if !self.flags.contains(Flags::NamedFifoChecked) {
             self.flags.insert(Flags::NamedFifoChecked);
-            // pipe(2) pipes are S_IFIFO with st_dev == 0.
-            let named = sys::fstat(fd)
-                .is_ok_and(|stat| sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0);
-            if named {
+            if sys::fstat(fd).is_ok_and(|stat| sys::is_named_pipe(&stat)) {
                 self.flags.insert(Flags::NamedFifo);
             }
         }

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -1289,7 +1289,9 @@ impl Flags {
             }
             // `fifo_select` reports a named pipe's readiness (data or EOF) this way.
             #[cfg(target_os = "macos")]
-            if kqueue_event.filter == EVFILT::USER {
+            if kqueue_event.filter == EVFILT::USER
+                && kqueue_event.fflags & crate::fifo_select::NOTE_FIFO_READABLE != 0
+            {
                 flags.insert(Flags::Readable);
             }
         }

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -328,13 +328,11 @@ impl FilePoll {
         FileType::Pipe
     }
 
-    /// Whether `fd` is a named pipe (see `fifo_select`). Decided by `fstat` when
-    /// a readable registration starts (not on its re-arms) and then kept in
-    /// `Flags::NamedFifo`.
+    /// `fstat` once per readable registration (not per re-arm), kept in `Flags::NamedFifo`.
     #[cfg(target_os = "macos")]
     fn is_named_fifo(&mut self, fd: Fd) -> bool {
         if !self.flags.contains(Flags::NamedFifo) && !self.flags.contains(Flags::PollReadable) {
-            // pipe(2) pipes are S_IFIFO with st_dev == 0 (XNU pipe_stat).
+            // pipe(2) pipes are S_IFIFO with st_dev == 0.
             let named = sys::fstat(fd)
                 .is_ok_and(|stat| sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0);
             if named {
@@ -1013,8 +1011,6 @@ impl FilePoll {
 
             let named_fifo = flag == Flags::Readable && self.flags.contains(Flags::NamedFifo);
             if named_fifo {
-                // Before the owner closes the fd, and before the knote delete
-                // below: a delivery that raced this is what the delete removes.
                 crate::fifo_select::disarm(Fd::from_native(watcher_fd), fd);
             }
 
@@ -1235,8 +1231,7 @@ pub enum Flags {
 
     // What is the type of file descriptor?
     Fifo,
-    /// macOS: a named pipe, whose readiness comes from `fifo_select` instead
-    /// of an `EVFILT_READ` knote (kqueue never reports its EOF).
+    /// macOS: readable waits go through `fifo_select`, not a knote.
     NamedFifo,
 
     OneShot,
@@ -1287,7 +1282,6 @@ impl Flags {
             if kqueue_event.filter == EVFILT::MEMORYSTATUS {
                 flags.insert(Flags::MemoryPressure);
             }
-            // `fifo_select` reports a named pipe's readiness (data or EOF) this way.
             #[cfg(target_os = "macos")]
             if kqueue_event.filter == EVFILT::USER
                 && kqueue_event.fflags & crate::fifo_select::NOTE_FIFO_READABLE != 0

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -328,6 +328,22 @@ impl FilePoll {
         FileType::Pipe
     }
 
+    /// Whether `fd` is a named pipe (see `fifo_select`). Decided by `fstat` when
+    /// a readable registration starts (not on its re-arms) and then kept in
+    /// `Flags::NamedFifo`.
+    #[cfg(target_os = "macos")]
+    fn is_named_fifo(&mut self, fd: Fd) -> bool {
+        if !self.flags.contains(Flags::NamedFifo) && !self.flags.contains(Flags::PollReadable) {
+            // pipe(2) pipes are S_IFIFO with st_dev == 0 (XNU pipe_stat).
+            let named = sys::fstat(fd)
+                .is_ok_and(|stat| sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0);
+            if named {
+                self.flags.insert(Flags::NamedFifo);
+            }
+        }
+        self.flags.contains(Flags::NamedFifo)
+    }
+
     // Note: these handlers take no loop parameter: holding a
     // protected `&mut Loop` across `on_update` would alias the fresh `&mut Loop`
     // that downstream `__bun_run_file_poll` handlers conjure via
@@ -658,7 +674,22 @@ impl FilePoll {
             }
         }
         #[cfg(target_os = "macos")]
-        {
+        let named_fifo = flag == Flags::Readable && self.is_named_fifo(fd);
+        #[cfg(target_os = "macos")]
+        if named_fifo {
+            self.flags.insert(Flags::WasEverRegistered);
+            if let Err(err) = crate::fifo_select::arm(
+                Fd::from_native(watcher_fd),
+                fd,
+                Pollable::init(self).ptr() as u64,
+                self.generation_number as u64,
+            ) {
+                self.deactivate(loop_);
+                return Err(err);
+            }
+        }
+        #[cfg(target_os = "macos")]
+        if !named_fifo {
             use bun_sys::darwin::{EV, EVFILT, NOTE, kevent64_s};
             // SAFETY: all-zero is a valid kevent64_s
             let mut changelist: [kevent64_s; 2] = bun_core::ffi::zeroed();
@@ -980,10 +1011,21 @@ impl FilePoll {
             // SAFETY: all-zero is a valid kevent64_s
             let mut changelist: [kevent64_s; 2] = bun_core::ffi::zeroed();
 
+            let named_fifo = flag == Flags::Readable && self.flags.contains(Flags::NamedFifo);
+            if named_fifo {
+                // Before the owner closes the fd, and before the knote delete
+                // below: a delivery that raced this is what the delete removes.
+                crate::fifo_select::disarm(Fd::from_native(watcher_fd), fd);
+            }
+
             changelist[0] = match flag {
                 Flags::Readable => kevent64_s {
                     ident: u64::try_from(fd.native()).expect("int cast"),
-                    filter: EVFILT::READ,
+                    filter: if named_fifo {
+                        EVFILT::USER
+                    } else {
+                        EVFILT::READ
+                    },
                     data: 0,
                     fflags: 0,
                     udata: Pollable::init(self).ptr() as u64,
@@ -1193,6 +1235,9 @@ pub enum Flags {
 
     // What is the type of file descriptor?
     Fifo,
+    /// macOS: a named pipe, whose readiness comes from `fifo_select` instead
+    /// of an `EVFILT_READ` knote (kqueue never reports its EOF).
+    NamedFifo,
 
     OneShot,
     NeedsRearm,
@@ -1241,6 +1286,11 @@ impl Flags {
             #[cfg(target_os = "macos")]
             if kqueue_event.filter == EVFILT::MEMORYSTATUS {
                 flags.insert(Flags::MemoryPressure);
+            }
+            // `fifo_select` reports a named pipe's readiness (data or EOF) this way.
+            #[cfg(target_os = "macos")]
+            if kqueue_event.filter == EVFILT::USER {
+                flags.insert(Flags::Readable);
             }
         }
         flags

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -328,10 +328,11 @@ impl FilePoll {
         FileType::Pipe
     }
 
-    /// `fstat` once per readable registration (not per re-arm), kept in `Flags::NamedFifo`.
+    /// One `fstat` per poll; the answer is kept in `Flags::NamedFifo`.
     #[cfg(target_os = "macos")]
     fn is_named_fifo(&mut self, fd: Fd) -> bool {
-        if !self.flags.contains(Flags::NamedFifo) && !self.flags.contains(Flags::PollReadable) {
+        if !self.flags.contains(Flags::NamedFifoChecked) {
+            self.flags.insert(Flags::NamedFifoChecked);
             // pipe(2) pipes are S_IFIFO with st_dev == 0.
             let named = sys::fstat(fd)
                 .is_ok_and(|stat| sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0);
@@ -1233,6 +1234,7 @@ pub enum Flags {
     Fifo,
     /// macOS: readable waits go through `fifo_select`, not a knote.
     NamedFifo,
+    NamedFifoChecked,
 
     OneShot,
     NeedsRearm,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2028,7 +2028,10 @@ impl VirtualMachine {
                 rare.detach_socket_groups_from_loop();
             }
             // SAFETY: this thread's loop; nothing ticks it any more.
-            unsafe { (*vm.uws_loop()).internal_loop_data.jsc_vm = core::ptr::null_mut() };
+            unsafe {
+                (*vm.uws_loop()).internal_loop_data.jsc_vm = core::ptr::null_mut();
+                Async::loop_closing(vm.uws_loop());
+            }
             bun_uws::free_thread_loop();
             teardown_log!("teardown: uSockets loop freed");
             #[cfg(windows)]

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -627,10 +627,8 @@ bun_io::impl_buffered_reader_parent! {
 impl Drop for FileResponseStream {
     fn drop(&mut self) {
         bun_output::scoped_log!(FileResponseStream, "deinit");
-        // The reader's own `Drop` leaves the poll registered because we cleared
-        // `CLOSE_HANDLE`: return the FilePoll to its pool here, before the fd it
-        // watches is closed below. `bun.destroy(this)` is owned by `heap::take`
-        // in `deref`, not here.
+        // `CLOSE_HANDLE` is cleared, so the reader's own `Drop` leaves the poll
+        // registered. `bun.destroy(this)` is owned by `heap::take` in `deref`.
         #[cfg(unix)]
         self.reader.with_mut(|reader| {
             if matches!(reader.handle, bun_io::pipes::PollOrFd::Poll(_)) {

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -627,9 +627,18 @@ bun_io::impl_buffered_reader_parent! {
 impl Drop for FileResponseStream {
     fn drop(&mut self) {
         bun_output::scoped_log!(FileResponseStream, "deinit");
-        // `self.reader` (BufferedReader) is torn down by its own `Drop` as a
-        // field — closes the poll handle. `bun.destroy(this)` is owned by
-        // `heap::take` in `deref`, not here.
+        // The reader's own `Drop` leaves the poll registered because we cleared
+        // `CLOSE_HANDLE`: return the FilePoll to its pool here, before the fd it
+        // watches is closed below. `bun.destroy(this)` is owned by `heap::take`
+        // in `deref`, not here.
+        #[cfg(unix)]
+        self.reader.with_mut(|reader| {
+            if matches!(reader.handle, bun_io::pipes::PollOrFd::Poll(_)) {
+                reader
+                    .handle
+                    .close_impl(None, None::<fn(*mut c_void)>, false);
+            }
+        });
         if self.auto_close.get() {
             #[cfg(windows)]
             Closer::close(self.fd.get(), bun_sys::windows::libuv::Loop::get());

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -713,8 +713,7 @@ impl ReadFile {
         }
 
         self.could_block = !bun_sys::is_regular_file(stat.st_mode as _);
-        // pipe(2) pipes are S_IFIFO with st_dev == 0 (XNU pipe_stat); kqueue
-        // reports their EOF, but not a named pipe's (see bun_io::fifo_select).
+        // pipe(2) pipes are S_IFIFO with st_dev == 0.
         #[cfg(target_os = "macos")]
         if bun_sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0 {
             self.io_poll.flags.insert(io::Flags::NamedFifo);

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -713,6 +713,12 @@ impl ReadFile {
         }
 
         self.could_block = !bun_sys::is_regular_file(stat.st_mode as _);
+        // pipe(2) pipes are S_IFIFO with st_dev == 0 (XNU pipe_stat); kqueue
+        // reports their EOF, but not a named pipe's (see bun_io::fifo_select).
+        #[cfg(target_os = "macos")]
+        if bun_sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0 {
+            self.io_poll.flags.insert(io::Flags::NamedFifo);
+        }
         self.total_size =
             SizeType::try_from((stat.st_size as i64).max(0).min(MAX_SIZE as i64)).unwrap();
 

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -713,9 +713,8 @@ impl ReadFile {
         }
 
         self.could_block = !bun_sys::is_regular_file(stat.st_mode as _);
-        // pipe(2) pipes are S_IFIFO with st_dev == 0.
         #[cfg(target_os = "macos")]
-        if bun_sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0 {
+        if bun_sys::is_named_pipe(&stat) {
             self.io_poll.flags.insert(io::Flags::NamedFifo);
         }
         self.total_size =

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -948,6 +948,13 @@ mod linux_syscall;
 pub fn is_regular_file(mode: Mode) -> bool {
     kind_from_mode(mode) == FileKind::File
 }
+/// A FIFO made with `mkfifo`, as opposed to a `pipe(2)` pipe, which XNU's
+/// `pipe_stat` reports with `st_dev == 0`.
+#[cfg(target_os = "macos")]
+#[inline]
+pub fn is_named_pipe(stat: &Stat) -> bool {
+    S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0
+}
 #[cfg(windows)]
 pub use bun_errno::Win32ErrorExt;
 pub use bun_errno::{E, GetErrno, S, SystemErrno, e_from_negated, get_errno};

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7431,15 +7431,13 @@ pub fn kevent(
     }
 }
 
-/// `select(2)` for readability, with no timeout (macOS only). `readfds` is a
-/// bitmap of the descriptors to wait on, 32 per word; the kernel leaves only
-/// the ready ones set. Returns how many are ready. `EINTR` is returned, not
-/// retried: the caller's set may be stale by then.
+/// `select(2)` with no timeout on a read set of `readfds.len() * 32` fds (macOS
+/// only). The kernel leaves only the ready bits set. `EINTR` is not retried.
 #[cfg(target_os = "macos")]
 pub fn select_readable(readfds: &mut [u32]) -> Maybe<usize> {
     let nfds = c_int::try_from(readfds.len() * 32).expect("int cast");
-    // SAFETY: `readfds` holds the `nfds / 32` words the kernel reads and writes
-    // back; the write and error sets and the timeout may be null.
+    // SAFETY: `readfds` holds the `nfds / 32` words the kernel reads and writes;
+    // the other sets and the timeout may be null.
     let rc = unsafe {
         nocancel::select(
             nfds,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1389,6 +1389,8 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    #[cfg(target_os = "macos")]
+    pub const select: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1396,7 +1398,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1506,6 +1508,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "select",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -1683,6 +1686,15 @@ mod nocancel {
         ) -> isize;
         #[link_name = "poll$NOCANCEL"]
         pub(crate) fn poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int) -> c_int;
+        // `_DARWIN_UNLIMITED_SELECT` select(2): no FD_SETSIZE limit; a set is ceil(nfds/32) words.
+        #[link_name = "select$DARWIN_EXTSN$NOCANCEL"]
+        pub(crate) fn select(
+            nfds: c_int,
+            readfds: *mut u32,
+            writefds: *mut u32,
+            errorfds: *mut u32,
+            timeout: *mut libc::timeval,
+        ) -> c_int;
         // Remaining `$NOCANCEL` variants Bun links against.
         // safe: by-value `c_int` fd; bad fd → -1/EBADF, no UB.
         #[link_name = "close$NOCANCEL"]
@@ -7416,6 +7428,30 @@ pub fn kevent(
             E::EINTR => continue,
             e => return Err(Error::from_code(e, Tag::kevent).with_fd(fd)),
         }
+    }
+}
+
+/// `select(2)` for readability, with no timeout (macOS only). `readfds` is a
+/// bitmap of the descriptors to wait on, 32 per word; the kernel leaves only
+/// the ready ones set. Returns how many are ready. `EINTR` is returned, not
+/// retried: the caller's set may be stale by then.
+#[cfg(target_os = "macos")]
+pub fn select_readable(readfds: &mut [u32]) -> Maybe<usize> {
+    let nfds = c_int::try_from(readfds.len() * 32).expect("int cast");
+    // SAFETY: `readfds` holds the `nfds / 32` words the kernel reads and writes
+    // back; the write and error sets and the timeout may be null.
+    let rc = unsafe {
+        nocancel::select(
+            nfds,
+            readfds.as_mut_ptr(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+        )
+    };
+    match get_errno(rc) {
+        E::SUCCESS => Ok(rc as usize),
+        e => Err(Error::from_code(e, Tag::select)),
     }
 }
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1183,15 +1183,12 @@ test.skipIf(isWindows)("Response(Bun.file(FIFO)) frames the body as chunked, not
 });
 
 // The stream owns the FIFO's fd itself, so it clears the reader's CLOSE_HANDLE
-// flag, and the reader's own teardown skips the FilePoll in that mode: the
-// poll stayed registered after the response ended at EOF and its ref kept the
-// event loop, and so the process, alive.
-// The idle sweep runs every few seconds, so the fixture takes that long to end.
-test.concurrent.skipIf(isWindows)(
-  "process exits after a FIFO file response completes at EOF",
-  async () => {
-    using dir = tempDir("serve-fifo-eof-exit", {
-      "fixture.ts": `
+// flag, and the reader's own teardown skips the FilePoll in that mode: the poll
+// stayed registered after the response was gone and its ref kept the event
+// loop, and so the process, alive.
+test.concurrent.skipIf(isWindows)("process exits after a FIFO file response is torn down", async () => {
+  using dir = tempDir("serve-fifo-exit", {
+    "fixture.ts": `
 import { openSync, writeSync, closeSync } from "node:fs";
 
 const fifoPath = process.argv[2];
@@ -1201,9 +1198,6 @@ writeSync(writerFd, "fifo-body");
 const server = Bun.serve({
   port: 0,
   hostname: "127.0.0.1",
-  // How the body ends after the pipe's EOF is not what this test is about;
-  // a short idle timeout ends the connection either way.
-  idleTimeout: 1,
   fetch() {
     return new Response(Bun.file(fifoPath));
   },
@@ -1211,39 +1205,32 @@ const server = Bun.serve({
 
 const res = await fetch("http://127.0.0.1:" + server.port + "/");
 const reader = res.body.getReader();
-// The first chunk proves the server opened the pipe and drained what we wrote;
-// closing the last writer afterwards delivers EOF to the server's reader.
+// The first chunk proves the server opened the pipe and drained what we wrote,
+// so its read is parked on the poll when the response is closed.
 const first = await reader.read();
 const body = Buffer.from(first.value).toString();
 closeSync(writerFd);
-try {
-  for (;;) {
-    const { done } = await reader.read();
-    if (done) break;
-  }
-} catch {}
-
 server.stop(true);
 console.log(body);
 `,
-    });
+  });
 
-    const fifoPath = join(String(dir), "body.fifo");
-    mkfifo(fifoPath);
+  const fifoPath = join(String(dir), "body.fifo");
+  mkfifo(fifoPath);
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.ts", fifoPath],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts", fifoPath],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "fifo-body", stderr: "", exitCode: 0 });
-  },
-  20_000,
-);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe("fifo-body");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
 
 // A request that declares a body arms the request-body (onData) callback on
 // the uWS response before the fetch handler runs. uWS keeps a single shared

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1182,6 +1182,69 @@ test.skipIf(isWindows)("Response(Bun.file(FIFO)) frames the body as chunked, not
   }
 });
 
+// The stream owns the FIFO's fd itself, so it clears the reader's CLOSE_HANDLE
+// flag, and the reader's own teardown skips the FilePoll in that mode: the
+// poll stayed registered after the response ended at EOF and its ref kept the
+// event loop, and so the process, alive.
+// The idle sweep runs every few seconds, so the fixture takes that long to end.
+test.concurrent.skipIf(isWindows)(
+  "process exits after a FIFO file response completes at EOF",
+  async () => {
+    using dir = tempDir("serve-fifo-eof-exit", {
+      "fixture.ts": `
+import { openSync, writeSync, closeSync } from "node:fs";
+
+const fifoPath = process.argv[2];
+const writerFd = openSync(fifoPath, "r+");
+writeSync(writerFd, "fifo-body");
+
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  // How the body ends after the pipe's EOF is not what this test is about;
+  // a short idle timeout ends the connection either way.
+  idleTimeout: 1,
+  fetch() {
+    return new Response(Bun.file(fifoPath));
+  },
+});
+
+const res = await fetch("http://127.0.0.1:" + server.port + "/");
+const reader = res.body.getReader();
+// The first chunk proves the server opened the pipe and drained what we wrote;
+// closing the last writer afterwards delivers EOF to the server's reader.
+const first = await reader.read();
+const body = Buffer.from(first.value).toString();
+closeSync(writerFd);
+try {
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+} catch {}
+
+server.stop(true);
+console.log(body);
+`,
+    });
+
+    const fifoPath = join(String(dir), "body.fifo");
+    mkfifo(fifoPath);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts", fifoPath],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "fifo-body", stderr: "", exitCode: 0 });
+  },
+  20_000,
+);
+
 // A request that declares a body arms the request-body (onData) callback on
 // the uWS response before the fetch handler runs. uWS keeps a single shared
 // userdata slot per response, so when the handler returns a file response

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,9 +6,10 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, closeSync, constants, mkdirSync, openSync, writeSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { mkfifo } from "mkfifo";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -647,6 +648,57 @@ describe("bunshell", () => {
       expect(results).toEqual([...Array(firstFailure).fill(ok), ...Array(results.length - firstFailure).fill(emfile)]);
       expect(exitCode).toBe(0);
     });
+  });
+
+  // The builtin cat drains what the writer sent, then waits for more; the
+  // writer closes. On macOS neither kqueue nor poll(2) reports that EOF for a
+  // named pipe (only buffered bytes), so both spellings used to hang there
+  // after printing the data.
+  describe.skipIf(isWindows)("builtin cat reads a named pipe (FIFO) to EOF", () => {
+    for (const [spelling, command] of [
+      ["as a redirect", "cat < ${fifo}"],
+      ["as an argument", "cat ${fifo}"],
+    ]) {
+      test.concurrent(spelling, async () => {
+        using dir = tempDir("builtin-cat-fifo", {});
+        const fifo = join(String(dir), "in.fifo");
+        mkfifo(fifo);
+        // A write end cannot be opened before a reader exists; this one never
+        // reads, so every byte goes to cat, whose own open then finds a writer.
+        const holder = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+        let writer = openSync(fifo, "w");
+        try {
+          await using proc = Bun.spawn({
+            cmd: [
+              bunExe(),
+              "-e",
+              `import { $ } from "bun";
+               const fifo = process.env.FIFO;
+               await $\`${command}\`;
+               console.log("done");`,
+            ],
+            env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1", FIFO: fifo },
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          writeSync(writer, "hello\n");
+
+          let stdout = "";
+          for await (const chunk of proc.stdout) {
+            stdout += Buffer.from(chunk).toString();
+            if (writer !== -1 && stdout.includes("hello\n")) {
+              closeSync(writer);
+              writer = -1;
+            }
+          }
+          const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+          expect({ stdout, stderr, exitCode }).toEqual({ stdout: "hello\ndone\n", stderr: "", exitCode: 0 });
+        } finally {
+          if (writer !== -1) closeSync(writer);
+          closeSync(holder);
+        }
+      });
+    }
   });
 
   describe("operators no spaces", async () => {

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
+import { randomBytes } from "node:crypto";
+import { closeSync, constants, openSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -52,5 +55,223 @@ describe("Bun.file read-loop target selection", () => {
     const buf = new Uint8Array(await Bun.file(p).slice(start, end).arrayBuffer());
     expect(buf.length).toBe(end - start);
     expect(Bun.hash(buf)).toBe(Bun.hash(bytes.subarray(start, end)));
+  });
+});
+
+// Whole-file reads of a named pipe. All but the last end with the reader
+// having drained the pipe and then learning that the last writer closed; on
+// macOS that EOF is invisible to kqueue and poll(2) (they only see buffered
+// bytes on a FIFO), so the reader has to wait for it differently than it does
+// for a pipe(2) pipe, and each of these used to leave the child blocked
+// forever there.
+describe.skipIf(isWindows)("reading a named pipe", () => {
+  function readFifoInChild(script: string, fifo: string, stdin: number | "ignore" = "ignore") {
+    return Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, FIFO: fifo },
+      stdin,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  // When a FIFO end gets closed is what these tests are about, so each one is
+  // closed explicitly at the right moment; `using` only covers the failure paths.
+  function openFd(file: string, flags: number | string) {
+    let fd = openSync(file, flags);
+    return {
+      get fd() {
+        return fd;
+      },
+      close() {
+        if (fd !== -1) closeSync(fd);
+        fd = -1;
+      },
+      [Symbol.dispose]() {
+        this.close();
+      },
+    };
+  }
+
+  // The child must already have the FIFO open for reading before a writer can
+  // connect to it: a non-blocking open for writing fails with ENXIO until then.
+  async function openWriterOnceChildIsReading(fifo: string, child: Bun.Subprocess) {
+    const deadline = performance.now() + 10_000;
+    while (true) {
+      try {
+        return openFd(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
+      } catch (err: any) {
+        if (err.code !== "ENXIO") throw err;
+      }
+      const exited = child.exitCode ?? child.signalCode;
+      if (exited !== null || performance.now() > deadline) {
+        throw new Error(
+          `nothing opened ${fifo} for reading; child ${exited === null ? "is still running" : `exited (${exited})`}`,
+        );
+      }
+      await Bun.sleep(5);
+    }
+  }
+
+  it.concurrent("bytes() collects a payload that arrives in pieces and ends when the writer closes", async () => {
+    const payload = randomBytes(256 * 1024);
+    using dir = tempDir("bun-file-read-fifo", {});
+    const fifo = path.join(String(dir), "in.fifo");
+    mkfifo(fifo);
+    // The write end can only be opened, and written to without EPIPE, while
+    // some reader has the FIFO open; `holder` is that reader until the child
+    // has opened its own. It never reads, so every byte goes to the child.
+    using holder = openFd(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    using writer = openFd(fifo, "w");
+    await using proc = readFifoInChild(
+      `const bytes = await Bun.file(process.env.FIFO).bytes(); process.stdout.write(bytes.length + " " + Bun.hash(bytes));`,
+      fifo,
+    );
+    const stderr = proc.stderr.text();
+    // The write end is blocking, so this write only completes as the child
+    // drains the pipe, and closing it afterwards is what ends the child's
+    // read. The child cannot exit before that unless it failed; dropping
+    // `holder` then leaves the pipe without readers, so the blocked write
+    // fails with EPIPE instead of waiting forever.
+    const childDied = proc.exited.then(async exitCode => {
+      holder.close();
+      throw new Error(`child exited with ${exitCode} before the payload was written: ${await stderr}`);
+    });
+    const written = await Promise.race([Bun.write(Bun.file(writer.fd), payload), childDied]);
+    writer.close();
+    const [stdout, stderrText, exitCode] = await Promise.all([proc.stdout.text(), stderr, proc.exited]);
+
+    expect({ written, stdout, stderr: stderrText }).toEqual({
+      written: payload.length,
+      stdout: `${payload.length} ${Bun.hash(payload)}`,
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("text() waits for a writer that connects after the read started", async () => {
+    using dir = tempDir("bun-file-read-fifo-late-writer", {});
+    const fifo = path.join(String(dir), "late.fifo");
+    mkfifo(fifo);
+
+    await using proc = readFifoInChild(`process.stdout.write(await Bun.file(process.env.FIFO).text());`, fifo);
+    using writer = await openWriterOnceChildIsReading(fifo, proc);
+    writeSync(writer.fd, "written after the reader opened\n");
+    writer.close();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "written after the reader opened\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("text() resolves empty when the writer connects and closes without writing", async () => {
+    using dir = tempDir("bun-file-read-fifo-empty", {});
+    const fifo = path.join(String(dir), "empty.fifo");
+    mkfifo(fifo);
+
+    await using proc = readFifoInChild(
+      `const text = await Bun.file(process.env.FIFO).text(); process.stdout.write(JSON.stringify(text));`,
+      fifo,
+    );
+    using writer = await openWriterOnceChildIsReading(fifo, proc);
+    writer.close();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: '""', stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("Bun.stdin.text() reads a FIFO inherited as stdin to EOF", async () => {
+    using dir = tempDir("bun-file-read-fifo-stdin", {});
+    const fifo = path.join(String(dir), "stdin.fifo");
+    mkfifo(fifo);
+
+    // Same dance as above: a reader has to exist before the write end can be
+    // opened; here that reader becomes the child's stdin.
+    using readEnd = openFd(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    using writer = openFd(fifo, "w");
+    await using proc = readFifoInChild(
+      `process.stdout.write(JSON.stringify(await Bun.stdin.text()));`,
+      fifo,
+      readEnd.fd,
+    );
+    // The child has its own descriptor for the read end now.
+    readEnd.close();
+    writeSync(writer.fd, "stdin is a named pipe\n");
+    writer.close();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify("stdin is a named pipe\n"), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  // The macOS wait is a select(2); this is the case where a plain fd_set
+  // would not hold the descriptor (FD_SETSIZE is 1024 there).
+  it.concurrent("Bun.file(fd) reads a FIFO whose descriptor number is above FD_SETSIZE", async () => {
+    using dir = tempDir("bun-file-read-fifo-high-fd", {});
+    const fifo = path.join(String(dir), "high.fifo");
+    mkfifo(fifo);
+
+    await using proc = readFifoInChild(
+      `import { constants, openSync } from "node:fs";
+       while (openSync("/dev/null", "r") < 1024) {}
+       const fd = openSync(process.env.FIFO, constants.O_RDONLY | constants.O_NONBLOCK);
+       const text = await Bun.file(fd).text();
+       process.stdout.write(JSON.stringify({ fd, text }));`,
+      fifo,
+    );
+    using writer = await openWriterOnceChildIsReading(fifo, proc);
+    writeSync(writer.fd, "read through a high fd\n");
+    writer.close();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { fd, text } = JSON.parse(stdout);
+    expect(fd).toBeGreaterThanOrEqual(1024);
+    expect(text).toBe("read through a high fd\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // A read that is waiting for a writer which never shows up must not keep
+  // its VM from shutting down: the wait has to happen outside the job's VM
+  // borrow, which terminate() waits for.
+  it.concurrent("terminate() completes while a worker's read is waiting on an idle writer", async () => {
+    using dir = tempDir("bun-file-read-fifo-worker", {
+      "main.fixture.ts": `
+        const worker = new Worker(new URL("./worker.fixture.ts", import.meta.url).href);
+        const closed = new Promise(resolve => worker.addEventListener("close", resolve));
+        worker.addEventListener("message", ({ data }) => console.log(data));
+        // Our stdin is closed once the test has connected a writer to the FIFO.
+        await Bun.stdin.text();
+        worker.terminate();
+        await closed;
+        console.log("terminated");
+      `,
+      "worker.fixture.ts": `
+        const read = Bun.file(process.env.FIFO!).text();
+        postMessage("reading");
+        await read;
+        postMessage("the read finished, which it should not have");
+      `,
+    });
+    const fifo = path.join(String(dir), "idle.fifo");
+    mkfifo(fifo);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.fixture.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, FIFO: fifo },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Connecting a writer proves the worker's read has the FIFO open; never
+    // writing to it keeps that read waiting for the rest of the test.
+    using _idleWriter = await openWriterOnceChildIsReading(fifo, proc);
+    proc.stdin.end();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "reading\nterminated\n", stderr: "" });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
 import { exec } from "node:child_process";
+import { closeSync, constants, openSync, writeSync } from "node:fs";
+import { join } from "node:path";
 
 test.concurrent("pipe does the right thing", async () => {
   // Note: Bun.spawnSync uses memfd_create on Linux for pipe, which means we see
@@ -32,6 +35,67 @@ test.concurrent("file does the right thing", async () => {
   `);
   expect(await result.stderr.text()).toMatchInlineSnapshot(`""`);
   expect(await result.exited).toBe(0);
+});
+
+// stdin as a named pipe (`bun script.js < fifo`). The reader drains what the
+// writer sent and then waits; the writer closes. On macOS neither kqueue nor
+// poll(2) reports that EOF for a FIFO (only bytes that are buffered), so the
+// end of each of these streams never arrived there.
+describe.skipIf(isWindows)("stdin is a named pipe (FIFO)", () => {
+  // Runs `script` with a blocking FIFO read end as stdin and a writer already
+  // connected to the FIFO (a write end cannot be opened before a reader exists,
+  // and a blocking read end cannot be opened before a writer does). Once the
+  // child has echoed `payload`, the writer closes; the child must then finish.
+  async function runWithFifoStdin(script: string, payload: string) {
+    using dir = tempDir("stdin-fifo", {});
+    const fifo = join(String(dir), "stdin.fifo");
+    mkfifo(fifo);
+    const holder = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    let writer = openSync(fifo, "w");
+    const stdin = openSync(fifo, "r");
+    closeSync(holder);
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdin,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      closeSync(stdin);
+      writeSync(writer, payload);
+
+      let stdout = "";
+      for await (const chunk of proc.stdout) {
+        stdout += Buffer.from(chunk).toString();
+        if (writer !== -1 && stdout.includes(`data:${payload}`)) {
+          closeSync(writer);
+          writer = -1;
+        }
+      }
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    } finally {
+      if (writer !== -1) closeSync(writer);
+    }
+  }
+
+  test.concurrent("process.stdin emits 'end' after the last writer closes", async () => {
+    const result = await runWithFifoStdin(
+      `process.stdin.on("data", d => process.stdout.write("data:" + d)).on("end", () => process.stdout.write("end\\n"));`,
+      "hello\n",
+    );
+    expect(result).toEqual({ stdout: "data:hello\nend\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("Bun.stdin.stream() ends after the last writer closes", async () => {
+    const result = await runWithFifoStdin(
+      `for await (const chunk of Bun.stdin.stream()) process.stdout.write("data:" + new TextDecoder().decode(chunk));
+       process.stdout.write("done\\n");`,
+      "hello\n",
+    );
+    expect(result).toEqual({ stdout: "data:hello\ndone\n", stderr: "", exitCode: 0 });
+  });
 });
 
 test.concurrent("stdin with 'readable' event handler should receive data when paused", async () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -7,9 +7,18 @@ import {
   readableStreamToText,
 } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { createReadStream, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  createReadStream,
+  openSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { join } from "node:path";
 
 it("TransformStream", async () => {
@@ -425,7 +434,7 @@ it("ReadableStream.prototype.values", async () => {
   expect(chunks.join("")).toBe("helloworld");
 });
 
-it.todoIf(isWindows || isMacOS)("Bun.file() read text from pipe", async () => {
+it.todoIf(isWindows)("Bun.file() read text from pipe", async () => {
   const fifoPath = join(tmpdirSync(), "bun-streams-test-fifo");
   try {
     unlinkSync(fifoPath);
@@ -466,6 +475,48 @@ it.todoIf(isWindows || isMacOS)("Bun.file() read text from pipe", async () => {
   expect(output.length).toBe(large.length + 1);
   expect(output).toBe(large + "\n");
   expect(status).toBe(0);
+});
+
+// The stream drains what the writer sent and waits for more; then the last
+// writer closes. On macOS neither kqueue nor poll(2) reports that EOF for a
+// named pipe (only buffered bytes), so the stream never ended there.
+it.skipIf(isWindows)("Bun.file(fifo).stream() ends after the last writer closes", async () => {
+  using dir = tempDir("bun-file-fifo-stream", {});
+  const fifo = join(String(dir), "in.fifo");
+  mkfifo(fifo, 0o666);
+  // A write end cannot be opened before a reader exists; this one never reads,
+  // so every byte goes to the child, whose own open then finds a writer
+  // (a FIFO with no writer reads as EOF at once).
+  const holder = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+  let writer = openSync(fifo, "w");
+  try {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `for await (const chunk of Bun.file(process.env.FIFO).stream()) process.stdout.write("data:" + new TextDecoder().decode(chunk));
+         process.stdout.write("done\\n");`,
+      ],
+      env: { ...bunEnv, FIFO: fifo },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    writeSync(writer, "hello\n");
+
+    let stdout = "";
+    for await (const chunk of proc.stdout) {
+      stdout += Buffer.from(chunk).toString();
+      if (writer !== -1 && stdout.includes("data:hello\n")) {
+        closeSync(writer);
+        writer = -1;
+      }
+    }
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "data:hello\ndone\n", stderr: "", exitCode: 0 });
+  } finally {
+    if (writer !== -1) closeSync(writer);
+    closeSync(holder);
+  }
 });
 
 it("exists globally", () => {


### PR DESCRIPTION
### Problem
- On macOS a reader of a named pipe never sees EOF once it waits after draining the pipe. `Bun.file(fifo).text()` never resolves (#30520). The shell builtin `cat < fifo` prints the data and never exits. `process.stdin`, `Bun.stdin.stream()` and `Bun.file(fifo).stream()` never end.
- Cause: XNU's `EVFILT_READ` filter for a FIFO fires only while bytes are buffered, and `poll(2)` is built on it. The last writer's close posts nothing. Both of Bun's kqueues register that filter: `FilePoll` (`src/io/posix_event_loop.rs`) for the loop readers, `Poll::apply_kqueue` (`src/io/lib.rs`) for `ReadFile` on the io thread. `select(2)` does wake for the close.

### Fix
- A poll on a named pipe (`bun_sys::is_named_pipe`: `S_IFIFO` with a non-zero `st_dev`; `pipe(2)` pipes have `st_dev == 0` and keep kqueue) arms `src/io/fifo_select.rs` instead of a knote. One thread blocks in `select` on every armed FIFO. A readable one is disarmed (one-shot) and delivered into its owner's kqueue as an `EVFILT_USER` event with the poll's `udata`, so both dispatchers handle it unchanged.
- Correct because `select` reports data or no writers, and `read` with no writers returns 0, so a read after delivery never blocks. Each registration has an id, and a delivery goes only to the registration `select` observed. Every unregister disarms before the fd closes and deletes the knote under the delivery lock, and `bun_io::loop_closing` forgets a kqueue's waits before the loop is freed, so a poll that is gone is never delivered.
- `FileResponseStream::drop` now returns its FilePoll: it clears `CLOSE_HANDLE`, so the reader's `Drop` left the poll registered, and a FIFO response kept the process alive. #37083 fixes the same leak with a helper; whichever lands second rebases.
- Verified: new cases in `process-stdin.test.ts`, `bunshell.test.ts` (builtin `cat` needs `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`), `streams.test.js` (plus its FIFO test, `todo` on macOS since #14513), `bun-serve-file.test.ts` (hangs on Linux without the drop change), and the six `bun-file-read.test.ts` cases from #37823, which this PR supersedes. The darwin lanes pass all of them (builds 103580, 103703).

### Background
- A FIFO read returns 0 only when nothing is buffered and every writer has closed. XNU's filter for a `pipe(2)` pipe reports `EV_EOF`; the one for a FIFO does not.
- A poll is Bun's registration of one fd with a kqueue. Its `udata` is a tagged pointer the kqueue's owner decodes; uSockets hands tagged events to the `FilePoll` dispatch whatever the filter, and the io thread dispatches on `udata` alone.
- `PosixBufferedReader` (`src/io/PipeReader.rs`) reads on the loop thread and re-registers after each read. The shell, `FileReader` and `FileResponseStream` embed it. `ReadFile` is the off-thread whole-file read behind `Bun.file(x).text()`.
- `EVFILT_USER` is a kqueue filter that user code triggers with `NOTE_TRIGGER`, from any thread; its low 24 `fflags` bits come back to the reader.

<details><summary>Notes</summary>

- No macOS machine in this environment: the tests were not run there before CI. On the darwin lanes (macOS 14.8.9 x64, 15.7.7, 26.4 and 26.6.2 aarch64) `process-stdin.test.ts` 20 pass, `bunshell.test.ts` 428 pass, `streams.test.js` 188 pass, `bun-file-read.test.ts` 11 pass, 0 fail.
- Go hit the same kernel behavior and stopped using kqueue for FIFOs on darwin (golang/go#24164). Node's `process.stdin` over a FIFO hangs the same way on macOS.
- XNU: `vn_kqfilter` attaches a FIFO's knote to the vnode and `filt_vnode_common` activates it when `fifo_charcount() != 0`; `fifo_close_internal` only calls `socantrcvmore()` on the socket. `fifo_select` -> `soo_select` -> `soreadable()`, which includes `SS_CANTRCVMORE`. `fifo_read` returns 0 when `fi_writers < 1` and the buffer is empty. `pipe_stat` leaves `st_dev` 0.
- `select$DARWIN_EXTSN$NOCANCEL` is the `_DARWIN_UNLIMITED_SELECT` flavor: the read set is a bitmap of `fd / 32 + 1` words with no `FD_SETSIZE` cap. The fd-above-1024 test pins it.
- The watcher keys entries by (kqueue, fd), so two loops on one fd each get their own event, and arming an fd a kqueue already has armed replaces the entry, as kqueue does for one `ident`. The per-registration id covers the window between `select` returning and the delivery taking the lock: an owner can disarm, close the fd, and a new owner can arm a FIFO that reuses the number; that new registration is not delivered.
- If `select` fails with something other than `EINTR`/`EAGAIN` (an fd closed behind its owner's back), the thread forgets the fds that `fcntl` rejects, as a kqueue drops the knote of a closed fd, and backs off 10 ms if there was none. A live fd is never delivered without readiness: the owner's read on a blocking FIFO would block its loop.
- Close on XNU wakes a `select` that includes the fd (`fileproc_drain`), and the thread rebuilds its set from the registrations on every wake, so an fd is never put back after `disarm`.
- The delivered event carries `NOTE_FIFO_READABLE` in `fflags`, and the `FilePoll` decode keys on that bit, so a writable wait (#37852's macOS half) can be added with a second bit.
- `ReadFile` keeps parking on the io thread as before, so a worker's `terminate()` still cancels a pending FIFO read (the last `bun-file-read` case).
- The first readable registration of a `FilePoll` on macOS now costs one `fstat`; `NamedFifoChecked` keeps the answer for the poll's lifetime.
- Test protocol: the parent opens a non-blocking read end, then the writer, then (for stdin) a blocking read end, so every open returns at once. The child echoes what it read, and only then does the parent close the writer. That is the reader-parked-then-EOF ordering the bug needs, and the ordering of the original report.
- The serve test ends the response with `server.stop(true)` after the first chunk: how a FIFO response body terminates at EOF is a separate problem (#37082), and the test only needs the process to exit once the response is gone. Without the drop change the process never exits.
- Also ran `bun-serve-file.test.ts`, `bun-stdin-slice.test.ts` and `bun-file-fd-read.test.ts` in full with the debug build on Linux, and `cargo clippy` for `bun_runtime`, `bun_jsc`, `bun_event_loop`, `bun_io`, `bun_sys` on `aarch64-apple-darwin` and `x86_64-apple-darwin`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js, test/js/node/process/process-stdin.test.ts, test/js/bun/util/bun-file-read.test.ts, test/js/bun/shell/bunshell.test.ts, test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->