### PR TITLE
CompressionStream: honor a level option for brotli, zstd, and the zlib formats

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -97,9 +97,11 @@ declare var CompressionStream: Bun.__internal.UseLibDomIfAvailable<
      * @param strategy Bun extension. Its `highWaterMark` (bytes, default 64 KiB) bounds how much
      * output one input chunk produces per step: the largest piece a reader receives per `read()`,
      * and how far decoding runs ahead of a slow reader. A chunk larger than that may produce up to
-     * its own size per step.
+     * its own size per step. Its `level` selects the compression level: 0-9 for the zlib formats,
+     * 0-11 for brotli (quality), 1-22 for zstd. Omitted means the format's default
+     * (zlib default, brotli 11, zstd 3).
      */
-    new (format: Bun.CompressionFormat, strategy?: { highWaterMark?: number }): CompressionStream;
+    new (format: Bun.CompressionFormat, strategy?: { highWaterMark?: number; level?: number }): CompressionStream;
   }
 >;
 

--- a/src/brotli_sys/brotli_c.rs
+++ b/src/brotli_sys/brotli_c.rs
@@ -265,4 +265,6 @@ impl BrotliEncoder {
 
 pub const BROTLI_MIN_QUALITY: c_int = 0;
 pub const BROTLI_MAX_QUALITY: c_int = 11;
+/// `BrotliEncoderParameter::BROTLI_PARAM_QUALITY` (encode.h).
+pub const BROTLI_PARAM_QUALITY: c_uint = 1;
 pub const BROTLI_DEFAULT_WINDOW: c_int = 22;

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
@@ -151,8 +151,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCompressionStreamConst
     ASSERT(format.has_value());
     size_t highWaterMark = parseCodecHighWaterMark(lexicalGlobalObject, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
+    std::optional<int32_t> level = parseCompressionLevel(lexicalGlobalObject, callFrame->argument(1), *format);
+    RETURN_IF_EXCEPTION(scope, {});
 
-    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), false, highWaterMark);
+    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), false, highWaterMark, level.has_value(), level.value_or(0));
     if (!coder) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "failed to initialize compressor"_s);
         return {};

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
@@ -149,12 +149,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCompressionStreamConst
     auto format = parseCompressionFormat(lexicalGlobalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(format.has_value());
-    size_t highWaterMark = parseCodecHighWaterMark(lexicalGlobalObject, callFrame->argument(1));
-    RETURN_IF_EXCEPTION(scope, {});
-    std::optional<int32_t> level = parseCompressionLevel(lexicalGlobalObject, callFrame->argument(1), *format);
+    CodecOptions options = parseCodecOptions(lexicalGlobalObject, callFrame->argument(1), *format);
     RETURN_IF_EXCEPTION(scope, {});
 
-    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), false, highWaterMark, level.has_value(), level.value_or(0));
+    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), false, options.highWaterMark, options.level.has_value(), options.level.value_or(0));
     if (!coder) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "failed to initialize compressor"_s);
         return {};

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -15,7 +15,9 @@
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
+#include <cmath>
 #include <limits>
+#include <wtf/text/MakeString.h>
 
 namespace Bun {
 namespace WebStreams {
@@ -62,6 +64,53 @@ size_t parseCodecHighWaterMark(JSGlobalObject* globalObject, JSValue strategy)
     if (highWaterMark >= static_cast<double>(std::numeric_limits<size_t>::max()))
         return std::numeric_limits<size_t>::max();
     return static_cast<size_t>(highWaterMark);
+}
+
+std::optional<int32_t> parseCompressionLevel(JSGlobalObject* globalObject, JSValue strategy, CompressionFormat format)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // parseCodecHighWaterMark already rejected a non-object, non-undefined argument.
+    if (!strategy.isObject())
+        return std::nullopt;
+    JSValue levelValue = asObject(strategy)->get(globalObject, Identifier::fromString(vm, "level"_s));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    if (levelValue.isUndefined())
+        return std::nullopt;
+    double level = levelValue.toNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    int32_t min = 0;
+    int32_t max = 0;
+    ASCIILiteral name;
+    switch (format) {
+    case CompressionFormat::Deflate:
+    case CompressionFormat::DeflateRaw:
+    case CompressionFormat::Gzip:
+        // zlib compression levels.
+        min = 0;
+        max = 9;
+        name = format == CompressionFormat::Gzip ? "gzip"_s : (format == CompressionFormat::DeflateRaw ? "deflate-raw"_s : "deflate"_s);
+        break;
+    case CompressionFormat::Brotli:
+        // BROTLI_MIN_QUALITY .. BROTLI_MAX_QUALITY.
+        min = 0;
+        max = 11;
+        name = "brotli"_s;
+        break;
+    case CompressionFormat::Zstd:
+        // The range Bun.zstdCompressSync accepts.
+        min = 1;
+        max = 22;
+        name = "zstd"_s;
+        break;
+    }
+    // !(>= && <=) also rejects NaN.
+    if (!(level >= min && level <= max) || level != std::trunc(level)) {
+        throwRangeError(globalObject, scope, makeString("The compression level must be an integer between "_s, min, " and "_s, max, " for "_s, name));
+        return std::nullopt;
+    }
+    return static_cast<int32_t>(level);
 }
 
 // BufferSource → (ptr, len). `scratch` owns the bytes when `chunk` is a string

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -52,45 +52,40 @@ std::optional<CompressionFormat> parseCompressionFormat(JSGlobalObject* globalOb
 // node:zlib stream adapter (src/js/internal/streams/iter/transform.ts).
 static constexpr double kDefaultCodecHighWaterMark = 64 * 1024;
 
-size_t parseCodecHighWaterMark(JSGlobalObject* globalObject, JSValue strategy)
+CodecOptions parseCodecOptions(JSGlobalObject* globalObject, JSValue strategy, std::optional<CompressionFormat> levelFormat)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    CodecOptions result { static_cast<size_t>(kDefaultCodecHighWaterMark), std::nullopt };
     QueuingStrategyDict dict = convertQueuingStrategyDict(globalObject, strategy);
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, result);
     double highWaterMark = extractHighWaterMark(globalObject, dict, kDefaultCodecHighWaterMark);
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, result);
     // +Infinity (spec-legal) means "never split a chunk's output"; the coder floors at one byte.
-    if (highWaterMark >= static_cast<double>(std::numeric_limits<size_t>::max()))
-        return std::numeric_limits<size_t>::max();
-    return static_cast<size_t>(highWaterMark);
-}
+    result.highWaterMark = highWaterMark >= static_cast<double>(std::numeric_limits<size_t>::max())
+        ? std::numeric_limits<size_t>::max()
+        : static_cast<size_t>(highWaterMark);
 
-std::optional<int32_t> parseCompressionLevel(JSGlobalObject* globalObject, JSValue strategy, CompressionFormat format)
-{
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    // parseCodecHighWaterMark already rejected a non-object, non-undefined argument.
-    if (!strategy.isObject())
-        return std::nullopt;
+    if (!levelFormat || !strategy.isObject())
+        return result;
     JSValue levelValue = asObject(strategy)->get(globalObject, Identifier::fromString(vm, "level"_s));
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    RETURN_IF_EXCEPTION(scope, result);
     if (levelValue.isUndefined())
-        return std::nullopt;
+        return result;
     double level = levelValue.toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    RETURN_IF_EXCEPTION(scope, result);
 
     int32_t min = 0;
     int32_t max = 0;
     ASCIILiteral name;
-    switch (format) {
+    switch (*levelFormat) {
     case CompressionFormat::Deflate:
     case CompressionFormat::DeflateRaw:
     case CompressionFormat::Gzip:
         // zlib compression levels.
         min = 0;
         max = 9;
-        name = format == CompressionFormat::Gzip ? "gzip"_s : (format == CompressionFormat::DeflateRaw ? "deflate-raw"_s : "deflate"_s);
+        name = *levelFormat == CompressionFormat::Gzip ? "gzip"_s : (*levelFormat == CompressionFormat::DeflateRaw ? "deflate-raw"_s : "deflate"_s);
         break;
     case CompressionFormat::Brotli:
         // BROTLI_MIN_QUALITY .. BROTLI_MAX_QUALITY.
@@ -108,9 +103,10 @@ std::optional<int32_t> parseCompressionLevel(JSGlobalObject* globalObject, JSVal
     // !(>= && <=) also rejects NaN.
     if (!(level >= min && level <= max) || level != std::trunc(level)) {
         throwRangeError(globalObject, scope, makeString("The compression level must be an integer between "_s, min, " and "_s, max, " for "_s, name));
-        return std::nullopt;
+        return result;
     }
-    return static_cast<int32_t>(level);
+    result.level = static_cast<int32_t>(level);
+    return result;
 }
 
 // BufferSource → (ptr, len). `scratch` owns the bytes when `chunk` is a string

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -7,7 +7,7 @@
 
 // CompressionStreamCoder.rs. Each transform call runs one bounded step; `more` means the coder
 // must be stepped again (with no input, it kept the tail) before the next chunk is fed.
-extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress, size_t highWaterMark);
+extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress, size_t highWaterMark, bool hasLevel, int32_t level);
 // Releases the cell's reference (in-flight off-thread steps hold their own).
 extern "C" void CompressionStreamCoder__destroy(void* coder);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, bool* more);
@@ -24,6 +24,10 @@ std::optional<CompressionFormat> parseCompressionFormat(JSC::JSGlobalObject*, JS
 // read() and how far the coder runs ahead of a slow consumer. Throws RangeError / TypeError as
 // ExtractHighWaterMark does; `size` is ignored.
 size_t parseCodecHighWaterMark(JSC::JSGlobalObject*, JSC::JSValue strategy);
+// CompressionStream only: the `level` member of the same second argument selects the
+// compression level (zlib formats 0-9, brotli quality 0-11, zstd 1-22; absent = the
+// format's default). Throws RangeError on a non-integer or out-of-range value.
+std::optional<int32_t> parseCompressionLevel(JSC::JSGlobalObject*, JSC::JSValue strategy, CompressionFormat);
 
 } // namespace WebStreams
 } // namespace Bun

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -24,13 +24,10 @@ struct CodecOptions {
     size_t highWaterMark;
     std::optional<int32_t> level;
 };
-// One pass over the optional second constructor argument, read like a queuing strategy:
-// - highWaterMark (bytes, default 64 KiB) is the output bound of one codec step, i.e. the largest
-//   piece a consumer gets per read() and how far the coder runs ahead of a slow consumer. Throws
-//   RangeError / TypeError as ExtractHighWaterMark does; `size` is ignored.
-// - level, read only when `levelFormat` is engaged (CompressionStream), selects the compression
-//   level (zlib formats 0-9, brotli quality 0-11, zstd 1-22; absent = the format's default).
-//   Throws RangeError when invalid.
+// One pass over the optional second constructor argument (read like a queuing strategy; `size` is
+// ignored). highWaterMark (bytes, default 64 KiB) bounds one codec step's output. level, read only
+// when `levelFormat` is engaged (CompressionStream), selects the compression level: zlib formats
+// 0-9, brotli quality 0-11, zstd 1-22. Throws RangeError on an invalid value of either.
 CodecOptions parseCodecOptions(JSC::JSGlobalObject*, JSC::JSValue strategy, std::optional<CompressionFormat> levelFormat);
 
 } // namespace WebStreams

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -19,14 +19,19 @@ namespace Bun {
 namespace WebStreams {
 
 std::optional<CompressionFormat> parseCompressionFormat(JSC::JSGlobalObject*, JSC::JSValue formatValue);
-// The optional second constructor argument, read like a queuing strategy: its highWaterMark (bytes,
-// default 64 KiB) is the output bound of one codec step, i.e. the largest piece a consumer gets per
-// read() and how far the coder runs ahead of a slow consumer. Throws RangeError / TypeError as
-// ExtractHighWaterMark does; `size` is ignored.
-size_t parseCodecHighWaterMark(JSC::JSGlobalObject*, JSC::JSValue strategy);
-// CompressionStream only: the `level` member of the same argument (zlib formats 0-9, brotli
-// quality 0-11, zstd 1-22; absent = the format's default). Throws RangeError when invalid.
-std::optional<int32_t> parseCompressionLevel(JSC::JSGlobalObject*, JSC::JSValue strategy, CompressionFormat);
+
+struct CodecOptions {
+    size_t highWaterMark;
+    std::optional<int32_t> level;
+};
+// One pass over the optional second constructor argument, read like a queuing strategy:
+// - highWaterMark (bytes, default 64 KiB) is the output bound of one codec step, i.e. the largest
+//   piece a consumer gets per read() and how far the coder runs ahead of a slow consumer. Throws
+//   RangeError / TypeError as ExtractHighWaterMark does; `size` is ignored.
+// - level, read only when `levelFormat` is engaged (CompressionStream), selects the compression
+//   level (zlib formats 0-9, brotli quality 0-11, zstd 1-22; absent = the format's default).
+//   Throws RangeError when invalid.
+CodecOptions parseCodecOptions(JSC::JSGlobalObject*, JSC::JSValue strategy, std::optional<CompressionFormat> levelFormat);
 
 } // namespace WebStreams
 } // namespace Bun

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -24,9 +24,8 @@ std::optional<CompressionFormat> parseCompressionFormat(JSC::JSGlobalObject*, JS
 // read() and how far the coder runs ahead of a slow consumer. Throws RangeError / TypeError as
 // ExtractHighWaterMark does; `size` is ignored.
 size_t parseCodecHighWaterMark(JSC::JSGlobalObject*, JSC::JSValue strategy);
-// CompressionStream only: the `level` member of the same second argument selects the
-// compression level (zlib formats 0-9, brotli quality 0-11, zstd 1-22; absent = the
-// format's default). Throws RangeError on a non-integer or out-of-range value.
+// CompressionStream only: the `level` member of the same argument (zlib formats 0-9, brotli
+// quality 0-11, zstd 1-22; absent = the format's default). Throws RangeError when invalid.
 std::optional<int32_t> parseCompressionLevel(JSC::JSGlobalObject*, JSC::JSValue strategy, CompressionFormat);
 
 } // namespace WebStreams

--- a/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
@@ -152,7 +152,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDecompressionStreamCon
     size_t highWaterMark = parseCodecHighWaterMark(lexicalGlobalObject, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
 
-    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), true, highWaterMark);
+    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), true, highWaterMark, false, 0);
     if (!coder) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "failed to initialize decompressor"_s);
         return {};

--- a/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
@@ -149,10 +149,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDecompressionStreamCon
     auto format = parseCompressionFormat(lexicalGlobalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(format.has_value());
-    size_t highWaterMark = parseCodecHighWaterMark(lexicalGlobalObject, callFrame->argument(1));
+    CodecOptions options = parseCodecOptions(lexicalGlobalObject, callFrame->argument(1), std::nullopt);
     RETURN_IF_EXCEPTION(scope, {});
 
-    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), true, highWaterMark, false, 0);
+    void* coder = CompressionStreamCoder__create(static_cast<uint8_t>(*format), true, options.highWaterMark, false, 0);
     if (!coder) [[unlikely]] {
         throwTypeError(lexicalGlobalObject, scope, "failed to initialize decompressor"_s);
         return {};

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -196,8 +196,6 @@ impl CompressionStreamCoder {
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, false) => {
                 let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
                 // Spec: "default compression level". Z_DEFAULT_COMPRESSION = -1.
-                // The caller validates an explicit `level` against the format's
-                // range (JSCompressionStreamShared.cpp).
                 // SAFETY: `s` is a zeroed, #[repr(C)] z_stream; zlibVersion() is
                 // a static C string.
                 let rc = unsafe {
@@ -789,8 +787,7 @@ impl AsyncInput {
 
 // ─── extern "C" surface (called from JSCompressionStream.cpp) ──────────────
 
-/// `level` (with `has_level`) is the compression level the constructor's options
-/// carry, already range-checked per format by the caller; ignored for decompression.
+/// `level` (present when `has_level`) is range-checked by the caller; ignored for decompression.
 #[unsafe(no_mangle)]
 pub extern "C" fn CompressionStreamCoder__create(
     format: u8,

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -190,17 +190,20 @@ impl CompressionStreamCoder {
         format: Format,
         decompress: bool,
         high_water_mark: usize,
+        level: Option<i32>,
     ) -> Result<Box<Self>, CodecError> {
         let backend = match (format, decompress) {
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, false) => {
                 let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
                 // Spec: "default compression level". Z_DEFAULT_COMPRESSION = -1.
+                // The caller validates an explicit `level` against the format's
+                // range (JSCompressionStreamShared.cpp).
                 // SAFETY: `s` is a zeroed, #[repr(C)] z_stream; zlibVersion() is
                 // a static C string.
                 let rc = unsafe {
                     zlib::deflateInit2_(
                         &raw mut *s,
-                        -1,
+                        level.unwrap_or(-1),
                         8, // Z_DEFLATED
                         format.window_bits(),
                         8, // default mem_level
@@ -239,6 +242,19 @@ impl CompressionStreamCoder {
                     brotli::BrotliEncoderCreateInstance(None, None, ptr::null_mut())
                 })
                 .ok_or(CodecError::Message("failed to initialize brotli encoder"))?;
+                if let Some(quality) = level {
+                    // SAFETY: `p` was just created and is exclusively owned here.
+                    let ok = brotli::BrotliEncoderSetParameter(
+                        unsafe { &mut *p.as_ptr() },
+                        brotli::BROTLI_PARAM_QUALITY,
+                        quality as u32,
+                    ) != 0;
+                    if !ok {
+                        // SAFETY: `p` was created above and not stored anywhere.
+                        unsafe { brotli::BrotliEncoderDestroyInstance(p.as_ptr()) };
+                        return Err(CodecError::Message("failed to set brotli quality"));
+                    }
+                }
                 Backend::BrotliEncode(p)
             }
             (Format::Brotli, true) => {
@@ -252,6 +268,17 @@ impl CompressionStreamCoder {
             (Format::Zstd, false) => {
                 let p = NonNull::new(zstd::ZSTD_createCCtx())
                     .ok_or(CodecError::Message("failed to initialize zstd encoder"))?;
+                if let Some(lvl) = level {
+                    // SAFETY: `p` was just created and is exclusively owned here.
+                    let rc = unsafe {
+                        zstd::ZSTD_CCtx_setParameter(p.as_ptr(), zstd::ZSTD_c_compressionLevel, lvl)
+                    };
+                    if zstd::ZSTD_isError(rc) != 0 {
+                        // SAFETY: `p` was created above and not stored anywhere.
+                        unsafe { zstd::ZSTD_freeCCtx(p.as_ptr()) };
+                        return Err(CodecError::Message("failed to set zstd level"));
+                    }
+                }
                 Backend::ZstdEncode(p)
             }
             (Format::Zstd, true) => {
@@ -762,16 +789,21 @@ impl AsyncInput {
 
 // ─── extern "C" surface (called from JSCompressionStream.cpp) ──────────────
 
+/// `level` (with `has_level`) is the compression level the constructor's options
+/// carry, already range-checked per format by the caller; ignored for decompression.
 #[unsafe(no_mangle)]
 pub extern "C" fn CompressionStreamCoder__create(
     format: u8,
     decompress: bool,
     high_water_mark: usize,
+    has_level: bool,
+    level: i32,
 ) -> *mut CompressionStreamCoder {
     let Some(format) = Format::from_u8(format) else {
         return ptr::null_mut();
     };
-    match CompressionStreamCoder::new(format, decompress, high_water_mark.max(1)) {
+    let level = (has_level && !decompress).then_some(level);
+    match CompressionStreamCoder::new(format, decompress, high_water_mark.max(1), level) {
         Ok(b) => Box::into_raw(b),
         Err(_) => ptr::null_mut(),
     }

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -34,6 +34,9 @@ pub mod c {
     // ZSTD_EndDirective
     pub const ZSTD_e_continue: ZSTD_EndDirective = 0;
 
+    // ZSTD_cParameter
+    pub const ZSTD_c_compressionLevel: ZSTD_cParameter = 100;
+
     pub const ZSTD_reset_session_and_parameters: ZSTD_ResetDirective = 3;
 
     // ZSTD_ErrorCode (zstd_errors.h) — only the public stable subset.

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1284,7 +1284,8 @@ describe("CompressionStream level option", () => {
   });
 
   test("DecompressionStream ignores level", () => {
-    expect(new DecompressionStream("brotli", { level: 3 } as any)).toBeInstanceOf(DecompressionStream);
+    // Out of range for every format: proves the member is ignored, not validated.
+    expect(new DecompressionStream("brotli", { level: 99 } as any)).toBeInstanceOf(DecompressionStream);
   });
 });
 

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1189,7 +1189,7 @@ test("errored pipeline releases the compression coder eagerly", async () => {
 describe("CompressionStream level option", () => {
   // Deterministic semi-random text: enough entropy that the level changes the output.
   let seed = 42;
-  const rand = () => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+  const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
   let text = "";
   for (let i = 0; text.length < 64_000; i++) {
     text += `<section id="s${i}"><p>${rand().toString(36).slice(2)} lorem ipsum ${((i * 2654435761) >>> 0).toString(36)}</p></section>`;

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1253,7 +1253,15 @@ describe("CompressionStream level option", () => {
 
   test("level combines with highWaterMark", async () => {
     const highWaterMark = 1024;
-    const out = await compress("brotli", { level: 1, highWaterMark });
+    const [out, q1, dflt] = await Promise.all([
+      compress("brotli", { level: 1, highWaterMark }),
+      compress("brotli", { level: 1 }),
+      compress("brotli"),
+    ]);
+    // The level took effect (quality 1 output is larger than the quality 11 default)...
+    expect(out.length).toBeGreaterThan(dflt.length);
+    // ...and highWaterMark only bounds the pieces, it does not change the bytes.
+    expect(out.equals(q1)).toBe(true);
     expect(zlib.brotliDecompressSync(out).equals(input)).toBe(true);
   });
 

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1183,6 +1183,103 @@ test("errored pipeline releases the compression coder eagerly", async () => {
   expect(exitCode).toBe(0);
 }, 60_000);
 
+// The `level` member of the second argument (a Bun extension, next to
+// highWaterMark) selects the compression level; absent keeps each format's
+// default (zlib default, brotli 11, zstd 3). Issue #40098.
+describe("CompressionStream level option", () => {
+  // Deterministic semi-random text: enough entropy that the level changes the output.
+  let seed = 42;
+  const rand = () => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+  let text = "";
+  for (let i = 0; text.length < 64_000; i++) {
+    text += `<section id="s${i}"><p>${rand().toString(36).slice(2)} lorem ipsum ${((i * 2654435761) >>> 0).toString(36)}</p></section>`;
+  }
+  const input = Buffer.from(text);
+
+  async function compress(
+    format: "gzip" | "deflate-raw" | "brotli" | "zstd",
+    options?: { level?: number; highWaterMark?: number },
+  ): Promise<Buffer> {
+    const cs = new CompressionStream(format, options);
+    const writer = cs.writable.getWriter();
+    const written = (async () => {
+      await writer.write(input);
+      await writer.close();
+    })();
+    const pieces = await Array.fromAsync(cs.readable);
+    await written;
+    return Buffer.concat(pieces);
+  }
+
+  test("brotli honors level as the quality", async () => {
+    const [q1, q11, dflt] = await Promise.all([
+      compress("brotli", { level: 1 }),
+      compress("brotli", { level: 11 }),
+      compress("brotli"),
+    ]);
+    expect(q1.length).toBeGreaterThan(q11.length);
+    // The default stays quality 11.
+    expect(dflt.equals(q11)).toBe(true);
+    expect(zlib.brotliDecompressSync(q1).equals(input)).toBe(true);
+    expect(zlib.brotliDecompressSync(q11).equals(input)).toBe(true);
+  });
+
+  test("gzip honors level", async () => {
+    const [stored, best] = await Promise.all([compress("gzip", { level: 0 }), compress("gzip", { level: 9 })]);
+    // Level 0 stores the input, so the output is larger than the input.
+    expect(stored.length).toBeGreaterThan(input.length);
+    expect(best.length).toBeLessThan(input.length);
+    expect(zlib.gunzipSync(stored).equals(input)).toBe(true);
+    expect(zlib.gunzipSync(best).equals(input)).toBe(true);
+  });
+
+  test("deflate-raw honors level", async () => {
+    const [stored, best] = await Promise.all([
+      compress("deflate-raw", { level: 0 }),
+      compress("deflate-raw", { level: 9 }),
+    ]);
+    expect(stored.length).toBeGreaterThan(input.length);
+    expect(best.length).toBeLessThan(input.length);
+    expect(zlib.inflateRawSync(stored).equals(input)).toBe(true);
+    expect(zlib.inflateRawSync(best).equals(input)).toBe(true);
+  });
+
+  test("zstd honors level", async () => {
+    const [z1, z19] = await Promise.all([compress("zstd", { level: 1 }), compress("zstd", { level: 19 })]);
+    expect(z1.length).toBeGreaterThan(z19.length);
+    expect(zlib.zstdDecompressSync(z1).equals(input)).toBe(true);
+    expect(zlib.zstdDecompressSync(z19).equals(input)).toBe(true);
+  });
+
+  test("level combines with highWaterMark", async () => {
+    const highWaterMark = 1024;
+    const out = await compress("brotli", { level: 1, highWaterMark });
+    expect(zlib.brotliDecompressSync(out).equals(input)).toBe(true);
+  });
+
+  test("an out-of-range or non-integer level throws RangeError", () => {
+    expect(() => new CompressionStream("brotli", { level: 12 })).toThrow(
+      new RangeError("The compression level must be an integer between 0 and 11 for brotli"),
+    );
+    expect(() => new CompressionStream("brotli", { level: -1 })).toThrow(RangeError);
+    expect(() => new CompressionStream("brotli", { level: 4.5 })).toThrow(RangeError);
+    expect(() => new CompressionStream("brotli", { level: NaN })).toThrow(RangeError);
+    expect(() => new CompressionStream("gzip", { level: 10 })).toThrow(
+      new RangeError("The compression level must be an integer between 0 and 9 for gzip"),
+    );
+    expect(() => new CompressionStream("zstd", { level: 0 })).toThrow(
+      new RangeError("The compression level must be an integer between 1 and 22 for zstd"),
+    );
+    expect(() => new CompressionStream("zstd", { level: 23 })).toThrow(RangeError);
+    // An explicit undefined means "absent", like every WebIDL dictionary member.
+    expect(new CompressionStream("brotli", { level: undefined })).toBeInstanceOf(CompressionStream);
+  });
+
+  test("DecompressionStream ignores level", () => {
+    expect(new DecompressionStream("brotli", { level: 3 } as any)).toBeInstanceOf(DecompressionStream);
+  });
+});
+
 // Chunks > 128 KiB run the codec on a WorkPool thread. VM teardown
 // (Heap::lastChanceToFinalize) runs the cell's CFinalizer even while that
 // transform is mid-flight — it must release the cell's reference, not free


### PR DESCRIPTION
### Problem

- `CompressionStream("brotli")` always compresses at brotli quality 11 and no option can lower it. The reporter measured ~190x the time of `node:zlib` brotli quality 4 on a 400 KB payload. The same applies to `zstd` (fixed at the library default 3) and the zlib formats (fixed at the zlib default). Fixes #40098.
- The constructor's second argument is parsed as a QueuingStrategy (`parseCodecHighWaterMark`, `src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp`), so a `quality` or `level` member passes dictionary conversion and is dropped. `CompressionStreamCoder::new` (`src/runtime/webcore/CompressionStreamCoder.rs`) created each encoder with no parameters.

### Fix

- `CompressionStream` now reads a `level` member from the same second argument: 0-9 for the zlib formats, 0-11 for brotli (the quality), 1-22 for zstd (the range `Bun.zstdCompressSync` accepts). Absent keeps each format's current default, so existing output is unchanged.
- A non-integer or out-of-range value throws a RangeError that names the valid range, instead of being ignored.
- The value flows through `CompressionStreamCoder__create` into `deflateInit2_`, `BrotliEncoderSetParameter(BROTLI_PARAM_QUALITY)`, or `ZSTD_CCtx_setParameter(ZSTD_c_compressionLevel)`. `DecompressionStream` ignores `level`, like any irrelevant dictionary member.
- Verified: `test/js/web/streams/compression.test.ts` (new `CompressionStream level option` block, 5 of 7 tests fail on stock bun). Also the node webstreams compression tests, `zstd.test.ts`, and `bun-types.test.ts`.

### Background

- The WHATWG constructor takes only a format string. Bun already extends it: extra formats (`brotli`, `zstd`) and a `{ highWaterMark }` second argument that bounds the output of one codec step. `level` joins that existing dictionary, so both extensions live in one place.
- With the issue's repro, `new CompressionStream("brotli", { level: 4 })` now produces byte-for-byte the `node:zlib` quality-4 output (64175 bytes vs 52297 at the default 11) at the matching speed.

<details><summary>Notes</summary>

- The option name is `level` for every format, matching `Bun.gzipSync` / `Bun.zstdCompressSync`. The Node-style `{ params: { [BROTLI_PARAM_QUALITY]: n } }` shape from the issue stays unsupported: it belongs to `node:zlib`, not to this constructor.
- The brotli default stays quality 11 (node's `BROTLI_DEFAULT_QUALITY`). Changing the default would silently change output bytes for existing users.
- Rust side: added `BROTLI_PARAM_QUALITY` to `src/brotli_sys/brotli_c.rs` and `ZSTD_c_compressionLevel` to `src/zstd/lib.rs` (values match vendor headers). A failed parameter set destroys the just-created encoder before returning the error.
- Range validation lives in C++ (`parseCompressionLevel`) so the throw carries a precise message. The Rust `create` trusts the validated value.
- `packages/bun-types/globals.d.ts`: the `CompressionStream` constructor signature and JSDoc now include `level`.
- Suites run: `test/js/web/streams/compression.test.ts` (72 pass), `test-whatwg-webstreams-compression.js`, `test-webstreams-decompression-reject-trailing.js`, `test/js/bun/util/zstd.test.ts` (92 pass), `test/integration/bun-types/bun-types.test.ts` (15 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/compression.test.ts
bun test v1.4.1 (4448a2e21)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [10.68ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.47ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.62ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.02ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [15.38ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [21.20ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [47.84ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [9.07ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [19.43ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [50.18ms]
(
... (truncated)

release without fix: 1 skipped
bun test v1.4.1-canary.1 (f46976b03)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [0.31ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [0.05ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [0.04ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [0.02ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [0.87ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [0.69ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [3.65ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [0.57ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [0.38ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [0.49ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [0.28ms]
(pass) CompressionStream and DecompressionStream > zstd > decompr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/compression.test.ts
bun test v1.4.1 (4448a2e21)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [10.13ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.75ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.24ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.36ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [15.03ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [20.87ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [47.16ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [9.04ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [19.41ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [49.93ms]
(
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 623ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp.o
[2/9] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp.o
[3/9] cxx obj/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp.o
[4/9] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[5/9] gen cpp.rs (cppbind)
[5/9] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_brotli_sys v0.0.0 (/workspace/bun/src/brotli_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/htt
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/globals.d.ts                    |   6 +-
 src/brotli_sys/brotli_c.rs                         |   2 +
 .../webcore/streams/JSCompressionStream.cpp        |   4 +-
 .../webcore/streams/JSCompressionStreamShared.cpp  |  57 +++++++++--
 .../webcore/streams/JSCompressionStreamShared.h    |  17 ++--
 .../webcore/streams/JSDecompressionStream.cpp      |   4 +-
 src/runtime/webcore/CompressionStreamCoder.rs      |  33 ++++++-
 src/zstd/lib.rs                                    |   3 +
 test/js/web/streams/compression.test.ts            | 106 +++++++++++++++++++++
 9 files changed, 212 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-types/globals.d.ts                               1      1      0
src/brotli_sys/brotli_c.rs                                    1      2      0
src/jsc/bindings/webcore/streams/JSCompressionStream.cpp      2      3      0
…/bindings/webcore/streams/JSCompressionStreamShared.cpp      2      4      0
…sc/bindings/webcore/streams/JSCompressionStreamShared.h      3      7      0
…/jsc/bindings/webcore/streams/JSDecompressionStream.cpp      2      4      0
src/runtime/webcore/CompressionStreamCoder.rs                 4      5      0
src/zstd/lib.rs                                               1      2      0
test/js/web/streams/compression.test.ts                       3      4      0
```

</details>

**root cause** · written by the author bot

The root cause was that the brotli path of CompressionStream hardcoded quality 11 and the constructor's second argument was accepted but never read, so callers had no way to trade compression ratio for speed. The fix parses the optional second argument once into a CodecOptions struct, validating a level option per format (0-9 for zlib, 0-11 for brotli, 1-22 for zstd), and threads that level through the coder ABI so deflate, brotli, and zstd apply it during compression while decompression ignores it. Defaults are preserved when no level is given, and invalid values now throw a RangeError ins…

<!-- robobun:evidence:end -->