### PR TITLE
worker_threads: stop the worker when process.exit() is called from an 'exit' listener

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -601,8 +601,7 @@ impl ExitHandler {
     /// reference instead; the body re-enters JS so no `&mut` is held.
     pub(crate) fn dispatch_on_exit(vm: &VirtualMachine) {
         let exit_code = vm.exit_handler.exit_code;
-        // `process.on('exit')` handlers are user script (see `on_exit`); a worker's
-        // process.exit() inside one throws a termination that lands here.
+        // `process.on('exit')` handlers are user script (see `on_exit`).
         if vm.script_allowed() && !vm.exit_handler.skip_exit_listeners {
             let global = vm.global();
             let _ = jsc::from_js_host_call_generic(global, || {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -604,9 +604,11 @@ impl ExitHandler {
         // `process.on('exit')` handlers are user script (see `on_exit`).
         if vm.script_allowed() && !vm.exit_handler.skip_exit_listeners {
             let global = vm.global();
-            let _ = jsc::from_js_host_call_generic(global, || {
+            if let Err(err) = jsc::from_js_host_call_generic(global, || {
                 Process__dispatchOnExit(global, exit_code)
-            });
+            }) {
+                let _ = crate::task::report_error_or_terminate(global, err);
+            }
         }
         if vm.worker.is_none() {
             Bun__WebView__closeAllForTermination();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -601,9 +601,8 @@ impl ExitHandler {
     /// reference instead; the body re-enters JS so no `&mut` is held.
     pub(crate) fn dispatch_on_exit(vm: &VirtualMachine) {
         let exit_code = vm.exit_handler.exit_code;
-        // `process.on('exit')` handlers are user script (see `on_exit`). In a worker,
-        // a process.exit() inside one throws the VM's termination to unwind the
-        // handler; outside script, this frame is where it lands.
+        // `process.on('exit')` handlers are user script (see `on_exit`); a worker's
+        // process.exit() inside one throws a termination that lands here.
         if vm.script_allowed() && !vm.exit_handler.skip_exit_listeners {
             let global = vm.global();
             let _ = jsc::from_js_host_call_generic(global, || {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -601,9 +601,14 @@ impl ExitHandler {
     /// reference instead; the body re-enters JS so no `&mut` is held.
     pub(crate) fn dispatch_on_exit(vm: &VirtualMachine) {
         let exit_code = vm.exit_handler.exit_code;
-        // `process.on('exit')` handlers are user script (see `on_exit`).
+        // `process.on('exit')` handlers are user script (see `on_exit`). In a worker,
+        // a process.exit() inside one throws the VM's termination to unwind the
+        // handler; outside script, this frame is where it lands.
         if vm.script_allowed() && !vm.exit_handler.skip_exit_listeners {
-            Process__dispatchOnExit(vm.global(), exit_code);
+            let global = vm.global();
+            let _ = jsc::from_js_host_call_generic(global, || {
+                Process__dispatchOnExit(global, exit_code)
+            });
         }
         if vm.worker.is_none() {
             Bun__WebView__closeAllForTermination();

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3674,10 +3674,8 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);
     // Main-thread Bun__Process__exit is noreturn. In a worker it returns with the
-    // thread's termination requested, also when re-entered from a process.on('exit')
-    // handler. The caller's next exception check (process.exit()'s own, right after
-    // this call) throws the TerminationException, and the script unwinds up to the
-    // native frame that entered it. Node: reallyExit, then the stack guard check.
+    // thread's termination requested (also from inside a process.on('exit') handler);
+    // the caller's next exception check throws it, like Node's stack guard check.
     throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3674,8 +3674,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);
     // Main-thread Bun__Process__exit is noreturn. In a worker it returns with the
-    // thread's termination requested (also from inside a process.on('exit') handler);
-    // the caller's next exception check throws it, like Node's stack guard check.
+    // thread's termination requested; the caller's next exception check throws it.
     throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3673,9 +3673,11 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     // while native shutdown (profiles, cleanup hooks, SQLite close) still runs.
     zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);
-    // Main-thread Bun__Process__exit is noreturn. In a worker it returns; the
-    // WebWorker exit path it called requests JSC termination (guarded so it's a
-    // no-op when re-entered from a process.on('exit') handler).
+    // Main-thread Bun__Process__exit is noreturn. In a worker it returns with the
+    // thread's termination requested, also when re-entered from a process.on('exit')
+    // handler: the caller's next exception check (process.exit()'s, after this call)
+    // throws the TerminationException and the script unwinds there, as Node's
+    // reallyExit + stack guard check does.
     throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3675,9 +3675,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     Bun__Process__exit(zigGlobal, exitCode);
     // Main-thread Bun__Process__exit is noreturn. In a worker it returns with the
     // thread's termination requested, also when re-entered from a process.on('exit')
-    // handler: the caller's next exception check (process.exit()'s, after this call)
-    // throws the TerminationException and the script unwinds there, as Node's
-    // reallyExit + stack guard check does.
+    // handler. The caller's next exception check (process.exit()'s own, right after
+    // this call) throws the TerminationException, and the script unwinds up to the
+    // native frame that entered it. Node: reallyExit, then the stack guard check.
     throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1111,13 +1111,11 @@ impl WebWorker {
     /// other threads may concurrently hold `&WebWorker` on another
     /// thread; producing `&mut` here would be aliased-&mut UB.
     ///
-    /// `vm` is the caller's: `self.vm` is already null while the 'exit' handlers
-    /// run from `shutdown()`, and a process.exit() made there stops the script too.
+    /// `vm` is the caller's: `self.vm` is already null while `shutdown()` runs the 'exit' handlers.
     pub fn exit(&self, vm: &VirtualMachine) {
         self.exit_called.store(true, Ordering::Relaxed);
         let _ = self.set_requested_terminate();
-        // Stop subsequent JS at the next safepoint (process.exit()'s own exception
-        // check, right after `reallyExit` returns). From an immediate this runs
+        // Stop subsequent JS at the next safepoint. From an immediate this runs
         // before the turn's poll; the wake is what ends it.
         vm.handle_ref().request_termination();
     }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1111,18 +1111,14 @@ impl WebWorker {
     /// other threads may concurrently hold `&WebWorker` on another
     /// thread; producing `&mut` here would be aliased-&mut UB.
     ///
-    /// `vm` is the caller's, not `self.vm`: that is already null while the
-    /// 'exit' handlers run from `shutdown()`, and a process.exit() made there
-    /// must stop the script like any other (Node's `reallyExit` never returns
-    /// to the handler, and the later 'exit' handlers do not run).
+    /// `vm` is the caller's: `self.vm` is already null while the 'exit' handlers
+    /// run from `shutdown()`, and a process.exit() made there stops the script too.
     pub fn exit(&self, vm: &VirtualMachine) {
         self.exit_called.store(true, Ordering::Relaxed);
         let _ = self.set_requested_terminate();
-        // Stop subsequent JS at the next safepoint. For process.exit() that is its
-        // own exception check right after `reallyExit` returns: the calling script
-        // unwinds up to the native frame that entered it (from an 'exit' handler,
-        // the dispatch in `on_exit()`). From an immediate this runs before the
-        // turn's poll; the wake is what ends it.
+        // Stop subsequent JS at the next safepoint (process.exit()'s own exception
+        // check, right after `reallyExit` returns). From an immediate this runs
+        // before the turn's poll; the wake is what ends it.
         vm.handle_ref().request_termination();
     }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1118,10 +1118,11 @@ impl WebWorker {
     pub fn exit(&self, vm: &VirtualMachine) {
         self.exit_called.store(true, Ordering::Relaxed);
         let _ = self.set_requested_terminate();
-        // Stop subsequent JS at the next safepoint: process.exit()'s own exception
-        // check right after `reallyExit` returns, so the calling script unwinds
-        // there. From an immediate this runs before the turn's poll; the wake is
-        // what ends it.
+        // Stop subsequent JS at the next safepoint. For process.exit() that is its
+        // own exception check right after `reallyExit` returns: the calling script
+        // unwinds up to the native frame that entered it (from an 'exit' handler,
+        // the dispatch in `on_exit()`). From an immediate this runs before the
+        // turn's poll; the wake is what ends it.
         vm.handle_ref().request_termination();
     }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1110,18 +1110,19 @@ impl WebWorker {
     /// Takes `&self` (not `&mut self`) because `request_termination` /
     /// other threads may concurrently hold `&WebWorker` on another
     /// thread; producing `&mut` here would be aliased-&mut UB.
-    pub fn exit(&self) {
+    ///
+    /// `vm` is the caller's, not `self.vm`: that is already null while the
+    /// 'exit' handlers run from `shutdown()`, and a process.exit() made there
+    /// must stop the script like any other (Node's `reallyExit` never returns
+    /// to the handler, and the later 'exit' handlers do not run).
+    pub fn exit(&self, vm: &VirtualMachine) {
         self.exit_called.store(true, Ordering::Relaxed);
         let _ = self.set_requested_terminate();
-        // Stop subsequent JS at the next safepoint. `this.vm` is null during
-        // `vm.onExit()` (shutdown nulls it first), so a re-entrant
-        // process.exit() from an exit handler does not re-arm the trap.
-        let vm_ptr = self.vm_ptr();
-        if !vm_ptr.is_null() {
-            // From an immediate this runs before the turn's poll; the wake is what ends it.
-            // SAFETY: this thread's live VM.
-            unsafe { (*vm_ptr).handle_ref().request_termination() };
-        }
+        // Stop subsequent JS at the next safepoint: process.exit()'s own exception
+        // check right after `reallyExit` returns, so the calling script unwinds
+        // there. From an immediate this runs before the turn's poll; the wake is
+        // what ends it.
+        vm.handle_ref().request_termination();
     }
 
     // =========================================================================

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -68,9 +68,7 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
     let vm = global_object.bun_vm().as_mut();
     vm.exit_handler.exit_code = code;
     if let Some(worker) = vm.worker_ref() {
-        // @190n: we may need to use requestTerminate or throwTerminationException
-        // instead to terminate the worker sooner
-        worker.exit();
+        worker.exit(vm);
     } else {
         // A watch-reload kill-signal handler may call process.exit; node restarts the child
         // regardless. `process.exit()` must never return control to JS, so replace the process

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2352,6 +2352,39 @@ describe("a worker that stops itself from an immediate exits right away", () => 
   });
 });
 
+// Node: process.exit() inside an 'exit' listener stops the worker there, however
+// the listeners were reached. The rest of that listener and the later 'exit'
+// listeners do not run, and the code it passed is the worker's exit code.
+describe("process.exit() inside an 'exit' listener does not return", () => {
+  test.concurrent.each([
+    ["the event loop draining", "process.exitCode = 3;"],
+    ["process.exit()", "process.exit(3);"],
+  ])("'exit' reached by %s", async (_label, reach) => {
+    const workerSrc = `const { writeSync } = require("node:fs");
+      process.on("exit", code => {
+        writeSync(2, "first " + code + "\\n");
+        process.exit(7);
+        writeSync(2, "after process.exit\\n");
+      });
+      process.on("exit", code => writeSync(2, "second " + code + "\\n"));
+      ${reach}`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true });
+         w.on("exit", code => console.log("exit " + code));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "exit 7\n", stderr: "first 3\n", exitCode: 0 });
+  });
+});
+
 // Node's setupPortReferencing: the parent side of parentPort keeps the parent
 // alive while the Worker has 'message' listeners, independently of unref().
 test("an unref'ed worker with a 'message' listener still delivers to the parent", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2353,12 +2353,13 @@ describe("a worker that stops itself from an immediate exits right away", () => 
 });
 
 // Node: process.exit() inside an 'exit' listener stops the worker there, however
-// the listeners were reached. The rest of that listener and the later 'exit'
-// listeners do not run, and the code it passed is the worker's exit code.
+// the listeners were reached. The rest of that listener, the later 'exit'
+// listeners, and anything after an outer process.exit() do not run, and the code
+// it passed is the worker's exit code.
 describe("process.exit() inside an 'exit' listener does not return", () => {
   test.concurrent.each([
     ["the event loop draining", "process.exitCode = 3;"],
-    ["process.exit()", "process.exit(3);"],
+    ["process.exit()", 'process.exit(3); writeSync(2, "after the outer process.exit\\n");'],
   ])("'exit' reached by %s", async (_label, reach) => {
     const workerSrc = `const { writeSync } = require("node:fs");
       process.on("exit", code => {


### PR DESCRIPTION
### Problem
- In a `node:worker_threads` Worker, `process.exit(7)` called inside a `process.on('exit')` listener returns. The rest of that listener runs, and so does every later 'exit' listener. Node and Bun's main thread stop at the call. The worker does exit with code 7.
- Cause: `WebWorker::exit()` (`src/jsc/web_worker.rs:1113`) requested the thread's termination only when `self.vm` was non-null. `shutdown()` nulls that pointer before it runs the 'exit' listeners (`src/jsc/web_worker.rs:1025`). So a `process.exit()` made from a listener during the natural exit recorded the code and returned. No trap, no `TerminationException`, and the emit loop had no reason to stop.

### Fix
- `WebWorker::exit()` takes the caller's VM (`Bun__Process__exit` in `src/runtime/node/node_process.rs` has it) and calls `vm.handle_ref().request_termination()` on every call. The VM is alive during the 'exit' listeners. Only the worker's back-pointer to it was cleared.
- Correct because the re-entrant call now ends like any other `process.exit()` in a worker. `request_termination()` closes the handle's gate and arms the `NeedTermination` trap. `Process_functionExit`'s `RETURN_IF_EXCEPTION` after `reallyExit` (`src/jsc/bindings/BunProcess.cpp:874`) throws the `TerminationException`, so the listener unwinds. `EventEmitter::innerInvokeEventListeners` already breaks out when the gate is closed, so the later listeners do not run. Node does the same: `reallyExit` stops the thread at the next stack guard check.
- `ExitHandler::dispatch_on_exit` (`src/jsc/VirtualMachine.rs:602`) now runs `Process__dispatchOnExit` under `from_js_host_call_generic` and folds an `Err` with `report_error_or_terminate`, the dispatcher pattern `flush_logs` uses. A termination that escapes the emit and reaches `on_exit()` outside script is taken there, so teardown starts clean. Today the emit loop clears it first, so this changes nothing observable. It makes the landing frame explicit instead of a property of the emitter.
- Verified: `test/js/node/worker_threads/worker_threads.test.ts`, new `describe("process.exit() inside an 'exit' listener does not return")`. The loop-drain case fails on bun 1.4.0 and on main. Node v26 prints the expected output for both fixtures. Also ran the full `worker_threads.test.ts` (139 pass), `process.test.js`, `process-on.test.ts`, `worker.test.ts`, `worker-terminate-lifetime.test.ts`, and 19 vendored `test-worker-*exit*` / `test-process-exit*` tests.

### Background
- A worker's stop has two parts. The `VmHandle` gate (`VmHandle::stop()`, read as `scriptAllowed()` / `isStoppingOrStopped()` in C++) is Bun's: native to JS entries, and the emit loop, refuse once it is closed. The `NeedTermination` trap is JSC's: `notifyNeedTermination()` sets a bit, and the next trap check (a `RETURN_IF_EXCEPTION` in native code, a function prologue or loop back-edge in JS) throws the uncatchable `TerminationException`, which unwinds the script.
- `process.exit(code)` is `setExitCode`, emit `'exit'`, then `reallyExit(code)`. `reallyExit` is `Bun__Process__exit`: noreturn on the main thread, a termination request in a worker. `Process__dispatchOnExit` runs the listeners once per process (`m_isExiting`), so a nested `process.exit()` skips straight to `reallyExit`.
- A worker that exits on its own (loop drained) runs `spin()` → `shutdown()` → `VirtualMachine::on_exit()` → the 'exit' listeners → `teardown()`. `shutdown()` unpublishes the worker's VM pointer first so a racing parent `terminate()` finds nothing to stop.
- `from_js_host_call_generic` runs a native call under an exception scope. If an exception is pending afterwards it returns `Err`. A `TerminationException` is taken only when no script frame is on the stack (`takeTerminationOutsideScript`). Beneath script it stays pending for the frames above to unwind with. `report_error_or_terminate` is the fold a dispatcher applies to that `Err`: stand down on a termination, report anything else as uncaught.

<details><summary>Notes</summary>

Repro (bun 1.4.0, also main and 1.3.14):

```js
import { Worker, isMainThread } from "node:worker_threads";
const say = s => require("fs").writeSync(2, (isMainThread ? "main: " : "worker: ") + s + "\n");
if (isMainThread) new Worker(new URL(import.meta.url)).on("exit", c => say("worker exit code=" + c));
else {
  process.on("exit", c => { say("listener 1 code=" + c + " -> process.exit(7)"); process.exit(7); say("STILL RUNNING after process.exit(7)"); });
  process.on("exit", c => say("listener 2 code=" + c));
  process.exitCode = 3;
}
```

Before: `listener 1 code=3 -> process.exit(7)`, `STILL RUNNING after process.exit(7)`, `listener 2 code=3`, `worker exit code=7`. After (and Node v26): `listener 1 code=3 -> process.exit(7)`, `worker exit code=7`.

Other routes to the 'exit' listeners already stopped at the call, because `self.vm` is live there: `process.exit()` at the top level or from a callback (`Process_functionExit` runs the listeners itself), and an uncaught exception (`on_unhandled_rejection` runs them before it arms the trap). The test covers the loop-drain route (the bug) and the `process.exit()` route (unchanged). The second row also checks that nothing after the outer `process.exit(3)` runs. The uncaught route is not in the test: Bun reports the worker's 'error' event before the listeners run and Node does not, a separate divergence that would make the case encode Bun's current output.

Where the termination lands today. `innerInvokeEventListeners` calls the listener through the `NakedPtr<Exception>` overload of `JSC::call`, which clears any exception, termination included. `Bun__reportUnhandledError` ignores a termination. The next listener is refused by the gate check in the loop. So `emit` returns with nothing pending. In the outer `process.exit(3)` case, `Process_functionExit`'s check after `Process__dispatchOnExit` therefore sees nothing and calls `reallyExit` a second time, which arms the trap again and unwinds the top-level script. Node calls `reallyExit` once. The observable behavior is the same, and it is what the test pins.

The `dispatch_on_exit` wrapper is for the case where the emit leaves the termination pending (a self-review of this change composed it with #40128, which makes the emit loop keep a termination pending, and found the exception riding through `deferred_tasks.run()` and the napi cleanup hooks until `GlobalObject::forbidExecution` cleared it as a side effect). With the wrapper, `on_exit()` takes it right after the dispatch. In the uncaught route, `dispatch_on_exit` can run beneath script. There the termination stays pending, as that route wants.

Also checked under the debug build with `BUN_JSC_validateExceptionChecks=1`: a direct `process.reallyExit(7)` from an 'exit' listener stops at the listener's next JS call (the same stack guard model Node relies on with its `nop()` after `reallyExit`), and a throwing 'exit' listener followed by a `process.exit(7)` in the next listener exits 7 with nothing after it. A throwing 'exit' listener on the main thread behaves as before.

Pre-existing failures seen locally with and without the change, none of which call `process.exit()` in a worker: `worker.test.ts` "a message flood from a worker does not starve the parent's event loop", "preload with an un-awaited import() ..." and "terminate() while fs.readFile completions keep arriving" (debug-build timing: the last one's script alone takes 4.7 s on this host under load), `worker-terminate-lifetime.test.ts` "terminate() while dns.lookup() is in flight ..." (the known `node:fs` binding LSan leak on `terminate()`), and `process.test.js` "process" (`USER` unset in this container).

Not changed here: the neighbouring census row (a microtask queued in a 'beforeExit' listener right before `process.exit()` runs after the 'exit' listeners in a worker) is a different path, covered by #38016. A throwing 'exit' listener during the drain route reports nothing in a worker (`uncaught_exception` returns early once `is_shutting_down` is set); Node reports it. That is a separate follow-up.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1103.32ms]
(pass) all worker_threads module properties are present [22.46ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.20ms]
(pass) all worker_threads worker instance properties are present [155.79ms]
(pass) threadId module and worker property is consistent [210.22ms]
(pass) receiveMessageOnPort works across threads [1058.22ms]
(pass) receiveMessageOnPort works as FIFO [12.37ms]
(pass) you can override globalThis.postMessage [1113.65ms]
(pass) support require in eval [1043.59ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1048.96ms]
(pass) support require in eval for a file that doesnt exist [1027.24ms]
(pass) support worker eval that throws [1000.62ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [4335.32ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (408d63ef3)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [18.28ms]
(pass) all worker_threads module properties are present [0.33ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.36ms]
(pass) all worker_threads worker instance properties are present [0.69ms]
(pass) threadId module and worker property is consistent [4.27ms]
(pass) receiveMessageOnPort works across threads [16.47ms]
(pass) receiveMessageOnPort works as FIFO [0.21ms]
(pass) you can override globalThis.postMessage [16.65ms]
(pass) support require in eval [14.80ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [14.68ms]
(pass) support require in eval for a file that doesnt exist [14.11ms]
(pass) support worker eval that throws [12.93ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [69.96ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [34.08ms]
(pass) execArgv option > can specify an array of strings [34.96ms]
(pass) eval does not leak source code [1945.77
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1115.49ms]
(pass) all worker_threads module properties are present [26.08ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [24.03ms]
(pass) all worker_threads worker instance properties are present [155.66ms]
(pass) threadId module and worker property is consistent [209.67ms]
(pass) receiveMessageOnPort works across threads [1050.41ms]
(pass) receiveMessageOnPort works as FIFO [11.85ms]
(pass) you can override globalThis.postMessage [1071.89ms]
(pass) support require in eval [1036.89ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1092.53ms]
(pass) support require in eval for a file that doesnt exist [1035.20ms]
(pass) support worker eval that throws [1033.51ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [4212.19ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 874ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/35] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/35] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/35] gen cpp.rs (cppbind)
[4/35] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/35] gen JS modules (bundle-modules)
Preprocess modules (7325ms)
Bundle modules (34ms)
Postprocesss modules (29ms)
Bundle Functions (620ms)
Generate Code (19ms)

[8.04s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[5/30] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          |  7 ++++-
 src/jsc/bindings/BunProcess.cpp                    |  5 ++--
 src/jsc/web_worker.rs                              | 16 ++++------
 src/runtime/node/node_process.rs                   |  4 +--
 test/js/node/worker_threads/worker_threads.test.ts | 34 ++++++++++++++++++++++
 5 files changed, 49 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/VirtualMachine.rs                               8      5      0
src/jsc/bindings/BunProcess.cpp                         5      4      0
src/jsc/web_worker.rs                                   5      4      0
src/runtime/node/node_process.rs                        1      1      0
test/js/node/worker_threads/worker_threads.test.ts      4      2      0
```

</details>

<!-- robobun:evidence:end -->