### PR TITLE
worker: keep a TerminationException pending through microtask jobs, event listeners, and emit()

### DIFF
--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -247,7 +247,7 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
 
         if (!jsFunction) [[unlikely]]
             continue;
-        if (WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[unlikely]]
+        if (WebCore::clientData(vm)->isStoppingOrStopped(vm) || vm.hasPendingTerminationException()) [[unlikely]]
             break;
 
         JSC::JSGlobalObject* lexicalGlobalObject = jsFunction->globalObject();
@@ -256,9 +256,18 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
             continue;
 
         fired = true;
-        WTF::NakedPtr<JSC::Exception> exceptionPtr;
-        call(lexicalGlobalObject, jsFunction, callData, thisValue, arguments, exceptionPtr);
-        auto* exception = exceptionPtr.get();
+        JSC::Exception* exception = nullptr;
+        {
+            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            call(lexicalGlobalObject, jsFunction, callData, thisValue, arguments);
+            exception = scope.exception();
+            // A TerminationException stays pending: emit() unwinds on it, and no further listener
+            // is entered. The NakedPtr overload of call() would have cleared it unconditionally,
+            // and Bun__reportUnhandledError never reports a termination, so it was lost and the
+            // script that called emit() kept running after terminate().
+            if (exception && !scope.clearExceptionExceptTermination()) [[unlikely]]
+                return fired;
+        }
 
         if (exception) [[unlikely]] {
             auto errorIdentifier = vm.propertyNames->error;

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -261,10 +261,7 @@ bool EventEmitter::innerInvokeEventListeners(const Identifier& eventType, Simple
             auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
             call(lexicalGlobalObject, jsFunction, callData, thisValue, arguments);
             exception = scope.exception();
-            // A TerminationException stays pending: emit() unwinds on it, and no further listener
-            // is entered. The NakedPtr overload of call() would have cleared it unconditionally,
-            // and Bun__reportUnhandledError never reports a termination, so it was lost and the
-            // script that called emit() kept running after terminate().
+            // A TerminationException is not this listener's error: it stays pending and emit() unwinds on it.
             if (exception && !scope.clearExceptionExceptTermination()) [[unlikely]]
                 return fired;
         }

--- a/src/jsc/bindings/webcore/JSEventListener.cpp
+++ b/src/jsc/bindings/webcore/JSEventListener.cpp
@@ -225,8 +225,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
     // InspectorInstrumentation::didCallFunction(&scriptExecutionContext);
 
     if (scope.exception()) [[unlikely]] {
-        // A TerminationException is not this listener's error: tryClearException() keeps it pending and
-        // reportException() ignores it, so the dispatch unwinds on it.
+        // A TerminationException is not this listener's error: it stays pending and the dispatch unwinds on it.
         auto* exception = scope.exception();
         (void)scope.tryClearException();
         event.target()->uncaughtExceptionInEventHandler();

--- a/src/jsc/bindings/webcore/JSEventListener.cpp
+++ b/src/jsc/bindings/webcore/JSEventListener.cpp
@@ -156,8 +156,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
 
     VM& vm = scriptExecutionContext.vm();
     JSLockHolder lock(vm);
-    // An earlier listener of this dispatch met a termination (a node:vm timeout keeps the VM's gate
-    // open): it is unwinding, and nothing enters script on top of it.
+    // A termination is unwinding (a node:vm timeout keeps the VM's gate open): enter no script on top of it.
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return;
 
@@ -226,10 +225,8 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
     // InspectorInstrumentation::didCallFunction(&scriptExecutionContext);
 
     if (scope.exception()) [[unlikely]] {
-        // A TerminationException is not this listener's uncaught error: tryClearException() leaves it
-        // pending and reportException() ignores it, so the frames above this dispatch unwind on it.
-        // The NakedPtr overload of profiledCall() would have cleared it unconditionally, and a
-        // microtask-only loop that dispatches events would keep running after terminate().
+        // A TerminationException is not this listener's error: tryClearException() keeps it pending and
+        // reportException() ignores it, so the dispatch unwinds on it.
         auto* exception = scope.exception();
         (void)scope.tryClearException();
         event.target()->uncaughtExceptionInEventHandler();

--- a/src/jsc/bindings/webcore/JSEventListener.cpp
+++ b/src/jsc/bindings/webcore/JSEventListener.cpp
@@ -155,6 +155,11 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         return;
 
     VM& vm = scriptExecutionContext.vm();
+    // An earlier listener of this dispatch met a termination (a node:vm timeout keeps the VM's gate
+    // open): it is unwinding, and nothing enters script on top of it.
+    if (vm.hasPendingTerminationException()) [[unlikely]]
+        return;
+
     JSLockHolder lock(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
@@ -216,22 +221,21 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
             return jsNull();
         return toJS(lexicalGlobalObject, globalObject, *currentTarget);
     }();
-    NakedPtr<JSC::Exception> uncaughtException;
-    JSValue retval = JSC::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Other, handleEventFunction, callData, thisValue, args, uncaughtException);
+    JSValue retval = JSC::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Other, handleEventFunction, callData, thisValue, args);
 
     // InspectorInstrumentation::didCallFunction(&scriptExecutionContext);
 
-    auto handleExceptionIfNeeded = [&](JSC::Exception* exception) -> bool {
-        if (exception) {
-            event.target()->uncaughtExceptionInEventHandler();
-            reportException(lexicalGlobalObject, exception);
-            return true;
-        }
-        return false;
-    };
-
-    if (handleExceptionIfNeeded(uncaughtException))
+    if (scope.exception()) [[unlikely]] {
+        // A TerminationException is not this listener's uncaught error: tryClearException() leaves it
+        // pending and reportException() ignores it, so the frames above this dispatch unwind on it.
+        // The NakedPtr overload of profiledCall() would have cleared it unconditionally, and a
+        // microtask-only loop that dispatches events would keep running after terminate().
+        auto* exception = scope.exception();
+        (void)scope.tryClearException();
+        event.target()->uncaughtExceptionInEventHandler();
+        reportException(lexicalGlobalObject, exception);
         return;
+    }
 
     // Node handles promises in the return value and throws an uncaught exception on nextTick if it rejects.
     // See event_target.js function addCatch in node

--- a/src/jsc/bindings/webcore/JSEventListener.cpp
+++ b/src/jsc/bindings/webcore/JSEventListener.cpp
@@ -155,12 +155,12 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         return;
 
     VM& vm = scriptExecutionContext.vm();
+    JSLockHolder lock(vm);
     // An earlier listener of this dispatch met a termination (a node:vm timeout keeps the VM's gate
     // open): it is unwinding, and nothing enters script on top of it.
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return;
 
-    JSLockHolder lock(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     // See https://dom.spec.whatwg.org/#dispatching-events spec on calling handleEvent.

--- a/test/js/web/workers/worker-terminate-funnels-fixture.ts
+++ b/test/js/web/workers/worker-terminate-funnels-fixture.ts
@@ -618,7 +618,10 @@ const FAMILIES: Record<string, Entry[]> = {
     {
       name: "EventTarget dispatch",
       phases: ["inside", "after"],
-      worker: `const et = new EventTarget(); et.addEventListener("x", () => hit(() => et.dispatchEvent(new Event("x")))); setImmediate(() => et.dispatchEvent(new Event("x")));`,
+      // The re-arm is a later dispatch, like the other entries' follow-on completions. A synchronous
+      // re-dispatch from inside the listener recursed until the stack overflowed; that uncaught
+      // RangeError stops the worker, so it never reached the "after" point.
+      worker: `const et = new EventTarget(); et.addEventListener("x", () => hit(() => setImmediate(() => et.dispatchEvent(new Event("x"))))); setImmediate(() => et.dispatchEvent(new Event("x")));`,
     },
     {
       name: "process.on('exit') handlers",

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1172,18 +1172,21 @@ test(
                 loop + " await 0; } })();" +
                 "}, 0);";
               const w = new Worker(src, { eval: true });
-              const exited = new Promise(r => w.once("exit", r));
+              const exited = new Promise(r => w.once("exit", c => r("exit code " + c)));
+              const errored = new Promise(r => w.once("error", e => r("error " + (e && e.message))));
               const hang = Bun.sleep(${deadline}).then(() => "HANG");
-              let code;
-              if (exit !== undefined) {
-                code = await Promise.race([exited, hang]);
-              } else {
-                await new Promise(r => w.once("message", r));
-                code = await Promise.race([w.terminate(), hang]);
-              }
-              if (code === "HANG" || (exit !== undefined && code !== exit)) {
-                console.log((code === "HANG" ? "HANG " : "exit code " + code + " ") + name + " round " + i);
+              const fail = why => {
+                console.log(why + " " + name + " round " + i);
                 process.exit(2);
+              };
+              if (exit !== undefined) {
+                const got = await Promise.race([exited, errored, hang]);
+                if (got !== "exit code " + exit) fail(got);
+              } else {
+                const got = await Promise.race([new Promise(r => w.once("message", r)), exited, errored, hang]);
+                if (got !== "go") fail(got + " before 'go'");
+                const code = await Promise.race([w.terminate(), hang]);
+                if (code === "HANG") fail("HANG");
               }
             }
           }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1108,6 +1108,90 @@ test(
   timeout,
 );
 
+// A worker in a microtask-only loop could not be terminated when the terminate() trap was serviced inside
+// native code that caught the TerminationException and dropped it, so the checkpoint never stopped, the
+// worker never returned to its event loop, and `await worker.terminate()` never settled:
+// - the BunPerformMicrotaskJob handler in JSC (the job for `queueMicrotask()` and for the C++ web
+//   streams' start/pull reactions) cleared it with a plain clearException() (oven-sh/WebKit#491);
+// - JSEventListener::handleEvent and EventEmitter::innerInvokeEventListeners took it through the
+//   NakedPtr<Exception> overload of JSC::call(), which clears unconditionally, and then reported it to
+//   a reporter that ignores terminations.
+//
+// Every shape except the stream ones is deterministic: the listener or callback posts 'go' and spins,
+// so terminate() lands inside it while the `await 0` continuation is already queued behind it. Two
+// things would hide the bug, so the shapes avoid them: module linking during startup re-arms a dropped
+// termination (a DeferTermination scope fires the trap again), so the loop starts from a timer; and a
+// drain started after a timer callback is refused at its entry once the VM is stopping, so the listener
+// shapes spin from their second call, inside the checkpoint the `await 0` continuation runs in. The
+// stream shapes are the reported ones; there the trap only sometimes lands inside the start reaction.
+test(
+  "terminate() while a microtask-only loop keeps entering native-dispatched callbacks",
+  async () => {
+    const rounds = 2;
+    const deadline = slow ? 30_000 : 10_000;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const spin = "parentPort.postMessage('go'); for (;;) {}";
+        const spinOnSecondCall = "let n = 0; const L = () => { if (n++) { " + spin + " } };";
+        const shapes = {
+          queueMicrotask: { loop: "queueMicrotask(() => { " + spin + " });" },
+          read: { loop: "new Response('abc').body.getReader().read();", settle: true },
+          tee: { loop: "new Response('abc').body.tee();", settle: true },
+          eventTarget: {
+            setup: spinOnSecondCall + "const et = new EventTarget(); et.addEventListener('x', L);",
+            loop: "et.dispatchEvent(new Event('x'));",
+          },
+          abortSignal: {
+            setup: spinOnSecondCall,
+            loop: "{ const ac = new AbortController(); ac.signal.addEventListener('abort', L); ac.abort(); }",
+          },
+          processEmit: { setup: spinOnSecondCall + "process.on('evt', L);", loop: "process.emit('evt');" },
+        };
+        (async () => {
+          for (const [name, { setup, loop, settle }] of Object.entries(shapes)) {
+            for (let i = 0; i < ${rounds}; i++) {
+              const src =
+                "const { parentPort } = require('worker_threads');" +
+                (setup ?? "") +
+                "setTimeout(() => {" +
+                (settle ? "parentPort.postMessage('go');" : "") +
+                "(async () => { for (;;) { " + loop + " await 0; } })();" +
+                "}, 0);";
+              const w = new Worker(src, { eval: true });
+              await new Promise(r => w.once("message", r));
+              if (settle) await Bun.sleep(10);
+              const code = await Promise.race([
+                w.terminate(),
+                Bun.sleep(${deadline}).then(() => "HANG"),
+              ]);
+              if (code === "HANG") {
+                console.log("HANG " + name + " round " + i);
+                process.exit(2);
+              }
+            }
+          }
+          console.log("PASS");
+          process.exit(0);
+        })();
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
 // A worker terminated while async-iterable bodies are being driven (a `Bun.serve` handler returning
 // `new Response(asyncGenerator())`, a `fetch()` with an async-iterable request body): the pump met the
 // termination as the abrupt completion of `iterator.next()` and went on to notify the iterator —

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1108,11 +1108,12 @@ test(
   timeout,
 );
 
-// A worker in a microtask-only loop could not be terminated when the terminate() trap was serviced inside
-// native code that caught the TerminationException and dropped it, so the checkpoint never stopped, the
-// worker never returned to its event loop, and `await worker.terminate()` never settled:
+// A worker in a microtask-only loop could not be stopped (terminate(), or its own process.exit()) when
+// the termination trap was serviced inside native code that caught the TerminationException and dropped
+// it, so the checkpoint never stopped, the worker never returned to its event loop, and the worker never
+// exited:
 // - the BunPerformMicrotaskJob handler in JSC (the job for `queueMicrotask()` and for the C++ web
-//   streams' start/pull reactions) cleared it with a plain clearException() (oven-sh/WebKit#491);
+//   streams' start/pull/write reactions) cleared it with a plain clearException() (oven-sh/WebKit#491);
 // - JSEventListener::handleEvent and EventEmitter::innerInvokeEventListeners took it through the
 //   NakedPtr<Exception> overload of JSC::call(), which clears unconditionally, and then reported it to
 //   a reporter that ignores terminations.
@@ -1123,12 +1124,13 @@ test(
 // termination (a DeferTermination scope fires the trap again), so the loop starts from a timer; and a
 // drain started after a timer callback is refused at its entry once the VM is stopping, so the listener
 // shapes spin from their second call, inside the checkpoint the `await 0` continuation runs in. The
-// stream shapes are the reported ones; there the trap only sometimes lands inside the start reaction.
+// stream shapes are the reported ones; they post 'go' once the loop has run for a while, and there the
+// trap only sometimes lands inside the start reaction.
 test(
-  "terminate() while a microtask-only loop keeps entering native-dispatched callbacks",
+  "terminate() or process.exit() while a microtask-only loop keeps entering native-dispatched callbacks",
   async () => {
-    const rounds = 2;
-    const deadline = slow ? 30_000 : 10_000;
+    const roundsPerShape = 2;
+    const deadline = slow ? 20_000 : 6_000;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -1139,8 +1141,8 @@ test(
         const spinOnSecondCall = "let n = 0; const L = () => { if (n++) { " + spin + " } };";
         const shapes = {
           queueMicrotask: { loop: "queueMicrotask(() => { " + spin + " });" },
-          read: { loop: "new Response('abc').body.getReader().read();", settle: true },
-          tee: { loop: "new Response('abc').body.tee();", settle: true },
+          read: { loop: "new Response('abc').body.getReader().read();", progress: true },
+          tee: { loop: "new Response('abc').body.tee();", progress: true },
           eventTarget: {
             setup: spinOnSecondCall + "const et = new EventTarget(); et.addEventListener('x', L);",
             loop: "et.dispatchEvent(new Event('x'));",
@@ -1150,26 +1152,37 @@ test(
             loop: "{ const ac = new AbortController(); ac.signal.addEventListener('abort', L); ac.abort(); }",
           },
           processEmit: { setup: spinOnSecondCall + "process.on('evt', L);", loop: "process.emit('evt');" },
+          // process.exit() inside the job: the worker exits on its own with that code, and runs nothing after.
+          exitInQueueMicrotask: { loop: "queueMicrotask(() => { process.exit(42); });", exit: 42 },
+          exitInWritableStreamWrite: {
+            loop: "new WritableStream({ write() { process.exit(42); } }).getWriter().write('x');",
+            exit: 42,
+          },
         };
         (async () => {
-          for (const [name, { setup, loop, settle }] of Object.entries(shapes)) {
-            for (let i = 0; i < ${rounds}; i++) {
+          for (const [name, { setup, loop, progress, exit }] of Object.entries(shapes)) {
+            for (let i = 0; i < ${roundsPerShape}; i++) {
               const src =
                 "const { parentPort } = require('worker_threads');" +
                 (setup ?? "") +
+                (progress ? "let k = 0;" : "") +
                 "setTimeout(() => {" +
-                (settle ? "parentPort.postMessage('go');" : "") +
-                "(async () => { for (;;) { " + loop + " await 0; } })();" +
+                "(async () => { for (;;) { " +
+                (progress ? "if (k++ === 50) parentPort.postMessage('go');" : "") +
+                loop + " await 0; } })();" +
                 "}, 0);";
               const w = new Worker(src, { eval: true });
-              await new Promise(r => w.once("message", r));
-              if (settle) await Bun.sleep(10);
-              const code = await Promise.race([
-                w.terminate(),
-                Bun.sleep(${deadline}).then(() => "HANG"),
-              ]);
-              if (code === "HANG") {
-                console.log("HANG " + name + " round " + i);
+              const exited = new Promise(r => w.once("exit", r));
+              const hang = Bun.sleep(${deadline}).then(() => "HANG");
+              let code;
+              if (exit !== undefined) {
+                code = await Promise.race([exited, hang]);
+              } else {
+                await new Promise(r => w.once("message", r));
+                code = await Promise.race([w.terminate(), hang]);
+              }
+              if (code === "HANG" || (exit !== undefined && code !== exit)) {
+                console.log((code === "HANG" ? "HANG " : "exit code " + code + " ") + name + " round " + i);
                 process.exit(2);
               }
             }


### PR DESCRIPTION
### Problem
- `await worker.terminate()` never settles when the worker runs a microtask-only loop (`for (;;) { ...; await 0; }`) and the termination trap is serviced inside native code that catches the `TerminationException` and drops it. Repro shapes: `new Response('abc').body.getReader().read()`, `queueMicrotask(cb)`, `et.dispatchEvent(e)` with a busy listener, `process.emit('x')` with a busy listener, `ac.abort()`. Bun 1.3.14 terminates each in about 30 ms. Bun 1.4.0 hangs, the worker thread at 100% CPU inside the microtask checkpoint. `process.exit()` inside such a callback (a `queueMicrotask` callback, a `WritableStream` sink `write()`, an event listener) runs the `'exit'` listeners and then keeps running the other queued microtasks, so the worker never exits.
- Three catch sites drop it. The `BunPerformMicrotaskJob` arm of `runInternalMicrotask` (`JSMicrotask.cpp`) used a plain `clearException()`. `JSEventListener::handleEvent` and `EventEmitter::innerInvokeEventListeners` called `JSC::call` through its `NakedPtr<Exception>` overload, which clears unconditionally (`CallData.cpp:80`), then handed the exception to `reportException` / `Bun__reportUnhandledError`, which both ignore a termination. `VMTraps::handleTraps` clears the trap bit when it throws, so nothing delivers it again.

### Fix
- oven-sh/WebKit#491 (merged): the `BunPerformMicrotaskJob` arm uses `clearExceptionExceptTermination()` and returns with the termination pending, like the `PromiseReactionJob` arm. Main already carries it: the pin in #35343 (`aea1f010`) includes that commit, so this PR no longer touches `scripts/build/deps/webkit.ts`.
- `JSEventListener::handleEvent` and `EventEmitter::innerInvokeEventListeners` call the plain overload under their `TopExceptionScope` and use `tryClearException()` / `clearExceptionExceptTermination()`, the pattern `NodeTimerObject.cpp` already uses. A termination stays pending, so `dispatchEvent()` and `emit()` unwind to the checkpoint, which stops. A termination that is already pending refuses the next listener (a node:vm timeout keeps the VM's gate open).
- Correct because a termination is not the listener's uncaught error. It is the VM's stop, and the only frame allowed to take it is the drain boundary (`GlobalObject::drainMicrotasks` → `takeTerminationOutsideScript`). Every other JSC job kind and every other Bun catch site already leaves it pending.
- Verified: `test/js/web/workers/worker-terminate-lifetime.test.ts` (one new test, eight shapes: six `terminate()` shapes and two `process.exit()` shapes). Stock 1.4.0 (WebKit without #491): `HANG queueMicrotask round 0`. Main (WebKit with #491, without the C++ change): `HANG eventTarget round 0`. Full change: passes, 3/3 runs. Also ran the rest of that file, `worker-terminate-funnels.test.ts`, `test/js/node/worker_threads/`, `test/js/node/events/`, `test/js/web/abort/`, `test/js/web/workers/worker.test.ts`.
- `worker-terminate-funnels-fixture.ts`: the "EventTarget dispatch [after]" case re-dispatched synchronously from inside its listener, so it recursed until the stack overflowed. It passed only because the worker kept running after that uncaught RangeError (the dropped termination). The re-arm is now a later dispatch, like the other entries.

### Background
- A `TerminationException` is the exception JSC throws to unwind script after another thread calls `VM::notifyNeedTermination()`, which is what `worker.terminate()` does (and `process.exit()` in a worker). `VMTraps::handleTraps` services the trap once, at the next trap check (a `RETURN_IF_EXCEPTION` in native code, or a `check_traps` at a JS loop back-edge), and clears the trap bit.
- `MicrotaskQueue::runMicrotask` checks `clearExceptionExceptTermination()` after every job. A pending termination stops the checkpoint. A dropped one lets the `await 0` continuation run, and the loop never reaches the event loop, where Bun's gate (`isStoppingOrStopped`) would refuse the next drain.
- `JSC::call(..., NakedPtr<Exception>&)` is JSC's "give me the exception" overload. It clears whatever was thrown, termination included. WebCore pairs it with `forbidExecution()` on the worker. Bun's equivalent gate closes before the trap fires, and its catch sites keep the exception pending instead.
- #36806 proposes to re-throw the termination from `Bun__reportUnhandledError`. It covers the emit() site but not `reportException`, and it changes that callback's post-condition for every caller. The two changes are independent.

<details><summary>Notes</summary>

Mechanism, verified with gdb on the debug-ASAN build (breakpoint on `VM::throwTerminationException`, watchpoint on `VM::m_exception`, breakpoint on `VMTraps::fireTrap`):

- Stream shape, hung run: `throwTerminationException` fires inside a `RETURN_IF_EXCEPTION` of the stream start reaction (`JSBoundFunction::create` / `nativeGetInternalBuffer`), beneath `jsWebStreamsHandler_onRSDefaultControllerStartFulfilled` <- `callMicrotask` <- `runInternalMicrotask`. The next write to `m_exception` is `0x0` from `TopExceptionScope::clearException` <- `runInternalMicrotask` (the `BunPerformMicrotaskJob` arm). No further writes. Worker stack at the hang: `BlobInternalReadableStreamSourcePrototype__startCallback` <- `materializeNativeSource` <- `getReader` <- async function body <- `MicrotaskQueue::drainImpl` <- `VM::drainMicrotasks` <- `jsFunctionDrainMicrotaskQueue` <- `JSNextTickQueue::drain` <- `GlobalObject::drainMicrotasks` <- `EventLoop::tick`.
- Stream shape, terminating run: the throw lands in `ZigGlobalObject__createNativeReadableStream` (the `Response.body` getter, not inside a job). The only later write is from `Bun__GlobalObject__clearExceptionsForExit` during shutdown.
- EventTarget shape (WebKit with #491, C++ unfixed): the throw lands in the listener via `operationHandleTraps`; cleared by `TopExceptionScope::clearException` <- `JSC::call` <- `JSC::profiledCall` <- `JSEventListener::handleEvent`.

Two rescues make naive repro shapes pass on the unfixed build, which is why the test is shaped the way it is. (1) Any `DeferTermination` scope re-arms a dropped termination: `undoDeferTerminationSlow(DeferForAWhile)` calls `fireTrap(NeedTermination)` because `m_hasTerminationRequest` stays true. Module linking during worker startup hits one (`moduleNamespaceObjectStructure()` lazy init), and the re-fired trap then lands outside the listener. The loop therefore starts from a timer. (2) A drain that starts after a timer callback is refused at `GlobalObject::drainMicrotasks` (`isStoppingOrStopped`), so a drop during a synchronous first dispatch ends the loop anyway. The listener shapes spin from their second call, which runs from the `await 0` continuation inside an ongoing checkpoint.

Hang rates on stock 1.4.0, terminate 10 ms after the worker's first message, 4 runs each: `Response.body.getReader().read()` 4/4, `Response.body.tee()` 4/4, `Blob.stream().getReader()` 2/4, `await 0` alone 0/4, `Promise.resolve().then()` 0/8, JS-source `ReadableStream({start})` 0/8, `ReadableStream({pull})` 2/8. The deterministic shapes in the test hang 100% on stock 1.4.0 with and without JIT and on debug-ASAN.

Other `NakedPtr<Exception>` catch sites that report and continue exist (`JSCallbackData::invokeCallback`, used by `JSAbortAlgorithm` and `JSPerformanceObserverCallback`). Not changed here: their callers are native dispatch, not a JS loop, and need their own verification.

`Bun.sleep(10)` before `terminate()` in the stream shapes is the offset from the report, not a wait for a condition.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->
