### PR TITLE
compile cache: persist the bytecode the main VM compiled instead of re-parsing every module on a second VM at exit

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -1,17 +1,20 @@
 //! Node-compatible on-disk compile cache (`NODE_COMPILE_CACHE`): entries in a
 //! version-tagged subdir store the post-transpile source + JSC bytecode; the
 //! stored source is byte-compared on load so stale caches recompile normally.
+//! Misses collect the bytecode the main VM compiles via the `SourceProvider` hooks (ZigSourceProvider.cpp).
 
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::ffi::c_void;
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 use bstr::ByteSlice;
 use bun_boringssl::c as boring;
 use bun_collections::{HashMap, IdentityContext};
 use bun_core::String as BunString;
 use bun_core::{Mutex, ZStr, env_var};
-use bun_options_types::Format;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 use bun_sys::{self as sys, Fd, O};
+
+use crate::ResolvedSource;
 
 pub const STATUS_FAILED: i32 = 0;
 pub const STATUS_ENABLED: i32 = 1;
@@ -40,23 +43,92 @@ struct CacheState {
     entries: HashMap<u64, Entry, IdentityContext<u64>>,
 }
 
-// SAFETY: `CacheState` is only reached through the global `STATE` mutex; the
-// `sys::Dir` fd is just an integer handle.
+// SAFETY: only reached through `STATE`; the fd is an integer and a `Pending::Provider` pointer is never dereferenced here.
 unsafe impl Send for CacheState {}
 
+/// Per-`Entry` id so a provider for an older version of a file cannot attach to a newer entry under the same key; 0 means none.
+static NEXT_ENTRY_ID: AtomicU64 = AtomicU64::new(1);
+
 struct Entry {
+    id: u64,
     /// `path.text` of the module (absolute file path).
     filename: Box<[u8]>,
     is_cjs: bool,
     code_hash: [u8; HASH_SIZE],
     code_size: u32,
-    /// Post-transpile text; `None` when the module never transpiled
-    /// successfully (parse error) — mirrors Node's "not initialized" state.
+    /// Post-transpile text; `None` on parse failure (Node's "not initialized") or once persisted.
     code: Option<Box<[u8]>>,
     /// Deserialized bytecode blob handed to JSC (the cache was accepted).
     /// Kept alive for the process — `ZigSourceProvider` wraps it, no copy.
     blob: Option<AlignedBlob>,
+    /// Where a miss's bytecode comes from at persist time.
+    pending: Pending,
     persisted: bool,
+}
+
+enum Pending {
+    None,
+    /// The `Zig::SourceProvider` collecting this entry's bytecode; its destructor detaches under `STATE`.
+    Provider(*const c_void),
+    /// Flattened bytecode from a provider that went away, or from a persist whose write failed.
+    Blob(Box<[u8]>),
+}
+
+impl Entry {
+    fn new(filename: &[u8], is_cjs: bool, code_hash: [u8; HASH_SIZE], code_size: u32) -> Self {
+        Self {
+            id: NEXT_ENTRY_ID.fetch_add(1, Ordering::Relaxed),
+            filename: filename.into(),
+            is_cjs,
+            code_hash,
+            code_size,
+            code: None,
+            blob: None,
+            pending: Pending::None,
+            persisted: false,
+        }
+    }
+
+    /// A miss that no provider is collecting for yet.
+    fn wants_collection(&self) -> bool {
+        self.blob.is_none() && !self.persisted && matches!(self.pending, Pending::None)
+    }
+
+    /// Takes the flattened bytecode for this miss, ending collection. Caller holds `STATE`.
+    fn take_bytecode(&mut self) -> Option<Box<[u8]>> {
+        match core::mem::replace(&mut self.pending, Pending::None) {
+            Pending::None => None,
+            Pending::Blob(blob) => Some(blob),
+            Pending::Provider(provider) => {
+                let mut out: Option<Box<[u8]>> = None;
+                // SAFETY: the caller holds `STATE`, which the provider's destructor needs to detach, so it is alive.
+                unsafe {
+                    ZigSourceProvider__commitNodeCompileCache(
+                        provider,
+                        (&raw mut out).cast(),
+                        commit_sink,
+                    );
+                }
+                out
+            }
+        }
+    }
+}
+
+unsafe extern "C" {
+    /// Flattens what the provider collected and invokes `sink` at most once, synchronously.
+    fn ZigSourceProvider__commitNodeCompileCache(
+        provider: *const c_void,
+        context: *mut c_void,
+        sink: unsafe extern "C" fn(context: *mut c_void, bytecode: *const u8, len: usize),
+    );
+}
+
+unsafe extern "C" fn commit_sink(context: *mut c_void, bytecode: *const u8, len: usize) {
+    // SAFETY: `context` is the `out` slot `take_bytecode` passed; C++ hands `len` readable bytes.
+    unsafe {
+        *context.cast::<Option<Box<[u8]>>>() = Some(bun_core::ffi::slice(bytecode, len).into());
+    }
 }
 
 /// 128-byte-aligned blob. JSC's bytecode decoder reads the blob in place and
@@ -539,10 +611,44 @@ pub fn get_dir() -> Option<Vec<u8>> {
 // Fetch-time hook (read + validate)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Module-fetch hook: register/refresh the entry for `filename`; returns the
-/// validated bytecode blob when the on-disk cache matches `code` (post-
-/// transpile text). The pointer stays valid for the process (entry map owns it).
-pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usize)> {
+/// Outcome of [`fetch`], applied to the module's `ResolvedSource`.
+pub enum Fetch {
+    /// The on-disk entry matches `code`; the blob stays valid for the process.
+    Accepted { ptr: *mut u8, len: usize },
+    /// Nothing usable on disk: the provider collects what JSC compiles for this entry.
+    Collect { key: u64, entry_id: u64 },
+}
+
+impl Fetch {
+    fn for_entry(key: u64, entry: &Entry) -> Option<Self> {
+        if let Some(blob) = &entry.blob {
+            return Some(Self::Accepted {
+                ptr: blob.ptr.as_ptr(),
+                len: blob.len,
+            });
+        }
+        entry.wants_collection().then_some(Self::Collect {
+            key,
+            entry_id: entry.id,
+        })
+    }
+
+    pub fn apply(self, source: &mut ResolvedSource) {
+        match self {
+            Self::Accepted { ptr, len } => {
+                source.bytecode_cache = ptr;
+                source.bytecode_cache_size = len;
+            }
+            Self::Collect { key, entry_id } => {
+                source.node_compile_cache_key = key;
+                source.node_compile_cache_entry_id = entry_id;
+            }
+        }
+    }
+}
+
+/// Module-fetch hook: register/refresh the entry for `filename` against `code` (post-transpile text).
+pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<Fetch> {
     if !is_enabled() || filename.is_empty() || !bun_paths::is_absolute(filename) {
         return None;
     }
@@ -558,29 +664,20 @@ pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usi
     if let Some(entry) = state.entries.get(&key) {
         if entry.code_hash == code_hash && entry.code_size == code_size {
             // Same module, unchanged code (e.g. re-required): reuse.
-            return entry.blob.as_ref().map(|b| (b.ptr.as_ptr(), b.len));
+            return Fetch::for_entry(key, entry);
         }
     }
 
-    let mut entry = Entry {
-        filename: filename.into(),
-        is_cjs,
-        code_hash,
-        code_size,
-        code: None,
-        blob: None,
-        persisted: false,
-    };
+    let mut entry = Entry::new(filename, is_cjs, code_hash, code_size);
 
     read_cache_file(state, key, &mut entry, Some(code));
 
-    let result = if entry.blob.is_some() {
+    if entry.blob.is_some() {
         cclog!(
             "[compile cache] code cache for {} {} was accepted, keeping the in-memory entry\n",
             type_name(is_cjs),
             display_name(filename, is_cjs)
         );
-        entry.blob.as_ref().map(|b| (b.ptr.as_ptr(), b.len))
     } else {
         cclog!(
             "[compile cache] code cache for {} {} was not initialized, initializing the in-memory entry\n",
@@ -588,8 +685,9 @@ pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usi
             display_name(filename, is_cjs)
         );
         entry.code = Some(code.into());
-        None
-    };
+    }
+    let result = Fetch::for_entry(key, &entry);
+    // A replaced entry's provider detaches with the old entry id and is ignored.
     if let Some(old) = state.entries.insert(key, entry) {
         if let Some(blob) = old.blob {
             // Never freed; see RETIRED_BLOBS for the invariant.
@@ -612,20 +710,63 @@ pub fn note_parse_failure(filename: &[u8], is_cjs: bool) {
     if state.entries.contains_key(&key) {
         return;
     }
-    let mut entry = Entry {
-        filename: filename.into(),
-        is_cjs,
-        code_hash: [0u8; HASH_SIZE],
-        code_size: 0,
-        code: None,
-        blob: None,
-        persisted: false,
-    };
+    let mut entry = Entry::new(filename, is_cjs, [0u8; HASH_SIZE], 0);
     // The read is attempted (and logged) like Node; without current code the
     // stored entry can never validate, so this only populates the log.
     read_cache_file(state, key, &mut entry, None);
     entry.blob = None;
     state.entries.insert(key, entry);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Provider attachment (ZigSourceProvider.cpp)
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The provider recorded the top-level block; `false` when its ticket is stale or another provider attached first.
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__NodeCompileCache__attach(
+    key: u64,
+    entry_id: u64,
+    provider: *const c_void,
+) -> bool {
+    let mut guard = STATE.lock();
+    let Some(entry) = guard.as_mut().and_then(|state| state.entries.get_mut(&key)) else {
+        return false;
+    };
+    if entry.id != entry_id || !entry.wants_collection() {
+        return false;
+    }
+    entry.pending = Pending::Provider(provider);
+    true
+}
+
+/// An attached provider is being destroyed: forget its pointer and keep a copy of its bytecode.
+/// # Safety
+/// `bytecode` points to `len` readable bytes (null only when `len == 0`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__NodeCompileCache__detach(
+    key: u64,
+    entry_id: u64,
+    provider: *const c_void,
+    bytecode: *const u8,
+    len: usize,
+) {
+    // SAFETY: per fn contract.
+    let bytecode = unsafe { bun_core::ffi::slice(bytecode, len) };
+    let mut guard = STATE.lock();
+    let Some(entry) = guard.as_mut().and_then(|state| state.entries.get_mut(&key)) else {
+        return;
+    };
+    if entry.id != entry_id {
+        return;
+    }
+    if matches!(entry.pending, Pending::Provider(attached) if attached == provider) {
+        entry.pending = Pending::None;
+    }
+    // Never displace a newer provider or a blob a failed write is retrying.
+    if !bytecode.is_empty() && !entry.persisted && matches!(entry.pending, Pending::None) {
+        entry.pending = Pending::Blob(bytecode.into());
+    }
 }
 
 fn cache_basename(key: u64) -> [u8; 16] {
@@ -865,77 +1006,117 @@ fn read_cache_file(state: &CacheState, key: u64, entry: &mut Entry, code: Option
 // Persist (exit + flush)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Bytecode generation runs on one long-lived worker thread with its own JSC
-/// VM (`getVMForBytecodeCache`), mirroring `bun build --bytecode`'s bundler
-/// threads, so only a single extra VM ever exists.
-struct GenJob {
-    format: Format,
-    code: Box<[u8]>,
-    url: Box<[u8]>,
-    resp: std::sync::mpsc::SyncSender<Option<Box<[u8]>>>,
-}
-
-fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]>> {
-    use std::sync::mpsc;
-    static WORKER: Mutex<Option<mpsc::Sender<GenJob>>> = Mutex::new(None);
-
-    let (resp_tx, resp_rx) = mpsc::sync_channel(1);
-    {
-        let mut guard = WORKER.lock();
-        if guard.is_none() {
-            let (tx, rx) = mpsc::channel::<GenJob>();
-            let spawned = std::thread::Builder::new()
-                .name("BunCompileCache".to_string())
-                // JSC parsing of large modules needs a deep stack.
-                .stack_size(16 * 1024 * 1024)
-                .spawn(move || {
-                    for job in rx {
-                        let mut url = BunString::clone_utf8(&job.url);
-                        let result = crate::cached_bytecode::__bun_jsc_generate_cached_bytecode(
-                            job.format, &job.code, &mut url,
-                        );
-                        url.deref();
-                        let _ = job.resp.send(result);
-                    }
-                });
-            match spawned {
-                Ok(_) => *guard = Some(tx),
-                Err(_) => return None,
-            }
-        }
-        let tx = guard.as_ref().expect("set above");
-        if tx
-            .send(GenJob {
-                format,
-                code: code.into(),
-                url: url.into(),
-                resp: resp_tx,
-            })
-            .is_err()
-        {
-            return None;
-        }
-    }
-    resp_rx.recv().ok().flatten()
-}
-
-/// One unit of persist work, snapshotted out of `STATE` so bytecode generation runs with the lock
-/// dropped. `code` is moved out (concurrent `fetch` sees `code: None` and skips). Keys hash
-/// `(is_cjs, filename)` — not content — so Phase 3 re-checks `code_hash` before touching the entry.
-struct PersistJob {
+/// Writes one entry file (`header | code | hole to 128 | blob`) via tmpfile + rename.
+fn write_entry_file(
+    dir: &[u8],
+    dir_handle: &sys::Dir,
     key: u64,
-    format: Format,
-    code: Box<[u8]>,
-    filename: Box<[u8]>,
-    is_cjs: bool,
-    code_size: u32,
-    code_hash: [u8; HASH_SIZE],
+    entry: &Entry,
+    code: &[u8],
+    blob: &[u8],
+) -> Result<(), ()> {
+    let logging = LOG_ENABLED.load(Ordering::Relaxed);
+    let tname = type_name(entry.is_cjs);
+    let name = if logging {
+        display_name(&entry.filename, entry.is_cjs)
+    } else {
+        String::new()
+    };
+
+    let Ok(cache_size) = u32::try_from(blob.len()) else {
+        return Err(());
+    };
+    let cache_hash = sha256(blob);
+
+    let basename = cache_basename(key);
+    let mut tmpname_buf = PathBuffer::uninit();
+    let tmpname_zstr: &ZStr =
+        match bun_resolver::fs::FileSystem::tmpname(&basename, &mut tmpname_buf[..], key) {
+            Ok(z) => z,
+            Err(_) => return Err(()),
+        };
+
+    cclog!("[compile cache] Creating temporary file for cache of {name} ({tname})...");
+
+    // 0600 like Node: entries contain the module's post-transpile source.
+    let mut tmpfile = match sys::Tmpfile::create_with_mode(dir_handle.fd(), tmpname_zstr, 0o600) {
+        Ok(t) => t,
+        Err(e) => {
+            cclog!("failed. {}\n", errno_name(&e));
+            return Err(());
+        }
+    };
+    let _close = sys::CloseOnDrop::new(tmpfile.fd);
+
+    let tmp_display = if logging {
+        format!(
+            "{}{}{}",
+            dir.as_bstr(),
+            SEP as char,
+            tmpname_zstr.as_bytes().as_bstr()
+        )
+    } else {
+        String::new()
+    };
+    cclog!(" -> {tmp_display}\n");
+    cclog!(
+        "[compile cache] writing cache for {tname} {name} to temporary file {tmp_display} [{MAGIC} {} {cache_size} {} {}]...",
+        entry.code_size,
+        hex(&entry.code_hash),
+        hex(&cache_hash)
+    );
+
+    let mut header_bytes = [0u8; HEADER_SIZE];
+    header_bytes[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+    header_bytes[4..8].copy_from_slice(&entry.code_size.to_le_bytes());
+    header_bytes[8..12].copy_from_slice(&cache_size.to_le_bytes());
+    header_bytes[12..12 + HASH_SIZE].copy_from_slice(&entry.code_hash);
+    header_bytes[12 + HASH_SIZE..HEADER_SIZE].copy_from_slice(&cache_hash);
+    // ManuallyDrop: the fd is owned by `_close` above.
+    let file = core::mem::ManuallyDrop::new(sys::File::from_fd(tmpfile.fd));
+    let write_all = || -> sys::Maybe<()> {
+        file.pwrite_all(&header_bytes, 0)?;
+        file.pwrite_all(code, HEADER_SIZE as i64)?;
+        // The gap up to the 128-aligned blob offset is a hole (zeros).
+        file.pwrite_all(blob, blob_file_offset(entry.code_size) as i64)?;
+        Ok(())
+    };
+    if let Err(e) = write_all() {
+        cclog!("failed: {}\n", errno_name(&e));
+        let _ = sys::unlinkat(dir_handle.fd(), tmpname_zstr);
+        return Err(());
+    }
+    cclog!("success\n");
+
+    let mut dest_z = [0u8; 17];
+    dest_z[..16].copy_from_slice(&basename);
+    let dest_zstr = ZStr::from_buf(&dest_z, 16);
+    let final_display = if logging {
+        format!(
+            "{}{}{}",
+            dir.as_bstr(),
+            SEP as char,
+            core::str::from_utf8(&basename).expect("hex")
+        )
+    } else {
+        String::new()
+    };
+    cclog!("[compile cache] Renaming {tmp_display} to {final_display}...");
+    if let Err(e) = tmpfile.finish(dest_zstr) {
+        cclog!("failed: {}\n", errno_name(&e));
+        let _ = sys::unlinkat(dir_handle.fd(), tmpname_zstr);
+        return Err(());
+    }
+    cclog!("success\n");
+    Ok(())
 }
 
-/// Phase 1 (locked): decide what needs persisting and move the source code
-/// out of the entries.
-fn collect_persist_jobs(state: &mut CacheState) -> Vec<PersistJob> {
-    let mut jobs = Vec::new();
+/// Writes every miss that has bytecode; holding `STATE` throughout keeps `Pending::Provider` pointers alive.
+fn persist_pass() {
+    let mut guard = STATE.lock();
+    let Some(state) = guard.as_mut() else { return };
+    let dir: &[u8] = &state.dir;
+    let dir_handle = &state.dir_handle;
     let logging = LOG_ENABLED.load(Ordering::Relaxed);
     for (&key, entry) in state.entries.iter_mut() {
         let tname = type_name(entry.is_cjs);
@@ -955,189 +1136,18 @@ fn collect_persist_jobs(state: &mut CacheState) -> Vec<PersistJob> {
             cclog!("[compile cache] skip persisting {tname} {name} because cache was the same\n");
             continue;
         }
-        let Some(code) = entry.code.take() else {
+        // No bytecode: never compiled. No code: never transpiled.
+        let bytecode = entry.take_bytecode();
+        let (Some(bytecode), Some(code)) = (bytecode, entry.code.as_deref()) else {
             cclog!(
                 "[compile cache] skip persisting {tname} {name} because the cache was not initialized\n"
             );
             continue;
         };
-        jobs.push(PersistJob {
-            key,
-            format: if entry.is_cjs {
-                Format::Cjs
-            } else {
-                Format::Esm
-            },
-            code,
-            filename: entry.filename.clone(),
-            is_cjs: entry.is_cjs,
-            code_size: entry.code_size,
-            code_hash: entry.code_hash,
-        });
-    }
-    jobs
-}
-
-/// Phase 3 (locked): write one generated blob to disk. `Ok(())` on success;
-/// on any I/O failure returns `Err(())` and the caller restores the taken
-/// `entry.code` and leaves `persisted` false so a later pass may retry.
-fn write_persist_job_locked(
-    state: &mut CacheState,
-    job: &PersistJob,
-    blob: &[u8],
-) -> Result<(), ()> {
-    let logging = LOG_ENABLED.load(Ordering::Relaxed);
-    let tname = type_name(job.is_cjs);
-    let name = if logging {
-        display_name(&job.filename, job.is_cjs)
-    } else {
-        String::new()
-    };
-
-    let cache_size = blob.len() as u32;
-    let cache_hash = sha256(blob);
-
-    let basename = cache_basename(job.key);
-    let mut tmpname_buf = PathBuffer::uninit();
-    let tmpname_zstr: &ZStr =
-        match bun_resolver::fs::FileSystem::tmpname(&basename, &mut tmpname_buf[..], job.key) {
-            Ok(z) => z,
-            Err(_) => return Err(()),
-        };
-
-    cclog!("[compile cache] Creating temporary file for cache of {name} ({tname})...");
-
-    // 0600 like Node: entries contain the module's post-transpile source.
-    let mut tmpfile =
-        match sys::Tmpfile::create_with_mode(state.dir_handle.fd(), tmpname_zstr, 0o600) {
-            Ok(t) => t,
-            Err(e) => {
-                cclog!("failed. {}\n", errno_name(&e));
-                return Err(());
-            }
-        };
-    let _close = sys::CloseOnDrop::new(tmpfile.fd);
-
-    let tmp_display = if logging {
-        format!(
-            "{}{}{}",
-            state.dir.as_bstr(),
-            SEP as char,
-            tmpname_zstr.as_bytes().as_bstr()
-        )
-    } else {
-        String::new()
-    };
-    cclog!(" -> {tmp_display}\n");
-    cclog!(
-        "[compile cache] writing cache for {tname} {name} to temporary file {tmp_display} [{MAGIC} {} {cache_size} {} {}]...",
-        job.code_size,
-        hex(&job.code_hash),
-        hex(&cache_hash)
-    );
-
-    let mut header_bytes = [0u8; HEADER_SIZE];
-    header_bytes[0..4].copy_from_slice(&MAGIC.to_le_bytes());
-    header_bytes[4..8].copy_from_slice(&job.code_size.to_le_bytes());
-    header_bytes[8..12].copy_from_slice(&cache_size.to_le_bytes());
-    header_bytes[12..12 + HASH_SIZE].copy_from_slice(&job.code_hash);
-    header_bytes[12 + HASH_SIZE..HEADER_SIZE].copy_from_slice(&cache_hash);
-    // ManuallyDrop: the fd is owned by `_close` above.
-    let file = core::mem::ManuallyDrop::new(sys::File::from_fd(tmpfile.fd));
-    let write_all = || -> sys::Maybe<()> {
-        file.pwrite_all(&header_bytes, 0)?;
-        file.pwrite_all(&job.code, HEADER_SIZE as i64)?;
-        // The gap up to the 128-aligned blob offset is a hole (zeros).
-        file.pwrite_all(blob, blob_file_offset(job.code_size) as i64)?;
-        Ok(())
-    };
-    if let Err(e) = write_all() {
-        cclog!("failed: {}\n", errno_name(&e));
-        let _ = sys::unlinkat(state.dir_handle.fd(), tmpname_zstr);
-        return Err(());
-    }
-    cclog!("success\n");
-
-    let mut dest_z = [0u8; 17];
-    dest_z[..16].copy_from_slice(&basename);
-    let dest_zstr = ZStr::from_buf(&dest_z, 16);
-    let final_display = if logging {
-        format!(
-            "{}{}{}",
-            state.dir.as_bstr(),
-            SEP as char,
-            core::str::from_utf8(&basename).expect("hex")
-        )
-    } else {
-        String::new()
-    };
-    cclog!("[compile cache] Renaming {tmp_display} to {final_display}...");
-    if let Err(e) = tmpfile.finish(dest_zstr) {
-        cclog!("failed: {}\n", errno_name(&e));
-        let _ = sys::unlinkat(state.dir_handle.fd(), tmpname_zstr);
-        return Err(());
-    }
-    cclog!("success\n");
-    Ok(())
-}
-
-/// Full persist pass. `STATE` is held only for snapshot and file-write phases; bytecode
-/// generation runs with the lock dropped so concurrent module loads are not stalled.
-fn persist_pass() {
-    // Phase 1: snapshot under the lock.
-    let jobs = {
-        let mut guard = STATE.lock();
-        let Some(state) = guard.as_mut() else { return };
-        collect_persist_jobs(state)
-    };
-
-    // Phase 2: generate bytecode, unlocked.
-    let mut generated: Vec<(PersistJob, Option<Box<[u8]>>)> = Vec::with_capacity(jobs.len());
-    for job in jobs {
-        let blob = generate_bytecode(job.format, &job.code, &job.filename);
-        if blob.is_none() {
-            cclog!(
-                "[compile cache] generating cache for {} {} failed, skipping\n",
-                type_name(job.is_cjs),
-                display_name(&job.filename, job.is_cjs)
-            );
-        }
-        generated.push((job, blob));
-    }
-
-    // Phase 3: write files and update entries under the lock.
-    let mut guard = STATE.lock();
-    let Some(state) = guard.as_mut() else { return };
-    for (job, blob) in generated {
-        let Some(blob) = blob else {
-            // Do not retry on the next persist pass. Skip if the entry now
-            // holds different content (file changed and was re-fetched).
-            if let Some(entry) = state.entries.get_mut(&job.key) {
-                if entry.code_hash == job.code_hash && entry.code_size == job.code_size {
-                    entry.persisted = true;
-                }
-            }
-            continue;
-        };
-        let wrote = write_persist_job_locked(state, &job, &blob);
-        let Some(entry) = state.entries.get_mut(&job.key) else {
-            continue;
-        };
-        if entry.code_hash != job.code_hash || entry.code_size != job.code_size {
-            // The entry was repopulated with different content mid-pass; the
-            // write we just did is stale (the header check corrects it on
-            // the next load) and the taken code must not overwrite the new.
-            continue;
-        }
-        match wrote {
+        match write_entry_file(dir, dir_handle, key, entry, code, &bytecode) {
             Ok(()) => entry.persisted = true,
-            // Keep the source so a later pass can retry, matching the old
-            // in-place behavior for failed writes.
-            Err(()) => {
-                if entry.code.is_none() {
-                    entry.code = Some(job.code);
-                }
-            }
+            // Keep the bytecode so a later pass (flush, exit) retries the write.
+            Err(()) => entry.pending = Pending::Blob(bytecode),
         }
     }
 

--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -51,6 +51,9 @@ pub struct ResolvedSource {
     /// was used at build time. If empty, the origin is derived from source_url.
     /// This is converted to a file:// URL on the C++ side.
     pub bytecode_origin_path: BunString,
+    /// Compile-cache miss to collect bytecode for; `entry_id == 0` means none.
+    pub node_compile_cache_key: u64,
+    pub node_compile_cache_entry_id: u64,
 }
 
 impl Default for ResolvedSource {
@@ -70,6 +73,8 @@ impl Default for ResolvedSource {
             bytecode_cache_size: 0,
             module_info: core::ptr::null_mut(),
             bytecode_origin_path: BunString::empty(),
+            node_compile_cache_key: 0,
+            node_compile_cache_entry_id: 0,
         }
     }
 }

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -15,13 +15,213 @@
 #include <sys/stat.h>
 #include <JavaScriptCore/SourceCodeKey.h>
 #include <mimalloc.h>
+#include <JavaScriptCore/BytecodeCacheError.h>
+#include <JavaScriptCore/CachedTypes.h>
 #include <JavaScriptCore/CodeCache.h>
+#include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/UnlinkedFunctionCodeBlock.h>
+#include <JavaScriptCore/UnlinkedFunctionExecutable.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+
+extern "C" bool Bun__NodeCompileCache__attach(uint64_t key, uint64_t entryId, const void* provider);
+extern "C" void Bun__NodeCompileCache__detach(uint64_t key, uint64_t entryId, const void* provider, const uint8_t* bytecode, size_t bytecodeLength);
 
 namespace Zig {
 
 using SourceOrigin = JSC::SourceOrigin;
 using String = WTF::String;
 using SourceProviderSourceType = JSC::SourceProviderSourceType;
+
+// Collects a compile-cache miss's bytecode in the incremental layout jsc's --diskCache uses; commit() may run off the VM thread.
+class NodeCompileCacheCollector {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NodeCompileCacheCollector);
+
+public:
+    NodeCompileCacheCollector(uint64_t key, uint64_t entryId)
+        : m_key(key)
+        , m_entryId(entryId)
+    {
+    }
+
+    void addTopLevel(const JSC::BytecodeCacheGenerator& generator, const SourceProvider* providerHandle)
+    {
+        {
+            Locker locker { m_lock };
+            // A second compile of the same provider (--isolate) builds a tree we never registered.
+            if (m_state != State::AwaitingTopLevel)
+                return;
+            RefPtr<JSC::CachedBytecode> topLevel = generator();
+            if (!topLevel) {
+                m_state = State::Done;
+                return;
+            }
+            m_bytecode = JSC::CachedBytecode::create();
+            pin(topLevel->leafExecutables());
+            m_bytecode->addGlobalUpdate(topLevel.releaseNonNull());
+            m_state = State::Collecting;
+        }
+        // Attach takes the Rust lock a persist holds while calling commit(); never nest it inside m_lock.
+        if (!Bun__NodeCompileCache__attach(m_key, m_entryId, providerHandle))
+            discard();
+    }
+
+    void addFunction(const JSC::UnlinkedFunctionExecutable* executable, JSC::CodeSpecializationKind kind, const JSC::UnlinkedFunctionCodeBlock* codeBlock)
+    {
+        Locker locker { m_lock };
+        if (m_state != State::Collecting) {
+            if (m_state == State::Done)
+                m_pins.clear();
+            return;
+        }
+
+        // A debugger attaching mid-run recompiles in a different mode; the file must stay uniform.
+        if (!m_codeGenerationMode)
+            m_codeGenerationMode = codeBlock->codeGenerationMode();
+        if (*m_codeGenerationMode != codeBlock->codeGenerationMode()) {
+            stopCollecting();
+            return;
+        }
+
+        // Only a function whose parent's encoding is in the file has a slot to patch.
+        if (!m_bytecode->leafExecutables().contains(executable))
+            return;
+        // Recompiles after jettison/delete: the first encoding is still right.
+        const uint8_t kindBit = kind == JSC::CodeSpecializationKind::CodeForCall ? RecordedForCall : RecordedForConstruct;
+        auto recorded = m_recorded.add(executable, 0);
+        if (recorded.iterator->value & kindBit)
+            return;
+        recorded.iterator->value |= kindBit;
+
+        // The size accessors are non-const in JSC; they only read vector sizes.
+        auto& block = *const_cast<JSC::UnlinkedFunctionCodeBlock*>(codeBlock);
+        const size_t nestedFunctions = block.numberOfFunctionDecls() + block.numberOfFunctionExprs();
+        const size_t budget = storedBytesBase + storedBytesPerBytecodeByte * block.instructionsSize() + storedBytesPerNestedFunction * nestedFunctions;
+        if (nestedFunctions && m_nestedFunctionOverhead > budget)
+            return;
+
+        JSC::BytecodeCacheError error;
+        RefPtr<JSC::CachedBytecode> update = JSC::encodeFunctionCodeBlock(executable->vm(), codeBlock, error);
+        if (!update || error.isValid())
+            return;
+        if (update->size() > budget) {
+            if (nestedFunctions) {
+                const size_t overhead = update->size() - budget;
+                m_nestedFunctionOverhead = m_nestedFunctionOverhead ? std::min(m_nestedFunctionOverhead, overhead) : overhead;
+            }
+            return;
+        }
+        pin(update->leafExecutables());
+        m_bytecode->addFunctionUpdate(executable, kind, update.releaseNonNull());
+    }
+
+    Vector<uint8_t> commit()
+    {
+        Locker locker { m_lock };
+        RefPtr<JSC::CachedBytecode> bytecode = std::exchange(m_bytecode, nullptr);
+        m_recorded.clear();
+        m_state = State::Done;
+        if (!bytecode)
+            return {};
+
+        const size_t size = bytecode->sizeForUpdate();
+        Vector<uint8_t> blob(FillWith {}, size, uint8_t(0));
+        bytecode->commitUpdates([&](off_t offset, std::span<const uint8_t> data) {
+            RELEASE_ASSERT(offset >= 0 && data.size() <= size && static_cast<size_t>(offset) <= size - data.size());
+            memcpySpan(blob.mutableSpan().subspan(static_cast<size_t>(offset), data.size()), data);
+        });
+        return blob;
+    }
+
+    // ~SourceProvider: hand the Rust entry what was collected and make it forget this pointer.
+    void detach(const SourceProvider* providerHandle)
+    {
+        {
+            Locker locker { m_lock };
+            if (m_state != State::Collecting && m_state != State::Frozen)
+                return;
+        }
+        Vector<uint8_t> blob = commit();
+        Bun__NodeCompileCache__detach(m_key, m_entryId, providerHandle, blob.span().data(), blob.size());
+    }
+
+private:
+    enum class State : uint8_t {
+        AwaitingTopLevel,
+        // Attached to the Rust entry (or about to be) and accepting functions.
+        Collecting,
+        // Still attached; keeps what was collected but accepts no more.
+        Frozen,
+        // Never attached, or already committed.
+        Done,
+    };
+
+    static constexpr uint8_t RecordedForCall = 1 << 0;
+    static constexpr uint8_t RecordedForConstruct = 1 << 1;
+
+    // Every nested-function stub in an update copies the enclosing TDZ lists (tens of KB in bundles); skip updates whose size is not explained by their bytecode.
+    static constexpr size_t storedBytesBase = 4 * 1024;
+    static constexpr size_t storedBytesPerBytecodeByte = 8;
+    static constexpr size_t storedBytesPerNestedFunction = 512;
+
+    // The leaf map is keyed by raw cell address, so every registered executable must outlive the map.
+    void pin(const JSC::LeafExecutableMap& leaves) WTF_REQUIRES_LOCK(m_lock)
+    {
+        m_pins.reserveCapacity(m_pins.size() + leaves.size());
+        for (const auto* executable : leaves.keys())
+            m_pins.append(JSC::Strong<JSC::Unknown>(executable->vm(), JSC::JSValue(executable)));
+    }
+
+    void stopCollecting() WTF_REQUIRES_LOCK(m_lock)
+    {
+        m_state = State::Frozen;
+        m_bytecode->leafExecutables().clear();
+        m_recorded.clear();
+        m_pins.clear();
+    }
+
+    void discard()
+    {
+        Locker locker { m_lock };
+        m_bytecode = nullptr;
+        m_recorded.clear();
+        m_pins.clear();
+        m_state = State::Done;
+    }
+
+    const uint64_t m_key;
+    const uint64_t m_entryId;
+    Lock m_lock;
+    State m_state WTF_GUARDED_BY_LOCK(m_lock) { State::AwaitingTopLevel };
+    RefPtr<JSC::CachedBytecode> m_bytecode WTF_GUARDED_BY_LOCK(m_lock);
+    std::optional<OptionSet<JSC::CodeGenerationMode>> m_codeGenerationMode WTF_GUARDED_BY_LOCK(m_lock);
+    // 0 until an update with nested functions has been rejected.
+    size_t m_nestedFunctionOverhead WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    // Recorded* bits per function JSC has already reported (stored or not).
+    HashMap<const JSC::UnlinkedFunctionExecutable*, uint8_t> m_recorded WTF_GUARDED_BY_LOCK(m_lock);
+    // Only touched on the VM thread; commit() (any thread) leaves these alone.
+    Vector<JSC::Strong<JSC::Unknown>> m_pins WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+void SourceProvider::cacheBytecode(const JSC::BytecodeCacheGenerator& generator) const
+{
+    if (auto* collector = m_nodeCompileCache.get())
+        collector->addTopLevel(generator, this);
+}
+
+void SourceProvider::updateCache(const JSC::UnlinkedFunctionExecutable* executable, const JSC::SourceCode&, JSC::CodeSpecializationKind kind, const JSC::UnlinkedFunctionCodeBlock* codeBlock) const
+{
+    if (auto* collector = m_nodeCompileCache.get())
+        collector->addFunction(executable, kind, codeBlock);
+}
+
+// Called under the Rust cache lock, which ~SourceProvider's detach also needs, so the provider is alive.
+extern "C" void ZigSourceProvider__commitNodeCompileCache(const SourceProvider* provider, void* context, void (*sink)(void* context, const uint8_t* bytecode, size_t bytecodeLength))
+{
+    Vector<uint8_t> blob = provider->nodeCompileCache()->commit();
+    if (!blob.isEmpty())
+        sink(context, blob.span().data(), blob.size());
+}
 
 SourceOrigin toSourceOrigin(const String& sourceURL, bool isBuiltin)
 {
@@ -141,6 +341,9 @@ Ref<SourceProvider> SourceProvider::create(
 
     auto provider = getProvider();
 
+    if (resolvedSource.node_compile_cache_entry_id != 0)
+        provider->m_nodeCompileCache = makeUnique<NodeCompileCacheCollector>(resolvedSource.node_compile_cache_key, resolvedSource.node_compile_cache_entry_id);
+
     if (shouldGenerateCodeCoverage) {
         ByteRangeMapping__generate(Bun::toString(provider->sourceURL()), Bun::toString(provider->source().toStringWithoutCopying()), provider->asID());
     }
@@ -152,6 +355,17 @@ Ref<SourceProvider> SourceProvider::create(
     return provider;
 }
 
+SourceProvider::SourceProvider(void* bunVM, ResolvedSource resolvedSource, Ref<WTF::StringImpl>&& sourceImpl,
+    JSC::SourceTaintedOrigin taintedness,
+    const SourceOrigin& sourceOrigin, WTF::String&& sourceURL,
+    const TextPosition& startPosition, JSC::SourceProviderSourceType sourceType)
+    : Base(sourceOrigin, WTF::move(sourceURL), String(), taintedness, startPosition, sourceType)
+    , m_resolvedSource(resolvedSource)
+    , m_bunVM(bunVM)
+    , m_source(WTF::move(sourceImpl))
+{
+}
+
 StringView SourceProvider::source() const
 {
     return StringView(m_source.get());
@@ -159,6 +373,8 @@ StringView SourceProvider::source() const
 
 SourceProvider::~SourceProvider()
 {
+    if (m_nodeCompileCache)
+        m_nodeCompileCache->detach(this);
     if (m_resolvedSource.already_bundled) {
         BunString str = Bun::toString(sourceURL());
         Bun__removeSourceProviderSourceMap(m_bunVM, this, &str);

--- a/src/jsc/bindings/ZigSourceProvider.h
+++ b/src/jsc/bindings/ZigSourceProvider.h
@@ -19,6 +19,7 @@ class SourceProvider;
 namespace Zig {
 
 class GlobalObject;
+class NodeCompileCacheCollector;
 
 JSC::SourceID sourceIDForSourceURL(const WTF::String& sourceURL);
 JSC::SourceOrigin toSourceOrigin(const String& sourceURL, bool isBuiltin);
@@ -42,24 +43,24 @@ public:
         return m_cachedBytecode.copyRef();
     };
 
+    // Node compile cache hooks; no-ops unless the entry missed on disk.
+    void cacheBytecode(const JSC::BytecodeCacheGenerator&) const final;
+    void updateCache(const JSC::UnlinkedFunctionExecutable*, const JSC::SourceCode&, JSC::CodeSpecializationKind, const JSC::UnlinkedFunctionCodeBlock*) const final;
+    NodeCompileCacheCollector* nodeCompileCache() const { return m_nodeCompileCache.get(); }
+
     ResolvedSource m_resolvedSource;
 
 private:
     SourceProvider(void* bunVM, ResolvedSource resolvedSource, Ref<WTF::StringImpl>&& sourceImpl,
         JSC::SourceTaintedOrigin taintedness,
         const SourceOrigin& sourceOrigin, WTF::String&& sourceURL,
-        const TextPosition& startPosition, JSC::SourceProviderSourceType sourceType)
-        : Base(sourceOrigin, WTF::move(sourceURL), String(), taintedness, startPosition, sourceType)
-        , m_bunVM(bunVM)
-        , m_source(sourceImpl)
-    {
-        m_resolvedSource = resolvedSource;
-    }
+        const TextPosition& startPosition, JSC::SourceProviderSourceType sourceType);
 
     // Stored directly (not via the creating global) so the destructor stays
     // valid when the provider outlives its global under --isolate caching.
     void* m_bunVM;
     RefPtr<JSC::CachedBytecode> m_cachedBytecode;
+    std::unique_ptr<NodeCompileCacheCollector> m_nodeCompileCache;
     Ref<WTF::StringImpl> m_source;
     unsigned m_hash = 0;
 };

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -134,6 +134,9 @@ typedef struct ResolvedSource {
     // File path used as source origin for bytecode cache validation.
     // Converted to file:// URL. If empty, origin is derived from source_url.
     BunString bytecode_origin_path;
+    // Compile-cache miss to collect bytecode for; entry_id == 0 means none.
+    uint64_t node_compile_cache_key;
+    uint64_t node_compile_cache_entry_id;
 } ResolvedSource;
 inline constexpr uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -656,9 +656,7 @@ fn arm_watch_reload_grace_timer() {
     let reload_started = bun_core::is_process_reload_in_progress_on_another_thread;
     let handler_running = crate::posix_signal_handle::is_emitting_watch_kill_signal;
     let force = || -> ! {
-        // Same as the sibling reload paths: execve never reaches on_exit, so
-        // flush the compile cache first (safe off the JS thread; generation
-        // runs on its own worker VM).
+        // execve never reaches on_exit, so flush the compile cache first.
         crate::node_compile_cache::persist_now();
         Output::flush();
         bun_core::reload_process(

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3048,7 +3048,7 @@ fn transpile_source_code_inner(
                     // Node compile cache hook (transpiler-cache-hit path); must
                     // read `output_code` before it is consumed below. UTF-16
                     // output would hash differently than the print path — skip.
-                    let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
+                    let node_compile_cache = if bun_jsc::node_compile_cache::is_enabled()
                         && source.path.is_file()
                         && loader.is_java_script_like()
                         && !matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
@@ -3119,19 +3119,19 @@ fn transpile_source_code_inner(
                     } else {
                         ResolvedSourceTag::Javascript
                     };
-                    let (bytecode_cache, bytecode_cache_size) =
-                        node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
-                    return Ok(OwnedResolvedSource::from(ResolvedSource {
+                    let mut resolved_source = ResolvedSource {
                         source_code,
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         is_commonjs_module,
                         module_info,
                         tag,
-                        bytecode_cache,
-                        bytecode_cache_size,
                         ..Default::default()
-                    }));
+                    };
+                    if let Some(fetched) = node_compile_cache {
+                        fetched.apply(&mut resolved_source);
+                    }
+                    return Ok(OwnedResolvedSource::from(resolved_source));
                 }
 
                 // Link import records.
@@ -3306,7 +3306,7 @@ fn transpile_source_code_inner(
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
                     let written = printer.ctx.get_written();
-                    let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
+                    let node_compile_cache = if bun_jsc::node_compile_cache::is_enabled()
                         && path.is_file()
                         && loader.is_java_script_like()
                     {
@@ -3326,9 +3326,8 @@ fn transpile_source_code_inner(
                     };
                     resolved_source.is_commonjs_module = is_commonjs_module;
                     resolved_source.module_info = module_info;
-                    if let Some((ptr, size)) = node_compile_cache_blob {
-                        resolved_source.bytecode_cache = ptr;
-                        resolved_source.bytecode_cache_size = size;
+                    if let Some(fetched) = node_compile_cache {
+                        fetched.apply(&mut resolved_source);
                     }
                     return Ok(OwnedResolvedSource::from(resolved_source));
                 }
@@ -3392,7 +3391,7 @@ fn transpile_source_code_inner(
                 let written = printer.ctx.get_written();
                 // Node compile cache hook (sync transpile path). `fetch` copies
                 // `written`; the printer may be replaced below.
-                let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
+                let node_compile_cache = if bun_jsc::node_compile_cache::is_enabled()
                     && path.is_file()
                     && loader.is_java_script_like()
                 {
@@ -3421,19 +3420,19 @@ fn transpile_source_code_inner(
                 // (fd close handled by `_fd_guard` registered above; spec
                 // :251-256 `defer` fires on every exit path.)
 
-                let (bytecode_cache, bytecode_cache_size) =
-                    node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
-                return Ok(OwnedResolvedSource::from(ResolvedSource {
+                let mut resolved_source = ResolvedSource {
                     source_code,
                     specifier: input_specifier.dupe_ref(),
                     source_url: create_if_different(input_specifier, path.text),
                     is_commonjs_module,
                     module_info,
                     tag,
-                    bytecode_cache,
-                    bytecode_cache_size,
                     ..Default::default()
-                }));
+                };
+                if let Some(fetched) = node_compile_cache {
+                    fetched.apply(&mut resolved_source);
+                }
+                return Ok(OwnedResolvedSource::from(resolved_source));
             }
         }
 

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -22,7 +22,6 @@
     ]
   },
   "src/jsc/NodeCompileCache.rs": {
-    "thread spawn": 1,
     "unsafe impl Send": [
       "AlignedBlob",
       "CacheState"

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -293,6 +293,150 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  async function runWithCompileCache(dir, script, cacheDir, extraEnv = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), script],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_COMPILE_CACHE: cacheDir, ...extraEnv },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Entry layout: magic u32 | code_size u32 | cache_size u32 | sha256(code) | sha256(bytecode) | code.
+  const entryHeaderSize = 3 * 4 + 2 * 32;
+  function compileCacheEntryFor(cacheDir, marker) {
+    const entries = [...new Bun.Glob("*/*").scanSync({ cwd: cacheDir, onlyFiles: true })].map(name => {
+      const bytes = fs.readFileSync(path.join(cacheDir, name));
+      const codeSize = bytes.readUInt32LE(4);
+      return {
+        bytecodeSize: bytes.readUInt32LE(8),
+        code: bytes.subarray(entryHeaderSize, entryHeaderSize + codeSize).toString(),
+      };
+    });
+    const matching = entries.filter(entry => entry.code.includes(marker));
+    expect(matching).toHaveLength(1);
+    return matching[0];
+  }
+
+  const depFunctions = `
+    function add(a, b) {
+      let total = a;
+      for (let i = 0; i < b; i++) total += 1;
+      return total;
+    }
+    function greet(name) {
+      const parts = ["hello", name];
+      return parts.join(" ");
+    }
+    function neverCalled(value) {
+      return JSON.stringify({ value, doubled: value * 2 });
+    }
+  `;
+  const depMarker = "compile-cache-dep-marker";
+
+  test.each([
+    [
+      "CommonJS",
+      {
+        "dep.js": `${depFunctions}\nmodule.exports = { add, greet, neverCalled, marker: "${depMarker}" };`,
+        "load.js": `require("./dep.js"); console.log("loaded");`,
+        "run.js": `const dep = require("./dep.js"); console.log(dep.add(2, 3), dep.greet("cache"));`,
+      },
+    ],
+    [
+      "ESM",
+      {
+        "dep.mjs": `${depFunctions}\nexport { add, greet, neverCalled };\nexport const marker = "${depMarker}";`,
+        "load.mjs": `import "./dep.mjs"; console.log("loaded");`,
+        "run.mjs": `import { add, greet } from "./dep.mjs"; console.log(add(2, 3), greet("cache"));`,
+      },
+    ],
+  ])("compile cache stores the bytecode of the functions a %s module actually ran", async (kind, files) => {
+    using dir = tempDir("compile-cache-lazy", files);
+    const ext = kind === "ESM" ? ".mjs" : ".js";
+    const onlyLoadedDir = path.join(String(dir), "cc-loaded");
+    const ranDir = path.join(String(dir), "cc-ran");
+
+    expect(await runWithCompileCache(dir, `load${ext}`, onlyLoadedDir)).toEqual({
+      stdout: "loaded\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await runWithCompileCache(dir, `run${ext}`, ranDir)).toEqual({
+      stdout: "5 hello cache\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    // The run that called add() and greet() also stores their bytecode; neverCalled() stays a stub in both.
+    const onlyLoaded = compileCacheEntryFor(onlyLoadedDir, depMarker);
+    const ran = compileCacheEntryFor(ranDir, depMarker);
+    expect(ran.code).toBe(onlyLoaded.code);
+    expect(ran.bytecodeSize).toBeGreaterThan(onlyLoaded.bytecodeSize);
+
+    // The functions recorded as updates are loaded back from the entry.
+    const warm = await runWithCompileCache(dir, `run${ext}`, ranDir, { NODE_DEBUG_NATIVE: "COMPILE_CACHE" });
+    expect(warm.stdout).toBe("5 hello cache\n");
+    expect(warm.stderr).toContain(`dep${ext} was accepted`);
+    expect(warm.stderr).not.toContain("writing cache");
+    expect(warm.exitCode).toBe(0);
+  });
+
+  test("compile cache persists modules loaded by a worker_threads Worker", async () => {
+    using dir = tempDir("compile-cache-worker", {
+      "main.js": `
+        const { Worker } = require("worker_threads");
+        new Worker("./worker.js").on("exit", code => console.log("worker exit", code));
+      `,
+      "worker.js": `console.log(require("./worker-dep.js").twice(21));`,
+      "worker-dep.js": `function twice(n) { return n * 2; }\nmodule.exports = { twice, marker: "compile-cache-worker-dep" };`,
+    });
+    const cacheDir = path.join(String(dir), "cc");
+
+    // The worker's VM is torn down before exit; its bytecode must still reach the exit persist.
+    expect(await runWithCompileCache(dir, "main.js", cacheDir)).toEqual({
+      stdout: "42\nworker exit 0\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    // main.js, worker.js and worker-dep.js.
+    expect([...new Bun.Glob("*/*").scanSync({ cwd: cacheDir, onlyFiles: true })]).toHaveLength(3);
+    expect(compileCacheEntryFor(cacheDir, "compile-cache-worker-dep").bytecodeSize).toBeGreaterThan(0);
+  });
+
+  test("compile cache persists the version of a module that was rewritten and re-required in the same process", async () => {
+    using dir = tempDir("compile-cache-rewrite", {
+      "dep.js": `module.exports = { version() { return "v1"; }, marker: "compile-cache-rewrite" };`,
+      // The marker is assembled at runtime so only dep.js's entry contains it verbatim.
+      "main.js": `
+        const fs = require("fs");
+        const dep = require.resolve("./dep.js");
+        const versions = [require(dep).version()];
+        const marker = ["compile-cache", "rewrite"].join("-");
+        fs.writeFileSync(dep, 'module.exports = { version() { return "v2"; }, marker: "' + marker + '" };');
+        delete require.cache[dep];
+        versions.push(require(dep).version());
+        console.log(versions.join(","));
+      `,
+    });
+    const cacheDir = path.join(String(dir), "cc");
+
+    expect(await runWithCompileCache(dir, "main.js", cacheDir)).toEqual({
+      stdout: "v1,v2\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(compileCacheEntryFor(cacheDir, "compile-cache-rewrite").code).toContain('"v2"');
+
+    // dep.js is now v2 on disk, so the persisted entry must be v2's bytecode.
+    const warm = await runWithCompileCache(dir, "main.js", cacheDir, { NODE_DEBUG_NATIVE: "COMPILE_CACHE" });
+    expect(warm.stdout).toBe("v2,v2\n");
+    expect(warm.stderr).toContain("dep.js was accepted");
+    expect(warm.exitCode).toBe(0);
+  });
+
   const compileCacheEnv = { ...bunEnv };
   delete compileCacheEnv.NODE_COMPILE_CACHE;
   delete compileCacheEnv.NODE_COMPILE_CACHE_PORTABLE;


### PR DESCRIPTION
### What does this PR do?

\`module.enableCompileCache()\` (tsc's \`bin/tsc\` calls it) used to hand every missed module to a dedicated thread with its own JSC VM at exit, re-parse it there, eagerly compile every function and encode all of it. For \`bun --bun tsc\` that is a 5.5 MB re-parse and a 16 MB blob on every cold run, and the exit stalls for hundreds of ms to several seconds.

The \`SourceProvider\` now implements JSC's \`cacheBytecode\` / \`updateCache\` hooks (the same shape jsc's \`--diskCache\` uses): the top-level code block is recorded when JSC generates it and each function is recorded when it is actually compiled. Persisting flattens those already-encoded bytes and writes the file. No second VM, no thread, no re-parse, and the entry only holds the functions that ran.

\`bun --bun tsc --help\`, release build, macOS arm64:

| | before | after |
|---|---|---|
| cold (cache miss) | 296 ms | 191 ms |
| warm (cache hit) | 49 ms | 33 ms |
| entry size for \`_tsc.js\` | 21 MB | 7.7 MB |

### How did you verify your code works?

- \`test/js/node/module/node-module-module.test.js\` (new tests: functions that ran are stored, lazy stubs are not; worker_threads modules are persisted; a rewritten module persists the new version)
- Node's \`test-compile-cache-*.js\` parallel tests
- \`test/internal/source-lints\`
- Drove the debug and release binaries on tsc and small CJS/ESM modules cold and warm with \`NODE_DEBUG_NATIVE=COMPILE_CACHE\`