### PR TITLE
node:http2: keep setLocalWindowSize() off SETTINGS_INITIAL_WINDOW_SIZE

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -216,6 +216,11 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
+    /// Connection-level receive window update (node's session.state window fields): `size` is
+    /// what the peer has been told it may send, `consumed` what it has sent since the last
+    /// WINDOW_UPDATE. Called whenever either moves, while the connection is mutably borrowed —
+    /// the embedder must only store the values.
+    fn on_recv_window(&self, _size: i64, _consumed: i64) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
     /// inbound frames for it are not treated as frames on an idle stream.
@@ -420,6 +425,17 @@ impl Connection {
         );
     }
 
+    fn note_recv_window(&self, sink: &impl Sink) {
+        sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
+    }
+
+    /// The embedder advertised `delta` more connection-level receive window (a WINDOW_UPDATE on
+    /// stream 0 it wrote itself): accept that much more DATA before the §6.9.1 overflow check.
+    pub fn grow_recv_window(&mut self, sink: &impl Sink, delta: i64) {
+        self.recv_window.grow(delta);
+        self.note_recv_window(sink);
+    }
+
     fn send_rst_stream(&mut self, sink: &impl Sink, stream_id: u32, code: ErrorCode) {
         self.write_frame(
             sink,
@@ -571,6 +587,7 @@ impl Connection {
             let inc = self.recv_window.take_update();
             if inc > 0 {
                 self.send_window_update(sink, 0, inc);
+                self.note_recv_window(sink);
             }
         }
         let mut buf = std::mem::take(&mut self.replenish_buf);
@@ -1366,6 +1383,7 @@ impl Connection {
 
         // §6.9: the whole declared frame counts against the connection recv window on receipt.
         self.recv_window.on_data(hdr.length as i64);
+        self.note_recv_window(sink);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,
@@ -1484,6 +1502,7 @@ impl Connection {
 
         // §6.9: the whole frame counts against the connection recv window.
         self.recv_window.on_data(consumed);
+        self.note_recv_window(sink);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -982,10 +982,14 @@ pub struct H2FrameParser {
     remote_settings: Cell<Option<FullSettingsPayload>>,
 
     // local Window limits the download of data
-    // current window size for the connection
+    // current window size for the connection (what setLocalWindowSize asked for)
     window_size: Cell<u64>,
-    // used window size for the connection
-    used_window_size: Cell<u64>,
+    /// The engine's connection-level receive window, mirrored through `Sink::on_recv_window`
+    /// so `state` can be read inside a dispatch (the engine cell is borrowed there):
+    /// what the peer has been told it may send, and what it has sent since the last
+    /// WINDOW_UPDATE on stream 0.
+    recv_window_size: Cell<i64>,
+    recv_window_consumed: Cell<i64>,
 
     // remote Window limits the upload of data
     // remote window size for the connection
@@ -1221,8 +1225,6 @@ pub struct Stream {
     weight: u16,
     // current window size for the stream
     window_size: u64,
-    // used window size for the stream
-    used_window_size: u64,
     // remote window size for the stream
     remote_window_size: u64,
     // remote used window size for the stream
@@ -1760,7 +1762,6 @@ impl Stream {
             // which is what stream.state.weight reports when no priority was signaled.
             weight: 16,
             window_size: initial_window_size as u64,
-            used_window_size: 0,
             remote_window_size: remote_window_size as u64,
             remote_used_window_size: 0,
             signal: None,
@@ -3494,7 +3495,7 @@ impl H2FrameParser {
             // held this borrow.
             let pending = self.pending_recv_window_growth.replace(0);
             if pending > 0 {
-                engine.recv_window.grow(pending);
+                engine.grow_recv_window(self, pending);
             }
             // Apply outbound DATA the legacy encoder wrote since the last batch, so the engine's
             // send windows reflect what is actually in flight (§6.9.1 overflow stays peer-error
@@ -3628,6 +3629,11 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_frame_counters(&self, received: u64, sent: u64) {
         self.engine_frames_received.set(received);
         self.engine_frames_sent.set(sent);
+    }
+
+    fn on_recv_window(&self, size: i64, consumed: i64) {
+        self.recv_window_size.set(size);
+        self.recv_window_consumed.set(consumed);
     }
 
     fn write(&self, bytes: &[u8]) -> crate::api::h2::connection::WriteResult {
@@ -4456,18 +4462,12 @@ impl H2FrameParser {
                 .throw_invalid_arguments(format_args!("Expected windowSize to be a number")));
         }
         let window_size_value: u32 = window_size.to_u32();
-        if this.used_window_size.get() > window_size_value as u64 {
-            return Err(global_object.throw_invalid_arguments(format_args!(
-                "Expected windowSize to be greater than usedWindowSize"
-            )));
-        }
         let old_window_size = this.window_size.get();
         this.window_size.set(window_size_value as u64);
-        if this.local_settings.get().initial_window_size < window_size_value {
-            let mut s = this.local_settings.get();
-            s.initial_window_size = window_size_value;
-            this.local_settings.set(s);
-        }
+        // Like nghttp2_session_set_local_window_size(stream_id 0): only the connection-level
+        // window moves. SETTINGS_INITIAL_WINDOW_SIZE stays as advertised; the engine sizes each
+        // new stream's receive window from it, and raising it without a SETTINGS frame leaves
+        // the peer stopped at the old stream window while we wait for half of the new one.
         if window_size_value as u64 > old_window_size {
             let increment: u32 = (window_size_value as u64 - old_window_size) as u32;
             this.send_window_update(0, UInt31WithReserved::init(increment, false));
@@ -4478,7 +4478,7 @@ impl H2FrameParser {
             // delta keeps that path panic-free.
             match this.engine.try_borrow_mut() {
                 Ok(mut guard) => match guard.as_mut() {
-                    Some(engine) => engine.recv_window.grow(increment as i64),
+                    Some(engine) => engine.grow_recv_window(this, increment as i64),
                     None => {
                         // The engine is created lazily on the first inbound read; carry the
                         // growth forward so it applies when that happens.
@@ -4493,14 +4493,6 @@ impl H2FrameParser {
                         .set(this.pending_recv_window_growth.get() + increment as i64);
                 }
             }
-        }
-        for (_, item) in this.streams.get().iter() {
-            // SAFETY: item is &*mut Stream from streams.iter(); the boxed Stream outlives the iteration
-            let stream = unsafe { &mut **item };
-            if stream.used_window_size > window_size_value as u64 {
-                continue;
-            }
-            stream.window_size = window_size_value as u64;
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -4535,6 +4527,12 @@ impl H2FrameParser {
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let result = JSValue::create_empty_object(global_object, 9);
+        // node (nghttp2_session_get_*): effectiveLocalWindowSize is the connection window we
+        // want, localWindowSize is what the peer may still send on it (advertised minus what it
+        // sent since the last WINDOW_UPDATE), effectiveRecvDataLength is that consumed amount.
+        // Growth queued for the engine is already on the wire, so it counts as advertised.
+        let advertised = this.recv_window_size.get() + this.pending_recv_window_growth.get();
+        let consumed = this.recv_window_consumed.get().max(0);
         result.put(
             global_object,
             b"effectiveLocalWindowSize",
@@ -4543,7 +4541,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"effectiveRecvDataLength",
-            JSValue::js_number((this.window_size.get() - this.used_window_size.get()) as f64),
+            JSValue::js_number(consumed as f64),
         );
         result.put(
             global_object,
@@ -4558,7 +4556,6 @@ impl H2FrameParser {
 
         let settings = this.remote_settings.get().unwrap_or_default();
         let remote_iws = settings.initial_window_size;
-        let local_iws = this.local_settings.get().initial_window_size;
         let local_hts = this.local_settings.get().header_table_size;
         result.put(
             global_object,
@@ -4568,7 +4565,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"localWindowSize",
-            JSValue::js_number(local_iws as f64),
+            JSValue::js_number((advertised - consumed).max(0) as f64),
         );
         result.put(
             global_object,
@@ -7549,7 +7546,8 @@ impl H2FrameParser {
             ),
             remote_settings: Cell::new(None),
             window_size: Cell::new(DEFAULT_WINDOW_SIZE),
-            used_window_size: Cell::new(0),
+            recv_window_size: Cell::new(DEFAULT_WINDOW_SIZE as i64),
+            recv_window_consumed: Cell::new(0),
             remote_window_size: Cell::new(DEFAULT_WINDOW_SIZE),
             remote_used_window_size: Cell::new(0),
             max_header_list_pairs: Cell::new(128),

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4671,6 +4671,86 @@ it("Http2Stream pull-mode read() after pause() replenishes the receive window", 
   }
 });
 
+// setLocalWindowSize() grows the connection-level receive window only (nghttp2's
+// nghttp2_session_set_local_window_size with stream id 0). It used to also raise the local
+// SETTINGS_INITIAL_WINDOW_SIZE without sending a SETTINGS frame, so every new stream waited for
+// half of the raised window before replenishing while the peer still stopped at the 64 KiB it
+// was actually told: any body larger than that stalled forever.
+describe("setLocalWindowSize() and bodies larger than the initial stream window", () => {
+  const PAYLOAD = 2 * 1024 * 1024;
+  const WINDOW = 1 << 24;
+
+  it("server session: receives a POST body larger than the stream window", async () => {
+    const server = http2.createServer();
+    const { promise, resolve, reject } = Promise.withResolvers();
+    let serverSession;
+    server.on("session", session => {
+      serverSession = session;
+      session.setLocalWindowSize(WINDOW);
+    });
+    server.on("stream", stream => {
+      let received = 0;
+      stream.on("data", chunk => (received += chunk.length));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end();
+        resolve(received);
+      });
+      stream.on("error", reject);
+    });
+    await new Promise(r => server.listen(0, "127.0.0.1", r));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      client.on("error", reject);
+      const req = client.request({ ":path": "/", ":method": "POST" });
+      req.on("error", reject);
+      req.end(Buffer.alloc(PAYLOAD, "x"));
+      expect(await promise).toBe(PAYLOAD);
+      expect({
+        effectiveLocalWindowSize: serverSession.state.effectiveLocalWindowSize,
+        initialWindowSize: serverSession.localSettings.initialWindowSize,
+      }).toEqual({
+        effectiveLocalWindowSize: WINDOW,
+        initialWindowSize: http2.getDefaultSettings().initialWindowSize,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("client session: receives a response body larger than the stream window", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(Buffer.alloc(PAYLOAD, "y"));
+    });
+    await new Promise(r => server.listen(0, "127.0.0.1", r));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.setLocalWindowSize(WINDOW);
+      const req = client.request({ ":path": "/" });
+      req.on("error", reject);
+      let received = 0;
+      req.on("data", chunk => (received += chunk.length));
+      req.on("end", () => resolve(received));
+      expect(await promise).toBe(PAYLOAD);
+      expect({
+        effectiveLocalWindowSize: client.state.effectiveLocalWindowSize,
+        initialWindowSize: client.localSettings.initialWindowSize,
+      }).toEqual({
+        effectiveLocalWindowSize: WINDOW,
+        initialWindowSize: http2.getDefaultSettings().initialWindowSize,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
 // The outbound cork buffer is thread-local across every Http2Session. Interleaving
 // respond()/write() across two sessions used to let the second session's corked
 // HEADERS be prepended to the first session's multi-frame DATA batch and sent to


### PR DESCRIPTION
### Problem
- `Http2Session.setLocalWindowSize(n)` stalls every body larger than the advertised stream window. A 2 MB POST into a server that called `setLocalWindowSize(1 << 24)` delivers exactly 65535 bytes and then hangs forever. Client sessions hang the same way on responses.
- Cause: `H2FrameParser::set_local_window_size` (`src/runtime/api/bun/h2_frame_parser.rs`) raised `local_settings.initial_window_size` to `n` without a SETTINGS frame. `rewrite_read` copies that into the engine, so each new stream got `RecvWindow::new(n)` and only sent a stream WINDOW_UPDATE after `n / 2` bytes, while the peer stopped at the 65535 bytes it was actually told.

### Fix
- `set_local_window_size` no longer touches `initial_window_size` or the per-stream `window_size` fields. Only the connection window grows and a stream 0 WINDOW_UPDATE goes out. This is what nghttp2 does for `nghttp2_session_set_local_window_size` with stream id 0.
- `session.state.localWindowSize` used to read the raised setting, which is how node's `setLocalWindowSize` tests passed. It now reports what node reports: the connection receive window the peer may still use. The engine mirrors its `recv_window` into the parser through a new `Sink::on_recv_window`, so the value is exact even when `state` is read inside a frame callback. `effectiveRecvDataLength` now reports the bytes consumed since the last WINDOW_UPDATE (it reported the whole window before).
- The dead `used_window_size` fields and the never reachable "greater than usedWindowSize" check go away with them.
- Verified: `test/js/node/http2/node-http2.test.js` (two new tests, both time out on the release binary). Also the rest of `test/js/node/http2/` and the window, settings, flow control and `setLocalWindowSize` files from `test/js/node/test/parallel/test-http2-*.js`.

### Background
- HTTP/2 has two receive windows. The connection window (stream 0) starts at 65535 and only grows through WINDOW_UPDATE frames. Each stream window starts at `SETTINGS_INITIAL_WINDOW_SIZE`, which a peer only learns from a SETTINGS frame.
- The engine in `src/runtime/api/bun/h2/connection.rs` replenishes a window after half of it is consumed. It therefore has to size each window exactly as the peer sees it, or the peer blocks while the engine waits.
- `Sink` is the callback trait the engine uses to reach the JS binding (`H2FrameParser`). The binding owns the engine in a `RefCell` that stays borrowed for a whole read batch, so values that JS can ask for during a callback are mirrored into `Cell`s through `Sink` methods (the frame counters already work this way).

<details><summary>Notes</summary>

- node semantics for `session.state` (`Http2Session::RefreshState` in `node_http2.cc`): `effectiveLocalWindowSize` is `nghttp2_session_get_effective_local_window_size`, `localWindowSize` is `nghttp2_session_get_local_window_size` (`local_window_size - recv_window_size`), `effectiveRecvDataLength` is `nghttp2_session_get_effective_recv_data_length`.
- Probed with the debug build against node: default settings, `settings: { initialWindowSize: 100000 }` on either side, `setLocalWindowSize` called from inside a `stream` event (the engine is borrowed there, so the growth takes the pending path), and a shrink to 20 (`effectiveLocalWindowSize` 20, `localWindowSize` 65535 on both).
- `test-http2-server-setLocalWindowSize.js`, `test-http2-client-setLocalWindowSize.js`, `test-http2-session-stream-state.js` and `test-http2-client-destroy.js` pass before and after.
- Shrinking the window still does not implement nghttp2's `recv_reduction` (Bun never shrinks the engine window). That is unchanged by this PR.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (4448a2e21)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [832.75ms]
(pass) node none > Client Basics > should be able to send a POST request [551.31ms]
(pass) node none > Client Basics > constants [17.97ms]
(pass) node none > Client Basics > getDefaultSettings [6.71ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.13ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.07ms]
(pass) node none > Client Basics > should be able to send data using end [573.96ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [563.56ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 2 failed, 6 skipped
bun test v1.4.0-canary.1 (4448a2e21)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.83ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.38ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.13ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.06ms]
(pass) node none > Client Basics > is possible to abort request [1.60ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.68ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.63ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.12ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [32.24ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (4448a2e21)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [860.48ms]
(pass) node none > Client Basics > should be able to send a POST request [572.51ms]
(pass) node none > Client Basics > constants [17.94ms]
(pass) node none > Client Basics > getDefaultSettings [6.74ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.72ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.09ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.16ms]
(pass) node none > Client Basics > should be able to send data using end [589.84ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [576.41ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0b11c75434
  features     baseline

23 deps, 129 codegen, 1172 objects in 762ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [5.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] fetch zlib
[zlib] up to date
[9/1243] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 31ms
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen bake
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs   | 19 ++++++++
 src/runtime/api/bun/h2_frame_parser.rs | 58 ++++++++++++------------
 test/js/node/http2/node-http2.test.js  | 80 ++++++++++++++++++++++++++++++++++
 3 files changed, 127 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2/connection.rs        6      5      0
src/runtime/api/bun/h2_frame_parser.rs     11     10      0
test/js/node/http2/node-http2.test.js       2      1      0
```

</details>

<!-- robobun:evidence:end -->