### PR TITLE
webview: retire the transport with its global under bun test --isolate

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4191,6 +4191,9 @@ extern "C" void Zig__GlobalObject__forbidExecution(Zig::GlobalObject* globalObje
 // workers, ports, channels and sockets are stopped before anything else of the file is swept.
 extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::GlobalObject* globalObject)
 {
+    // The WebView transports are process singletons bound to the global that spawned the browser.
+    // They reject their pending promises on this global while its context is still intact.
+    Bun::retireWebViewsForTestIsolation(globalObject);
     globalObject->scriptExecutionContext()->prepareForDestruction();
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4191,8 +4191,6 @@ extern "C" void Zig__GlobalObject__forbidExecution(Zig::GlobalObject* globalObje
 // workers, ports, channels and sockets are stopped before anything else of the file is swept.
 extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::GlobalObject* globalObject)
 {
-    // The WebView transports are process singletons bound to the global that spawned the browser.
-    // They reject their pending promises on this global while its context is still intact.
     Bun::retireWebViewsForTestIsolation(globalObject);
     globalObject->scriptExecutionContext()->prepareForDestruction();
 }

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -89,6 +89,8 @@ extern "C" int32_t Bun__Chrome__ensure(Zig::GlobalObject*, const char* userDataD
 // Copies and queues one chunk; a failure arrives later as Bun__Chrome__onPipeClosed.
 extern "C" void Bun__Chrome__writePipe(const char* data, size_t len);
 #endif
+// Unpublishes and kills the spawned Chrome without reporting its exit back here.
+extern "C" void Bun__Chrome__retire();
 extern "C" void* Blob__fromBytesWithType(JSC::JSGlobalObject*, const uint8_t* ptr, size_t len, const char* mime);
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(Zig::GlobalObject*, void* impl);
 extern "C" void Bun__EventLoop__enter(Zig::GlobalObject*);
@@ -533,6 +535,7 @@ void Transport::onWritable()
 
 void Transport::onData(const char* data, int length)
 {
+    if (m_dead) return; // late bytes from a connection rejectAllAndMarkDead gave up on
     m_rx.append(std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(data), static_cast<size_t>(length)));
 
@@ -1348,6 +1351,17 @@ uint32_t Transport::registerView(JSWebView* v)
     uint32_t id = m_nextViewId++;
     m_views.add(id, JSC::Weak<JSWebView>(v, &webViewWeakOwner()));
     return id;
+}
+
+void Transport::retireGlobal(Zig::GlobalObject* global)
+{
+    if (m_global != global) return;
+    // Closes the socket (pipe mode) or drops the WebSocket, then rejects every
+    // view's pending promises on the outgoing global. No-op if Chrome already
+    // died during the file; the process below is then gone or on its way out.
+    rejectAllAndMarkDead("WebView closed: its test file finished"_s);
+    Bun__Chrome__retire();
+    m_global = nullptr;
 }
 
 // --- CDP::Ops --------------------------------------------------------------

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1356,9 +1356,6 @@ uint32_t Transport::registerView(JSWebView* v)
 void Transport::retireGlobal(Zig::GlobalObject* global)
 {
     if (m_global != global) return;
-    // Closes the socket (pipe mode) or drops the WebSocket, then rejects every
-    // view's pending promises on the outgoing global. No-op if Chrome already
-    // died during the file; the process below is then gone or on its way out.
     rejectAllAndMarkDead("WebView closed: its test file finished"_s);
     Bun__Chrome__retire();
     m_global = nullptr;

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -417,11 +417,7 @@ public:
     void onWritable();
     void onClose();
 
-    // `bun test --isolate` is retiring `global` on a live VM. The transport
-    // belongs to the global that spawned or connected it, so everything it
-    // routes goes with that global: the views are closed, their pending
-    // promises rejected, a spawned Chrome is killed. The next file's first
-    // `new Bun.WebView()` starts from None. No-op for any other global.
+    // `bun test --isolate` retires `global`: its views close, their promises reject, a spawned Chrome dies.
     void retireGlobal(Zig::GlobalObject* global);
 
     Zig::GlobalObject* m_global = nullptr;

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -417,6 +417,13 @@ public:
     void onWritable();
     void onClose();
 
+    // `bun test --isolate` is retiring `global` on a live VM. The transport
+    // belongs to the global that spawned or connected it, so everything it
+    // routes goes with that global: the views are closed, their pending
+    // promises rejected, a spawned Chrome is killed. The next file's first
+    // `new Bun.WebView()` starts from None. No-op for any other global.
+    void retireGlobal(Zig::GlobalObject* global);
+
     Zig::GlobalObject* m_global = nullptr;
     TransportMode m_mode = TransportMode::None;
     // POSIX pipe mode: the usockets-adopted socketpair fd. Null on Windows.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -52,8 +52,7 @@ pub(crate) struct ChromeProcess {
     // Intrusive refcount (`.deref()` called in on_process_exit); kept raw
     // because the refcount, not this struct, owns the allocation.
     process: NonNull<Process>,
-    /// Set by [`Bun__Chrome__retire`]: the transport has already let go of
-    /// this Chrome, so its exit is only reaped, not reported to C++.
+    /// Set by [`Bun__Chrome__retire`]: the exit is reaped but not reported to C++.
     retired: bool,
     #[cfg(windows)]
     pipes: WindowsPipes,
@@ -99,11 +98,7 @@ extern "C" fn Bun__Chrome__kill() {
     }
 }
 
-/// `bun test --isolate` is retiring the global that spawned this Chrome
-/// (Transport::retireGlobal, after it rejected everything pending). Unpublish
-/// and kill the process now so the next file's `new Bun.WebView()` can spawn
-/// its own without waiting for this one to be reaped; `on_exit` still reaps
-/// it, but no longer tells C++ about a death the transport has moved past.
+/// Transport::retireGlobal (`bun test --isolate`): unpublish and kill this Chrome so the next file can spawn its own at once.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__Chrome__retire() {
     let this = INSTANCE.swap(ptr::null_mut(), Ordering::Relaxed);
@@ -115,8 +110,7 @@ extern "C" fn Bun__Chrome__retire() {
     chrome.retired = true;
     #[cfg(windows)]
     {
-        // Events from this Chrome that are still queued carry its generation
-        // and are dropped in `QueuedEvent::deliver`.
+        // Queued events from this Chrome carry its generation; `QueuedEvent::deliver` drops them.
         GENERATION.fetch_add(1, Ordering::Relaxed);
         chrome.pipes.close();
     }

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -192,12 +192,8 @@ impl ChromeProcess {
     unsafe fn on_exit(this: *mut ChromeProcess, process: *mut Process, status: &Status) {
         scoped_log!(Chrome, "chrome exited: {}", status);
         // A retired Chrome was already unpublished by `Bun__Chrome__retire`.
-        let _ = INSTANCE.compare_exchange(
-            this,
-            ptr::null_mut(),
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-        );
+        let _ =
+            INSTANCE.compare_exchange(this, ptr::null_mut(), Ordering::Relaxed, Ordering::Relaxed);
         // SAFETY: caller contract; nothing else references the allocation once INSTANCE is cleared.
         let mut chrome = unsafe { bun_core::heap::take(this) };
         debug_assert_eq!(process, chrome.process.as_ptr());

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -52,6 +52,9 @@ pub(crate) struct ChromeProcess {
     // Intrusive refcount (`.deref()` called in on_process_exit); kept raw
     // because the refcount, not this struct, owns the allocation.
     process: NonNull<Process>,
+    /// Set by [`Bun__Chrome__retire`]: the transport has already let go of
+    /// this Chrome, so its exit is only reaped, not reported to C++.
+    retired: bool,
     #[cfg(windows)]
     pipes: WindowsPipes,
     #[cfg(windows)]
@@ -94,6 +97,31 @@ extern "C" fn Bun__Chrome__kill() {
             let _ = i.process.as_mut().kill(9);
         }
     }
+}
+
+/// `bun test --isolate` is retiring the global that spawned this Chrome
+/// (Transport::retireGlobal, after it rejected everything pending). Unpublish
+/// and kill the process now so the next file's `new Bun.WebView()` can spawn
+/// its own without waiting for this one to be reaped; `on_exit` still reaps
+/// it, but no longer tells C++ about a death the transport has moved past.
+#[unsafe(no_mangle)]
+extern "C" fn Bun__Chrome__retire() {
+    let this = INSTANCE.swap(ptr::null_mut(), Ordering::Relaxed);
+    // SAFETY: INSTANCE held a live heap-allocated pointer; `on_exit` only
+    // frees it after it runs, and we have just taken it out of INSTANCE.
+    let Some(chrome) = (unsafe { this.as_mut() }) else {
+        return;
+    };
+    chrome.retired = true;
+    #[cfg(windows)]
+    {
+        // Events from this Chrome that are still queued carry its generation
+        // and are dropped in `QueuedEvent::deliver`.
+        GENERATION.fetch_add(1, Ordering::Relaxed);
+        chrome.pipes.close();
+    }
+    // SAFETY: `process` is live until `on_exit` derefs it.
+    let _ = unsafe { chrome.process.as_mut().kill(9) };
 }
 
 /// Returns the parent's socketpair fd (POSIX, owned by usockets from then on), 0 (Windows), or -1 on failure.
@@ -163,14 +191,22 @@ impl ChromeProcess {
     /// Safety: `this` is the pointer published in INSTANCE (freed here); `process` is the exit callback's own argument, which carries the `&mut Process` already live in its frame (as in `SyncWindowsProcess::on_process_exit`).
     unsafe fn on_exit(this: *mut ChromeProcess, process: *mut Process, status: &Status) {
         scoped_log!(Chrome, "chrome exited: {}", status);
-        debug_assert_eq!(INSTANCE.load(Ordering::Relaxed), this);
-        INSTANCE.store(ptr::null_mut(), Ordering::Relaxed);
+        // A retired Chrome was already unpublished by `Bun__Chrome__retire`.
+        let _ = INSTANCE.compare_exchange(
+            this,
+            ptr::null_mut(),
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
         // SAFETY: caller contract; nothing else references the allocation once INSTANCE is cleared.
         let mut chrome = unsafe { bun_core::heap::take(this) };
         debug_assert_eq!(process, chrome.process.as_ptr());
         chrome.close_transport();
         // SAFETY: caller contract; this drops the strong ref taken by to_process.
         unsafe { Process::deref(process) };
+        if chrome.retired {
+            return;
+        }
         let signo: i32 = status.signal_code().map_or(0, |s| s as i32);
         #[cfg(windows)]
         PipeEvent::Exited { signo }.post(chrome.generation);
@@ -655,7 +691,10 @@ impl Endpoints {
 
     /// Publishes the singleton and returns our fd for C++ to adopt.
     fn attach(mut self, process: NonNull<Process>) -> crate::Result<i32> {
-        let self_ptr = bun_core::heap::into_raw(Box::new(ChromeProcess { process }));
+        let self_ptr = bun_core::heap::into_raw(Box::new(ChromeProcess {
+            process,
+            retired: false,
+        }));
         // SAFETY: `self_ptr` is a freshly-allocated, exclusively-owned Box that
         // owns `process` and outlives it.
         unsafe {
@@ -798,6 +837,7 @@ impl Endpoints {
         let generation = GENERATION.load(Ordering::Relaxed).wrapping_add(1);
         let self_ptr = bun_core::heap::into_raw(Box::new(ChromeProcess {
             process,
+            retired: false,
             pipes,
             generation,
         }));

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -37,6 +37,9 @@ pub(crate) struct HostProcess {
     // Intrusive refcount (`.deref()` called in on_process_exit); kept raw
     // because the refcount, not this struct, owns the allocation.
     process: NonNull<Process>,
+    /// Set by [`Bun__WebViewHost__retire`]: C++ has already let go of this
+    /// host, so its exit is only reaped, not reported.
+    retired: bool,
 }
 
 // PORTING.md §Global mutable state: JS-thread-only singleton ptr → AtomicPtr.
@@ -63,6 +66,23 @@ extern "C" fn Bun__WebViewHost__kill() {
             let _ = i.process.as_mut().kill(9);
         }
     }
+}
+
+/// `bun test --isolate` is retiring the global that spawned this host
+/// (HostClient::retireGlobal, after it rejected everything pending). Unpublish
+/// and kill the process now so the next file's `new Bun.WebView()` can spawn
+/// its own without waiting for this one to be reaped.
+#[unsafe(no_mangle)]
+extern "C" fn Bun__WebViewHost__retire() {
+    let this = INSTANCE.swap(ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);
+    // SAFETY: INSTANCE held a live heap-allocated pointer; on_process_exit
+    // only frees it after it runs, and we have just taken it out of INSTANCE.
+    let Some(host) = (unsafe { this.as_mut() }) else {
+        return;
+    };
+    host.retired = true;
+    // SAFETY: `process` is live until on_process_exit derefs it.
+    let _ = unsafe { host.process.as_mut().kill(9) };
 }
 
 /// Lazy: first `new Bun.WebView()` calls this via C++. Returns the parent
@@ -116,14 +136,22 @@ bun_spawn::link_impl_ProcessExit! {
         // pending promises and mark the host dead.
         on_process_exit(_process, status, _rusage) => {
             scoped_log!(WebViewHost, "child exited: {}", status);
-            let signo: i32 = status.signal_code().map_or(0, |s| s as i32);
-            Bun__WebViewHost__childDied(signo);
+            // A retired host was already unpublished by Bun__WebViewHost__retire.
+            if !(*this).retired {
+                let signo: i32 = status.signal_code().map_or(0, |s| s as i32);
+                Bun__WebViewHost__childDied(signo);
+            }
             // `this` was heap-allocated in spawn(); process is the
             // intrusive-rc *mut Process whose strong ref we hold. `deref()`
             // drops that ref, then drop the Box.
             Process::deref((*this).process.as_ptr());
             drop(bun_core::heap::take(this));
-            INSTANCE.store(ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);
+            let _ = INSTANCE.compare_exchange(
+                this,
+                ptr::null_mut(),
+                core::sync::atomic::Ordering::Relaxed,
+                core::sync::atomic::Ordering::Relaxed,
+            );
         },
     }
 }
@@ -197,7 +225,10 @@ fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) ->
         let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
         let process =
             NonNull::new(spawned.to_process(event_loop)).expect("toProcess returned null");
-        let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess { process }));
+        let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess {
+            process,
+            retired: false,
+        }));
         // SAFETY: `self_ptr` is a freshly-allocated, exclusively-owned Box that
         // owns `process` and outlives it.
         unsafe {

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -37,8 +37,7 @@ pub(crate) struct HostProcess {
     // Intrusive refcount (`.deref()` called in on_process_exit); kept raw
     // because the refcount, not this struct, owns the allocation.
     process: NonNull<Process>,
-    /// Set by [`Bun__WebViewHost__retire`]: C++ has already let go of this
-    /// host, so its exit is only reaped, not reported.
+    /// Set by [`Bun__WebViewHost__retire`]: the exit is reaped but not reported to C++.
     retired: bool,
 }
 
@@ -68,10 +67,7 @@ extern "C" fn Bun__WebViewHost__kill() {
     }
 }
 
-/// `bun test --isolate` is retiring the global that spawned this host
-/// (HostClient::retireGlobal, after it rejected everything pending). Unpublish
-/// and kill the process now so the next file's `new Bun.WebView()` can spawn
-/// its own without waiting for this one to be reaped.
+/// HostClient::retireGlobal (`bun test --isolate`): unpublish and kill this host so the next file can spawn its own at once.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__WebViewHost__retire() {
     let this = INSTANCE.swap(ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -117,8 +117,7 @@ JSWebView::~JSWebView()
     if (m_closed) return;
     if (m_backend == WebViewBackend::Chrome) {
         auto& t = CDP::transport();
-        // Only this view's own session entry: a browser spawned after this
-        // view's transport was retired may reuse the session id string.
+        // Only this view's own entry: a browser spawned after a retire can reuse the session id string.
         if (!m_sessionId.isEmpty()) {
             auto it = t.m_sessions.find(m_sessionId);
             if (it != t.m_sessions.end() && it->value == m_viewId) t.m_sessions.remove(it);

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -117,7 +117,12 @@ JSWebView::~JSWebView()
     if (m_closed) return;
     if (m_backend == WebViewBackend::Chrome) {
         auto& t = CDP::transport();
-        if (!m_sessionId.isEmpty()) t.m_sessions.remove(m_sessionId);
+        // Only this view's own session entry: a browser spawned after this
+        // view's transport was retired may reuse the session id string.
+        if (!m_sessionId.isEmpty()) {
+            auto it = t.m_sessions.find(m_sessionId);
+            if (it != t.m_sessions.end() && it->value == m_viewId) t.m_sessions.remove(it);
+        }
         if (m_viewId) t.m_views.remove(m_viewId);
         t.updateKeepAlive();
         return;
@@ -373,6 +378,14 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     // synchronous and the attach chain owned by the navigate promise (which
     // resolves on Page.loadEventFired, so one await covers the whole sequence).
     return view;
+}
+
+void retireWebViewsForTestIsolation(Zig::GlobalObject* global)
+{
+    CDP::transport().retireGlobal(global);
+#if OS(DARWIN)
+    WK::client().retireGlobal(global);
+#endif
 }
 
 // --- Setup -----------------------------------------------------------------

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -224,6 +224,12 @@ JSC::JSValue toJS(JSC::JSGlobalObject*, WebCore::JSDOMGlobalObject*, WebViewEven
 
 void setupJSWebViewClassStructure(JSC::LazyClassStructure::Initializer&);
 
+// `bun test --isolate` is retiring `global` on a live VM. Each backend's
+// transport is a process singleton bound to the global that spawned it; this
+// closes that global's views, rejects their pending promises and lets the
+// browser process go, so the next file spawns its own.
+void retireWebViewsForTestIsolation(Zig::GlobalObject* global);
+
 // Shared weak owner for HostClient.viewsById and Transport.m_pending/
 // .m_sessions. Roots a view while m_pendingActivityCount > 0.
 JSC::WeakHandleOwner& webViewWeakOwner();

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -224,10 +224,7 @@ JSC::JSValue toJS(JSC::JSGlobalObject*, WebCore::JSDOMGlobalObject*, WebViewEven
 
 void setupJSWebViewClassStructure(JSC::LazyClassStructure::Initializer&);
 
-// `bun test --isolate` is retiring `global` on a live VM. Each backend's
-// transport is a process singleton bound to the global that spawned it; this
-// closes that global's views, rejects their pending promises and lets the
-// browser process go, so the next file spawns its own.
+// `bun test --isolate` retires `global`: the transports bound to it close their views and let their browser go.
 void retireWebViewsForTestIsolation(Zig::GlobalObject* global);
 
 // Shared weak owner for HostClient.viewsById and Transport.m_pending/

--- a/src/runtime/webview/WebKitBackend.cpp
+++ b/src/runtime/webview/WebKitBackend.cpp
@@ -41,6 +41,8 @@ using namespace WebViewProto;
 
 // Spawn + process-exit watch implemented in HostProcess.rs (EVFILT_PROC).
 extern "C" int32_t Bun__WebViewHost__ensure(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit);
+// Unpublishes and kills the host without reporting its exit back here.
+extern "C" void Bun__WebViewHost__retire();
 extern "C" void* Blob__fromMmapWithType(JSC::JSGlobalObject*, uint8_t* ptr, size_t len, const char* mime);
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(Zig::GlobalObject*, void* impl);
 extern "C" JSC::EncodedJSValue JSBuffer__fromMmap(Zig::GlobalObject*, void* ptr, size_t length);
@@ -484,8 +486,17 @@ void HostClient::onClose()
     rejectAllAndMarkDead("WebView host process died"_s);
 }
 
+void HostClient::retireGlobal(Zig::GlobalObject* g)
+{
+    if (global != g) return;
+    rejectAllAndMarkDead("WebView closed: its test file finished"_s);
+    Bun__WebViewHost__retire();
+    global = nullptr;
+}
+
 void HostClient::onData(const char* data, int length)
 {
+    if (dead) return;
     rx.append(std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(data), static_cast<size_t>(length)));
 
     auto& vm = global->vm();

--- a/src/runtime/webview/WebKitBackend.h
+++ b/src/runtime/webview/WebKitBackend.h
@@ -59,6 +59,8 @@ struct HostClient {
     void onData(const char* data, int length);
     void onWritable();
     void onClose();
+    // `bun test --isolate` is retiring `global`. See CDP::Transport::retireGlobal.
+    void retireGlobal(Zig::GlobalObject* global);
 };
 
 HostClient& client();

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -16,11 +16,19 @@ const screenshot = Buffer.alloc(100_000);
 for (let i = 0; i < screenshot.length; i++) screenshot[i] = (i * 7) & 0xff;
 const screenshotBase64 = screenshot.toString("base64");
 
+// `--exit-delay=<ms>`: how long the process outlives the command pipe, the way
+// a real browser takes a moment to shut down after the pipe closes. Default 0.
+const exitDelay = Number(process.argv.find(a => a.startsWith("--exit-delay="))?.slice("--exit-delay=".length) ?? 0);
+
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
+  },
+  // The command gets no reply, ever.
+  __fake_no_reply() {
+    return NO_REPLY;
   },
   // The process stays alive; only the reply pipe goes away.
   __fake_close_replies() {
@@ -94,7 +102,11 @@ while (!commandsClosed) {
   } catch {
     break;
   }
-  if (n === 0) process.exit(0); // the parent closed its end: it is gone or shutting down
+  if (n === 0) {
+    // The parent closed its end: it is gone or shutting down.
+    if (exitDelay > 0) await Bun.sleep(exitDelay);
+    process.exit(0);
+  }
   pending = Buffer.concat([pending, chunk.subarray(0, n)]);
   let nul: number;
   while ((nul = pending.indexOf(0)) !== -1) {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -10,7 +10,7 @@
 // scenario prints one JSON value; `outcome()` turns a promise into
 // { resolved } or { rejected: message }.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
 const fixture = join(import.meta.dir, "fake-chrome-fixture.ts");
@@ -157,6 +157,58 @@ test.concurrent("the browser exiting rejects what it owed, and the next WebView 
     second.close();
   `);
   expect(result).toEqual({ death: transportLost, second: "alive again" });
+});
+
+// `bun test --isolate` replaces the global object between files. The transport
+// is bound to the global that spawned the browser, so it has to go with that
+// file: its open views are closed, their pending promises rejected, and the
+// next file spawns a browser of its own. The fake outlives its pipes by 20 s
+// like a real browser shutting down, so the next file cannot depend on the
+// old process having gone away by itself.
+test.concurrent("bun test --isolate retires the transport with the file that spawned it", async () => {
+  const file = /* js */ `
+    import { test } from "bun:test";
+    const backend = {
+      type: "chrome",
+      url: false,
+      path: ${JSON.stringify(bunExe())},
+      argv: [${JSON.stringify(fixture)}, "--exit-delay=20000"],
+      stderr: "inherit",
+    };
+    test("leaves a view open with a command in flight", async () => {
+      const view = new Bun.WebView({ backend, width: 100, height: 100 });
+      await view.navigate("http://fake/" + import.meta.file);
+      console.log(JSON.stringify({ file: import.meta.file, url: view.url }));
+      view.evaluate("__fake_no_reply()").catch(e => {
+        console.log(JSON.stringify({ file: import.meta.file, rejected: e.message, isError: e instanceof Error }));
+      });
+    });
+  `;
+  using dir = tempDir("webview-isolate", { "a.test.ts": file, "b.test.ts": file });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate", "a.test.ts", "b.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The first stdout line is the `bun test` banner.
+  const lines = stdout
+    .split("\n")
+    .filter(line => line.startsWith("{"))
+    .map(line => JSON.parse(line));
+  // The first file's evaluate is rejected when its global retires; the second
+  // file's is still in flight when the run ends. Discovery order decides
+  // which file is which.
+  const [first, second] = lines[0]?.file === "b.test.ts" ? ["b.test.ts", "a.test.ts"] : ["a.test.ts", "b.test.ts"];
+  expect(lines).toEqual([
+    { file: first, url: "http://fake/" + first },
+    { file: first, rejected: "WebView closed: its test file finished", isError: true },
+    { file: second, url: "http://fake/" + second },
+  ]);
+  expect(stderr).toContain(" 2 pass");
+  expect(exitCode).toBe(0);
 });
 
 // On POSIX fd 3 and fd 4 are one socket, so losing a single direction is not


### PR DESCRIPTION
### Problem
- `bun test --parallel` (it implies `--isolate`) on Windows crashes in `JSC::TypeInfoBlob::blob` under `JSCell::JSCell`, from `Bun::CDP::Ops::close` (`createError(g, "WebView closed")`) and `Transport::handleResponse` (`createBuffer(g, ...)`). Sentry BUN-30VN and BUN-3DG7 (1.4.0), then BUN-2VZ1 in the GC marker.
- `CDP::transport()` is a process singleton that caches `m_global`, the global that spawned Chrome (ChromeBackend.cpp:311). `--isolate` replaces the global between files and `ensureSpawned` returns early while the transport is up, so the next file's view allocates with a collected global's freed structures.
- On POSIX the swap's socket sweep marks the transport dead. The Windows pipes are libuv handles, not usockets, so nothing retired it there.

### Fix
- `Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation` calls `retireWebViewsForTestIsolation(global)`: the CDP transport (and the WebKit host client on macOS) rejects the pending promises on the outgoing global, marks its views closed and clears `m_global`.
- `Bun__Chrome__retire` / `Bun__WebViewHost__retire` unpublish and kill the browser. Its exit handler still reaps it but no longer reports the death. The next file spawns its own browser at once (before, it failed with "Failed to spawn Chrome" until the old one was reaped).
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts` (new case, fails on main on Linux and Windows), the 58 real-Chrome tests, and `--isolate` / `--parallel` runs with real Chrome.

### Background
- `--isolate` keeps one JSC VM and creates a fresh `Zig::GlobalObject` per file. The old global is unprotected and collected.
- `CDP::Transport` owns the `--remote-debugging-pipe` connection, the pending-reply map and one `Weak<JSWebView>` per view, and allocates replies with `m_global`'s structures.
- A `Structure` is JSC's shape record for an object. A cell allocated with a structure from a collected global reads freed memory: the `TypeInfoBlob::blob` fault.

<details><summary>Notes</summary>

BUN-3DG7 is the same user and tag set (Windows x64, `bun test --parallel`, `webview_chrome`), one more 1.4.0 event: a fault in `StringImpl::isSymbol` under `IdentifierRepHash::hash`, `PropertyTable::reinsert` and the `PropertyTable` copy constructor (PropertyTable.cpp:116). That is a `Structure` of the dead global having its property table copied, the same freed-structure read one step later.

Repro with the released 1.4.1 canary on Windows, `bun test --isolate` over five files that each open a view against the fake Chrome from `test/js/bun/webview/fake-chrome-fixture.ts`, take a screenshot and then `close()`. Every other file gets objects built on the dead global: the screenshot `Buffer` has no `length`, the "WebView closed" `Error` has no `message`, and `instanceof Error` is false. That is the same path as the Sentry events, before the structure memory was unmapped.

Repro on Linux with the released bun: the swap's socket sweep rejects file 1's pending evaluate with "Chrome process closed the pipe", and file 2's `new Bun.WebView()` throws "Failed to spawn Chrome" because `Bun__Chrome__ensure` refuses to spawn while the old process is published. The fake now takes `--exit-delay=<ms>` so it outlives its pipes like a real browser does; the new test uses 20 s.

The WebSocket transport mode (`backend.url`, or an auto-detected DevToolsActivePort) had the same stale `m_global` on every platform: `WebSocket::stop()` during `prepareForDestruction` drops the connection without a callback, so the transport stayed in WebSocket mode with a dead socket. The retire hook runs before `prepareForDestruction`, so the pending promises are rejected while the context is intact.

`onData` now returns on a dead transport, and `~JSWebView` removes its session entry only when the entry still points at that view. A browser spawned by a later file can hand out the same session id string (the fake does).

Other suites run: `test/js/bun/webview/` with `BUN_CHROME_PATH` pointing at a `--no-sandbox` wrapper (this container runs as root), 58 pass in `webview-chrome.test.ts`. `--isolate` and `--parallel` with real Chrome across 3 files: each file spawns its own Chrome, no process is left behind.
</details>

