### PR TITLE
dns: make --dns-result-order and setDefaultResultOrder apply to fetch and Bun.connect

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -33,7 +33,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:dns`](https://nodejs.org/api/dns.html)
 
-🟢 Fully implemented. Missing `resolveTlsa`. Bun ignores the `Resolver` `maxTimeout` option, and the callback-style `Resolver` class cannot be subclassed (`dns.promises.Resolver` can).
+🟢 Fully implemented. Missing `resolveTlsa`. Bun ignores the `Resolver` `maxTimeout` option, and the callback-style `Resolver` class cannot be subclassed (`dns.promises.Resolver` can). `setDefaultResultOrder()` changes the dial order of `fetch()` and `Bun.connect()` for the whole process, including other worker threads, because they share one DNS cache. The `dns.lookup()` default stays per-thread like in Node.js.
 
 ### [`node:events`](https://nodejs.org/api/events.html)
 

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -297,6 +297,7 @@ export function getJS2NativeRust() {
   // so the linker doesn't see two definitions.
   const handExported = new Set<string>([
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_setRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting",
   ]);

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -462,7 +462,26 @@ impl Order {
             bun_core::Global::exit(1)
         })
     }
+
+    /// The process-wide default result order. The connect-path DNS cache
+    /// (`bun_runtime::dns_jsc::internal::process_results`) reads it to decide
+    /// which address family leads the RFC 8305 interleave. Set from
+    /// `--dns-result-order` and `dns.setDefaultResultOrder`.
+    pub fn global_default() -> Order {
+        match GLOBAL_DEFAULT_ORDER.load(core::sync::atomic::Ordering::Relaxed) {
+            4 => Order::Ipv4first,
+            6 => Order::Ipv6first,
+            _ => Order::Verbatim,
+        }
+    }
+
+    pub fn set_global_default(order: Order) {
+        GLOBAL_DEFAULT_ORDER.store(order as u8, core::sync::atomic::Ordering::Relaxed);
+    }
 }
+
+static GLOBAL_DEFAULT_ORDER: core::sync::atomic::AtomicU8 =
+    core::sync::atomic::AtomicU8::new(Order::Verbatim as u8);
 
 /// The process-wide DNS
 /// cache lives in `bun_runtime` (it owns libinfo/libuv worker threads + JSC

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -74,6 +74,12 @@ const getRuntimeDefaultResultOrderOption = $newRustFunction(
   0,
 );
 
+const setRuntimeDefaultResultOrderOption = $newRustFunction(
+  "runtime/dns_jsc/dns.rs",
+  "Resolver.setRuntimeDefaultResultOrderOption",
+  1,
+);
+
 function newResolver(options) {
   if (!newResolver.native) {
     newResolver.native = $newRustFunction("runtime/dns_jsc/dns.rs", "Resolver.newResolver", 1);
@@ -92,6 +98,9 @@ function defaultResultOrder() {
 function setDefaultResultOrder(order) {
   validateOrder(order);
   defaultResultOrder.value = order;
+  // The connect path (fetch, Bun.connect) dials through the internal DNS
+  // cache, not dns.lookup; push the order down so it applies there too.
+  setRuntimeDefaultResultOrderOption(order);
 }
 
 function getDefaultResultOrder() {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1218,6 +1218,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
 
         if let Some(order) = args.option(b"--dns-result-order") {
             ctx.runtime_options.dns_result_order = order.into();
+            // The connect-path DNS cache (fetch, Bun.connect, bun install)
+            // reads the process-wide order; run/repl_command still validate
+            // the string and exit on an invalid value.
+            if let Some(parsed) = bun_dns::Order::from_string(order) {
+                bun_dns::Order::set_global_default(parsed);
+            }
         }
 
         let has_cron_title = args.option(b"--cron-title");

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3203,10 +3203,15 @@ pub mod internal {
         unsafe { std::ptr::from_mut::<RequestResult>((*req).result.as_mut().unwrap()) }
     }
 
-    /// Change the process default result order. Completed cache entries were
-    /// packed with the old order, so drop them; otherwise the new order would
-    /// only take effect once they expire (up to the cache TTL). In-flight
-    /// entries pack with the new order when they complete, so they stay.
+    /// Change the process default result order and invalidate every cache
+    /// entry: completed entries were packed with the old order, and an
+    /// in-flight lookup may still pack with it (the work-pool thread reads the
+    /// order before this lock is taken, then publishes its result after it is
+    /// released). An invalid entry is never served to a new lookup, so the
+    /// next one re-resolves under the new order; waiters already registered on
+    /// an in-flight entry still get its result. A lookup whose `Request` is
+    /// created after this walk reads the new order: the creation locks this
+    /// same cache, which orders it after the store above.
     pub(crate) fn set_default_order(order: bun_dns::Order) {
         if bun_dns::Order::global_default() == order {
             return;
@@ -3220,15 +3225,13 @@ pub mod internal {
             // SAFETY: entries 0..len are valid heap Requests; refcount/valid
             // are only mutated under `global_cache().lock()`, held here.
             unsafe {
-                if (*entry).result.is_some() {
-                    (*entry).valid = false;
-                    if (*entry).refcount == 0 {
-                        let len = guard.len;
-                        let _ = guard.delete_entry_at(len, i);
-                        Request::deinit(entry);
-                        // delete_entry_at swapped the last entry into slot i.
-                        continue;
-                    }
+                (*entry).valid = false;
+                if (*entry).result.is_some() && (*entry).refcount == 0 {
+                    let len = guard.len;
+                    let _ = guard.delete_entry_at(len, i);
+                    Request::deinit(entry);
+                    // delete_entry_at swapped the last entry into slot i.
+                    continue;
                 }
             }
             i += 1;
@@ -6054,6 +6057,13 @@ impl Resolver {
     // default, the order must reach the connect-path DNS cache that fetch()
     // and Bun.connect() dial through (Node applies it there via undici's
     // `dns.lookup`). See #40178.
+    //
+    // Deliberate Node divergence: Node scopes setDefaultResultOrder per
+    // thread. Bun keeps the `dns.lookup` default per thread (the JS-side
+    // cache in node/dns.ts), but the connect path shares one process-global
+    // DNS cache, so the order there is process-wide: a worker's call changes
+    // the dial order for every thread. docs/runtime/nodejs-compat.mdx states
+    // this, and dns-interleave.test.ts pins it.
     pub(crate) fn set_runtime_default_result_order_option(
         global_this: &JSGlobalObject,
         frame: &CallFrame,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2465,14 +2465,23 @@ pub mod internal {
     // Pack getaddrinfo results into one allocation with address families
     // interleaved (RFC 8305 §4) so an unroutable family can never fill all
     // CONCURRENT_CONNECTIONS parallel connect attempts. See #4938 / #33278.
+    // The family that leads the interleave follows the process default order
+    // (`--dns-result-order` / `dns.setDefaultResultOrder`); `verbatim` keeps
+    // the resolver's first family first. See #40178.
     fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
         let mut n_first: usize = 0;
-        let first_family = if info.is_null() {
-            netc::AF_UNSPEC
-        } else {
-            // SAFETY: info is a live addrinfo node; freed by caller after we return.
-            unsafe { (*info).ai_family }
+        let first_family = match bun_dns::Order::global_default() {
+            bun_dns::Order::Ipv4first => netc::AF_INET,
+            bun_dns::Order::Ipv6first => netc::AF_INET6,
+            bun_dns::Order::Verbatim => {
+                if info.is_null() {
+                    netc::AF_UNSPEC
+                } else {
+                    // SAFETY: info is a live addrinfo node; freed by caller after we return.
+                    unsafe { (*info).ai_family }
+                }
+            }
         };
         let mut info_: *mut AddrInfo = info;
         while !info_.is_null() {
@@ -3192,6 +3201,38 @@ pub mod internal {
     extern "C" fn get_request_result(req: *mut Request) -> *mut RequestResult {
         // SAFETY: caller (usockets) only invokes this after notify, when result is set
         unsafe { std::ptr::from_mut::<RequestResult>((*req).result.as_mut().unwrap()) }
+    }
+
+    /// Change the process default result order. Completed cache entries were
+    /// packed with the old order, so drop them; otherwise the new order would
+    /// only take effect once they expire (up to the cache TTL). In-flight
+    /// entries pack with the new order when they complete, so they stay.
+    pub(crate) fn set_default_order(order: bun_dns::Order) {
+        if bun_dns::Order::global_default() == order {
+            return;
+        }
+        bun_dns::Order::set_global_default(order);
+
+        let mut guard = global_cache().lock();
+        let mut i: usize = 0;
+        while i < guard.len {
+            let entry = guard.cache[i];
+            // SAFETY: entries 0..len are valid heap Requests; refcount/valid
+            // are only mutated under `global_cache().lock()`, held here.
+            unsafe {
+                if (*entry).result.is_some() {
+                    (*entry).valid = false;
+                    if (*entry).refcount == 0 {
+                        let len = guard.len;
+                        let _ = guard.delete_entry_at(len, i);
+                        Request::deinit(entry);
+                        // delete_entry_at swapped the last entry into slot i.
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+        }
     }
 
     // FFI exports.
@@ -6007,6 +6048,28 @@ impl Resolver {
         };
         order.to_js(global_this)
     }
+
+    // FFI shim emitted by `export_host_fn!` below (JS2Native link name).
+    // `dns.setDefaultResultOrder` body: beyond the JS-side `node:dns` lookup
+    // default, the order must reach the connect-path DNS cache that fetch()
+    // and Bun.connect() dial through (Node applies it there via undici's
+    // `dns.lookup`). See #40178.
+    pub(crate) fn set_runtime_default_result_order_option(
+        global_this: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = frame.arguments();
+        if args.is_empty() || !args[0].is_string() {
+            return Ok(JSValue::UNDEFINED);
+        }
+        let slice = args[0].to_slice(global_this)?;
+        if let Some(order) = Order::from_string(slice.slice()) {
+            // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
+            global_this.bun_vm().as_mut().dns_result_order = order as u8;
+            internal::set_default_order(order);
+        }
+        Ok(JSValue::UNDEFINED)
+    }
 }
 
 // ───────── JS host-fn FFI exports ─────────
@@ -6065,6 +6128,10 @@ export_host_fn!(
 export_host_fn!(
     Resolver::get_runtime_default_result_order_option,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption"
+);
+export_host_fn!(
+    Resolver::set_runtime_default_result_order_option,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_setRuntimeDefaultResultOrderOption"
 );
 export_host_fn!(
     internal::seed_cache_for_testing,

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -305,6 +305,47 @@ describe.concurrent("dns result order reaches the connect path", () => {
     });
   });
 
+  // Deliberate Node divergence: Node scopes setDefaultResultOrder per thread.
+  // Bun's connect path shares one process-global DNS cache, so a worker's
+  // call changes the dial order for the whole process, while the dns.lookup
+  // default stays per-thread. See docs/runtime/nodejs-compat.mdx.
+  test("setDefaultResultOrder in a Worker changes the connect-path order process-wide", async () => {
+    const { out, stderr, exitCode, signal } = await run(/* js */ `
+      const dns = require("node:dns");
+      const { Worker } = require("node:worker_threads");
+      const worker = new Worker('require("node:dns").setDefaultResultOrder("ipv4first")', { eval: true });
+      await new Promise((resolve, reject) => {
+        worker.on("exit", resolve);
+        worker.on("error", reject);
+      });
+      const order = dnsCacheSeed("order-worker.test", ["::1", "127.0.0.1"]);
+      const lookupDefault = dns.getDefaultResultOrder();
+      console.log(JSON.stringify({ ok: true, order, lookupDefault }));
+      process.exit(0);
+    `);
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      // The connect path follows the worker's order; the main thread's
+      // dns.lookup default is untouched.
+      out: { ok: true, order: [4, 6], lookupDefault: "verbatim" },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("--dns-result-order with an invalid value exits with an error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--dns-result-order=bogus", "-e", "console.log('reached')"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Invalid DNS result order");
+    expect(exitCode).toBe(1);
+  });
+
   test("fetch() connects through an ipv4first-seeded entry", async () => {
     const { out, stderr, exitCode, signal } = await run(
       /* js */ `

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -15,7 +15,7 @@ import { bunEnv, bunExe, isLinux, isMusl } from "harness";
 // each scenario runs in its own process. Every test also does a real fetch()
 // through the seeded entry, which is consumed by usockets via
 // Bun__addrinfo_getRequestResult and start_connections().
-async function run(body: string, timeoutMs = 10_000) {
+async function run(body: string, timeoutMs = 10_000, execArgs: string[] = []) {
   const fixture = /* js */ `
     const { dnsCacheSeed } = require("bun:internal-for-testing");
     if (typeof dnsCacheSeed !== "function") {
@@ -26,7 +26,7 @@ async function run(body: string, timeoutMs = 10_000) {
     ${body}
   `;
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
+    cmd: [bunExe(), ...execArgs, "-e", fixture],
     env: {
       ...bunEnv,
       HTTP_PROXY: undefined,
@@ -195,4 +195,134 @@ describe.concurrent("getaddrinfo interleave (RFC 8305)", () => {
     },
     20_000,
   );
+});
+
+// https://github.com/oven-sh/bun/issues/40178: the connect-path cache ignored
+// --dns-result-order and dns.setDefaultResultOrder; the first getaddrinfo
+// family always led the interleave.
+describe.concurrent("dns result order reaches the connect path", () => {
+  test("--dns-result-order=ipv4first leads the interleave with IPv4", async () => {
+    const { out, stderr, exitCode, signal } = await run(
+      /* js */ `
+        const order = dnsCacheSeed("order-v4flag.test", ["::1", "::1", "127.0.0.1", "127.0.0.1"]);
+        console.log(JSON.stringify({ ok: true, order }));
+        process.exit(0);
+      `,
+      10_000,
+      ["--dns-result-order=ipv4first"],
+    );
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [4, 6, 4, 6] },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("--dns-result-order=ipv6first leads the interleave with IPv6", async () => {
+    const { out, stderr, exitCode, signal } = await run(
+      /* js */ `
+        const order = dnsCacheSeed("order-v6flag.test", ["127.0.0.1", "127.0.0.1", "::1", "::1"]);
+        console.log(JSON.stringify({ ok: true, order }));
+        process.exit(0);
+      `,
+      10_000,
+      ["--dns-result-order=ipv6first"],
+    );
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [6, 4, 6, 4] },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("--dns-result-order=verbatim keeps the resolver's first family first", async () => {
+    const { out, stderr, exitCode, signal } = await run(
+      /* js */ `
+        const order = dnsCacheSeed("order-verbatim.test", ["::1", "127.0.0.1"]);
+        console.log(JSON.stringify({ ok: true, order }));
+        process.exit(0);
+      `,
+      10_000,
+      ["--dns-result-order=verbatim"],
+    );
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [6, 4] },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("ipv4first with a single-family answer keeps the answer intact", async () => {
+    const { out, stderr, exitCode, signal } = await run(
+      /* js */ `
+        const order = dnsCacheSeed("order-v6only.test", ["::1", "::1", "::1"]);
+        console.log(JSON.stringify({ ok: true, order }));
+        process.exit(0);
+      `,
+      10_000,
+      ["--dns-result-order=ipv4first"],
+    );
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [6, 6, 6] },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("dns.setDefaultResultOrder('ipv4first') applies to later connect-path lookups", async () => {
+    const { out, stderr, exitCode, signal } = await run(/* js */ `
+      require("node:dns").setDefaultResultOrder("ipv4first");
+      const order = dnsCacheSeed("order-sdro.test", ["::1", "::1", "127.0.0.1", "127.0.0.1"]);
+      console.log(JSON.stringify({ ok: true, order }));
+      process.exit(0);
+    `);
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [4, 6, 4, 6] },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("changing the order drops completed cache entries packed with the old order", async () => {
+    const { out, stderr, exitCode, signal } = await run(/* js */ `
+      dnsCacheSeed("order-stale.test", ["::1", "127.0.0.1"]);
+      const before = Bun.dns.getCacheStats().size;
+      require("node:dns").setDefaultResultOrder("ipv4first");
+      const after = Bun.dns.getCacheStats().size;
+      console.log(JSON.stringify({ ok: true, before, after }));
+      process.exit(0);
+    `);
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, before: 1, after: 0 },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  test("fetch() connects through an ipv4first-seeded entry", async () => {
+    const { out, stderr, exitCode, signal } = await run(
+      /* js */ `
+        using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
+        const port = server.port;
+        const order = dnsCacheSeed("order-fetch-" + port + ".test", ["::1", "127.0.0.1"]);
+        const res = await fetch("http://order-fetch-" + port + ".test:" + port + "/");
+        console.log(JSON.stringify({ ok: true, order, body: await res.text() }));
+        process.exit(0);
+      `,
+      10_000,
+      ["--dns-result-order=ipv4first"],
+    );
+    expect({ out, stderr, exitCode, signal }).toEqual({
+      out: { ok: true, order: [4, 6], body: "ok" },
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  });
 });


### PR DESCRIPTION
### Problem

- `fetch()` and `Bun.connect()` ignore `--dns-result-order` and `dns.setDefaultResultOrder`. They always dial the first family that getaddrinfo returns, AAAA first on most dual-stack hosts (#40178).
- The connect path resolves through the internal DNS cache, not `dns.lookup`. Its packer (`process_results`, `src/runtime/dns_jsc/dns.rs`) never read the order. The flag only reached the `node:dns` lookup default.

### Fix

- Add a process-wide default order to `bun_dns` (`src/dns/lib.rs`). `process_results` now picks the family that leads the RFC 8305 interleave from it: `ipv4first` leads with A, `ipv6first` with AAAA, `verbatim` (the default) keeps the resolver's first family, as before.
- `--dns-result-order` sets the global when the CLI parses it. `dns.setDefaultResultOrder` sets it through a new native hook and invalidates every cache entry, so entries packed with the old order are not served until the TTL expires. The walk also covers in-flight lookups, whose worker thread can read the order before the change and publish after it.
- Correct because only the lead family changes. The interleave from #36295 stays intact, so a blackholed family still cannot occupy all four parallel connect attempts. Node applies both knobs to fetch via undici's `dns.lookup`.
- Verified: 9 new tests in `test/js/bun/dns/dns-interleave.test.ts` (6 fail on unfixed bun). Also `test/js/bun/dns/`, `test/js/node/dns/`, `test/js/node/test/parallel/test-dns-set-default-order.js`.

### Background

- The cache packs getaddrinfo results once per host and usockets dials up to 4 addresses from that list in parallel. The winner serves the request, so the packed order decides the preferred family.
- `dnsCacheSeed` (`bun:internal-for-testing`) runs literal addresses through the real packer and returns the packed family order. The tests assert that order instead of racing real sockets.
- Deliberate Node divergence: Node scopes `setDefaultResultOrder` per thread. Bun's connect path shares one process-global cache, so the order there is process-wide. The `dns.lookup` default stays per-thread like Node. Documented in `docs/runtime/nodejs-compat.mdx` and pinned by a worker test.

<details><summary>Notes</summary>

Reproduction on main (Linux, `/etc/hosts` host with servers on both families, `BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG=1` so getaddrinfo returns `::1` first): every run of `fetch()` under `--dns-result-order=ipv4first` was served over IPv6. With this change, `verbatim` serves over IPv6, `ipv4first` over IPv4 (3/3 runs each), and `dns.setDefaultResultOrder("ipv4first")` followed by `fetch()` serves over IPv4.

The reporter's other two claims: the happy-eyeballs stall (blackholed AAAA-first) was fixed by #36295 in v1.4.0, verified with a backlog-0 blackhole on `::1` (50/50 fetches under 10 ms). The `node:http` `family` option works on main (`family: 4` and `family: 6` both honored).

Order change and in-flight lookups: `set_default_order` stores the new order, then marks every entry invalid under the cache lock. A work-pool lookup that read the old order before the store publishes into an entry that the walk already invalidated, so new lookups re-resolve. A lookup created after the walk observes the new order because request creation takes the same lock. Waiters already registered on an in-flight entry still get its result, the same as a lookup that started before the change.

The interleave index math handles a lead family with zero matching entries: all entries fall into the "other" partition and keep their relative order unchanged (covered by the single-family test).

Suites run: `test/js/bun/dns/` (29 pre-existing failures in `resolve-dns.test.ts` also fail on stock bun in this sandbox, they need public DNS), `test/js/node/dns/node-dns.test.js` (29 pre-existing failures, same cause), `test/js/node/test/parallel/test-dns-set-default-order.js`, `test/regression/issue/28948.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/dns/dns-interleave.test.ts

<!-- robobun:evidence:end -->