### PR TITLE
require.cache: deleting an ES module that is still loading is a no-op

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -738,8 +738,7 @@ static bool isModuleEvaluating(JSC::AbstractModuleRecord* record)
     return cyclic && cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluating;
 }
 
-// True once no load of this entry is in flight: the record finished evaluating
-// (with or without an error), or the load failed and the entry caches the error.
+// No load of this entry is in flight: it evaluated (maybe with an error) or its load failed.
 static bool isModuleLoadSettled(JSC::ModuleRegistryEntry* entry)
 {
     switch (entry->status()) {
@@ -788,14 +787,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globa
     auto key = JSC::Identifier::fromString(vm, asString(keyValue)->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
     auto* moduleLoader = globalObject->moduleLoader();
-    // require.cache only lists ES modules that finished evaluating (its `has`
-    // and `get` traps go through functionEsmNamespaceForCjs). A module that is
-    // still loading is not in it, so deleting its key is a no-op like deleting
-    // any other missing key. Evicting the entry mid-load would make the next
-    // import() of the key build a second record for the same module while the
-    // loader's [[LoadedModules]] caches and pending microtasks hold the first.
-    // removeEntry() drops every (key, type) variant with a full scan of the
-    // map, so check each variant the same way.
+    // A module that is still loading is not in require.cache (see
+    // functionEsmNamespaceForCjs), so deleting it is a no-op. Evicting it would
+    // give the next import() a second record for the key while [[LoadedModules]]
+    // still holds the first. removeEntry() drops every (key, type) variant.
     for (auto& [mapKey, entry] : moduleLoader->moduleMap()) {
         if (mapKey.first == key.impl() && entry && !isModuleLoadSettled(entry.get()))
             return JSValue::encode(jsBoolean(false));

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -794,9 +794,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globa
     // any other missing key. Evicting the entry mid-load would make the next
     // import() of the key build a second record for the same module while the
     // loader's [[LoadedModules]] caches and pending microtasks hold the first.
-    // removeEntry() drops every (key, type) variant, so check each of them.
+    // removeEntry() drops every (key, type) variant with a full scan of the
+    // map, so check each variant the same way.
     for (auto& [mapKey, entry] : moduleLoader->moduleMap()) {
-        if (mapKey.first == key.impl() && !isModuleLoadSettled(entry.get()))
+        if (mapKey.first == key.impl() && entry && !isModuleLoadSettled(entry.get()))
             return JSValue::encode(jsBoolean(false));
     }
     return JSValue::encode(jsBoolean(moduleLoader->removeEntry(key))); // takes the loader's cellLock itself

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -787,8 +787,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globa
     auto key = JSC::Identifier::fromString(vm, asString(keyValue)->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
     auto* moduleLoader = globalObject->moduleLoader();
-    // A module that is still loading is not in require.cache, so deleting it is a no-op.
-    // Evicting it would give the next import() a second record for the same key.
+    // A module whose load is in flight is not in require.cache and is not evicted.
     for (auto& [mapKey, entry] : moduleLoader->moduleMap()) {
         if (mapKey.first == key.impl() && entry && !isModuleLoadSettled(entry.get()))
             return JSValue::encode(jsBoolean(false));

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -738,6 +738,29 @@ static bool isModuleEvaluating(JSC::AbstractModuleRecord* record)
     return cyclic && cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluating;
 }
 
+// True once no load of this entry is in flight: the record finished evaluating
+// (with or without an error), or the load failed and the entry caches the error.
+static bool isModuleLoadSettled(JSC::ModuleRegistryEntry* entry)
+{
+    switch (entry->status()) {
+    case JSC::ModuleRegistryEntry::Status::New:
+    case JSC::ModuleRegistryEntry::Status::Fetching:
+        return false;
+    case JSC::ModuleRegistryEntry::Status::FetchFailed:
+    case JSC::ModuleRegistryEntry::Status::InstantiationFailed:
+    case JSC::ModuleRegistryEntry::Status::EvaluationFailed:
+        return true;
+    case JSC::ModuleRegistryEntry::Status::Fetched:
+        break;
+    }
+    auto* record = entry->record();
+    if (!record)
+        return false;
+    if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record))
+        return cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated;
+    return record->moduleEnvironmentMayBeNull() != nullptr;
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -764,7 +787,19 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globa
         return JSValue::encode(jsBoolean(false));
     auto key = JSC::Identifier::fromString(vm, asString(keyValue)->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsBoolean(globalObject->moduleLoader()->removeEntry(key))); // takes the loader's cellLock itself
+    auto* moduleLoader = globalObject->moduleLoader();
+    // require.cache only lists ES modules that finished evaluating (its `has`
+    // and `get` traps go through functionEsmNamespaceForCjs). A module that is
+    // still loading is not in it, so deleting its key is a no-op like deleting
+    // any other missing key. Evicting the entry mid-load would make the next
+    // import() of the key build a second record for the same module while the
+    // loader's [[LoadedModules]] caches and pending microtasks hold the first.
+    // removeEntry() drops every (key, type) variant, so check each of them.
+    for (auto& [mapKey, entry] : moduleLoader->moduleMap()) {
+        if (mapKey.first == key.impl() && !isModuleLoadSettled(entry.get()))
+            return JSValue::encode(jsBoolean(false));
+    }
+    return JSValue::encode(jsBoolean(moduleLoader->removeEntry(key))); // takes the loader's cellLock itself
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryEvaluatedKeys, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -787,10 +787,8 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globa
     auto key = JSC::Identifier::fromString(vm, asString(keyValue)->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
     auto* moduleLoader = globalObject->moduleLoader();
-    // A module that is still loading is not in require.cache (see
-    // functionEsmNamespaceForCjs), so deleting it is a no-op. Evicting it would
-    // give the next import() a second record for the key while [[LoadedModules]]
-    // still holds the first. removeEntry() drops every (key, type) variant.
+    // A module that is still loading is not in require.cache, so deleting it is a no-op.
+    // Evicting it would give the next import() a second record for the same key.
     for (auto& [mapKey, entry] : moduleLoader->moduleMap()) {
         if (mapKey.first == key.impl() && entry && !isModuleLoadSettled(entry.get()))
             return JSValue::encode(jsBoolean(false));

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -309,6 +309,166 @@ describe.concurrent("require.cache", () => {
     }, 20000);
   });
 
+  // `delete require.cache[path]` of an ES module evicts its registry entry. A
+  // module that is still loading or evaluating is not in require.cache (`in`
+  // says false), so deleting it must be a no-op: evicting it mid-load made the
+  // next import() of the same path create a second record for it, which the
+  // loader's import cache did not expect (segfault at address 0x10 on the
+  // next import(), or the module evaluating twice).
+  describe("delete require.cache[esm] of a module that is still loading", () => {
+    // Every fixture records into one object and prints it once the event loop
+    // drains, so the test compares the whole outcome instead of line order.
+    const report = `
+      const result = (globalThis.__result ??= { evaluated: 0 });
+      process.on("beforeExit", () => console.log(JSON.stringify(result)));
+      module.exports = result;
+    `;
+
+    async function run(dir: string, entry: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), entry],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { result: stdout.trim() ? JSON.parse(stdout.trim()) : stdout, stderr, exitCode };
+    }
+
+    // a.mjs is fetched, then its CommonJS dependency runs before a.mjs evaluates.
+    // The dependency evicts a.mjs and imports it again.
+    const deleteThenImport = {
+      "report.cjs": report,
+      "a.mjs": `
+        import "./b.cjs";
+        export const x = 1;
+        globalThis.__result.evaluated++;
+      `,
+      "b.cjs": `
+        const result = require("./report.cjs");
+        const key = require("node:path").join(__dirname, "a.mjs");
+        result.inCacheBeforeDelete = key in require.cache;
+        result.deleted = delete require.cache[key];
+        import("./a.mjs").then(
+          ns => { result.depImport = ns.x; },
+          e => { result.depImport = String(e); },
+        );
+      `,
+      "main.mjs": `
+        const ns = await import("./a.mjs");
+        globalThis.__result.mainImport = ns.x;
+        globalThis.__result.secondImportIsSame = (await import("./a.mjs")) === ns;
+      `,
+    };
+
+    test("import() of the module from its dependency", async () => {
+      using dir = tempDir("require-cache-delete-loading-import", deleteThenImport);
+      expect(await run(String(dir), "main.mjs")).toEqual({
+        result: {
+          evaluated: 1,
+          inCacheBeforeDelete: false,
+          deleted: true,
+          mainImport: 1,
+          secondImportIsSame: true,
+          depImport: 1,
+        },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("import() of the module from its dependency, module is the entry point", async () => {
+      using dir = tempDir("require-cache-delete-loading-entry", deleteThenImport);
+      expect(await run(String(dir), "a.mjs")).toEqual({
+        result: { evaluated: 1, inCacheBeforeDelete: false, deleted: true, depImport: 1 },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("require() of the module from its dependency", async () => {
+      using dir = tempDir("require-cache-delete-loading-require", {
+        ...deleteThenImport,
+        "b.cjs": `
+          const result = require("./report.cjs");
+          const key = require("node:path").join(__dirname, "a.mjs");
+          result.deleted = delete require.cache[key];
+          result.depRequire = require("./a.mjs").x;
+        `,
+      });
+      expect(await run(String(dir), "main.mjs")).toEqual({
+        result: { evaluated: 1, deleted: true, depRequire: 1, mainImport: 1, secondImportIsSame: true },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("while the module's top level is running", async () => {
+      using dir = tempDir("require-cache-delete-evaluating", {
+        "report.cjs": report,
+        "a.mjs": `
+          import { createRequire } from "node:module";
+          const require = createRequire(import.meta.url);
+          require("./c.cjs");
+          export const x = 1;
+          globalThis.__result.evaluated++;
+        `,
+        "c.cjs": `
+          const result = require("./report.cjs");
+          const key = require("node:path").join(__dirname, "a.mjs");
+          result.inCacheBeforeDelete = key in require.cache;
+          result.deleted = delete require.cache[key];
+          import("./a.mjs").then(
+            ns => { result.depImport = ns.x; },
+            e => { result.depImport = String(e); },
+          );
+        `,
+        "main.mjs": `
+          const ns = await import("./a.mjs");
+          globalThis.__result.mainImport = ns.x;
+        `,
+      });
+      expect(await run(String(dir), "main.mjs")).toEqual({
+        result: { evaluated: 1, inCacheBeforeDelete: false, deleted: true, mainImport: 1, depImport: 1 },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("an evaluated module is still evicted", async () => {
+      using dir = tempDir("require-cache-delete-evaluated", {
+        "report.cjs": report,
+        "a.mjs": `
+          export const x = 1;
+          globalThis.__result.evaluated++;
+        `,
+        "main.mjs": `
+          import { createRequire } from "node:module";
+          import { join } from "node:path";
+          const require = createRequire(import.meta.url);
+          const result = require("./report.cjs");
+          const key = join(import.meta.dir, "a.mjs");
+          const first = await import("./a.mjs");
+          result.inCacheBeforeDelete = key in require.cache;
+          result.deleted = delete require.cache[key];
+          result.inCacheAfterDelete = key in require.cache;
+          result.secondImportIsSame = (await import("./a.mjs")) === first;
+        `,
+      });
+      expect(await run(String(dir), "main.mjs")).toEqual({
+        result: {
+          evaluated: 2,
+          inCacheBeforeDelete: true,
+          deleted: true,
+          inCacheAfterDelete: false,
+          secondImportIsSame: false,
+        },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
   // These tests are extra slow in debug builds
   describe("files transpiled and loaded don't leak file paths", () => {
     test("via require()", async () => {

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -332,7 +332,7 @@ describe.concurrent("require.cache", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { result: stdout.trim() ? JSON.parse(stdout.trim()) : stdout, stderr, exitCode };
+      return { stdout, stderr, exitCode };
     }
 
     // a.mjs is fetched, then its CommonJS dependency runs before a.mjs evaluates.
@@ -363,27 +363,25 @@ describe.concurrent("require.cache", () => {
 
     test("import() of the module from its dependency", async () => {
       using dir = tempDir("require-cache-delete-loading-import", deleteThenImport);
-      expect(await run(String(dir), "main.mjs")).toEqual({
-        result: {
-          evaluated: 1,
-          inCacheBeforeDelete: false,
-          deleted: true,
-          mainImport: 1,
-          secondImportIsSame: true,
-          depImport: 1,
-        },
-        stderr: "",
-        exitCode: 0,
+      const { stdout, stderr, exitCode } = await run(String(dir), "main.mjs");
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        evaluated: 1,
+        inCacheBeforeDelete: false,
+        deleted: true,
+        mainImport: 1,
+        secondImportIsSame: true,
+        depImport: 1,
       });
+      expect(exitCode).toBe(0);
     });
 
     test("import() of the module from its dependency, module is the entry point", async () => {
       using dir = tempDir("require-cache-delete-loading-entry", deleteThenImport);
-      expect(await run(String(dir), "a.mjs")).toEqual({
-        result: { evaluated: 1, inCacheBeforeDelete: false, deleted: true, depImport: 1 },
-        stderr: "",
-        exitCode: 0,
-      });
+      const { stdout, stderr, exitCode } = await run(String(dir), "a.mjs");
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ evaluated: 1, inCacheBeforeDelete: false, deleted: true, depImport: 1 });
+      expect(exitCode).toBe(0);
     });
 
     test("require() of the module from its dependency", async () => {
@@ -396,11 +394,16 @@ describe.concurrent("require.cache", () => {
           result.depRequire = require("./a.mjs").x;
         `,
       });
-      expect(await run(String(dir), "main.mjs")).toEqual({
-        result: { evaluated: 1, deleted: true, depRequire: 1, mainImport: 1, secondImportIsSame: true },
-        stderr: "",
-        exitCode: 0,
+      const { stdout, stderr, exitCode } = await run(String(dir), "main.mjs");
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        evaluated: 1,
+        deleted: true,
+        depRequire: 1,
+        mainImport: 1,
+        secondImportIsSame: true,
       });
+      expect(exitCode).toBe(0);
     });
 
     test("while the module's top level is running", async () => {
@@ -428,11 +431,16 @@ describe.concurrent("require.cache", () => {
           globalThis.__result.mainImport = ns.x;
         `,
       });
-      expect(await run(String(dir), "main.mjs")).toEqual({
-        result: { evaluated: 1, inCacheBeforeDelete: false, deleted: true, mainImport: 1, depImport: 1 },
-        stderr: "",
-        exitCode: 0,
+      const { stdout, stderr, exitCode } = await run(String(dir), "main.mjs");
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        evaluated: 1,
+        inCacheBeforeDelete: false,
+        deleted: true,
+        mainImport: 1,
+        depImport: 1,
       });
+      expect(exitCode).toBe(0);
     });
 
     test("an evaluated module is still evicted", async () => {
@@ -455,17 +463,16 @@ describe.concurrent("require.cache", () => {
           result.secondImportIsSame = (await import("./a.mjs")) === first;
         `,
       });
-      expect(await run(String(dir), "main.mjs")).toEqual({
-        result: {
-          evaluated: 2,
-          inCacheBeforeDelete: true,
-          deleted: true,
-          inCacheAfterDelete: false,
-          secondImportIsSame: false,
-        },
-        stderr: "",
-        exitCode: 0,
+      const { stdout, stderr, exitCode } = await run(String(dir), "main.mjs");
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        evaluated: 2,
+        inCacheBeforeDelete: true,
+        deleted: true,
+        inCacheAfterDelete: false,
+        secondImportIsSame: false,
       });
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
### Problem
- `delete require.cache[path]` of an ES module that is still loading evicts its registry entry. The next `import()` of the path builds a second record for the same module while the loader's `[[LoadedModules]]` cache and pending microtasks hold the first one. Release: `Segmentation fault at address 0x10` in `JSModuleLoader::loadModule`. Debug: `ASSERT(loadedEntry->record() == loaded)` at `JSModuleLoader.cpp:630` (`import()`), `ASSERT(iter->value.m_module.get() == *resultRecord)` at `:955` (`require()`). When the records line up, the module evaluates twice.
- Cause: `functionEsmRegistryDelete` (`src/jsc/bindings/ZigGlobalObject.cpp`) calls `removeEntry()` for every state. The `has` and `get` traps already answer "not in the cache" for a module that has not finished evaluating, so the delete acts on a key the cache says is absent.
- Shape: a CommonJS dependency of an ES module runs the decache idiom (`delete require.cache[importer]; import(importer)`) while the importer is mid-load.

### Fix
- `functionEsmRegistryDelete` evicts only entries whose load has settled: the record is `Evaluated` (with or without an error) or the entry caches a fetch, instantiation, or evaluation error. A loading module keeps its entry, so a later `import()` or `require()` joins the in-flight load. Node evaluates the module once in all of these cases.
- Deleting an evaluated module still evicts it. The decache idiom and the leak tests are unchanged.
- Verified: `test/cli/run/require-cache.test.ts`, 5 new tests. Four fail on the released binary (one segfault, three double evaluations). Also `test/js/node/module/`, `test/js/bun/test/mock/`, `test/js/bun/resolve/require*`, `test/js/bun/plugin/`, `test/cli/hot/hot.test.ts`.

### Background
- The registry maps a module key to a `ModuleRegistryEntry`: the load promises, the status (`New`, `Fetching`, `Fetched`, or a failure), and once fetched the record. Bun exposes evaluated ES modules through `require.cache` so `delete` can evict them. `removeEntry()` is a Bun addition to JSC.
- A module's CommonJS dependencies run while the module's graph is still being fetched (the CJS body runs when the synthetic module record is made), before the module itself evaluates. That is the window these repros hit.
- `[[LoadedModules]]` is the per-realm and per-module cache from a specifier to the record it loaded. It is only valid while it agrees with the registry.

<details><summary>Notes</summary>

Direction: #39674 (WebKit bump for oven-sh/WebKit#472) fixes the same crash from the engine side and keeps the opposite semantics: deleting an in-flight module evicts it and the next `import()` loads the file again. Its `mock.module()` and `Bun.plugin` coverage is still needed with this change (those paths call `removeEntry()` directly and are not gated here). Two of its `require-cache.test.ts` tests assert the evict semantics (`loads: [1, 2]`, and a second `import()` that starts a replacement load while the first is held) and would need to change if this lands. #38072's tests assert that a module which deletes itself during its own evaluation re-evaluates on the second `require()`; with this change the second `require()` returns the same namespace.

Repro (3 files, release 1.4.0):

```js
// entry.mjs
import("./a.mjs").then(ns => console.log("entry", ns.x));
// a.mjs
import "./b.cjs";
export const x = 1;
console.log("a evaluated");
// b.cjs
delete require.cache[__dirname + "/a.mjs"]; // `in require.cache` is false here
import("./a.mjs").then(ns => console.log("b", ns.x));
```

Before: `a evaluated`, `entry 1`, then the segfault. `bun a.mjs`: `a evaluated` twice. With `require("./a.mjs")` in b.cjs: `a evaluated` twice (debug: the `:955` assert). Deleting from a CJS module `require()`d by the module's own top level (record `Evaluating`): `a evaluated` twice. After: one evaluation and both imports resolve to the same namespace in all four shapes. Node prints `a evaluated` once for each.

Under the debug ASAN build the RSS leak tests in this file time out with and without this change (they did before it too).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/require-cache.test.ts

<!-- robobun:evidence:end -->