### PR TITLE
shell: stop deeply nested if clauses from overflowing the parser stack

### DIFF
--- a/src/shell_parser/error.rs
+++ b/src/shell_parser/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     Unknown,
     #[error("Lex")]
     Lex,
+    #[error("NestingTooDeep")]
+    NestingTooDeep,
     #[error(transparent)]
     Alloc(#[from] bun_alloc::AllocError),
 }
@@ -29,6 +31,7 @@ impl Error {
             Self::Unexpected => "Unexpected",
             Self::Unknown => "Unknown",
             Self::Lex => "Lex",
+            Self::NestingTooDeep => "NestingTooDeep",
             Self::Alloc(_) => "OutOfMemory",
         }
     }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -10,7 +10,7 @@ use std::io::Write as _;
 
 use bun_alloc::Arena as Bump;
 use bun_alloc::ArenaVecExt as _;
-use bun_core::{String as BunString, strings};
+use bun_core::{StackCheck, String as BunString, strings};
 
 // `strings::Cursor` aliased as `CodepointCursor` for readability.
 type CodepointCursor = strings::Cursor;
@@ -39,6 +39,8 @@ pub enum ParseError {
     Unknown,
     #[error("Lex")]
     Lex,
+    #[error("NestingTooDeep")]
+    NestingTooDeep,
 }
 
 impl From<ParseError> for crate::Error {
@@ -49,6 +51,7 @@ impl From<ParseError> for crate::Error {
             ParseError::Unexpected => crate::Error::Unexpected,
             ParseError::Unknown => crate::Error::Unknown,
             ParseError::Lex => crate::Error::Lex,
+            ParseError::NestingTooDeep => crate::Error::NestingTooDeep,
         }
     }
 }
@@ -719,6 +722,9 @@ pub struct Parser<'bump> {
     pub(crate) current: u32,
     pub errors: bun_alloc::ArenaVec<'bump, ParserError<'bump>>,
     pub(crate) inside_subshell: Option<SubshellKind>,
+    /// Every nesting construct (`if`, subshell, command substitution) recurses
+    /// through `parse_stmt`, which consults this before descending.
+    stack_check: StackCheck,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -758,6 +764,7 @@ impl<'bump> Parser<'bump> {
             current: 0,
             errors: bun_alloc::ArenaVec::new_in(bump),
             inside_subshell: None,
+            stack_check: StackCheck::init(),
         })
     }
 
@@ -778,6 +785,7 @@ impl<'bump> Parser<'bump> {
             current: self.current,
             errors: core::mem::replace(&mut self.errors, bun_alloc::ArenaVec::new_in(self.alloc)),
             inside_subshell: Some(kind),
+            stack_check: self.stack_check,
         }
     }
 
@@ -837,6 +845,11 @@ impl<'bump> Parser<'bump> {
     }
 
     pub(crate) fn parse_stmt(&mut self) -> ParseResult<ast::Stmt<'bump>> {
+        if !self.stack_check.is_safe_to_recurse() {
+            self.add_error(format_args!("Nesting depth exceeded"))?;
+            return Err(ParseError::NestingTooDeep.into());
+        }
+
         let mut exprs = bun_alloc::ArenaVec::new_in(self.alloc);
 
         while if self.inside_subshell.is_none() {

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -1,4 +1,5 @@
 import { shellInternals } from "bun:internal-for-testing";
+import { bunEnv, bunExe } from "harness";
 import { createTestBuilder, redirect } from "./util";
 const { parse } = shellInternals;
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -1066,5 +1067,33 @@ describe("parse shell invalid input", () => {
     await TestBuilder.command`echo (echo foo && echo hi)`.error("Unexpected token: `(`").run();
 
     await TestBuilder.command`echo foo >`.error("Redirection with no file").run();
+  });
+
+  // Every `if` clause is one more level of parser recursion. Without a depth
+  // guard the parser runs off the end of the native stack.
+  test("if clauses nested too deeply throw instead of overflowing the stack", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const depth = 20000;
+        const src = "if true; then ".repeat(depth) + "echo x" + "; fi".repeat(depth);
+        try {
+          Bun.$\`\${{ raw: src }}\`;
+          console.log("parsed");
+        } catch (e) {
+          console.log("error:", e.message);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("error: Nesting depth exceeded\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- A shell template with about 9000 nested `if ...; then ...; fi` clauses kills bun with SIGSEGV (exit 139) while `Bun.$` constructs the script. Nothing is spawned, no JS error is thrown. Inside a Worker (4 MB stack) about 4000 clauses are enough.
- The parser recurses once per clause: `parse_if_clause` -> `parse_if_body` -> `parse_stmt` -> `parse_expr` -> `parse_binary` -> `parse_pipeline` -> `parse_compound_cmd` -> `parse_if_clause` (`src/shell_parser/parse.rs:1204`). Nothing checks the remaining stack. The lexer caps subshell and `$(...)` nesting at 128, but `if` nesting has no cap.

### Fix
- `Parser` carries a `bun_core::StackCheck`, seated in `Parser::new` and copied into every subparser. `parse_stmt` consults it before it descends. Every nesting construct (`if`, `( )`, `$( )`) passes through `parse_stmt`, so one check covers all of them.
- When fewer than 128 KiB of stack remain, the parser records the error "Nesting depth exceeded" and returns the new `ParseError::NestingTooDeep`. `Bun.$` throws it as a normal JS error. The check is thread aware, so a Worker gets the same clean error at its lower depth.
- Verified: `test/js/bun/shell/parse.test.ts` (the new test crashes the child with SIGSEGV on stock bun and on the unfixed debug build). Also `bunshell.test.ts`, `lex.test.ts` and `throw.test.ts` on the debug build.

### Background
- `StackCheck` caches the current thread's stack end (from WTF's `StackBounds`, set up by `configure_thread`). `is_safe_to_recurse` reads the stack pointer and returns true while more than 128 KiB (256 KiB on Windows) remain. The JS parser, the printer and the JSON, TOML and YAML parsers already use it the same way.
- The shell parser is a recursive descent parser over a token slice. A nested `if` is parsed as a compound command inside the body of the enclosing `if`, so input nesting maps one to one onto native recursion.

<details><summary>Notes</summary>

Thresholds on the debug ASAN build: 500 nested clauses parse and execute, 3000 report "Nesting depth exceeded". Release frames are several times smaller, so the release limit is close to the old crash point (about 8000 on an 8 MiB main stack).

Repro on stock bun (exit 139, nothing on stderr):

```js
const D = 10000;
Bun.$`${{ raw: "if true; then ".repeat(D) + "echo x" + "; fi".repeat(D) }}`;
```

Interpreting a nested `if` script is a separate state machine and is not touched by this change.
</details>
