### PR TITLE
js_printer: resolve string ropes into a local copy instead of the shared AST node

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1875,10 +1875,33 @@ impl EString {
         true
     }
 
+    /// Flatten the rope in place. Only the pass that owns the node may call
+    /// this (the parser, on its own thread). Code that reads an AST other
+    /// threads are also reading, such as the printer, uses [`Self::flattened`].
     pub fn resolve_rope_if_needed(&mut self, bump: &Bump) {
         if self.next.is_none() || !self.is_utf8() {
             return;
         }
+        self.data = Str::new(self.flatten_rope(bump));
+        self.next = None;
+    }
+
+    /// Copy of `self` with the rope flattened into `bump`. `self` and its
+    /// `next` chain are only read. The bundler prints a module into every
+    /// chunk that includes it, in parallel, from one AST, so the printer must
+    /// never write to a node: a `data` / `next` write here races the other
+    /// printers' reads (tail printed twice or dropped, or a torn `next`).
+    pub fn flattened(&self, bump: &Bump) -> EString {
+        let mut copy = self.shallow_clone();
+        if copy.next.is_some() && copy.is_utf8() {
+            copy.data = Str::new(self.flatten_rope(bump));
+            copy.next = None;
+        }
+        copy
+    }
+
+    /// The rope's bytes, concatenated into a fresh `bump` slice.
+    fn flatten_rope<'b>(&self, bump: &'b Bump) -> &'b [u8] {
         let mut bytes = bun_alloc::ArenaVec::<u8>::with_capacity_in(self.rope_len as usize, bump);
         bytes.extend_from_slice(&self.data);
         let mut str_ = self.next;
@@ -1886,8 +1909,7 @@ impl EString {
             bytes.extend_from_slice(&part.get().data);
             str_ = part.get().next;
         }
-        self.data = Str::new(bytes.into_bump_slice());
-        self.next = None;
+        bytes.into_bump_slice()
     }
 
     /// Return UTF-8 bytes, transcoding if UTF-16.

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1875,8 +1875,7 @@ impl EString {
         true
     }
 
-    /// Flatten the rope in place. For the pass that owns the node (the parser).
-    /// Readers of an AST shared with other threads use [`Self::flattened`].
+    /// Flatten in place. Parser only; shared-AST readers use [`Self::flattened`].
     pub fn resolve_rope_if_needed(&mut self, bump: &Bump) {
         if self.next.is_none() || !self.is_utf8() {
             return;
@@ -1885,9 +1884,7 @@ impl EString {
         self.next = None;
     }
 
-    /// Copy of `self` with the rope flattened into `bump`; `self` and its chain
-    /// are only read. The bundler prints one module into every chunk that
-    /// includes it, in parallel, so the printer must not write to the node.
+    /// Copy with the rope flattened into `bump`; `self` is only read (the printer runs in parallel).
     pub fn flattened(&self, bump: &Bump) -> EString {
         let mut copy = self.shallow_clone();
         if copy.next.is_some() && copy.is_utf8() {

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1685,8 +1685,7 @@ pub struct EString {
 // Also exported as `String`; `EString` avoids colliding with bun_core::String.
 pub use EString as String;
 
-/// Result of [`EString::flattened`]: the node itself when it is not a rope, else
-/// a local copy whose `data` is the flattened rope.
+/// [`EString::flattened`] result: the node itself, or an owned copy when a rope was flattened.
 pub enum Flattened<'a> {
     Borrowed(&'a EString),
     Owned(EString),
@@ -1902,8 +1901,7 @@ impl EString {
         self.next = None;
     }
 
-    /// `self` when it is not a rope, else a copy with the rope flattened into
-    /// `bump`. Never writes to `self`: the printer runs in parallel on shared nodes.
+    /// `self` if not a rope, else a copy flattened into `bump`. Never writes to `self`.
     pub fn flattened(&self, bump: &Bump) -> Flattened<'_> {
         if self.next.is_none() || !self.is_utf8() {
             return Flattened::Borrowed(self);

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1685,6 +1685,24 @@ pub struct EString {
 // Also exported as `String`; `EString` avoids colliding with bun_core::String.
 pub use EString as String;
 
+/// Result of [`EString::flattened`]: the node itself when it is not a rope, else
+/// a local copy whose `data` is the flattened rope.
+pub enum Flattened<'a> {
+    Borrowed(&'a EString),
+    Owned(EString),
+}
+
+impl core::ops::Deref for Flattened<'_> {
+    type Target = EString;
+    #[inline]
+    fn deref(&self) -> &EString {
+        match self {
+            Flattened::Borrowed(s) => s,
+            Flattened::Owned(s) => s,
+        }
+    }
+}
+
 impl Default for EString {
     fn default() -> Self {
         Self {
@@ -1884,14 +1902,16 @@ impl EString {
         self.next = None;
     }
 
-    /// Copy with the rope flattened into `bump`; `self` is only read (the printer runs in parallel).
-    pub fn flattened(&self, bump: &Bump) -> EString {
-        let mut copy = self.shallow_clone();
-        if copy.next.is_some() && copy.is_utf8() {
-            copy.data = Str::new(self.flatten_rope(bump));
-            copy.next = None;
+    /// `self` when it is not a rope, else a copy with the rope flattened into
+    /// `bump`. Never writes to `self`: the printer runs in parallel on shared nodes.
+    pub fn flattened(&self, bump: &Bump) -> Flattened<'_> {
+        if self.next.is_none() || !self.is_utf8() {
+            return Flattened::Borrowed(self);
         }
-        copy
+        let mut copy = self.shallow_clone();
+        copy.data = Str::new(self.flatten_rope(bump));
+        copy.next = None;
+        Flattened::Owned(copy)
     }
 
     /// The rope's bytes, concatenated into a fresh `bump` slice.

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1875,9 +1875,8 @@ impl EString {
         true
     }
 
-    /// Flatten the rope in place. Only the pass that owns the node may call
-    /// this (the parser, on its own thread). Code that reads an AST other
-    /// threads are also reading, such as the printer, uses [`Self::flattened`].
+    /// Flatten the rope in place. For the pass that owns the node (the parser).
+    /// Readers of an AST shared with other threads use [`Self::flattened`].
     pub fn resolve_rope_if_needed(&mut self, bump: &Bump) {
         if self.next.is_none() || !self.is_utf8() {
             return;
@@ -1886,11 +1885,9 @@ impl EString {
         self.next = None;
     }
 
-    /// Copy of `self` with the rope flattened into `bump`. `self` and its
-    /// `next` chain are only read. The bundler prints a module into every
-    /// chunk that includes it, in parallel, from one AST, so the printer must
-    /// never write to a node: a `data` / `next` write here races the other
-    /// printers' reads (tail printed twice or dropped, or a torn `next`).
+    /// Copy of `self` with the rope flattened into `bump`; `self` and its chain
+    /// are only read. The bundler prints one module into every chunk that
+    /// includes it, in parallel, so the printer must not write to the node.
     pub fn flattened(&self, bump: &Bump) -> EString {
         let mut copy = self.shallow_clone();
         if copy.next.is_some() && copy.is_utf8() {

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -424,8 +424,6 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     {
                         continue;
                     }
-                    // The key node is shared with every other chunk printing
-                    // this file; read it, never flatten it in place.
                     let name: &[u8] = match &prop.key.as_ref().unwrap().data {
                         ExprData::EString(s) => s
                             .flattened(temp_arena)

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -424,8 +424,13 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     {
                         continue;
                     }
-                    let name = match &mut prop.key.as_mut().unwrap().data {
-                        ExprData::EString(s) => s.slice(temp_arena),
+                    // The key node is shared with every other chunk printing
+                    // this file; read it, never flatten it in place.
+                    let name: &[u8] = match &prop.key.as_ref().unwrap().data {
+                        ExprData::EString(s) => s
+                            .flattened(temp_arena)
+                            .string(temp_arena)
+                            .expect("OOM"),
                         _ => unreachable!(),
                     };
                     if name == b"default" || name == b"__esModule" || !js_lexer::is_identifier(name)

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -426,7 +426,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     }
                     let name: &[u8] = match &prop.key.as_ref().unwrap().data {
                         ExprData::EString(s) => {
-                            s.flattened(temp_arena).string(temp_arena).expect("OOM")
+                            bun_core::handle_oom(s.flattened(temp_arena).string(temp_arena))
                         }
                         _ => unreachable!(),
                     };

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -425,10 +425,9 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                         continue;
                     }
                     let name: &[u8] = match &prop.key.as_ref().unwrap().data {
-                        ExprData::EString(s) => s
-                            .flattened(temp_arena)
-                            .string(temp_arena)
-                            .expect("OOM"),
+                        ExprData::EString(s) => {
+                            s.flattened(temp_arena).string(temp_arena).expect("OOM")
+                        }
                         _ => unreachable!(),
                     };
                     if name == b"default" || name == b"__esModule" || !js_lexer::is_identifier(name)

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -433,7 +433,7 @@ pub(crate) fn generate_code_for_lazy_export(
                     // across the `&mut self` call to `generate_named_export_in_file` below.
                     let alloc: &bun_alloc::Arena =
                         unsafe { bun_ptr::detach_lifetime_ref::<bun_alloc::Arena>(this.arena()) };
-                    let name: &[u8] = key_str.flattened(alloc).string(alloc).expect("OOM");
+                    let name: &[u8] = bun_core::handle_oom(key_str.flattened(alloc).string(alloc));
 
                     // TODO: support non-identifier names
                     if !js_lexer::is_identifier(name) {

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -417,11 +417,8 @@ pub(crate) fn generate_code_for_lazy_export(
             if let ExprData::EObject(e_object) = &expr.data {
                 for property in e_object.properties.slice() {
                     let _: &G::Property = property;
-                    // `Expr`/`ExprData`/`StoreRef<_>` are `Copy`. Copy `key` out so
-                    // `key_str: StoreRef<E::EString>` is a mutable local — `slice()` resolves
-                    // the rope in-place via `DerefMut` into the arena slot.
                     let Some(key) = property.key else { continue };
-                    let ExprData::EString(mut key_str) = key.data else {
+                    let ExprData::EString(key_str) = key.data else {
                         continue;
                     };
                     let Some(value) = property.value else {
@@ -436,7 +433,7 @@ pub(crate) fn generate_code_for_lazy_export(
                     // across the `&mut self` call to `generate_named_export_in_file` below.
                     let alloc: &bun_alloc::Arena =
                         unsafe { bun_ptr::detach_lifetime_ref::<bun_alloc::Arena>(this.arena()) };
-                    let name = key_str.slice(alloc);
+                    let name: &[u8] = key_str.flattened(alloc).string(alloc).expect("OOM");
 
                     // TODO: support non-identifier names
                     if !js_lexer::is_identifier(name) {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3450,10 +3450,7 @@ pub(crate) mod __gated_printer {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
                         if let Some(str) = e.index.data.as_e_string() {
-                            // Resolve into a local copy: the AST node is shared
-                            // with every other thread printing this module.
-                            let mut str = str.shallow_clone();
-                            str.resolve_rope_if_needed(self.bump);
+                            let str = str.flattened(self.bump);
                             if str.is_utf8() {
                                 if let Some(value) =
                                     self.try_to_get_imported_enum_value(e.target, str.slice8())
@@ -3765,14 +3762,9 @@ pub(crate) mod __gated_printer {
                         return;
                     }
 
-                    // Resolve the rope into a local copy, never through the
-                    // `StoreRef`: the bundler prints a shared module into every
-                    // chunk that includes it, concurrently, from the same AST.
-                    // Writing `data` / `next = None` into the node races the
-                    // other printers' reads (torn `next` pointer, or the tail
-                    // printed twice).
-                    let mut e = e.shallow_clone();
-                    e.resolve_rope_if_needed(self.bump);
+                    // A local copy: other threads may be printing this node
+                    // right now (one print per chunk), see `EString::flattened`.
+                    let e = e.flattened(self.bump);
                     self.add_source_mapping(expr.loc);
 
                     // If this was originally a template literal, print it as one as long as we're not minifying
@@ -3935,12 +3927,12 @@ pub(crate) mod __gated_printer {
                     }
 
                     self.print(b"`");
-                    match &mut e.head {
+                    match &e.head {
                         E::TemplateContents::Raw(raw) => self.print_raw_template_literal(raw),
                         E::TemplateContents::Cooked(cooked) => {
                             if cooked.is_present() {
-                                cooked.resolve_rope_if_needed(self.bump);
-                                self.print_string_characters_e_string(cooked, b'`');
+                                let cooked = cooked.flattened(self.bump);
+                                self.print_string_characters_e_string(&cooked, b'`');
                             }
                         }
                     }
@@ -3953,12 +3945,8 @@ pub(crate) mod __gated_printer {
                             E::TemplateContents::Raw(raw) => self.print_raw_template_literal(raw),
                             E::TemplateContents::Cooked(cooked) => {
                                 if cooked.is_present() {
-                                    // `parts` is `*mut [TemplatePart]` but accessed `&[T]`
-                                    // here. We resolve a local copy of the
-                                    // EString header (the rope chain is StoreRef-linked and Copy) and
-                                    // prints from that — the arena node stays roped.
-                                    let mut local = E::EString { ..*cooked };
-                                    local.resolve_rope_if_needed(self.bump);
+                                    // `parts` aliases the shared AST node.
+                                    let local = cooked.flattened(self.bump);
                                     self.print_string_characters_e_string(&local, b'`');
                                 }
                             }
@@ -4661,11 +4649,9 @@ pub(crate) mod __gated_printer {
                     self.print_symbol(priv_.ref_);
                 }
                 ExprData::EString(key_str) => {
-                    // Local copy; see the `ExprData::EString` arm of `print_expr`.
-                    let mut key_str = key_str.shallow_clone();
+                    let key_str = key_str.flattened(self.bump);
                     self.add_source_mapping(key.loc);
                     if key_str.is_utf8() {
-                        key_str.resolve_rope_if_needed(self.bump);
                         self.print_space_before_identifier();
                         let mut allow_shorthand = true;
                         if !IS_JSON && lexer::is_identifier(key_str.slice8()) {
@@ -4918,10 +4904,7 @@ pub(crate) mod __gated_printer {
 
                                 match &property.key.data {
                                     ExprData::EString(str) => {
-                                        // Local copy; see the `ExprData::EString`
-                                        // arm of `print_expr`.
-                                        let mut str = str.shallow_clone();
-                                        str.resolve_rope_if_needed(self.bump);
+                                        let str = str.flattened(self.bump);
                                         self.add_source_mapping(property.key.loc);
 
                                         if str.is_utf8() {
@@ -4972,7 +4955,7 @@ pub(crate) mod __gated_printer {
                                                 ) {
                                                     if Self::MAY_HAVE_MODULE_INFO && tlm.is_export {
                                                         // reshaped for borrowck — bump access first.
-                                                        let str8 = str.slice(self.bump);
+                                                        let str8 = str.string(self.bump).expect("OOM");
                                                         if let Some(mi) = self.module_info() {
                                                             let name_id = mi.str(str8);
                                                             mi.add_export_info_local(

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3762,8 +3762,6 @@ pub(crate) mod __gated_printer {
                         return;
                     }
 
-                    // A local copy: other threads may be printing this node
-                    // right now (one print per chunk), see `EString::flattened`.
                     let e = e.flattened(self.bump);
                     self.add_source_mapping(expr.loc);
 
@@ -3945,7 +3943,6 @@ pub(crate) mod __gated_printer {
                             E::TemplateContents::Raw(raw) => self.print_raw_template_literal(raw),
                             E::TemplateContents::Cooked(cooked) => {
                                 if cooked.is_present() {
-                                    // `parts` aliases the shared AST node.
                                     let local = cooked.flattened(self.bump);
                                     self.print_string_characters_e_string(&local, b'`');
                                 }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3449,7 +3449,10 @@ pub(crate) mod __gated_printer {
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
-                        if let Some(mut str) = e.index.data.as_e_string() {
+                        if let Some(str) = e.index.data.as_e_string() {
+                            // Resolve into a local copy: the AST node is shared
+                            // with every other thread printing this module.
+                            let mut str = str.shallow_clone();
                             str.resolve_rope_if_needed(self.bump);
                             if str.is_utf8() {
                                 if let Some(value) =
@@ -3762,7 +3765,13 @@ pub(crate) mod __gated_printer {
                         return;
                     }
 
-                    let mut e = *e;
+                    // Resolve the rope into a local copy, never through the
+                    // `StoreRef`: the bundler prints a shared module into every
+                    // chunk that includes it, concurrently, from the same AST.
+                    // Writing `data` / `next = None` into the node races the
+                    // other printers' reads (torn `next` pointer, or the tail
+                    // printed twice).
+                    let mut e = e.shallow_clone();
                     e.resolve_rope_if_needed(self.bump);
                     self.add_source_mapping(expr.loc);
 
@@ -4652,7 +4661,8 @@ pub(crate) mod __gated_printer {
                     self.print_symbol(priv_.ref_);
                 }
                 ExprData::EString(key_str) => {
-                    let mut key_str = *key_str;
+                    // Local copy; see the `ExprData::EString` arm of `print_expr`.
+                    let mut key_str = key_str.shallow_clone();
                     self.add_source_mapping(key.loc);
                     if key_str.is_utf8() {
                         key_str.resolve_rope_if_needed(self.bump);
@@ -4908,7 +4918,9 @@ pub(crate) mod __gated_printer {
 
                                 match &property.key.data {
                                     ExprData::EString(str) => {
-                                        let mut str = *str;
+                                        // Local copy; see the `ExprData::EString`
+                                        // arm of `print_expr`.
+                                        let mut str = str.shallow_clone();
                                         str.resolve_rope_if_needed(self.bump);
                                         self.add_source_mapping(property.key.loc);
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4952,8 +4952,9 @@ pub(crate) mod __gated_printer {
                                                 ) {
                                                     if Self::MAY_HAVE_MODULE_INFO && tlm.is_export {
                                                         // reshaped for borrowck — bump access first.
-                                                        let str8 =
-                                                            str.string(self.bump).expect("OOM");
+                                                        let str8 = bun_core::handle_oom(
+                                                            str.string(self.bump),
+                                                        );
                                                         if let Some(mi) = self.module_info() {
                                                             let name_id = mi.str(str8);
                                                             mi.add_export_info_local(

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4952,7 +4952,8 @@ pub(crate) mod __gated_printer {
                                                 ) {
                                                     if Self::MAY_HAVE_MODULE_INFO && tlm.is_export {
                                                         // reshaped for borrowck — bump access first.
-                                                        let str8 = str.string(self.bump).expect("OOM");
+                                                        let str8 =
+                                                            str.string(self.bump).expect("OOM");
                                                         if let Some(mi) = self.module_info() {
                                                             let name_id = mi.str(str8);
                                                             mi.add_export_info_local(

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1650,6 +1650,75 @@ test("Bun.build can be called thousands of times in one process without crashing
   expect(exitCode).toBe(0);
 }, 180_000);
 
+// A module shared by several entry points is printed once per chunk, and those
+// prints run in parallel on the thread pool against the same AST. The printer
+// used to flatten `"a" + "b" + "c"` ropes in place, through the `StoreRef`, so
+// one thread's write of `data` / `next = None` raced every other thread's read
+// of the same node. Observed results on the unfixed printer: the tail printed
+// twice ("abcbc"), the tail dropped ("a"), or a crash on a torn `next` pointer
+// (a `Bus error` / `Segmentation fault` at a 4 GiB aligned address).
+//
+// The race needs many chunks printing many ropes at the same time, so this
+// builds 64 entry points over one module with 400 folded ropes, twice, and
+// checks every folded string in every output. With the in-place flatten the
+// first build corrupts hundreds of strings on a 16 core machine.
+//
+// Needs an explicit timeout: two real 64-entry bundles on a debug build take
+// well over bun:test's 5s default.
+test("Bun.build does not corrupt folded string ropes shared across chunks", async () => {
+  const ENTRIES = 64;
+  const ROPES = 400;
+  const ROUNDS = 2;
+  let shared = "export function helper(...a) { return a; }\n";
+  for (let i = 0; i < ROPES; i++) {
+    // The rope is a call argument inside an arrow body, the shape the printer
+    // crashed on in the field. It folds only with `minify.syntax`.
+    shared +=
+      `export const fn${i} = helper("first${i}", () => { const q = ${i}; ` +
+      `helper(q, "alpha-${i}-" + "beta-" + "gamma-" + "delta-${i}"); return q; });\n`;
+  }
+  const files: Record<string, string> = { "shared.js": shared };
+  for (let i = 0; i < ENTRIES; i++) {
+    files[`entry${i}.js`] = `import * as s from "./shared.js";\nconsole.log(s, ${i});\n`;
+  }
+  files["run.ts"] = `
+    import { join } from "node:path";
+    const dir = process.argv[2];
+    const entrypoints = Array.from({ length: ${ENTRIES} }, (_, i) => join(dir, "entry" + i + ".js"));
+    let bad = 0;
+    for (let round = 0; round < ${ROUNDS}; round++) {
+      const res = await Bun.build({ entrypoints, minify: { syntax: true }, target: "bun" });
+      if (!res.success) throw new AggregateError(res.logs, "build failed");
+      for (const output of res.outputs) {
+        const text = await output.text();
+        for (let i = 0; i < ${ROPES}; i++) {
+          const expected = '"alpha-' + i + '-beta-gamma-delta-' + i + '"';
+          if (!text.includes(expected)) {
+            bad++;
+            if (bad <= 5) {
+              const actual = text.match(new RegExp('"alpha-' + i + '-[^"]*"'));
+              console.log("BAD round " + round + " " + output.path + " expected " + expected + " got " + actual?.[0]);
+            }
+          }
+        }
+      }
+    }
+    console.log("DONE " + bad);
+  `;
+  const dir = tempDirWithFiles("bun-build-rope-print-race", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(dir, "run.ts"), dir],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("DONE 0");
+  expect(exitCode).toBe(0);
+}, 180_000);
+
 test("sourcemap sourcesContent is valid JSON when source contains C0 control chars", async () => {
   // RFC 8259 only allows \" \\ \/ \b \f \n \r \t and six-char \u escapes; \v
   // and \xNN are JavaScript-only. A VT (0x0B) or BEL (0x07) in the input used

--- a/test/internal/source-lints/printer-rope-in-place.test.ts
+++ b/test/internal/source-lints/printer-rope-in-place.test.ts
@@ -1,0 +1,111 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// The printer and the linker's chunk generation read ASTs that other threads
+// are reading at the same time: the bundler prints a module into every chunk
+// that includes it, in parallel, from one AST. An in-place rope flatten there
+// (`E::String::resolve_rope_if_needed`, or anything built on it) writes `data`
+// and `next = None` into the shared node while the other printers read it.
+// The observed results were the tail printed twice, the tail dropped, and a
+// crash on a torn `next` pointer (`Bus error at address 0x56700000000`).
+//
+// `StoreRef<T>` is `Copy` and implements `DerefMut`, so `let mut e = *e;
+// e.resolve_rope_if_needed(bump)` compiles and silently mutates the arena node.
+// The read-only form is `e.flattened(bump)`, which returns a local copy with the
+// rope flattened into `bump`. The `&mut self` rope methods are for the parser,
+// which owns its nodes.
+//
+//   x.resolve_rope_if_needed(bump)   → let x = x.flattened(bump);
+//   x.slice(bump)                    → x.flattened(bump).string(bump)
+//   x.is_identifier(bump)            → is_identifier(x.flattened(bump).slice8())
+//   x.to_utf8(bump)                  → x.flattened(bump).string(bump)
+//   e_string_mut()                   → e_string() (a `StoreRef`, read it only)
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+// Code that runs on the shared, post-parse AST with other threads.
+const SCOPE = ["src/js_printer/", "src/bundler/linker_context/", "src/bundler/LinkerContext.rs"];
+
+const rustSources = globAllSources().rust.filter(abs => {
+  if (!abs.endsWith(".rs")) return false;
+  const rel = path.relative(root, abs).replaceAll(path.sep, "/");
+  return SCOPE.some(s => (s.endsWith("/") ? rel.startsWith(s) : rel === s));
+});
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout).
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const BANNED: { name: string; re: RegExp; hint: string }[] = [
+  {
+    name: "E::String::resolve_rope_if_needed",
+    re: /\.resolve_rope_if_needed\(/g,
+    hint: "flattened(bump)",
+  },
+  {
+    // The `E::String` method takes the arena; `StoreSlice::slice()` and the
+    // other no-argument `slice()` accessors do not match.
+    name: "E::String::slice(bump)",
+    re: /\.slice\(\s*[A-Za-z_][\w.:]*\s*\)/g,
+    hint: "flattened(bump).string(bump)",
+  },
+  {
+    // Method form with an argument; the free fn `js_lexer::is_identifier(x)`
+    // has no leading `.`.
+    name: "E::String::is_identifier(bump)",
+    re: /\.is_identifier\(\s*[A-Za-z_]/g,
+    hint: "is_identifier(flattened(bump).slice8())",
+  },
+  {
+    // `bun_core::String::to_utf8()` takes no argument and is fine.
+    name: "E::String::to_utf8(bump)",
+    re: /\.to_utf8\(\s*[A-Za-z_]/g,
+    hint: "flattened(bump).string(bump)",
+  },
+  {
+    name: "ExprData::e_string_mut",
+    re: /\.e_string_mut\(/g,
+    hint: "e_string() and read through the StoreRef",
+  },
+];
+
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions do not count. `[ \t]*`, not
+  // `\s*`, so the newline before a comment survives and line numbers hold.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  const lines = stripped.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    for (const { name, re, hint } of BANNED) {
+      re.lastIndex = 0;
+      if (re.test(lines[i])) {
+        offenders.push(`${source}:${i + 1}: ${name} (use ${hint}): ${lines[i].trim()}`);
+      }
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the printer and linker never flatten a string rope in place", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `Bun.build` with several entry points and no splitting can crash while printing a shared module: `Bus error at address 0x56700000000` in `BabyVec::extend_from_slice` under `EString::resolve_rope_if_needed` (Sentry BUN-4Q7C; BUN-4TEP is the same crash with 11 events in one day, `Segmentation fault at 0x27B00000000`, the top Rust-frame crash group on 1.4.0 this week; both macOS arm64). More often it silently emits wrong code: a folded string prints as `"abcbc"` or `"a"` instead of `"abc"`.
- Cause: `print_expr` (`src/js_printer/lib.rs:3768`) did `let mut e = *e; e.resolve_rope_if_needed(self.bump)`. `e` is a `StoreRef<EString>`, so the call goes through `DerefMut` and writes `data` and `next = None` into the shared AST node. Every chunk that includes the module prints it from the same AST, on its own pool thread, at the same time. Three more printer sites and two linker sites did the same.

### Fix
- Add `EString::flattened(&self, bump) -> Flattened<'_>`: the node itself when it is not a rope, else a local copy with the rope flattened into `bump` (`Flattened` derefs to `EString`). It only reads the node and its chain. The printer and the linker's chunk generation now use it everywhere; `resolve_rope_if_needed(&mut self)` stays for the parser, which owns its nodes.
- A source lint (`test/internal/source-lints/printer-rope-in-place.test.ts`) rejects the `&mut self` rope methods (`resolve_rope_if_needed`, `slice(bump)`, `is_identifier(bump)`, `to_utf8(bump)`) and `e_string_mut` in `src/js_printer` and the linker, so the in-place form cannot return there.
- Correct because a concurrent reader used to see the new `data` with the old `next` (tail twice), the old `data` with `next = None` (tail dropped), or a torn `next`: an 8-byte field at offset 12 of a `packed(4)` struct, so the store of `None` is not atomic and the reader gets the old pointer with its low half zeroed. That is the 4 GiB aligned fault address. With no write, every reader sees the parsed rope.
- Verified: `test/bundler/bun-build-api.test.ts` (new test, fails 3/3 on the unfixed debug build with 1200+ corrupted strings per run), the new lint, `bundler_string`, `bundler_minify`, `bundler_edgecase`, `bundler_loader`, `bundler_cjs2esm`, `bundler_bun`, `bundler_splitting`, `css-modules`, `transpiler/transpiler.test.js`, `transpiler/macro-test.test.ts`.

### Background
- A rope is a folded concatenation: under `minify.syntax`, `"a" + "b" + "c"` becomes one `EString` whose `next` chain holds the other parts. The printer flattens it on output.
- `StoreRef<T>` is the AST's arena pointer. It is `Copy` and implements `DerefMut`, so a `&mut self` method on a copied `StoreRef` mutates the arena node, not a local.
- The linker prints chunks in parallel. Without splitting, a module imported by N entry points is printed N times concurrently.

<details><summary>Notes</summary>

- The `macros` tag on the Sentry event was a coincidence. The repro has no macros. The user's build used them, which is why the report pointed there.
- Repro without the test harness: 64 entry points importing one module with 400 ropes of the shape `helper(q, "alpha-" + "beta-" + "gamma-" + "delta")` inside arrow bodies, `minify: { syntax: true }`. Release 1.4.0 on Linux x64: `Segmentation fault at address 0x3DE00000000` in 1 of 5 runs, 200 to 2000 corrupted strings in the others. The debug build corrupts every run.
- The fault address is the old `next` pointer with the low 32 bits cleared (the writer's store of `None` landed half way). `0x3DE_0000_0000`, `0x567_0000_0000` and `0x27B_0000_0000` all sit inside mimalloc's hint range (2 to 6 TiB), where the worker arenas live.
- The Zig printer wrote in place too (5 sites in `js_printer.zig`). Its pointers were 8-byte aligned, so the null store could not tear: Zig could misprint, not crash. The `packed(4)` `StoreRef` added the crash.
- Why not make the in-place resolve thread safe instead: it is a cache write into a shared node. It would need `next` moved to an 8-byte aligned offset and `data` + `next` published together (a separate slot behind one Release store, or a 16-byte CAS). It saves one memcpy of the parts per extra chunk that prints the node. The read-only copy keeps the AST immutable during printing, which the template arm already relied on, and needs no layout change.
- The flattened bytes go into the printer's bump, which in the bundler is the worker's pinned heap, so the old in-place write did not dangle. Only the race was wrong.
- `Template::fold` can still link onto a shared rope chain through `EString::push` (print time via the mangled-props path, and parse time with inlined enums). That is the `Template::fold` bug tracked in #38998 and is not changed here.
- Also seen while probing, not addressed here: a macro that returns `Response.json(...)` or a `Blob` with `type: "application/json"` is inlined as a base64 data URL string, not as an object, because the content type arrives as `application/json;charset=utf-8` and `expr_from_blob` matches the mime type exactly.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
