### PR TITLE
mimalloc: clear theap->heap on heap delete so a cached theap cannot match a reused heap address (pin bump pending oven-sh/mimalloc#25)

### DIFF
--- a/patches/mimalloc/theap-cache-aba.patch
+++ b/patches/mimalloc/theap-cache-aba.patch
@@ -1,0 +1,17 @@
+--- a/src/theap.c
++++ b/src/theap.c
+@@ -670,6 +670,14 @@ void _mi_heap_detach_theaps( mi_heap_t* heap ) {
+                                 else { mi_assert_internal(theap->tld->theaps == theap); theap->tld->theaps = theap->tnext; }
+             theap->tnext = theap->tprev = NULL;       
+             theap->tld = NULL;
++            // Also clear `heap` (as `_mi_tld_detach_theaps` does). The owning thread's
++            // `_mi_theap_cached` can still point at this theap, and `_mi_heap_theap` only
++            // compares `theap->heap` with the requested heap: if a later `mi_heap_new` reuses
++            // this heap's address, a stale `heap` would hand that thread this detached theap,
++            // whose pages are destroyed (an ABA on the heap address). Doing it while holding the
++            // tld lock is safe: the thread is not in `mi_thread_theaps_done` for this theap, and
++            // the theap is no longer in the tld list for a later pass.
++            mi_atomic_store_ptr_release(mi_heap_t, &theap->heap, NULL);
+             mi_lock_release(&tld->theaps_lock);
+           }
+           else {

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -24,6 +24,13 @@ export const mimalloc: Dependency = {
     commit: MIMALLOC_COMMIT,
   }),
 
+  // oven-sh/mimalloc#25: a heap delete must clear `theap->heap` on the theaps
+  // it detaches, or a thread's cached theap matches a new heap created at the
+  // same address and allocates from destroyed pages (oven-sh/mimalloc#26 has
+  // the regression test). CI stand-in only: this becomes a pin bump once those
+  // PRs are merged, and the patch does not apply on top of #25.
+  patches: ["patches/mimalloc/theap-cache-aba.patch"],
+
   build: cfg => {
     // ─── Override behavior (global malloc replacement) ───
     //   ASAN:    OFF — ASAN interceptors must see the real malloc.


### PR DESCRIPTION
Draft until oven-sh/mimalloc#24, #25 and #26 are merged. Then this becomes a two-line pin bump (`MIMALLOC_COMMIT` in `scripts/build/deps/mimalloc.ts` and the literal in `test/js/node/process/process.test.js`) and the patch file goes away. The patch is here so CI builds and tests the store on every platform in the meantime; it must not merge in this form, because oven-sh/mimalloc#25 rewrites the lines it patches and the next pin bump would fail `git apply`.

### Problem
- The mimalloc dev3 sync (#37367) carried upstream 36e8fc33, which dropped the `theap->heap = NULL` store from the heap-delete detach path (`_mi_heap_detach_theaps`, `src/theap.c:656` at the pin). A thread's one-entry theap cache (`_mi_theap_cached`, checked only by `theap->heap == heap` in `include/mimalloc/prim-tls.h:392`) then matches a new heap created at the address of a destroyed one, and the thread allocates from a detached theap whose pages went back to the arena. Upstream had that store before, with a comment naming this exact ABA; the thread-exit path still has it.
- The fork's `test-heap-aba` (oven-sh/mimalloc#26) shows it on the pin: a debug build segfaults in `mi_heap_malloc`, a release build hands out 127 of 1024 blocks that `mi_heap_of` attributes to no heap.
- Bun is not shown to reach this path: `MimallocArena` allocates only on the thread that created or last reset the heap (asserted in debug builds), and a debug build instrumented to abort on the stale cache hit ran 1630 tests without firing. This restores an allocator invariant Bun depends on; it is not tied to a Bun-level symptom.

### Fix
- Restores the store under the tld lock, at the point where the thread-exit path already clears it. oven-sh/mimalloc#25 owns that change (it also keeps `theap->tld` valid until the theap struct is freed, for a cross-thread free that is mid-flight); oven-sh/mimalloc#26 adds the regression test. This PR will pin the fork head that contains both.
- Correct because a detached theap then matches no heap, so the cache refreshes on the next use. Holding the tld lock keeps it clear of the heap-delete vs thread-exit race the fork tests (`test-heap-delete-race`): the owner cannot be collecting this theap while the lock is held, and after the unlink it no longer sees it.
- Verified: the fork suite on the #25 tree with the test (Linux x64, Debug and Release). Bun: `bun bd` with the patch applied, then `test/js/bun/transpiler`, `test/bundler/bundler_edgecase.test.ts`, `test/js/web/workers/worker.test.ts` (the three `terminate() races` failures there are debug-build timing and identical on the unpatched pin).

### Background
- mimalloc v3 splits a `mi_heap_t` into per-thread `mi_theap_t`s. `_mi_heap_theap(heap)` finds the calling thread's theap through a versioned thread-local slot (`heap->theap`), with `_mi_theap_cached` (the theap of the last heap this thread used) as a front cache keyed only by the `theap->heap` pointer. The slot is versioned, so only the cache can go stale.
- `mi_heap_destroy` detaches the heap's theaps from every thread's tld list and frees them. A detached theap stays alive while a thread's cache references it (the cache holds a refcount).
- Bun's `MimallocArena` (Rust) is `mi_heap_new` + `mi_heap_malloc` + `mi_heap_destroy`, used for parser and transpiler arenas. `mi_heap_new` allocates the heap struct from the main heap, which refreshes the creating thread's cache, so the same-thread destroy-then-new pattern Bun uses does not hit the ABA.

<details><summary>Notes</summary>

This came out of an investigation of Sentry BUN-4CG0 (`SIGSEGV` in `JSC::MarkedBlock::Handle::sweep` from `LocalAllocator::tryAllocateIn`, `MarkedBlock::Header::m_vm` NULL while the `Handle` is intact: the 16 KiB block reads back as zeros while JSC owns it). The event rate rose after the dev3 sync, but the signature is older than mimalloc as JSC's allocator: #24194 (2025-10, Bun 1.2.23 on macOS arm64, libpas-backed JSC) is the same frame chain. The cause of that crash is not established by this PR.

What was ruled out for BUN-4CG0, with evidence:
- The fork's hole-purging feature and its park handoff (free blocks inside a live page are discarded with `MADV_FREE_REUSABLE`; the sweep runs on the scavenger thread for a thread parked in `kevent`/`epoll`), which fork commit 6df95990 in the same sync made run on nearly every park: the sweep arithmetic (16 KiB and 4 KiB OS pages, large pages, the unformed tail), the park/wake handshake, the abandoned-page claim protocol, the `used` accounting, the arena purge and bitmap paths, the Bun side of the park contract (`packages/bun-usockets/src/eventing/epoll_kqueue.c`, signal handlers, spawn), and the 101 upstream commits after the sync point were each read end to end. No fault found.
- A JSC-like stress test against a `MI_DEBUG_FULL` build of the pinned fork (16 KiB aligned blocks, cross-thread frees, 9000 short-lived threads, heap create/destroy/delete, 770k park handoffs, 900k discards, emulated 16 KiB OS pages, variants for purge delay, commit on demand, reclaim on free): 100k iterations per variant, zero corruption.
- The theap cache ABA is the one defect that is new in the window. Its symptom chain would fit (a stale allocation lands in arena slices that are free, the JS thread reuses those slices for fresh MarkedBlock pages, the stale user zero-fills its block), but no Bun input is known to reach it: the instrumented build ran `test/js/bun/transpiler`, `test/transpiler`, `test/js/web/workers`, `test/js/node/worker_threads`, `test/bundler/bun-build-api.test.ts`, `bundler_edgecase`, `bundler_splitting`, `bundler_bun`, `bundler_npm`, `test/cli/install/bun-install.test.ts`, `test/js/bun/glob` and `test/bake` without a hit.
- No Bun test is included: the change is in a dependency and no Bun-level input reaches the path, so nothing fails before and passes after. The regression test lives in the fork.
- Patch files in `patches/` need plain `--- a/` headers; with a `diff --git` header `git apply` skips them silently from `vendor/<dep>` (#35099).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->