### PR TITLE
resolver: stop deeply nested exports targets from overflowing the stack

### DIFF
--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -763,14 +763,24 @@ pub enum ValueLocation<'p> {
 
 impl ValueLocation<'_> {
     /// First byte of the value, falling back to the nearest key/container location.
+    /// Iterative: the chain is as long as the array nesting, which can be deep enough to overflow the stack.
     pub fn resolve(&self, contents: &[u8]) -> bun_ast::Loc {
-        match self {
-            ValueLocation::Property(key_loc) => property_value_loc_or_key(contents, *key_loc),
-            ValueLocation::ArrayItem(array, index) => {
-                let array_loc = array.resolve(contents);
-                array_item_loc(contents, array_loc, *index).unwrap_or(array_loc)
+        let mut indices: Vec<usize> = Vec::new();
+        let mut cur = self;
+        let key_loc = loop {
+            match cur {
+                ValueLocation::Property(key_loc) => break *key_loc,
+                ValueLocation::ArrayItem(array, index) => {
+                    indices.push(*index);
+                    cur = array;
+                }
             }
+        };
+        let mut loc = property_value_loc_or_key(contents, key_loc);
+        for &index in indices.iter().rev() {
+            loc = array_item_loc(contents, loc, index).unwrap_or(loc);
         }
+        loc
     }
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1062,12 +1062,7 @@ impl<'a> Visitor<'a> {
         vloc: json_parser::ValueLocation<'_>,
     ) -> Entry {
         if !self.stack_check.is_safe_to_recurse() {
-            // `ValueLocation::resolve` recurses per `ArrayItem` link: as deep as the nesting that ran out of stack.
-            let mut property = &vloc;
-            while let json_parser::ValueLocation::ArrayItem(parent, _) = property {
-                property = parent;
-            }
-            let loc = property.resolve(&self.source.contents);
+            let loc = vloc.resolve(&self.source.contents);
             return self.too_deep(bun_ast::Range { loc, len: 1 });
         }
         match value {

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1062,9 +1062,7 @@ impl<'a> Visitor<'a> {
         vloc: json_parser::ValueLocation<'_>,
     ) -> Entry {
         if !self.stack_check.is_safe_to_recurse() {
-            // `ValueLocation::resolve` recurses once per `ArrayItem` link, and
-            // the chain is as deep as the nesting that exhausted the stack.
-            // Point at the enclosing property instead.
+            // `ValueLocation::resolve` recurses per `ArrayItem` link: as deep as the nesting that ran out of stack.
             let mut property = &vloc;
             while let json_parser::ValueLocation::ArrayItem(parent, _) = property {
                 property = parent;
@@ -1286,8 +1284,7 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// Bounds the per-level recursion in `resolve_target`. The JSON parser's
-    /// guard does not cover it: its frames are smaller, so it accepts deeper targets.
+    /// Guards `resolve_target`'s recursion; the JSON parser's guard (smaller frames) accepts deeper targets.
     pub(crate) stack_check: StackCheck,
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1062,7 +1062,14 @@ impl<'a> Visitor<'a> {
         vloc: json_parser::ValueLocation<'_>,
     ) -> Entry {
         if !self.stack_check.is_safe_to_recurse() {
-            let loc = vloc.resolve(&self.source.contents);
+            // `ValueLocation::resolve` recurses once per `ArrayItem` link, and
+            // the chain is as deep as the nesting that exhausted the stack.
+            // Point at the enclosing property instead.
+            let mut property = &vloc;
+            while let json_parser::ValueLocation::ArrayItem(parent, _) = property {
+                property = parent;
+            }
+            let loc = property.resolve(&self.source.contents);
             return self.too_deep(bun_ast::Range { loc, len: 1 });
         }
         match value {
@@ -1279,9 +1286,8 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
-    /// `resolve_target` recurses once per nesting level of an `exports` or
-    /// `imports` target. The JSON parser bounds its own recursion, but its
-    /// frames are smaller, so a target it accepts can still be too deep here.
+    /// Bounds the per-level recursion in `resolve_target`. The JSON parser's
+    /// guard does not cover it: its frames are smaller, so it accepts deeper targets.
     pub(crate) stack_check: StackCheck,
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1,6 +1,7 @@
 use bun_ast as js_ast;
 use bun_collections::{ArrayHashMap, StringArrayHashMap};
 use bun_core::Output;
+use bun_core::StackCheck;
 use bun_core::strings;
 use bun_js_parser::lexer as js_lexer;
 use bun_paths::{self as resolve_path, MAX_PATH_BYTES, PathBuffer, SEP_STR};
@@ -1014,7 +1015,11 @@ impl ExportsMap {
         log: &mut bun_ast::Log,
         json: js_ast::Expr,
     ) -> Option<ExportsMap> {
-        let mut visitor = Visitor { source, log };
+        let mut visitor = Visitor {
+            source,
+            log,
+            stack_check: StackCheck::init(),
+        };
 
         let root = visitor.visit(json);
 
@@ -1029,6 +1034,7 @@ impl ExportsMap {
 pub(crate) struct Visitor<'a> {
     pub(crate) source: &'a bun_ast::Source,
     pub(crate) log: &'a mut bun_ast::Log,
+    stack_check: StackCheck,
 }
 
 impl<'a> Visitor<'a> {
@@ -1055,6 +1061,10 @@ impl<'a> Visitor<'a> {
         value: &js_ast::E::JsonValue,
         vloc: json_parser::ValueLocation<'_>,
     ) -> Entry {
+        if !self.stack_check.is_safe_to_recurse() {
+            let loc = vloc.resolve(&self.source.contents);
+            return self.too_deep(bun_ast::Range { loc, len: 1 });
+        }
         match value {
             js_ast::E::JsonValue::Null => Entry {
                 data: EntryData::Null,
@@ -1197,6 +1207,18 @@ impl<'a> Visitor<'a> {
             data: EntryData::Invalid,
         }
     }
+
+    #[cold]
+    fn too_deep(&mut self, first_token: bun_ast::Range) -> Entry {
+        self.log.add_range_warning(
+            Some(self.source),
+            first_token,
+            b"This value is nested too deeply",
+        );
+        Entry {
+            data: EntryData::Invalid,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1257,6 +1279,10 @@ pub(crate) struct ESModule<'a> {
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub(crate) module_type: &'a mut ModuleType,
+    /// `resolve_target` recurses once per nesting level of an `exports` or
+    /// `imports` target. The JSON parser bounds its own recursion, but its
+    /// frames are smaller, so a target it accepts can still be too deep here.
+    pub(crate) stack_check: StackCheck,
 }
 
 #[derive(Clone)]
@@ -1810,6 +1836,15 @@ impl<'a> ESModule<'a> {
         subpath: &[u8],
         internal: bool,
     ) -> Resolution {
+        if !self.stack_check.is_safe_to_recurse() {
+            if let Some(logs) = self.debug_logs.as_deref_mut() {
+                logs.add_note(b"The package target is nested too deeply".to_vec());
+            }
+            return Resolution {
+                status: Status::InvalidPackageConfiguration,
+                ..Default::default()
+            };
+        }
         match &target.data {
             EntryData::String(str) => {
                 let mb = module_bufs();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -244,7 +244,7 @@ impl FdZero for ::bun_sys::Fd {
 
 use self::bun_paths as ResolvePath;
 use ::bun_ast::import_record as ast;
-use ::bun_core::{FeatureFlags, Generation};
+use ::bun_core::{FeatureFlags, Generation, StackCheck};
 use bun_ast::Msg;
 use bun_collections::BoundedArray;
 use bun_dotenv::env_loader as DotEnv;
@@ -2679,6 +2679,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            stack_check: StackCheck::init(),
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
@@ -2736,6 +2737,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            stack_check: StackCheck::init(),
                                         }
                                         .resolve(
                                             b"/",
@@ -3174,6 +3176,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            stack_check: StackCheck::init(),
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
@@ -3213,6 +3216,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            stack_check: StackCheck::init(),
                                         }
                                         .resolve(
                                             b"/",
@@ -5010,6 +5014,7 @@ impl<'a> Resolver<'a> {
             },
             debug_logs: self.debug_logs.as_mut(),
             module_type: &mut module_type,
+            stack_check: StackCheck::init(),
         }
         .resolve_imports(import_path, &imports_map.root);
         let _ = module_type;

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -859,8 +859,9 @@ describe("package.json exports targets longer than the maximum path length", () 
 describe("package.json exports targets nested too deeply", () => {
   // Shallow enough for the JSON parser, which stops at about 800 levels on
   // debug builds, yet deep enough to exhaust the native stack that is left at
-  // the deepest JS frame. JS may use 7 MiB of the 8 MiB main stack (the engine
-  // default is 5 MiB), so about 1 MiB remains for the resolver down there.
+  // the deepest JS frame on an 8 MiB main stack: JS may use 7 MiB of it (the
+  // engine default is 5 MiB), so about 1 MiB remains for the resolver down
+  // there. A platform with a larger main stack resolves the target instead.
   const depth = isDebug || isASAN ? 400 : 10000;
   const env = { ...bunEnv, BUN_JSC_maxPerThreadStackUsage: String(7 * 1024 * 1024) };
   const targets = {
@@ -872,7 +873,7 @@ describe("package.json exports targets nested too deeply", () => {
   };
 
   for (const [shape, target] of Object.entries(targets)) {
-    it.concurrent(`reports a resolution error for a deeply nested ${shape} target`, async () => {
+    it.concurrent(`does not crash on a deeply nested ${shape} target`, async () => {
       using dir = tempDir(`resolver-exports-deep-${shape}`, {
         "package.json": JSON.stringify({ name: "host" }),
         "node_modules/test-pkg/package.json": `{"name":"test-pkg","exports":{".":${target},"./shallow":"./t.js"}}`,
@@ -890,7 +891,8 @@ describe("package.json exports targets nested too deeply", () => {
               if (!(e instanceof RangeError)) throw e;
               if (outcome !== undefined) return;
               try {
-                outcome = "resolved " + require.resolve("test-pkg");
+                require.resolve("test-pkg");
+                outcome = "resolved";
               } catch (e2) {
                 // Still too deep to enter the call: the frame above retries.
                 if (e2 instanceof RangeError) throw e2;
@@ -912,7 +914,13 @@ describe("package.json exports targets nested too deeply", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "caught MODULE_NOT_FOUND\n", stderr: "", exitCode: 0 });
+      // The stack check turns the walk into a resolution error when too little
+      // stack remains. With more stack the target resolves. Neither may crash.
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: expect.stringMatching(/^(caught MODULE_NOT_FOUND|resolved)\n$/),
+        stderr: "",
+        exitCode: 0,
+      });
     });
   }
 });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1,7 +1,19 @@
 import { pathToFileURL } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { chmodSync, chownSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  isASAN,
+  isDebug,
+  isLinux,
+  isMacOS,
+  isWindows,
+  joinP,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
 import { join, resolve, sep } from "path";
 
 const fixture = (...segs: string[]) => resolve(import.meta.dir, "fixtures", ...segs);
@@ -839,6 +851,70 @@ describe("package.json exports targets longer than the maximum path length", () 
       expect({ stdout, exitCode }).toEqual({ stdout: "caught MODULE_NOT_FOUND\n", exitCode: 0 });
     },
   );
+});
+
+// The resolver walks an `exports` target once per nesting level, with larger
+// native frames than the JSON parser that produced it. A target the parser
+// accepts can therefore still run the resolver off the end of the stack.
+describe("package.json exports targets nested too deeply", () => {
+  // Shallow enough for the JSON parser, which stops at about 800 levels on
+  // debug builds, yet deep enough to exhaust the native stack that is left at
+  // the deepest JS frame. JS may use 7 MiB of the 8 MiB main stack (the engine
+  // default is 5 MiB), so about 1 MiB remains for the resolver down there.
+  const depth = isDebug || isASAN ? 400 : 10000;
+  const env = { ...bunEnv, BUN_JSC_maxPerThreadStackUsage: String(7 * 1024 * 1024) };
+  const targets = {
+    array: "[".repeat(depth) + '"./t.js"' + "]".repeat(depth),
+    conditions:
+      Array.from({ length: depth }, (_, i) => (i % 2 ? '{"node":' : '{"default":')).join("") +
+      '"./t.js"' +
+      "}".repeat(depth),
+  };
+
+  for (const [shape, target] of Object.entries(targets)) {
+    it.concurrent(`reports a resolution error for a deeply nested ${shape} target`, async () => {
+      using dir = tempDir(`resolver-exports-deep-${shape}`, {
+        "package.json": JSON.stringify({ name: "host" }),
+        "node_modules/test-pkg/package.json": `{"name":"test-pkg","exports":{".":${target},"./shallow":"./t.js"}}`,
+        "node_modules/test-pkg/t.js": "module.exports = 1;\n",
+        // Resolve a shallow entry first so package.json is parsed and cached
+        // while plenty of stack remains. Then resolve the deep entry from the
+        // deepest JS frame the engine allows, where little native stack is left.
+        "index.js": `
+          require.resolve("test-pkg/shallow");
+          let outcome;
+          function deep() {
+            try {
+              deep();
+            } catch (e) {
+              if (!(e instanceof RangeError)) throw e;
+              if (outcome !== undefined) return;
+              try {
+                outcome = "resolved " + require.resolve("test-pkg");
+              } catch (e2) {
+                // Still too deep to enter the call: the frame above retries.
+                if (e2 instanceof RangeError) throw e2;
+                outcome = "caught " + e2.code;
+              }
+            }
+          }
+          deep();
+          console.log(outcome);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        env,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "caught MODULE_NOT_FOUND\n", stderr: "", exitCode: 0 });
+    });
+  }
 });
 
 // A package.json `imports` entry whose value is a bare package specifier

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -859,11 +859,12 @@ describe("package.json exports targets longer than the maximum path length", () 
 describe("package.json exports targets nested too deeply", () => {
   // Shallow enough for the JSON parser, which stops at about 800 levels on
   // debug builds, yet deep enough to exhaust the native stack that is left at
-  // the deepest JS frame on an 8 MiB main stack: JS may use 7 MiB of it (the
-  // engine default is 5 MiB), so about 1 MiB remains for the resolver down
-  // there. A platform with a larger main stack resolves the target instead.
+  // the deepest JS frame. JS may use all but the last 1 to 2 MiB of the main
+  // stack (the engine default is 5 MiB): the linker gives bun an 18 MiB main
+  // stack on macOS and Windows, Linux has the 8 MiB rlimit default.
   const depth = isDebug || isASAN ? 400 : 10000;
-  const env = { ...bunEnv, BUN_JSC_maxPerThreadStackUsage: String(7 * 1024 * 1024) };
+  const jsStackMiB = isMacOS || isWindows ? 16 : 7;
+  const env = { ...bunEnv, BUN_JSC_maxPerThreadStackUsage: String(jsStackMiB * 1024 * 1024) };
   const targets = {
     array: "[".repeat(depth) + '"./t.js"' + "]".repeat(depth),
     conditions:


### PR DESCRIPTION
### Problem
- A package.json `exports` (or `imports`) target nested about 40000 levels deep (`[[[..."./t.js"...]]]`, or alternating condition objects at about 30000) kills bun with SIGSEGV when the package is imported. `bun build` and imports inside a Worker (at about 15000) die the same way. 1.3.14 reported a clean "Cannot find package" for every depth because its JSON parser stopped first.
- `ESModule::resolve_target` (`src/resolver/package_json.rs:1831`) recurses once per nesting level through its `Map` and `Array` arms and never checks the stack. The JSON parser that produced the target is guarded by `StackCheck`, but its frames are smaller, so every depth the parser accepts above about 35000 overflows the resolver.

### Fix
- `ESModule` carries a `StackCheck`, seated at each of the five places the resolver builds one. `resolve_target` consults it on entry and returns `Status::InvalidPackageConfiguration` (with a debug note) when fewer than 128 KiB remain. The caller turns that into the usual "Cannot find package" resolution error, the same result an invalid `exports` shape gets today.
- `Visitor`, which turns the parsed JSON into the `Entry` tree right after parsing, recurses the same way. It gets the same guard and reports "This value is nested too deeply" as a package.json warning. `ValueLocation::resolve` (`src/parsers/json.rs`), which the visitor's warnings use to locate a value inside nested arrays, walked one frame per array level. It now collects the indices and descends iteratively.
- Verified: `test/js/bun/resolve/resolve.test.ts` (two new tests, array and conditions shapes). Both crash the child with exit 139 on stock bun and on the unfixed debug build. Also the rest of `resolve.test.ts`, `require.test.ts`, `import-custom-condition.test.ts` and `test/bundler/esbuild/packagejson.test.ts` on the debug build.

### Background
- `StackCheck` caches the thread's stack end (from WTF's `StackBounds`) and `is_safe_to_recurse` compares it with the stack pointer. The JS parser and the JSON, TOML and YAML parsers use it the same way.
- A package.json is parsed once per process and cached. Resolution of an `exports` entry can therefore run much later, from a deeper native stack than the parse did. The test uses that: it resolves a shallow entry first, then resolves the deep entry from the deepest JS frame the engine allows.

<details><summary>Notes</summary>

Depth windows measured on this machine (8 MiB main stack). Stock release: array targets resolve at 1400 and 20000 levels from a shallow stack, crash at 30000 and above, and the JSON parser reports a clean error at 200000. Debug ASAN: the JSON parser stops at about 1500 array levels (about 900 object levels), the resolver survives 1400 from a shallow stack and crashes at 800 when about 3 MiB of stack remain, so one resolver frame is roughly 5 KiB there.

The test sets `BUN_JSC_maxPerThreadStackUsage` to 7 MiB in the child so that JS recursion leaves about 1 MiB of native stack (the engine default of 5 MiB leaves 3 MiB). With that, 400 levels crash the unfixed debug build and 10000 levels crash the unfixed release build, while both stay far below the JSON parser's limit for the shallow parse. The JS side retries one frame up whenever `require.resolve` itself throws a `RangeError`, so the call always enters native code at the deepest frame that has room for it.

The test accepts two outcomes: "caught MODULE_NOT_FOUND" (the guard tripped) and "resolved" (the target fit in the stack that was left). Windows reserves an 18 MiB main stack and the release ASAN build has smaller frames than the debug build, so those lanes resolve the target. Only a crash fails the test.

With the fix, `bun --verbose`-style resolver debug logs show "The package target is nested too deeply" at the depth where the guard tripped.

Repro (stock 1.4, exit 139): write `node_modules/pkg/package.json` with `{"name":"pkg","exports":{".":` + `"[".repeat(45000) + '"./t.js"' + "]".repeat(45000)` + `}}`, add `t.js`, then `import 'pkg'`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->