### PR TITLE
bake: keep a route failed while a sibling client component has a pending resolution failure

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5874,6 +5874,8 @@ pub mod bv2_impl {
             // parse_result.value (invalidating the `result` pointer).
             let source_index = result.source.index;
             let target = result.ast.target;
+            let use_directive = result.use_directive;
+            let source_path = result.source.path.text;
             let mut resolve_result = this.resolve_import_records(&mut ResolveImportRecordCtx {
                 import_records: &mut result.ast.import_records,
                 source: &result.source,
@@ -5885,6 +5887,24 @@ pub mod bv2_impl {
             if let Some(err) = resolve_result.last_error {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
                 resolve_result.resolve_queue.clear();
+
+                // With a separate SSR graph, a failed "use client" file skips
+                // server-component-boundary registration (the Success arm), so
+                // the server graph would have no node for it and routes no
+                // edge to its failure. Give the dev server a placeholder.
+                if use_directive == crate::UseDirective::Client
+                    && target == Target::Browser
+                    && this.framework.as_ref().is_some_and(|f| {
+                        f.server_components
+                            .as_ref()
+                            .is_some_and(|sc| sc.separate_ssr_graph)
+                    })
+                {
+                    if let Some(dev) = this.dev_server {
+                        dev.insert_stale_client_component_boundary(source_path)
+                            .expect("oom");
+                    }
+                }
 
                 // Preserve the parsed import_records on the graph so any plugin
                 // onResolve tasks already dispatched for *other* records in this

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -326,6 +326,7 @@ bun_dispatch::link_interface! {
         fn handle_parse_task_failure(err: crate::Error, graph: bake_types::Graph, abs_path: &[u8], log: *const bun_ast::Log, bv2: *mut bundle_v2::BundleV2<'_>) -> Result<(), crate::Error>;
         fn put_or_overwrite_asset(path: *const (), contents: &[u8], content_hash: u64) -> Result<(), crate::Error>;
         fn track_resolution_failure(import_source: &[u8], specifier: &[u8], renderer: bake_types::Graph, loader: bun_ast::Loader) -> Result<(), crate::Error>;
+        fn insert_stale_client_component_boundary(abs_path: &[u8]) -> Result<(), crate::Error>;
         fn is_file_cached(abs_path: &[u8], side: bake_types::Graph) -> Option<bake_types::CacheEntry>;
         fn asset_hash(abs_path: &[u8]) -> Option<u64>;
         fn current_bundle_start_data() -> *mut ();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5056,6 +5056,27 @@ impl DevServer {
         Ok(())
     }
 
+    /// A `"use client"` file that fails before bundling never reaches
+    /// server-component-boundary registration, so the server graph gets no
+    /// node for it and routes that import it get no edge to the failure.
+    /// Insert a stale placeholder marked as a boundary so a route's failure
+    /// trace crosses into the client graph and finds the failure.
+    pub(crate) fn insert_stale_client_component_boundary(
+        &mut self,
+        abs_path: &[u8],
+    ) -> crate::Result<()> {
+        let _g = self.graph_safety_lock.guard();
+        // `trace_imports` panics when a boundary has no client-graph file.
+        self.client_graph
+            .insert_empty(abs_path, FileKind::Unknown)?;
+        let idx = self
+            .server_graph
+            .insert_stale(abs_path, bake::Graph::Server)?;
+        self.server_graph.bundled_files.values_mut()[idx.get() as usize]
+            .is_client_component_boundary = true;
+        Ok(())
+    }
+
     /// Return a log to write resolution failures into.
     pub(crate) fn get_log_for_resolution_failures(
         &mut self,

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1144,6 +1144,11 @@ bun_bundler::link_impl_DevServerHandle! {
                 .track_resolution_failure(import_source, specifier, renderer, loader)
                 .map_err(Into::into)
         },
+        insert_stale_client_component_boundary(abs_path) => {
+            (*this)
+                .insert_stale_client_component_boundary(abs_path)
+                .map_err(Into::into)
+        },
         is_file_cached(abs_path, side) => {
             (*this).is_file_cached(abs_path, side).map(|e| {
                 use bun_bundler::bake_types::CacheKind;

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -358,6 +358,65 @@ devTest("removing 'use client' from a component with a pending resolution failur
     expect(res).toBeInstanceOf(Response);
   },
 });
+// Regression test for #40113: with separateSSRGraph, a "use client" file
+// whose import fails to resolve is parsed under the browser target, so its
+// failure is attributed to the client graph. The file never reached
+// server-component-boundary registration, so the server graph had no node
+// for it and the route had no edge to the failure. Editing a sibling client
+// component then let checkRouteFailures trace nothing, mark the route
+// Loaded, and run it, which threw "Failed to load bundled module" and left
+// the route's server module permanently stuck.
+devTest("a sibling client component's resolution failure keeps the route failed after an unrelated edit", {
+  framework: {
+    ...minimalFramework,
+    serverComponents: {
+      ...minimalFramework.serverComponents!,
+      separateSSRGraph: true,
+    },
+  },
+  files: {
+    "routes/index.ts": `
+      import * as Comp from '../components/Comp';
+      import '../components/Sibling';
+      export default function (req, meta) {
+        return new Response('page: ' + (typeof Comp.marker));
+      }
+    `,
+    "components/Comp.ts": `
+      "use client";
+      export const marker = "initial";
+    `,
+    "components/Sibling.ts": `
+      "use client";
+      import './sibling-missing';
+      export const sibling = 1;
+    `,
+  },
+  async test(dev) {
+    // Sibling.ts cannot resolve './sibling-missing', so the route serves
+    // the build error page.
+    let res = await dev.fetch("/");
+    expect(await res.text()).toContain("<title>Bun - Build Failed</title>");
+    expect(res.status).toBe(500);
+
+    // Edit the client component that compiles cleanly. The rebuild only
+    // contains Comp.ts, so the route's failure trace must still reach
+    // Sibling's failure through the boundary placeholder in the server
+    // graph. Before the fix this request ran the route and poisoned its
+    // server module registry entry.
+    await dev.write("components/Comp.ts", `"use client";\nexport const marker = "edited";`, { errors: null });
+    res = await dev.fetch("/");
+    expect(await res.text()).toContain("<title>Bun - Build Failed</title>");
+    expect(res.status).toBe(500);
+
+    // Create the missing file. Every import resolves now, so the route
+    // must recover and render.
+    await dev.write("components/sibling-missing.ts", `export {};`, { errors: null });
+    res = await dev.fetch("/");
+    expect(await res.text()).toBe("page: object");
+    expect(res.status).toBe(200);
+  },
+});
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),


### PR DESCRIPTION
### Problem
- With `serverComponents.separateSSRGraph`, a route imports a `"use client"` file whose own import does not resolve. The route serves the build error page. After an edit to a sibling client component, the next request runs the route and throws `Failed to load bundled module 'components/Sibling.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.` The route then never recovers: `null is not an object (evaluating 'pageModule.streaming')`.
- Cause: the file is parsed under the browser target, so its resolution failure goes to the client graph (`src/bundler/bundle_v2.rs:5885`). The failure skips server component boundary registration, so the server graph has no node for the file and the route has no edge to it. `check_route_failures` (`src/runtime/bake/DevServer.rs:2236`) traces the route, finds nothing, and marks it loaded.

### Fix
- When such a file fails import resolution, the bundler calls a new dev server hook, `insert_stale_client_component_boundary`.
- The hook inserts a stale server-graph node flagged `is_client_component_boundary`, the placeholder shape the success path creates. Route edges attach to it, and the failure trace crosses from it into the client graph, where the failure is recorded.
- The route stays on the build error page until the failure clears, so it never runs with a missing module.
- Verified: new test in `test/bake/dev/bundle.test.ts`, fails on unfixed bun at the post-edit step. Also ran the bake dev suites bundle, esm, hot, html, css, response-to-bake-response, incremental-graph-edge-deletion.

### Background
- The dev server keeps two incremental graphs: server files (routes, SSR copies) and browser files. A route's failure check walks the server graph and crosses into the client graph only at client component boundary nodes.
- A boundary is a `"use client"` file. A successful parse registers it: a reference proxy stub in the server graph, plus an SSR copy when the graphs are separate. A failed parse or resolve skips that step.
- Server-side failures and `"use client"` syntax errors are attributed to the server graph, so only this resolve path had the hole.

<details><summary>Notes</summary>

Reproduction (from the issue): a route imports two `"use client"` components. One imports `./sibling-missing`, which does not exist.

1. `GET /` serves the build error page (correct).
2. Edit the clean component.
3. `GET /` previously ran the route and threw `throwNotFound` for the sibling. The route's server HMR module was cached in `Pending` state with `exports = null`, and nothing ever invalidated it.
4. Create the missing file.
5. `GET /` previously failed with `pageModule.streaming` on null. With the fix it renders.

The step 5 symptom is downstream of step 3: the registry entry for the route module is created before its dependencies parse, and the synchronous `throwNotFound` leaves it `Pending` with null exports. With the route held in the failed state, that request never runs, so the registry is never poisoned.

Variants checked against the unfixed build:

- A syntax error in the sibling instead of an unresolved import already behaved correctly. Its parse failure carries the original (server) target, so the failure lands in the server graph and is traceable.
- `separateSSRGraph: false` already behaved correctly for the same reason.

The placeholder node is keyed by the file's absolute path, the same key the real reference proxy chunk uses. When the failure clears and the client component bundles, the stub chunk lands on the same node and replaces the placeholder. The hook also ensures a client-graph node exists, because the server-to-client crossing in `trace_imports` panics when a boundary has no client-graph file.

Pre-existing failure seen while testing: `production > import.meta properties are inlined in catch-all routes during production build` times out at 5s under the debug ASAN build, with and without this diff.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-W17YSG
[0;30mdev|[0m Started development server: http://localhost:37005
[0;30mdev|[0m [32mBundled page in 189ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 75ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 66ms[
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-3bMZ2m
[0;30mdev|[0m Started development server: http://localhost:42693
[0;30mdev|[0m [32mBundled page in 2ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 1ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 1ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [199.33ms]
[0;30mdev|[0m Started development server: http://localhos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-32Z3B4
[0;30mdev|[0m Started development server: http://localhost:37625
[0;30mdev|[0m [32mBundled page in 198ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 79ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 40ms[
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b989994901
  features     baseline

23 deps, 129 codegen, 1172 objects in 643ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [13.00ms]
[5/1244] gen bindgenv2
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 18ms

  react-refresh.js  4.81 KB  (entry point)

[8/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1217] fetch 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs           | 20 +++++++++++++
 src/bundler/lib.rs                 |  1 +
 src/runtime/bake/DevServer.rs      | 21 ++++++++++++++
 src/runtime/bake/dev_server/mod.rs |  5 ++++
 test/bake/dev/bundle.test.ts       | 59 ++++++++++++++++++++++++++++++++++++++
 5 files changed, 106 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/bundle_v2.rs                5      2      0
src/bundler/lib.rs                      1      1      0
src/runtime/bake/DevServer.rs           4      2      0
src/runtime/bake/dev_server/mod.rs      2      1      0
test/bake/dev/bundle.test.ts            1      2      0
```

</details>

**root cause** · written by the author bot

In separate SSR graph mode, a "use client" file is parsed under the browser target, so its resolution failure was recorded only in the client graph while the failed file never registered a server component boundary, leaving the server graph with no node connecting the route to the failure. As a result, the route failure trace found nothing, a rebuild triggered by editing a sibling component cleared the route's failed state, and the route ran against a module that never bundled. The fix adds a dev server hook that inserts a stale server graph node flagged as a client component boundary when …

<!-- robobun:evidence:end -->