### PR TITLE
Module loader: a mocked module whose export getter loads an importer of it keeps one record (WebKit bump for oven-sh/WebKit#492)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-492-47837107";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -885,6 +885,70 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(exitCode).toBe(0);
 });
 
+// An import() leaves k.ts with a pending onLoad. A require() of a module that imports k.ts then re-issues the fetch
+// synchronously, and that onLoad call itself require()s another importer of k.ts, which re-issues the fetch a third
+// time. The loader must keep one record for k.ts, the one the nested (third) fetch produced: both importers see the
+// same namespace and read k = 3, and the outer fetch does not settle the entry a second time (a debug build asserts on
+// that). Two shapes: the pending fetch belongs to a dependency edge (a.ts imports k.ts, so k.ts has a registry entry
+// while its fetch is pending) or to the top-level import() of k.ts itself (no entry exists until the require() creates
+// one).
+describe.concurrent("an onLoad hook that loads another importer of the module it is loading keeps one record", () => {
+  for (const [shape, pendingImport] of [
+    ["a dependency edge", "./a.ts"],
+    ["a top-level import()", "./k.ts"],
+  ] as const) {
+    it(`the pending fetch comes from ${shape}`, async () => {
+      using dir = tempDir("plugin-onload-reentrant-fetch", {
+        "k.ts": `export const k = 0;`,
+        "a.ts": `import * as kns from "./k.ts"; export const a = kns.k;`,
+        "m.ts": `import * as kns from "./k.ts"; export const k = kns.k; export { kns };`,
+        "n.ts": `import * as kns from "./k.ts"; export const k = kns.k; export { kns };`,
+        "entry.ts": `
+          let calls = 0;
+          const { promise: firstFetchStarted, resolve: markFirstFetch } = Promise.withResolvers();
+          Bun.plugin({
+            name: "k-loader",
+            setup(build) {
+              build.onLoad({ filter: /[\\\\/]k\\.ts$/ }, () => {
+                // The nested require() below re-enters this hook and bumps calls before this call returns, so
+                // each call keeps its own number: the record from call 2 says k = 2, the one from call 3 says k = 3.
+                const thisCall = ++calls;
+                if (thisCall === 1) {
+                  markFirstFetch();
+                  return new Promise(() => {});
+                }
+                if (thisCall === 2) globalThis.n = require("./n.ts");
+                return { contents: "export const k = " + thisCall + ";", loader: "ts" };
+              });
+            },
+          });
+          import(${JSON.stringify(pendingImport)});
+          await firstFetchStarted;
+          const m = require("./m.ts");
+          const n = globalThis.n;
+          console.log(JSON.stringify({ calls, mK: m.k, nK: n.k, sameNamespace: m.kns === n.kns }));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+        calls: 3,
+        mK: 3,
+        nK: 3,
+        sameNamespace: true,
+      });
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
 // Spawned in a subprocess because clearAll() would wipe the plugins the rest of this file relies on.
 describe.concurrent("Bun.plugin.clearAll()", () => {
   async function run(src: string) {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -7,7 +7,8 @@
 // - Write test for export {foo} from "./foo"
 // - Write test for import {foo} from "./foo"; export {foo}
 
-import { expect, mock, spyOn, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -212,4 +213,101 @@ test("onResolve plugin errors surface from mock.module; an unresolvable specifie
   } finally {
     Bun.plugin.clearAll();
   }
+});
+
+// A factory export getter runs while the mocked module is being created. If it loads a module that imports the
+// mocked specifier, the loader meets its own in-progress entry. The nested load must not produce a second record
+// for the same key: every importer, and the registry, have to end up on the one record.
+describe("a factory export getter that loads a module which imports the mocked specifier", () => {
+  // The getter counts its calls so that the two candidate records are distinguishable: the nested load creates the
+  // module first (call 2), and that is the record the registry keeps. The outer call's record (call 1) is dropped.
+  const files = {
+    "bunfig.toml": `[test]\npreload = ["./preload.ts"]\n`,
+    "preload.ts": `
+      import { mock } from "bun:test";
+      let calls = 0;
+      mock.module("virt-cycle", () => ({
+        get g() {
+          calls++;
+          if (calls === 1) {
+            globalThis.n = require("./n.ts");
+            return "outer";
+          }
+          return "inner";
+        },
+      }));
+    `,
+    "n.ts": `
+      import * as v from "virt-cycle";
+      export * from "./s.ts";
+      export const vg = v.g;
+      export const vns = v;
+    `,
+    "s.ts": `export const s = 1;`,
+    "c.cjs": `
+      const v = require("virt-cycle");
+      module.exports = { v, g: v.g };
+    `,
+  };
+
+  async function runTest(files: Record<string, string>) {
+    using dir = tempDir("mock-module-getter-cycle", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "main.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const line = stdout.split("\n").find(l => l.startsWith("{"));
+    expect(line, stderr).toBeDefined();
+    return { result: JSON.parse(line!), stderr, exitCode };
+  }
+
+  test.concurrent("through require()", async () => {
+    const { result, stderr, exitCode } = await runTest({
+      ...files,
+      "main.test.ts": `
+        import { test } from "bun:test";
+        test("one record", () => {
+          const c = require("./c.cjs");
+          const n = globalThis.n;
+          console.log(JSON.stringify({
+            cG: c.g,
+            nVg: n.vg,
+            sameNamespace: c.v === n.vns,
+            reexport: n.s,
+            requireAgain: require("virt-cycle") === c.v,
+          }));
+        });
+      `,
+    });
+    expect(result).toEqual({ cG: "inner", nVg: "inner", sameNamespace: true, reexport: 1, requireAgain: true });
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("through import", async () => {
+    const { result, stderr, exitCode } = await runTest({
+      ...files,
+      "main.test.ts": `
+        import { test } from "bun:test";
+        import * as v from "virt-cycle";
+        test("one record", () => {
+          const n = globalThis.n;
+          console.log(JSON.stringify({
+            vG: v.g,
+            nVg: n.vg,
+            sameNamespace: v === n.vns,
+            reexport: n.s,
+            requireAgain: require("virt-cycle") === v,
+          }));
+        });
+      `,
+    });
+    expect(result).toEqual({ vG: "inner", nVg: "inner", sameNamespace: true, reexport: 1, requireAgain: true });
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
> `WEBKIT_VERSION` points at the preview tag `autobuild-preview-pr-492-47837107` while oven-sh/WebKit#492 is open. It has to move to the merged main sha before this lands.

### Problem
- A `mock.module()` factory getter that `require()`s an ES module which imports the mocked specifier leaves the key with two live module records: the CommonJS side and the ES module get different namespaces. A debug build trips `ASSERT(m_status == Status::Fetching)` in `ModuleRegistryEntry::fetchComplete`. Sentry BUN-4QBM crashed on this path.
- Cause: `require(esm)` runs the loader synchronously, so `JSModuleLoader::hostLoadImportedModule` advances a `Fetching` entry inline with `fetch()` and `makeModule()`. Both run user code (a load hook, the getter) that can load the same key again first. The inline code then completed the entry a second time from state read before the call.

### Fix
- oven-sh/WebKit#492 moves the inline steps into the registry entry: `ModuleRegistryEntry::settleFetch` and `settleModule` apply a step only while the entry is still at it, and a fetch is registered before its hook runs. The first completion wins on every path, as it already did on the `import()` path.
- This PR pins that preview build (`autobuild-preview-pr-492-47837107`: `ceb9f90fb7`, the commit main pins, plus the fix) and adds the shapes: the getter through `require()` and `import` (`mock-module.test.ts`), and a load hook that loads another importer of the module it is loading, with the pending fetch on a dependency edge or a top-level `import()` (`plugins.test.ts`).
- Verified: on 1.4.0 the `require()` getter test fails (`cG: "outer"`, `sameNamespace: false`). The two load hook tests fail on a debug build of the unmodified engine (`ASSERT(status() == Pending)` in `JSPromise::fulfillPromise`, `ASSERT(mapEntry->status() != New)`). All pass with the fix. Other suites in the notes.

### Background
- A `ModuleRegistryEntry` is the loader's per-key state: `New` -> `Fetching` -> `Fetched`, one record. `fetchComplete()` stores it.
- A `mock.module()` object becomes a `SyntheticModuleRecord`. Its generator (`src/jsc/modules/ObjectModule.cpp`) reads every property when the record is created, so user getters run inside `makeModule`.

<details><summary>Notes</summary>

Sequence on 1.4.0, with the repro in the test. `c.cjs` requires `virt-cycle`. The loader replays `makeModule("virt-cycle")`, which calls the getter (call 1). The getter requires `n.ts`. `n.ts` imports `virt-cycle`, so the nested load finds the entry `Fetching` and replays `makeModule` again: the getter runs a second time (call 2, returns `"inner"`), record V2 is stored, the module promise is fulfilled with V2, and `n.ts` links against V2. Back in the outer call, `makeModule` returns V1 (`g: "outer"`), `fetchComplete(V1)` replaces the record and `fulfillPromise(V1)` overwrites the settled promise's result. The outer then continues on the load promise the nested call created, links V2, and returns `registryEntry("virt-cycle")->record()`, which is V1. So `c.g === "outer"`, `n.vg === "inner"`, `c.v !== n.vns`. With the fix the outer call sees the module promise already settled and leaves the entry alone: one record (V2), both sides read `"inner"`.

The `import` shape passes before and after: `moduleRegistryModuleSettled` in `JSMicrotask.cpp` already returns when the module promise is no longer pending. Same outcome there: the getter runs twice and the nested call's record is kept. `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` ("a user-defined getter can itself load the modules that import the export it backs") covers that path for builtins and still passes.

Sentry BUN-4QBM (one event, macOS arm64, 1.4.0, `bun test`) faulted at `0x68` in `AbstractModuleRecord::getModuleNamespace`, called from the inner `functionEsmLoadSync` under the outer `require`'s `makeModule` of an object module. `0x68` is `m_exportEntries` of a null record: `getModuleNamespace` appends `hostResolveImportedModule()` for each `export * from` without a null check, and that is a `[[LoadedModules]]` lookup. So the record it was given was never linked. Two records for one key is the state that produces that (the registry record is not the one the load linked). The exact graph that puts an unlinked record with star exports in the registry is not reproduced: four hand-built variants and the shape above all stay in the two-records defect without crashing. This change removes the second record, which is the precondition.

Release builds still have no check in `getModuleNamespace` for a missing `[[LoadedModules]]` entry, and `JSModuleLoader::getImportedModule` dereferences `find()` with only a debug assertion. Those are hardening changes in oven-sh/WebKit, separate from this fix.

Suites run on the fixed engine: `test/js/bun/test/mock/`, `test/js/bun/resolve/`, `test/js/bun/plugin/`, `test/js/node/module/`, `test/cli/run/require-cache.test.ts` (the RSS leak tests time out on this machine on the unmodified engine too). Local verification of the engine change: `UnifiedSource-runtime-26` (the bundle with `JSModuleLoader.cpp`) recompiled from the WebKit branch with the compile command the `b7f217b4a6` linux debug-asan tarball ships, swapped into its `libJavaScriptCore.a`, and `bun bd` relinked against it. On that build the new `require()` test passes and the assertion is gone. The same tests pass against the downloaded preview tarball. `test/cli/run/require-cache.test.ts` has seven RSS leak tests that time out on this machine with the unmodified engine too, and `load the same empty JS file 2000 times` in `test/js/bun/resolve/` times out the same way. Everything else listed above passes.

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 6 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/plugin/plugins.test.ts' 'test/js/bun/test/mock/mock-module.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1777.69ms]
(pass) require > beep:boop returns 42 [13.67ms]
(pass) require > object module works [12.19ms]
(pass) module > throws with require() [20.41ms]
(pass) module > async module works with async import [29.57ms]
(pass) module > sync module module works with require() [6.65ms]
(pass) module > sync module module works with require.resolve() [4.51ms]
(pass) module > sync module module works with import [116.18ms]
(pass) module > modules are overridable [27.43ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [8.68ms]
(pass) dynamic import > beep:boop returns 42 [6.46ms]
(pass) dynamic import > async:onLoad returns 42 [46.28ms]
(pass) dynamic import > async object loader returns 42 [25.83ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [173.60ms]
(pass) errors > valid loaders work [33.43ms]
(pass) errors > handles invalid 'target' [5.73ms]
(pass) errors > handles 'target' that throws while being coerced to a string [7.63ms]
(pass) errors > handles a 'target' whose toString throws [7.21ms]
(pass) errors > invalid loaders throw [14.68ms]
(pass) errors > transpiler errors work [11.66ms]
(pass) errors > invalid async return value [22.15ms]
(pass) errors > async errors work [20.08ms]
(pass) errors > invalid onLoad objects throw [13.95ms]
(pass) errors > async transpiler errors work [25.04ms]
(pass) errors > onLoad returns the rejected promise [25.02ms]
(pass) errors > can work with http urls [8
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts              |   2 +-
 test/js/bun/plugin/plugins.test.ts        |  64 +++++++++++++++++++
 test/js/bun/test/mock/mock-module.test.ts | 100 +++++++++++++++++++++++++++++-
 3 files changed, 164 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 15 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
scripts/build/deps/webkit.ts                   1      2      0
test/js/bun/plugin/plugins.test.ts             3      3      0
test/js/bun/test/mock/mock-module.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->










