### PR TITLE
test(net): cover unref() then ref() before connect()

### DIFF
--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -779,6 +779,7 @@ describe.concurrent("unref()/pause() around connect()", () => {
   });
 
   it.each([
+    ["before connect()", `s.unref(); s.ref(); s.resume(); s.connect(port, "127.0.0.1");`],
     ["right after connect()", `s.connect(port, "127.0.0.1"); s.unref(); s.ref(); s.resume();`],
     ["while the connect is in flight", `s.connect(port, "127.0.0.1"); ${inFlight("s.unref(); s.ref(); s.resume();")}`],
   ])("ref() after unref() %s keeps holding the loop", async (_, client) => {


### PR DESCRIPTION
Follow-up to #39856, requested in [this review thread](https://github.com/oven-sh/bun/pull/39856#discussion_r3828056965).

### Problem
- The `ref() after unref()` matrix in `test/js/node/net/node-net.test.ts` has two rows. Both call `unref()` and `ref()` after `connect()`. The `before connect()` timing has no coverage.
- Before `connect()` the socket has no handle. `unref()` and `ref()` only toggle `kUserUnrefed` and queue `once("connect")` handlers, and `initSocketHandle` reads the final state when the handle is created (`src/js/node/net.ts`). The two existing rows go through the native `js_unref`/`js_ref` path instead.

### Fix
- Add one row: `s.unref(); s.ref(); s.resume(); s.connect(port, "127.0.0.1");`. The server ends the connection, so the expected output is `connected` then `closed`.
- The row discriminates. With `s.unref()` alone before `connect()` the process exits after `connected` and never prints `closed`. With `unref()` then `ref()` it prints both. I ran both variants three times each against the debug build.
- Verified: `bun bd test test/js/node/net/node-net.test.ts -t "unref\(\)/pause\(\) around connect\(\)"`, 10 pass. The row also passes on the 1.4.0 canary (4448a2e21), which predates #39856. The pre-handle path already worked, so this is coverage, not a fix.

### Background
- `Socket.prototype.unref()`/`ref()` in `net.ts` have two paths. With a handle they call into the native socket. Without one they record the preference in `kUserUnrefed` and re-apply it on `connect`.
- #39856 made a pending connect hold the event loop regardless of the ref state. `unref()` only takes effect once the socket is established.

<details><summary>Notes</summary>

The full file has 10 failures in my container on unmodified main. All are environmental: `node-unref-fixture.js` and the `#13126` test need outbound DNS, and the `net.Socket read` TCP tests bind `Bun.listen({hostname: "localhost"})` to `::1` while the client's `ADDRCONFIG` lookup returns only `127.0.0.1` (no non-loopback IPv6 in the container). Node behaves the same on such a host. None relate to this change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->