### PR TITLE
fix(node:dns): validate rrtype case-sensitively

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -44,6 +44,23 @@ const IANA_DNS_PORT = 53;
 const IPv6RE = /^\[([^[\]]*)\]/;
 const addrSplitRE = /(^.+?)(?::(\d+))?$/;
 
+// Matches the case-sensitive rrtype validation in Node.js
+// (lib/internal/dns/utils.js `RRTYPES`).
+const RRTYPES = new Set([
+  "A",
+  "AAAA",
+  "ANY",
+  "CAA",
+  "CNAME",
+  "MX",
+  "NAPTR",
+  "NS",
+  "PTR",
+  "SOA",
+  "SRV",
+  "TXT",
+]);
+
 function translateErrorCode(promise: Promise<any>) {
   return promise.catch(error => {
     return Promise.$reject(withTranslatedError(error));
@@ -408,6 +425,8 @@ var InternalResolver = class Resolver {
       rrtype = "A";
     } else if (typeof rrtype !== "string") {
       throw $ERR_INVALID_ARG_TYPE("rrtype", "string", rrtype);
+    } else if (!RRTYPES.has(rrtype)) {
+      throw $ERR_INVALID_ARG_VALUE("rrtype", rrtype);
     }
 
     callback = validateResolve(hostname, callback);
@@ -804,6 +823,8 @@ const promises = {
       rrtype = "A";
     } else if (typeof rrtype !== "string") {
       throw $ERR_INVALID_ARG_TYPE("rrtype", "string", rrtype);
+    } else if (!RRTYPES.has(rrtype)) {
+      throw $ERR_INVALID_ARG_VALUE("rrtype", rrtype);
     }
 
     switch (rrtype?.toLowerCase()) {
@@ -880,7 +901,9 @@ const promises = {
       if (typeof rrtype === "undefined") {
         rrtype = "A";
       } else if (typeof rrtype !== "string") {
-        rrtype = null;
+        throw $ERR_INVALID_ARG_TYPE("rrtype", "string", rrtype);
+      } else if (!RRTYPES.has(rrtype)) {
+        throw $ERR_INVALID_ARG_VALUE("rrtype", rrtype);
       }
       switch (rrtype?.toLowerCase()) {
         case "a":

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -602,6 +602,32 @@ describe("test invalid arguments", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/39553
+  describe.each([
+    ["dns.resolve", rrtype => dns.resolve("localhost", rrtype, () => {})],
+    ["dns.promises.resolve", rrtype => dns_promises.resolve("localhost", rrtype)],
+    [
+      "dns.promises.Resolver#resolve",
+      rrtype => new dns_promises.Resolver().resolve("localhost", rrtype),
+    ],
+  ])("%s", (_, fn) => {
+    it("throws ERR_INVALID_ARG_VALUE for lowercase rrtype", () => {
+      expect(() => fn("a")).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+    });
+
+    it("throws ERR_INVALID_ARG_VALUE for unknown rrtype", () => {
+      expect(() => fn("bogus")).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+    });
+
+    it("accepts uppercase rrtype values", () => {
+      expect(() => fn("A")).not.toThrow();
+      const result = fn("A");
+      if (result instanceof Promise) {
+        result.catch(() => {});
+      }
+    });
+  });
+
   it("dns.promises.resolve with undefined rrtype does not throw", async () => {
     // Node's promises API treats undefined rrtype as "A"
     const promise = dns_promises.resolve("localhost", undefined);


### PR DESCRIPTION
Fixes #39553

Validate rrtype argument case-sensitively and support the 14 standard DNS record types.
