### PR TITLE
fix(node:dns): validate hostname in dns.lookup

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -234,19 +234,6 @@ function validateLocalAddresses(first, second) {
   }
 }
 
-function invalidHostname(hostname) {
-  if (invalidHostname.warned) {
-    return;
-  }
-
-  invalidHostname.warned = true;
-  process.emitWarning(
-    `The provided hostname "${String(hostname)}" is not a valid hostname, and is supported in the dns module solely for compatibility.`,
-    "DeprecationWarning",
-    "DEP0118",
-  );
-}
-
 function translateLookupOptions(options) {
   if (!options || typeof options !== "object") {
     options = { family: options };
@@ -280,8 +267,8 @@ function validateLookupOptions(options) {
 }
 
 function lookup(hostname, options, callback) {
-  if (typeof hostname !== "string" && hostname) {
-    throw $ERR_INVALID_ARG_TYPE("hostname", "string", hostname);
+  if (hostname) {
+    validateString(hostname, "hostname");
   }
 
   if (typeof options === "function") {
@@ -302,13 +289,7 @@ function lookup(hostname, options, callback) {
   validateLookupOptions(options);
 
   if (!hostname) {
-    invalidHostname(hostname);
-    if (options.all) {
-      callback(null, []);
-    } else {
-      callback(null, null, 4);
-    }
-    return;
+    throw $ERR_INVALID_ARG_VALUE("hostname", hostname, "must be a non-empty string");
   }
 
   const family = isIP(hostname);
@@ -736,8 +717,8 @@ const promises = {
   ...errorCodes,
 
   lookup(hostname, options) {
-    if (typeof hostname !== "string" && hostname) {
-      throw $ERR_INVALID_ARG_TYPE("hostname", "string", hostname);
+    if (hostname) {
+      validateString(hostname, "hostname");
     }
 
     if (typeof options === "number") {
@@ -751,15 +732,7 @@ const promises = {
     validateLookupOptions(options);
 
     if (!hostname) {
-      invalidHostname(hostname);
-      return Promise.$resolve(
-        options.all
-          ? []
-          : {
-              address: null,
-              family: 4,
-            },
-      );
+      throw $ERR_INVALID_ARG_VALUE("hostname", hostname, "must be a non-empty string");
     }
 
     const family = isIP(hostname);

--- a/test/js/node/test/parallel/test-c-ares.js
+++ b/test/js/node/test/parallel/test-c-ares.js
@@ -29,9 +29,9 @@ const dnsPromises = dns.promises;
 (async function() {
   let res;
 
-  res = await dnsPromises.lookup(null);
-  assert.strictEqual(res.address, null);
-  assert.strictEqual(res.family, 4);
+  assert.throws(() => dnsPromises.lookup(null), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
 
   res = await dnsPromises.lookup('127.0.0.1');
   assert.strictEqual(res.address, '127.0.0.1');
@@ -43,10 +43,9 @@ const dnsPromises = dns.promises;
 })().then(common.mustCall());
 
 // Try resolution without hostname.
-dns.lookup(null, common.mustSucceed((result, addressType) => {
-  assert.strictEqual(result, null);
-  assert.strictEqual(addressType, 4);
-}));
+assert.throws(() => dns.lookup(null, common.mustNotCall()), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
 dns.lookup('127.0.0.1', common.mustSucceed((result, addressType) => {
   assert.strictEqual(result, '127.0.0.1');

--- a/test/js/node/test/parallel/test-dns-lookup.js
+++ b/test/js/node/test/parallel/test-dns-lookup.js
@@ -35,11 +35,6 @@ common.expectWarning({
       'These APIs are for internal testing only. Do not use them.',
     ]
   } : {}),
-  // For calling `dns.lookup` with falsy `hostname`.
-  'DeprecationWarning': {
-    DEP0118: 'The provided hostname "false" is not a valid ' +
-      'hostname, and is supported in the dns module solely for compatibility.'
-  }
 });
 
 assert.throws(() => {
@@ -151,12 +146,13 @@ assert.throws(() => dnsPromises.lookup(false, () => {}),
 (async function() {
   let res;
 
-  res = await dnsPromises.lookup(false, {
+  assert.throws(() => dnsPromises.lookup(false, {
     hints: 0,
     family: 0,
     all: true
+  }), {
+    code: 'ERR_INVALID_ARG_VALUE',
   });
-  assert.deepStrictEqual(res, []);
 
   res = await dnsPromises.lookup('127.0.0.1', {
     hints: 0,
@@ -173,14 +169,13 @@ assert.throws(() => dnsPromises.lookup(false, () => {}),
   assert.deepStrictEqual(res, { address: '127.0.0.1', family: 4 });
 })().then(common.mustCall());
 
-dns.lookup(false, {
+assert.throws(() => dns.lookup(false, {
   hints: 0,
   family: 0,
   all: true
-}, common.mustSucceed((result, addressType) => {
-  assert.deepStrictEqual(result, []);
-  assert.strictEqual(addressType, undefined);
-}));
+}, common.mustNotCall()), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
 dns.lookup('127.0.0.1', {
   hints: 0,

--- a/test/js/node/test/parallel/test-dns.js
+++ b/test/js/node/test/parallel/test-dns.js
@@ -189,18 +189,15 @@ assert.deepStrictEqual(dns.getServers(), []);
   assert.throws(() => dnsPromises.lookup(common.mustNotCall()), errorReg);
 }
 
-// dns.lookup should accept falsey values
+// dns.lookup should reject falsey values
 {
-  const checkCallback = (err, address, family) => {
-    assert.ifError(err);
-    assert.strictEqual(address, null);
-    assert.strictEqual(family, 4);
-  };
-
-  ['', null, undefined, 0, NaN].forEach(async (value) => {
-    const res = await dnsPromises.lookup(value);
-    assert.deepStrictEqual(res, { address: null, family: 4 });
-    dns.lookup(value, common.mustCall(checkCallback));
+  ['', null, undefined, 0, NaN].forEach((value) => {
+    assert.throws(() => dnsPromises.lookup(value), {
+      code: 'ERR_INVALID_ARG_VALUE',
+    });
+    assert.throws(() => dns.lookup(value, common.mustNotCall()), {
+      code: 'ERR_INVALID_ARG_VALUE',
+    });
   });
 }
 
@@ -245,52 +242,111 @@ assert.throws(() => dns.lookup('', {
   name: 'TypeError'
 });
 
-dns.lookup('', { family: 4, hints: 0 }, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', { family: 4, hints: 0 }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  family: 6,
-  hints: dns.ADDRCONFIG
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    family: 6,
+    hints: dns.ADDRCONFIG
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', { hints: dns.V4MAPPED }, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', { hints: dns.V4MAPPED }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  hints: dns.ADDRCONFIG | dns.V4MAPPED
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  hints: dns.ALL
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    hints: dns.ALL
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  hints: dns.V4MAPPED | dns.ALL
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    hints: dns.V4MAPPED | dns.ALL
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL,
-  family: 'IPv4'
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL,
+    family: 'IPv4'
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
-dns.lookup('', {
-  hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL,
-  family: 'IPv6'
-}, common.mustCall());
+assert.throws(() => {
+  dns.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL,
+    family: 'IPv6'
+  }, common.mustNotCall());
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
 (async function() {
-  await dnsPromises.lookup('', { family: 4, hints: 0 });
-  await dnsPromises.lookup('', { family: 6, hints: dns.ADDRCONFIG });
-  await dnsPromises.lookup('', { hints: dns.V4MAPPED });
-  await dnsPromises.lookup('', { hints: dns.ADDRCONFIG | dns.V4MAPPED });
-  await dnsPromises.lookup('', { hints: dns.ALL });
-  await dnsPromises.lookup('', { hints: dns.V4MAPPED | dns.ALL });
-  await dnsPromises.lookup('', {
-    hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
+  assert.throws(() => dnsPromises.lookup('', { family: 4, hints: 0 }), {
+    code: 'ERR_INVALID_ARG_VALUE',
   });
-  await dnsPromises.lookup('', { order: 'verbatim' });
+  assert.throws(() => dnsPromises.lookup('', {
+    family: 6,
+    hints: dns.ADDRCONFIG
+  }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => dnsPromises.lookup('', { hints: dns.V4MAPPED }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => dnsPromises.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED
+  }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => dnsPromises.lookup('', { hints: dns.ALL }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => dnsPromises.lookup('', {
+    hints: dns.V4MAPPED | dns.ALL
+  }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => dnsPromises.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
+  }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => dnsPromises.lookup('', { order: 'verbatim' }), {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
 })().then(common.mustCall());
 
 {


### PR DESCRIPTION
Fixes #37464

Validate hostname in dns.lookup to prevent invalid hostnames from being passed to c-ares.
