### PR TITLE
process.versions: report the ICU and Unicode versions of the linked library

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -275,9 +275,7 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
     putDirectNamed(vm, object, "uv"_s, JSValue(JSC::jsOwnedString(vm, String::fromLatin1(uv_version_string()))));
 #endif
     putVersion("napi", "10");
-    // Ask the linked ICU instead of using U_ICU_VERSION / U_UNICODE_VERSION.
-    // macOS links the system libicucore, so the headers the build compiled
-    // against can be a different ICU than the one the process runs with.
+    // macOS links the system libicucore: U_ICU_VERSION is the header's version, not the library's.
     {
         UVersionInfo versionInfo;
         char versionString[U_MAX_VERSION_STRING_LENGTH];

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -67,6 +67,9 @@
 #include "napi_handle_scope.h"
 #include "napi_external.h"
 
+#include <unicode/uchar.h>
+#include <unicode/uversion.h>
+
 #ifndef WIN32
 #include <errno.h>
 #include <dlfcn.h>
@@ -272,8 +275,19 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
     putDirectNamed(vm, object, "uv"_s, JSValue(JSC::jsOwnedString(vm, String::fromLatin1(uv_version_string()))));
 #endif
     putVersion("napi", "10");
-    putVersion("icu", U_ICU_VERSION);
-    putVersion("unicode", U_UNICODE_VERSION);
+    // Ask the linked ICU instead of using U_ICU_VERSION / U_UNICODE_VERSION.
+    // macOS links the system libicucore, so the headers the build compiled
+    // against can be a different ICU than the one the process runs with.
+    {
+        UVersionInfo versionInfo;
+        char versionString[U_MAX_VERSION_STRING_LENGTH];
+        u_getVersion(versionInfo);
+        u_versionToString(versionInfo, versionString);
+        putDirectNamed(vm, object, "icu"_s, JSC::jsOwnedString(vm, String::fromLatin1(versionString)));
+        u_getUnicodeVersion(versionInfo);
+        u_versionToString(versionInfo, versionString);
+        putDirectNamed(vm, object, "unicode"_s, JSC::jsOwnedString(vm, String::fromLatin1(versionString)));
+    }
     putVersion("sqlite", Bun__sqlite3_version());
 
 #define STRINGIFY_IMPL(x) #x

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -491,6 +491,20 @@ it("ICU version does not regress", () => {
   expect(parseFloat(process.versions.icu, 10) || 0).toBeGreaterThanOrEqual(parseFloat(min, 10));
 });
 
+it("process.versions.icu and process.versions.unicode describe the ICU the process runs with", () => {
+  // macOS links the system libicucore, so the ICU the build compiled against
+  // can differ from the one the process runs with. String.prototype.toUpperCase
+  // goes through ICU's case mapping, and U+10D70 GARAY SMALL LETTER A only has
+  // an uppercase (U+10D50) from Unicode 16 (ICU 76) on.
+  const hasUnicode16 = "\u{10D70}".toUpperCase() === "\u{10D50}";
+  expect({
+    unicode16: parseFloat(process.versions.unicode) >= 16,
+    icu76: parseInt(process.versions.icu) >= 76,
+  }).toEqual({ unicode16: hasUnicode16, icu76: hasUnicode16 });
+  expect(process.versions.icu).toMatch(/^\d+\.\d+(\.\d+)*$/);
+  expect(process.versions.unicode).toMatch(/^\d+\.\d+(\.\d+)*$/);
+});
+
 it("process.env.TZ", () => {
   var origTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,4 +1,5 @@
 import { spawnSync, which } from "bun";
+import { CString, dlopen, ptr } from "bun:ffi";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
 import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
@@ -503,6 +504,27 @@ it("process.versions.icu and process.versions.unicode describe the ICU the proce
   }).toEqual({ unicode16: hasUnicode16, icu76: hasUnicode16 });
   expect(process.versions.icu).toMatch(/^\d+\.\d+(\.\d+)*$/);
   expect(process.versions.unicode).toMatch(/^\d+\.\d+(\.\d+)*$/);
+});
+
+it.skipIf(!isMacOS)("process.versions.icu and process.versions.unicode match the system libicucore", () => {
+  // dlopen returns the image bun itself links (-licucore), so these are the
+  // versions of the ICU that does the work in this process.
+  const { symbols } = dlopen("/usr/lib/libicucore.A.dylib", {
+    u_getVersion: { args: ["ptr"], returns: "void" },
+    u_getUnicodeVersion: { args: ["ptr"], returns: "void" },
+    u_versionToString: { args: ["ptr", "ptr"], returns: "void" },
+  });
+  const version = new Uint8Array(4);
+  const string = new Uint8Array(20);
+  const read = getVersion => {
+    getVersion(ptr(version));
+    symbols.u_versionToString(ptr(version), ptr(string));
+    return new CString(ptr(string)).toString();
+  };
+  expect({ icu: process.versions.icu, unicode: process.versions.unicode }).toEqual({
+    icu: read(symbols.u_getVersion),
+    unicode: read(symbols.u_getUnicodeVersion),
+  });
 });
 
 it("process.env.TZ", () => {


### PR DESCRIPTION
### Problem
- `test/js/web/url/url.test.ts` is red on the macOS 14 x64 CI agent (builds 102878 and 104040): `url > special-scheme hosts use the Unicode 16 IDNA table` throws `TypeError: Invalid URL` for `new URL("http://foo\u180E:80/")`. `test-whatwg-url-toascii.js` and `test-whatwg-url-custom-domainto.js` fail on the same box for the same reason.
- The three tests skip when `parseInt(process.versions.icu) < 76`, as #38013 intended. But `process.versions.icu` is `U_ICU_VERSION` (`src/jsc/bindings/BunProcess.cpp:275`), a constant from the headers of the build. The darwin build compiles against ICU 78.1 headers and links the system `libicucore` at run time. On macOS 14.8.9 that library is ICU 74.1 with the Unicode 15.1 IDNA table, which still rejects U+180E. The skip never fires.

### Fix
- `process.versions.icu` and `process.versions.unicode` now come from `u_getVersion()` and `u_getUnicodeVersion()`, formatted with `u_versionToString()`. This is the version of the ICU the process runs with.
- Correct because the value is meant to describe the linked library. On Linux, Windows, FreeBSD and Android, ICU is static, so the value is unchanged (`78.3`, `17.0`). On macOS it becomes the real one: `74.1` on macOS 14, `76.1` on macOS 15, `78.1` on macOS 26. The skips in the three tests then match the IDNA table in use.
- Two new tests in `test/js/node/process/process.test.js`. One runs everywhere: `process.versions.unicode >= 16` and `icu >= 76` must agree with a runtime probe (`"\u{10D70}".toUpperCase()`, a Garay letter that only uppercases from Unicode 16 on). One runs on macOS only: it reads `u_getVersion()` and `u_getUnicodeVersion()` from `/usr/lib/libicucore.A.dylib` through `bun:ffi` and requires equality with `process.versions`. The main artifact fails both on macOS 14 and the second on macOS 15. The PR artifact passes both (table in the notes).
- Verified: `test/js/node/process/process.test.js`, `test/js/web/url/url.test.ts`, `test/js/web/intl/intl.test.ts`, `test-whatwg-url-toascii.js`, `test-whatwg-url-custom-domainto.js` on Linux and, with the PR artifact, on the macOS 14 box.

### Background
- The darwin artifacts are cross-compiled on Linux. `scripts/build/deps/webkit.ts` deletes the prebuilt `include/unicode` on darwin, so the ICU headers come from the macOS SDK, and `scripts/build/bun.ts` links `-licucore`. The header version and the library version are independent.
- UTS #46 (IDNA) maps or rejects code points by a table that changes with each Unicode release. Unicode 16 made U+180E and U+206A..U+206F ignored and changed U+1E9E and U+04C0. ICU 76 is the first release with that table.
- `u_getVersion()` fills a `UVersionInfo` (4 bytes) from the linked library. `u_versionToString()` prints it as `major.minor`, the same format as `U_ICU_VERSION`.

Culprit: #38013 removed bun's own Unicode 16 IDNA pre-pass and added the `process.versions.icu < 76` skips, which rely on the value being the runtime version.

<details><summary>Notes</summary>

`process.versions` against `libicucore` (`u_getVersion` / `u_getUnicodeVersion` through `bun:ffi`) on the CI fleet. "main" is the current main artifact, "PR" is the darwin artifact of build 104063:

| box | macOS | libicucore | main | PR |
| --- | --- | --- | --- | --- |
| darwin-x64-matzo | 14.8.9 | 74.1 / 15.1 | 78.1 / 17.0 (mismatch) | 74.1 / 15.1 |
| darwin-arm64-ciabatta | 15.7.9 | 76.1 / 16.0 | 78.1 / 17.0 (mismatch) | 76.1 / 16.0 |
| darwin-arm64-crouton | 26.6.1 | 78.1 / 17.0 | 78.1 / 17.0 | 78.1 / 17.0 |

The Garay probe alone is only able to fail on macOS 14 (the 76 threshold is the same on both sides on macOS 15 and 26). The `libicucore` equality test also fails on macOS 15 before the fix. Neither can fail on Linux or Windows, where ICU is static and `U_ICU_VERSION` equals `u_getVersion()`.

With the main artifact on darwin-x64-matzo (macOS 14):

```
"http://foo᠎:80/" => TypeError: Invalid URL
"http://Ӏ.com/"   => TypeError: Invalid URL
url.test.ts: 26 pass, 1 fail
test-whatwg-url-toascii.js: fails
test-whatwg-url-custom-domainto.js: fails ("lookout.net")
process.test.js (new tests): 2 fail
  {icu76: true, unicode16: true} vs runtime {false, false}
  {icu: "78.1", unicode: "17.0"} vs libicucore {icu: "74.1", unicode: "15.1"}
```

With the PR artifact on the same box: `url.test.ts` 26 pass 1 skip, both node tests print `1..0 # Skipped: ICU predates Unicode 16`, and the two new tests pass.

The darwin lanes shard files across agents. In build 104063 (first push) `url.test.ts` ran on the 14.8.9 agent and the skip fired, while `process.test.js` landed on the 15.7.9 and 26.6.1 agents. In build 104133 (current head) both x64 shards ran on 14.8.9 agents and both arm64 shards on macOS 15 guests, so `process.test.js` with the `libicucore` test ran and passed on macOS 14 and 15. The macOS 14 and 15 results in the table are from manual runs of the artifacts on those boxes.

`u_getVersion`, `u_getUnicodeVersion` and `u_versionToString` are all exported by `libicucore` (resolved through `dlopen` on macOS 14, 15 and 26). `U_DISABLE_RENAMING=1` (`scripts/build/flags.ts`) keeps the names unversioned on darwin, as for every other ICU call bun makes.

Node reports `U_ICU_VERSION` too, but it bundles ICU, so the constant is the linked version there.
</details>
