### PR TITLE
server: take StaticRoute, FileRoute, HTMLBundle and DirectoryRoute to zero unsafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
  "bun_libuv_sys",
  "bun_opaque",
  "bun_paths",
+ "bun_ptr",
  "bun_windows_sys",
  "libc",
  "strum",

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -992,6 +992,17 @@ impl JSValue {
         // so aliasing with other `as_class_ref` borrows is fine.
         self.as_::<T>().map(|p| unsafe { &*p })
     }
+
+    /// [`as_class_ref`](Self::as_class_ref) as a [`ThisPtr`](bun_ptr::ThisPtr),
+    /// for `m_ctx` payloads that are intrusively refcounted: lets the caller
+    /// take its own ref (`RefPtr::from_this`) or dispatch into a
+    /// `ThisPtr`-taking entry point. Same frame-scoped validity.
+    #[inline]
+    pub fn as_class_this_ptr<T: JsClass>(self) -> Option<bun_ptr::ThisPtr<T>> {
+        // SAFETY: as for `as_class_ref` — the pointer is the live payload of the
+        // cell `self` encodes, which the stack scan keeps alive for this frame.
+        self.as_::<T>().map(|p| unsafe { bun_ptr::ThisPtr::new(p) })
+    }
     /// `JSValue.asPromise()` — downcast to `JSPromise` (matches `JSInternalPromise` too).
     /// Returns a raw pointer; conjuring a
     /// `&'static mut` here would permit aliased `&mut` UB across two calls on

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1374,19 +1374,15 @@ pub mod js_bundler {
         // `crate::api::js_bundle_completion_task` (bun_runtime owns it because its
         // fields name `Config`/`Plugin`/`HTMLBundle::Route`; lower-tier crates
         // cannot depend on those).
-        let completion =
-            crate::api::js_bundle_completion_task::create_and_schedule_completion_task(
-                config,
-                plugins.and_then(core::ptr::NonNull::new),
-                global_this,
-            )
-            .map_err(|_| JsError::OutOfMemory)?;
-        // SAFETY: `completion` is the freshly-boxed allocation returned above;
-        // sole owner on the JS thread until enqueued task runs.
-        unsafe {
-            (*completion).promise = jsc::JSPromiseStrong::init(global_this);
-            Ok((*completion).promise.value())
-        }
+        let mut completion = crate::api::js_bundle_completion_task::JSBundleCompletionTask::new(
+            config,
+            plugins.and_then(core::ptr::NonNull::new),
+            global_this,
+        );
+        completion.promise = jsc::JSPromiseStrong::init(global_this);
+        let promise = completion.promise.value();
+        completion.schedule();
+        Ok(promise)
     }
 
     /// `Bun.build(config)`

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -31,6 +31,7 @@ use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf, platform};
 use bun_paths::{self as paths, PathBuffer, SEP};
 use bun_ptr::BackRef;
 use bun_ptr::RefCount;
+use bun_ptr::RefPtr;
 use bun_standalone_graph::StandaloneModuleGraph::{
     CompileErrorReason, CompileResult, Flags as StandaloneFlags, target_base_public_path,
     to_executable,
@@ -76,7 +77,10 @@ pub struct JSBundleCompletionTask {
     /// is still queued itself instead of waiting behind other VMs' builds.
     pub(crate) stage: core::sync::atomic::AtomicU8,
 
-    pub(crate) html_build_task: Option<*mut html_bundle::Route>,
+    /// The route this build is for, kept alive until `on_complete` hands it
+    /// the result (leaked with the rest of the route if the build is cancelled
+    /// at VM teardown).
+    pub(crate) html_build_task: Option<RefPtr<html_bundle::Route>>,
 
     pub(crate) result: BundleV2Result,
 
@@ -135,60 +139,56 @@ impl JSBundleCompletionTask {
 // never touch the count itself.
 unsafe impl Send for JSBundleCompletionTask {}
 
-/// `BundleV2.createAndScheduleCompletionTask` — construct, take a process-keepalive
-/// ref, and hand the task to the bundle-thread singleton.
-pub(crate) fn create_and_schedule_completion_task(
-    config: JSBundlerConfig,
-    plugins: Option<NonNull<Plugin>>,
-    global_this: &JSGlobalObject,
-) -> crate::Result<*mut JSBundleCompletionTask> {
-    let vm = global_this.bun_vm_ptr();
-    let env = global_this.bun_vm().transpiler.env;
-    let completion = bun_core::heap::into_raw(Box::new(JSBundleCompletionTask {
-        ref_count: RefCount::init(),
-        config,
-        bundle_ticket: Some(global_this.bun_vm().ticket()),
-        global_this: BackRef::new(global_this),
-        promise: jsc::JSPromiseStrong::default(),
-        poll_ref: KeepAlive::init(),
-        env,
-        log: bun_ast::Log::init(),
-        cancelled: core::sync::atomic::AtomicBool::new(false),
-        bundle_loop: core::sync::atomic::AtomicPtr::new(ptr::null_mut()),
-        stage: core::sync::atomic::AtomicU8::new(Stage::Queued as u8),
-        html_build_task: None,
-        result: BundleV2Result::Pending,
-        next: bun_threading::Link::new(),
-        transpiler: ptr::null_mut(),
-        plugins,
-        started_at_ns: 0,
-    }));
-    // SAFETY: freshly-boxed allocation with ref_count == 1; sole handle.
-    unsafe {
-        if let Some(plugin) = (*completion).plugins {
-            (*plugin.as_ptr()).set_config(completion.cast());
+impl JSBundleCompletionTask {
+    /// An unscheduled build of `config`; see [`schedule`](Self::schedule).
+    pub(crate) fn new(
+        config: JSBundlerConfig,
+        plugins: Option<NonNull<Plugin>>,
+        global_this: &JSGlobalObject,
+    ) -> JSBundleCompletionTask {
+        JSBundleCompletionTask {
+            ref_count: RefCount::init(),
+            config,
+            bundle_ticket: Some(global_this.bun_vm().ticket()),
+            global_this: BackRef::new(global_this),
+            promise: jsc::JSPromiseStrong::default(),
+            poll_ref: KeepAlive::init(),
+            env: global_this.bun_vm().transpiler.env,
+            log: bun_ast::Log::init(),
+            cancelled: core::sync::atomic::AtomicBool::new(false),
+            bundle_loop: core::sync::atomic::AtomicPtr::new(ptr::null_mut()),
+            stage: core::sync::atomic::AtomicU8::new(Stage::Queued as u8),
+            html_build_task: None,
+            result: BundleV2Result::Pending,
+            next: bun_threading::Link::new(),
+            transpiler: ptr::null_mut(),
+            plugins,
+            started_at_ns: 0,
         }
     }
 
-    // Ensure this exists before we spawn the thread to prevent any race
-    // conditions from creating two
-    let _ = WorkPool::get();
+    /// `BundleV2.createAndScheduleCompletionTask` — take a process-keepalive
+    /// ref and hand the task to the bundle-thread singleton. The one ref `new`
+    /// created travels with the task and is released by `on_complete_anytask`.
+    pub(crate) fn schedule(mut self) {
+        self.poll_ref.ref_(self.global_this.bun_vm().loop_ctx());
+        let plugins = self.plugins;
+        let completion = RefPtr::new(self).into_raw();
+        if let Some(plugin) = plugins {
+            Plugin::opaque_mut(plugin.as_ptr()).set_config(completion.cast());
+        }
 
-    // Out on the bundle thread from here until it posts the completion: it
-    // reads this VM's env loader and the plugin cell, so the VM cancels it at
-    // teardown (registry) and waits for it (`bundle_ticket`).
-    crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(completion).expect("completion"))
-        .register();
-    bun_bundler::bundle_v2::singleton::enqueue::<JSBundleCompletionTask>(completion);
+        // Ensure this exists before we spawn the thread to prevent any race
+        // conditions from creating two
+        let _ = WorkPool::get();
 
-    // SAFETY: `completion` is live (refcount==1); `vm` outlives this call.
-    unsafe {
-        (*completion)
-            .poll_ref
-            .ref_(jsc::virtual_machine::VirtualMachine::event_loop_ctx(vm))
-    };
-
-    Ok(completion)
+        // Out on the bundle thread from here until it posts the completion: it
+        // reads this VM's env loader and the plugin cell, so the VM cancels it at
+        // teardown (registry) and waits for it (`bundle_ticket`).
+        crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(completion).expect("completion"))
+            .register();
+        bun_bundler::bundle_v2::singleton::enqueue::<JSBundleCompletionTask>(completion);
+    }
 }
 
 /// `if (s.slice().len > 0) s.slice() else null` for the windows-options block.
@@ -634,12 +634,10 @@ impl JSBundleCompletionTask {
             return Ok(());
         }
 
-        if let Some(html_build_task) = this.html_build_task {
+        if let Some(html_build_task) = this.html_build_task.take() {
             this.plugins = None;
-            // SAFETY: `html_build_task` is a backref set by `HTMLBundle::Route` which
-            // bumped its own refcount before scheduling and stays alive until this returns.
-            // R-2: deref as shared — `on_complete` takes `&self`.
-            unsafe { html_bundle::Route::on_complete(&*html_build_task, this) };
+            html_build_task.on_complete(this);
+            html_build_task.deref();
             return Ok(());
         }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1754,8 +1754,7 @@ fn on_js_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
                 ..Default::default()
             },
         );
-        // SAFETY: `response` holds a ref for the duration of the call.
-        unsafe { StaticRoute::on_request(response.as_ptr(), bun_uws::AnyRequest::H1(req), resp) };
+        StaticRoute::on_request(response.this_ptr(), bun_uws::AnyRequest::H1(req), resp);
         return;
     }
 
@@ -1795,8 +1794,7 @@ fn on_asset_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
         return not_found(resp);
     };
     req.set_yield(false);
-    // SAFETY: `dev.assets` holds a ref on `asset` for as long as it is stored.
-    unsafe { StaticRoute::on(asset.as_ptr(), resp) };
+    StaticRoute::on(asset.this_ptr(), resp);
 }
 
 pub(super) use bun_core::fmt::parse_hex_to_int;
@@ -2681,10 +2679,10 @@ impl DevServer {
 
         // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in
         // this fn; the shared reborrow ends with this statement.
-        let cached: Option<*mut StaticRoute> =
+        let cached: Option<bun_ptr::ThisPtr<StaticRoute>> =
             unsafe { (*route_bundle).data.html().cached_response.as_ref() }
-                .map(route_bundle::StaticRouteRef::as_ptr);
-        let blob: *mut StaticRoute = match cached {
+                .map(route_bundle::StaticRouteRef::this_ptr);
+        let blob: bun_ptr::ThisPtr<StaticRoute> = match cached {
             Some(blob) => blob,
             None => 'generate: {
                 // SAFETY: `generate_html_payload` reads `route_bundle.data` /
@@ -2705,14 +2703,13 @@ impl DevServer {
                         ..Default::default()
                     },
                 );
-                let blob = response.as_ptr();
+                let blob = response.this_ptr();
                 // SAFETY: per-access reborrow; no other `&` into `*route_bundle` live.
                 unsafe { (*route_bundle).data.html_mut().cached_response = Some(response) };
                 break 'generate blob;
             }
         };
-        // SAFETY: blob is a live boxed StaticRoute owned by html.cached_response
-        unsafe { StaticRoute::on_with_method(blob, method, resp) };
+        StaticRoute::on_with_method(blob, method, resp);
     }
 }
 
@@ -2894,9 +2891,10 @@ impl DevServer {
             unsafe { &mut *self_ptr }.route_bundle_ptr(bundle_index);
         // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in
         // this fn; the shared reborrow ends with this statement.
-        let cached: Option<*mut StaticRoute> = unsafe { (*route_bundle).client_bundle.as_ref() }
-            .map(route_bundle::StaticRouteRef::as_ptr);
-        let client_bundle: *mut StaticRoute = match cached {
+        let cached: Option<bun_ptr::ThisPtr<StaticRoute>> =
+            unsafe { (*route_bundle).client_bundle.as_ref() }
+                .map(route_bundle::StaticRouteRef::this_ptr);
+        let client_bundle: bun_ptr::ThisPtr<StaticRoute> = match cached {
             Some(client_bundle) => client_bundle,
             None => 'generate: {
                 // SAFETY: `generate_client_bundle` reads `*route_bundle` and
@@ -2914,7 +2912,7 @@ impl DevServer {
                         ..Default::default()
                     },
                 );
-                let client_bundle = bundle.as_ptr();
+                let client_bundle = bundle.this_ptr();
                 // SAFETY: per-access reborrow; no other `&` into `*route_bundle` live.
                 unsafe { (*route_bundle).client_bundle = Some(bundle) };
                 break 'generate client_bundle;
@@ -2924,8 +2922,7 @@ impl DevServer {
         let source_map_id = unsafe { &*route_bundle }.source_map_id();
         // SAFETY: `source_maps` is disjoint from `route_bundles`.
         unsafe { &mut (*self_ptr).source_maps }.add_weak_ref(source_map_id);
-        // SAFETY: client_bundle is a live boxed StaticRoute owned by route_bundle.client_bundle
-        unsafe { StaticRoute::on_with_method(client_bundle, method, resp) };
+        StaticRoute::on_with_method(client_bundle, method, resp);
     }
 }
 
@@ -5216,7 +5213,7 @@ fn on_request(dev: &mut DevServer, req: &mut Request, mut resp: AnyResponse) -> 
 impl DevServer {
     pub(crate) fn respond_for_html_bundle(
         &mut self,
-        html: *mut HTMLBundleRoute,
+        html: bun_ptr::ThisPtr<HTMLBundleRoute>,
         req: &mut Request,
         resp: AnyResponse,
     ) -> Result<(), AllocError> {
@@ -5256,14 +5253,10 @@ impl DevServer {
             route_bundle::UnresolvedIndex::Framework(route_index) => {
                 &raw mut self.router.route_ptr_mut(route_index).bundle
             }
-            route_bundle::UnresolvedIndex::Html(html) => {
-                // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
-                // allocation; single-threaded (uws JS-thread callback).
-                // R-2: `dev_server_id` is `Cell<Option<Index>>`; `Cell::as_ptr`
-                // yields the inner `*mut Option<Index>` so the `*index_location`
-                // read/write below stays raw and matches the framework arm's type.
-                unsafe { (*html).dev_server_id.as_ptr() }
-            }
+            // R-2: `dev_server_id` is `Cell<Option<Index>>`; `Cell::as_ptr`
+            // yields the inner `*mut Option<Index>` so the `*index_location`
+            // read/write below stays raw and matches the framework arm's type.
+            route_bundle::UnresolvedIndex::Html(html) => html.dev_server_id.as_ptr(),
         };
         // SAFETY: index_location points into self/html which outlive this fn
         if let Some(bundle_index) = unsafe { *index_location } {
@@ -5274,9 +5267,7 @@ impl DevServer {
 
         // A file delivers its html to one route bundle only: a route `server.reload()` re-registers reuses it.
         if let route_bundle::UnresolvedIndex::Html(html) = route {
-            // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
-            // allocation; single-threaded (uws JS-thread callback).
-            let html_ref = unsafe { &*html };
+            let html_ref = &*html;
             if let Some(existing) = self
                 .client_graph
                 .bundled_files
@@ -5303,10 +5294,7 @@ impl DevServer {
                     })
                 }
                 route_bundle::UnresolvedIndex::Html(html) => 'brk: {
-                    // SAFETY: caller guarantees `html` is live; single-threaded.
-                    // R-2: shared deref — only `bundle.path` is read; mutation of
-                    // `dev_server_id` goes through the `Cell` `index_location` above.
-                    let html_ref = unsafe { &*html };
+                    let html_ref = &*html;
                     let incremental_graph_index = self.client_graph.insert_stale_extra(
                         &html_ref.bundle.path,
                         bake::Graph::Client,
@@ -5316,8 +5304,7 @@ impl DevServer {
                         [incremental_graph_index.get() as usize];
                     file.html_route_bundle_index = Some(bundle_index);
                     break 'brk route_bundle::Data::Html(route_bundle::Html {
-                        // SAFETY: `html` is a live IntrusiveRc-managed allocation.
-                        html_bundle: unsafe { bun_ptr::RefPtr::init_ref(html) },
+                        html_bundle: bun_ptr::RefPtr::from_this(html),
                         bundled_file: incremental_graph_index,
                         script_injection_offset: None,
                         cached_response: None,
@@ -6170,9 +6157,9 @@ impl EntryPointList {
 /// `<'a>` retained only for the owning `DevServer<'a>`'s `Transpiler` borrows.
 #[derive(Default)]
 pub struct HTMLRouter {
-    pub(crate) map: StringHashMap<*mut HTMLBundleRoute>,
+    pub(crate) map: StringHashMap<bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Mut>>,
     /// If a catch-all route exists, it is not stored in map, but here.
-    pub(crate) fallback: Option<*mut HTMLBundleRoute>,
+    pub(crate) fallback: Option<bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Mut>>,
 }
 
 impl HTMLRouter {
@@ -6183,11 +6170,19 @@ impl HTMLRouter {
         }
     }
 
-    pub fn get(&self, path: &[u8]) -> Option<*mut HTMLBundleRoute> {
-        self.map.get(path).copied().or(self.fallback)
+    pub fn get(&self, path: &[u8]) -> Option<bun_ptr::ThisPtr<HTMLBundleRoute>> {
+        self.map
+            .get(path)
+            .copied()
+            .or(self.fallback)
+            .map(|r| r.this_ptr())
     }
 
-    pub(crate) fn put(&mut self, path: &[u8], route: *mut HTMLBundleRoute) -> crate::Result<()> {
+    pub(crate) fn put(
+        &mut self,
+        path: &[u8],
+        route: bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Mut>,
+    ) -> crate::Result<()> {
         if path == b"/*" {
             self.fallback = Some(route);
         } else {

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -36,22 +36,18 @@ pub struct Framework {
 /// rendered HTML page, asset, source map response); released on drop. The
 /// `StaticRoute::on*` handlers take their own ref per in-flight response, so
 /// the route itself may outlive this handle.
-pub(crate) struct StaticRouteRef(bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>);
+pub(crate) struct StaticRouteRef(bun_ptr::RefPtr<StaticRoute>);
 
 impl StaticRouteRef {
     pub(crate) fn init_from_any_blob(blob: AnyBlob, options: InitFromBytesOptions<'_>) -> Self {
-        let route = StaticRoute::init_from_any_blob(blob, options);
-        // SAFETY: `route` is the fresh `heap::into_raw` allocation (non-null,
-        // write provenance) carrying one ref, which this handle owns until
-        // `Drop` releases it, so the pointee outlives the `BackRef`.
-        Self(unsafe { bun_ptr::BackRef::from_raw_mut(route) })
+        Self(StaticRoute::init_from_any_blob(blob, options))
     }
 
-    /// For the `StaticRoute::on*` handlers, which take the route as the
-    /// `*mut` they register as uws userdata.
+    /// For the `StaticRoute::on*` handlers, which register the route as uws
+    /// userdata.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *mut StaticRoute {
-        self.0.as_ptr()
+    pub(crate) fn this_ptr(&self) -> bun_ptr::ThisPtr<StaticRoute> {
+        self.0.this_ptr()
     }
 }
 
@@ -59,14 +55,14 @@ impl core::ops::Deref for StaticRouteRef {
     type Target = StaticRoute;
     #[inline]
     fn deref(&self) -> &StaticRoute {
-        self.0.get()
+        &self.0
     }
 }
 
 impl Drop for StaticRouteRef {
     #[inline]
     fn drop(&mut self) {
-        <StaticRoute as bun_ptr::CellRefCounted>::deref_nn(self.0.into());
+        self.0.deref();
     }
 }
 
@@ -142,12 +138,9 @@ impl RouteBundle {
 #[derive(Clone, Copy)]
 pub(crate) enum UnresolvedIndex {
     Framework(framework_router::RouteIndex),
-    /// BACKREF: `getOrPutRouteBundle` writes
-    /// `dev_server_id` back through this pointer and `.initRef(html)` takes
-    /// its own ref when stored. Carried as a raw mutable pointer (not `&`/
-    /// `&mut`) so the writeback doesn't require a `&const → &mut` cast and
-    /// the borrow doesn't conflict with `&mut DevServer`.
-    Html(*mut HTMLBundleRoute),
+    /// `getOrPutRouteBundle` writes `dev_server_id` back through this and
+    /// takes its own ref when stored.
+    Html(bun_ptr::ThisPtr<HTMLBundleRoute>),
 }
 
 pub struct RouteBundle {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3533,7 +3533,7 @@ fn transpile_source_code_inner(
             let html_bundle = crate::api::HTMLBundle::init(global, path.text);
             use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
             Ok(OwnedResolvedSource::from(ResolvedSource {
-                jsvalue_for_export: crate::api::HTMLBundle::to_js(html_bundle.into_raw(), global),
+                jsvalue_for_export: crate::api::HTMLBundle::to_js(html_bundle, global),
                 specifier: input_specifier.dupe_ref(),
                 source_url: create_if_different(input_specifier, path.text),
                 tag: ResolvedSourceTag::ExportDefaultObject,

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -1,19 +1,18 @@
 //! Serve a directory tree at a URL prefix: `"/static/*": { dir: "./public" }`.
 
 use core::cell::Cell;
-use core::ffi::c_void;
 use core::mem::size_of;
-use core::ptr::NonNull;
 
 use bun_core::strings;
 use bun_http::Method;
 use bun_io::FileType;
 use bun_paths::resolve_path;
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_resolver::fs::StatHash;
 use bun_sys::{self, Fd, File};
 use bun_uws::{AnyRequest, AnyResponse};
 
-use crate::server::file_response_stream::StartOptions as FileResponseStreamOptions;
+use crate::server::file_response_stream::{StartOptions as FileResponseStreamOptions, StreamOwner};
 use crate::server::file_route::{status_for_preconditions, write_any_status, write_content_range};
 use crate::server::jsc::{JSGlobalObject, JsResult};
 use crate::server::{AnyServer, FileResponseStream, HTTPStatusText, RangeRequest};
@@ -30,7 +29,6 @@ struct StatCacheEntry {
 }
 
 #[derive(bun_ptr::CellRefCounted)]
-#[ref_count(destroy = DirectoryRoute::deinit)]
 pub struct DirectoryRoute {
     ref_count: Cell<u32>,
     server: Cell<Option<AnyServer>>,
@@ -61,7 +59,7 @@ impl DirectoryRoute {
         root: &[u8],
         url_prefix: &[u8],
         enable_stat_cache: bool,
-    ) -> JsResult<*mut DirectoryRoute> {
+    ) -> JsResult<RefPtr<DirectoryRoute>> {
         debug_assert!(url_prefix.last() == Some(&b'/'));
         debug_assert!(!strings::contains(url_prefix, b"//"));
 
@@ -87,48 +85,31 @@ impl DirectoryRoute {
             stat_cache.push(Cell::new(StatCacheEntry::default()));
         }
 
-        Ok(bun_core::heap::into_raw(Box::new(DirectoryRoute {
+        Ok(RefPtr::new(DirectoryRoute {
             ref_count: Cell::new(1),
             server: Cell::new(None),
             root_fd: Cell::new(root_fd),
             url_prefix: url_prefix.to_vec().into_boxed_slice(),
             stat_cache: stat_cache.into_boxed_slice(),
             stat_cache_path_bytes: Cell::new(0),
-        })))
+        }))
     }
 
-    fn deinit(this: *mut DirectoryRoute) {
-        // SAFETY: heap-allocated in `create`; refcount has reached 0.
-        let this = unsafe { bun_core::heap::take(this) };
-        drop(File::from_fd(this.root_fd.get()));
+    pub fn on_head_request(this: ThisPtr<DirectoryRoute>, req: AnyRequest, resp: AnyResponse) {
+        Self::on(this, req, resp, Method::HEAD);
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn on_head_request(this: *mut DirectoryRoute, req: AnyRequest, resp: AnyResponse) {
-        Self::on(NonNull::new(this).unwrap(), req, resp, Method::HEAD);
-    }
-
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn on_request(this: *mut DirectoryRoute, req: AnyRequest, resp: AnyResponse) {
+    pub fn on_request(this: ThisPtr<DirectoryRoute>, req: AnyRequest, resp: AnyResponse) {
         let method = Method::find(req.method()).unwrap_or(Method::GET);
-        Self::on(NonNull::new(this).unwrap(), req, resp, method);
+        Self::on(this, req, resp, method);
     }
 
-    // `this_ptr` (not `&self`) because it is stashed as `FileResponseStream`'s
-    // ctx userdata; `on_stream_complete` may drop the last ref after a reload,
-    // and `Box::from_raw` on a `&self`-derived pointer is UB under Stacked
-    // Borrows. See src/CLAUDE.md §Pointer provenance at FFI boundaries.
-    fn on(
-        this_ptr: NonNull<DirectoryRoute>,
-        mut req: AnyRequest,
-        resp: AnyResponse,
-        method: Method,
-    ) {
-        let this = bun_ptr::BackRef::from(this_ptr);
+    fn on(this: ThisPtr<DirectoryRoute>, mut req: AnyRequest, resp: AnyResponse, method: Method) {
         debug_assert!(this.server.get().is_some());
-        this.ref_();
+        // Held until the response completes; a reload can drop the route
+        // table's ref while a `FileResponseStream` is still streaming.
         let guard = ResponseGuard {
-            route: this_ptr,
+            route: Some(RefPtr::from_this(this)),
             resp,
         };
         if let Some(mut server) = this.server.get() {
@@ -259,7 +240,7 @@ impl DirectoryRoute {
         );
 
         let server = this.server.get().unwrap();
-        FileResponseStream::start(&FileResponseStreamOptions {
+        FileResponseStream::start(FileResponseStreamOptions {
             fd: file.into_raw(),
             auto_close: true,
             resp,
@@ -269,10 +250,7 @@ impl DirectoryRoute {
             offset: body_offset,
             length: Some(body_len),
             idle_timeout: server.config().idle_timeout,
-            ctx: guard.into_ctx(),
-            on_complete: on_stream_complete,
-            on_abort: None,
-            on_error: on_stream_error,
+            owner: StreamOwner::DirectoryRoute(guard.into_route()),
         });
     }
 
@@ -371,42 +349,45 @@ impl DirectoryRoute {
         (ms, buf, len)
     }
 
-    fn on_response_complete(this: NonNull<DirectoryRoute>, resp: AnyResponse) {
+    /// The last thing a response does with the route; callers then release
+    /// the ref `on()` took for it.
+    pub(crate) fn on_response_complete(&self, resp: AnyResponse) {
         resp.clear_aborted();
         resp.clear_on_writable();
         resp.clear_timeout();
-        if let Some(mut server) = bun_ptr::BackRef::from(this).server.get() {
+        if let Some(mut server) = self.server.get() {
             server.on_static_request_complete();
         }
-        // SAFETY: intrusive refcount; `ref_()` in `on()` pairs with this.
-        unsafe { Self::deref(this.as_ptr()) };
     }
 }
 
-/// Releases the route ref (and file, if any) on every non-streaming return.
+impl Drop for DirectoryRoute {
+    fn drop(&mut self) {
+        drop(File::from_fd(self.root_fd.get()));
+    }
+}
+
+/// Completes the response and releases its route ref (closing the file, if
+/// any, as it drops) on every non-streaming return.
 struct ResponseGuard {
-    route: NonNull<DirectoryRoute>,
+    route: Option<RefPtr<DirectoryRoute>>,
     resp: AnyResponse,
 }
 
 impl ResponseGuard {
-    fn into_ctx(self) -> *mut c_void {
-        core::mem::ManuallyDrop::new(self).route.as_ptr().cast()
+    /// Hand the ref to the `FileResponseStream` instead.
+    fn into_route(mut self) -> RefPtr<DirectoryRoute> {
+        self.route.take().expect("taken once")
     }
 }
 
 impl Drop for ResponseGuard {
     fn drop(&mut self) {
-        DirectoryRoute::on_response_complete(self.route, self.resp);
+        if let Some(route) = self.route.take() {
+            route.on_response_complete(self.resp);
+            route.deref();
+        }
     }
-}
-
-fn on_stream_complete(ctx: *mut c_void, resp: AnyResponse) {
-    DirectoryRoute::on_response_complete(NonNull::new(ctx.cast()).unwrap(), resp);
-}
-
-fn on_stream_error(ctx: *mut c_void, resp: AnyResponse, _err: bun_sys::Error) {
-    DirectoryRoute::on_response_complete(NonNull::new(ctx.cast()).unwrap(), resp);
 }
 
 // `Stat` is ~144 bytes; boxing it would add a heap alloc on the hot path.

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -22,6 +22,7 @@ use bun_sys::{self as sys, Fd};
 use bun_uws::{AnyResponse, WriteResult};
 
 use crate::server::jsc::{EventLoopHandle, VirtualMachine};
+use crate::server::{DirectoryRoute, FileRoute};
 
 bun_output::declare_scope!(FileResponseStream, hidden);
 
@@ -39,10 +40,8 @@ pub(crate) struct FileResponseStream {
     auto_close: Cell<bool>,
     idle_timeout: Cell<u8>,
 
-    ctx: Cell<*mut c_void>,
-    on_complete: Cell<fn(*mut c_void, AnyResponse)>,
-    on_abort: Cell<Option<fn(*mut c_void, AnyResponse)>>,
-    on_error: Cell<fn(*mut c_void, AnyResponse, sys::Error)>,
+    /// Taken by whichever of complete / abort / error fires first.
+    owner: Cell<Option<StreamOwner>>,
 
     mode: Cell<Mode>,
     reader: JsCell<BufferedReader>,
@@ -110,16 +109,59 @@ pub(crate) struct StartOptions {
     /// should be `stat.size - offset` (after Range/slice clamping).
     pub length: Option<u64>,
     pub idle_timeout: u8,
-    pub ctx: *mut c_void,
-    pub on_complete: fn(*mut c_void, AnyResponse),
-    /// Fires instead of `on_complete` when the client disconnects mid-stream.
-    /// If `None`, abort is reported via `on_complete`.
-    pub on_abort: Option<fn(*mut c_void, AnyResponse)>,
-    pub on_error: fn(*mut c_void, AnyResponse, sys::Error),
+    pub owner: StreamOwner,
+}
+
+/// Who hears about the end of the stream. Exactly one of complete / abort /
+/// error is delivered, exactly once.
+pub(crate) enum StreamOwner {
+    /// The ref `FileRoute::on` took for this response; released on delivery.
+    FileRoute(bun_ptr::RefPtr<FileRoute>),
+    /// Likewise for `DirectoryRoute::on`.
+    DirectoryRoute(bun_ptr::RefPtr<DirectoryRoute>),
+    Ctx {
+        ctx: *mut c_void,
+        on_complete: fn(*mut c_void, AnyResponse),
+        /// Fires instead of `on_complete` when the client disconnects
+        /// mid-stream. If `None`, abort is reported via `on_complete`.
+        on_abort: Option<fn(*mut c_void, AnyResponse)>,
+        on_error: fn(*mut c_void, AnyResponse, sys::Error),
+    },
+}
+
+enum StreamEnd {
+    Complete,
+    Abort,
+    Error(sys::Error),
+}
+
+impl StreamOwner {
+    fn deliver(self, resp: AnyResponse, end: StreamEnd) {
+        match self {
+            StreamOwner::FileRoute(route) => {
+                route.on_response_complete(resp);
+                route.deref();
+            }
+            StreamOwner::DirectoryRoute(route) => {
+                route.on_response_complete(resp);
+                route.deref();
+            }
+            StreamOwner::Ctx {
+                ctx,
+                on_complete,
+                on_abort,
+                on_error,
+            } => match end {
+                StreamEnd::Complete => on_complete(ctx, resp),
+                StreamEnd::Abort => on_abort.unwrap_or(on_complete)(ctx, resp),
+                StreamEnd::Error(err) => on_error(ctx, resp, err),
+            },
+        }
+    }
 }
 
 impl FileResponseStream {
-    pub(crate) fn start(opts: &StartOptions) {
+    pub(crate) fn start(opts: StartOptions) {
         let use_sendfile = can_sendfile(opts.resp, opts.file_type, opts.length);
 
         // Heap-allocate; the raw pointer is handed to uWS callbacks and freed
@@ -135,10 +177,7 @@ impl FileResponseStream {
                 fd: Cell::new(opts.fd),
                 auto_close: Cell::new(opts.auto_close),
                 idle_timeout: Cell::new(opts.idle_timeout),
-                ctx: Cell::new(opts.ctx),
-                on_complete: Cell::new(opts.on_complete),
-                on_abort: Cell::new(opts.on_abort),
-                on_error: Cell::new(opts.on_error),
+                owner: Cell::new(Some(opts.owner)),
                 mode: Cell::new(if use_sendfile {
                     Mode::Sendfile
                 } else {
@@ -255,6 +294,12 @@ impl FileResponseStream {
         self.state.set(self.state.get() | flags);
     }
 
+    fn deliver(&self, resp: AnyResponse, end: StreamEnd) {
+        if let Some(owner) = self.owner.take() {
+            owner.deliver(resp, end);
+        }
+    }
+
     // ───────────────────────── reader backend ─────────────────────────
 
     #[allow(
@@ -279,7 +324,7 @@ impl FileResponseStream {
             self.insert_state(State::RESPONSE_DONE);
             self.detach_resp();
             resp.end(chunk, resp.should_close_connection());
-            (self.on_complete.get())(self.ctx.get(), resp);
+            self.deliver(resp, StreamEnd::Complete);
             return false;
         }
 
@@ -453,7 +498,7 @@ impl FileResponseStream {
         self.detach_resp();
         let resp = self.resp.get();
         resp.end_send_file(self.sendfile.get().offset, resp.should_close_connection());
-        (self.on_complete.get())(self.ctx.get(), resp);
+        self.deliver(resp, StreamEnd::Complete);
         // `end_send_file` bypasses every shouldCloseConnection() gate: it does
         // not go through internalEnd, and the onWritable gate is skipped
         // because this frame returns `false` to it. Run the gate here — after
@@ -482,12 +527,7 @@ impl FileResponseStream {
         if !self.state.get().contains(State::RESPONSE_DONE) {
             self.insert_state(State::RESPONSE_DONE);
             self.detach_resp();
-            (self
-                .on_abort
-                .get()
-                .unwrap_or_else(|| self.on_complete.get()))(
-                self.ctx.get(), self.resp.get()
-            );
+            self.deliver(self.resp.get(), StreamEnd::Abort);
         }
         self.finish();
     }
@@ -498,7 +538,7 @@ impl FileResponseStream {
             self.detach_resp();
             let resp = self.resp.get();
             resp.force_close();
-            (self.on_error.get())(self.ctx.get(), resp, err);
+            self.deliver(resp, StreamEnd::Error(err));
         }
         self.finish();
     }
@@ -531,7 +571,7 @@ impl FileResponseStream {
             self.detach_resp();
             let resp = self.resp.get();
             resp.end_without_body(resp.should_close_connection());
-            (self.on_complete.get())(self.ctx.get(), resp);
+            self.deliver(resp, StreamEnd::Complete);
             // This end runs uncorked (reader callbacks), so no cork or parser
             // gate will run the close check; do it here, after `on_complete`
             // like `end_sendfile`, so the callbacks see a live socket.

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -1,5 +1,4 @@
 use core::cell::Cell;
-use core::ffi::c_void;
 use core::mem::size_of;
 
 use bun_core::String as BunString;
@@ -9,12 +8,13 @@ use bun_http_types::ETag;
 use bun_http_types::ETag::StringPointer;
 use bun_io::Closer;
 use bun_io::FileType;
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_resolver::fs::StatHash;
 use bun_sys::{self, Fd};
 use bun_uws::{AnyRequest, AnyResponse};
 
 use crate::node::types::PathOrFileDescriptor;
-use crate::server::file_response_stream::StartOptions as FileResponseStreamOptions;
+use crate::server::file_response_stream::{StartOptions as FileResponseStreamOptions, StreamOwner};
 use crate::server::jsc::{JSGlobalObject, JSValue, JsResult, VirtualMachine};
 
 use crate::server::{AnyServer, FileResponseStream, HTTPStatusText, RangeRequest};
@@ -23,20 +23,14 @@ use crate::webcore::body::Value as BodyValue;
 use crate::webcore::{Blob, FetchHeaders, Response};
 
 #[derive(bun_ptr::CellRefCounted)]
-#[ref_count(destroy = FileRoute::deinit)]
 pub struct FileRoute {
-    // Owned via intrusive refcount; the
-    // raw `*mut FileRoute` is round-tripped through `FileResponseStream`'s
-    // `ctx: *mut c_void` userdata, so `Rc<FileRoute>` is unsuitable. See
-    // StaticRoute.rs note re: FFI userdata fallback to RefPtr.
     ref_count: Cell<u32>,
     server: Cell<Option<AnyServer>>,
     blob: Blob,
     headers: Headers,
     status_code: u16,
-    // Mutated on every request (`on()` runs `hash()`); FileRoute is reached via
-    // a shared `*const Self` from the route table, so wrap for interior
-    // mutability. `StatHash` is small POD with `Default`, so `Cell` +
+    // Mutated on every request (`on()` runs `hash()`) through a shared
+    // `&Self`; `StatHash` is small POD with `Default`, so `Cell` +
     // `take()/set()` gives safe read-modify-write on the single-threaded JS
     // event loop.
     stat_hash: Cell<StatHash>,
@@ -64,6 +58,19 @@ fn sp_slice<'a>(ptr: StringPointer, buf: &'a [u8]) -> &'a [u8] {
     &buf[ptr.offset as usize..][..ptr.length as usize]
 }
 
+/// What `FileRoute::serve` left for `on()` to do with the open fd.
+enum Serve {
+    /// The response is finished; close the fd and complete.
+    Done,
+    /// Hand the fd to a `FileResponseStream`.
+    Stream {
+        file_type: FileType,
+        pollable: bool,
+        offset: u64,
+        length: Option<u64>,
+    },
+}
+
 impl FileRoute {
     /// Exposes the private `server` Cell to the route table (`AnyRoute::set_server`).
     #[inline]
@@ -81,10 +88,6 @@ impl FileRoute {
         if self.has_last_modified_header {
             if let Some(last_modified) = self.headers.get(b"last-modified") {
                 let mut string = BunString::borrow_utf8(last_modified);
-                // `defer string.deref()` — handled by Drop on bun_core::String
-                // SAFETY: `VirtualMachine::get()` returns the live per-thread
-                // singleton; FileRoute is only ever reached from a server
-                // request callback on the JS thread.
                 let global = VirtualMachine::get().as_mut().global();
                 let date_f64 = bun_jsc::bun_string_jsc::parse_date(&mut string, global)?;
                 if !date_f64.is_nan() && date_f64.is_finite() {
@@ -105,33 +108,30 @@ impl FileRoute {
         Ok(None)
     }
 
-    pub(crate) fn init_from_blob(blob: Blob, opts: &InitOptions<'_>) -> *mut FileRoute {
-        let headers = headers_from(opts.headers, &blob);
-        bun_core::heap::into_raw(Box::new(FileRoute {
+    fn new(blob: Blob, headers: Headers, server: Option<AnyServer>, status_code: u16) -> FileRoute {
+        FileRoute {
             ref_count: Cell::new(1),
-            server: Cell::new(opts.server),
+            server: Cell::new(server),
             has_last_modified_header: headers.get(b"last-modified").is_some(),
             has_content_length_header: headers.get(b"content-length").is_some(),
             has_content_range_header: headers.get(b"content-range").is_some(),
             has_date_header: headers.get(b"date").is_some(),
             blob,
             headers,
-            status_code: opts.status_code,
+            status_code,
             stat_hash: Cell::new(StatHash::default()),
-        }))
-    }
-
-    fn deinit(this: *mut FileRoute) {
-        // SAFETY: `this` was allocated via heap::alloc in init_from_blob/from_js and the
-        // intrusive ref_count has reached 0.
-        // `headers` is freed by its own Drop when the Box is dropped.
-        unsafe {
-            (*this).blob.deinit();
-            drop(bun_core::heap::take(this));
         }
     }
 
-    pub fn from_js(global: &JSGlobalObject, argument: JSValue) -> JsResult<Option<*mut FileRoute>> {
+    pub(crate) fn init_from_blob(blob: Blob, opts: &InitOptions<'_>) -> RefPtr<FileRoute> {
+        let headers = headers_from(opts.headers, &blob);
+        RefPtr::new(FileRoute::new(blob, headers, opts.server, opts.status_code))
+    }
+
+    pub fn from_js(
+        global: &JSGlobalObject,
+        argument: JSValue,
+    ) -> JsResult<Option<RefPtr<FileRoute>>> {
         // `as_class_ref` is the safe shared-borrow downcast (one audited
         // unsafe in `JSValue`); `get_body_value`/`get_init_headers`/
         // `status_code` all take `&self`.
@@ -167,18 +167,12 @@ impl FileRoute {
                 let headers = headers_from(response.get_init_headers(), &blob);
                 let status_code = response.status_code();
 
-                return Ok(Some(bun_core::heap::into_raw(Box::new(FileRoute {
-                    ref_count: Cell::new(1),
-                    server: Cell::new(None),
-                    has_last_modified_header: headers.get(b"last-modified").is_some(),
-                    has_content_length_header: headers.get(b"content-length").is_some(),
-                    has_content_range_header: headers.get(b"content-range").is_some(),
-                    has_date_header: headers.get(b"date").is_some(),
+                return Ok(Some(RefPtr::new(FileRoute::new(
                     blob,
                     headers,
+                    None,
                     status_code,
-                    stat_hash: Cell::new(StatHash::default()),
-                }))));
+                ))));
             }
         }
         if let Some(blob) = argument.as_class_ref::<Blob>() {
@@ -190,18 +184,7 @@ impl FileRoute {
                     "expected blob not to be heap-allocated"
                 );
                 let headers = headers_from(None, &b);
-                return Ok(Some(bun_core::heap::into_raw(Box::new(FileRoute {
-                    ref_count: Cell::new(1),
-                    server: Cell::new(None),
-                    headers,
-                    blob: b,
-                    has_content_length_header: false,
-                    has_last_modified_header: false,
-                    has_content_range_header: false,
-                    has_date_header: false,
-                    status_code: 200,
-                    stat_hash: Cell::new(StatHash::default()),
-                }))));
+                return Ok(Some(RefPtr::new(FileRoute::new(b, headers, None, 200))));
             }
         }
         Ok(None)
@@ -263,57 +246,34 @@ impl FileRoute {
         }
     }
 
-    /// # Safety
-    /// `this` must point to a live heap `FileRoute` (intrusive ref held by the
-    /// route table) for the duration of the call.
-    // Forwards `this` to `Self::on` without dereferencing; not_unsafe_ptr_arg_deref
-    // is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn on_head_request(this: *mut FileRoute, req: AnyRequest, resp: AnyResponse) {
-        // SAFETY: forwarded with the same precondition.
-        unsafe { Self::on(this, req, resp, Method::HEAD) };
+    pub(crate) fn on_head_request(this: ThisPtr<FileRoute>, req: AnyRequest, resp: AnyResponse) {
+        Self::on(this, req, resp, Method::HEAD);
     }
 
-    // Forwards `this` to `Self::on` without dereferencing; not_unsafe_ptr_arg_deref
-    // is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn on_request(this: *mut FileRoute, req: AnyRequest, resp: AnyResponse) {
+    pub(crate) fn on_request(this: ThisPtr<FileRoute>, req: AnyRequest, resp: AnyResponse) {
         let method = Method::find(req.method()).unwrap_or(Method::GET);
-        // SAFETY: `this` is a live heap FileRoute — intrusive ref held by the
-        // route table; only reached from the uWS route callback.
-        unsafe { Self::on(this, req, resp, method) };
+        Self::on(this, req, resp, method);
     }
 
-    // Takes `*mut FileRoute` (not `&self`) because `this_ptr` is stashed as
-    // `FileResponseStream`'s `ctx` userdata; the async `on_stream_complete`
-    // may hold the last ref after a reload drops the route table's. Within
-    // the body the route-table ref + the `ref_()` below keep `*this_ptr`
-    // alive, and every per-request mutation (`ref_count`, `stat_hash`) goes
-    // through `Cell`, so a single `&FileRoute` is sound under Stacked
-    // Borrows for the whole call.
-    /// # Safety
-    /// `this_ptr` must point to a live heap `FileRoute` for the duration of
-    /// this call. The `ref_()` taken below keeps it alive until
-    /// `on_response_complete`. All mutation through `this` goes via `Cell`, so
-    /// the shared borrow is sound.
-    pub(crate) unsafe fn on(
-        this_ptr: *mut FileRoute,
+    pub(crate) fn on(
+        this: ThisPtr<FileRoute>,
         mut req: AnyRequest,
         resp: AnyResponse,
         method: Method,
     ) {
-        // SAFETY: see fn-level Safety doc.
-        let this = unsafe { &*this_ptr };
         debug_assert!(this.server.get().is_some());
-        this.ref_();
-        if let Some(mut server) = this.server.get() {
+        // Held until `on_response_complete`; a reload can drop the route
+        // table's ref while a `FileResponseStream` is still streaming.
+        let route = RefPtr::from_this(this);
+        if let Some(mut server) = route.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
         }
-        let store = this.blob.store().unwrap().clone();
+        let store = route.blob.store().unwrap().clone();
         let Some(path) = store.get_path() else {
             req.set_yield(true);
-            Self::on_response_complete(this_ptr, resp);
+            route.on_response_complete(resp);
+            route.deref();
             return;
         };
 
@@ -326,7 +286,6 @@ impl FileRoute {
                 path_buffer[..path.len()].copy_from_slice(path);
                 path_buffer[path.len()] = 0;
                 bun_sys::open(
-                    // SAFETY: path_buffer[path.len()] == 0 written above
                     bun_core::ZStr::from_buf(&path_buffer[..], path.len()),
                     open_flags,
                     0,
@@ -340,29 +299,56 @@ impl FileRoute {
 
         let Ok(fd) = fd_result else {
             req.set_yield(true);
-            Self::on_response_complete(this_ptr, resp);
+            route.on_response_complete(resp);
+            route.deref();
             return;
         };
 
-        // `fd_owned` tracks whether this function is still responsible for
-        // closing the file descriptor and releasing the route ref. Every
-        // non-streaming return — bodiless status codes (304/204/205/307/308),
-        // HEAD, non-streamable files, and the two JS-exception early-return
-        // paths below — hits this defer, so neither the fd nor the route ref
+        // Every non-streaming outcome — bodiless status codes
+        // (304/204/205/307/308), HEAD, non-streamable files, and the JS-exception
+        // early returns — is `Serve::Done`, so neither the fd nor the route ref
         // (or the server's pending_requests counter) can leak regardless of
-        // which branch runs. The streaming path clears `fd_owned` right
-        // before handing ownership to `FileResponseStream`.
-        let mut fd_guard = scopeguard::guard(true, move |owned| {
-            if owned {
+        // which branch ran.
+        match route.serve(fd, path, &mut req, resp, method) {
+            Serve::Done => {
                 #[cfg(windows)]
                 Closer::close(fd, bun_sys::windows::libuv::Loop::get());
                 #[cfg(not(windows))]
                 Closer::close(fd, ());
-                // SAFETY: this_ptr is valid; ref taken above keeps FileRoute alive until on_response_complete
-                Self::on_response_complete(this_ptr, resp);
+                route.on_response_complete(resp);
+                route.deref();
             }
-        });
+            Serve::Stream {
+                file_type,
+                pollable,
+                offset,
+                length,
+            } => {
+                let server = route.server.get().unwrap();
+                FileResponseStream::start(FileResponseStreamOptions {
+                    fd,
+                    auto_close: true,
+                    resp,
+                    vm: bun_ptr::BackRef::new(server.vm()),
+                    file_type,
+                    pollable,
+                    offset,
+                    length,
+                    idle_timeout: server.config().idle_timeout,
+                    owner: StreamOwner::FileRoute(route),
+                });
+            }
+        }
+    }
 
+    fn serve(
+        &self,
+        fd: Fd,
+        path: &[u8],
+        req: &mut AnyRequest,
+        resp: AnyResponse,
+        method: Method,
+    ) -> Serve {
         let (can_serve_file, size, file_type, pollable): (bool, u64, FileType, bool) = 'brk: {
             let stat = match bun_sys::fstat(fd) {
                 Ok(s) => s,
@@ -371,7 +357,7 @@ impl FileRoute {
             };
 
             let stat_size: u64 = u64::try_from(stat.st_size.max(0)).expect("int cast");
-            let _size: u64 = stat_size.min(this.blob.size.get());
+            let _size: u64 = stat_size.min(self.blob.size.get());
 
             let mode = stat.st_mode as bun_sys::Mode;
             if bun_sys::S::ISDIR(mode) {
@@ -380,9 +366,9 @@ impl FileRoute {
 
             // `Cell::take` → mutate → `set`: single-threaded event loop, no
             // re-entry reads `stat_hash` between take/set.
-            let mut sh = this.stat_hash.take();
+            let mut sh = self.stat_hash.take();
             sh.hash(&stat, path);
-            this.stat_hash.set(sh);
+            self.stat_hash.set(sh);
 
             if bun_sys::S::ISFIFO(mode) || bun_sys::S::ISCHR(mode) {
                 break 'brk (true, _size, FileType::Pipe, true);
@@ -397,7 +383,7 @@ impl FileRoute {
 
         if !can_serve_file {
             req.set_yield(true);
-            return;
+            return Serve::Done;
         }
 
         // Range applies to the slice the route was configured with, not the
@@ -407,72 +393,66 @@ impl FileRoute {
         // set Content-Range — they're managing partial responses themselves.
         let range: RangeRequest::Result = if (method == Method::GET || method == Method::HEAD)
             && file_type == FileType::File
-            && this.status_code == 200
-            && !this.has_content_range_header
+            && self.status_code == 200
+            && !self.has_content_range_header
         {
-            RangeRequest::from_request(&req, size)
+            RangeRequest::from_request(req, size)
         } else {
             RangeRequest::Result::None
         };
 
-        let etag = this.headers.get(b"etag").filter(|v| !v.is_empty());
+        let etag = self.headers.get(b"etag").filter(|v| !v.is_empty());
         let last_modified_ms = if req.header(b"if-modified-since").is_some()
             || req.header(b"if-unmodified-since").is_some()
         {
-            let Ok(lmd) = this.last_modified_date() else {
-                return;
+            let Ok(lmd) = self.last_modified_date() else {
+                return Serve::Done;
             };
             lmd
         } else {
             None
         };
-        let status_code = status_for_preconditions(
-            &req,
-            method,
-            this.status_code,
-            etag,
-            last_modified_ms,
-            range,
-        );
+        let status_code =
+            status_for_preconditions(req, method, self.status_code, etag, last_modified_ms, range);
 
         req.set_yield(false);
 
         write_any_status(resp, status_code);
-        if this.has_date_header {
+        if self.has_date_header {
             resp.mark_wrote_date_header();
         }
         resp.write_mark();
-        this.write_headers(resp);
+        self.write_headers(resp);
 
         // Bodiless statuses end before the range switch so a 304 emits no
         // Content-Range. FileResponseStream ships via sendfile/write(), so a
         // null-body status must never start it; 307/308 routes skip it too.
         if HTTPStatusText::is_null_body(status_code) || matches!(status_code, 307 | 308) {
             resp.end_without_body(resp.should_close_connection());
-            return;
+            return Serve::Done;
         }
         if status_code == 412 {
             resp.end(b"", resp.should_close_connection());
-            return;
+            return Serve::Done;
         }
 
         let (body_offset, body_len): (u64, Option<u64>) = match range {
             RangeRequest::Result::Satisfiable { .. } => {
                 let (start, len) = write_content_range(resp, range, size).unwrap();
-                (this.blob.offset.get() + start, Some(len))
+                (self.blob.offset.get() + start, Some(len))
             }
             RangeRequest::Result::Unsatisfiable => {
                 write_content_range(resp, range, size);
                 resp.end(b"", resp.should_close_connection());
-                return;
+                return Serve::Done;
             }
             RangeRequest::Result::None => (
                 if file_type == FileType::File {
-                    this.blob.offset.get()
+                    self.blob.offset.get()
                 } else {
                     0
                 },
-                if file_type == FileType::File && this.blob.size.get() > 0 {
+                if file_type == FileType::File && self.blob.size.get() > 0 {
                     Some(size)
                 } else {
                     None
@@ -487,49 +467,33 @@ impl FileRoute {
 
         if method == Method::HEAD {
             resp.end_without_body(resp.should_close_connection());
-            return;
+            return Serve::Done;
         }
 
-        // Hand ownership of the fd to FileResponseStream; disable the defer close.
-        // The route ref taken at the top of on() is released in on_stream_complete.
-        *fd_guard = false;
-        FileResponseStream::start(&FileResponseStreamOptions {
-            fd,
-            auto_close: true,
-            resp,
-            vm: bun_ptr::BackRef::new(this.server.get().unwrap().vm()),
+        Serve::Stream {
             file_type,
             pollable,
             offset: body_offset,
             length: body_len,
-            idle_timeout: this.server.get().unwrap().config().idle_timeout,
-            ctx: this_ptr.cast::<c_void>(),
-            on_complete: on_stream_complete,
-            on_abort: None,
-            on_error: on_stream_error,
-        });
+        }
     }
 
-    fn on_response_complete(this: *mut FileRoute, resp: AnyResponse) {
+    /// The last thing a response does with the route; callers then release
+    /// the ref `on()` took for it.
+    pub(crate) fn on_response_complete(&self, resp: AnyResponse) {
         resp.clear_aborted();
         resp.clear_on_writable();
         resp.clear_timeout();
-        // SAFETY: `this` is live (ref held by caller); `deref()` may free it.
-        unsafe {
-            if let Some(mut server) = (*this).server.get() {
-                server.on_static_request_complete();
-            }
-            Self::deref(this);
+        if let Some(mut server) = self.server.get() {
+            server.on_static_request_complete();
         }
     }
 }
 
-fn on_stream_complete(ctx: *mut c_void, resp: AnyResponse) {
-    FileRoute::on_response_complete(ctx.cast::<FileRoute>(), resp);
-}
-
-fn on_stream_error(ctx: *mut c_void, resp: AnyResponse, _err: bun_sys::Error) {
-    FileRoute::on_response_complete(ctx.cast::<FileRoute>(), resp);
+impl Drop for FileRoute {
+    fn drop(&mut self) {
+        self.blob.deinit();
+    }
 }
 
 /// RFC 9110 §13.2.2 precondition evaluation for a GET/HEAD file response.

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -14,12 +14,10 @@ use bun_core::strings;
 use bun_http::Headers;
 use bun_http_types::Method::Method;
 use bun_jsc::JsCell;
-use bun_ptr::{AsCtxPtr, IntrusiveRc, RefCount};
+use bun_ptr::{RefCount, RefPtr, ThisPtr};
 use bun_uws::{AnyRequest, AnyResponse};
 
-use crate::api::js_bundle_completion_task::{
-    JSBundleCompletionTask, create_and_schedule_completion_task,
-};
+use crate::api::js_bundle_completion_task::JSBundleCompletionTask;
 use crate::api::js_bundler::js_bundler::{self as JSBundler, Config as JSBundlerConfig};
 use crate::api::output_file_jsc::OutputFileJsc as _;
 use crate::bake::dev_server::route_bundle;
@@ -39,14 +37,11 @@ use debug_scope::HTMLBundle as debug;
 // .classes.ts codegen wires toJS/fromJS/fromJSDirect via #[bun_jsc::JsClass].
 // HTMLBundle can be owned by JavaScript as well as any number of Server instances,
 // hence the ref count alongside the JS wrapper.
-// `*mut HTMLBundle` is the m_ctx payload of a
-// `.classes.ts` wrapper — FFI rule says intrusive `RefPtr`.
 #[derive(bun_ptr::RefCounted)]
 #[ref_count(debug_name = "HTMLBundle")]
 pub struct HTMLBundle {
     ref_count: RefCount<HTMLBundle>,
-    // JSC_BORROW field on heap struct.
-    pub global: *const JSGlobalObject,
+    pub global: bun_ptr::BackRef<JSGlobalObject>,
     pub path: Box<[u8]>,
 }
 
@@ -83,39 +78,34 @@ const _: () = {
             if p.is_null() { None } else { Some(p) }
         }
         fn to_js(self, _global: &JSGlobalObject) -> JSValue {
-            // HTMLBundle is *only* constructed via `init()` → `IntrusiveRc::new`
+            // HTMLBundle is *only* constructed via `init()` → `RefPtr::new`
             // (heap-boxed, intrusive-refcounted) and wrapped via the inherent
-            // `HTMLBundle::to_js(*mut Self, …)` below, which
+            // `HTMLBundle::to_js(RefPtr<Self>, …)` below, which
             // wraps the *existing* `*HTMLBundle` allocation; re-boxing a
             // by-value `self` here would split the allocation from its refcount
             // and make `finalize`'s `deref` target the wrong heap block. No
             // code path holds an owned by-value `HTMLBundle`, so this trait
             // method is genuinely unreachable.
-            unreachable!("HTMLBundle::to_js: use the inherent *mut Self overload")
+            unreachable!("HTMLBundle::to_js: use the inherent RefPtr<Self> overload")
         }
         // `noConstructor: true` — no `HTMLBundle__getConstructor` export; trait default applies.
     }
 
     impl HTMLBundle {
-        /// `jsc.Codegen.JSHTMLBundle.toJS` — wraps an existing intrusive-
-        /// refcounted allocation. The JS wrapper takes one ref (released in
-        /// `finalize`), so callers must have already accounted for that ref.
-        pub fn to_js(this: *mut HTMLBundle, global: &JSGlobalObject) -> JSValue {
-            // `this` is a live `IntrusiveRc::new`-boxed allocation; ownership
-            // of one ref transfers to the C++ wrapper (deref'd via
-            // `HTMLBundleClass__finalize` → `finalize()`).
-            __create(global.as_mut_ptr(), this)
+        /// `jsc.Codegen.JSHTMLBundle.toJS` — the JS wrapper takes over `this`'
+        /// ref (released in `finalize`).
+        pub fn to_js(this: RefPtr<HTMLBundle>, global: &JSGlobalObject) -> JSValue {
+            __create(global.as_mut_ptr(), this.into_raw())
         }
     }
 };
 
 impl HTMLBundle {
     /// Initialize an HTMLBundle given a path.
-    pub(crate) fn init(global: &JSGlobalObject, path: &[u8]) -> IntrusiveRc<HTMLBundle> {
-        // Box::from aborts on OOM.
-        IntrusiveRc::new(HTMLBundle {
+    pub(crate) fn init(global: &JSGlobalObject, path: &[u8]) -> RefPtr<HTMLBundle> {
+        RefPtr::new(HTMLBundle {
             ref_count: RefCount::init(),
-            global,
+            global: bun_ptr::BackRef::new(global),
             path: Box::<[u8]>::from(path),
         })
     }
@@ -124,8 +114,6 @@ impl HTMLBundle {
     pub fn finalize(self: Box<Self>) {
         bun_ptr::finalize_js_box_noop(self);
     }
-
-    // `path: Box<[u8]>` auto-drops; dealloc handled by IntrusiveRc — no explicit Drop body.
 
     pub(crate) fn get_index(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         bun_jsc::bun_string_jsc::create_utf8_for_js(global, &this.path)
@@ -155,16 +143,14 @@ pub(crate) type HTMLBundleRoute = Route;
 /// html file on multiple endpoints.
 // R-2 (host-fn re-entrancy): every uws/event-loop-reachable method takes
 // `&self`; per-field interior mutability via `Cell` (Copy) / `JsCell`
-// (non-Copy). `*mut Route` is recovered from uws userdata and the
-// `JSBundleCompletionTask` backref while a prior `&Route` may still be on the
+// (non-Copy). A `Route` is re-entered from uws callbacks and the
+// `JSBundleCompletionTask` while a prior `&Route` may still be on the
 // stack — `&mut self` would alias (UB); `&self` + `UnsafeCell` is sound.
 #[derive(bun_ptr::RefCounted)]
 #[ref_count(debug_name = "HTMLBundleRoute")]
 pub struct Route {
-    // FFI userdata — *Route is recovered from uws callback
-    // userdata (on_aborted, JSBundleCompletionTask backref). §Pointers FFI
-    // rule → `bun_ptr::RefPtr<HTMLBundle>` + `impl RefCounted`.
-    pub(crate) bundle: IntrusiveRc<HTMLBundle>,
+    /// Released in `Drop`.
+    pub(crate) bundle: RefPtr<HTMLBundle>,
     /// One HTMLBundle.Route can be specified multiple times
     ref_count: RefCount<Route>,
     // TODO: attempt to remove the null case. null is only present during server
@@ -176,62 +162,38 @@ pub struct Route {
     /// registered with the bundler.
     pub(crate) dev_server_id: Cell<Option<route_bundle::Index>>,
     /// When state == .pending, incomplete responses are stored here.
-    // Raw `*mut` because the pointer is handed to uws onAborted callback and
-    // compared by identity; allocation/free is via heap::alloc/from_raw.
-    pub(crate) pending_responses: JsCell<Vec<*mut PendingResponse>>,
+    pending_responses: JsCell<Vec<PendingResponse>>,
 }
 
 pub enum State {
     Pending,
-    /// `None` while the server's plugins are still loading. In either form the
-    /// route holds a pending request on `Route::server` (`schedule_bundle`).
-    Building(Option<*mut JSBundleCompletionTask>),
+    /// The server's plugins are loading, or the `JSBundleCompletionTask` (which
+    /// holds a ref on this route until it delivers the result) is running. In
+    /// either case the route holds a pending request on `Route::server`
+    /// (`schedule_bundle`).
+    Building,
     Err(Log),
-    /// Intrusive-refcounted; freed via `StaticRoute::deref_` in `State::deinit`.
-    Html(*mut StaticRoute),
+    /// Released in `State::deinit`.
+    Html(RefPtr<StaticRoute>),
 }
 
-// `State::deinit` is *only* invoked from `Route::deinit` and the
-// dev-mode reset in `onAnyRequest`; ordinary `this.state = ...` overwrites in
-// `onComplete`/`onPluginsResolved`/etc. do NOT run it. Mapping it to `impl Drop`
-// would fire on every assignment — in particular `on_complete`'s
-// `self.state = State::Err/Html` would spuriously cancel and double-deref the
-// completion task (whose matching deref is the caller's `defer this.deref()` in
-// `JSBundleCompletionTask.onComplete`). So `deinit` stays an explicit method.
+// `State::deinit` is *only* invoked from `Route::drop` and the dev-mode reset
+// in `on_any_request`; ordinary `state.set(...)` overwrites in
+// `on_complete`/`on_plugins_resolved`/etc. never replace a `State::Html`, so
+// they do not need it.
 impl State {
-    fn deinit(&mut self) {
-        match mem::replace(self, State::Pending) {
-            State::Err(_log) => {
-                // Log drops itself
-            }
-            State::Building(Some(c)) => {
-                // SAFETY: `c` was produced by `create_and_schedule_completion_task`
-                // (heap::alloc, refcount ≥ 1) and we hold one of those refs.
-                unsafe {
-                    (*c).cancelled
-                        .store(true, core::sync::atomic::Ordering::Release);
-                    RefCount::<JSBundleCompletionTask>::deref(c);
-                }
-            }
-            State::Building(None) => {}
-            State::Html(html) => {
-                // SAFETY: `html` was produced by `StaticRoute::clone` (heap::alloc,
-                // refcount == 1) or via `ref_()`; this drops our ref.
-                unsafe { StaticRoute::deref_(html) };
-            }
-            State::Pending => {}
+    fn deinit(self) {
+        if let State::Html(html) = self {
+            html.deref();
         }
     }
-}
 
-impl State {
     fn memory_cost(&self) -> usize {
         match self {
             State::Pending => 0,
-            State::Building(_) => 0,
+            State::Building => 0,
             State::Err(log) => log.memory_cost(),
-            // SAFETY: `*html` is a live intrusive-refcounted allocation while held.
-            State::Html(html) => unsafe { (**html).memory_cost() },
+            State::Html(html) => html.memory_cost(),
         }
     }
 }
@@ -245,16 +207,10 @@ impl Route {
         cost
     }
 
-    /// # Safety
-    /// `html_bundle` must point to a live `IntrusiveRc`-managed `HTMLBundle`
-    /// allocation; this takes one ref on it.
-    // Forwards `html_bundle` to `IntrusiveRc::init_ref` without dereferencing it
-    // here; not_unsafe_ptr_arg_deref is a false positive on forwarding wrappers.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn init(html_bundle: *mut HTMLBundle) -> IntrusiveRc<Route> {
-        IntrusiveRc::new(Route {
-            // SAFETY: caller contract.
-            bundle: unsafe { IntrusiveRc::<HTMLBundle>::init_ref(html_bundle) },
+    /// Takes its own ref on `html_bundle`.
+    pub(crate) fn init(html_bundle: ThisPtr<HTMLBundle>) -> RefPtr<Route> {
+        RefPtr::new(Route {
+            bundle: RefPtr::from_this(html_bundle),
             pending_responses: JsCell::new(Vec::new()),
             ref_count: RefCount::init(),
             server: Cell::new(None),
@@ -263,22 +219,17 @@ impl Route {
         })
     }
 
-    pub(crate) fn on_request(this: *mut Self, req: AnyRequest, resp: AnyResponse) {
+    pub(crate) fn on_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse) {
         Self::on_any_request(this, req, resp, false);
     }
 
-    pub(crate) fn on_head_request(this: *mut Self, req: AnyRequest, resp: AnyResponse) {
+    pub(crate) fn on_head_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse) {
         Self::on_any_request(this, req, resp, true);
     }
 
-    fn on_any_request(this: *mut Self, mut req: AnyRequest, resp: AnyResponse, is_head: bool) {
-        // SAFETY: `this` is a live IntrusiveRc-managed allocation; `ScopedRef`
-        // bumps the count and derefs on every exit path.
-        let _keep_alive = unsafe { bun_ptr::ScopedRef::new(this) };
-        // SAFETY: held alive by `_keep_alive`; single-threaded (uws JS-thread
-        // callback). R-2: deref as shared (`&*`) — every method below takes
-        // `&self`; mutation goes through `Cell`/`JsCell`.
-        let route = unsafe { &*this };
+    fn on_any_request(this: ThisPtr<Self>, mut req: AnyRequest, resp: AnyResponse, is_head: bool) {
+        let _keep_alive = this.ref_guard();
+        let route: &Route = &this;
 
         let Some(server) = route.server.get() else {
             resp.end_without_body(true);
@@ -293,9 +244,6 @@ impl Route {
                 match req {
                     AnyRequest::H1(h1) => {
                         // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-                        // R-2: pass the raw `this` (not `route: &Route`) so
-                        // DevServer's `*mut Route` userdata path doesn't alias
-                        // a live shared borrow.
                         bun_core::handle_oom(dev.respond_for_html_bundle(
                             this,
                             bun_opaque::opaque_deref_mut(h1),
@@ -311,9 +259,8 @@ impl Route {
             }
 
             // Simpler development workflow which rebundles on every request.
-            // R-2: swap the state out *before* running its destructor so no
-            // `&mut State` borrow into `route.state` is live across the
-            // `StaticRoute::deref_` / `JSBundleCompletionTask::deref` calls.
+            // R-2: swap the state out *before* releasing what it holds so no
+            // borrow into `route.state` is live across `StaticRoute`'s deref.
             if matches!(route.state.get(), State::Html(_) | State::Err(_)) {
                 route.state.replace(State::Pending).deinit();
             }
@@ -331,10 +278,10 @@ impl Route {
                             bstr::BStr::new(req.url())
                         );
                     }
-                    bun_core::handle_oom(route.schedule_bundle(server));
+                    bun_core::handle_oom(Self::schedule_bundle(this, server));
                     continue;
                 }
-                State::Building(_) => {
+                State::Building => {
                     if bun_core::Environment::ENABLE_LOGS {
                         bun_output::scoped_log!(
                             debug,
@@ -349,25 +296,14 @@ impl Route {
                         resp.end_without_body(true);
                         return;
                     };
-                    let pending = bun_core::heap::into_raw(Box::new(PendingResponse {
+                    let pending = PendingResponse {
                         method,
                         resp,
-                        route: this,
+                        route: RefPtr::from_this(this),
                         is_response_pending: Cell::new(true),
-                    }));
-
+                    };
                     route.pending_responses.with_mut(|v| v.push(pending));
-
-                    // SAFETY: `this` is a live IntrusiveRc-managed allocation;
-                    // matched by the deref in `PendingResponse` drop / on_aborted.
-                    unsafe { RefCount::<Route>::ref_(this) };
-                    resp.on_aborted(
-                        |p, r| {
-                            // SAFETY: `p` was registered from a live `heap::into_raw` allocation above.
-                            unsafe { PendingResponse::on_aborted(p, r) }
-                        },
-                        pending,
-                    );
+                    resp.on_aborted_this(Self::on_pending_response_aborted, this);
                     req.set_yield(false);
                 }
                 State::Err(_log) => {
@@ -390,11 +326,9 @@ impl Route {
                         );
                     }
                     if is_head {
-                        // SAFETY: `*html` is a live intrusive-refcounted allocation.
-                        unsafe { StaticRoute::on_head_request(*html, req, resp) };
+                        StaticRoute::on_head_request(html.this_ptr(), req, resp);
                     } else {
-                        // SAFETY: see above.
-                        unsafe { StaticRoute::on_request(*html, req, resp) };
+                        StaticRoute::on_request(html.this_ptr(), req, resp);
                     }
                 }
             }
@@ -411,19 +345,19 @@ impl Route {
     /// on the route's behalf; the clients waiting in `pending_responses` only
     /// count as connections and can disconnect at any time. `finish_building`
     /// releases the pending request when the route leaves `State::Building`.
-    fn schedule_bundle(&self, mut server: AnyServer) -> Result<(), crate::Error> {
-        match server.get_or_load_plugins(ServePluginsCallback::HtmlBundleRoute(self.as_ctx_ptr())) {
+    fn schedule_bundle(this: ThisPtr<Self>, mut server: AnyServer) -> Result<(), crate::Error> {
+        match server.get_or_load_plugins(ServePluginsCallback::HtmlBundleRoute(this)) {
             GetOrStartLoadResult::Err => {
-                self.state.set(State::Err(Log::init()));
+                this.state.set(State::Err(Log::init()));
             }
             GetOrStartLoadResult::Ready(plugins) => {
                 let plugins = plugins.map(NonNull::from);
                 server.on_pending_request();
-                self.on_plugins_resolved(plugins)?;
+                Self::on_plugins_resolved(this, plugins)?;
             }
             GetOrStartLoadResult::Pending => {
                 server.on_pending_request();
-                self.state.set(State::Building(None));
+                this.state.set(State::Building);
             }
         }
         Ok(())
@@ -452,25 +386,22 @@ impl Route {
     }
 
     pub(crate) fn on_plugins_resolved(
-        &self,
+        this: ThisPtr<Self>,
         plugins: Option<NonNull<JSBundler::Plugin>>,
     ) -> Result<(), crate::Error> {
-        // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-        let global = bun_opaque::opaque_deref(self.bundle.global);
-        let server = self.server.get().expect("server set");
+        let global = this.bundle.global.get();
+        let server = this.server.get().expect("server set");
         let development = server.config().development;
-        // SAFETY: `bun_vm()` returns the live `*mut VirtualMachine` for a Bun-owned
-        // global; single-threaded JS thread, no other &mut alias active.
         let vm = global.bun_vm().as_mut();
 
         let mut config = JSBundlerConfig::default();
         // `Config` owns its fields and
         // drops on early-return.
-        config.entry_points.insert(&self.bundle.path)?;
+        config.entry_points.insert(&this.bundle.path)?;
         // An import attribute or a bunfig `[loader]` entry may have made this html. `ext` is `""` without one.
         config.loaders = Some(bun_options_types::schema::api::LoaderMap {
             extensions: vec![Box::from(
-                bun_paths::fs::PathName::init(&self.bundle.path).ext,
+                bun_paths::fs::PathName::init(&this.bundle.path).ext,
             )],
             loaders: vec![bun_options_types::schema::api::Loader::html],
         });
@@ -561,20 +492,12 @@ impl Route {
             bundler_options::SourceMapOption::None
         };
 
-        let completion_task = create_and_schedule_completion_task(config, plugins, global)?;
-        // SAFETY: `completion_task` is the freshly-boxed allocation (refcount==1); sole owner.
-        unsafe {
-            (*completion_task).started_at_ns =
-                bun_core::util::Timespec::now_allow_mocked_time().ns();
-            (*completion_task).html_build_task = Some(self.as_ctx_ptr());
-        }
-        self.state.set(State::Building(Some(completion_task)));
-
+        let mut completion_task = JSBundleCompletionTask::new(config, plugins, global);
+        completion_task.started_at_ns = bun_core::util::Timespec::now_allow_mocked_time().ns();
         // While we're building, ensure this doesn't get freed.
-        // SAFETY: `self` is a live IntrusiveRc-managed allocation; matched by the
-        // deref at the top of `on_complete`. `RefCount` is `Cell`-backed so the
-        // `*const → *mut` cast carries sufficient (UnsafeCell) provenance.
-        unsafe { RefCount::<Route>::ref_(self.as_ctx_ptr()) };
+        completion_task.html_build_task = Some(RefPtr::from_this(this));
+        this.state.set(State::Building);
+        completion_task.schedule();
         Ok(())
     }
 
@@ -589,10 +512,8 @@ impl Route {
         Ok(())
     }
 
+    /// Called by the build task, which holds a ref on this route across the call.
     pub(crate) fn on_complete(&self, completion_task: &mut JSBundleCompletionTask) {
-        // For the build task — matches the ref() taken in on_plugins_resolved.
-        // SAFETY: self is IntrusiveRc-managed; `adopt` consumes the prior +1 on Drop.
-        let _drop_build_ref = unsafe { bun_ptr::ScopedRef::<Route>::adopt(self.as_ctx_ptr()) };
         // Still allocated, even if it has been stopped and its JS wrapper
         // collected since: the route holds a pending request on it until
         // `finish_building` (see `schedule_bundle`).
@@ -644,13 +565,10 @@ impl Route {
                     break 'bundle;
                 };
 
-                // `AnyRoute::Static` carries
-                // an intrusive `*mut StaticRoute` here; defer appending the HTML
-                // entry-point until after cloning so we retain the sole owner for
-                // the `clone()` mutable borrow. Static routes are keyed by
-                // `dest_path`, so registration order is immaterial.
-                let mut this_html_route: Option<(core::ptr::NonNull<StaticRoute>, Box<[u8]>)> =
-                    None;
+                // The HTML entry point is registered after the loop: `clone()`
+                // needs it by `&mut` before it is shared. Static routes are keyed
+                // by `dest_path`, so registration order is immaterial.
+                let mut this_html_route: Option<(StaticRoute, Box<[u8]>)> = None;
 
                 // Create static routes for each output file
                 // Index loop because the SourceMap branch reads a sibling entry.
@@ -708,16 +626,7 @@ impl Route {
                         headers.append(b"SourceMap", route_path);
                     }
 
-                    let cached_blob_size = blob.size() as u64;
-                    let static_route = bun_core::heap::into_raw_nn(Box::new(StaticRoute {
-                        ref_count: Cell::new(1),
-                        blob,
-                        server: Cell::new(Some(server)),
-                        status_code: 200,
-                        headers,
-                        cached_blob_size,
-                        has_date: false,
-                    }));
+                    let static_route = StaticRoute::new(blob, headers, Some(server), 200);
 
                     let mut route_path: &[u8] = &output_files[i].dest_path;
                     // The route path gets cloned inside of appendStaticRoute.
@@ -728,27 +637,23 @@ impl Route {
                     }
 
                     if i == html_index {
-                        // Defer registration so we retain unique ownership for `clone()`.
                         this_html_route = Some((static_route, Box::<[u8]>::from(route_path)));
                         continue;
                     }
 
                     bun_core::handle_oom(server.append_static_route(
                         route_path,
-                        AnyRoute::Static(static_route),
+                        AnyRoute::Static(RefPtr::new(static_route)),
                         MethodOptional::Any,
                     ));
                 }
 
-                let (html_route, html_route_path) =
+                let (mut html_route, html_route_path) =
                     this_html_route.expect("the loop above visited html_index");
-                // SAFETY: html_route is a fresh heap::alloc with ref_count=1;
-                // sole owner before registration.
-                let html_route_clone =
-                    bun_core::handle_oom(unsafe { &mut *html_route.as_ptr() }.clone(global_this));
+                let html_route_clone = html_route.clone(global_this);
                 bun_core::handle_oom(server.append_static_route(
                     &html_route_path,
-                    AnyRoute::Static(html_route),
+                    AnyRoute::Static(RefPtr::new(html_route)),
                     MethodOptional::Any,
                 ));
                 self.state.set(State::Html(html_route_clone));
@@ -769,17 +674,7 @@ impl Route {
         // (which writes responses and may run uws callbacks) holds no borrow
         // into `self.pending_responses`.
         let pending = self.pending_responses.replace(Vec::new());
-        for pending_response_ptr in pending {
-            // SAFETY: every entry was created via heap::alloc in on_any_request and
-            // is removed exactly once (here, or via on_aborted which removes without
-            // freeing). Shared — the pending flag is a `Cell`.
-            let pending_response = unsafe { &*pending_response_ptr };
-            // `defer pending_response.deinit()` — heap::take + Drop at scope end.
-            let _drop = scopeguard::guard(pending_response_ptr, |p| {
-                // SAFETY: see above; reconstitutes the Box and runs `Drop`.
-                drop(unsafe { bun_core::heap::take(p) });
-            });
-
+        for pending_response in pending {
             let resp = pending_response.resp;
             let method = pending_response.method;
             if !pending_response.is_response_pending.get() {
@@ -792,11 +687,9 @@ impl Route {
             match self.state.get() {
                 State::Html(html) => {
                     if method == Method::HEAD {
-                        // SAFETY: `*html` is a live intrusive-refcounted allocation.
-                        unsafe { StaticRoute::on_head(*html, resp) };
+                        StaticRoute::on_head(html.this_ptr(), resp);
                     } else {
-                        // SAFETY: see above.
-                        unsafe { StaticRoute::on(*html, resp) };
+                        StaticRoute::on(html.this_ptr(), resp);
                     }
                 }
                 State::Err(_log) => {
@@ -832,12 +725,8 @@ impl Drop for Route {
     fn drop(&mut self) {
         // pending responses keep a ref to the route
         debug_assert!(self.pending_responses.get().is_empty());
-        // `pending_responses` (Vec) and `bundle` (IntrusiveRc) auto-drop.
-        // `state` has no `Drop` glue for the intrusive-pointer variants — release
-        // them explicitly.
-        // `with_mut` is fine here — refcount==0 so no other `&Route` exists.
-        self.state.with_mut(|s| s.deinit());
-        // The Box free is handled by IntrusiveRc dealloc.
+        self.state.replace(State::Pending).deinit();
+        self.bundle.deref();
     }
 }
 
@@ -846,10 +735,8 @@ pub struct PendingResponse {
     method: Method,
     resp: AnyResponse,
     is_response_pending: Cell<bool>,
-    // Raw ptr because the route owns the Vec containing this
-    // PendingResponse; an `IntrusiveRc<Route>` field would form a cycle through
-    // `Drop`. The ref is bumped/dropped manually via `RefCount::<Route>` calls.
-    route: *mut Route,
+    /// Released in `Drop`.
+    route: RefPtr<Route>,
 }
 
 impl Drop for PendingResponse {
@@ -859,48 +746,28 @@ impl Drop for PendingResponse {
             self.resp.clear_on_writable();
             self.resp.end_without_body(true);
         }
-        // SAFETY: `route` was a live IntrusiveRc-managed Route when stored;
-        // matches the `ref()` taken when this PendingResponse was created.
-        unsafe { RefCount::<Route>::deref(self.route) };
-        // The Box free is handled by the heap::take caller.
+        self.route.deref();
     }
 }
 
-impl PendingResponse {
-    /// # Safety
-    /// `this` must point to a live `PendingResponse` previously boxed via
-    /// `heap::into_raw` and registered with `resp.on_aborted`; it may be freed
-    /// (via `heap::take`) by this call.
-    unsafe fn on_aborted(this: *mut PendingResponse, _resp: AnyResponse) {
-        // SAFETY: caller contract. Shared — the pending flag is a `Cell`, and
-        // the `heap::take` below goes through `this`, not this borrow.
-        let this_ref = unsafe { &*this };
-        debug_assert!(this_ref.is_response_pending.get());
-        this_ref.is_response_pending.set(false);
-
+impl Route {
+    /// uws onAborted for a response waiting in `pending_responses`.
+    fn on_pending_response_aborted(this: ThisPtr<Self>, resp: AnyResponse) {
         // Technically, this could be the final ref count, but we don't want to risk it
-        let route_ptr = this_ref.route;
-        // SAFETY: this.route is a valid IntrusiveRc-managed allocation;
-        // `ScopedRef` bumps the count and derefs on every exit path.
-        let _keep_route = unsafe { bun_ptr::ScopedRef::new(route_ptr) };
+        let _keep_alive = this.ref_guard();
 
-        // SAFETY: single-threaded; Route is alive (we hold a ref). R-2: deref as
-        // shared (`&*`); `pending_responses` is `JsCell`-wrapped.
-        let route = unsafe { &*route_ptr };
-        // R-2: scope the `&mut Vec` to the find+remove only — `RefCount::deref`
-        // can run `Route::drop` (which `get()`s `pending_responses`) and must
-        // not overlap a live `with_mut` borrow.
-        let removed = route.pending_responses.with_mut(|v| {
-            if let Some(index) = v.iter().position(|&p| p == this) {
-                v.remove(index);
-                true
-            } else {
-                false
-            }
+        // R-2: scope the `&mut Vec` to the find+remove only — dropping the
+        // removed entry releases a route ref and must not overlap a live
+        // `with_mut` borrow.
+        let removed = this.pending_responses.with_mut(|v| {
+            v.iter()
+                .position(|p| p.resp == resp)
+                .map(|index| v.remove(index))
         });
-        if removed {
-            // SAFETY: matches `heap::into_raw` in on_any_request; Drop releases the route ref taken there.
-            drop(unsafe { bun_core::heap::take(this) });
+        if let Some(pending_response) = removed {
+            debug_assert!(pending_response.is_response_pending.get());
+            pending_response.is_response_pending.set(false);
+            drop(pending_response);
         }
     }
 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1922,7 +1922,7 @@ where
         }
 
         let server = self.server();
-        FileResponseStream::start(&file_response_stream::StartOptions {
+        FileResponseStream::start(file_response_stream::StartOptions {
             fd,
             auto_close,
             resp,
@@ -1936,10 +1936,12 @@ where
                 None
             },
             idle_timeout: server.config().idle_timeout,
-            ctx: self.as_ctx_ptr().cast::<c_void>(),
-            on_complete: Self::on_file_stream_complete,
-            on_abort: Some(Self::on_file_stream_abort),
-            on_error: Self::on_file_stream_error,
+            owner: file_response_stream::StreamOwner::Ctx {
+                ctx: self.as_ctx_ptr().cast::<c_void>(),
+                on_complete: Self::on_file_stream_complete,
+                on_abort: Some(Self::on_file_stream_abort),
+                on_error: Self::on_file_stream_error,
+            },
         });
     }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -4,6 +4,7 @@ use bun_core::ZBox;
 
 use bun_collections::StringHashMap;
 use bun_core::strings;
+use bun_ptr::ThisPtr;
 use bun_uws_sys as uws;
 use bun_wyhash::Wyhash;
 
@@ -322,89 +323,30 @@ impl ServerConfig {
     }
 }
 
-// NOTE: free `extern "C"` fns are monomorphized per `<SSL, T>` and registered
-// via the raw `c::uws_method_handler` overload.
-
-/// # Safety
-/// `entry` must be a live route pointer that outlives `app` — it is registered
-/// as the uWS userdata and dereferenced from request callbacks for the lifetime
-/// of the app.
-// Forwards `entry` to `T::set_server` and to uWS as opaque userdata without
-// dereferencing it here; not_unsafe_ptr_arg_deref is a false positive on
-// opaque-token forwarding.
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub(crate) fn apply_static_route<const SSL: bool, T>(
+pub(crate) fn apply_static_route<const SSL: bool, T: StaticRouteLike>(
     server: AnyServer,
     app: &mut uws::NewApp<SSL>,
-    entry: *mut T,
+    entry: ThisPtr<T>,
     path: &[u8],
     method: http_method::Optional,
     path_has_user_head_route: bool,
-) where
-    T: StaticRouteLike<SSL>,
-{
-    // SAFETY: caller passes a live route pointer for the lifetime of the app.
-    unsafe { T::set_server(entry, server) };
+) {
+    entry.set_server(server);
 
-    // Trampolines: uWS hands us an opaque `uws_res*`, a live `Request*`, and the
-    // user_data pointer (= `entry`). Cast back to the typed `Response<SSL>` /
-    // `T` and dispatch into the trait. Monomorphized per `<SSL, T>`.
-    extern "C" fn handler<const SSL: bool, T: StaticRouteLike<SSL>>(
-        resp: *mut uws::uws_res,
-        req: *mut uws::Request,
-        user_data: *mut core::ffi::c_void,
-    ) {
-        // SAFETY: uWS invokes this with non-null `resp`/`req` for the duration
-        // of the callback; `user_data` is the `entry` pointer registered below,
-        // kept alive by the route table for the lifetime of the app.
-        let route = user_data.cast::<T>();
-        let resp = uws::NewAppResponse::<SSL>::cast_res(resp);
-        // `Response<SSL>` is a `#[repr(C)]` opaque over `uws_res`; pointer cast
-        // selects the matching `AnyResponse` variant for the const-generic SSL flag.
-        let any_resp = if SSL {
-            bun_uws_sys::AnyResponse::SSL(resp.cast())
-        } else {
-            bun_uws_sys::AnyResponse::TCP(resp.cast())
-        };
-        // SAFETY: `route`, `req`, and `resp` are non-null and valid for the
-        // duration of this uWS callback (see invariants established above);
-        // `on_request` only dereferences them while this frame is live.
-        unsafe { T::on_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp) };
-    }
-
-    extern "C" fn head<const SSL: bool, T: StaticRouteLike<SSL>>(
-        resp: *mut uws::uws_res,
-        req: *mut uws::Request,
-        user_data: *mut core::ffi::c_void,
-    ) {
-        // SAFETY: see `handler` above.
-        let route = user_data.cast::<T>();
-        let resp = uws::NewAppResponse::<SSL>::cast_res(resp);
-        let any_resp = if SSL {
-            bun_uws_sys::AnyResponse::SSL(resp.cast())
-        } else {
-            bun_uws_sys::AnyResponse::TCP(resp.cast())
-        };
-        // SAFETY: `route`, `req`, and `resp` validity is guaranteed by uWS for
-        // the callback's duration — same invariants as `handler` above.
-        unsafe { T::on_head_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp) };
-    }
-
-    let user_data = entry.cast::<core::ffi::c_void>();
     // Only answer HEAD from an entry that serves GET (HEAD must mirror GET,
     // RFC 9110 section 9.3.2) or HEAD itself, and never displace an explicit HEAD
     // handler route: uWS keeps the last registration for the same method and path.
     if !path_has_user_head_route && serves_head(&method) {
-        app.head(path, Some(head::<SSL, T>), user_data);
+        app.method_this(Method::HEAD, path, T::on_head_request, entry);
     }
     match method {
         http_method::Optional::Any => {
-            app.any(path, Some(handler::<SSL, T>), user_data);
+            app.any_this(path, T::on_request, entry);
         }
         http_method::Optional::Method(m) => {
             let mut iter = m.iter();
             while let Some(method_) = iter.next() {
-                app.method(method_, path, Some(handler::<SSL, T>), user_data);
+                app.method_this(method_, path, T::on_request, entry);
             }
         }
     }
@@ -420,176 +362,84 @@ fn serves_head(method: &http_method::Optional) -> bool {
     }
 }
 
-/// # Safety
-/// `entry` must be a live route pointer that outlives `app` — it is registered
-/// as the uWS userdata and dereferenced from request callbacks for the lifetime
-/// of the app.
-// Forwards `entry` to `T::set_server` and to uWS as opaque userdata without
-// dereferencing it here; not_unsafe_ptr_arg_deref is a false positive on
-// opaque-token forwarding.
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub(crate) fn apply_static_route_h3<T>(
+pub(crate) fn apply_static_route_h3<T: StaticRouteLike>(
     server: AnyServer,
     app: &mut uws::h3::App,
-    entry: *mut T,
+    entry: ThisPtr<T>,
     path: &[u8],
     method: http_method::Optional,
     path_has_user_head_route: bool,
-) where
-    T: StaticRouteLike<false>,
-{
-    // SAFETY: caller passes a live route pointer for the lifetime of the app.
-    unsafe { T::set_server(entry, server) };
-
-    fn handler<T: StaticRouteLike<false>>(
-        route: &mut T,
-        req: &mut uws::h3::Request,
-        resp: &mut uws::h3::Response,
-    ) {
-        // SAFETY: `route` is the `entry` userdata kept alive by the route table.
-        unsafe {
-            T::on_request(
-                route,
-                bun_uws_sys::AnyRequest::H3(req),
-                bun_uws_sys::AnyResponse::H3(resp),
-            )
-        };
-    }
-    fn head<T: StaticRouteLike<false>>(
-        route: &mut T,
-        req: &mut uws::h3::Request,
-        resp: &mut uws::h3::Response,
-    ) {
-        // SAFETY: see `handler` above.
-        unsafe {
-            T::on_head_request(
-                route,
-                bun_uws_sys::AnyRequest::H3(req),
-                bun_uws_sys::AnyResponse::H3(resp),
-            )
-        };
-    }
+) {
+    entry.set_server(server);
 
     if !path_has_user_head_route && serves_head(&method) {
-        app.head(path, entry, head::<T>);
+        app.method_this(Method::HEAD, path, T::on_head_request, entry);
     }
     match method {
-        http_method::Optional::Any => app.any(path, entry, handler::<T>),
+        http_method::Optional::Any => app.any_this(path, T::on_request, entry),
         http_method::Optional::Method(m) => {
             let mut iter = m.iter();
             while let Some(method_) = iter.next() {
-                app.method(method_, path, entry, handler::<T>);
+                app.method_this(method_, path, T::on_request, entry);
             }
         }
     }
 }
 
 /// Per-route trait that `apply_static_route{,_h3}` monomorphizes over
-/// (`StaticRoute`/`FileRoute`/`HTMLBundle.Route`).
-/// Receivers are raw `*mut Self` because the route is registered as the uWS
-/// userdata pointer and the inherent impls (`StaticRoute::on_request` etc.) need
-/// `*mut` to mutate state and stash `self` into onAborted callbacks.
-pub(crate) trait StaticRouteLike<const SSL: bool>: 'static {
-    /// SAFETY: `this` is a live route pointer for the lifetime of the app.
-    unsafe fn set_server(this: *mut Self, server: AnyServer);
-    /// SAFETY: `this` is a live route pointer; `req`/`resp` carry FFI handles
-    /// valid for the duration of the uWS callback.
-    unsafe fn on_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    );
-    /// SAFETY: see `on_request`.
-    unsafe fn on_head_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    );
+/// (`StaticRoute`/`FileRoute`/`DirectoryRoute`/`HTMLBundle.Route`). The route
+/// is the uWS route userdata; the route table holds a ref on it for as long as
+/// it is registered.
+pub(crate) trait StaticRouteLike: Sized + 'static {
+    fn set_server(&self, server: AnyServer);
+    fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse);
+    fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse);
 }
 
-impl<const SSL: bool> StaticRouteLike<SSL> for super::StaticRoute {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live; `server` is a Cell so &mut
-        // is not required.
-        unsafe { (*this).server.set(Some(server)) };
+impl StaticRouteLike for super::StaticRoute {
+    fn set_server(&self, server: AnyServer) {
+        self.server.set(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
-        // SAFETY: forwarded to the inherent impl with the same contract.
-        unsafe { Self::on_request(this, req, resp) }
-    }
-    unsafe fn on_head_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
-        // SAFETY: forwarded to the inherent impl with the same contract.
-        unsafe { Self::on_head_request(this, req, resp) }
-    }
-}
-
-impl<const SSL: bool> StaticRouteLike<SSL> for super::FileRoute {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live.
-        unsafe { (*this).set_server(Some(server)) };
-    }
-    unsafe fn on_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
+    fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_request(this, req, resp)
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
+    fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_head_request(this, req, resp)
     }
 }
 
-impl<const SSL: bool> StaticRouteLike<SSL> for super::DirectoryRoute {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live.
-        unsafe { (*this).set_server(Some(server)) };
+impl StaticRouteLike for super::FileRoute {
+    fn set_server(&self, server: AnyServer) {
+        self.set_server(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
+    fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_request(this, req, resp)
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
+    fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_head_request(this, req, resp)
     }
 }
 
-impl<const SSL: bool> StaticRouteLike<SSL> for super::html_bundle::Route {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live.
-        unsafe { (*this).server.set(Some(server)) };
+impl StaticRouteLike for super::DirectoryRoute {
+    fn set_server(&self, server: AnyServer) {
+        self.set_server(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
+    fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_request(this, req, resp)
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
-        req: bun_uws_sys::AnyRequest,
-        resp: bun_uws_sys::AnyResponse,
-    ) {
+    fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
+        Self::on_head_request(this, req, resp)
+    }
+}
+
+impl StaticRouteLike for super::html_bundle::Route {
+    fn set_server(&self, server: AnyServer) {
+        self.server.set(Some(server));
+    }
+    fn on_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
+        Self::on_request(this, req, resp)
+    }
+    fn on_head_request(this: ThisPtr<Self>, req: uws::AnyRequest, resp: uws::AnyResponse) {
         Self::on_head_request(this, req, resp)
     }
 }

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -4,11 +4,11 @@
 use core::cell::Cell;
 use core::mem::size_of;
 
-use crate::Error;
 use bun_http::headers::api::StringPointer;
 use bun_http::headers::append_etag;
 use bun_http::{Headers, Method};
 use bun_http_types::ETag;
+use bun_ptr::{RefPtr, ThisPtr};
 
 use bun_http_types::MimeType::MimeType;
 use bun_jsc::HTTPHeaderName;
@@ -20,17 +20,16 @@ use crate::webcore::body::Value as BodyValue;
 use crate::webcore::headers_ref::any_blob_content_type;
 use crate::webcore::{AnyBlob, FetchHeaders, InternalBlob, Response};
 
-// bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — single-thread refcount.
-// `*StaticRoute` is also passed as uws onAborted/
-// onWritable userdata; the intrusive `ref_count` Cell + `*mut Self` receivers
-// preserve write provenance through the FFI userdata round-trip so the eventual
-// `heap::take` in `deref_` is sound.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct StaticRoute {
+    ref_count: Cell<u32>,
+    /// The ref that in-flight responses (whose uws userdata is this route)
+    /// collectively hold: taken by the first, released with the last in
+    /// `on_response_complete`.
+    pending_ref: Cell<Option<RefPtr<StaticRoute>>>,
+    pending_responses: Cell<u32>,
     // TODO: Remove optional. StaticRoute requires a server object or else it will
     // not ensure it is alive while sending a large blob.
-    // `pub(super)` so sibling route modules (HTMLBundle) can construct directly.
-    pub(super) ref_count: Cell<u32>,
     pub(crate) server: Cell<Option<AnyServer>>,
     pub(crate) status_code: u16,
     pub(crate) blob: AnyBlob,
@@ -59,29 +58,30 @@ impl<'a> Default for InitFromBytesOptions<'a> {
 }
 
 impl StaticRoute {
-    // pub const ref / deref — intrusive refcount accessors.
-    // `ref_()`/`deref()` are provided by `#[derive(CellRefCounted)]`; `deref_`
-    // is kept as a thin alias so existing call sites keep
-    // working without renaming.
-    /// # Safety
-    /// `this` must have been produced by `heap::alloc` in one of the
-    /// constructors below (write provenance preserved through FFI userdata
-    /// round-trips). Caller must not hold any live `&`/`&mut` to `*this` across
-    /// this call when the refcount may reach zero.
-    #[inline]
-    pub(crate) unsafe fn deref_(this: *mut Self) {
-        // SAFETY: forwarded caller contract — see `CellRefCounted::deref`.
-        unsafe { <Self as bun_ptr::CellRefCounted>::deref(this) }
+    pub(crate) fn new(
+        blob: AnyBlob,
+        headers: Headers,
+        server: Option<AnyServer>,
+        status_code: u16,
+    ) -> StaticRoute {
+        StaticRoute {
+            ref_count: Cell::new(1),
+            pending_ref: Cell::new(None),
+            pending_responses: Cell::new(0),
+            cached_blob_size: blob.size(),
+            has_date: headers.get(b"date").is_some(),
+            blob,
+            headers,
+            server: Cell::new(server),
+            status_code,
+        }
     }
 
     /// Ownership of `blob` is transferred to this function.
-    // `AnyBlob` has drop glue (e.g.
-    // `InternalBlob.bytes: Vec<u8>`), so a `&AnyBlob` + `ptr::read` would alias
-    // and double-free when the caller's value drops. Take by value instead.
     pub(crate) fn init_from_any_blob(
         blob: AnyBlob,
         options: InitFromBytesOptions<'_>,
-    ) -> *mut StaticRoute {
+    ) -> RefPtr<StaticRoute> {
         let mut headers = bun_http_jsc::headers_jsc::from_fetch_headers(
             options.headers,
             any_blob_content_type(&blob),
@@ -101,17 +101,12 @@ impl StaticRoute {
             }
         }
 
-        let cached_blob_size = blob.size();
-        let has_date = headers.get(b"date").is_some();
-        bun_core::heap::into_raw(Box::new(StaticRoute {
-            ref_count: Cell::new(1),
+        RefPtr::new(StaticRoute::new(
             blob,
-            cached_blob_size,
-            has_date,
             headers,
-            server: Cell::new(options.server),
-            status_code: options.status_code,
-        }))
+            options.server,
+            options.status_code,
+        ))
     }
 
     /// Create a static route to be used on a single response, freeing the bytes once sent.
@@ -121,31 +116,26 @@ impl StaticRoute {
         options: InitFromBytesOptions<'_>,
     ) {
         let temp_route = StaticRoute::init_from_any_blob(blob, options);
-        // SAFETY: init_from_any_blob returns a freshly boxed StaticRoute (ref_count=1)
-        // with write provenance; on()/deref_() consume it via that same *mut.
-        unsafe {
-            StaticRoute::on(temp_route, resp);
-            StaticRoute::deref_(temp_route);
-        }
+        StaticRoute::on(temp_route.this_ptr(), resp);
+        temp_route.deref();
     }
 
-    pub(crate) fn clone(
-        &mut self,
-        global_this: &JSGlobalObject,
-    ) -> Result<*mut StaticRoute, Error> {
+    pub(crate) fn clone(&mut self, global_this: &JSGlobalObject) -> RefPtr<StaticRoute> {
         let blob = self.blob.to_blob(global_this);
         let duped = blob.dupe();
         self.blob = AnyBlob::Blob(blob);
 
-        Ok(bun_core::heap::into_raw(Box::new(StaticRoute {
+        RefPtr::new(StaticRoute {
             ref_count: Cell::new(1),
+            pending_ref: Cell::new(None),
+            pending_responses: Cell::new(0),
             blob: AnyBlob::Blob(duped),
             cached_blob_size: self.cached_blob_size,
             has_date: self.has_date,
             headers: self.headers.clone(),
             server: Cell::new(self.server.get()),
             status_code: self.status_code,
-        })))
+        })
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
@@ -155,7 +145,7 @@ impl StaticRoute {
     pub fn from_js(
         global_this: &JSGlobalObject,
         argument: JSValue,
-    ) -> JsResult<Option<*mut StaticRoute>> {
+    ) -> JsResult<Option<RefPtr<StaticRoute>>> {
         // `as_class_ref` is the safe shared-borrow downcast (one audited
         // unsafe in `JSValue`); every `Response` accessor used below takes
         // `&self` (interior mutability for `body`), so no `&mut` is needed.
@@ -246,56 +236,40 @@ impl StaticRoute {
                 }
             }
 
-            let cached_blob_size = blob.size();
-            let has_date = headers.get(b"date").is_some();
-            return Ok(Some(bun_core::heap::into_raw(Box::new(StaticRoute {
-                ref_count: Cell::new(1),
+            return Ok(Some(RefPtr::new(StaticRoute::new(
                 blob,
-                cached_blob_size,
-                has_date,
                 headers,
-                server: Cell::new(None),
-                status_code: response.status_code(),
-            }))));
+                None,
+                response.status_code(),
+            ))));
         }
 
         Ok(None)
     }
 
     // HEAD requests have no body.
-    /// # Safety
-    /// `this` must point to a live heap-allocated `StaticRoute` produced by one of
-    /// the constructors (write provenance intact).
-    pub(crate) unsafe fn on_head_request(this: *mut Self, mut req: AnyRequest, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            // Evaluate conditional request preconditions for HEAD with 200 status
-            if (*this).status_code == 200 {
-                if Self::render_precondition(this, &mut req, resp) {
-                    return;
-                }
+    pub(crate) fn on_head_request(this: ThisPtr<Self>, mut req: AnyRequest, resp: AnyResponse) {
+        // Evaluate conditional request preconditions for HEAD with 200 status
+        if this.status_code == 200 {
+            if Self::render_precondition(this, &mut req, resp) {
+                return;
             }
-
-            // Continue with normal HEAD request handling
-            req.set_yield(false);
-            Self::on_head(this, resp);
         }
+
+        // Continue with normal HEAD request handling
+        req.set_yield(false);
+        Self::on_head(this, resp);
     }
 
-    /// # Safety
-    /// See [`on_head_request`].
-    pub(crate) unsafe fn on_head(this: *mut Self, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            debug_assert!((*this).server.get().is_some());
-            (*this).ref_();
-            if let Some(mut server) = (*this).server.get() {
-                server.on_pending_request();
-                resp.timeout(server.config().idle_timeout);
-            }
-            resp.corked(|| (*this).render_metadata_and_end(resp));
-            Self::on_response_complete(this, resp);
+    pub(crate) fn on_head(this: ThisPtr<Self>, resp: AnyResponse) {
+        debug_assert!(this.server.get().is_some());
+        Self::retain_for_response(this);
+        if let Some(mut server) = this.server.get() {
+            server.on_pending_request();
+            resp.timeout(server.config().idle_timeout);
         }
+        resp.corked(|| this.render_metadata_and_end(resp));
+        Self::on_response_complete(this, resp);
     }
 
     fn render_metadata_and_end(&self, resp: AnyResponse) {
@@ -315,108 +289,84 @@ impl StaticRoute {
         resp.end_without_body(resp.should_close_connection());
     }
 
-    /// # Safety
-    /// See [`on_head_request`].
-    pub(crate) unsafe fn on_request(this: *mut Self, req: AnyRequest, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            let method = Method::find(req.method()).unwrap_or(Method::GET);
-            if method == Method::GET {
-                Self::on_get(this, req, resp);
-            } else if method == Method::HEAD {
-                Self::on_head_request(this, req, resp);
-            } else {
-                // For other methods, use the original behavior
-                let mut req = req;
-                req.set_yield(false);
-                Self::on(this, resp);
-            }
-        }
-    }
-
-    /// # Safety
-    /// See [`on_head_request`].
-    pub(crate) unsafe fn on_get(this: *mut Self, mut req: AnyRequest, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            // Evaluate conditional request preconditions for GET with 200 status
-            if (*this).status_code == 200 {
-                if Self::render_precondition(this, &mut req, resp) {
-                    return;
-                }
-            }
-
-            // Continue with normal GET request handling
+    pub(crate) fn on_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse) {
+        let method = Method::find(req.method()).unwrap_or(Method::GET);
+        if method == Method::GET {
+            Self::on_get(this, req, resp);
+        } else if method == Method::HEAD {
+            Self::on_head_request(this, req, resp);
+        } else {
+            // For other methods, use the original behavior
+            let mut req = req;
             req.set_yield(false);
             Self::on(this, resp);
         }
     }
 
-    /// # Safety
-    /// See [`on_head_request`].
-    pub(crate) unsafe fn on(this: *mut Self, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            debug_assert!((*this).server.get().is_some());
-            (*this).ref_();
-            if let Some(mut server) = (*this).server.get() {
-                server.on_pending_request();
-                resp.timeout(server.config().idle_timeout);
-            }
-            let mut finished = false;
-            (*this).do_render_blob(resp, &mut finished);
-            if finished {
-                Self::on_response_complete(this, resp);
+    pub(crate) fn on_get(this: ThisPtr<Self>, mut req: AnyRequest, resp: AnyResponse) {
+        // Evaluate conditional request preconditions for GET with 200 status
+        if this.status_code == 200 {
+            if Self::render_precondition(this, &mut req, resp) {
                 return;
             }
-
-            Self::to_async(this, resp);
         }
+
+        // Continue with normal GET request handling
+        req.set_yield(false);
+        Self::on(this, resp);
     }
 
-    /// # Safety
-    /// `this` has ref_count >= 1 held until `on_response_complete`; uws stores the
-    /// raw pointer and calls back on the same thread. Receiving `*mut Self` (rather
-    /// than `&self`) preserves write provenance through the FFI userdata round-trip
-    /// so the eventual `heap::take` in `deref_` is sound.
-    unsafe fn to_async(this: *mut Self, resp: AnyResponse) {
-        resp.on_aborted(
-            |this: *mut StaticRoute, resp| {
-                // SAFETY: uws invokes with the same userdata pointer registered
-                // below, on the same thread, while the route holds a ref.
-                unsafe { Self::on_aborted(this, resp) }
-            },
-            this,
-        );
-        resp.on_writable(
-            |this: *mut StaticRoute, off, resp| {
-                // SAFETY: see on_aborted closure above.
-                unsafe { Self::on_writable(this, off, resp) }
-            },
-            this,
-        );
+    pub(crate) fn on(this: ThisPtr<Self>, resp: AnyResponse) {
+        debug_assert!(this.server.get().is_some());
+        Self::retain_for_response(this);
+        if let Some(mut server) = this.server.get() {
+            server.on_pending_request();
+            resp.timeout(server.config().idle_timeout);
+        }
+        let mut finished = false;
+        this.do_render_blob(resp, &mut finished);
+        if finished {
+            Self::on_response_complete(this, resp);
+            return;
+        }
+
+        Self::to_async(this, resp);
     }
 
-    /// # Safety
-    /// uws callback: `this` is the userdata registered in `to_async`.
-    unsafe fn on_aborted(this: *mut Self, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe { Self::on_response_complete(this, resp) };
+    fn to_async(this: ThisPtr<Self>, resp: AnyResponse) {
+        resp.on_aborted_this(Self::on_aborted, this);
+        resp.on_writable_this(Self::on_writable, this);
     }
 
-    /// # Safety
-    /// `this` must be a live heap-allocated route with write provenance; may free
-    /// `*this` via `deref_` when the refcount reaches zero.
-    unsafe fn on_response_complete(this: *mut Self, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            resp.clear_aborted();
-            resp.clear_on_writable();
-            resp.clear_timeout();
-            if let Some(mut server) = (*this).server.get() {
-                server.on_static_request_complete();
+    fn on_aborted(this: ThisPtr<Self>, resp: AnyResponse) {
+        Self::on_response_complete(this, resp);
+    }
+
+    /// The response whose uws userdata is this route keeps it alive until
+    /// `on_response_complete`.
+    fn retain_for_response(this: ThisPtr<Self>) {
+        let n = this.pending_responses.get();
+        if n == 0 {
+            this.pending_ref.set(Some(RefPtr::from_this(this)));
+        }
+        this.pending_responses.set(n + 1);
+    }
+
+    /// May free `this`.
+    fn on_response_complete(this: ThisPtr<Self>, resp: AnyResponse) {
+        resp.clear_aborted();
+        resp.clear_on_writable();
+        resp.clear_timeout();
+        if let Some(mut server) = this.server.get() {
+            server.on_static_request_complete();
+        }
+        let n = this.pending_responses.get() - 1;
+        this.pending_responses.set(n);
+        if n == 0 {
+            let pending_ref = this.pending_ref.take();
+            if let Some(pending_ref) = pending_ref {
+                pending_ref.deref();
             }
-            Self::deref_(this);
         }
     }
 
@@ -453,22 +403,17 @@ impl StaticRoute {
         self.render_bytes(resp, did_finish);
     }
 
-    /// # Safety
-    /// uws callback: `this` is the userdata registered in `to_async`.
-    unsafe fn on_writable(this: *mut Self, write_offset: u64, resp: AnyResponse) -> bool {
-        // SAFETY: caller contract.
-        unsafe {
-            if let Some(server) = (*this).server.get() {
-                resp.timeout(server.config().idle_timeout);
-            }
-
-            if !(*this).on_writable_bytes(write_offset, resp) {
-                return false;
-            }
-
-            Self::on_response_complete(this, resp);
-            true
+    fn on_writable(this: ThisPtr<Self>, write_offset: u64, resp: AnyResponse) -> bool {
+        if let Some(server) = this.server.get() {
+            resp.timeout(server.config().idle_timeout);
         }
+
+        if !this.on_writable_bytes(write_offset, resp) {
+            return false;
+        }
+
+        Self::on_response_complete(this, resp);
+        true
     }
 
     fn on_writable_bytes(&self, write_offset: u64, resp: AnyResponse) -> bool {
@@ -531,126 +476,102 @@ impl StaticRoute {
         self.do_write_headers(resp);
     }
 
-    /// # Safety
-    /// See [`on_head_request`].
-    pub(crate) unsafe fn on_with_method(this: *mut Self, method: Method, resp: AnyResponse) {
-        // SAFETY: caller contract.
-        unsafe {
-            match method {
-                Method::GET => Self::on(this, resp),
-                Method::HEAD => Self::on_head(this, resp),
-                _ => {
-                    (*this).do_write_status(405, resp); // Method not allowed
-                    resp.write_header(b"Allow", b"GET, HEAD");
-                    resp.write_header_int(b"Content-Length", 0);
-                    resp.end_without_body(resp.should_close_connection());
-                }
+    pub(crate) fn on_with_method(this: ThisPtr<Self>, method: Method, resp: AnyResponse) {
+        match method {
+            Method::GET => Self::on(this, resp),
+            Method::HEAD => Self::on_head(this, resp),
+            _ => {
+                this.do_write_status(405, resp); // Method not allowed
+                resp.write_header(b"Allow", b"GET, HEAD");
+                resp.write_header_int(b"Content-Length", 0);
+                resp.end_without_body(resp.should_close_connection());
             }
         }
     }
 
     /// RFC 9110 §13.2.2 precondition evaluation. Writes a 412 or 304 response
     /// and returns `true` when a precondition short-circuits the request.
-    ///
-    /// # Safety
-    /// See [`on_head_request`]. May free `*this` via `on_response_complete` when it
-    /// returns `true`.
-    unsafe fn render_precondition(
-        this: *mut Self,
-        req: &mut AnyRequest,
-        resp: AnyResponse,
-    ) -> bool {
-        // SAFETY: caller contract.
-        unsafe {
-            let etag = (*this).headers.get(b"etag").filter(|v| !v.is_empty());
-            // Deferred: `parse_http_date` allocates + calls into WTF; only run it
-            // when the client actually sent a date-based conditional header.
-            let last_modified = || {
-                (*this)
-                    .headers
-                    .get(b"last-modified")
-                    .and_then(crate::jsc_hooks::parse_http_date)
-            };
+    fn render_precondition(this: ThisPtr<Self>, req: &mut AnyRequest, resp: AnyResponse) -> bool {
+        let etag = this.headers.get(b"etag").filter(|v| !v.is_empty());
+        // Deferred: `parse_http_date` allocates + calls into WTF; only run it
+        // when the client actually sent a date-based conditional header.
+        let last_modified = || {
+            this.headers
+                .get(b"last-modified")
+                .and_then(crate::jsc_hooks::parse_http_date)
+        };
 
-            // Step 1: If-Match (strong comparison); step 2: If-Unmodified-Since
-            // (only when If-Match is absent).
-            let precondition_failed =
-                if let Some(im) = req.header(b"if-match").filter(|v| !v.is_empty()) {
-                    !ETag::if_match(etag, im)
-                } else if let Some(ius) = req
-                    .header(b"if-unmodified-since")
-                    .and_then(crate::jsc_hooks::parse_http_date)
-                {
-                    matches!(last_modified(), Some(lm) if lm / 1000 > ius / 1000)
-                } else {
-                    false
-                };
-            if precondition_failed {
-                return Self::render_bodiless(this, req, resp, 412);
-            }
-
-            // Step 3: If-None-Match (weak comparison). Presence suppresses step 4.
-            let not_modified = if let Some(if_none_match) = req.header(b"if-none-match") {
-                match etag {
-                    Some(etag) if !if_none_match.is_empty() => {
-                        ETag::if_none_match(etag, if_none_match)
-                    }
-                    _ => false,
-                }
-            // Step 4: If-Modified-Since (only when If-None-Match is absent).
-            } else if let Some(ims) = req
-                .header(b"if-modified-since")
+        // Step 1: If-Match (strong comparison); step 2: If-Unmodified-Since
+        // (only when If-Match is absent).
+        let precondition_failed =
+            if let Some(im) = req.header(b"if-match").filter(|v| !v.is_empty()) {
+                !ETag::if_match(etag, im)
+            } else if let Some(ius) = req
+                .header(b"if-unmodified-since")
                 .and_then(crate::jsc_hooks::parse_http_date)
             {
-                // §13.1.3: 304 when Last-Modified <= If-Modified-Since. HTTP-date
-                // is second-granular, so compare at second precision.
-                match last_modified() {
-                    Some(lm) => lm / 1000 <= ims / 1000,
-                    None => false,
-                }
+                matches!(last_modified(), Some(lm) if lm / 1000 > ius / 1000)
             } else {
                 false
             };
-
-            if !not_modified {
-                return false;
-            }
-
-            Self::render_bodiless(this, req, resp, 304)
+        if precondition_failed {
+            return Self::render_bodiless(this, req, resp, 412);
         }
+
+        // Step 3: If-None-Match (weak comparison). Presence suppresses step 4.
+        let not_modified = if let Some(if_none_match) = req.header(b"if-none-match") {
+            match etag {
+                Some(etag) if !if_none_match.is_empty() => ETag::if_none_match(etag, if_none_match),
+                _ => false,
+            }
+        // Step 4: If-Modified-Since (only when If-None-Match is absent).
+        } else if let Some(ims) = req
+            .header(b"if-modified-since")
+            .and_then(crate::jsc_hooks::parse_http_date)
+        {
+            // §13.1.3: 304 when Last-Modified <= If-Modified-Since. HTTP-date
+            // is second-granular, so compare at second precision.
+            match last_modified() {
+                Some(lm) => lm / 1000 <= ims / 1000,
+                None => false,
+            }
+        } else {
+            false
+        };
+
+        if !not_modified {
+            return false;
+        }
+
+        Self::render_bodiless(this, req, resp, 304)
     }
 
-    /// # Safety
-    /// See [`on_head_request`]. Frees `*this` via `on_response_complete`.
-    unsafe fn render_bodiless(
-        this: *mut Self,
+    /// May free `this`.
+    fn render_bodiless(
+        this: ThisPtr<Self>,
         req: &mut AnyRequest,
         resp: AnyResponse,
         status: u16,
     ) -> bool {
-        // SAFETY: caller contract.
-        unsafe {
-            req.set_yield(false);
-            (*this).ref_();
-            if let Some(mut server) = (*this).server.get() {
-                server.on_pending_request();
-                resp.timeout(server.config().idle_timeout);
-            }
-            (*this).do_write_status(status, resp);
-            (*this).do_write_headers(resp);
-            if !HTTPStatusText::is_null_body(status) {
-                resp.write_header_int(b"Content-Length", 0);
-            }
-            resp.end_without_body(resp.should_close_connection());
-            Self::on_response_complete(this, resp);
-            true
+        req.set_yield(false);
+        Self::retain_for_response(this);
+        if let Some(mut server) = this.server.get() {
+            server.on_pending_request();
+            resp.timeout(server.config().idle_timeout);
         }
+        this.do_write_status(status, resp);
+        this.do_write_headers(resp);
+        if !HTTPStatusText::is_null_body(status) {
+            resp.write_header_int(b"Content-Length", 0);
+        }
+        resp.end_without_body(resp.should_close_connection());
+        Self::on_response_complete(this, resp);
+        true
     }
 }
 
 impl Drop for StaticRoute {
     fn drop(&mut self) {
-        // Box drop handles the dealloc; Headers has its own Drop.
         self.blob.detach();
     }
 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -139,19 +139,14 @@ pub(crate) fn write_status<const SSL: bool>(resp: *mut uws_sys::NewAppResponse<S
 }
 
 // ─── AnyRoute ────────────────────────────────────────────────────────────────
-// §Pointers: all
-// three concrete route types carry an intrusive `ref_count: Cell<u32>` and are
-// heap-allocated via `heap::alloc`; their pointers round-trip through uws
-// callback userdata (`ctx: *mut c_void`), so `Rc<T>` is unsuitable (would add
-// a second header and break the round-trip). Hold them as raw intrusive
-// pointers.
+/// The route table's ref on each route; `StaticRouteEntry`'s `Drop` releases it.
 pub enum AnyRoute {
     /// Serve a static file — `"/robots.txt": new Response(...)`
-    Static(core::ptr::NonNull<StaticRoute>),
+    Static(bun_ptr::RefPtr<StaticRoute>),
     /// Serve a file from disk
-    File(core::ptr::NonNull<FileRoute>),
+    File(bun_ptr::RefPtr<FileRoute>),
     /// Serve a directory tree — `"/static/*": { dir: "./public" }`
-    Directory(core::ptr::NonNull<DirectoryRoute>),
+    Directory(bun_ptr::RefPtr<DirectoryRoute>),
     /// Bundle an HTML import — `import html from "./index.html"; "/": html`
     Html(bun_ptr::RefPtr<html_bundle::Route>),
     /// Use file-system routing — `"/*": { dir: …, style: "nextjs-pages" }`
@@ -159,18 +154,12 @@ pub enum AnyRoute {
 }
 
 impl AnyRoute {
-    // `Static`/`File` payloads are intrusive-refcounted heap allocations whose
-    // +1 ref is held by the route table for the entire lifetime of this
-    // `AnyRoute` value, so the `BackRef` invariant (pointee outlives holder)
-    // is satisfied for any borrow scoped to `&self`. Wrapping the `NonNull`
-    // in a transient `BackRef` centralises the deref under that invariant
-    // instead of repeating a raw `NonNull::as_ref` per arm.
     pub(crate) fn memory_cost(&self) -> usize {
         match self {
-            AnyRoute::Static(p) => bun_ptr::BackRef::from(*p).memory_cost(),
-            AnyRoute::File(p) => bun_ptr::BackRef::from(*p).memory_cost(),
-            AnyRoute::Directory(p) => bun_ptr::BackRef::from(*p).memory_cost(),
-            AnyRoute::Html(r) => r.data().memory_cost(),
+            AnyRoute::Static(r) => r.memory_cost(),
+            AnyRoute::File(r) => r.memory_cost(),
+            AnyRoute::Directory(r) => r.memory_cost(),
+            AnyRoute::Html(r) => r.memory_cost(),
             AnyRoute::FrameworkRouter(_) => {
                 core::mem::size_of::<crate::bake::FileSystemRouterType>()
             }
@@ -179,12 +168,9 @@ impl AnyRoute {
 
     pub(crate) fn deref_(&self) {
         match self {
-            // SAFETY: intrusive refcount; ptr was heap-allocated with rc=1.
-            AnyRoute::Static(p) => unsafe { StaticRoute::deref_(p.as_ptr()) },
-            // SAFETY: see above.
-            AnyRoute::File(p) => unsafe { FileRoute::deref(p.as_ptr()) },
-            // SAFETY: see above.
-            AnyRoute::Directory(p) => unsafe { DirectoryRoute::deref(p.as_ptr()) },
+            AnyRoute::Static(r) => r.deref(),
+            AnyRoute::File(r) => r.deref(),
+            AnyRoute::Directory(r) => r.deref(),
             AnyRoute::Html(r) => r.deref(),
             AnyRoute::FrameworkRouter(_) => {} // not reference counted
         }
@@ -2470,14 +2456,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         server_config::RouteMethod::Any => false,
                     });
 
-            // Each `p`/`r` is the live `RefPtr<_>` stored in `entry.route`;
             // `app`/`h3_app` are the live uWS app handles owned by `self`.
             match &entry.route {
-                AnyRoute::Static(p) => {
+                AnyRoute::Static(r) => {
                     server_config::apply_static_route::<SSL, StaticRoute>(
                         any_server,
                         app,
-                        p.as_ptr(),
+                        r.this_ptr(),
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2488,7 +2473,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                p.as_ptr(),
+                                r.this_ptr(),
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2496,11 +2481,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         }
                     }
                 }
-                AnyRoute::File(p) => {
+                AnyRoute::File(r) => {
                     server_config::apply_static_route::<SSL, FileRoute>(
                         any_server,
                         app,
-                        p.as_ptr(),
+                        r.this_ptr(),
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2511,7 +2496,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                p.as_ptr(),
+                                r.this_ptr(),
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2519,11 +2504,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         }
                     }
                 }
-                AnyRoute::Directory(p) => {
+                AnyRoute::Directory(r) => {
                     server_config::apply_static_route::<SSL, DirectoryRoute>(
                         any_server,
                         app,
-                        p.as_ptr(),
+                        r.this_ptr(),
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2534,7 +2519,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                p.as_ptr(),
+                                r.this_ptr(),
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2546,7 +2531,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, html_bundle::Route>(
                         any_server,
                         app,
-                        r.as_ptr(),
+                        r.this_ptr(),
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2557,7 +2542,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                r.as_ptr(),
+                                r.this_ptr(),
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2571,7 +2556,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         bun_core::handle_oom(
                             unsafe { &mut *dev }
                                 .html_router
-                                .put(&entry.path, r.as_ptr()),
+                                .put(&entry.path, r.this_ptr().into()),
                         );
                     }
                     needs_plugins = true;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -689,30 +689,24 @@ impl AnyRoute {
                 }
             }
 
-            return Ok(AnyRoute::File(
-                NonNull::new(FileRoute::init_from_blob(
-                    blob,
-                    &super::file_route::InitOptions {
-                        server: None,
-                        status_code: 200,
-                        headers,
-                    },
-                ))
-                .expect("FileRoute::init_from_blob returns a fresh heap allocation"),
-            ));
+            return Ok(AnyRoute::File(FileRoute::init_from_blob(
+                blob,
+                &super::file_route::InitOptions {
+                    server: None,
+                    status_code: 200,
+                    headers,
+                },
+            )));
         }
 
-        Ok(AnyRoute::Static(
-            NonNull::new(StaticRoute::init_from_any_blob(
-                AnyBlob::Blob(blob),
-                super::static_route::InitFromBytesOptions {
-                    server: None,
-                    headers,
-                    ..Default::default()
-                },
-            ))
-            .expect("StaticRoute::init_from_any_blob returns a fresh heap allocation"),
-        ))
+        Ok(AnyRoute::Static(StaticRoute::init_from_any_blob(
+            AnyBlob::Blob(blob),
+            super::static_route::InitFromBytesOptions {
+                server: None,
+                headers,
+                ..Default::default()
+            },
+        )))
     }
 
     pub(crate) fn html_route_from_js(
@@ -720,30 +714,21 @@ impl AnyRoute {
         init_ctx: &mut ServerInitContext,
     ) -> JsResult<Option<AnyRoute>> {
         use bun_collections::zig_hash_map::MapEntry as StdEntry;
-        if let Some(html_bundle) = <HTMLBundle as bun_jsc::JsClass>::from_js(argument) {
+        if let Some(html_bundle) = argument.as_class_this_ptr::<HTMLBundle>() {
             let entry = init_ctx
                 .dedupe_html_bundle_map
-                .entry(html_bundle.cast_const());
+                .entry(html_bundle.as_ptr().cast_const());
             // HashMap aborts on OOM (repo-wide abort-on-OOM policy).
             return Ok(Some(match entry {
                 StdEntry::Vacant(v) => {
-                    // The rc=1 `Route::init(..)` goes in the map and
-                    // that same value is returned to the caller (the map slot is a
-                    // non-owning borrow, freed by `dedupe_html_bundle_map.deinit`
-                    // *without* deref). `RefPtr<T>` has no `Drop`, so a bit-copy
-                    // here keeps the net refcount at 1 — bumping for the map
-                    // slot would leak +1 per first-seen HTMLBundle.
-                    // SAFETY: `html_bundle` is the live `RefPtr<HTMLBundle>` from the
-                    // route map; `init` consumes its +1 ref into the new `Route`.
+                    // The rc=1 `Route::init(..)` is returned to the caller; the
+                    // map slot is a non-owning back-reference for deduping later
+                    // entries in this same config.
                     let route = html_bundle::Route::init(html_bundle);
-                    // SAFETY: `route.data` is the just-allocated NonNull (rc=1);
-                    // wrap without bumping so the map slot stays non-owning
-                    // (`RefPtr<T>` has no `Drop`; the map slot is a non-owning bit-copy).
-                    let borrowed = unsafe { RefPtr::from_raw(route.as_ptr()) };
-                    v.insert(borrowed);
+                    v.insert(route.this_ptr().into());
                     AnyRoute::Html(route)
                 }
-                StdEntry::Occupied(o) => AnyRoute::Html(o.get().dupe_ref()),
+                StdEntry::Occupied(o) => AnyRoute::Html(RefPtr::from_this(o.get().this_ptr())),
             }));
         }
 
@@ -802,9 +787,7 @@ impl AnyRoute {
                         url_prefix,
                         stat_cache,
                     )?;
-                    return Ok(Some(AnyRoute::Directory(NonNull::new(route).expect(
-                        "DirectoryRoute::create returns a fresh heap allocation",
-                    ))));
+                    return Ok(Some(AnyRoute::Directory(route)));
                 }
 
                 let style: FrameworkRouter::Style =
@@ -862,22 +845,18 @@ impl AnyRoute {
         }
 
         if let Some(file_route) = FileRoute::from_js(global, argument)? {
-            return Ok(Some(AnyRoute::File(
-                NonNull::new(file_route)
-                    .expect("FileRoute::from_js returns a fresh heap allocation"),
-            )));
+            return Ok(Some(AnyRoute::File(file_route)));
         }
         match StaticRoute::from_js(global, argument)? {
-            Some(s) => Ok(Some(AnyRoute::Static(
-                NonNull::new(s).expect("StaticRoute::from_js returns a fresh heap allocation"),
-            ))),
+            Some(s) => Ok(Some(AnyRoute::Static(s))),
             None => Ok(None),
         }
     }
 }
 
 pub struct ServerInitContext<'a> {
-    pub(crate) dedupe_html_bundle_map: HashMap<*const HTMLBundle, RefPtr<html_bundle::Route>>,
+    pub(crate) dedupe_html_bundle_map:
+        HashMap<*const HTMLBundle, bun_ptr::BackRef<html_bundle::Route, bun_ptr::Mut>>,
     pub(crate) js_string_allocations: bake::StringRefList,
     pub global: &'a JSGlobalObject,
     pub(crate) framework_router_list: Vec<bake::FileSystemRouterType>,
@@ -900,7 +879,8 @@ pub(crate) enum ServePluginsState {
         /// Promise may be empty if the plugin load finishes synchronously.
         plugin: Box<JSBundler::Plugin>,
         promise: jsc::JSPromiseStrong,
-        html_bundle_routes: Vec<*mut html_bundle::Route>,
+        /// Each holds a ref, released once the route is told the outcome.
+        html_bundle_routes: Vec<RefPtr<html_bundle::Route>>,
         // LIFETIMES.tsv classifies this BORROW_PARAM (`Option<&'a DevServer>`),
         // but `ServePlugins` is a refcounted heap object handed across FFI as
         // a raw promise-context pointer with dynamic lifetime, so a borrowed
@@ -923,12 +903,7 @@ pub enum GetOrStartLoadResult<'a> {
 
 #[derive(Clone, Copy)]
 pub enum ServePluginsCallback<'a> {
-    /// Raw `*mut` because the route is stored in
-    /// `ServePluginsState::Pending.html_bundle_routes` and later resolved via
-    /// `on_plugins_resolved`/`on_plugins_rejected`. R-2: those now take `&self`
-    /// (mutation goes through `Cell`/`JsCell`), so the `*mut` spelling is
-    /// signature-only; callers pass `Route::as_ctx_ptr(&self)`.
-    HtmlBundleRoute(*mut html_bundle::Route),
+    HtmlBundleRoute(bun_ptr::ThisPtr<html_bundle::Route>),
     DevServer(&'a DevServer),
 }
 
@@ -997,12 +972,7 @@ impl ServePlugins {
                 } => {
                     match cb {
                         ServePluginsCallback::HtmlBundleRoute(route) => {
-                            // SAFETY: caller passed a live `&mut Route` coerced to `*mut`; we
-                            // bump its intrusive refcount before storing so it outlives the
-                            // pending state. Write provenance is preserved for the later
-                            // `&mut *route` in handle_on_resolve/handle_on_reject.
-                            unsafe { bun_ptr::RefCount::<html_bundle::Route>::ref_(route) };
-                            html_bundle_routes.push(route);
+                            html_bundle_routes.push(RefPtr::from_this(route));
                         }
                         ServePluginsCallback::DevServer(server) => {
                             debug_assert!(
@@ -1142,15 +1112,11 @@ impl ServePlugins {
         };
 
         for route in html_bundle_routes {
-            // BACKREF: route was ref'd when stored (intrusive +1 keeps it alive
-            // for this call). R-2: `on_plugins_resolved` takes `&self`.
-            let route_nn = NonNull::new(route).expect("html_bundle::Route ref'd when stored");
-            bun_core::handle_oom(
-                bun_ptr::BackRef::from(route_nn)
-                    .on_plugins_resolved(Some(NonNull::from(plugin_ref))),
-            );
-            // SAFETY: paired with the `ref_` taken when the route was pushed.
-            unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
+            bun_core::handle_oom(html_bundle::Route::on_plugins_resolved(
+                route.this_ptr(),
+                Some(NonNull::from(plugin_ref)),
+            ));
+            route.deref();
         }
         if let Some(mut server) = dev_server {
             // SAFETY: dev_server outlives plugin load (stored as a back-reference
@@ -1177,12 +1143,8 @@ impl ServePlugins {
         drop(promise); // Drop on JscStrong releases the slot.
 
         for route in html_bundle_routes {
-            // BACKREF: route was ref'd when stored (intrusive +1 keeps it alive
-            // for this call). R-2: `on_plugins_rejected` takes `&self`.
-            let route_nn = NonNull::new(route).expect("html_bundle::Route ref'd when stored");
-            bun_core::handle_oom(bun_ptr::BackRef::from(route_nn).on_plugins_rejected());
-            // SAFETY: route was ref'd when stored; pair with that ref
-            unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
+            bun_core::handle_oom(route.on_plugins_rejected());
+            route.deref();
         }
         if let Some(mut server) = dev_server {
             // SAFETY: dev_server outlives plugin load

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -5,12 +5,14 @@ use core::ptr;
 use bun_core::ZStr;
 use bun_http_types::Method::Method;
 
+use crate::response::Response;
 use crate::socket_context::BunSocketContextOptions;
 use crate::web_socket::c::uws_ws;
 use crate::{
-    ListenSocket as UwsListenSocket, Opcode, Request, SendStatus, WebSocketBehavior, us_socket_t,
-    uws_res,
+    AnyRequest, AnyResponse, ListenSocket as UwsListenSocket, Opcode, Request, SendStatus,
+    WebSocketBehavior, thunk, us_socket_t, uws_res,
 };
+use bun_ptr::ThisPtr;
 
 // This file provides Rust bindings for the uWebSockets App class.
 // It wraps the C API exposed in libuwsockets.cpp which provides a C interface
@@ -224,6 +226,51 @@ impl<const SSL: bool> App<SSL> {
             Method::TRACE => self.trace(pattern, handler, user_data),
             _ => {}
         }
+    }
+
+    /// [`method`](Self::method) with an intrusively-refcounted `U` as the
+    /// route userdata. The registrant keeps a ref on `this` for as long as the
+    /// route is registered, so the trampoline can hand the handler a `ThisPtr`.
+    pub fn method_this<U: 'static, H>(
+        &mut self,
+        method_: Method,
+        pattern: &[u8],
+        _handler: H,
+        this: ThisPtr<U>,
+    ) where
+        H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+    {
+        self.method(
+            method_,
+            pattern,
+            Some(Self::route_this_thunk::<U, H>),
+            this.as_ptr().cast(),
+        );
+    }
+
+    /// [`any`](Self::any) counterpart of [`method_this`](Self::method_this).
+    pub fn any_this<U: 'static, H>(&mut self, pattern: &[u8], _handler: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+    {
+        self.any(
+            pattern,
+            Some(Self::route_this_thunk::<U, H>),
+            this.as_ptr().cast(),
+        );
+    }
+
+    extern "C" fn route_this_thunk<U: 'static, H>(
+        resp: *mut uws_res,
+        req: *mut Request,
+        user_data: *mut c_void,
+    ) where
+        H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+    {
+        let resp = Response::<SSL>::res_to_any(resp);
+        // SAFETY: `user_data` is the `ThisPtr` registered with this thunk; the registrant holds a ref on it while the route is registered.
+        let this = unsafe { ThisPtr::new(user_data.cast::<U>()) };
+        thunk::zst::<H>()(this, AnyRequest::H1(req), resp)
     }
 
     pub fn domain(&mut self, pattern: &ZStr) {

--- a/src/uws_sys/BodyReaderMixin.rs
+++ b/src/uws_sys/BodyReaderMixin.rs
@@ -36,13 +36,7 @@ impl<const SSL: bool> BodyResponse for Response<SSL> {
     }
     #[inline]
     fn to_any(&mut self) -> AnyResponse {
-        // `From<*mut Response<{true,false}>>` exist as two concrete impls, not a
-        // const-generic one, so dispatch on `SSL` here.
-        if SSL {
-            AnyResponse::SSL(std::ptr::from_mut::<Self>(self).cast())
-        } else {
-            AnyResponse::TCP(std::ptr::from_mut::<Self>(self).cast())
-        }
+        Response::<SSL>::res_to_any(self.downcast())
     }
 }
 

--- a/src/uws_sys/Cargo.toml
+++ b/src/uws_sys/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 bun_alloc.workspace = true
 bun_opaque.workspace = true
+bun_ptr.workspace = true
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -17,6 +17,7 @@ use crate::thunk;
 use crate::thunk::OpaqueHandle;
 use crate::us_socket_t;
 use bun_core::{BoundedArray, Fd};
+use bun_ptr::ThisPtr;
 
 // ─── Forward-declared opaques (cycle-break: were `bun_uws::*`, tier > 0) ───
 /// Remote socket address as returned by uWS. The IP text is copied into
@@ -85,6 +86,16 @@ impl<const SSL: bool> Response<SSL> {
     #[inline]
     pub fn cast_res(res: *mut c::uws_res) -> *mut Response<SSL> {
         res.cast::<Response<SSL>>()
+    }
+
+    /// The `AnyResponse` variant for this `SSL` flag.
+    #[inline]
+    pub fn res_to_any(res: *mut c::uws_res) -> AnyResponse {
+        if SSL {
+            AnyResponse::SSL(res.cast())
+        } else {
+            AnyResponse::TCP(res.cast())
+        }
     }
 
     #[inline]
@@ -625,7 +636,7 @@ unsafe impl<const SSL: bool> OpaqueHandle for Response<SSL> {}
 // align 1; C++ owns the real bytes.
 unsafe impl OpaqueHandle for H3Response {}
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AnyResponse {
     SSL(*mut TLSResponse),
     TCP(*mut TCPResponse),
@@ -924,6 +935,38 @@ impl AnyResponse {
             <U, H: [Fn(*mut U, AnyResponse) + Copy + 'static]>
             |u; r, any| -> () { thunk::zst::<H>()(u, any) }
         }
+    }
+
+    /// [`on_writable`](Self::on_writable) for a handler owned by an
+    /// intrusively-refcounted `U`: the registrant passes the `ThisPtr` it was
+    /// dispatched with and keeps a ref on `U` until it clears the handler, so
+    /// the trampoline can hand the handler a `ThisPtr` again.
+    pub fn on_writable_this<U: 'static, H>(self, _handler: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, u64, AnyResponse) -> bool + Copy + 'static,
+    {
+        self.on_writable(
+            |u: *mut U, off, any| {
+                // SAFETY: `u` is the `ThisPtr` registered below; the registrant holds a ref on it until the handler is cleared.
+                thunk::zst::<H>()(unsafe { ThisPtr::new(u) }, off, any)
+            },
+            this.as_ptr(),
+        )
+    }
+
+    /// [`on_aborted`](Self::on_aborted) counterpart of
+    /// [`on_writable_this`](Self::on_writable_this).
+    pub fn on_aborted_this<U: 'static, H>(self, _handler: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, AnyResponse) + Copy + 'static,
+    {
+        self.on_aborted(
+            |u: *mut U, any| {
+                // SAFETY: `u` is the `ThisPtr` registered below; the registrant holds a ref on it until the handler is cleared.
+                thunk::zst::<H>()(unsafe { ThisPtr::new(u) }, any)
+            },
+            this.as_ptr(),
+        )
     }
 
     pub fn clear_aborted(self) {

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -9,6 +9,8 @@ use crate::SocketAddress;
 use crate::response::{State, WriteResult};
 use crate::socket_context::BunSocketContextOptions;
 use crate::thunk;
+use crate::{AnyRequest, AnyResponse};
+use bun_ptr::ThisPtr;
 
 // ──────────────────────────────────────────────────────────────────────────
 // ListenSocket
@@ -353,6 +355,24 @@ enum RouteKind {
     Any,
 }
 
+impl RouteKind {
+    fn from_method(m: bun_http_types::Method::Method) -> Option<RouteKind> {
+        use bun_http_types::Method::Method as M;
+        Some(match m {
+            M::GET => RouteKind::Get,
+            M::POST => RouteKind::Post,
+            M::PUT => RouteKind::Put,
+            M::DELETE => RouteKind::Delete,
+            M::PATCH => RouteKind::Patch,
+            M::OPTIONS => RouteKind::Options,
+            M::HEAD => RouteKind::Head,
+            M::CONNECT => RouteKind::Connect,
+            M::TRACE => RouteKind::Trace,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, strum::IntoStaticStr)]
 pub enum AddServerNameError {
     FailedToAddServerName,
@@ -424,6 +444,33 @@ impl App {
                 thunk::zst::<H>()(ud, thunk::handle_mut(req), thunk::handle_mut(res));
             }
         }
+        Self::route_raw(which, this, pattern, Some(cb::<UD, H>), ud.cast());
+    }
+
+    /// `route` for an intrusively-refcounted `U` as the route userdata; see
+    /// [`method_this`](Self::method_this).
+    fn route_this<U: 'static, H>(which: RouteKind, this: &mut App, pattern: &[u8], ud: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+    {
+        extern "C" fn cb<U: 'static, H>(res: *mut Response, req: *mut Request, p: *mut c_void)
+        where
+            H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+        {
+            // SAFETY: `p` is the `ThisPtr` registered with this thunk; the registrant holds a ref on it while the route is registered.
+            let this = unsafe { ThisPtr::new(p.cast::<U>()) };
+            thunk::zst::<H>()(this, AnyRequest::H3(req), AnyResponse::H3(res));
+        }
+        Self::route_raw(which, this, pattern, Some(cb::<U, H>), ud.as_ptr().cast());
+    }
+
+    fn route_raw(
+        which: RouteKind,
+        this: &mut App,
+        pattern: &[u8],
+        cb: c::Handler,
+        ud: *mut c_void,
+    ) {
         let f = match which {
             RouteKind::Get => c::uws_h3_app_get,
             RouteKind::Post => c::uws_h3_app_post,
@@ -437,15 +484,7 @@ impl App {
             RouteKind::Any => c::uws_h3_app_any,
         };
         // SAFETY: this is a live FFI handle; pattern ptr/len valid for read; trampoline is `extern "C"`
-        unsafe {
-            f(
-                this,
-                pattern.as_ptr(),
-                pattern.len(),
-                Some(cb::<UD, H>),
-                ud.cast(),
-            )
-        }
+        unsafe { f(this, pattern.as_ptr(), pattern.len(), cb, ud) }
     }
 
     h3_route_methods! {
@@ -463,19 +502,34 @@ impl App {
     where
         H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
     {
-        use bun_http_types::Method::Method as M;
-        match m {
-            M::GET => self.get(p, ud, h),
-            M::POST => self.post(p, ud, h),
-            M::PUT => self.put(p, ud, h),
-            M::DELETE => self.delete(p, ud, h),
-            M::PATCH => self.patch(p, ud, h),
-            M::OPTIONS => self.options(p, ud, h),
-            M::HEAD => self.head(p, ud, h),
-            M::CONNECT => Self::route(RouteKind::Connect, self, p, ud, h),
-            M::TRACE => Self::route(RouteKind::Trace, self, p, ud, h),
-            _ => {}
+        if let Some(kind) = RouteKind::from_method(m) {
+            Self::route(kind, self, p, ud, h);
         }
+    }
+
+    /// [`method`](Self::method) with an intrusively-refcounted `U` as the
+    /// route userdata. The registrant keeps a ref on `this` for as long as the
+    /// route is registered, so the trampoline can hand the handler a `ThisPtr`.
+    pub fn method_this<U: 'static, H>(
+        &mut self,
+        m: bun_http_types::Method::Method,
+        p: &[u8],
+        _h: H,
+        this: ThisPtr<U>,
+    ) where
+        H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+    {
+        if let Some(kind) = RouteKind::from_method(m) {
+            Self::route_this::<U, H>(kind, self, p, this);
+        }
+    }
+
+    /// [`any`](Self::any) counterpart of [`method_this`](Self::method_this).
+    pub fn any_this<U: 'static, H>(&mut self, p: &[u8], _h: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, AnyRequest, AnyResponse) + Copy + 'static,
+    {
+        Self::route_this::<U, H>(RouteKind::Any, self, p, this);
     }
 
     pub fn listen_with_config<UD, H>(&mut self, ud: *mut UD, _handler: H, config: &ListenConfig)


### PR DESCRIPTION
### What

Same treatment as #40055 for the `Bun.serve` route objects: `StaticRoute.rs` 29 → 0, `HTMLBundle.rs` 24 → 0, `FileRoute.rs` 7 → 0, `DirectoryRoute.rs` 2 → 0 (plus −27 across `ServerConfig.rs`, `mod.rs`, `server_body.rs`, `DevServer.rs`, `js_bundle_completion_task.rs`), by fixing the layer underneath instead of annotating call sites:

- **Typed uws userdata.** `bun_uws_sys` gets `AnyResponse::on_writable_this` / `on_aborted_this` and `App::method_this` / `any_this` (H1 and H3): the registrant passes the `ThisPtr<U>` it was dispatched with and keeps a ref while registered; the trampoline hands the handler a `ThisPtr<U>` (the one `unsafe` per trampoline lives there). `ServerConfig`'s hand-written per-route trampolines are gone; `StaticRouteLike` takes `ThisPtr<Self>`.
- **Ownership.** `AnyRoute::{Static,File,Directory,Html}` hold `RefPtr`; constructors return `RefPtr`; `StaticRoute::clone` no longer needs `&mut *ptr`. The ref that in-flight responses hold on a `StaticRoute` is an explicit `RefPtr` taken by the first outstanding response and released with the last (`pending_responses`), rather than a bare `ref_()` whose matching `deref_` trusted the userdata pointer. `FileRoute`/`DirectoryRoute` hand `FileResponseStream` a `StreamOwner::{FileRoute,DirectoryRoute}(RefPtr)` instead of `(ctx, fn, fn, fn)`; `RequestContext` keeps the raw `Ctx` form.
- **HTMLBundle.** `PendingResponse`s are stored by value and found by `AnyResponse` equality on abort (userdata is the route); the build task owns a `RefPtr<Route>` released after `on_complete`; `State::Html` holds a `RefPtr<StaticRoute>`; `State::Building` drops its task pointer (the cancel-and-deref arm in `State::deinit` was unreachable — the task's ref keeps the route alive while building — and would have double-released the enqueue ref if reached). `Route::drop` now releases its `HTMLBundle` ref (the `IntrusiveRc` field previously leaked it).
- `JSBundleCompletionTask::new()` + `schedule(self)` replace `create_and_schedule_completion_task` + post-hoc raw field writes; `poll_ref.ref_` moves to just before enqueue.
- `JSValue::as_class_this_ptr::<T>()` sibling of `as_class_ref` for refcounted `m_ctx` payloads.

### Testing

Debug+ASAN: every `bun-serve-static*` / `bun-serve-html*` test, `bun-serve-routes`, `bun-serve-file`, `serve-directory-routes`, `serve-http3`, `test/bake/dev/html.test.ts` pass; `serve.test.ts` 296/297 (the uid-0 privileged-port case fails in the sandbox regardless). Hand-driven under the debug binary: GET/HEAD/304 on a static route, full and aborted (AbortController + raw socket destroy) reads of a 2 MB static body, `server.reload({routes})` mid-stream + GC, file route incl. HEAD/Range, HTML import route incl. concurrent requests, abort during build, reload, `development: {hmr:false}` — exit 0, no ASAN output. `rust-check-all` for windows-msvc / apple-darwin passes.