### PR TITLE
fix: ensure WebSocket error events have correct type

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4619,7 +4619,7 @@ declare module "bun" {
 
   interface WebSocketEventMap {
     close: CloseEvent;
-    error: Event;
+    error: ErrorEvent;
     message: MessageEvent;
     open: Event;
   }

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -124,7 +124,58 @@ declare var Worker: Bun.__internal.UseLibDomIfAvailable<
 /**
  * A WebSocket client implementation.
  */
-interface WebSocket extends Bun.__internal.LibEmptyOrBunWebSocket {}
+interface WebSocket extends Bun.__internal.LibEmptyOrBunWebSocket {
+  addEventListener(
+    type: "close",
+    listener: (this: WebSocket, ev: CloseEvent) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: "error",
+    listener: (this: WebSocket, ev: ErrorEvent) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: "message",
+    listener: (this: WebSocket, ev: MessageEvent) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: "open",
+    listener: (this: WebSocket, ev: Event) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: "close",
+    listener: (this: WebSocket, ev: CloseEvent) => any,
+    options?: boolean | Bun.EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: "error",
+    listener: (this: WebSocket, ev: ErrorEvent) => any,
+    options?: boolean | Bun.EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: "message",
+    listener: (this: WebSocket, ev: MessageEvent) => any,
+    options?: boolean | Bun.EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: "open",
+    listener: (this: WebSocket, ev: Event) => any,
+    options?: boolean | Bun.EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | Bun.EventListenerOptions,
+  ): void;
+}
 /**
  * A WebSocket client implementation.
  */


### PR DESCRIPTION
Fixes #36329

Ensure WebSocket error events have correct type.
