### PR TITLE
webview: let a dead transport release its browser, and route closeAll() through it

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -514,7 +514,7 @@ Closing is synchronous and idempotent. It destroys the page's renderer process, 
 Bun.WebView.closeAll();
 ```
 
-Force-kills (`SIGKILL`) both the Chrome subprocess and the WebKit host subprocess. Pending promises on every view reject on the next event-loop tick. Subsequent `new Bun.WebView()` calls respawn as needed.
+Closes every view and force-kills (`SIGKILL`) both the Chrome subprocess and the WebKit host subprocess. Pending promises on every view reject with `Error("WebView closed by WebView.closeAll()")`, and every later method call on those views throws `ERR_INVALID_STATE`. The next `new Bun.WebView()` spawns a fresh browser.
 
 Bun calls this automatically at process exit, so browser subprocesses never outlive your script.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9353,11 +9353,12 @@ declare module "bun" {
     constructor(options?: WebView.ConstructorOptions);
 
     /**
-     * Force-kill all browser subprocesses (Chrome and the WKWebView host).
-     * Pending promises on all views reject on the next event loop tick.
+     * Close every view and force-kill all browser subprocesses (Chrome and
+     * the WKWebView host). Pending promises on all views reject with
+     * `Error("WebView closed by WebView.closeAll()")`.
      *
      * Called automatically at process exit. Call manually to reclaim browser
-     * resources early — subsequent `new Bun.WebView()` calls respawn them.
+     * resources early — the next `new Bun.WebView()` spawns a fresh browser.
      * Idempotent: calling when no subprocesses are alive is a no-op.
      */
     static closeAll(): void;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1295,6 +1295,8 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
         ws->setNativeCallbacks({}); // prevent wsOnClose re-entry
         ws->close(std::nullopt, WTF::String());
     }
+    // A dead transport leaves no published Chrome behind, so the next `new Bun.WebView()` spawns at once.
+    Bun__Chrome__retire();
     m_mode = TransportMode::None;
     m_wsOpen = false;
     m_wsPending.clear();
@@ -1357,7 +1359,6 @@ void Transport::retireGlobal(Zig::GlobalObject* global)
 {
     if (m_global != global) return;
     rejectAllAndMarkDead("WebView closed: its test file finished"_s);
-    Bun__Chrome__retire();
     m_global = nullptr;
 }
 

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -80,12 +80,12 @@ static INSTANCE: AtomicPtr<ChromeProcess> = AtomicPtr::new(ptr::null_mut());
 #[cfg(windows)]
 static GENERATION: AtomicU32 = AtomicU32::new(0);
 
-/// Called from WebView.closeAll() and dispatchOnExit. Chrome spawns its own
-/// renderer/gpu/utility children (the "process model" zygote tree) — tracked
-/// by Chrome's own ProcessSingleton, they exit when the browser process
-/// dies. SIGKILL here takes the browser process, the zygote tree follows.
-/// The C++ side doesn't touch JS state; EVFILT_PROC → Bun__Chrome__died →
-/// rejectAllAndMarkDead handles promise rejection on the next loop tick.
+/// Called from dispatchOnExit. Chrome spawns its own renderer/gpu/utility
+/// children (the "process model" zygote tree) — tracked by Chrome's own
+/// ProcessSingleton, they exit when the browser process dies. SIGKILL here
+/// takes the browser process, the zygote tree follows. The C++ side doesn't
+/// touch JS state; EVFILT_PROC → Bun__Chrome__died → rejectAllAndMarkDead
+/// handles promise rejection on the next loop tick.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__Chrome__kill() {
     // SAFETY: JS-thread-only global; see INSTANCE decl.
@@ -98,7 +98,7 @@ extern "C" fn Bun__Chrome__kill() {
     }
 }
 
-/// Transport::retireGlobal (`bun test --isolate`): unpublish and kill this Chrome so the next file can spawn its own at once.
+/// Transport::rejectAllAndMarkDead: unpublish and kill this Chrome so the next `new Bun.WebView()` spawns its own at once.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__Chrome__retire() {
     let this = INSTANCE.swap(ptr::null_mut(), Ordering::Relaxed);

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -46,10 +46,10 @@ pub(crate) struct HostProcess {
 static INSTANCE: core::sync::atomic::AtomicPtr<HostProcess> =
     core::sync::atomic::AtomicPtr::new(ptr::null_mut());
 
-/// Called from WebView.closeAll() and dispatchOnExit. Socket EOF handles
-/// normal parent-death (including SIGKILL of Bun — kernel closes fds, child
-/// reads 0, CFRunLoopStop). This catches the clean-exit path where the child
-/// hasn't yet noticed EOF before we return from main(). WKWebView's own
+/// Called from dispatchOnExit. Socket EOF handles normal parent-death
+/// (including SIGKILL of Bun — kernel closes fds, child reads 0,
+/// CFRunLoopStop). This catches the clean-exit path where the child hasn't
+/// yet noticed EOF before we return from main(). WKWebView's own
 /// WebContent/GPU/Network helpers are XPC-connected to the child — when the
 /// child dies they get connection-invalidated and exit.
 #[unsafe(no_mangle)]
@@ -67,7 +67,7 @@ extern "C" fn Bun__WebViewHost__kill() {
     }
 }
 
-/// HostClient::retireGlobal (`bun test --isolate`): unpublish and kill this host so the next file can spawn its own at once.
+/// HostClient::rejectAllAndMarkDead: unpublish and kill this host so the next `new Bun.WebView()` spawns its own at once.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__WebViewHost__retire() {
     let this = INSTANCE.swap(ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -387,6 +387,14 @@ void retireWebViewsForTestIsolation(Zig::GlobalObject* global)
 #endif
 }
 
+void closeAllWebViews()
+{
+    CDP::transport().rejectAllAndMarkDead("WebView closed by WebView.closeAll()"_s);
+#if OS(DARWIN)
+    WK::client().rejectAllAndMarkDead("WebView closed by WebView.closeAll()"_s);
+#endif
+}
+
 // --- Setup -----------------------------------------------------------------
 
 void setupJSWebViewClassStructure(LazyClassStructure::Initializer& init)
@@ -403,14 +411,14 @@ void setupJSWebViewClassStructure(LazyClassStructure::Initializer& init)
 
 // ---------------------------------------------------------------------------
 // Termination hook. Called from dispatchOnExit (same path as SQLite's
-// Bun__closeAllSQLiteDatabasesForTermination) and from WebView.closeAll().
-// SIGKILLs both browser subprocesses — no CDP Browser.close, no promise
-// rejection, no socket teardown. At dispatchOnExit the event loop is past
-// the point of processing any reply; the only thing that matters is the
-// subprocesses don't outlive us. Chrome's zygote tree (renderer/gpu/utility)
-// exits when the browser process dies; WebKit's WebContent/GPU/Network
-// helpers exit via XPC-invalidated when the host dies. Idempotent: kill(9)
-// on a reaped pid returns ESRCH and we discard it.
+// Bun__closeAllSQLiteDatabasesForTermination). SIGKILLs both browser
+// subprocesses — no CDP Browser.close, no promise rejection, no socket
+// teardown. At dispatchOnExit the event loop is past the point of processing
+// any reply; the only thing that matters is the subprocesses don't outlive
+// us. Chrome's zygote tree (renderer/gpu/utility) exits when the browser
+// process dies; WebKit's WebContent/GPU/Network helpers exit via
+// XPC-invalidated when the host dies. Idempotent: kill(9) on a reaped pid
+// returns ESRCH and we discard it. WebView.closeAll() is closeAllWebViews().
 // ---------------------------------------------------------------------------
 
 extern "C" void Bun__Chrome__kill();

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -227,6 +227,9 @@ void setupJSWebViewClassStructure(JSC::LazyClassStructure::Initializer&);
 // `bun test --isolate` retires `global`: the transports bound to it close their views and let their browser go.
 void retireWebViewsForTestIsolation(Zig::GlobalObject* global);
 
+// WebView.closeAll(): every view closes, its pending promises reject, the browser processes die.
+void closeAllWebViews();
+
 // Shared weak owner for HostClient.viewsById and Transport.m_pending/
 // .m_sessions. Roots a view while m_pendingActivityCount > 0.
 JSC::WeakHandleOwner& webViewWeakOwner();

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -19,7 +19,6 @@ static JSC_DECLARE_HOST_FUNCTION(callWebView);
 static JSC_DECLARE_HOST_FUNCTION(constructWebView);
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewConstructorCloseAll);
 
-extern "C" void Bun__WebView__closeAllForTermination();
 extern "C" size_t Bun__Feature__webview_chrome;
 extern "C" size_t Bun__Feature__webview_webkit;
 
@@ -86,14 +85,9 @@ JSC_DEFINE_HOST_FUNCTION(callWebView, (JSGlobalObject * globalObject, CallFrame*
         "Class constructor WebView cannot be invoked without 'new'"_s);
 }
 
-// SIGKILLs both browser subprocesses. The onProcessExit path (EVFILT_PROC →
-// Bun__Chrome__died / Bun__WebViewHost__childDied) rejects pending promises
-// and marks transports dead on the next event loop tick — we don't touch JS
-// state here. Calling on an already-dead process is a no-op (kill(9) returns
-// ESRCH, discarded).
 JSC_DEFINE_HOST_FUNCTION(jsWebViewConstructorCloseAll, (JSGlobalObject*, CallFrame*))
 {
-    Bun__WebView__closeAllForTermination();
+    closeAllWebViews();
     return JSValue::encode(jsUndefined());
 }
 
@@ -330,6 +324,12 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "width"_s, 1, 16384, jsNumber(width));
     if (height == 0 || height > 16384)
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "height"_s, 1, 16384, jsNumber(height));
+
+    // A global that `bun test --isolate` is retiring must not bind a new browser to itself.
+    if (zigGlobalObject->scriptExecutionContext()->activeDOMObjectsAreStopped()) [[unlikely]] {
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE,
+            "Bun.WebView cannot be created while its global object is shutting down"_s);
+    }
 
     Structure* structure = zigGlobalObject->m_JSWebViewClassStructure.get(zigGlobalObject);
     JSValue newTarget = callFrame->newTarget();

--- a/src/runtime/webview/WebKitBackend.cpp
+++ b/src/runtime/webview/WebKitBackend.cpp
@@ -464,6 +464,8 @@ void HostClient::rejectAllAndMarkDead(const WTF::String& reason)
     // against EOF) the socket is still polling — close it. The dead guard
     // above short-circuits the reentrant onClose.
     if (auto* s = std::exchange(sock, nullptr)) us_socket_close(s, 0, nullptr);
+    // A dead client leaves no published host behind, so the next `new Bun.WebView()` spawns at once.
+    Bun__WebViewHost__retire();
     if (!global) return;
     auto* g = global;
     JSValue err = createError(g, reason);
@@ -490,7 +492,6 @@ void HostClient::retireGlobal(Zig::GlobalObject* g)
 {
     if (global != g) return;
     rejectAllAndMarkDead("WebView closed: its test file finished"_s);
-    Bun__WebViewHost__retire();
     global = nullptr;
 }
 

--- a/test/js/bun/webview/mock-cdp.ts
+++ b/test/js/bun/webview/mock-cdp.ts
@@ -1,0 +1,109 @@
+// A mock CDP endpoint: a Bun.serve WebSocket speaking just enough of the
+// protocol for navigate(), reload() and goBack() to work, and leaving every
+// evaluate() a scenario sends unanswered so it is still in flight when the
+// connection goes away. Used by webview-chrome-disconnect.test.ts: inside a
+// scenario process, and in the test process itself for the --isolate case,
+// where the views connect from a child `bun test`.
+
+export interface MockCDP {
+  /** ws:// URL for `backend.url`. */
+  url: string;
+  /** "open" and "close" in the order the server saw them. */
+  events: string[];
+  /** While true, a committed navigation is followed by Page.loadEventFired so
+   * the op resolves. Scenarios turn it off to leave a navigation committed
+   * but never loaded. */
+  completeLoads: boolean;
+  emit(method: string, params: unknown, sessionId?: string): void;
+  /** Abrupt connection loss, as if the browser died. */
+  drop(): void;
+  stop(): void;
+  newView(): Bun.WebView;
+}
+
+export function startMockCDP(): MockCDP {
+  let sock: Bun.ServerWebSocket<undefined> | undefined;
+  let targets = 0;
+  let loads = 0;
+  let lastUrl = "about:blank";
+  const mock = {
+    events: [] as string[],
+    completeLoads: true,
+    emit(method: string, params: unknown, sessionId?: string) {
+      sock!.send(JSON.stringify(sessionId ? { method, params, sessionId } : { method, params }));
+    },
+    drop() {
+      sock!.terminate();
+    },
+  } as MockCDP;
+  function commit(sessionId: string | undefined, url: string, loaderId: string) {
+    lastUrl = url;
+    mock.emit(
+      "Page.frameNavigated",
+      { frame: { id: "F", loaderId, url, mimeType: "text/html" }, type: "Navigation" },
+      sessionId,
+    );
+    if (mock.completeLoads) mock.emit("Page.loadEventFired", { timestamp: loads }, sessionId);
+  }
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response(null, { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        sock = ws;
+        mock.events.push("open");
+      },
+      close() {
+        mock.events.push("close");
+      },
+      message(ws, raw) {
+        const { id, method, params = {}, sessionId } = JSON.parse(String(raw));
+        const reply = (result: unknown) =>
+          ws.send(JSON.stringify(sessionId ? { id, result, sessionId } : { id, result }));
+        switch (method) {
+          case "Target.createTarget":
+            targets++;
+            return reply({ targetId: "T" + targets });
+          case "Target.attachToTarget":
+            return reply({ sessionId: "S" + params.targetId.slice(1) });
+          case "Page.navigate": {
+            const loaderId = "L" + ++loads;
+            reply({ frameId: "F", loaderId });
+            return commit(sessionId, params.url, loaderId);
+          }
+          case "Page.reload":
+            reply({});
+            return commit(sessionId, lastUrl, "L" + ++loads);
+          case "Page.getNavigationHistory":
+            return reply({
+              currentIndex: 1,
+              entries: [
+                { id: 1, url: "about:blank" },
+                { id: 2, url: lastUrl },
+              ],
+            });
+          case "Page.navigateToHistoryEntry":
+            reply({});
+            return commit(sessionId, "about:blank", "L" + ++loads);
+          case "Runtime.evaluate":
+            // The backend fetches document.title after every load; answer
+            // that. Any evaluate() a scenario sends itself is deliberately
+            // left unanswered, so it is still waiting for a reply when the
+            // connection goes away.
+            if (params.expression === "document.title") return reply({ result: { type: "string", value: "mock" } });
+            return;
+          default:
+            return reply({});
+        }
+      },
+    },
+  });
+  mock.url = "ws://127.0.0.1:" + server.port + "/devtools/browser/mock";
+  mock.stop = () => server.stop(true);
+  mock.newView = () => new Bun.WebView({ backend: { type: "chrome", url: mock.url }, width: 100, height: 100 });
+  return mock;
+}

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -6,9 +6,10 @@
 // Page.loadEventFired. Losing Chrome after that point must still settle
 // the promise and clear view.loading.
 //
-// Most tests here drive the backend from a mock CDP endpoint (a Bun.serve
-// WebSocket speaking just enough of the protocol), so they run without a
-// browser and can leave a navigation committed-but-never-loaded exactly.
+// Most tests here drive the backend from a mock CDP endpoint (mock-cdp.ts, a
+// Bun.serve WebSocket speaking just enough of the protocol), so they run
+// without a browser and can leave a navigation committed-but-never-loaded
+// exactly.
 // The last test repeats the scenario against a real Chrome in pipe mode.
 //
 // Every test runs in a subprocess: the CDP transport is a process-wide
@@ -16,94 +17,18 @@
 // would break any other test sharing it.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { startMockCDP } from "./mock-cdp.ts";
 
-const mockCDP = /* js */ `
-  function startMockCDP() {
-    let sock;
-    let targets = 0;
-    let loads = 0;
-    let lastUrl = "about:blank";
-    const mock = {
-      // While true, a committed navigation is followed by Page.loadEventFired
-      // so the op resolves. Scenarios turn it off to leave a navigation
-      // committed but never loaded.
-      completeLoads: true,
-      emit(method, params, sessionId) {
-        sock.send(JSON.stringify(sessionId ? { method, params, sessionId } : { method, params }));
-      },
-      // Abrupt connection loss, as if the browser died.
-      drop() {
-        sock.terminate();
-      },
-    };
-    function commit(sessionId, url, loaderId) {
-      lastUrl = url;
-      mock.emit("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" }, type: "Navigation" }, sessionId);
-      if (mock.completeLoads) mock.emit("Page.loadEventFired", { timestamp: loads }, sessionId);
-    }
-    const server = Bun.serve({
-      port: 0,
-      hostname: "127.0.0.1",
-      fetch(req, server) {
-        if (server.upgrade(req)) return;
-        return new Response(null, { status: 400 });
-      },
-      websocket: {
-        open(ws) {
-          sock = ws;
-        },
-        message(ws, raw) {
-          const { id, method, params = {}, sessionId } = JSON.parse(String(raw));
-          const reply = result => ws.send(JSON.stringify(sessionId ? { id, result, sessionId } : { id, result }));
-          switch (method) {
-            case "Target.createTarget":
-              targets++;
-              return reply({ targetId: "T" + targets });
-            case "Target.attachToTarget":
-              return reply({ sessionId: "S" + params.targetId.slice(1) });
-            case "Page.navigate": {
-              const loaderId = "L" + ++loads;
-              reply({ frameId: "F", loaderId });
-              return commit(sessionId, params.url, loaderId);
-            }
-            case "Page.reload":
-              reply({});
-              return commit(sessionId, lastUrl, "L" + ++loads);
-            case "Page.getNavigationHistory":
-              return reply({ currentIndex: 1, entries: [{ id: 1, url: "about:blank" }, { id: 2, url: lastUrl }] });
-            case "Page.navigateToHistoryEntry":
-              reply({});
-              return commit(sessionId, "about:blank", "L" + ++loads);
-            case "Runtime.evaluate":
-              // The backend fetches document.title after every load; answer
-              // that. Any evaluate() a scenario sends itself is deliberately
-              // left unanswered, so it is still waiting for a reply when the
-              // connection goes away.
-              if (params.expression === "document.title") return reply({ result: { type: "string", value: "mock" } });
-              return;
-            default:
-              return reply({});
-          }
-        },
-      },
-    });
-    mock.stop = () => server.stop(true);
-    mock.newView = () =>
-      new Bun.WebView({
-        backend: { type: "chrome", url: "ws://127.0.0.1:" + server.port + "/devtools/browser/mock" },
-        width: 100,
-        height: 100,
-      });
-    return mock;
-  }
-`;
+// Scenario processes import the mock from the test's directory.
+const mockCDP = /* js */ `import { startMockCDP } from "./mock-cdp.ts";\n`;
 
 // Runs a scenario after the mock definitions in a fresh bun process and
 // returns the JSON it printed.
 async function runScenario(body: string): Promise<unknown> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", mockCDP + body],
+    cwd: import.meta.dir,
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -186,6 +111,54 @@ test.concurrent("a dropped connection rejects the committed navigation of every 
   });
 });
 
+// `bun test --isolate` replaces the global object between files. A transport
+// connected over WebSocket is bound to the global that connected it, like the
+// pipe one (see webview-chrome-pipe.test.ts), so it has to go with that file:
+// the connection closes, the open views' pending promises reject, and the next
+// file connects again. The mock lives in this process so that it outlives the
+// child's files.
+test.concurrent("bun test --isolate retires a WebSocket transport with the file that connected it", async () => {
+  const mock = startMockCDP();
+  try {
+    const file = /* js */ `
+      import { test } from "bun:test";
+      test("leaves a view open with a command in flight", async () => {
+        const view = new Bun.WebView({ backend: { type: "chrome", url: ${JSON.stringify(mock.url)} }, width: 100, height: 100 });
+        await view.navigate("http://mock/" + import.meta.file);
+        console.log(JSON.stringify({ file: import.meta.file, url: view.url }));
+        view.evaluate("1").catch(e => {
+          console.log(JSON.stringify({ file: import.meta.file, rejected: e.message, isError: e instanceof Error }));
+        });
+      });
+    `;
+    using dir = tempDir("webview-ws-isolate", { "a.test.ts": file, "b.test.ts": file });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const lines = stdout
+      .split("\n")
+      .filter(line => line.startsWith("{"))
+      .map(line => JSON.parse(line));
+    const [first, second] = lines[0]?.file === "b.test.ts" ? ["b.test.ts", "a.test.ts"] : ["a.test.ts", "b.test.ts"];
+    expect(lines).toEqual([
+      { file: first, url: "http://mock/" + first },
+      { file: first, rejected: "WebView closed: its test file finished", isError: true },
+      { file: second, url: "http://mock/" + second },
+    ]);
+    // The first file's connection closed before the second file's opened.
+    expect(mock.events.slice(0, 3)).toEqual(["open", "close", "open"]);
+    expect(stderr).toContain(" 2 pass");
+    expect(exitCode).toBe(0);
+  } finally {
+    mock.stop();
+  }
+});
+
 // The connection stays up but the view's own page goes away. The promise
 // was already rejected on these paths; they also have to clear loading.
 test.concurrent.each([
@@ -265,8 +238,7 @@ const chromeInstalled =
         await committed.promise;
         const loadingBefore = view.loading;
 
-        // Still waiting for Chrome's reply when it dies; rejects once the
-        // death has been processed.
+        // Still waiting for Chrome's reply when closeAll() runs.
         let unanswered = "pending";
         const unansweredDone = view.evaluate("new Promise(() => {})").then(
           () => (unanswered = "resolved"),
@@ -285,10 +257,13 @@ const chromeInstalled =
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout, stderr).toEndWith("}\n");
-    // Whichever the event loop sees first, the pipe closing or the process
-    // exit, decides the wording; both must settle everything.
-    const died = expect.stringMatching(/^rejected: Chrome (killed by signal \d+|process closed the pipe|exited)$/);
-    expect(JSON.parse(stdout)).toEqual({ loadingBefore: true, unanswered: died, navigate: died, loadingAfter: false });
+    const closed = "rejected: WebView closed by WebView.closeAll()";
+    expect(JSON.parse(stdout)).toEqual({
+      loadingBefore: true,
+      unanswered: closed,
+      navigate: closed,
+      loadingAfter: false,
+    });
     expect(exitCode, stderr).toBe(0);
   },
 );

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -32,7 +32,7 @@ const prelude = /* js */ `
     argv: [${JSON.stringify(fixture)}],
     stderr: "inherit",
   };
-  const newView = () => new Bun.WebView({ backend, width: 100, height: 100 });
+  const newView = (overrides = {}) => new Bun.WebView({ backend: { ...backend, ...overrides }, width: 100, height: 100 });
   const outcome = promise => promise.then(resolved => ({ resolved }), e => ({ rejected: e.message }));
   const print = value => console.log(JSON.stringify(value));
   const big = ${BIG};
@@ -136,27 +136,47 @@ test.concurrent("an expression that throws rejects", async () => {
   expect(result).toEqual({ rejected: expect.stringContaining("inside the fake") });
 });
 
+// Once the loss has been reported, the old process is no longer in the way:
+// the next WebView spawns without waiting for it to be reaped.
 test.concurrent("the browser exiting rejects what it owed, and the next WebView respawns it", async () => {
   const result = await runScenario(`
     const first = newView();
     await first.navigate("http://fake/1");
     const death = await outcome(first.evaluate("__fake_exit(3)"));
-    // Construction fails until the old process has been reaped; retry.
-    let second;
-    for (;;) {
-      try {
-        second = newView();
-        break;
-      } catch (e) {
-        if (!/Failed to spawn Chrome/.test(e.message)) throw e;
-        await Bun.sleep(1);
-      }
-    }
+    const second = newView();
     await second.navigate("http://fake/2");
     print({ death, second: await second.evaluate("'alive again'") });
     second.close();
   `);
   expect(result).toEqual({ death: transportLost, second: "alive again" });
+});
+
+// closeAll() closes every view and kills the browser at once. The fake would
+// outlive its pipes by 20 s, so the next WebView only spawns in the same tick
+// if closeAll() let go of the old process itself.
+test.concurrent("closeAll() rejects what is pending and the next WebView spawns at once", async () => {
+  const result = await runScenario(`
+    const first = newView({ argv: [${JSON.stringify(fixture)}, "--exit-delay=20000"] });
+    await first.navigate("http://fake/1");
+    const pending = outcome(first.evaluate("__fake_no_reply()"));
+    Bun.WebView.closeAll();
+    let afterClose;
+    try {
+      first.evaluate("1");
+      afterClose = "accepted";
+    } catch (e) {
+      afterClose = e.code;
+    }
+    const second = newView();
+    await second.navigate("http://fake/2");
+    print({ pending: await pending, afterClose, second: await second.evaluate("'alive again'") });
+    second.close();
+  `);
+  expect(result).toEqual({
+    pending: { rejected: "WebView closed by WebView.closeAll()" },
+    afterClose: "ERR_INVALID_STATE",
+    second: "alive again",
+  });
 });
 
 // `bun test --isolate` replaces the global object between files. The transport
@@ -180,7 +200,15 @@ test.concurrent("bun test --isolate retires the transport with the file that spa
       await view.navigate("http://fake/" + import.meta.file);
       console.log(JSON.stringify({ file: import.meta.file, url: view.url }));
       view.evaluate("__fake_no_reply()").catch(e => {
-        console.log(JSON.stringify({ file: import.meta.file, rejected: e.message, isError: e instanceof Error }));
+        // Runs while the file's global is being retired: no new browser may bind to it.
+        let late;
+        try {
+          new Bun.WebView({ backend, width: 100, height: 100 });
+          late = "created";
+        } catch (err) {
+          late = err.code;
+        }
+        console.log(JSON.stringify({ file: import.meta.file, rejected: e.message, isError: e instanceof Error, late }));
       });
     });
   `;
@@ -204,7 +232,7 @@ test.concurrent("bun test --isolate retires the transport with the file that spa
   const [first, second] = lines[0]?.file === "b.test.ts" ? ["b.test.ts", "a.test.ts"] : ["a.test.ts", "b.test.ts"];
   expect(lines).toEqual([
     { file: first, url: "http://fake/" + first },
-    { file: first, rejected: "WebView closed: its test file finished", isError: true },
+    { file: first, rejected: "WebView closed: its test file finished", isError: true, late: "ERR_INVALID_STATE" },
     { file: second, url: "http://fake/" + second },
   ]);
   expect(stderr).toContain(" 2 pass");

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -563,9 +563,7 @@ test("WebView.closeAll is a static function", () => {
 
 it("chrome: closeAll() kills the subprocess and pending promises reject", async () => {
   // Subprocess-isolated — closeAll() SIGKILLs the one shared Chrome, which
-  // would break subsequent tests in this file. ensureSpawned respawns on
-  // the next WebView construction, but only after EVFILT_PROC has cleared
-  // the Zig instance global — race prone in-process.
+  // would break subsequent tests in this file.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -575,12 +573,9 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
-        // SIGKILL → socket EOF or EVFILT_PROC (whichever the event loop sees
-        // first) → rejectAllAndMarkDead on next tick. Both race outcomes
-        // reject; the message differs ("closed the pipe" vs "killed by signal").
         await p.then(
           () => { throw new Error("should have rejected"); },
-          e => { if (!/closed the pipe|signal|killed/i.test(e.message)) throw e; },
+          e => { if (e.message !== "WebView closed by WebView.closeAll()") throw e; },
         );
         console.log("rejected");
       `,
@@ -596,8 +591,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
 it("chrome: a new WebView respawns Chrome after the previous one died", async () => {
   // Subprocess-isolated like the closeAll() test above. The dead Chrome's
   // remaining close/exit notifications drain after the respawn and must not
-  // be taken for the new one. Construction fails until the old process has
-  // been reaped (see the comment on the closeAll() test), hence the retry.
+  // be taken for the new one.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -609,16 +603,7 @@ it("chrome: a new WebView respawns Chrome after the previous one died", async ()
         const pending = first.evaluate("new Promise(() => {})");
         Bun.WebView.closeAll();
         await pending.catch(() => {});
-        let second;
-        for (;;) {
-          try {
-            second = new Bun.WebView({ backend, width: 200, height: 200 });
-            break;
-          } catch (e) {
-            if (!/Failed to spawn Chrome/.test(e.message)) throw e;
-            await Bun.sleep(1);
-          }
-        }
+        const second = new Bun.WebView({ backend, width: 200, height: 200 });
         await second.navigate("data:text/html,<body>second</body>");
         console.log(await second.evaluate("document.body.textContent"));
         second.close();
@@ -680,18 +665,7 @@ it("chrome: views orphaned by a Chrome death are closed, even after a new view r
           blank: probe(() => blank.navigate("data:text/html,<body>blank</body>")),
         };
 
-        // Construction fails until the dead Chrome has been reaped (see the
-        // respawn test above), hence the retry.
-        let fresh;
-        for (;;) {
-          try {
-            fresh = open();
-            break;
-          } catch (e) {
-            if (!/Failed to spawn Chrome/.test(e.message)) throw e;
-            await Bun.sleep(1);
-          }
-        }
+        const fresh = open();
         await fresh.navigate("data:text/html,<body>fresh</body>");
         const freshBody = await fresh.evaluate("document.body.textContent");
 
@@ -718,8 +692,7 @@ it("chrome: views orphaned by a Chrome death are closed, even after a new view r
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout, stderr).toEndWith("}\n");
   expect(JSON.parse(stdout)).toEqual({
-    // Pipe EOF and the exit notification race; the wording follows the winner.
-    death: expect.stringMatching(/^Chrome (killed by signal \d+|process closed the pipe|exited)$/),
+    death: "WebView closed by WebView.closeAll()",
     whileDead: {
       busy: "ERR_INVALID_STATE",
       idle: "ERR_INVALID_STATE",

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -940,9 +940,7 @@ it("close() rejects pending promises", async () => {
 
 it("WebView.closeAll() kills the host subprocess and pending promises reject", async () => {
   // Subprocess-isolated — closeAll() SIGKILLs the one shared WKWebView host,
-  // which would break subsequent tests. ensureSpawned respawns on the next
-  // WebView construction, but only after EVFILT_PROC has cleared the Zig
-  // instance global — race prone in-process.
+  // which would break subsequent tests.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -952,12 +950,9 @@ it("WebView.closeAll() kills the host subprocess and pending promises reject", a
         await view.navigate("data:text/html," + encodeURIComponent("<body>test</body>"));
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
-        // SIGKILL → socket EOF or EVFILT_PROC (whichever wins) →
-        // rejectAllAndMarkDead on next tick. Both paths reject; the message
-        // differs ("host process died" vs "killed by signal").
         await p.then(
           () => { throw new Error("should have rejected"); },
-          e => { if (!/died|signal|killed/i.test(e.message)) throw e; },
+          e => { if (e.message !== "WebView closed by WebView.closeAll()") throw e; },
         );
         console.log("rejected");
       `,
@@ -1012,20 +1007,7 @@ it("views orphaned by a host death are closed, even after a new view respawns th
           blank: probe(() => blank.navigate(html("<body>blank</body>"))),
         };
 
-        // The client is marked dead as soon as the event loop sees the
-        // socket EOF or the exit notification, whichever comes first; a
-        // respawn is refused until the exit has been reaped, so the
-        // constructor can throw briefly after closeAll(). Retry.
-        let fresh;
-        for (let attempt = 0; ; attempt++) {
-          try {
-            fresh = open();
-            break;
-          } catch (e) {
-            if (attempt === 500) throw e;
-            await Bun.sleep(10);
-          }
-        }
+        const fresh = open();
         await fresh.navigate(html("<body>fresh</body>"));
         const freshBody = await fresh.evaluate("document.body.textContent");
 
@@ -1051,8 +1033,7 @@ it("views orphaned by a host death are closed, even after a new view respawns th
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout, stderr).toEndWith("}\n");
   expect(JSON.parse(stdout)).toEqual({
-    // Socket EOF and the exit notification race; the wording follows the winner.
-    death: expect.stringMatching(/^WebView host process (died|killed by signal \d+|exited)$/),
+    death: "WebView closed by WebView.closeAll()",
     whileDead: {
       busy: "ERR_INVALID_STATE",
       idle: "ERR_INVALID_STATE",


### PR DESCRIPTION
Follow-up to #40165.

### Problem
- `WebView.closeAll()` only sent `SIGKILL`. A `new Bun.WebView()` in the same tick bound to the dying transport, and a later one threw "Failed to spawn Chrome" until the old process was reaped (`Bun__Chrome__ensure` refuses to spawn while a process is published). The docs promise "respawn as needed". Three tests carried reap-retry loops for this.
- Every other path that marks the transport dead while the process lives (a closed reply pipe on Windows, a corrupt frame from the WebKit host, a pipe that cannot be adopted) left the same stuck state.
- #40165 covered `bun test --isolate` for the pipe transport only. The WebSocket mode had no test.

### Fix
- `rejectAllAndMarkDead` calls `Bun__Chrome__retire()` / `Bun__WebViewHost__retire()`: a dead transport never leaves a published browser behind. The adopt-failure branches retire too, and the spawn entry points assert in debug builds that nothing is published. `retireGlobal` shrinks to `rejectAllAndMarkDead` plus clearing the cached global.
- `WebView.closeAll()` goes through `rejectAllAndMarkDead("WebView closed by WebView.closeAll()")` on both backends and throws `ERR_INVALID_STATE` off the main thread. Over WebSocket it used to be a no-op (no process to kill); it now closes the connection and the views. Process exit stays kill-only.
- The constructor throws `ERR_INVALID_STATE` once the global's active DOM objects are stopped, so a handler that runs while `--isolate` retires a file cannot bind a new browser to the dying global.
- Verified: `webview-chrome-pipe.test.ts` (new `closeAll()` case and the late-creation check fail on main), `webview-chrome-disconnect.test.ts` (new WebSocket `closeAll()` and `--isolate` cases on the mock CDP server, now in `mock-cdp.ts`), the real-Chrome suite with its new Worker case.

### Background
- The CDP `Transport` and the WebKit `HostClient` are process singletons, each bound to one published browser process (`INSTANCE` in ChromeProcess.rs / HostProcess.rs) and to the global that spawned it.
- `rejectAllAndMarkDead` is where a transport dies: it closes the connection, rejects every pending promise and marks the views closed. Every loss path ends there.
- `Bun__Chrome__retire` (#40165) unpublishes and kills the process and marks it retired, so `on_exit` only reaps it.

<details><summary>Notes</summary>

Fail-before with main's `src/`: `closeAll() rejects what is pending and the next WebView spawns at once` fails (the next view binds to the dying transport or throws), the `--isolate` case fails on `late: "created"` instead of `ERR_INVALID_STATE`, and the real-Chrome `closeAll()` disconnect case rejects with "Chrome killed by signal 9" instead of the new message. The WebSocket `--isolate` case passes on main as well: it documents what #40165 fixed in that mode, which no test exercised.

`closeAll()` on a transport that never spawned anything marks it dead with no published process to retire. The next constructor resets it and spawns. The fake browser in `webview-chrome-pipe.test.ts` takes `--exit-delay=20000` in the `closeAll()` case, so the same-tick spawn only works if `closeAll()` unpublished the old process itself.

Once `INSTANCE` lets go of a retired process, only its exit handler references it. When bun exits before the exit is reaped, LeakSanitizer on the ASAN lane reported the `Process` and its `ChromeProcess` box as leaks (the same memory was live before, but reachable through `INSTANCE`). Retired processes now hang off a static `RETIRED` list until `on_exit` frees them.

Real Chrome here runs through a `--no-sandbox` wrapper in `BUN_CHROME_PATH` (this container is root): all 5 files in `test/js/bun/webview/`, 77 pass, 59 skip (WebKit), 6 todo.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview.test.ts, test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts, test/js/bun/webview/webview-chrome-disconnect.test.ts

<!-- robobun:evidence:end -->