### PR TITLE
bun:ffi: return undefined for a NULL napi_value from cc() and throw the scheduled napi exception

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3418,6 +3418,20 @@ extern "C" bool NapiEnv__hasPendingException(napi_env env)
     return scope.exception() != nullptr;
 }
 
+// The wrapper that bun:ffi cc() compiles around a function with a napi_env
+// calls this after the function returns. napi_throw* only schedules the
+// exception on the env; Node throws it when the native function returns, and
+// this is that return. True means an exception is pending and the wrapper
+// hands JSC the empty value instead of a result.
+extern "C" bool NapiEnv__throwPendingException(napi_env env)
+{
+    if (env->throwPendingException()) {
+        return true;
+    }
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(env->vm());
+    return scope.exception() != nullptr;
+}
+
 extern "C" uint32_t napi_internal_get_version(napi_env env)
 {
     return env->napiModule().nm_version;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3418,8 +3418,7 @@ extern "C" bool NapiEnv__hasPendingException(napi_env env)
     return scope.exception() != nullptr;
 }
 
-// bun:ffi cc() wrappers call this once the compiled function returns, since
-// napi_throw* only schedules the exception on the env.
+// Called by the wrapper bun:ffi cc() generates, after the compiled function returns.
 extern "C" bool NapiEnv__throwPendingException(napi_env env)
 {
     if (env->throwPendingException()) {

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3418,11 +3418,8 @@ extern "C" bool NapiEnv__hasPendingException(napi_env env)
     return scope.exception() != nullptr;
 }
 
-// The wrapper that bun:ffi cc() compiles around a function with a napi_env
-// calls this after the function returns. napi_throw* only schedules the
-// exception on the env; Node throws it when the native function returns, and
-// this is that return. True means an exception is pending and the wrapper
-// hands JSC the empty value instead of a result.
+// bun:ffi cc() wrappers call this once the compiled function returns, since
+// napi_throw* only schedules the exception on the env.
 extern "C" bool NapiEnv__throwPendingException(napi_env env)
 {
     if (env->throwPendingException()) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -64,6 +64,7 @@ typedef enum {
 } napi_status;
 BUN_FFI_IMPORT void* NapiHandleScope__open(void* napi_env, bool detached);
 BUN_FFI_IMPORT void NapiHandleScope__close(void* napi_env, void* handleScope);
+BUN_FFI_IMPORT bool NapiEnv__throwPendingException(void* napi_env);
 BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #endif
 

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -260,8 +260,7 @@ impl fmt::Display for ToJSFormatter<'_> {
             None => match self.tag {
                 ABIType::Void => Ok(()),
                 ABIType::NapiEnv => writer.write_str("((napi_env)&Bun__thisFFIModuleNapiEnv)"),
-                // A NULL napi_value is `undefined`, as in Node. Its raw bits are the
-                // empty JSValue, which JS code must never see.
+                // NULL is `undefined`, as in Node; its raw bits would be the empty JSValue.
                 ABIType::NapiValue => write!(
                     writer,
                     "({sym} ? ((EncodedJSValue) {{.asNapiValue = {sym} }}) : ValueUndefined)",

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -141,7 +141,7 @@ static ABI_TABLE: [AbiRow; 22] = {
     /* U64Fast   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),              Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
     /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
     /* NapiEnv   */ r(b"napi_env",   None,                                    None),
-    /* NapiValue */ r(b"napi_value", None,                                    Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
+    /* NapiValue */ r(b"napi_value", None,                                    None),
     /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_TYPED_ARRAY_VECTOR("),  None),
     /* BufferLen */ r(b"uint64_t",   None,                                    None),
     ]
@@ -260,6 +260,13 @@ impl fmt::Display for ToJSFormatter<'_> {
             None => match self.tag {
                 ABIType::Void => Ok(()),
                 ABIType::NapiEnv => writer.write_str("((napi_env)&Bun__thisFFIModuleNapiEnv)"),
+                // A NULL napi_value is `undefined`, as in Node. Its raw bits are the
+                // empty JSValue, which JS code must never see.
+                ABIType::NapiValue => write!(
+                    writer,
+                    "({sym} ? ((EncodedJSValue) {{.asNapiValue = {sym} }}) : ValueUndefined)",
+                    sym = BStr::new(self.symbol)
+                ),
                 ABIType::Buffer => writer.write_str("0"),
                 _ => unreachable!(),
             },

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2226,8 +2226,6 @@ impl Function {
         writer.write_all(b"    ")?;
 
         if self.needs_handle_scope() {
-            // napi_throw* only schedules the exception on the env. Node throws it
-            // when the native function returns; this wrapper is that return.
             writer.write_all(
                 b"  NapiHandleScope__close(&Bun__thisFFIModuleNapiEnv, handleScope);\n\
                   \x20   if (NapiEnv__throwPendingException(&Bun__thisFFIModuleNapiEnv)) return 0;\n",

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2226,8 +2226,11 @@ impl Function {
         writer.write_all(b"    ")?;
 
         if self.needs_handle_scope() {
+            // napi_throw* only schedules the exception on the env. Node throws it
+            // when the native function returns; this wrapper is that return.
             writer.write_all(
-                b"  NapiHandleScope__close(&Bun__thisFFIModuleNapiEnv, handleScope);\n",
+                b"  NapiHandleScope__close(&Bun__thisFFIModuleNapiEnv, handleScope);\n\
+                  \x20   if (NapiEnv__throwPendingException(&Bun__thisFFIModuleNapiEnv)) return 0;\n",
             )?;
         }
 
@@ -2581,6 +2584,7 @@ impl CompilerRT {
         unsafe extern "C" {
             fn NapiHandleScope__open(env: *mut napi::NapiEnv, escapable: bool) -> *mut c_void;
             fn NapiHandleScope__close(env: *mut napi::NapiEnv, current: *mut c_void);
+            fn NapiEnv__throwPendingException(env: *mut napi::NapiEnv) -> bool;
         }
         state
             .add_symbol(
@@ -2592,6 +2596,12 @@ impl CompilerRT {
             .add_symbol(
                 zstr!("NapiHandleScope__close"),
                 NapiHandleScope__close as *const c_void,
+            )
+            .expect("unreachable");
+        state
+            .add_symbol(
+                zstr!("NapiEnv__throwPendingException"),
+                NapiEnv__throwPendingException as *const c_void,
             )
             .expect("unreachable");
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1087,6 +1087,97 @@ describe("double <-> JSValue conversions", () => {
   });
 });
 
+describe("napi_value results from cc()-compiled C", () => {
+  // cc()-compiled C resolves napi_* from the host process; that lookup is only
+  // exercised on POSIX today (see cc-fixture.c).
+  it.skipIf(isWindows)("a NULL napi_value is undefined and a scheduled napi exception is thrown", async () => {
+    using dir = tempDir("bun-ffi-napi-null-return", {
+      "napi_null.c": /* c */ `
+        typedef struct napi_env_fake* napi_env_t;
+        typedef struct napi_value_fake* napi_value_t;
+        extern int napi_create_string_utf8(napi_env_t env, const char* str, unsigned long long length, napi_value_t* result);
+        extern int napi_throw_error(napi_env_t env, const char* code, const char* msg);
+
+        napi_value_t returns_null(napi_env_t env) {
+          return 0;
+        }
+        napi_value_t returns_string(napi_env_t env) {
+          napi_value_t result;
+          napi_create_string_utf8(env, "hello", 5, &result);
+          return result;
+        }
+        napi_value_t throws_then_returns_null(napi_env_t env) {
+          napi_throw_error(env, "ERR_FROM_C", "thrown from C");
+          return 0;
+        }
+        int throws_then_returns_int(napi_env_t env) {
+          napi_throw_error(env, 0, "thrown from int-returning C");
+          return 42;
+        }
+        int returns_int(napi_env_t env) {
+          return 42;
+        }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "napi_null.c"),
+          symbols: {
+            returns_null: { args: ["napi_env"], returns: "napi_value" },
+            returns_string: { args: ["napi_env"], returns: "napi_value" },
+            throws_then_returns_null: { args: ["napi_env"], returns: "napi_value" },
+            throws_then_returns_int: { args: ["napi_env"], returns: "int" },
+            returns_int: { args: ["napi_env"], returns: "int" },
+          },
+        });
+
+        function caught(fn) {
+          try {
+            return { returned: fn() };
+          } catch (e) {
+            return { threw: [e.code ?? null, e.message] };
+          }
+        }
+
+        const nullValue = symbols.returns_null();
+        console.log(
+          JSON.stringify({
+            nullValue: [typeof nullValue, nullValue === undefined],
+            string: symbols.returns_string(),
+            thrownNull: caught(() => symbols.throws_then_returns_null()),
+            thrownInt: caught(() => symbols.throws_then_returns_int()),
+            // The scheduled exception must not leak into the next call.
+            afterThrow: caught(() => symbols.returns_int()),
+          }),
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        nullValue: ["undefined", true],
+        string: "hello",
+        thrownNull: { threw: ["ERR_FROM_C", "thrown from C"] },
+        thrownInt: { threw: [null, "thrown from int-returning C"] },
+        afterThrow: { returned: 42 },
+      },
+      exitCode: 0,
+    });
+  });
+});
+
 describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", () => {
   const plantedHeader = "#define bool int\n#define true 100\n#define false 0\n";
   const files = {

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1170,7 +1170,8 @@ describe("napi_value results from cc()-compiled C", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
-    expect({ results, stderr, exitCode }).toMatchObject({
+    // stderr is in the received object so a failure shows it; it is not asserted.
+    expect({ results, stderr }).toMatchObject({
       results: {
         nullValue: ["undefined", true],
         string: "hello",
@@ -1179,8 +1180,8 @@ describe("napi_value results from cc()-compiled C", () => {
         thrownVoid: { threw: [null, "thrown from void C"] },
         afterThrow: { returned: 42 },
       },
-      exitCode: 0,
     });
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1117,6 +1117,9 @@ describe("napi_value results from cc()-compiled C", () => {
         int returns_int(napi_env_t env) {
           return 42;
         }
+        void throws_from_void(napi_env_t env) {
+          napi_throw_error(env, 0, "thrown from void C");
+        }
       `,
       "fixture.js": /* js */ `
         import { cc } from "bun:ffi";
@@ -1130,6 +1133,7 @@ describe("napi_value results from cc()-compiled C", () => {
             throws_then_returns_null: { args: ["napi_env"], returns: "napi_value" },
             throws_then_returns_int: { args: ["napi_env"], returns: "int" },
             returns_int: { args: ["napi_env"], returns: "int" },
+            throws_from_void: { args: ["napi_env"], returns: "void" },
           },
         });
 
@@ -1148,6 +1152,7 @@ describe("napi_value results from cc()-compiled C", () => {
             string: symbols.returns_string(),
             thrownNull: caught(() => symbols.throws_then_returns_null()),
             thrownInt: caught(() => symbols.throws_then_returns_int()),
+            thrownVoid: caught(() => symbols.throws_from_void()),
             // The scheduled exception must not leak into the next call.
             afterThrow: caught(() => symbols.returns_int()),
           }),
@@ -1171,6 +1176,7 @@ describe("napi_value results from cc()-compiled C", () => {
         string: "hello",
         thrownNull: { threw: ["ERR_FROM_C", "thrown from C"] },
         thrownInt: { threw: [null, "thrown from int-returning C"] },
+        thrownVoid: { threw: [null, "thrown from void C"] },
         afterThrow: { returned: 42 },
       },
       exitCode: 0,


### PR DESCRIPTION
### Problem
- A `cc()` function declared `returns: "napi_value"` that returns `NULL` hands JS the raw bits. `NULL` is the empty JSValue. The next use crashes: `typeof` faults at address 0x5 (`JSValue::isString` reads `m_type` of a null cell), a property read faults at 0x0. This is the signature of BUN-4NMR.
- `napi_throw*` only schedules the exception on the `NapiEnv` (`napi.h:420`). Node throws it when the native function returns. The wrapper `cc()` compiles never did (`src/runtime/ffi/ffi_body.rs:2228`), so the call looked like it returned normally.

### Fix
- `ToJSFormatter` emits `(v ? ((EncodedJSValue){.asNapiValue = v}) : ValueUndefined)` for a `napi_value` result. `NULL` is `undefined`, as in Node.
- After the call, a wrapper with a `napi_env` calls the new `NapiEnv__throwPendingException`. It throws the scheduled exception, and the wrapper returns the empty value, as JSC expects from a host function.
- Only the `cc()` path changes. `dlopen`, `linkSymbols`, `CFunction` and `JSCallback` reject napi types already.
- Verified: `test/js/bun/ffi/cc.test.ts` (new test; fails on 1.4.0 with the 0x5 segfault, and on an unfixed debug build with UBSan `member call on null pointer of type 'JSC::JSCell'` at `JSCJSValueCell.h:42`). Also all of `test/js/bun/ffi/`.

### Background
- `cc()` compiles the user's C with TinyCC and generates a C wrapper per symbol (`ffi_body.rs`). The wrapper is the JSC host function: it reads the arguments from the call frame, calls the user's function, and converts the result with `ABIType::to_js`.
- A `napi_value` is an `EncodedJSValue` in Bun, so the conversion is a reinterpretation. `0` is `JSValue()`, the empty value. JS code never holds it, and every type check on it dereferences a null cell.
- Bun's Node-API keeps a thrown value in `NapiEnv::m_pendingException` and throws it once the addon function returns to its call wrapper. `cc()` functions have no such wrapper. The new call sits next to the handle scope close, which the same functions get (`needs_handle_scope`).

<details><summary>Notes</summary>

Repro on 1.4.0:

```c
napi_value returns_null(napi_env env) { return NULL; }
napi_value throws_then_null(napi_env env) { napi_throw_error(env, "CODE", "boom"); return NULL; }
```

```js
const { symbols } = cc({ source: "x.c", symbols: {
  returns_null: { args: ["napi_env"], returns: "napi_value" },
  throws_then_null: { args: ["napi_env"], returns: "napi_value" },
}});
try { symbols.throws_then_null(); console.log("no throw"); } catch {}
console.log(typeof symbols.returns_null());
```

Output: `no throw`, then `panic(main thread): Segmentation fault at address 0x5`.

The same codegen is in 1.3.14 (`src/runtime/ffi/ffi.zig`), so this is not a 1.4.0 regression.

The generated tail of a wrapper with a `napi_env` now reads:

```c
    NapiHandleScope__close(&Bun__thisFFIModuleNapiEnv, handleScope);
    if (NapiEnv__throwPendingException(&Bun__thisFFIModuleNapiEnv)) return 0;
    return (return_value ? ((EncodedJSValue) {.asNapiValue = return_value }) : ValueUndefined).asZigRepr;
```

`NapiEnv__throwPendingException` mirrors `NapiEnv__hasPendingException` next to it in `napi.cpp`: it throws the scheduled exception, then reports whether any exception is pending (also one a napi call raised directly), so the wrapper returns empty in both cases.

Suites run on the debug build: `test/js/bun/ffi/` (187 pass). `ffi.test.js > ptr argument: ArrayBuffer cells through an FTL-compiled call site` times out at 5 s on this debug+ASAN machine with and without this change; it is the stress test from #39829 and unrelated to `cc()`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->