### PR TITLE
compile cache: encode the bytecode the main VM compiled instead of re-parsing every module on a second VM

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "b7f217b4a657fff5d475d5815d7efa94a7cbc5a3";
+export const WEBKIT_VERSION = "autobuild-preview-pr-493-0cd61870";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -9,9 +9,11 @@ use bun_boringssl::c as boring;
 use bun_collections::{HashMap, IdentityContext};
 use bun_core::String as BunString;
 use bun_core::{Mutex, ZStr, env_var};
-use bun_options_types::Format;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 use bun_sys::{self as sys, Fd, O};
+
+use crate::ResolvedSource;
+use crate::VM;
 
 pub const STATUS_FAILED: i32 = 0;
 pub const STATUS_ENABLED: i32 = 1;
@@ -45,6 +47,8 @@ struct CacheState {
 unsafe impl Send for CacheState {}
 
 struct Entry {
+    /// A re-fetch with different content gets a new id, so [`deliver`] can drop bytecode for the old one.
+    id: u64,
     /// `path.text` of the module (absolute file path).
     filename: Box<[u8]>,
     is_cjs: bool,
@@ -56,7 +60,15 @@ struct Entry {
     /// Deserialized bytecode blob handed to JSC (the cache was accepted).
     /// Kept alive for the process — `ZigSourceProvider` wraps it, no copy.
     blob: Option<AlignedBlob>,
+    /// Bytecode the compiling VM delivered for a miss, not yet written.
+    generated: Option<Box<[u8]>>,
     persisted: bool,
+}
+
+static NEXT_ENTRY_ID: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
+
+fn next_entry_id() -> u64 {
+    NEXT_ENTRY_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 /// 128-byte-aligned blob. JSC's bytecode decoder reads the blob in place and
@@ -539,10 +551,48 @@ pub fn get_dir() -> Option<Vec<u8>> {
 // Fetch-time hook (read + validate)
 // ──────────────────────────────────────────────────────────────────────────
 
+/// What [`fetch`] found: accepted on-disk bytecode, or the entry the compiling VM should [`deliver`] to.
+pub struct Fetch {
+    blob: Option<(*mut u8, usize)>,
+    key: u64,
+    entry_id: u64,
+}
+
+impl Fetch {
+    fn hit(blob: &AlignedBlob) -> Self {
+        Self {
+            blob: Some((blob.ptr.as_ptr(), blob.len)),
+            key: 0,
+            entry_id: 0,
+        }
+    }
+
+    fn miss(entry: &Entry, key: u64) -> Self {
+        Self {
+            blob: None,
+            key,
+            entry_id: if entry.persisted || entry.generated.is_some() {
+                0
+            } else {
+                entry.id
+            },
+        }
+    }
+
+    pub fn apply(&self, resolved_source: &mut ResolvedSource) {
+        if let Some((ptr, size)) = self.blob {
+            resolved_source.bytecode_cache = ptr;
+            resolved_source.bytecode_cache_size = size;
+        }
+        resolved_source.node_compile_cache_key = self.key;
+        resolved_source.node_compile_cache_entry_id = self.entry_id;
+    }
+}
+
 /// Module-fetch hook: register/refresh the entry for `filename`; returns the
 /// validated bytecode blob when the on-disk cache matches `code` (post-
 /// transpile text). The pointer stays valid for the process (entry map owns it).
-pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usize)> {
+pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<Fetch> {
     if !is_enabled() || filename.is_empty() || !bun_paths::is_absolute(filename) {
         return None;
     }
@@ -558,29 +608,34 @@ pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usi
     if let Some(entry) = state.entries.get(&key) {
         if entry.code_hash == code_hash && entry.code_size == code_size {
             // Same module, unchanged code (e.g. re-required): reuse.
-            return entry.blob.as_ref().map(|b| (b.ptr.as_ptr(), b.len));
+            return Some(match &entry.blob {
+                Some(blob) => Fetch::hit(blob),
+                None => Fetch::miss(entry, key),
+            });
         }
     }
 
     let mut entry = Entry {
+        id: next_entry_id(),
         filename: filename.into(),
         is_cjs,
         code_hash,
         code_size,
         code: None,
         blob: None,
+        generated: None,
         persisted: false,
     };
 
     read_cache_file(state, key, &mut entry, Some(code));
 
-    let result = if entry.blob.is_some() {
+    let result = if let Some(blob) = &entry.blob {
         cclog!(
             "[compile cache] code cache for {} {} was accepted, keeping the in-memory entry\n",
             type_name(is_cjs),
             display_name(filename, is_cjs)
         );
-        entry.blob.as_ref().map(|b| (b.ptr.as_ptr(), b.len))
+        Fetch::hit(blob)
     } else {
         cclog!(
             "[compile cache] code cache for {} {} was not initialized, initializing the in-memory entry\n",
@@ -588,7 +643,7 @@ pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usi
             display_name(filename, is_cjs)
         );
         entry.code = Some(code.into());
-        None
+        Fetch::miss(&entry, key)
     };
     if let Some(old) = state.entries.insert(key, entry) {
         if let Some(blob) = old.blob {
@@ -596,7 +651,30 @@ pub fn fetch(filename: &[u8], is_cjs: bool, code: &[u8]) -> Option<(*mut u8, usi
             RETIRED_BLOBS.lock().push(blob);
         }
     }
-    result
+    Some(result)
+}
+
+/// The compiling VM hands over a missed module's bytecode (`None`: encoding failed); stale entry ids are ignored.
+pub fn deliver(key: u64, entry_id: u64, bytecode: Option<&[u8]>) {
+    let mut guard = STATE.lock();
+    let Some(state) = guard.as_mut() else { return };
+    let Some(entry) = state.entries.get_mut(&key) else {
+        return;
+    };
+    if entry.id != entry_id || entry.persisted {
+        return;
+    }
+    match bytecode {
+        Some(bytes) => entry.generated = Some(bytes.into()),
+        None => {
+            cclog!(
+                "[compile cache] generating cache for {} {} failed, skipping\n",
+                type_name(entry.is_cjs),
+                display_name(&entry.filename, entry.is_cjs)
+            );
+            entry.persisted = true;
+        }
+    }
 }
 
 /// Parse-failure hook: mirrors Node registering an entry before compilation.
@@ -613,12 +691,14 @@ pub fn note_parse_failure(filename: &[u8], is_cjs: bool) {
         return;
     }
     let mut entry = Entry {
+        id: next_entry_id(),
         filename: filename.into(),
         is_cjs,
         code_hash: [0u8; HASH_SIZE],
         code_size: 0,
         code: None,
         blob: None,
+        generated: None,
         persisted: false,
     };
     // The read is attempted (and logged) like Node; without current code the
@@ -865,79 +945,136 @@ fn read_cache_file(state: &CacheState, key: u64, entry: &mut Entry, code: Option
 // Persist (exit + flush)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Bytecode generation runs on one long-lived worker thread with its own JSC
-/// VM (`getVMForBytecodeCache`), mirroring `bun build --bytecode`'s bundler
-/// threads, so only a single extra VM ever exists.
-struct GenJob {
-    format: Format,
-    code: Box<[u8]>,
-    url: Box<[u8]>,
-    resp: std::sync::mpsc::SyncSender<Option<Box<[u8]>>>,
+unsafe extern "C" {
+    fn Bun__NodeCompileCache__encodePending(vm: &VM);
 }
 
-fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]>> {
-    use std::sync::mpsc;
-    static WORKER: Mutex<Option<mpsc::Sender<GenJob>>> = Mutex::new(None);
-
-    let (resp_tx, resp_rx) = mpsc::sync_channel(1);
-    {
-        let mut guard = WORKER.lock();
-        if guard.is_none() {
-            let (tx, rx) = mpsc::channel::<GenJob>();
-            let spawned = std::thread::Builder::new()
-                .name("BunCompileCache".to_string())
-                // JSC parsing of large modules needs a deep stack.
-                .stack_size(16 * 1024 * 1024)
-                .spawn(move || {
-                    for job in rx {
-                        let mut url = BunString::clone_utf8(&job.url);
-                        let result = crate::cached_bytecode::__bun_jsc_generate_cached_bytecode(
-                            job.format, &job.code, &mut url,
-                        );
-                        url.deref();
-                        let _ = job.resp.send(result);
-                    }
-                });
-            match spawned {
-                Ok(_) => *guard = Some(tx),
-                Err(_) => return None,
-            }
-        }
-        let tx = guard.as_ref().expect("set above");
-        if tx
-            .send(GenJob {
-                format,
-                code: code.into(),
-                url: url.into(),
-                resp: resp_tx,
-            })
-            .is_err()
-        {
-            return None;
-        }
+/// Encodes every missed module `vm` compiled and [`deliver`]s the bytes; runs on `vm`'s thread with its lock held.
+pub fn encode_pending(vm: &VM) {
+    if !is_enabled() {
+        return;
     }
-    resp_rx.recv().ok().flatten()
+    // SAFETY: `vm` is the live VM of the calling thread per fn contract.
+    unsafe { Bun__NodeCompileCache__encodePending(vm) };
 }
 
-/// One unit of persist work, snapshotted out of `STATE` so bytecode generation runs with the lock
-/// dropped. `code` is moved out (concurrent `fetch` sees `code: None` and skips). Keys hash
-/// `(is_cjs, filename)` — not content — so Phase 3 re-checks `code_hash` before touching the entry.
-struct PersistJob {
+/// Writes one entry's stored source + bytecode; `Err(())` leaves it unpersisted so a later pass may retry.
+fn write_entry(
+    dir: &[u8],
+    dir_handle: &sys::Dir,
     key: u64,
-    format: Format,
-    code: Box<[u8]>,
-    filename: Box<[u8]>,
-    is_cjs: bool,
-    code_size: u32,
-    code_hash: [u8; HASH_SIZE],
+    entry: &Entry,
+    blob: &[u8],
+) -> Result<(), ()> {
+    let logging = LOG_ENABLED.load(Ordering::Relaxed);
+    let tname = type_name(entry.is_cjs);
+    let name = if logging {
+        display_name(&entry.filename, entry.is_cjs)
+    } else {
+        String::new()
+    };
+    let Some(code) = entry.code.as_deref() else {
+        return Err(());
+    };
+
+    let cache_size = blob.len() as u32;
+    let cache_hash = sha256(blob);
+
+    let basename = cache_basename(key);
+    let mut tmpname_buf = PathBuffer::uninit();
+    let tmpname_zstr: &ZStr =
+        match bun_resolver::fs::FileSystem::tmpname(&basename, &mut tmpname_buf[..], key) {
+            Ok(z) => z,
+            Err(_) => return Err(()),
+        };
+
+    cclog!("[compile cache] Creating temporary file for cache of {name} ({tname})...");
+
+    // 0600 like Node: entries contain the module's post-transpile source.
+    let mut tmpfile = match sys::Tmpfile::create_with_mode(dir_handle.fd(), tmpname_zstr, 0o600) {
+        Ok(t) => t,
+        Err(e) => {
+            cclog!("failed. {}\n", errno_name(&e));
+            return Err(());
+        }
+    };
+    let _close = sys::CloseOnDrop::new(tmpfile.fd);
+
+    let tmp_display = if logging {
+        format!(
+            "{}{}{}",
+            dir.as_bstr(),
+            SEP as char,
+            tmpname_zstr.as_bytes().as_bstr()
+        )
+    } else {
+        String::new()
+    };
+    cclog!(" -> {tmp_display}\n");
+    cclog!(
+        "[compile cache] writing cache for {tname} {name} to temporary file {tmp_display} [{MAGIC} {} {cache_size} {} {}]...",
+        entry.code_size,
+        hex(&entry.code_hash),
+        hex(&cache_hash)
+    );
+
+    let mut header_bytes = [0u8; HEADER_SIZE];
+    header_bytes[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+    header_bytes[4..8].copy_from_slice(&entry.code_size.to_le_bytes());
+    header_bytes[8..12].copy_from_slice(&cache_size.to_le_bytes());
+    header_bytes[12..12 + HASH_SIZE].copy_from_slice(&entry.code_hash);
+    header_bytes[12 + HASH_SIZE..HEADER_SIZE].copy_from_slice(&cache_hash);
+    // ManuallyDrop: the fd is owned by `_close` above.
+    let file = core::mem::ManuallyDrop::new(sys::File::from_fd(tmpfile.fd));
+    let write_all = || -> sys::Maybe<()> {
+        file.pwrite_all(&header_bytes, 0)?;
+        file.pwrite_all(code, HEADER_SIZE as i64)?;
+        // The gap up to the 128-aligned blob offset is a hole (zeros).
+        file.pwrite_all(blob, blob_file_offset(entry.code_size) as i64)?;
+        Ok(())
+    };
+    if let Err(e) = write_all() {
+        cclog!("failed: {}\n", errno_name(&e));
+        let _ = sys::unlinkat(dir_handle.fd(), tmpname_zstr);
+        return Err(());
+    }
+    cclog!("success\n");
+
+    let mut dest_z = [0u8; 17];
+    dest_z[..16].copy_from_slice(&basename);
+    let dest_zstr = ZStr::from_buf(&dest_z, 16);
+    let final_display = if logging {
+        format!(
+            "{}{}{}",
+            dir.as_bstr(),
+            SEP as char,
+            core::str::from_utf8(&basename).expect("hex")
+        )
+    } else {
+        String::new()
+    };
+    cclog!("[compile cache] Renaming {tmp_display} to {final_display}...");
+    if let Err(e) = tmpfile.finish(dest_zstr) {
+        cclog!("failed: {}\n", errno_name(&e));
+        let _ = sys::unlinkat(dir_handle.fd(), tmpname_zstr);
+        return Err(());
+    }
+    cclog!("success\n");
+    Ok(())
 }
 
-/// Phase 1 (locked): decide what needs persisting and move the source code
-/// out of the entries.
-fn collect_persist_jobs(state: &mut CacheState) -> Vec<PersistJob> {
-    let mut jobs = Vec::new();
+/// Writes every entry whose bytecode has been delivered; touches no VM, so any thread may run it.
+fn persist_pass() {
+    let mut guard = STATE.lock();
+    let Some(state) = guard.as_mut() else { return };
+    let CacheState {
+        dir,
+        dir_handle,
+        entries,
+        ..
+    } = state;
     let logging = LOG_ENABLED.load(Ordering::Relaxed);
-    for (&key, entry) in state.entries.iter_mut() {
+    for (&key, entry) in entries.iter_mut() {
         let tname = type_name(entry.is_cjs);
         let name = if logging {
             display_name(&entry.filename, entry.is_cjs)
@@ -955,225 +1092,57 @@ fn collect_persist_jobs(state: &mut CacheState) -> Vec<PersistJob> {
             cclog!("[compile cache] skip persisting {tname} {name} because cache was the same\n");
             continue;
         }
-        let Some(code) = entry.code.take() else {
+        let Some(generated) = entry.generated.take() else {
             cclog!(
                 "[compile cache] skip persisting {tname} {name} because the cache was not initialized\n"
             );
             continue;
         };
-        jobs.push(PersistJob {
-            key,
-            format: if entry.is_cjs {
-                Format::Cjs
-            } else {
-                Format::Esm
-            },
-            code,
-            filename: entry.filename.clone(),
-            is_cjs: entry.is_cjs,
-            code_size: entry.code_size,
-            code_hash: entry.code_hash,
-        });
-    }
-    jobs
-}
-
-/// Phase 3 (locked): write one generated blob to disk. `Ok(())` on success;
-/// on any I/O failure returns `Err(())` and the caller restores the taken
-/// `entry.code` and leaves `persisted` false so a later pass may retry.
-fn write_persist_job_locked(
-    state: &mut CacheState,
-    job: &PersistJob,
-    blob: &[u8],
-) -> Result<(), ()> {
-    let logging = LOG_ENABLED.load(Ordering::Relaxed);
-    let tname = type_name(job.is_cjs);
-    let name = if logging {
-        display_name(&job.filename, job.is_cjs)
-    } else {
-        String::new()
-    };
-
-    let cache_size = blob.len() as u32;
-    let cache_hash = sha256(blob);
-
-    let basename = cache_basename(job.key);
-    let mut tmpname_buf = PathBuffer::uninit();
-    let tmpname_zstr: &ZStr =
-        match bun_resolver::fs::FileSystem::tmpname(&basename, &mut tmpname_buf[..], job.key) {
-            Ok(z) => z,
-            Err(_) => return Err(()),
-        };
-
-    cclog!("[compile cache] Creating temporary file for cache of {name} ({tname})...");
-
-    // 0600 like Node: entries contain the module's post-transpile source.
-    let mut tmpfile =
-        match sys::Tmpfile::create_with_mode(state.dir_handle.fd(), tmpname_zstr, 0o600) {
-            Ok(t) => t,
-            Err(e) => {
-                cclog!("failed. {}\n", errno_name(&e));
-                return Err(());
+        match write_entry(dir, dir_handle, key, entry, &generated) {
+            Ok(()) => {
+                entry.persisted = true;
+                entry.code = None;
             }
-        };
-    let _close = sys::CloseOnDrop::new(tmpfile.fd);
-
-    let tmp_display = if logging {
-        format!(
-            "{}{}{}",
-            state.dir.as_bstr(),
-            SEP as char,
-            tmpname_zstr.as_bytes().as_bstr()
-        )
-    } else {
-        String::new()
-    };
-    cclog!(" -> {tmp_display}\n");
-    cclog!(
-        "[compile cache] writing cache for {tname} {name} to temporary file {tmp_display} [{MAGIC} {} {cache_size} {} {}]...",
-        job.code_size,
-        hex(&job.code_hash),
-        hex(&cache_hash)
-    );
-
-    let mut header_bytes = [0u8; HEADER_SIZE];
-    header_bytes[0..4].copy_from_slice(&MAGIC.to_le_bytes());
-    header_bytes[4..8].copy_from_slice(&job.code_size.to_le_bytes());
-    header_bytes[8..12].copy_from_slice(&cache_size.to_le_bytes());
-    header_bytes[12..12 + HASH_SIZE].copy_from_slice(&job.code_hash);
-    header_bytes[12 + HASH_SIZE..HEADER_SIZE].copy_from_slice(&cache_hash);
-    // ManuallyDrop: the fd is owned by `_close` above.
-    let file = core::mem::ManuallyDrop::new(sys::File::from_fd(tmpfile.fd));
-    let write_all = || -> sys::Maybe<()> {
-        file.pwrite_all(&header_bytes, 0)?;
-        file.pwrite_all(&job.code, HEADER_SIZE as i64)?;
-        // The gap up to the 128-aligned blob offset is a hole (zeros).
-        file.pwrite_all(blob, blob_file_offset(job.code_size) as i64)?;
-        Ok(())
-    };
-    if let Err(e) = write_all() {
-        cclog!("failed: {}\n", errno_name(&e));
-        let _ = sys::unlinkat(state.dir_handle.fd(), tmpname_zstr);
-        return Err(());
-    }
-    cclog!("success\n");
-
-    let mut dest_z = [0u8; 17];
-    dest_z[..16].copy_from_slice(&basename);
-    let dest_zstr = ZStr::from_buf(&dest_z, 16);
-    let final_display = if logging {
-        format!(
-            "{}{}{}",
-            state.dir.as_bstr(),
-            SEP as char,
-            core::str::from_utf8(&basename).expect("hex")
-        )
-    } else {
-        String::new()
-    };
-    cclog!("[compile cache] Renaming {tmp_display} to {final_display}...");
-    if let Err(e) = tmpfile.finish(dest_zstr) {
-        cclog!("failed: {}\n", errno_name(&e));
-        let _ = sys::unlinkat(state.dir_handle.fd(), tmpname_zstr);
-        return Err(());
-    }
-    cclog!("success\n");
-    Ok(())
-}
-
-/// Full persist pass. `STATE` is held only for snapshot and file-write phases; bytecode
-/// generation runs with the lock dropped so concurrent module loads are not stalled.
-fn persist_pass() {
-    // Phase 1: snapshot under the lock.
-    let jobs = {
-        let mut guard = STATE.lock();
-        let Some(state) = guard.as_mut() else { return };
-        collect_persist_jobs(state)
-    };
-
-    // Phase 2: generate bytecode, unlocked.
-    let mut generated: Vec<(PersistJob, Option<Box<[u8]>>)> = Vec::with_capacity(jobs.len());
-    for job in jobs {
-        let blob = generate_bytecode(job.format, &job.code, &job.filename);
-        if blob.is_none() {
-            cclog!(
-                "[compile cache] generating cache for {} {} failed, skipping\n",
-                type_name(job.is_cjs),
-                display_name(&job.filename, job.is_cjs)
-            );
-        }
-        generated.push((job, blob));
-    }
-
-    // Phase 3: write files and update entries under the lock.
-    let mut guard = STATE.lock();
-    let Some(state) = guard.as_mut() else { return };
-    for (job, blob) in generated {
-        let Some(blob) = blob else {
-            // Do not retry on the next persist pass. Skip if the entry now
-            // holds different content (file changed and was re-fetched).
-            if let Some(entry) = state.entries.get_mut(&job.key) {
-                if entry.code_hash == job.code_hash && entry.code_size == job.code_size {
-                    entry.persisted = true;
-                }
-            }
-            continue;
-        };
-        let wrote = write_persist_job_locked(state, &job, &blob);
-        let Some(entry) = state.entries.get_mut(&job.key) else {
-            continue;
-        };
-        if entry.code_hash != job.code_hash || entry.code_size != job.code_size {
-            // The entry was repopulated with different content mid-pass; the
-            // write we just did is stale (the header check corrects it on
-            // the next load) and the taken code must not overwrite the new.
-            continue;
-        }
-        match wrote {
-            Ok(()) => entry.persisted = true,
-            // Keep the source so a later pass can retry, matching the old
-            // in-place behavior for failed writes.
-            Err(()) => {
-                if entry.code.is_none() {
-                    entry.code = Some(job.code);
-                }
-            }
+            Err(()) => entry.generated = Some(generated),
         }
     }
-
     cclog!("[compile cache] Clear deserialized cache.\n");
-    // Drop persisted code copies; blobs stay alive (JSC providers reference
-    // them) and entries stay so unchanged re-fetches keep hitting in memory.
-    for entry in state.entries.values_mut() {
-        if entry.persisted {
-            entry.code = None;
-        }
-    }
 }
 
-/// `module.flushCompileCache()`.
-pub fn flush() {
+/// `module.flushCompileCache()`; runs on the calling VM's thread.
+pub fn flush(vm: &VM) {
     if !is_enabled() {
         return;
     }
     cclog!("[compile cache] module.flushCompileCache() requested.\n");
+    encode_pending(vm);
     persist_pass();
     cclog!("[compile cache] module.flushCompileCache() finished.\n");
 }
 
 /// Exit-time persist; runs once, from the main VM's `on_exit`.
-pub fn persist_at_exit() {
+pub fn persist_at_exit(vm: &VM) {
     static DONE: AtomicBool = AtomicBool::new(false);
     if !is_enabled() || DONE.swap(true, Ordering::Relaxed) {
         return;
     }
-    persist_now();
+    encode_pending(vm);
+    persist_pass();
 }
 
 /// Non-latching sibling of [`persist_at_exit`] for paths where the process may survive (e.g. a
 /// self-directed signal that proves non-fatal). Leaves the exit latch unset so a later real exit
 /// still persists modules loaded after this point.
-pub fn persist_now() {
+pub fn persist_now(vm: &VM) {
+    if !is_enabled() {
+        return;
+    }
+    encode_pending(vm);
+    persist_pass();
+}
+
+/// For threads that own no VM (`--watch` reload): writes what was delivered so far, the rest is lost.
+pub fn persist_now_off_thread() {
     if !is_enabled() {
         return;
     }
@@ -1225,6 +1194,24 @@ pub extern "C" fn Bun__NodeCompileCache__getDir() -> BunString {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Bun__NodeCompileCache__flush() {
-    flush();
+pub extern "C" fn Bun__NodeCompileCache__flush(vm: &VM) {
+    flush(vm);
+}
+
+#[unsafe(no_mangle)]
+/// # Safety
+/// `bytecode` is null (encoding failed) or valid for `len` bytes.
+pub unsafe extern "C" fn Bun__NodeCompileCache__deliver(
+    key: u64,
+    entry_id: u64,
+    bytecode: *const u8,
+    len: usize,
+) {
+    let bytes = if bytecode.is_null() {
+        None
+    } else {
+        // SAFETY: per fn contract.
+        Some(unsafe { core::slice::from_raw_parts(bytecode, len) })
+    };
+    deliver(key, entry_id, bytes);
 }

--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -51,6 +51,9 @@ pub struct ResolvedSource {
     /// was used at build time. If empty, the origin is derived from source_url.
     /// This is converted to a file:// URL on the C++ side.
     pub bytecode_origin_path: BunString,
+    /// Node compile cache entry that missed on disk (`entry_id == 0`: none); see `Fetch::apply`.
+    pub node_compile_cache_key: u64,
+    pub node_compile_cache_entry_id: u64,
 }
 
 impl Default for ResolvedSource {
@@ -70,6 +73,8 @@ impl Default for ResolvedSource {
             bytecode_cache_size: 0,
             module_info: core::ptr::null_mut(),
             bytecode_origin_path: BunString::empty(),
+            node_compile_cache_key: 0,
+            node_compile_cache_entry_id: 0,
         }
     }
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -530,7 +530,7 @@ impl VMHolder {
         // Node runs RunAtExit (incl. compile cache) on self-directed fatal signals. Non-latching:
         // the signal may prove non-fatal, and latching here would no-op the real exit's persist.
         // https://github.com/nodejs/node/blob/main/src/env.cc (AtExit(FlushCompileCache))
-        crate::node_compile_cache::persist_now();
+        crate::node_compile_cache::persist_now(vm.jsc_vm_mut());
     }
 }
 
@@ -1713,10 +1713,11 @@ impl VirtualMachine {
         }
         self.has_run_cleanup_hooks = true;
 
-        // Persist the Node compile cache (NODE_COMPILE_CACHE /
-        // module.enableCompileCache()) after user exit handlers ran.
+        // Persist the Node compile cache after user exit handlers ran; a worker only encodes, the main exit writes.
         if self.is_main_thread() {
-            crate::node_compile_cache::persist_at_exit();
+            crate::node_compile_cache::persist_at_exit(self.jsc_vm_mut());
+        } else {
+            crate::node_compile_cache::encode_pending(self.jsc_vm_mut());
         }
     }
 
@@ -3877,7 +3878,7 @@ impl VirtualMachine {
                 );
             // execve will not reach on_exit; flush the compile cache here like
             // node's child does via AtExit(FlushCompileCache) on every restart.
-            crate::node_compile_cache::persist_now();
+            crate::node_compile_cache::persist_now(self.jsc_vm_mut());
             bun_core::Output::flush();
             bun_core::reload_process(should_clear_terminal, false);
         }

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -71,6 +71,10 @@ class DOMWrapperWorld;
 #include "HTTPHeaderIdentifiers.h"
 #include "DOMURLBaseCache.h"
 #include <JavaScriptCore/HeapObserver.h>
+#include <JavaScriptCore/SourceCodeKey.h>
+namespace JSC {
+class UnlinkedCodeBlock;
+}
 namespace Zig {
 class GlobalObject;
 }
@@ -271,6 +275,15 @@ public:
     // only owner once the previous global is GC'd, so a weak map would empty
     // after every swap.
     WTF::UncheckedKeyHashMap<WTF::String, RefPtr<JSC::SourceProvider>> isolationSourceProviderCache;
+
+    // Node compile cache misses this VM compiled and has not encoded yet (Zig::SourceProvider::didGenerateUnlinkedCodeBlock).
+    struct NodeCompileCachePending {
+        uint64_t cacheKey;
+        uint64_t entryId;
+        JSC::SourceCodeKey key;
+        JSC::Weak<JSC::UnlinkedCodeBlock> codeBlock;
+    };
+    Vector<NodeCompileCachePending> nodeCompileCachePending;
 
 private:
     bool isWebCoreJSClientData() const final { return true; }

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -15,7 +15,13 @@
 #include <sys/stat.h>
 #include <JavaScriptCore/SourceCodeKey.h>
 #include <mimalloc.h>
+#include <JavaScriptCore/CachedTypes.h>
 #include <JavaScriptCore/CodeCache.h>
+#include <JavaScriptCore/UnlinkedCodeBlock.h>
+#include <JavaScriptCore/WeakInlines.h>
+#include "BunClientData.h"
+
+extern "C" void Bun__NodeCompileCache__deliver(uint64_t key, uint64_t entryId, const uint8_t* bytecode, size_t length);
 
 namespace Zig {
 
@@ -155,6 +161,31 @@ Ref<SourceProvider> SourceProvider::create(
 StringView SourceProvider::source() const
 {
     return StringView(m_source.get());
+}
+
+void SourceProvider::didGenerateUnlinkedCodeBlock(JSC::VM& vm, const JSC::SourceCodeKey& key, JSC::UnlinkedCodeBlock* codeBlock) const
+{
+    if (!m_resolvedSource.node_compile_cache_entry_id)
+        return;
+    if (codeBlock->codeType() != JSC::GlobalCode && codeBlock->codeType() != JSC::ModuleCode)
+        return;
+    WebCore::clientData(vm)->nodeCompileCachePending.append({ m_resolvedSource.node_compile_cache_key, m_resolvedSource.node_compile_cache_entry_id, key, JSC::Weak<JSC::UnlinkedCodeBlock>(codeBlock) });
+}
+
+// VM thread only: called before JSC__VM__runGC drops unlinked function code, and at persist time.
+extern "C" void Bun__NodeCompileCache__encodePending(JSC::VM* vm)
+{
+    auto pending = std::exchange(WebCore::clientData(*vm)->nodeCompileCachePending, {});
+    for (auto& entry : pending) {
+        JSC::UnlinkedCodeBlock* codeBlock = entry.codeBlock.get();
+        if (!codeBlock)
+            continue;
+        RefPtr<JSC::CachedBytecode> bytecode = JSC::encodeCodeBlock(*vm, entry.key, codeBlock);
+        if (bytecode)
+            Bun__NodeCompileCache__deliver(entry.cacheKey, entry.entryId, bytecode->span().data(), bytecode->span().size());
+        else
+            Bun__NodeCompileCache__deliver(entry.cacheKey, entry.entryId, nullptr, 0);
+    }
 }
 
 SourceProvider::~SourceProvider()

--- a/src/jsc/bindings/ZigSourceProvider.h
+++ b/src/jsc/bindings/ZigSourceProvider.h
@@ -42,6 +42,9 @@ public:
         return m_cachedBytecode.copyRef();
     };
 
+    // Node compile cache (misses only): the block is encoded once, before Bun's GC drops unlinked code or at persist time.
+    void didGenerateUnlinkedCodeBlock(JSC::VM&, const JSC::SourceCodeKey&, JSC::UnlinkedCodeBlock*) const final;
+
     ResolvedSource m_resolvedSource;
 
 private:

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5143,9 +5143,13 @@ JSC::EncodedJSValue JSC__JSValue__toError_(JSC::EncodedJSValue JSValue0)
 
 #pragma mark - JSC::VM
 
+extern "C" void Bun__NodeCompileCache__encodePending(JSC::VM* vm);
+
 size_t JSC__VM__runGC(JSC::VM* vm, bool sync)
 {
     JSC::JSLockHolder lock(vm);
+    // Both branches below drop unlinked function code; the compile cache wants it first.
+    Bun__NodeCompileCache__encodePending(vm);
 
 #if IS_MALLOC_DEBUGGING_ENABLED && OS(DARWIN)
     if (!malloc_zone_check(nullptr)) {

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -134,6 +134,9 @@ typedef struct ResolvedSource {
     // File path used as source origin for bytecode cache validation.
     // Converted to file:// URL. If empty, origin is derived from source_url.
     BunString bytecode_origin_path;
+    // Node compile cache entry that missed on disk (NodeCompileCache.rs); entry_id == 0: none.
+    uint64_t node_compile_cache_key;
+    uint64_t node_compile_cache_entry_id;
 } ResolvedSource;
 inline constexpr uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -592,10 +592,15 @@ where
         // With --watch-kill-signal listeners registered, reload via the event
         // loop so the JS thread emits them before execve (node runs the child's
         // handlers on kill); otherwise execve immediately (node's default kill).
-        if RELOAD_IMMEDIATELY && !crate::posix_signal_handle::watch_kill_signal_has_listeners() {
-            crate::node_compile_cache::persist_now();
-            Output::flush();
+        // The compile cache also needs the JS thread, to encode what it compiled.
+        if RELOAD_IMMEDIATELY {
             flush_changed_paths_for_reload();
+        }
+        if RELOAD_IMMEDIATELY
+            && !crate::posix_signal_handle::watch_kill_signal_has_listeners()
+            && !crate::node_compile_cache::is_enabled()
+        {
+            Output::flush();
             bun_core::reload_process(
                 CLEAR_SCREEN.load(core::sync::atomic::Ordering::Relaxed),
                 false,
@@ -656,10 +661,8 @@ fn arm_watch_reload_grace_timer() {
     let reload_started = bun_core::is_process_reload_in_progress_on_another_thread;
     let handler_running = crate::posix_signal_handle::is_emitting_watch_kill_signal;
     let force = || -> ! {
-        // Same as the sibling reload paths: execve never reaches on_exit, so
-        // flush the compile cache first (safe off the JS thread; generation
-        // runs on its own worker VM).
-        crate::node_compile_cache::persist_now();
+        // execve never reaches on_exit; this thread owns no VM, so only already-encoded modules are persisted.
+        crate::node_compile_cache::persist_now_off_thread();
         Output::flush();
         bun_core::reload_process(
             CLEAR_SCREEN.load(core::sync::atomic::Ordering::Relaxed),

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -869,7 +869,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRegister, (JSGlobalObject * globalObject, JSC
 
 extern "C" int32_t Bun__NodeCompileCache__enable(const BunString* dir, int32_t portable, BunString* outDirectory, BunString* outMessage);
 extern "C" BunString Bun__NodeCompileCache__getDir();
-extern "C" void Bun__NodeCompileCache__flush();
+extern "C" void Bun__NodeCompileCache__flush(JSC::VM*);
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionEnableCompileCache,
     (JSGlobalObject * globalObject,
@@ -942,7 +942,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionFlushCompileCache,
     (JSGlobalObject * globalObject,
         JSC::CallFrame* callFrame))
 {
-    Bun__NodeCompileCache__flush();
+    Bun__NodeCompileCache__flush(&globalObject->vm());
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3048,7 +3048,7 @@ fn transpile_source_code_inner(
                     // Node compile cache hook (transpiler-cache-hit path); must
                     // read `output_code` before it is consumed below. UTF-16
                     // output would hash differently than the print path — skip.
-                    let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
+                    let node_compile_cache = if bun_jsc::node_compile_cache::is_enabled()
                         && source.path.is_file()
                         && loader.is_java_script_like()
                         && !matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
@@ -3119,19 +3119,19 @@ fn transpile_source_code_inner(
                     } else {
                         ResolvedSourceTag::Javascript
                     };
-                    let (bytecode_cache, bytecode_cache_size) =
-                        node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
-                    return Ok(OwnedResolvedSource::from(ResolvedSource {
+                    let mut resolved_source = ResolvedSource {
                         source_code,
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         is_commonjs_module,
                         module_info,
                         tag,
-                        bytecode_cache,
-                        bytecode_cache_size,
                         ..Default::default()
-                    }));
+                    };
+                    if let Some(fetched) = node_compile_cache {
+                        fetched.apply(&mut resolved_source);
+                    }
+                    return Ok(OwnedResolvedSource::from(resolved_source));
                 }
 
                 // Link import records.
@@ -3306,7 +3306,7 @@ fn transpile_source_code_inner(
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
                     let written = printer.ctx.get_written();
-                    let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
+                    let node_compile_cache = if bun_jsc::node_compile_cache::is_enabled()
                         && path.is_file()
                         && loader.is_java_script_like()
                     {
@@ -3326,9 +3326,8 @@ fn transpile_source_code_inner(
                     };
                     resolved_source.is_commonjs_module = is_commonjs_module;
                     resolved_source.module_info = module_info;
-                    if let Some((ptr, size)) = node_compile_cache_blob {
-                        resolved_source.bytecode_cache = ptr;
-                        resolved_source.bytecode_cache_size = size;
+                    if let Some(fetched) = node_compile_cache {
+                        fetched.apply(&mut resolved_source);
                     }
                     return Ok(OwnedResolvedSource::from(resolved_source));
                 }
@@ -3392,7 +3391,7 @@ fn transpile_source_code_inner(
                 let written = printer.ctx.get_written();
                 // Node compile cache hook (sync transpile path). `fetch` copies
                 // `written`; the printer may be replaced below.
-                let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
+                let node_compile_cache = if bun_jsc::node_compile_cache::is_enabled()
                     && path.is_file()
                     && loader.is_java_script_like()
                 {
@@ -3421,19 +3420,19 @@ fn transpile_source_code_inner(
                 // (fd close handled by `_fd_guard` registered above; spec
                 // :251-256 `defer` fires on every exit path.)
 
-                let (bytecode_cache, bytecode_cache_size) =
-                    node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
-                return Ok(OwnedResolvedSource::from(ResolvedSource {
+                let mut resolved_source = ResolvedSource {
                     source_code,
                     specifier: input_specifier.dupe_ref(),
                     source_url: create_if_different(input_specifier, path.text),
                     is_commonjs_module,
                     module_info,
                     tag,
-                    bytecode_cache,
-                    bytecode_cache_size,
                     ..Default::default()
-                }));
+                };
+                if let Some(fetched) = node_compile_cache {
+                    fetched.apply(&mut resolved_source);
+                }
+                return Ok(OwnedResolvedSource::from(resolved_source));
             }
         }
 

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -80,7 +80,7 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
                 !vm.env_loader().has_set_no_clear_terminal_on_reload(
                     !bun_core::Output::enable_ansi_colors_stdout(),
                 );
-            bun_jsc::node_compile_cache::persist_now();
+            bun_jsc::node_compile_cache::persist_now(vm.jsc_vm_mut());
             bun_core::Output::flush();
             bun_core::reload_process(should_clear_terminal, false);
         }

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -22,7 +22,6 @@
     ]
   },
   "src/jsc/NodeCompileCache.rs": {
-    "thread spawn": 1,
     "unsafe impl Send": [
       "AlignedBlob",
       "CacheState"

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -293,6 +293,177 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  async function runWithCompileCache(dir, script, cacheDir, extraEnv = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), script],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_COMPILE_CACHE: cacheDir, ...extraEnv },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Entry layout (src/jsc/NodeCompileCache.rs): magic u32 | code_size u32 |
+  // cache_size u32 | sha256(code) | sha256(bytecode), then the stored source.
+  const entryHeaderSize = 3 * 4 + 2 * 32;
+  function compileCacheEntryFor(cacheDir, marker) {
+    const entries = [...new Bun.Glob("*/*").scanSync({ cwd: cacheDir, onlyFiles: true })].map(name => {
+      const bytes = fs.readFileSync(path.join(cacheDir, name));
+      const codeSize = bytes.readUInt32LE(4);
+      return {
+        bytecodeSize: bytes.readUInt32LE(8),
+        code: bytes.subarray(entryHeaderSize, entryHeaderSize + codeSize).toString(),
+      };
+    });
+    const matching = entries.filter(entry => entry.code.includes(marker));
+    expect(matching).toHaveLength(1);
+    return matching[0];
+  }
+
+  const depFunctions = `
+    function add(a, b) {
+      let total = a;
+      for (let i = 0; i < b; i++) total += 1;
+      return total;
+    }
+    function greet(name) {
+      const parts = ["hello", name];
+      return parts.join(" ");
+    }
+    function neverCalled(value) {
+      return JSON.stringify({ value, doubled: value * 2 });
+    }
+  `;
+  const depMarker = "compile-cache-dep-marker";
+
+  test.each([
+    [
+      "CommonJS",
+      {
+        "dep.js": `${depFunctions}\nmodule.exports = { add, greet, neverCalled, marker: "${depMarker}" };`,
+        "load.js": `require("./dep.js"); console.log("loaded");`,
+        "run.js": `const dep = require("./dep.js"); console.log(dep.add(2, 3), dep.greet("cache"));`,
+      },
+    ],
+    [
+      "ESM",
+      {
+        "dep.mjs": `${depFunctions}\nexport { add, greet, neverCalled };\nexport const marker = "${depMarker}";`,
+        "load.mjs": `import "./dep.mjs"; console.log("loaded");`,
+        "run.mjs": `import { add, greet } from "./dep.mjs"; console.log(add(2, 3), greet("cache"));`,
+      },
+    ],
+  ])("compile cache stores the bytecode of the functions a %s module actually ran", async (kind, files) => {
+    using dir = tempDir("compile-cache-lazy", files);
+    const ext = kind === "ESM" ? ".mjs" : ".js";
+    const onlyLoadedDir = path.join(String(dir), "cc-loaded");
+    const ranDir = path.join(String(dir), "cc-ran");
+
+    expect(await runWithCompileCache(dir, `load${ext}`, onlyLoadedDir)).toEqual({
+      stdout: "loaded\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await runWithCompileCache(dir, `run${ext}`, ranDir)).toEqual({
+      stdout: "5 hello cache\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    // Same source either way; the entry written by the run that called add()
+    // and greet() additionally holds their compiled bytecode. neverCalled()
+    // stays a lazy stub in both, so neither entry pays for it.
+    const onlyLoaded = compileCacheEntryFor(onlyLoadedDir, depMarker);
+    const ran = compileCacheEntryFor(ranDir, depMarker);
+    expect(ran.code).toBe(onlyLoaded.code);
+    expect(ran.bytecodeSize).toBeGreaterThan(onlyLoaded.bytecodeSize);
+
+    // The functions recorded as updates are loaded back from the entry.
+    const warm = await runWithCompileCache(dir, `run${ext}`, ranDir, { NODE_DEBUG_NATIVE: "COMPILE_CACHE" });
+    expect(warm.stdout).toBe("5 hello cache\n");
+    expect(warm.stderr).toContain(`dep${ext} was accepted`);
+    expect(warm.stderr).not.toContain("writing cache");
+    expect(warm.exitCode).toBe(0);
+  });
+
+  test("compile cache keeps the functions that ran before a GC dropped their unlinked code", async () => {
+    using dir = tempDir("compile-cache-gc", {
+      "dep.js": `${depFunctions}\nmodule.exports = { add, greet, neverCalled, marker: "${depMarker}" };`,
+      "load.js": `require("./dep.js"); console.log("loaded");`,
+      // Bun.gc() deletes every unlinked function code block; the entry must have been encoded before that.
+      "run.js": `const dep = require("./dep.js"); console.log(dep.add(2, 3)); Bun.gc(true); setTimeout(() => {}, 1);`,
+    });
+    const onlyLoadedDir = path.join(String(dir), "cc-loaded");
+    const ranDir = path.join(String(dir), "cc-ran");
+    expect(await runWithCompileCache(dir, "load.js", onlyLoadedDir)).toEqual({
+      stdout: "loaded\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await runWithCompileCache(dir, "run.js", ranDir)).toEqual({ stdout: "5\n", stderr: "", exitCode: 0 });
+    const onlyLoaded = compileCacheEntryFor(onlyLoadedDir, depMarker);
+    const ran = compileCacheEntryFor(ranDir, depMarker);
+    expect(ran.code).toBe(onlyLoaded.code);
+    expect(ran.bytecodeSize).toBeGreaterThan(onlyLoaded.bytecodeSize);
+  });
+
+  test("compile cache persists modules loaded by a worker_threads Worker", async () => {
+    using dir = tempDir("compile-cache-worker", {
+      "main.js": `
+        const { Worker } = require("worker_threads");
+        new Worker("./worker.js").on("exit", code => console.log("worker exit", code));
+      `,
+      "worker.js": `console.log(require("./worker-dep.js").twice(21));`,
+      "worker-dep.js": `function twice(n) { return n * 2; }\nmodule.exports = { twice, marker: "compile-cache-worker-dep" };`,
+    });
+    const cacheDir = path.join(String(dir), "cc");
+
+    // The worker's modules are compiled on the worker's VM, which is torn down
+    // before the process exits; their bytecode still has to reach the exit
+    // persist. One cold run (a debug-build worker is slow to start).
+    expect(await runWithCompileCache(dir, "main.js", cacheDir)).toEqual({
+      stdout: "42\nworker exit 0\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    // main.js, worker.js and worker-dep.js.
+    expect([...new Bun.Glob("*/*").scanSync({ cwd: cacheDir, onlyFiles: true })]).toHaveLength(3);
+    expect(compileCacheEntryFor(cacheDir, "compile-cache-worker-dep").bytecodeSize).toBeGreaterThan(0);
+  });
+
+  test("compile cache persists the version of a module that was rewritten and re-required in the same process", async () => {
+    using dir = tempDir("compile-cache-rewrite", {
+      "dep.js": `module.exports = { version() { return "v1"; }, marker: "compile-cache-rewrite" };`,
+      // The marker is assembled at runtime so that only dep.js's entry
+      // contains it verbatim.
+      "main.js": `
+        const fs = require("fs");
+        const dep = require.resolve("./dep.js");
+        const versions = [require(dep).version()];
+        const marker = ["compile-cache", "rewrite"].join("-");
+        fs.writeFileSync(dep, 'module.exports = { version() { return "v2"; }, marker: "' + marker + '" };');
+        delete require.cache[dep];
+        versions.push(require(dep).version());
+        console.log(versions.join(","));
+      `,
+    });
+    const cacheDir = path.join(String(dir), "cc");
+
+    expect(await runWithCompileCache(dir, "main.js", cacheDir)).toEqual({
+      stdout: "v1,v2\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(compileCacheEntryFor(cacheDir, "compile-cache-rewrite").code).toContain('"v2"');
+
+    // dep.js is now v2 on disk, so the persisted entry must be v2's bytecode.
+    const warm = await runWithCompileCache(dir, "main.js", cacheDir, { NODE_DEBUG_NATIVE: "COMPILE_CACHE" });
+    expect(warm.stdout).toBe("v2,v2\n");
+    expect(warm.stderr).toContain("dep.js was accepted");
+    expect(warm.exitCode).toBe(0);
+  });
+
   const compileCacheEnv = { ...bunEnv };
   delete compileCacheEnv.NODE_COMPILE_CACHE;
   delete compileCacheEnv.NODE_COMPILE_CACHE_PORTABLE;


### PR DESCRIPTION
### What does this PR do?

`module.enableCompileCache()` persisted a missed module by sending its source to a dedicated thread with a second JSC VM, re-parsing it there, and eagerly compiling every function. This removes that thread and VM.

Instead, the `SourceProvider` receives the live top-level `UnlinkedCodeBlock` from JSC right after `CodeCache` generates it (new hook in oven-sh/WebKit#493) and keeps a `Weak` to it on the VM's client data. The block is encoded once with `encodeCodeBlock()`:

- right before Bun's GC drops unlinked function code (`JSC__VM__runGC` → `deleteAllUnlinkedCodeBlocks`), or
- at persist time (exit, `module.flushCompileCache()`, a `--watch` reload),

whichever comes first. That writes the top-level block plus the code blocks of every function that ran up to that point. Functions that never ran stay lazy stubs. Nothing is rooted: a block the GC already collected is simply not cached this run.

- File format is unchanged: one `CachedBytecode`, loaded by the same decode path as before.
- Workers encode what they compiled in their own `on_exit` and hand the bytes to the entry; the main thread's exit writes them.
- Entries carry an id, so bytecode for a module that was rewritten and re-required in one process is dropped in favor of the new version's.
- `--watch` reloads go through the JS thread when the cache is enabled (same path `--watch-kill-signal` listeners already use), so modules are encoded before `execve`. The grace timer still forces the reload if the JS thread is stuck; it persists only what was already encoded.
- No `leafExecutables()` / `addFunctionUpdate` use, so this composes with oven-sh/WebKit#490.

Why encode before the GC: a CommonJS program only evaluates to its wrapper function, so the tree is empty until the wrapper body runs, and Bun's `runGC` (which `run_command` calls right after the entrypoint's synchronous evaluation) detaches every unlinked function code block. Encoding at that point captures everything compiled during startup.

Supersedes #39167 (same goal, incremental-update layout). #39405 (mmap the sidecars) can rebase on top.

`WEBKIT_VERSION` points at the PR preview build of oven-sh/WebKit#493; swap to the main sha once it lands.

### How did you verify your code works?

Built with `bun run build:local` against the WebKit branch.

- `test/js/node/module/node-module-module.test.js` (52 pass, includes new tests: a module's ran functions are in the entry and larger than a load-only entry; functions that ran before `Bun.gc(true)` are kept; worker modules persist; rewrite-and-re-require persists v2)
- `test/cli/watch/watch.test.ts` (8 pass; `NODE_COMPILE_CACHE persists across a --watch reload`)
- `test/internal/source-lints/` (162 pass; the thread-spawn inventory entry is gone)
- Manual: `BUN_JSC_reportBytecodeCacheDecodeTimes=1` shows the warm run decoding the entries; `dep.js` entry is 2.0 KB when only loaded vs 2.8 KB when one of its functions ran, with or without a `setTimeout`/`Bun.gc()` before exit.