### PR TITLE
cron: remove all unsafe from Bun.cron

### DIFF
--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -121,7 +121,7 @@ interface Export {
   modPath: string; // `crate::…` (relative to bun_runtime) or `bun_jsc::…`
   params: Param[];
   ret: string;
-  shape: "host" | "lazy" | "generic" | "rust";
+  shape: "host" | "reaction" | "lazy" | "generic" | "rust";
   isUnsafe: boolean;
 }
 
@@ -279,6 +279,17 @@ for (const { dir, crate } of scanRoots) {
       let shape: Export["shape"];
       if (abi === "rust") shape = "rust";
       else if (
+        params.length === 3 &&
+        /^(?:(?:::)?bun_ptr::)?ThisPtr\s*</.test(params[0].ty) &&
+        /JSGlobalObject$/.test(params[1].ty) &&
+        /CallFrame$/.test(params[2].ty) &&
+        isJsRet
+      ) {
+        // Promise reaction: `JSValue::then(global, ctx, resolve, reject)` stashes
+        // `ctx` as the trailing argument; the thunk hands it back typed.
+        shape = "reaction";
+        abi ??= "jsc";
+      } else if (
         params.length === 2 &&
         /JSGlobalObject$/.test(params[0].ty) &&
         /CallFrame$/.test(params[1].ty) &&
@@ -424,6 +435,22 @@ function emitThunk(e: Export): string {
 // ${loc}
 ${emitNoMangle(e.abi, e.symbol, "g: *mut JSGlobalObject, cf: *mut CallFrame", "JSValue", body, /*unsafeFn*/ true)}`;
     }
+    case "reaction": {
+      const wrap = retIsJsResult ? "host_fn::host_fn_static_raw" : "host_fn::host_fn_static_passthrough_raw";
+      const body = `    // SAFETY: JSC trampoline guarantees g/cf are non-null and valid; the
+    // trailing argument is the \`ctx\` this reaction was registered with via
+    // \`JSValue::then\`, on which the registrant holds a ref until it runs.
+    unsafe {
+        ${wrap}(g, cf, |g, cf| {
+            let args = cf.arguments();
+            let this = ::bun_ptr::ThisPtr::new(args[args.len() - 1].as_promise_ptr());
+            ${impl}(this, g, cf)
+        })
+    }`;
+      return `
+// ${loc}
+${emitNoMangle(e.abi, e.symbol, "g: *mut JSGlobalObject, cf: *mut CallFrame", "JSValue", body, /*unsafeFn*/ true)}`;
+    }
     case "lazy": {
       // Lazy property creator: `(g) -> JSValue`. ABI is whatever the C++ decl
       // uses — `e.abi` (default `c` for direct `extern "C"` calls; `jsc` for
@@ -559,7 +586,7 @@ writeIfNotChanged(path.join(outBase, "generated_host_exports.rs"), header + impo
 
 console.log(
   `generated_host_exports.rs: ${exportsFound.length} exports ` +
-    `(host=${exportsFound.filter(e => e.shape === "host").length}, ` +
+    `(host=${exportsFound.filter(e => e.shape === "host" || e.shape === "reaction").length}, ` +
     `lazy=${exportsFound.filter(e => e.shape === "lazy").length}, ` +
     `generic=${exportsFound.filter(e => e.shape === "generic").length}, ` +
     `rust=${exportsFound.filter(e => e.shape === "rust").length}); ` +

--- a/src/dispatch/lib.rs
+++ b/src/dispatch/lib.rs
@@ -145,6 +145,7 @@ pub fn link_interface(input: TokenStream) -> TokenStream {
     let variants = &variants;
     let methods = &methods;
     let kind = format_ident!("{}Kind", name);
+    let owner_trait = format_ident!("{}Owner", name);
     let impl_macro = format_ident!("link_impl_{}", name);
 
     // ── per-method type aliases ──
@@ -267,10 +268,7 @@ pub fn link_interface(input: TokenStream) -> TokenStream {
             })
             .collect();
 
-        quote! {
-            ( #v for $T:ty => | $th:ident | {
-                #( #mn ( #( #an_mv:ident ),* ) => #e_mv:expr , )*
-            } ) => {
+        let body = quote! {
                 const _: () = {
                     #(
                         #[unsafe(no_mangle)]
@@ -290,6 +288,24 @@ pub fn link_interface(input: TokenStream) -> TokenStream {
                         }
                     )*
                 };
+        };
+        quote! {
+            // `for extern T`: `T` is foreign to the impl crate, so the
+            // `Owner` impl (orphan rule) is skipped; such owners construct the
+            // handle with `new(kind, ptr)`.
+            ( #v for extern $T:ty => | $th:ident | {
+                #( #mn ( #( #an_mv:ident ),* ) => #e_mv:expr , )*
+            } ) => {
+                #body
+            };
+            ( #v for $T:ty => | $th:ident | {
+                #( #mn ( #( #an_mv:ident ),* ) => #e_mv:expr , )*
+            } ) => {
+                // SAFETY: this macro invocation is what links the variant to `$T`.
+                unsafe impl $crate::#owner_trait for $T {
+                    const KIND: $crate::#kind = $crate::#kind::#v;
+                }
+                #body
             };
         }
     });
@@ -305,7 +321,26 @@ pub fn link_interface(input: TokenStream) -> TokenStream {
             pub owner: *mut (),
         }
 
+        /// Implemented by `link_impl_*!` for the type each variant dispatches
+        /// to, so generic code can name the variant for `T` as `T::KIND`.
+        ///
+        /// # Safety
+        /// `KIND`'s `link_impl_*!` must name `Self` (the dispatch casts the
+        /// owner pointer back to that type). Only the macro implements this.
+        #vis unsafe trait #owner_trait {
+            const KIND: #kind;
+        }
+
         impl #name {
+            /// [`new`](Self::new) with the variant taken from `T`'s
+            /// `link_impl_*!` registration.
+            ///
+            /// SAFETY: `owner` must be live for every dispatch through the
+            /// returned handle.
+            #[inline]
+            pub unsafe fn of<T: #owner_trait>(owner: *mut T) -> Self {
+                Self { kind: T::KIND, owner: owner as *mut () }
+            }
             /// SAFETY: `owner` must be a live `*mut T` where `T` is the
             /// concrete type the `kind` variant's `link_impl_*!` was written
             /// for, and must remain live for every dispatch through the

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1502,6 +1502,12 @@ impl NullDelimitedEnvMap {
     pub fn as_ptr(&self) -> *const *const c_char {
         self.envp.as_ptr()
     }
+    /// The `KEY=VALUE` entries as C strings.
+    pub fn iter(&self) -> impl Iterator<Item = &core::ffi::CStr> {
+        self._storage.iter().map(|s| {
+            core::ffi::CStr::from_bytes_until_nul(s).expect("entries are built NUL-terminated")
+        })
+    }
 }
 
 pub struct StdEnvMapWrapper {

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -406,7 +406,7 @@ fn win32_errno_name(code: u32) -> Option<&'static str> {
 // Wire the above into bun_core's `ErrnoNames` hook. `()` owner — pure
 // stateless functions; the handle is the const `ErrnoNames::SYS`.
 bun_core::link_impl_ErrnoNames! {
-    Sys for () => |_this| {
+    Sys for extern () => |_this| {
         name(errno) => system_errno_name(errno),
         max_dense() => system_errno_max_dense(),
         win32_name(code) => win32_errno_name(code),

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -985,7 +985,7 @@ impl<'a> subprocess::StaticPipeWriterProcess for SecurityScanSubprocess<'a> {
 }
 
 bun_spawn::link_impl_ProcessExit! {
-    SecurityScan for SecurityScanSubprocess => |this| {
+    SecurityScan for SecurityScanSubprocess<'static> => |this| {
         on_process_exit(process, status, rusage) =>
             (*this).on_process_exit(&mut *process, status, rusage),
     }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -99,6 +99,16 @@ impl JSValue {
         self.as_ptr_address() as *mut T
     }
 
+    /// The counterpart of passing `this.as_ptr()` as the `ctx` of [`then`](Self::then):
+    /// the reaction's trailing argument, as the `ThisPtr` it was minted from.
+    /// The caller took a ref before `then` and the reaction holds it until it
+    /// runs, so the pointee is live.
+    #[inline]
+    pub fn as_promise_this<T>(self) -> bun_ptr::ThisPtr<T> {
+        // SAFETY: see doc — the reaction's ctx is a live, ref'd `T`.
+        unsafe { bun_ptr::ThisPtr::new(self.as_promise_ptr::<T>()) }
+    }
+
     /// Attach `(resolve, reject)` reactions to this Promise, passing `ctx` as
     /// the trailing argument to each. Thin wrapper over `JSC__JSValue___then`.
     ///

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -99,16 +99,6 @@ impl JSValue {
         self.as_ptr_address() as *mut T
     }
 
-    /// The counterpart of passing `this.as_ptr()` as the `ctx` of [`then`](Self::then):
-    /// the reaction's trailing argument, as the `ThisPtr` it was minted from.
-    /// The caller took a ref before `then` and the reaction holds it until it
-    /// runs, so the pointee is live.
-    #[inline]
-    pub fn as_promise_this<T>(self) -> bun_ptr::ThisPtr<T> {
-        // SAFETY: see doc — the reaction's ctx is a live, ref'd `T`.
-        unsafe { bun_ptr::ThisPtr::new(self.as_promise_ptr::<T>()) }
-    }
-
     /// Attach `(resolve, reject)` reactions to this Promise, passing `ctx` as
     /// the trailing argument to each. Thin wrapper over `JSC__JSValue___then`.
     ///

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -1005,7 +1005,7 @@ pub static IS_DISABLED: AtomicBool = AtomicBool::new(false);
 // ──────────────────────────────────────────────────────────────────────────
 
 bun_ast::link_impl_TranspilerCacheImpl! {
-    Jsc for bun_ast::RuntimeTranspilerCache => |this| {
+    Jsc for extern bun_ast::RuntimeTranspilerCache => |this| {
         get(source, parser_options, used_jsx) => {
             let this = &mut *this;
             let parser_options = parser_options.cast::<ParserOptions<'_>>().as_ref();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4783,14 +4783,8 @@ impl VirtualMachine {
         // `SavedSourceMap`'s `Drop` frees each stored map along with its table.
         drop(core::mem::take(&mut self.source_mappings));
 
-        // Drain cron jobs BEFORE taking rare_data off `self`: the teardown
-        // hook reads `self.rare_data` to find the job list, so calling it
-        // after `take()` is a no-op and `RareData::drop`'s
-        // `debug_assert!(cron_jobs.is_empty())` fires.
-        if self.rare_data.is_some() {
-            if let Some(hooks) = runtime_hooks() {
-                (hooks.stop_cron_for_vm_teardown)(self);
-            }
+        if let Some(hooks) = runtime_hooks() {
+            (hooks.stop_cron_for_vm_teardown)(self);
         }
         if let Some(rare) = self.rare_data.take() {
             // Paired with `rare_data()`'s register_root_region. Without this,

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -30,8 +30,8 @@ use super::uuid::UUID;
 //
 //   - `mysql_context` / `postgresql_context` / `ssl_ctx_cache` / `editor_context`
 //     → moved to `bun_runtime::jsc_hooks::RuntimeState` (already there).
-//   - `cron_jobs` / `node_fs_stat_watcher_scheduler`
-//     → erased `*mut c_void` slots; high tier lazy-inits.
+//   - `node_fs_stat_watcher_scheduler`
+//     → erased `*mut c_void` slot; high tier lazy-inits.
 //   - the `bun test --isolate` watcher/server registries → moved to
 //     `bun_runtime::jsc_hooks::ActiveHandles` so the entries keep their
 //     concrete types.
@@ -209,8 +209,6 @@ pub struct RareData {
     pub(crate) entropy_cache: Option<Box<EntropyCache>>,
 
     pub(crate) hot_map: Option<HotMap>,
-    /// `Vec<*mut bun_runtime::api::cron::CronJob>` — only stored/iterated here.
-    pub cron_jobs: Vec<*mut c_void>,
 
     // TODO: make this per JSGlobalObject instead of global
     // This does not handle ShadowRealm correctly!
@@ -305,7 +303,6 @@ impl Default for RareData {
             stdout_mode: 0,
             entropy_cache: None,
             hot_map: None,
-            cron_jobs: Vec::new(),
             cleanup_hooks: Vec::new(),
             file_polls: None,
             spawn_ipc_group: SocketGroup::default(),
@@ -1064,15 +1061,14 @@ fn get_tls_default_ciphers_from_js(
 impl Drop for RareData {
     fn drop(&mut self) {
         // pipe_read_scratch / h2_padded_frame_buffer / spawn_sync_event_loop_ /
-        // s3_default_client / default_csrf_secret / cleanup_hooks / cron_jobs /
-        // path_buf / tls_default_ciphers:
+        // s3_default_client / default_csrf_secret / cleanup_hooks / path_buf /
+        // tls_default_ciphers:
         // all dropped automatically via field Drop.
 
         if let Some(engine) = self.boring_ssl_engine.take() {
             // SAFETY: engine was created by ENGINE_new.
             unsafe { boring::ENGINE_free(engine) };
         }
-        debug_assert!(self.cron_jobs.is_empty());
 
         if let Some(s) = self.default_client_ssl_ctx.take() {
             // SAFETY: returned by ssl_ctx_cache.get_or_create_opts with +1 ref.

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -349,7 +349,7 @@ pub(crate) unsafe extern "C" fn on_abort_signal(ctx: *mut c_void, reason: JSValu
 }
 
 bun_spawn::link_impl_ProcessExit! {
-    Subprocess for Subprocess => |this| {
+    Subprocess for Subprocess<'static> => |this| {
         // `process` forwarded raw (not reborrowed) so `on_process_exit` can
         // hand it to `VirtualMachine::on_subprocess_exit` without a const→mut
         // provenance cast.

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -14,7 +14,7 @@ use std::io::Write as _;
 use super::cron_parser;
 use super::cron_parser::{CronExpression, CronTz};
 
-use core::ffi::c_char;
+use core::ffi::CStr;
 use std::cell::Cell;
 
 #[cfg(not(windows))]
@@ -29,14 +29,16 @@ use bun_jsc::{
 #[cfg(not(target_os = "macos"))]
 use bun_paths::PathBuffer;
 use bun_paths::{self as path};
-use bun_ptr::{AsCtxPtr as _, ThisPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_resolver::fs::FileSystem;
 #[cfg(not(target_os = "macos"))]
 use bun_resolver::fs::RealFS;
 
 #[cfg(not(windows))]
 use crate::api::bun::process::SpawnResultExt as _;
-use crate::api::bun::process::{self as spawn, Process, Rusage, SpawnOptions, Status};
+use crate::api::bun::process::{
+    self as spawn, Process, ProcessHandle, Rusage, SpawnOptions, Status,
+};
 use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 use bun_core::ZStr;
 use bun_core::strings;
@@ -66,12 +68,18 @@ use crate::jsc_hooks::timer_all_mut as timer_all;
 // ============================================================================
 
 /// Shared base for [`CronRegisterJob`] and [`CronRemoveJob`].
-// Note: `finish()` `heap::take`-drops `this`, so every method on the path to
-// it takes a `ThisPtr<Self>` receiver (never `&mut self`, whose Stacked
-// Borrows FnEntry protector would make the in-flight dealloc UB) and touches
-// nothing after the call that may free `this`. Mutable state lives in
-// `Cell`/`JsCell` fields so every access is a short shared borrow.
-trait CronJobBase: Sized {
+// Note: `finish()` releases the job's single owning ref (freeing `this`), so
+// every method on the path to it takes a `ThisPtr<Self>` receiver (never
+// `&mut self`, whose Stacked Borrows FnEntry protector would make the
+// in-flight dealloc UB) and touches nothing after the call that may free
+// `this`. Mutable state lives in `Cell`/`JsCell` fields so every access is a
+// short shared borrow.
+trait CronJobBase: Sized + bun_ptr::AnyRefCounted<DestructorCtx = ()> {
+    /// The single owning ref; released by `finish`.
+    fn owner(&self) -> &Cell<Option<RefPtr<Self>>>;
+    fn promise(&self) -> &JsCell<jsc::JSPromiseStrong>;
+    fn global(&self) -> GlobalRef;
+    fn poll(&self) -> &JsCell<KeepAlive>;
     fn remaining_fds(&self) -> &Cell<i8>;
     fn err_msg(&self) -> &JsCell<Option<Vec<u8>>>;
     fn has_called_process_exit(&self) -> &Cell<bool>;
@@ -90,7 +98,7 @@ trait CronJobBase: Sized {
     fn title_bytes(&self) -> &[u8];
 
     #[cfg(all(not(target_os = "macos"), not(windows)))]
-    fn prepare_list_crontab(&self, this_ptr: *mut core::ffi::c_void) -> Option<*const c_char>
+    fn prepare_list_crontab(&self, this_ptr: *mut core::ffi::c_void) -> Option<ZString>
     where
         Self: BufferedReaderParent,
     {
@@ -118,10 +126,31 @@ trait CronJobBase: Sized {
     }
 
     fn check_finished(&self) -> JobAction;
-    /// Consumes and frees `this`; callers return without touching it again.
-    fn finish(this: ThisPtr<Self>);
     /// May free `this`.
     fn advance_state(this: ThisPtr<Self>);
+
+    /// Settles the promise and releases the owning ref, freeing `this`; the
+    /// job's `Drop` (process detach, reader teardown) runs inside the
+    /// enter/exit scope. Callers return without touching `this` again.
+    fn finish(this: ThisPtr<Self>) {
+        let owner = this.owner().take().expect("cron job finished twice");
+        this.poll().with_mut(|p| p.unref(bun_io::js_vm_ctx()));
+        let global = this.global();
+        let ev = VirtualMachine::get().event_loop_mut();
+        ev.enter();
+        if let Some(msg) = this.err_msg().replace(None) {
+            let err = global.create_error_instance(format_args!("{}", bstr::BStr::new(&msg)));
+            let _ = this
+                .promise()
+                .with_mut(|p| p.reject_with_async_stack(&global, Ok(err)));
+        } else {
+            let _ = this
+                .promise()
+                .with_mut(|p| p.resolve(&global, JSValue::UNDEFINED));
+        }
+        owner.deref();
+        ev.exit();
+    }
 
     fn set_err(&self, args: core::fmt::Arguments<'_>) {
         if self.err_msg().get().is_none() {
@@ -195,11 +224,15 @@ enum JobAction {
 // CronRegisterJob
 // ============================================================================
 
+#[derive(bun_ptr::CellRefCounted)]
 struct CronRegisterJob {
-    promise: jsc::JSPromiseStrong,
+    ref_count: Cell<u32>,
+    /// The single owning ref; released by `finish`.
+    owner: Cell<Option<RefPtr<CronRegisterJob>>>,
+    promise: JsCell<jsc::JSPromiseStrong>,
     // LIFETIMES.tsv: JSC_BORROW → GlobalRef
     global: GlobalRef,
-    poll: KeepAlive,
+    poll: JsCell<KeepAlive>,
 
     bun_exe: &'static ZStr,
     abs_path: ZString,
@@ -210,8 +243,7 @@ struct CronRegisterJob {
     parsed_cron: CronExpression,
 
     state: Cell<RegisterState>,
-    // LIFETIMES.tsv: SHARED — `Process` is intrusively refcounted (`*mut`).
-    process: Cell<Option<*mut Process>>,
+    process: JsCell<Option<ProcessHandle>>,
     stdout_reader: JsCell<OutputReader>,
     #[cfg(windows)]
     stderr_reader: JsCell<OutputReader>,
@@ -268,6 +300,18 @@ impl CronJobBase for CronRegisterJob {
     fn title_bytes(&self) -> &[u8] {
         self.title.as_bytes()
     }
+    fn owner(&self) -> &Cell<Option<RefPtr<Self>>> {
+        &self.owner
+    }
+    fn promise(&self) -> &JsCell<jsc::JSPromiseStrong> {
+        &self.promise
+    }
+    fn global(&self) -> GlobalRef {
+        self.global
+    }
+    fn poll(&self) -> &JsCell<KeepAlive> {
+        &self.poll
+    }
     fn remaining_fds(&self) -> &Cell<i8> {
         &self.remaining_fds
     }
@@ -285,13 +329,7 @@ impl CronJobBase for CronRegisterJob {
         if !self.has_called_process_exit.get() || self.remaining_fds.get() != 0 {
             return JobAction::Pending;
         }
-        if let Some(proc) = self.process.take() {
-            // SAFETY: `proc` is the intrusive-RC pointer returned by `to_process`.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
+        self.process.set(None);
         if self.err_msg.get().is_some() {
             return JobAction::Finish;
         }
@@ -390,37 +428,13 @@ impl CronJobBase for CronRegisterJob {
             }
         }
     }
-
-    /// Consumes and frees `this` (`heap::take`).
-    fn finish(this: ThisPtr<Self>) {
-        // SAFETY: `this` is the unique Box<Self> leaked in cron_register; every
-        // caller returns without touching it again.
-        let mut job = unsafe { bun_core::heap::take(this.as_ptr()) };
-        job.poll.unref(bun_io::js_vm_ctx());
-        let ev = VirtualMachine::get().event_loop_mut();
-        ev.enter();
-        if let Some(msg) = job.err_msg.get() {
-            let _ = job.promise.reject_with_async_stack(
-                &job.global,
-                Ok(job
-                    .global
-                    .create_error_instance(format_args!("{}", bstr::BStr::new(msg)))),
-            );
-        } else {
-            let _ = job.promise.resolve(&job.global, JSValue::UNDEFINED);
-        }
-        // Drop runs INSIDE the enter/exit scope so Process detach/deref and
-        // reader teardown observe the entered event-loop state.
-        drop(job);
-        ev.exit();
-    }
 }
 
 impl CronRegisterJob {
     /// May free `this` (via spawn → synchronous exit → finish, or error path).
     fn spawn_cmd(
         this: ThisPtr<Self>,
-        argv: &mut [*const c_char],
+        argv: &[&CStr],
         stdin_opt: spawn::Stdio,
         stdout_opt: spawn::Stdio,
     ) {
@@ -435,22 +449,22 @@ impl CronRegisterJob {
         let Some(crontab_path) = this.prepare_list_crontab(this.as_ptr().cast()) else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 3] = [crontab_path, c"-l".as_ptr(), core::ptr::null()];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Buffer);
+        let argv = [crontab_path.as_cstr(), c"-l"];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Buffer);
     }
 
     /// May free `this`; see [`CronJobBase`] note.
     #[cfg(not(target_os = "macos"))]
     fn process_crontab_and_install(this: ThisPtr<Self>) {
-        let Ok((crontab_path, tmp_path_ptr)) = this.prepare_install_crontab() else {
+        let Ok((crontab_path, tmp_path)) = this.prepare_install_crontab() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 3] = [crontab_path, tmp_path_ptr, core::ptr::null()];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
+        let argv = [crontab_path.as_cstr(), tmp_path.as_cstr()];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
     #[cfg(not(target_os = "macos"))]
-    fn prepare_install_crontab(&self) -> Result<(*const c_char, *const c_char), ()> {
+    fn prepare_install_crontab(&self) -> Result<(ZString, ZString), ()> {
         let mut result: Vec<u8> = Vec::new();
         let filtered = self.stdout_reader.with_mut(|r| {
             filter_crontab(
@@ -489,8 +503,8 @@ impl CronRegisterJob {
                 return Err(());
             }
         };
-        let tmp_path_ptr = tmp_path.as_ptr();
-        self.tmp_path.set(Some(tmp_path));
+        self.tmp_path
+            .set(Some(ZString::from_bytes(tmp_path.as_bytes())));
 
         let file = match File::openat(
             Fd::cwd(),
@@ -512,14 +526,13 @@ impl CronRegisterJob {
         let _ = file.close(); // close error is non-actionable
 
         self.state.set(RegisterState::InstallingCrontab);
-        // Note: explicit deinit of old reader before reassign — Drop handles it.
         self.stdout_reader
             .set(OutputReader::init::<CronRegisterJob>());
         let Some(crontab_path) = find_crontab() else {
             self.set_err(format_args!("crontab not found in PATH"));
             return Err(());
         };
-        Ok((crontab_path, tmp_path_ptr.cast()))
+        Ok((crontab_path, tmp_path))
     }
 
     // -- macOS --
@@ -657,14 +670,8 @@ impl CronRegisterJob {
         let Ok(uid_str) = this.prepare_bootout() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 4] = [
-            c"/bin/launchctl".as_ptr().cast(),
-            c"bootout".as_ptr().cast(),
-            uid_str.as_ptr().cast(),
-            core::ptr::null(),
-        ];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
-        drop(uid_str);
+        let argv = [c"/bin/launchctl", c"bootout", uid_str.as_cstr()];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
     /// May free `this`; see [`CronJobBase`] note.
@@ -673,16 +680,13 @@ impl CronRegisterJob {
         let Ok((uid_str, plist_path)) = this.prepare_bootstrap() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 5] = [
-            c"/bin/launchctl".as_ptr().cast(),
-            c"bootstrap".as_ptr().cast(),
-            uid_str.as_ptr().cast(),
-            plist_path.as_ptr().cast(),
-            core::ptr::null(),
+        let argv = [
+            c"/bin/launchctl",
+            c"bootstrap",
+            uid_str.as_cstr(),
+            plist_path.as_cstr(),
         ];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
-        drop(uid_str);
-        drop(plist_path);
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
     #[cfg(target_os = "macos")]
@@ -840,10 +844,12 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
                 bstr::BStr::new(bun_exe.as_bytes())
             )));
     }
-    let mut job_box = Box::new(CronRegisterJob {
-        promise: jsc::JSPromiseStrong::init(global),
+    let job = RefPtr::new(CronRegisterJob {
+        ref_count: Cell::new(1),
+        owner: Cell::new(None),
+        promise: JsCell::new(jsc::JSPromiseStrong::init(global)),
         global: GlobalRef::from(global),
-        poll: KeepAlive::default(),
+        poll: JsCell::new(KeepAlive::default()),
         bun_exe,
         abs_path,
         schedule: ZString::from_bytes(normalized_schedule),
@@ -851,7 +857,7 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
         #[cfg(windows)]
         parsed_cron: parsed,
         state: Cell::new(RegisterState::ReadingCrontab),
-        process: Cell::new(None),
+        process: JsCell::new(None),
         stdout_reader: JsCell::new(OutputReader::init::<CronRegisterJob>()),
         #[cfg(windows)]
         stderr_reader: JsCell::new(OutputReader::init::<CronRegisterJob>()),
@@ -860,14 +866,13 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
         exit_status: JsCell::new(None),
         err_msg: JsCell::new(None),
         tmp_path: JsCell::new(None),
-        // SAFETY: `vm_mut().event_loop()` returns the live per-thread `jsc::EventLoop`.
         event_loop_handle: EventLoopHandle::init(vm_mut().event_loop().cast::<()>()),
     });
-    job_box.poll.ref_(bun_io::js_vm_ctx());
-    let promise_value = job_box.promise.value();
-    // SAFETY: `job` is the freshly-leaked Box; `start_*` consumes it on
-    // synchronous failure or hands it to the event loop on success.
-    let job = unsafe { ThisPtr::new(bun_core::heap::into_raw(job_box)) };
+    job.poll.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
+    let promise_value = job.promise.get().value();
+    let this = job.this_ptr();
+    this.owner.set(Some(job));
+    let job = this;
 
     #[cfg(target_os = "macos")]
     CronRegisterJob::start_mac(job);
@@ -885,25 +890,23 @@ impl CronRegisterJob {
 
     /// May free `this`; see [`CronJobBase`] note.
     fn start_windows(this: ThisPtr<Self>) {
-        let Ok((task_name, xml_path_ptr)) = this.prepare_schtasks_create() else {
+        let Ok((task_name, xml_path)) = this.prepare_schtasks_create() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 9] = [
-            b"schtasks\0".as_ptr().cast(),
-            b"/create\0".as_ptr().cast(),
-            b"/xml\0".as_ptr().cast(),
-            xml_path_ptr,
-            b"/tn\0".as_ptr().cast(),
-            task_name.as_ptr().cast(),
-            b"/np\0".as_ptr().cast(),
-            b"/f\0".as_ptr().cast(),
-            core::ptr::null(),
+        let argv = [
+            c"schtasks",
+            c"/create",
+            c"/xml",
+            xml_path.as_cstr(),
+            c"/tn",
+            task_name.as_cstr(),
+            c"/np",
+            c"/f",
         ];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
-        drop(task_name);
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
-    fn prepare_schtasks_create(&self) -> Result<(ZString, *const c_char), ()> {
+    fn prepare_schtasks_create(&self) -> Result<(ZString, ZString), ()> {
         self.state.set(RegisterState::InstallingCrontab);
 
         let task_name = match alloc_print_z(format_args!(
@@ -944,8 +947,8 @@ impl CronRegisterJob {
                 return Err(());
             }
         };
-        let xml_path_ptr = xml_path.as_ptr();
-        self.tmp_path.set(Some(xml_path));
+        self.tmp_path
+            .set(Some(ZString::from_bytes(xml_path.as_bytes())));
 
         let file = match File::openat(
             Fd::cwd(),
@@ -966,24 +969,15 @@ impl CronRegisterJob {
         }
         let _ = file.close(); // close error is non-actionable
 
-        Ok((task_name, xml_path_ptr.cast()))
+        Ok((task_name, xml_path))
     }
 }
 
 impl Drop for CronRegisterJob {
     fn drop(&mut self) {
-        // stdout_reader / stderr_reader drop via their own Drop.
-        if let Some(proc) = self.process.take() {
-            // SAFETY: intrusive-RC pointer; we hold a ref.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
         if let Some(p) = self.tmp_path.replace(None) {
             let _ = sys::unlink(&p);
         }
-        // err_msg, abs_path, schedule, title freed via field Drop.
     }
 }
 
@@ -994,16 +988,19 @@ const ASCII_WHITESPACE: [u8; 6] = *b" \t\n\r\x0b\x0c";
 // CronRemoveJob
 // ============================================================================
 
+#[derive(bun_ptr::CellRefCounted)]
 struct CronRemoveJob {
-    promise: jsc::JSPromiseStrong,
+    ref_count: Cell<u32>,
+    /// The single owning ref; released by `finish`.
+    owner: Cell<Option<RefPtr<CronRemoveJob>>>,
+    promise: JsCell<jsc::JSPromiseStrong>,
     // LIFETIMES.tsv: JSC_BORROW → GlobalRef
     global: GlobalRef,
-    poll: KeepAlive,
+    poll: JsCell<KeepAlive>,
     title: ZString,
 
     state: Cell<RemoveState>,
-    // LIFETIMES.tsv: SHARED — `Process` is intrusively refcounted (`*mut`).
-    process: Cell<Option<*mut Process>>,
+    process: JsCell<Option<ProcessHandle>>,
     stdout_reader: JsCell<OutputReader>,
     #[cfg(windows)]
     stderr_reader: JsCell<OutputReader>,
@@ -1055,6 +1052,18 @@ impl CronJobBase for CronRemoveJob {
     fn title_bytes(&self) -> &[u8] {
         self.title.as_bytes()
     }
+    fn owner(&self) -> &Cell<Option<RefPtr<Self>>> {
+        &self.owner
+    }
+    fn promise(&self) -> &JsCell<jsc::JSPromiseStrong> {
+        &self.promise
+    }
+    fn global(&self) -> GlobalRef {
+        self.global
+    }
+    fn poll(&self) -> &JsCell<KeepAlive> {
+        &self.poll
+    }
     fn remaining_fds(&self) -> &Cell<i8> {
         &self.remaining_fds
     }
@@ -1072,13 +1081,7 @@ impl CronJobBase for CronRemoveJob {
         if !self.has_called_process_exit.get() || self.remaining_fds.get() != 0 {
             return JobAction::Pending;
         }
-        if let Some(proc) = self.process.take() {
-            // SAFETY: intrusive-RC pointer; we hold a ref.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
+        self.process.set(None);
         if self.err_msg.get().is_some() {
             return JobAction::Finish;
         }
@@ -1158,30 +1161,6 @@ impl CronJobBase for CronRemoveJob {
             }
         }
     }
-
-    /// Consumes and frees `this` (`heap::take`).
-    fn finish(this: ThisPtr<Self>) {
-        // SAFETY: `this` is the unique Box<Self> leaked in cron_remove; every
-        // caller returns without touching it again.
-        let mut job = unsafe { bun_core::heap::take(this.as_ptr()) };
-        job.poll.unref(bun_io::js_vm_ctx());
-        let ev = VirtualMachine::get().event_loop_mut();
-        ev.enter();
-        if let Some(msg) = job.err_msg.get() {
-            let _ = job.promise.reject_with_async_stack(
-                &job.global,
-                Ok(job
-                    .global
-                    .create_error_instance(format_args!("{}", bstr::BStr::new(msg)))),
-            );
-        } else {
-            let _ = job.promise.resolve(&job.global, JSValue::UNDEFINED);
-        }
-        // Drop runs INSIDE the enter/exit scope so Process detach/deref and
-        // reader teardown observe the entered event-loop state.
-        drop(job);
-        ev.exit();
-    }
 }
 
 impl CronRemoveJob {
@@ -1205,7 +1184,7 @@ impl CronRemoveJob {
     /// May free `this` (via spawn → synchronous exit → finish, or error path).
     fn spawn_cmd(
         this: ThisPtr<Self>,
-        argv: &mut [*const c_char],
+        argv: &[&CStr],
         stdin_opt: spawn::Stdio,
         stdout_opt: spawn::Stdio,
     ) {
@@ -1218,22 +1197,22 @@ impl CronRemoveJob {
         let Some(crontab_path) = this.prepare_list_crontab(this.as_ptr().cast()) else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 3] = [crontab_path, c"-l".as_ptr(), core::ptr::null()];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Buffer);
+        let argv = [crontab_path.as_cstr(), c"-l"];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Buffer);
     }
 
     /// May free `this`; see [`CronJobBase`] note.
     #[cfg(not(target_os = "macos"))]
     fn remove_crontab_entry(this: ThisPtr<Self>) {
-        let Ok((crontab_path, tmp_path_ptr)) = this.prepare_filtered_crontab() else {
+        let Ok((crontab_path, tmp_path)) = this.prepare_filtered_crontab() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 3] = [crontab_path, tmp_path_ptr, core::ptr::null()];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
+        let argv = [crontab_path.as_cstr(), tmp_path.as_cstr()];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
     #[cfg(not(target_os = "macos"))]
-    fn prepare_filtered_crontab(&self) -> Result<(*const c_char, *const c_char), ()> {
+    fn prepare_filtered_crontab(&self) -> Result<(ZString, ZString), ()> {
         let mut result: Vec<u8> = Vec::new();
         let filtered = self.stdout_reader.with_mut(|r| {
             filter_crontab(
@@ -1255,8 +1234,8 @@ impl CronRemoveJob {
                 return Err(());
             }
         };
-        let tmp_path_ptr = tmp_path.as_ptr();
-        self.tmp_path.set(Some(tmp_path));
+        self.tmp_path
+            .set(Some(ZString::from_bytes(tmp_path.as_bytes())));
 
         let file = match File::openat(
             Fd::cwd(),
@@ -1284,7 +1263,7 @@ impl CronRemoveJob {
             self.set_err(format_args!("crontab not found in PATH"));
             return Err(());
         };
-        Ok((crontab_path, tmp_path_ptr.cast()))
+        Ok((crontab_path, tmp_path))
     }
 
     /// May free `this`; see [`CronJobBase`] note.
@@ -1293,14 +1272,8 @@ impl CronRemoveJob {
         let Ok(uid_str) = this.prepare_bootout() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 4] = [
-            c"/bin/launchctl".as_ptr().cast(),
-            c"bootout".as_ptr().cast(),
-            uid_str.as_ptr().cast(),
-            core::ptr::null(),
-        ];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
-        drop(uid_str);
+        let argv = [c"/bin/launchctl", c"bootout", uid_str.as_cstr()];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 }
 
@@ -1322,13 +1295,15 @@ pub(crate) fn cron_remove(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
         )));
     }
 
-    let mut job_box = Box::new(CronRemoveJob {
-        promise: jsc::JSPromiseStrong::init(global),
+    let job = RefPtr::new(CronRemoveJob {
+        ref_count: Cell::new(1),
+        owner: Cell::new(None),
+        promise: JsCell::new(jsc::JSPromiseStrong::init(global)),
         global: GlobalRef::from(global),
-        poll: KeepAlive::default(),
+        poll: JsCell::new(KeepAlive::default()),
         title: ZString::from_bytes(title_slice.slice()),
         state: Cell::new(RemoveState::ReadingCrontab),
-        process: Cell::new(None),
+        process: JsCell::new(None),
         stdout_reader: JsCell::new(OutputReader::init::<CronRemoveJob>()),
         #[cfg(windows)]
         stderr_reader: JsCell::new(OutputReader::init::<CronRemoveJob>()),
@@ -1337,14 +1312,13 @@ pub(crate) fn cron_remove(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
         exit_status: JsCell::new(None),
         err_msg: JsCell::new(None),
         tmp_path: JsCell::new(None),
-        // SAFETY: `vm_mut().event_loop()` returns the live per-thread `jsc::EventLoop`.
         event_loop_handle: EventLoopHandle::init(vm_mut().event_loop().cast::<()>()),
     });
-    job_box.poll.ref_(bun_io::js_vm_ctx());
-    let promise_value = job_box.promise.value();
-    // SAFETY: `job` is the freshly-leaked Box; `start_*` consumes it on
-    // synchronous failure or hands it to the event loop on success.
-    let job = unsafe { ThisPtr::new(bun_core::heap::into_raw(job_box)) };
+    job.poll.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
+    let promise_value = job.promise.get().value();
+    let this = job.this_ptr();
+    this.owner.set(Some(job));
+    let job = this;
     #[cfg(target_os = "macos")]
     CronRemoveJob::start_mac(job);
     #[cfg(windows)]
@@ -1361,16 +1335,8 @@ impl CronRemoveJob {
         let Ok(task_name) = this.prepare_schtasks_delete() else {
             return Self::finish(this);
         };
-        let mut argv: [*const c_char; 6] = [
-            b"schtasks\0".as_ptr().cast(),
-            b"/delete\0".as_ptr().cast(),
-            b"/tn\0".as_ptr().cast(),
-            task_name.as_ptr().cast(),
-            b"/f\0".as_ptr().cast(),
-            core::ptr::null(),
-        ];
-        Self::spawn_cmd(this, &mut argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
-        drop(task_name);
+        let argv = [c"schtasks", c"/delete", c"/tn", task_name.as_cstr(), c"/f"];
+        Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
     fn prepare_schtasks_delete(&self) -> Result<ZString, ()> {
@@ -1385,13 +1351,6 @@ impl CronRemoveJob {
 
 impl Drop for CronRemoveJob {
     fn drop(&mut self) {
-        if let Some(proc) = self.process.take() {
-            // SAFETY: intrusive-RC pointer; we hold a ref.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
         if let Some(p) = self.tmp_path.replace(None) {
             let _ = sys::unlink(&p);
         }
@@ -1412,8 +1371,10 @@ impl Drop for CronRemoveJob {
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = Self::destroy_impl)]
 pub struct CronJob {
-    // bun.ptr.RefCount(...) intrusive — keep raw count for IntrusiveRc compat.
     ref_count: Cell<u32>,
+    /// Set from the allocating `RefPtr` so `&self` host fns can reach the
+    /// `ThisPtr`-taking paths that may release refs.
+    self_ref: Cell<BackRef<CronJob, bun_ptr::Mut>>,
     // pub: `bun_core::from_field_ptr!(CronJob, event_loop_timer)` needs `offset_of!` visibility.
     // `JsCell` is `#[repr(transparent)]`, so the byte offset of the inner
     // `EventLoopTimer` is identical and the dispatch.rs `owner!` macro works
@@ -1431,10 +1392,9 @@ pub struct CronJob {
     /// Last computed wall-clock fire target (ms epoch); floors the next search
     /// so monotonic-vs-wall skew can't recompute the same minute.
     last_next_ms: Cell<f64>,
-    /// True while a ref() is held across an in-flight callback promise.
-    /// Released exactly once by either onPromiseResolve/Reject or
-    /// clearAllForVM(.teardown).
-    pending_ref: Cell<bool>,
+    /// The ref held across an in-flight callback promise. Released exactly
+    /// once by either onPromiseResolve/Reject or clearAllForVM(.teardown).
+    pending_ref: JsCell<Option<RefPtr<CronJob>>>,
     /// True between onTimerFire's cb.call() and processing of its result.
     in_fire: Cell<bool>,
 }
@@ -1473,7 +1433,7 @@ impl CronJob {
     /// the wrapper and pass the real Promise to unhandledRejection.
     fn maybe_downgrade(&self) {
         if self.stopped.get()
-            && !self.pending_ref.get()
+            && self.pending_ref.get().is_none()
             && !matches!(self.this_value.get(), JsRef::Finalized)
         {
             self.this_value.with_mut(|v| v.downgrade());
@@ -1482,11 +1442,9 @@ impl CronJob {
 
     /// May free `this`.
     fn release_pending_ref(this: ThisPtr<Self>) {
-        if this.pending_ref.get() {
-            this.pending_ref.set(false);
+        if let Some(pending) = this.pending_ref.replace(None) {
             this.maybe_downgrade();
-            // SAFETY: `this` is a live Box-allocated CronJob; this releases one ref.
-            unsafe { Self::deref(this.as_ptr()) };
+            pending.deref();
         }
     }
 
@@ -1504,19 +1462,14 @@ impl CronJob {
     /// May free `this`.
     fn finish_deferred_stop(this: ThisPtr<Self>, vm: &VirtualMachine) {
         this.stop_internal(vm);
-        Self::remove_from_list(this, vm);
+        Self::remove_from_list(this);
     }
 
     /// The fake heap dropped this job's timer (`useRealTimers()` /
     /// `clearAllTimers()`): stop the job as `stop()` would, so it does not
     /// keep the event loop alive for a timer that can no longer fire.
-    ///
-    /// # Safety
-    /// `this` was recovered from a node just popped off the fake heap and no
-    /// JS has run since; a scheduled job's wrapper keeps it alive.
-    pub(crate) unsafe fn stop_dropped_from_fake_heap(this: *mut Self) {
-        // SAFETY: caller contract — `this` is a live scheduled job.
-        Self::self_stop(unsafe { ThisPtr::new(this) }, VirtualMachine::get());
+    pub(crate) fn stop_dropped_from_fake_heap(this: ThisPtr<Self>) {
+        Self::self_stop(this, VirtualMachine::get());
     }
 
     /// May free `this`.
@@ -1525,35 +1478,22 @@ impl CronJob {
         // list removal + downgrade to finishDeferredStop (called from
         // scheduleNext after settle) so onPromiseReject can read pendingPromise
         // and clearAllForVM(.teardown) can release pending_ref.
-        if this.in_fire.get() || this.pending_ref.get() {
+        if this.in_fire.get() || this.pending_ref.get().is_some() {
             this.stopped.set(true);
             this.poll_ref.with_mut(|p| p.unref(bun_io::js_vm_ctx()));
             return;
         }
         this.stop_internal(vm);
-        Self::remove_from_list(this, vm);
+        Self::remove_from_list(this);
     }
 
     /// May free `this`.
-    fn remove_from_list(this: ThisPtr<Self>, vm: &VirtualMachine) {
-        // Note: `RareData::cron_jobs` stores the opaque
-        // `rare_data::high_tier::CronJob`; cast through `*mut ()` for compare.
-        let needle = this.as_ptr().cast::<()>();
-        // Single JS thread; mutation of the per-VM Vec. Route through the
-        // thread-local raw pointer (`VirtualMachine::get`) instead of upcasting
-        // `&VirtualMachine` so the `invalid_reference_casting` lint stays clean.
-        let _ = vm;
-        let rare = VirtualMachine::get().as_mut().rare_data.as_mut();
-        if let Some(rare) = rare {
-            if let Some(i) = rare
-                .cron_jobs
-                .iter()
-                .position(|&j| j.cast::<()>() == needle)
-            {
-                rare.cron_jobs.swap_remove(i);
-                // SAFETY: `this` is a live Box-allocated CronJob; this releases one ref.
-                unsafe { Self::deref(this.as_ptr()) };
-            }
+    fn remove_from_list(this: ThisPtr<Self>) {
+        let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() else {
+            return;
+        };
+        if let Some(i) = jobs.iter().position(|j| j.as_ptr() == this.as_ptr()) {
+            jobs.swap_remove(i).deref();
         }
     }
 
@@ -1563,25 +1503,17 @@ impl CronJob {
     /// happens, so release the pending ref here to avoid leaking the struct.
     pub(crate) fn clear_all_for_vm<const MODE: ClearMode>(vm: &mut VirtualMachine) {
         // Drain the list first so `stop_internal` (which re-enters the VM)
-        // doesn't alias the `rare` borrow.
-        let jobs: Vec<*mut ()> = match vm.rare_data.as_mut() {
-            Some(rare) => core::mem::take(&mut rare.cron_jobs)
-                .into_iter()
-                .map(|j| j.cast::<()>())
-                .collect(),
-            None => return,
+        // doesn't alias the list borrow.
+        let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() else {
+            return;
         };
-        for job in jobs {
-            // Note: stored as opaque `rare_data::high_tier::CronJob`; the
-            // concrete type is this `CronJob` (see `register` push site).
-            // SAFETY: the list holds a ref for each entry.
-            let job = unsafe { ThisPtr::new(job.cast::<CronJob>()) };
-            job.stop_internal(vm);
+        for job in core::mem::take(jobs) {
+            let this = job.this_ptr();
+            this.stop_internal(vm);
             if MODE == ClearMode::Teardown {
-                Self::release_pending_ref(job);
+                Self::release_pending_ref(this);
             }
-            // SAFETY: `job` is a live Box-allocated CronJob; this releases one ref.
-            unsafe { Self::deref(job.as_ptr()) };
+            job.deref();
         }
     }
 
@@ -1667,9 +1599,8 @@ impl CronJob {
             return;
         }
 
-        // SAFETY: per-thread VM; `event_loop()` returns the live VM-owned
-        // pointer. `enter_scope` calls `enter()` now and `exit()` on drop, and
-        // holds the raw pointer (not `&mut`) so re-entrant JS can re-borrow.
+        // `enter()` now, `exit()` on drop; holds the raw pointer (not `&mut`)
+        // so re-entrant JS can re-borrow.
         let _ev_guard = vm.enter_event_loop_scope();
 
         this.in_fire.set(true);
@@ -1696,18 +1627,16 @@ impl CronJob {
         if let Some(promise) = result.as_any_promise() {
             match promise.status() {
                 jsc::js_promise::Status::Pending => {
-                    this.ref_();
-                    this.pending_ref.set(true);
+                    this.pending_ref.set(Some(RefPtr::from_this(this)));
                     js::pending_promise_set_cached(js_this, &this.global, result);
                     result.then(
                         &this.global,
                         this.as_ptr(),
-                        Bun__CronJob__onPromiseResolve,
-                        Bun__CronJob__onPromiseReject,
+                        crate::generated_host_exports::Bun__CronJob__onPromiseResolve,
+                        crate::generated_host_exports::Bun__CronJob__onPromiseReject,
                     );
                     // `then()` returns `()`, so re-check the VM status and
-                    // recover on termination — otherwise `pending_ref` and the
-                    // `ref_()` above leak.
+                    // recover on termination — otherwise `pending_ref` leaks.
                     if vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
                         js::pending_promise_set_cached(js_this, &this.global, JSValue::UNDEFINED);
                         Self::release_pending_ref(this);
@@ -1729,8 +1658,6 @@ impl CronJob {
                             jsc::JSPromise::opaque_mut(p).result(this.global.vm())
                         }
                     };
-                    // SAFETY: `vm.global` is live; `&mut` derived via the thread-local
-                    // raw pointer (avoids `&T` → `&mut T` provenance laundering).
                     let global_ref = vm.global();
                     VirtualMachine::get()
                         .as_mut()
@@ -1744,11 +1671,7 @@ impl CronJob {
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn stop(&self, _global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        // R-2: `self_stop` may `deref()` the list entry; route through the shared-
-        // provenance ctx pointer (interior mutation only).
-        // SAFETY: `self` is the live heap job; the calling JS wrapper holds a ref.
-        let this = unsafe { ThisPtr::new(self.as_ctx_ptr()) };
-        Self::self_stop(this, self.global.bun_vm());
+        Self::self_stop(self.self_ref.get().this_ptr(), self.global.bun_vm());
         Ok(frame.this())
     }
 
@@ -1800,11 +1723,11 @@ impl CronJob {
             }
         };
 
-        // SAFETY: `bun_vm()` returns the per-thread singleton.
         let vm = global.bun_vm().as_mut();
 
-        let job = bun_core::heap::into_raw(Box::new(CronJob {
+        let job = RefPtr::new(CronJob {
             ref_count: Cell::new(1),
+            self_ref: Cell::new(BackRef::dangling()),
             event_loop_timer: JsCell::new(EventLoopTimer::init_paused(EventLoopTimerTag::CronJob)),
             global: GlobalRef::from(global),
             parsed,
@@ -1813,15 +1736,13 @@ impl CronJob {
             this_value: JsCell::new(JsRef::empty()),
             stopped: Cell::new(false),
             last_next_ms: Cell::new(0.0),
-            pending_ref: Cell::new(false),
+            pending_ref: JsCell::new(None),
             in_fire: Cell::new(false),
-        }));
-        // SAFETY: just allocated; live with refcount == 1.
-        let job = unsafe { ThisPtr::new(job) };
+        });
+        job.self_ref.set(BackRef::from(job.this_ptr()));
 
         let Some(next_time) = job.compute_next_timespec() else {
-            // SAFETY: `job` is a live Box-allocated CronJob; this releases one ref.
-            unsafe { Self::deref(job.as_ptr()) };
+            job.deref();
             return Err(global.throw_invalid_arguments(format_args!(
                 "Cron expression '{}' has no future occurrences",
                 bstr::BStr::new(schedule_slice.slice())
@@ -1832,18 +1753,14 @@ impl CronJob {
         // stop/release jobs. Main-thread VMs without --hot never enumerate it,
         // so skip the list ref + append entirely.
         if vm.hot_reload == HotReload::Hot || vm.worker.is_some() {
-            job.ref_(); // owned by cron_jobs entry
-            // Note: `RareData::cron_jobs` stores the opaque high-tier
-            // placeholder type; cast through `*mut ()` and let inference pick
-            // the element type.
-            vm.rare_data()
-                .cron_jobs
-                .push(job.as_ptr().cast::<()>().cast());
+            if let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() {
+                jobs.push(job.dupe_ref());
+            }
         }
 
-        // SAFETY: `job` is a fresh `heap::alloc` pointer; ownership of one
-        // ref transfers to the C++ wrapper (released via `finalize` → `deref`).
-        let js_value = unsafe { Self::to_js_ptr(job.as_ptr(), global) };
+        // `job`'s ref moves to the JS wrapper (released via `finalize`).
+        let js_value = Self::to_js_nonnull(job.data, global);
+        let job = job.into_this_ptr();
         job.this_value.with_mut(|v| v.set_strong(js_value, global));
         js::cron_set_cached(js_value, global, schedule_arg);
         js::callback_set_cached(
@@ -1864,38 +1781,13 @@ impl CronJob {
     }
 }
 
-// These MUST be *function* symbols: C++ `promiseHandlerID` compares the handler
-// pointer passed to `JSValue::then` against `&Bun__CronJob__onPromiseResolve`
-// by identity. A `static JSHostFn` would export a data slot whose address never
-// matches the inner shim, tripping RELEASE_ASSERT_NOT_REACHED.
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn Bun__CronJob__onPromiseResolve(
-        global: *mut JSGlobalObject,
-        frame: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC passes valid non-null pointers for the host call's duration.
-        let (global, frame) = unsafe { (&*global, &*frame) };
-        jsc::host_fn::to_js_host_fn_result(global, on_promise_resolve(global, frame))
-    }
-}
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn Bun__CronJob__onPromiseReject(
-        global: *mut JSGlobalObject,
-        frame: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC passes valid non-null pointers for the host call's duration.
-        let (global, frame) = unsafe { (&*global, &*frame) };
-        jsc::host_fn::to_js_host_fn_result(global, on_promise_reject(global, frame))
-    }
-}
-
-fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+// C++ `promiseHandlerID` compares the handler passed to `JSValue::then` against
+// these symbols by address, so they must stay function exports.
+// HOST_EXPORT(Bun__CronJob__onPromiseResolve, jsc)
+pub fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
-    let this: *mut CronJob = args[args.len() - 1].as_promise_ptr::<CronJob>();
-    // SAFETY: `pending_ref` holds a ref on `this` until `release_pending_ref`.
-    let this = unsafe { ThisPtr::new(this) };
+    // `pending_ref` holds the ref taken before `then` until `release_pending_ref`.
+    let this = args[args.len() - 1].as_promise_this::<CronJob>();
     let _guard = scopeguard::guard(this, CronJob::release_pending_ref);
     let vm = this.global.bun_vm();
     if let Some(js_this) = this.this_value.get().try_get() {
@@ -1905,11 +1797,10 @@ fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
     Ok(JSValue::UNDEFINED)
 }
 
-fn on_promise_reject(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+// HOST_EXPORT(Bun__CronJob__onPromiseReject, jsc)
+pub fn on_promise_reject(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
-    let this: *mut CronJob = args[args.len() - 1].as_promise_ptr::<CronJob>();
-    // SAFETY: `pending_ref` holds a ref on `this` until `release_pending_ref`.
-    let this = unsafe { ThisPtr::new(this) };
+    let this = args[args.len() - 1].as_promise_this::<CronJob>();
     let _guard = scopeguard::guard(this, CronJob::release_pending_ref);
     let vm = this.global.bun_vm().as_mut();
     let err = args[0];
@@ -2017,9 +1908,8 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
 // ============================================================================
 
 /// Trait abstracting over CronRegisterJob/CronRemoveJob for `spawn_cmd_generic`.
-trait SpawnCmdTarget: CronJobBase + BufferedReaderParent {
-    const EXIT_KIND: bun_spawn::ProcessExitKind;
-    fn process_slot(&self) -> &Cell<Option<*mut Process>>;
+trait SpawnCmdTarget: CronJobBase + BufferedReaderParent + spawn::ProcessExitOwner {
+    fn process_slot(&self) -> &JsCell<Option<ProcessHandle>>;
     #[cfg(unix)]
     fn stdout_reader(&self) -> &JsCell<OutputReader>;
     #[cfg(windows)]
@@ -2042,9 +1932,11 @@ bun_spawn::link_impl_ProcessExit! {
     }
 }
 
+impl spawn::ProcessExitOwner for CronRegisterJob {
+    const KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRegister;
+}
 impl SpawnCmdTarget for CronRegisterJob {
-    const EXIT_KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRegister;
-    fn process_slot(&self) -> &Cell<Option<*mut Process>> {
+    fn process_slot(&self) -> &JsCell<Option<ProcessHandle>> {
         &self.process
     }
     #[cfg(unix)]
@@ -2056,9 +1948,11 @@ impl SpawnCmdTarget for CronRegisterJob {
         &self.stderr_reader
     }
 }
+impl spawn::ProcessExitOwner for CronRemoveJob {
+    const KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRemove;
+}
 impl SpawnCmdTarget for CronRemoveJob {
-    const EXIT_KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRemove;
-    fn process_slot(&self) -> &Cell<Option<*mut Process>> {
+    fn process_slot(&self) -> &JsCell<Option<ProcessHandle>> {
         &self.process
     }
     #[cfg(unix)]
@@ -2078,32 +1972,26 @@ impl SpawnCmdTarget for CronRemoveJob {
 /// see [`CronJobBase`] note. Callers must not touch `this` after this returns.
 fn spawn_cmd_generic<T: SpawnCmdTarget>(
     this: ThisPtr<T>,
-    argv: &mut [*const c_char],
+    argv: &[&CStr],
     stdin_opt: spawn::Stdio,
     stdout_opt: spawn::Stdio,
 ) {
     let Ok(process) = spawn_cmd_prepare(this, argv, stdin_opt, stdout_opt) else {
         return T::finish(this);
     };
-    // SAFETY: `process` was just allocated by `to_process`; we hold the only
-    // ref. `this` is the owning `Box<T>` (only freed in `T::finish`, gated on
-    // `has_called_process_exit`), so it outlives `process`.
-    unsafe {
-        (*process).set_exit_handler(bun_spawn::ProcessExit::new(T::EXIT_KIND, this.as_ptr()))
-    };
-    // SAFETY: `process` is live; `watch_or_reap` may synchronously invoke the
-    // exit handler (which re-enters `this` via the vtable thunk).
-    match unsafe { (*process).watch_or_reap() } {
+    process.set_exit_handler(this);
+    // The exit handler (`on_process_exit` → `maybe_finished`) may free `this`;
+    // it only runs synchronously on the `Ok(true)` and `on_exit` paths, after
+    // which neither `this` nor the slot is touched and the handle is dropped.
+    match process.watch_or_reap() {
+        Ok(false) => this.process_slot().set(Some(process)),
+        Ok(true) => {}
         Err(err) => {
-            // SAFETY: we hold a ref on `process` via `process_slot()`; it is live.
-            if !unsafe { (*process).has_exited() } {
-                // SAFETY: all-zero is a valid Rusage.
+            if !process.has_exited() {
                 let rusage = bun_core::ffi::zeroed::<Rusage>();
-                // SAFETY: `process` is live (ref held); no borrows of `this` remain.
-                unsafe { (*process).on_exit(Status::Err(err), &rusage) };
+                process.on_exit(Status::Err(err), &rusage);
             }
         }
-        Ok(_) => {}
     }
 }
 
@@ -2116,31 +2004,28 @@ fn spawn_cmd_generic<T: SpawnCmdTarget>(
 /// cell itself, so the reader's `with_mut` borrow is the only one live.
 fn spawn_cmd_prepare<T: SpawnCmdTarget>(
     this: ThisPtr<T>,
-    argv: &mut [*const c_char],
+    argv: &[&CStr],
     stdin_opt: spawn::Stdio,
     stdout_opt: spawn::Stdio,
-) -> Result<*mut Process, ()> {
+) -> Result<ProcessHandle, ()> {
     let this_ptr: *mut core::ffi::c_void = this.as_ptr().cast();
     this.has_called_process_exit().set(false);
     this.exit_status().set(None);
     this.remaining_fds().set(0);
 
     #[cfg(not(windows))]
-    let resolved_argv0: Option<*const c_char> = None;
+    let resolved_argv0: Option<*const core::ffi::c_char> = None;
     #[cfg(windows)]
-    let resolved_argv0: Option<*const c_char>;
+    let resolved_argv0: Option<*const core::ffi::c_char>;
     // Hoisted to function scope: `resolved_argv0` borrows into this buffer on
-    // Windows and must outlive the SpawnOptions construction below.
+    // Windows and must outlive the spawn below.
     #[cfg(windows)]
     let mut path_buf = PathBuffer::uninit();
     #[cfg(windows)]
     {
         // Resolve the executable via bun.which, matching Bun.spawn's behavior.
-        // `Transpiler::env()` is the audited safe `&Loader` accessor for the
-        // process-lifetime dotenv loader (centralised single-unsafe deref).
         let path_env = vm_mut().transpiler.env().map.get(b"PATH").unwrap_or(b"");
-        // SAFETY: argv[0] is a NUL-terminated string from caller.
-        let argv0 = unsafe { core::ffi::CStr::from_ptr(argv[0]) }.to_bytes();
+        let argv0 = argv[0].to_bytes();
         match bun_which::which(&mut path_buf, path_env, b"", argv0) {
             Some(p) => resolved_argv0 = Some(p.as_ptr().cast()),
             None => {
@@ -2153,13 +2038,13 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
         }
     }
     #[cfg(unix)]
-    let envp: *const *const c_char = bun_core::c_environ();
+    let env = spawn::SpawnEnv::Inherit;
     #[cfg(windows)]
     let envp_owned;
     #[cfg(windows)]
-    let envp: *const *const c_char = {
-        // `Transpiler::env_mut()` is the audited safe `&mut Loader` accessor
-        // (process-lifetime singleton; centralised single-unsafe deref).
+    let env_strings: Vec<&CStr>;
+    #[cfg(windows)]
+    let env = {
         match vm_mut()
             .transpiler
             .env_mut()
@@ -2168,7 +2053,8 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
         {
             Ok(v) => {
                 envp_owned = v;
-                envp_owned.as_ptr().cast()
+                env_strings = envp_owned.iter().collect();
+                spawn::SpawnEnv::Strings(&env_strings)
             }
             Err(_) => {
                 this.set_err(format_args!("Failed to create environment block"));
@@ -2219,31 +2105,28 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
     #[cfg(windows)]
     let mut spawn_options = spawn_options;
 
-    // SAFETY: `argv`/`envp` are local null-terminated C-string arrays with
-    // argv[0] non-null; valid for this call.
-    let spawned =
-        match unsafe { spawn::spawn_process(&spawn_options, argv.as_mut_ptr().cast(), envp) } {
-            Ok(Ok(sp)) => sp,
-            Ok(Err(err)) => {
-                // `spawn_process_windows` only `heap::take`s the `Stdio::Buffer`
-                // raw `*mut uv::Pipe` on the SUCCESS path; on every error return
-                // ownership stays with the caller and `WindowsStdio` has no
-                // `Drop`. Reclaim it (uv_close + free if init'd) here.
-                #[cfg(windows)]
-                spawn_options.stderr.deinit();
-                this.set_err(format_args!(
-                    "Failed to spawn process: {}",
-                    bstr::BStr::new(err.name())
-                ));
-                return Err(());
-            }
-            Err(e) => {
-                #[cfg(windows)]
-                spawn_options.stderr.deinit();
-                this.set_err(format_args!("Failed to spawn process: {}", e.name()));
-                return Err(());
-            }
-        };
+    let spawned = match spawn::spawn_process_cstr(&spawn_options, argv, env) {
+        Ok(Ok(sp)) => sp,
+        Ok(Err(err)) => {
+            // `spawn_process_windows` only `heap::take`s the `Stdio::Buffer`
+            // raw `*mut uv::Pipe` on the SUCCESS path; on every error return
+            // ownership stays with the caller and `WindowsStdio` has no
+            // `Drop`. Reclaim it (uv_close + free if init'd) here.
+            #[cfg(windows)]
+            spawn_options.stderr.deinit();
+            this.set_err(format_args!(
+                "Failed to spawn process: {}",
+                bstr::BStr::new(err.name())
+            ));
+            return Err(());
+        }
+        Err(e) => {
+            #[cfg(windows)]
+            spawn_options.stderr.deinit();
+            this.set_err(format_args!("Failed to spawn process: {}", e.name()));
+            return Err(());
+        }
+    };
     #[cfg(windows)]
     let mut spawned = spawned;
 
@@ -2309,44 +2192,23 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
         }
     }
 
-    // SAFETY: `vm_mut().event_loop()` returns the live per-thread `jsc::EventLoop`.
     let ev_handle = EventLoopHandle::init(vm_mut().event_loop().cast::<()>());
-    let process = spawned.to_process(ev_handle);
-    this.process_slot().set(Some(process));
-    Ok(process)
+    Ok(spawned.to_process_handle(ev_handle))
 }
 
 /// Find crontab binary using bun.which (searches PATH).
 #[cfg(not(target_os = "macos"))]
-fn find_crontab() -> Option<*const c_char> {
+fn find_crontab() -> Option<ZString> {
     #[cfg(windows)]
     {
         return None;
     }
     #[cfg(not(windows))]
     {
-        // The returned `*const c_char` borrows this buffer, so it must outlive
-        // the call. `Bun.cron` is exposed on every `BunObject`, so this is
-        // reachable from the main JS thread *and* any Worker thread
-        // concurrently — a process-global `static` would be a data race.
-        // `thread_local!` gives each JS thread its own scratch buffer; the
-        // returned pointer is consumed on the same thread (copied by
-        // `posix_spawn`) before any later call can overwrite it. Non-Windows
-        // only, so `MAX_PATH_BYTES` is ≤4 KiB and inline TLS is fine.
-        thread_local! {
-            static BUF: core::cell::RefCell<bun_core::PathBuffer> =
-                const { core::cell::RefCell::new(bun_core::PathBuffer::ZEROED) };
-        }
         let path_env = env_var::PATH.get().unwrap_or(b"/usr/bin:/bin");
-        // `bun_which::which` is a pure PATH walk that cannot reenter
-        // `find_crontab`, so the `RefCell` borrow is never contested. The
-        // returned raw pointer escapes the `RefMut` guard but stays valid:
-        // it points into per-thread storage and is consumed by `posix_spawn`
-        // on this thread before any later call could overwrite the buffer.
-        BUF.with_borrow_mut(|buf| {
-            let found = bun_which::which(buf, path_env, b"", b"crontab")?;
-            Some(found.as_ptr().cast())
-        })
+        let mut buf = PathBuffer::uninit();
+        let found = bun_which::which(&mut buf, path_env, b"", b"crontab")?;
+        Some(ZString::from_bytes(found.as_bytes()))
     }
 }
 
@@ -2355,7 +2217,6 @@ fn resolve_path(
     frame: &CallFrame,
     path_: &[u8],
 ) -> crate::Result<ZString> {
-    // SAFETY: `bun_vm()` returns the per-thread singleton.
     let vm = global.bun_vm().as_mut();
     let srcloc = frame.get_caller_src_loc(global);
     let caller_utf8 = srcloc.str.to_utf8();

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1784,10 +1784,12 @@ impl CronJob {
 // C++ `promiseHandlerID` compares the handler passed to `JSValue::then` against
 // these symbols by address, so they must stay function exports.
 // HOST_EXPORT(Bun__CronJob__onPromiseResolve, jsc)
-pub fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    let args = frame.arguments();
+pub fn on_promise_resolve(
+    this: ThisPtr<CronJob>,
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
     // `pending_ref` holds the ref taken before `then` until `release_pending_ref`.
-    let this = args[args.len() - 1].as_promise_this::<CronJob>();
     let _guard = scopeguard::guard(this, CronJob::release_pending_ref);
     let vm = this.global.bun_vm();
     if let Some(js_this) = this.this_value.get().try_get() {
@@ -1798,9 +1800,12 @@ pub fn on_promise_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 }
 
 // HOST_EXPORT(Bun__CronJob__onPromiseReject, jsc)
-pub fn on_promise_reject(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+pub fn on_promise_reject(
+    this: ThisPtr<CronJob>,
+    _global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
     let args = frame.arguments();
-    let this = args[args.len() - 1].as_promise_this::<CronJob>();
     let _guard = scopeguard::guard(this, CronJob::release_pending_ref);
     let vm = this.global.bun_vm().as_mut();
     let err = args[0];

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1937,7 +1937,8 @@ bun_spawn::link_impl_ProcessExit! {
     }
 }
 
-impl spawn::ProcessExitOwner for CronRegisterJob {
+// SAFETY: `link_impl_ProcessExit!` above registers `CronRegister => CronRegisterJob`.
+unsafe impl spawn::ProcessExitOwner for CronRegisterJob {
     const KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRegister;
 }
 impl SpawnCmdTarget for CronRegisterJob {
@@ -1953,7 +1954,8 @@ impl SpawnCmdTarget for CronRegisterJob {
         &self.stderr_reader
     }
 }
-impl spawn::ProcessExitOwner for CronRemoveJob {
+// SAFETY: `link_impl_ProcessExit!` above registers `CronRemove => CronRemoveJob`.
+unsafe impl spawn::ProcessExitOwner for CronRemoveJob {
     const KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRemove;
 }
 impl SpawnCmdTarget for CronRemoveJob {

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1913,7 +1913,7 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
 // ============================================================================
 
 /// Trait abstracting over CronRegisterJob/CronRemoveJob for `spawn_cmd_generic`.
-trait SpawnCmdTarget: CronJobBase + BufferedReaderParent + spawn::ProcessExitOwner {
+trait SpawnCmdTarget: CronJobBase + BufferedReaderParent + bun_spawn::ProcessExitOwner {
     fn process_slot(&self) -> &JsCell<Option<ProcessHandle>>;
     #[cfg(unix)]
     fn stdout_reader(&self) -> &JsCell<OutputReader>;
@@ -1937,10 +1937,6 @@ bun_spawn::link_impl_ProcessExit! {
     }
 }
 
-// SAFETY: `link_impl_ProcessExit!` above registers `CronRegister => CronRegisterJob`.
-unsafe impl spawn::ProcessExitOwner for CronRegisterJob {
-    const KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRegister;
-}
 impl SpawnCmdTarget for CronRegisterJob {
     fn process_slot(&self) -> &JsCell<Option<ProcessHandle>> {
         &self.process
@@ -1953,10 +1949,6 @@ impl SpawnCmdTarget for CronRegisterJob {
     fn stderr_reader(&self) -> &JsCell<OutputReader> {
         &self.stderr_reader
     }
-}
-// SAFETY: `link_impl_ProcessExit!` above registers `CronRemove => CronRemoveJob`.
-unsafe impl spawn::ProcessExitOwner for CronRemoveJob {
-    const KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRemove;
 }
 impl SpawnCmdTarget for CronRemoveJob {
     fn process_slot(&self) -> &JsCell<Option<ProcessHandle>> {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1478,7 +1478,7 @@ mod vm_loader_ctx {
     // (`main`, `blob_loader`) form a transient `&VirtualMachine` scoped to the
     // single call, which never spans the re-entrant path.
     bun_bundler::link_impl_VmLoaderCtx! {
-        Runtime for VirtualMachine => |this| {
+        Runtime for extern VirtualMachine => |this| {
             origin_host() => (*this).origin.host,
             origin_path() => (*this).origin.path,
             loaders() => &raw const (*this).transpiler.options.loaders,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -102,6 +102,10 @@ pub(crate) struct RuntimeState {
     /// The resolver's PackageManager wake-handler context (module queue + VM
     /// handle); the resolver holds a raw pointer to it. Freed with the state.
     pub(crate) wake_ctx: Option<Box<bun_jsc::async_module::WakeContext>>,
+    /// In-process `Bun.cron()` jobs that `--hot` reload / worker teardown must
+    /// stop; one ref per entry, released by `CronJob::remove_from_list` /
+    /// `clear_all_for_vm`.
+    pub(crate) cron_jobs: Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -193,6 +197,17 @@ pub(crate) fn timer_all_mut() -> &'static mut timer::All {
     // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
     // single JS thread so no concurrent `&mut`.
     unsafe { &mut (*state).timer }
+}
+
+#[inline]
+pub(crate) fn cron_jobs_mut() -> Option<&'static mut Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>>
+{
+    let state = runtime_state();
+    if state.is_null() {
+        return None;
+    }
+    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread.
+    Some(unsafe { &mut (*state).cron_jobs })
 }
 
 #[inline]
@@ -396,6 +411,7 @@ unsafe fn init_runtime_state(
         },
         active_handles: ActiveHandles::default(),
         wake_ctx: None,
+        cron_jobs: Vec::new(),
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 
@@ -679,7 +695,9 @@ unsafe fn deinit_runtime_state(_vm: *mut VirtualMachine, state: OpaqueRuntimeSta
         // SAFETY: per fn contract — `state` is the unique `heap::alloc` result
         // from `init_runtime_state`; the TLS was just cleared so no other live
         // alias exists on this thread.
-        drop(unsafe { bun_core::heap::take(state.cast::<RuntimeState>()) });
+        let state = unsafe { bun_core::heap::take(state.cast::<RuntimeState>()) };
+        debug_assert!(state.cron_jobs.is_empty());
+        drop(state);
     }
     // Free the thread-local AST stores allocated by `Transpiler::init_in_place`
     // (via `Store::create()`). They live in TLS without a Drop, so each worker

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -153,7 +153,7 @@ impl ClearedTimers {
             // job was scheduled and its JS wrapper (strong while scheduled)
             // keeps it alive; no JS has run since; the `FakeTimers` borrow
             // ended before this call.
-            unsafe { CronJob::stop_dropped_from_fake_heap(job) };
+            CronJob::stop_dropped_from_fake_heap(unsafe { bun_ptr::ThisPtr::new(job) });
         }
     }
 }

--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -60,8 +60,9 @@ pub use bun_spawn_sys::{Argv, CStrPtr, Envp, ffi};
 
 pub use bun_spawn_sys::RusageFields;
 pub use process::{
-    Dup2, Exited, ExtraPipe, PidT, Poller, Process, Rusage, SignalCodeExt, SpawnOptions,
-    SpawnProcessResult, SpawnResultExt, Status, StdioKind, WaiterThread, spawn_process,
+    Dup2, Exited, ExtraPipe, PidT, Poller, Process, ProcessExitOwner, ProcessHandle, Rusage,
+    SignalCodeExt, SpawnEnv, SpawnOptions, SpawnProcessResult, SpawnResultExt, Status, StdioKind,
+    WaiterThread, spawn_process, spawn_process_cstr,
 };
 
 // Variant types live in `bun_runtime`/`bun_install`; each provides its body

--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -60,9 +60,9 @@ pub use bun_spawn_sys::{Argv, CStrPtr, Envp, ffi};
 
 pub use bun_spawn_sys::RusageFields;
 pub use process::{
-    Dup2, Exited, ExtraPipe, PidT, Poller, Process, ProcessExitOwner, ProcessHandle, Rusage,
-    SignalCodeExt, SpawnEnv, SpawnOptions, SpawnProcessResult, SpawnResultExt, Status, StdioKind,
-    WaiterThread, spawn_process, spawn_process_cstr,
+    Dup2, Exited, ExtraPipe, PidT, Poller, Process, ProcessHandle, Rusage, SignalCodeExt, SpawnEnv,
+    SpawnOptions, SpawnProcessResult, SpawnResultExt, Status, StdioKind, WaiterThread,
+    spawn_process, spawn_process_cstr,
 };
 
 // Variant types live in `bun_runtime`/`bun_install`; each provides its body

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -142,6 +142,63 @@ impl Drop for Process {
     }
 }
 
+/// The type a [`ProcessExitKind`] variant's `link_impl_ProcessExit!` was
+/// written for; implement it next to that macro call.
+pub trait ProcessExitOwner {
+    const KIND: ProcessExitKind;
+}
+
+/// The exit-handler owner's handle on a [`Process`]: one owned ref, and
+/// dropping it detaches the handler before releasing that ref. The owner must
+/// stay live until the handle is dropped or the exit has been dispatched —
+/// keeping the handle in one of the owner's fields satisfies that.
+///
+/// Every method projects a call-scoped borrow of the `Process` (its own heap
+/// allocation, event-loop thread only); none escapes this type. Dropping the
+/// handle from inside the exit handler re-enters the `Process` whose `on_exit`
+/// is dispatching, exactly as the raw-pointer owners do.
+pub struct ProcessHandle(bun_ptr::RefPtr<Process>);
+
+impl ProcessHandle {
+    #[inline]
+    #[allow(clippy::mut_from_ref)]
+    fn process_mut(&self) -> &mut Process {
+        // SAFETY: we hold a ref, so the pointee is live; the borrow ends with
+        // the forwarding call (see the type-level note on re-entrancy).
+        unsafe { &mut *self.0.as_ptr() }
+    }
+
+    /// Dispatch this process's exit to `owner` (see the type-level contract).
+    pub fn set_exit_handler<T: ProcessExitOwner>(&self, owner: bun_ptr::ThisPtr<T>) {
+        // SAFETY: `T::KIND` names `T`'s own `link_impl_ProcessExit!`; `owner`
+        // is live now (`ThisPtr` invariant) and, per the type-level contract,
+        // for every dispatch.
+        let h = unsafe { ProcessExit::new(T::KIND, owner.as_ptr()) };
+        self.process_mut().set_exit_handler(h);
+    }
+
+    /// See [`Process::watch_or_reap`]; may synchronously run the exit handler.
+    pub fn watch_or_reap(&self) -> bun_sys::Result<bool> {
+        self.process_mut().watch_or_reap()
+    }
+
+    /// See [`Process::on_exit`]; runs the exit handler.
+    pub fn on_exit(&self, status: Status, rusage: &Rusage) {
+        self.process_mut().on_exit(status, rusage)
+    }
+
+    pub fn has_exited(&self) -> bool {
+        self.0.data().has_exited()
+    }
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        self.process_mut().detach();
+        self.0.deref();
+    }
+}
+
 impl Process {
     pub fn memory_cost(&self) -> usize {
         core::mem::size_of::<Self>()
@@ -1522,6 +1579,14 @@ impl WindowsSpawnResult {
     pub fn to_process(&mut self, _event_loop: impl Sized) -> *mut Process {
         self.process.take().unwrap()
     }
+
+    /// [`to_process`](Self::to_process), returning the owning handle.
+    pub fn to_process_handle(&mut self, event_loop: impl Sized) -> ProcessHandle {
+        // SAFETY: `to_process` returns the live heap `Process` allocated by
+        // `spawn_process_windows` with its initial ref; that ref moves into
+        // the handle.
+        ProcessHandle(unsafe { bun_ptr::RefPtr::from_raw(self.to_process(event_loop)) })
+    }
 }
 
 #[cfg(windows)]
@@ -1679,8 +1744,15 @@ impl WindowsSpawnOptions {
 /// `bun_spawn_sys`. The result type itself lives in the leaf `-sys` crate (no
 /// `Process`/`EventLoopHandle` dependency); `to_process` is added here as a
 /// trait method so callers keep the `.to_process(loop_, sync)` spelling.
-pub trait SpawnResultExt {
+pub trait SpawnResultExt: Sized {
     fn to_process(self, event_loop: EventLoopHandle) -> *mut Process;
+
+    /// [`to_process`](Self::to_process), returning the owning handle.
+    fn to_process_handle(self, event_loop: EventLoopHandle) -> ProcessHandle {
+        // SAFETY: `to_process` returns a live heap `Process` whose initial ref
+        // the caller owns; that ref moves into the handle.
+        ProcessHandle(unsafe { bun_ptr::RefPtr::from_raw(self.to_process(event_loop)) })
+    }
 }
 
 #[cfg(unix)]
@@ -1763,6 +1835,49 @@ mod spawn_process_body {
         {
             spawn_process_windows(options, argv, envp)
         }
+    }
+
+    /// The environment block handed to the child by [`spawn_process_cstr`].
+    #[derive(Clone, Copy)]
+    pub enum SpawnEnv<'a> {
+        /// This process's own `environ`.
+        Inherit,
+        /// `KEY=VALUE` strings; the null-terminated pointer block is built here.
+        Strings(&'a [&'a core::ffi::CStr]),
+    }
+
+    /// [`spawn_process`] for callers holding borrowed C strings: builds the
+    /// null-terminated `argv`/`envp` pointer blocks for the duration of the call.
+    pub fn spawn_process_cstr(
+        options: &SpawnOptions,
+        argv: &[&core::ffi::CStr],
+        env: SpawnEnv<'_>,
+    ) -> Result<bun_sys::Result<SpawnProcessResult>, crate::Error> {
+        assert!(!argv.is_empty(), "spawn_process_cstr: argv[0] is required");
+        let argv: Vec<CStrPtr> = argv
+            .iter()
+            .map(|s| s.as_ptr())
+            .chain(core::iter::once(core::ptr::null()))
+            .collect();
+        let env_block: Vec<CStrPtr>;
+        let envp: Envp = match env {
+            // libuv: a null `env` inherits the parent's environment.
+            #[cfg(windows)]
+            SpawnEnv::Inherit => core::ptr::null(),
+            #[cfg(unix)]
+            SpawnEnv::Inherit => bun_core::c_environ(),
+            SpawnEnv::Strings(strings) => {
+                env_block = strings
+                    .iter()
+                    .map(|s| s.as_ptr())
+                    .chain(core::iter::once(core::ptr::null()))
+                    .collect();
+                env_block.as_ptr()
+            }
+        };
+        // SAFETY: both blocks are null-terminated arrays of NUL-terminated
+        // strings borrowed for the call; argv[0] is non-null (asserted).
+        unsafe { spawn_process(options, argv.as_ptr(), envp) }
     }
 
     #[cfg(windows)]
@@ -3873,5 +3988,6 @@ mod spawn_process_body {
 pub use spawn_process_body::spawn_process;
 #[cfg(unix)]
 pub use spawn_process_body::spawn_process_posix;
+pub use spawn_process_body::{SpawnEnv, spawn_process_cstr};
 
 pub use spawn_process_body::sync;

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -144,7 +144,11 @@ impl Drop for Process {
 
 /// The type a [`ProcessExitKind`] variant's `link_impl_ProcessExit!` was
 /// written for; implement it next to that macro call.
-pub trait ProcessExitOwner {
+///
+/// # Safety
+/// `KIND` must be the variant whose `link_impl_ProcessExit!` names `Self`:
+/// the exit dispatch casts the owner pointer back to that type.
+pub unsafe trait ProcessExitOwner {
     const KIND: ProcessExitKind;
 }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -142,16 +142,6 @@ impl Drop for Process {
     }
 }
 
-/// The type a [`ProcessExitKind`] variant's `link_impl_ProcessExit!` was
-/// written for; implement it next to that macro call.
-///
-/// # Safety
-/// `KIND` must be the variant whose `link_impl_ProcessExit!` names `Self`:
-/// the exit dispatch casts the owner pointer back to that type.
-pub unsafe trait ProcessExitOwner {
-    const KIND: ProcessExitKind;
-}
-
 /// The exit-handler owner's handle on a [`Process`]: one owned ref, and
 /// dropping it detaches the handler before releasing that ref. The owner must
 /// stay live until the handle is dropped or the exit has been dispatched —
@@ -173,11 +163,10 @@ impl ProcessHandle {
     }
 
     /// Dispatch this process's exit to `owner` (see the type-level contract).
-    pub fn set_exit_handler<T: ProcessExitOwner>(&self, owner: bun_ptr::ThisPtr<T>) {
-        // SAFETY: `T::KIND` names `T`'s own `link_impl_ProcessExit!`; `owner`
-        // is live now (`ThisPtr` invariant) and, per the type-level contract,
-        // for every dispatch.
-        let h = unsafe { ProcessExit::new(T::KIND, owner.as_ptr()) };
+    pub fn set_exit_handler<T: crate::ProcessExitOwner>(&self, owner: bun_ptr::ThisPtr<T>) {
+        // SAFETY: `owner` is live now (`ThisPtr` invariant) and, per the
+        // type-level contract, for every dispatch.
+        let h = unsafe { ProcessExit::of(owner.as_ptr()) };
         self.process_mut().set_exit_handler(h);
     }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1812,7 +1812,8 @@ mod spawn_process_body {
     /// # Safety
     /// `argv` must point to a null-terminated array of NUL-terminated C
     /// strings with at least one non-null element; `envp` must point to a
-    /// null-terminated array of NUL-terminated C strings. Both must remain
+    /// null-terminated array of NUL-terminated C strings, or be null on
+    /// Windows (libuv then inherits the parent environment). Both must remain
     /// valid for the duration of the call.
     pub unsafe fn spawn_process(
         options: &SpawnOptions,
@@ -1868,8 +1869,9 @@ mod spawn_process_body {
                 env_block.as_ptr()
             }
         };
-        // SAFETY: both blocks are null-terminated arrays of NUL-terminated
-        // strings borrowed for the call; argv[0] is non-null (asserted).
+        // SAFETY: `argv` is a null-terminated array of NUL-terminated strings
+        // with argv[0] non-null (asserted); `envp` is likewise, or null on
+        // Windows for `Inherit`. Both are borrowed for the call.
         unsafe { spawn_process(options, argv.as_ptr(), envp) }
     }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9382,7 +9382,7 @@ fn sink_tty_winsize(_fd: Fd) -> Option<bun_core::Winsize> {
 
 // Backs `bun_core::OutputSink[Sys]` — stderr/mkdir/open/QuietWriter.
 bun_core::link_impl_OutputSink! {
-    Sys for () => |_this| {
+    Sys for extern () => |_this| {
         stderr() => bun_core::output::File(Fd::stderr()),
         make_path(cwd, dir) => mkdir_recursive_at(cwd, dir).map_err(|_| bun_core::Error::Unexpected),
         create_file(cwd, path) =>


### PR DESCRIPTION
### What

Stacked on #40055 (uses its `bun_ptr` / host-export generator additions). Takes `src/runtime/api/cron.rs` from 34 `unsafe` sites to **zero** by fixing the layers below rather than annotating call sites:

- `CronRegisterJob` / `CronRemoveJob` own themselves through a `RefPtr` released in `finish` (was `heap::into_raw` + `heap::take`); `finish` is one shared `CronJobBase` method.
- The spawned `crontab`/`launchctl`/`schtasks` child is a `bun_spawn::ProcessHandle` (owning ref; `Drop` = detach + deref; typed `set_exit_handler<T: ProcessExitOwner>`), and argv/env are `&[&CStr]` end to end via a new safe `bun_spawn::spawn_process_cstr(options, argv, SpawnEnv)` — no raw `*const c_char` arrays or `CStr::from_ptr` in the caller.
- The promise reactions are `HOST_EXPORT`s using a new generator shape: an impl of the form `fn(this: ThisPtr<T>, &JSGlobalObject, &CallFrame) -> JsResult<JSValue>` gets a thunk that hands back the `ctx` registered with `JSValue::then` as a typed `ThisPtr` (replaces the hand-written `jsc_host_abi!` shims and `as_promise_ptr` + `ThisPtr::new` at each reaction; reusable for the other ~20 `as_promise_ptr` sites).
- The per-VM job list moves from an erased `Vec<*mut c_void>` in `bun_jsc::RareData` to `RuntimeState::cron_jobs: Vec<RefPtr<CronJob>>`; the pending-promise ref is `JsCell<Option<RefPtr<Self>>>` instead of a bool + manual `ref_()`/`deref()`; `stop()` reaches the `ThisPtr` paths through a `self_ref` back-reference set at allocation; FakeTimers hands `stop_dropped_from_fake_heap` a `ThisPtr`.

### Testing

Debug+ASAN, cronie installed: `cron.test.ts` 82 pass / 35 skip (Windows-only), `in-process-cron.test.ts` 27 pass, `cron-local-time.test.ts` 30 pass; `cron-parse.test.ts` unchanged (its `<50ms` case fails on every debug build). By hand: `PATH=/nonexistent` register/remove reject; register → `crontab -l` → remove round-trip; stop-inside-callback and pending-promise re-arm under fake timers; worker terminate with a pending cron promise; `--hot` reload ×3. `rust-check-all` for x86_64-pc-windows-msvc and aarch64-apple-darwin passes.