### PR TITLE
s3: validate partSize, queueSize and retry before narrowing them

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -270,7 +270,8 @@ declare module "bun" {
     /**
      * Number of parts to upload in parallel for multipart uploads.
      * - Default: 5
-     * - Maximum: 255
+     * - Minimum: 1
+     * - Maximum: 255 (larger values are clamped to 255)
      *
      * Increasing this value can improve upload speeds for large files
      * but uses more memory.
@@ -280,6 +281,7 @@ declare module "bun" {
     /**
      * Number of retry attempts for failed uploads.
      * - Default: 3
+     * - Minimum: 0
      * - Maximum: 255
      *
      * @example

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -48,6 +48,47 @@ pub(crate) fn get_truthy_string_utf8(
     Ok(Some(str.into_utf8()))
 }
 
+/// `opts.{name}` via ToNumber, truncated, checked against `min..=max` before narrowing.
+fn get_optional_int_in_range(
+    opts: JSValue,
+    global: &JSGlobalObject,
+    name: &'static [u8],
+    min: i64,
+    max: Option<i64>,
+) -> JsResult<Option<i64>> {
+    let Some(value) = opts.get(global, name)? else {
+        return Ok(None);
+    };
+    if value.is_undefined_or_null() {
+        return Ok(None);
+    }
+    let number = value.to_number(global)?;
+    if number.is_nan() {
+        return Err(global.throw_range_error(
+            number,
+            RangeErrorOptions {
+                field_name: name,
+                msg: b"an integer",
+                ..Default::default()
+            },
+        ));
+    }
+    let truncated = number.trunc();
+    if truncated < min as f64 || max.is_some_and(|max| truncated > max as f64) {
+        return Err(global.throw_range_error(
+            number,
+            RangeErrorOptions {
+                min,
+                max: max.unwrap_or(i64::MAX),
+                field_name: name,
+                ..Default::default()
+            },
+        ));
+    }
+    // `as` saturates, so an unbounded `Infinity` becomes `i64::MAX`.
+    Ok(Some(truncated as i64))
+}
+
 const ACL_ONE_OF: &str = "\"private\", \"public-read\", \"public-read-write\", \"aws-exec-read\", \
 \"authenticated-read\", \"bucket-owner-read\", \"bucket-owner-full-control\", \"log-delivery-write\"";
 
@@ -145,70 +186,30 @@ pub(crate) fn get_credentials_with_options(
                 new_credentials.changed_credentials = true;
             }
 
-            if let Some(page_size) = opts.get_optional::<i64>(global_object, "pageSize")? {
-                if page_size < MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64
-                    || page_size > MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64
-                {
-                    return Err(global_object.throw_range_error(
-                        page_size,
-                        RangeErrorOptions {
-                            min: MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64,
-                            max: MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64,
-                            field_name: b"pageSize",
-                            ..Default::default()
-                        },
-                    ));
-                } else {
-                    new_credentials.options.part_size = page_size as u64;
-                }
-            }
-            if let Some(part_size) = opts.get_optional::<i64>(global_object, "partSize")? {
-                if part_size < MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64
-                    || part_size > MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64
-                {
-                    return Err(global_object.throw_range_error(
-                        part_size,
-                        RangeErrorOptions {
-                            min: MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64,
-                            max: MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64,
-                            field_name: b"partSize",
-                            ..Default::default()
-                        },
-                    ));
-                } else {
+            // `pageSize` is the deprecated alias. `partSize` is applied last and wins.
+            for name in [b"pageSize".as_slice(), b"partSize".as_slice()] {
+                if let Some(part_size) = get_optional_int_in_range(
+                    opts,
+                    global_object,
+                    name,
+                    MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64,
+                    Some(MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64),
+                )? {
                     new_credentials.options.part_size = part_size as u64;
                 }
             }
 
-            if let Some(queue_size) = opts.get_optional::<i32>(global_object, "queueSize")? {
-                if queue_size < 1 {
-                    return Err(global_object.throw_range_error(
-                        queue_size as i64,
-                        RangeErrorOptions {
-                            min: 1,
-                            field_name: b"queueSize",
-                            ..Default::default()
-                        },
-                    ));
-                } else {
-                    new_credentials.options.queue_size = queue_size.min(i32::from(u8::MAX)) as u8;
-                }
+            // Values above 255 clamp to the u8 field instead of throwing.
+            if let Some(queue_size) =
+                get_optional_int_in_range(opts, global_object, b"queueSize", 1, None)?
+            {
+                new_credentials.options.queue_size = queue_size.min(i64::from(u8::MAX)) as u8;
             }
 
-            if let Some(retry) = opts.get_optional::<i32>(global_object, "retry")? {
-                if !(0..=255).contains(&retry) {
-                    return Err(global_object.throw_range_error(
-                        retry as i64,
-                        RangeErrorOptions {
-                            min: 0,
-                            max: 255,
-                            field_name: b"retry",
-                            ..Default::default()
-                        },
-                    ));
-                } else {
-                    new_credentials.options.retry = retry as u8;
-                }
+            if let Some(retry) =
+                get_optional_int_in_range(opts, global_object, b"retry", 0, Some(255))?
+            {
+                new_credentials.options.retry = retry as u8;
             }
             if let Some(acl) =
                 opts.get_optional_enum_from_map(global_object, "acl", &ACL::MAP, ACL_ONE_OF)?

--- a/test/js/bun/s3/s3-numeric-options-coerce.test.ts
+++ b/test/js/bun/s3/s3-numeric-options-coerce.test.ts
@@ -98,4 +98,71 @@ describe("S3Client upload options coercion", () => {
     expect(() => make({ queueSize: "0" })).toThrow(RangeError);
     expect(() => make({ partSize: "1024" })).toThrow(RangeError);
   });
+
+  function rangeErrorMessage(opts: Record<string, unknown>): string {
+    let err: unknown;
+    try {
+      make(opts);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RangeError);
+    return (err as RangeError).message;
+  }
+
+  // The range check runs on the coerced number, before it is narrowed to the
+  // native field, so the message reports what the caller passed.
+  test("retry above 2^31 reports the received value, not the saturated i32", () => {
+    expect(rangeErrorMessage({ retry: 2 ** 32 + 3 })).toBe(
+      'The value of "retry" is out of range. It must be >= 0 and <= 255. Received 4294967299',
+    );
+    expect(rangeErrorMessage({ retry: 2 ** 31 })).toContain("Received 2147483648");
+    expect(rangeErrorMessage({ retry: Infinity })).toContain("Received Infinity");
+    expect(rangeErrorMessage({ retry: -1 })).toContain("Received -1");
+  });
+
+  test("retry: NaN throws instead of silently meaning 0 retries", () => {
+    expect(rangeErrorMessage({ retry: NaN })).toBe(
+      'The value of "retry" is out of range. It must be an integer. Received NaN',
+    );
+    expect(rangeErrorMessage({ retry: "not a number" })).toContain("Received NaN");
+    expect(rangeErrorMessage({ retry: Number(undefined) })).toContain("Received NaN");
+  });
+
+  test("queueSize and partSize report NaN as NaN, not as 0", () => {
+    expect(rangeErrorMessage({ queueSize: NaN })).toBe(
+      'The value of "queueSize" is out of range. It must be an integer. Received NaN',
+    );
+    expect(rangeErrorMessage({ partSize: NaN })).toBe(
+      'The value of "partSize" is out of range. It must be an integer. Received NaN',
+    );
+    expect(rangeErrorMessage({ pageSize: NaN })).toContain('"pageSize"');
+  });
+
+  test("queueSize below 1 reports the value before truncation", () => {
+    expect(rangeErrorMessage({ queueSize: 0.5 })).toBe(
+      'The value of "queueSize" is out of range. It must be >= 1. Received 0.5',
+    );
+    expect(rangeErrorMessage({ queueSize: -0.5 })).toContain("Received -0.5");
+    expect(rangeErrorMessage({ queueSize: -Infinity })).toContain("Received -Infinity");
+  });
+
+  test("pageSize and partSize are both validated, and partSize is kept", () => {
+    expect(Bun.inspect(make({ pageSize: 10485760, partSize: 20971520 }))).toContain("partSize: 20971520");
+    expect(Bun.inspect(make({ pageSize: 20971520, partSize: 10485760 }))).toContain("partSize: 10485760");
+    expect(rangeErrorMessage({ pageSize: 1024, partSize: 10485760 })).toContain('"pageSize"');
+  });
+
+  test("queueSize above 255 still clamps to 255", () => {
+    for (const queueSize of [256, 2 ** 32 + 3, Infinity, "1000"]) {
+      expect(Bun.inspect(make({ queueSize }))).toContain("queueSize: 255");
+    }
+  });
+
+  test("in-range floats still truncate", () => {
+    const inspected = Bun.inspect(make({ retry: 255.9, queueSize: 1.9, partSize: 5242880.9 }));
+    expect(inspected).toContain("retry: 255");
+    expect(inspected).toContain("queueSize: 1");
+    expect(inspected).toContain("partSize: 5242880");
+  });
 });


### PR DESCRIPTION
### Problem
- The S3 option parser coerced `retry` and `queueSize` to `i32` before the range check, so the RangeError for `retry: 2 ** 32 + 3` said `Received 2147483647`, and `queueSize: NaN` or `partSize: NaN` said `Received 0`.
- `retry: NaN` coerced to `0` and passed the `0..=255` check, so `retry: Number(process.env.S3_RETRY)` with the variable unset silently disabled retries (1 attempt instead of 4).
- The cause is `opts.get_optional::<i32>()` in `src/runtime/webcore/s3/credentials_jsc.rs:203-232`: `coerce::<i32>` saturates to `i32::MAX` and maps NaN to 0, and the checks ran on that result.

### Fix
- One helper, `get_optional_int_in_range`, reads the option, applies ToNumber, rejects NaN with `It must be an integer. Received NaN`, checks `min..=max` on the f64, and only then narrows. The message reports the value the caller passed.
- `partSize`, `pageSize`, `queueSize` and `retry` use it. Numeric strings and in-range floats still coerce and truncate (the 1.3.x behavior that #34309 pinned). `queueSize` above 255 still clamps to 255 (#29813). `null` and `undefined` still mean "not set".
- The `queueSize` JSDoc now states the minimum and the clamp, and `retry` states its minimum.
- Verified: `test/js/bun/s3/s3-numeric-options-coerce.test.ts` (7 new tests, 4 fail on bun 1.4.0). Also `s3-queueSize-validation.test.ts`, `s3-argument-validation.test.ts`, and `test/integration/bun-types/bun-types.test.ts`.

### Background
- `get_credentials_with_options` parses the options object that `Bun.s3.file()`, `new S3Client()`, `.writer()` and `Bun.write()` accept, and merges it over the client defaults.
- `throw_range_error` formats Node's `ERR_OUT_OF_RANGE` message (`The value of "x" is out of range. It must be >= a and <= b. Received v`). With no `min`/`max` it prints the `msg` field instead, here `an integer`.
- `retry` and `queue_size` are `u8` fields on `MultiPartUploadOptions`, `part_size` is `u64`. The checks have to run before the value is narrowed to those widths.

<details><summary>Notes</summary>

Probe on bun 1.4.0 (`Bun.s3.file("k", creds).writer({ [key]: v })`):

```
retry NaN        -> accepted (0 retries)
retry 1.5        -> accepted (1 retry, truncation kept)
retry 2**31      -> RangeError ... Received 2147483647
retry 2**32+3    -> RangeError ... Received 2147483647
retry Infinity   -> RangeError ... Received 2147483647
queueSize NaN    -> RangeError It must be >= 1. Received 0
queueSize 256    -> accepted (clamped to 255, kept)
partSize NaN     -> RangeError ... Received 0
```

With this change the same probes give `Received NaN`, `Received 2147483648`, `Received 4294967299`, `Received Infinity`, and `retry: NaN` throws. A fake S3 endpoint on loopback that answers every UploadPart with 500 counted 4 attempts for `retry: 3` and 2 attempts for `retry: 1.5`, both unchanged.

A BigInt option (`partSize: 10485760n`) used to coerce through `coerce_to_int64`. ToNumber throws `TypeError: Cannot convert a BigInt value to a number` for it now. The type declarations only allow `number`.

Two tests in `test/js/bun/s3/s3.test.ts` fail locally with `egress denied by robobun-proxy` because the S3 client sends a 127.0.0.1 endpoint through `HTTP_PROXY` while `fetch()` honors `NO_PROXY`. That is a separate issue and not changed here.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-numeric-options-coerce.test.ts"
bun test v1.4.1 (861e9ae04)

test/js/bun/s3/s3-numeric-options-coerce.test.ts:
(pass) presign expiresIn coercion > expiresIn: "3600" -> X-Amz-Expires=3600 [30.51ms]
(pass) presign expiresIn coercion > expiresIn: "60" -> X-Amz-Expires=60 [3.08ms]
(pass) presign expiresIn coercion > expiresIn: 1.5 -> X-Amz-Expires=1 [2.77ms]
(pass) presign expiresIn coercion > expiresIn: 3599.9999 -> X-Amz-Expires=3599 [2.67ms]
(pass) presign expiresIn coercion > expiresIn: Infinity -> X-Amz-Expires=2147483647 [2.78ms]
(pass) presign expiresIn coercion > expiresIn: 2147483648 -> X-Amz-Expires=2147483647 [2.55ms]
(pass) presign expiresIn coercion > expiresIn: null is ignored (default 86400) [5.31ms]
(pass) presign expiresIn coercion > expiresIn: 0 still throws (field-specific validation) [5.58ms]
(pass) S3Client upload options coercion > partSize accepts numeric strings and floats [6.63ms]
(pass) S3Client upload options coercion > partSize string above 2^31 does not wrap to 32 bits [4.63ms]
(pass) S3Clien
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/s3/s3-numeric-options-coerce.test.ts:
(pass) presign expiresIn coercion > expiresIn: "3600" -> X-Amz-Expires=3600 [0.23ms]
(pass) presign expiresIn coercion > expiresIn: "60" -> X-Amz-Expires=60 [0.03ms]
(pass) presign expiresIn coercion > expiresIn: 1.5 -> X-Amz-Expires=1 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: 3599.9999 -> X-Amz-Expires=3599 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: Infinity -> X-Amz-Expires=2147483647 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: 2147483648 -> X-Amz-Expires=2147483647 [0.01ms]
(pass) presign expiresIn coercion > expiresIn: null is ignored (default 86400) [0.03ms]
(pass) presign expiresIn coercion > expiresIn: 0 still throws (field-specific validation) [0.07ms]
(pass) S3Client upload options coercion > partSize accepts numeric strings and floats [0.10ms]
(pass) S3Client upload options coercion > partSize string above 2^31 does not wrap to 32 bits [0.04ms]
(pass) S3Client upload options coercion > partSize string out of range reports the received value, not a wrapped negative [1.00ms]
(pass) S3Client upload options coercion > pageSize (legacy 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-numeric-options-coerce.test.ts"
bun test v1.4.1 (861e9ae04)

test/js/bun/s3/s3-numeric-options-coerce.test.ts:
(pass) presign expiresIn coercion > expiresIn: "3600" -> X-Amz-Expires=3600 [13.66ms]
(pass) presign expiresIn coercion > expiresIn: "60" -> X-Amz-Expires=60 [3.16ms]
(pass) presign expiresIn coercion > expiresIn: 1.5 -> X-Amz-Expires=1 [2.82ms]
(pass) presign expiresIn coercion > expiresIn: 3599.9999 -> X-Amz-Expires=3599 [2.69ms]
(pass) presign expiresIn coercion > expiresIn: Infinity -> X-Amz-Expires=2147483647 [2.78ms]
(pass) presign expiresIn coercion > expiresIn: 2147483648 -> X-Amz-Expires=2147483647 [2.71ms]
(pass) presign expiresIn coercion > expiresIn: null is ignored (default 86400) [4.28ms]
(pass) presign expiresIn coercion > expiresIn: 0 still throws (field-specific validation) [5.74ms]
(pass) S3Client upload options coercion > partSize accepts numeric strings and floats [6.52ms]
(pass) S3Client upload options coercion > partSize string above 2^31 does not wrap to 32 bits [4.69ms]
(pass) S3Clien
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3fe7e7732e
  features     baseline

23 deps, 129 codegen, 1172 objects in 730ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [16.00ms]
[3/1244] gen bindgenv2
[4/1244] gen .bind.ts → GeneratedBindings.cpp
[5/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [39.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch zlib
[zlib] up to date
[8/1243] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/s3.d.ts                       |   4 +-
 src/runtime/webcore/s3/credentials_jsc.rs        | 117 ++++++++++++-----------
 test/js/bun/s3/s3-numeric-options-coerce.test.ts |  67 +++++++++++++
 3 files changed, 129 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
packages/bun-types/s3.d.ts                            1      1      0
src/runtime/webcore/s3/credentials_jsc.rs             6     10      0
test/js/bun/s3/s3-numeric-options-coerce.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->