### PR TITLE
test(socket): reset the accepted socket's peer in-process instead of killing a child

### DIFF
--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4479,11 +4479,8 @@ describe.concurrent("close() error after the peer resets the connection", () => 
   describe.each(["tcp", "tls"] as const)("%s", transport => {
     // The peer resets in-process with terminate(): it closes with SO_LINGER{1,0}, so the
     // kernel sends a bare RST with nothing queued ahead of it (a TLS terminate() writes
-    // no close_notify, #39632). That is the same segment a process killed with unread
-    // data in its receive buffer produces, without the race such a kill has: over
-    // loopback the delivery of the last write is asynchronous, and a teardown that beat
-    // it found an empty receive buffer and sent a FIN, which the accepted side read as
-    // a clean end.
+    // no close_notify, #39632). A peer process killed with unread data produces the same
+    // RST, but over macOS loopback that kill raced the delivery of the last write (#40108).
     it("the accepted socket reports the reset as read ECONNRESET", async () => {
       const closedWith = Promise.withResolvers<CloseError>();
       const greet = (socket: Socket) => socket.write("greeting");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4477,34 +4477,15 @@ describe.concurrent("close() error after the peer resets the connection", () => 
   const readReset = { reported: true, code: "ECONNRESET", syscall: "read" };
 
   describe.each(["tcp", "tls"] as const)("%s", transport => {
-    // The peer lives in a child process that is killed while data it never read sits
-    // in its receive buffer: the kernel then closes its socket with an RST, and
-    // nothing (no FIN, and for TLS no close_notify) is queued ahead of the reset. An
-    // in-process terminate() is not usable for the TLS case: it writes a close_notify
-    // first, and on POSIX the reading side consumes that as a clean end.
-    const peerSource = `
-      await Bun.connect({
-        hostname: "127.0.0.1",
-        port: Number(process.argv[2]),
-        tls: ${transport === "tls" ? JSON.stringify({ ca: tls.cert }) : "undefined"},
-        socket: {
-          data(socket) {
-            // The greeting arrived, so both sides are fully open. Stop reading: what
-            // the server writes next stays unread in this process's receive buffer.
-            socket.pause();
-            socket.write("ready");
-          },
-          close() {},
-          error() {},
-        },
-      });
-      await Bun.stdin.text(); // keeps the process alive until the test kills it
-    `;
-
+    // The peer resets in-process with terminate(): it closes with SO_LINGER{1,0}, so the
+    // kernel sends a bare RST with nothing queued ahead of it (a TLS terminate() writes
+    // no close_notify, #39632). That is the same segment a process killed with unread
+    // data in its receive buffer produces, without the race such a kill has: over
+    // loopback the delivery of the last write is asynchronous, and a teardown that beat
+    // it found an empty receive buffer and sent a FIN, which the accepted side read as
+    // a clean end.
     it("the accepted socket reports the reset as read ECONNRESET", async () => {
-      const ready = Promise.withResolvers<Socket>();
       const closedWith = Promise.withResolvers<CloseError>();
-      let received = "";
       const greet = (socket: Socket) => socket.write("greeting");
       using listener = Bun.listen({
         hostname: "127.0.0.1",
@@ -4516,32 +4497,30 @@ describe.concurrent("close() error after the peer resets the connection", () => 
           },
           handshake(socket, success, authorizationError) {
             if (success) greet(socket);
-            else ready.reject(authorizationError ?? new Error("server handshake failed"));
+            else closedWith.reject(authorizationError ?? new Error("server handshake failed"));
           },
-          data(socket, chunk) {
-            received += chunk.toString();
-            if (received.includes("ready")) ready.resolve(socket);
-          },
+          data() {},
           close(_socket, error) {
-            ready.reject(new Error("the accepted socket closed before the peer was ready"));
             closedWith.resolve(error as CloseError);
           },
         },
       });
-      using dir = tempDir("socket-peer-reset", { "peer.ts": peerSource });
-      await using peer = Bun.spawn({
-        cmd: [bunExe(), "peer.ts", String(listener.port)],
-        cwd: String(dir),
-        env: bunEnv,
-        stdin: "pipe",
-      });
-      // A peer that dies before it connects would otherwise leave `ready` pending.
-      // Once `ready` is settled, the exit caused by the kill below is ignored.
-      peer.exited.then(code => ready.reject(new Error(`the peer exited before it was ready (exit code ${code})`)));
 
-      const accepted = await ready.promise;
-      accepted.write("left unread in the peer's receive buffer");
-      peer.kill("SIGKILL");
+      const greeted = Promise.withResolvers<Socket>();
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: listener.port,
+        tls: transport === "tls" ? { ca: tls.cert } : undefined,
+        socket: {
+          // The greeting arrived, so both sides are fully open (for tls, both handshakes are done).
+          data: socket => greeted.resolve(socket),
+          error: (_socket, error) => greeted.reject(error),
+          connectError: (_socket, error) => greeted.reject(error),
+          close: () => greeted.reject(new Error("the peer closed before the greeting arrived")),
+        },
+      });
+      const peer = await greeted.promise;
+      peer.terminate();
 
       expect(closeErrorShape(await closedWith.promise)).toEqual(readReset);
     });


### PR DESCRIPTION
### Problem
- `test/js/bun/net/socket.test.ts` > `close() error after the peer resets the connection > tcp > the accepted socket reports the reset as read ECONNRESET` fails on the darwin x64 lane: `closeErrorShape(...)` gets `{ reported: false, code: undefined, syscall: undefined }` instead of `read ECONNRESET`. 14 builds between 08:44Z and 13:20Z today, for example 103585.
- The test from #39615 spawns a peer process, writes to it, and kills it with SIGKILL so the kernel closes the socket with unread data and sends an RST. Over loopback the delivery of that write is asynchronous. The teardown after the kill takes about 0.7 ms on the Intel minis (tcpdump). When delivery is slower, the peer's receive buffer is empty at close, xnu sends a FIN (`tcp_disconnect`), and the accepted socket reads a clean end. The RST that follows arrives too late.

### Fix
- The peer resets in-process with `terminate()` for tcp and tls. It closes with `SO_LINGER{1,0}`, so the kernel sends a bare RST whatever is queued. A TLS `terminate()` sends no close_notify since #39632, which is why the child process was needed before.
- The accepted side takes the same path as before: a poll error, `recv()` ECONNRESET, `close(socket, error)` with `read ECONNRESET`. The kernel path is the same too: a kill with unread data and an `SO_LINGER` close both reach `tcp_drop`.
- Verified on darwin-x64-bagel (macOS 14.8.9) with the build 103585 binary: a 3 ms dummynet delay on loopback makes the old test fail 3 of 3 runs (tcp and tls) with the CI shape, and the new test passes 3 of 3 under the same delay. Also the debug build on Linux and the canary on Windows x64 (5 of 5).

### Background
- On xnu, `close()` sends an RST only if the receive buffer holds unread data or `SO_LINGER` is set with a zero timeout. Otherwise it sends a FIN.
- Loopback delivery on macOS goes through the DLIL input thread. `send()` returns before the peer's socket has the data. Under load that delay reached 0.8 ms on the CI minis.
- usockets reports a FIN as `recv() == 0`, which ends the socket cleanly. An RST is reported as a poll error with `ECONNRESET`.

<details><summary>Notes</summary>

- Not caused by #39860 or #39949: 143 darwin x64 test jobs on commits that include both ran between 03:00Z and 08:05Z without one failure. The failures started at 08:44Z on every Intel mini (bagel, matzo, pretzel, crumpet, naan, rye, cornbread) and stopped with the fleet's daily reboot at 13:27Z (0 of 37 jobs since). Job durations in both windows were the same (568 s mean), so the host condition that widened the delivery delay is unknown.
- Packet capture of a failing run (3 ms delay on the server to peer direction): greeting, `ready`, then the peer's FIN 1.0 ms after `ready`, then the payload 3.5 ms later, then three RSTs from the peer.
- The delay was a pf dummynet rule limited to root's connections (`dummynet out quick on lo0 proto tcp from any to any user root pipe 1`, `dnctl pipe 1 config delay 3`), so CI jobs on the host were not affected. pf was disabled and flushed afterwards.
- The repro probe `lo_async_probe.py` (write, then FIONREAD on the other end) showed the data absent right after `send()` in 30 to 98 percent of 3000 tries, with a delay of 4 to 160 us idle and up to 787 us under 16 CPU burners plus process churn.
- Whole file on the Linux debug build: 85 pass, 6 skip, 9 fail. The same 9 fail on pristine main in this container (`localhost` resolution and external network), as noted in #40040.
- Overlap: #40040 extends the third test in this block to tls and #39653 rewords the comment this PR removes. Either one lands with a one-hunk conflict against this PR.
- Self-review: one nit, the new comment narrated the removed child peer. Trimmed in 6ed6df6860f to one clause that points here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->