### PR TITLE
node:http: treat an empty Transfer-Encoding value as absent like node

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -291,6 +291,12 @@ struct HttpResponseData;
              * the still-encoded body handed to the app; Bun.serve rejects it
              * (RFC 9112 6.1). node:http accepts it to match llhttp. */
             bool multipleCodings: 1 = false;
+            /* Some Transfer-Encoding field value holds a byte other than
+             * space/tab. llhttp flags Transfer-Encoding as present only once
+             * such a byte arrives, so node:http treats a request whose TE
+             * field values are all empty or whitespace-only as if the header
+             * were absent (no error, Content-Length framing applies). */
+            bool nonEmptyValue: 1 = false;
         };
 
         TransferEncoding getTransferEncoding()
@@ -315,6 +321,9 @@ struct HttpResponseData;
 
                     // Parse comma-separated values, ensuring "chunked" is last if present
                     const auto value = h->value;
+                    if (value.find_first_not_of(" \t") != std::string_view::npos) {
+                        te.nonEmptyValue = true;
+                    }
                     size_t pos = 0;
 
                     while (pos < value.length()) {
@@ -1261,6 +1270,18 @@ struct HttpResponseData;
 
             /* Check Transfer-Encoding header validity and conflicts */
             HttpRequest::TransferEncoding transferEncoding = req->getTransferEncoding();
+
+            /* node:http compat: llhttp flags Transfer-Encoding as present only
+             * once a non-whitespace value byte arrives, so a TE field whose
+             * value is empty or whitespace-only is treated as if the header
+             * were absent: the body is framed by Content-Length (or has zero
+             * length) and no error is raised. Bun.serve keeps treating it as
+             * present and rejects below; treating it as absent is the
+             * Content-Length fallback that getTransferEncoding() guards
+             * against. */
+            if (IsNodeHttp && transferEncoding.has && !transferEncoding.nonEmptyValue) {
+                transferEncoding = {};
+            }
 
             /* RFC 9112 6.1: Transfer-Encoding was introduced in HTTP/1.1. A server that
              * receives an HTTP/1.0 message containing a Transfer-Encoding header field

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -321,15 +321,18 @@ struct HttpResponseData;
 
                     // Parse comma-separated values, ensuring "chunked" is last if present
                     const auto value = h->value;
-                    if (value.find_first_not_of(" \t") != std::string_view::npos) {
-                        te.nonEmptyValue = true;
-                    }
                     size_t pos = 0;
 
                     while (pos < value.length()) {
                         // Skip leading whitespace
                         while (pos < value.length() && (value[pos] == ' ' || value[pos] == '\t')) {
                             pos++;
+                        }
+
+                        /* Any byte left after the whitespace skip is non-whitespace:
+                         * a coding-token byte or a comma. */
+                        if (pos < value.length()) {
+                            te.nonEmptyValue = true;
                         }
 
                         // Remember start of this token

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -103,41 +103,39 @@ test("should not duplicate transfer-encoding header in response when explicitly 
 // value as if the header were absent: no clientError, Content-Length framing
 // applies. oven-sh/bun#40124: Bun served the request AND fired a spurious
 // clientError, so a typical handler destroyed the live connection.
-for (const [name, te] of [
+test.each([
   ["empty", ""],
   ["whitespace-only", "   "],
-] as const) {
-  test(`${name} Transfer-Encoding value is ignored like node, no clientError`, async () => {
-    const events: string[] = [];
-    await using server = createServer((req, res) => {
-      events.push(`request ${req.url}`);
-      res.end("ok");
-    });
-    server.on("clientError", (err: any, socket) => {
-      events.push(`clientError ${err.code}`);
-      socket.destroy();
-    });
-    await once(server.listen(0, "127.0.0.1"), "listening");
-    const { port } = server.address() as AddressInfo;
-
-    const { promise, resolve } = Promise.withResolvers<string>();
-    // Pipeline a second request: the spurious clientError kills the
-    // connection after the first response, so /b proves it survived.
-    const socket = connect(port, "127.0.0.1", () => {
-      socket.write(
-        `GET /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding:${te}\r\n\r\n` +
-          "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
-      );
-    });
-    let raw = "";
-    socket.on("data", chunk => (raw += chunk.toString()));
-    socket.on("error", () => {});
-    socket.on("close", () => resolve(raw));
-    const response = await promise;
-    expect(events).toEqual(["request /a", "request /b"]);
-    expect(response.match(/HTTP\/1\.1 200/g)).toHaveLength(2);
+])("%s Transfer-Encoding value is ignored like node, no clientError", async (name, te) => {
+  const events: string[] = [];
+  await using server = createServer((req, res) => {
+    events.push(`request ${req.url}`);
+    res.end("ok");
   });
-}
+  server.on("clientError", (err: any, socket) => {
+    events.push(`clientError ${err.code}`);
+    socket.destroy();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  // Pipeline a second request: the spurious clientError kills the
+  // connection after the first response, so /b proves it survived.
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(
+      `GET /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding:${te}\r\n\r\n` +
+        "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+    );
+  });
+  let raw = "";
+  socket.on("data", chunk => (raw += chunk.toString()));
+  socket.on("error", () => {});
+  socket.on("close", () => resolve(raw));
+  const response = await promise;
+  expect(events).toEqual(["request /a", "request /b"]);
+  expect(response.match(/HTTP\/1\.1 200/g)).toHaveLength(2);
+});
 
 test("empty Transfer-Encoding with Content-Length frames the body like node", async () => {
   const events: string[] = [];

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -174,8 +174,10 @@ test("empty Transfer-Encoding with Content-Length frames the body like node", as
 // Boundary of the leniency: node errors once any non-whitespace value byte
 // arrives, even one that names no coding.
 test("comma-only Transfer-Encoding value still fires clientError like node", async () => {
-  const { promise, resolve } = Promise.withResolvers<any>();
+  const { promise, resolve, reject } = Promise.withResolvers<any>();
+  const urls: string[] = [];
   await using server = createServer((req, res) => {
+    urls.push(req.url!);
     req.resume();
     res.end("ok");
   });
@@ -186,13 +188,22 @@ test("comma-only Transfer-Encoding value still fires clientError like node", asy
   await once(server.listen(0, "127.0.0.1"), "listening");
   const { port } = server.address() as AddressInfo;
 
+  // Pipeline a follow-up with Connection: close so that, if the comma value
+  // were wrongly treated as absent, /b is served and the socket closes,
+  // rejecting below instead of idling on keep-alive until the test times out.
   const socket = connect(port, "127.0.0.1", () => {
-    socket.write("GET / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: ,\r\n\r\n");
+    socket.write(
+      "GET /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: ,\r\n\r\n" +
+        "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+    );
   });
+  socket.resume();
   socket.on("error", () => {});
+  socket.on("close", () => reject(new Error(`socket closed without clientError, served: ${urls.join(",")}`)));
   const err = await promise;
   socket.destroy();
   expect(err.code).toBe("HPE_INVALID_TRANSFER_ENCODING");
+  expect(urls).toEqual(["/a"]);
 });
 
 // Value lengths landing parseTrailerFields' 8-byte field-value scan on the

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -98,6 +98,103 @@ test("should not duplicate transfer-encoding header in response when explicitly 
   expect(bodySection).toContain("Goodbye, World!");
 });
 
+// llhttp flags Transfer-Encoding as present only once a non-whitespace value
+// byte arrives, so node treats a TE field with an empty (or whitespace-only)
+// value as if the header were absent: no clientError, Content-Length framing
+// applies. oven-sh/bun#40124: Bun served the request AND fired a spurious
+// clientError, so a typical handler destroyed the live connection.
+for (const [name, te] of [
+  ["empty", ""],
+  ["whitespace-only", "   "],
+] as const) {
+  test(`${name} Transfer-Encoding value is ignored like node, no clientError`, async () => {
+    const events: string[] = [];
+    await using server = createServer((req, res) => {
+      events.push(`request ${req.url}`);
+      res.end("ok");
+    });
+    server.on("clientError", (err: any, socket) => {
+      events.push(`clientError ${err.code}`);
+      socket.destroy();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const { promise, resolve } = Promise.withResolvers<string>();
+    // Pipeline a second request: the spurious clientError kills the
+    // connection after the first response, so /b proves it survived.
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write(
+        `GET /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding:${te}\r\n\r\n` +
+          "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+      );
+    });
+    let raw = "";
+    socket.on("data", chunk => (raw += chunk.toString()));
+    socket.on("error", () => {});
+    socket.on("close", () => resolve(raw));
+    const response = await promise;
+    expect(events).toEqual(["request /a", "request /b"]);
+    expect(response.match(/HTTP\/1\.1 200/g)).toHaveLength(2);
+  });
+}
+
+test("empty Transfer-Encoding with Content-Length frames the body like node", async () => {
+  const events: string[] = [];
+  await using server = createServer((req, res) => {
+    let body = "";
+    req.on("data", d => (body += d));
+    req.on("end", () => {
+      events.push(`request ${req.url} body=${body}`);
+      res.end("ok");
+    });
+  });
+  server.on("clientError", (err: any, socket) => {
+    events.push(`clientError ${err.code}`);
+    socket.destroy();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(
+      "POST /p HTTP/1.1\r\nHost: x\r\nTransfer-Encoding:\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+    );
+  });
+  let raw = "";
+  socket.on("data", chunk => (raw += chunk.toString()));
+  socket.on("error", () => {});
+  socket.on("close", () => resolve(raw));
+  const response = await promise;
+  expect(events).toEqual(["request /p body=hello"]);
+  expect(response).toStartWith("HTTP/1.1 200");
+});
+
+// Boundary of the leniency: node errors once any non-whitespace value byte
+// arrives, even one that names no coding.
+test("comma-only Transfer-Encoding value still fires clientError like node", async () => {
+  const { promise, resolve } = Promise.withResolvers<any>();
+  await using server = createServer((req, res) => {
+    req.resume();
+    res.end("ok");
+  });
+  server.on("clientError", (err, socket) => {
+    socket.destroy();
+    resolve(err);
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write("GET / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: ,\r\n\r\n");
+  });
+  socket.on("error", () => {});
+  const err = await promise;
+  socket.destroy();
+  expect(err.code).toBe("HPE_INVALID_TRANSFER_ENCODING");
+});
+
 // Value lengths landing parseTrailerFields' 8-byte field-value scan on the
 // alignments where its last load reaches past the terminating CRLF CRLF: that
 // read leaves the heap allocation without the section's post-padding (ASAN).


### PR DESCRIPTION
### Problem
- A request with an empty `Transfer-Encoding` value makes a node:http server emit `request`, serve the response, and then also emit a spurious `clientError` with `HPE_INVALID_TRANSFER_ENCODING`. A typical `clientError` handler calls `socket.destroy()`, which kills the live connection mid-response. Node emits no error at all for this input. Fixes #40124.
- With a `Content-Length` next to the empty value, Bun rejected the request before `request`. Node serves it and frames the body with `Content-Length`.
- The cause: `getTransferEncoding()` (`packages/bun-uws/src/HttpParser.h:296`) marks the header present even when its value names no coding, and the node:http parser then routes that into the deferred invalid-TE path at `HttpParser.h:1281`.

### Fix
- For the node:http parser only: a `Transfer-Encoding` field whose values are all empty or whitespace-only is treated as if the header were absent. `Content-Length` framing applies and no error is raised.
- This matches llhttp, which flags `Transfer-Encoding` as present only once a non-whitespace value byte arrives. Verified against Node v26.3.0: empty and whitespace-only values are accepted, while any non-whitespace byte (even a lone comma) still errors. The comma case keeps Bun's existing dispatch-then-`clientError` path.
- Bun.serve is unchanged. It still rejects the empty value with 400 (the anti-smuggling stance, `test/js/bun/http/request-smuggling.test.ts`).
- Verified: `test/js/node/http/node-http-transfer-encoding.test.ts` (4 new tests, stock bun fails 3). Also `test/js/bun/http/request-smuggling.test.ts`, `test/js/node/http/node-http.test.ts`, and the `test-http-invalid-te` / reject-chunked-with-content-length parallel tests.

### Background
- Bun has two instantiations of the uWS HTTP parser, selected by the `IsNodeHttp` template flag: one for `Bun.serve` and one for the node:http compat server. The node one follows llhttp behavior.
- An empty `Transfer-Encoding` treated as absent falls back to `Content-Length` framing. That is a request-smuggling vector when a front proxy disagrees, which is why `Bun.serve` treats the header as present and rejects. llhttp (and so Node) accepts it, and node:http compat follows llhttp.
- The deferred invalid-TE path exists because llhttp reports a non-chunked TE without `Content-Length` only after the request head completes: Node dispatches `request` first and the error then surfaces through `clientError`. The empty value was wrongly lumped into that bucket.

<details><summary>Notes</summary>

Node v26.3.0 probe results (raw socket, `Transfer-Encoding:<value>`, with and without `Content-Length: 5`):

| value | no CL | with CL |
|---|---|---|
| `` (empty) | request, 200, no error | request, body `hello`, 200 |
| ` ` (spaces) | request, 200, no error | request, body `hello`, 200 |
| ` ,` | `HPE_INVALID_TRANSFER_ENCODING` | `HPE_INVALID_CONTENT_LENGTH` |
| ` bogus` | `HPE_INVALID_TRANSFER_ENCODING` | `HPE_INVALID_CONTENT_LENGTH` |

Bun before this change served the no-CL case and then fired `clientError`, and rejected the with-CL case before `request`.

The new struct bit `nonEmptyValue` is set per TE field when the value contains a byte other than space or tab. The `invalid` bit can only be set after a `chunked` token was named, so `invalid` implies `nonEmptyValue` and the reset cannot clear a detected smuggling error.

The reporter asked for a 400 before `request`. That contradicts Node for every invalid-TE shape (Node dispatches `request` first, the error follows on `clientError`), and for the empty value Node raises no error at all. node:http compat follows Node here.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [723.86ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [493.95ms]
131 |   let raw = "";
132 |   socket.on("data", chunk => (raw += chunk.toString()));
133 |   socket.on("error", () => {});
134 |   socket.on("close", () => resolve(raw));
135 |   const response = await promise;
136 |   expect(events).toEqual(["request /a", "request /b"]);
                       ^
error: expect(received).toEqual(expected)

  [
    "request /a",
-   "request /b",
+   "clientError HPE_INVALID_TRANSFER_ENCODING",
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-transfer-encoding.test.ts:136:18)
(fail) empty Transfer-Encoding value is ignored like node, no clientError [113.77ms]
131 |   let raw = "";
132 |   socket.on("data", chunk => (raw += chunk.toString()));
133 |
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (14f4ebc07)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [11.48ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [8.92ms]
(pass) empty Transfer-Encoding value is ignored like node, no clientError [3.66ms]
(pass) whitespace-only Transfer-Encoding value is ignored like node, no clientError [2.66ms]
(pass) empty Transfer-Encoding with Content-Length frames the body like node [3.91ms]
(pass) comma-only Transfer-Encoding value still fires clientError like node [3.02ms]
(pass) chunked request trailers parse at every field-value scan boundary [5.61ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [2.92ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [2.09ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [2.77ms]
(pass) insecureHTTPParser accepts a CTL byte in a trailer value like node [3.07ms]
(pass) Content-Length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [2.09ms]
(pass) content-length: 5 in trailer section fires clientError HP
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [725.28ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [484.03ms]
(pass) empty Transfer-Encoding value is ignored like node, no clientError [101.30ms]
(pass) whitespace-only Transfer-Encoding value is ignored like node, no clientError [72.13ms]
(pass) empty Transfer-Encoding with Content-Length frames the body like node [95.05ms]
(pass) comma-only Transfer-Encoding value still fires clientError like node [95.08ms]
(pass) chunked request trailers parse at every field-value scan boundary [227.06ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [100.24ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [65.25ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [80.43ms]
(pass) insecureHTTPParser accepts a CTL byte in a tra
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 658ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/12] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 13s
[8/12] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[9/12] link bun-profile
[11/12] strip bun
[11/12] bun-profile --revision
1.4.1-canary.1+b29f3ff46
[build] done
bun test v1.4.1-canary.1 (b29f3ff46)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [11.76ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [9.17ms]
(pass) empty Transfer-Encoding value is ignored like node, no clientError [3.79ms]
(pass) whitespace-only Transfer-Encoding value is ignored like node, no clientError [2.58ms]
(pass) empty Transfer-Encoding with Content-Length frames the b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h                  |  24 +++++
 .../node/http/node-http-transfer-encoding.test.ts  | 106 +++++++++++++++++++++
 2 files changed, 130 insertions(+)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-uws/src/HttpParser.h                          3      3      0
test/js/node/http/node-http-transfer-encoding.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->