### PR TITLE
Apply the __DATA_DIRTY segment rename to native darwin links

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1067,9 +1067,13 @@ export const linkerFlags: Flag[] = [
     // src/exe_format/macho.rs). Fold __DATA_DIRTY into __DATA instead: it
     // holds a single 8-byte JSC::SourceProfiler hook and is only meaningful
     // as a dyld-shared-cache page-grouping hint, which executables don't use.
+    // Every darwin link gets this, not just cross links: a native source
+    // build can link with ld64.lld too (nixpkgs' LLVM toolchain — #40107),
+    // and under Apple's ld, which already orders __DATA_DIRTY before __BUN,
+    // the fold is harmless.
     flag: "-Wl,-rename_segment,__DATA_DIRTY,__DATA",
-    when: c => c.darwin && c.crossTarget !== undefined,
-    desc: "macOS cross-link: keep __BUN as the last content segment so `bun build --compile` can grow it",
+    when: c => c.darwin,
+    desc: "macOS: keep __BUN as the last content segment so `bun build --compile` can grow it",
   },
   {
     // Identical-code folding, on top of -dead_strip: dead_strip removes

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -192,6 +192,24 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
     expect(machoPostlinkCommand(linux)).toBe("");
   });
 
+  test("__DATA_DIRTY is folded into __DATA on every darwin link", () => {
+    // `bun build --compile` grows the __BUN placeholder in place, so __BUN
+    // must stay the last content segment before __LINKEDIT. ld64.lld orders
+    // unknown segments by creation order and leaves __DATA_DIRTY after
+    // __BUN, which OverlappingSegments-fails the first graph that outgrows
+    // the 16 KiB placeholder. Native source builds can link with ld64.lld
+    // too (nixpkgs' LLVM toolchain — #40107), so the rename must not be
+    // keyed on crossTarget.
+    const rename = "-Wl,-rename_segment,__DATA_DIRTY,__DATA";
+    expect(computeFlags(resolveDarwin()).ldflags).toContain(rename);
+
+    // Simulate the native-link flag evaluation (a darwin host resolves
+    // crossTarget to undefined, which a non-darwin test host can't produce
+    // through resolveConfig).
+    const native = { ...resolveDarwin(), crossTarget: undefined };
+    expect(computeFlags(native).ldflags).toContain(rename);
+  });
+
   test("the __BUN sectalign workaround applies to x64 only", () => {
     const arm64 = computeFlags(resolveDarwin());
     const x64 = computeFlags(resolveDarwin({ arch: "x64" }));


### PR DESCRIPTION
### Problem
- A native macOS source build that links with ld64.lld (the nixpkgs LLVM toolchain, issue #40107) places `__DATA_DIRTY` after the `__BUN` segment. `bun build --compile` then fails with `Error writing standalone module graph: OverlappingSegments` once the module graph outgrows the 16 KiB `__BUN` placeholder.
- The existing workaround, `-Wl,-rename_segment,__DATA_DIRTY,__DATA`, is keyed on `crossTarget !== undefined` in `scripts/build/flags.ts:1071`. Native links never get it.

### Fix
- Key the rename on `c.darwin`, so every darwin link folds `__DATA_DIRTY` into `__DATA` and `__BUN` stays the last content segment before `__LINKEDIT`.
- This is safe under Apple's ld: it orders `__DATA_DIRTY` before `__BUN` already, and `-rename_segment` is a documented ld64 option. `__DATA_DIRTY` is only a dyld-shared-cache page-grouping hint, which executables do not use.
- The reporter tested this exact change in the failing nixpkgs environment.
- Verified: new flag assertion in `test/internal/macos-cross-config.test.ts`, fails without the flags.ts change. Full file passes. `bun scripts/build.ts --configure-only` still works on Linux.

### Background
- `bun build --compile` with `--target=bun` grows the running executable's `__BUN` segment in place. Only `__LINKEDIT` can shift, so `__BUN` must be last. `src/exe_format/macho.rs:506` rejects any other layout with `OverlappingSegments`.
- Apple's ld orders known segments canonically. ld64.lld orders unknown segments by creation order, so the `-sectcreate`'d `__BUN` lands before the input objects' `__DATA_DIRTY`.
- The shipped macOS binaries cross-compile from Linux and already use this flag.

<details><summary>Notes</summary>

- The broken binary's segment order is `__DATA, __BUN, __DATA_DIRTY, __LINKEDIT` (reporter's `otool -l` dump). The official release binary has `__DATA, __BUN, __LINKEDIT`.
- `__DATA_DIRTY` in bun's objects holds a single 8-byte `JSC::SourceProfiler` hook.
- The test simulates a native darwin link by clearing `crossTarget` on a resolved darwin config, because `resolveConfig` on a non-darwin host always produces a cross config.
- Open PR #36739 re-keys the same flag on `darwinLld` (cross or native ASAN). That gate still misses the native non-ASAN lld case from the issue, so this PR keys on darwin unconditionally. If #36739 lands first, the resolution is to keep the unconditional darwin gate for this one flag.
- Pre-existing `tsc` errors in `scripts/build` (ci.ts, jsonByteClass.ts, rust-lto-fix-cli.ts, xmlByteClass.ts) are unchanged by this diff.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/internal/macos-cross-config.test.ts

<!-- robobun:evidence:end -->