### PR TITLE
docs: fix Statement.all/get examples to show retained bound params

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -628,7 +628,7 @@ declare module "bun:sqlite" {
      * // => [{bar: "baz"}]
      *
      * stmt.all();
-     * // => []
+     * // => [{bar: "baz"}]
      *
      * stmt.all("foo");
      * // => [{bar: "foo"}]
@@ -651,7 +651,7 @@ declare module "bun:sqlite" {
      * // => {bar: "baz"}
      *
      * stmt.get();
-     * // => null
+     * // => {bar: "baz"}
      *
      * stmt.get("foo");
      * // => {bar: "foo"}


### PR DESCRIPTION
docs: fix Statement.all/get examples to show retained bound params

Fixes #26622
