### PR TITLE
socket: remove the remaining unsafe from socket_body.rs and UpgradedDuplex.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ version = "0.0.0"
 dependencies = [
  "bun_core",
  "bun_opaque",
+ "bun_ptr",
 ]
 
 [[package]]

--- a/src/boringssl_sys/Cargo.toml
+++ b/src/boringssl_sys/Cargo.toml
@@ -11,5 +11,6 @@ workspace = true
 
 [dependencies]
 bun_opaque.workspace = true
+bun_ptr.workspace = true
 bun_core.workspace = true
 

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -665,6 +665,8 @@ unsafe extern "C" fn alpn_select_thunk<H: AlpnSelectCallback>(
                 || selected.len() > usize::from(u8::MAX)
                 || sel.start < range.start
                 || sel.end > range.end
+                || !alpn_protocols(offered)
+                    .any(|p| p.as_ptr() == selected.as_ptr() && p.len() == selected.len())
             {
                 return SSL_TLSEXT_ERR_ALERT_FATAL;
             }
@@ -714,6 +716,67 @@ pub fn select_next_proto<'a>(prefs: &[u8], offered: &'a [u8]) -> Option<&'a [u8]
         return None;
     }
     alpn_protocols(prefs).find_map(|want| alpn_protocols(offered).find(|got| *got == want))
+}
+
+#[cfg(test)]
+mod alpn_select_tests {
+    use super::*;
+
+    static OFFERED: &[u8] = b"\x02h2\x08http/1.1";
+
+    fn run<H: AlpnSelectCallback>() -> (c_int, *const u8, u8) {
+        let mut out: *const u8 = core::ptr::null();
+        let mut out_len: u8 = 0;
+        // `SSL` is an opaque ZST; the handlers below never touch it.
+        let ssl = core::ptr::NonNull::<SSL>::dangling().as_ptr();
+        // SAFETY: `OFFERED` outlives the call; out-params are locals.
+        let rc = unsafe {
+            alpn_select_thunk::<H>(
+                ssl,
+                &raw mut out,
+                &raw mut out_len,
+                OFFERED.as_ptr(),
+                OFFERED.len() as c_uint,
+                core::ptr::null_mut(),
+            )
+        };
+        (rc, out, out_len)
+    }
+
+    struct Entry;
+    impl AlpnSelectCallback for Entry {
+        fn select<'o>(_: &SSL, offered: &'o [u8]) -> Result<Option<&'o [u8]>, AlpnReject> {
+            Ok(alpn_protocols(offered).nth(1))
+        }
+    }
+
+    struct SubSlice;
+    impl AlpnSelectCallback for SubSlice {
+        fn select<'o>(_: &SSL, offered: &'o [u8]) -> Result<Option<&'o [u8]>, AlpnReject> {
+            Ok(Some(&offered[1..2]))
+        }
+    }
+
+    struct Straddle;
+    impl AlpnSelectCallback for Straddle {
+        fn select<'o>(_: &SSL, offered: &'o [u8]) -> Result<Option<&'o [u8]>, AlpnReject> {
+            Ok(Some(&offered[1..5]))
+        }
+    }
+
+    #[test]
+    fn accepts_exactly_one_offered_entry() {
+        let (rc, out, len) = run::<Entry>();
+        assert_eq!(rc, SSL_TLSEXT_ERR_OK);
+        assert_eq!(len, 8);
+        assert_eq!(out, OFFERED[4..].as_ptr());
+    }
+
+    #[test]
+    fn rejects_a_subslice_that_is_not_an_entry() {
+        assert_eq!(run::<SubSlice>().0, SSL_TLSEXT_ERR_ALERT_FATAL);
+        assert_eq!(run::<Straddle>().0, SSL_TLSEXT_ERR_ALERT_FATAL);
+    }
 }
 
 impl Drop for GeneralNames {

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -270,6 +270,39 @@ unsafe extern "C" {
 #[repr(transparent)]
 pub struct OwnedSslCtx(core::ptr::NonNull<SSL_CTX>);
 
+/// A typed `SSL` ex-data index: allocated once (per `static`) with
+/// `SSL_get_ex_new_index`, so distinct slots never alias and everything read
+/// through a slot was written as the same `T`.
+pub struct ExDataSlot<T> {
+    index: std::sync::OnceLock<c_int>,
+    _marker: core::marker::PhantomData<fn() -> T>,
+}
+
+impl<T> ExDataSlot<T> {
+    pub const fn new() -> Self {
+        ExDataSlot {
+            index: std::sync::OnceLock::new(),
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    fn index(&self) -> c_int {
+        *self.index.get_or_init(|| {
+            // SAFETY: no argp/callbacks; BoringSSL just hands out the next index.
+            let i = unsafe {
+                SSL_get_ex_new_index(0, core::ptr::null_mut(), core::ptr::null_mut(), None, None)
+            };
+            assert!(i >= 0, "SSL_get_ex_new_index failed");
+            i
+        })
+    }
+}
+
+// SAFETY: holds only an index.
+unsafe impl<T> Sync for ExDataSlot<T> {}
+// SAFETY: holds only an index.
+unsafe impl<T> Send for ExDataSlot<T> {}
+
 impl OwnedSslCtx {
     /// Takes the +1 `raw` carries; `None` when `raw` is null.
     ///
@@ -281,6 +314,11 @@ impl OwnedSslCtx {
 
     pub fn as_ptr(&self) -> *mut SSL_CTX {
         self.0.as_ptr()
+    }
+
+    /// The context this reference keeps alive.
+    pub fn ctx(&self) -> &SSL_CTX {
+        SSL_CTX::opaque_ref(self.0.as_ptr())
     }
 
     /// Transfers the reference back out; the caller must free it.
@@ -514,6 +552,38 @@ impl SSL {
         }
     }
 
+    /// `SSL_set_tlsext_host_name` — the SNI name to send in the ClientHello.
+    pub fn set_tlsext_host_name(&mut self, name: &core::ffi::CStr) -> c_int {
+        // SAFETY: `self` is live; BoringSSL copies the NUL-terminated `name`.
+        unsafe { SSL_set_tlsext_host_name(self, name.as_ptr()) }
+    }
+
+    /// `SSL_set_alpn_protos` — the client's wire-format ALPN list (copied).
+    pub fn set_alpn_protos(&mut self, protos: &[u8]) -> c_int {
+        // SAFETY: `self` is live; `protos` is readable for its length and copied.
+        unsafe { SSL_set_alpn_protos(self, protos.as_ptr(), protos.len()) }
+    }
+
+    /// Store a back-reference to `data` in `slot`. The `BackRef` obligation
+    /// applies to the connection: `data` outlives this `SSL`, or the slot is
+    /// cleared first. Returns whether BoringSSL accepted the write.
+    pub fn set_ex_data<T>(&self, slot: &ExDataSlot<T>, data: Option<bun_ptr::BackRef<T>>) -> bool {
+        let p = data.map_or(core::ptr::null_mut(), |r| {
+            r.as_const_ptr().cast_mut().cast()
+        });
+        // SAFETY: `self` is live; BoringSSL stores `p` opaquely.
+        unsafe { SSL_set_ex_data(core::ptr::from_ref(self).cast_mut(), slot.index(), p) == 1 }
+    }
+
+    /// Read back what [`set_ex_data`](Self::set_ex_data) stored in `slot`.
+    pub fn ex_data<T>(&self, slot: &ExDataSlot<T>) -> Option<bun_ptr::BackRef<T>> {
+        // SAFETY: `self` is live; `slot`'s index is only ever written through
+        // `set_ex_data::<T>`, so a non-null value is a `BackRef<T>`.
+        let p = unsafe { SSL_get_ex_data(self, slot.index()) }.cast::<T>();
+        // SAFETY: non-null values in this slot are `BackRef<T>`s (see above).
+        (!p.is_null()).then(|| unsafe { bun_ptr::BackRef::from_raw(p) })
+    }
+
     /// The peer's leaf certificate, borrowed from this SSL's cert chain.
     pub fn peer_leaf_certificate(&mut self) -> Option<&mut X509> {
         // SAFETY: the chain and its entries are owned by this SSL and outlive
@@ -526,6 +596,124 @@ impl SSL {
             sk_X509_value(cert_chain, 0).as_mut()
         }
     }
+}
+
+impl SSL_CTX {
+    /// `SSL_CTX_get_verify_mode`.
+    pub fn verify_mode(&self) -> c_int {
+        // SAFETY: `self` is live; read-only.
+        unsafe { SSL_CTX_get_verify_mode(self) }
+    }
+
+    /// Take another reference on this context.
+    pub fn up_ref(&self) -> OwnedSslCtx {
+        // SAFETY: `self` is live; the +1 is owned by the returned guard.
+        unsafe { SSL_CTX_up_ref(core::ptr::from_ref(self).cast_mut()) };
+        OwnedSslCtx(core::ptr::NonNull::from(self))
+    }
+
+    /// Install `H` as this context's server-side ALPN selection hook
+    /// (`SSL_CTX_set_alpn_select_cb`).
+    pub fn set_alpn_select_callback<H: AlpnSelectCallback>(&self) {
+        // SAFETY: `self` is live; the callback and null `arg` are stored opaquely.
+        unsafe {
+            SSL_CTX_set_alpn_select_cb(
+                core::ptr::from_ref(self).cast_mut(),
+                Some(alpn_select_thunk::<H>),
+                core::ptr::null_mut(),
+            )
+        }
+    }
+}
+
+/// A fatal `no_application_protocol` alert from an [`AlpnSelectCallback`].
+pub struct AlpnReject;
+
+/// Server-side ALPN selection (`SSL_CTX_set_alpn_select_cb`), with the
+/// pointer plumbing done once in this crate.
+pub trait AlpnSelectCallback {
+    /// `offered` is the client's wire-format protocol list (non-empty). Return
+    /// the chosen protocol as a sub-slice of `offered` (see
+    /// [`select_next_proto`]), `Ok(None)` to proceed without ALPN, or
+    /// `Err(AlpnReject)` to fail the handshake.
+    fn select<'o>(ssl: &SSL, offered: &'o [u8]) -> Result<Option<&'o [u8]>, AlpnReject>;
+}
+
+unsafe extern "C" fn alpn_select_thunk<H: AlpnSelectCallback>(
+    ssl: *mut SSL,
+    out: *mut *const u8,
+    out_len: *mut u8,
+    in_: *const u8,
+    in_len: c_uint,
+    _arg: *mut c_void,
+) -> c_int {
+    if ssl.is_null() || in_.is_null() || in_len == 0 {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+    // SAFETY: BoringSSL passes the live handshaking SSL and `in_len` bytes at `in_`.
+    let (ssl, offered) = unsafe {
+        (
+            SSL::opaque_ref(ssl),
+            core::slice::from_raw_parts(in_, in_len as usize),
+        )
+    };
+    match H::select(ssl, offered) {
+        Ok(Some(selected)) => {
+            let range = offered.as_ptr_range();
+            let sel = selected.as_ptr_range();
+            if selected.is_empty()
+                || selected.len() > usize::from(u8::MAX)
+                || sel.start < range.start
+                || sel.end > range.end
+            {
+                return SSL_TLSEXT_ERR_ALERT_FATAL;
+            }
+            // SAFETY: `out`/`out_len` are BoringSSL's out-params for this call;
+            // `selected` lies inside `offered`, which BoringSSL keeps alive
+            // until it has copied the selection.
+            unsafe {
+                *out = selected.as_ptr();
+                *out_len = selected.len() as u8;
+            }
+            SSL_TLSEXT_ERR_OK
+        }
+        Ok(None) => SSL_TLSEXT_ERR_NOACK,
+        Err(AlpnReject) => SSL_TLSEXT_ERR_ALERT_FATAL,
+    }
+}
+
+/// The entries of an RFC 7301 wire-format protocol list (`len | bytes`)*.
+/// Stops at the first malformed entry.
+pub fn alpn_protocols(list: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let mut rest = list;
+    core::iter::from_fn(move || {
+        let (&len, tail) = rest.split_first()?;
+        let len = usize::from(len);
+        if len == 0 || tail.len() < len {
+            rest = &[];
+            return None;
+        }
+        let (proto, tail) = tail.split_at(len);
+        rest = tail;
+        Some(proto)
+    })
+}
+
+/// Whether `list` is a well-formed, non-empty RFC 7301 protocol list
+/// (`ssl_is_valid_alpn_list`).
+fn alpn_list_is_valid(list: &[u8]) -> bool {
+    !list.is_empty() && alpn_protocols(list).map(|p| p.len() + 1).sum::<usize>() == list.len()
+}
+
+/// `SSL_select_next_proto` for ALPN: the first protocol in `prefs` (wire
+/// format, in preference order) that `offered` also lists, returned as the
+/// matching entry of `offered`. `None` when either list is malformed or
+/// nothing overlaps.
+pub fn select_next_proto<'a>(prefs: &[u8], offered: &'a [u8]) -> Option<&'a [u8]> {
+    if !alpn_list_is_valid(prefs) || !alpn_list_is_valid(offered) {
+        return None;
+    }
+    alpn_protocols(prefs).find_map(|want| alpn_protocols(offered).find(|got| *got == want))
 }
 
 impl Drop for GeneralNames {
@@ -920,6 +1108,13 @@ unsafe extern "C" {
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
     pub fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
     pub fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, data: *mut c_void) -> c_int;
+    pub fn SSL_get_ex_new_index(
+        argl: core::ffi::c_long,
+        argp: *mut c_void,
+        unused: *mut c_void,
+        dup_unused: Option<unsafe extern "C" fn()>,
+        free_func: Option<unsafe extern "C" fn()>,
+    ) -> c_int;
     pub fn SSL_set_tlsext_host_name(ssl: *mut SSL, name: *const c_char) -> c_int;
     pub fn SSL_set_alpn_protos(ssl: *mut SSL, protos: *const u8, protos_len: usize) -> c_int;
     pub fn SSL_get0_alpn_selected(ssl: *const SSL, out_data: *mut *const u8, out_len: *mut c_uint);

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2054,13 +2054,26 @@ function generateRust(
             `    ${T}::${fastId}(this, global${args.length ? ", " + argFwd : ""})`,
           );
         }
-        thunk(
-          names.fn,
-          `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
-          passThis
-            ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
-            : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
-        );
+        if (sharedThis) {
+          // `*mut T` + receiver-generic helper: the method takes `&self` or
+          // `this: ThisPtr<Self>` and inference picks (see `HostReceiver`).
+          thunk(
+            names.fn,
+            `(this: *mut ${T}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            `    // SAFETY: C++ passes the wrapper's live \`m_ctx\`.\n    ` +
+              (passThis
+                ? `    unsafe { host_fn::host_fn_this_value_ptr(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v)) }`
+                : `    unsafe { host_fn::host_fn_this_ptr(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c)) }`),
+          );
+        } else {
+          thunk(
+            names.fn,
+            `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            passThis
+              ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
+              : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
+          );
+        }
       }
     }
   }

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -537,29 +537,64 @@ pub fn host_fn_construct_this<R: IntoHostConstructReturn>(
 // (Phase 3 of `R-2-design.md` deletes them and drops the `_shared` suffix).
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Prototype method (`sharedThis`): `fn(&self, &JSGlobalObject, &CallFrame) -> R`.
+/// How a `sharedThis` prototype method receives the wrapper's `m_ctx`: as a
+/// plain `&T`, or as a [`ThisPtr<T>`](bun_ptr::ThisPtr) when the method needs
+/// the allocation's root pointer (to take/release intrusive refs on itself or
+/// hand itself to a dispatch path that may). The generated thunk is generic
+/// over this, so the method's own signature picks.
+pub trait HostReceiver<'a, T: 'a>: Sized {
+    /// # Safety
+    /// `this` is the live, non-null `m_ctx` of a JS wrapper that stays rooted
+    /// for `'a`.
+    unsafe fn from_m_ctx(this: *mut T) -> Self;
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for &'a T {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { &*this }
+    }
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for bun_ptr::ThisPtr<T> {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { bun_ptr::ThisPtr::new(this) }
+    }
+}
+
+/// Prototype method (`sharedThis`) taking `&self` or `this: ThisPtr<Self>`.
+///
+/// # Safety
+/// `this` is the live `m_ctx` of the JS wrapper the call was dispatched on.
 #[track_caller]
 #[inline]
-pub fn host_fn_this_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame) -> R,
+pub unsafe fn host_fn_this_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe))
 }
 
-/// Prototype method (`sharedThis`, passThis):
-/// `fn(&self, &JSGlobalObject, &CallFrame, JSValue) -> R`.
+/// [`host_fn_this_ptr`] with `passThis`.
+///
+/// # Safety
+/// As [`host_fn_this_ptr`].
 #[track_caller]
 #[inline]
-pub fn host_fn_this_value_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
+pub unsafe fn host_fn_this_value_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
     js_this: JSValue,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame, JSValue) -> R,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame, JSValue) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe, js_this))
 }
 
@@ -847,6 +882,86 @@ pub fn new_function_with_data(
         function,
         data,
     )
+}
+
+/// A host function that receives a native `&Context` through its callee's
+/// data slot (see [`ContextFunction`]).
+pub trait ContextHostFn {
+    type Context;
+    fn call(
+        ctx: &Self::Context,
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> crate::JsResult<JSValue>;
+}
+
+/// A JS function created by [`ContextFunction::new`] whose data slot holds a
+/// [`BackRef`](bun_ptr::BackRef) to a native context. The function is the
+/// back-reference's holder: the context keeps this handle (whose `Drop` clears
+/// the slot, turning later calls into no-ops returning `undefined`) for as long
+/// as — and no longer than — it lives at that address. The JS function itself
+/// must be kept GC-reachable by its holder while this handle exists.
+pub struct ContextFunction(JSValue);
+
+impl ContextFunction {
+    /// Create a JS function that calls `H` with `ctx`'s pointee.
+    #[track_caller]
+    pub fn new<H: ContextHostFn>(
+        global_object: &JSGlobalObject,
+        symbol_name: Option<&EncodedSlice>,
+        arg_count: u32,
+        ctx: bun_ptr::BackRef<H::Context>,
+    ) -> Self {
+        ContextFunction(new_function_with_data(
+            global_object,
+            symbol_name,
+            arg_count,
+            context_host_fn::<H>,
+            ctx.as_const_ptr().cast_mut().cast(),
+        ))
+    }
+
+    #[inline]
+    pub fn value(&self) -> JSValue {
+        self.0
+    }
+}
+
+impl Drop for ContextFunction {
+    fn drop(&mut self) {
+        set_function_data(self.0, None);
+    }
+}
+
+#[cfg(all(windows, target_arch = "x86_64"))]
+unsafe extern "sysv64" fn context_host_fn<H: ContextHostFn>(
+    global: *mut JSGlobalObject,
+    frame: *mut CallFrame,
+) -> JSValue {
+    context_host_fn_body::<H>(global, frame)
+}
+#[cfg(not(all(windows, target_arch = "x86_64")))]
+unsafe extern "C" fn context_host_fn<H: ContextHostFn>(
+    global: *mut JSGlobalObject,
+    frame: *mut CallFrame,
+) -> JSValue {
+    context_host_fn_body::<H>(global, frame)
+}
+
+#[inline(always)]
+fn context_host_fn_body<H: ContextHostFn>(
+    global: *mut JSGlobalObject,
+    frame: *mut CallFrame,
+) -> JSValue {
+    let global = bun_opaque::opaque_deref(global);
+    let frame = bun_opaque::opaque_deref(frame);
+    to_js_host_call(global, || match get_function_data(frame.callee()) {
+        // SAFETY: written by `ContextFunction::new::<H>` from a
+        // `BackRef<H::Context>` whose holder (this function's handle, kept by
+        // the context) clears the slot before the context goes away.
+        Some(ctx) => H::call(unsafe { &*ctx.cast::<H::Context>() }, global, frame),
+        None => Ok(JSValue::UNDEFINED),
+    })
 }
 
 // ───────────────────────── DOMCall codegen helpers ─────────────────────────

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -136,7 +136,22 @@ fn expand_host_fn(args: &HostFnArgs, func: &ItemFn) -> syn::Result<TokenStream2>
         .inputs
         .first()
         .is_some_and(|a| matches!(a, FnArg::Receiver(r) if r.mutability.is_none()));
-    let this_reborrow = if receiver_is_shared {
+    // A typed `this: ThisPtr<Self>` first parameter gets the root pointer
+    // wrapped instead of reborrowed.
+    let first_is_this_ptr = func.sig.inputs.first().is_some_and(|a| match a {
+        FnArg::Typed(pt) => match &*pt.ty {
+            syn::Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "ThisPtr"),
+            _ => false,
+        },
+        _ => false,
+    });
+    let this_reborrow = if first_is_this_ptr {
+        quote! { let __t = unsafe { ::bun_ptr::ThisPtr::new(__this) }; }
+    } else if receiver_is_shared {
         quote! { let __t = unsafe { &*__this }; }
     } else {
         quote! { let __t = unsafe { &mut *__this }; }

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -235,6 +235,13 @@ impl<T> From<ThisPtr<T>> for BackRef<T, Root> {
     }
 }
 
+impl<T> From<ThisPtr<T>> for core::ptr::NonNull<T> {
+    #[inline]
+    fn from(p: ThisPtr<T>) -> Self {
+        p.0
+    }
+}
+
 impl<T: ?Sized, P> Copy for BackRef<T, P> {}
 impl<T: ?Sized, P> Clone for BackRef<T, P> {
     #[inline]
@@ -639,6 +646,49 @@ impl<T> core::ops::Deref for ThisPtr<T> {
     #[inline]
     fn deref(&self) -> &T {
         self.get()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OwnedThis<T> — single-owner heap allocation that hands out `ThisPtr`s.
+//
+// `Box<T>` asserts unique access on every touch, which is wrong for a callback
+// hub whose address is also held by C / JS / a task queue and re-entered while
+// a method on it is running. `OwnedThis` keeps the ownership (drop frees) but
+// only ever lends the pointee as `ThisPtr<T>` / `&T`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The unique owner of a heap-allocated `T` that is otherwise reached through
+/// [`ThisPtr`] copies. Dropping it drops and frees the `T`; every `ThisPtr`
+/// lent from it must be dead by then (the usual back-reference obligation).
+pub struct OwnedThis<T>(core::ptr::NonNull<T>);
+
+impl<T> OwnedThis<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
+    }
+
+    /// A dispatch handle to the pointee (root provenance).
+    #[inline]
+    pub fn this_ptr(&self) -> ThisPtr<T> {
+        ThisPtr(self.0)
+    }
+}
+
+impl<T> core::ops::Deref for OwnedThis<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: we own the live allocation.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Drop for OwnedThis<T> {
+    fn drop(&mut self) {
+        // SAFETY: `new` leaked exactly this `Box`; we are its unique owner.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
     }
 }
 

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -107,13 +107,8 @@ impl SSLContextCache {
                 // via compact_locked / Drop, both of which hold this mutex.
                 let entry = unsafe { &**entry };
                 if !entry.ctx.is_null() {
-                    let ctx = entry.ctx;
-                    // SAFETY: ctx non-null and tombstone write is serialized by this mutex;
-                    // the up_ref is the +1 `from_raw` takes.
-                    return unsafe {
-                        boringssl::SSL_CTX_up_ref(ctx);
-                        OwnedSslCtx::from_raw(ctx)
-                    };
+                    // Tombstone write is serialized by this mutex.
+                    return Some(boringssl::SSL_CTX::opaque_ref(entry.ctx).up_ref());
                 }
             }
         }
@@ -138,12 +133,7 @@ impl SSLContextCache {
             // SAFETY: existing map value is a live heap Entry (see above).
             let entry = unsafe { &mut **gop.value_ptr };
             if !entry.ctx.is_null() {
-                let existing = entry.ctx;
-                // SAFETY: existing non-null; the up_ref is the +1 `from_raw` takes.
-                return unsafe {
-                    boringssl::SSL_CTX_up_ref(existing);
-                    OwnedSslCtx::from_raw(existing)
-                };
+                return Some(boringssl::SSL_CTX::opaque_ref(entry.ctx).up_ref());
             }
             // Tombstone — adopt the rebuilt CTX into the existing slot.
             // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -35,6 +35,7 @@ pub use crate::generated_classes::js_SecureContext as js;
 #[bun_jsc::JsClass]
 #[repr(C)]
 pub struct SecureContext {
+    /// The one `SSL_CTX` reference this wrapper owns.
     pub ctx: boringssl::OwnedSslCtx,
     /// `BunSocketContextOptions.digest()` — exactly the fields that reach
     /// `us_ssl_ctx_from_options`. Stored so an `intern()` WeakGCMap hit (keyed by
@@ -319,19 +320,11 @@ impl SecureContext {
         d: [u8; 32],
     ) -> JsResult<Box<SecureContext>> {
         let mut err = uws::create_bun_socket_error_t::none;
-        // Note: spec is `global.bunVM().rareData().sslCtxCache()`. In the
-        // Rust crate split, `bun_jsc::RareData::ssl_ctx_cache()` returns an
-        // opaque cycle-break stub; the concrete per-VM `SSLContextCache` lives
-        // on this crate's `RuntimeState` (one per JS thread, same lifetime as
-        // `RareData`). Reach it via the thread-local — same instance
-        // `Bun__RareData__sslCtxCache` hands out over FFI.
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-        // SAFETY: `state` is the boxed per-thread `RuntimeState` installed by
-        // `init_runtime_state`; the embedded `ssl_ctx_cache` has a stable
-        // address for the VM's lifetime and is only touched from the JS thread.
-        let cache = unsafe { &mut (*state).ssl_ctx_cache };
-        let Some(ctx) = cache.get_or_create_digest(ctx_opts, d, &mut err) else {
+        // The per-VM `SSLContextCache` lives on this thread's `RuntimeState`
+        // (`bun_jsc::RareData::ssl_ctx_cache()` is an opaque cycle-break stub).
+        let Some(ctx) = crate::jsc_hooks::with_ssl_ctx_cache(|cache| {
+            cache.get_or_create_digest(ctx_opts, d, &mut err)
+        }) else {
             // `err` is only set for the input-validation paths (bad PEM, missing
             // file, …). When BoringSSL itself fails (e.g. unsupported curve) the
             // enum is still `.none`; surface the library error stack instead of

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -26,7 +26,7 @@ use bun_jsc::array_buffer::BinaryType;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
-    CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsClass, JsRef, JsResult, StrongOptional,
+    CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsRef, JsResult, StrongOptional,
 };
 use bun_ptr::RefPtr;
 
@@ -100,23 +100,34 @@ const MAX_PAYLOAD_SIZE_WITHOUT_FRAME: usize = 16384 - FrameHeader::BYTE_SIZE - 1
 enum BunSocket {
     #[default]
     None,
-    Tls(bun_ptr::BackRef<TLSSocket>),
-    TlsWriteonly(bun_ptr::BackRef<TLSSocket>),
-    Tcp(bun_ptr::BackRef<TCPSocket>),
-    TcpWriteonly(bun_ptr::BackRef<TCPSocket>),
+    Tls(bun_ptr::BackRef<TLSSocket, bun_ptr::Root>),
+    TlsWriteonly(bun_ptr::BackRef<TLSSocket, bun_ptr::Root>),
+    Tcp(bun_ptr::BackRef<TCPSocket, bun_ptr::Root>),
+    TcpWriteonly(bun_ptr::BackRef<TCPSocket, bun_ptr::Root>),
+}
+
+/// The ref a `BunSocket::*Writeonly` attachment holds on its socket; held
+/// only to be dropped on detach.
+enum WriteonlySocketRef {
+    Tls(#[allow(dead_code)] RefPtr<TLSSocket>),
+    Tcp(#[allow(dead_code)] RefPtr<TCPSocket>),
 }
 
 /// The parser's attachment to a native socket, and its owner: attaching either
 /// installs the parser as the socket's native callback (`Tls`/`Tcp`) or, when
-/// that slot is taken, takes a ref on the socket (`*Writeonly`); `detach` /
+/// that slot is taken, holds a ref on the socket (`*Writeonly`); `detach` /
 /// `Drop` undo whichever one it was. Readers take a [`BunSocket`] snapshot.
 #[derive(Default)]
-struct NativeSocket(Cell<BunSocket>);
+struct NativeSocket {
+    socket: Cell<BunSocket>,
+    /// Held while `socket` is a `*Writeonly`.
+    writeonly_ref: Cell<Option<WriteonlySocketRef>>,
+}
 
 impl NativeSocket {
     #[inline]
     fn get(&self) -> BunSocket {
-        self.0.get()
+        self.socket.get()
     }
 
     /// `attach_native_callback` stores `h2` (a ref on the parser) in the
@@ -125,39 +136,32 @@ impl NativeSocket {
     /// write-only mode and hold a ref on the socket instead.
     fn attach<const SSL: bool>(
         &self,
-        socket: *mut crate::socket::NewSocket<SSL>,
+        socket: bun_ptr::ThisPtr<crate::socket::NewSocket<SSL>>,
         h2: RefPtr<H2FrameParser>,
+        attached: fn(bun_ptr::BackRef<crate::socket::NewSocket<SSL>, bun_ptr::Root>) -> BunSocket,
+        writeonly: fn(bun_ptr::BackRef<crate::socket::NewSocket<SSL>, bun_ptr::Root>) -> BunSocket,
+        writeonly_ref: fn(RefPtr<crate::socket::NewSocket<SSL>>) -> WriteonlySocketRef,
     ) {
-        debug_assert!(matches!(self.0.get(), BunSocket::None));
-        // BACKREF: `socket` is the live `m_ctx` borrowed from the JS wrapper
-        // rooted by the caller's `socket_js`.
-        let socket_nn = NonNull::new(socket).expect("NewSocket m_ctx");
-        let socket = bun_ptr::BackRef::from(socket_nn);
-        self.0
+        debug_assert!(matches!(self.socket.get(), BunSocket::None));
+        // BACKREF: `socket` is the live `m_ctx` of the JS wrapper rooted by the
+        // caller's `socket_js`.
+        self.socket
             .set(if socket.attach_native_callback(NativeCallbacks::H2(h2)) {
-                if SSL {
-                    BunSocket::Tls(bun_ptr::BackRef::from(socket_nn.cast::<TLSSocket>()))
-                } else {
-                    BunSocket::Tcp(bun_ptr::BackRef::from(socket_nn.cast::<TCPSocket>()))
-                }
+                attached(socket.into())
             } else {
-                // The ref `detach` releases.
-                socket.ref_();
-                if SSL {
-                    BunSocket::TlsWriteonly(bun_ptr::BackRef::from(socket_nn.cast::<TLSSocket>()))
-                } else {
-                    BunSocket::TcpWriteonly(bun_ptr::BackRef::from(socket_nn.cast::<TCPSocket>()))
-                }
+                self.writeonly_ref
+                    .set(Some(writeonly_ref(RefPtr::from_this(socket))));
+                writeonly(socket.into())
             });
     }
 
     fn detach(&self) {
-        match self.0.replace(BunSocket::None) {
+        match self.socket.replace(BunSocket::None) {
             BunSocket::Tcp(socket) => socket.detach_native_callback(),
             BunSocket::Tls(socket) => socket.detach_native_callback(),
-            // The ref `attach` took.
-            BunSocket::TcpWriteonly(socket) => TCPSocket::deref(socket.get()),
-            BunSocket::TlsWriteonly(socket) => TLSSocket::deref(socket.get()),
+            BunSocket::TcpWriteonly(_) | BunSocket::TlsWriteonly(_) => {
+                drop(self.writeonly_ref.take());
+            }
             BunSocket::None => {}
         }
     }
@@ -7506,15 +7510,27 @@ impl H2FrameParser {
         }
 
         this.detach_native_socket();
-        if let Some(socket) = TLSSocket::from_js(socket_js) {
+        if let Some(socket) = socket_js.as_class_this_ptr::<TLSSocket>() {
             bun_output::scoped_log!(H2FrameParser, "TLSSocket attached");
-            this.native_socket.attach::<true>(socket, this.ref_guard());
+            this.native_socket.attach(
+                socket,
+                this.ref_guard(),
+                BunSocket::Tls,
+                BunSocket::TlsWriteonly,
+                WriteonlySocketRef::Tls,
+            );
             // if we started with non native and go to native we now control the backpressure internally
             this.has_nonnative_backpressure.set(false);
             let _ = this.flush();
-        } else if let Some(socket) = TCPSocket::from_js(socket_js) {
+        } else if let Some(socket) = socket_js.as_class_this_ptr::<TCPSocket>() {
             bun_output::scoped_log!(H2FrameParser, "TCPSocket attached");
-            this.native_socket.attach::<false>(socket, this.ref_guard());
+            this.native_socket.attach(
+                socket,
+                this.ref_guard(),
+                BunSocket::Tcp,
+                BunSocket::TcpWriteonly,
+                WriteonlySocketRef::Tcp,
+            );
             // if we started with non native and go to native we now control the backpressure internally
             this.has_nonnative_backpressure.set(false);
             let _ = this.flush();
@@ -7653,17 +7669,25 @@ impl H2FrameParser {
 
         // check if socket is provided, and if it is a valid native socket
         if let Some(socket_js) = options.get(global_object, "native")? {
-            if let Some(socket) = TLSSocket::from_js(socket_js) {
+            if let Some(socket) = socket_js.as_class_this_ptr::<TLSSocket>() {
                 bun_output::scoped_log!(H2FrameParser, "TLSSocket attached");
-                this_ref
-                    .native_socket
-                    .attach::<true>(socket, this_ref.ref_guard());
+                this_ref.native_socket.attach(
+                    socket,
+                    this_ref.ref_guard(),
+                    BunSocket::Tls,
+                    BunSocket::TlsWriteonly,
+                    WriteonlySocketRef::Tls,
+                );
                 let _ = this_ref.flush();
-            } else if let Some(socket) = TCPSocket::from_js(socket_js) {
+            } else if let Some(socket) = socket_js.as_class_this_ptr::<TCPSocket>() {
                 bun_output::scoped_log!(H2FrameParser, "TCPSocket attached");
-                this_ref
-                    .native_socket
-                    .attach::<false>(socket, this_ref.ref_guard());
+                this_ref.native_socket.attach(
+                    socket,
+                    this_ref.ref_guard(),
+                    BunSocket::Tcp,
+                    BunSocket::TcpWriteonly,
+                    WriteonlySocketRef::Tcp,
+                );
                 let _ = this_ref.flush();
             }
         }

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1473,12 +1473,13 @@ impl CronJob {
 
     /// May free `this`.
     fn remove_from_list(this: ThisPtr<Self>) {
-        let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() else {
-            return;
-        };
-        if let Some(i) = jobs.iter().position(|j| j.as_ptr() == this.as_ptr()) {
-            drop(jobs.swap_remove(i));
-        }
+        let entry = crate::jsc_hooks::with_cron_jobs(|jobs| {
+            let i = jobs.iter().position(|j| j.as_ptr() == this.as_ptr())?;
+            Some(jobs.swap_remove(i))
+        })
+        .flatten();
+        // Released outside the list borrow: may free `this`.
+        drop(entry);
     }
 
     /// `.reload`: --hot — promises in flight will still settle on this VM, so
@@ -1488,10 +1489,10 @@ impl CronJob {
     pub(crate) fn clear_all_for_vm<const MODE: ClearMode>(vm: &mut VirtualMachine) {
         // Drain the list first so `stop_internal` (which re-enters the VM)
         // doesn't alias the list borrow.
-        let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() else {
+        let Some(jobs) = crate::jsc_hooks::with_cron_jobs(core::mem::take) else {
             return;
         };
-        for job in core::mem::take(jobs) {
+        for job in jobs {
             let this = job.this_ptr();
             this.stop_internal(vm);
             if MODE == ClearMode::Teardown {
@@ -1735,9 +1736,7 @@ impl CronJob {
         // stop/release jobs. Main-thread VMs without --hot never enumerate it,
         // so skip the list ref + append entirely.
         if vm.hot_reload == HotReload::Hot || vm.worker.is_some() {
-            if let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() {
-                jobs.push(job.clone());
-            }
+            crate::jsc_hooks::with_cron_jobs(|jobs| jobs.push(job.clone()));
         }
 
         // `job`'s ref moves to the JS wrapper (released via `finalize`).

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1234,7 +1234,10 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::BundleV2PluginLoad => release!(bun_bundler::bundle_v2::api::JSBundler::Load),
         task_tag::ShellYesTask => release!(ShellYesTask),
         task_tag::CppTask => release!(CppTask),
-        task_tag::DuplexUpgradeContext => release!(crate::socket::DuplexUpgradeContext),
+        task_tag::DuplexUpgradeContext => crate::socket::DuplexUpgradeContext::release_unrun(
+            // SAFETY: as `release!`.
+            unsafe { bun_ptr::ThisPtr::new(task.ptr.cast()) },
+        ),
         task_tag::FetchTasklet => release!(FetchTasklet),
         task_tag::FetchTaskletDeinit => release!(crate::webcore::fetch::FetchTaskletDeinitHop),
         task_tag::FetchTaskletPromiseSettle => {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -195,15 +195,21 @@ pub(crate) fn timer_all_mut() -> &'static mut timer::All {
     unsafe { &mut (*state).timer }
 }
 
+/// Runs `f` against this thread's in-process cron job list (`None` before the
+/// runtime state exists). A callback rather than a `&'static mut`, which two
+/// callers could hold at once; `f` must not re-enter anything that reaches the
+/// list.
 #[inline]
-pub(crate) fn cron_jobs_mut() -> Option<&'static mut Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>>
-{
+pub(crate) fn with_cron_jobs<R>(
+    f: impl FnOnce(&mut Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>) -> R,
+) -> Option<R> {
     let state = runtime_state();
     if state.is_null() {
         return None;
     }
-    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread.
-    Some(unsafe { &mut (*state).cron_jobs })
+    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread; the
+    // borrow ends when `f` returns.
+    Some(f(unsafe { &mut (*state).cron_jobs }))
 }
 
 #[inline]
@@ -282,14 +288,6 @@ pub(crate) fn default_client_ssl_ctx(vm: &VirtualMachine) -> *mut bun_uws::SslCt
     let rare = vm.as_mut().rare_data();
     if rare.default_client_ssl_ctx.is_none() {
         let mut err = bun_uws::create_bun_socket_error_t::none;
-        let state = runtime_state();
-        debug_assert!(
-            !state.is_null(),
-            "default_client_ssl_ctx before init_runtime_state"
-        );
-        // SAFETY: per-thread `RuntimeState`; `ssl_ctx_cache` has a stable
-        // address for the VM's lifetime and is only touched from the JS thread.
-        let cache = unsafe { &mut (*state).ssl_ctx_cache };
         // Mode-neutral CTX (VERIFY_NONE). `us_internal_ssl_attach` overrides
         // each client SSL to VERIFY_PEER + the shared bundled-root store, so
         // `new WebSocket("wss://…")` (which shares this CTX and defaults to
@@ -298,7 +296,7 @@ pub(crate) fn default_client_ssl_ctx(vm: &VirtualMachine) -> *mut bun_uws::SslCt
         // to the same CTX rather than building a second one with the same
         // digest. The +1 ref returned here is held for the VM's lifetime, so
         // the entry never tombstones.
-        match cache.get_or_create_opts(&Default::default(), &mut err) {
+        match with_ssl_ctx_cache(|cache| cache.get_or_create_opts(&Default::default(), &mut err)) {
             Some(ctx) => rare.default_client_ssl_ctx = Some(ctx),
             None => bun_core::Output::panic(format_args!(
                 "default client SSL_CTX init failed: {}",
@@ -322,15 +320,24 @@ fn ssl_ctx_cache_get_or_create(
     opts: &bun_uws::SocketContext::BunSocketContextOptions,
     err: &mut bun_uws::create_bun_socket_error_t,
 ) -> Option<bun_boringssl::c::OwnedSslCtx> {
+    with_ssl_ctx_cache(|cache| cache.get_or_create_opts(opts, err))
+}
+
+/// Runs `f` against this thread's `SSL_CTX` cache. Takes a callback rather than
+/// handing out a `&'static mut`, which two callers could hold at once.
+#[inline]
+pub(crate) fn with_ssl_ctx_cache<R>(
+    f: impl FnOnce(&mut crate::api::SSLContextCache::SSLContextCache) -> R,
+) -> R {
     let state = runtime_state();
     debug_assert!(
         !state.is_null(),
-        "ssl_ctx_cache_get_or_create before init_runtime_state"
+        "runtime_state() before init_runtime_state"
     );
-    // SAFETY: per-thread `RuntimeState`; `ssl_ctx_cache` has a stable
-    // address for the VM's lifetime and is only touched from the JS thread.
-    let cache = unsafe { &mut (*state).ssl_ctx_cache };
-    cache.get_or_create_opts(opts, err)
+    // SAFETY: `state` is the per-thread `RuntimeState` boxed in
+    // `init_runtime_state`, address-stable until VM teardown, and only the JS
+    // thread reaches here — so this `&mut` is unique for `f`'s duration.
+    f(unsafe { &mut (*state).ssl_ctx_cache })
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -137,6 +137,8 @@ pub(crate) fn new_detached_socket(global: &JSGlobalObject, frame: &CallFrame) ->
         let socket = NewSocket::<SSL>::new(NewSocket::<SSL> {
             socket: Cell::new(uws::NewSocketHandler::<SSL>::DETACHED),
             ref_count: bun_ptr::RefCount::init(),
+            io_ref: Cell::new(None),
+            named_pipe_ref: Cell::new(None),
             protos: JsCell::new(None),
             handlers: JsCell::new(None),
             local_binding: JsCell::new(None),
@@ -156,7 +158,8 @@ pub(crate) fn new_detached_socket(global: &JSGlobalObject, frame: &CallFrame) ->
             twin: JsCell::new(None),
             verify_error: JsCell::new(None),
         });
-        socket.get_this_value(global)
+        // The JS wrapper adopts the creation ref.
+        socket.into_this_ptr().get_this_value(global)
     }
 
     Ok(if !is_ssl {

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -44,22 +44,7 @@ use bun_sys::windows::libuv as uv;
 
 bun_output::define_scoped_log!(log, Listener, visible);
 
-/// Runs `f` against this thread's `SSL_CTX` cache. Takes a callback rather than
-/// handing out a `&'static mut`, which two callers could hold at once.
-#[inline]
-fn with_ssl_ctx_cache<R>(
-    f: impl FnOnce(&mut crate::api::SSLContextCache::SSLContextCache) -> R,
-) -> R {
-    let state = crate::jsc_hooks::runtime_state();
-    debug_assert!(
-        !state.is_null(),
-        "runtime_state() before init_runtime_state"
-    );
-    // SAFETY: `state` is the per-thread `RuntimeState` boxed in
-    // `init_runtime_state`, address-stable until VM teardown, and only the JS
-    // thread reaches here — so this `&mut` is unique for `f`'s duration.
-    f(unsafe { &mut (*state).ssl_ctx_cache })
-}
+use crate::jsc_hooks::with_ssl_ctx_cache;
 
 // Route through the codegen'd `toJS` wrapper so we
 // can hand the C++ side an already-heap-allocated `*mut Listener` (the
@@ -631,6 +616,8 @@ impl Listener {
 
         let this_socket = NewSocket::<SSL>::new(NewSocket::<SSL> {
             ref_count: bun_ptr::RefCount::init(),
+            io_ref: Cell::new(None),
+            named_pipe_ref: Cell::new(None),
             handlers: JsCell::new(Some(Rc::clone(&listener.handlers))),
             socket: Cell::new(uws::NewSocketHandler::<SSL>::DETACHED),
             protos: JsCell::new(listener.protos.clone()),
@@ -649,8 +636,10 @@ impl Listener {
             twin: JsCell::new(None),
             verify_error: JsCell::new(None),
         });
-        let s = this_socket;
-        s.ref_();
+        // The named-pipe context's ref; the JS wrapper adopts the creation ref.
+        let s = this_socket.this_ptr();
+        NewSocket::hold_io_ref(s);
+        let _ = this_socket.into_this_ptr();
         // See `on_create`: each accepted named-pipe connection holds the loop
         // on its own so `conn.unref()` is meaningful.
         s.poll_ref.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
@@ -676,6 +665,8 @@ impl Listener {
 
         let this_socket = NewSocket::<SSL>::new(NewSocket::<SSL> {
             ref_count: bun_ptr::RefCount::init(),
+            io_ref: Cell::new(None),
+            named_pipe_ref: Cell::new(None),
             handlers: JsCell::new(Some(Rc::clone(&listener.handlers))),
             socket: Cell::new(socket),
             protos: JsCell::new(listener.protos.clone()),
@@ -695,8 +686,10 @@ impl Listener {
             twin: JsCell::new(None),
             verify_error: JsCell::new(None),
         });
-        let s = this_socket;
-        s.ref_();
+        // The ext slot's ref; the JS wrapper adopts the creation ref.
+        let s = this_socket.this_ptr();
+        NewSocket::hold_io_ref(s);
+        let this_socket = this_socket.into_this_ptr();
         // Each accepted socket holds the event loop on its own (same as a
         // client socket after `connect_finish`), so `conn.unref()` works and
         // `server.unref()`/`server.close()` don't tear out live connections'
@@ -1242,6 +1235,8 @@ impl Listener {
                     } else {
                         TLSSocket::new(TLSSocket {
                             ref_count: bun_ptr::RefCount::init(),
+                            io_ref: Cell::new(None),
+                            named_pipe_ref: Cell::new(None),
                             handlers: JsCell::new(Some(Rc::clone(&handlers))),
                             socket: Cell::new(uws::NewSocketHandler::<true>::DETACHED),
                             connection: JsCell::new(Some(connection)),
@@ -1261,6 +1256,8 @@ impl Listener {
                             twin: JsCell::new(None),
                             verify_error: JsCell::new(None),
                         })
+                        // The JS wrapper adopts the creation ref (`get_this_value` below).
+                        .into_this_ptr()
                     };
                     let tls_ref = tls;
                     tls_ref.reset_client_tls_flags(crate::socket::resolve_reject_unauthorized(
@@ -1280,7 +1277,7 @@ impl Listener {
                         default_data,
                     );
                     tls_ref.poll_ref.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
-                    tls_ref.ref_();
+                    TLSSocket::hold_io_ref(tls_ref);
 
                     let ctx_for_pipe = owned_ssl_ctx.take();
                     // Note: re-borrow connection from the socket field — `connection`
@@ -1331,6 +1328,8 @@ impl Listener {
                     } else {
                         TCPSocket::new(TCPSocket {
                             ref_count: bun_ptr::RefCount::init(),
+                            io_ref: Cell::new(None),
+                            named_pipe_ref: Cell::new(None),
                             handlers: JsCell::new(Some(Rc::clone(&handlers))),
                             socket: Cell::new(uws::NewSocketHandler::<false>::DETACHED),
                             connection: JsCell::new(Some(connection)),
@@ -1348,6 +1347,8 @@ impl Listener {
                             twin: JsCell::new(None),
                             verify_error: JsCell::new(None),
                         })
+                        // The JS wrapper adopts the creation ref (`get_this_value` below).
+                        .into_this_ptr()
                     };
                     let tcp_ref = tcp;
                     tcp_ref.update_flags(|f| {
@@ -1356,7 +1357,7 @@ impl Listener {
                             socket_config.pause_on_connect,
                         )
                     });
-                    tcp_ref.ref_();
+                    TCPSocket::hold_io_ref(tcp_ref);
                     TCPSocket::data_set_cached(
                         tcp_ref.get_this_value(global),
                         global,
@@ -1547,7 +1548,7 @@ fn connect_finish<const IS_SSL: bool>(
         // still-connecting socket. Close the previous native socket before
         // reusing this wrapper so `do_connect` does not alias two native
         // sockets onto one ext slot.
-        prev.detach_for_reconnect();
+        NewSocket::detach_for_reconnect(prev);
         // Dropping the previous `Rc` here is safe even mid-callback: a `Scope`
         // from a `data`/`close` handler that synchronously re-entered `connect`
         // still holds its own reference.
@@ -1568,6 +1569,8 @@ fn connect_finish<const IS_SSL: bool>(
     } else {
         NewSocket::<IS_SSL>::new(NewSocket::<IS_SSL> {
             ref_count: bun_ptr::RefCount::init(),
+            io_ref: Cell::new(None),
+            named_pipe_ref: Cell::new(None),
             handlers: JsCell::new(Some(handlers)),
             socket: Cell::new(uws::NewSocketHandler::<IS_SSL>::DETACHED),
             connection: JsCell::new(Some(connection)),
@@ -1585,10 +1588,12 @@ fn connect_finish<const IS_SSL: bool>(
             twin: JsCell::new(None),
             verify_error: JsCell::new(None),
         })
+        // The JS wrapper adopts the creation ref (`get_this_value` below).
+        .into_this_ptr()
     };
     // Either the caller's JS-owned socket (reconnect) or the fresh one above.
     let socket_ref = socket;
-    socket_ref.ref_();
+    NewSocket::hold_io_ref(socket_ref);
     NewSocket::<IS_SSL>::data_set_cached(socket_ref.get_this_value(global), global, default_data);
     // On the reuse-prev path, `prev.this_value` was downgraded to Weak by the
     // previous close's `mark_inactive()`. `get_this_value()` returns the
@@ -1620,7 +1625,7 @@ fn connect_finish<const IS_SSL: bool>(
     // borrow is needed here.
     // An already-open fd socket runs `on_open` synchronously; what settling
     // the connect promise there left pending is not a connect failure.
-    let opened_err = match socket_ref.do_connect() {
+    let opened_err = match NewSocket::do_connect(socket_ref) {
         Ok(()) => None,
         Err(crate::Error::Js(err)) => Some(err),
         Err(_) => {
@@ -1673,9 +1678,8 @@ fn connect_finish<const IS_SSL: bool>(
             };
             {
                 let this = socket;
+                // Releases the `io_ref` taken above.
                 let handled = NewSocket::<IS_SSL>::handle_connect_error(this, errno, 0);
-                // Balance the unconditional `socket_ref.ref_()` above.
-                NewSocket::deref(&this);
                 // A `connectError` handler that threw on this synchronous failure
                 // throws from `connect()`.
                 handled?;

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -13,12 +13,14 @@
 //! JavaScript callbacks for handling connection events and errors.
 
 use core::cell::Cell;
-use core::ffi::{CStr, c_uint, c_void};
+use core::ffi::{CStr, c_uint};
 
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsResult, host_fn};
+use bun_ptr::{BackRef, Root};
 use bun_uws::{us_bun_verify_error_t, uws_callback};
 
+use super::DuplexUpgradeContext;
 use super::ssl_wrapper::SSLWrapper;
 use crate::generated_classes::js_TLSSocket;
 use crate::timer::{ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
@@ -35,15 +37,17 @@ pub(crate) struct UpgradedDuplex {
     // JSC_BORROW per LIFETIMES.tsv.
     pub global: Option<GlobalRef>,
     pub ssl_error: JsCell<CertError>,
-    // JSC_BORROW per LIFETIMES.tsv. `Option` so the struct is zero-initializable
-    // (socket_body.rs `DuplexUpgradeContext` two-phase init builds this field as
-    // `zeroed()` before overwriting via `from()`).
+    // JSC_BORROW per LIFETIMES.tsv.
     pub vm: Option<&'static VirtualMachine>,
-    pub handlers: Handlers,
-    pub on_data_callback: Cell<JSValue>,
-    pub on_end_callback: Cell<JSValue>,
-    pub on_writable_callback: Cell<JSValue>,
-    pub on_close_callback: Cell<JSValue>,
+    /// The container holding self as `.upgrade`, set right after it is
+    /// allocated; events go to its `on_*` entry points.
+    pub owner: Cell<Option<BackRef<DuplexUpgradeContext, Root>>>,
+    /// The `origin` listener thunks handed to JS; their context is `self`, and
+    /// dropping the handle (in `teardown`) neuters them.
+    on_data_callback: JsCell<Option<host_fn::ContextFunction>>,
+    on_end_callback: JsCell<Option<host_fn::ContextFunction>>,
+    on_writable_callback: JsCell<Option<host_fn::ContextFunction>>,
+    on_close_callback: JsCell<Option<host_fn::ContextFunction>>,
     pub event_loop_timer: JsCell<EventLoopTimer>,
     pub current_timeout: Cell<u32>,
     /// Transport bytes that arrived before the TLS engine existed.
@@ -80,7 +84,7 @@ pub struct CertError {
 }
 // `Box<CStr>` drops automatically — no explicit Drop needed.
 
-type WrapperType = SSLWrapper<*mut UpgradedDuplex>;
+type WrapperType = SSLWrapper<BackRef<UpgradedDuplex>>;
 
 /// Server-side peer-certificate policy for a duplex TLS upgrade, resolved in
 /// `js_upgrade_duplex_to_tls` and applied via `SSLWrapper::set_server_verify`.
@@ -93,23 +97,7 @@ pub(crate) struct ServerVerify {
     pub reject_unauthorized: bool,
 }
 
-pub struct Handlers {
-    // BACKREF per LIFETIMES.tsv — container holding self as `.upgrade`.
-    pub ctx: *mut (),
-    pub(crate) on_open: fn(*mut ()),
-    pub(crate) on_handshake: fn(*mut (), bool, us_bun_verify_error_t),
-    pub(crate) on_data: fn(*mut (), &[u8]),
-    pub on_close: fn(*mut ()),
-    pub(crate) on_end: fn(*mut ()),
-    pub(crate) on_writable: fn(*mut ()),
-    pub(crate) on_error: fn(*mut (), JSValue),
-    pub(crate) on_timeout: fn(*mut ()),
-    /// A new resumable TLS session (serialized SSL_SESSION) - node's
-    /// `'session'` event on the wrapping TLSSocket.
-    pub(crate) on_session: fn(*mut (), &[u8]),
-    /// An NSS key-log line - node's `'keylog'` event.
-    pub(crate) on_keylog: fn(*mut (), &[u8]),
-}
+type Owner = DuplexUpgradeContext;
 
 use crate::jsc_hooks::timer_all_mut as timer_all;
 
@@ -117,68 +105,65 @@ use crate::jsc_hooks::timer_all_mut as timer_all;
 /// into the owning `JSTLSSocket` wrapper's visited `values:` slot (the GC
 /// root). All four `get_js_handlers` slots follow the identical
 /// `NewFunctionWithData(global, null, 0, fn, self)` → `ensureStillAlive` →
-/// `setFunctionData(self)` → store pattern.
+/// store pattern.
 #[inline]
-fn lazy_js_handler(
-    shadow: &Cell<JSValue>,
-    js_wrapper: JSValue,
+fn lazy_js_handler<H: host_fn::ContextHostFn<Context = UpgradedDuplex>>(
+    this: &UpgradedDuplex,
+    shadow: &JsCell<Option<host_fn::ContextFunction>>,
     set_slot: fn(JSValue, &JSGlobalObject, JSValue),
     global: &JSGlobalObject,
-    func: host_fn::JsHostFn,
-    this_ptr: *mut c_void,
 ) -> JSValue {
-    if !shadow.get().is_empty() {
-        return shadow.get();
+    if let Some(f) = shadow.get().as_ref() {
+        return f.value();
     }
-    let callback = host_fn::new_function_with_data(global, None, 0, func, this_ptr);
+    let f = host_fn::ContextFunction::new::<H>(global, None, 0, BackRef::new(this));
+    let callback = f.value();
     callback.ensure_still_alive();
-    host_fn::set_function_data(callback, Some(this_ptr));
-    set_slot(js_wrapper, global, callback);
-    shadow.set(callback);
+    set_slot(this.js_wrapper, global, callback);
+    shadow.set(Some(f));
     callback
 }
 
 impl UpgradedDuplex {
-    // SAFETY (all handlers): the SSLWrapper handlers ctx is `self as *mut
-    // Self`, live for the wrapper's lifetime.
-
     #[inline]
     fn wrapper_ref(&self) -> Option<&WrapperType> {
         self.wrapper.get().as_ref()
     }
 
-    fn on_open(this: *mut Self) {
+    /// Dispatch into the owning context, once it has installed itself.
+    #[inline]
+    fn emit(&self, f: impl FnOnce(bun_ptr::ThisPtr<Owner>)) {
+        if let Some(owner) = self.owner.get() {
+            f(owner.this_ptr());
+        }
+    }
+
+    fn on_open(this: BackRef<Self>) {
         bun_output::scoped_log!(UpgradedDuplex, "onOpen");
-        // SAFETY: see handler note above.
-        let this = unsafe { &*this };
-        (this.handlers.on_open)(this.handlers.ctx);
+        this.emit(Owner::on_open);
     }
 
-    fn on_data(this: *mut Self, decoded_data: &[u8]) {
+    fn on_data(this: BackRef<Self>, decoded_data: &[u8]) {
         bun_output::scoped_log!(UpgradedDuplex, "onData ({})", decoded_data.len());
-        // SAFETY: see handler note above.
-        let this = unsafe { &*this };
-        (this.handlers.on_data)(this.handlers.ctx, decoded_data);
+        this.emit(|o| Owner::on_data(o, decoded_data));
     }
 
-    fn on_session(this: *mut Self, session: &[u8]) {
+    fn on_session(this: BackRef<Self>, session: &[u8]) {
         bun_output::scoped_log!(UpgradedDuplex, "onSession ({})", session.len());
-        // SAFETY: see handler note above.
-        let this = unsafe { &*this };
-        (this.handlers.on_session)(this.handlers.ctx, session);
+        this.emit(|o| Owner::on_session(o, session));
     }
 
-    fn on_keylog(this: *mut Self, line: &[u8]) {
+    fn on_keylog(this: BackRef<Self>, line: &[u8]) {
         bun_output::scoped_log!(UpgradedDuplex, "onKeylog ({})", line.len());
-        // SAFETY: see handler note above.
-        let this = unsafe { &*this };
-        (this.handlers.on_keylog)(this.handlers.ctx, line);
+        this.emit(|o| Owner::on_keylog(o, line));
     }
 
-    fn on_handshake(this: *mut Self, handshake_success: bool, ssl_error: us_bun_verify_error_t) {
+    fn on_handshake(
+        this: BackRef<Self>,
+        handshake_success: bool,
+        ssl_error: us_bun_verify_error_t,
+    ) {
         bun_output::scoped_log!(UpgradedDuplex, "onHandshake");
-        // SAFETY: see handler note above.
-        let this = unsafe { &*this };
         this.ssl_error.set(CertError {
             error_no: ssl_error.error_no,
             code: ssl_error
@@ -190,17 +175,15 @@ impl UpgradedDuplex {
                 .filter(|_| ssl_error.error_no != 0)
                 .map(Into::into),
         });
-        (this.handlers.on_handshake)(this.handlers.ctx, handshake_success, ssl_error);
+        this.emit(|o| Owner::on_handshake(o, handshake_success, ssl_error));
         // Retry writes parked during the handshake, like openssl.c's `ssl_write_wants_read`.
         if handshake_success && !this.is_shutdown() {
-            (this.handlers.on_writable)(this.handlers.ctx);
+            this.emit(Owner::on_writable);
         }
     }
 
-    fn on_close(this: *mut Self) {
+    fn on_close(this: BackRef<Self>) {
         bun_output::scoped_log!(UpgradedDuplex, "onClose");
-        // SAFETY: see handler note above.
-        let this = unsafe { &*this };
 
         // Keep the wrapper (and so its visited `duplex*` slots) reachable
         // across `handlers.on_close`, which downgrades the socket's own strong
@@ -208,7 +191,7 @@ impl UpgradedDuplex {
         let js_wrapper = this.js_wrapper;
         js_wrapper.ensure_still_alive();
 
-        (this.handlers.on_close)(this.handlers.ctx);
+        this.emit(Owner::on_close);
         // closes the underlying duplex
         this.call_write_or_end(None, false);
 
@@ -260,25 +243,28 @@ impl UpgradedDuplex {
             let buffer = match bun_jsc::array_buffer::BinaryType::Buffer.to_js(data, &global) {
                 Ok(b) => b,
                 Err(err) => {
-                    (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
+                    self.on_error(global.take_error(err));
                     return;
                 }
             };
             buffer.ensure_still_alive();
 
             if let Err(err) = write_or_end.call(&global, duplex, &[buffer]) {
-                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
+                self.on_error(global.take_error(err));
             }
         } else {
             if let Err(err) = write_or_end.call(&global, duplex, &[JSValue::NULL]) {
-                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
+                self.on_error(global.take_error(err));
             }
         }
     }
 
-    fn internal_write(this: *mut Self, encoded_data: &[u8]) {
-        // SAFETY: see handler note above.
-        unsafe { &*this }.write_encrypted(encoded_data);
+    fn on_error(&self, err_value: JSValue) {
+        self.emit(|o| Owner::on_error(o, err_value));
+    }
+
+    fn internal_write(this: BackRef<Self>, encoded_data: &[u8]) {
+        this.write_encrypted(encoded_data);
     }
 
     fn write_encrypted(&self, encoded_data: &[u8]) {
@@ -360,7 +346,7 @@ impl UpgradedDuplex {
         if self.wrapper_ref().is_none_or(|w| w.ssl.get().is_none()) {
             return;
         }
-        (self.handlers.on_end)(self.handlers.ctx);
+        self.emit(Owner::on_end);
     }
 
     pub(crate) fn on_timeout(&self) {
@@ -380,14 +366,13 @@ impl UpgradedDuplex {
             return;
         }
 
-        (self.handlers.on_timeout)(self.handlers.ctx);
+        self.emit(Owner::on_timeout);
     }
 
     pub(crate) fn from(
         global: &JSGlobalObject,
         js_wrapper: JSValue,
         origin: JSValue,
-        handlers: Handlers,
     ) -> UpgradedDuplex {
         js_TLSSocket::duplex_origin_set_cached(js_wrapper, global, origin);
         UpgradedDuplex {
@@ -396,12 +381,12 @@ impl UpgradedDuplex {
             origin: Cell::new(origin),
             global: Some(GlobalRef::from(global)),
             wrapper: JsCell::new(None),
-            handlers,
+            owner: Cell::new(None),
             ssl_error: JsCell::new(CertError::default()),
-            on_data_callback: Cell::new(JSValue::ZERO),
-            on_end_callback: Cell::new(JSValue::ZERO),
-            on_writable_callback: Cell::new(JSValue::ZERO),
-            on_close_callback: Cell::new(JSValue::ZERO),
+            on_data_callback: JsCell::new(None),
+            on_end_callback: JsCell::new(None),
+            on_writable_callback: JsCell::new(None),
+            on_close_callback: JsCell::new(None),
             event_loop_timer: JsCell::new(EventLoopTimer::init_paused(
                 EventLoopTimerTag::UpgradedDuplex,
             )),
@@ -416,63 +401,53 @@ impl UpgradedDuplex {
         let array = JSValue::create_empty_array(global, 4)?;
         array.ensure_still_alive();
 
-        let this_ptr = std::ptr::from_ref(self).cast_mut().cast::<c_void>();
-        let js_wrapper = self.js_wrapper;
         array.put_index(
             global,
             0,
-            lazy_js_handler(
+            lazy_js_handler::<OnReceivedData>(
+                self,
                 &self.on_data_callback,
-                js_wrapper,
                 js_TLSSocket::duplex_on_data_set_cached,
                 global,
-                __jsc_host_on_received_data,
-                this_ptr,
             ),
         )?;
         array.put_index(
             global,
             1,
-            lazy_js_handler(
+            lazy_js_handler::<OnEnd>(
+                self,
                 &self.on_end_callback,
-                js_wrapper,
                 js_TLSSocket::duplex_on_end_set_cached,
                 global,
-                __jsc_host_on_end,
-                this_ptr,
             ),
         )?;
         array.put_index(
             global,
             2,
-            lazy_js_handler(
+            lazy_js_handler::<OnWritable>(
+                self,
                 &self.on_writable_callback,
-                js_wrapper,
                 js_TLSSocket::duplex_on_writable_set_cached,
                 global,
-                __jsc_host_on_writable,
-                this_ptr,
             ),
         )?;
         array.put_index(
             global,
             3,
-            lazy_js_handler(
+            lazy_js_handler::<OnCloseJs>(
+                self,
                 &self.on_close_callback,
-                js_wrapper,
                 js_TLSSocket::duplex_on_close_set_cached,
                 global,
-                __jsc_host_on_close_js,
-                this_ptr,
             ),
         )?;
 
         Ok(array)
     }
 
-    fn wrapper_handlers(&self) -> super::ssl_wrapper::Handlers<*mut UpgradedDuplex> {
+    fn wrapper_handlers(&self) -> super::ssl_wrapper::Handlers<BackRef<UpgradedDuplex>> {
         super::ssl_wrapper::Handlers {
-            ctx: std::ptr::from_ref(self).cast_mut(),
+            ctx: BackRef::new(self),
             on_open: Self::on_open,
             on_handshake: Self::on_handshake,
             on_data: Self::on_data,
@@ -578,10 +553,13 @@ impl UpgradedDuplex {
         !self.is_closed()
     }
 
-    fn ssl(&self) -> Option<*mut bun_boringssl_sys::SSL> {
+    /// `bun_uws::UpgradedDuplex` link-time-dispatch shim (`src/uws_sys/lib.rs`);
+    /// the others are emitted by `#[uws_callback(export = ...)]` on the methods here.
+    #[uws_callback(export = "UpgradedDuplex__ssl", no_catch)]
+    fn ssl(&self) -> *mut bun_boringssl_sys::SSL {
         self.wrapper_ref()
             .and_then(|w| w.ssl.get())
-            .map(|p| p.as_ptr())
+            .map_or(core::ptr::null_mut(), |p| p.as_ptr())
     }
 
     #[uws_callback(export = "UpgradedDuplex__ssl_error", no_catch)]
@@ -670,11 +648,7 @@ impl UpgradedDuplex {
             &self.on_writable_callback,
             &self.on_close_callback,
         ] {
-            let value = cb.get();
-            if !value.is_empty() {
-                host_fn::set_function_data(value, None);
-                cb.set(JSValue::ZERO);
-            }
+            cb.set(None);
         }
         self.ssl_error.set(CertError::default());
         self.pending_data.set(Vec::new());
@@ -689,20 +663,19 @@ impl Drop for UpgradedDuplex {
     }
 }
 
-// SAFETY (all four host fns): the function data is the `*mut UpgradedDuplex`
-// installed by `get_js_handlers`; `teardown` clears it before the storage is
-// freed, so a non-null data pointer is live for the call.
+// The four `origin` listeners `get_js_handlers` hands to JS. Their context slot
+// is this `UpgradedDuplex`; `teardown` clears it before the storage is freed.
 
-#[bun_jsc::host_fn]
-fn on_received_data(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    bun_output::scoped_log!(UpgradedDuplex, "onReceivedData");
-
-    let function = frame.callee();
-    let [data_arg] = frame.arguments_as_array::<1>();
-
-    if let Some(self_ptr) = host_fn::get_function_data(function) {
-        // SAFETY: see host-fn note above.
-        let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
+struct OnReceivedData;
+impl host_fn::ContextHostFn for OnReceivedData {
+    type Context = UpgradedDuplex;
+    fn call(
+        this: &UpgradedDuplex,
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        bun_output::scoped_log!(UpgradedDuplex, "onReceivedData");
+        let [data_arg] = frame.arguments_as_array::<1>();
         if frame.arguments_count() >= 1 {
             if !this.origin.get().is_empty() {
                 if data_arg.is_empty_or_undefined_or_null() {
@@ -721,89 +694,51 @@ fn on_received_data(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                         )
                         .to_js();
                     error_value.ensure_still_alive();
-                    (this.handlers.on_error)(this.handlers.ctx, error_value);
+                    this.on_error(error_value);
                 }
             }
         }
+        Ok(JSValue::UNDEFINED)
     }
-    Ok(JSValue::UNDEFINED)
 }
 
-#[bun_jsc::host_fn]
-fn on_end(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    bun_output::scoped_log!(UpgradedDuplex, "onEnd");
-    let function = frame.callee();
-
-    if let Some(self_ptr) = host_fn::get_function_data(function) {
-        // SAFETY: see host-fn note above.
-        let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
-
+struct OnEnd;
+impl host_fn::ContextHostFn for OnEnd {
+    type Context = UpgradedDuplex;
+    fn call(this: &UpgradedDuplex, _: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+        bun_output::scoped_log!(UpgradedDuplex, "onEnd");
         this.transport_eof.set(true);
         if this.wrapper_ref().is_some() {
-            (this.handlers.on_end)(this.handlers.ctx);
+            this.emit(Owner::on_end);
         } else {
             // EOF before `start_tls` ran. Hold it so `drain_pending` reports it
             // in order, after any bytes staged in the same window.
             this.pending_end.set(true);
         }
+        Ok(JSValue::UNDEFINED)
     }
-    Ok(JSValue::UNDEFINED)
 }
 
-#[bun_jsc::host_fn]
-fn on_writable(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    bun_output::scoped_log!(UpgradedDuplex, "onWritable");
-
-    let function = frame.callee();
-
-    if let Some(self_ptr) = host_fn::get_function_data(function) {
-        // SAFETY: see host-fn note above.
-        let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
+struct OnWritable;
+impl host_fn::ContextHostFn for OnWritable {
+    type Context = UpgradedDuplex;
+    fn call(this: &UpgradedDuplex, _: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+        bun_output::scoped_log!(UpgradedDuplex, "onWritable");
         // flush pending data
         this.flush();
         // call onWritable (will flush on demand)
-        (this.handlers.on_writable)(this.handlers.ctx);
+        this.emit(Owner::on_writable);
+        Ok(JSValue::UNDEFINED)
     }
-
-    Ok(JSValue::UNDEFINED)
 }
 
-#[bun_jsc::host_fn]
-fn on_close_js(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    bun_output::scoped_log!(UpgradedDuplex, "onCloseJS");
-
-    let function = frame.callee();
-
-    if let Some(self_ptr) = host_fn::get_function_data(function) {
-        // SAFETY: see host-fn note above.
-        let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
+struct OnCloseJs;
+impl host_fn::ContextHostFn for OnCloseJs {
+    type Context = UpgradedDuplex;
+    fn call(this: &UpgradedDuplex, _: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+        bun_output::scoped_log!(UpgradedDuplex, "onCloseJS");
         // flush pending data
         this.close();
-    }
-
-    Ok(JSValue::UNDEFINED)
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// `bun_uws::UpgradedDuplex` link-time-dispatch shims (cycle break).
-//
-// `src/uws_sys/lib.rs` declares `UpgradedDuplex` as an opaque handle and binds
-// these symbols via `extern "C"` so the low-tier socket dispatch can call into
-// the runtime without an upward crate dep. Signatures MUST match the
-// `unsafe extern "C"` block there.
-//
-// All but `ssl` are emitted by `#[uws_callback(export = "...")]` on the
-// inherent methods above; `ssl` keeps a hand-written shim because the safe
-// method returns `Option<*mut SSL>` while the C ABI flattens to a nullable
-// raw pointer.
-// ──────────────────────────────────────────────────────────────────────────
-
-#[unsafe(no_mangle)]
-extern "C" fn UpgradedDuplex__ssl(this: *const c_void) -> *mut bun_boringssl_sys::SSL {
-    // SAFETY: `this` is a live `*const UpgradedDuplex` from the uws_sys opaque handle.
-    unsafe {
-        (*this.cast::<UpgradedDuplex>())
-            .ssl()
-            .unwrap_or(core::ptr::null_mut())
+        Ok(JSValue::UNDEFINED)
     }
 }

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -281,9 +281,11 @@ impl WindowsNamedPipeContext {
             socket
         };
         match_socket!(socket, |s: NewSocket<SSL>| {
+            // `create()`'s ref, taken out first so a reconnect from the
+            // handler can install its own; released once the handler is done.
+            let ours = s.named_pipe_ref.take();
             let failed = NewSocket::handle_connect_error(s, errno, 0);
-            // Release the +1 ref taken in `create()`.
-            s.get().deref();
+            drop(ours);
             failed
         });
     }
@@ -306,9 +308,10 @@ impl WindowsNamedPipeContext {
             (socket, ptr::addr_of_mut!((*this).named_pipe))
         };
         match_socket!(socket, |s: NewSocket<SSL>| {
+            // See `fail_connect`.
+            let ours = s.named_pipe_ref.take();
             let closed = NewSocket::on_close(s, socket_from_named_pipe::<SSL>(pipe), 0, None);
-            // Release the +1 ref taken in `create()`.
-            s.get().deref();
+            drop(ours);
             closed
         });
         // SAFETY: `this` is the live ctx pointer registered in create();
@@ -428,7 +431,7 @@ impl WindowsNamedPipeContext {
 
             // Take a +1 intrusive ref so the wrapped JS socket outlives this context.
             match_socket!(socket, |s: NewSocket<SSL>| {
-                s.ref_();
+                NewSocket::hold_named_pipe_ref(s);
                 Ok(())
             });
 
@@ -518,7 +521,7 @@ impl Drop for WindowsNamedPipeContext {
             core::mem::replace(&mut self.socket, SocketType::None),
             // +1 ref taken in `create()`; this is the matching release.
             |s: NewSocket<SSL>| {
-                s.get().deref();
+                s.release_named_pipe_ref();
                 Ok(())
             }
         );

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2,18 +2,18 @@
 
 use core::cell::Cell;
 use core::ffi::{c_int, c_uint, c_void};
-use core::ptr::{self, NonNull};
+use core::ptr::NonNull;
 
 use bun_core::EncodedSlice;
 use bun_io::KeepAlive;
 use bun_jsc::EncodedSliceJsc as _;
 use bun_jsc::JsCell;
 use bun_jsc::bun_string_jsc;
-use bun_ptr::RefPtr;
+use bun_ptr::{AsCtxPtr as _, BackRef, OwnedThis, RefPtr, ThisPtr};
 // do NOT `use bun_boringssl_sys::SSL` here — it shadows the
 // `const SSL: bool` generic param in `NewSocket<SSL>` below, making rustc
 // resolve `<SSL>` as a type arg (E0747). Use the qualified path instead.
-use bun_boringssl_sys::SSL_CTX;
+use bun_boringssl_sys::{OwnedSslCtx, SSL_CTX};
 use bun_collections::VecExt;
 use bun_core::{self, fmt as bun_fmt};
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsRef, JsResult, SystemError};
@@ -23,7 +23,7 @@ use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsRef, JsResult, 
 use bun_jsc::SysErrorJsc;
 // `bun_jsc::VirtualMachine` is the *module* (alias of `virtual_machine`); name the
 // struct directly so `VirtualMachine::get()` resolves as an associated fn.
-use super::upgraded_duplex::{Handlers as UpgradedDuplexHandlers, UpgradedDuplex};
+use super::upgraded_duplex::UpgradedDuplex;
 use crate::crypto::boringssl_jsc::err_to_js as boringssl_err_to_js;
 use crate::node::{BlobOrStringOrBuffer, StringObjects, StringOrBuffer};
 use crate::socket::{SSLConfig, SSLConfigFromJs};
@@ -105,170 +105,144 @@ macro_rules! log {
 /// its `arg` is shared across every accepted connection — using it for a
 /// per-connection `*TLSSocket` is a UAF when handshakes overlap. Read the
 /// socket back from the per-SSL ex_data slot set in `onOpen` instead.
-extern "C" fn select_alpn_callback(
-    ssl: *mut bun_boringssl_sys::SSL,
-    out: *mut *const u8,
-    outlen: *mut u8,
-    in_: *const u8,
-    inlen: c_uint,
-    _arg: *mut c_void,
-) -> c_int {
-    // BoringSSL never invokes the ALPN callback with a null `SSL*`; route
-    // through the const-asserted opaque-ZST accessor so the call is safe.
-    let this_ptr =
-        tls_socket_functions::ffi::SSL_get_ex_data(boringssl_sys::SSL::opaque_ref(ssl), 0);
-    if this_ptr.is_null() {
-        return boringssl_sys::SSL_TLSEXT_ERR_NOACK;
-    }
-    // SAFETY: ex_data slot 0 holds a `*mut TLSSocket` (set in on_open), kept
-    // live for this handshake callback by the JS wrapper's ref.
-    let this = unsafe { bun_ptr::ThisPtr::new(this_ptr.cast::<TLSSocket>()) };
-    // Same handlers-presence guard as every other dispatch entry point:
-    // an idle socket has dropped its Handlers, and the ALPN selection
-    // callback can still fire for a connection JS already detached -
-    // get_handlers() would panic. NOACK falls through to the static list.
-    if !this.has_handlers() {
-        return boringssl_sys::SSL_TLSEXT_ERR_NOACK;
-    }
-    // Dynamic per-connection ALPN: when the listener's config carries an
-    // `alpnCallback` handler, consult it with the client's protocol list (and
-    // the SNI name) before the static ALPNProtocols list. The JS handler
-    // returns `false` when the server has no ALPNCallback (fall through to
-    // the static list), the selected protocol string, or anything else to
-    // refuse the connection with a fatal no_application_protocol alert - the
-    // same contract as Node's ALPNCallback.
-    {
-        let handlers = this.get_handlers();
-        let callback = handlers.on_alpn_callback();
-        if !callback.is_empty() && !in_.is_null() && inlen > 0 {
-            // Snapshot the per-loop BIO routing state around everything below that
-            // can run JS touching another TLS socket (the callback, its `error`
-            // handler, the selection's `toString`, the scope's checkpoint), and
-            // restore it on every path back to BoringSSL — after the scope guard
-            // below has exited, since this guard is declared first. Connected
-            // usockets only: UpgradedDuplex/Pipe own mem BIOs whose BIO_get_data
-            // is a BUF_MEM*, not loop_ssl_data.
-            const LOOP_STATE_SLOTS: usize = 6; // US_SSL_LOOP_STATE_SLOTS
-            debug_assert_eq!(
-                LOOP_STATE_SLOTS as core::ffi::c_int,
-                tls_socket_functions::ffi::us_internal_ssl_loop_state_slots(),
-                "loop-state snapshot size drifted from US_SSL_LOOP_STATE_SLOTS in internal.h"
-            );
-            let mut saved_loop_state: [*mut c_void; LOOP_STATE_SLOTS] =
-                [core::ptr::null_mut(); LOOP_STATE_SLOTS];
-            if matches!(this.socket.get().socket, uws::InternalSocket::Connected(_)) {
-                tls_socket_functions::ffi::us_internal_ssl_loop_state_save(
-                    boringssl_sys::SSL::opaque_ref(ssl),
-                    saved_loop_state.as_mut_ptr(),
+struct TlsSocketAlpnSelect<const SSL: bool>;
+
+impl<const SSL: bool> boringssl_sys::AlpnSelectCallback for TlsSocketAlpnSelect<SSL> {
+    fn select<'o>(
+        ssl: &bun_boringssl_sys::SSL,
+        offered: &'o [u8],
+    ) -> Result<Option<&'o [u8]>, boringssl_sys::AlpnReject> {
+        use boringssl_sys::AlpnReject;
+        let Some(this) = ssl.ex_data(NewSocket::<SSL>::tls_socket_slot()) else {
+            return Ok(None);
+        };
+        // Same handlers-presence guard as every other dispatch entry point:
+        // an idle socket has dropped its Handlers, and the ALPN selection
+        // callback can still fire for a connection JS already detached -
+        // get_handlers() would panic. NOACK falls through to the static list.
+        if !this.has_handlers() {
+            return Ok(None);
+        }
+        // Dynamic per-connection ALPN: when the listener's config carries an
+        // `alpnCallback` handler, consult it with the client's protocol list (and
+        // the SNI name) before the static ALPNProtocols list. The JS handler
+        // returns `false` when the server has no ALPNCallback (fall through to
+        // the static list), the selected protocol string, or anything else to
+        // refuse the connection with a fatal no_application_protocol alert - the
+        // same contract as Node's ALPNCallback.
+        {
+            let handlers = this.get_handlers();
+            let callback = handlers.on_alpn_callback();
+            if !callback.is_empty() {
+                // Snapshot the per-loop BIO routing state around everything below that
+                // can run JS touching another TLS socket (the callback, its `error`
+                // handler, the selection's `toString`, the scope's checkpoint), and
+                // restore it on every path back to BoringSSL — after the scope guard
+                // below has exited, since this guard is declared first. Connected
+                // usockets only: UpgradedDuplex/Pipe own mem BIOs whose BIO_get_data
+                // is a BUF_MEM*, not loop_ssl_data.
+                const LOOP_STATE_SLOTS: usize = 6; // US_SSL_LOOP_STATE_SLOTS
+                debug_assert_eq!(
+                    LOOP_STATE_SLOTS as core::ffi::c_int,
+                    tls_socket_functions::ffi::us_internal_ssl_loop_state_slots(),
+                    "loop-state snapshot size drifted from US_SSL_LOOP_STATE_SLOTS in internal.h"
                 );
-            }
-            // (A no-op for the all-null snapshot of a non-Connected socket.)
-            let _restore_loop_state = scopeguard::guard(saved_loop_state, |mut saved| {
-                tls_socket_functions::ffi::us_internal_ssl_loop_state_restore(saved.as_mut_ptr());
-            });
-            // Exited (and, at loop entry, checkpointed) when this block ends or
-            // returns, before the loop state is restored.
-            let _scope = ScopeExit {
-                socket: this,
-                scope: Some(handlers.enter()),
-            };
-            let global = handlers.global_object;
-            let this_value = this.get_this_value(&global);
-            let wire_len = inlen as usize;
-            // BoringSSL's ALPN callback is these sockets' landing frame for this
-            // event: whatever it leaves pending is folded before returning to C.
-            let buffer = match JSValue::create_buffer_from_length(&global, wire_len) {
-                Ok(b) => b,
-                Err(err) => {
-                    crate::dispatch::fold(Err(err));
-                    return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
+                let mut saved_loop_state: [*mut c_void; LOOP_STATE_SLOTS] =
+                    [core::ptr::null_mut(); LOOP_STATE_SLOTS];
+                if matches!(this.socket.get().socket, uws::InternalSocket::Connected(_)) {
+                    tls_socket_functions::ffi::us_internal_ssl_loop_state_save(
+                        ssl,
+                        saved_loop_state.as_mut_ptr(),
+                    );
                 }
-            };
-            if let Some(ab) = buffer.as_array_buffer(&global) {
-                // SAFETY: `ab.ptr` points at a fresh `wire_len`-byte JS buffer
-                // and `in_` is valid for `inlen` per the callback contract.
-                unsafe { core::ptr::copy_nonoverlapping(in_, ab.ptr, wire_len) };
-            }
-            // SAFETY: `ssl` is the live SSL handle passed into this ALPN
-            // callback; SSL_get_servername reads the negotiated SNI name and
-            // returns NULL or a NUL-terminated string owned by the SSL.
-            let servername_ptr = unsafe { boringssl_sys::SSL_get_servername(ssl.cast_const(), 0) };
-            let servername_js = if servername_ptr.is_null() {
-                JSValue::UNDEFINED
-            } else {
-                // SAFETY: BoringSSL hands back a NUL-terminated name.
-                let name = unsafe { core::ffi::CStr::from_ptr(servername_ptr) };
-                EncodedSlice::latin1(name.to_bytes()).to_js(&global)
-            };
-            let result =
-                match callback.call(&global, this_value, &[this_value, servername_js, buffer]) {
+                // (A no-op for the all-null snapshot of a non-Connected socket.)
+                let _restore_loop_state = scopeguard::guard(saved_loop_state, |mut saved| {
+                    tls_socket_functions::ffi::us_internal_ssl_loop_state_restore(
+                        saved.as_mut_ptr(),
+                    );
+                });
+                // Exited (and, at loop entry, checkpointed) when this block ends or
+                // returns, before the loop state is restored.
+                let _scope = ScopeExit {
+                    socket: this.get(),
+                    scope: Some(handlers.enter()),
+                };
+                let global = handlers.global_object;
+                let this_value = this.get_this_value(&global);
+                // BoringSSL's ALPN callback is these sockets' landing frame for this
+                // event: whatever it leaves pending is folded before returning to C.
+                let buffer = match jsc::ArrayBuffer::create_buffer(&global, offered) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        crate::dispatch::fold(Err(err));
+                        return Err(AlpnReject);
+                    }
+                };
+                let servername_js = match ssl.servername() {
+                    Some(name) => EncodedSlice::latin1(name).to_js(&global),
+                    None => JSValue::UNDEFINED,
+                };
+                let result = match callback.call(
+                    &global,
+                    this_value,
+                    &[this_value, servername_js, buffer],
+                ) {
                     Ok(v) => v,
                     Err(err) => global.take_exception(err),
                 };
-            if let Some(err_value) = result.to_error() {
-                crate::dispatch::fold(
-                    handlers.call_error_handler(this_value, &[this_value, err_value]),
-                );
-                return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
-            }
-            if !result.is_boolean() || result.to_boolean() {
-                // The server has an ALPNCallback and it answered: a string
-                // selects that protocol for this connection; anything else
-                // refuses it.
-                let chosen = match result.to_utf8(&global) {
-                    Ok(chosen) => chosen,
-                    Err(err) => {
-                        // The selection's ToString threw (a Symbol or a throwing
-                        // toString): hand it to `error` like the callback's own
-                        // throw, then refuse the protocol.
-                        let err_value = global.take_error(err);
-                        crate::dispatch::fold(
-                            handlers.call_error_handler(this_value, &[this_value, err_value]),
-                        );
-                        return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
-                    }
-                };
-                let chosen_bytes = chosen.slice();
-                if !result.is_string() || chosen_bytes.is_empty() || chosen_bytes.len() > 255 {
-                    return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
+                if let Some(err_value) = result.to_error() {
+                    crate::dispatch::fold(
+                        handlers.call_error_handler(this_value, &[this_value, err_value]),
+                    );
+                    return Err(AlpnReject);
                 }
-                let mut wire = Vec::with_capacity(chosen_bytes.len() + 1);
-                wire.push(chosen_bytes.len() as u8);
-                wire.extend_from_slice(chosen_bytes);
-                this.protos.set(Some(wire.into_boxed_slice()));
-                // Fall through to the standard selection below, which now
-                // negotiates against the single chosen protocol (and sends the
-                // fatal alert if the client did not actually offer it).
+                if !result.is_boolean() || result.to_boolean() {
+                    // The server has an ALPNCallback and it answered: a string
+                    // selects that protocol for this connection; anything else
+                    // refuses it.
+                    let chosen = match result.to_utf8(&global) {
+                        Ok(chosen) => chosen,
+                        Err(err) => {
+                            // The selection's ToString threw (a Symbol or a throwing
+                            // toString): hand it to `error` like the callback's own
+                            // throw, then refuse the protocol.
+                            let err_value = global.take_error(err);
+                            crate::dispatch::fold(
+                                handlers.call_error_handler(this_value, &[this_value, err_value]),
+                            );
+                            return Err(AlpnReject);
+                        }
+                    };
+                    let chosen_bytes = chosen.slice();
+                    if !result.is_string() || chosen_bytes.is_empty() || chosen_bytes.len() > 255 {
+                        return Err(AlpnReject);
+                    }
+                    let mut wire = Vec::with_capacity(chosen_bytes.len() + 1);
+                    wire.push(chosen_bytes.len() as u8);
+                    wire.extend_from_slice(chosen_bytes);
+                    this.protos.set(Some(wire.into_boxed_slice()));
+                    // Fall through to the standard selection below, which now
+                    // negotiates against the single chosen protocol (and sends the
+                    // fatal alert if the client did not actually offer it).
+                }
             }
         }
-    }
-    if let Some(protos) = this.protos.get() {
-        if protos.is_empty() {
-            return boringssl_sys::SSL_TLSEXT_ERR_NOACK;
-        }
-        // SAFETY: out/outlen/in are valid per BoringSSL ALPN callback contract.
-        let status = unsafe {
-            boringssl_sys::SSL_select_next_proto(
-                out.cast::<*mut u8>(),
-                outlen,
-                protos.as_ptr(),
-                c_uint::try_from(protos.len()).expect("int cast"),
-                in_,
-                inlen,
-            )
-        };
-        // Previous versions of Node.js returned SSL_TLSEXT_ERR_NOACK if no protocol
-        // match was found. This would neither cause a fatal alert nor would it result
-        // in a useful ALPN response as part of the Server Hello message.
-        // We now return SSL_TLSEXT_ERR_ALERT_FATAL in that case as per Section 3.2
-        // of RFC 7301, which causes a fatal no_application_protocol alert.
-        if status == boringssl_sys::OPENSSL_NPN_NEGOTIATED {
-            boringssl_sys::SSL_TLSEXT_ERR_OK
+        if let Some(protos) = this.protos.get() {
+            if protos.is_empty() {
+                return Ok(None);
+            }
+            // Previous versions of Node.js returned SSL_TLSEXT_ERR_NOACK if no protocol
+            // match was found. This would neither cause a fatal alert nor would it result
+            // in a useful ALPN response as part of the Server Hello message.
+            // We now return SSL_TLSEXT_ERR_ALERT_FATAL in that case as per Section 3.2
+            // of RFC 7301, which causes a fatal no_application_protocol alert.
+            match boringssl_sys::select_next_proto(protos, offered) {
+                Some(selected) => Ok(Some(selected)),
+                None => Err(AlpnReject),
+            }
         } else {
-            boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL
+            Ok(None)
         }
-    } else {
-        boringssl_sys::SSL_TLSEXT_ERR_NOACK
     }
 }
 
@@ -295,13 +269,21 @@ extern "C" fn select_alpn_callback(
 #[derive(bun_ptr::RefCounted)]
 pub struct NewSocket<const SSL: bool> {
     pub(crate) socket: Cell<uws::NewSocketHandler<SSL>>,
-    /// `SSL_CTX` this client connection was opened with. Server-accepted
-    /// sockets and plain TCP leave this `None` (the Listener / SecureContext
-    /// owns the ref there).
-    pub(crate) owned_ssl_ctx: JsCell<Option<boringssl_sys::OwnedSslCtx>>,
+    /// The `SSL_CTX` ref this client connection was opened with.
+    /// Server-accepted sockets and plain TCP leave this `None` (the Listener /
+    /// SecureContext owns the ref there).
+    pub(crate) owned_ssl_ctx: JsCell<Option<OwnedSslCtx>>,
 
     pub(crate) flags: Cell<Flags>,
     pub(crate) ref_count: bun_ptr::RefCount<Self>,
+    /// The ref held on behalf of whatever native owner currently points at
+    /// this socket — the uSockets ext slot (accept / connect, from
+    /// `connect_finish` until close or connect error), the `DuplexUpgradeContext`
+    /// or `upgradeTLS` twin that drives it. Released by the close /
+    /// connect-error / reconnect paths via [`release_io_ref`](Self::release_io_ref).
+    pub(crate) io_ref: Cell<Option<RefPtr<Self>>>,
+    /// Windows: the ref `WindowsNamedPipeContext` holds on the socket it wraps.
+    pub(crate) named_pipe_ref: Cell<Option<RefPtr<Self>>>,
     /// The callbacks this socket dispatches to: shared with its listener and
     /// sibling sockets (server), or with its own reconnects and TLS twin
     /// (client). `None` once the socket has gone idle or been detached, which
@@ -356,11 +338,24 @@ impl<const SSL: bool> Drop for NewSocket<SSL> {
 }
 
 /// Settles `IS_ACTIVE` against the `Handlers` the close callback entered with —
-/// it may have synchronously reconnected onto a fresh set — then consumes the
-/// +1 the caller transferred into `on_close`.
+/// it may have synchronously reconnected onto a fresh set — then releases the
+/// owner's `io_ref`.
 struct CloseTeardown<const SSL: bool> {
     socket: bun_ptr::ThisPtr<NewSocket<SSL>>,
     entered: Rc<Handlers>,
+    /// The closed native socket's `io_ref`, taken before the user's handler
+    /// runs so a synchronous reconnect can install its own.
+    io_ref: Option<RefPtr<NewSocket<SSL>>>,
+}
+
+impl<const SSL: bool> CloseTeardown<SSL> {
+    fn new(socket: bun_ptr::ThisPtr<NewSocket<SSL>>, entered: &Rc<Handlers>) -> Self {
+        CloseTeardown {
+            socket,
+            entered: Rc::clone(entered),
+            io_ref: socket.io_ref.take(),
+        }
+    }
 }
 
 impl<const SSL: bool> Drop for CloseTeardown<SSL> {
@@ -375,7 +370,7 @@ impl<const SSL: bool> Drop for CloseTeardown<SSL> {
             self.entered.mark_inactive();
         }
         // Last: this can be the final ref, freeing the socket read above.
-        this.get().deref();
+        drop(self.io_ref.take());
     }
 }
 
@@ -402,24 +397,26 @@ impl PendingSystemError {
     }
 }
 
-/// `needs_deref` releases the ref the now-detached native socket held. The idle
+/// `io_ref` is the ref the failed connection held. The idle
 /// teardown is gated on the socket still holding the `Handlers` we entered with:
 /// `onConnectError` can reconnect, and we must not tear that connection down.
 struct ConnectErrorTeardown<const SSL: bool> {
     socket: bun_ptr::ThisPtr<NewSocket<SSL>>,
     entered: Rc<Handlers>,
-    needs_deref: bool,
+    /// The failed connection's `io_ref` (the native socket's, or the one
+    /// `connect_finish` took for a connect that failed synchronously), taken
+    /// before the user's handler runs so a synchronous reconnect can install
+    /// its own.
+    io_ref: Option<RefPtr<NewSocket<SSL>>>,
 }
 
 impl<const SSL: bool> Drop for ConnectErrorTeardown<SSL> {
     fn drop(&mut self) {
         let this = self.socket;
-        // `deref` before `mark_inactive`, as the hand-rolled guard did. It
+        // Release before `mark_inactive`, as the hand-rolled guard did. It
         // cannot free the socket here: `handle_connect_error`'s `_guard`
         // is declared before this guard, so it outlives it.
-        if self.needs_deref {
-            this.get().deref();
-        }
+        drop(self.io_ref.take());
         if this.handlers_are(&self.entered) {
             this.mark_inactive();
         }
@@ -429,12 +426,12 @@ impl<const SSL: bool> Drop for ConnectErrorTeardown<SSL> {
 /// Balances a [`Handlers::enter`] on every exit path, including `?` returns.
 /// Bind it to a named local — `let _ = ...` drops at the end of the statement,
 /// running the exit before the user's callback.
-struct ScopeExit<const SSL: bool> {
-    socket: bun_ptr::ThisPtr<NewSocket<SSL>>,
+struct ScopeExit<'a, const SSL: bool> {
+    socket: &'a NewSocket<SSL>,
     scope: Option<super::handlers::Scope>,
 }
 
-impl<const SSL: bool> Drop for ScopeExit<SSL> {
+impl<const SSL: bool> Drop for ScopeExit<'_, SSL> {
     fn drop(&mut self) {
         if let Some(scope) = self.scope.take() {
             self.socket.exit_scope(scope);
@@ -443,13 +440,6 @@ impl<const SSL: bool> Drop for ScopeExit<SSL> {
 }
 
 impl<const SSL: bool> NewSocket<SSL> {
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
-    #[inline]
-    fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
-    }
-
     // ─── R-2 interior-mutability helpers ─────────────────────────────────────
 
     /// Read-modify-write the packed `Cell<Flags>` through `&self`.
@@ -460,30 +450,47 @@ impl<const SSL: bool> NewSocket<SSL> {
         self.flags.set(v);
     }
 
-    /// `self`'s address as `*mut Self` for uSockets ext slots / refcount FFI.
-    /// All mutated fields are `UnsafeCell`-backed, so the `*mut` spelling is
-    /// purely to match C signatures; callbacks deref it as `&*const` (shared).
-    #[inline]
-    pub(crate) fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
+    /// The per-`SSL` ex-data slot `on_open` points back at the owning socket
+    /// through (read by the ALPN select callback).
+    fn tls_socket_slot() -> &'static boringssl_sys::ExDataSlot<Self> {
+        static TCP: boringssl_sys::ExDataSlot<NewSocket<false>> = boringssl_sys::ExDataSlot::new();
+        static TLS: boringssl_sys::ExDataSlot<NewSocket<true>> = boringssl_sys::ExDataSlot::new();
+        let slot: &'static dyn core::any::Any = if SSL { &TLS } else { &TCP };
+        slot.downcast_ref()
+            .expect("SSL selects the matching static")
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-
-    // Intrusive refcount API.
-    pub fn ref_(&self) {
-        // SAFETY: `self` is live; `RefCount::ref_` only reads/writes the
-        // embedded `ref_count` Cell (interior-mutable), so `&self`→`*mut`
-        // is sound for that access.
-        unsafe { bun_ptr::RefCount::<Self>::ref_(self.as_ctx_ptr()) };
+    /// Take the [`io_ref`](Self::io_ref) for the native owner now pointing at
+    /// this socket.
+    pub(crate) fn hold_io_ref(this: ThisPtr<Self>) {
+        Self::adopt_io_ref(RefPtr::from_this(this));
     }
-    // R-2: takes `&self` — every mutated field is `UnsafeCell`-backed, so the
-    // `*mut Self` formed for `RefCount::deref` (and `Drop`) writes only
-    // through interior-mutable storage.
-    pub fn deref(&self) {
-        // SAFETY: `self` is live; if count hits 0, `RefCounted::destructor`
-        // (→ `Drop`) runs and `self` is not used after.
-        unsafe { bun_ptr::RefCount::<Self>::deref(self.as_ctx_ptr()) };
+
+    /// Move an owner's ref into [`io_ref`](Self::io_ref) ahead of a dispatch
+    /// that releases it (`on_close`, `handle_connect_error`).
+    pub(crate) fn adopt_io_ref(owner: RefPtr<Self>) -> ThisPtr<Self> {
+        let this = owner.this_ptr();
+        let prev = this.io_ref.replace(Some(owner));
+        debug_assert!(prev.is_none(), "NewSocket io_ref already held");
+        this
+    }
+
+    /// Release the [`io_ref`](Self::io_ref), if held. May free `self`;
+    /// nothing may touch it afterwards.
+    pub(crate) fn release_io_ref(&self) {
+        drop(self.io_ref.take());
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn hold_named_pipe_ref(this: ThisPtr<Self>) {
+        let prev = this.named_pipe_ref.replace(Some(RefPtr::from_this(this)));
+        debug_assert!(prev.is_none(), "NewSocket named_pipe_ref already held");
+    }
+
+    /// See [`release_io_ref`](Self::release_io_ref).
+    #[cfg(windows)]
+    pub(crate) fn release_named_pipe_ref(&self) {
+        drop(self.named_pipe_ref.take());
     }
 
     // ── codegen accessors ──
@@ -539,11 +546,11 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
     }
 
-    /// Heap-allocates the socket; ownership passes to the intrusive refcount.
-    /// The returned handle is live by construction.
-    pub(crate) fn new(init: Self) -> bun_ptr::ThisPtr<Self> {
-        // SAFETY: freshly allocated, non-null.
-        unsafe { bun_ptr::ThisPtr::new(bun_core::heap::into_raw(Box::new(init))) }
+    /// Heap-allocates the socket. The returned ref is the one the JS wrapper
+    /// adopts (`get_this_value` → `to_js`; released by `finalize`): hand it
+    /// over with `into_this_ptr()` once the wrapper exists.
+    pub(crate) fn new(init: Self) -> RefPtr<Self> {
+        RefPtr::new(init)
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
@@ -579,10 +586,8 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// Connect to `self.connection` (must be `Some`). Reads the field directly
     /// rather than taking it by-ref so the single caller in `connect_finish`
     /// doesn't need a disjoint borrow.
-    pub(crate) fn do_connect(&self) -> crate::Result<()> {
+    pub(crate) fn do_connect(this: ThisPtr<Self>) -> crate::Result<()> {
         // Keep `self` alive across the re-entrant connect path.
-        // SAFETY: `self` is live for this call and outlives the sockets below.
-        let this = unsafe { bun_ptr::ThisPtr::new(self.as_ctx_ptr()) };
         let _guard = RefPtr::from_this(this);
 
         // `VirtualMachine::get()` yields the canonical `*mut` (write
@@ -596,22 +601,19 @@ impl<const SSL: bool> NewSocket<SSL> {
         } else {
             uws::SocketKind::BunSocketTcp
         };
-        let flags: i32 = if self.flags.get().contains(Flags::ALLOW_HALF_OPEN) {
+        let flags: i32 = if this.flags.get().contains(Flags::ALLOW_HALF_OPEN) {
             uws::LIBUS_SOCKET_ALLOW_HALF_OPEN
         } else {
             0
         };
         let ssl_ctx: Option<*mut uws::SslCtx> = if SSL {
-            self.owned_ssl_ctx
-                .get()
-                .as_ref()
-                .map(|p| p.as_ptr().cast::<uws::SslCtx>())
+            this.owned_ssl_ctx.get().as_ref().map(|c| c.as_ptr().cast())
         } else {
             None
         };
 
         use super::listener::UnixOrHost;
-        match self.connection.get() {
+        match this.connection.get() {
             Some(UnixOrHost::Host { host, port }) => {
                 // getaddrinfo doesn't accept bracketed IPv6.
                 let raw: &[u8] = host;
@@ -622,16 +624,16 @@ impl<const SSL: bool> NewSocket<SSL> {
                 };
                 let hostz = bun_core::ZBox::from_bytes(clean);
                 let port = *port;
-                // `host` borrow ends here; `self.connection` no longer borrowed.
+                // `host` borrow ends here; `this.connection` no longer borrowed.
                 // `ZBox` guarantees a trailing NUL; host bytes contain no interior NUL.
                 let host_c = hostz.as_zstr().as_cstr();
 
                 // Bind to the requested local address before connecting, if any.
-                let local = self.local_binding.get();
+                let local = this.local_binding.get();
                 let local_z = local
                     .as_ref()
                     .map(|(h, p)| (bun_core::ZBox::from_bytes(h), *p));
-                self.socket.set(
+                this.socket.set(
                     match group.connect(
                         kind,
                         ssl_ctx,
@@ -667,11 +669,11 @@ impl<const SSL: bool> NewSocket<SSL> {
                     return Err(crate::Error::FailedToOpenSocket);
                 }
                 *uws::us_socket_t::opaque_mut(s).ext() = Some(this);
-                self.socket.set(SocketHandler::<SSL>::from(s));
+                this.socket.set(SocketHandler::<SSL>::from(s));
             }
             Some(UnixOrHost::Fd(f)) => {
                 // The fd is connected, so it is registered paused outright; a dial is paused in on_open.
-                let flags = if self.flags.get().contains(Flags::PAUSE_ON_CONNECT) {
+                let flags = if this.flags.get().contains(Flags::PAUSE_ON_CONNECT) {
                     flags | uws::LIBUS_SOCKET_OPEN_PAUSED
                 } else {
                     flags
@@ -692,10 +694,10 @@ impl<const SSL: bool> NewSocket<SSL> {
                 }
                 *uws::us_socket_t::opaque_mut(s).ext() = Some(this);
                 let sock = SocketHandler::<SSL>::from(s);
-                self.socket.set(sock);
+                this.socket.set(sock);
                 Self::on_open(this, sock)?;
             }
-            None => unreachable!("do_connect requires self.connection to be set"),
+            None => unreachable!("do_connect requires this.connection to be set"),
         }
         Ok(())
     }
@@ -964,7 +966,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if fatal_send_errno != 0 {
             let global = handlers.global_object;
             let _scope = ScopeExit {
-                socket: this,
+                socket: &this,
                 scope: Some(handlers.enter()),
             };
             let this_value = this.get_this_value(&global);
@@ -995,7 +997,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -1040,7 +1042,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -1130,7 +1132,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         this.buffered_data_for_node_net
             .with_mut(|b| b.clear_and_free());
 
-        let needs_deref = !this.socket.get().is_detached();
+        let io_ref = this.io_ref.take();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
 
         let vm = handlers.vm;
@@ -1148,7 +1150,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let cleanup = ConnectErrorTeardown {
             socket: this,
             entered: Rc::clone(&handlers),
-            needs_deref,
+            io_ref,
         };
 
         if vm.script_execution_status() != jsc::ScriptExecutionStatus::Running {
@@ -1233,7 +1235,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         };
 
         let _scope_guard = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -1290,7 +1292,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         // `_scope_guard` (declared after `cleanup`) drops first → scope.exit();
-        // then `cleanup` → needs_deref/mark_inactive/deref.
+        // then `cleanup` → io_ref release/mark_inactive/deref.
         Ok(())
     }
 
@@ -1344,28 +1346,26 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// handles Connected/Connecting; Pipe/UpgradedDuplex back-pointers do
     /// not live in the ext slot so those are left for the caller's existing
     /// `debug_assert!` to catch.
-    pub(crate) fn detach_for_reconnect(&self) {
-        let old = self.socket.get();
-        let Some(ext) = old.ext::<*mut c_void>() else {
+    pub(crate) fn detach_for_reconnect(this: ThisPtr<Self>) {
+        let old = this.socket.get();
+        if !old.set_ext_owner::<Self>(None) {
             return;
-        };
-        // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
-        unsafe { *ext = core::ptr::null_mut() };
-        self.socket.set(SocketHandler::<SSL>::DETACHED);
-        self.buffered_data_for_node_net
+        }
+        this.socket.set(SocketHandler::<SSL>::DETACHED);
+        this.buffered_data_for_node_net
             .with_mut(|b| b.clear_and_free());
-        self.detach_native_callback();
+        this.detach_native_callback();
         old.close(uws::CloseCode::Failure);
-        self.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
-        if self.flags.get().contains(Flags::IS_ACTIVE) {
-            self.update_flags(|f| f.remove(Flags::IS_ACTIVE));
-            if let Some(h) = self.handlers_opt() {
+        this.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
+        if this.flags.get().contains(Flags::IS_ACTIVE) {
+            this.update_flags(|f| f.remove(Flags::IS_ACTIVE));
+            if let Some(h) = this.handlers_opt() {
                 if h.mark_inactive() {
-                    self.handlers.set(None);
+                    this.handlers.set(None);
                 }
             }
         }
-        self.deref();
+        this.release_io_ref();
     }
 
     pub(crate) fn mark_inactive(&self) {
@@ -1423,7 +1423,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         this: bun_ptr::ThisPtr<Self>,
         socket: SocketHandler<SSL>,
     ) -> JsResult<()> {
-        let this_ptr = this.as_ptr();
         // A late event on a socket that already released its Handlers through
         // a path that did not route back through this dispatch - e.g. a
         // JS-side destroy on a TLS socket driven by an upgraded duplex. There
@@ -1434,7 +1433,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         log!(
             "onOpen {} {:p} {} {}",
             if this.is_server() { "S" } else { "C" },
-            this_ptr,
+            this.as_ptr(),
             this.socket.get().is_detached(),
             this.ref_count.get()
         );
@@ -1456,32 +1455,20 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // Add SNI support for TLS (mongodb and others requires this)
         if SSL {
-            if let Some(ssl_ptr) = this.socket.get().ssl() {
-                if tls_socket_functions::ffi::SSL_is_init_finished(boringssl_sys::SSL::opaque_ref(
-                    ssl_ptr,
-                )) == 0
-                {
+            if let Some(ssl) = this.socket.get().ssl_mut() {
+                if tls_socket_functions::ffi::SSL_is_init_finished(ssl) == 0 {
                     if let Some(server_name) = this.server_name.get() {
                         let host: &[u8] = server_name.as_ref();
                         if !host.is_empty() {
                             let host_z = bun_core::ZBox::from_bytes(host);
-                            // SAFETY: `host_z` is NUL-terminated; FFI reads until NUL.
-                            unsafe {
-                                boringssl_sys::SSL_set_tlsext_host_name(ssl_ptr, host_z.as_ptr())
-                            };
+                            ssl.set_tlsext_host_name(host_z.as_zstr().as_cstr());
                         }
                     } else if let Some(connection) = this.connection.get() {
                         if let super::listener::UnixOrHost::Host { host, .. } = connection {
                             let host: &[u8] = host.as_ref();
                             if !host.is_empty() {
                                 let host_z = bun_core::ZBox::from_bytes(host);
-                                // SAFETY: `host_z` is NUL-terminated; FFI reads until NUL.
-                                unsafe {
-                                    boringssl_sys::SSL_set_tlsext_host_name(
-                                        ssl_ptr,
-                                        host_z.as_ptr(),
-                                    )
-                                };
+                                ssl.set_tlsext_host_name(host_z.as_zstr().as_cstr());
                             }
                         }
                     }
@@ -1490,26 +1477,14 @@ impl<const SSL: bool> NewSocket<SSL> {
                     // selector consults the callback first and falls back to
                     // the static list). The callback reads `this` from the SSL,
                     // not the CTX-level arg (shared across the listener).
-                    // ffi-safe-fn: opaque-ZST `&SSL`/`&SSL_CTX` redecls;
-                    // `ssl_ptr` non-null in this branch and `SSL_get_SSL_CTX`
-                    // never returns null for a live SSL.
+                    // `SSL_get_SSL_CTX` never returns null for a live SSL.
                     if this.acts_as_tls_server()
                         && (this.protos.get().is_some()
                             || !this.get_handlers().on_alpn_callback().is_empty())
                     {
-                        let ssl_ref = boringssl_sys::SSL::opaque_ref(ssl_ptr);
-                        tls_socket_functions::ffi::SSL_set_ex_data(
-                            ssl_ref,
-                            0,
-                            this_ptr.cast::<c_void>(),
-                        );
-                        tls_socket_functions::ffi::SSL_CTX_set_alpn_select_cb(
-                            SSL_CTX::opaque_ref(tls_socket_functions::ffi::SSL_get_SSL_CTX(
-                                ssl_ref,
-                            )),
-                            Some(select_alpn_callback),
-                            ptr::null_mut(),
-                        );
+                        ssl.set_ex_data(Self::tls_socket_slot(), Some(BackRef::new(this.get())));
+                        SSL_CTX::opaque_ref(tls_socket_functions::ffi::SSL_get_SSL_CTX(ssl))
+                            .set_alpn_select_callback::<TlsSocketAlpnSelect<SSL>>();
                     }
                     // A rejecting client must refuse a bad chain DURING the
                     // handshake, like node observably does (its post-verify
@@ -1517,37 +1492,21 @@ impl<const SSL: bool> NewSocket<SSL> {
                     if !this.acts_as_tls_server()
                         && this.flags.get().contains(Flags::REJECT_UNAUTHORIZED)
                     {
-                        tls_socket_functions::ffi::us_internal_ssl_set_inline_reject(
-                            boringssl_sys::SSL::opaque_ref(ssl_ptr),
-                        );
+                        tls_socket_functions::ffi::us_internal_ssl_set_inline_reject(ssl);
                     }
                     if let Some(protos) = this.protos.get() {
                         if this.acts_as_tls_server() {
                             // Registered above (selector + ex_data); nothing
                             // further to do for the static server list here.
                         } else {
-                            // SAFETY: `ssl_ptr` non-null in this branch;
-                            // `protos.as_ptr()` is readable for `protos.len()`
-                            // bytes (borrowed `&[u8]` from `this.protos`) and
-                            // BoringSSL copies the buffer internally — raw
-                            // ptr+len pair is the genuine FFI precondition here.
-                            unsafe {
-                                boringssl_sys::SSL_set_alpn_protos(
-                                    ssl_ptr,
-                                    protos.as_ptr(),
-                                    protos.len(),
-                                );
-                            }
+                            ssl.set_alpn_protos(protos);
                         }
                     }
                 }
             }
         }
 
-        if let Some(ctx) = socket.ext::<*mut c_void>() {
-            // SAFETY: ext slot is sized for `*mut anyopaque`.
-            unsafe { *ctx = this_ptr.cast::<c_void>() };
-        }
+        socket.set_ext_owner(Some(this.into()));
 
         let handlers = this.get_handlers();
         let global = handlers.global_object;
@@ -1584,7 +1543,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
         let result = match callback.call(&global, this_value, &[this_value]) {
@@ -1716,7 +1675,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -1878,7 +1837,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -1967,7 +1926,7 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// `session_buffer` fault rule simulates the allocation throwing: that
     /// failure needs JSC heap exhaustion, so it is unreachable from a test
     /// without injection.
-    fn create_dispatch_buffer(global: &JSGlobalObject, len: usize) -> JsResult<JSValue> {
+    fn create_dispatch_buffer(global: &JSGlobalObject, payload: &[u8]) -> JsResult<JSValue> {
         #[cfg(socket_fault_injection)]
         {
             let mut out: isize = 0;
@@ -1975,20 +1934,17 @@ impl<const SSL: bool> NewSocket<SSL> {
             // Deliberately skips `US_FAULT_CHECK`'s `us_fault_armed` fast-path
             // load: session/keylog dispatch is a few calls per connection, not
             // a per-packet hot path, so the unarmed-case lock is fine.
-            // SAFETY: `out`/`clamp` are valid for the duration of the call.
-            if unsafe {
-                bun_uws_sys::fault_inject::us_fault_hit(
-                    bun_uws_sys::fault_inject::SESSION_BUFFER,
-                    -1,
-                    &mut out,
-                    &mut clamp,
-                )
-            } != 0
+            if bun_uws_sys::fault_inject::us_fault_hit(
+                bun_uws_sys::fault_inject::SESSION_BUFFER,
+                -1,
+                &mut out,
+                &mut clamp,
+            ) != 0
             {
                 return Err(global.throw_out_of_memory());
             }
         }
-        JSValue::create_buffer_from_length(global, len)
+        jsc::ArrayBuffer::create_buffer(global, payload)
     }
 
     /// A new resumable TLS session arrived (the peer's NewSessionTicket was
@@ -2017,19 +1973,12 @@ impl<const SSL: bool> NewSocket<SSL> {
             return Ok(());
         }
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
         let global = handlers.global_object;
         let this_value = this.get_this_value(&global);
-        let buffer = Self::create_dispatch_buffer(&global, session.len())?;
-        if let Some(ab) = buffer.as_array_buffer(&global) {
-            // SAFETY: `ab.ptr` points to a freshly-created `session.len()`-byte
-            // JS buffer kept alive on the stack; `session` is valid for its length.
-            unsafe {
-                core::ptr::copy_nonoverlapping(session.as_ptr(), ab.ptr, session.len());
-            }
-        }
+        let buffer = Self::create_dispatch_buffer(&global, session)?;
         let result = match callback.call(&global, this_value, &[this_value, buffer]) {
             Ok(v) => v,
             Err(err) => global.take_exception(err),
@@ -2060,19 +2009,12 @@ impl<const SSL: bool> NewSocket<SSL> {
             return Ok(());
         }
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
         let global = handlers.global_object;
         let this_value = this.get_this_value(&global);
-        let buffer = Self::create_dispatch_buffer(&global, line.len())?;
-        if let Some(ab) = buffer.as_array_buffer(&global) {
-            // SAFETY: `ab.ptr` points to a freshly-created `line.len()`-byte
-            // JS buffer kept alive on the stack; `line` is valid for its length.
-            unsafe {
-                core::ptr::copy_nonoverlapping(line.as_ptr(), ab.ptr, line.len());
-            }
-        }
+        let buffer = Self::create_dispatch_buffer(&global, line)?;
         let result = match callback.call(&global, this_value, &[this_value, buffer]) {
             Ok(v) => v,
             Err(err) => global.take_exception(err),
@@ -2101,7 +2043,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if !this.has_handlers() {
             this.detach_native_callback();
             this.socket.set(SocketHandler::<SSL>::DETACHED);
-            this.get().deref();
+            this.release_io_ref();
             return Ok(());
         }
         let handlers = this.get_handlers();
@@ -2119,18 +2061,17 @@ impl<const SSL: bool> NewSocket<SSL> {
         // gets its own dispatch — fire its (pre-upgrade) close handler
         // here, then retire it. `raw.twin == None` so this doesn't
         // recurse, and `onClose` derefs the +1 we took at creation.
+        // Before the twin's handlers run: they are user code and may reconnect
+        // this socket, which installs a fresh `io_ref`.
+        let cleanup = CloseTeardown::new(this, &handlers);
         if let Some(raw) = this.twin.with_mut(|t| t.take()) {
-            // `on_close` consumes the twin's +1 via its `CloseTeardown`, so
-            // hand over the raw pointer rather than letting `RefPtr::drop`
-            // release it a second time. This frame is the twin's trampoline for
-            // the event, so what its handlers left pending is folded here and
-            // this socket's own close proceeds regardless.
-            crate::dispatch::fold(Self::on_close(raw.into_this_ptr(), socket, err, reason));
+            // `on_close` releases the twin's ref via its `CloseTeardown`, so
+            // hand it over as the twin's `io_ref`. This frame is the twin's
+            // trampoline for the event, so what its handlers left pending is
+            // folded here and this socket's own close proceeds regardless.
+            let raw = Self::adopt_io_ref(raw);
+            crate::dispatch::fold(Self::on_close(raw, socket, err, reason));
         }
-        let cleanup = CloseTeardown {
-            socket: this,
-            entered: Rc::clone(&handlers),
-        };
 
         if this.flags.get().contains(Flags::FINALIZING) {
             drop(cleanup);
@@ -2158,7 +2099,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -2234,7 +2175,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // the handlers must be kept alive for the duration of the function call
         // that way if we need to call the error handler, we can
         let _scope = ScopeExit {
-            socket: this,
+            socket: &this,
             scope: Some(handlers.enter()),
         };
 
@@ -2607,7 +2548,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn end_buffered(
-        this: &Self,
+        this: ThisPtr<Self>,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -2619,7 +2560,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         let args = callframe.arguments_undef::<2>();
         // `write_or_end_buffered` reaches `internal_flush`, which re-enters JS.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         let result = match this.write_or_end_buffered::<true>(global, args.ptr[0], args.ptr[1]) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -2716,13 +2657,10 @@ impl<const SSL: bool> NewSocket<SSL> {
                 // fast-ish path: use writev() to avoid cloning to another buffer.
                 if let uws::InternalSocket::Connected(connected) = socket.socket {
                     if !buffer.slice().is_empty() {
-                        // SAFETY: `connected` is a live `*mut us_socket_t` (guard above).
-                        let rc = unsafe {
-                            (*connected).write2(
-                                self.buffered_data_for_node_net.get().slice(),
-                                buffer.slice(),
-                            )
-                        };
+                        let rc = uws::us_socket_t::opaque_mut(connected).write2(
+                            self.buffered_data_for_node_net.get().slice(),
+                            buffer.slice(),
+                        );
                         let written: usize = usize::try_from(rc.max(0)).expect("int cast");
                         let leftover = total_to_write.saturating_sub(written);
                         if leftover == 0 {
@@ -3119,7 +3057,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn terminate(
-        this: &Self,
+        this: ThisPtr<Self>,
         _global: &JSGlobalObject,
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -3127,8 +3065,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Capture the in-flight-connect state before close_and_detach() sets
         // DETACHED. Resetting a SEMI_SOCKET (Connected arm, handshake not yet
         // established) dispatches no terminal callback in us_socket_close, so
-        // on_close/mark_inactive never runs — balance connect_finish's ref_(),
-        // downgrade the Strong this_value, and release the event-loop ref here,
+        // on_close/mark_inactive never runs — release the `io_ref`
+        // connect_finish took, downgrade the Strong this_value, and release the
+        // event-loop ref here,
         // exactly as close() does. Without it those refs leak (LSan-caught).
         let socket = this.socket.get();
         let is_semi_connect = socket.socket.get().is_some() && !socket.is_established();
@@ -3142,7 +3081,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             if !matches!(this.this_value.get(), JsRef::Finalized) {
                 this.this_value.with_mut(|r| r.downgrade());
             }
-            this.deref();
+            this.release_io_ref();
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -3166,7 +3105,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
     #[bun_jsc::host_fn(method)]
     pub fn close(
-        this: &Self,
+        this: ThisPtr<Self>,
         global: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -3177,15 +3116,15 @@ impl<const SSL: bool> NewSocket<SSL> {
         // `on_close` without a prior `on_open` is wrong, and the natural
         // failure path delivers `on_connect_error` from the loop instead).
         // Closing one here therefore runs *no* terminal callback, stranding
-        // the +1 `connect_finish` took on `this` (whose matching `deref()`
-        // lives in `on_close`/`handle_connect_error`) and the Strong
-        // `this_value` upgrade. node:net reaches this for every aborted /
+        // the `io_ref` `connect_finish` took on `this` (otherwise released by
+        // `on_close`/`handle_connect_error`) and the Strong `this_value`
+        // upgrade. node:net reaches this for every aborted /
         // `autoSelectFamily`-timed-out attempt via `_handle.close()`.
         //
         // `socket.socket.get().is_some()` is `true` only for the
         // `Connected(us_socket_t)` arm — the `Connecting` arm fires
-        // `on_connecting_error` synchronously inside `close()` and so does
-        // its own `deref()`; double-releasing it would underflow.
+        // `on_connecting_error` synchronously inside `close()`, which releases
+        // `io_ref` itself.
         let is_semi_connect = socket.socket.get().is_some() && !socket.is_established();
         // `_handle.close()` is the net.Socket `_destroy()` path. Node closes the fd
         // with no close_notify (crypto_tls.cc sends the alert only from DoShutdown,
@@ -3207,17 +3146,17 @@ impl<const SSL: bool> NewSocket<SSL> {
             if !matches!(this.this_value.get(), JsRef::Finalized) {
                 this.this_value.with_mut(|r| r.downgrade());
             }
-            // Balance `connect_finish`'s `socket_ref.ref_()`. The JS wrapper
-            // we were called through holds the remaining +1, so refcount
-            // stays ≥ 1 across this call.
-            this.deref();
+            // Release `connect_finish`'s `io_ref`. The JS wrapper we were
+            // called through holds the remaining +1, so refcount stays >= 1
+            // across this call.
+            this.release_io_ref();
         }
         Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn end(
-        this: &Self,
+        this: ThisPtr<Self>,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -3231,7 +3170,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         // `write_or_end` reaches `internal_flush`, which re-enters JS.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         let result = match this.write_or_end::<true>(global, args.mut_(), false) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3351,7 +3290,7 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// `us_socket_raw_write`. No second context, no `Handlers.clone()`.
     #[bun_jsc::host_fn(method)]
     pub(crate) fn upgrade_tls(
-        this: &Self,
+        this: ThisPtr<Self>,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -3367,7 +3306,7 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// (`checkServerIdentity`), so its internal entry point sets it; the public
     /// `upgradeTLS` never does.
     fn upgrade_tls_impl(
-        this: &Self,
+        this: ThisPtr<Self>,
         global: &JSGlobalObject,
         opts: JSValue,
         defers_server_identity: bool,
@@ -3458,22 +3397,12 @@ impl<const SSL: bool> NewSocket<SSL> {
             // servername / ALPN still come from the surrounding tls config.
             if let Some(t) = opts.get_truthy(global, "tls")? {
                 if !t.is_boolean() {
-                    ssl_opts = SSLConfig::from_js(
-                        // SAFETY: per-thread VM singleton.
-                        VirtualMachine::get().as_mut(),
-                        global,
-                        t,
-                    )?;
+                    ssl_opts = SSLConfig::from_js(VirtualMachine::get().as_mut(), global, t)?;
                 }
             }
         } else if let Some(tls_js) = opts.get_truthy(global, "tls")? {
             if !tls_js.is_boolean() {
-                ssl_opts = SSLConfig::from_js(
-                    // SAFETY: per-thread VM singleton.
-                    VirtualMachine::get().as_mut(),
-                    global,
-                    tls_js,
-                )?;
+                ssl_opts = SSLConfig::from_js(VirtualMachine::get().as_mut(), global, tls_js)?;
             } else if tls_js.to_boolean() {
                 ssl_opts = Some(crate::socket::tls_true_defaults(handlers.vm));
             }
@@ -3487,14 +3416,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             // `bun_jsc::rare_data::RareData::ssl_ctx_cache()` returns
             // the high-tier opaque ZST stub (cycle-break); the concrete
             // `SSLContextCache` lives on this thread's `RuntimeState`.
-            let cache = {
-                let state = crate::jsc_hooks::runtime_state();
-                debug_assert!(!state.is_null(), "RuntimeState not installed");
-                // SAFETY: per-thread `RuntimeState` boxed by `init_runtime_state`;
-                // stable address for the VM's lifetime, JS-thread-only access.
-                unsafe { &mut (*state).ssl_ctx_cache }
-            };
-            owned_ctx = cache.get_or_create(cfg, &mut create_err);
+            owned_ctx = crate::jsc_hooks::with_ssl_ctx_cache(|cache| {
+                cache.get_or_create(cfg, &mut create_err)
+            });
             if owned_ctx.is_none() {
                 // us_ssl_ctx_from_options only sets *err for the CA/cipher
                 // cases; bad cert/key/DH return NULL with err==.none and the
@@ -3521,20 +3445,22 @@ impl<const SSL: bool> NewSocket<SSL> {
         let vm = handlers.vm;
 
         let cfg = ssl_opts.as_ref();
-        let ctx_ptr = owned_ctx.as_ref().map(|c| c.as_ptr());
-        let reject_unauthorized = upgrade_reject_policy(vm, cfg, is_server, ctx_ptr);
+        let ctx_ref = owned_ctx.as_ref().map(OwnedSslCtx::ctx);
+        let reject_unauthorized = upgrade_reject_policy(vm, cfg, is_server, ctx_ref);
         let (adopt_request_cert, adopt_reject_unauthorized) = match cfg {
             Some(c) => (c.request_cert != 0, c.reject_unauthorized != 0),
             None => (
-                server_ctx_requests_cert(ctx_ptr),
-                server_ctx_rejects_unauthorized(ctx_ptr),
+                server_ctx_requests_cert(ctx_ref),
+                server_ctx_rejects_unauthorized(ctx_ref),
             ),
         };
         let mut initial_flags = Flags::initial(reject_unauthorized);
         initial_flags.set(Flags::DEFERS_SERVER_IDENTITY, defers_server_identity);
         initial_flags.set(Flags::TLS_SERVER_ROLE, is_server);
-        let tls: bun_ptr::ThisPtr<TLSSocket> = TLSSocket::new(TLSSocket {
+        let tls_owned = TLSSocket::new(TLSSocket {
             ref_count: bun_ptr::RefCount::init(),
+            io_ref: Cell::new(None),
+            named_pipe_ref: Cell::new(None),
             handlers: JsCell::new(Some(handlers)),
             socket: Cell::new(SocketHandler::<true>::DETACHED),
             owned_ssl_ctx: JsCell::new(owned_ctx),
@@ -3554,6 +3480,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             twin: JsCell::new(None),
             verify_error: JsCell::new(None),
         });
+        let tls: ThisPtr<TLSSocket> = tls_owned.this_ptr();
         // Never shadow this with a long-lived borrow: it would alias the
         // reference dispatch materialises from the ext slot during
         // `on_open`/`start_tls_handshake`.
@@ -3564,29 +3491,33 @@ impl<const SSL: bool> NewSocket<SSL> {
             .as_mut()
             .rare_data()
             .bun_connect_group::<true>(loop_);
-        // SAFETY: `raw_socket` is the live `*mut us_socket_t` extracted from
-        // `InternalSocket::Connected` above; `owned_ssl_ctx` is the +1 ref
-        // taken from SecureContext/ssl_ctx_cache and never null here.
-        let new_raw: NonNull<uws::us_socket_t> = match unsafe {
-            (*raw_socket).adopt_tls(
+        // `owned_ssl_ctx` is the ref taken from SecureContext/ssl_ctx_cache above.
+        let ssl_ctx = uws::SslCtx::opaque_mut(
+            tls.owned_ssl_ctx
+                .get()
+                .as_ref()
+                .expect("upgradeTLS resolved an SSL_CTX")
+                .as_ptr(),
+        );
+        let new_raw: NonNull<uws::us_socket_t> = match uws::us_socket_t::opaque_mut(raw_socket)
+            .adopt_tls(
                 group,
                 uws::SocketKind::BunSocketTls,
-                &mut *(tls.owned_ssl_ctx.get().as_ref().unwrap().as_ptr()),
+                ssl_ctx,
                 sni,
                 !is_server,
                 adopt_request_cert,
                 adopt_reject_unauthorized,
                 core::mem::size_of::<*mut c_void>() as i32,
                 core::mem::size_of::<*mut c_void>() as i32,
-            )
-        } {
+            ) {
             Some(s) => s,
             None => {
                 let err = boringssl_sys::ERR_get_error();
                 let _clear_err = ClearErrorQueue(err != 0);
-                // `deref` runs `Drop`, which drops the owned_ctx
-                // ref and the handlers `Rc`. Sole owner of the fresh allocation.
-                tls.get().deref();
+                // Sole owner of the fresh allocation: this drops the owned_ctx
+                // ref and the handlers `Rc`.
+                drop(tls_owned);
                 if err != 0 {
                     return Err(global.throw_value(boringssl_err_to_js(global, err)));
                 }
@@ -3618,11 +3549,10 @@ impl<const SSL: bool> NewSocket<SSL> {
             // active_connections=1 it holds is transferring to `raw`.
             this.this_value.with_mut(|r| r.downgrade());
         }
-        // Release the retired TCP wrapper's ref on EVERY exit past this point,
-        // including the `?` early-returns below.
-        // SAFETY: `this` owns the outstanding ref this guard consumes; the JS
-        // wrapper's own +1 keeps the allocation alive across the whole call.
-        let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        // Release the retired TCP wrapper's ext-slot ref on EVERY exit past this
+        // point, including the `?` early-returns below; the JS wrapper's own +1
+        // keeps the allocation alive across the whole call.
+        let _io_ref = this.io_ref.take();
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
 
@@ -3630,13 +3560,17 @@ impl<const SSL: bool> NewSocket<SSL> {
         *uws::us_socket_t::opaque_mut(new_raw.as_ptr()).ext() = Some(tls);
         tls.socket
             .set(SocketHandler::<true>::from(new_raw.as_ptr()));
-        tls.ref_();
+        // The ext slot's ref; the JS wrapper adopts the creation ref below.
+        TLSSocket::hold_io_ref(tls);
+        let _ = tls_owned.into_this_ptr();
 
         // The `raw` half — same `us_socket_t*`, ORIGINAL pre-upgrade
         // *Handlers, writes bypass SSL. Dispatch reaches it via the
         // `ssl_raw_tap` ciphertext hook, never via the ext slot.
         let raw = TLSSocket::new(TLSSocket {
             ref_count: bun_ptr::RefCount::init(),
+            io_ref: Cell::new(None),
+            named_pipe_ref: Cell::new(None),
             handlers: JsCell::new(raw_handlers),
             socket: Cell::new(SocketHandler::<true>::from(new_raw.as_ptr())),
             owned_ssl_ctx: JsCell::new(None),
@@ -3658,11 +3592,10 @@ impl<const SSL: bool> NewSocket<SSL> {
             twin: JsCell::new(None),
             verify_error: JsCell::new(None),
         });
-        let raw_ref = raw;
-        raw_ref.ref_();
-        // SAFETY: `raw` came from `TLSSocket::new` (heap::alloc); intrusive +1 held.
-        tls.twin
-            .set(Some(unsafe { RefPtr::from_raw(raw.as_ptr()) }));
+        let raw_ref = raw.this_ptr();
+        // `tls` holds a ref on its twin; the JS wrapper adopts the creation ref below.
+        tls.twin.set(Some(RefPtr::from_this(raw_ref)));
+        let _ = raw.into_this_ptr();
         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
         bun_opaque::opaque_deref_mut(new_raw.as_ptr()).set_ssl_raw_tap(true);
 
@@ -3713,34 +3646,40 @@ impl<const SSL: bool> NewSocket<SSL> {
         array.put_index(global, 1, tls_js_value)?;
         Ok(array)
     }
+}
 
-    // ──────────────────────────────────────────────────────────────────────
-    // TLS-only accessor methods. Rust cannot const-select inherent methods on a const
-    // generic bool, so these are all forwarding methods that branch on `SSL`
-    // at runtime (monomorphised away).
-    //
-    // rustc does not unify `NewSocket<SSL>` with `NewSocket<true>`
-    // inside an `if SSL { .. }` block. The cast is sound because both
-    // monomorphisations have identical layout and the branch only runs when
-    // `SSL == true` (so `Self` *is* `TLSSocket`).
-    // ──────────────────────────────────────────────────────────────────────
-
+/// `Some(self)` for `TLSSocket`, `None` for `TCPSocket`: rustc does not unify
+/// `NewSocket<SSL>` with `NewSocket<true>` inside an `if SSL { .. }` block, so
+/// the TLS-only accessors below select through this instead.
+pub trait TlsView {
+    fn as_tls(&self) -> Option<&TLSSocket>;
+}
+impl TlsView for TLSSocket {
     #[inline(always)]
-    fn as_tls(this: &Self) -> &TLSSocket {
-        debug_assert!(SSL);
-        // SAFETY: only called from the `if SSL` branch; `NewSocket<SSL>` and
-        // `NewSocket<true>` are the same monomorphisation when `SSL == true`.
-        unsafe { &*std::ptr::from_ref::<Self>(this).cast::<TLSSocket>() }
+    fn as_tls(&self) -> Option<&TLSSocket> {
+        Some(self)
     }
+}
+impl TlsView for TCPSocket {
+    #[inline(always)]
+    fn as_tls(&self) -> Option<&TLSSocket> {
+        None
+    }
+}
 
+// TLS-only accessor methods, forwarding to `tls_socket_functions`.
+impl<const SSL: bool> NewSocket<SSL>
+where
+    Self: TlsView,
+{
     #[bun_jsc::host_fn(method)]
     pub(crate) fn disable_renegotiation(
         this: &Self,
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::disable_renegotiation(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::disable_renegotiation(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3751,8 +3690,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::is_session_reused(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::is_session_reused(this, g, f)
         } else {
             Ok(JSValue::FALSE)
         }
@@ -3763,16 +3702,16 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::set_verify_mode(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::set_verify_mode(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
     pub(crate) fn renegotiate(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::renegotiate(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::renegotiate(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3783,32 +3722,32 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_tls_ticket(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_tls_ticket(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
     pub(crate) fn set_session(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::set_session(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::set_session(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
     pub(crate) fn get_session(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_session(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_session(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_alpn_protocol(this: &Self, g: &JSGlobalObject) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_alpn_protocol(Self::as_tls(this), g)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_alpn_protocol(this, g)
         } else {
             Ok(JSValue::FALSE)
         }
@@ -3819,8 +3758,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::set_key_cert(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::set_key_cert(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3831,8 +3770,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::export_keying_material(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::export_keying_material(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3843,16 +3782,16 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_ephemeral_key_info(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_ephemeral_key_info(this, g, f)
         } else {
             Ok(JSValue::NULL)
         }
     }
     #[bun_jsc::host_fn(method)]
     pub(crate) fn get_cipher(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_cipher(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_cipher(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3863,8 +3802,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_tls_peer_finished_message(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_tls_peer_finished_message(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3875,8 +3814,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_tls_finished_message(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_tls_finished_message(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3887,8 +3826,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_shared_sigalgs(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_shared_sigalgs(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3899,8 +3838,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_tls_version(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_tls_version(this, g, f)
         } else {
             Ok(JSValue::NULL)
         }
@@ -3911,8 +3850,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::set_max_send_fragment(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::set_max_send_fragment(this, g, f)
         } else {
             Ok(JSValue::FALSE)
         }
@@ -3923,8 +3862,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_peer_certificate(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_peer_certificate(this, g, f)
         } else {
             Ok(JSValue::NULL)
         }
@@ -3935,8 +3874,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_certificate(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_certificate(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3947,8 +3886,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_peer_x509_certificate(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_peer_x509_certificate(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3959,8 +3898,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_x509_certificate(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_x509_certificate(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3971,8 +3910,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::get_servername(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::get_servername(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3983,8 +3922,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         g: &JSGlobalObject,
         f: &CallFrame,
     ) -> JsResult<JSValue> {
-        if SSL {
-            tls_socket_functions::set_servername(Self::as_tls(this), g, f)
+        if let Some(this) = this.as_tls() {
+            tls_socket_functions::set_servername(this, g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -4014,9 +3953,10 @@ macro_rules! impl_socket_js_class {
                 $gen::from_js_direct(value).map(|p| p.as_ptr())
             }
             fn to_js(self, global: &JSGlobalObject) -> JSValue {
-                // Ownership of the boxed `NewSocket` transfers to the C++
-                // wrapper (freed via `${typeName}Class__finalize`).
-                $gen::to_js(bun_core::heap::into_raw(Box::new(self)), global)
+                // The C++ wrapper adopts the creation reference (released via
+                // `${typeName}Class__finalize`).
+                let this = <$ty>::new(self).into_this_ptr();
+                <$ty>::to_js(&*this, global)
             }
             // `noConstructor: true` — no `${name}__getConstructor` export; trait default applies.
         }
@@ -4041,20 +3981,20 @@ impl NativeCallbacks {
     /// `Ok(false)`: nothing attached, dispatch to the JS handlers.
     pub(crate) fn on_data(&self, data: &[u8]) -> JsResult<bool> {
         let h2 = match self {
-            NativeCallbacks::H2(h2) => h2.as_ptr(),
+            NativeCallbacks::H2(h2) => h2.this_ptr(),
             NativeCallbacks::None => return Ok(false),
         };
-        // SAFETY: `on_native_read` takes a keepalive; `h2` stays live across re-entry.
-        unsafe { (*h2).on_native_read(data) }?;
+        // `on_native_read` takes a keepalive; `h2` stays live across re-entry.
+        h2.on_native_read(data)?;
         Ok(true)
     }
     pub(crate) fn on_writable(&self) -> bool {
         let h2 = match self {
-            NativeCallbacks::H2(h2) => h2.as_ptr(),
+            NativeCallbacks::H2(h2) => h2.this_ptr(),
             NativeCallbacks::None => return false,
         };
-        // SAFETY: `on_native_writable` takes a keepalive; `h2` stays live across re-entry.
-        unsafe { (*h2).on_native_writable() };
+        // `on_native_writable` takes a keepalive; `h2` stays live across re-entry.
+        h2.on_native_writable();
         true
     }
 }
@@ -4125,7 +4065,7 @@ fn upgrade_reject_policy(
     vm: &VirtualMachine,
     cfg: Option<&SSLConfig>,
     is_server: bool,
-    ctx: Option<*mut SSL_CTX>,
+    ctx: Option<&SSL_CTX>,
 ) -> bool {
     if cfg.is_none() && is_server {
         server_ctx_rejects_unauthorized(ctx)
@@ -4137,18 +4077,16 @@ fn upgrade_reject_policy(
 /// A bare server-side `secureContext` carries no parsed config, so the policy
 /// comes from the ctx itself: `us_ssl_ctx_from_options` sets
 /// `FAIL_IF_NO_PEER_CERT` iff the context was created with `rejectUnauthorized`.
-fn server_ctx_rejects_unauthorized(ctx: Option<*mut SSL_CTX>) -> bool {
+fn server_ctx_rejects_unauthorized(ctx: Option<&SSL_CTX>) -> bool {
     let Some(ctx) = ctx else { return false };
     const MODE: c_int =
         boringssl_sys::SSL_VERIFY_PEER | boringssl_sys::SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-    // SAFETY: `ctx` is the +1 `SSL_CTX` ref held for this socket; read-only.
-    unsafe { boringssl_sys::SSL_CTX_get_verify_mode(ctx) & MODE == MODE }
+    ctx.verify_mode() & MODE == MODE
 }
 
-fn server_ctx_requests_cert(ctx: Option<*mut SSL_CTX>) -> bool {
+fn server_ctx_requests_cert(ctx: Option<&SSL_CTX>) -> bool {
     let Some(ctx) = ctx else { return false };
-    // SAFETY: `ctx` is the +1 `SSL_CTX` ref held for this socket; read-only.
-    unsafe { boringssl_sys::SSL_CTX_get_verify_mode(ctx) & boringssl_sys::SSL_VERIFY_PEER != 0 }
+    ctx.verify_mode() & boringssl_sys::SSL_VERIFY_PEER != 0
 }
 
 impl Default for Flags {
@@ -4186,30 +4124,11 @@ impl SocketMode {
 // DuplexUpgradeContext
 // ──────────────────────────────────────────────────────────────────────────
 
-impl bun_event_loop::Taskable for DuplexUpgradeContext {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::DuplexUpgradeContext;
-    /// The context's one queued hop will not run, and nothing else frees the
-    /// context. If the TLSSocket is still attached (a `StartTLS` that never
-    /// ran: no wrapper was created, so no close ever detached it), route it
-    /// through its close first — that consumes our +1 and detaches it from the
-    /// duplex, so its finalizer during ~VM finds nothing to reach into — then
-    /// free the context.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract; the single queue entry for `this`.
-        let ctx = unsafe { bun_ptr::ThisPtr::new(this) };
-        ctx.queued.set(false);
-        if let Some(tls) = ctx.tls.replace(None) {
-            let socket = ctx.duplex_socket();
-            // `Err` is left pending for the release dispatcher's fold.
-            let _ = TLSSocket::on_close(tls.into_this_ptr(), socket, 0, None);
-        }
-        // SAFETY: fn contract; nothing else frees the context and no borrow of it is live.
-        unsafe { Self::deinit(this) };
-    }
-}
-
 pub(crate) struct DuplexUpgradeContext {
     pub upgrade: UpgradedDuplex,
+    /// The context owns itself from `js_upgrade_duplex_to_tls` until
+    /// [`deinit`](Self::deinit) drops this.
+    self_own: Cell<Option<OwnedThis<Self>>>,
     // We only us a tls and not a raw socket when upgrading a Duplex, Duplex dont support socketpairs
     pub tls: JsCell<Option<RefPtr<TLSSocket>>>,
     // task used to deinit the context in the next tick, vm is used to enqueue the task
@@ -4226,10 +4145,10 @@ pub(crate) struct DuplexUpgradeContext {
     /// Config to build a fresh `SSL_CTX` from (legacy `{ca,cert,key}` callers).
     /// Mutually exclusive with `owned_ctx` — `runEvent` prefers `owned_ctx`.
     pub ssl_config: JsCell<Option<SSLConfig>>,
-    /// Prebuilt `SSL_CTX` (from `opts.tls.secureContext` — the memoised
-    /// `tls.createSecureContext` path). Moved into `start_tls_with_ctx`;
-    /// dropped in `deinit` if Close races ahead of StartTLS.
-    pub owned_ctx: JsCell<Option<boringssl_sys::OwnedSslCtx>>,
+    /// One ref on a prebuilt `SSL_CTX` (from `opts.tls.secureContext` — the
+    /// memoised `tls.createSecureContext` path). Adopted by `start_tls_with_ctx`
+    /// on success, dropped with the context if Close races ahead of StartTLS.
+    pub owned_ctx: JsCell<Option<OwnedSslCtx>>,
     pub is_open: Cell<bool>,
     /// Server-side `requestCert`/`rejectUnauthorized`, applied to the `SSL*`
     /// when `StartTLS` builds it. Unused for client upgrades.
@@ -4260,7 +4179,7 @@ impl DuplexUpgradeContext {
         self.tls.get().as_ref().map(|t| t.this_ptr())
     }
 
-    fn on_open(this: bun_ptr::ThisPtr<Self>) {
+    pub(super) fn on_open(this: bun_ptr::ThisPtr<Self>) {
         this.is_open.set(true);
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls_this_ptr() {
@@ -4268,26 +4187,26 @@ impl DuplexUpgradeContext {
         }
     }
 
-    fn on_data(this: bun_ptr::ThisPtr<Self>, decoded_data: &[u8]) {
+    pub(super) fn on_data(this: bun_ptr::ThisPtr<Self>, decoded_data: &[u8]) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls_this_ptr() {
             crate::dispatch::fold(TLSSocket::on_data(tls, socket, decoded_data));
         }
     }
 
-    fn on_session(this: bun_ptr::ThisPtr<Self>, session: &[u8]) {
+    pub(super) fn on_session(this: bun_ptr::ThisPtr<Self>, session: &[u8]) {
         if let Some(tls) = this.tls_this_ptr() {
             crate::dispatch::fold(TLSSocket::on_session(tls, session));
         }
     }
 
-    fn on_keylog(this: bun_ptr::ThisPtr<Self>, line: &[u8]) {
+    pub(super) fn on_keylog(this: bun_ptr::ThisPtr<Self>, line: &[u8]) {
         if let Some(tls) = this.tls_this_ptr() {
             crate::dispatch::fold(TLSSocket::on_keylog(tls, line));
         }
     }
 
-    fn on_handshake(
+    pub(super) fn on_handshake(
         this: bun_ptr::ThisPtr<Self>,
         success: bool,
         ssl_error: uws::us_bun_verify_error_t,
@@ -4303,21 +4222,21 @@ impl DuplexUpgradeContext {
         }
     }
 
-    fn on_end(this: bun_ptr::ThisPtr<Self>) {
+    pub(super) fn on_end(this: bun_ptr::ThisPtr<Self>) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls_this_ptr() {
             crate::dispatch::fold(TLSSocket::on_end(tls, socket));
         }
     }
 
-    fn on_writable(this: bun_ptr::ThisPtr<Self>) {
+    pub(super) fn on_writable(this: bun_ptr::ThisPtr<Self>) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls_this_ptr() {
             crate::dispatch::fold(TLSSocket::on_writable(tls, socket));
         }
     }
 
-    fn on_error(this: bun_ptr::ThisPtr<Self>, err_value: JSValue) {
+    pub(super) fn on_error(this: bun_ptr::ThisPtr<Self>, err_value: JSValue) {
         if this.is_open.get() {
             if let Some(tls) = this.tls_this_ptr() {
                 crate::dispatch::fold(tls.handle_error(err_value));
@@ -4330,21 +4249,16 @@ impl DuplexUpgradeContext {
             // duplex events — skip the TLSSocket instead of hitting
             // `has_handlers() == false` in `onOpen`.
             //
-            // Refcount: `tls.socket` is `InternalSocket::UpgradedDuplex`
-            // here (assigned in `js_upgrade_duplex_to_tls` *before*
-            // `start_tls()` enqueues anything and before any duplex
-            // callback can dispatch), so `handle_connect_error`'s
-            // `needs_deref = !is_detached()` is `true` and it consumes
-            // the owner's +1 we hold. Do NOT let `RefPtr::Drop`
-            // fire on top of that (over-deref → UAF on the JS wrapper's
-            // pointee).
+            // Refcount: `adopt_io_ref` installs our +1 as the socket's
+            // `io_ref` and `handle_connect_error` releases it; nothing here
+            // may release it a second time.
             //
             // Neuter the JS listener thunks now, while the wrapper is still
             // strongly held, so the later `StartTLS` → `deinit` → `Drop`
             // teardown (after `handle_connect_error` downgrades it) is a
             // no-op on already-cleared shadows.
             this.upgrade.teardown();
-            let p = tls.into_this_ptr();
+            let p = TLSSocket::adopt_io_ref(tls);
             crate::dispatch::fold(TLSSocket::handle_connect_error(
                 p,
                 sys::SystemErrno::ECONNREFUSED as c_int,
@@ -4353,14 +4267,14 @@ impl DuplexUpgradeContext {
         }
     }
 
-    fn on_timeout(this: bun_ptr::ThisPtr<Self>) {
+    pub(super) fn on_timeout(this: bun_ptr::ThisPtr<Self>) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls_this_ptr() {
             crate::dispatch::fold(TLSSocket::on_timeout(tls, socket));
         }
     }
 
-    fn on_close(this: bun_ptr::ThisPtr<Self>) {
+    pub(super) fn on_close(this: bun_ptr::ThisPtr<Self>) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls.replace(None) {
             // `TLSSocket::on_close` consumes the +1 we hold (its scope-exit deref
@@ -4372,7 +4286,7 @@ impl DuplexUpgradeContext {
             // `UpgradedDuplex::on_close` → `call_write_or_end`) hits the null-check
             // in `on_error` instead of reading the Handlers that `TLSSocket::on_close`
             // → `mark_inactive` just released.
-            let p = tls.into_this_ptr();
+            let p = TLSSocket::adopt_io_ref(tls);
             crate::dispatch::fold(TLSSocket::on_close(p, socket, 0, None));
         }
 
@@ -4395,8 +4309,7 @@ impl DuplexUpgradeContext {
                 // spinning up a wrapper that would dispatch `onOpen` into
                 // the dead socket.
                 if this.tls.get().is_none() {
-                    // SAFETY: `this` is the task's live context; no borrow of `*this` is live.
-                    unsafe { Self::deinit(this.as_ptr()) };
+                    Self::deinit(this);
                     return;
                 }
                 log!(
@@ -4421,17 +4334,15 @@ impl DuplexUpgradeContext {
                     }
                     let errno = sys::SystemErrno::ECONNREFUSED as c_int;
                     if let Some(tls) = this.tls.replace(None) {
-                        // `handle_connect_error` consumes our +1 — `tls.socket`
-                        // is `InternalSocket::UpgradedDuplex` (set before
-                        // `start_tls()` was queued), so `needs_deref =
-                        // !is_detached()` is true — and detaches. Null
+                        // `handle_connect_error` consumes our +1 (installed as
+                        // `io_ref` by `adopt_io_ref`) and detaches. Null
                         // `this.tls` so `deinit` doesn't deref again.
                         //
                         // Neuter the JS listener thunks now, while the wrapper
                         // is still strongly held, so the `deinit` → `Drop`
                         // teardown below is a no-op on already-cleared shadows.
                         this.upgrade.teardown();
-                        let p = tls.into_this_ptr();
+                        let p = TLSSocket::adopt_io_ref(tls);
                         crate::dispatch::fold(TLSSocket::handle_connect_error(p, errno, 0));
                     }
                     // `start_tls`/`start_tls_with_ctx` failed before the
@@ -4439,8 +4350,7 @@ impl DuplexUpgradeContext {
                     // was never registered and nothing will schedule
                     // `.Close`. Same as the `tls == null` early-return
                     // above: tear down here.
-                    // SAFETY: `this` is the task's live context; no borrow of `*this` is live.
-                    unsafe { Self::deinit(this.as_ptr()) };
+                    Self::deinit(this);
                     return;
                 }
                 this.ssl_config.set(None); // Drop frees.
@@ -4457,8 +4367,7 @@ impl DuplexUpgradeContext {
             // Previously this only called `upgrade.close()` and never `deinit`,
             // leaking the SSLWrapper, the strong refs, and this struct itself
             // for every duplex-upgraded TLS socket.
-            // SAFETY: `this` is the task's live context; no borrow of `*this` is live.
-            EventState::Close => unsafe { Self::deinit(this.as_ptr()) },
+            EventState::Close => Self::deinit(this),
         }
     }
 
@@ -4472,9 +4381,12 @@ impl DuplexUpgradeContext {
             // Already in the queue: that entry runs the updated `task_event`.
             return;
         }
-        this.vm
-            .event_loop_mut()
-            .enqueue_task(jsc::Task::init(this.as_ptr()));
+        // Dispatched by `task_tag::DuplexUpgradeContext` to `run_event` /
+        // `release_unrun`.
+        this.vm.event_loop_mut().enqueue_task(jsc::Task::new(
+            bun_event_loop::task_tag::DuplexUpgradeContext,
+            this.as_ptr().cast(),
+        ));
     }
 
     fn deinit_in_next_tick(this: bun_ptr::ThisPtr<Self>) {
@@ -4496,32 +4408,37 @@ impl DuplexUpgradeContext {
         this.upgrade.close();
     }
 
-    /// # Safety
-    /// `this` must be the unique live pointer to the heap allocation produced
-    /// in `js_upgrade_duplex_to_tls`. Frees the allocation; callers must not
-    /// hold a `&`/`&mut Self` across this call (taking `&mut self` here would
-    /// be a Stacked Borrows protector violation when the backing `Box` is
-    /// reclaimed below).
-    unsafe fn deinit(this: *mut Self) {
-        // SAFETY: fn contract — the live allocation registered in `js_upgrade_duplex_to_tls`.
-        crate::jsc_hooks::ActiveHandle::DuplexUpgrade(unsafe {
-            core::ptr::NonNull::new_unchecked(this)
-        })
-        .unregister();
-        {
-            // SAFETY: `this` is live; this borrow ends with the block, before the `heap::take` free below.
-            let ctx = unsafe { &*this };
-            ctx.tls.set(None);
-            // Close raced ahead of StartTLS — drop the unconsumed config / ctx.
-            ctx.ssl_config.set(None);
-            ctx.owned_ctx.set(None);
+    /// The queued hop (see [`enqueue_self_task`](Self::enqueue_self_task))
+    /// will never run because the VM is tearing down, and nothing else frees
+    /// the context. If the TLSSocket is still attached (a `StartTLS` that never
+    /// ran: no wrapper was created, so no close ever detached it), route it
+    /// through its close first — that consumes our +1 and detaches it from the
+    /// duplex, so its finalizer during ~VM finds nothing to reach into — then
+    /// free the context.
+    pub(crate) fn release_unrun(this: ThisPtr<Self>) {
+        this.queued.set(false);
+        if let Some(tls) = this.tls.replace(None) {
+            let socket = this.duplex_socket();
+            // `Err` is left pending for the release dispatcher's fold.
+            let _ = TLSSocket::on_close(TLSSocket::adopt_io_ref(tls), socket, 0, None);
         }
-        // `UpgradedDuplex` cleanup
-        // runs via `Drop` when `heap::take(this)` frees the containing
-        // struct below; an explicit call here would double-free.
-        // SAFETY: heap-allocated in `js_upgrade_duplex_to_tls`; this is the
-        // matching free. No `&`/`&mut Self` survives past this point.
-        drop(unsafe { bun_core::heap::take(this) });
+        Self::deinit(this);
+    }
+
+    /// Frees the context; nothing may touch `this` afterwards.
+    fn deinit(this: ThisPtr<Self>) {
+        drop(this.self_own.take());
+    }
+}
+
+impl Drop for DuplexUpgradeContext {
+    fn drop(&mut self) {
+        crate::jsc_hooks::ActiveHandle::DuplexUpgrade(NonNull::from(&*self)).unregister();
+        // Release the owner's +1 on the TLSSocket, then — close raced ahead of
+        // StartTLS — drop the unconsumed config and ctx before `upgrade` tears down.
+        self.tls.set(None);
+        self.ssl_config.set(None);
+        self.owned_ctx.set(None);
     }
 }
 
@@ -4538,10 +4455,10 @@ pub fn js_upgrade_tls_deferred(
 ) -> JsResult<JSValue> {
     jsc::mark_binding!();
     let [socket, opts] = callframe.arguments_as_array::<2>();
-    if let Some(this) = socket.as_class_ref::<TCPSocket>() {
+    if let Some(this) = socket.as_class_this_ptr::<TCPSocket>() {
         return NewSocket::<false>::upgrade_tls_impl(this, global, opts, true);
     }
-    if let Some(this) = socket.as_class_ref::<TLSSocket>() {
+    if let Some(this) = socket.as_class_this_ptr::<TLSSocket>() {
         return NewSocket::<true>::upgrade_tls_impl(this, global, opts, true);
     }
     Err(global.throw(format_args!("Expected a socket instance")))
@@ -4643,12 +4560,8 @@ pub fn js_upgrade_duplex_to_tls(
         default_data.ensure_still_alive();
     }
 
-    let reject_unauthorized = upgrade_reject_policy(
-        handlers.vm,
-        socket_config,
-        is_server,
-        owned_ctx.as_ref().map(|c| c.as_ptr()),
-    );
+    let ctx_ref = owned_ctx.as_ref().map(OwnedSslCtx::ctx);
+    let reject_unauthorized = upgrade_reject_policy(handlers.vm, socket_config, is_server, ctx_ref);
     // Server-side peer-cert policy, applied per-SSL once the engine exists.
     // A bare `secureContext` carries no parsed config, so read `requestCert`
     // back off the ctx's verify mode the same way `upgrade_reject_policy` does
@@ -4656,7 +4569,7 @@ pub fn js_upgrade_duplex_to_tls(
     let server_verify = crate::socket::upgraded_duplex::ServerVerify {
         request_cert: match socket_config {
             Some(cfg) => cfg.request_cert != 0,
-            None => server_ctx_requests_cert(owned_ctx.as_ref().map(|c| c.as_ptr())),
+            None => server_ctx_requests_cert(ctx_ref),
         },
         reject_unauthorized,
     };
@@ -4671,6 +4584,8 @@ pub fn js_upgrade_duplex_to_tls(
         };
     let tls = TLSSocket::new(TLSSocket {
         ref_count: bun_ptr::RefCount::init(),
+        io_ref: Cell::new(None),
+        named_pipe_ref: Cell::new(None),
         handlers: JsCell::new(Some(handlers)),
         socket: Cell::new(SocketHandler::<true>::DETACHED),
         owned_ssl_ctx: JsCell::new(None),
@@ -4692,108 +4607,45 @@ pub fn js_upgrade_duplex_to_tls(
         twin: JsCell::new(None),
         verify_error: JsCell::new(None),
     });
-    let tls_ref = tls;
+    // The JS wrapper adopts the creation ref.
+    let tls_ref = tls.into_this_ptr();
     let tls_js_value = tls_ref.get_this_value(global);
     TLSSocket::data_set_cached(tls_js_value, global, default_data);
 
-    let has_owned_ctx = owned_ctx.is_some();
-
-    // `DuplexUpgradeContext` is self-referential: `task.ctx` and
-    // `upgrade.handlers.ctx` both point at the containing allocation, and
-    // `UpgradedDuplex` has fn-ptr-niched fields plus a `Drop` impl, so it
-    // cannot be value-constructed with a placeholder and assigned later
-    // (`=` would Drop the placeholder; `zeroed()` is an invalid value).
-    // Allocate uninit, leak to a raw pointer for the stable address, then
-    // field-write everything in place — `upgrade` last, once the address is
-    // known.
-    let duplex_context: *mut DuplexUpgradeContext = bun_core::heap::into_raw(Box::new(
-        core::mem::MaybeUninit::<DuplexUpgradeContext>::uninit(),
-    ))
-    .cast();
-    // SAFETY: fresh heap allocation; every field is `ptr::write`-initialized
-    // below before any read or `&mut DuplexUpgradeContext` is formed.
-    unsafe {
-        ptr::addr_of_mut!((*duplex_context).tls)
-            .write(JsCell::new(Some(RefPtr::from_raw(tls.as_ptr()))));
-        ptr::addr_of_mut!((*duplex_context).vm).write(VirtualMachine::get());
-        ptr::addr_of_mut!((*duplex_context).task_event).write(Cell::new(EventState::StartTLS));
-        ptr::addr_of_mut!((*duplex_context).queued).write(Cell::new(false));
-        // When `owned_ctx` is set, `runEvent` builds from it and ignores
-        // `ssl_config` for SSL_CTX construction; servername/ALPN already
-        // copied onto `tls` above so the config's only remaining use is the
-        // legacy build path.
-        ptr::addr_of_mut!((*duplex_context).ssl_config).write(JsCell::new(if has_owned_ctx {
-            None
-        } else {
-            ssl_opts.take()
-        }));
-        ptr::addr_of_mut!((*duplex_context).owned_ctx).write(JsCell::new(owned_ctx));
-        ptr::addr_of_mut!((*duplex_context).is_open).write(Cell::new(false));
-        ptr::addr_of_mut!((*duplex_context).server_verify).write(server_verify);
-        ptr::addr_of_mut!((*duplex_context).mode).write(if is_server {
+    // When `owned_ctx` is set, `runEvent` builds from it and ignores
+    // `ssl_config` for SSL_CTX construction; servername/ALPN were already
+    // copied onto `tls` above, so the config's only remaining use is the legacy
+    // build path and it is dropped here otherwise.
+    let ssl_config = if owned_ctx.is_none() {
+        ssl_opts.take()
+    } else {
+        None
+    };
+    drop(ssl_opts);
+    let duplex_context = OwnedThis::new(DuplexUpgradeContext {
+        upgrade: UpgradedDuplex::from(global, tls_js_value, duplex),
+        self_own: Cell::new(None),
+        // The owner's ref on `tls`, released by its close / connect-error path.
+        tls: JsCell::new(Some(RefPtr::from_this(tls_ref))),
+        vm: VirtualMachine::get(),
+        task_event: Cell::new(EventState::StartTLS),
+        queued: Cell::new(false),
+        ssl_config: JsCell::new(ssl_config),
+        owned_ctx: JsCell::new(owned_ctx),
+        is_open: Cell::new(false),
+        server_verify,
+        mode: if is_server {
             SocketMode::DuplexServer
         } else {
             SocketMode::Client
-        });
-        ptr::addr_of_mut!((*duplex_context).upgrade).write(UpgradedDuplex::from(
-            global,
-            tls_js_value,
-            duplex,
-            UpgradedDuplexHandlers {
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_open: |c: *mut ()| {
-                    DuplexUpgradeContext::on_open(bun_ptr::ThisPtr::new(c.cast()))
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_data: |c: *mut (), d| {
-                    DuplexUpgradeContext::on_data(bun_ptr::ThisPtr::new(c.cast()), d)
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_handshake: |c: *mut (), ok, err| {
-                    DuplexUpgradeContext::on_handshake(bun_ptr::ThisPtr::new(c.cast()), ok, err)
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_close: |c: *mut ()| {
-                    DuplexUpgradeContext::on_close(bun_ptr::ThisPtr::new(c.cast()))
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_end: |c: *mut ()| DuplexUpgradeContext::on_end(bun_ptr::ThisPtr::new(c.cast())),
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_writable: |c: *mut ()| {
-                    DuplexUpgradeContext::on_writable(bun_ptr::ThisPtr::new(c.cast()))
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_error: |c: *mut (), e| {
-                    DuplexUpgradeContext::on_error(bun_ptr::ThisPtr::new(c.cast()), e)
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_timeout: |c: *mut ()| {
-                    DuplexUpgradeContext::on_timeout(bun_ptr::ThisPtr::new(c.cast()))
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_session: |c: *mut (), s| {
-                    DuplexUpgradeContext::on_session(bun_ptr::ThisPtr::new(c.cast()), s)
-                },
-                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_keylog: |c: *mut (), l| {
-                    DuplexUpgradeContext::on_keylog(bun_ptr::ThisPtr::new(c.cast()), l)
-                },
-                ctx: duplex_context.cast::<()>(),
-            },
-        ));
-    }
-    // ssl_opts is moved into duplexContext.ssl_config when owned_ctx == null;
-    // otherwise it was only used for protos/server_name and is freed here.
-    // SAFETY: every field initialized above; nothing frees the context before this fn returns.
-    let duplex_context_ref = unsafe { bun_ptr::ThisPtr::new(duplex_context) };
-    if duplex_context_ref.ssl_config.get().is_none() {
-        drop(ssl_opts.take());
-    }
-    // Disarm the guard — either moved into duplexContext or just
-    // freed above; both the move-target and the deinit case must not see it
-    // freed again on a later throw.
-    let _ = ssl_opts;
-    tls_ref.ref_();
+        },
+    });
+    let duplex_context_ref = duplex_context.this_ptr();
+    duplex_context_ref.self_own.set(Some(duplex_context));
+    duplex_context_ref
+        .upgrade
+        .owner
+        .set(Some(duplex_context_ref.into()));
 
     tls_ref.socket.set(duplex_context_ref.duplex_socket());
     tls_ref.mark_active();
@@ -4806,12 +4658,8 @@ pub fn js_upgrade_duplex_to_tls(
 
     // A TLS socket over a JS duplex is in no uSockets group, so the VM's stop
     // phase closes it through this owner (see `stop_for_vm_teardown`) rather
-    // than leaving it to a GC finalizer.
-    // SAFETY: non-null, fully initialised; unregistered again in `deinit`.
-    crate::jsc_hooks::ActiveHandle::DuplexUpgrade(unsafe {
-        core::ptr::NonNull::new_unchecked(duplex_context)
-    })
-    .register();
+    // than leaving it to a GC finalizer. Unregistered again on drop.
+    crate::jsc_hooks::ActiveHandle::DuplexUpgrade(duplex_context_ref.into()).register();
     DuplexUpgradeContext::start_tls(duplex_context_ref);
 
     let array = JSValue::create_empty_array(global, 2)?;
@@ -4884,21 +4732,14 @@ pub fn js_create_socket_pair(global: &JSGlobalObject, _frame: &CallFrame) -> JsR
 
     #[cfg(not(windows))]
     {
-        let mut fds_: [libc::c_int; 2] = [0, 0];
-        // SAFETY: libc FFI.
-        let rc =
-            unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds_.as_mut_ptr()) };
-        if rc != 0 {
-            let err = sys::Error::from_code(sys::get_errno(rc), sys::Tag::socketpair);
-            return Err(global.throw_value(err.to_js(global)));
-        }
-
-        let _ = sys::update_nonblocking(sys::Fd::from_native(fds_[0]), true);
-        let _ = sys::update_nonblocking(sys::Fd::from_native(fds_[1]), true);
+        let fds = match sys::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, true) {
+            Ok(fds) => fds,
+            Err(err) => return Err(global.throw_value(err.to_js(global))),
+        };
 
         let array = JSValue::create_empty_array(global, 2)?;
-        array.put_index(global, 0, JSValue::js_number(fds_[0] as f64))?;
-        array.put_index(global, 1, JSValue::js_number(fds_[1] as f64))?;
+        array.put_index(global, 0, JSValue::js_number(fds[0].native() as f64))?;
+        array.put_index(global, 1, JSValue::js_number(fds[1].native() as f64))?;
         Ok(array)
     }
 }
@@ -4922,27 +4763,8 @@ pub fn js_set_socket_options(global: &JSGlobalObject, callframe: &CallFrame) -> 
 
     #[cfg(unix)]
     {
-        // `bun_sys` exposes no public wrapper, so call libc directly.
         let setsockopt = |level: libc::c_int, opt: libc::c_int| -> Option<sys::Error> {
-            let val: libc::c_int = buffer_size;
-            // SAFETY: libc FFI; `val` lives for the call.
-            let rc = unsafe {
-                libc::setsockopt(
-                    file_descriptor.native(),
-                    level,
-                    opt,
-                    (&raw const val).cast::<c_void>(),
-                    core::mem::size_of::<libc::c_int>() as libc::socklen_t,
-                )
-            };
-            if rc != 0 {
-                Some(sys::Error::from_code(
-                    sys::get_errno(rc),
-                    sys::Tag::setsockopt,
-                ))
-            } else {
-                None
-            }
+            sys::setsockopt_int(file_descriptor, level, opt, buffer_size).err()
         };
         if is_for_send_buffer {
             if let Some(err) = setsockopt(libc::SOL_SOCKET, libc::SO_SNDBUF) {
@@ -5175,8 +4997,7 @@ pub mod testing_apis {
                 target_fd,
             };
 
-            // SAFETY: rule is a valid stack pointer for the duration of the call.
-            unsafe { fi::us_fault_set(syscall, &rule) };
+            fi::us_fault_set(syscall, &rule);
             Ok(JSValue::TRUE)
         }
     }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -35,7 +35,6 @@ pub(super) mod ffi {
     }
 
     // ssl.h
-    pub(crate) const TLSEXT_NAMETYPE_host_name: c_int = 0;
 
     // evp.h key types (NID values)
     pub(crate) const EVP_PKEY_RSA: c_int = 6;
@@ -171,7 +170,6 @@ pub(super) mod ffi {
         // scalars / `&mut` out-params leave no caller-side precondition, so
         // declare them `safe fn` here and route callers through
         // `SSL::opaque_ref` (panics on null, which every site already guards).
-        pub(crate) safe fn SSL_get_servername(ssl: &SSL, ty: c_int) -> *const c_char;
         pub(crate) safe fn SSL_is_init_finished(ssl: &SSL) -> c_int;
         /// Installs the inline-reject verify recorder (usockets openssl.c);
         /// the BIO hook + handshake drive then keep a rejected client's
@@ -183,7 +181,6 @@ pub(super) mod ffi {
             out_data: &mut *const u8,
             out_len: &mut c_uint,
         );
-        pub(crate) safe fn SSL_get_ex_data(ssl: &SSL, idx: c_int) -> *mut c_void;
         /// Save/restore the per-loop BIO routing state around in-handshake JS
         /// callbacks (defined in usockets' openssl.c). The caller's snapshot
         /// array must have exactly `us_internal_ssl_loop_state_slots()`
@@ -202,9 +199,6 @@ pub(super) mod ffi {
             callback: super::boringssl::SSL_verify_cb,
         );
         pub(crate) safe fn SSL_is_server(ssl: &SSL) -> c_int;
-        // Opaque-ZST `&SSL` + opaque `*mut c_void` payload (BoringSSL stores
-        // it verbatim, never derefs) ⇒ no caller-side precondition.
-        pub(crate) safe fn SSL_set_ex_data(ssl: &SSL, idx: c_int, data: *mut c_void) -> c_int;
         // Returns the borrowed parent CTX (always non-null for a live `SSL*`).
         pub(crate) safe fn SSL_get_SSL_CTX(ssl: &SSL) -> *mut SSL_CTX;
         // Swaps the cert/key/chain (and session-related state) this connection
@@ -231,23 +225,6 @@ pub(super) mod ffi {
             ssl: *mut SSL,
             chain: *mut core::ffi::c_void,
         ) -> core::ffi::c_int;
-        // Stores `cb`/`arg` opaquely on the CTX (BoringSSL never derefs `arg`
-        // outside the callback). Opaque-ZST `&SSL_CTX` + by-value fn-ptr +
-        // opaque `*mut c_void` ⇒ no caller-side precondition.
-        pub(crate) safe fn SSL_CTX_set_alpn_select_cb(
-            ctx: &SSL_CTX,
-            cb: Option<
-                unsafe extern "C" fn(
-                    ssl: *mut SSL,
-                    out: *mut *const u8,
-                    out_len: *mut u8,
-                    in_: *const u8,
-                    in_len: c_uint,
-                    arg: *mut c_void,
-                ) -> c_int,
-            >,
-            arg: *mut c_void,
-        );
         // Returns the borrowed cert store of a live `SSL_CTX*`.
         pub(crate) safe fn SSL_CTX_get_cert_store(ctx: &SSL_CTX) -> *mut X509_STORE;
         // The process-wide default root store; up-refs before returning, so
@@ -296,16 +273,10 @@ pub(super) fn get_servername(
         return Ok(JSValue::UNDEFINED);
     };
 
-    let servername = ffi::SSL_get_servername(
-        boringssl::SSL::opaque_ref(ssl_ptr),
-        ffi::TLSEXT_NAMETYPE_host_name,
-    );
-    if servername.is_null() {
+    let Some(servername) = boringssl::SSL::opaque_ref(ssl_ptr).servername() else {
         return Ok(JSValue::UNDEFINED);
-    }
-    // SAFETY: SSL_get_servername returns a NUL-terminated C string owned by the SSL session.
-    let slice = unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-    bun_string_jsc::create_utf8_for_js(global, slice)
+    };
+    bun_string_jsc::create_utf8_for_js(global, servername)
 }
 
 pub(super) fn set_servername(

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1453,12 +1453,10 @@ impl JSValkeyClient {
                 // Per-VM weak cache: a `duplicate()`'d client (or any
                 // other client with the same config) hits the same
                 // `SSL_CTX*` instead of rebuilding.
-                let state = crate::jsc_hooks::runtime_state();
-                debug_assert!(!state.is_null(), "RuntimeState not installed");
-                // SAFETY: per-thread `RuntimeState`; `ssl_ctx_cache` has a
-                // stable address for the VM's lifetime, JS-thread-only.
-                let cache = unsafe { &mut (*state).ssl_ctx_cache };
-                self._secure.set(cache.get_or_create(custom, &mut err));
+                self._secure
+                    .set(crate::jsc_hooks::with_ssl_ctx_cache(|cache| {
+                        cache.get_or_create(custom, &mut err)
+                    }));
             }
             self._secure.get().is_none()
         } else {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3083,6 +3083,24 @@ mod posix_impl {
     // (Darwin defines MSG_NOSIGNAL=0x80000).
     #[cfg(unix)]
     pub(crate) const SEND_FLAGS_NONBLOCK: i32 = libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL;
+    /// `setsockopt(2)` with an `int` option value.
+    pub fn setsockopt_int(fd: Fd, level: i32, optname: i32, value: i32) -> Maybe<()> {
+        // SAFETY: `value` lives for the call and `optlen` is its exact size.
+        let rc = unsafe {
+            libc::setsockopt(
+                fd.native(),
+                level,
+                optname,
+                core::ptr::from_ref(&value).cast(),
+                core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        if rc != 0 {
+            return Err(Error::from_code_int(last_errno(), Tag::setsockopt));
+        }
+        Ok(())
+    }
+
     /// `fcntl(F_GETFD)` then OR in `FD_CLOEXEC`.
     pub fn set_close_on_exec(fd: Fd) -> Maybe<()> {
         let fl = fcntl(fd, libc::F_GETFD, 0)?;

--- a/src/uws_sys/ConnectingSocket.rs
+++ b/src/uws_sys/ConnectingSocket.rs
@@ -47,10 +47,6 @@ impl ConnectingSocket {
         us_connecting_socket_get_dns_error(self)
     }
 
-    pub(crate) fn get_native_handle(&mut self) -> *mut c_void {
-        us_connecting_socket_get_native_handle(self)
-    }
-
     pub(crate) fn is_closed(&mut self) -> bool {
         us_connecting_socket_is_closed(self) == 1
     }
@@ -88,9 +84,6 @@ unsafe extern "C" {
     pub(crate) safe fn us_connecting_socket_ext(s: &mut ConnectingSocket) -> *mut c_void;
     pub(crate) safe fn us_connecting_socket_get_error(s: &mut ConnectingSocket) -> i32;
     pub(crate) safe fn us_connecting_socket_get_dns_error(s: &mut ConnectingSocket) -> i32;
-    pub(crate) safe fn us_connecting_socket_get_native_handle(
-        s: &mut ConnectingSocket,
-    ) -> *mut c_void;
     pub(crate) safe fn us_connecting_socket_is_closed(s: &mut ConnectingSocket) -> i32;
     pub(crate) safe fn us_connecting_socket_is_shut_down(s: &mut ConnectingSocket) -> i32;
     pub(crate) safe fn us_connecting_socket_long_timeout(s: &mut ConnectingSocket, seconds: c_uint);

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -463,10 +463,15 @@ pub mod fault_inject {
     }
 
     unsafe extern "C" {
-        pub fn us_fault_set(syscall: c_int, rule: *const UsFaultRule);
+        // safe: `rule` is copied; `out`/`clamp` are written in place.
+        pub safe fn us_fault_set(syscall: c_int, rule: &UsFaultRule);
         pub safe fn us_fault_clear_all();
-        pub fn us_fault_hit(syscall: c_int, fd: c_int, out: *mut isize, clamp: *mut c_int)
-        -> c_int;
+        pub safe fn us_fault_hit(
+            syscall: c_int,
+            fd: c_int,
+            out: &mut isize,
+            clamp: &mut c_int,
+        ) -> c_int;
     }
 }
 pub use socket::{

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -607,10 +607,9 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
     pub fn get_native_handle(&self) -> Option<*mut c_void> {
         match self.socket {
             InternalSocket::Connected(s) => sock(s).get_native_handle(),
-            InternalSocket::Connecting(s) => {
-                let h = conn(s).get_native_handle();
-                if h.is_null() { None } else { Some(h) }
-            }
+            // A connecting socket has no fd / `SSL` yet
+            // (`us_connecting_socket_get_native_handle` returns a `-1` sentinel).
+            InternalSocket::Connecting(_) => None,
             InternalSocket::UpgradedDuplex(s) if IS_SSL => duplex(s).ssl().map(|p| p.cast()),
             InternalSocket::UpgradedDuplex(_) => None,
             #[cfg(windows)]
@@ -636,6 +635,25 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             }
             InternalSocket::Connecting(s) => {
                 conn(s).ext::<Option<NonNull<Owner>>>().take().is_some()
+            }
+            _ => false,
+        }
+    }
+
+    /// Point the socket's ext slot at `owner` (or clear it). Every socket in
+    /// a Bun-created group has a one-pointer ext slot (`connect_group`,
+    /// `adopt_group`, the listen/connect paths all size it as
+    /// `Option<NonNull<_>>`), so this writes exactly that pointer. Returns
+    /// `false` for transports without ext storage.
+    pub fn set_ext_owner<Owner>(&self, owner: Option<NonNull<Owner>>) -> bool {
+        match self.socket {
+            InternalSocket::Connected(s) => {
+                *sock(s).ext::<Option<NonNull<Owner>>>() = owner;
+                true
+            }
+            InternalSocket::Connecting(s) => {
+                *conn(s).ext::<Option<NonNull<Owner>>>() = owner;
+                true
             }
             _ => false,
         }


### PR DESCRIPTION
### What

Same treatment as #40055 / #40136 for `Bun.connect`/`Bun.listen` sockets and the TLS-over-duplex path: `src/runtime/socket/socket_body.rs` 57 → **0** and `UpgradedDuplex.rs` 15 → **0** (plus Listener 44→37, tls_socket_functions 38→36, SSLContextCache 16→14, SecureContext 10→7, js_valkey 36→34, WindowsNamedPipe 38→36), by fixing the layers below:

- **`ThisPtr<Self>` host-fn receivers.** `generate-classes.ts` passes the wrapper's root `m_ctx` pointer to a receiver-generic helper (`host_fn::host_fn_this_ptr` over `HostReceiver` = `&T` | `ThisPtr<T>`), and `#[host_fn]` accepts `this: ThisPtr<Self>`; methods that may release the socket's refs (`end`, `close`, `terminate`, `upgrade_tls`, `do_connect`, …) take `ThisPtr<Self>` instead of minting one from `&self`. `JSValue::as_class_this_ptr` for the downcast sites.
- **Typed ref ownership.** The ref held on behalf of the uSockets ext slot / in-flight connect / accept / duplex owner is `NewSocket::io_ref: Cell<Option<RefPtr<Self>>>` (`hold_io_ref` / `adopt_io_ref` / `release_io_ref` at exactly the old `ref_()`/`deref()` points; Windows named pipes get `named_pipe_ref`, the h2 write-only attachment `H2FrameParser::writeonly_socket_ref`). The hand-written `RefCounted` impl + `deinit_and_destroy` become `#[derive(RefCounted)]` + `Drop`; `finalize` → `finalize_js_box`. `DuplexUpgradeContext` is single-owner via a new `bun_ptr::OwnedThis<T>` (Box-backed, lends `ThisPtr`), built by value — no `MaybeUninit`/`ptr::write`, no fake refcount.
- **UpgradedDuplex** holds `BackRef<DuplexUpgradeContext, Mut>` and calls `on_*` directly (the 10-entry fn-pointer table is gone); its `SSLWrapper` ctx is a `BackRef<UpgradedDuplex>`; the JS callbacks are `ContextHostFn` impls via `host_fn::new_function_with_context`.
- **BoringSSL / SSL_CTX ownership.** `create_ssl_context`, `SecureContext::borrow`, `SSLContextCache::get_or_create*` return `OwnedSslCtx`; `Listener.secure_ctx`, `SecureContext.ctx`, valkey `_secure` hold `OwnedSslCtx`; `SSLWrapper::init_with_owned_ctx`; every cache site goes through `jsc_hooks::with_ssl_ctx_cache`. ALPN selection is a typed `SSL_CTX::set_alpn_select_callback::<H: AlpnSelectCallback>()` with `select_next_proto` as a pure two-iterator find over validated lists; `SSL::{servername, set_tlsext_host_name, set_alpn_protos, set_ex_data_ref, ex_data_ref}`, `SSL_CTX::{verify_mode, up_ref}`.
- **uws_sys**: `NewSocketHandler::write_ext`, `get_native_handle()` returns `None` while `Connecting` (it used to return uSockets' `(void*)-1` sentinel, which every `ssl()` caller would have handed to BoringSSL; not JS-reachable pre-open today, so no test), `us_fault_set/hit` as `safe fn`; `bun_sys::setsockopt_int`; the internal `createSocketPair` test helper uses `bun_sys::socketpair` (now CLOEXEC too).
- `RefPtr` debug tracking only computes `return_address()` under `debug_assertions`.

### Testing

Debug+ASAN: node-tls-{upgrade,connect,server,duplex-close-throw-uaf,duplex-write-throw-error-value,connect-hostname-verification,context}, renegotiation, bun/net {socket,socket-retention,tcp-server,socket-syscall-fault}, ssl-ctx-cache, tls-syscall-fault, bun-connect-x509, valkey, websocket-client/proxy all pass; node-http2 362 pass; node parallel test-tls-{inception,js-stream,socket-close,destroy-stream,alpn-server-client} exit 0; node-net 85/85 apart from the timing-bound "reused handle" leak case on a loaded debug box (passes standalone, delta 0). Hand-driven `Bun.connect`/`Bun.listen` TLS echo, `socket.upgradeTLS()`, and a `new tls.TLSSocket(duplex)` pair produce the same event order as the release binary. `rust-check-all` windows-x64 / mac-arm64 ok; clippy clean.