### PR TITLE
bun:test: make performance.timeOrigin follow the fake clock

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -281,6 +281,10 @@ pub struct VirtualMachine {
     pub(crate) origin_timestamp: u64,
     /// For fake timers: override performance.now() with a specific value (in nanoseconds).
     pub overridden_performance_now: Option<u64>,
+    /// For fake timers: the wall-clock time (ms since the Unix epoch) that the
+    /// overridden `performance.now() == 0` corresponds to, so that
+    /// `performance.timeOrigin + performance.now()` tracks the fake `Date.now()`.
+    pub overridden_time_origin: Option<f64>,
     pub(crate) macro_event_loop: EventLoop,
     pub regular_event_loop: EventLoop,
     pub event_loop: *mut EventLoop, // BORROW_FIELD — points at sibling regular_event_loop/macro_event_loop

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1407,7 +1407,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsNow, (JSC::JSGlobalObject * globalObject, JSC
     return JSValue::encode(jsNumber(globalObject->jsDateNow()));
 }
 
-extern "C" void Bun__FakeTimers__setSystemTime(double ms);
+extern "C" void Bun__FakeTimers__setSystemTime(JSC::JSGlobalObject* globalObject, double ms);
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
@@ -1425,7 +1425,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
     globalObject->overridenDateNow = ms;
     // Rebase the Rust-side fake-timers offset so advanceTimersByTime ticks
     // from this value instead of the activation-time clock.
-    Bun__FakeTimers__setSystemTime(ms);
+    Bun__FakeTimers__setSystemTime(globalObject, ms);
 
     return JSValue::encode(callframe->thisValue());
 }

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -96,6 +96,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsPerformanceConstructor);
 // Attributes
 
 static JSC_DECLARE_CUSTOM_GETTER(jsPerformanceConstructor);
+static JSC_DECLARE_CUSTOM_GETTER(jsPerformance_timeOrigin);
 static JSC_DECLARE_CUSTOM_GETTER(jsPerformance_timing);
 static JSC_DECLARE_CUSTOM_GETTER(jsPerformance_onresourcetimingbufferfull);
 static JSC_DECLARE_CUSTOM_SETTER(setJSPerformance_onresourcetimingbufferfull);
@@ -192,6 +193,7 @@ template<> void JSPerformanceDOMConstructor::initializeProperties(VM& vm, JSDOMG
 
 static const HashTableValue JSPerformancePrototypeTableValues[] = {
     { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsPerformanceConstructor, 0 } },
+    { "timeOrigin"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsPerformance_timeOrigin, 0 } },
     { "timing"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsPerformance_timing, 0 } },
     { "onresourcetimingbufferfull"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsPerformance_onresourcetimingbufferfull, setJSPerformance_onresourcetimingbufferfull } },
     { "toJSON"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsPerformancePrototypeFunction_toJSON, 0 } },
@@ -252,12 +254,6 @@ void JSPerformance::finishCreation(VM& vm)
         functionPerformanceNow, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor,
         &DOMJITSignatureForPerformanceNow);
     Bun::putDirectNamed(vm, this, "now"_s, now);
-
-    this->putDirect(
-        vm,
-        JSC::Identifier::fromString(vm, "timeOrigin"_s),
-        jsNumber(Bun__readOriginTimerStart(static_cast<Zig::GlobalObject*>(this->globalObject())->bunVM())),
-        PropertyAttribute::ReadOnly | 0);
 }
 
 JSObject* JSPerformance::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
@@ -285,6 +281,17 @@ JSC_DEFINE_CUSTOM_GETTER(jsPerformanceConstructor, (JSGlobalObject * lexicalGlob
     if (!prototype) [[unlikely]]
         return throwVMTypeError(lexicalGlobalObject, throwScope);
     return JSValue::encode(JSPerformance::getConstructor(JSC::getVM(lexicalGlobalObject), prototype->globalObject()));
+}
+
+static inline JSValue jsPerformance_timeOriginGetter(JSGlobalObject& lexicalGlobalObject, JSPerformance& thisObject)
+{
+    UNUSED_PARAM(lexicalGlobalObject);
+    return jsNumber(thisObject.wrapped().timeOrigin());
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsPerformance_timeOrigin, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSPerformance>::get<jsPerformance_timeOriginGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
 
 static inline JSValue jsPerformance_timingGetter(JSGlobalObject& lexicalGlobalObject, JSPerformance& thisObject)

--- a/src/jsc/bindings/webcore/Performance.cpp
+++ b/src/jsc/bindings/webcore/Performance.cpp
@@ -78,8 +78,8 @@ DOMHighResTimeStamp Performance::now() const
 
 DOMHighResTimeStamp Performance::timeOrigin() const
 {
-    // return reduceTimeResolution(m_timeOrigin.approximateWallTime().secondsSinceEpoch()).milliseconds();
-    return m_timeOrigin.secondsSinceEpoch().milliseconds();
+    // Read it each time: bun:test fake timers move the origin along with now().
+    return Bun__readOriginTimerStart(bunVM(scriptExecutionContext()->vm()));
 }
 
 Seconds Performance::reduceTimeResolution(Seconds seconds)

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -52,6 +52,10 @@ pub fn read_origin_timer(vm: &VirtualMachine) -> u64 {
 
 // HOST_EXPORT(Bun__readOriginTimerStart, c)
 pub fn read_origin_timer_start(vm: &VirtualMachine) -> f64 {
+    // Fake timers reset performance.now() to 0, so the origin moves with them.
+    if let Some(overridden) = vm.overridden_time_origin {
+        return overridden;
+    }
     // timespce to milliseconds
     ((vm.origin_timestamp as f64) + crate::virtual_machine::ORIGIN_RELATIVE_EPOCH as f64)
         / 1_000_000.0

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -72,6 +72,9 @@ impl CurrentTime {
         bun_core::mock_time::set_wall_ms(date_now);
 
         vm.overridden_performance_now = Some(offset.ns());
+        // `Date.now() == date_now_offset + performance.now()`, so the offset is
+        // the fake clock's `performance.timeOrigin`.
+        vm.overridden_time_origin = Some(date_now_offset);
     }
 
     pub(crate) fn clear(&self, global: &JSGlobalObject) {
@@ -86,16 +89,18 @@ impl CurrentTime {
         // SAFETY: FFI call into C++ JSMock; global is a valid &JSGlobalObject
         JSMock__setOverridenDateNow(global, f64::NAN);
         vm.overridden_performance_now = None;
+        vm.overridden_time_origin = None;
     }
 }
 
 /// `jest.setSystemTime` (C++ `JSMock__jsSetSystemTime`) writes
 /// `globalObject->overridenDateNow` directly; rebase `date_now_offset` here so
 /// the next `advanceTimersByTime` recomputes `Date.now` from the set time
-/// instead of the stale activation-time offset. No-op when fake timers are
-/// inactive or `ms` is NaN (the "clear override" sentinel).
+/// instead of the stale activation-time offset. `performance.now()` does not
+/// move, so `performance.timeOrigin` follows the rebased offset. No-op when
+/// fake timers are inactive or `ms` is NaN (the "clear override" sentinel).
 #[unsafe(no_mangle)]
-extern "C" fn Bun__FakeTimers__setSystemTime(ms: f64) {
+extern "C" fn Bun__FakeTimers__setSystemTime(global: &JSGlobalObject, ms: f64) {
     if ms.is_nan() {
         return;
     }
@@ -107,6 +112,7 @@ extern "C" fn Bun__FakeTimers__setSystemTime(ms: f64) {
         .date_now_offset
         .store(date_now_offset.to_bits(), Ordering::Relaxed);
     bun_core::mock_time::set_wall_ms(ms);
+    global.bun_vm().as_mut().overridden_time_origin = Some(date_now_offset);
 }
 
 use crate::jsc_hooks::timer_all;

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,5 +1,6 @@
 import { RedisClient, SQL } from "bun";
 import { heapStats } from "bun:jsc";
+import { setSystemTime } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { spawnSync as childProcessSpawnSync } from "node:child_process";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -597,6 +598,41 @@ describe("performance.now() mocking", () => {
     vi.advanceTimersByTime(500);
     expect(performance.now()).toBe(perfStart + 1500);
     expect(Date.now()).toBe(dateStart + 1500);
+  });
+
+  test("performance.timeOrigin follows the fake clock", () => {
+    const realTimeOrigin = performance.timeOrigin;
+    const fakeNow = new Date("2000-01-01T00:00:00.000Z").getTime();
+    vi.useFakeTimers({ now: fakeNow });
+
+    // performance.now() restarts at 0, so the fake epoch is the origin.
+    expect(performance.now()).toBe(0);
+    expect(performance.timeOrigin).toBe(fakeNow);
+    expect(performance.timeOrigin + performance.now()).toBe(Date.now());
+
+    vi.advanceTimersByTime(5000);
+    expect(performance.timeOrigin).toBe(fakeNow);
+    expect(performance.timeOrigin + performance.now()).toBe(Date.now());
+
+    // setSystemTime moves Date.now() but not performance.now(), so the origin moves with it.
+    const jumped = new Date("2010-06-15T12:00:00.000Z").getTime();
+    setSystemTime(jumped);
+    expect(Date.now()).toBe(jumped);
+    expect(performance.now()).toBe(5000);
+    expect(performance.timeOrigin).toBe(jumped - 5000);
+    expect(performance.timeOrigin + performance.now()).toBe(Date.now());
+    expect(performance.toJSON().timeOrigin).toBe(performance.timeOrigin);
+
+    vi.useRealTimers();
+    expect(performance.timeOrigin).toBe(realTimeOrigin);
+  });
+
+  test("performance.timeOrigin is not affected by setSystemTime without fake timers", () => {
+    const realTimeOrigin = performance.timeOrigin;
+    setSystemTime(new Date("2000-01-01T00:00:00.000Z"));
+    expect(new Date().getUTCFullYear()).toBe(2000);
+    expect(performance.timeOrigin).toBe(realTimeOrigin);
+    setSystemTime();
   });
 });
 


### PR DESCRIPTION
### Problem
- Under `jest.useFakeTimers({ now })`, `Date.now()` returns the fake time and `performance.now()` restarts at 0, but `performance.timeOrigin` stays at the real process start. `performance.timeOrigin + performance.now()` is then neither the fake time nor the real time: it is the real process start, so it jumps backwards by the process age at activation. Tracing code that computes `hrTime = timeOrigin + performance.now()` records 2026 next to `Date` values of 2000 in one test.
- The cause is `JSPerformance::finishCreation` (`src/jsc/bindings/webcore/JSPerformance.cpp:258`): `timeOrigin` was a read-only own data property, computed once at construction. The fake clock (`src/runtime/test_runner/timers/FakeTimers.rs`) overrides `Date.now()` and `performance.now()` but had no way to move it.

### Fix
- `timeOrigin` is now a getter on `Performance.prototype`, as in Node and browsers. It reads `Bun__readOriginTimerStart` on each access. `Performance::timeOrigin()` (used by `toJSON()`) reads the same function.
- The VM gains `overridden_time_origin`, next to `overridden_performance_now`. The fake clock sets it to `date_now_offset`, the value that already satisfies `Date.now() == date_now_offset + performance.now()`. `useRealTimers()` clears it. `setSystemTime()` under fake timers moves `Date.now()` but not `performance.now()`, so it moves the origin too. `setSystemTime()` without fake timers leaves the real origin alone, as before.
- Correct because `timeOrigin` is by definition the wall-clock time at which `performance.now()` reads 0. With the fake clock that time is `date_now_offset`, so `timeOrigin + now() == Date.now()` holds after `useFakeTimers({ now })`, after `advanceTimersByTime`, and after `setSystemTime`. `@sinonjs/fake-timers` (Jest) sets `timeOrigin` to the install epoch too.
- Verified: `test/js/bun/test/fake-timers/fake-timers.test.ts` (two new tests, the first fails on the released binary). Also `test/js/web/timers/performance.test.js`, `test/js/node/perf_hooks/perf_hooks.test.ts`, `test/js/deno/performance/performance.test.ts`, `test/js/bun/test/test-timers.test.ts`, `test/cli/test/isolation.test.ts`, the cron and jsonwebtoken suites.

### Background
- `performance.now()` is a monotonic clock in milliseconds since `timeOrigin`. `Bun__readOriginTimer` (`src/jsc/virtual_machine_exports.rs`) returns it in nanoseconds, or the fake value when `vm.overridden_performance_now` is set.
- `performance.timeOrigin` is the wall-clock time (ms since the Unix epoch) that `performance.now() == 0` maps to. `Bun__readOriginTimerStart` returns it from `vm.origin_timestamp`.
- The bun:test fake clock keeps one `Timespec` (`CURRENT_TIME`) for fake monotonic time and one `date_now_offset` that maps it to the fake `Date.now()`. `useFakeTimers` resets the monotonic value to 0 and sets the offset to the requested `now`.
- A `DOMAttribute | CustomAccessor` entry in a prototype hash table is a getter that JSC type-checks: `this` must be a `Performance` instance, or JSC throws a `TypeError` before the getter runs.

<details><summary>Notes</summary>

Repro (released bun 1.4.0, `bun test`):

```js
const { test, expect, jest } = require("bun:test");
test("timeOrigin follows the fake clock", () => {
  jest.useFakeTimers({ now: new Date("2000-01-01T00:00:00Z") });
  console.log(new Date().toISOString(), new Date(performance.timeOrigin + performance.now()).toISOString());
  // before: 2000-01-01T00:00:00.000Z 2026-08-22T14:04:35.616Z
  // after:  2000-01-01T00:00:00.000Z 2000-01-01T00:00:00.000Z
  expect(new Date(performance.timeOrigin + performance.now()).getUTCFullYear()).toBe(2000);
});
```

Observable shape change: `timeOrigin` moves from an own enumerable data property of `performance` to an accessor on `Performance.prototype`, which is where Node and browsers put it. `Object.keys(performance)` no longer lists it. `JSON.stringify(performance)` and `performance.toJSON()` still include it, and the value is the same.

`performance.now()` still restarts at 0 on `useFakeTimers()`. This matches `@sinonjs/fake-timers` (the Jest engine) and the existing tests in `fake-timers.test.ts` assert it. A consequence that this PR does not change: `performance.mark()` entries recorded before `useFakeTimers()` stay on the real timeline, so a `measure()` that spans the activation has a negative duration. Jest stubs `mark()` and `measure()` under fake timers instead. The alternative is to not reset `performance.now()` at activation and let the fake monotonic clock continue from the real reading, which keeps marks comparable across activation. That is a one-line change in `FakeTimers::activate` plus the two assertions in the existing tests, if that behaviour is preferred.

`setSystemTime()` under fake timers: `@sinonjs/fake-timers` pins `timeOrigin` at the install epoch, so there `timeOrigin + now() != Date.now()` after `setSystemTime`. This PR moves the origin instead, so the invariant also holds for the documented `useFakeTimers(); setSystemTime(date)` idiom.

`Bun__FakeTimers__setSystemTime` now takes the global object so it can reach the VM. `reset_for_isolation` (the `--isolate` file boundary) goes through `CurrentTime::clear` and so also clears the override.

Related open PR: #38740 moves the fake clock statics to per-VM storage and touches the same lines in `FakeTimers.rs`. This change is independent of it and rebases onto it mechanically (set the override where `date_now_offset` is written).

Formatting: `prettier` and `clang-format` checks pass. `rustfmt` reports pre-existing diffs in `FakeTimers.rs` (import order, `MIN_TIMESPEC` layout) that this PR does not touch.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [26.51ms]
(pass) advanceTimersToNextTimer > one setTimeout [8.09ms]
(pass) advanceTimersToNextTimer > setInterval [7.11ms]
(pass) advanceTimersToNextTimer > sorted timeouts [10.97ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.47ms]
(pass) advanceTimersByTime > setInterval [6.07ms]
(pass) runOnlyPendingTimers > two setIntervals [7.40ms]
(pass) runAllTimers > two setIntervals [7.75ms]
(pass) getTimerCount > returns correct count of pending timers [6.59ms]
(pass) getTimerCount > throws error if fake timers not active [3.63ms]
(pass) clearAllTimers > clears all pending timers [4.39ms]
(pass) clearAllTimers > throws error if fake timers not active [2.69ms]
(pass) AbortSignal.timeout > pending signals stay alive while the fake heap holds their timer [381.78ms]
(pass) AbortSignal.timeout > useRealTimers() releases the signals whose timers it dropped [401.83ms]
(pass) AbortSignal.tim
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [10.42ms]
(pass) advanceTimersToNextTimer > one setTimeout [0.15ms]
(pass) advanceTimersToNextTimer > setInterval [0.09ms]
(pass) advanceTimersToNextTimer > sorted timeouts [0.10ms]
(pass) advanceTimersToNextTimer > alternating intervals [0.10ms]
(pass) advanceTimersByTime > setInterval [0.09ms]
(pass) runOnlyPendingTimers > two setIntervals [0.10ms]
(pass) runAllTimers > two setIntervals [0.06ms]
(pass) getTimerCount > returns correct count of pending timers [0.06ms]
(pass) getTimerCount > throws error if fake timers not active [0.06ms]
(pass) clearAllTimers > clears all pending timers [0.05ms]
(pass) clearAllTimers > throws error if fake timers not active [0.02ms]
(pass) AbortSignal.timeout > pending signals stay alive while the fake heap holds their timer [8.66ms]
(pass) AbortSignal.timeout > useRealTimers() releases the signals whose timers it dropped [6.36ms]
(pass) AbortSignal.timeout > clearAllTimers() releases the signals whose timers it cleared [6.30ms]
(pass) AbortSignal.timeout > a signal the program still holds is left unaborted once its fake timer 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [27.77ms]
(pass) advanceTimersToNextTimer > one setTimeout [7.82ms]
(pass) advanceTimersToNextTimer > setInterval [7.24ms]
(pass) advanceTimersToNextTimer > sorted timeouts [11.21ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.63ms]
(pass) advanceTimersByTime > setInterval [6.18ms]
(pass) runOnlyPendingTimers > two setIntervals [7.32ms]
(pass) runAllTimers > two setIntervals [8.04ms]
(pass) getTimerCount > returns correct count of pending timers [6.75ms]
(pass) getTimerCount > throws error if fake timers not active [3.89ms]
(pass) clearAllTimers > clears all pending timers [5.08ms]
(pass) clearAllTimers > throws error if fake timers not active [2.61ms]
(pass) AbortSignal.timeout > pending signals stay alive while the fake heap holds their timer [389.08ms]
(pass) AbortSignal.timeout > useRealTimers() releases the signals whose timers it dropped [404.88ms]
(pass) AbortSignal.tim
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 694ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/10] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/10] gen cpp.rs (cppbind)
[2/10] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                        |  4 +++
 src/jsc/bindings/JSMockFunction.cpp              |  4 +--
 src/jsc/bindings/webcore/JSPerformance.cpp       | 19 +++++++++----
 src/jsc/bindings/webcore/Performance.cpp         |  4 +--
 src/jsc/virtual_machine_exports.rs               |  4 +++
 src/runtime/test_runner/timers/FakeTimers.rs     | 12 ++++++--
 test/js/bun/test/fake-timers/fake-timers.test.ts | 36 ++++++++++++++++++++++++
 7 files changed, 70 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/VirtualMachine.rs                             1      1      0
src/jsc/bindings/JSMockFunction.cpp                   1      2      0
src/jsc/bindings/webcore/JSPerformance.cpp            2      4      0
src/jsc/bindings/webcore/Performance.cpp              1      1      0
src/jsc/virtual_machine_exports.rs                    1      2      0
src/runtime/test_runner/timers/FakeTimers.rs          1      3      0
test/js/bun/test/fake-timers/fake-timers.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->