### PR TITLE
js_parser: tree-shake classes whose computed keys are side-effect-free references

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5287,14 +5287,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
 
-            // ToPropertyKey on a computed key can run user code unless it's a primitive literal.
-            if property.flags.contains(Flags::Property::IsComputed)
-                && !property
-                    .key
-                    .map(|key| key.unwrap_inlined().is_primitive_literal())
-                    .unwrap_or(false)
-            {
-                return false;
+            // ToPropertyKey on a computed key can run user code (a custom
+            // "toString"), so a non-primitive literal key keeps the class.
+            // A side-effect-free reference (`[TypeId]`, `[Ns.TypeId]`) is
+            // accepted anyway: such keys are almost always string or symbol
+            // constants, and rejecting them blocks tree-shaking of entire
+            // libraries that brand classes with type-id fields (#40114).
+            if property.flags.contains(Flags::Property::IsComputed) {
+                let Some(key) = property.key else {
+                    return false;
+                };
+                let key = key.unwrap_inlined();
+                let is_reference = matches!(
+                    key.data,
+                    js_ast::ExprData::EIdentifier(_)
+                        | js_ast::ExprData::EImportIdentifier(_)
+                        | js_ast::ExprData::ECommonjsExportIdentifier(_)
+                        | js_ast::ExprData::EDot(_)
+                );
+                if !key.is_primitive_literal()
+                    && !(is_reference && self.expr_can_be_removed_if_unused_without_dce_check(&key))
+                {
+                    return false;
+                }
             }
 
             // Non-static values/initializers only run on construction or access, never for an unused class.

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1633,6 +1633,43 @@ describe("bundler", () => {
       stdout: `{"0":"FOO","1":"BAR","FOO":0,"BAR":1}`,
     },
   });
+  // https://github.com/oven-sh/bun/issues/40114
+  // A computed class member key that is a side-effect-free reference (a local
+  // const, an import item) must not block tree-shaking of the class.
+  itBundled("dce/TreeShakingClassComputedKeyReference", {
+    files: {
+      "/entry.js": /* js */ `
+        import { used } from './lib';
+        console.log(used);
+      `,
+      "/lib.js": /* js */ `
+        import * as Other from './other';
+        export const used = 1;
+        const TypeId = '~lib/TypeId';
+        class REMOVE1 { [TypeId]; }
+        class REMOVE2 { [TypeId] = 'x' }
+        class REMOVE3 { [TypeId]() {} }
+        class REMOVE4 { static [TypeId] = 'x' }
+        class REMOVE5 {
+          [TypeId];
+          [Other.TypeId];
+          constructor() {
+            this[TypeId] = TypeId;
+            this[Other.TypeId] = Other.TypeId;
+          }
+        }
+        export const makeREMOVE5 = () => new REMOVE5();
+        let keep1 = class { [unboundKEEP] = 'x' };
+      `,
+      "/other.js": /* js */ `
+        export const TypeId = '~other/TypeId';
+        export const REMOVE6 = 'only the tree-shaken class references this module';
+      `,
+    },
+    treeShaking: true,
+    dce: true,
+    dceKeepMarkerCount: 2,
+  });
   itBundled("dce/TreeShakingUnaryOperators", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- Bun 1.4 bundles Effect's unused multipart parser and all five `multipasta` modules. The minimal Effect entry point grows from 163 KB to 271 KB. Fixes #40114.
- The cause is the computed-key check in `class_can_be_removed_if_unused` (`src/js_parser/p.rs:5290`). Since #36528 it accepts only primitive literal keys. A key like `[TypeId]`, where `TypeId` is a local const string, marks the whole class as non-removable. Effect brands every class this way, so each unused class pins its module and its imports.

### Fix
- Accept a computed key that is a reference (`EIdentifier`, `EImportIdentifier`, `ECommonjsExportIdentifier`, `EDot`) when `expr_can_be_removed_if_unused` holds for it. Primitive literal keys stay accepted. All other shapes still keep the class.
- This restores the 1.3.14 behavior for the reference shapes, and keeps the #36528 carve-out: `class { [{ toString() { console.log(1) } }] = 'x' }` is still kept, because an object literal key is not a reference. The existing `keep6`/`keep7` cases in `dce.test.ts` cover that.
- An unbound identifier key still keeps the class. `expr_can_be_removed_if_unused` rejects unbound identifiers because they can throw a `ReferenceError`.
- Verified: `test/bundler/esbuild/dce.test.ts` (new `dce/TreeShakingClassComputedKeyReference`, fails on 1.4). The Effect repro returns to the exact 1.3.14 output: 161015 bytes, zero `multipasta` references. Also ran `bundler_edgecase`, `esbuild/default`, `esbuild/ts`, `esbuild/lower`, and `transpiler/transpiler`, all 0 fail.

### Background
- `class_can_be_removed_if_unused` decides whether an unused class statement or expression can be dropped by tree-shaking. The parser computes this flag per statement, and the bundler's linker uses it when it drops unused parts of a module.
- `ToPropertyKey` coerces a computed key value when the class is defined. A key whose value has a custom `toString` can run user code, so dropping such a class is observable. That is why #36528 stopped accepting arbitrary keys.
- For a reference key the value is unknown at parse time. In practice these are string or symbol type-id constants. Keeping every class with a reference key blocks tree-shaking of whole libraries, so the pre-1.4 pragmatic stance is restored for exactly those shapes.

<details><summary>Notes</summary>

- Repro chain: `effect/dist/unstable/http/HttpServerRequest.js` defines `export const TypeId = "~effect/http/HttpServerRequest"` and classes with `[TypeId]`, `[HttpIncomingMessage.TypeId]`, and `[Multipart.TypeId]` members. The kept classes reference `Multipart.js`, which imports `multipasta`.
- Both the local const form (`[TypeId]`, an `EIdentifier`) and the namespace import form (`[Multipart.TypeId]`, an `EImportIdentifier` after the visit pass) appear in the repro, so the fix accepts both.
- esbuild (current) accepts only primitive literals and known `Symbol` instances here, and keeps the Effect multipart code too (292 KB on the same repro). Bun 1.3.14 accepted any removable key expression, which also dropped observable `ToPropertyKey` side effects from object literal keys. This change sits between the two: references yes, literals with possible custom `toString` no.
- The object literal arm of `expr_can_be_removed_if_unused` (`EObject` computed keys) was primitive-only in 1.3.14 as well, so it is unchanged.
- The unsound corner that remains is a reference bound to an object with a side-effectful `toString`. 1.3.14 and every earlier release had the same behavior, with no issue reports.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/esbuild/dce.test.ts

<!-- robobun:evidence:end -->