### PR TITLE
install: warn when a patchedDependencies entry no longer applies, and fail --frozen-lockfile

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -174,6 +174,8 @@ bun install --frozen-lockfile
 
 Bun does not enable `--frozen-lockfile` automatically in CI; pass the flag or use `bun ci`. If there is no lockfile at all, `--frozen-lockfile` installs from `package.json` without writing one.
 
+`--frozen-lockfile` also fails when a [`patchedDependencies`](/pm/cli/patch) entry in `package.json` no longer applies to any installed version of the package, for example after the package moved to a new version. Re-create the patch for the new version, or remove the stale entry.
+
 `--frozen-lockfile` works on a pruned monorepo checkout (e.g. `turbo prune` output, or a Docker context with only some workspace folders copied in). If a workspace listed in `bun.lock` is missing its `package.json` on disk, Bun skips it with a `note:` and does not install its exclusive dependencies. If a remaining workspace depends on a skipped one, the install fails.
 
 To validate the lockfile without installing, use `bun install --frozen-lockfile --dry-run`.

--- a/docs/pm/cli/patch.mdx
+++ b/docs/pm/cli/patch.mdx
@@ -64,6 +64,10 @@ bun patch --commit react --patches-dir=mypatches
 bun patch-commit react
 ```
 
+#### When a patch stops applying
+
+A patch is keyed by the exact `name@version` in `patchedDependencies`. When the package resolves to a different version, the patch is no longer applied. `bun install` prints a warning for every key that matches no installed version, and `bun install --frozen-lockfile` fails. Re-create the patch for the new version with `bun patch`, or remove the stale entry from `package.json`.
+
 ---
 
 <Patch />

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -822,14 +822,22 @@ pub fn install_with_manager(
                         section,
                         loaded_lockfile_name(&load_result)
                     );
+                    bun_core::note!(
+                        "try re-running without <d>--frozen-lockfile<r> and commit the updated lockfile"
+                    );
                 } else if has_orphaned_patches {
+                    // A re-run without --frozen-lockfile does not converge here: the stale key lives only in package.json.
                     bun_core::note!(
                         "a patchedDependencies entry in package.json no longer applies to any installed package version"
                     );
+                    bun_core::note!(
+                        "re-create the patch for the installed version with <d>bun patch<r>, or remove the stale entry from package.json"
+                    );
+                } else {
+                    bun_core::note!(
+                        "try re-running without <d>--frozen-lockfile<r> and commit the updated lockfile"
+                    );
                 }
-                bun_core::note!(
-                    "try re-running without <d>--frozen-lockfile<r> and commit the updated lockfile"
-                );
             }
             Global::crash();
         }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -688,12 +688,8 @@ pub fn install_with_manager(
         }
     };
     let lockfile_before_clean = core::mem::replace(&mut manager.lockfile, new_lockfile);
-    let has_orphaned_patches = if !manager.options.dry_run {
-        Output::flush();
-        crate::update_transitive::warn_orphaned_patches(manager)
-    } else {
-        false
-    };
+    Output::flush();
+    let has_orphaned_patches = crate::update_transitive::warn_orphaned_patches(manager);
     let requests_removed_from_lockfile = if manager.subcommand == Subcommand::Remove {
         count_requests_removed_from_lockfile(manager, &lockfile_before_clean)
     } else {

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -688,10 +688,12 @@ pub fn install_with_manager(
         }
     };
     let lockfile_before_clean = core::mem::replace(&mut manager.lockfile, new_lockfile);
-    if manager.subcommand == Subcommand::Update && !manager.options.dry_run {
+    let has_orphaned_patches = if !manager.options.dry_run {
         Output::flush();
-        crate::update_transitive::warn_orphaned_patches(manager);
-    }
+        crate::update_transitive::warn_orphaned_patches(manager)
+    } else {
+        false
+    };
     let requests_removed_from_lockfile = if manager.subcommand == Subcommand::Remove {
         count_requests_removed_from_lockfile(manager, &lockfile_before_clean)
     } else {
@@ -792,7 +794,7 @@ pub fn install_with_manager(
     {
         'frozen_lockfile: {
             let changed_section = frozen_changed_section(manager, root_package_json_path);
-            if changed_section.is_none() {
+            if changed_section.is_none() && !has_orphaned_patches {
                 if load_result.loaded_from_text_lockfile() {
                     if bun_core::handle_oom(Lockfile::eql(
                         &manager.lockfile,
@@ -823,6 +825,10 @@ pub fn install_with_manager(
                         "{} in package.json changed since {} was saved",
                         section,
                         loaded_lockfile_name(&load_result)
+                    );
+                } else if has_orphaned_patches {
+                    bun_core::note!(
+                        "a patchedDependencies entry in package.json no longer applies to any installed package version"
                     );
                 }
                 bun_core::note!(

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -711,12 +711,13 @@ pub(crate) fn print_kept_patched(manager: &mut PackageManager) {
     manager.kept_patched_text = render_kept_rows(&rows);
 }
 
-/// After the lockfile is cleaned: one warning per root `patchedDependencies` key whose `name@version` no longer names an installed npm package. Returns true when any such key exists, even at a silent log level.
+/// After the lockfile is cleaned: one warning per root `patchedDependencies` key whose `name@version` no longer names an installed npm package. Returns true when any such key exists, even when the output stays quiet.
 pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) -> bool {
     if manager.lockfile.patched_dependencies.count() == 0 {
         return false;
     }
-    let silent = manager.options.log_level == LogLevel::Silent;
+    // A dry run can hold resolutions it will not commit, so it detects orphans without the warning.
+    let quiet = manager.options.log_level == LogLevel::Silent || manager.options.dry_run;
     let keys: Vec<Box<[u8]>> = {
         let log = manager.log_mut();
         // SAFETY: written once inside `PackageManager::init` on this thread; only read afterwards.
@@ -781,7 +782,7 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) -> bool {
             continue;
         }
         any_orphaned = true;
-        if silent {
+        if quiet {
             continue;
         }
         if now.is_empty() {
@@ -799,7 +800,7 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) -> bool {
             );
         }
     }
-    if !silent {
+    if !quiet {
         Output::flush();
     }
     any_orphaned

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -711,13 +711,13 @@ pub(crate) fn print_kept_patched(manager: &mut PackageManager) {
     manager.kept_patched_text = render_kept_rows(&rows);
 }
 
-/// After `bun update` cleaned the lockfile: one warning per root `patchedDependencies` key whose `name@version` no longer names an installed npm package.
-pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
-    if manager.lockfile.patched_dependencies.count() == 0
-        || manager.options.log_level == LogLevel::Silent
-    {
-        return;
+/// After the lockfile is cleaned: one warning per root `patchedDependencies` key whose `name@version` no longer names an installed npm package.
+/// Returns true when at least one such orphaned key exists (detected even when the log level is silent).
+pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) -> bool {
+    if manager.lockfile.patched_dependencies.count() == 0 {
+        return false;
     }
+    let silent = manager.options.log_level == LogLevel::Silent;
     let keys: Vec<Box<[u8]>> = {
         let log = manager.log_mut();
         // SAFETY: written once inside `PackageManager::init` on this thread; only read afterwards.
@@ -730,10 +730,10 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
             .workspace_package_json_cache
             .get_with_path(log, path, opts)
         else {
-            return;
+            return false;
         };
         let Some(patched) = entry.root.get_object(b"patchedDependencies") else {
-            return;
+            return false;
         };
         let mut keys: Vec<Box<[u8]>> = Vec::with_capacity(patched.property_count());
         patched.for_each_property(|key, _, _| keys.push(Box::from(key)));
@@ -743,6 +743,7 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
+    let mut any_orphaned = false;
     for key in keys {
         let Some(at) = strings::last_index_of_char(&key, b'@').filter(|&at| at > 0) else {
             continue;
@@ -780,6 +781,10 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
         if still_applies {
             continue;
         }
+        any_orphaned = true;
+        if silent {
+            continue;
+        }
         if now.is_empty() {
             bun_core::warn!(
                 "{} no longer applies ({} is no longer installed)",
@@ -795,7 +800,10 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
             );
         }
     }
-    Output::flush();
+    if !silent {
+        Output::flush();
+    }
+    any_orphaned
 }
 
 /// Newest release the rows still resolving to `pkg_id` allow, when it is newer than the installed one.

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -711,8 +711,7 @@ pub(crate) fn print_kept_patched(manager: &mut PackageManager) {
     manager.kept_patched_text = render_kept_rows(&rows);
 }
 
-/// After the lockfile is cleaned: one warning per root `patchedDependencies` key whose `name@version` no longer names an installed npm package.
-/// Returns true when at least one such orphaned key exists (detected even when the log level is silent).
+/// After the lockfile is cleaned: one warning per root `patchedDependencies` key whose `name@version` no longer names an installed npm package. Returns true when any such key exists, even at a silent log level.
 pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) -> bool {
     if manager.lockfile.patched_dependencies.count() == 0 {
         return false;

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -686,6 +686,9 @@ test.concurrent("`bun install --frozen-lockfile` fails when a patchedDependencie
   expect(stderr).toContain(
     "a patchedDependencies entry in package.json no longer applies to any installed package version",
   );
+  // the generic re-run hint cannot converge here: the stale key lives only in package.json
+  expect(stderr).toContain("re-create the patch for the installed version with bun patch, or remove the stale entry");
+  expect(stderr).not.toContain("try re-running without --frozen-lockfile");
   expect(exitCode).not.toBe(0);
   // the documented validation form fails too (without the warning: dry runs stay quiet)
   const dry = await run(dir, "install", "--frozen-lockfile", "--dry-run");

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -687,6 +687,11 @@ test.concurrent("`bun install --frozen-lockfile` fails when a patchedDependencie
     "a patchedDependencies entry in package.json no longer applies to any installed package version",
   );
   expect(exitCode).not.toBe(0);
+  // the documented validation form fails too (without the warning: dry runs stay quiet)
+  const dry = await run(dir, "install", "--frozen-lockfile", "--dry-run");
+  expect(dry.stderr).not.toContain("warn:");
+  expect(dry.stderr).toContain("lockfile had changes, but lockfile is frozen");
+  expect(dry.exitCode).not.toBe(0);
 });
 
 // bun.lock still records the `no-deps: 1.0.0` override; package.json is edited without an install in between, so the update sees the new overrides first.

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -650,6 +650,42 @@ test.concurrent(
   },
 );
 
+// A version bump that leaves a patchedDependencies key behind is reported on every install, not only `bun update` (#40106).
+test.concurrent("`bun install` warns when a patchedDependencies key no longer matches the installed version", async () => {
+  const dir = await setup({
+    "package.json": pkgJson({ "no-deps": "1.0.0" }, PATCHED),
+    "patches/no-deps@1.0.0.patch": NO_DEPS_PATCH,
+  });
+  // the patch applies: installs stay quiet
+  expect(await install(dir)).not.toContain("warn:");
+  // a routine bump makes the key stale
+  await write(join(dir, "package.json"), stringify(pkgJson({ "no-deps": "1.1.0" }, PATCHED)));
+  const orphaned = "warn: patches/no-deps@1.0.0.patch no longer applies (no-deps is now 1.1.0)\n";
+  expect(await install(dir)).toContain(orphaned);
+  // and every later install repeats the warning until package.json is fixed
+  expect(await install(dir)).toContain(orphaned);
+  expect(await file(join(dir, "node_modules", "no-deps", "patched.txt")).exists()).toBeFalse();
+});
+
+// A declared patch that silently stopped applying fails --frozen-lockfile; a patched map edit alone still passes it (frozen-lockfile-pruned.test.ts) (#40106).
+test.concurrent("`bun install --frozen-lockfile` fails when a patchedDependencies key no longer applies", async () => {
+  const dir = await setup({
+    "package.json": pkgJson({ "no-deps": "1.0.0" }, PATCHED),
+    "patches/no-deps@1.0.0.patch": NO_DEPS_PATCH,
+  });
+  // in sync: frozen install passes
+  await frozen(dir);
+  await write(join(dir, "package.json"), stringify(pkgJson({ "no-deps": "1.1.0" }, PATCHED)));
+  await install(dir);
+  const { stderr, exitCode } = await run(dir, "install", "--frozen-lockfile");
+  expect(stderr).toContain("warn: patches/no-deps@1.0.0.patch no longer applies (no-deps is now 1.1.0)\n");
+  expect(stderr).toContain("lockfile had changes, but lockfile is frozen");
+  expect(stderr).toContain(
+    "a patchedDependencies entry in package.json no longer applies to any installed package version",
+  );
+  expect(exitCode).not.toBe(0);
+});
+
 // bun.lock still records the `no-deps: 1.0.0` override; package.json is edited without an install in between, so the update sees the new overrides first.
 async function overriddenThenEdited(overrides?: Json) {
   const dependencies = { "one-range-dep": "1.0.0" };

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -651,21 +651,24 @@ test.concurrent(
 );
 
 // A version bump that leaves a patchedDependencies key behind is reported on every install, not only `bun update` (#40106).
-test.concurrent("`bun install` warns when a patchedDependencies key no longer matches the installed version", async () => {
-  const dir = await setup({
-    "package.json": pkgJson({ "no-deps": "1.0.0" }, PATCHED),
-    "patches/no-deps@1.0.0.patch": NO_DEPS_PATCH,
-  });
-  // the patch applies: installs stay quiet
-  expect(await install(dir)).not.toContain("warn:");
-  // a routine bump makes the key stale
-  await write(join(dir, "package.json"), stringify(pkgJson({ "no-deps": "1.1.0" }, PATCHED)));
-  const orphaned = "warn: patches/no-deps@1.0.0.patch no longer applies (no-deps is now 1.1.0)\n";
-  expect(await install(dir)).toContain(orphaned);
-  // and every later install repeats the warning until package.json is fixed
-  expect(await install(dir)).toContain(orphaned);
-  expect(await file(join(dir, "node_modules", "no-deps", "patched.txt")).exists()).toBeFalse();
-});
+test.concurrent(
+  "`bun install` warns when a patchedDependencies key no longer matches the installed version",
+  async () => {
+    const dir = await setup({
+      "package.json": pkgJson({ "no-deps": "1.0.0" }, PATCHED),
+      "patches/no-deps@1.0.0.patch": NO_DEPS_PATCH,
+    });
+    // the patch applies: installs stay quiet
+    expect(await install(dir)).not.toContain("warn:");
+    // a routine bump makes the key stale
+    await write(join(dir, "package.json"), stringify(pkgJson({ "no-deps": "1.1.0" }, PATCHED)));
+    const orphaned = "warn: patches/no-deps@1.0.0.patch no longer applies (no-deps is now 1.1.0)\n";
+    expect(await install(dir)).toContain(orphaned);
+    // and every later install repeats the warning until package.json is fixed
+    expect(await install(dir)).toContain(orphaned);
+    expect(await file(join(dir, "node_modules", "no-deps", "patched.txt")).exists()).toBeFalse();
+  },
+);
 
 // A declared patch that silently stopped applying fails --frozen-lockfile; a patched map edit alone still passes it (frozen-lockfile-pruned.test.ts) (#40106).
 test.concurrent("`bun install --frozen-lockfile` fails when a patchedDependencies key no longer applies", async () => {


### PR DESCRIPTION
### Problem
- A `patchedDependencies` key in `package.json` is matched by the exact `name@version`. When the package moves to a new version, the key matches nothing, and the patch is silently not applied. There is no warning, and `bun install --frozen-lockfile` exits 0 (#40106).
- Bun already detects this case, but only `bun update` calls `warn_orphaned_patches` (`src/install/PackageManager/install_with_manager.rs:691`). Plain installs skip the check.

### Fix
- Call `warn_orphaned_patches` on every install. Each stale key prints `warn: <patch> no longer applies (<name> is now <version>)`.
- The function now returns whether any orphaned key exists. A silent log level or a dry run suppresses the warning line but still detects the key.
- Under `--frozen-lockfile`, an orphaned key fails the install with `error: lockfile had changes, but lockfile is frozen` and a note that names the cause. This includes the documented `--frozen-lockfile --dry-run` validation form. A patched map edit alone still passes, as the existing tests in `frozen-lockfile-pruned.test.ts` require: a patch added after `bun.lock` was written still applies and passes.
- Verified: two new tests in `test/cli/install/bun-update-transitive.test.ts` (both fail on stock bun). Also ran the patch, lockfile, frozen, isolated, workspaces, dedupe, and migration install suites.

### Background
- `bun.lock` records only the patches that applied: the writer matches each package against the patched map by the `name@version` hash and emits the hits. A stale key therefore lives in `package.json` and nowhere else.
- `warn_orphaned_patches` (`src/install/update_transitive.rs`) reads the root `package.json` keys, and compares each `name@version` against the lockfile's installed versions of that name. Non-npm resolutions and version-less keys are skipped.
- The frozen comparison intentionally excludes the patched map itself, so the failure predicate is "a declared patch no longer applies", not "the patched map changed".

<details><summary>Notes</summary>

- Repro (issue): pin a patched package to a new version, then `bun install --frozen-lockfile` exits 0 and the patched behavior is gone. Confirmed on 1.4.0.
- An alternative was to fail frozen installs on `summary.patched_dependencies_changed`. That breaks the documented workflows covered by `frozen-lockfile-pruned.test.ts` ("patchedDependencies added/removed after bun.lock was written still passes --frozen-lockfile"), so the narrower predicate is used instead.
- The dry-run suppression of the warning exists because a dry `bun update` can hold resolutions it will not commit. Detection still runs, so the frozen check sees the orphan.
- pnpm errors on a non-applying patch by default, with `allowNonAppliedPatches` as the opt-out. This PR does not add an escape hatch: removing the stale key from `package.json` is the fix, and the warning path stays non-fatal outside `--frozen-lockfile`.
- Suites run with the debug build: bun-update-transitive (176), frozen-lockfile-pruned (101), bun-install-patch (31), bun-patch (37), bun-lock (40), bun-lockb (7), bun-dedupe (76), isolated-install (82), bun-workspaces (75), migration (complex-workspace fails on stock bun locally too; yarn-lock-migration passes alone).
- Docs: short notes added to `docs/pm/cli/install.mdx` and `docs/pm/cli/patch.mdx`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update-transitive.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-update-transitive.test.ts:
(pass) `bun update` moves a transitive dependency within its dependent's range (isolated linker) [783.55ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (binary lockfile) [824.89ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (text lockfile) [872.10ms]
(pass) `bun update --latest` still moves transitive dependencies only within their ranges [847.33ms]
(pass) `bun update no-deps` reaches a package that is only a transitive dependency [995.86ms]
(pass) `bun update` with a pattern reaches a package that is only a transitive dependency [655.04ms]
(pass) `bun update` with a bare `*` reaches a package that is only a transitive dependency [675.53ms]
(pass) `bun update` with a negated name reaches a package that is only a transitive dependency [686.57ms]
(pass) `bun update --latest no-deps` reaches a package that is only a transitive dependency [839.19ms
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/bun-update-transitive.test.ts:
(pass) without a lockfile, `bun update <undeclared>` is rejected and writes no lockfile [13.13ms]
(pass) without a lockfile, `bun update <declared>` resolves and saves [110.52ms]
(pass) `bun update <name>` and a pattern that match nothing in bun.lockb name that file [116.30ms]
(pass) `bun update <name>` and a pattern that match nothing in bun.lock name that file [116.97ms]
(pass) `bun update <name>` naming a package with nothing newer is the same no-op as a bare rerun [126.25ms]
(pass) `bun update --dry-run` (bare) prints the plan as summary rows and writes nothing [149.26ms]
(pass) `bun update --frozen-lockfile` refuses to move the transitive dependency [149.84ms]
(pass) `bun update --dry-run` (--latest) prints the plan as summary rows and writes nothing [149.59ms]
(pass) `bun update --latest` still moves transitive dependencies only within their ranges [153.25ms]
(pass) `bun update` with a pattern reaches a package that is only a transitive dependency [153.28ms]
(pass) `bun update` with a pattern alongside a direct name reaches a package that is only a transitive dependency [153.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update-transitive.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-update-transitive.test.ts:
(pass) `bun update` moves a transitive dependency within its dependent's range (binary lockfile) [818.59ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (isolated linker) [839.19ms]
(pass) `bun update` moves a transitive dependency within its dependent's range (text lockfile) [891.85ms]
(pass) `bun update --latest` still moves transitive dependencies only within their ranges [858.94ms]
(pass) `bun update no-deps` reaches a package that is only a transitive dependency [999.45ms]
(pass) `bun update` with a pattern reaches a package that is only a transitive dependency [672.59ms]
(pass) `bun update` with a bare `*` reaches a package that is only a transitive dependency [683.50ms]
(pass) `bun update` with a negated name reaches a package that is only a transitive dependency [690.39ms]
(pass) `bun update --latest no-deps` reaches a package that is only a transitive dependency [840.44ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/cli/install.mdx                            |  2 +
 docs/pm/cli/patch.mdx                              |  4 ++
 src/install/PackageManager/install_with_manager.rs | 26 ++++++++----
 src/install/update_transitive.rs                   | 26 +++++++-----
 test/cli/install/bun-update-transitive.test.ts     | 47 ++++++++++++++++++++++
 5 files changed, 88 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
docs/pm/cli/install.mdx                                 1      1      0
docs/pm/cli/patch.mdx                                   1      2      0
src/install/PackageManager/install_with_manager.rs      6      6      0
src/install/update_transitive.rs                        4      7      0
test/cli/install/bun-update-transitive.test.ts          2      5      0
```

</details>

**root cause** · written by the author bot

Patches in patchedDependencies are keyed by exact version, so when a dependency update moved a patched package to a new version the stale key no longer matched anything installed and Bun silently skipped the patch, with install and even --frozen-lockfile exiting zero. The fix detects these orphaned entries during install by comparing the patchedDependencies keys in package.json against the patches actually applied, emits a warning naming the stale entry, and treats the mismatch as a lockfile divergence under --frozen-lockfile so the install fails. The frozen-lockfile error also prints a pat…

<!-- robobun:evidence:end -->