### PR TITLE
Fix the bake error overlay highlighter dropping template literal text after `${`

### DIFF
--- a/src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts
+++ b/src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts
@@ -397,63 +397,60 @@ export class DraculaSyntaxHighlighter {
 
   private lexString(): Token | null {
     const quote = this.peek();
-    if (quote !== '"' && quote !== "'" && quote !== "`") return null;
-
-    if (quote === "`") {
-      return this.lexTemplateString();
-    }
+    if (quote !== '"' && quote !== "'") return null;
 
     const value = this.consumeString(quote);
     return this.createToken(TokenType.String, value, TokenClass.String);
   }
 
-  private lexTemplateString(): Token | null {
-    const tokens: Token[] = [];
+  // A template literal is several tokens: one string token per quasi, and for
+  // each interpolation the `${`, the tokens of the expression, and the `}`.
+  private *lexTemplateString(): Generator<Token> {
     let str = this.consume(); // Initial backtick
 
     while (this.pos < this.text.length) {
       const char = this.peek();
-      const prevChar = this.peek(-1);
 
-      if (char === "`" && prevChar !== "\\") {
+      if (char === "\\") {
+        str += this.consume(2);
+        continue;
+      }
+
+      if (char === "`") {
         str += this.consume();
-        tokens.push(this.createToken(TokenType.TemplateString, str, TokenClass.String));
         break;
       }
 
-      if (char === "$" && this.peek(1) === "{" && prevChar !== "\\") {
+      if (char === "$" && this.peek(1) === "{") {
         if (str) {
-          tokens.push(this.createToken(TokenType.TemplateString, str, TokenClass.String));
+          yield this.createToken(TokenType.TemplateString, str, TokenClass.String);
           str = "";
         }
+        yield this.createToken(TokenType.TemplateInterpolation, this.consume(2), TokenClass.Operator);
 
-        const interpStart = this.consume(2);
-        tokens.push(this.createToken(TokenType.TemplateInterpolation, interpStart, TokenClass.Operator));
-
-        let braceCount = 1;
-        while (this.pos < this.text.length && braceCount > 0) {
+        // `{` and `}` always lex as single-character punctuators, so peeking
+        // at the next character before lexing the next token is enough to
+        // find the `}` that closes this interpolation.
+        let braceDepth = 1;
+        while (this.pos < this.text.length) {
           const c = this.peek();
-          if (c === "{") braceCount++;
-          if (c === "}") braceCount--;
-
-          if (braceCount === 0) {
-            tokens.push(this.createToken(TokenType.TemplateInterpolation, this.consume(), TokenClass.Operator));
-          } else {
-            const token = this.nextToken();
-            if (token) tokens.push(token);
+          if (c === "{") {
+            braceDepth++;
+          } else if (c === "}" && --braceDepth === 0) {
+            yield this.createToken(TokenType.TemplateInterpolation, this.consume(), TokenClass.Operator);
+            break;
           }
+          yield* this.lexToken();
         }
         continue;
       }
 
-      if (char === "\\") {
-        str += this.consume(2);
-      } else {
-        str += this.consume();
-      }
+      str += this.consume();
     }
 
-    return tokens[0]; // Return first token, others will be picked up in next iterations
+    if (str) {
+      yield this.createToken(TokenType.TemplateString, str, TokenClass.String);
+    }
   }
 
   private lexComment(): Token | null {
@@ -494,8 +491,13 @@ export class DraculaSyntaxHighlighter {
     return null;
   }
 
-  private nextToken(): Token | null {
-    if (this.pos >= this.text.length) return null;
+  private *lexToken(): Generator<Token> {
+    if (this.pos >= this.text.length) return;
+
+    if (this.peek() === "`") {
+      yield* this.lexTemplateString();
+      return;
+    }
 
     const token =
       this.lexWhitespace() ||
@@ -509,17 +511,16 @@ export class DraculaSyntaxHighlighter {
       this.createToken(TokenType.Operator, this.consume(), TokenClass.Operator);
 
     // Reset extends/implements state after non-whitespace tokens
-    if (token?.type !== TokenType.Whitespace && token?.type !== TokenType.Newline) {
+    if (token.type !== TokenType.Whitespace && token.type !== TokenType.Newline) {
       this.isAfterExtendsOrImplements = false;
     }
 
-    return token;
+    yield token;
   }
 
   private *tokenize(): Generator<Token> {
     while (this.pos < this.text.length) {
-      const token = this.nextToken();
-      if (token) yield token;
+      yield* this.lexToken();
     }
   }
 

--- a/src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts
+++ b/src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts
@@ -403,8 +403,6 @@ export class DraculaSyntaxHighlighter {
     return this.createToken(TokenType.String, value, TokenClass.String);
   }
 
-  // A template literal is several tokens: one string token per quasi, and for
-  // each interpolation the `${`, the tokens of the expression, and the `}`.
   private *lexTemplateString(): Generator<Token> {
     let str = this.consume(); // Initial backtick
 
@@ -428,9 +426,7 @@ export class DraculaSyntaxHighlighter {
         }
         yield this.createToken(TokenType.TemplateInterpolation, this.consume(2), TokenClass.Operator);
 
-        // `{` and `}` always lex as single-character punctuators, so peeking
-        // at the next character before lexing the next token is enough to
-        // find the `}` that closes this interpolation.
+        // `{` and `}` always lex as single-character punctuators.
         let braceDepth = 1;
         while (this.pos < this.text.length) {
           const c = this.peek();

--- a/test/bake/syntax-highlighter.test.ts
+++ b/test/bake/syntax-highlighter.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { syntaxHighlight } from "../../src/runtime/bake/client/JavaScriptSyntaxHighlighter";
+
+// The dev server error overlay runs each source line of a code preview through
+// syntaxHighlight() on its own. The result is the line's tokens wrapped in
+// spans, with every token body HTML-escaped. Undoing that gives back the
+// source text the overlay shows for the line.
+function sourceText(html: string): string {
+  return html
+    .replace(/<\/?span[^>]*>/g, "")
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+test("syntaxHighlight tokenizes a template literal with an interpolation", () => {
+  expect(syntaxHighlight("let a = `x${1}y`;")).toMatchInlineSnapshot(
+    `"<span class="syntax-pink">let</span> <span class="syntax-fg">a</span> <span class="syntax-pink">=</span> <span class="syntax-yellow">\`x</span><span class="syntax-pink">\${</span><span class="syntax-purple">1</span><span class="syntax-pink">}</span><span class="syntax-yellow">y\`</span><span class="syntax-pink">;</span>"`,
+  );
+});
+
+test("syntaxHighlight tokenizes a nested template literal", () => {
+  expect(syntaxHighlight("`a${`b${c}d`}e`")).toMatchInlineSnapshot(
+    `"<span class="syntax-yellow">\`a</span><span class="syntax-pink">\${</span><span class="syntax-yellow">\`b</span><span class="syntax-pink">\${</span><span class="syntax-fg">c</span><span class="syntax-pink">}</span><span class="syntax-yellow">d\`</span><span class="syntax-pink">}</span><span class="syntax-yellow">e\`</span>"`,
+  );
+});
+
+test.each([
+  // interpolations
+  "let a = `x${1}y`;",
+  "`${a}`",
+  "f(`a${b}c${d}e`)",
+  "`${ {a: 1}.a }`",
+  "`a${`b${c}d`}e`",
+  '`a${ "}" }b`',
+  // escapes
+  "`a\\`b${c}\\${d}`",
+  "`a\\\\`+b",
+  // one line of a template literal that spans several lines
+  "const q = `first line of a",
+  "  second line`;",
+  "`a${b",
+  "`a${b}c",
+  // no template literal
+  'const s = "plain";',
+  "`no interp`",
+])("syntaxHighlight keeps the source text of %s", line => {
+  expect(sourceText(syntaxHighlight(line))).toBe(line);
+});

--- a/test/bake/syntax-highlighter.test.ts
+++ b/test/bake/syntax-highlighter.test.ts
@@ -2,12 +2,11 @@ import { expect, test } from "bun:test";
 import { syntaxHighlight } from "../../src/runtime/bake/client/JavaScriptSyntaxHighlighter";
 
 // The dev server error overlay runs each source line of a code preview through
-// syntaxHighlight() on its own. The result is the line's tokens wrapped in
-// spans, with every token body HTML-escaped. Undoing that gives back the
-// source text the overlay shows for the line.
-function sourceText(html: string): string {
-  return html
-    .replace(/<\/?span[^>]*>/g, "")
+// syntaxHighlight() on its own. The result is a run of <span class="...">
+// elements, one per colored token, with bare text for whitespace. Every token
+// body is HTML-escaped.
+function unescapeHtml(text: string): string {
+  return text
     .replace(/&quot;/g, '"')
     .replace(/&#039;/g, "'")
     .replace(/&lt;/g, "<")
@@ -15,35 +14,174 @@ function sourceText(html: string): string {
     .replace(/&amp;/g, "&");
 }
 
-test("syntaxHighlight tokenizes a template literal with an interpolation", () => {
-  expect(syntaxHighlight("let a = `x${1}y`;")).toMatchInlineSnapshot(
-    `"<span class="syntax-pink">let</span> <span class="syntax-fg">a</span> <span class="syntax-pink">=</span> <span class="syntax-yellow">\`x</span><span class="syntax-pink">\${</span><span class="syntax-purple">1</span><span class="syntax-pink">}</span><span class="syntax-yellow">y\`</span><span class="syntax-pink">;</span>"`,
-  );
-});
+// [class, text] per token. Bare text has the class "".
+function tokens(html: string): [string, string][] {
+  const out: [string, string][] = [];
+  for (const m of html.matchAll(/<span class="([^"]*)">([^<]*)<\/span>|([^<]+)/g)) {
+    out.push(m[3] === undefined ? [m[1], unescapeHtml(m[2])] : ["", unescapeHtml(m[3])]);
+  }
+  return out;
+}
 
-test("syntaxHighlight tokenizes a nested template literal", () => {
-  expect(syntaxHighlight("`a${`b${c}d`}e`")).toMatchInlineSnapshot(
-    `"<span class="syntax-yellow">\`a</span><span class="syntax-pink">\${</span><span class="syntax-yellow">\`b</span><span class="syntax-pink">\${</span><span class="syntax-fg">c</span><span class="syntax-pink">}</span><span class="syntax-yellow">d\`</span><span class="syntax-pink">}</span><span class="syntax-yellow">e\`</span>"`,
-  );
+function sourceText(html: string): string {
+  return tokens(html)
+    .map(([, text]) => text)
+    .join("");
+}
+
+test.each<[string, [string, string][]]>([
+  [
+    "let a = `x${1}y`;",
+    [
+      ["syntax-pink", "let"],
+      ["", " "],
+      ["syntax-fg", "a"],
+      ["", " "],
+      ["syntax-pink", "="],
+      ["", " "],
+      ["syntax-yellow", "`x"],
+      ["syntax-pink", "${"],
+      ["syntax-purple", "1"],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "y`"],
+      ["syntax-pink", ";"],
+    ],
+  ],
+  [
+    // a nested template literal
+    "`a${`b${c}d`}e`",
+    [
+      ["syntax-yellow", "`a"],
+      ["syntax-pink", "${"],
+      ["syntax-yellow", "`b"],
+      ["syntax-pink", "${"],
+      ["syntax-fg", "c"],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "d`"],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "e`"],
+    ],
+  ],
+  [
+    // braces inside the interpolation do not close it
+    "`${ {a: 1}.a }`",
+    [
+      ["syntax-yellow", "`"],
+      ["syntax-pink", "${"],
+      ["", " "],
+      ["syntax-pink", "{"],
+      ["syntax-fg", "a"],
+      ["syntax-pink", ":"],
+      ["", " "],
+      ["syntax-purple", "1"],
+      ["syntax-pink", "}"],
+      ["syntax-pink", "."],
+      ["syntax-fg", "a"],
+      ["", " "],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "`"],
+    ],
+  ],
+  [
+    "`${f({x})}`",
+    [
+      ["syntax-yellow", "`"],
+      ["syntax-pink", "${"],
+      ["syntax-green", "f"],
+      ["syntax-pink", "("],
+      ["syntax-pink", "{"],
+      ["syntax-fg", "x"],
+      ["syntax-pink", "}"],
+      ["syntax-pink", ")"],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "`"],
+    ],
+  ],
+  [
+    // a brace inside a string inside the interpolation is part of the string
+    '`a${ "}" }b`',
+    [
+      ["syntax-yellow", "`a"],
+      ["syntax-pink", "${"],
+      ["", " "],
+      ["syntax-yellow", '"}"'],
+      ["", " "],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "b`"],
+    ],
+  ],
+  [
+    // \` and \${ are literal text
+    "`a\\`b${c}\\${d}`",
+    [
+      ["syntax-yellow", "`a\\`b"],
+      ["syntax-pink", "${"],
+      ["syntax-fg", "c"],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "\\${d}`"],
+    ],
+  ],
+  [
+    // \\ is one escape, so the backtick after it closes the literal
+    "`a\\\\`+b",
+    [
+      ["syntax-yellow", "`a\\\\`"],
+      ["syntax-pink", "+"],
+      ["syntax-fg", "b"],
+    ],
+  ],
+  [
+    // \\ is one escape, so the ${ after it starts an interpolation
+    "`\\\\${a}`",
+    [
+      ["syntax-yellow", "`\\\\"],
+      ["syntax-pink", "${"],
+      ["syntax-fg", "a"],
+      ["syntax-pink", "}"],
+      ["syntax-yellow", "`"],
+    ],
+  ],
+  [
+    // the first line of a template literal that spans several lines
+    "const q = `first line of a",
+    [
+      ["syntax-pink", "const"],
+      ["", " "],
+      ["syntax-fg", "q"],
+      ["", " "],
+      ["syntax-pink", "="],
+      ["", " "],
+      ["syntax-yellow", "`first line of a"],
+    ],
+  ],
+  [
+    // a line that ends inside an interpolation
+    "`a${b",
+    [
+      ["syntax-yellow", "`a"],
+      ["syntax-pink", "${"],
+      ["syntax-fg", "b"],
+    ],
+  ],
+])("syntaxHighlight tokenizes %s", (line, expected) => {
+  expect(tokens(syntaxHighlight(line))).toEqual(expected);
 });
 
 test.each([
-  // interpolations
   "let a = `x${1}y`;",
   "`${a}`",
+  "`${a}${b}`",
   "f(`a${b}c${d}e`)",
   "`${ {a: 1}.a }`",
   "`a${`b${c}d`}e`",
   '`a${ "}" }b`',
-  // escapes
   "`a\\`b${c}\\${d}`",
   "`a\\\\`+b",
-  // one line of a template literal that spans several lines
+  "`\\\\${a}`",
   "const q = `first line of a",
   "  second line`;",
   "`a${b",
   "`a${b}c",
-  // no template literal
   'const s = "plain";',
   "`no interp`",
 ])("syntaxHighlight keeps the source text of %s", line => {

--- a/test/bake/syntax-highlighter.test.ts
+++ b/test/bake/syntax-highlighter.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { syntaxHighlight } from "../../src/runtime/bake/client/JavaScriptSyntaxHighlighter";
+import { syntaxHighlight } from "bake/JavaScriptSyntaxHighlighter";
 
 // The dev server error overlay runs each source line of a code preview through
 // syntaxHighlight() on its own. The result is a run of <span class="...">

--- a/test/bake/syntax-highlighter.test.ts
+++ b/test/bake/syntax-highlighter.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
 import { syntaxHighlight } from "bake/JavaScriptSyntaxHighlighter";
+import { expect, test } from "bun:test";
 
 // The dev server error overlay runs each source line of a code preview through
 // syntaxHighlight() on its own. The result is a run of <span class="...">


### PR DESCRIPTION
### Problem
- The dev server error overlay shows a truncated source line when the line has a template literal with an interpolation. `syntaxHighlight("let a = \`x${1}y\`;")` returns the spans for `let a = \`x` and `;`. The `${1}y\`` part is gone. A line where the literal does not close (one line of a multi-line template literal) loses the literal entirely.
- `lexTemplateString()` in `src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts:410` collects every token of the literal into a local array, moves `pos` past the whole literal, and returns only `tokens[0]`. Nothing queues the rest. When the literal has no `${` and no closing backtick, the array is empty and `lexPunctuator()` emits an empty token at end of text instead.

### Fix
- `lexTemplateString()` is now a generator. It yields each quasi as a string token, then `${`, the tokens of the expression, and `}` for each interpolation, in source order. It yields the last quasi even when the literal does not close on this line.
- `nextToken()` becomes the generator `lexToken()`. It dispatches a backtick to `lexTemplateString()` and yields one token otherwise. The interpolation loop recurses through it, so a nested template literal or an object literal inside `${}` keeps its tokens in order.
- This is correct because the highlighter must emit every character of the line once. The old code consumed characters it never emitted. The brace depth check stays sound: `{` and `}` always lex as single-character punctuators, so a peek before each `lexToken()` call finds the `}` that closes the interpolation.
- Verified: `test/bake/syntax-highlighter.test.ts` (26 tests, 23 fail on main). The tests compare the `[class, text]` token list of each line, so they pin where each token starts and ends. Also the bake client bundle builds through `bake-codegen.ts` with the change.

### Background
- The overlay (`src/runtime/bake/client/overlay.ts:301` and `:625`) highlights one source line at a time with `syntaxHighlight()`. The highlighter has no state across lines, so a template literal that spans lines reaches it as an unterminated literal on each line.
- A quasi is the literal text between the backticks and the `${}` interpolations of a template literal.
- `tokenize()` was already a generator. `lexTemplateString()` and `lexToken()` now use the same shape, and `yield*` gives the recursion for nested literals.

<details><summary>Notes</summary>

Reproduce on main:

```
bun -e 'import { syntaxHighlight } from "./src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts"; console.log(syntaxHighlight("let a = `x${1}y`;"))'
```

Output on main: `<span class="syntax-yellow">\`x</span><span class="syntax-pink">;</span>` after the `let a =` spans.

Probe results on main, as the source text of the highlighted output versus the input:

- `` `${a}` `` gives `` ` ``
- `` f(`a${b}c${d}e`) `` gives `` f(`a) ``
- `` `a${`b${c}d`}e` `` gives `` `a ``
- `` const q = `first line of a `` gives `const q = ` and an empty span
- `` `a\\`+b `` gives an empty string. The old close check `prevChar !== "\\"` treated the second backslash of `\\` as an escape of the backtick, so the literal never closed.

Escape handling. Before and after this change, a backslash consumes the next character, so `` \` `` and `\${` are literal text. The change is the removal of the `prevChar !== "\\"` guards on the closing backtick and on `${`. Those guards also fired on the second backslash of `\\`, so `` `a\\` `` never closed and `` `\\${a}` `` had no interpolation. The tests for `` `a\\`+b `` and `` `\\${a}` `` pin the new behavior.

Test design. A check that the highlighted text round-trips to the input cannot see token boundaries: it passed with the brace depth tracking removed, and with the old escape guards restored. The `tokenizes` cases compare the full token list and fail under both of those mutations. The `keeps the source text` cases stay as the direct check for the dropped text.

PR #40122 removes dead code from the same file (the unused `consumeTemplateString()`, `highlight()`, and friends) and adds `test/bake/syntax-highlighter.test.ts` with two tests that pin the output of simpler lines. This PR does not touch those methods. The two PRs add a test file at the same path, so the second one to land needs a rebase that keeps both sets of tests.

The one `tsc -p src/runtime/bake/tsconfig.json` error, `Cannot find type definition file for 'react/experimental'`, is present on main in this environment too.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 23 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/syntax-highlighter.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/syntax-highlighter.test.ts:
162 |       ["syntax-pink", "${"],
163 |       ["syntax-fg", "b"],
164 |     ],
165 |   ],
166 | ])("syntaxHighlight tokenizes %s", (line, expected) => {
167 |   expect(tokens(syntaxHighlight(line))).toEqual(expected);
                                              ^
error: expect(received).toEqual(expected)

  [
    [
      "syntax-pink",
      "let",
    ],
    [
      "",
      " ",
    ],
    [
      "syntax-fg",
      "a",
    ],
    [
      "",
      " ",
    ],
    [
      "syntax-pink",
      "=",
    ],
    [
      "",
      " ",
    ],
    [
      "syntax-yellow",
      "`x",
    ],
    [
      "syntax-pink",
-     "${",
-   ],
-   [
-     "syntax-purple",
-     "1",
-   ],
-   [
-     "syntax-pink",
-     "}",
-   ],
-   [
-     "syntax-yellow",
-     "y`",
-   ],
-   [
-     "syntax-pink",
      ";",
    ],
  ]

- Expected  - 16
+ Received  + 0

      at <anonymous> (/workspace/bun/test/bake/syntax-highlighter.test.ts:167:
... (truncated)

release without fix: 23 FAILED
bun test v1.4.1-canary.1 (6c8b59bc8)

test/bake/syntax-highlighter.test.ts:
162 |       ["syntax-pink", "${"],
163 |       ["syntax-fg", "b"],
164 |     ],
165 |   ],
166 | ])("syntaxHighlight tokenizes %s", (line, expected) => {
167 |   expect(tokens(syntaxHighlight(line))).toEqual(expected);
                                              ^
error: expect(received).toEqual(expected)

  [
    [
      "syntax-pink",
      "let",
    ],
    [
      "",
      " ",
    ],
    [
      "syntax-fg",
      "a",
    ],
    [
      "",
      " ",
    ],
    [
      "syntax-pink",
      "=",
    ],
    [
      "",
      " ",
    ],
    [
      "syntax-yellow",
      "`x",
    ],
    [
      "syntax-pink",
-     "${",
-   ],
-   [
-     "syntax-purple",
-     "1",
-   ],
-   [
-     "syntax-pink",
-     "}",
-   ],
-   [
-     "syntax-yellow",
-     "y`",
-   ],
-   [
-     "syntax-pink",
      ";",
    ],
  ]

- Expected  - 16
+ Received  + 0

      at <anonymous> (/workspace/bun/test/bake/syntax-highlighter.test.ts:167:41)
(fail) syntaxHighlight tokenizes let a = `x${1}y`; [1.20ms]
162 |       ["syntax-pink", "${"],
163 |       ["syntax-fg", "b"],
164 |     ],
165 |   ],
166 | 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/syntax-highlighter.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/syntax-highlighter.test.ts:
(pass) syntaxHighlight tokenizes let a = `x${1}y`; [99.05ms]
(pass) syntaxHighlight tokenizes `a${`b${c}d`}e` [11.38ms]
(pass) syntaxHighlight tokenizes `${ {a: 1}.a }` [19.58ms]
(pass) syntaxHighlight tokenizes `${f({x})}` [14.74ms]
(pass) syntaxHighlight tokenizes `a${ "}" }b` [11.24ms]
(pass) syntaxHighlight tokenizes `a\`b${c}\${d}` [6.17ms]
(pass) syntaxHighlight tokenizes `a\\`+b [3.75ms]
(pass) syntaxHighlight tokenizes `\\${a}` [4.48ms]
(pass) syntaxHighlight tokenizes const q = `first line of a [7.89ms]
(pass) syntaxHighlight tokenizes `a${b [3.30ms]
(pass) syntaxHighlight keeps the source text of let a = `x${1}y`; [15.68ms]
(pass) syntaxHighlight keeps the source text of `${a}` [4.95ms]
(pass) syntaxHighlight keeps the source text of `${a}${b}` [7.80ms]
(pass) syntaxHighlight keeps the source text of f(`a${b}c${d}e`) [12.06ms]
(pass) syntaxHighlight keeps the source text of `${ {a: 1}.a }` [16.15ms]
(pass) syntaxHighlight k
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 627ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/36] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/36] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[4/36] gen cpp.rs (cppbind)
[5/36] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[6/36] gen JS modules (bundle-modules)
Preprocess modules (7336ms)
Bundle modules (60ms)
Postprocesss modules (25ms)
Bundle Functions (631ms)
Generate Code (17ms)

[8.07s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[6/31] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nig
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../bake/client/JavaScriptSyntaxHighlighter.ts     |  71 ++++----
 test/bake/syntax-highlighter.test.ts               | 189 +++++++++++++++++++++
 2 files changed, 223 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/bake/client/JavaScriptSyntaxHighlighter.ts      2      5      0
test/bake/syntax-highlighter.test.ts                        0      3      0
```

</details>

<!-- robobun:evidence:end -->