### PR TITLE
dns: remove the remaining unsafe from the resolver module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
  "bun_core",
  "bun_libuv_sys",
  "bun_opaque",
+ "bun_ptr",
  "libc",
  "strum",
 ]
@@ -1595,6 +1596,7 @@ dependencies = [
  "bun_libuv_sys",
  "bun_opaque",
  "bun_paths",
+ "bun_ptr",
  "bun_windows_sys",
  "bun_wyhash",
  "bytemuck",

--- a/src/cares_sys/Cargo.toml
+++ b/src/cares_sys/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 bun_opaque.workspace = true
+bun_ptr.workspace = true
 strum.workspace = true
 libc.workspace = true
 bun_alloc.workspace = true

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1146,14 +1146,18 @@ impl Channel {
     /// `ares_set_servers_ports` with `servers` in order (c-ares copies them);
     /// an empty slice clears the list.
     pub fn set_servers(&self, servers: &mut [struct_ares_addr_port_node]) -> Result<(), Error> {
+        let len = servers.len();
         let base = servers.as_mut_ptr();
-        for i in 0..servers.len() {
-            servers[i].next = if i + 1 < servers.len() {
-                // SAFETY: `i + 1` is in bounds of `servers`.
-                unsafe { base.add(i + 1) }
-            } else {
-                ptr::null_mut()
-            };
+        for i in 0..len {
+            // SAFETY: `i` and `i + 1` (when used) are in bounds of `servers`;
+            // every write goes through `base` so the links stay valid for it.
+            unsafe {
+                (*base.add(i)).next = if i + 1 < len {
+                    base.add(i + 1)
+                } else {
+                    ptr::null_mut()
+                };
+            }
         }
         let head = if servers.is_empty() {
             ptr::null_mut()

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -8,12 +8,12 @@
 #[cfg(windows)]
 use core::ffi::c_short;
 use core::ffi::{c_char, c_int, c_uint, c_ushort, c_void};
-use core::ptr;
+use core::ptr::{self, NonNull};
 
 #[cfg(windows)]
-use crate::winsock::{sockaddr, sockaddr_in, sockaddr_in6, socklen_t};
+use crate::winsock::{sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t};
 #[cfg(not(windows))]
-use libc::{sockaddr, sockaddr_in, sockaddr_in6, socklen_t};
+use libc::{sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t};
 
 pub type ares_socklen_t = socklen_t;
 
@@ -296,297 +296,352 @@ type hostent_int = c_short;
 #[cfg(not(windows))]
 type hostent_int = c_int;
 
-#[repr(C)]
-pub struct struct_hostent {
-    pub h_name: *mut c_char,
-    pub h_aliases: *mut *mut c_char, // NUL-terminated array of NUL-terminated strings
-    pub h_addrtype: hostent_int,
-    pub h_length: hostent_int,
-    pub h_addr_list: *mut *mut c_char, // NUL-terminated array
-}
-
-// ─── callback-wrapper note ─────────────────────────────────────────────────
-// Rust cannot take a fn pointer as a const generic on
-// stable, so the wrappers below are expressed as a trait: the implementing
-// type provides the callback as a trait method, and the `extern "C"` thunk is
-// monomorphized per `T: Trait`.
+// ──────────────────────────────────────────────────────────────────────────
+// Owned c-ares allocations
 // ──────────────────────────────────────────────────────────────────────────
 
-pub trait HostentHandler: Sized {
-    fn on_hostent(&mut self, status: Option<Error>, timeouts: i32, results: *mut struct_hostent);
+/// A reply structure that c-ares allocates and that is released with the
+/// matching `ares_free_*` function.
+///
+/// # Safety
+/// `free` must be the deallocator c-ares documents for `Self`.
+pub unsafe trait AresAllocated {
+    /// # Safety
+    /// `this` was allocated by c-ares as a `Self` and is not used afterwards.
+    unsafe fn free(this: *mut Self);
+}
+
+/// Owning pointer to a c-ares-allocated `T`; frees it on drop.
+pub struct AresBox<T: AresAllocated>(NonNull<T>);
+
+impl<T: AresAllocated> AresBox<T> {
+    /// # Safety
+    /// `raw` is null or a `T` that c-ares handed over for the caller to free.
+    #[inline]
+    unsafe fn from_raw(raw: *mut T) -> Option<Self> {
+        NonNull::new(raw).map(Self)
+    }
+}
+
+impl<T: AresAllocated> core::ops::Deref for AresBox<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: sole owner of a live c-ares allocation (see `from_raw`).
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T: AresAllocated> core::ops::DerefMut for AresBox<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: as `deref`; `&mut self` is the only access path.
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl<T: AresAllocated> Drop for AresBox<T> {
+    fn drop(&mut self) {
+        // SAFETY: `from_raw` contract — c-ares allocated it and we own it.
+        unsafe { T::free(self.0.as_ptr()) }
+    }
+}
+
+macro_rules! ares_free_data_types {
+    ($($t:ty),+ $(,)?) => {$(
+        // SAFETY: `ares_free_data` is the documented deallocator for every
+        // `ares_parse_*_reply` list / `ares_get_servers_ports` result.
+        unsafe impl AresAllocated for $t {
+            unsafe fn free(this: *mut Self) {
+                // SAFETY: trait contract.
+                unsafe { ares_free_data(this.cast::<c_void>()) }
+            }
+        }
+    )+};
+}
+ares_free_data_types!(
+    struct_ares_caa_reply,
+    struct_ares_srv_reply,
+    struct_ares_mx_reply,
+    struct_ares_txt_reply,
+    struct_ares_naptr_reply,
+    struct_ares_soa_reply,
+    struct_ares_addr_port_node,
+);
+// SAFETY: `ares_free_hostent` is the documented deallocator for parsed hostents.
+unsafe impl AresAllocated for struct_hostent {
+    unsafe fn free(this: *mut Self) {
+        // SAFETY: trait contract.
+        unsafe { ares_free_hostent(this) }
+    }
+}
+// SAFETY: `ares_freeaddrinfo` is the documented deallocator for `ares_addrinfo`.
+unsafe impl AresAllocated for AddrInfo {
+    unsafe fn free(this: *mut Self) {
+        // SAFETY: trait contract.
+        unsafe { ares_freeaddrinfo(this) }
+    }
+}
+
+/// Bytes of a NUL-terminated string c-ares owns, or `&[]` for null.
+///
+/// # Safety
+/// `p` is null or a NUL-terminated string that lives at least as long as `'a`.
+#[inline]
+unsafe fn c_str_bytes<'a>(p: *const u8) -> &'a [u8] {
+    if p.is_null() {
+        &[]
+    } else {
+        // SAFETY: fn contract.
+        unsafe { core::ffi::CStr::from_ptr(p.cast::<c_char>()) }.to_bytes()
+    }
+}
+
+/// Iterate a null-terminated array of pointers c-ares owns.
+///
+/// # Safety
+/// `p` is null or points at a null-terminated array of pointers that lives at
+/// least as long as `'a`.
+#[inline]
+unsafe fn null_terminated_array<'a, T: 'a>(p: *mut *mut T) -> impl Iterator<Item = *mut T> + 'a {
+    let mut i = 0usize;
+    core::iter::from_fn(move || {
+        if p.is_null() {
+            return None;
+        }
+        // SAFETY: fn contract — in bounds up to and including the terminator.
+        let item = unsafe { *p.add(i) };
+        if item.is_null() {
+            None
+        } else {
+            i += 1;
+            Some(item)
+        }
+    })
+}
+
+macro_rules! ares_linked_list {
+    ($($t:ty),+ $(,)?) => {$(
+        impl $t {
+            /// The next record of this reply, if any.
+            #[inline]
+            pub fn next(&self) -> Option<&$t> {
+                // SAFETY: c-ares links `next` to null or to the following node
+                // of the same reply, which lives as long as the head does.
+                unsafe { self.next.as_ref() }
+            }
+            /// This record and every one after it.
+            #[inline]
+            pub fn iter(&self) -> impl Iterator<Item = &$t> + Clone {
+                core::iter::successors(Some(self), |n| n.next())
+            }
+        }
+    )+};
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// struct hostent
+// ──────────────────────────────────────────────────────────────────────────
+
+#[repr(C)]
+pub struct struct_hostent {
+    h_name: *mut c_char,
+    h_aliases: *mut *mut c_char, // null-terminated array of NUL-terminated strings
+    h_addrtype: hostent_int,
+    h_length: hostent_int,
+    h_addr_list: *mut *mut c_char, // null-terminated array of `h_length`-byte addresses
 }
 
 impl struct_hostent {
-    // toJSResponse alias deleted — lives in bun_runtime::dns_jsc (extension trait).
-
-    pub(crate) unsafe extern "C" fn host_callback_wrapper<T: HostentHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        hostent: *mut struct_hostent,
-    ) {
-        // SAFETY: ctx was passed as `*mut T` to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_hostent(Error::get(status), timeouts, ptr::null_mut());
-            return;
+    /// The official host name.
+    #[inline]
+    pub fn name(&self) -> Option<&[u8]> {
+        if self.h_name.is_null() {
+            None
+        } else {
+            // SAFETY: c-ares sets `h_name` to a NUL-terminated string it owns
+            // for the hostent's lifetime.
+            Some(unsafe { c_str_bytes(self.h_name.cast::<u8>()) })
         }
-        this.on_hostent(None, timeouts, hostent);
     }
 
-    // One `extern "C"` thunk per lookup name.
-    pub unsafe extern "C" fn callback_wrapper_cname<T: HostentHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_hostent(Error::get(status), timeouts, ptr::null_mut());
-            return;
-        }
+    /// Whether the alias array is present at all (an absent array and an
+    /// empty one are reported differently by `node:dns`).
+    #[inline]
+    pub fn has_aliases(&self) -> bool {
+        !self.h_aliases.is_null()
+    }
+
+    /// The alias names.
+    #[inline]
+    pub fn aliases(&self) -> impl Iterator<Item = &[u8]> {
+        // SAFETY: c-ares sets `h_aliases` to null or a null-terminated array of
+        // NUL-terminated strings, all owned for the hostent's lifetime.
+        unsafe { null_terminated_array(self.h_aliases) }.map(|p| unsafe { c_str_bytes(p.cast()) })
+    }
+
+    /// `AF_INET` or `AF_INET6`.
+    #[inline]
+    pub fn addrtype(&self) -> c_int {
+        c_int::from(self.h_addrtype)
+    }
+
+    /// Whether the address array is present at all.
+    #[inline]
+    pub fn has_addr_list(&self) -> bool {
+        !self.h_addr_list.is_null()
+    }
+
+    /// The raw network-order addresses, each `h_length` bytes (4 for
+    /// `AF_INET`, 16 for `AF_INET6`).
+    #[inline]
+    pub fn addresses(&self) -> impl Iterator<Item = &[u8]> {
+        let len = usize::try_from(self.h_length).unwrap_or(0);
+        // SAFETY: c-ares sets `h_addr_list` to null or a null-terminated array
+        // of `h_length`-byte buffers, all owned for the hostent's lifetime.
+        unsafe { null_terminated_array(self.h_addr_list) }
+            .map(move |p| unsafe { core::slice::from_raw_parts(p.cast::<u8>(), len) })
+    }
+
+    /// `ares_parse_a_reply` keeping only the hostent (CNAME chain + name).
+    pub fn parse_cname(buffer: &[u8]) -> Result<Option<AresBox<Self>>, Error> {
         let mut start: *mut struct_hostent = ptr::null_mut();
         let mut addrttls = [struct_ares_addrttl::default(); 256];
-        let mut naddrttls: i32 = 256;
-        // SAFETY: c-ares FFI; pointers are valid stack/null per contract.
-        let result = unsafe {
+        let mut naddrttls: c_int = 256;
+        // SAFETY: `buffer` is a valid slice; out-params are live stack slots.
+        let rc = unsafe {
             ares_parse_a_reply(
-                buffer,
-                buffer_length,
+                buffer.as_ptr(),
+                c_len(buffer),
                 &raw mut start,
                 addrttls.as_mut_ptr(),
                 &raw mut naddrttls,
             )
         };
-        if result != ARES_SUCCESS {
-            this.on_hostent(Error::get(result), timeouts, ptr::null_mut());
-            return;
-        }
-        this.on_hostent(None, timeouts, start);
+        // SAFETY: on success c-ares hands over `start` for us to free.
+        parsed(rc, || unsafe { AresBox::from_raw(start) })
     }
 
-    pub unsafe extern "C" fn callback_wrapper_ns<T: HostentHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_hostent(Error::get(status), timeouts, ptr::null_mut());
-            return;
-        }
+    /// `ares_parse_ns_reply`.
+    pub fn parse_ns(buffer: &[u8]) -> Result<Option<AresBox<Self>>, Error> {
         let mut start: *mut struct_hostent = ptr::null_mut();
-        // SAFETY: c-ares FFI; pointers are valid stack/null per contract.
-        let result = unsafe { ares_parse_ns_reply(buffer, buffer_length, &raw mut start) };
-        if result != ARES_SUCCESS {
-            this.on_hostent(Error::get(result), timeouts, ptr::null_mut());
-            return;
-        }
-        this.on_hostent(None, timeouts, start);
+        // SAFETY: `buffer` is a valid slice; `start` is a live stack slot.
+        let rc = unsafe { ares_parse_ns_reply(buffer.as_ptr(), c_len(buffer), &raw mut start) };
+        // SAFETY: on success c-ares hands over `start` for us to free.
+        parsed(rc, || unsafe { AresBox::from_raw(start) })
     }
 
-    pub unsafe extern "C" fn callback_wrapper_ptr<T: HostentHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_hostent(Error::get(status), timeouts, ptr::null_mut());
-            return;
-        }
+    /// `ares_parse_ptr_reply` (no address filter).
+    pub fn parse_ptr(buffer: &[u8]) -> Result<Option<AresBox<Self>>, Error> {
         let mut start: *mut struct_hostent = ptr::null_mut();
-        // SAFETY: c-ares FFI; pointers are valid stack/null per contract.
-        let result = unsafe {
+        // SAFETY: `buffer` is a valid slice; `start` is a live stack slot; a
+        // null `addr` with length 0 is the documented "no filter" input.
+        let rc = unsafe {
             ares_parse_ptr_reply(
-                buffer,
-                buffer_length,
+                buffer.as_ptr(),
+                c_len(buffer),
                 ptr::null(),
                 0,
                 AF::INET,
                 &raw mut start,
             )
         };
-        if result != ARES_SUCCESS {
-            this.on_hostent(Error::get(result), timeouts, ptr::null_mut());
-            return;
-        }
-        this.on_hostent(None, timeouts, start);
-    }
-
-    /// FFI destroy — frees a c-ares-allocated hostent.
-    pub unsafe fn destroy(this: *mut struct_hostent) {
-        // SAFETY: caller guarantees `this` was allocated by c-ares (or is null).
-        unsafe { ares_free_hostent(this) };
+        // SAFETY: on success c-ares hands over `start` for us to free.
+        parsed(rc, || unsafe { AresBox::from_raw(start) })
     }
 }
 
+#[inline]
+fn c_len(buffer: &[u8]) -> c_int {
+    c_int::try_from(buffer.len()).unwrap_or(c_int::MAX)
+}
+
+#[inline]
+fn parsed<T>(rc: c_int, take: impl FnOnce() -> Option<T>) -> Result<Option<T>, Error> {
+    if rc != ARES_SUCCESS {
+        return Err(Error::get(rc).unwrap());
+    }
+    Ok(take())
+}
+
+/// An A/AAAA answer: the parsed hostent plus the per-address TTLs.
 pub struct hostent_with_ttls {
-    pub hostent: *mut struct_hostent,
+    pub hostent: AresBox<struct_hostent>,
     pub ttls: [c_int; 256],
 }
 
-impl Default for hostent_with_ttls {
-    fn default() -> Self {
-        Self {
-            hostent: ptr::null_mut(),
-            ttls: [-1; 256],
-        }
-    }
-}
-
-pub trait HostentWithTtlsHandler: Sized {
-    /// `hostent_with_ttls::parse_a` or `parse_aaaa` — selects the c-ares reply
-    /// parser for [`hostent_with_ttls::callback_wrapper`].
-    const PARSE: fn(&[u8]) -> Result<Box<hostent_with_ttls>, Error>;
-
-    fn on_hostent_with_ttls(
-        &mut self,
-        status: Option<Error>,
-        timeouts: i32,
-        results: Option<Box<hostent_with_ttls>>,
-    );
-}
-
 impl hostent_with_ttls {
-    // toJSResponse alias deleted — lives in bun_runtime::dns_jsc.
-
-    pub unsafe extern "C" fn callback_wrapper<T: HostentWithTtlsHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_hostent_with_ttls(Error::get(status), timeouts, None);
-            return;
-        }
-        // SAFETY: c-ares passes the reply buffer it owns; valid for `buffer_length` bytes.
-        let buffer = unsafe {
-            core::slice::from_raw_parts(buffer, usize::try_from(buffer_length).unwrap_or(0))
-        };
-        match (T::PARSE)(buffer) {
-            Ok(result) => this.on_hostent_with_ttls(None, timeouts, Some(result)),
-            Err(err) => this.on_hostent_with_ttls(Some(err), timeouts, None),
-        }
-    }
-
     pub fn parse_a(buffer: &[u8]) -> Result<Box<hostent_with_ttls>, Error> {
         let mut start: *mut struct_hostent = ptr::null_mut();
         let mut addrttls = [struct_ares_addrttl::default(); 256];
         let mut naddrttls: c_int = 256;
-        // SAFETY: c-ares FFI; `buffer` is a valid slice; out-params are valid
-        // stack pointers per contract.
-        let result = unsafe {
+        // SAFETY: `buffer` is a valid slice; out-params are live stack slots.
+        let rc = unsafe {
             ares_parse_a_reply(
                 buffer.as_ptr(),
-                c_int::try_from(buffer.len()).unwrap_or(c_int::MAX),
+                c_len(buffer),
                 &raw mut start,
                 addrttls.as_mut_ptr(),
                 &raw mut naddrttls,
             )
         };
-        if result != ARES_SUCCESS {
-            return Err(Error::get(result).unwrap());
+        // SAFETY: on success c-ares hands over `start` for us to free.
+        let hostent =
+            parsed(rc, || unsafe { AresBox::from_raw(start) })?.ok_or(Error::ENOTFOUND)?;
+        let mut ttls = [-1; 256];
+        let n = usize::try_from(naddrttls).unwrap_or(0).min(256);
+        for (dst, src) in ttls.iter_mut().zip(&addrttls[..n]) {
+            *dst = src.ttl;
         }
-        let mut with_ttls = Box::new(hostent_with_ttls::default());
-        with_ttls.hostent = start;
-        for (i, ttl) in addrttls[..usize::try_from(naddrttls).expect("int cast")]
-            .iter()
-            .enumerate()
-        {
-            with_ttls.ttls[i] = ttl.ttl;
-        }
-        Ok(with_ttls)
+        Ok(Box::new(hostent_with_ttls { hostent, ttls }))
     }
 
     pub fn parse_aaaa(buffer: &[u8]) -> Result<Box<hostent_with_ttls>, Error> {
         let mut start: *mut struct_hostent = ptr::null_mut();
         let mut addr6ttls = [struct_ares_addr6ttl::default(); 256];
         let mut naddr6ttls: c_int = 256;
-        // SAFETY: c-ares FFI; `buffer` is a valid slice; out-params are valid
-        // stack pointers per contract.
-        let result = unsafe {
+        // SAFETY: `buffer` is a valid slice; out-params are live stack slots.
+        let rc = unsafe {
             ares_parse_aaaa_reply(
                 buffer.as_ptr(),
-                c_int::try_from(buffer.len()).unwrap_or(c_int::MAX),
+                c_len(buffer),
                 &raw mut start,
                 addr6ttls.as_mut_ptr(),
                 &raw mut naddr6ttls,
             )
         };
-        if result != ARES_SUCCESS {
-            return Err(Error::get(result).unwrap());
+        // SAFETY: on success c-ares hands over `start` for us to free.
+        let hostent =
+            parsed(rc, || unsafe { AresBox::from_raw(start) })?.ok_or(Error::ENOTFOUND)?;
+        let mut ttls = [-1; 256];
+        let n = usize::try_from(naddr6ttls).unwrap_or(0).min(256);
+        for (dst, src) in ttls.iter_mut().zip(&addr6ttls[..n]) {
+            *dst = src.ttl;
         }
-        let mut with_ttls = Box::new(hostent_with_ttls::default());
-        with_ttls.hostent = start;
-        for (i, ttl) in addr6ttls[..usize::try_from(naddr6ttls).expect("int cast")]
-            .iter()
-            .enumerate()
-        {
-            with_ttls.ttls[i] = ttl.ttl;
-        }
-        Ok(with_ttls)
+        Ok(Box::new(hostent_with_ttls { hostent, ttls }))
     }
 }
 
-impl Drop for hostent_with_ttls {
-    fn drop(&mut self) {
-        // SAFETY: hostent was allocated by ares_parse_*_reply (or null).
-        unsafe { ares_free_hostent(self.hostent) };
-    }
-}
-
-#[repr(C)]
-pub struct struct_nameinfo {
-    pub node: *mut u8,
-    pub service: *mut u8,
-}
-
-pub trait NameinfoHandler: Sized {
-    fn on_nameinfo(&mut self, status: Option<Error>, timeouts: i32, info: Option<struct_nameinfo>);
-}
-
-impl struct_nameinfo {
-    // toJSResponse alias deleted — lives in bun_runtime::dns_jsc.
-
-    pub(crate) unsafe extern "C" fn callback_wrapper<T: NameinfoHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        node: *mut u8,
-        service: *mut u8,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_nameinfo(Error::get(status), timeouts, None);
-            return;
-        }
-        this.on_nameinfo(None, timeouts, Some(struct_nameinfo { node, service }));
-    }
+/// The `(node, service)` strings `ares_getnameinfo` reports; borrowed for the
+/// duration of the completion callback.
+#[derive(Clone, Copy)]
+pub struct NameInfo<'a> {
+    pub node: Option<&'a [u8]>,
+    pub service: Option<&'a [u8]>,
 }
 
 bun_opaque::opaque_ffi! { pub struct struct_Channeldata; }
 
+// ──────────────────────────────────────────────────────────────────────────
+// ares_addrinfo
+// ──────────────────────────────────────────────────────────────────────────
+
 #[repr(C)]
 pub struct AddrInfo_cname {
-    pub ttl: c_int,
-    pub alias: *mut u8,
-    pub name: *mut u8,
-    pub next: *mut AddrInfo_cname,
+    ttl: c_int,
+    alias: *mut u8,
+    name: *mut u8,
+    next: *mut AddrInfo_cname,
 }
 
 #[repr(C)]
@@ -596,55 +651,46 @@ pub struct AddrInfo_node {
     pub family: c_int,
     pub socktype: c_int,
     pub protocol: c_int,
-    pub addrlen: ares_socklen_t,
-    pub addr: *mut sockaddr,
-    pub next: *mut AddrInfo_node,
+    addrlen: ares_socklen_t,
+    addr: *mut sockaddr,
+    next: *mut AddrInfo_node,
 }
+ares_linked_list!(AddrInfo_node);
 
 impl AddrInfo_node {
-    pub fn count(&self) -> u32 {
-        let mut len: u32 = 0;
-        let mut node: *const AddrInfo_node = self;
-        while !node.is_null() {
-            len += 1;
-            // SAFETY: node is non-null per loop condition; chain owned by c-ares.
-            node = unsafe { (*node).next };
+    /// The raw `sockaddr` bytes of this address (`addrlen` of them).
+    #[inline]
+    pub fn sockaddr_bytes(&self) -> &[u8] {
+        if self.addr.is_null() {
+            return &[];
         }
-        len
+        // SAFETY: c-ares allocates `addr` as an `addrlen`-byte sockaddr owned
+        // by the enclosing `ares_addrinfo` (which outlives `&self`).
+        unsafe { core::slice::from_raw_parts(self.addr.cast::<u8>(), self.addrlen as usize) }
     }
 }
 
 #[repr(C)]
 pub struct AddrInfo {
-    pub cnames_: *mut AddrInfo_cname,
-    pub node: *mut AddrInfo_node,
-    pub name_: *mut c_char,
-}
-
-pub trait AddrInfoHandler: Sized {
-    fn on_addr_info(&mut self, status: Option<Error>, timeouts: i32, results: *mut AddrInfo);
+    cnames_: *mut AddrInfo_cname,
+    node: *mut AddrInfo_node,
+    name_: *mut c_char,
 }
 
 impl AddrInfo {
-    // toJSArray alias deleted — lives in bun_runtime::dns_jsc.
-
-    // Consumers walk `cnames_` / `node` pointer chains directly.
-
-    pub(crate) unsafe extern "C" fn callback_wrapper<T: AddrInfoHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        addr_info: *mut AddrInfo,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        this.on_addr_info(Error::get(status), timeouts, addr_info);
+    /// The resolved addresses.
+    #[inline]
+    pub fn nodes(&self) -> impl Iterator<Item = &AddrInfo_node> {
+        // SAFETY: c-ares sets `node` to null or the head of a list it owns for
+        // this addrinfo's lifetime.
+        unsafe { self.node.as_ref() }
+            .into_iter()
+            .flat_map(AddrInfo_node::iter)
     }
 
-    /// FFI destroy — frees a c-ares-allocated addrinfo chain.
-    pub unsafe fn destroy(this: *mut AddrInfo) {
-        // SAFETY: caller guarantees `this` was allocated by c-ares (or is null).
-        unsafe { ares_freeaddrinfo(this) };
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.node.is_null()
     }
 }
 
@@ -659,6 +705,149 @@ pub struct AddrInfo_hints {
 // SAFETY: four `c_int` fields; all-zero is a valid hints value (S021).
 unsafe impl bun_core::ffi::Zeroable for AddrInfo_hints {}
 
+// ──────────────────────────────────────────────────────────────────────────
+// Completion handlers
+//
+// Every query hands c-ares a `Box<H>` as its callback argument; c-ares calls
+// back exactly once per query (with `ARES_ECANCELLED` / `ARES_EDESTRUCTION`
+// on cancel / channel destroy), and the thunk gives the box back to `H`.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Receiver for an `ares_query` reply of one record type.
+pub trait QueryHandler: Sized {
+    /// Record-type name (`"srv"`, `"ns"`, …) — `ns`/`soa` accept an empty name.
+    const LOOKUP_NAME: &'static str;
+    const NS_TYPE: NSType;
+    /// The parsed reply.
+    type Reply;
+    /// Parse the raw answer; `Ok(None)` is a well-formed answer with no data.
+    fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, Error>;
+    fn on_reply(self: Box<Self>, status: Option<Error>, timeouts: i32, reply: Option<Self::Reply>);
+}
+
+/// Receiver for `ares_getaddrinfo`.
+pub trait AddrInfoHandler: Sized {
+    fn on_addr_info(
+        self: Box<Self>,
+        status: Option<Error>,
+        timeouts: i32,
+        result: Option<AresBox<AddrInfo>>,
+    );
+}
+
+/// Receiver for `ares_gethostbyaddr`. The hostent is c-ares' and only valid
+/// during the call.
+pub trait HostentHandler: Sized {
+    fn on_hostent(
+        self: Box<Self>,
+        status: Option<Error>,
+        timeouts: i32,
+        hostent: Option<&struct_hostent>,
+    );
+}
+
+/// Receiver for `ares_getnameinfo`.
+pub trait NameInfoHandler: Sized {
+    fn on_nameinfo(
+        self: Box<Self>,
+        status: Option<Error>,
+        timeouts: i32,
+        info: Option<NameInfo<'_>>,
+    );
+}
+
+#[inline]
+fn into_arg<H>(ctx: Box<H>) -> *mut c_void {
+    Box::into_raw(ctx).cast::<c_void>()
+}
+
+unsafe extern "C" fn query_callback<H: QueryHandler>(
+    arg: *mut c_void,
+    status: c_int,
+    timeouts: c_int,
+    abuf: *mut u8,
+    alen: c_int,
+) {
+    // SAFETY: `arg` is the `Box<H>` `Channel::query` registered for exactly
+    // this one callback.
+    let this = unsafe { Box::from_raw(arg.cast::<H>()) };
+    if status != ARES_SUCCESS {
+        this.on_reply(Error::get(status), timeouts, None);
+        return;
+    }
+    // SAFETY: on success c-ares passes the answer it owns, `alen` bytes long.
+    let buffer = unsafe { core::slice::from_raw_parts(abuf, usize::try_from(alen).unwrap_or(0)) };
+    match H::parse(buffer) {
+        Ok(reply) => this.on_reply(None, timeouts, reply),
+        Err(err) => this.on_reply(Some(err), timeouts, None),
+    }
+}
+
+unsafe extern "C" fn addrinfo_callback<H: AddrInfoHandler>(
+    arg: *mut c_void,
+    status: c_int,
+    timeouts: c_int,
+    result: *mut AddrInfo,
+) {
+    // SAFETY: `arg` is the `Box<H>` `Channel::get_addr_info` registered for
+    // exactly this one callback; `result` is null or handed over for us to free.
+    let (this, result) = unsafe { (Box::from_raw(arg.cast::<H>()), AresBox::from_raw(result)) };
+    this.on_addr_info(Error::get(status), timeouts, result);
+}
+
+unsafe extern "C" fn host_callback<H: HostentHandler>(
+    arg: *mut c_void,
+    status: c_int,
+    timeouts: c_int,
+    hostent: *mut struct_hostent,
+) {
+    // SAFETY: `arg` is the `Box<H>` `Channel::get_host_by_addr` registered for
+    // exactly this one callback; `hostent` is null or c-ares' own, valid for
+    // the call.
+    let (this, hostent) = unsafe { (Box::from_raw(arg.cast::<H>()), hostent.as_ref()) };
+    if status != ARES_SUCCESS {
+        this.on_hostent(Error::get(status), timeouts, None);
+        return;
+    }
+    this.on_hostent(None, timeouts, hostent);
+}
+
+unsafe extern "C" fn nameinfo_callback<H: NameInfoHandler>(
+    arg: *mut c_void,
+    status: c_int,
+    timeouts: c_int,
+    node: *mut u8,
+    service: *mut u8,
+) {
+    // SAFETY: `arg` is the `Box<H>` `Channel::get_name_info` registered for
+    // exactly this one callback.
+    let this = unsafe { Box::from_raw(arg.cast::<H>()) };
+    if status != ARES_SUCCESS {
+        this.on_nameinfo(Error::get(status), timeouts, None);
+        return;
+    }
+    let opt = |p: *mut u8| {
+        if p.is_null() {
+            None
+        } else {
+            // SAFETY: c-ares passes NUL-terminated strings valid for the call.
+            Some(unsafe { c_str_bytes(p) })
+        }
+    };
+    this.on_nameinfo(
+        None,
+        timeouts,
+        Some(NameInfo {
+            node: opt(node),
+            service: opt(service),
+        }),
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Channel
+// ──────────────────────────────────────────────────────────────────────────
+
 #[derive(Copy, Clone, Default)]
 pub struct ChannelOptions {
     pub timeout: Option<i32>,
@@ -668,41 +857,53 @@ pub struct ChannelOptions {
 bun_opaque::opaque_ffi! {
     /// Opaque c-ares channel handle. `UnsafeCell` makes the type `!Freeze` so a
     /// `&Channel` does not assert immutability of the C-owned state (c-ares
-    /// mutates the channel on every dispatch/process call).
+    /// mutates the channel on every dispatch/process call, and its completion
+    /// callbacks re-enter through the same handle).
     pub struct Channel;
 }
-// Load-bearing: `ares_cancel`/`ares_process_fd` are declared `safe fn(&mut Channel)`
-// on the basis that re-entrant callbacks re-deriving `&mut Channel` from a raw
-// pointer cannot conflict because `Channel` claims zero bytes. If this type ever
-// gains a non-ZST field, those signatures must revert to `unsafe fn(*mut Channel)`.
-const _: () = assert!(core::mem::size_of::<Channel>() == 0);
 
-/// Implemented by the type that owns a `*mut Channel` and receives socket-
-/// state callbacks.
-///
-/// R-2: methods take `&self`. The c-ares `sock_state_cb` re-enters the
-/// container while a `&self` borrow may already be live in `on_dns_poll`;
-/// the implementor routes mutation through interior mutability.
-pub trait ChannelContainer: Sized {
-    fn on_dns_socket_state(&self, socket: ares_socket_t, readable: bool, writable: bool);
-    fn set_channel(&self, channel: *mut Channel);
+/// The owner of a live `ares_channel`; `ares_destroy` on drop, which fails
+/// every pending query with `ARES_EDESTRUCTION` into its callback and then
+/// reports each closed socket through the socket-state callback.
+pub struct OwnedChannel(NonNull<Channel>);
+
+impl core::ops::Deref for OwnedChannel {
+    type Target = Channel;
+    #[inline]
+    fn deref(&self) -> &Channel {
+        Channel::opaque_ref(self.0.as_ptr())
+    }
 }
 
-/// Trait for `Channel::resolve`: ties a lookup-name string to its NSType and
-/// the `extern "C"` parse-thunk used as the ares_callback.
-/// The dns_jsc consumer impls it per (T, record-type).
-pub trait ResolveHandler: Sized {
-    const LOOKUP_NAME: &'static [u8];
-    const NS_TYPE: NSType;
-    /// The `ares_callback`-compatible thunk that parses the reply and forwards
-    /// to `Self`.
-    unsafe extern "C" fn raw_callback(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
+impl Drop for OwnedChannel {
+    fn drop(&mut self) {
+        // SAFETY: the live channel `ares_init_options` returned to `Channel::init`.
+        unsafe { ares_destroy(self.0.as_ptr()) }
+    }
+}
+
+/// The object a channel reports socket-state changes to. It owns the
+/// [`OwnedChannel`] (so outlives it) and is reached re-entrantly from inside
+/// `process`/`cancel`/drop, hence the [`ThisPtr`](bun_ptr::ThisPtr) receiver.
+pub trait ChannelOwner: Sized {
+    fn on_socket_state(
+        this: bun_ptr::ThisPtr<Self>,
+        socket: ares_socket_t,
+        readable: bool,
+        writable: bool,
     );
+}
+
+unsafe extern "C" fn sock_state_callback<C: ChannelOwner>(
+    data: *mut c_void,
+    socket: ares_socket_t,
+    readable: c_int,
+    writable: c_int,
+) {
+    // SAFETY: `data` is the `owner` `Channel::init` registered, which owns the
+    // channel making this call and so is live.
+    let this = unsafe { bun_ptr::ThisPtr::new(data.cast::<C>()) };
+    C::on_socket_state(this, socket, readable != 0, writable != 0);
 }
 
 /// Copy `src` into the caller-owned stack `buf`, NUL-terminate, and return a
@@ -719,22 +920,15 @@ fn copy_nul_terminated(buf: &mut [u8], src: &[u8]) -> *const c_char {
 }
 
 impl Channel {
-    pub fn init<C: ChannelContainer>(this: &C, options: ChannelOptions) -> Option<Error> {
+    /// Create a channel reporting socket state to `*owner`, which must keep
+    /// the returned channel (and drop it before going away itself).
+    pub fn init<C: ChannelOwner>(
+        owner: bun_ptr::ThisPtr<C>,
+        options: ChannelOptions,
+    ) -> Result<OwnedChannel, Error> {
         let mut channel: *mut Channel = ptr::null_mut();
 
         library_init();
-
-        unsafe extern "C" fn on_sock_state<C: ChannelContainer>(
-            ctx: *mut c_void,
-            socket: ares_socket_t,
-            readable: c_int,
-            writable: c_int,
-        ) {
-            // SAFETY: `ctx` is the `&C` registered below; `on_dns_socket_state`
-            // takes `&self` (R-2) so the shared borrow is sufficient.
-            let container = unsafe { &*ctx.cast_const().cast::<C>() };
-            container.on_dns_socket_state(socket, readable != 0, writable != 0);
-        }
 
         let mut opts = Options {
             // Android note: c-ares can't auto-discover servers (no /etc/resolv.conf,
@@ -744,11 +938,8 @@ impl Channel {
             // channel to call ares_set_servers_ports). Letting the 127.0.0.1
             // default stand means setServers() works as the documented workaround.
             flags: ARES_FLAG_NOCHECKRESP,
-            sock_state_cb: Some(on_sock_state::<C>),
-            // R-2: `*mut` spelling is signature-only (c-ares stores a `void*`); the
-            // callback derefs as shared (`&*const`) and the implementor mutates via
-            // interior mutability.
-            sock_state_cb_data: std::ptr::from_ref::<C>(this).cast_mut().cast::<c_void>(),
+            sock_state_cb: Some(sock_state_callback::<C>),
+            sock_state_cb_data: owner.as_ptr().cast::<c_void>(),
             timeout: options.timeout.unwrap_or(-1),
             tries: options.tries.unwrap_or(4),
             ..Default::default()
@@ -769,26 +960,18 @@ impl Channel {
             // Don't `ares_library_cleanup()` here: `library_init()` is `run_once!`, so
             // tearing down the library on a per-channel failure would leave every later
             // `Channel::init()` running against an uninitialized c-ares.
-            return Some(err);
+            return Err(err);
         }
-
-        this.set_channel(channel);
-        None
-    }
-
-    /// FFI destroy — `ares_destroy`.
-    pub unsafe fn destroy(this: *mut Channel) {
-        // SAFETY: caller guarantees `this` is a live channel returned by `ares_init_options`.
-        unsafe { ares_destroy(this) };
+        Ok(OwnedChannel(NonNull::new(channel).ok_or(Error::ENOMEM)?))
     }
 
     /// See c-ares `ares_getaddrinfo` documentation.
-    pub fn get_addr_info<T: AddrInfoHandler>(
-        &mut self,
+    pub fn get_addr_info<H: AddrInfoHandler>(
+        &self,
         host: &[u8],
         port: u16,
         hints: &[AddrInfo_hints],
-        ctx: &mut T,
+        handler: Box<H>,
     ) {
         let mut host_buf = [0u8; 1024];
         let mut port_buf = [0u8; 21];
@@ -809,144 +992,184 @@ impl Channel {
         } else {
             ptr::null()
         };
-        // SAFETY: c-ares FFI; host/port/hints are NUL-terminated stack buffers or null; ctx outlives the channel.
+        // SAFETY: c-ares FFI; host/port/hints are NUL-terminated stack buffers
+        // or null; `handler` is given back to `addrinfo_callback` exactly once.
         unsafe {
             ares_getaddrinfo(
-                self,
+                self.as_mut_ptr(),
                 host_ptr,
                 port_ptr,
                 hints_,
-                AddrInfo::callback_wrapper::<T>,
-                std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
+                addrinfo_callback::<H>,
+                into_arg(handler),
             );
         }
     }
 
-    pub fn resolve<T: ResolveHandler>(&mut self, name: &[u8], ctx: &mut T) {
+    /// `ares_query` for `H`'s record type; names c-ares would reject are
+    /// failed synchronously with `EBADNAME` through the same handler.
+    pub fn query<H: QueryHandler>(&self, name: &[u8], handler: Box<H>) {
         if name.len() >= 1023
             || bun_core::strings::contains_char(name, 0)
-            || (name.is_empty() && !(T::LOOKUP_NAME == b"ns" || T::LOOKUP_NAME == b"soa"))
+            || (name.is_empty() && !(H::LOOKUP_NAME == "ns" || H::LOOKUP_NAME == "soa"))
         {
-            // SAFETY: thunk handles ARES_EBADNAME path.
-            unsafe {
-                T::raw_callback(
-                    std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
-                    ARES_EBADNAME,
-                    0,
-                    ptr::null_mut(),
-                    0,
-                )
-            };
+            handler.on_reply(Error::get(ARES_EBADNAME), 0, None);
             return;
         }
 
         let mut name_buf = [0u8; 1024];
         let name_ptr = copy_nul_terminated(&mut name_buf, name);
 
-        // SAFETY: c-ares FFI; name_ptr is a NUL-terminated stack buffer; ctx outlives the channel.
+        // SAFETY: c-ares FFI; `name_ptr` is a NUL-terminated stack buffer;
+        // `handler` is given back to `query_callback` exactly once.
         unsafe {
             ares_query(
-                self,
+                self.as_mut_ptr(),
                 name_ptr,
                 NSClass::ns_c_in,
-                T::NS_TYPE,
-                Some(T::raw_callback),
-                std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
+                H::NS_TYPE,
+                Some(query_callback::<H>),
+                into_arg(handler),
             );
         }
     }
 
-    pub fn get_host_by_addr<T: HostentHandler>(&mut self, ip_addr: &[u8], ctx: &mut T) {
+    /// `ares_gethostbyaddr`; an unparseable address fails synchronously with
+    /// `ENOTIMP` through the same handler.
+    pub fn get_host_by_addr<H: HostentHandler>(&self, ip_addr: &[u8], handler: Box<H>) {
         // "0000:0000:0000:0000:0000:ffff:192.168.100.228".length = 45
         const BUF_SIZE: usize = 46;
         let mut addr_buf = [0u8; BUF_SIZE];
-        let addr_ptr: *const c_char = 'brk: {
-            if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE {
-                break 'brk ptr::null();
-            }
-            copy_nul_terminated(&mut addr_buf, ip_addr)
-        };
-
-        // https://c-ares.org/ares_inet_pton.html
-        // https://github.com/c-ares/c-ares/blob/7f3262312f246556d8c1bdd8ccc1844847f42787/src/lib/ares_gethostbyaddr.c#L71-L72
-        // `ares_inet_pton` allows passing raw bytes as `dst`,
-        // which can avoid the use of `struct_in_addr` to reduce extra bytes.
-        let mut addr = [0u8; 16];
-        if !addr_ptr.is_null() {
-            // SAFETY: c-ares FFI; addr_ptr is a NUL-terminated stack buffer, addr is 16-byte stack scratch.
-            if unsafe { ares_inet_pton(AF::INET, addr_ptr, addr.as_mut_ptr().cast::<c_void>()) } > 0
-            {
-                // SAFETY: c-ares FFI; addr holds a 4-byte in_addr written by ares_inet_pton; ctx outlives the channel.
-                unsafe {
-                    ares_gethostbyaddr(
-                        self,
-                        addr.as_ptr().cast::<c_void>(),
-                        4,
-                        AF::INET,
-                        Some(struct_hostent::host_callback_wrapper::<T>),
-                        std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
-                    );
+        if !ip_addr.is_empty() && ip_addr.len() < BUF_SIZE {
+            copy_nul_terminated(&mut addr_buf, ip_addr);
+            let text = core::ffi::CStr::from_bytes_until_nul(&addr_buf).unwrap();
+            // https://c-ares.org/ares_inet_pton.html
+            // https://github.com/c-ares/c-ares/blob/7f3262312f246556d8c1bdd8ccc1844847f42787/src/lib/ares_gethostbyaddr.c#L71-L72
+            // `ares_inet_pton` allows passing raw bytes as `dst`,
+            // which can avoid the use of `struct_in_addr` to reduce extra bytes.
+            let mut addr = [0u8; 16];
+            for (family, len) in [(AF::INET, 4), (AF::INET6, 16)] {
+                if inet_pton(family, text, &mut addr) > 0 {
+                    // SAFETY: c-ares FFI; `addr` holds the `len`-byte address
+                    // `inet_pton` wrote; `handler` is given back to
+                    // `host_callback` exactly once.
+                    unsafe {
+                        ares_gethostbyaddr(
+                            self.as_mut_ptr(),
+                            addr.as_ptr().cast::<c_void>(),
+                            len,
+                            family,
+                            Some(host_callback::<H>),
+                            into_arg(handler),
+                        );
+                    }
+                    return;
                 }
-                return;
-            // SAFETY: c-ares FFI; addr_ptr is a NUL-terminated stack buffer, addr is 16-byte stack scratch.
-            } else if unsafe {
-                ares_inet_pton(AF::INET6, addr_ptr, addr.as_mut_ptr().cast::<c_void>())
-            } > 0
-            {
-                // SAFETY: c-ares FFI; addr holds a 16-byte in6_addr written by ares_inet_pton; ctx outlives the channel.
-                unsafe {
-                    ares_gethostbyaddr(
-                        self,
-                        addr.as_ptr().cast::<c_void>(),
-                        16,
-                        AF::INET6,
-                        Some(struct_hostent::host_callback_wrapper::<T>),
-                        std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
-                    );
-                }
-                return;
             }
         }
-        // SAFETY: invoking the thunk directly with ENOTIMP.
-        unsafe {
-            struct_hostent::host_callback_wrapper::<T>(
-                std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
-                ARES_ENOTIMP,
-                0,
-                ptr::null_mut(),
-            );
-        }
+        handler.on_hostent(Error::get(ARES_ENOTIMP), 0, None);
     }
 
     /// https://c-ares.org/ares_getnameinfo.html
-    pub fn get_name_info<T: NameinfoHandler>(&mut self, sa: &mut sockaddr, ctx: &mut T) {
-        let salen: ares_socklen_t = if sa.sa_family == AF::INET as _ {
-            core::mem::size_of::<sockaddr_in>() as ares_socklen_t
+    pub fn get_name_info<H: NameInfoHandler>(&self, sa: &sockaddr_storage, handler: Box<H>) {
+        let salen = if c_int::from(sa.ss_family) == AF::INET {
+            core::mem::size_of::<sockaddr_in>()
         } else {
-            core::mem::size_of::<sockaddr_in6>() as ares_socklen_t
+            core::mem::size_of::<sockaddr_in6>()
         };
-        // SAFETY: c-ares FFI; sa is a valid sockaddr of size `salen`; ctx outlives the channel.
+        // SAFETY: c-ares FFI; `sa` is a sockaddr_storage, which holds `salen`
+        // bytes for either family; `handler` is given back to
+        // `nameinfo_callback` exactly once.
         unsafe {
             ares_getnameinfo(
-                self,
-                std::ptr::from_ref::<sockaddr>(sa),
-                salen,
+                self.as_mut_ptr(),
+                ptr::from_ref(sa).cast::<sockaddr>(),
+                salen as ares_socklen_t,
                 // node returns ENOTFOUND for addresses like 255.255.255.255:80
                 // So, it requires setting the ARES_NI_NAMEREQD flag
                 ARES_NI_NAMEREQD | ARES_NI_LOOKUPHOST | ARES_NI_LOOKUPSERVICE,
-                Some(struct_nameinfo::callback_wrapper::<T>),
-                std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
+                Some(nameinfo_callback::<H>),
+                into_arg(handler),
             );
         }
     }
 
+    /// `ares_process_fd` — runs completion callbacks synchronously.
     #[inline]
-    pub fn process(&mut self, fd: ares_socket_t, readable: bool, writable: bool) {
-        ares_process_fd(
-            self,
-            if readable { fd } else { ARES_SOCKET_BAD },
-            if writable { fd } else { ARES_SOCKET_BAD },
-        );
+    pub fn process(&self, fd: ares_socket_t, readable: bool, writable: bool) {
+        // SAFETY: live channel handle plus scalars.
+        unsafe {
+            ares_process_fd(
+                self.as_mut_ptr(),
+                if readable { fd } else { ARES_SOCKET_BAD },
+                if writable { fd } else { ARES_SOCKET_BAD },
+            )
+        }
+    }
+
+    /// `ares_cancel` — fails every pending query with `ECANCELLED` into its callback.
+    #[inline]
+    pub fn cancel(&self) {
+        // SAFETY: live channel handle.
+        unsafe { ares_cancel(self.as_mut_ptr()) }
+    }
+
+    /// Number of queries not yet completed.
+    #[inline]
+    pub fn active_queries(&self) -> usize {
+        // SAFETY: live channel handle.
+        unsafe { ares_queue_active_queries(self.as_mut_ptr()) }
+    }
+
+    #[inline]
+    pub fn set_local_ip4(&self, ip: u32) {
+        // SAFETY: live channel handle plus a scalar.
+        unsafe { ares_set_local_ip4(self.as_mut_ptr(), ip) }
+    }
+
+    #[inline]
+    pub fn set_local_ip6(&self, ip6: &[u8; 16]) {
+        // SAFETY: live channel handle; c-ares copies the 16 bytes.
+        unsafe { ares_set_local_ip6(self.as_mut_ptr(), ip6.as_ptr()) }
+    }
+
+    /// `ares_get_servers_ports`: the configured servers (`None` if there are none).
+    pub fn servers(&self) -> Result<Option<AresBox<struct_ares_addr_port_node>>, Error> {
+        let mut servers: *mut struct_ares_addr_port_node = ptr::null_mut();
+        // SAFETY: live channel handle; `servers` is a stack out-param whose
+        // result c-ares hands over for us to free.
+        let rc = unsafe { ares_get_servers_ports(self.as_mut_ptr(), &raw mut servers) };
+        // SAFETY: as above.
+        parsed(rc, || unsafe { AresBox::from_raw(servers) })
+    }
+
+    /// `ares_set_servers_ports` with `servers` in order (c-ares copies them);
+    /// an empty slice clears the list.
+    pub fn set_servers(&self, servers: &mut [struct_ares_addr_port_node]) -> Result<(), Error> {
+        let base = servers.as_mut_ptr();
+        for i in 0..servers.len() {
+            servers[i].next = if i + 1 < servers.len() {
+                // SAFETY: `i + 1` is in bounds of `servers`.
+                unsafe { base.add(i + 1) }
+            } else {
+                ptr::null_mut()
+            };
+        }
+        let head = if servers.is_empty() {
+            ptr::null_mut()
+        } else {
+            base
+        };
+        // SAFETY: live channel handle; `head` is null or a list linked within
+        // `servers`, which outlives the call.
+        let rc = unsafe { ares_set_servers_ports(self.as_mut_ptr(), head) };
+        for server in servers.iter_mut() {
+            server.next = ptr::null_mut();
+        }
+        if rc != ARES_SUCCESS {
+            return Err(Error::get(rc).unwrap());
+        }
+        Ok(())
     }
 }
 
@@ -967,14 +1190,12 @@ fn library_init() {
     }}
 }
 
-pub(crate) type ares_callback =
-    Option<unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int)>;
-pub(crate) type ares_host_callback =
+type ares_callback = Option<unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int)>;
+type ares_host_callback =
     Option<unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut struct_hostent)>;
-pub(crate) type ares_nameinfo_callback =
+type ares_nameinfo_callback =
     Option<unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, *mut u8)>;
-pub(crate) type ares_addrinfo_callback =
-    unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut AddrInfo);
+type ares_addrinfo_callback = unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut AddrInfo);
 
 unsafe extern "C" {
     fn ares_library_init_mem(
@@ -983,23 +1204,16 @@ unsafe extern "C" {
         afree: Option<unsafe extern "C" fn(*mut c_void)>,
         arealloc: Option<unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void>,
     ) -> c_int;
-    pub fn ares_init_options(
+    fn ares_init_options(
         channelptr: *mut *mut Channel,
         options: *mut Options,
         optmask: c_int,
     ) -> c_int;
-    pub fn ares_destroy(channel: *mut Channel);
-    // Opaque handle by exclusive reference only — `Channel` is `!Freeze`/`!Sync`
-    // (UnsafeCell + PhantomData<*mut u8>). Note: `ares_cancel`/`ares_process_fd`
-    // synchronously invoke stored completion callbacks which may re-enter the
-    // resolver and re-derive a `&mut Channel` from a raw pointer; this is sound
-    // because `Channel` is a ZST (`UnsafeCell<[u8;0]>`), so `&mut Channel`
-    // claims zero bytes and overlapping `&mut` do not conflict under Stacked
-    // Borrows — the borrow checker does NOT gate the raw-pointer callbacks.
-    pub safe fn ares_cancel(channel: &mut Channel);
-    pub safe fn ares_set_local_ip4(channel: &mut Channel, local_ip: c_uint);
-    pub fn ares_set_local_ip6(channel: *mut Channel, local_ip6: *const u8);
-    pub fn ares_getaddrinfo(
+    fn ares_destroy(channel: *mut Channel);
+    fn ares_cancel(channel: *mut Channel);
+    fn ares_set_local_ip4(channel: *mut Channel, local_ip: c_uint);
+    fn ares_set_local_ip6(channel: *mut Channel, local_ip6: *const u8);
+    fn ares_getaddrinfo(
         channel: *mut Channel,
         node: *const c_char,
         service: *const c_char,
@@ -1007,11 +1221,8 @@ unsafe extern "C" {
         callback: ares_addrinfo_callback,
         arg: *mut c_void,
     );
-    pub fn ares_freeaddrinfo(ai: *mut AddrInfo);
-}
-
-unsafe extern "C" {
-    pub fn ares_query(
+    fn ares_freeaddrinfo(ai: *mut AddrInfo);
+    fn ares_query(
         channel: *mut Channel,
         name: *const c_char,
         dnsclass: NSClass,
@@ -1019,7 +1230,7 @@ unsafe extern "C" {
         callback: ares_callback,
         arg: *mut c_void,
     );
-    pub fn ares_gethostbyaddr(
+    fn ares_gethostbyaddr(
         channel: *mut Channel,
         addr: *const c_void,
         addrlen: c_int,
@@ -1027,7 +1238,7 @@ unsafe extern "C" {
         callback: ares_host_callback,
         arg: *mut c_void,
     );
-    pub fn ares_getnameinfo(
+    fn ares_getnameinfo(
         channel: *mut Channel,
         sa: *const sockaddr,
         salen: ares_socklen_t,
@@ -1035,14 +1246,8 @@ unsafe extern "C" {
         callback: ares_nameinfo_callback,
         arg: *mut c_void,
     );
-    // Opaque handle by exclusive reference + scalars only.
-    pub safe fn ares_process_fd(
-        channel: &mut Channel,
-        read_fd: ares_socket_t,
-        write_fd: ares_socket_t,
-    );
-    // Pure read of opaque `!Sync` handle.
-    pub safe fn ares_queue_active_queries(channel: &Channel) -> usize;
+    fn ares_process_fd(channel: *mut Channel, read_fd: ares_socket_t, write_fd: ares_socket_t);
+    fn ares_queue_active_queries(channel: *const Channel) -> usize;
 }
 
 #[repr(C)]
@@ -1082,89 +1287,74 @@ impl Default for struct_ares_addr6ttl {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Generic reply-record plumbing. The six `struct_ares_{caa,srv,mx,txt,naptr,soa}_reply`
-// types share an identical c-ares callback thunk modulo (reply type, parse fn),
-// and all six `ares_parse_*_reply` externs share the signature
-// `(abuf *const u8, alen c_int, out *mut *mut R) -> c_int`. Collapsed from six
-// copy-pasted `callback_wrapper` bodies + six per-type handler traits.
+// Reply records. The six `struct_ares_{caa,srv,mx,txt,naptr,soa}_reply`
+// parsers share the signature `(abuf, alen, out *mut *mut R) -> c_int`.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// A c-ares reply record whose parser has the canonical 3-arg signature.
-pub trait AresReply: Sized {
-    /// SAFETY: thin forward to the matching `ares_parse_*_reply` extern.
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int;
+pub trait AresReply: AresAllocated + Sized {
+    /// # Safety
+    /// Thin forward to the matching `ares_parse_*_reply` extern.
+    unsafe fn parse_raw(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int;
+
+    /// Parse a raw answer into an owned reply (`None`: parsed, but empty).
+    fn parse(buffer: &[u8]) -> Result<Option<AresBox<Self>>, Error> {
+        let mut start: *mut Self = ptr::null_mut();
+        // SAFETY: `buffer` is a valid slice; `start` is a live stack slot.
+        let rc = unsafe { Self::parse_raw(buffer.as_ptr(), c_len(buffer), &raw mut start) };
+        // SAFETY: on success c-ares hands over `start` for us to free.
+        parsed(rc, || unsafe { AresBox::from_raw(start) })
+    }
 }
 
-/// Receiver for a parsed `R` reply (replaces the per-type `*Handler` traits).
-pub trait ReplyHandler<R: AresReply>: Sized {
-    fn on_reply(&mut self, status: Option<Error>, timeouts: i32, results: *mut R);
+macro_rules! ares_reply_parsers {
+    ($($t:ty => $parse:ident),+ $(,)?) => {$(
+        impl AresReply for $t {
+            unsafe fn parse_raw(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
+                // SAFETY: caller upholds the `parse_raw` contract; thin FFI forward.
+                unsafe { $parse(abuf, alen, out) }
+            }
+        }
+    )+};
 }
-
-/// Generic `ares_callback` thunk. Monomorphized per `(R, T)` to a concrete
-/// `unsafe extern "C" fn`, so the fn-pointer ABI passed to `ares_query` is
-/// identical to the former hand-rolled `callback_wrapper`s.
-pub unsafe extern "C" fn ares_reply_callback<R: AresReply, T: ReplyHandler<R>>(
-    ctx: *mut c_void,
-    status: c_int,
-    timeouts: c_int,
-    buffer: *mut u8,
-    buffer_length: c_int,
-) {
-    // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-    let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-    if status != ARES_SUCCESS {
-        this.on_reply(Error::get(status), timeouts, ptr::null_mut());
-        return;
-    }
-    let mut start: *mut R = ptr::null_mut();
-    // SAFETY: c-ares FFI; pointers are valid stack/null per contract.
-    let result = unsafe { R::parse(buffer, buffer_length, &raw mut start) };
-    if result != ARES_SUCCESS {
-        this.on_reply(Error::get(result), timeouts, ptr::null_mut());
-        return;
-    }
-    this.on_reply(None, timeouts, start);
-}
+ares_reply_parsers!(
+    struct_ares_caa_reply => ares_parse_caa_reply,
+    struct_ares_srv_reply => ares_parse_srv_reply,
+    struct_ares_mx_reply => ares_parse_mx_reply,
+    struct_ares_txt_reply => ares_parse_txt_reply,
+    struct_ares_naptr_reply => ares_parse_naptr_reply,
+    struct_ares_soa_reply => ares_parse_soa_reply,
+);
 
 #[repr(C)]
 pub struct struct_ares_caa_reply {
-    pub next: *mut struct_ares_caa_reply,
+    next: *mut struct_ares_caa_reply,
     pub critical: c_int,
-    pub(crate) property: *mut u8,
-    pub(crate) plength: usize,
-    pub(crate) value: *mut u8,
-    pub(crate) length: usize,
-}
-
-impl AresReply for struct_ares_caa_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_caa_reply(abuf, alen, out) }
-    }
+    property: *mut u8,
+    plength: usize,
+    value: *mut u8,
+    length: usize,
 }
 
 impl struct_ares_caa_reply {
-    /// Safe view of the c-ares-owned property tag bytes.
+    /// The property tag bytes.
     #[inline]
     pub fn property_bytes(&self) -> &[u8] {
         if self.property.is_null() {
             &[]
         } else {
-            // SAFETY: c-ares allocates `property` as a contiguous buffer of
-            // `plength` bytes that lives until `ares_free_data` is called on the
-            // list head; the `&self` borrow is shorter than that. c-ares never
-            // sets a non-zero length with a null pointer.
+            // SAFETY: c-ares allocates `property` as `plength` bytes owned by
+            // this node for `&self`'s lifetime.
             unsafe { core::slice::from_raw_parts(self.property, self.plength) }
         }
     }
-    /// Safe view of the c-ares-owned value bytes.
+    /// The value bytes.
     #[inline]
     pub fn value_bytes(&self) -> &[u8] {
         if self.value.is_null() {
             &[]
         } else {
-            // SAFETY: same invariant as `property_bytes` — `value` points to
-            // `length` bytes owned by the reply node for `&self`'s lifetime.
+            // SAFETY: as `property_bytes`, for `value`/`length`.
             unsafe { core::slice::from_raw_parts(self.value, self.length) }
         }
     }
@@ -1172,57 +1362,52 @@ impl struct_ares_caa_reply {
 
 #[repr(C)]
 pub struct struct_ares_srv_reply {
-    pub next: *mut struct_ares_srv_reply,
-    pub host: *mut u8,
+    next: *mut struct_ares_srv_reply,
+    host: *mut u8,
     pub priority: c_ushort,
     pub weight: c_ushort,
     pub port: c_ushort,
 }
 
-impl AresReply for struct_ares_srv_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_srv_reply(abuf, alen, out) }
+impl struct_ares_srv_reply {
+    #[inline]
+    pub fn host_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `host` to a NUL-terminated string this node owns.
+        unsafe { c_str_bytes(self.host) }
     }
 }
 
 #[repr(C)]
 pub struct struct_ares_mx_reply {
-    pub next: *mut struct_ares_mx_reply,
-    pub host: *mut u8,
+    next: *mut struct_ares_mx_reply,
+    host: *mut u8,
     pub priority: c_ushort,
 }
 
-impl AresReply for struct_ares_mx_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_mx_reply(abuf, alen, out) }
+impl struct_ares_mx_reply {
+    #[inline]
+    pub fn host_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `host` to a NUL-terminated string this node owns.
+        unsafe { c_str_bytes(self.host) }
     }
 }
 
 #[repr(C)]
 pub struct struct_ares_txt_reply {
-    pub next: *mut struct_ares_txt_reply,
-    pub(crate) txt: *mut u8,
-    pub(crate) length: usize,
-}
-
-impl AresReply for struct_ares_txt_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_txt_reply(abuf, alen, out) }
-    }
+    next: *mut struct_ares_txt_reply,
+    txt: *mut u8,
+    length: usize,
 }
 
 impl struct_ares_txt_reply {
-    /// Safe view of the c-ares-owned TXT record bytes.
+    /// The TXT record bytes.
     #[inline]
     pub fn txt_bytes(&self) -> &[u8] {
         if self.txt.is_null() {
             &[]
         } else {
-            // SAFETY: c-ares allocates `txt` as `length` bytes that live until
-            // `ares_free_data` on the list head; `&self` is the shorter borrow.
+            // SAFETY: c-ares allocates `txt` as `length` bytes owned by this
+            // node for `&self`'s lifetime.
             unsafe { core::slice::from_raw_parts(self.txt, self.length) }
         }
     }
@@ -1230,26 +1415,42 @@ impl struct_ares_txt_reply {
 
 #[repr(C)]
 pub struct struct_ares_naptr_reply {
-    pub next: *mut struct_ares_naptr_reply,
-    pub flags: *mut u8,
-    pub service: *mut u8,
-    pub regexp: *mut u8,
-    pub replacement: *mut u8,
+    next: *mut struct_ares_naptr_reply,
+    flags: *mut u8,
+    service: *mut u8,
+    regexp: *mut u8,
+    replacement: *mut u8,
     pub order: c_ushort,
     pub preference: c_ushort,
 }
 
-impl AresReply for struct_ares_naptr_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_naptr_reply(abuf, alen, out) }
+impl struct_ares_naptr_reply {
+    #[inline]
+    pub fn flags_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `flags` to a NUL-terminated string this node owns.
+        unsafe { c_str_bytes(self.flags) }
+    }
+    #[inline]
+    pub fn service_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `service` to a NUL-terminated string this node owns.
+        unsafe { c_str_bytes(self.service) }
+    }
+    #[inline]
+    pub fn regexp_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `regexp` to a NUL-terminated string this node owns.
+        unsafe { c_str_bytes(self.regexp) }
+    }
+    #[inline]
+    pub fn replacement_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `replacement` to a NUL-terminated string this node owns.
+        unsafe { c_str_bytes(self.replacement) }
     }
 }
 
 #[repr(C)]
 pub struct struct_ares_soa_reply {
-    pub nsname: *mut u8,
-    pub hostmaster: *mut u8,
+    nsname: *mut u8,
+    hostmaster: *mut u8,
     pub serial: c_uint,
     pub refresh: c_uint,
     pub retry: c_uint,
@@ -1257,240 +1458,155 @@ pub struct struct_ares_soa_reply {
     pub minttl: c_uint,
 }
 
-impl AresReply for struct_ares_soa_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_soa_reply(abuf, alen, out) }
+impl struct_ares_soa_reply {
+    #[inline]
+    pub fn nsname_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `nsname` to a NUL-terminated string this reply owns.
+        unsafe { c_str_bytes(self.nsname) }
+    }
+    #[inline]
+    pub fn hostmaster_bytes(&self) -> &[u8] {
+        // SAFETY: c-ares sets `hostmaster` to a NUL-terminated string this reply owns.
+        unsafe { c_str_bytes(self.hostmaster) }
     }
 }
 
+ares_linked_list!(
+    struct_ares_caa_reply,
+    struct_ares_srv_reply,
+    struct_ares_mx_reply,
+    struct_ares_txt_reply,
+    struct_ares_naptr_reply,
+    struct_ares_addr_port_node,
+);
+
+/// Everything an `ANY` query answered, per record type.
+#[derive(Default)]
 pub struct struct_any_reply {
     pub a_reply: Option<Box<hostent_with_ttls>>,
     pub aaaa_reply: Option<Box<hostent_with_ttls>>,
-    pub mx_reply: *mut struct_ares_mx_reply,
-    pub ns_reply: *mut struct_hostent,
-    pub txt_reply: *mut struct_ares_txt_reply,
-    pub srv_reply: *mut struct_ares_srv_reply,
-    pub ptr_reply: *mut struct_hostent,
-    pub naptr_reply: *mut struct_ares_naptr_reply,
-    pub soa_reply: *mut struct_ares_soa_reply,
-    pub caa_reply: *mut struct_ares_caa_reply,
-}
-
-impl Default for struct_any_reply {
-    fn default() -> Self {
-        Self {
-            a_reply: None,
-            aaaa_reply: None,
-            mx_reply: ptr::null_mut(),
-            ns_reply: ptr::null_mut(),
-            txt_reply: ptr::null_mut(),
-            srv_reply: ptr::null_mut(),
-            ptr_reply: ptr::null_mut(),
-            naptr_reply: ptr::null_mut(),
-            soa_reply: ptr::null_mut(),
-            caa_reply: ptr::null_mut(),
-        }
-    }
-}
-
-pub trait AnyHandler: Sized {
-    fn on_any(
-        &mut self,
-        status: Option<Error>,
-        timeouts: i32,
-        results: Option<Box<struct_any_reply>>,
-    );
+    pub mx_reply: Option<AresBox<struct_ares_mx_reply>>,
+    pub ns_reply: Option<AresBox<struct_hostent>>,
+    pub txt_reply: Option<AresBox<struct_ares_txt_reply>>,
+    pub srv_reply: Option<AresBox<struct_ares_srv_reply>>,
+    pub ptr_reply: Option<AresBox<struct_hostent>>,
+    pub naptr_reply: Option<AresBox<struct_ares_naptr_reply>>,
+    pub soa_reply: Option<AresBox<struct_ares_soa_reply>>,
+    pub caa_reply: Option<AresBox<struct_ares_caa_reply>>,
 }
 
 impl struct_any_reply {
-    // toJSResponse / toJS aliases deleted.
-
-    pub unsafe extern "C" fn callback_wrapper<T: AnyHandler>(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
-    ) {
-        // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
-        let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        if status != ARES_SUCCESS {
-            this.on_any(Error::get(status), timeouts, None);
-            return;
-        }
-        // SAFETY: c-ares guarantees `buffer` is non-null and readable for
-        // `buffer_length` bytes on a successful callback.
-        let buffer = unsafe {
-            core::slice::from_raw_parts(buffer, usize::try_from(buffer_length).unwrap_or(0))
-        };
-        match Self::parse(buffer) {
-            Ok(reply) => this.on_any(None, timeouts, Some(reply)),
-            Err(err) => this.on_any(Some(err), timeouts, None),
-        }
-    }
-
-    /// Parse a DNS `ANY` reply buffer into a heap-allocated aggregate. Returns
-    /// the last per-record parse error if no record type parsed successfully.
-    pub(crate) fn parse(buffer: &[u8]) -> Result<Box<Self>, Error> {
+    /// Parse a DNS `ANY` reply buffer. Returns the last per-record parse error
+    /// if no record type parsed successfully.
+    pub fn parse(buffer: &[u8]) -> Result<Box<Self>, Error> {
         let mut any_success = false;
-        let mut last_error: Option<c_int> = None;
+        let mut last_error: Option<Error> = None;
         let mut reply = Box::new(struct_any_reply::default());
-        let abuf = buffer.as_ptr();
-        let alen = c_int::try_from(buffer.len()).unwrap_or(c_int::MAX);
 
-        match hostent_with_ttls::parse_a(buffer) {
-            Ok(result) => {
-                reply.a_reply = Some(result);
-                any_success = true;
+        fn note<T>(
+            r: Result<T, Error>,
+            any_success: &mut bool,
+            last_error: &mut Option<Error>,
+        ) -> Option<T> {
+            match r {
+                Ok(v) => {
+                    *any_success = true;
+                    Some(v)
+                }
+                Err(e) => {
+                    *last_error = Some(e);
+                    None
+                }
             }
-            Err(err) => last_error = Some(err as c_int),
         }
 
-        match hostent_with_ttls::parse_aaaa(buffer) {
-            Ok(result) => {
-                reply.aaaa_reply = Some(result);
-                any_success = true;
-            }
-            Err(err) => last_error = Some(err as c_int),
-        }
-
-        // SAFETY: c-ares FFI; `abuf[..alen]` is a valid slice; out-params are
-        // valid stack pointers per contract.
-        let mut result = unsafe { ares_parse_mx_reply(abuf, alen, &raw mut reply.mx_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_ns_reply(abuf, alen, &raw mut reply.ns_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_txt_reply(abuf, alen, &raw mut reply.txt_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_srv_reply(abuf, alen, &raw mut reply.srv_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe {
-            ares_parse_ptr_reply(
-                abuf,
-                alen,
-                ptr::null(),
-                0,
-                AF::INET,
-                &raw mut reply.ptr_reply,
-            )
-        };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_naptr_reply(abuf, alen, &raw mut reply.naptr_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_soa_reply(abuf, alen, &raw mut reply.soa_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
-
-        // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_caa_reply(abuf, alen, &raw mut reply.caa_reply) };
-        if result == ARES_SUCCESS {
-            any_success = true;
-        } else {
-            last_error = Some(result);
-        }
+        reply.a_reply = note(
+            hostent_with_ttls::parse_a(buffer),
+            &mut any_success,
+            &mut last_error,
+        );
+        reply.aaaa_reply = note(
+            hostent_with_ttls::parse_aaaa(buffer),
+            &mut any_success,
+            &mut last_error,
+        );
+        reply.mx_reply = note(
+            struct_ares_mx_reply::parse(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.ns_reply = note(
+            struct_hostent::parse_ns(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.txt_reply = note(
+            struct_ares_txt_reply::parse(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.srv_reply = note(
+            struct_ares_srv_reply::parse(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.ptr_reply = note(
+            struct_hostent::parse_ptr(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.naptr_reply = note(
+            struct_ares_naptr_reply::parse(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.soa_reply = note(
+            struct_ares_soa_reply::parse(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
+        reply.caa_reply = note(
+            struct_ares_caa_reply::parse(buffer),
+            &mut any_success,
+            &mut last_error,
+        )
+        .flatten();
 
         if !any_success {
-            return Err(Error::get(last_error.unwrap()).unwrap());
+            return Err(last_error.unwrap());
         }
         Ok(reply)
     }
 }
 
-impl Drop for struct_any_reply {
-    fn drop(&mut self) {
-        // a_reply / aaaa_reply are Box<hostent_with_ttls>; their Drop frees the
-        // inner hostent via ares_free_hostent.
-        // SAFETY: each field is either null or a c-ares allocation matching its free fn.
-        unsafe {
-            if !self.mx_reply.is_null() {
-                ares_free_data(self.mx_reply.cast::<c_void>());
-            }
-            if !self.ns_reply.is_null() {
-                ares_free_hostent(self.ns_reply);
-            }
-            if !self.txt_reply.is_null() {
-                ares_free_data(self.txt_reply.cast::<c_void>());
-            }
-            if !self.srv_reply.is_null() {
-                ares_free_data(self.srv_reply.cast::<c_void>());
-            }
-            if !self.ptr_reply.is_null() {
-                ares_free_hostent(self.ptr_reply);
-            }
-            if !self.naptr_reply.is_null() {
-                ares_free_data(self.naptr_reply.cast::<c_void>());
-            }
-            if !self.soa_reply.is_null() {
-                ares_free_data(self.soa_reply.cast::<c_void>());
-            }
-            if !self.caa_reply.is_null() {
-                ares_free_data(self.caa_reply.cast::<c_void>());
-            }
-        }
-    }
-}
-
 unsafe extern "C" {
-    pub fn ares_parse_a_reply(
+    fn ares_parse_a_reply(
         abuf: *const u8,
         alen: c_int,
         host: *mut *mut struct_hostent,
         addrttls: *mut struct_ares_addrttl,
         naddrttls: *mut c_int,
     ) -> c_int;
-    pub fn ares_parse_aaaa_reply(
+    fn ares_parse_aaaa_reply(
         abuf: *const u8,
         alen: c_int,
         host: *mut *mut struct_hostent,
         addrttls: *mut struct_ares_addr6ttl,
         naddrttls: *mut c_int,
     ) -> c_int;
-    pub fn ares_parse_caa_reply(
+    fn ares_parse_caa_reply(
         abuf: *const u8,
         alen: c_int,
         caa_out: *mut *mut struct_ares_caa_reply,
     ) -> c_int;
-    pub fn ares_parse_ptr_reply(
+    fn ares_parse_ptr_reply(
         abuf: *const u8,
         alen: c_int,
         addr: *const c_void,
@@ -1498,38 +1614,34 @@ unsafe extern "C" {
         family: c_int,
         host: *mut *mut struct_hostent,
     ) -> c_int;
-    pub fn ares_parse_ns_reply(
-        abuf: *const u8,
-        alen: c_int,
-        host: *mut *mut struct_hostent,
-    ) -> c_int;
-    pub fn ares_parse_srv_reply(
+    fn ares_parse_ns_reply(abuf: *const u8, alen: c_int, host: *mut *mut struct_hostent) -> c_int;
+    fn ares_parse_srv_reply(
         abuf: *const u8,
         alen: c_int,
         srv_out: *mut *mut struct_ares_srv_reply,
     ) -> c_int;
-    pub fn ares_parse_mx_reply(
+    fn ares_parse_mx_reply(
         abuf: *const u8,
         alen: c_int,
         mx_out: *mut *mut struct_ares_mx_reply,
     ) -> c_int;
-    pub fn ares_parse_txt_reply(
+    fn ares_parse_txt_reply(
         abuf: *const u8,
         alen: c_int,
         txt_out: *mut *mut struct_ares_txt_reply,
     ) -> c_int;
-    pub fn ares_parse_naptr_reply(
+    fn ares_parse_naptr_reply(
         abuf: *const u8,
         alen: c_int,
         naptr_out: *mut *mut struct_ares_naptr_reply,
     ) -> c_int;
-    pub fn ares_parse_soa_reply(
+    fn ares_parse_soa_reply(
         abuf: *const u8,
         alen: c_int,
         soa_out: *mut *mut struct_ares_soa_reply,
     ) -> c_int;
-    pub fn ares_free_hostent(host: *mut struct_hostent);
-    pub fn ares_free_data(dataptr: *mut c_void);
+    fn ares_free_hostent(host: *mut struct_hostent);
+    fn ares_free_data(dataptr: *mut c_void);
 }
 
 #[repr(C)]
@@ -1537,42 +1649,64 @@ unsafe extern "C" {
 union union_unnamed_4 {
     addr4: in_addr,
     addr6: struct_ares_in6_addr,
+    bytes: [u8; 16],
 }
 
+/// One DNS server entry (`ares_addr_port_node`).
 #[repr(C)]
 pub struct struct_ares_addr_port_node {
-    pub next: *mut struct_ares_addr_port_node,
+    next: *mut struct_ares_addr_port_node,
     pub family: c_int,
     addr: union_unnamed_4,
     pub udp_port: c_int,
     pub tcp_port: c_int,
 }
-// SAFETY: `#[repr(C)]` POD — raw ptr, `c_int`s, and a byte-array union.
-// All-zero is the state callers fill before `ares_inet_pton` (S021).
-unsafe impl bun_core::ffi::Zeroable for struct_ares_addr_port_node {}
 
 impl struct_ares_addr_port_node {
-    /// Type-erased pointer to the in_addr/in6_addr union, for `ares_inet_ntop`.
-    /// The union field stays private (active arm depends on `family`), but
-    /// callers need its address to round-trip through c-ares' presentation
-    /// converters.
-    #[inline]
-    pub fn addr_ptr(&self) -> *const c_void {
-        ptr::addr_of!(self.addr).cast::<c_void>()
+    /// An unlinked entry for [`Channel::set_servers`]; `addr` holds the
+    /// network-order address (4 bytes used for `AF_INET`).
+    pub fn new(family: c_int, addr: &[u8; 16], udp_port: c_int, tcp_port: c_int) -> Self {
+        Self {
+            next: ptr::null_mut(),
+            family,
+            addr: union_unnamed_4 { bytes: *addr },
+            udp_port,
+            tcp_port,
+        }
     }
-    /// Mutable counterpart of `addr_ptr` for `ares_inet_pton` to fill.
-    #[inline]
-    pub fn addr_mut_ptr(&mut self) -> *mut c_void {
-        ptr::addr_of_mut!(self.addr).cast::<c_void>()
+
+    /// The address in presentation form, written into `dst` (NUL-terminated
+    /// there); `None` if `dst` is too small.
+    pub fn ip_text<'a>(&self, dst: &'a mut [u8]) -> Option<&'a [u8]> {
+        // SAFETY: `addr` is the in_addr/in6_addr union for `family`; `dst` is a
+        // slice, so valid for `dst.len()` writes.
+        unsafe { crate::ntop(self.family, ptr::addr_of!(self.addr).cast::<c_void>(), dst) }
     }
 }
 
+/// https://c-ares.org/docs/ares_inet_pton.html into a 16-byte buffer (4 used
+/// for `AF_INET`).
+///
+/// ## Returns
+/// - `1` if `src` was valid for the specified address family
+/// - `0` if `src` was not parseable in the specified address family
+/// - `-1` if some system error occurred. `errno` will have been set.
+#[inline]
+pub fn inet_pton(af: c_int, src: &core::ffi::CStr, dst: &mut [u8; 16]) -> c_int {
+    if af != AF::INET && af != AF::INET6 {
+        return -1;
+    }
+    // SAFETY: `src` is NUL-terminated; `dst` has room for the largest (16-byte)
+    // address `af` can produce.
+    unsafe { ares_inet_pton(af, src.as_ptr(), dst.as_mut_ptr().cast::<c_void>()) }
+}
+
 unsafe extern "C" {
-    pub fn ares_set_servers_ports(
+    fn ares_set_servers_ports(
         channel: *mut Channel,
         servers: *mut struct_ares_addr_port_node,
     ) -> c_int;
-    pub fn ares_get_servers_ports(
+    fn ares_get_servers_ports(
         channel: *mut Channel,
         servers: *mut *mut struct_ares_addr_port_node,
     ) -> c_int;
@@ -1871,72 +2005,60 @@ pub const ARES_SOCKET_BAD: ares_socket_t = -1;
 
 // Bun__canonicalizeIP_ host fn: see bun_runtime::dns_jsc::cares_jsc
 
-/// Creates a sockaddr structure from an address, port.
-///
-/// # Parameters
-/// - `addr`: A byte slice representing the IP address.
-/// - `port`: A 16-bit unsigned integer representing the port number.
-/// - `sa`: A pointer to a sockaddr structure where the result will be stored.
-///
-/// # Returns
-///
-/// This function returns 0 on success.
-pub fn get_sockaddr(addr: &[u8], port: u16, sa: &mut sockaddr) -> c_int {
+/// Build the `sockaddr_storage` for `addr`:`port`, or `None` if `addr` is not
+/// an IPv4/IPv6 literal. IPv4-mapped `::ffff:a.b.c.d` is stored as `AF_INET`:
+/// the consumer is `ares_getnameinfo`, which (unlike the OS getnameinfo Node
+/// uses) has no v4-mapped handling and would issue an ip6.arpa PTR query that
+/// never resolves.
+pub fn get_sockaddr(addr: &[u8], port: u16) -> Option<sockaddr_storage> {
     const BUF_SIZE: usize = 128;
 
     let mut buf = [0u8; BUF_SIZE];
     if addr.is_empty() || addr.len() >= BUF_SIZE {
-        return -1;
+        return None;
     }
-    let addr_ptr = copy_nul_terminated(&mut buf, addr);
+    copy_nul_terminated(&mut buf, addr);
+    let text = core::ffi::CStr::from_bytes_until_nul(&buf).ok()?;
 
-    {
-        // SAFETY: caller-provided sockaddr storage; reinterpreting as sockaddr_in.
-        let in_: &mut sockaddr_in =
-            unsafe { &mut *std::ptr::from_mut::<sockaddr>(sa).cast::<sockaddr_in>() };
-        // SAFETY: c-ares FFI; `addr_ptr` is a NUL-terminated stack buffer, dst is `sin_addr` storage.
-        if unsafe { ares_inet_pton(AF::INET, addr_ptr, (&raw mut in_.sin_addr).cast::<c_void>()) }
-            == 1
-        {
-            in_.sin_family = AF::INET as _;
-            in_.sin_port = port.to_be();
-            return 0;
-        }
-    }
     let mut octets = [0u8; 16];
-    // SAFETY: c-ares FFI; `addr_ptr` is a NUL-terminated stack buffer, dst is a
-    // 16-byte `in6_addr`-sized buffer.
-    if unsafe { ares_inet_pton(AF::INET6, addr_ptr, (&raw mut octets).cast::<c_void>()) } != 1 {
-        return -1;
+    let mut storage: sockaddr_storage = bun_core::ffi::zeroed();
+    if inet_pton(AF::INET, text, &mut octets) == 1 {
+        write_in4(
+            &mut storage,
+            [octets[0], octets[1], octets[2], octets[3]],
+            port,
+        );
+        return Some(storage);
     }
-
+    if inet_pton(AF::INET6, text, &mut octets) != 1 {
+        return None;
+    }
     if octets[..12] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff] {
-        // IPv4-mapped `::ffff:a.b.c.d`: store as AF_INET. The consumer is
-        // `ares_getnameinfo`, which (unlike the OS getnameinfo Node uses) has
-        // no v4-mapped handling and would issue an ip6.arpa PTR query that
-        // never resolves.
-        // SAFETY: caller-provided sockaddr storage; reinterpreting as sockaddr_in.
-        let in_: &mut sockaddr_in =
-            unsafe { &mut *std::ptr::from_mut::<sockaddr>(sa).cast::<sockaddr_in>() };
-        in_.sin_family = AF::INET as _;
-        in_.sin_port = port.to_be();
-        // SAFETY: `sin_addr` is 4 bytes of POD on every target.
-        unsafe {
-            (&raw mut in_.sin_addr)
-                .cast::<[u8; 4]>()
-                .write([octets[12], octets[13], octets[14], octets[15]]);
-        }
-        return 0;
+        write_in4(
+            &mut storage,
+            [octets[12], octets[13], octets[14], octets[15]],
+            port,
+        );
+        return Some(storage);
     }
-
-    // SAFETY: caller-provided sockaddr storage; reinterpreting as sockaddr_in6.
-    let in6: &mut sockaddr_in6 =
-        unsafe { &mut *std::ptr::from_mut::<sockaddr>(sa).cast::<sockaddr_in6>() };
+    let mut in6: sockaddr_in6 = bun_core::ffi::zeroed();
     in6.sin6_family = AF::INET6 as _;
     in6.sin6_port = port.to_be();
     // SAFETY: `sin6_addr` is 16 bytes of POD on every target.
     unsafe { (&raw mut in6.sin6_addr).cast::<[u8; 16]>().write(octets) };
-    0
+    // SAFETY: `sockaddr_storage` is at least as large and aligned as `sockaddr_in6`.
+    unsafe { (&raw mut storage).cast::<sockaddr_in6>().write(in6) };
+    Some(storage)
+}
+
+fn write_in4(storage: &mut sockaddr_storage, octets: [u8; 4], port: u16) {
+    let mut in4: sockaddr_in = bun_core::ffi::zeroed();
+    in4.sin_family = AF::INET as _;
+    in4.sin_port = port.to_be();
+    // SAFETY: `sin_addr` is 4 bytes of POD on every target.
+    unsafe { (&raw mut in4.sin_addr).cast::<[u8; 4]>().write(octets) };
+    // SAFETY: `sockaddr_storage` is at least as large and aligned as `sockaddr_in`.
+    unsafe { (&raw mut *storage).cast::<sockaddr_in>().write(in4) };
 }
 
 /// The C `struct in_addr` (4-byte IPv4 address), as c-ares' `ares_options.servers`

--- a/src/cares_sys/lib.rs
+++ b/src/cares_sys/lib.rs
@@ -9,10 +9,8 @@ pub mod c_ares_draft;
 pub mod winsock {
     use core::ffi::c_int;
     pub(crate) type socklen_t = c_int; // ws2tcpip.h: `typedef int socklen_t;`
-    // Same nominal type as `bun_sys::posix::sockaddr*`; sin_addr is `in_addr{s_addr}`
-    // (vs the previous `[u8;4]`) but the only caller (c_ares.rs `get_sockaddr`)
-    // takes `&raw mut → cast<c_void>`, so the field's nominal type is transparent.
-    pub(crate) use bun_libuv_sys::{sockaddr, sockaddr_in, sockaddr_in6};
+    // Same nominal types as `bun_sys::posix::sockaddr*` (the ws2def.h mirrors).
+    pub(crate) use bun_libuv_sys::{sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage};
 }
 
 /// `c_ares` and `c_ares_draft` resolve to the same module.

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2054,13 +2054,26 @@ function generateRust(
             `    ${T}::${fastId}(this, global${args.length ? ", " + argFwd : ""})`,
           );
         }
-        thunk(
-          names.fn,
-          `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
-          passThis
-            ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
-            : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
-        );
+        if (sharedThis) {
+          // `*mut T` + receiver-generic helper: the method takes `&self` or
+          // `this: ThisPtr<Self>` and inference picks (see `HostReceiver`).
+          thunk(
+            names.fn,
+            `(this: *mut ${T}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            `    // SAFETY: C++ passes the wrapper's live \`m_ctx\`.\n    ` +
+              (passThis
+                ? `    unsafe { host_fn::host_fn_this_value_ptr(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v)) }`
+                : `    unsafe { host_fn::host_fn_this_ptr(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c)) }`),
+          );
+        } else {
+          thunk(
+            names.fn,
+            `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            passThis
+              ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
+              : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
+          );
+        }
       }
     }
   }

--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -144,6 +144,14 @@ function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraL
         `{\n        // SAFETY: C++ caller passes \`${n}_len\` live elements at \`${n}\` (or 0).\n        unsafe { ::bun_core::ffi::slice(${n}, ${n}_len) }\n    }`,
     };
   }
+  // `Option<&CStr>` — C passes a nullable `const char*`.
+  if (/^Option\s*<\s*&\s*(?:(?:core|std)::ffi::)?CStr\s*>$/.test(ty)) {
+    return {
+      cTy: `*const c_char`,
+      deref: n =>
+        `{\n        // SAFETY: C++ caller passes null or a NUL-terminated string live for the call.\n        if ${n}.is_null() { None } else { Some(unsafe { ::core::ffi::CStr::from_ptr(${n}) }) }\n    }`,
+    };
+  }
   // Other slice shapes (`&mut [T]`, `&'a [T]`) and `&str` are NOT FFI-safe; reject.
   if (/^&[^\[]*\[/.test(ty) || /^&\s*str\b/.test(ty)) {
     throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\` (const) or (ptr, len)`);

--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -145,7 +145,7 @@ function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraL
     };
   }
   // `Option<&CStr>` — C passes a nullable `const char*`.
-  if (/^Option\s*<\s*&\s*(?:(?:core|std)::ffi::)?CStr\s*>$/.test(ty)) {
+  if (/^Option\s*<\s*&\s*(?:'\w+\s+)?(?:(?:::)?(?:core|std)::ffi::)?CStr\s*>$/.test(ty)) {
     return {
       cTy: `*const c_char`,
       deref: n =>

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -498,21 +498,21 @@ pub mod internal {
         fn Bun__addrinfo_registerQuic(request: *mut c_void, pc: *mut c_void);
     }
 
-    unsafe extern "Rust" {
+    unsafe extern "C" {
         /// `bun.dns.internal.prefetch` — kick off an async DNS resolution for
         /// `(hostname, port)` so the result is cached by the time the connect
         /// path needs it. The resolver/event-loop machinery lives in
         /// `bun_runtime::dns_jsc::internal::prefetch`; lower-tier crates
         /// (`bun_install`) reach it via this link-time extern to avoid a crate
-        /// cycle. Defined `#[no_mangle]` in `bun_runtime::dns_jsc`.
+        /// cycle. Defined (as a `HOST_EXPORT`) in `bun_runtime::dns_jsc`.
         fn __bun_dns_prefetch(loop_: *mut c_void, hostname: *const u8, len: usize, port: u16);
     }
 
     #[inline]
     pub fn prefetch<L>(loop_: *mut L, hostname: &[u8], port: u16) {
-        // SAFETY: link-time extern; `hostname` is NUL-terminated and live for
-        // the call. Prefetch is a perf hint — the body short-circuits if no
-        // resolver is available.
+        // SAFETY: link-time extern; `loop_` is this thread's live uws loop and
+        // `hostname` is live for the call. Prefetch is a perf hint — the body
+        // short-circuits if no resolver is available.
         unsafe {
             __bun_dns_prefetch(
                 loop_.cast::<c_void>(),

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -13,19 +13,16 @@ use bun_wyhash::Wyhash11 as Wyhash;
 // the body of this crate stays cfg-free.
 #[cfg(not(windows))]
 mod sock {
-    // `addrinfo`/`freeaddrinfo` are re-exported from the crate root below;
-    // the rest are crate-internal.
     pub(crate) use libc::{
-        AF_INET, AF_INET6, AF_UNIX, IPPROTO_TCP, IPPROTO_UDP, SOCK_DGRAM, SOCK_STREAM, sockaddr_un,
+        AF_INET, AF_INET6, AF_UNIX, IPPROTO_TCP, IPPROTO_UDP, SOCK_DGRAM, SOCK_STREAM, addrinfo,
+        sockaddr_un,
     };
-    pub use libc::{addrinfo, freeaddrinfo};
 }
 #[cfg(windows)]
 mod sock {
     pub(crate) use bun_windows_sys::ws2_32::{
-        AF_INET, AF_INET6, AF_UNIX, IPPROTO_TCP, IPPROTO_UDP, SOCK_DGRAM, SOCK_STREAM,
+        AF_INET, AF_INET6, AF_UNIX, IPPROTO_TCP, IPPROTO_UDP, SOCK_DGRAM, SOCK_STREAM, addrinfo,
     };
-    pub use bun_windows_sys::ws2_32::{addrinfo, freeaddrinfo};
     // Windows SDK ships <afunix.h> (SOCKADDR_UN) since win10_rs4 but neither
     // windows-sys nor bun_windows_sys export it. Mirror the on-the-wire layout
     // (`{ family: u16, path: [108]u8 }`) here so address_to_string stays
@@ -36,10 +33,6 @@ mod sock {
         pub sun_path: [u8; 108],
     }
 }
-
-// Re-export the cfg-dispatched addrinfo type + matching free so callers don't
-// duplicate the POSIX/Windows split (see dns_jsc::dns).
-pub use sock::{addrinfo, freeaddrinfo};
 
 #[cfg(windows)]
 pub const AI_V4MAPPED: c_int = 2048;
@@ -298,59 +291,14 @@ pub struct GetAddrInfoResult {
 
 pub type ResultList = Vec<GetAddrInfoResult>;
 
-pub enum ResultAny {
-    Addrinfo(*mut sock::addrinfo),
-    List(ResultList),
-}
-
-impl Drop for ResultAny {
-    fn drop(&mut self) {
-        match self {
-            ResultAny::Addrinfo(addrinfo) => {
-                if !addrinfo.is_null() {
-                    // SAFETY: addrinfo was allocated by C getaddrinfo (see LIFETIMES.tsv)
-                    unsafe { sock::freeaddrinfo(*addrinfo) };
-                }
-            }
-            ResultAny::List(_list) => {
-                // Vec drops itself
-            }
-        }
-    }
-}
-
 impl GetAddrInfoResult {
-    pub fn to_list(addrinfo: &sock::addrinfo) -> ResultList {
-        let mut list = ResultList::with_capacity(addr_info_count(addrinfo) as usize);
-
-        let mut addr: *const sock::addrinfo = addrinfo;
-        while !addr.is_null() {
-            // SAFETY: addr is non-null, points into the getaddrinfo result chain
-            let a = unsafe { &*addr };
-            if let Some(r) = Self::from_addr_info(a) {
-                list.push(r);
-            }
-            addr = a.ai_next;
-        }
-
-        list
-    }
-
-    pub fn from_addr_info(addrinfo: &sock::addrinfo) -> Option<GetAddrInfoResult> {
-        let sockaddr = addrinfo.ai_addr;
-        if sockaddr.is_null() {
-            return None;
-        }
-        Some(GetAddrInfoResult {
-            // SAFETY: `ai_addr` is non-null and points to a valid sockaddr per
-            // getaddrinfo's contract. `.cast()` erases the nominal-type
-            // mismatch on Windows (ws2_32::sockaddr ↔ the libuv-sys mirror
-            // `bun_sys::posix::sockaddr` routes to) — both are the 16-byte
-            // ws2def.h `SOCKADDR`.
-            address: unsafe { Address::init_posix(sockaddr.cast()) },
-            // no TTL in POSIX getaddrinfo()
-            ttl: 0,
-        })
+    /// Every entry of a `getaddrinfo(3)` result that carries an address (no
+    /// TTL in POSIX getaddrinfo()).
+    pub fn to_list(list: &bun_sys::net::AddrInfoList) -> ResultList {
+        list.iter()
+            .filter_map(|entry| entry.address())
+            .map(|address| GetAddrInfoResult { address, ttl: 0 })
+            .collect()
     }
 }
 
@@ -404,18 +352,6 @@ pub fn address_to_string(address: &Address) -> BunString {
         }
         _ => BunString::EMPTY,
     }
-}
-
-pub fn addr_info_count(addrinfo: &sock::addrinfo) -> u32 {
-    let mut count: u32 = 1;
-    let mut current: *mut sock::addrinfo = addrinfo.ai_next;
-    while !current.is_null() {
-        // SAFETY: current is non-null, points into the getaddrinfo result chain
-        let cur = unsafe { &*current };
-        count += (!cur.ai_addr.is_null()) as u32;
-        current = cur.ai_next;
-    }
-    count
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -389,6 +389,18 @@ impl EventLoopHandle {
         uws_loop.internal_loop_data.set_parent_raw(tag, ptr);
     }
 
+    /// The event loop registered as `uws_loop`'s parent by
+    /// [`set_as_parent_of`](Self::set_as_parent_of) (panics if none was). The
+    /// loop is owned by (and torn down with) that event loop, so while the
+    /// loop is alive so is its parent.
+    #[inline]
+    pub fn parent_of(uws_loop: &UwsLoop) -> EventLoopHandle {
+        let (tag, ptr) = uws_loop.internal_loop_data.get_parent_raw();
+        // SAFETY: `(tag, ptr)` was stored by `set_as_parent_of` from a live
+        // event loop that owns `uws_loop` (see doc).
+        unsafe { Self::from_tag_ptr(tag, ptr) }
+    }
+
     pub fn from_any(any: &mut AnyEventLoop) -> EventLoopHandle {
         match any {
             AnyEventLoop::Js { owner } => EventLoopHandle::Js { owner: *owner },

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -76,7 +76,6 @@ pub mod task_tag {
         FetchTaskletDeinit,
         FetchTaskletPromiseSettle,
         FSWatchTask,
-        GetAddrInfoLibuvComplete,
         HotReloadTask,
         WatchReloadTask,
         JSBundleCompletionTask,

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -6,6 +6,14 @@ use core::ptr::NonNull;
 
 use crate::{JsResult, Task};
 
+/// The context of a [`ManagedTask::new_boxed`] task.
+pub trait RunOnce: Sized {
+    fn run(self) -> JsResult<()>;
+    /// The task was released unrun (its VM is tearing down: script is
+    /// forbidden, the JSC heap is still alive). Default: just drop.
+    fn cancelled(self) {}
+}
+
 pub struct ManagedTask {
     // Opaque userdata pointer round-tripped through `new`/`run`; raw by design.
     pub ctx: Option<NonNull<c_void>>,
@@ -59,6 +67,26 @@ impl ManagedTask {
             },
             ctx: NonNull::new(ctx.cast::<c_void>()),
             cleanup: None,
+        }));
+        ManagedTask::task(managed)
+    }
+
+    /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
+    /// the queue is released unrun).
+    pub fn new_boxed<T: RunOnce>(ctx: Box<T>) -> Task {
+        fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
+            // passes it back exactly once.
+            T::run(*unsafe { Box::from_raw(p.cast::<T>()) })
+        }
+        fn drop_ctx<T: RunOnce>(p: *mut c_void) {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`.
+            T::cancelled(*unsafe { Box::from_raw(p.cast::<T>()) });
+        }
+        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
+            callback: run::<T>,
+            ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
+            cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)
     }

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -77,15 +77,15 @@ impl ManagedTask {
         fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
             // passes it back exactly once.
-            T::run(*unsafe { Box::from_raw(p.cast::<T>()) })
+            T::run(*unsafe { bun_core::heap::take(p.cast::<T>()) })
         }
         fn drop_ctx<T: RunOnce>(p: *mut c_void) {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`.
-            T::cancelled(*unsafe { Box::from_raw(p.cast::<T>()) });
+            T::cancelled(*unsafe { bun_core::heap::take(p.cast::<T>()) });
         }
         let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
             callback: run::<T>,
-            ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
+            ctx: NonNull::new(bun_core::heap::into_raw(ctx).cast::<c_void>()),
             cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -29,10 +29,10 @@ impl ManagedTask {
 
     /// # Safety
     /// `this` must be the live `*mut ManagedTask` embedded in a `Task` returned
-    /// by `new()`/`new_owned()`; ownership transfers — `this` is freed (via
+    /// by `new()`/`new_boxed()`; ownership transfers — `this` is freed (via
     /// `heap::take`) before return on both Ok and Err paths.
     pub unsafe fn run(this: *mut ManagedTask) -> JsResult<()> {
-        // SAFETY: `this` was produced by `heap::into_raw` in `new`/`new_owned`
+        // SAFETY: `this` was produced by `heap::into_raw` in `new`/`new_boxed`
         // (caller contract). Reconstituting the Box here frees it at scope
         // exit on both the Ok and Err paths.
         let this = unsafe { bun_core::heap::take(this) };
@@ -41,7 +41,7 @@ impl ManagedTask {
         callback(ctx.unwrap().as_ptr())
     }
 
-    /// Free without running: the owned context (if `new_owned`) is dropped.
+    /// Free without running: the owned context (if `new_boxed`) is dropped.
     ///
     /// # Safety
     /// As [`run`](Self::run); the task is not queued anywhere.
@@ -86,24 +86,6 @@ impl ManagedTask {
         let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
             callback: run::<T>,
             ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
-            cleanup: Some(drop_ctx::<T>),
-        }));
-        ManagedTask::task(managed)
-    }
-
-    pub fn new_owned<T>(ctx: *mut T, callback: fn(*mut T) -> JsResult<()>) -> Task {
-        fn drop_ctx<T>(p: *mut c_void) {
-            // SAFETY: `p` is the `heap::into_raw(Box<T>)` stored in `ctx` by `new_owned`.
-            unsafe { bun_core::heap::destroy(p.cast::<T>()) };
-        }
-        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
-            // SAFETY: same fn-pointer ABI cast as `new`.
-            callback: unsafe {
-                bun_ptr::cast_fn_ptr::<fn(*mut T) -> JsResult<()>, fn(*mut c_void) -> JsResult<()>>(
-                    callback,
-                )
-            },
-            ctx: NonNull::new(ctx.cast::<c_void>()),
             cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -19,6 +19,10 @@ pub struct ManagedTask {
     pub ctx: Option<NonNull<c_void>>,
     pub(crate) callback: fn(*mut c_void) -> JsResult<()>,
     pub cleanup: Option<fn(*mut c_void)>,
+    /// Held by the thread that boxed a `new_boxed` payload (which need not be
+    /// `Send`); `run`/`release` assert they are on it. Debug-only, zero-sized
+    /// in release.
+    origin: bun_core::ThreadLock,
 }
 
 impl ManagedTask {
@@ -36,6 +40,7 @@ impl ManagedTask {
         // (caller contract). Reconstituting the Box here frees it at scope
         // exit on both the Ok and Err paths.
         let this = unsafe { bun_core::heap::take(this) };
+        this.origin.lock_or_assert();
         let callback = this.callback;
         let ctx = this.ctx;
         callback(ctx.unwrap().as_ptr())
@@ -48,6 +53,7 @@ impl ManagedTask {
     pub unsafe fn release(this: *mut ManagedTask) {
         // SAFETY: fn contract.
         let this = unsafe { bun_core::heap::take(this) };
+        this.origin.lock_or_assert();
         if let (Some(cleanup), Some(ctx)) = (this.cleanup, this.ctx) {
             cleanup(ctx.as_ptr());
         }
@@ -67,12 +73,15 @@ impl ManagedTask {
             },
             ctx: NonNull::new(ctx.cast::<c_void>()),
             cleanup: None,
+            origin: bun_core::ThreadLock::init_unlocked(),
         }));
         ManagedTask::task(managed)
     }
 
     /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
-    /// the queue is released unrun).
+    /// the queue is released unrun). `T` need not be `Send`: the `Task` is for
+    /// this thread's own queue (`enqueue_task`), never a `ConcurrentTask` /
+    /// `JsPoster` hand-off to another thread — debug builds assert that.
     pub fn new_boxed<T: RunOnce + 'static>(ctx: Box<T>) -> Task {
         fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
@@ -87,6 +96,7 @@ impl ManagedTask {
             callback: run::<T>,
             ctx: NonNull::new(bun_core::heap::into_raw(ctx).cast::<c_void>()),
             cleanup: Some(drop_ctx::<T>),
+            origin: bun_core::ThreadLock::init_locked(),
         }));
         ManagedTask::task(managed)
     }

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -73,7 +73,7 @@ impl ManagedTask {
 
     /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
     /// the queue is released unrun).
-    pub fn new_boxed<T: RunOnce>(ctx: Box<T>) -> Task {
+    pub fn new_boxed<T: RunOnce + 'static>(ctx: Box<T>) -> Task {
         fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
             // passes it back exactly once.

--- a/src/http/H3Client.rs
+++ b/src/http/H3Client.rs
@@ -39,7 +39,7 @@ bun_core::declare_scope!(h3_client, hidden);
 
 pub(crate) use client_context::ClientContext;
 pub use client_session::ClientSession;
-pub use pending_connect::PendingConnect;
+pub use pending_connect::{DnsPendingConnect, PendingConnect};
 pub use stream::Stream;
 
 /// Live-object counters for the leak test in fetch-http3-client.test.ts.

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -156,6 +156,40 @@ impl PendingConnect {
     }
 }
 
+/// A [`PendingConnect`] parked on the DNS cache until its lookup resolves;
+/// consumed by exactly one of [`notify`](Self::notify) /
+/// [`notify_threadsafe`](Self::notify_threadsafe). Dropping it unconsumed
+/// leaks (it is never freed off the HTTP thread).
+pub struct DnsPendingConnect(NonNull<PendingConnect>);
+
+// SAFETY: `notify_threadsafe` is the documented cross-thread entry (it only
+// queues the pointer under `RESOLVED`'s lock and wakes the HTTP thread);
+// `notify` is HTTP-thread-only, like every other `PendingConnect` method.
+unsafe impl Send for DnsPendingConnect {}
+
+impl DnsPendingConnect {
+    #[inline]
+    pub fn new(pc: Box<PendingConnect>) -> Self {
+        Self(NonNull::from(Box::leak(pc)))
+    }
+
+    /// The lookup resolved. HTTP thread only (the registrant's thread), like
+    /// every other `PendingConnect` method; use
+    /// [`notify_threadsafe`](Self::notify_threadsafe) anywhere else.
+    #[inline]
+    pub fn notify(self) {
+        // SAFETY: the box `new` leaked, consumed once here.
+        unsafe { PendingConnect::on_dns_resolved(self.0.as_ptr()) }
+    }
+
+    /// The lookup resolved (any thread).
+    #[inline]
+    pub fn notify_threadsafe(self) {
+        // SAFETY: the box `new` leaked, consumed once here.
+        unsafe { PendingConnect::on_dns_resolved_threadsafe(self.0.as_ptr()) }
+    }
+}
+
 /// Heap-allocated `PendingConnect` handed from DNS worker → HTTP thread.
 /// `*mut T` is `!Send` by default; this wrapper asserts the actual contract:
 /// the pointee is touched by exactly one thread at a time (producer pushes,

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -156,15 +156,14 @@ impl PendingConnect {
     }
 }
 
-/// A [`PendingConnect`] parked on the DNS cache until its lookup resolves;
-/// consumed by exactly one of [`notify`](Self::notify) /
-/// [`notify_threadsafe`](Self::notify_threadsafe). Dropping it unconsumed
-/// leaks (it is never freed off the HTTP thread).
+/// A [`PendingConnect`] parked on the DNS cache until its lookup resolves on
+/// some other thread; consumed by [`notify_threadsafe`](Self::notify_threadsafe)
+/// (the only thing another thread may do with a `PendingConnect`). Dropping it
+/// unconsumed leaks (it is never freed off the HTTP thread).
 pub struct DnsPendingConnect(NonNull<PendingConnect>);
 
-// SAFETY: `notify_threadsafe` is the documented cross-thread entry (it only
-// queues the pointer under `RESOLVED`'s lock and wakes the HTTP thread);
-// `notify` is HTTP-thread-only, like every other `PendingConnect` method.
+// SAFETY: the only operation is `notify_threadsafe`, which queues the pointer
+// under `RESOLVED`'s lock and wakes the HTTP thread.
 unsafe impl Send for DnsPendingConnect {}
 
 impl DnsPendingConnect {
@@ -173,20 +172,20 @@ impl DnsPendingConnect {
         Self(NonNull::from(Box::leak(pc)))
     }
 
-    /// The lookup resolved. HTTP thread only (the registrant's thread), like
-    /// every other `PendingConnect` method; use
-    /// [`notify_threadsafe`](Self::notify_threadsafe) anywhere else.
-    #[inline]
-    pub fn notify(self) {
-        // SAFETY: the box `new` leaked, consumed once here.
-        unsafe { PendingConnect::on_dns_resolved(self.0.as_ptr()) }
-    }
-
     /// The lookup resolved (any thread).
     #[inline]
     pub fn notify_threadsafe(self) {
         // SAFETY: the box `new` leaked, consumed once here.
         unsafe { PendingConnect::on_dns_resolved_threadsafe(self.0.as_ptr()) }
+    }
+}
+
+impl PendingConnect {
+    /// The lookup had already resolved when this was registered (HTTP thread).
+    #[inline]
+    pub fn on_dns_resolved_now(self: Box<Self>) {
+        // SAFETY: `into_raw` of the box we own; consumed once here.
+        unsafe { Self::on_dns_resolved(Box::into_raw(self)) }
     }
 }
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -270,7 +270,7 @@ pub use parent_death_watchdog as ParentDeathWatchdog;
 // ─── public surface (was bun_io's crate root) ──────────────────────────────
 
 #[cfg(not(windows))]
-pub use posix_event_loop::{FilePoll, Loop};
+pub use posix_event_loop::{FilePoll, Loop, OwnedFilePoll};
 #[cfg(windows)]
 pub use windows_event_loop::{FilePoll, Loop};
 

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -301,6 +301,55 @@ pub struct FilePoll {
     pub(crate) allocator_type: AllocatorType,
 }
 
+/// The single owner of a [`FilePoll`] slot in its loop's [`Store`]: derefs to
+/// the poll, and returns the slot (`deinit`) on drop.
+#[cfg(not(windows))]
+pub struct OwnedFilePoll(core::ptr::NonNull<FilePoll>);
+
+#[cfg(not(windows))]
+impl OwnedFilePoll {
+    #[inline]
+    pub fn new(vm: EventLoopCtx, fd: Fd, flags: FlagsSet, owner: Owner) -> Self {
+        Self(
+            core::ptr::NonNull::new(FilePoll::init(vm, fd, flags, owner))
+                .expect("FilePoll::init returns a live hive slot"),
+        )
+    }
+
+    /// The poll's address (what the loop dispatches on), for identity checks.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut FilePoll {
+        self.0.as_ptr()
+    }
+}
+
+#[cfg(not(windows))]
+impl core::ops::Deref for OwnedFilePoll {
+    type Target = FilePoll;
+    #[inline]
+    fn deref(&self) -> &FilePoll {
+        // SAFETY: the live slot `FilePoll::init` returned; only `drop` releases it.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+#[cfg(not(windows))]
+impl core::ops::DerefMut for OwnedFilePoll {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut FilePoll {
+        // SAFETY: as `deref`; this is the slot's only owner.
+        unsafe { self.0.as_mut() }
+    }
+}
+
+#[cfg(not(windows))]
+impl Drop for OwnedFilePoll {
+    fn drop(&mut self) {
+        // SAFETY: as `deref_mut`; `deinit` unregisters and returns the slot.
+        unsafe { self.0.as_mut() }.deinit();
+    }
+}
+
 #[cfg(not(windows))]
 impl FilePoll {
     fn update_flags(&mut self, updated: FlagsSet) {
@@ -538,6 +587,33 @@ impl FilePoll {
             fd
         );
         poll
+    }
+
+    /// [`register`](Self::register) on `ctx`'s loop; the `&mut Loop` is
+    /// scoped to the call.
+    pub fn register_on(
+        &mut self,
+        ctx: EventLoopCtx,
+        flag: Flags,
+        one_shot: bool,
+    ) -> sys::Result<()> {
+        self.register(ctx.loop_mut(), flag, one_shot)
+    }
+
+    /// [`register_with_fd`](Self::register_with_fd) on `ctx`'s loop.
+    pub fn register_with_fd_on(
+        &mut self,
+        ctx: EventLoopCtx,
+        flag: Flags,
+        one_shot: OneShotFlag,
+        fd: Fd,
+    ) -> sys::Result<()> {
+        self.register_with_fd(ctx.loop_mut(), flag, one_shot, fd)
+    }
+
+    /// [`unregister`](Self::unregister) on `ctx`'s loop.
+    pub fn unregister_on(&mut self, ctx: EventLoopCtx, force_unregister: bool) -> sys::Result<()> {
+        self.unregister(ctx.loop_mut(), force_unregister)
     }
 
     pub fn register(&mut self, loop_: &mut Loop, flag: Flags, one_shot: bool) -> sys::Result<()> {

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -537,29 +537,64 @@ pub fn host_fn_construct_this<R: IntoHostConstructReturn>(
 // (Phase 3 of `R-2-design.md` deletes them and drops the `_shared` suffix).
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Prototype method (`sharedThis`): `fn(&self, &JSGlobalObject, &CallFrame) -> R`.
+/// How a `sharedThis` prototype method receives the wrapper's `m_ctx`: as a
+/// plain `&T`, or as a [`ThisPtr<T>`](bun_ptr::ThisPtr) when the method needs
+/// the allocation's root pointer (to take/release intrusive refs on itself or
+/// hand itself to a dispatch path that may). The generated thunk is generic
+/// over this, so the method's own signature picks.
+pub trait HostReceiver<'a, T: 'a>: Sized {
+    /// # Safety
+    /// `this` is the live, non-null `m_ctx` of a JS wrapper that stays rooted
+    /// for `'a`.
+    unsafe fn from_m_ctx(this: *mut T) -> Self;
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for &'a T {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { &*this }
+    }
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for bun_ptr::ThisPtr<T> {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { bun_ptr::ThisPtr::new(this) }
+    }
+}
+
+/// Prototype method (`sharedThis`) taking `&self` or `this: ThisPtr<Self>`.
+///
+/// # Safety
+/// `this` is the live `m_ctx` of the JS wrapper the call was dispatched on.
 #[track_caller]
 #[inline]
-pub fn host_fn_this_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame) -> R,
+pub unsafe fn host_fn_this_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe))
 }
 
-/// Prototype method (`sharedThis`, passThis):
-/// `fn(&self, &JSGlobalObject, &CallFrame, JSValue) -> R`.
+/// [`host_fn_this_ptr`] with `passThis`.
+///
+/// # Safety
+/// As [`host_fn_this_ptr`].
 #[track_caller]
 #[inline]
-pub fn host_fn_this_value_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
+pub unsafe fn host_fn_this_value_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
     js_this: JSValue,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame, JSValue) -> R,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame, JSValue) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe, js_this))
 }
 

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -555,7 +555,7 @@ impl<'a, T: 'a> HostReceiver<'a, T> for &'a T {
         unsafe { &*this }
     }
 }
-impl<'a, T: 'a> HostReceiver<'a, T> for bun_ptr::ThisPtr<T> {
+impl<'a, T: bun_ptr::AnyRefCounted + 'a> HostReceiver<'a, T> for bun_ptr::ThisPtr<T> {
     #[inline(always)]
     unsafe fn from_m_ctx(this: *mut T) -> Self {
         // SAFETY: trait contract.

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -106,6 +106,12 @@ unsafe impl JsAffine for () {}
 // SAFETY: see the group note above.
 unsafe impl JsAffine for bool {}
 // SAFETY: see the group note above.
+unsafe impl JsAffine for u8 {}
+// SAFETY: a `RefPtr` to an intrusively-refcounted `T` must be released where
+// `T`'s count may be touched — for the single-threaded counts, `T`'s own
+// thread; a job's `Js` side is exactly that.
+unsafe impl<T: bun_ptr::AnyRefCounted> JsAffine for bun_ptr::RefPtr<T> {}
+// SAFETY: see the group note above.
 unsafe impl<T: JsAffine> JsAffine for Option<T> {}
 // SAFETY: see the group note above.
 unsafe impl<T: JsAffine> JsAffine for Box<T> {}

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -136,7 +136,22 @@ fn expand_host_fn(args: &HostFnArgs, func: &ItemFn) -> syn::Result<TokenStream2>
         .inputs
         .first()
         .is_some_and(|a| matches!(a, FnArg::Receiver(r) if r.mutability.is_none()));
-    let this_reborrow = if receiver_is_shared {
+    // A typed `this: ThisPtr<Self>` first parameter gets the root pointer
+    // wrapped instead of reborrowed.
+    let first_is_this_ptr = func.sig.inputs.first().is_some_and(|a| match a {
+        FnArg::Typed(pt) => match &*pt.ty {
+            syn::Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "ThisPtr"),
+            _ => false,
+        },
+        _ => false,
+    });
+    let this_reborrow = if first_is_this_ptr {
+        quote! { let __t = unsafe { ::bun_ptr::ThisPtr::new(__this) }; }
+    } else if receiver_is_shared {
         quote! { let __t = unsafe { &*__this }; }
     } else {
         quote! { let __t = unsafe { &mut *__this }; }

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -3006,6 +3006,182 @@ unsafe extern "C" {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Typed `uv_getaddrinfo` — the request is a `Box<T>` embedding the
+// `uv_getaddrinfo_t`; libuv owns it from submission until its one completion
+// callback hands it back.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The owned `addrinfo` list of a completed `uv_getaddrinfo` (libuv re-packs
+/// the wide result into one `uv__malloc` block, so this is freed with
+/// `uv_freeaddrinfo`, never `ws2_32!freeaddrinfo`).
+pub struct UvAddrInfo(*mut addrinfo);
+
+impl UvAddrInfo {
+    /// The first entry, or `None` if the lookup produced nothing.
+    #[inline]
+    pub fn head(&self) -> Option<&addrinfo> {
+        // SAFETY: null or the list libuv allocated, owned until drop.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl Drop for UvAddrInfo {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: the block `uv_getaddrinfo` allocated, freed exactly once.
+            unsafe { uv_freeaddrinfo(self.0.cast()) }
+        }
+    }
+}
+
+/// A heap request type that embeds the `uv_getaddrinfo_t` it is submitted with.
+pub trait GetAddrInfoRequest: Sized {
+    fn uv_req(&mut self) -> &mut uv_getaddrinfo_t;
+    /// The completion (event-loop thread): `status` is 0, a `UV_EAI_*` code, or
+    /// `UV_ECANCELED`.
+    fn on_complete(this: Box<Self>, status: c_int, result: UvAddrInfo);
+}
+
+/// A submitted [`GetAddrInfoRequest`] that has not completed yet, for
+/// [`cancel`](Self::cancel): a back-reference into the request libuv holds.
+/// Holder obligation (taken on by keeping the value [`getaddrinfo`] returns):
+/// drop it no later than the request box handed back to
+/// [`on_complete`](GetAddrInfoRequest::on_complete) is freed.
+pub struct InflightGetAddrInfo(ptr::NonNull<uv_getaddrinfo_t>);
+
+impl InflightGetAddrInfo {
+    /// `uv_cancel`: if the work has not started, complete it soon with
+    /// `UV_ECANCELED`; otherwise no effect.
+    #[inline]
+    pub fn cancel(&self) {
+        // SAFETY: holder contract — the request is still owned by libuv.
+        let _ = unsafe { uv_cancel(self.0.as_ptr().cast::<uv_req_t>()) };
+    }
+}
+
+unsafe extern "C" fn getaddrinfo_complete<T: GetAddrInfoRequest>(
+    req: *mut uv_getaddrinfo_t,
+    status: c_int,
+    res: *mut addrinfo,
+) {
+    // SAFETY: `req.data` is the `Box<T>` `getaddrinfo` submitted, handed back
+    // for this one callback; `res` (== `req.addrinfo`) is ours to free.
+    let this = unsafe { Box::from_raw((*req).data.cast::<T>()) };
+    T::on_complete(this, status, UvAddrInfo(res));
+}
+
+/// `uv_getaddrinfo` on `loop_`. On `Ok` libuv owns `req` until
+/// [`GetAddrInfoRequest::on_complete`]; on a synchronous failure (e.g.
+/// `UV_EINVAL` for an over-long name) the request comes straight back.
+pub fn getaddrinfo<T: GetAddrInfoRequest>(
+    loop_: *mut Loop,
+    req: Box<T>,
+    node: &core::ffi::CStr,
+    service: &core::ffi::CStr,
+    hints: Option<&addrinfo>,
+) -> Result<InflightGetAddrInfo, (ReturnCode, Box<T>)> {
+    let raw = Box::into_raw(req);
+    // SAFETY: `raw` is the allocation just leaked, which lives until the
+    // callback re-boxes it, and `uv` points into it; node/service are
+    // NUL-terminated; hints is a live `addrinfo` or null (libuv copies it).
+    let (rc, uv) = unsafe {
+        let uv = ptr::NonNull::from((*raw).uv_req());
+        (*uv.as_ptr()).data = raw.cast::<c_void>();
+        let rc = uv_getaddrinfo(
+            loop_,
+            uv.as_ptr(),
+            Some(getaddrinfo_complete::<T>),
+            node.as_ptr(),
+            service.as_ptr(),
+            hints.map_or(ptr::null(), |h| ptr::from_ref(h).cast::<c_void>()),
+        );
+        (rc, uv)
+    };
+    if rc.int() < 0 {
+        // SAFETY: libuv did not take the request; we still own `raw`.
+        return Err((rc, unsafe { Box::from_raw(raw) }));
+    }
+    Ok(InflightGetAddrInfo(uv))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Typed `uv_poll_t` on a socket — a heap handle plus owner data; libuv holds
+// its address from init until the close callback frees it.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The owner data's poll callback.
+pub trait SocketPollHandler: Sized {
+    /// `status < 0` is an error; otherwise `events` is the ready `UV_READABLE`
+    /// / `UV_WRITABLE` set. May close the poll (drop its [`SocketPoll`]).
+    fn on_poll(data: &Self, status: c_int, events: c_int);
+}
+
+#[repr(C)]
+struct SocketPollBox<T> {
+    handle: UnsafeCell<uv_poll_t>,
+    data: T,
+}
+
+/// The owner's handle to a started socket poll. Dropping it `uv_close`s the
+/// handle; the allocation (and `T`) is freed in the close callback.
+pub struct SocketPoll<T: SocketPollHandler>(ptr::NonNull<SocketPollBox<T>>);
+
+impl<T: SocketPollHandler> SocketPoll<T> {
+    /// `uv_poll_init_socket`; `Err` gives `data` back.
+    pub fn init(loop_: *mut Loop, socket: uv_os_sock_t, data: T) -> Result<Self, (c_int, T)> {
+        let boxed = Box::new(SocketPollBox {
+            handle: UnsafeCell::new(bun_core::ffi::zeroed()),
+            data,
+        });
+        // SAFETY: `handle` is a zeroed `uv_poll_t` at a stable heap address.
+        let rc = unsafe { uv_poll_init_socket(loop_, boxed.handle.get(), socket) };
+        if rc < 0 {
+            return Err((rc, boxed.data));
+        }
+        Ok(SocketPoll(ptr::NonNull::from(Box::leak(boxed))))
+    }
+
+    #[inline]
+    fn handle(&self) -> *mut uv_poll_t {
+        // SAFETY: the live allocation `init` leaked; freed only by `close_cb`.
+        unsafe { self.0.as_ref() }.handle.get()
+    }
+
+    /// `uv_poll_start` (or re-start with a new event set).
+    #[inline]
+    pub fn start(&self, events: c_int) -> c_int {
+        // SAFETY: initialised, not yet closed handle.
+        unsafe { uv_poll_start(self.handle(), events, Some(Self::poll_cb)) }
+    }
+
+    #[inline]
+    pub fn data(&self) -> &T {
+        // SAFETY: the live allocation `init` leaked; freed only by `close_cb`.
+        &unsafe { self.0.as_ref() }.data
+    }
+
+    unsafe extern "C" fn poll_cb(handle: *mut uv_poll_t, status: c_int, events: c_int) {
+        // SAFETY: `handle` is the first field of the `SocketPollBox<T>` that
+        // registered this callback, live until `close_cb`.
+        let data = unsafe { &(*handle.cast::<SocketPollBox<T>>()).data };
+        T::on_poll(data, status, events);
+    }
+
+    unsafe extern "C" fn close_cb(handle: *mut uv_handle_t) {
+        // SAFETY: `handle` is the first field of the `SocketPollBox<T>` `init`
+        // leaked; libuv is done with it.
+        drop(unsafe { Box::from_raw(handle.cast::<SocketPollBox<T>>()) });
+    }
+}
+
+impl<T: SocketPollHandler> Drop for SocketPoll<T> {
+    fn drop(&mut self) {
+        // SAFETY: initialised, not yet closed handle; `close_cb` frees it.
+        unsafe { uv_close(self.handle().cast::<uv_handle_t>(), Some(Self::close_cb)) }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Layout assertions (Windows x64).
 //
 // Authoritative `sizeof`s taken from a `cl.exe`-compiled probe against

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -3035,8 +3035,8 @@ impl Drop for UvAddrInfo {
 
 /// The owner of a `uv_getaddrinfo` lookup.
 pub trait GetAddrInfoRequest: Sized {
-    /// The completion (event-loop thread): `status` is 0, a `UV_EAI_*` code, or
-    /// `UV_ECANCELED`.
+    /// The completion (event-loop thread): `status` is 0, or a `UV_EAI_*` code
+    /// (`UV_EAI_CANCELED` for a `uv_cancel`led lookup).
     fn on_complete(this: Box<Self>, status: c_int, result: UvAddrInfo);
 }
 
@@ -3055,7 +3055,7 @@ pub struct InflightGetAddrInfo(std::rc::Rc<Cell<*mut uv_getaddrinfo_t>>);
 
 impl InflightGetAddrInfo {
     /// `uv_cancel`: if the work has not started, complete it soon with
-    /// `UV_ECANCELED`; otherwise (or once completed) no effect.
+    /// `UV_EAI_CANCELED`; otherwise (or once completed) no effect.
     #[inline]
     pub fn cancel(&self) {
         let req = self.0.get();

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -3141,16 +3141,27 @@ struct SocketPollBox<T> {
 pub struct SocketPoll<T: SocketPollHandler>(ptr::NonNull<SocketPollBox<T>>);
 
 impl<T: SocketPollHandler> SocketPoll<T> {
-    /// `uv_poll_init_socket`; `Err` gives `data` back.
-    pub fn init(loop_: *mut Loop, socket: uv_os_sock_t, data: T) -> Result<Self, (c_int, T)> {
+    /// `uv_poll_init_socket`; `Err` is its status (`data` is dropped, once
+    /// libuv is done with the handle if it had already linked it).
+    pub fn init(loop_: *mut Loop, socket: uv_os_sock_t, data: T) -> Result<Self, c_int> {
         let boxed = Box::new(SocketPollBox {
             handle: UnsafeCell::new(bun_core::ffi::zeroed()),
             data,
         });
+        let handle = boxed.handle.get();
         // SAFETY: `handle` is a zeroed `uv_poll_t` at a stable heap address.
-        let rc = unsafe { uv_poll_init_socket(loop_, boxed.handle.get(), socket) };
+        let rc = unsafe { uv_poll_init_socket(loop_, handle, socket) };
         if rc < 0 {
-            return Err((rc, boxed.data));
+            // win/poll.c links the handle into the loop (`uv__handle_init`,
+            // which sets `type`) before the `getsockopt` that can still fail;
+            // a linked handle must leave through `uv_close`.
+            // SAFETY: `handle` is the zeroed-or-initialised `uv_poll_t` above.
+            if unsafe { (*handle).type_ } == HandleType::Poll {
+                let raw = Box::into_raw(boxed);
+                // SAFETY: initialised, not started; `close_cb` frees `raw`.
+                unsafe { uv_close(raw.cast::<uv_handle_t>(), Some(Self::close_cb)) };
+            }
+            return Err(rc);
         }
         Ok(SocketPoll(ptr::NonNull::from(Box::leak(boxed))))
     }

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -3006,9 +3006,9 @@ unsafe extern "C" {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Typed `uv_getaddrinfo` — the request is a `Box<T>` embedding the
-// `uv_getaddrinfo_t`; libuv owns it from submission until its one completion
-// callback hands it back.
+// Typed `uv_getaddrinfo` — libuv owns a heap `uv_getaddrinfo_t` (plus the
+// caller's `Box<T>`) from submission until its one completion callback hands
+// the `Box<T>` back.
 // ──────────────────────────────────────────────────────────────────────────
 
 /// The owned `addrinfo` list of a completed `uv_getaddrinfo` (libuv re-packs
@@ -3034,28 +3034,37 @@ impl Drop for UvAddrInfo {
     }
 }
 
-/// A heap request type that embeds the `uv_getaddrinfo_t` it is submitted with.
+/// The owner of a `uv_getaddrinfo` lookup.
 pub trait GetAddrInfoRequest: Sized {
-    fn uv_req(&mut self) -> &mut uv_getaddrinfo_t;
     /// The completion (event-loop thread): `status` is 0, a `UV_EAI_*` code, or
     /// `UV_ECANCELED`.
     fn on_complete(this: Box<Self>, status: c_int, result: UvAddrInfo);
 }
 
-/// A submitted [`GetAddrInfoRequest`] that has not completed yet, for
-/// [`cancel`](Self::cancel): a back-reference into the request libuv holds.
-/// Holder obligation (taken on by keeping the value [`getaddrinfo`] returns):
-/// drop it no later than the request box handed back to
-/// [`on_complete`](GetAddrInfoRequest::on_complete) is freed.
-pub struct InflightGetAddrInfo(ptr::NonNull<uv_getaddrinfo_t>);
+/// What libuv holds for one lookup: the request, the token its
+/// [`InflightGetAddrInfo`] shares, and the owner to hand back.
+#[repr(C)]
+struct GetAddrInfoReq<T> {
+    uv: uv_getaddrinfo_t,
+    inflight: std::rc::Rc<Cell<*mut uv_getaddrinfo_t>>,
+    owner: Box<T>,
+}
+
+/// The cancel handle of a submitted lookup. It shares a token with the request
+/// that the completion clears first, so a handle kept past completion is inert.
+pub struct InflightGetAddrInfo(std::rc::Rc<Cell<*mut uv_getaddrinfo_t>>);
 
 impl InflightGetAddrInfo {
     /// `uv_cancel`: if the work has not started, complete it soon with
-    /// `UV_ECANCELED`; otherwise no effect.
+    /// `UV_ECANCELED`; otherwise (or once completed) no effect.
     #[inline]
     pub fn cancel(&self) {
-        // SAFETY: holder contract — the request is still owned by libuv.
-        let _ = unsafe { uv_cancel(self.0.as_ptr().cast::<uv_req_t>()) };
+        let req = self.0.get();
+        if !req.is_null() {
+            // SAFETY: non-null ⇔ the completion has not run, so libuv still
+            // owns the request `getaddrinfo` allocated at this address.
+            let _ = unsafe { uv_cancel(req.cast::<uv_req_t>()) };
+        }
     }
 }
 
@@ -3064,44 +3073,50 @@ unsafe extern "C" fn getaddrinfo_complete<T: GetAddrInfoRequest>(
     status: c_int,
     res: *mut addrinfo,
 ) {
-    // SAFETY: `req.data` is the `Box<T>` `getaddrinfo` submitted, handed back
-    // for this one callback; `res` (== `req.addrinfo`) is ours to free.
-    let this = unsafe { Box::from_raw((*req).data.cast::<T>()) };
-    T::on_complete(this, status, UvAddrInfo(res));
+    // SAFETY: `req` is the first field of the `GetAddrInfoReq<T>` `getaddrinfo`
+    // leaked, handed back for this one callback; `res` (== `req.addrinfo`) is
+    // ours to free.
+    let this = unsafe { Box::from_raw(req.cast::<GetAddrInfoReq<T>>()) };
+    this.inflight.set(ptr::null_mut());
+    T::on_complete(this.owner, status, UvAddrInfo(res));
 }
 
-/// `uv_getaddrinfo` on `loop_`. On `Ok` libuv owns `req` until
+/// `uv_getaddrinfo` on `loop_`. On `Ok` libuv holds `owner` until
 /// [`GetAddrInfoRequest::on_complete`]; on a synchronous failure (e.g.
-/// `UV_EINVAL` for an over-long name) the request comes straight back.
+/// `UV_EINVAL` for an over-long name) it comes straight back.
 pub fn getaddrinfo<T: GetAddrInfoRequest>(
     loop_: *mut Loop,
-    req: Box<T>,
+    owner: Box<T>,
     node: &core::ffi::CStr,
     service: &core::ffi::CStr,
     hints: Option<&addrinfo>,
 ) -> Result<InflightGetAddrInfo, (ReturnCode, Box<T>)> {
-    let raw = Box::into_raw(req);
-    // SAFETY: `raw` is the allocation just leaked, which lives until the
-    // callback re-boxes it, and `uv` points into it; node/service are
-    // NUL-terminated; hints is a live `addrinfo` or null (libuv copies it).
-    let (rc, uv) = unsafe {
-        let uv = ptr::NonNull::from((*raw).uv_req());
-        (*uv.as_ptr()).data = raw.cast::<c_void>();
-        let rc = uv_getaddrinfo(
+    let inflight = std::rc::Rc::new(Cell::new(ptr::null_mut()));
+    let raw = Box::into_raw(Box::new(GetAddrInfoReq {
+        uv: bun_core::ffi::zeroed(),
+        inflight: std::rc::Rc::clone(&inflight),
+        owner,
+    }));
+    let uv = raw.cast::<uv_getaddrinfo_t>();
+    // SAFETY: `uv` is the first field of the allocation just leaked, which
+    // lives until the callback re-boxes it; node/service are NUL-terminated;
+    // hints is a live `addrinfo` or null (libuv copies it).
+    let rc = unsafe {
+        uv_getaddrinfo(
             loop_,
-            uv.as_ptr(),
+            uv,
             Some(getaddrinfo_complete::<T>),
             node.as_ptr(),
             service.as_ptr(),
             hints.map_or(ptr::null(), |h| ptr::from_ref(h).cast::<c_void>()),
-        );
-        (rc, uv)
+        )
     };
     if rc.int() < 0 {
         // SAFETY: libuv did not take the request; we still own `raw`.
-        return Err((rc, unsafe { Box::from_raw(raw) }));
+        return Err((rc, unsafe { Box::from_raw(raw) }.owner));
     }
-    Ok(InflightGetAddrInfo(uv))
+    inflight.set(uv);
+    Ok(InflightGetAddrInfo(inflight))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -3017,11 +3017,10 @@ unsafe extern "C" {
 pub struct UvAddrInfo(*mut addrinfo);
 
 impl UvAddrInfo {
-    /// The first entry, or `None` if the lookup produced nothing.
+    /// Give up ownership: null, or the list to free with `uv_freeaddrinfo`.
     #[inline]
-    pub fn head(&self) -> Option<&addrinfo> {
-        // SAFETY: null or the list libuv allocated, owned until drop.
-        unsafe { self.0.as_ref() }
+    pub fn into_raw(self) -> *mut addrinfo {
+        core::mem::ManuallyDrop::new(self).0
     }
 }
 

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -235,6 +235,13 @@ impl<T> From<ThisPtr<T>> for BackRef<T, Root> {
     }
 }
 
+impl<T> From<ThisPtr<T>> for core::ptr::NonNull<T> {
+    #[inline]
+    fn from(p: ThisPtr<T>) -> Self {
+        p.0
+    }
+}
+
 impl<T: ?Sized, P> Copy for BackRef<T, P> {}
 impl<T: ?Sized, P> Clone for BackRef<T, P> {
     #[inline]
@@ -641,6 +648,64 @@ impl<T> core::ops::Deref for ThisPtr<T> {
         self.get()
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OwnedThis<T> — single-owner heap allocation that hands out `ThisPtr`s.
+//
+// `Box<T>` asserts unique access on every touch, which is wrong for a callback
+// hub whose address is also held by C / JS / a task queue and re-entered while
+// a method on it is running. `OwnedThis` keeps the ownership (drop frees) but
+// only ever lends the pointee as `ThisPtr<T>` / `&T`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The unique owner of a heap-allocated `T` that is otherwise reached through
+/// [`ThisPtr`] copies. Dropping it drops and frees the `T`; every `ThisPtr`
+/// lent from it must be dead by then (the usual back-reference obligation).
+pub struct OwnedThis<T>(core::ptr::NonNull<T>);
+
+impl<T> OwnedThis<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
+    }
+
+    /// A dispatch handle to the pointee (root provenance).
+    #[inline]
+    pub fn this_ptr(&self) -> ThisPtr<T> {
+        ThisPtr(self.0)
+    }
+
+    /// Take the value back out (every lent `ThisPtr` must be dead).
+    #[inline]
+    pub fn into_inner(self) -> T {
+        let this = core::mem::ManuallyDrop::new(self);
+        // SAFETY: `new` leaked exactly this `Box`; `self` is forgotten so
+        // `Drop` does not free it again.
+        *unsafe { Box::from_raw(this.0.as_ptr()) }
+    }
+}
+
+impl<T> core::ops::Deref for OwnedThis<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: we own the live allocation.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Drop for OwnedThis<T> {
+    fn drop(&mut self) {
+        // SAFETY: `new` leaked exactly this `Box`; we are its unique owner.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
+}
+
+// SAFETY: `OwnedThis<T>` is the unique owner of a heap `T` (a `Box<T>` that
+// lends `ThisPtr`s); the auto-trait bounds are `Box<T>`'s.
+unsafe impl<T: Send> Send for OwnedThis<T> {}
+// SAFETY: as above — `&OwnedThis<T>` only yields `&T`.
+unsafe impl<T: Sync> Sync for OwnedThis<T> {}
 
 // SAFETY: `BackRef<T, P>` is morally `&T` (Deref/get) with, for `P = Mut`, an
 // unsafe `get_mut` escape hatch whose exclusivity is the caller's per-site

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -669,7 +669,10 @@ impl<T> OwnedThis<T> {
         OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
     }
 
-    /// A dispatch handle to the pointee (root provenance).
+    /// A dispatch handle to the pointee (root provenance). Like every
+    /// [`ThisPtr`], it and its copies are valid only while this `OwnedThis`
+    /// lives: whoever it is handed to takes on that holder obligation (the
+    /// [`BackRef`] contract), which is what makes this safe to call.
     #[inline]
     pub fn this_ptr(&self) -> ThisPtr<T> {
         ThisPtr(self.0)

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -735,7 +735,15 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
         poll_tag::GET_ADDR_INFO_REQUEST => {
             #[cfg(target_os = "macos")]
             {
-                crate::dns_jsc::dns_sd::SharedConnection::on_readable();
+                use crate::dns_jsc::dns_sd::SharedConnection;
+                let p = owner.ptr.cast::<SharedConnection>().cast_const();
+                // SAFETY: tag set at `SharedConnection::get` with `Rc::as_ptr` of the
+                // `Rc` that owns this poll (so is live); take a counted handle for the callback.
+                let this = unsafe {
+                    std::rc::Rc::increment_strong_count(p);
+                    std::rc::Rc::from_raw(p)
+                };
+                SharedConnection::on_readable(this);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -1005,8 +1013,15 @@ pub(crate) unsafe fn __bun_fire_timer(
         EventLoopTimerTag::DnsSdConnection => {
             #[cfg(target_os = "macos")]
             {
-                // One connection per thread; it owns the timer that fired.
-                crate::dns_jsc::dns_sd::SharedConnection::on_early_out();
+                use crate::dns_jsc::dns_sd::SharedConnection;
+                let p = owner!(SharedConnection, early_out_timer).cast_const();
+                // SAFETY: the container is the `Rc`-held connection whose armed timer
+                // fired (its `Drop` removes the timer first); take a counted handle for the callback.
+                let this = unsafe {
+                    std::rc::Rc::increment_strong_count(p);
+                    std::rc::Rc::from_raw(p)
+                };
+                SharedConnection::on_early_out(this);
                 Ok(())
             }
             #[cfg(not(target_os = "macos"))]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -270,11 +270,6 @@ pub(crate) fn run_task(
                 ))
             };
         }
-        #[cfg(windows)]
-        task_tag::GetAddrInfoLibuvComplete => {
-            // SAFETY: boxed in `on_raw_libuv_complete`; the arm consumes it.
-            unsafe { bun_core::heap::take(cast_ptr!(crate::dns_jsc::LibuvCompleteHolder)) }.run();
-        }
         task_tag::ValkeyDeferredClose => {
             // SAFETY: boxed at the enqueue site; the arm consumes it.
             unsafe {
@@ -589,7 +584,7 @@ fn run_task_cold(task: Task) {
 /// `release_task_unrun` track `bun_event_loop::task_tag::COUNT`. Bump when
 /// adding a variant — and give it an arm in both.
 const _: () = assert!(
-    task_tag::COUNT == 61,
+    task_tag::COUNT == 60,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -725,18 +720,22 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
             unsafe { crate::shell::io_writer::on_poll(&mut *h, size_or_offset as isize, hup) }
         }),
         poll_tag::DNS_RESOLVER => {
-            // R-2: deref as shared (`&*const`) — `on_dns_poll` takes `&self` and
-            // `Channel::process` re-enters the resolver via c-ares callbacks.
-            // SAFETY: tag set with this pointee type at `FilePoll::init`.
-            let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
-            // SAFETY: `poll` outlives this call (caller contract).
-            resolver.on_dns_poll(unsafe { &mut *poll });
+            let (fd, readable, writable) = (
+                poll_ref.fd.native(),
+                poll_ref.is_readable(),
+                poll_ref.is_writable(),
+            );
+            // SAFETY: tag set with this pointee type at `FilePoll::init`; the
+            // resolver owns the poll, so it is live. `on_dns_poll` re-enters
+            // the resolver via c-ares callbacks (and may release the poll), so
+            // it gets a `ThisPtr` and the fd, not `poll`.
+            let resolver = unsafe { bun_ptr::ThisPtr::new(owner.ptr.cast::<DNSResolver>()) };
+            DNSResolver::on_dns_poll(resolver, fd, readable, writable);
         }
         poll_tag::GET_ADDR_INFO_REQUEST => {
             #[cfg(target_os = "macos")]
             {
-                let shared = owner.ptr.cast::<crate::dns_jsc::dns_sd::SharedConnection>();
-                crate::dns_jsc::dns_sd::SharedConnection::on_readable(shared);
+                crate::dns_jsc::dns_sd::SharedConnection::on_readable();
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -1006,11 +1005,9 @@ pub(crate) unsafe fn __bun_fire_timer(
         EventLoopTimerTag::DnsSdConnection => {
             #[cfg(target_os = "macos")]
             {
-                timer_arm!(
-                    crate::dns_jsc::dns_sd::SharedConnection,
-                    early_out_timer,
-                    |c, _now, _vm| crate::dns_jsc::dns_sd::SharedConnection::on_early_out(c)
-                )
+                // One connection per thread; it owns the timer that fired.
+                crate::dns_jsc::dns_sd::SharedConnection::on_early_out();
+                Ok(())
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -1020,10 +1017,11 @@ pub(crate) unsafe fn __bun_fire_timer(
                 Ok(())
             }
         }
-        // R-2: shared deref — `check_timeouts` re-enters via `ares_process_fd`.
+        // `check_timeouts` re-enters via `ares_process_fd` and may release
+        // refs on the resolver, hence the `ThisPtr`.
         EventLoopTimerTag::DNSResolver => {
             timer_arm!(DNSResolver, event_loop_timer, |c, now, vm| {
-                (&*c.cast_const()).check_timeouts(&*now, &*vm)
+                DNSResolver::check_timeouts(bun_ptr::ThisPtr::new(c), &*now, &*vm)
             })
         }
         EventLoopTimerTag::WindowsNamedPipe => {
@@ -1294,12 +1292,6 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
             release!(crate::valkey_jsc::js_valkey::ValkeyDeferredClose)
         }
         // ── Windows-only producers ───────────────────────────────────────
-        task_tag::GetAddrInfoLibuvComplete => {
-            #[cfg(windows)]
-            release!(crate::dns_jsc::LibuvCompleteHolder);
-            #[cfg(not(windows))]
-            unreachable!("windows-only tag");
-        }
         task_tag::WindowsNamedPipeContext => {
             #[cfg(windows)]
             release!(crate::socket::WindowsNamedPipeContext);

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -21,43 +21,26 @@ fn utf8_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
 
 // ── struct_hostent ─────────────────────────────────────────────────────────
 pub(crate) fn hostent_to_js_response(
-    this: &mut c_ares::struct_hostent,
+    this: &c_ares::struct_hostent,
     global_this: &JSGlobalObject,
     lookup_name: &'static [u8], // PERF: could be monomorphized per lookup name — profile if hot
 ) -> JsResult<JSValue> {
     if lookup_name == b"cname" {
         // A cname lookup always returns a single record but we follow the common API here.
-        if this.h_name.is_null() {
+        let Some(name) = this.name() else {
             return JSValue::create_empty_array(global_this, 0);
-        }
-        // SAFETY: h_name is non-null NUL-terminated C string from c-ares.
-        let name = unsafe { bun_core::ffi::cstr(this.h_name) }.to_bytes();
+        };
         return bun_string_jsc::to_js_array(global_this, &[bstr::String::borrow_utf8(name)]);
     }
 
-    if this.h_aliases.is_null() {
+    if !this.has_aliases() {
         return JSValue::create_empty_array(global_this, 0);
     }
 
-    let mut count: u32 = 0;
-    // SAFETY: h_aliases is a non-null NULL-terminated array of C strings.
-    while unsafe { !(*this.h_aliases.add(count as usize)).is_null() } {
-        count += 1;
-    }
+    let array = JSValue::create_empty_array(global_this, this.aliases().count())?;
 
-    let array = JSValue::create_empty_array(global_this, count as usize)?;
-    count = 0;
-
-    loop {
-        // SAFETY: h_aliases is a non-null NULL-terminated array of C strings.
-        let alias = unsafe { *this.h_aliases.add(count as usize) };
-        if alias.is_null() {
-            break;
-        }
-        // SAFETY: alias is a non-null NUL-terminated C string from c-ares.
-        let alias_slice = unsafe { bun_core::ffi::cstr(alias) }.to_bytes();
-        array.put_index(global_this, count, utf8_to_js(global_this, alias_slice)?)?;
-        count += 1;
+    for (i, alias) in (0u32..).zip(this.aliases()) {
+        array.put_index(global_this, i, utf8_to_js(global_this, alias)?)?;
     }
 
     Ok(array)
@@ -65,65 +48,37 @@ pub(crate) fn hostent_to_js_response(
 
 // ── hostent_with_ttls ──────────────────────────────────────────────────────
 pub(crate) fn hostent_with_ttls_to_js_response(
-    this: &mut c_ares::hostent_with_ttls,
+    this: &c_ares::hostent_with_ttls,
     global_this: &JSGlobalObject,
     lookup_name: &'static [u8], // PERF: could be monomorphized per lookup name — profile if hot
 ) -> JsResult<JSValue> {
     if lookup_name == b"a" || lookup_name == b"aaaa" {
-        // SAFETY: this.hostent is a c-ares-owned hostent pointer (non-null on success path).
-        let hostent = unsafe { &*this.hostent };
-        if hostent.h_addr_list.is_null() {
+        let hostent = &*this.hostent;
+        if !hostent.has_addr_list() {
             return JSValue::create_empty_array(global_this, 0);
         }
 
-        let mut count: u32 = 0;
-        // SAFETY: h_addr_list is a non-null NULL-terminated array of address bytes.
-        while unsafe { !(*hostent.h_addr_list.add(count as usize)).is_null() } {
-            count += 1;
-        }
+        let array = JSValue::create_empty_array(global_this, hostent.addresses().count())?;
 
-        let array = JSValue::create_empty_array(global_this, count as usize)?;
-        count = 0;
-
-        loop {
-            // SAFETY: h_addr_list is a non-null NULL-terminated array of address bytes.
-            let addr = unsafe { *hostent.h_addr_list.add(count as usize) };
-            if addr.is_null() {
-                break;
-            }
-            // bun_dns::Address (= bun_sys::net::Address) only exposes init_posix,
-            // so build a sockaddr_in/in6 on the stack and copy through that.
+        for (count, addr) in (0u32..).zip(hostent.addresses()) {
             let addr_string = {
-                // h_addrtype is c_short on Windows, c_int on POSIX; widen for the compare.
-                #[allow(clippy::useless_conversion)]
-                let address = if i32::from(hostent.h_addrtype) == c_ares::AF::INET6 {
-                    // SAFETY: addr points to ≥16 bytes for AF_INET6.
-                    let bytes: [u8; 16] = unsafe { *(addr as *const [u8; 16]) };
-                    let mut sa6: super::netc::sockaddr_in6 = bun_core::ffi::zeroed();
-                    sa6.sin6_family = super::netc::AF_INET6 as _;
-                    sa6.sin6_addr.s6_addr = bytes;
-                    // SAFETY: &sa6 is a valid sockaddr_in6.
-                    unsafe { bun_dns::Address::init_posix((&raw const sa6).cast()) }
+                let ip: std::net::IpAddr = if hostent.addrtype() == c_ares::AF::INET6 {
+                    <[u8; 16]>::try_from(addr)
+                        .map_or(std::net::Ipv6Addr::UNSPECIFIED, std::net::Ipv6Addr::from)
+                        .into()
                 } else {
-                    // SAFETY: addr points to ≥4 bytes for AF_INET.
-                    let bytes: [u8; 4] = unsafe { *(addr as *const [u8; 4]) };
-                    let mut sa4: super::netc::sockaddr_in = bun_core::ffi::zeroed();
-                    sa4.sin_family = super::netc::AF_INET as _;
-                    sa4.sin_addr.s_addr = u32::from_ne_bytes(bytes);
-                    // SAFETY: &sa4 is a valid sockaddr_in.
-                    unsafe { bun_dns::Address::init_posix((&raw const sa4).cast()) }
+                    <[u8; 4]>::try_from(addr)
+                        .map_or(std::net::Ipv4Addr::UNSPECIFIED, std::net::Ipv4Addr::from)
+                        .into()
                 };
+                let address = bun_dns::Address::from_ip(ip, 0);
                 match address_to_js(&address, global_this) {
                     Ok(v) => v,
                     Err(_) => return Ok(global_this.throw_out_of_memory_value()),
                 }
             };
 
-            let ttl: Option<c_int> = if (count as usize) < this.ttls.len() {
-                Some(this.ttls[count as usize])
-            } else {
-                None
-            };
+            let ttl: Option<c_int> = this.ttls.get(count as usize).copied();
             let result_object = JSValue::create_empty_object(global_this, 2);
             result_object.put(global_this, b"address", addr_string);
             result_object.put(
@@ -136,7 +91,6 @@ pub(crate) fn hostent_with_ttls_to_js_response(
                 },
             );
             array.put_index(global_this, count, result_object)?;
-            count += 1;
         }
 
         Ok(array)
@@ -146,25 +100,21 @@ pub(crate) fn hostent_with_ttls_to_js_response(
     }
 }
 
-// ── struct_nameinfo ────────────────────────────────────────────────────────
+// ── NameInfo ───────────────────────────────────────────────────────────────
 pub(crate) fn nameinfo_to_js_response(
-    this: &mut c_ares::struct_nameinfo,
+    this: &c_ares::NameInfo<'_>,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     let array = JSValue::create_empty_array(global_this, 2)?; // [node, service]
 
-    if !this.node.is_null() {
-        // SAFETY: node is a non-null NUL-terminated C string from c-ares.
-        let node_slice = unsafe { bun_core::ffi::cstr(this.node.cast()) }.to_bytes();
-        array.put_index(global_this, 0, utf8_to_js(global_this, node_slice)?)?;
+    if let Some(node) = this.node {
+        array.put_index(global_this, 0, utf8_to_js(global_this, node)?)?;
     } else {
         array.put_index(global_this, 0, JSValue::UNDEFINED)?;
     }
 
-    if !this.service.is_null() {
-        // SAFETY: service is a non-null NUL-terminated C string from c-ares.
-        let service_slice = unsafe { bun_core::ffi::cstr(this.service.cast()) }.to_bytes();
-        array.put_index(global_this, 1, utf8_to_js(global_this, service_slice)?)?;
+    if let Some(service) = this.service {
+        array.put_index(global_this, 1, utf8_to_js(global_this, service)?)?;
     } else {
         array.put_index(global_this, 1, JSValue::UNDEFINED)?;
     }
@@ -174,105 +124,49 @@ pub(crate) fn nameinfo_to_js_response(
 
 // ── AddrInfo ───────────────────────────────────────────────────────────────
 pub(crate) fn addr_info_to_js_array(
-    addr_info: &mut c_ares::AddrInfo,
+    addr_info: &c_ares::AddrInfo,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
-    // LIFETIMES.tsv rows 254/256: AddrInfo.node / AddrInfo_node.next are FFI → *mut AddrInfo_node.
-    if addr_info.node.is_null() {
-        return JSValue::create_empty_array(global_this, 0);
-    }
-    // SAFETY: node is non-null (checked above); c-ares owns the linked list.
-    let array =
-        JSValue::create_empty_array(global_this, unsafe { (*addr_info.node).count() } as usize)?;
+    let array = JSValue::create_empty_array(global_this, addr_info.nodes().count())?;
 
-    {
-        let mut j: u32 = 0;
-        let mut current: *mut c_ares::AddrInfo_node = addr_info.node;
-        while !current.is_null() {
-            // SAFETY: current is non-null (loop guard); c-ares owns the linked list.
-            let this_node = unsafe { &*current };
-            // bun_dns::Address::init_posix copies from the raw sockaddr by family,
-            // so we hand it `this_node.addr` directly after asserting a known family.
-            debug_assert!(
-                this_node.family == c_ares::AF::INET || this_node.family == c_ares::AF::INET6
-            );
-            // SAFETY: addr is non-null sockaddr_in/in6 for AF_INET/AF_INET6 (c-ares contract).
-            let address = unsafe { bun_dns::Address::init_posix(this_node.addr.cast()) };
-            array.put_index(
+    for (j, this_node) in (0u32..).zip(addr_info.nodes()) {
+        debug_assert!(
+            this_node.family == c_ares::AF::INET || this_node.family == c_ares::AF::INET6
+        );
+        let address = bun_dns::Address::from_sockaddr_bytes(this_node.sockaddr_bytes())
+            .unwrap_or_else(|| {
+                bun_dns::Address::from_ip(std::net::Ipv4Addr::UNSPECIFIED.into(), 0)
+            });
+        array.put_index(
+            global_this,
+            j,
+            result_to_js(
+                &bun_dns::GetAddrInfoResult {
+                    address,
+                    ttl: this_node.ttl,
+                },
                 global_this,
-                j,
-                result_to_js(
-                    &bun_dns::GetAddrInfoResult {
-                        address,
-                        ttl: this_node.ttl,
-                    },
-                    global_this,
-                )?,
-            )?;
-            j += 1;
-            current = this_node.next;
-        }
+            )?,
+        )?;
     }
 
     Ok(array)
 }
 
-// ── shared count-then-walk → JS array helper ───────────────────────────────
+// ── shared walk → JS array helper ──────────────────────────────────────────
 //
-// Every `struct_ares_*_reply` is an intrusive singly-linked list with a
-// `.next: *mut Self` field. The two-pass walk (count, then
-// `create_empty_array` + `put_index`) is done once generically here.
-// The trait is `unsafe` because impls promise `next()`
-// is either null or a valid pointer into the same c-ares-owned list.
+// Every `struct_ares_*_reply` is an intrusive singly-linked list; the two-pass
+// walk (count, then `create_empty_array` + `put_index`) is done once here.
 
-/// SAFETY: impls must return null or a valid pointer into the same
-/// c-ares-owned linked list.
-unsafe trait CAresLinked {
-    fn next(&self) -> *mut Self;
-}
-
-macro_rules! impl_cares_linked {
-    ($($t:ty),+ $(,)?) => {$(
-        // SAFETY: `.next` is the c-ares-owned intrusive list pointer.
-        unsafe impl CAresLinked for $t {
-            #[inline]
-            fn next(&self) -> *mut Self { self.next }
-        }
-    )+};
-}
-
-impl_cares_linked!(
-    c_ares::struct_ares_caa_reply,
-    c_ares::struct_ares_srv_reply,
-    c_ares::struct_ares_mx_reply,
-    c_ares::struct_ares_txt_reply,
-    c_ares::struct_ares_naptr_reply,
-);
-
-fn cares_list_to_js_array<T: CAresLinked>(
-    head: &T,
+fn cares_list_to_js_array<'a, T: 'a>(
+    iter: impl Iterator<Item = &'a T> + Clone,
     global_this: &JSGlobalObject,
     mut to_js: impl FnMut(&T, &JSGlobalObject) -> JsResult<JSValue>,
 ) -> JsResult<JSValue> {
-    let mut count: usize = 0;
-    let mut p: *const T = head;
-    while !p.is_null() {
-        // SAFETY: `p` walks the c-ares-owned linked list (CAresLinked invariant).
-        unsafe { p = (*p).next() };
-        count += 1;
-    }
+    let array = JSValue::create_empty_array(global_this, iter.clone().count())?;
 
-    let array = JSValue::create_empty_array(global_this, count)?;
-
-    p = head;
-    let mut i: u32 = 0;
-    while !p.is_null() {
-        // SAFETY: `p` walks the c-ares-owned linked list (CAresLinked invariant);
-        // shared access only — the `to_js` builders never mutate the reply.
-        let node = unsafe { &*p };
+    for (i, node) in (0u32..).zip(iter) {
         array.put_index(global_this, i, to_js(node, global_this)?)?;
-        p = node.next();
-        i += 1;
     }
 
     Ok(array)
@@ -280,11 +174,11 @@ fn cares_list_to_js_array<T: CAresLinked>(
 
 // ── struct_ares_caa_reply ──────────────────────────────────────────────────
 pub(crate) fn caa_reply_to_js_response(
-    this: &mut c_ares::struct_ares_caa_reply,
+    this: &c_ares::struct_ares_caa_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    cares_list_to_js_array(this, global_this, caa_reply_to_js)
+    cares_list_to_js_array(this.iter(), global_this, caa_reply_to_js)
 }
 
 fn caa_reply_to_js(
@@ -308,11 +202,11 @@ fn caa_reply_to_js(
 
 // ── struct_ares_srv_reply ──────────────────────────────────────────────────
 pub(crate) fn srv_reply_to_js_response(
-    this: &mut c_ares::struct_ares_srv_reply,
+    this: &c_ares::struct_ares_srv_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    cares_list_to_js_array(this, global_this, srv_reply_to_js)
+    cares_list_to_js_array(this.iter(), global_this, srv_reply_to_js)
 }
 
 fn srv_reply_to_js(
@@ -333,20 +227,22 @@ fn srv_reply_to_js(
     );
     obj.put(global_this, b"port", JSValue::js_number(this.port as f64));
 
-    // SAFETY: host is a non-null NUL-terminated C string from c-ares.
-    let host = unsafe { bun_core::ffi::cstr(this.host.cast()) }.to_bytes();
-    obj.put(global_this, b"name", utf8_to_js(global_this, host)?);
+    obj.put(
+        global_this,
+        b"name",
+        utf8_to_js(global_this, this.host_bytes())?,
+    );
 
     Ok(obj)
 }
 
 // ── struct_ares_mx_reply ───────────────────────────────────────────────────
 pub(crate) fn mx_reply_to_js_response(
-    this: &mut c_ares::struct_ares_mx_reply,
+    this: &c_ares::struct_ares_mx_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    cares_list_to_js_array(this, global_this, mx_reply_to_js)
+    cares_list_to_js_array(this.iter(), global_this, mx_reply_to_js)
 }
 
 fn mx_reply_to_js(
@@ -360,20 +256,22 @@ fn mx_reply_to_js(
         JSValue::js_number(this.priority as f64),
     );
 
-    // SAFETY: host is a non-null NUL-terminated C string from c-ares.
-    let host = unsafe { bun_core::ffi::cstr(this.host.cast()) }.to_bytes();
-    obj.put(global_this, b"exchange", utf8_to_js(global_this, host)?);
+    obj.put(
+        global_this,
+        b"exchange",
+        utf8_to_js(global_this, this.host_bytes())?,
+    );
 
     Ok(obj)
 }
 
 // ── struct_ares_txt_reply ──────────────────────────────────────────────────
 pub(crate) fn txt_reply_to_js_response(
-    this: &mut c_ares::struct_ares_txt_reply,
+    this: &c_ares::struct_ares_txt_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    cares_list_to_js_array(this, global_this, txt_reply_to_js)
+    cares_list_to_js_array(this.iter(), global_this, txt_reply_to_js)
 }
 
 fn txt_reply_to_js(
@@ -387,12 +285,13 @@ fn txt_reply_to_js(
 }
 
 fn txt_reply_to_js_for_any(
-    this: &mut c_ares::struct_ares_txt_reply,
+    this: &c_ares::struct_ares_txt_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    let array =
-        cares_list_to_js_array(this, global_this, |node, g| utf8_to_js(g, node.txt_bytes()))?;
+    let array = cares_list_to_js_array(this.iter(), global_this, |node, g| {
+        utf8_to_js(g, node.txt_bytes())
+    })?;
     let obj = JSValue::create_empty_object(global_this, 1);
     obj.put(global_this, b"entries", array);
     Ok(obj)
@@ -400,11 +299,11 @@ fn txt_reply_to_js_for_any(
 
 // ── struct_ares_naptr_reply ────────────────────────────────────────────────
 pub(crate) fn naptr_reply_to_js_response(
-    this: &mut c_ares::struct_ares_naptr_reply,
+    this: &c_ares::struct_ares_naptr_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    cares_list_to_js_array(this, global_this, naptr_reply_to_js)
+    cares_list_to_js_array(this.iter(), global_this, naptr_reply_to_js)
 }
 
 fn naptr_reply_to_js(
@@ -420,24 +319,25 @@ fn naptr_reply_to_js(
     );
     obj.put(global_this, b"order", JSValue::js_number(this.order as f64));
 
-    // SAFETY: flags is a non-null NUL-terminated C string from c-ares.
-    let flags = unsafe { bun_core::ffi::cstr(this.flags.cast()) }.to_bytes();
-    obj.put(global_this, b"flags", utf8_to_js(global_this, flags)?);
-
-    // SAFETY: service is a non-null NUL-terminated C string from c-ares.
-    let service = unsafe { bun_core::ffi::cstr(this.service.cast()) }.to_bytes();
-    obj.put(global_this, b"service", utf8_to_js(global_this, service)?);
-
-    // SAFETY: regexp is a non-null NUL-terminated C string from c-ares.
-    let regexp = unsafe { bun_core::ffi::cstr(this.regexp.cast()) }.to_bytes();
-    obj.put(global_this, b"regexp", utf8_to_js(global_this, regexp)?);
-
-    // SAFETY: replacement is a non-null NUL-terminated C string from c-ares.
-    let replacement = unsafe { bun_core::ffi::cstr(this.replacement.cast()) }.to_bytes();
+    obj.put(
+        global_this,
+        b"flags",
+        utf8_to_js(global_this, this.flags_bytes())?,
+    );
+    obj.put(
+        global_this,
+        b"service",
+        utf8_to_js(global_this, this.service_bytes())?,
+    );
+    obj.put(
+        global_this,
+        b"regexp",
+        utf8_to_js(global_this, this.regexp_bytes())?,
+    );
     obj.put(
         global_this,
         b"replacement",
-        utf8_to_js(global_this, replacement)?,
+        utf8_to_js(global_this, this.replacement_bytes())?,
     );
 
     Ok(obj)
@@ -445,7 +345,7 @@ fn naptr_reply_to_js(
 
 // ── struct_ares_soa_reply ──────────────────────────────────────────────────
 pub(crate) fn soa_reply_to_js_response(
-    this: &mut c_ares::struct_ares_soa_reply,
+    this: &c_ares::struct_ares_soa_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
@@ -454,7 +354,7 @@ pub(crate) fn soa_reply_to_js_response(
 }
 
 fn soa_reply_to_js(
-    this: &mut c_ares::struct_ares_soa_reply,
+    this: &c_ares::struct_ares_soa_reply,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     let obj = JSValue::create_empty_object(global_this, 7);
@@ -481,16 +381,15 @@ fn soa_reply_to_js(
         JSValue::js_number(this.minttl as f64),
     );
 
-    // SAFETY: nsname is a non-null NUL-terminated C string from c-ares.
-    let nsname = unsafe { bun_core::ffi::cstr(this.nsname.cast()) }.to_bytes();
-    obj.put(global_this, b"nsname", utf8_to_js(global_this, nsname)?);
-
-    // SAFETY: hostmaster is a non-null NUL-terminated C string from c-ares.
-    let hostmaster = unsafe { bun_core::ffi::cstr(this.hostmaster.cast()) }.to_bytes();
+    obj.put(
+        global_this,
+        b"nsname",
+        utf8_to_js(global_this, this.nsname_bytes())?,
+    );
     obj.put(
         global_this,
         b"hostmaster",
-        utf8_to_js(global_this, hostmaster)?,
+        utf8_to_js(global_this, this.hostmaster_bytes())?,
     );
 
     Ok(obj)
@@ -498,7 +397,7 @@ fn soa_reply_to_js(
 
 // ── struct_any_reply ───────────────────────────────────────────────────────
 pub(crate) fn any_reply_to_js_response(
-    this: &mut c_ares::struct_any_reply,
+    this: &c_ares::struct_any_reply,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
@@ -560,79 +459,65 @@ fn any_reply_append_all(
 }
 
 fn any_reply_to_js(
-    this: &mut c_ares::struct_any_reply,
+    this: &c_ares::struct_any_reply,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     // The field set is expanded manually here. Keep in lockstep with
     // `c_ares::struct_any_reply`'s fields.
     let len: usize = this.a_reply.is_some() as usize
         + this.aaaa_reply.is_some() as usize
-        + (!this.mx_reply.is_null()) as usize
-        + (!this.ns_reply.is_null()) as usize
-        + (!this.txt_reply.is_null()) as usize
-        + (!this.srv_reply.is_null()) as usize
-        + (!this.ptr_reply.is_null()) as usize
-        + (!this.naptr_reply.is_null()) as usize
-        + (!this.soa_reply.is_null()) as usize
-        + (!this.caa_reply.is_null()) as usize;
+        + this.mx_reply.is_some() as usize
+        + this.ns_reply.is_some() as usize
+        + this.txt_reply.is_some() as usize
+        + this.srv_reply.is_some() as usize
+        + this.ptr_reply.is_some() as usize
+        + this.naptr_reply.is_some() as usize
+        + this.soa_reply.is_some() as usize
+        + this.caa_reply.is_some() as usize;
 
     let array = JSValue::create_empty_array(global_this, len)?;
     let mut i: u32 = 0;
 
-    if let Some(reply) = this.a_reply.as_deref_mut() {
+    if let Some(reply) = this.a_reply.as_deref() {
         let response = hostent_with_ttls_to_js_response(reply, global_this, b"a")?;
         any_reply_append_all(global_this, array, &mut i, response, b"a")?;
     }
-    if let Some(reply) = this.aaaa_reply.as_deref_mut() {
+    if let Some(reply) = this.aaaa_reply.as_deref() {
         let response = hostent_with_ttls_to_js_response(reply, global_this, b"aaaa")?;
         any_reply_append_all(global_this, array, &mut i, response, b"aaaa")?;
     }
-    if !this.mx_reply.is_null() {
-        // SAFETY: non-null c-ares-owned linked list head.
-        let response = mx_reply_to_js_response(unsafe { &mut *this.mx_reply }, global_this, b"mx")?;
+    if let Some(reply) = this.mx_reply.as_deref() {
+        let response = mx_reply_to_js_response(reply, global_this, b"mx")?;
         any_reply_append_all(global_this, array, &mut i, response, b"mx")?;
     }
-    if !this.ns_reply.is_null() {
-        // SAFETY: non-null c-ares-owned hostent.
-        let response = hostent_to_js_response(unsafe { &mut *this.ns_reply }, global_this, b"ns")?;
+    if let Some(reply) = this.ns_reply.as_deref() {
+        let response = hostent_to_js_response(reply, global_this, b"ns")?;
         any_reply_append_all(global_this, array, &mut i, response, b"ns")?;
     }
-    if !this.txt_reply.is_null() {
-        // SAFETY: non-null c-ares-owned linked list head.
+    if let Some(reply) = this.txt_reply.as_deref() {
         // txt is the only reply type with the `to_js_for_any` shape (an `entries`
         // wrapper object) instead of the plain `to_js_response` shape.
-        let response =
-            txt_reply_to_js_for_any(unsafe { &mut *this.txt_reply }, global_this, b"txt")?;
+        let response = txt_reply_to_js_for_any(reply, global_this, b"txt")?;
         any_reply_append_all(global_this, array, &mut i, response, b"txt")?;
     }
-    if !this.srv_reply.is_null() {
-        // SAFETY: non-null c-ares-owned linked list head.
-        let response =
-            srv_reply_to_js_response(unsafe { &mut *this.srv_reply }, global_this, b"srv")?;
+    if let Some(reply) = this.srv_reply.as_deref() {
+        let response = srv_reply_to_js_response(reply, global_this, b"srv")?;
         any_reply_append_all(global_this, array, &mut i, response, b"srv")?;
     }
-    if !this.ptr_reply.is_null() {
-        // SAFETY: non-null c-ares-owned hostent.
-        let response =
-            hostent_to_js_response(unsafe { &mut *this.ptr_reply }, global_this, b"ptr")?;
+    if let Some(reply) = this.ptr_reply.as_deref() {
+        let response = hostent_to_js_response(reply, global_this, b"ptr")?;
         any_reply_append_all(global_this, array, &mut i, response, b"ptr")?;
     }
-    if !this.naptr_reply.is_null() {
-        // SAFETY: non-null c-ares-owned linked list head.
-        let response =
-            naptr_reply_to_js_response(unsafe { &mut *this.naptr_reply }, global_this, b"naptr")?;
+    if let Some(reply) = this.naptr_reply.as_deref() {
+        let response = naptr_reply_to_js_response(reply, global_this, b"naptr")?;
         any_reply_append_all(global_this, array, &mut i, response, b"naptr")?;
     }
-    if !this.soa_reply.is_null() {
-        // SAFETY: non-null c-ares-owned soa reply.
-        let response =
-            soa_reply_to_js_response(unsafe { &mut *this.soa_reply }, global_this, b"soa")?;
+    if let Some(reply) = this.soa_reply.as_deref() {
+        let response = soa_reply_to_js_response(reply, global_this, b"soa")?;
         any_reply_append_all(global_this, array, &mut i, response, b"soa")?;
     }
-    if !this.caa_reply.is_null() {
-        // SAFETY: non-null c-ares-owned linked list head.
-        let response =
-            caa_reply_to_js_response(unsafe { &mut *this.caa_reply }, global_this, b"caa")?;
+    if let Some(reply) = this.caa_reply.as_deref() {
+        let response = caa_reply_to_js_response(reply, global_this, b"caa")?;
         any_reply_append_all(global_this, array, &mut i, response, b"caa")?;
     }
 
@@ -707,40 +592,30 @@ impl ErrorDeferred {
             // enqueued task (VM-owned), so a `BackRef` captures the invariant.
             global_this: bun_ptr::BackRef<JSGlobalObject>,
         }
-        impl Context {
-            // `bun_event_loop::ManagedTask::new` expects
-            // `fn(*mut T) -> bun_event_loop::JsResult<()>` (tier-0 `bun_core::JsError`).
-            fn callback(this: *mut Context) -> bun_event_loop::JsResult<()> {
-                // SAFETY: `this` is the heap-allocated pointer passed to ManagedTask::new
-                // below; ManagedTask::run calls us exactly once with that pointer.
-                let this = unsafe { bun_core::heap::take(this) };
-                let global = this.global_this.get();
-                this.deferred.reject(global)
+        impl bun_event_loop::ManagedTask::RunOnce for Context {
+            fn run(self) -> bun_event_loop::JsResult<()> {
+                let global = self.global_this.get();
+                self.deferred.reject(global)
             }
         }
 
         let vm = global_this.bun_vm();
         // Worker terminate's `stop_dns_for_vm_teardown` fires EDESTRUCTION with
         // `is_shutting_down` already set; the task queue is about to be
-        // drained-without-run and ManagedTask has no cleanup here, so enqueuing
-        // would leak the `Context` and its `JSPromiseStrong` box. Drop now while
-        // JSC is still live so the Strong handle releases cleanly.
+        // drained-without-run, so enqueuing would only defer dropping the
+        // `Context` and its `JSPromiseStrong`. Drop now while JSC is still
+        // live so the Strong handle releases cleanly.
         if vm.is_shutting_down() {
             return;
         }
 
-        let context = bun_core::heap::into_raw(Box::new(Context {
+        let context = Box::new(Context {
             deferred: self,
             global_this: bun_ptr::BackRef::new(global_this),
-        }));
+        });
         // TODO(@heimskr): new custom Task type
-        // SAFETY: `bun_vm()` returns a non-null VM pointer (VM-owned for the lifetime of
-        // the JSGlobalObject).
         vm.as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
-                context,
-                Context::callback,
-            ));
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_boxed(context));
     }
 }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1572,9 +1572,9 @@ pub mod internal {
         }
 
         fn waiting_index(&self, request: ThisPtr<Request>) -> Option<usize> {
-            self.waiting
-                .iter()
-                .position(|w| core::ptr::eq(w.request.as_const_ptr(), request.as_ptr().cast_const()))
+            self.waiting.iter().position(|w| {
+                core::ptr::eq(w.request.as_const_ptr(), request.as_ptr().cast_const())
+            })
         }
 
         fn add_waiter(&mut self, request: ThisPtr<Request>, owner: DNSRequestOwner) {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2,6 +2,7 @@
 
 use core::cell::Cell;
 use core::ffi::{CStr, c_int, c_void};
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use bun_collections::ArrayHashMap;
@@ -22,7 +23,6 @@ use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromiseStrong, JSValue, JsCell, JsResult,
     SystemError, host_fn,
 };
-use bun_paths::MAX_PATH_BYTES;
 use bun_ptr::{BackRef, RefPtr, ThisPtr};
 #[cfg(windows)]
 use bun_sys::windows::libuv;
@@ -51,6 +51,8 @@ pub(crate) mod netc {
 pub(crate) mod netc {
     pub(crate) use bun_libuv_sys::{addrinfo, sockaddr_in, sockaddr_in6, sockaddr_storage};
     pub(crate) use bun_sys::windows::ws2_32::{AF_INET, AF_INET6, AF_UNSPEC, SOCK_STREAM};
+    /// The libuv spelling: `c_ares::Error::init_eai` reads UV_EAI_* codes on Windows.
+    pub(crate) const EAI_NONAME: core::ffi::c_int = bun_libuv_sys::UV_EAI_NONAME;
 }
 type SockaddrStorage = netc::sockaddr_storage;
 type AddrInfo = netc::addrinfo;
@@ -69,6 +71,24 @@ fn global_resolver(global_this: &JSGlobalObject) -> ThisPtr<Resolver> {
 #[inline]
 fn c_str(z: &bun::ZStr) -> &CStr {
     CStr::from_bytes_until_nul(z.as_bytes_with_nul()).expect("ZStr ends in NUL")
+}
+
+/// Stack NUL-termination for a name `do_lookup` admitted (`is_valid_hostname`:
+/// at most 254 bytes, no NUL). `NI_MAXHOST`-sized so it never truncates one.
+struct HostnameBuf([u8; 1025]);
+
+impl HostnameBuf {
+    #[inline]
+    fn new() -> Self {
+        Self([0; 1025])
+    }
+
+    fn z(&mut self, name: &[u8]) -> &CStr {
+        let len = name.len().min(self.0.len() - 1);
+        self.0[..len].copy_from_slice(&name[..len]);
+        self.0[len] = 0;
+        CStr::from_bytes_until_nul(&self.0[..=len]).expect("NUL written above")
+    }
 }
 
 /// Bridge the JS-thread `VirtualMachine` to the aio-level `EventLoopCtx` used
@@ -212,16 +232,10 @@ pub(crate) mod lib_uv_backend {
         let request = GetAddrInfoRequest::init(cache, Some(this), global_this);
 
         let hints = query.options.to_libc();
-        let mut port_buf = [0u8; 128];
-        let port_len = bun_fmt::print_int(&mut port_buf, query.port);
-        port_buf[port_len] = 0;
-        let port_z = CStr::from_bytes_until_nul(&port_buf).expect("NUL written above");
-
-        // `do_lookup` rejects names of `MAX_PATH_BYTES` or more and names
-        // containing NUL, so this always fits and terminates.
-        let mut hostname = vec![0u8; query.name.len() + 1];
-        hostname[..query.name.len()].copy_from_slice(&query.name);
-        let host = CStr::from_bytes_until_nul(&hostname).expect("NUL written above");
+        let mut port_buf = [0u8; 21];
+        let port_z = bun_fmt::itoa_z(&mut port_buf, u64::from(query.port));
+        let mut host_buf = HostnameBuf::new();
+        let host = host_buf.z(&query.name);
 
         let promise = request.head.promise.value();
         match libuv::getaddrinfo(this.vm().uv_loop(), request, host, port_z, hints.as_ref()) {
@@ -277,26 +291,23 @@ fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBackend) -> &
 const PENDING_CACHE_CAPACITY: usize = 32;
 
 /// The identity of a lookup for the pending cache.
-pub struct PendingCacheKey {
+pub struct PendingCacheKey<'a> {
     hash: u64,
-    len: u16,
-    name: Box<[u8]>,
+    name: &'a [u8],
 }
 
-impl PendingCacheKey {
-    pub(crate) fn init(query: &GetAddrInfo) -> Self {
+impl<'a> PendingCacheKey<'a> {
+    pub(crate) fn init(query: &'a GetAddrInfo) -> Self {
         Self {
             hash: query.hash(),
-            len: query.name.len() as u16,
-            name: query.name.clone(),
+            name: &query.name,
         }
     }
 
-    pub(crate) fn from_name(name: &[u8]) -> Self {
+    pub(crate) fn from_name(name: &'a [u8]) -> Self {
         Self {
             hash: wyhash(name),
-            len: name.len() as u16,
-            name: Box::<[u8]>::from(name),
+            name,
         }
     }
 }
@@ -305,7 +316,6 @@ impl PendingCacheKey {
 /// completion drains the slot.
 struct PendingEntry<L> {
     hash: u64,
-    len: u16,
     name: Box<[u8]>,
     /// The lookups that joined after the one that owns the slot, in order.
     waiters: Vec<L>,
@@ -351,11 +361,11 @@ impl<L> PendingCache<L> {
         }
     }
 
-    fn get_or_put(&self, key: &PendingCacheKey) -> CacheHit {
+    fn get_or_put(&self, key: &PendingCacheKey<'_>) -> CacheHit {
         self.slots.with_mut(|slots| {
             for (i, slot) in slots.iter().enumerate() {
                 if let Some(entry) = slot {
-                    if entry.hash == key.hash && entry.len == key.len && entry.name == key.name {
+                    if entry.hash == key.hash && *entry.name == *key.name {
                         return CacheHit::Inflight(i as u8);
                     }
                 }
@@ -366,8 +376,7 @@ impl<L> PendingCache<L> {
             }
             let entry = PendingEntry {
                 hash: key.hash,
-                len: key.len,
-                name: key.name.clone(),
+                name: Box::from(key.name),
                 waiters: Vec::new(),
                 #[cfg(windows)]
                 uv_inflight: None,
@@ -453,18 +462,9 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         name: &[u8],
         global_this: &JSGlobalObject,
     ) -> Box<Self> {
-        let mut poll_ref = KeepAlive::init();
-        poll_ref.ref_(js_event_loop_ctx());
         Box::new(Self {
             pending_slot: cache.new_slot(),
-            head: CAresLookup {
-                resolver: resolver.map(RefPtr::from_this),
-                global_this: BackRef::new(global_this),
-                promise: JSPromiseStrong::init(global_this),
-                poll_ref,
-                name: Box::<[u8]>::from(name),
-                _marker: core::marker::PhantomData,
-            },
+            head: CAresLookup::init(resolver, global_this, name),
         })
     }
 
@@ -522,17 +522,9 @@ impl GetHostByAddrInfoRequest {
         name: &[u8],
         global_this: &JSGlobalObject,
     ) -> Box<Self> {
-        let mut poll_ref = KeepAlive::init();
-        poll_ref.ref_(js_event_loop_ctx());
         Box::new(Self {
             pending_slot: cache.new_slot(),
-            head: CAresReverse {
-                resolver: resolver.map(RefPtr::from_this),
-                global_this: BackRef::new(global_this),
-                promise: JSPromiseStrong::init(global_this),
-                poll_ref,
-                name: Box::<[u8]>::from(name),
-            },
+            head: CAresReverse::init(resolver, global_this, name),
         })
     }
 
@@ -789,23 +781,13 @@ pub mod get_addr_info_request {
             };
             let query_name = core::mem::take(&mut query.name); // freed at end of scope
             let hints = query.options.to_libc();
-            let mut port_buf = [0u8; 128];
-            let port_len = bun_fmt::print_int(&mut port_buf, query.port);
-            port_buf[port_len] = 0;
-            let port_z = CStr::from_bytes_until_nul(&port_buf).expect("NUL written above");
-
-            // `do_lookup` rejects names of `MAX_PATH_BYTES` or more and names
-            // containing NUL, so this always terminates where expected.
-            let mut hostname = Vec::with_capacity(query_name.len() + 1);
-            hostname.extend_from_slice(&query_name);
-            hostname.push(0);
-            let host = CStr::from_bytes_until_nul(&hostname).expect("NUL written above");
+            let mut port_buf = [0u8; 21];
+            let port_z = bun_fmt::itoa_z(&mut port_buf, u64::from(query.port));
+            let mut host_buf = HostnameBuf::new();
+            let host = host_buf.z(&query_name);
             let debug_timer = Output::DebugTimer::start();
-            let result = bun_sys::net::AddrInfoList::lookup(
-                Some(host),
-                if port_len > 0 { Some(port_z) } else { None },
-                hints.as_ref(),
-            );
+            let result =
+                bun_sys::net::AddrInfoList::lookup(Some(host), Some(port_z), hints.as_ref());
             bun_sys::syslog!(
                 "getaddrinfo({}, {}) = {} ({})",
                 bstr::BStr::new(&query_name),
@@ -845,7 +827,7 @@ impl GetAddrInfoRequest {
             let status = if !results.is_empty() {
                 0
             } else {
-                query.empty_status()
+                dns_sd::EMPTY_STATUS
             };
             (results, status)
         });
@@ -1276,19 +1258,10 @@ impl Outcome {
     }
 }
 
-#[inline]
-fn keep_alive(outcome: &Outcome) {
-    outcome.keep_alive();
-}
-
 impl Drop for DNSLookup {
     fn drop(&mut self) {
         bun_output::scoped_log!(DNSLookup, "deinit");
-        // DNSLookup is always created on the JS event loop (it holds a JSGlobalObject),
-        // so the Js-arm vtable is the correct EventLoopCtx for KeepAlive::unref.
-        self.poll_ref.unref(Async::posix_event_loop::get_vm_ctx(
-            Async::AllocatorType::Js,
-        ));
+        self.poll_ref.unref(js_event_loop_ctx());
         drop(self.resolver.take());
     }
 }
@@ -1326,7 +1299,7 @@ impl Resolver {
     /// Windows: `uv_getaddrinfo` requests are uv *requests* on this thread's
     /// loop, which the teardown drains before closing the loop; cancel the ones
     /// still in flight so that drain is prompt (each completes through its
-    /// callback with UV_ECANCELED against the still-live VM).
+    /// callback with UV_EAI_CANCELED against the still-live VM).
     #[cfg(windows)]
     pub(crate) fn cancel_pending_uv_requests_for_teardown(&self) {
         for entry in self.pending_host_cache_native.slots.get().iter().flatten() {
@@ -1614,8 +1587,7 @@ pub mod internal {
                     if entry.is_expired(timestamp_to_store) {
                         bun_output::scoped_log!(dns, "get: expired entry");
                         if entry.refcount() == 0 {
-                            let len = self.cache.len();
-                            self.delete_entry_at(len, i);
+                            self.delete_entry_at(i);
                         }
                         // An expired entry that is still referenced is now
                         // invalid, so the next pass over `i` skips it.
@@ -1641,10 +1613,10 @@ pub mod internal {
             self.cache.len() * 5 >= MAX_ENTRIES * 4
         }
 
-        /// Free entry `i` of `len` (swap-remove).
-        fn delete_entry_at(&mut self, len: usize, i: usize) {
-            DNS_CACHE_SIZE.store(len - 1, Ordering::Relaxed);
+        /// Free entry `i` (swap-remove).
+        fn delete_entry_at(&mut self, i: usize) {
             drop(self.cache.swap_remove(i));
+            DNS_CACHE_SIZE.store(self.cache.len(), Ordering::Relaxed);
         }
 
         /// Free `entry` (a cached request or an orphan).
@@ -1652,8 +1624,7 @@ pub mod internal {
             let is =
                 |e: &bun_ptr::OwnedThis<Request>| core::ptr::eq(&raw const **e, entry.as_ptr());
             if let Some(i) = self.cache.iter().position(is) {
-                let len = self.cache.len();
-                self.delete_entry_at(len, i);
+                self.delete_entry_at(i);
             } else {
                 self.remove_orphan(entry);
             }
@@ -1743,6 +1714,51 @@ pub mod internal {
         hints_copy
     }
 
+    /// Chrome's `IsLocalHostname` (RFC 6761 §6.3): `localhost` or `*.localhost`, ASCII case-insensitive, one trailing dot allowed.
+    fn is_localhost_name(host: &[u8]) -> bool {
+        const DOT_LOCALHOST: &[u8] = b".localhost";
+        let host = host.strip_suffix(b".").unwrap_or(host);
+        strings::eql_case_insensitive_ascii(host, b"localhost", true)
+            || (host.len() >= DOT_LOCALHOST.len()
+                && strings::eql_case_insensitive_ascii(
+                    &host[host.len() - DOT_LOCALHOST.len()..],
+                    DOT_LOCALHOST,
+                    true,
+                ))
+    }
+
+    /// Chrome's `ServeLocalhost`: a localhost name is `[::1, 127.0.0.1]` without asking the resolver, narrowed like every other lookup by the family feature flags.
+    fn localhost_results(port: u16) -> AddrInfoResult {
+        #[cfg(not(windows))]
+        let family = get_hints().ai_family;
+        #[cfg(windows)]
+        let family = netc::AF_UNSPEC;
+        let nodes: Vec<_> = [
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        ]
+        .into_iter()
+        .filter(move |ip| family == netc::AF_UNSPEC || ip.is_ipv6() == (family == netc::AF_INET6))
+        .map(move |ip| synthetic_node(&bun_dns::Address::from_ip(ip, port)))
+        .collect();
+        process_results(nodes, 0)
+    }
+
+    /// Chrome's `IsAllLocalhostOfOneFamily`: every address is loopback and only one family is present, the shape glibc's AI_ADDRCONFIG produces for a hosts-file loopback name (crbug 42058 / 49024).
+    fn is_all_loopback_of_one_family(
+        addresses: impl Iterator<Item = Option<bun_dns::Address>>,
+    ) -> bool {
+        let (mut saw_v4, mut saw_v6) = (false, false);
+        for address in addresses {
+            match address.and_then(|a| a.ip()) {
+                Some(IpAddr::V4(ip)) if ip.is_loopback() => saw_v4 = true,
+                Some(IpAddr::V6(ip)) if ip.is_loopback() => saw_v6 = true,
+                _ => return false,
+            }
+        }
+        saw_v4 != saw_v6
+    }
+
     pub enum DNSRequestOwner {
         Socket(DnsWaitingSocket),
         Prefetch,
@@ -1777,34 +1793,32 @@ pub mod internal {
         );
     }
 
-    /// The `ai_family`/`ai_socktype`/`ai_addrlen` header for a synthesized
-    /// result entry.
-    fn synthetic_addrinfo(family: c_int) -> AddrInfo {
-        let mut n: AddrInfo = bun_core::ffi::zeroed();
-        n.ai_family = family;
-        n.ai_socktype = netc::SOCK_STREAM;
-        n.ai_addrlen = if family == netc::AF_INET6 {
+    /// One getaddrinfo()-shaped node: the `addrinfo` header and, if the node
+    /// has one, the socket address it points at.
+    type Node = (AddrInfo, Option<SockaddrStorage>);
+
+    /// A synthesized node for `address` (`SOCK_STREAM`, `ai_addrlen` by family).
+    fn synthetic_node(address: &bun_dns::Address) -> Node {
+        let family = address.family();
+        let mut info: AddrInfo = bun_core::ffi::zeroed();
+        info.ai_family = family;
+        info.ai_socktype = netc::SOCK_STREAM;
+        info.ai_addrlen = if family == netc::AF_INET6 {
             core::mem::size_of::<netc::sockaddr_in6>() as _
         } else {
             core::mem::size_of::<netc::sockaddr_in>() as _
         };
-        n
+        (info, Some(address.into_storage()))
     }
 
     // Pack getaddrinfo results into one allocation with address families
     // interleaved (RFC 8305 §4) so an unroutable family can never fill all
     // CONCURRENT_CONNECTIONS parallel connect attempts. See #4938 / #33278.
-    fn process_results(
-        nodes: impl Iterator<Item = (AddrInfo, Option<SockaddrStorage>)> + Clone,
-        err: c_int,
-    ) -> AddrInfoResult {
+    fn process_results(nodes: Vec<Node>, err: c_int) -> AddrInfoResult {
         let first_family = nodes
-            .clone()
-            .next()
+            .first()
             .map_or(netc::AF_UNSPEC, |(info, _)| info.ai_family);
-        let is_first = move |info: &AddrInfo| info.ai_family == first_family;
-        let count = nodes.clone().count();
-        let entry = |(info, addr): (AddrInfo, Option<SockaddrStorage>)| {
+        let entry = |(info, addr): Node| {
             // Windows getaddrinfo may return non-null ai_addr with families other
             // than AF_INET/AF_INET6; those entries keep a (zeroed) `addr`.
             let addr = addr.map(|a| {
@@ -1818,8 +1832,11 @@ pub mod internal {
         };
 
         // first, other, first, other, … then whatever is left of the longer run.
-        let mut firsts = nodes.clone().filter(move |(info, _)| is_first(info));
-        let mut others = nodes.filter(move |(info, _)| !is_first(info));
+        let count = nodes.len();
+        let (firsts, others): (Vec<Node>, Vec<Node>) = nodes
+            .into_iter()
+            .partition(|(info, _)| info.ai_family == first_family);
+        let (mut firsts, mut others) = (firsts.into_iter(), others.into_iter());
         let mut results: Vec<addrinfo_result_entry> = Vec::with_capacity(count);
         loop {
             match (firsts.next(), others.next()) {
@@ -1840,7 +1857,8 @@ pub mod internal {
         let result = match result {
             Ok(Some(list)) => process_results(
                 list.iter()
-                    .map(|e| (*e.raw(), e.address().map(bun_dns::Address::into_storage))),
+                    .map(|e| (*e.raw(), e.address().map(bun_dns::Address::into_storage)))
+                    .collect(),
                 0,
             ),
             Ok(None) => AddrInfoResult::new(Vec::new(), 0),
@@ -1893,12 +1911,20 @@ pub mod internal {
         let result = {
             let mut hints = get_hints();
             let mut result = bun_sys::net::AddrInfoList::lookup(host, service, Some(&hints));
-            // optional fallback
-            if result.as_ref().err() == Some(&netc::EAI_NONAME)
-                && (hints.ai_flags & netc::AI_ADDRCONFIG) != 0
+            // Chrome's retries: AI_ADDRCONFIG left nothing, or only one family's loopback.
+            if (hints.ai_flags & netc::AI_ADDRCONFIG) != 0
+                && match &result {
+                    Err(err) => *err == netc::EAI_NONAME,
+                    Ok(list) => is_all_loopback_of_one_family(
+                        list.iter().flat_map(|l| l.iter()).map(|e| e.address()),
+                    ),
+                }
             {
                 hints.ai_flags &= !netc::AI_ADDRCONFIG;
-                result = bun_sys::net::AddrInfoList::lookup(host, service, Some(&hints));
+                let unfiltered = bun_sys::net::AddrInfoList::lookup(host, service, Some(&hints));
+                if unfiltered.is_ok() || result.is_err() {
+                    result = unfiltered;
+                }
             }
             result
         };
@@ -1936,25 +1962,23 @@ pub mod internal {
     /// Complete an internal request: build an addrinfo chain and reuse `process_results` (happy-eyeballs order).
     #[cfg(target_os = "macos")]
     pub(super) fn dns_sd_complete(req: BackRef<Request, bun_ptr::Root>) {
-        let (results, empty_status) = req
-            .dns_sd
-            .with_mut(|query| (query.take_results(), query.empty_status()));
+        let results = req.dns_sd.with_mut(|query| query.take_results());
         let port = req.key.port;
         let req = req.this_ptr();
 
         if results.is_empty() {
-            after_result_entries(req, AddrInfoResult::new(Vec::new(), empty_status));
+            after_result_entries(req, AddrInfoResult::new(Vec::new(), dns_sd::EMPTY_STATUS));
             return;
         }
 
-        let nodes = results.iter().map(|r| {
-            let mut address = r.address;
-            address.set_port(port);
-            (
-                synthetic_addrinfo(address.family()),
-                Some(address.into_storage()),
-            )
-        });
+        let nodes = results
+            .iter()
+            .map(|r| {
+                let mut address = r.address;
+                address.set_port(port);
+                synthetic_node(&address)
+            })
+            .collect();
         after_result_entries(req, process_results(nodes, 0));
     }
 
@@ -2003,6 +2027,58 @@ pub mod internal {
         Ok(object)
     }
 
+    /// The `addresses: string[]` argument of the testing hooks below.
+    fn addresses_for_testing(
+        global: &JSGlobalObject,
+        addresses: JSValue,
+    ) -> JsResult<Vec<bun_dns::Address>> {
+        if !addresses.is_array() {
+            return Err(
+                global.throw_invalid_arguments(format_args!("expected addresses: string[]"))
+            );
+        }
+        let len = addresses.get_length(global)? as usize;
+        if len > 64 {
+            return Err(global
+                .throw_invalid_arguments(format_args!("addresses must have at most 64 entries")));
+        }
+        (0..len)
+            .map(|i| {
+                let address = addresses.get_index(global, i as u32)?.to_utf8(global)?;
+                match bun_core::ip_address::to_ip_address(address.slice()) {
+                    Some(ip) => Ok(bun_dns::Address::from_ip(ip, 0)),
+                    None => Err(global.throw_invalid_arguments(format_args!(
+                        "addresses[{i}] is not an IPv4 or IPv6 literal"
+                    ))),
+                }
+            })
+            .collect()
+    }
+
+    /// `bun:internal-for-testing`: [`is_localhost_name`] for one hostname.
+    pub(crate) fn is_localhost_name_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let hostname = frame.argument(0);
+        if !hostname.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!("expected (hostname: string)")));
+        }
+        let hostname = hostname.to_utf8(global)?;
+        Ok(JSValue::js_boolean(is_localhost_name(hostname.slice())))
+    }
+
+    /// `bun:internal-for-testing`: [`is_all_loopback_of_one_family`] over `addresses` laid out as a getaddrinfo() answer.
+    pub(crate) fn is_all_loopback_of_one_family_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let addrs = addresses_for_testing(global, frame.argument(0))?;
+        Ok(JSValue::js_boolean(is_all_loopback_of_one_family(
+            addrs.into_iter().map(Some),
+        )))
+    }
+
     /// `bun:internal-for-testing`: seed the connect-path DNS cache for `hostname`
     /// by running `addresses` through the real [`process_results`] interleave and
     /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it.
@@ -2011,42 +2087,17 @@ pub mod internal {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let args = frame.arguments();
-        if args.len() < 2 || !args[0].is_string() || !args[1].is_array() {
+        if args.len() < 2 || !args[0].is_string() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "expected (hostname: string, addresses: string[])"
             )));
         }
         let hostname_slice = args[0].to_utf8(global)?;
-        let len = args[1].get_length(global)? as usize;
-        if len == 0 || len > 64 {
-            return Err(
-                global.throw_invalid_arguments(format_args!("addresses must have 1..=64 entries"))
-            );
+        let addrs = addresses_for_testing(global, args[1])?;
+        if addrs.is_empty() {
+            return Err(global.throw_invalid_arguments(format_args!("addresses must not be empty")));
         }
-
-        let mut nodes: Vec<(AddrInfo, Option<SockaddrStorage>)> = Vec::with_capacity(len);
-        for i in 0..len {
-            let addr_slice = args[1].get_index(global, i as u32)?.to_utf8(global)?;
-            let addr_z = bun::ZBox::from_bytes(addr_slice.slice());
-            let mut octets = [0u8; 16];
-            let ip: std::net::IpAddr =
-                if c_ares::inet_pton(netc::AF_INET, c_str(&addr_z), &mut octets) > 0 {
-                    std::net::Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3]).into()
-                } else if c_ares::inet_pton(netc::AF_INET6, c_str(&addr_z), &mut octets) > 0 {
-                    std::net::Ipv6Addr::from(octets).into()
-                } else {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "addresses[{i}] is not an IPv4 or IPv6 literal"
-                    )));
-                };
-            let address = bun_dns::Address::from_ip(ip, 0);
-            nodes.push((
-                synthetic_addrinfo(address.family()),
-                Some(address.into_storage()),
-            ));
-        }
-
-        let results = process_results(nodes.iter().copied(), 0);
+        let results = process_results(addrs.iter().map(synthetic_node).collect(), 0);
 
         let out = JSValue::create_empty_array(global, results.entries().len())?;
         for (i, entry) in (0u32..).zip(results.entries().iter()) {
@@ -2169,6 +2220,32 @@ pub mod internal {
         DNS_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
         DNS_CACHE_SIZE.store(guard.len(), Ordering::Relaxed);
         drop(guard);
+
+        if host.is_some_and(|h| !bun_dns::is_valid_hostname(h)) {
+            bun_output::scoped_log!(
+                dns,
+                "getaddrinfo({}) = cache miss (not a hostname)",
+                bstr::BStr::new(host.unwrap_or(b""))
+            );
+            after_result_entries(req, AddrInfoResult::new(Vec::new(), netc::EAI_NONAME));
+            if let Some(is_cache_hit) = is_cache_hit {
+                *is_cache_hit = true;
+            }
+            return Some(req);
+        }
+
+        if host.is_some_and(is_localhost_name) {
+            bun_output::scoped_log!(
+                dns,
+                "getaddrinfo({}) = cache miss (localhost)",
+                bstr::BStr::new(host.unwrap_or(b""))
+            );
+            after_result_entries(req, localhost_results(port));
+            if let Some(is_cache_hit) = is_cache_hit {
+                *is_cache_hit = true;
+            }
+            return Some(req);
+        }
 
         #[cfg(target_os = "macos")]
         {
@@ -2856,10 +2933,10 @@ impl Resolver {
             &prev_global,
             T::reply_to_js(&addr, &prev_global, T::TYPE_NAME),
         );
-        keep_alive(&array);
+        array.keep_alive();
         head.on_complete(array);
 
-        keep_alive(&array);
+        array.keep_alive();
 
         for waiter in waiters {
             let new_global = waiter.global_this;
@@ -2871,9 +2948,9 @@ impl Resolver {
                 prev_global = new_global;
             }
 
-            keep_alive(&array);
+            array.keep_alive();
             waiter.on_complete(array);
-            keep_alive(&array);
+            array.keep_alive();
         }
     }
 
@@ -2904,10 +2981,10 @@ impl Resolver {
             &prev_global,
             super::cares_jsc::addr_info_to_js_array(&addr, &prev_global),
         );
-        keep_alive(&array);
+        array.keep_alive();
         head.on_complete_with_array(array);
 
-        keep_alive(&array);
+        array.keep_alive();
 
         for waiter in waiters {
             let new_global = waiter.global_this;
@@ -2919,9 +2996,9 @@ impl Resolver {
                 prev_global = new_global;
             }
 
-            keep_alive(&array);
+            array.keep_alive();
             waiter.on_complete_with_array(array);
-            keep_alive(&array);
+            array.keep_alive();
         }
         // `addr` (the c-ares `ares_addrinfo`) is freed once, after all consumers ran.
     }
@@ -2955,9 +3032,9 @@ impl Resolver {
         let mut prev_global = head.global_this;
 
         {
-            keep_alive(&array);
+            array.keep_alive();
             head.on_complete_with_array(array);
-            keep_alive(&array);
+            array.keep_alive();
         }
 
         for waiter in waiters {
@@ -2970,9 +3047,9 @@ impl Resolver {
                 prev_global = new_global;
             }
 
-            keep_alive(&array);
+            array.keep_alive();
             waiter.on_complete_with_array(array);
-            keep_alive(&array);
+            array.keep_alive();
         }
     }
 
@@ -3004,10 +3081,10 @@ impl Resolver {
             &prev_global,
             super::cares_jsc::hostent_to_js_response(addr, &prev_global, b""),
         );
-        keep_alive(&array);
+        array.keep_alive();
         head.on_complete(array);
 
-        keep_alive(&array);
+        array.keep_alive();
 
         for waiter in waiters {
             let new_global = waiter.global_this;
@@ -3019,9 +3096,9 @@ impl Resolver {
                 prev_global = new_global;
             }
 
-            keep_alive(&array);
+            array.keep_alive();
             waiter.on_complete(array);
-            keep_alive(&array);
+            array.keep_alive();
         }
     }
 
@@ -3051,10 +3128,10 @@ impl Resolver {
             &prev_global,
             super::cares_jsc::nameinfo_to_js_response(&name_info, &prev_global),
         );
-        keep_alive(&array);
+        array.keep_alive();
         head.on_complete(array);
 
-        keep_alive(&array);
+        array.keep_alive();
 
         for waiter in waiters {
             let new_global = waiter.global_this;
@@ -3066,9 +3143,9 @@ impl Resolver {
                 prev_global = new_global;
             }
 
-            keep_alive(&array);
+            array.keep_alive();
             waiter.on_complete(array);
-            keep_alive(&array);
+            array.keep_alive();
         }
     }
 
@@ -3500,12 +3577,7 @@ impl Resolver {
         options: GetAddrInfoOptions,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        // The system backends copy the hostname into a NUL-terminated buffer.
-        // Reject anything that cannot fit a `bun.PathBuffer` (the historical
-        // bound) or embeds a NUL. RFC 1035 caps hostnames at 253 octets and
-        // NI_MAXHOST is 1025, so this never rejects a name that could have
-        // resolved.
-        if name.len() >= MAX_PATH_BYTES || strings::contains_char(name, 0) {
+        if !bun_dns::is_valid_hostname(name) {
             let mut promise = JSPromiseStrong::init(global_this);
             let promise_value = promise.value();
             error_to_deferred(
@@ -4319,6 +4391,20 @@ pub fn get_runtime_default_result_order_option(
 // HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting)
 pub fn seed_cache_for_testing(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     internal::seed_cache_for_testing(global, frame)
+}
+// HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isLocalhostNameForTesting)
+pub fn is_localhost_name_for_testing(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    internal::is_localhost_name_for_testing(global, frame)
+}
+// HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isAllLoopbackOfOneFamilyForTesting)
+pub fn is_all_loopback_of_one_family_for_testing(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    internal::is_all_loopback_of_one_family_for_testing(global, frame)
 }
 // HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoErrorForTesting)
 pub fn getaddrinfo_error_for_testing(

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1,17 +1,14 @@
 //! DNS resolver — JSC bindings.
 
 use core::cell::Cell;
-use core::ffi::{c_char, c_int, c_void};
-use core::mem::MaybeUninit;
-use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use core::ptr::{self, NonNull};
+use core::ffi::{CStr, c_int, c_void};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use bun_collections::{ArrayHashMap, HiveArray};
+use bun_collections::ArrayHashMap;
 #[cfg(not(windows))]
 use bun_core::Output;
+use bun_core::strings;
 use bun_core::{self as bun, env_var, fmt as bun_fmt};
-use bun_core::{ZStr, strings};
 #[cfg(not(windows))]
 use bun_dns::ResultList as GetAddrInfoResultList;
 use bun_dns::{
@@ -19,23 +16,22 @@ use bun_dns::{
     Options as GetAddrInfoOptions, ResultAny as GetAddrInfoResultAny,
 };
 #[cfg(not(windows))]
-use bun_io::FilePoll;
+use bun_io::OwnedFilePoll;
 use bun_io::{self as Async, KeepAlive};
-use bun_jsc::bun_string_jsc;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromiseStrong, JSValue, JsCell, JsResult,
     SystemError, host_fn,
 };
-use bun_ptr::RefPtr;
+use bun_paths::MAX_PATH_BYTES;
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 #[cfg(windows)]
 use bun_sys::windows::libuv;
-#[cfg(not(windows))]
-use bun_sys::{self as sys};
-use bun_uws::{ConnectingSocket, Loop};
+use bun_uws::Loop;
 use bun_wyhash::hash as wyhash;
 
 use super::cares_jsc::error_to_deferred;
+use crate::jsc_hooks::timer_all_mut;
 use crate::socket::socket_address::inet::INET6_ADDRSTRLEN;
 use crate::timer::{ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 use bun_cares_sys::c_ares_draft as c_ares;
@@ -48,48 +44,33 @@ use bun_cares_sys::c_ares_draft as c_ares;
 pub(crate) mod netc {
     pub(crate) use bun_dns::AI_ADDRCONFIG;
     pub(crate) use libc::{
-        AF_INET, AF_INET6, AF_UNSPEC, EAI_NONAME, SOCK_STREAM, addrinfo, sockaddr, sockaddr_in,
-        sockaddr_in6, sockaddr_storage,
+        AF_INET, AF_INET6, AF_UNSPEC, EAI_NONAME, SOCK_STREAM, addrinfo, sockaddr_in, sockaddr_in6,
+        sockaddr_storage,
     };
 }
 #[cfg(windows)]
 pub(crate) mod netc {
-    pub(crate) use bun_libuv_sys::{
-        addrinfo, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage,
-    };
+    pub(crate) use bun_libuv_sys::{addrinfo, sockaddr_in, sockaddr_in6, sockaddr_storage};
     pub(crate) use bun_sys::windows::ws2_32::{AF_INET, AF_INET6, AF_UNSPEC, SOCK_STREAM};
-    /// The libuv spelling: `c_ares::Error::init_eai` reads UV_EAI_* codes on Windows.
-    pub(crate) const EAI_NONAME: core::ffi::c_int = bun_libuv_sys::UV_EAI_NONAME;
 }
 type SockaddrStorage = netc::sockaddr_storage;
 type AddrInfo = netc::addrinfo;
-type Sockaddr = netc::sockaddr;
 
-/// Helper: fetch the per-VM global DNS resolver (port of
-/// `RareData::globalDNSResolver`). The storage is
-/// [`crate::jsc_hooks::RuntimeState::global_dns_data`] — concrete
-/// `Option<Box<GlobalData>>`, freed by `deinit_runtime_state` on VM teardown.
-///
-/// R-2: returns `&Resolver` (shared). All Resolver mutation routes through
-/// `Cell` / `JsCell` fields, so a shared borrow is sufficient and avoids the
-/// `noalias` hazard when c-ares callbacks re-enter on the same global resolver.
+/// The per-VM global DNS resolver, created on first use; pinned by
+/// [`GlobalData`] until `deinit_runtime_state`.
 #[inline]
-fn global_resolver(global_this: &JSGlobalObject) -> &Resolver {
-    let gd = crate::jsc_hooks::global_dns_data().get_or_init(|| {
-        let gd = GlobalData::init(global_this.bun_vm());
-        gd.resolver.ref_(); // pin for the VM's lifetime
-        gd
-    });
-    &gd.resolver
+fn global_resolver(global_this: &JSGlobalObject) -> ThisPtr<Resolver> {
+    let gd =
+        crate::jsc_hooks::global_dns_data().get_or_init(|| GlobalData::init(global_this.bun_vm()));
+    gd.resolver.this_ptr()
 }
 
-/// Send-wrapper for raw pointers handed to the threaded work pool. The DNS
-/// `Request` is heap-allocated and only touched under `global_cache().lock()`,
-/// so crossing threads is sound — Rust just can't see that through `*mut T`.
-#[repr(transparent)]
-struct SendPtr<T>(*mut T);
-// SAFETY: see type doc — synchronization is provided by `global_cache()`.
-unsafe impl<T> Send for SendPtr<T> {}
+/// The C view of `z`: up to its first NUL (an embedded NUL truncates, as it
+/// would for any C resolver API).
+#[inline]
+fn c_str(z: &bun::ZStr) -> &CStr {
+    CStr::from_bytes_until_nul(z.as_bytes_with_nul()).expect("ZStr ends in NUL")
+}
 
 /// Bridge the JS-thread `VirtualMachine` to the aio-level `EventLoopCtx` used
 /// by `KeepAlive` / `FilePoll`. The DNS resolver always runs on the JS event
@@ -111,10 +92,6 @@ bun_output::declare_scope!(DNSLookup, visible);
 bun_output::declare_scope!(dns, hidden);
 bun_output::declare_scope!(DNSResolver, visible);
 
-// ──────────────────────────────────────────────────────────────────────────
-// C type aliases
-// ──────────────────────────────────────────────────────────────────────────
-
 const IANA_DNS_PORT: i32 = 53;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -134,44 +111,38 @@ mod lib_c {
     use super::*;
 
     pub(crate) fn lookup(
-        this: &Resolver,
+        this: ThisPtr<Resolver>,
         query_init: &GetAddrInfo,
         global_this: &JSGlobalObject,
     ) -> JSValue {
-        let key = get_addr_info_request::PendingCacheKey::init(query_init);
+        let key = PendingCacheKey::init(query_init);
 
-        let cache =
-            this.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheNative);
+        let cache = Resolver::pending_host_cache(&this, PendingCacheField::PendingHostCacheNative)
+            .get_or_put(&key);
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(this.as_ctx_ptr(), global_this);
-            // SAFETY: inflight points into resolver's pending-cache HiveArray slot.
-            unsafe { (*inflight).append(dns_lookup) };
-            // SAFETY: dns_lookup just heap-allocated; owned by the inflight list.
-            return unsafe { (*dns_lookup).promise.value() };
+            let dns_lookup = DNSLookup::init(Some(this), global_this);
+            let promise = dns_lookup.promise.value();
+            Resolver::pending_host_cache(&this, PendingCacheField::PendingHostCacheNative)
+                .append(inflight, dns_lookup);
+            return promise;
         }
 
         let query = query_init.clone();
 
-        // The backend result is filled in by the job's completion; until then
-        // the request (which the pending cache points at) holds a placeholder.
-        let request = GetAddrInfoRequest::init(
-            cache,
-            get_addr_info_request::Backend::CAres,
-            Some(this.as_ctx_ptr()),
-            global_this,
-            PendingCacheField::PendingHostCacheNative,
-        );
-        // SAFETY: request was just heap-allocated in init() and is exclusively owned here.
-        let promise_value = unsafe { (*request).head.promise.value() };
+        let request = get_addr_info_request::LibcRequest {
+            head: Some(DNSLookup::init_head(Some(this), global_this)),
+            pending_slot: cache.new_slot(),
+        };
+        let promise_value = request.head.as_ref().unwrap().promise.value();
 
         bun_jsc::Job::<get_addr_info_request::LibcLookup>::schedule(
             &global_this.js_thread(),
             get_addr_info_request::LibcLookup {
                 backend: get_addr_info_request::LibcBackend::Query(query),
             },
-            get_addr_info_request::LibcRequest(NonNull::new(request).expect("request")),
+            request,
         );
-        this.request_sent(this.vm());
+        Resolver::request_sent(this, this.vm());
 
         promise_value
     }
@@ -186,129 +157,112 @@ mod lib_c {
 pub(crate) mod lib_uv_backend {
     use super::*;
 
-    pub(crate) struct LibuvCompleteHolder {
-        uv_info: *mut libuv::uv_getaddrinfo_t,
+    /// A completed `uv_getaddrinfo`, queued as a task (see `on_complete`).
+    pub(crate) struct LibuvComplete {
+        request: Box<GetAddrInfoRequest>,
+        status: c_int,
+        result: libuv::UvAddrInfo,
     }
 
-    impl LibuvCompleteHolder {
-        pub(crate) fn run(self: Box<Self>) {
-            GetAddrInfoRequest::on_libuv_complete(self.uv_info);
+    impl bun_event_loop::ManagedTask::RunOnce for LibuvComplete {
+        fn run(self) -> bun_event_loop::JsResult<()> {
+            GetAddrInfoRequest::on_libuv_complete(*self.request, self.status, self.result);
+            Ok(())
+        }
+
+        /// A completion the stop phase cancelled and drained into the queue:
+        /// running it is what frees the request and its cache slot, and it only
+        /// settles promises (no callback runs; script is forbidden), so run it.
+        fn cancelled(self) {
+            let _ = self.run();
         }
     }
-    impl bun_event_loop::Taskable for LibuvCompleteHolder {
-        const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::GetAddrInfoLibuvComplete;
-        /// A uv_getaddrinfo the stop phase cancelled and drained into the queue:
-        /// its completion is what frees the request and its cache slot, and it
-        /// only settles promises (no callback runs; script is forbidden), so run it.
-        unsafe fn release_unrun(this: *mut Self) {
-            // SAFETY: fn contract — the box `on_raw_libuv_complete` queued.
-            unsafe { bun_core::heap::take(this) }.run();
+
+    impl libuv::GetAddrInfoRequest for GetAddrInfoRequest {
+        fn uv_req(&mut self) -> &mut libuv::uv_getaddrinfo_t {
+            self.backend.as_libc_uv_mut()
         }
-    }
 
-    extern "C" fn on_raw_libuv_complete(
-        uv_info: *mut libuv::uv_getaddrinfo_t,
-        _status: c_int,
-        _res: *mut libuv::addrinfo,
-    ) {
-        // TODO: We schedule a task to run because otherwise the promise will not be solved, we need to investigate this
-        // SAFETY: data was set to the GetAddrInfoRequest pointer before uv_getaddrinfo
-        let this: *mut GetAddrInfoRequest = unsafe { (*uv_info).data.cast() };
-
-        let task = jsc::Task::from_boxed(Box::new(LibuvCompleteHolder { uv_info }));
-        // SAFETY: `this` is the live GetAddrInfoRequest set as uv data.
-        unsafe {
-            (*this)
-                .head
-                .global_this()
-                .bun_vm()
-                .as_mut()
-                .enqueue_task(task);
+        fn on_complete(this: Box<Self>, status: c_int, result: libuv::UvAddrInfo) {
+            // TODO: We schedule a task to run because otherwise the promise will not be solved, we need to investigate this
+            let vm = this.head.global_this().bun_vm();
+            vm.as_mut()
+                .enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new_boxed(
+                    Box::new(LibuvComplete {
+                        request: this,
+                        status,
+                        result,
+                    }),
+                ));
         }
     }
 
     pub(crate) fn lookup(
-        this: &Resolver,
+        this: ThisPtr<Resolver>,
         query: GetAddrInfo,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        let key = get_addr_info_request::PendingCacheKey::init(&query);
+        let key = PendingCacheKey::init(&query);
 
-        let cache =
-            this.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheNative);
+        let host_cache =
+            Resolver::pending_host_cache(&this, PendingCacheField::PendingHostCacheNative);
+        let cache = host_cache.get_or_put(&key);
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(this.as_ctx_ptr(), global_this);
-            unsafe { (*inflight).append(dns_lookup) };
-            return Ok(unsafe { (*dns_lookup).promise.value() });
+            let dns_lookup = DNSLookup::init(Some(this), global_this);
+            let promise = dns_lookup.promise.value();
+            host_cache.append(inflight, dns_lookup);
+            return Ok(promise);
         }
 
         let request = GetAddrInfoRequest::init(
             cache,
             get_addr_info_request::Backend::Libc(get_addr_info_request::LibcBackend::uv_uninit()),
-            Some(this.as_ctx_ptr()),
+            Some(this),
             global_this,
-            PendingCacheField::PendingHostCacheNative,
         );
 
         let hints = query.options.to_libc();
         let mut port_buf = [0u8; 128];
         let port_len = bun_fmt::print_int(&mut port_buf, query.port);
         port_buf[port_len] = 0;
-        // SAFETY: port_buf[port_len] == 0 written above
-        let port_z = ZStr::from_buf(&port_buf[..], port_len);
+        let port_z = CStr::from_bytes_until_nul(&port_buf).expect("NUL written above");
 
-        let mut hostname = bun_paths::path_buffer_pool::get();
-        // Reserve the last byte for the NUL terminator so the index below can never
-        // exceed the buffer even if the upstream length guard in `doLookup` is bypassed.
-        let cap = hostname.len() - 1;
-        // `strings::copy` returns a slice borrowing `hostname`; take only its length
-        // so the mutable borrow ends immediately and `hostname` can be indexed again.
-        let copied_len = strings::copy(&mut hostname[..cap], query.name.as_ref()).len();
-        hostname[copied_len] = 0;
-        // SAFETY: hostname[copied_len] == 0 written above
-        let host = ZStr::from_buf(&hostname[..], copied_len);
+        // `do_lookup` rejects names of `MAX_PATH_BYTES` or more and names
+        // containing NUL, so this always fits and terminates.
+        let mut hostname = vec![0u8; query.name.len() + 1];
+        hostname[..query.name.len()].copy_from_slice(&query.name);
+        let host = CStr::from_bytes_until_nul(&hostname).expect("NUL written above");
 
-        // SAFETY: request lives until completion; backend.libc.uv is the embedded uv_getaddrinfo_t
-        let promise = unsafe {
-            (*request).backend.as_libc_uv_mut().data = request.cast::<c_void>();
-            let promise = (*request).head.promise.value();
-            let rc = libuv::uv_getaddrinfo(
-                this.vm().uv_loop(),
-                (*request).backend.as_libc_uv_mut(),
-                Some(on_raw_libuv_complete),
-                host.as_ptr().cast::<c_char>(),
-                port_z.as_ptr().cast::<c_char>(),
-                hints
-                    .as_ref()
-                    .map_or(ptr::null(), |h| (h as *const AddrInfo).cast()),
-            );
-            if rc.int() < 0 {
+        let promise = request.head.promise.value();
+        match libuv::getaddrinfo(this.vm().uv_loop(), request, host, port_z, hints.as_ref()) {
+            Ok(inflight) => {
+                if let CacheHit::New(pos) = cache {
+                    host_cache.set_uv_inflight(pos, inflight);
+                }
+                Ok(promise)
+            }
+            Err((rc, request)) => {
                 // uv_getaddrinfo can fail synchronously before it queues any work
                 // (e.g. UV_EINVAL from the 256-byte IDNA buffer for long hostnames,
                 // or UV_ENOMEM). Route the error through the same path the async
                 // completion would have taken so the pending-cache slot is released
                 // and the promise is rejected with a DNSException.
-                if let Some(resolver) = (*request).resolver_for_caching {
-                    if let Some(pos) = (*request).pending_slot {
-                        (*resolver).drain_pending_host_native(
-                            pos,
-                            (*request).head.global_this(),
-                            rc.int(),
-                            &GetAddrInfoResultAny::Addrinfo(ptr::null_mut()),
-                        );
-                        return Ok(promise);
-                    }
+                let request = *request;
+                if let (Some(resolver), Some(pos)) = (request.head.resolver(), request.pending_slot)
+                {
+                    Resolver::drain_pending_host_native(
+                        resolver,
+                        pos,
+                        rc.int(),
+                        &GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()),
+                        request.head,
+                    );
+                    return Ok(promise);
                 }
-                // Consume the request and move `head` out by value; `ptr::read`
-                // + `heap::take` would double-Drop `DNSLookup` (impls Drop).
-                let owned = *bun_core::heap::take(request);
-                let mut head = owned.head;
-                DNSLookup::process_get_addr_info_native(&mut head, rc.int(), ptr::null_mut());
-                return Ok(promise);
+                request.head.process_get_addr_info_native(rc.int());
+                Ok(promise)
             }
-            promise
-        };
-        Ok(promise)
+        }
     }
 }
 
@@ -336,194 +290,238 @@ fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBackend) -> &
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Pending cache — same-name lookups issued while one is in flight wait on it.
+// ──────────────────────────────────────────────────────────────────────────
+
+const PENDING_CACHE_CAPACITY: usize = 32;
+
+/// The identity of a lookup for the pending cache.
+pub struct PendingCacheKey {
+    hash: u64,
+    len: u16,
+    name: Box<[u8]>,
+}
+
+impl PendingCacheKey {
+    pub(crate) fn init(query: &GetAddrInfo) -> Self {
+        Self {
+            hash: query.hash(),
+            len: query.name.len() as u16,
+            name: query.name.clone(),
+        }
+    }
+
+    pub(crate) fn from_name(name: &[u8]) -> Self {
+        Self {
+            hash: wyhash(name),
+            len: name.len() as u16,
+            name: Box::<[u8]>::from(name),
+        }
+    }
+}
+
+/// One in-flight lookup other same-name lookups are chained onto until its
+/// completion drains the slot.
+struct PendingEntry<L> {
+    hash: u64,
+    len: u16,
+    name: Box<[u8]>,
+    /// The lookups that joined after the one that owns the slot, in order.
+    waiters: Vec<L>,
+    /// The in-flight `uv_getaddrinfo` (host-native cache only), so the stop
+    /// phase can cancel it. Valid while held: the slot is drained (dropping
+    /// this) by the request's completion, before the request is freed.
+    #[cfg(windows)]
+    uv_inflight: Option<libuv::InflightGetAddrInfo>,
+}
+
+/// Up to [`PENDING_CACHE_CAPACITY`] in-flight lookups of one kind, by slot.
+pub struct PendingCache<L> {
+    slots: JsCell<Vec<Option<PendingEntry<L>>>>,
+    /// Bit `i` set ⇔ `slots[i]` is occupied.
+    used: Cell<u32>,
+}
+const _: () = assert!(PENDING_CACHE_CAPACITY <= u32::BITS as usize);
+
+#[derive(Clone, Copy)]
+pub enum CacheHit {
+    /// A same-name lookup is in flight in this slot; wait on it.
+    Inflight(u8),
+    /// This lookup now owns the slot.
+    New(u8),
+    /// The cache is full; run uncached.
+    Disabled,
+}
+
+impl CacheHit {
+    #[inline]
+    fn new_slot(self) -> Option<u8> {
+        match self {
+            CacheHit::New(pos) => Some(pos),
+            _ => None,
+        }
+    }
+}
+
+impl<L> PendingCache<L> {
+    const fn init() -> Self {
+        Self {
+            slots: JsCell::new(Vec::new()),
+            used: Cell::new(0),
+        }
+    }
+
+    fn get_or_put(&self, key: &PendingCacheKey) -> CacheHit {
+        self.slots.with_mut(|slots| {
+            for (i, slot) in slots.iter().enumerate() {
+                if let Some(entry) = slot {
+                    if entry.hash == key.hash && entry.len == key.len && entry.name == key.name {
+                        return CacheHit::Inflight(i as u8);
+                    }
+                }
+            }
+            let i = (!self.used.get()).trailing_zeros() as usize;
+            if i >= PENDING_CACHE_CAPACITY {
+                return CacheHit::Disabled;
+            }
+            let entry = PendingEntry {
+                hash: key.hash,
+                len: key.len,
+                name: key.name.clone(),
+                waiters: Vec::new(),
+                #[cfg(windows)]
+                uv_inflight: None,
+            };
+            if i < slots.len() {
+                slots[i] = Some(entry);
+            } else {
+                slots.push(Some(entry));
+            }
+            self.used.set(self.used.get() | (1 << i));
+            CacheHit::New(i as u8)
+        })
+    }
+
+    fn append(&self, index: u8, waiter: L) {
+        self.slots.with_mut(|slots| {
+            slots[index as usize]
+                .as_mut()
+                .expect("pending DNS slot")
+                .waiters
+                .push(waiter)
+        });
+    }
+
+    /// Release the slot, returning the lookups that were waiting on it.
+    fn take(&self, index: u8) -> Vec<L> {
+        self.used.set(self.used.get() & !(1 << index));
+        self.slots
+            .with_mut(|slots| slots[index as usize].take())
+            .expect("pending DNS slot")
+            .waiters
+    }
+
+    fn any_pending(&self) -> bool {
+        self.used.get() != 0
+    }
+
+    #[cfg(windows)]
+    fn set_uv_inflight(&self, index: u8, inflight: libuv::InflightGetAddrInfo) {
+        self.slots.with_mut(|slots| {
+            slots[index as usize]
+                .as_mut()
+                .expect("pending DNS slot")
+                .uv_inflight = Some(inflight)
+        });
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // ResolveInfoRequest<T> — generic c-ares record request (SRV/SOA/TXT/…)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Each c-ares reply struct implements this with its record-type tag.
-pub trait CAresRecordType: Sized {
+/// Each c-ares record type implements this with its record-type tag.
+pub trait CAresRecordType: Sized + 'static {
     const TYPE_NAME: &'static str;
     /// `"query" + ucfirst(TYPE_NAME)` — each impl carries the precomputed
     /// literal so error paths report the right syscall.
     const SYSCALL: &'static str;
-    /// `"pending_{TYPE_NAME}_cache_cares"` — used to reach the matching HiveArray on `Resolver`.
-    const CACHE_FIELD: PendingCacheField;
     /// The DNS RR type passed to `ares_query`.
     const NS_TYPE: c_ares::NSType;
-    /// The `ares_callback` thunk that parses raw reply bytes for this record type
-    /// and forwards to `ResolveInfoRequest<Self>::on_cares_complete`. Used as
-    /// `ResolveHandler::raw_callback` for the generic `Channel::resolve` dispatch.
-    const RAW_CALLBACK: unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int);
-    fn to_js_response(
-        &mut self,
+    /// The parsed, owned reply.
+    type Reply;
+    fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, c_ares::Error>;
+    fn reply_to_js(
+        reply: &Self::Reply,
         global: &JSGlobalObject,
         type_name: &'static str,
     ) -> JsResult<JSValue>;
-    /// Free a reply; called once per reply, by `OwnedReply<Self>`'s `Drop`.
-    /// SAFETY: `this` must be the pointer an `OwnedReply<Self>` adopted; not aliased.
-    unsafe fn destroy(this: *mut Self);
-}
-
-/// The parsed reply of one query, freed by `T::destroy` when dropped.
-#[repr(transparent)]
-pub(crate) struct OwnedReply<T: CAresRecordType>(NonNull<T>);
-
-impl<T: CAresRecordType> OwnedReply<T> {
-    /// SAFETY: `reply` must be a live reply that `T::destroy` frees, and the
-    /// caller must give up every other use of it.
-    unsafe fn adopt(reply: NonNull<T>) -> Self {
-        Self(reply)
-    }
-}
-
-impl<T: CAresRecordType> core::ops::Deref for OwnedReply<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        // SAFETY: `adopt` took the only handle to a live reply; only `drop` frees it.
-        unsafe { self.0.as_ref() }
-    }
-}
-
-impl<T: CAresRecordType> core::ops::DerefMut for OwnedReply<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: as in `deref`; `&mut self` rules out any other live borrow.
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl<T: CAresRecordType> Drop for OwnedReply<T> {
-    fn drop(&mut self) {
-        // SAFETY: `adopt`'s contract; no borrow handed out by `deref` outlives `self`.
-        unsafe { T::destroy(self.0.as_ptr()) }
-    }
+    /// This record type's pending cache on `resolver`.
+    fn pending_cache(resolver: &Resolver) -> &PendingCache<CAresLookup<Self>>;
 }
 
 pub(crate) struct ResolveInfoRequest<T: CAresRecordType> {
-    // TODO: should be Option<&'a Resolver> (struct gets <'a>); raw ptr until reconciled with intrusive RC
-    pub resolver_for_caching: Option<*mut Resolver>,
-    /// Slot this request owns in the resolver's pending cache, which same-name
-    /// lookups chain onto until completion drains it; `None` when the cache was full.
-    pub pending_slot: Option<u8>,
-    pub head: CAresLookup<T>,
-    pub tail: *mut CAresLookup<T>, // INTRUSIVE — points at `head` or last appended node
-}
-
-pub mod resolve_info_request {
-    use super::*;
-
-    pub struct PendingCacheKey<T: CAresRecordType> {
-        pub(crate) hash: u64,
-        pub(crate) len: u16,
-        pub name: Box<[u8]>,
-        pub(crate) lookup: *mut ResolveInfoRequest<T>,
-    }
-
-    impl<T: CAresRecordType> PendingCacheKey<T> {
-        pub(crate) fn append(&mut self, cares_lookup: *mut CAresLookup<T>) {
-            // SAFETY: lookup/tail are valid while request is in the pending cache
-            unsafe {
-                let tail = (*self.lookup).tail;
-                (*tail).next = NonNull::new(cares_lookup);
-                (*self.lookup).tail = cares_lookup;
-            }
-        }
-
-        pub(crate) fn init(name: &[u8]) -> Self {
-            let hash = wyhash(name);
-            Self {
-                hash,
-                len: name.len() as u16,
-                name: Box::<[u8]>::from(name),
-                lookup: ptr::null_mut(),
-            }
-        }
-    }
+    /// See [`PendingEntry`]; `None` when the cache was full.
+    pending_slot: Option<u8>,
+    head: CAresLookup<T>,
 }
 
 impl<T: CAresRecordType> ResolveInfoRequest<T> {
     fn init(
-        cache: LookupCacheHit<Self>,
-        resolver: Option<*mut Resolver>,
+        cache: CacheHit,
+        resolver: Option<ThisPtr<Resolver>>,
         name: &[u8],
         global_this: &JSGlobalObject,
-        cache_field: PendingCacheField,
-    ) -> *mut Self {
+    ) -> Box<Self> {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-        let request = bun_core::heap::into_raw(Box::new(Self {
-            resolver_for_caching: resolver,
-            pending_slot: None,
+        Box::new(Self {
+            pending_slot: cache.new_slot(),
             head: CAresLookup {
-                // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
-                global_this: bun_ptr::BackRef::new(global_this),
+                resolver: resolver.map(RefPtr::from_this),
+                global_this: BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
-                allocated: false,
-                next: None,
                 name: Box::<[u8]>::from(name),
                 _marker: core::marker::PhantomData,
             },
-            // tail set to &head below
-            tail: ptr::null_mut(),
-        }));
-        // SAFETY: request just allocated
-        unsafe { (*request).tail = &raw mut (*request).head };
-        if let LookupCacheHit::New(new) = cache {
-            // SAFETY: `new` is &mut into resolver's HiveArray buffer
-            unsafe {
-                (*request).resolver_for_caching = resolver;
-                let pos = (*resolver.unwrap())
-                    .pending_cache_for::<T>(cache_field)
-                    .index_of(new)
-                    .unwrap();
-                (*request).pending_slot = Some(pos as u8);
-                (*new).lookup = request;
-            }
-        }
-        request
+        })
     }
 
     fn on_cares_complete(
-        this: *mut Self,
+        self,
         err_: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<OwnedReply<T>>,
+        result: Option<T::Reply>,
     ) {
-        // SAFETY: this is the heap-allocated request c-ares calls back with
-        unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
-                scopeguard::defer! { (*resolver).request_completed() };
-                if let Some(pos) = (*this).pending_slot {
-                    (*resolver).drain_pending_cares::<T>(pos, err_, timeout, result);
-                    return;
-                }
+        if let Some(resolver) = self.head.resolver() {
+            let resolver = scopeguard::guard(resolver, Resolver::request_completed);
+            if let Some(pos) = self.pending_slot {
+                Resolver::drain_pending_cares::<T>(
+                    *resolver, pos, err_, timeout, result, self.head,
+                );
+                return;
             }
-
-            // Consume the request and move `head` out by value; `ptr::read`
-            // + `heap::take` would double-Drop `CAresLookup<T>` (impls Drop).
-            let owned = *bun_core::heap::take(this);
-            let mut head = owned.head;
-            CAresLookup::<T>::process_resolve(&raw mut head, err_, timeout, result);
         }
+
+        self.head.process_resolve(err_, timeout, result.as_ref());
     }
 }
 
-// Wires `ResolveInfoRequest<T>` into `Channel::resolve` — the per-record
-// `T::RAW_CALLBACK` parses the raw DNS reply and calls back into
-// `on_cares_complete`.
-impl<T: CAresRecordType> c_ares::ResolveHandler for ResolveInfoRequest<T> {
-    const LOOKUP_NAME: &'static [u8] = T::TYPE_NAME.as_bytes();
+impl<T: CAresRecordType> c_ares::QueryHandler for ResolveInfoRequest<T> {
+    const LOOKUP_NAME: &'static str = T::TYPE_NAME;
     const NS_TYPE: c_ares::NSType = T::NS_TYPE;
-    unsafe extern "C" fn raw_callback(
-        ctx: *mut c_void,
-        status: c_int,
-        timeouts: c_int,
-        buffer: *mut u8,
-        buffer_length: c_int,
+    type Reply = T::Reply;
+    fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, c_ares::Error> {
+        T::parse(buffer)
+    }
+    fn on_reply(
+        self: Box<Self>,
+        status: Option<c_ares::Error>,
+        timeouts: i32,
+        reply: Option<Self::Reply>,
     ) {
-        // SAFETY: `ctx` is the `*mut ResolveInfoRequest<T>` handed to `ares_query`
-        // by `Channel::resolve`; the callback owns it for this call.
-        unsafe { (T::RAW_CALLBACK)(ctx, status, timeouts, buffer, buffer_length) }
+        Self::on_cares_complete(*self, status, timeouts, reply);
     }
 }
 
@@ -532,127 +530,55 @@ impl<T: CAresRecordType> c_ares::ResolveHandler for ResolveInfoRequest<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct GetHostByAddrInfoRequest {
-    // TODO: should be Option<&'a Resolver>; raw ptr for now
-    pub resolver_for_caching: Option<*mut Resolver>,
-    /// See [`ResolveInfoRequest::pending_slot`].
-    pub pending_slot: Option<u8>,
-    pub head: CAresReverse,
-    pub tail: *mut CAresReverse, // INTRUSIVE
-}
-
-pub mod get_host_by_addr_info_request {
-    use super::*;
-
-    pub struct PendingCacheKey {
-        pub(crate) hash: u64,
-        pub(crate) len: u16,
-        pub name: Box<[u8]>,
-        pub(crate) lookup: *mut GetHostByAddrInfoRequest,
-    }
-
-    impl PendingCacheKey {
-        pub(crate) fn append(&mut self, cares_lookup: *mut CAresReverse) {
-            // SAFETY: lookup/tail are valid while request is in the pending cache
-            unsafe {
-                let tail = (*self.lookup).tail;
-                (*tail).next = NonNull::new(cares_lookup);
-                (*self.lookup).tail = cares_lookup;
-            }
-        }
-
-        pub(crate) fn init(name: &[u8]) -> Self {
-            let hash = wyhash(name);
-            Self {
-                hash,
-                len: name.len() as u16,
-                name: Box::<[u8]>::from(name),
-                lookup: ptr::null_mut(),
-            }
-        }
-    }
+    /// See [`PendingEntry`].
+    pending_slot: Option<u8>,
+    head: CAresReverse,
 }
 
 impl GetHostByAddrInfoRequest {
-    /// Reverse lookups always cache through `pending_addr_cache_cares`, so no
-    /// `cache_field` selector is needed (unlike `ResolveInfoRequest::<T>::init`).
     fn init(
-        cache: LookupCacheHit<Self>,
-        resolver: Option<*mut Resolver>,
+        cache: CacheHit,
+        resolver: Option<ThisPtr<Resolver>>,
         name: &[u8],
         global_this: &JSGlobalObject,
-    ) -> *mut Self {
+    ) -> Box<Self> {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-        let request = bun_core::heap::into_raw(Box::new(Self {
-            resolver_for_caching: resolver,
-            pending_slot: None,
+        Box::new(Self {
+            pending_slot: cache.new_slot(),
             head: CAresReverse {
-                // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
-                global_this: bun_ptr::BackRef::new(global_this),
+                resolver: resolver.map(RefPtr::from_this),
+                global_this: BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
-                allocated: false,
-                next: None,
                 name: Box::<[u8]>::from(name),
             },
-            tail: ptr::null_mut(),
-        }));
-        // SAFETY: request just allocated; head is an inline field.
-        unsafe { (*request).tail = &raw mut (*request).head };
-        if let LookupCacheHit::New(new) = cache {
-            // SAFETY: `new` is &mut into resolver's HiveArray buffer; resolver/request are live.
-            unsafe {
-                (*request).resolver_for_caching = resolver;
-                let pos = (*resolver.unwrap())
-                    .pending_addr_cache_cares
-                    .get()
-                    .index_of(new)
-                    .unwrap();
-                (*request).pending_slot = Some(pos as u8);
-                (*new).lookup = request;
-            }
-        }
-        request
+        })
     }
 
     fn on_cares_complete(
-        this: *mut Self,
+        self,
         err_: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<*mut c_ares::struct_hostent>,
+        result: Option<&c_ares::struct_hostent>,
     ) {
-        // SAFETY: this is the heap-allocated request c-ares calls back with
-        unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
-                if let Some(pos) = (*this).pending_slot {
-                    (*resolver).drain_pending_addr_cares(pos, err_, timeout, result);
-                    return;
-                }
-            }
-
-            // Consume the request and move `head` out by value; `ptr::read`
-            // + `heap::take` would double-Drop `CAresReverse` (impls Drop).
-            let owned = *bun_core::heap::take(this);
-            let mut head = owned.head;
-            CAresReverse::process_resolve(&raw mut head, err_, timeout, result);
+        if let (Some(resolver), Some(pos)) = (self.head.resolver(), self.pending_slot) {
+            Resolver::drain_pending_addr_cares(resolver, pos, err_, timeout, result, self.head);
+            return;
         }
+
+        self.head.process_resolve(err_, timeout, result);
     }
 }
 
 impl c_ares::HostentHandler for GetHostByAddrInfoRequest {
     fn on_hostent(
-        &mut self,
+        self: Box<Self>,
         status: Option<c_ares::Error>,
         timeouts: i32,
-        results: *mut c_ares::struct_hostent,
+        hostent: Option<&c_ares::struct_hostent>,
     ) {
-        let result = if results.is_null() {
-            None
-        } else {
-            Some(results)
-        };
-        Self::on_cares_complete(std::ptr::from_mut::<Self>(self), status, timeouts, result);
+        Self::on_cares_complete(*self, status, timeouts, hostent);
     }
 }
 
@@ -661,115 +587,74 @@ impl c_ares::HostentHandler for GetHostByAddrInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresNameInfo {
-    pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
-    pub promise: JSPromiseStrong,
-    pub poll_ref: KeepAlive,
-    pub allocated: bool,
-    pub next: Option<NonNull<CAresNameInfo>>, // INTRUSIVE
-    pub name: Box<[u8]>,
+    global_this: BackRef<JSGlobalObject>,
+    promise: JSPromiseStrong,
+    poll_ref: KeepAlive,
+    name: Box<[u8]>,
 }
 
 impl CAresNameInfo {
-    /// SAFETY: `global_this` is a JSC_BORROW backref set at construction (both
-    /// `init()` and the inline `head` of `GetNameInfoRequest::init()`) from a
-    /// live `&JSGlobalObject`; never null, and the JSGlobalObject outlives every
-    /// in-flight DNS request.
     #[inline]
     fn global_this(&self) -> &JSGlobalObject {
         self.global_this.get()
     }
 
-    fn init(global_this: &JSGlobalObject, name: Box<[u8]>) -> *mut Self {
+    fn init(global_this: &JSGlobalObject, name: Box<[u8]>) -> Self {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-        bun_core::heap::into_raw(Box::new(Self {
-            global_this: bun_ptr::BackRef::new(global_this),
+        Self {
+            global_this: BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
-            allocated: true,
-            next: None,
             name,
-        }))
+        }
     }
 
-    /// SAFETY: `this` must be a live node — either the inline head of a `*Request`
-    /// (allocated == false; owner drops it) or a Boxed tail node (allocated == true;
-    /// freed via `Self::destroy`). No `&mut` may alias `*this` across this call.
-    unsafe fn process_resolve(
-        this: *mut Self,
+    fn process_resolve(
+        mut self,
         err_: Option<c_ares::Error>,
         _timeout: i32,
-        result: Option<c_ares::struct_nameinfo>,
+        result: Option<c_ares::NameInfo<'_>>,
     ) {
-        // SAFETY: see fn contract — `this` is a live node.
-        let global_this = unsafe { (*this).global_this() };
+        let global_this = self.global_this.get();
         if let Some(err) = err_ {
-            // SAFETY: see fn contract.
-            unsafe {
-                error_to_deferred(
-                    err,
-                    b"getnameinfo",
-                    Some((*this).name.as_ref()),
-                    &mut (*this).promise,
-                )
-                .reject_later(global_this);
-                Self::destroy(this);
-            }
+            error_to_deferred(
+                err,
+                b"getnameinfo",
+                Some(self.name.as_ref()),
+                &mut self.promise,
+            )
+            .reject_later(global_this);
             return;
         }
-        let Some(mut name_info) = result else {
-            // SAFETY: see fn contract.
-            unsafe {
-                error_to_deferred(
-                    c_ares::Error::ENOTFOUND,
-                    b"getnameinfo",
-                    Some((*this).name.as_ref()),
-                    &mut (*this).promise,
-                )
-                .reject_later(global_this);
-                Self::destroy(this);
-            }
+        let Some(name_info) = result else {
+            error_to_deferred(
+                c_ares::Error::ENOTFOUND,
+                b"getnameinfo",
+                Some(self.name.as_ref()),
+                &mut self.promise,
+            )
+            .reject_later(global_this);
             return;
         };
         let array = Outcome::of(
             global_this,
-            super::cares_jsc::nameinfo_to_js_response(&mut name_info, global_this),
+            super::cares_jsc::nameinfo_to_js_response(&name_info, global_this),
         );
-        // SAFETY: see fn contract.
-        unsafe { Self::on_complete(this, array) };
+        self.on_complete(array);
     }
 
-    /// SAFETY: see `process_resolve`.
-    unsafe fn on_complete(this: *mut Self, result: Outcome) {
-        // SAFETY: see fn contract — `this` is a live node.
-        let mut promise = unsafe { core::mem::take(&mut (*this).promise) };
-        // SAFETY: see fn contract — `this` is a live node.
-        let global_this = unsafe { (*this).global_this() };
+    fn on_complete(mut self, result: Outcome) {
+        let mut promise = core::mem::take(&mut self.promise);
+        let global_this = self.global_this();
         result.settle(&mut promise, global_this);
-        // SAFETY: see fn contract.
-        unsafe { Self::destroy(this) };
-    }
-
-    /// Conditionally free a heap-allocated tail node. Head nodes (`allocated == false`)
-    /// are inline fields of the parent `*Request` (or a stack local moved out of it) and
-    /// are dropped exactly once by their owner; this is a no-op for them.
-    /// SAFETY: `this` must point at a live node; if `(*this).allocated`, it must be the
-    /// exact pointer returned by `heap::alloc` in `init()`.
-    unsafe fn destroy(this: *mut Self) {
-        // SAFETY: see fn contract — `this` is a live node; if `allocated`, it is
-        // the exact pointer returned by `heap::alloc` in `init()`.
-        unsafe {
-            if (*this).allocated {
-                drop(bun_core::heap::take(this));
-            }
-        }
+        drop(self);
     }
 }
 
 impl Drop for CAresNameInfo {
     fn drop(&mut self) {
         self.poll_ref.unref(js_event_loop_ctx());
-        // self.name freed by Box<[u8]> Drop
     }
 }
 
@@ -778,131 +663,57 @@ impl Drop for CAresNameInfo {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct GetNameInfoRequest {
-    // TODO: should be Option<&'a Resolver>; raw ptr for now
-    pub resolver_for_caching: Option<*mut Resolver>,
-    /// See [`ResolveInfoRequest::pending_slot`].
-    pub pending_slot: Option<u8>,
-    pub head: CAresNameInfo,
-    pub tail: *mut CAresNameInfo, // INTRUSIVE
-}
-
-pub mod get_name_info_request {
-    use super::*;
-
-    pub struct PendingCacheKey {
-        pub(crate) hash: u64,
-        pub(crate) len: u16,
-        pub name: Box<[u8]>,
-        pub(crate) lookup: *mut GetNameInfoRequest,
-    }
-
-    impl PendingCacheKey {
-        pub(crate) fn append(&mut self, cares_lookup: *mut CAresNameInfo) {
-            // SAFETY: lookup/tail are valid while request is in the pending cache
-            unsafe {
-                let tail = (*self.lookup).tail;
-                (*tail).next = NonNull::new(cares_lookup);
-                (*self.lookup).tail = cares_lookup;
-            }
-        }
-
-        pub(crate) fn init(name: &[u8]) -> Self {
-            let hash = wyhash(name);
-            Self {
-                hash,
-                len: name.len() as u16,
-                name: Box::<[u8]>::from(name),
-                lookup: ptr::null_mut(),
-            }
-        }
-    }
+    /// The VM-global resolver (pinned for the VM's lifetime, so it outlives
+    /// every request).
+    resolver_for_caching: Option<BackRef<Resolver, bun_ptr::Mut>>,
+    /// See [`PendingEntry`].
+    pending_slot: Option<u8>,
+    head: CAresNameInfo,
 }
 
 impl GetNameInfoRequest {
     fn init(
-        cache: LookupCacheHit<Self>,
-        resolver: Option<*mut Resolver>,
+        cache: CacheHit,
+        resolver: Option<ThisPtr<Resolver>>,
         name: Box<[u8]>,
         global_this: &JSGlobalObject,
-        cache_field: PendingCacheField,
-    ) -> *mut Self {
-        let mut poll_ref = KeepAlive::init();
-        poll_ref.ref_(js_event_loop_ctx());
-        let request = bun_core::heap::into_raw(Box::new(Self {
-            resolver_for_caching: resolver,
-            pending_slot: None,
-            head: CAresNameInfo {
-                global_this: bun_ptr::BackRef::new(global_this),
-                promise: JSPromiseStrong::init(global_this),
-                poll_ref,
-                allocated: false,
-                next: None,
-                name,
-            },
-            tail: ptr::null_mut(),
-        }));
-        // SAFETY: `request` was just heap-allocated above; `head` is an inline field.
-        unsafe { (*request).tail = &raw mut (*request).head };
-        if let LookupCacheHit::New(new) = cache {
-            // SAFETY: `new` points into the resolver's HiveArray buffer; resolver/request are live.
-            unsafe {
-                (*request).resolver_for_caching = resolver;
-                let pos = (*resolver.unwrap())
-                    .pending_nameinfo_cache_cares
-                    .get()
-                    .index_of(new)
-                    .unwrap();
-                (*request).pending_slot = Some(pos as u8);
-                (*new).lookup = request;
-            }
-        }
-        let _ = cache_field;
-        request
+    ) -> Box<Self> {
+        Box::new(Self {
+            resolver_for_caching: resolver.map(BackRef::from),
+            pending_slot: cache.new_slot(),
+            head: CAresNameInfo::init(global_this, name),
+        })
     }
 
     fn on_cares_complete(
-        this: *mut Self,
+        self,
         err_: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<c_ares::struct_nameinfo>,
+        result: Option<c_ares::NameInfo<'_>>,
     ) {
-        // SAFETY: `this` is the heap-allocated request c-ares calls back with;
-        // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
-        unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
-                scopeguard::defer! { (*resolver).request_completed() };
-                if let Some(pos) = (*this).pending_slot {
-                    (*resolver).drain_pending_name_info_cares(pos, err_, timeout, result);
-                    return;
-                }
+        if let Some(resolver) = self.resolver_for_caching {
+            let resolver = scopeguard::guard(resolver.this_ptr(), Resolver::request_completed);
+            if let Some(pos) = self.pending_slot {
+                Resolver::drain_pending_name_info_cares(
+                    *resolver, pos, err_, timeout, result, self.head,
+                );
+                return;
             }
-
-            // Consume the request and move `head` out by value; `ptr::read`
-            // + `heap::take` would double-Drop `CAresNameInfo` (impls Drop).
-            let owned = *bun_core::heap::take(this);
-            let mut head = owned.head;
-            CAresNameInfo::process_resolve(&raw mut head, err_, timeout, result);
         }
+
+        self.head.process_resolve(err_, timeout, result);
     }
 }
 
-impl c_ares::NameinfoHandler for GetNameInfoRequest {
+impl c_ares::NameInfoHandler for GetNameInfoRequest {
     #[inline]
     fn on_nameinfo(
-        &mut self,
+        self: Box<Self>,
         status: Option<c_ares::Error>,
         timeouts: i32,
-        info: Option<c_ares::struct_nameinfo>,
+        info: Option<c_ares::NameInfo<'_>>,
     ) {
-        // SAFETY: `self` is the `heap::alloc`'d heap request registered with
-        // c-ares; `on_cares_complete` consumes it (heap::take) on every path.
-        // The c-ares callback wrapper does not touch `self` after this returns.
-        GetNameInfoRequest::on_cares_complete(
-            std::ptr::from_mut::<Self>(self),
-            status,
-            timeouts,
-            info,
-        );
+        Self::on_cares_complete(*self, status, timeouts, info);
     }
 }
 
@@ -911,13 +722,13 @@ impl c_ares::NameinfoHandler for GetNameInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetAddrInfoRequest {
+    /// Backend state that must live at the request's address (the libuv req,
+    /// the dns_sd query); nothing for c-ares / the work pool.
+    #[cfg_attr(not(any(windows, target_os = "macos")), allow(dead_code))]
     pub(crate) backend: get_addr_info_request::Backend,
-    // TODO: should be Option<&'a Resolver>; raw ptr for now
-    pub(crate) resolver_for_caching: Option<*mut Resolver>,
-    /// See [`ResolveInfoRequest::pending_slot`].
+    /// See [`PendingEntry`].
     pub(crate) pending_slot: Option<u8>,
     pub(crate) head: DNSLookup,
-    pub(crate) tail: *mut DNSLookup, // INTRUSIVE
 }
 
 pub mod get_addr_info_request {
@@ -929,36 +740,28 @@ pub mod get_addr_info_request {
         pub(crate) backend: LibcBackend,
     }
 
-    /// The request a [`LibcLookup`] completes: JS-thread state (promises,
-    /// keep-alive, resolver ref) at a stable address the resolver's pending
-    /// cache points at. Consumed by the completion; dropped unconsumed only
-    /// when the VM tears down first, in which case everything is freed and
-    /// nothing is settled.
+    /// The request a [`LibcLookup`] completes: JS-thread state (promise,
+    /// keep-alive, resolver ref) plus the pending-cache slot it owns. Consumed
+    /// by the completion; dropped unconsumed only when the VM tears down
+    /// first, in which case everything is freed and nothing is settled.
     #[cfg(not(windows))]
-    pub struct LibcRequest(pub(crate) NonNull<super::GetAddrInfoRequest>);
-    // SAFETY: only the JS thread touches the request (see type doc).
-    #[cfg(not(windows))]
-    unsafe impl bun_jsc::job::JsAffine for LibcRequest {}
+    #[derive(bun_jsc::JsAffine)]
+    pub struct LibcRequest {
+        pub(crate) head: Option<DNSLookup>,
+        pub(crate) pending_slot: Option<u8>,
+    }
     #[cfg(not(windows))]
     impl Drop for LibcRequest {
         fn drop(&mut self) {
-            let req = self.0.as_ptr();
-            // SAFETY: JS thread; the live heap request and its coalesced
-            // waiters, none of which anything else will touch again.
-            unsafe {
-                if let Some(resolver) = (*req).resolver_for_caching {
-                    if let Some(pos) = (*req).pending_slot {
-                        drop(
-                            (*resolver)
-                                .get_key_host(pos, PendingCacheField::PendingHostCacheNative),
-                        );
-                    }
-                }
-                let mut pending = (*req).head.next;
-                drop(*bun_core::heap::take(req));
-                while let Some(waiter) = pending {
-                    pending = (*waiter.as_ptr()).next;
-                    drop(bun_core::heap::take(waiter.as_ptr()));
+            if let (Some(head), Some(pos)) = (&self.head, self.pending_slot) {
+                if let Some(resolver) = head.resolver() {
+                    drop(
+                        Resolver::pending_host_cache(
+                            &resolver,
+                            PendingCacheField::PendingHostCacheNative,
+                        )
+                        .take(pos),
+                    );
                 }
             }
         }
@@ -977,56 +780,29 @@ pub mod get_addr_info_request {
         }
         fn then(
             this: Self,
-            request: LibcRequest,
+            mut request: LibcRequest,
             cx: &bun_jsc::JsThread<'_>,
         ) -> bun_jsc::JsResult<()> {
             // Consumed here: `then` takes over the request on every path, so
             // the release-on-drop must not run.
-            let req = core::mem::ManuallyDrop::new(request).0.as_ptr();
-            // SAFETY: the live heap request; `then` consumes it on every path.
-            unsafe { (*req).backend = Backend::Libc(this.backend) };
-            super::GetAddrInfoRequest::then(req, cx.global());
+            let pending_slot = request.pending_slot.take();
+            let head = request.head.take().expect("LibcRequest head");
+            let _ = cx;
+            super::GetAddrInfoRequest::then(this.backend, head, pending_slot);
             Ok(())
-        }
-    }
-
-    pub struct PendingCacheKey {
-        pub(crate) hash: u64,
-        pub(crate) len: u16,
-        pub name: Box<[u8]>,
-        pub(crate) lookup: *mut GetAddrInfoRequest,
-    }
-
-    impl PendingCacheKey {
-        pub(crate) fn append(&mut self, dns_lookup: *mut DNSLookup) {
-            // SAFETY: `lookup`/`tail` are valid while the request sits in the pending cache.
-            unsafe {
-                let tail = (*self.lookup).tail;
-                (*tail).next = NonNull::new(dns_lookup);
-                (*self.lookup).tail = dns_lookup;
-            }
-        }
-
-        pub(crate) fn init(query: &GetAddrInfo) -> Self {
-            Self {
-                hash: query.hash(),
-                len: query.name.len() as u16,
-                name: query.name.clone(),
-                lookup: ptr::null_mut(),
-            }
         }
     }
 
     #[cfg(target_os = "macos")]
     pub struct BackendDnsSd {
-        pub(crate) query: dns_sd::QueryState,
+        pub(crate) query: JsCell<dns_sd::QueryState>,
     }
 
     #[cfg(target_os = "macos")]
     impl BackendDnsSd {
         pub(crate) fn new(protocol: dns_sd::DNSServiceProtocol) -> Self {
             Self {
-                query: dns_sd::QueryState::new(protocol),
+                query: JsCell::new(dns_sd::QueryState::new(protocol)),
             }
         }
     }
@@ -1050,57 +826,32 @@ pub mod get_addr_info_request {
             let mut port_buf = [0u8; 128];
             let port_len = bun_fmt::print_int(&mut port_buf, query.port);
             port_buf[port_len] = 0;
-            // SAFETY: NUL written at port_buf[port_len]
-            let port_z = ZStr::from_buf(&port_buf[..], port_len);
+            let port_z = CStr::from_bytes_until_nul(&port_buf).expect("NUL written above");
 
-            let mut hostname = bun_paths::path_buffer_pool::get();
-            // Reserve the last byte for the NUL terminator so the index below
-            // can never exceed the buffer even if the upstream length guard in
-            // `doLookup` is bypassed.
-            let cap = hostname.len() - 1;
-            let copied_len = strings::copy(&mut hostname[..cap], &query_name).len();
-            hostname[copied_len] = 0;
-            let mut addrinfo: *mut AddrInfo = ptr::null_mut();
-            // SAFETY: hostname[copied_len] == 0
-            let host = ZStr::from_buf(&hostname[..], copied_len);
+            // `do_lookup` rejects names of `MAX_PATH_BYTES` or more and names
+            // containing NUL, so this always terminates where expected.
+            let mut hostname = Vec::with_capacity(query_name.len() + 1);
+            hostname.extend_from_slice(&query_name);
+            hostname.push(0);
+            let host = CStr::from_bytes_until_nul(&hostname).expect("NUL written above");
             let debug_timer = Output::DebugTimer::start();
-            // SAFETY: FFI; all pointers valid for the call duration
-            let err = unsafe {
-                libc::getaddrinfo(
-                    host.as_ptr().cast::<c_char>(),
-                    if port_len > 0 {
-                        port_z.as_ptr().cast::<c_char>()
-                    } else {
-                        ptr::null()
-                    },
-                    hints
-                        .as_ref()
-                        .map(std::ptr::from_ref)
-                        .unwrap_or(ptr::null()),
-                    &raw mut addrinfo,
-                )
-            };
-            sys::syslog!(
+            let result = bun_sys::net::AddrInfoList::lookup(
+                Some(host),
+                if port_len > 0 { Some(port_z) } else { None },
+                hints.as_ref(),
+            );
+            bun_sys::syslog!(
                 "getaddrinfo({}, {}) = {} ({})",
                 bstr::BStr::new(&query_name),
-                bstr::BStr::new(port_z.as_bytes()),
-                err,
+                bstr::BStr::new(port_z.to_bytes()),
+                result.as_ref().err().copied().unwrap_or(0),
                 debug_timer,
             );
-            if err != 0 || addrinfo.is_null() {
-                *self = LibcBackend::Err(err);
-                return;
-            }
-
-            // do not free addrinfo when err != 0: getaddrinfo only allocates the
-            // result list on success, so the out-pointer is unspecified on error.
-            let _free = scopeguard::guard(addrinfo, |a| {
-                // SAFETY: `a` was returned by libc::getaddrinfo (non-null per the check above).
-                unsafe { bun_dns::freeaddrinfo(a) }
-            });
-
-            // SAFETY: addrinfo is non-null (checked above); freed by `_free` guard after copy.
-            *self = LibcBackend::Success(GetAddrInfoResult::to_list(unsafe { &*addrinfo }));
+            *self = match result {
+                Ok(Some(list)) => LibcBackend::Success(GetAddrInfoResult::to_list(list.first())),
+                Ok(None) => LibcBackend::Err(0),
+                Err(err) => LibcBackend::Err(err),
+            };
         }
     }
 
@@ -1121,12 +872,13 @@ pub mod get_addr_info_request {
         CAres,
         #[cfg(target_os = "macos")]
         DnsSd(BackendDnsSd),
+        #[cfg(windows)]
         Libc(LibcBackend),
     }
 
     impl Backend {
         #[cfg(target_os = "macos")]
-        pub(crate) fn as_dns_sd_mut(&mut self) -> &mut BackendDnsSd {
+        pub(crate) fn dns_sd(&self) -> &BackendDnsSd {
             match self {
                 Backend::DnsSd(l) => l,
                 _ => unreachable!(),
@@ -1146,286 +898,141 @@ impl GetAddrInfoRequest {
     pub(crate) fn init(
         cache: CacheHit,
         backend: get_addr_info_request::Backend,
-        resolver: Option<*mut Resolver>,
+        resolver: Option<ThisPtr<Resolver>>,
         global_this: &JSGlobalObject,
-        cache_field: PendingCacheField,
-    ) -> *mut Self {
+    ) -> Box<Self> {
         bun_output::scoped_log!(GetAddrInfoRequest, "init");
-        let mut poll_ref = KeepAlive::init();
-        poll_ref.ref_(js_event_loop_ctx());
-        let request = bun_core::heap::into_raw(Box::new(Self {
+        Box::new(Self {
             backend,
-            resolver_for_caching: resolver,
-            pending_slot: None,
-            head: DNSLookup {
-                // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
-                global_this: bun_ptr::BackRef::new(global_this),
-                promise: JSPromiseStrong::init(global_this),
-                poll_ref,
-                allocated: false,
-                next: None,
-            },
-            tail: ptr::null_mut(),
-        }));
-        // SAFETY: request just allocated; head is an inline field.
-        unsafe { (*request).tail = &raw mut (*request).head };
-        if let CacheHit::New(new) = cache {
-            // SAFETY: `new` is &mut into resolver's HiveArray buffer; resolver/request are live.
-            unsafe {
-                (*request).resolver_for_caching = resolver;
-                let pos = (*resolver.unwrap())
-                    .pending_host_cache(cache_field)
-                    .index_of(new)
-                    .unwrap();
-                (*request).pending_slot = Some(pos as u8);
-                (*new).lookup = request;
-            }
-        }
-        request
+            pending_slot: cache.new_slot(),
+            head: DNSLookup::init_head(resolver, global_this),
+        })
     }
 
-    /// Reply callback (inside `DNSServiceProcessResult`): records state; completion happens in `on_readable`.
-    /// # Safety
-    /// `context` is the registered `*mut GetAddrInfoRequest`; `address`, if non-null, is a valid sockaddr.
+    /// Complete a dns_sd-backed request.
     #[cfg(target_os = "macos")]
-    pub(crate) unsafe extern "C" fn dns_sd_reply(
-        _sd_ref: dns_sd::DNSServiceRef,
-        flags: u32,
-        _interface_index: u32,
-        error_code: i32,
-        _hostname: *const c_char,
-        address: *const Sockaddr,
-        ttl: u32,
-        context: *mut c_void,
-    ) {
-        dns_sd::SharedConnection::note_reply(context);
-        // SAFETY: context is the *mut GetAddrInfoRequest passed to start().
-        let this: *mut Self = context.cast();
-        // SAFETY: `this` is the live heap request (JS thread); `address` is valid per dns_sd.h.
-        unsafe {
-            (*this)
-                .backend
-                .as_dns_sd_mut()
-                .query
-                .record_reply(flags, error_code, address, ttl);
-        }
-    }
-
-    /// Complete a dns_sd-backed request; `this` is the live heap request, consumed on every path.
-    #[cfg(target_os = "macos")]
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn complete_dns_sd(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live and exclusively owned here.
-        unsafe {
-            let query = &mut (*this).backend.as_dns_sd_mut().query;
+    pub(crate) fn complete_dns_sd(self) {
+        let (results, status) = self.backend.dns_sd().query.with_mut(|query| {
             let results = query.take_results();
             let status = if !results.is_empty() {
                 0
             } else {
-                dns_sd::EMPTY_STATUS
+                query.empty_status()
             };
-            bun_output::scoped_log!(
-                GetAddrInfoRequest,
-                "completeDnsSd: status={} results={}",
-                status,
-                results.len()
-            );
-            // Error path must be `Addrinfo(null)`: `drain_pending_host_native` keys on `result_any_to_js` == None.
-            let any = if status == 0 {
-                GetAddrInfoResultAny::List(results)
-            } else {
-                GetAddrInfoResultAny::Addrinfo(ptr::null_mut())
-            };
+            (results, status)
+        });
+        bun_output::scoped_log!(
+            GetAddrInfoRequest,
+            "completeDnsSd: status={} results={}",
+            status,
+            results.len()
+        );
+        // Error path must be `Addrinfo(null)`: `drain_pending_host_native` keys on `result_any_to_js` == None.
+        let any = if status == 0 {
+            GetAddrInfoResultAny::List(results)
+        } else {
+            GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut())
+        };
 
-            if let Some(resolver) = (*this).resolver_for_caching {
-                if let Some(pos) = (*this).pending_slot {
-                    (*resolver).drain_pending_host_native(
+        if let (Some(resolver), Some(pos)) = (self.head.resolver(), self.pending_slot) {
+            Resolver::drain_pending_host_native(resolver, pos, status, &any, self.head);
+            return;
+        }
+
+        if status != 0 {
+            self.head.process_get_addr_info_native(status);
+        } else {
+            self.head.on_complete_native(&any);
+        }
+    }
+
+    /// The JS-thread completion of a libc (work-pool) lookup.
+    #[cfg(not(windows))]
+    pub(crate) fn then(
+        backend: get_addr_info_request::LibcBackend,
+        head: DNSLookup,
+        pending_slot: Option<u8>,
+    ) {
+        bun_output::scoped_log!(GetAddrInfoRequest, "then");
+        match backend {
+            get_addr_info_request::LibcBackend::Success(result) => {
+                // `ResultAny` impls `Drop` (frees the list) — the by-value drop
+                // at the end of whichever callee receives `any`.
+                let any = GetAddrInfoResultAny::List(result);
+                if let (Some(resolver), Some(pos)) = (head.resolver(), pending_slot) {
+                    Resolver::drain_pending_host_native(resolver, pos, 0, &any, head);
+                    return;
+                }
+                head.on_complete_native(&any);
+            }
+            get_addr_info_request::LibcBackend::Err(err) => {
+                if let (Some(resolver), Some(pos)) = (head.resolver(), pending_slot) {
+                    Resolver::drain_pending_host_native(
+                        resolver,
                         pos,
-                        (*this).head.global_this(),
-                        status,
-                        &any,
+                        err,
+                        &GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()),
+                        head,
                     );
                     return;
                 }
+                head.process_get_addr_info_native(err);
             }
-
-            let owned = *bun_core::heap::take(this);
-            let mut head = owned.head;
-            if status != 0 {
-                DNSLookup::process_get_addr_info_native(&raw mut head, status, ptr::null_mut());
-            } else {
-                DNSLookup::on_complete_native(&raw mut head, &any);
-            }
+            get_addr_info_request::LibcBackend::Query(_) => unreachable!(),
         }
     }
 
-    #[cfg(not(windows))]
-    /// # Safety
-    /// `this` must be the live heap `GetAddrInfoRequest` whose `run` already
-    /// completed; consumed (freed) on every path.
-    // `this` is reclaimed via `heap::take` (Box::from_raw) inside; forming
-    // `&mut *this` at entry would invalidate the pointer's allocation
-    // provenance, so the param must stay `*mut`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn then(this: *mut Self, _global: &JSGlobalObject) {
-        bun_output::scoped_log!(GetAddrInfoRequest, "then");
-        // SAFETY: called on the JS thread with the heap request the lookup was
-        // created from; `resolver_for_caching` (if set) is the live ctx ref.
-        unsafe {
-            // Take the backend by value: `Success` holds a `Vec<GetAddrInfoResult>`
-            // (not `Clone`) that we move into `GetAddrInfoResultAny::List`. The
-            // request is consumed/freed on every path below, so the `CAres`
-            // placeholder left behind owns no resources.
-            let backend =
-                core::mem::replace(&mut (*this).backend, get_addr_info_request::Backend::CAres);
-            match backend {
-                get_addr_info_request::Backend::Libc(
-                    get_addr_info_request::LibcBackend::Success(result),
-                ) => {
-                    // `ResultAny` impls `Drop` (frees the list) — the by-value drop
-                    // at the end of whichever callee receives `any`.
-                    let any = GetAddrInfoResultAny::List(result);
-                    if let Some(resolver) = (*this).resolver_for_caching {
-                        if let Some(pos) = (*this).pending_slot {
-                            (*resolver).drain_pending_host_native(
-                                pos,
-                                (*this).head.global_this(),
-                                0,
-                                &any,
-                            );
-                            return;
-                        }
-                    }
-                    // Consume the request and move `head` out by value;
-                    // `ptr::read` + `heap::take` would double-Drop `DNSLookup`.
-                    let owned = *bun_core::heap::take(this);
-                    let mut head = owned.head;
-                    DNSLookup::on_complete_native(&raw mut head, &any);
-                }
-                get_addr_info_request::Backend::Libc(get_addr_info_request::LibcBackend::Err(
-                    err,
-                )) => {
-                    if let Some(resolver) = (*this).resolver_for_caching {
-                        if let Some(pos) = (*this).pending_slot {
-                            (*resolver).drain_pending_host_native(
-                                pos,
-                                (*this).head.global_this(),
-                                err,
-                                &GetAddrInfoResultAny::Addrinfo(ptr::null_mut()),
-                            );
-                            return;
-                        }
-                    }
-                    let owned = *bun_core::heap::take(this);
-                    let mut head = owned.head;
-                    DNSLookup::process_get_addr_info_native(&raw mut head, err, ptr::null_mut());
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    /// # Safety
-    /// `this` must be the heap `GetAddrInfoRequest` registered with c-ares;
-    /// consumed (freed) on every path.
-    // `this` is reclaimed via `heap::take` (Box::from_raw) inside; forming
-    // `&mut *this` at entry would invalidate the pointer's allocation
-    // provenance, so the param must stay `*mut`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn on_cares_complete(
-        this: *mut Self,
+        self,
         err_: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<*mut c_ares::AddrInfo>,
+        result: Option<c_ares::AresBox<c_ares::AddrInfo>>,
     ) {
         bun_output::scoped_log!(GetAddrInfoRequest, "onCaresComplete");
-        // SAFETY: `this` is the heap-allocated request c-ares calls back with;
-        // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
-        unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
-                if let Some(pos) = (*this).pending_slot {
-                    (*resolver).drain_pending_host_cares(pos, err_, timeout, result);
-                    return;
-                }
-            }
-
-            // Consume the request and move `head` out by value; `ptr::read`
-            // + `heap::take` would double-Drop `DNSLookup` (impls Drop).
-            let owned = *bun_core::heap::take(this);
-            let mut head = owned.head;
-            DNSLookup::process_get_addr_info(&raw mut head, err_, timeout, result);
+        if let (Some(resolver), Some(pos)) = (self.head.resolver(), self.pending_slot) {
+            Resolver::drain_pending_host_cares(resolver, pos, err_, timeout, result, self.head);
+            return;
         }
+
+        self.head
+            .process_get_addr_info(err_, timeout, result.as_deref());
     }
 
     #[cfg(windows)]
-    pub(crate) fn on_libuv_complete(uv_info: *mut libuv::uv_getaddrinfo_t) {
-        unsafe {
-            let retcode = (*uv_info).retcode.int();
-            bun_output::scoped_log!(GetAddrInfoRequest, "onLibUVComplete: status={}", retcode);
-            let this: *mut Self = (*uv_info).data.cast();
-            #[cfg(windows)]
-            debug_assert!(uv_info == core::ptr::from_mut((*this).backend.as_libc_uv_mut()));
+    pub(crate) fn on_libuv_complete(self, retcode: c_int, result: libuv::UvAddrInfo) {
+        bun_output::scoped_log!(GetAddrInfoRequest, "onLibUVComplete: status={}", retcode);
 
-            // On Windows, libuv's `uv_getaddrinfo` calls `GetAddrInfoW` then
-            // re-packs the wide result into a single ANSI block allocated via
-            // `uv__malloc`; that block must be released with `uv_freeaddrinfo`
-            // (== `uv__free`). `GetAddrInfoResultAny::Addrinfo`'s `Drop` calls
-            // `ws2_32!freeaddrinfo`, which is the wrong allocator here and
-            // would corrupt the heap. Convert to an owned `List` immediately, free the libuv
-            // buffer with the correct deallocator, and pass `List` downstream
-            // so `ResultAny::Drop` never sees libuv-owned memory.
-            let addrinfo = (*uv_info).addrinfo;
-            let result_any = if addrinfo.is_null() {
-                GetAddrInfoResultAny::Addrinfo(ptr::null_mut())
-            } else {
-                let list = GetAddrInfoResult::to_list(&*addrinfo);
-                libuv::uv_freeaddrinfo(addrinfo.cast());
-                GetAddrInfoResultAny::List(list)
-            };
+        // libuv re-packs the wide result into a `uv__malloc` block that
+        // `UvAddrInfo` frees with `uv_freeaddrinfo`; copy it into an owned
+        // `List` now so `ResultAny::Drop` (which calls `ws2_32!freeaddrinfo`)
+        // never sees libuv-owned memory.
+        let result_any = match result.head() {
+            None => GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()),
+            Some(head) => GetAddrInfoResultAny::List(GetAddrInfoResult::to_list(head)),
+        };
+        drop(result);
 
-            if let Some(resolver) = (*this).resolver_for_caching {
-                if let Some(pos) = (*this).pending_slot {
-                    (*resolver).drain_pending_host_native(
-                        pos,
-                        (*this).head.global_this(),
-                        retcode,
-                        &result_any,
-                    );
-                    return;
-                }
-            }
+        if let (Some(resolver), Some(pos)) = (self.head.resolver(), self.pending_slot) {
+            Resolver::drain_pending_host_native(resolver, pos, retcode, &result_any, self.head);
+            return;
+        }
 
-            // Consume the request and move `head` out by value; `ptr::read`
-            // + `heap::take` would double-Drop `DNSLookup` (impls Drop).
-            let owned = *bun_core::heap::take(this);
-            let mut head = owned.head;
-            // Inline `process_get_addr_info_native` so the success path can
-            // reuse the owned `List` instead of re-wrapping the (now-freed)
-            // raw `addrinfo` pointer.
-            if c_ares::Error::init_eai(retcode).is_some() {
-                DNSLookup::process_get_addr_info_native(&raw mut head, retcode, ptr::null_mut());
-            } else {
-                DNSLookup::on_complete_native(&raw mut head, &result_any);
-            }
+        if c_ares::Error::init_eai(retcode).is_some() {
+            self.head.process_get_addr_info_native(retcode);
+        } else {
+            self.head.on_complete_native(&result_any);
         }
     }
 }
 
-// Wires `GetAddrInfoRequest` into `Channel::get_addr_info`.
 impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
     fn on_addr_info(
-        &mut self,
+        self: Box<Self>,
         status: Option<c_ares::Error>,
         timeouts: i32,
-        results: *mut c_ares::AddrInfo,
+        result: Option<c_ares::AresBox<c_ares::AddrInfo>>,
     ) {
-        let result = if results.is_null() {
-            None
-        } else {
-            Some(results)
-        };
-        Self::on_cares_complete(std::ptr::from_mut::<Self>(self), status, timeouts, result);
+        Self::on_cares_complete(*self, status, timeouts, result);
     }
 }
 
@@ -1434,123 +1041,87 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresReverse {
-    pub resolver: Option<RefPtr<Resolver>>,
-    pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
-    pub promise: JSPromiseStrong,
-    pub poll_ref: KeepAlive,
-    pub allocated: bool,
-    pub next: Option<NonNull<CAresReverse>>, // INTRUSIVE
-    pub name: Box<[u8]>,
+    /// Keeps the resolver alive for the lookup; released in `Drop`.
+    resolver: Option<RefPtr<Resolver>>,
+    global_this: BackRef<JSGlobalObject>,
+    promise: JSPromiseStrong,
+    poll_ref: KeepAlive,
+    name: Box<[u8]>,
 }
 
 impl CAresReverse {
-    /// Borrow the owning `JSGlobalObject`.
-    ///
-    /// SAFETY: `global_this` is a JSC_BORROW backref set from a live
-    /// `&JSGlobalObject` in `init()` / `GetHostByAddrInfoRequest::init()`; the
-    /// global outlives every DNS request hung off of it, so the pointer is
-    /// always non-null and valid for the lifetime of `self`.
     #[inline]
     fn global_this(&self) -> &JSGlobalObject {
         self.global_this.get()
     }
 
+    #[inline]
+    fn resolver(&self) -> Option<ThisPtr<Resolver>> {
+        self.resolver.as_ref().map(RefPtr::this_ptr)
+    }
+
     fn init(
-        resolver: Option<*mut Resolver>,
+        resolver: Option<ThisPtr<Resolver>>,
         global_this: &JSGlobalObject,
         name: &[u8],
-    ) -> *mut Self {
+    ) -> Self {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-        bun_core::heap::into_raw(Box::new(Self {
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
-            global_this: bun_ptr::BackRef::new(global_this),
+        Self {
+            resolver: resolver.map(RefPtr::from_this),
+            global_this: BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
-            allocated: true,
-            next: None,
             name: Box::<[u8]>::from(name),
-        }))
+        }
     }
 
-    /// SAFETY: `this` must be a live node — either the inline head of a `*Request`
-    /// (allocated == false; owner drops it) or a Boxed tail node (allocated == true;
-    /// freed via `Self::destroy`). No `&mut` may alias `*this` across this call.
-    unsafe fn process_resolve(
-        this: *mut Self,
+    fn process_resolve(
+        mut self,
         err_: Option<c_ares::Error>,
         _timeout: i32,
-        result: Option<*mut c_ares::struct_hostent>,
+        result: Option<&c_ares::struct_hostent>,
     ) {
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let global_this = (*this).global_this();
-            if let Some(err) = err_ {
-                error_to_deferred(
-                    err,
-                    b"getHostByAddr",
-                    Some(&(*this).name),
-                    &mut (*this).promise,
-                )
+        let global_this = self.global_this.get();
+        if let Some(err) = err_ {
+            error_to_deferred(err, b"getHostByAddr", Some(&self.name), &mut self.promise)
                 .reject_later(global_this);
-                Self::destroy(this);
-                return;
-            }
-            let Some(node) = result else {
-                error_to_deferred(
-                    c_ares::Error::ENOTFOUND,
-                    b"getHostByAddr",
-                    Some(&(*this).name),
-                    &mut (*this).promise,
-                )
-                .reject_later(global_this);
-                Self::destroy(this);
-                return;
-            };
-            // node is a valid c-ares hostent for the callback's duration
-            let array = Outcome::of(
-                global_this,
-                super::cares_jsc::hostent_to_js_response(&mut *node, global_this, b""),
-            );
-            Self::on_complete(this, array);
+            return;
         }
+        let Some(node) = result else {
+            error_to_deferred(
+                c_ares::Error::ENOTFOUND,
+                b"getHostByAddr",
+                Some(&self.name),
+                &mut self.promise,
+            )
+            .reject_later(global_this);
+            return;
+        };
+        let array = Outcome::of(
+            global_this,
+            super::cares_jsc::hostent_to_js_response(node, global_this, b""),
+        );
+        self.on_complete(array);
     }
 
-    /// SAFETY: see `process_resolve`.
-    unsafe fn on_complete(this: *mut Self, result: Outcome) {
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let mut promise = core::mem::take(&mut (*this).promise);
-            let global_this = (*this).global_this();
-            result.settle(&mut promise, global_this);
-            if let Some(resolver) = (*this).resolver.as_ref() {
-                // RefPtr holds a live ref; request_completed mutates pending_requests counter only.
-                (*resolver.as_ptr()).request_completed();
-            }
-            Self::destroy(this);
+    fn on_complete(mut self, result: Outcome) {
+        let mut promise = core::mem::take(&mut self.promise);
+        let global_this = self.global_this();
+        result.settle(&mut promise, global_this);
+        if let Some(resolver) = self.resolver() {
+            Resolver::request_completed(resolver);
         }
-    }
-
-    /// SAFETY: `this` must point at a live node; if `(*this).allocated`, it must be the
-    /// exact pointer returned by `heap::alloc` in `init()`. Head nodes (`!allocated`)
-    /// are dropped by their owner; this is a no-op for them.
-    unsafe fn destroy(this: *mut Self) {
-        // SAFETY: see fn contract — `this` is live; if `allocated`, it is the
-        // exact pointer returned by `heap::alloc` in `init()`.
-        unsafe {
-            if (*this).allocated {
-                drop(bun_core::heap::take(this));
-            }
-        }
+        drop(self);
     }
 }
 
 impl Drop for CAresReverse {
     fn drop(&mut self) {
-        let _ = self.global_this();
         self.poll_ref.unref(js_event_loop_ctx());
-        // self.name freed by Box<[u8]> Drop
+        if let Some(resolver) = self.resolver.take() {
+            resolver.deref();
+        }
     }
 }
 
@@ -1558,132 +1129,92 @@ impl Drop for CAresReverse {
 // CAresLookup<T>
 // ──────────────────────────────────────────────────────────────────────────
 
-pub(crate) struct CAresLookup<T: CAresRecordType> {
-    pub resolver: Option<RefPtr<Resolver>>,
-    pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
-    pub promise: JSPromiseStrong,
-    pub poll_ref: KeepAlive,
-    pub allocated: bool,
-    pub next: Option<NonNull<CAresLookup<T>>>, // INTRUSIVE
-    pub name: Box<[u8]>,
+pub struct CAresLookup<T: CAresRecordType> {
+    /// Keeps the resolver alive for the lookup; released in `Drop`.
+    resolver: Option<RefPtr<Resolver>>,
+    global_this: BackRef<JSGlobalObject>,
+    promise: JSPromiseStrong,
+    poll_ref: KeepAlive,
+    name: Box<[u8]>,
     _marker: core::marker::PhantomData<T>,
 }
 
 impl<T: CAresRecordType> CAresLookup<T> {
-    fn new(data: Self) -> *mut Self {
-        debug_assert!(data.allocated); // deinit will not free this otherwise
-        bun_core::heap::into_raw(Box::new(data))
-    }
-
     fn init(
-        resolver: Option<*mut Resolver>,
+        resolver: Option<ThisPtr<Resolver>>,
         global_this: &JSGlobalObject,
         name: &[u8],
-    ) -> *mut Self {
+    ) -> Self {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-        Self::new(Self {
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
-            global_this: bun_ptr::BackRef::new(global_this),
+        Self {
+            resolver: resolver.map(RefPtr::from_this),
+            global_this: BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
-            allocated: true,
-            next: None,
             name: Box::<[u8]>::from(name),
             _marker: core::marker::PhantomData,
-        })
+        }
     }
 
-    /// Borrow the owning [`JSGlobalObject`].
-    ///
-    /// SAFETY: `global_this` is a JSC_BORROW backref set at construction (both
-    /// `init()` and the inline `head` of `ResolveInfoRequest::init()`) from a
-    /// live `&JSGlobalObject`; never null, and the JSGlobalObject outlives every
-    /// in-flight DNS request.
     #[inline]
     fn global_this(&self) -> &JSGlobalObject {
         self.global_this.get()
     }
 
-    /// SAFETY: `this` must be a live node — either the inline head of a `*Request`
-    /// (allocated == false; owner drops it) or a Boxed tail node (allocated == true;
-    /// freed via `Self::destroy`). No `&mut` may alias `*this` across this call.
-    unsafe fn process_resolve(
-        this: *mut Self,
+    #[inline]
+    fn resolver(&self) -> Option<ThisPtr<Resolver>> {
+        self.resolver.as_ref().map(RefPtr::this_ptr)
+    }
+
+    fn process_resolve(
+        mut self,
         err_: Option<c_ares::Error>,
         _timeout: i32,
-        result: Option<OwnedReply<T>>,
+        result: Option<&T::Reply>,
     ) {
         // syscall = "query" + ucfirst(TYPE_NAME); each `CAresRecordType` impl
         // carries the precomputed literal.
         let syscall = T::SYSCALL; // e.g. "querySrv"
 
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let global_this = (*this).global_this();
-            if let Some(err) = err_ {
-                error_to_deferred(
-                    err,
-                    syscall.as_bytes(),
-                    Some(&(*this).name),
-                    &mut (*this).promise,
-                )
+        let global_this = self.global_this.get();
+        if let Some(err) = err_ {
+            error_to_deferred(err, syscall.as_bytes(), Some(&self.name), &mut self.promise)
                 .reject_later(global_this);
-                Self::destroy(this);
-                return;
-            }
-            let Some(mut node) = result else {
-                error_to_deferred(
-                    c_ares::Error::ENOTFOUND,
-                    syscall.as_bytes(),
-                    Some(&(*this).name),
-                    &mut (*this).promise,
-                )
-                .reject_later(global_this);
-                Self::destroy(this);
-                return;
-            };
-
-            let array = Outcome::of(global_this, node.to_js_response(global_this, T::TYPE_NAME));
-            Self::on_complete(this, array);
+            return;
         }
+        let Some(node) = result else {
+            error_to_deferred(
+                c_ares::Error::ENOTFOUND,
+                syscall.as_bytes(),
+                Some(&self.name),
+                &mut self.promise,
+            )
+            .reject_later(global_this);
+            return;
+        };
+
+        let array = Outcome::of(global_this, T::reply_to_js(node, global_this, T::TYPE_NAME));
+        self.on_complete(array);
     }
 
-    /// SAFETY: see `process_resolve`.
-    unsafe fn on_complete(this: *mut Self, result: Outcome) {
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let mut promise = core::mem::take(&mut (*this).promise);
-            let global_this = (*this).global_this();
-            result.settle(&mut promise, global_this);
-            if let Some(resolver) = (*this).resolver.as_ref() {
-                // RefPtr holds a live ref; request_completed mutates pending_requests counter only.
-                (*resolver.as_ptr()).request_completed();
-            }
-            Self::destroy(this);
+    fn on_complete(mut self, result: Outcome) {
+        let mut promise = core::mem::take(&mut self.promise);
+        let global_this = self.global_this();
+        result.settle(&mut promise, global_this);
+        if let Some(resolver) = self.resolver() {
+            Resolver::request_completed(resolver);
         }
-    }
-
-    /// SAFETY: `this` must point at a live node; if `(*this).allocated`, it must be the
-    /// exact pointer returned by `heap::alloc` in `new()`. Head nodes (`!allocated`)
-    /// are dropped by their owner; this is a no-op for them.
-    unsafe fn destroy(this: *mut Self) {
-        // SAFETY: see fn contract — `this` is live; if `allocated`, it is the
-        // exact pointer returned by `heap::alloc` in `init()`.
-        unsafe {
-            if (*this).allocated {
-                drop(bun_core::heap::take(this));
-            }
-        }
+        drop(self);
     }
 }
 
 impl<T: CAresRecordType> Drop for CAresLookup<T> {
     fn drop(&mut self) {
-        let _ = self.global_this();
         self.poll_ref.unref(js_event_loop_ctx());
-        // self.name freed by Box<[u8]> Drop
+        if let Some(resolver) = self.resolver.take() {
+            resolver.deref();
+        }
     }
 }
 
@@ -1691,159 +1222,109 @@ impl<T: CAresRecordType> Drop for CAresLookup<T> {
 // DNSLookup
 // ──────────────────────────────────────────────────────────────────────────
 
-pub(crate) struct DNSLookup {
-    pub resolver: Option<RefPtr<Resolver>>,
-    pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
-    pub promise: JSPromiseStrong,
-    pub allocated: bool,
-    pub next: Option<NonNull<DNSLookup>>, // INTRUSIVE
-    pub poll_ref: KeepAlive,
+#[derive(bun_jsc::JsAffine)]
+pub struct DNSLookup {
+    /// Keeps the resolver alive for the lookup (and names the resolver whose
+    /// pending cache the owning request sits in); released in `Drop`.
+    resolver: Option<RefPtr<Resolver>>,
+    global_this: BackRef<JSGlobalObject>,
+    promise: JSPromiseStrong,
+    poll_ref: KeepAlive,
 }
 
 impl DNSLookup {
-    /// Borrow the owning `JSGlobalObject`.
-    ///
-    /// SAFETY (encapsulated): `global_this` is assigned exactly once at
-    /// construction from a live `&JSGlobalObject` (never null) and is a
-    /// JSC_BORROW backref — the global outlives every `DNSLookup` it spawns.
-    /// The pointee is the JSC heap global, not memory owned by `self`, so the
-    /// returned `&` remains valid even after `self` is dropped (drain loops
-    /// rely on this when caching the ref across `heap::take`).
     #[inline]
     fn global_this(&self) -> &JSGlobalObject {
         self.global_this.get()
     }
 
-    fn init(resolver: *mut Resolver, global_this: &JSGlobalObject) -> *mut Self {
-        bun_output::scoped_log!(DNSLookup, "init");
+    #[inline]
+    fn resolver(&self) -> Option<ThisPtr<Resolver>> {
+        self.resolver.as_ref().map(RefPtr::this_ptr)
+    }
 
+    /// A lookup joining an in-flight request.
+    fn init(resolver: Option<ThisPtr<Resolver>>, global_this: &JSGlobalObject) -> Self {
+        bun_output::scoped_log!(DNSLookup, "init");
+        Self::init_head(resolver, global_this)
+    }
+
+    /// The lookup embedded in a request.
+    fn init_head(resolver: Option<ThisPtr<Resolver>>, global_this: &JSGlobalObject) -> Self {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-
-        bun_core::heap::into_raw(Box::new(Self {
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: Some(unsafe { RefPtr::init_ref(resolver) }),
-            global_this: bun_ptr::BackRef::new(global_this),
+        Self {
+            resolver: resolver.map(RefPtr::from_this),
+            global_this: BackRef::new(global_this),
             poll_ref,
             promise: JSPromiseStrong::init(global_this),
-            allocated: true,
-            next: None,
-        }))
+        }
     }
 
-    /// SAFETY: `this` must be a live node — either the inline head of a `*Request`
-    /// (allocated == false; owner drops it) or a Boxed tail node (allocated == true;
-    /// freed via `Self::destroy`). No `&mut` may alias `*this` across this call.
-    unsafe fn on_complete_native(this: *mut Self, result: &GetAddrInfoResultAny) {
+    fn on_complete_native(self, result: &GetAddrInfoResultAny) {
         bun_output::scoped_log!(DNSLookup, "onCompleteNative");
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let global = (*this).global_this();
-            // A null addrinfo with no error is an empty answer.
-            let array = super::options_jsc::result_any_to_js(result, global)
-                .and_then(|a| a.map_or_else(|| JSValue::create_empty_array(global, 0), Ok));
-            Self::on_complete_with_array(this, Outcome::of(global, array));
-        }
+        let global = self.global_this();
+        // A null addrinfo with no error is an empty answer.
+        let array = super::options_jsc::result_any_to_js(result, global)
+            .and_then(|a| a.map_or_else(|| JSValue::create_empty_array(global, 0), Ok));
+        let outcome = Outcome::of(global, array);
+        self.on_complete_with_array(outcome);
     }
 
-    /// SAFETY: see `on_complete_native`.
-    unsafe fn process_get_addr_info_native(this: *mut Self, status: i32, result: *mut AddrInfo) {
+    fn process_get_addr_info_native(mut self, status: i32) {
         bun_output::scoped_log!(DNSLookup, "processGetAddrInfoNative: status={}", status);
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            if let Some(err) = c_ares::Error::init_eai(status) {
-                error_to_deferred(err, b"getaddrinfo", None, &mut (*this).promise)
-                    .reject_later((*this).global_this());
-                Self::destroy(this);
-                return;
-            }
-            Self::on_complete_native(this, &GetAddrInfoResultAny::Addrinfo(result));
+        if let Some(err) = c_ares::Error::init_eai(status) {
+            error_to_deferred(err, b"getaddrinfo", None, &mut self.promise)
+                .reject_later(self.global_this());
+            return;
         }
+        self.on_complete_native(&GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()))
     }
 
-    /// SAFETY: see `on_complete_native`.
-    unsafe fn process_get_addr_info(
-        this: *mut Self,
+    fn process_get_addr_info(
+        mut self,
         err_: Option<c_ares::Error>,
         _timeout: i32,
-        result: Option<*mut c_ares::AddrInfo>,
+        result: Option<&c_ares::AddrInfo>,
     ) {
         bun_output::scoped_log!(DNSLookup, "processGetAddrInfo");
-        // This path is reached when the pending-host cache is full (`.disabled`),
-        // so we own the c-ares result here. The cached path frees it in
-        // `drainPendingHostCares`; callers from there always pass `null`.
-        let _free = scopeguard::guard(result, |r| {
-            if let Some(r) = r {
-                // SAFETY: r is the c-ares-allocated AddrInfo; we own it on this path.
-                unsafe { c_ares::AddrInfo::destroy(r) };
-            }
-        });
-
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let global_this = (*this).global_this();
-            if let Some(err) = err_ {
-                error_to_deferred(err, b"getaddrinfo", None, &mut (*this).promise)
-                    .reject_later(global_this);
-                Self::destroy(this);
-                return;
-            }
-
-            // `r` is the c-ares-allocated AddrInfo valid for the callback's duration.
-            let Some(r) = result.filter(|r| !(**r).node.is_null()) else {
-                error_to_deferred(
-                    c_ares::Error::ENOTFOUND,
-                    b"getaddrinfo",
-                    None,
-                    &mut (*this).promise,
-                )
+        let global_this = self.global_this.get();
+        if let Some(err) = err_ {
+            error_to_deferred(err, b"getaddrinfo", None, &mut self.promise)
                 .reject_later(global_this);
-                Self::destroy(this);
-                return;
-            };
-            Self::on_complete(this, r);
+            return;
         }
+
+        let Some(r) = result.filter(|r| !r.is_empty()) else {
+            error_to_deferred(
+                c_ares::Error::ENOTFOUND,
+                b"getaddrinfo",
+                None,
+                &mut self.promise,
+            )
+            .reject_later(global_this);
+            return;
+        };
+        self.on_complete(r);
     }
 
-    /// SAFETY: see `on_complete_native`.
-    unsafe fn on_complete(this: *mut Self, result: *mut c_ares::AddrInfo) {
+    fn on_complete(self, result: &c_ares::AddrInfo) {
         bun_output::scoped_log!(DNSLookup, "onComplete");
-        // SAFETY: caller contract — `this` is live; result is a live c-ares AddrInfo
-        // owned by the caller's scopeguard; JSGlobalObject outlives the request.
-        unsafe {
-            let global = (*this).global_this();
-            let array = super::cares_jsc::addr_info_to_js_array(&mut *result, global);
-            Self::on_complete_with_array(this, Outcome::of(global, array));
-        }
+        let global = self.global_this();
+        let array = super::cares_jsc::addr_info_to_js_array(result, global);
+        let outcome = Outcome::of(global, array);
+        self.on_complete_with_array(outcome);
     }
 
-    /// SAFETY: see `on_complete_native`.
-    unsafe fn on_complete_with_array(this: *mut Self, result: Outcome) {
+    fn on_complete_with_array(mut self, result: Outcome) {
         bun_output::scoped_log!(DNSLookup, "onCompleteWithArray");
-        // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
-        unsafe {
-            let mut promise = core::mem::take(&mut (*this).promise);
-            let global_this = (*this).global_this();
-            result.settle(&mut promise, global_this);
-            if let Some(resolver) = (*this).resolver.as_ref() {
-                // RefPtr holds a live ref; request_completed mutates pending_requests counter only.
-                (*resolver.as_ptr()).request_completed();
-            }
-            Self::destroy(this);
+        let mut promise = core::mem::take(&mut self.promise);
+        let global_this = self.global_this();
+        result.settle(&mut promise, global_this);
+        if let Some(resolver) = self.resolver() {
+            Resolver::request_completed(resolver);
         }
-    }
-
-    /// SAFETY: `this` must point at a live node; if `(*this).allocated`, it must be the
-    /// exact pointer returned by `heap::alloc` in `init()`. Head nodes (`!allocated`)
-    /// are dropped by their owner; this is a no-op for them.
-    unsafe fn destroy(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; if `allocated`, it is the exact
-        // pointer from `heap::alloc` in `init()`.
-        unsafe {
-            if (*this).allocated {
-                drop(bun_core::heap::take(this));
-            }
-        }
+        drop(self);
     }
 }
 
@@ -1885,7 +1366,7 @@ impl Outcome {
         }
     }
 
-    /// The resolver backends' completion callbacks (c-ares poll, libinfo,
+    /// The resolver backends' completion callbacks (c-ares poll, dns_sd,
     /// libuv) land here to settle the lookup's promise with a value built by
     /// the resolver: this is their fold for what settling leaves pending
     /// (allocation failure, a terminating VM).
@@ -1907,12 +1388,14 @@ fn keep_alive(outcome: &Outcome) {
 impl Drop for DNSLookup {
     fn drop(&mut self) {
         bun_output::scoped_log!(DNSLookup, "deinit");
-        let _ = self.global_this();
         // DNSLookup is always created on the JS event loop (it holds a JSGlobalObject),
         // so the Js-arm vtable is the correct EventLoopCtx for KeepAlive::unref.
         self.poll_ref.unref(Async::posix_event_loop::get_vm_ctx(
             Async::AllocatorType::Js,
         ));
+        if let Some(resolver) = self.resolver.take() {
+            resolver.deref();
+        }
     }
 }
 
@@ -1921,69 +1404,61 @@ impl Drop for DNSLookup {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GlobalData {
-    pub(crate) resolver: Resolver,
+    pub(crate) resolver: RefPtr<Resolver>,
 }
 
 impl GlobalData {
     pub(crate) fn init(vm: &VirtualMachine) -> Box<Self> {
         Box::new(Self {
-            resolver: Resolver::setup(vm),
+            resolver: RefPtr::new(Resolver::setup(vm)),
         })
     }
 }
 
+impl Drop for GlobalData {
+    fn drop(&mut self) {
+        // Tear the channel down now (its pending queries fail into their
+        // callbacks and release their refs) rather than whenever the last ref
+        // goes; then release ours.
+        self.resolver.destroy_channel();
+        self.resolver.deref();
+    }
+}
+
 impl Resolver {
-    /// Worker-terminate / main-VM-destruct hook: tear down the c-ares channel
-    /// while the JSC VM, `RareData.file_polls`, event loop, and `runtime_state`
-    /// are all still live. `ares_destroy()` synchronously fires every pending
-    /// query callback with `ARES_EDESTRUCTION` and then the socket-state
-    /// callback for each fd it closes; those callback chains dereference
-    /// `DNSLookup::global_this` (to enqueue the rejection task) and the hive
-    /// `FilePoll` (to unregister it from the loop). Running this after either
-    /// is freed is a UAF (Node `test-worker-dns-terminate.js`).
     /// Windows: `uv_getaddrinfo` requests are uv *requests* on this thread's
     /// loop, which the teardown drains before closing the loop; cancel the ones
     /// still in flight so that drain is prompt (each completes through its
     /// callback with UV_ECANCELED against the still-live VM).
     #[cfg(windows)]
     pub(crate) fn cancel_pending_uv_requests_for_teardown(&self) {
-        // SAFETY: JS thread; no other borrow of the cache is live during the
-        // stop phase (completions run later, from the loop drain).
-        let cache = unsafe { self.pending_host_cache_native.get_mut() };
-        let mut set = cache.used.iter_set();
-        while let Some(index) = set.next() {
-            // SAFETY: a set slot is an initialised `PendingCacheKey`; JS thread.
-            let lookup = unsafe { (*cache.ptr_at(index)).lookup };
-            if lookup.is_null() {
-                continue;
-            }
-            // SAFETY: `lookup` is the live boxed request until its completion
-            // callback removes it from the cache.
-            unsafe {
-                if let get_addr_info_request::Backend::Libc(l) = &mut (*lookup).backend {
-                    let _ = libuv::uv_cancel(core::ptr::from_mut(&mut l.uv).cast());
-                }
+        for entry in self.pending_host_cache_native.slots.get().iter().flatten() {
+            if let Some(inflight) = &entry.uv_inflight {
+                inflight.cancel();
             }
         }
     }
 
-    /// `Stopped` if a channel was open (its pending queries just failed with
-    /// `ARES_EDESTRUCTION` into their callbacks).
+    /// Worker-terminate / main-VM-destruct hook: tear down the c-ares channel
+    /// while the JSC VM, `RareData.file_polls`, event loop, and `runtime_state`
+    /// are all still live. `ares_destroy()` synchronously fires every pending
+    /// query callback with `ARES_EDESTRUCTION` and then the socket-state
+    /// callback for each fd it closes; those callback chains dereference
+    /// `DNSLookup::global_this` (to enqueue the rejection task) and the
+    /// `FilePoll` (to unregister it from the loop). Running this after either
+    /// is freed is a UAF (Node `test-worker-dns-terminate.js`).
     ///
-    /// # Safety
-    /// `this` is a live resolver. It may be freed by the time this returns (a
-    /// failing query can drop the last reference); the caller touches nothing
-    /// of it afterwards.
-    pub(crate) unsafe fn close_channel_for_terminate(
-        this: *mut Self,
+    /// `Stopped` if a channel was open (its pending queries just failed with
+    /// `ARES_EDESTRUCTION` into their callbacks). The resolver may be gone by
+    /// the time this returns (a failing query can drop the last reference).
+    pub(crate) fn close_channel_for_terminate(
+        this: ThisPtr<Self>,
     ) -> bun_jsc::virtual_machine::SweepResult {
         use bun_jsc::virtual_machine::SweepResult;
         // Failing the pending queries releases their refs on this resolver from
         // inside `ares_destroy`; hold one so it outlives its own channel close.
-        // SAFETY: fn contract.
-        let _guard = unsafe { RefPtr::init_ref(this) };
-        // SAFETY: alive under the ref just taken.
-        let result = if unsafe { (*this).destroy_channel() } {
+        let _guard = this.ref_guard();
+        let result = if this.destroy_channel() {
             SweepResult::Stopped
         } else {
             SweepResult::Idle
@@ -1991,8 +1466,7 @@ impl Resolver {
         // `GetAddrInfoRequest`'s EDESTRUCTION path does not call
         // `request_completed()`, so the c-ares timeout timer (and its +1 ref on
         // this resolver plus the uws active-handle bump) can still be linked.
-        // SAFETY: as above. `_guard` then releases our ref (may free `this`).
-        unsafe { (*this).remove_timer() };
+        Self::remove_timer(this);
         result
     }
 }
@@ -2003,6 +1477,12 @@ impl Resolver {
 
 pub mod internal {
     use super::*;
+    use core::sync::atomic::{AtomicBool, AtomicU32};
+
+    use bun_uws::ConnectingSocket;
+    use bun_uws_sys::addrinfo::{
+        AddrInfoResult, DnsWaitingSocket, addrinfo_result, addrinfo_result_entry,
+    };
 
     // PORTING.md §Global mutable state: lazy env-var memo — an `OnceLock<u32>`
     // (idempotent init, safe concurrent read).
@@ -2020,7 +1500,7 @@ pub mod internal {
     // The stack key borrows the caller's host string; `to_owned()` copies
     // before storing on the heap `Request`.
     struct RequestKey<'a> {
-        pub(crate) host: Option<&'a ZStr>,
+        pub(crate) host: Option<&'a [u8]>,
         /// Used for getaddrinfo() to avoid glibc UDP port 0 bug, but NOT included in hash
         pub(crate) port: u16,
         /// Hash of hostname only - DNS results are port-agnostic
@@ -2043,7 +1523,7 @@ pub mod internal {
                 return false;
             }
             match (self.host.as_ref(), other.host) {
-                (Some(a), Some(b)) => a.as_bytes() == b.as_bytes(),
+                (Some(a), Some(b)) => a.as_bytes() == b,
                 (None, None) => true,
                 _ => false,
             }
@@ -2051,7 +1531,7 @@ pub mod internal {
     }
 
     impl<'a> RequestKey<'a> {
-        pub(crate) fn init(name: Option<&'a ZStr>, port: u16) -> Self {
+        pub(crate) fn init(name: Option<&'a [u8]>, port: u16) -> Self {
             let hash = if let Some(n) = name {
                 Self::generate_hash(n) // Don't include port
             } else {
@@ -2064,93 +1544,93 @@ pub mod internal {
             }
         }
 
-        fn generate_hash(name: &ZStr) -> u64 {
-            wyhash(name.as_bytes())
+        fn generate_hash(name: &[u8]) -> u64 {
+            wyhash(name)
         }
 
         pub(crate) fn to_owned(&self) -> RequestKeyOwned {
-            if let Some(host) = self.host {
-                let host_copy = bun::ZBox::from_bytes(host.as_bytes());
-                RequestKeyOwned {
-                    host: Some(host_copy),
-                    hash: self.hash,
-                    port: self.port,
-                }
-            } else {
-                RequestKeyOwned {
-                    host: None,
-                    hash: self.hash,
-                    port: self.port,
-                }
+            RequestKeyOwned {
+                host: self.host.map(bun::ZBox::from_bytes),
+                hash: self.hash,
+                port: self.port,
             }
         }
     }
 
-    // Crosses FFI to usockets via `Bun__addrinfo_getRequestResult` — layout MUST
-    // stay `{ info: ?*ResultEntry, err: c_int }` (8-byte thin ptr).
-    #[repr(C)]
-    pub struct RequestResult {
-        pub(crate) info: Option<NonNull<ResultEntry>>, // thin ptr; head of intrusive `ai_next` chain
-        pub(crate) err: c_int,
-    }
-    // Ownership of the ResultEntry buffer is `Request.result_buf` — this struct is
-    // a borrowed C-ABI view (`info` points at `result_buf[0]`). Do NOT free via
-    // this field.
-
+    /// The dns_sd query state of a connect-path lookup. Only the thread whose
+    /// `SharedConnection` issued the query touches it (from the reply callback
+    /// and completion), until `dns_sd_complete` publishes the result.
     #[cfg(target_os = "macos")]
     pub struct MacAsyncDNS {
-        pub(crate) query: dns_sd::QueryState,
+        pub(crate) query: JsCell<dns_sd::QueryState>,
     }
 
     #[cfg(target_os = "macos")]
     impl Default for MacAsyncDNS {
         fn default() -> Self {
             Self {
-                query: dns_sd::QueryState::new(0),
+                query: JsCell::new(dns_sd::QueryState::new(0)),
             }
         }
     }
 
+    /// One cached lookup. usockets, the QUIC client and the work pool all hold
+    /// it by address (`ThisPtr` / `BackRef`); the cache owns it and frees it
+    /// only once `refcount` is back to zero.
     pub struct Request {
         pub(crate) key: RequestKeyOwned,
-        pub(crate) result: Option<RequestResult>,
-        /// Owns the `[ResultEntry; N]` packed by `process_results`; `result.info`
-        /// borrows its first element. Freed by `Drop` in `Request::deinit`.
-        pub(crate) result_buf: Option<Box<[ResultEntry]>>,
-
-        pub(crate) notify: Vec<DNSRequestOwner>,
-
+        /// Set once, under the cache lock, when the lookup finishes; read
+        /// lock-free by usockets after it has been notified.
+        result: std::sync::OnceLock<AddrInfoResult>,
+        /// Who to notify when `result` lands; guarded by the cache lock (this
+        /// lock is only ever taken under it).
+        notify: bun_threading::Guarded<Vec<DNSRequestOwner>>,
         /// number of sockets that have a reference to result or are waiting for the result
         /// while this is non-zero, this entry cannot be freed
-        pub(crate) refcount: u32,
-
+        refcount: AtomicU32,
         /// Seconds since the epoch when this request was created.
         /// Not a precise timestamp.
         pub(crate) created_at: u32,
-
-        pub(crate) valid: bool,
-
+        valid: AtomicBool,
         #[cfg(target_os = "macos")]
         pub(crate) dns_sd: MacAsyncDNS,
     }
 
     impl Request {
-        pub(crate) fn new(key: RequestKeyOwned, refcount: u32, created_at: u32) -> *mut Self {
-            bun_core::heap::into_raw(Box::new(Self {
+        pub(crate) fn new(
+            key: RequestKeyOwned,
+            refcount: u32,
+            created_at: u32,
+        ) -> bun_ptr::OwnedThis<Self> {
+            bun_ptr::OwnedThis::new(Self {
                 key,
-                result: None,
-                result_buf: None,
-                notify: Vec::new(),
-                refcount,
+                result: std::sync::OnceLock::new(),
+                notify: bun_threading::Guarded::new(Vec::new()),
+                refcount: AtomicU32::new(refcount),
                 created_at,
-                valid: true,
+                valid: AtomicBool::new(true),
                 #[cfg(target_os = "macos")]
                 dns_sd: MacAsyncDNS::default(),
-            }))
+            })
         }
 
-        pub(crate) fn is_expired(&mut self, timestamp_to_store: &mut u32) -> bool {
-            if self.result.is_none() {
+        #[inline]
+        fn refcount(&self) -> u32 {
+            self.refcount.load(Ordering::Relaxed)
+        }
+
+        #[inline]
+        fn is_valid(&self) -> bool {
+            self.valid.load(Ordering::Relaxed)
+        }
+
+        #[inline]
+        pub(crate) fn has_result(&self) -> bool {
+            self.result.get().is_some()
+        }
+
+        pub(crate) fn is_expired(&self, timestamp_to_store: &mut u32) -> bool {
+            if !self.has_result() {
                 return false;
             }
 
@@ -2162,27 +1642,17 @@ pub mod internal {
             *timestamp_to_store = now;
 
             if now.saturating_sub(self.created_at) > get_max_dns_time_to_live_seconds() {
-                self.valid = false;
+                self.valid.store(false, Ordering::Relaxed);
                 return true;
             }
 
             false
         }
+    }
 
-        /// # Safety
-        /// `this` must be the heap-allocated `Request` returned by `Request::new`
-        /// with `refcount == 0`; freed by this call.
-        // `this` is reclaimed via `heap::take` (Box::from_raw); forming
-        // `&mut *this` at entry would invalidate the pointer's allocation
-        // provenance, so the param must stay `*mut`.
-        #[allow(clippy::not_unsafe_ptr_arg_deref)]
-        pub(crate) fn deinit(this: *mut Self) {
-            // SAFETY: this is a heap-allocated Request with refcount==0
-            unsafe {
-                debug_assert!((*this).notify.is_empty());
-                // `result_buf` (Box<[ResultEntry]>) and `key.host` freed by Drop.
-                drop(bun_core::heap::take(this));
-            }
+    impl Drop for Request {
+        fn drop(&mut self) {
+            debug_assert!(self.notify.lock().is_empty());
         }
     }
 
@@ -2193,45 +1663,45 @@ pub mod internal {
     /// The cache data guarded by `GLOBAL_CACHE`; the lock owns the data
     /// (PORTING.md §Concurrency).
     struct GlobalCache {
-        pub cache: [*mut Request; MAX_ENTRIES],
-        pub len: usize,
+        cache: Vec<bun_ptr::OwnedThis<Request>>,
+        /// Requests handed out while the cache had no room for them; freed
+        /// like cached ones once their last holder lets go.
+        orphans: Vec<bun_ptr::OwnedThis<Request>>,
     }
-
-    // SAFETY: every `*mut Request` stored here is a heap allocation transferred between
-    // threads only while `GLOBAL_CACHE` is locked; no thread-affine data hangs off it.
-    unsafe impl Send for GlobalCache {}
 
     impl GlobalCache {
         const fn new() -> Self {
             Self {
-                cache: [ptr::null_mut(); MAX_ENTRIES],
-                len: 0,
+                cache: Vec::new(),
+                orphans: Vec::new(),
             }
+        }
+
+        #[inline]
+        fn len(&self) -> usize {
+            self.cache.len()
         }
 
         fn get(
             &mut self,
             key: &RequestKey<'_>,
             timestamp_to_store: &mut u32,
-        ) -> Option<*mut Request> {
-            let mut len = self.len;
+        ) -> Option<ThisPtr<Request>> {
             let mut i: usize = 0;
-            while i < len {
-                let entry = self.cache[i];
-                // SAFETY: entries 0..len are valid heap Requests
-                unsafe {
-                    if (*entry).key.matches(key) && (*entry).valid {
-                        if (*entry).is_expired(timestamp_to_store) {
-                            bun_output::scoped_log!(dns, "get: expired entry");
-                            if (*entry).refcount == 0 {
-                                let _ = self.delete_entry_at(len, i);
-                                Request::deinit(entry);
-                                len = self.len;
-                            }
-                            continue;
+            while i < self.cache.len() {
+                let entry = &self.cache[i];
+                if entry.key.matches(key) && entry.is_valid() {
+                    if entry.is_expired(timestamp_to_store) {
+                        bun_output::scoped_log!(dns, "get: expired entry");
+                        if entry.refcount() == 0 {
+                            let len = self.cache.len();
+                            self.delete_entry_at(len, i);
                         }
-                        return Some(entry);
+                        // An expired entry that is still referenced is now
+                        // invalid, so the next pass over `i` skips it.
+                        continue;
                     }
+                    return Some(entry.this_ptr());
                 }
                 i += 1;
             }
@@ -2241,59 +1711,54 @@ pub mod internal {
         // To preserve memory, we use a 32 bit timestamp
         // However, we're almost out of time to use 32 bit timestamps for anything
         // So we set the epoch to January 1st, 2024 instead.
-        fn get_cache_timestamp() -> u32 {
+        pub(super) fn get_cache_timestamp() -> u32 {
             (bun::Timespec::now(bun::TimespecMockMode::AllowMockedTime).ms_unsigned() / 1000) as u32
         }
 
         fn is_nearly_full(&self) -> bool {
             // 80% full (value is kind of arbitrary)
             // Caller already holds GLOBAL_CACHE; no atomic load needed.
-            self.len * 5 >= self.cache.len() * 4
+            self.cache.len() * 5 >= MAX_ENTRIES * 4
         }
 
-        fn delete_entry_at(&mut self, len: usize, i: usize) -> Option<*mut Request> {
-            self.len -= 1;
+        /// Free entry `i` of `len` (swap-remove).
+        fn delete_entry_at(&mut self, len: usize, i: usize) {
             DNS_CACHE_SIZE.store(len - 1, Ordering::Relaxed);
-
-            if len > 1 {
-                let prev = self.cache[len - 1];
-                self.cache[i] = prev;
-                return Some(prev);
-            }
-            None
+            drop(self.cache.swap_remove(i));
         }
 
-        fn remove(&mut self, entry: *mut Request) {
-            let len = self.len;
-            // equivalent of swapRemove
-            for i in 0..len {
-                if self.cache[i] == entry {
-                    let _ = self.delete_entry_at(len, i);
-                    return;
-                }
+        /// Free `entry` (a cached request or an orphan).
+        fn remove(&mut self, entry: ThisPtr<Request>) {
+            let is =
+                |e: &bun_ptr::OwnedThis<Request>| core::ptr::eq(&raw const **e, entry.as_ptr());
+            if let Some(i) = self.cache.iter().position(is) {
+                let len = self.cache.len();
+                self.delete_entry_at(len, i);
+            } else if let Some(i) = self.orphans.iter().position(is) {
+                drop(self.orphans.swap_remove(i));
             }
         }
 
-        fn try_push(&mut self, entry: *mut Request) -> bool {
+        /// Cache `entry` (evicting an idle one if full); hands it back if
+        /// there was no room.
+        fn try_push(
+            &mut self,
+            entry: bun_ptr::OwnedThis<Request>,
+        ) -> Result<(), bun_ptr::OwnedThis<Request>> {
             // is the cache full?
-            if self.len >= self.cache.len() {
+            if self.cache.len() >= MAX_ENTRIES {
                 // check if there is an element to evict
-                for e in &mut self.cache[0..self.len] {
-                    // SAFETY: entries are valid
-                    unsafe {
-                        if (**e).refcount == 0 {
-                            Request::deinit(*e);
-                            *e = entry;
-                            return true;
-                        }
+                for e in self.cache.iter_mut() {
+                    if e.refcount() == 0 {
+                        *e = entry;
+                        return Ok(());
                     }
                 }
-                false
+                Err(entry)
             } else {
                 // just append to the end
-                self.cache[self.len] = entry;
-                self.len += 1;
-                true
+                self.cache.push(entry);
+                Ok(())
             }
         }
     }
@@ -2348,125 +1813,26 @@ pub mod internal {
         hints_copy
     }
 
-    /// Chrome's `IsLocalHostname` (RFC 6761 §6.3): `localhost` or `*.localhost`, ASCII case-insensitive, one trailing dot allowed.
-    fn is_localhost_name(host: &[u8]) -> bool {
-        const DOT_LOCALHOST: &[u8] = b".localhost";
-        let host = host.strip_suffix(b".").unwrap_or(host);
-        strings::eql_case_insensitive_ascii(host, b"localhost", true)
-            || (host.len() >= DOT_LOCALHOST.len()
-                && strings::eql_case_insensitive_ascii(
-                    &host[host.len() - DOT_LOCALHOST.len()..],
-                    DOT_LOCALHOST,
-                    true,
-                ))
-    }
-
-    /// Chrome's `ServeLocalhost`: a localhost name is `[::1, 127.0.0.1]` without asking the resolver, narrowed like every other lookup by the family feature flags.
-    fn localhost_results(port: u16) -> Box<[ResultEntry]> {
-        #[cfg(not(windows))]
-        let family = get_hints().ai_family;
-        #[cfg(windows)]
-        let family = netc::AF_UNSPEC;
-        let mut addrs: Vec<SockaddrStorage> = [
-            IpAddr::V6(Ipv6Addr::LOCALHOST),
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-        ]
-        .into_iter()
-        .filter(|ip| family == netc::AF_UNSPEC || ip.is_ipv6() == (family == netc::AF_INET6))
-        .map(|ip| bun_dns::Address::from_ip(ip, port).into_storage())
-        .collect();
-        let mut chain = addrinfo_chain(&mut addrs);
-        process_results(chain.as_mut_ptr())
-    }
-
-    /// Chrome's `IsAllLocalhostOfOneFamily`: every address is loopback and only one family is present, the shape glibc's AI_ADDRCONFIG produces for a hosts-file loopback name (crbug 42058 / 49024).
-    fn is_all_loopback_of_one_family(mut info: *const AddrInfo) -> bool {
-        let (mut saw_v4, mut saw_v6) = (false, false);
-        while !info.is_null() {
-            // SAFETY: `info` walks a live addrinfo list whose `ai_addr` matches `ai_family`.
-            unsafe {
-                let addr = (*info).ai_addr;
-                if addr.is_null() {
-                    return false;
-                }
-                match (*info).ai_family {
-                    netc::AF_INET => {
-                        let octets = (*addr.cast::<netc::sockaddr_in>())
-                            .sin_addr
-                            .s_addr
-                            .to_ne_bytes();
-                        if !Ipv4Addr::from(octets).is_loopback() {
-                            return false;
-                        }
-                        saw_v4 = true;
-                    }
-                    netc::AF_INET6 => {
-                        let octets = (*addr.cast::<netc::sockaddr_in6>()).sin6_addr.s6_addr;
-                        if !Ipv6Addr::from(octets).is_loopback() {
-                            return false;
-                        }
-                        saw_v6 = true;
-                    }
-                    _ => return false,
-                }
-                info = (*info).ai_next;
-            }
-        }
-        saw_v4 != saw_v6
-    }
-
-    // `Request` is passed opaquely to usockets and round-tripped back into
-    // Rust; the C side never dereferences fields, so layout is irrelevant.
-    #[allow(improper_ctypes)]
-    unsafe extern "C" {
-        fn us_internal_dns_callback(socket: *mut ConnectingSocket, req: *mut Request);
-        fn us_internal_dns_callback_threadsafe(socket: *mut ConnectingSocket, req: *mut Request);
-    }
-
     pub enum DNSRequestOwner {
-        Socket(*mut ConnectingSocket),           // FFI
-        Prefetch(*mut Loop),                     // FFI
-        Quic(*mut bun_http::H3::PendingConnect), // BORROW_PARAM
+        Socket(DnsWaitingSocket),
+        Prefetch,
+        Quic(bun_http::H3::DnsPendingConnect),
     }
 
     impl DNSRequestOwner {
-        /// # Safety
-        /// `req` must be a live cache `Request` with a populated `result`; the
-        /// callee may take ownership and free it.
-        // Forwards `req` to C++ without dereferencing; not_unsafe_ptr_arg_deref
-        // is a false positive on opaque-token forwarding.
-        #[allow(clippy::not_unsafe_ptr_arg_deref)]
-        pub(crate) fn notify_threadsafe(&self, req: *mut Request) {
+        pub(crate) fn notify_threadsafe(self, req: ThisPtr<Request>) {
             match self {
-                // SAFETY: `socket` is the live usockets handle stored when the request was registered.
-                DNSRequestOwner::Socket(socket) => unsafe {
-                    us_internal_dns_callback_threadsafe(*socket, req)
-                },
-                DNSRequestOwner::Prefetch(_) => freeaddrinfo(req, 0),
-                // SAFETY: `pc` is the live PendingConnect borrowed for the lifetime of the request.
-                DNSRequestOwner::Quic(pc) => unsafe {
-                    bun_http::H3::PendingConnect::on_dns_resolved_threadsafe(*pc)
-                },
+                DNSRequestOwner::Socket(socket) => socket.notify_threadsafe(),
+                DNSRequestOwner::Prefetch => freeaddrinfo(req, 0),
+                DNSRequestOwner::Quic(pc) => pc.notify_threadsafe(),
             }
         }
 
-        /// # Safety
-        /// `req` must be a live cache `Request` with a populated `result`; the
-        /// callee may take ownership and free it.
-        // Forwards `req` to C++ without dereferencing; not_unsafe_ptr_arg_deref
-        // is a false positive on opaque-token forwarding.
-        #[allow(clippy::not_unsafe_ptr_arg_deref)]
-        pub(crate) fn notify(&self, req: *mut Request) {
+        pub(crate) fn notify(self, req: ThisPtr<Request>) {
             match self {
-                DNSRequestOwner::Prefetch(_) => freeaddrinfo(req, 0),
-                // SAFETY: `socket` is the live usockets handle stored when the request was registered.
-                DNSRequestOwner::Socket(socket) => unsafe {
-                    us_internal_dns_callback(*socket, req)
-                },
-                // SAFETY: `pc` is the live PendingConnect borrowed for the lifetime of the request.
-                DNSRequestOwner::Quic(pc) => unsafe {
-                    bun_http::H3::PendingConnect::on_dns_resolved(*pc)
-                },
+                DNSRequestOwner::Prefetch => freeaddrinfo(req, 0),
+                DNSRequestOwner::Socket(socket) => socket.notify(),
+                DNSRequestOwner::Quic(pc) => pc.notify(),
             }
         }
     }
@@ -2476,177 +1842,97 @@ pub mod internal {
     /// no us_connecting_socket_t to hang the callback on. The .quic notify
     /// path frees the addrinfo request inline (via Bun__addrinfo_freeRequest),
     /// which re-acquires global_cache.lock — so drop it before notifying.
-    ///
-    /// # Safety
-    /// `request` must be a live cache `Request` (refcount held by the caller);
-    /// `pc` must stay valid until its `on_dns_resolved[_threadsafe]` fires.
-    // `request` is forwarded to `owner.notify`, which may free it inline
-    // (see fn doc); forming `&mut *request` at entry would be unsound across
-    // that hand-off, so the param must stay `*mut`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn register_quic(request: *mut Request, pc: *mut bun_http::H3::PendingConnect) {
+    pub(crate) fn register_quic(request: ThisPtr<Request>, pc: bun_http::H3::DnsPendingConnect) {
         let guard = global_cache().lock();
         let owner = DNSRequestOwner::Quic(pc);
-        // SAFETY: `request` is a live cache entry; `result`/`notify` are only
-        // touched under `global_cache().lock()`, which is held here.
-        unsafe {
-            if (*request).result.is_some() {
-                drop(guard);
-                owner.notify(request);
-                return;
-            }
-            (*request).notify.push(owner);
+        if request.has_result() {
+            drop(guard);
+            owner.notify(request);
+            return;
         }
+        request.notify.lock().push(owner);
         drop(guard);
     }
 
-    #[repr(C)]
-    pub struct ResultEntry {
-        pub(crate) info: AddrInfo,
-        pub(crate) addr: SockaddrStorage,
+    /// The `ai_family`/`ai_socktype`/`ai_addrlen` header for a synthesized
+    /// result entry.
+    fn synthetic_addrinfo(family: c_int) -> AddrInfo {
+        let mut n: AddrInfo = bun_core::ffi::zeroed();
+        n.ai_family = family;
+        n.ai_socktype = netc::SOCK_STREAM;
+        n.ai_addrlen = if family == netc::AF_INET6 {
+            core::mem::size_of::<netc::sockaddr_in6>() as _
+        } else {
+            core::mem::size_of::<netc::sockaddr_in>() as _
+        };
+        n
     }
 
     // Pack getaddrinfo results into one allocation with address families
     // interleaved (RFC 8305 §4) so an unroutable family can never fill all
     // CONCURRENT_CONNECTIONS parallel connect attempts. See #4938 / #33278.
-    fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
-        let mut count: usize = 0;
-        let mut n_first: usize = 0;
-        let first_family = if info.is_null() {
-            netc::AF_UNSPEC
-        } else {
-            // SAFETY: info is a live addrinfo node; freed by caller after we return.
-            unsafe { (*info).ai_family }
-        };
-        let mut info_: *mut AddrInfo = info;
-        while !info_.is_null() {
-            // SAFETY: info_ walks the libc-allocated addrinfo list; freed by caller after we return.
-            unsafe {
-                count += 1;
-                if (*info_).ai_family == first_family {
-                    n_first += 1;
+    fn process_results(
+        nodes: impl Iterator<Item = (AddrInfo, Option<SockaddrStorage>)> + Clone,
+        err: c_int,
+    ) -> AddrInfoResult {
+        let first_family = nodes
+            .clone()
+            .next()
+            .map_or(netc::AF_UNSPEC, |(info, _)| info.ai_family);
+        let is_first = move |info: &AddrInfo| info.ai_family == first_family;
+        let count = nodes.clone().count();
+        let entry = |(info, addr): (AddrInfo, Option<SockaddrStorage>)| {
+            // Windows getaddrinfo may return non-null ai_addr with families other
+            // than AF_INET/AF_INET6; those entries keep a (zeroed) `addr`.
+            let addr = addr.map(|a| {
+                if info.ai_family == netc::AF_INET || info.ai_family == netc::AF_INET6 {
+                    a
+                } else {
+                    bun_core::ffi::zeroed()
                 }
-                info_ = (*info_).ai_next;
-            }
-        }
-        let n_other = count - n_first;
-
-        let mut results: Box<[MaybeUninit<ResultEntry>]> = Box::new_uninit_slice(count);
-
-        let mut i_first: usize = 0;
-        let mut i_other: usize = 0;
-        info_ = info;
-        while !info_.is_null() {
-            // SAFETY: info_ is a valid addrinfo node (counted above); the slot
-            // mapping is a bijection over 0..count so every MaybeUninit slot
-            // is fully initialized exactly once.
-            unsafe {
-                let i = if (*info_).ai_family == first_family {
-                    let i = i_first;
-                    i_first += 1;
-                    if i < n_other { 2 * i } else { n_other + i }
-                } else {
-                    let j = i_other;
-                    i_other += 1;
-                    if j < n_first { 2 * j + 1 } else { n_first + j }
-                };
-                let entry = results[i].as_mut_ptr();
-                (*entry).info = *info_;
-                // Always initialize `addr`: assume_init() below requires every byte written.
-                // Windows getaddrinfo may return non-null ai_addr with families other than
-                // AF_INET/AF_INET6; zero `addr` for those rather than leaving it uninit.
-                if !(*info_).ai_addr.is_null() && (*info_).ai_family == netc::AF_INET {
-                    (*entry).addr = bun_core::ffi::zeroed();
-                    let addr_in = (&raw mut (*entry).addr).cast::<netc::sockaddr_in>();
-                    *addr_in = *(*info_).ai_addr.cast::<netc::sockaddr_in>();
-                } else if !(*info_).ai_addr.is_null() && (*info_).ai_family == netc::AF_INET6 {
-                    (*entry).addr = bun_core::ffi::zeroed();
-                    let addr_in = (&raw mut (*entry).addr).cast::<netc::sockaddr_in6>();
-                    *addr_in = *(*info_).ai_addr.cast::<netc::sockaddr_in6>();
-                } else {
-                    (*entry).addr = bun_core::ffi::zeroed();
-                }
-                info_ = (*info_).ai_next;
-            }
-        }
-
-        // SAFETY: every slot 0..count was written above
-        let mut results: Box<[ResultEntry]> = unsafe { results.assume_init() };
-
-        // set up pointers
-        for idx in 0..count {
-            let (left, right) = results.split_at_mut(idx + 1);
-            let entry = &mut left[idx];
-            entry.info.ai_canonname = ptr::null_mut();
-            if idx + 1 < count {
-                entry.info.ai_next = &raw mut right[0].info;
-            } else {
-                entry.info.ai_next = ptr::null_mut();
-            }
-            if !entry.info.ai_addr.is_null() {
-                entry.info.ai_addr = (&raw mut entry.addr).cast::<Sockaddr>();
-            }
-        }
-
-        results
-    }
-
-    /// addrinfo nodes for [`process_results`]; they point into `addrs`, which must outlive them.
-    fn addrinfo_chain(addrs: &mut [SockaddrStorage]) -> Box<[AddrInfo]> {
-        let mut nodes: Box<[AddrInfo]> = addrs
-            .iter_mut()
-            .map(|addr| {
-                let mut node: AddrInfo = bun_core::ffi::zeroed();
-                node.ai_family = addr.ss_family as c_int;
-                node.ai_socktype = netc::SOCK_STREAM;
-                node.ai_addrlen = if node.ai_family == netc::AF_INET6 {
-                    size_of::<netc::sockaddr_in6>() as _
-                } else {
-                    size_of::<netc::sockaddr_in>() as _
-                };
-                node.ai_addr = ptr::from_mut(addr).cast::<Sockaddr>();
-                node
-            })
-            .collect();
-        let base = nodes.as_mut_ptr();
-        for i in 1..nodes.len() {
-            // SAFETY: `i - 1` and `i` are in bounds of the boxed slice, which is not moved afterwards.
-            unsafe { (*base.add(i - 1)).ai_next = base.add(i) };
-        }
-        nodes
-    }
-
-    fn after_result(req: *mut Request, info: *mut AddrInfo, err: c_int) {
-        let results: Option<Box<[ResultEntry]>> = if !info.is_null() {
-            let res = process_results(info);
-            // ws2_32!getaddrinfo-allocated on Windows — free via the matching
-            // ws2_32!freeaddrinfo (NOT uv_freeaddrinfo: different allocator).
-            // `.cast()` is identity on POSIX, libuv_sys→ws2_32 addrinfo on Windows.
-            // SAFETY: `info` is non-null (checked above) and owned by getaddrinfo.
-            unsafe { bun_dns::freeaddrinfo(info.cast()) };
-            Some(res)
-        } else {
-            None
+            });
+            addrinfo_result_entry::new(info, addr.as_ref())
         };
-        after_result_entries(req, results, err);
+
+        // first, other, first, other, … then whatever is left of the longer run.
+        let mut firsts = nodes.clone().filter(move |(info, _)| is_first(info));
+        let mut others = nodes.filter(move |(info, _)| !is_first(info));
+        let mut results: Vec<addrinfo_result_entry> = Vec::with_capacity(count);
+        loop {
+            match (firsts.next(), others.next()) {
+                (None, None) => break,
+                (first, other) => {
+                    results.extend(first.map(entry));
+                    results.extend(other.map(entry));
+                }
+            }
+        }
+        AddrInfoResult::new(results, err)
     }
 
-    fn after_result_entries(req: *mut Request, results: Option<Box<[ResultEntry]>>, err: c_int) {
+    fn after_result(
+        req: ThisPtr<Request>,
+        result: Result<Option<bun_sys::net::AddrInfoList>, c_int>,
+    ) {
+        let result = match result {
+            Ok(Some(list)) => process_results(
+                list.iter()
+                    .map(|e| (*e.raw(), e.address().map(bun_dns::Address::into_storage))),
+                0,
+            ),
+            Ok(None) => AddrInfoResult::new(Vec::new(), 0),
+            Err(err) => AddrInfoResult::new(Vec::new(), err),
+        };
+        after_result_entries(req, result);
+    }
+
+    fn after_result_entries(req: ThisPtr<Request>, result: AddrInfoResult) {
         let guard = global_cache().lock();
 
-        // SAFETY: `req` is the heap-allocated cache entry; its mutable fields are
-        // only touched under `global_cache().lock()`, which is held here.
-        let notify = unsafe {
-            // Park the owning Box on `Request.result_buf`; `RequestResult.info`
-            // borrows its first element as a thin pointer for the C side.
-            (*req).result_buf = results;
-            let info = (*req)
-                .result_buf
-                .as_mut()
-                .and_then(|b| NonNull::new(b.as_mut_ptr()));
-            (*req).result = Some(RequestResult { info, err });
-            let notify = core::mem::take(&mut (*req).notify);
-            (*req).refcount -= 1;
+        let notify = {
+            let _ = req.result.set(result);
+            let notify = core::mem::take(&mut *req.notify.lock());
+            req.refcount.fetch_sub(1, Ordering::Relaxed);
             notify
         };
 
@@ -2658,164 +1944,93 @@ pub mod internal {
         }
     }
 
-    fn work_pool_callback(req: *mut Request) {
+    fn work_pool_callback(req: BackRef<Request, bun_ptr::Mut>) {
         let mut service_buf = [0u8; 21];
-        // SAFETY: `req` is the heap-allocated cache entry; `key` is set at construction and read-only.
-        let port = unsafe { (*req).key.port };
-        let service: *const c_char = if port > 0 {
-            bun_fmt::itoa_z(&mut service_buf, port as u64).as_ptr()
+        let port = req.key.port;
+        let service: Option<&CStr> = if port > 0 {
+            Some(bun_fmt::itoa_z(&mut service_buf, port as u64))
         } else {
-            ptr::null()
+            None
         };
+        let host: Option<&CStr> = req.key.host.as_deref().map(c_str);
 
         #[cfg(windows)]
-        unsafe {
+        let result = {
             use bun_sys::windows::ws2_32 as wsa;
-            libuv::uv__winsock_ensure();
-            let mut wsa_hints: wsa::addrinfo = bun_core::ffi::zeroed();
+            let mut wsa_hints: AddrInfo = bun_core::ffi::zeroed();
             wsa_hints.ai_family = wsa::AF_UNSPEC;
             wsa_hints.ai_socktype = wsa::SOCK_STREAM;
-
-            let mut addrinfo: *mut wsa::addrinfo = ptr::null_mut();
-            let err = wsa::getaddrinfo(
-                (*req)
-                    .key
-                    .host
-                    .as_ref()
-                    .map(|h| h.as_ptr().cast::<c_char>())
-                    .unwrap_or(ptr::null()),
-                service,
-                &wsa_hints,
-                &mut addrinfo,
-            );
-            after_result(req, addrinfo.cast(), err);
-        }
+            bun_sys::net::AddrInfoList::lookup(host, service, Some(&wsa_hints))
+        };
         #[cfg(not(windows))]
-        // SAFETY: FFI getaddrinfo; `req.key.host` is the owned NUL-terminated host
-        // set at construction, `hints`/`addrinfo` are stack locals.
-        unsafe {
-            let mut addrinfo: *mut AddrInfo = ptr::null_mut();
+        let result = {
             let mut hints = get_hints();
-
-            let host_ptr = (*req)
-                .key
-                .host
-                .as_ref()
-                .map(|h| h.as_ptr().cast::<c_char>())
-                .unwrap_or(ptr::null());
-            let mut err = libc::getaddrinfo(host_ptr, service, &raw const hints, &raw mut addrinfo);
-
-            // Chrome's retries: AI_ADDRCONFIG left nothing, or only one family's loopback.
-            if (hints.ai_flags & netc::AI_ADDRCONFIG) != 0
-                && (err == netc::EAI_NONAME
-                    || (err == 0 && is_all_loopback_of_one_family(addrinfo)))
+            let mut result = bun_sys::net::AddrInfoList::lookup(host, service, Some(&hints));
+            // optional fallback
+            if result.as_ref().err() == Some(&netc::EAI_NONAME)
+                && (hints.ai_flags & netc::AI_ADDRCONFIG) != 0
             {
                 hints.ai_flags &= !netc::AI_ADDRCONFIG;
-                let mut unfiltered: *mut AddrInfo = ptr::null_mut();
-                let retry_err =
-                    libc::getaddrinfo(host_ptr, service, &raw const hints, &raw mut unfiltered);
-                if retry_err == 0 || err != 0 {
-                    if !addrinfo.is_null() {
-                        bun_dns::freeaddrinfo(addrinfo);
-                    }
-                    addrinfo = unfiltered;
-                    err = retry_err;
-                }
+                result = bun_sys::net::AddrInfoList::lookup(host, service, Some(&hints));
             }
-            after_result(req, addrinfo, err);
-        }
+            result
+        };
+        after_result(req.this_ptr(), result);
     }
 
     #[cfg(target_os = "macos")]
-    fn lookup_dns_sd(req: *mut Request, loop_: jsc::EventLoopHandle) -> bool {
-        // SAFETY: `req` is the live heap-allocated request owned by the caller.
-        let Some(host) = (unsafe { (*req).key.host.as_ref() }) else {
+    fn lookup_dns_sd(req: ThisPtr<Request>, ctx: Async::EventLoopCtx) -> bool {
+        let Some(host) = req.key.host.as_ref() else {
             // Null host: fall through to getaddrinfo(NULL, service) on the work pool.
             return false;
         };
-        let Some(shared) = dns_sd::SharedConnection::get(
-            crate::api::bun::process::event_loop_handle_to_ctx(loop_),
-        ) else {
+        let Some(shared) = dns_sd::SharedConnection::get(ctx) else {
             return false;
         };
 
         let protocol = dns_sd::protocol_for_hints(&get_hints());
-        // SAFETY: `req` is the live heap-allocated request owned by the caller.
-        unsafe {
-            (*req).dns_sd = MacAsyncDNS {
-                query: dns_sd::QueryState::new(protocol),
-            };
-        }
-        let Some(_) = shared.start(
-            dns_sd::Inflight::Internal(req),
-            protocol,
-            host,
-            dns_sd_reply,
-            req.cast::<c_void>(),
-        ) else {
-            return false;
-        };
-
-        true
+        req.dns_sd.query.set(dns_sd::QueryState::new(protocol));
+        shared
+            .start(
+                dns_sd::InflightRequest::Internal(BackRef::from(req)),
+                protocol,
+                c_str(host),
+            )
+            .is_some()
     }
 
     #[cfg(target_os = "macos")]
-    unsafe extern "C" fn dns_sd_reply(
-        _sd_ref: dns_sd::DNSServiceRef,
-        flags: u32,
-        _interface_index: u32,
-        error_code: i32,
-        _hostname: *const c_char,
-        address: *const Sockaddr,
-        ttl: u32,
-        context: *mut c_void,
-    ) {
-        dns_sd::SharedConnection::note_reply(context);
-        let req: *mut Request = context.cast();
-        // SAFETY: `context` is the registered `req` (event-loop thread); `address` is valid per dns_sd.h.
-        unsafe {
-            (*req)
-                .dns_sd
-                .query
-                .record_reply(flags, error_code, address, ttl)
-        };
+    impl bun_sys::dns_sd::GetAddrInfoReply for Request {
+        fn on_reply(&self, reply: &bun_sys::dns_sd::Reply<'_>) {
+            dns_sd::SharedConnection::note_reply(core::ptr::from_ref(self).cast());
+            self.dns_sd.query.with_mut(|q| q.record_reply(reply));
+        }
     }
 
     /// Complete an internal request: build an addrinfo chain and reuse `process_results` (happy-eyeballs order).
     #[cfg(target_os = "macos")]
-    pub(super) fn dns_sd_complete(req: *mut Request) {
-        // SAFETY: `req` is live and exclusively owned on the event-loop thread.
-        let query = unsafe { &mut (*req).dns_sd.query };
-        let results = query.take_results();
-        // SAFETY: `req` is live; `key.port` is set at construction and read-only.
-        let port = unsafe { (*req).key.port };
+    pub(super) fn dns_sd_complete(req: BackRef<Request, bun_ptr::Mut>) {
+        let (results, empty_status) = req
+            .dns_sd
+            .query
+            .with_mut(|query| (query.take_results(), query.empty_status()));
+        let port = req.key.port;
+        let req = req.this_ptr();
 
         if results.is_empty() {
-            after_result_entries(req, None, dns_sd::EMPTY_STATUS);
+            after_result_entries(req, AddrInfoResult::new(Vec::new(), empty_status));
             return;
         }
 
-        let mut addrs: Box<[SockaddrStorage]> = results
-            .iter()
-            .map(|r| {
-                let mut storage = r.address.into_storage();
-                match storage.ss_family as c_int {
-                    // SAFETY: ss_family == AF_INET ⇒ storage holds a sockaddr_in.
-                    netc::AF_INET => unsafe {
-                        (*(&raw mut storage).cast::<netc::sockaddr_in>()).sin_port = port.to_be()
-                    },
-                    // SAFETY: ss_family == AF_INET6 ⇒ storage holds a sockaddr_in6.
-                    netc::AF_INET6 => unsafe {
-                        (*(&raw mut storage).cast::<netc::sockaddr_in6>()).sin6_port = port.to_be()
-                    },
-                    _ => {}
-                }
-                storage
-            })
-            .collect();
-        let mut chain = addrinfo_chain(&mut addrs);
-        let results = process_results(chain.as_mut_ptr());
-        after_result_entries(req, Some(results), 0);
+        let nodes = results.iter().map(|r| {
+            let mut address = r.address;
+            address.set_port(port);
+            (
+                synthetic_addrinfo(address.family()),
+                Some(address.into_storage()),
+            )
+        });
+        after_result_entries(req, process_results(nodes, 0));
     }
 
     static DNS_CACHE_HITS_COMPLETED: AtomicUsize = AtomicUsize::new(0);
@@ -2825,7 +2040,6 @@ pub mod internal {
     static DNS_CACHE_ERRORS: AtomicUsize = AtomicUsize::new(0);
     static GETADDRINFO_CALLS: AtomicUsize = AtomicUsize::new(0);
 
-    #[host_fn]
     pub(crate) fn get_dns_cache_stats(
         global_object: &JSGlobalObject,
         _frame: &CallFrame,
@@ -2864,58 +2078,6 @@ pub mod internal {
         Ok(object)
     }
 
-    /// The `addresses: string[]` argument of the testing hooks below, as sockaddrs.
-    fn addresses_for_testing(
-        global: &JSGlobalObject,
-        addresses: JSValue,
-    ) -> JsResult<Vec<SockaddrStorage>> {
-        if !addresses.is_array() {
-            return Err(
-                global.throw_invalid_arguments(format_args!("expected addresses: string[]"))
-            );
-        }
-        let len = addresses.get_length(global)? as usize;
-        if len > 64 {
-            return Err(global
-                .throw_invalid_arguments(format_args!("addresses must have at most 64 entries")));
-        }
-        (0..len)
-            .map(|i| {
-                let address = addresses.get_index(global, i as u32)?.to_utf8(global)?;
-                match bun_core::ip_address::to_ip_address(address.slice()) {
-                    Some(ip) => Ok(bun_dns::Address::from_ip(ip, 0).into_storage()),
-                    None => Err(global.throw_invalid_arguments(format_args!(
-                        "addresses[{i}] is not an IPv4 or IPv6 literal"
-                    ))),
-                }
-            })
-            .collect()
-    }
-
-    /// `bun:internal-for-testing`: [`is_localhost_name`] for one hostname.
-    pub(crate) fn is_localhost_name_for_testing(
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        let hostname = frame.argument(0);
-        if !hostname.is_string() {
-            return Err(global.throw_invalid_arguments(format_args!("expected (hostname: string)")));
-        }
-        let hostname = hostname.to_utf8(global)?;
-        Ok(JSValue::js_boolean(is_localhost_name(hostname.slice())))
-    }
-
-    /// `bun:internal-for-testing`: [`is_all_loopback_of_one_family`] over `addresses` laid out as a getaddrinfo() answer.
-    pub(crate) fn is_all_loopback_of_one_family_for_testing(
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        let mut addrs = addresses_for_testing(global, frame.argument(0))?;
-        let chain = addrinfo_chain(&mut addrs);
-        let head = chain.first().map_or(ptr::null(), ptr::from_ref);
-        Ok(JSValue::js_boolean(is_all_loopback_of_one_family(head)))
-    }
-
     /// `bun:internal-for-testing`: seed the connect-path DNS cache for `hostname`
     /// by running `addresses` through the real [`process_results`] interleave and
     /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it.
@@ -2924,22 +2086,45 @@ pub mod internal {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let args = frame.arguments();
-        if args.len() < 2 || !args[0].is_string() {
+        if args.len() < 2 || !args[0].is_string() || !args[1].is_array() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "expected (hostname: string, addresses: string[])"
             )));
         }
-        let hostname_slice = args[0].to_utf8(global)?;
-        let hostname_z = bun::ZBox::from_bytes(hostname_slice.slice());
-        let mut addrs = addresses_for_testing(global, args[1])?;
-        if addrs.is_empty() {
-            return Err(global.throw_invalid_arguments(format_args!("addresses must not be empty")));
+        let hostname_slice = args[0].to_slice(global)?;
+        let len = args[1].get_length(global)? as usize;
+        if len == 0 || len > 64 {
+            return Err(
+                global.throw_invalid_arguments(format_args!("addresses must have 1..=64 entries"))
+            );
         }
-        let mut chain = addrinfo_chain(&mut addrs);
-        let results = process_results(chain.as_mut_ptr());
 
-        let out = JSValue::create_empty_array(global, results.len())?;
-        for (i, entry) in (0u32..).zip(results.iter()) {
+        let mut nodes: Vec<(AddrInfo, Option<SockaddrStorage>)> = Vec::with_capacity(len);
+        for i in 0..len {
+            let addr_slice = args[1].get_index(global, i as u32)?.to_slice(global)?;
+            let addr_z = bun::ZBox::from_bytes(addr_slice.slice());
+            let mut octets = [0u8; 16];
+            let ip: std::net::IpAddr =
+                if c_ares::inet_pton(netc::AF_INET, c_str(&addr_z), &mut octets) > 0 {
+                    std::net::Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3]).into()
+                } else if c_ares::inet_pton(netc::AF_INET6, c_str(&addr_z), &mut octets) > 0 {
+                    std::net::Ipv6Addr::from(octets).into()
+                } else {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "addresses[{i}] is not an IPv4 or IPv6 literal"
+                    )));
+                };
+            let address = bun_dns::Address::from_ip(ip, 0);
+            nodes.push((
+                synthetic_addrinfo(address.family()),
+                Some(address.into_storage()),
+            ));
+        }
+
+        let results = process_results(nodes.iter().copied(), 0);
+
+        let out = JSValue::create_empty_array(global, results.entries().len())?;
+        for (i, entry) in (0u32..).zip(results.entries().iter()) {
             let fam: i32 = if entry.info.ai_family == netc::AF_INET6 {
                 6
             } else {
@@ -2948,25 +2133,16 @@ pub mod internal {
             out.put_index(global, i, JSValue::js_number_from_int32(fam))?;
         }
 
-        let key = RequestKey::init(Some(hostname_z.as_zstr()), 0);
+        let key = RequestKey::init(Some(hostname_slice.slice()), 0);
         let req = Request::new(key.to_owned(), 0, GlobalCache::get_cache_timestamp());
-        // SAFETY: `req` is freshly heap-allocated and exclusively owned until
-        // `try_push` transfers it to the lock-guarded cache.
-        unsafe {
-            (*req).result_buf = Some(results);
-            let info = (*req)
-                .result_buf
-                .as_mut()
-                .and_then(|b| NonNull::new(b.as_mut_ptr()));
-            (*req).result = Some(RequestResult { info, err: 0 });
-        }
+        let _ = req.result.set(results);
         let mut guard = global_cache().lock();
-        if !guard.try_push(req) {
+        if let Err(req) = guard.try_push(req) {
             drop(guard);
-            Request::deinit(req);
+            drop(req);
             return Err(global.throw_invalid_arguments(format_args!("DNS cache is full")));
         }
-        DNS_CACHE_SIZE.store(guard.len, Ordering::Relaxed);
+        DNS_CACHE_SIZE.store(guard.len(), Ordering::Relaxed);
         drop(guard);
         Ok(out)
     }
@@ -3003,11 +2179,11 @@ pub mod internal {
     }
 
     pub(crate) fn getaddrinfo(
-        loop_: *mut Loop,
-        host: Option<&ZStr>,
+        loop_: &Loop,
+        host: Option<&[u8]>,
         port: u16,
         is_cache_hit: Option<&mut bool>,
-    ) -> Option<*mut Request> {
+    ) -> Option<ThisPtr<Request>> {
         let preload = is_cache_hit.is_none();
         let key = RequestKey::init(host, port);
 
@@ -3025,23 +2201,21 @@ pub mod internal {
                     return None;
                 }
 
-                // SAFETY: `entry` is a live cache slot; refcount is only mutated under the held lock.
-                unsafe { (*entry).refcount += 1 };
+                entry.refcount.fetch_add(1, Ordering::Relaxed);
 
-                // SAFETY: `entry` is a live cache slot; `result` is only mutated under the held lock.
-                if unsafe { (*entry).result.is_some() } {
+                if entry.has_result() {
                     *is_cache_hit.unwrap() = true;
                     bun_output::scoped_log!(
                         dns,
                         "getaddrinfo({}) = cache hit",
-                        bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
+                        bstr::BStr::new(host.unwrap_or(b""))
                     );
                     DNS_CACHE_HITS_COMPLETED.fetch_add(1, Ordering::Relaxed);
                 } else {
                     bun_output::scoped_log!(
                         dns,
                         "getaddrinfo({}) = cache hit (inflight)",
-                        bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
+                        bstr::BStr::new(host.unwrap_or(b""))
                     );
                     DNS_CACHE_HITS_INFLIGHT.fetch_add(1, Ordering::Relaxed);
                 }
@@ -3062,37 +2236,14 @@ pub mod internal {
                 timestamp_to_store
             },
         );
-
-        let _ = guard.try_push(req);
+        let handle = req.this_ptr();
+        if let Err(orphan) = guard.try_push(req) {
+            guard.orphans.push(orphan);
+        }
+        let req = handle;
         DNS_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
-        DNS_CACHE_SIZE.store(guard.len, Ordering::Relaxed);
+        DNS_CACHE_SIZE.store(guard.len(), Ordering::Relaxed);
         drop(guard);
-
-        if host.is_some_and(|h| !bun_dns::is_valid_hostname(h.as_bytes())) {
-            bun_output::scoped_log!(
-                dns,
-                "getaddrinfo({}) = cache miss (not a hostname)",
-                bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
-            );
-            after_result_entries(req, None, netc::EAI_NONAME);
-            if let Some(is_cache_hit) = is_cache_hit {
-                *is_cache_hit = true;
-            }
-            return Some(req);
-        }
-
-        if host.is_some_and(|h| is_localhost_name(h.as_bytes())) {
-            bun_output::scoped_log!(
-                dns,
-                "getaddrinfo({}) = cache miss (localhost)",
-                bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
-            );
-            after_result_entries(req, Some(localhost_results(port)), 0);
-            if let Some(is_cache_hit) = is_cache_hit {
-                *is_cache_hit = true;
-            }
-            return Some(req);
-        }
 
         #[cfg(target_os = "macos")]
         {
@@ -3101,20 +2252,27 @@ pub mod internal {
                 .get()
                 .unwrap_or(false)
             {
-                // SAFETY: `loop_` is the live uSockets loop; its parent tag/ptr
-                // was set by `EventLoopHandle::set_as_parent_of` at startup.
-                let handle = unsafe {
-                    let (tag, ptr) = (*loop_).internal_loop_data.get_parent();
-                    jsc::EventLoopHandle::from_tag_ptr(tag, ptr)
+                // The loop's parent tag (set by `EventLoopHandle::set_as_parent_of`
+                // at startup) says which of this thread's event loops owns it.
+                let (tag, _) = loop_.internal_loop_data.get_parent();
+                let ctx = match tag {
+                    1 => Some(Async::posix_event_loop::get_vm_ctx(
+                        Async::AllocatorType::Js,
+                    )),
+                    2 => Some(Async::posix_event_loop::get_vm_ctx(
+                        Async::AllocatorType::Mini,
+                    )),
+                    _ => None,
                 };
-                let res = lookup_dns_sd(req, handle);
-                if res {
-                    bun_output::scoped_log!(
-                        dns,
-                        "getaddrinfo({}) = cache miss (dns_sd)",
-                        bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
-                    );
-                    return Some(req);
+                if let Some(ctx) = ctx {
+                    if lookup_dns_sd(req, ctx) {
+                        bun_output::scoped_log!(
+                            dns,
+                            "getaddrinfo({}) = cache miss (dns_sd)",
+                            bstr::BStr::new(host.unwrap_or(b""))
+                        );
+                        return Some(req);
+                    }
                 }
                 // if dns_sd was unavailable, fall back to the work pool
             }
@@ -3125,45 +2283,41 @@ pub mod internal {
         bun_output::scoped_log!(
             dns,
             "getaddrinfo({}) = cache miss (libc)",
-            bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
+            bstr::BStr::new(host.unwrap_or(b""))
         );
         // schedule the request to be executed on the work pool
-        run_on_work_pool(req);
+        run_on_work_pool(BackRef::from(req));
         Some(req)
     }
 
     /// getaddrinfo() on the work pool; the result reaches every waiter through
     /// the global cache, whichever thread asked. Also how a lookup whose
     /// per-thread mDNSResponder connection went away with its thread is
-    /// finished (see `SharedConnection::close_for_terminate`).
-    pub(super) fn run_on_work_pool(req: *mut Request) {
-        let _ = bun_threading::work_pool::WorkPool::go(SendPtr(req), |r: SendPtr<Request>| {
-            work_pool_callback(r.0)
-        });
+    /// finished (see `SharedConnection::close_for_terminate`). The request's
+    /// in-flight `refcount` keeps it alive until `after_result`.
+    pub(super) fn run_on_work_pool(req: BackRef<Request, bun_ptr::Mut>) {
+        let _ = bun_threading::work_pool::WorkPool::go(req, work_pool_callback);
     }
 
-    #[host_fn]
     pub(crate) fn prefetch_from_js(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
 
-        if arguments.len() < 1 {
+        if arguments.is_empty() {
             return Err(global_this.throw_not_enough_arguments("prefetch", 1, arguments.len()));
         }
 
         let hostname_or_url = arguments[0];
 
         let hostname_slice = if hostname_or_url.is_string() {
-            hostname_or_url.to_utf8(global_this)?
+            hostname_or_url.to_slice(global_this)?
         } else {
             return Err(
                 global_this.throw_invalid_arguments(format_args!("hostname must be a string"))
             );
         };
-
-        let hostname_z = bun::ZBox::from_bytes(hostname_slice.slice());
 
         let port: u16 = if arguments.len() > 1 && !arguments[1].is_undefined_or_null() {
             global_this.validate_integer_range::<u16>(
@@ -3179,171 +2333,91 @@ pub mod internal {
             443
         };
 
-        // SAFETY: `VirtualMachine::get()` returns the live thread-local VM (panics if absent).
         prefetch(
-            VirtualMachine::get().as_mut().uws_loop(),
-            Some(hostname_z.as_zstr()),
+            VirtualMachine::get().uws_loop_mut(),
+            Some(hostname_slice.slice()),
             port,
         );
         Ok(JSValue::UNDEFINED)
     }
 
-    pub(crate) fn prefetch(loop_: *mut Loop, hostname: Option<&ZStr>, port: u16) {
+    pub(crate) fn prefetch(loop_: &Loop, hostname: Option<&[u8]>, port: u16) {
         let _ = getaddrinfo(loop_, hostname, port, None);
     }
 
-    /// `bun_dns::__bun_dns_prefetch` body — declared `extern "Rust"` in the
-    /// lower-tier `bun_dns` crate so `bun_install` can prefetch registry
-    /// hostnames without a crate cycle. Link-time resolved.
-    ///
-    /// # Safety
-    /// `hostname` (if non-null) must point to a NUL-terminated `[u8; len]` live
-    /// for the duration of the call.
-    // `hostname` is null-guarded before the deref; the non-null contract is
-    // documented above and on the `bun_dns` extern decl.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[unsafe(no_mangle)]
-    fn __bun_dns_prefetch(loop_: *mut c_void, hostname: *const u8, len: usize, port: u16) {
-        let host = if hostname.is_null() || len == 0 {
-            None
-        } else {
-            // SAFETY: caller passes a NUL-terminated `[u8; len]` live for the call.
-            Some(unsafe { ZStr::from_raw(hostname, len) })
-        };
-        prefetch(loop_.cast::<Loop>(), host, port);
-    }
-
-    extern "C" fn us_getaddrinfo(
-        loop_: *mut Loop,
-        _host: *const c_char,
+    pub(crate) fn us_getaddrinfo(
+        loop_: &Loop,
+        host: Option<&CStr>,
         port: u16,
-        socket: *mut *mut c_void,
+        request: &mut *mut c_void,
     ) -> c_int {
-        let host: Option<&ZStr> = if _host.is_null() {
-            None
-        } else {
-            // SAFETY: caller passes NUL-terminated string; compute len via strlen.
-            Some(unsafe {
-                let p = _host.cast::<u8>();
-                ZStr::from_raw(p, libc::strlen(_host) as usize)
-            })
-        };
         let mut is_cache_hit = false;
-        let req = getaddrinfo(loop_, host, port, Some(&mut is_cache_hit)).unwrap();
-        // SAFETY: `socket` is the out-param the usockets caller passes; valid for one write.
-        unsafe { *socket = req.cast::<c_void>() };
+        let req = getaddrinfo(
+            loop_,
+            host.map(CStr::to_bytes),
+            port,
+            Some(&mut is_cache_hit),
+        )
+        .unwrap();
+        *request = req.as_ptr().cast::<c_void>();
         if is_cache_hit { 0 } else { 1 }
     }
 
-    extern "C" fn us_getaddrinfo_set(request: *mut Request, socket: *mut ConnectingSocket) {
+    pub(crate) fn us_getaddrinfo_set(request: ThisPtr<Request>, socket: &ConnectingSocket) {
         let _guard = global_cache().lock();
-        let query = DNSRequestOwner::Socket(socket);
-        // SAFETY: `request` is a live cache entry; `result`/`notify` are only
-        // touched under `global_cache().lock()`, which is held here.
-        unsafe {
-            if (*request).result.is_some() {
-                // Also wakes the loop: this can run inside the dns_ready_head drain itself.
-                query.notify_threadsafe(request);
-                return;
-            }
-            (*request).notify.push(DNSRequestOwner::Socket(socket));
+        // usockets keeps `socket` alive until it is notified or withdraws
+        // itself with `Bun__addrinfo_cancel`.
+        let query = DNSRequestOwner::Socket(DnsWaitingSocket::new(BackRef::new(socket)));
+        if request.has_result() {
+            query.notify(request);
+            return;
         }
+        request.notify.lock().push(query);
     }
 
-    extern "C" fn us_getaddrinfo_cancel(
-        request: *mut Request,
-        socket: *mut ConnectingSocket,
+    pub(crate) fn us_getaddrinfo_cancel(
+        request: ThisPtr<Request>,
+        socket: &ConnectingSocket,
     ) -> c_int {
         let _guard = global_cache().lock();
         // afterResult sets result and moves the notify list out under this same
         // lock, so once result is non-null the socket is no longer cancellable
         // (the callback has fired or is about to fire on the worker thread).
-        // SAFETY: `request` is a live cache entry; `result`/`notify` are only
-        // touched under `global_cache().lock()`, which is held here.
-        unsafe {
-            if (*request).result.is_some() {
-                return 0;
-            }
-            for (i, item) in (*request).notify.iter().enumerate() {
-                match item {
-                    DNSRequestOwner::Socket(s) if *s == socket => {
-                        (*request).notify.swap_remove(i);
-                        return 1;
-                    }
-                    _ => {}
+        if request.has_result() {
+            return 0;
+        }
+        let mut notify = request.notify.lock();
+        for (i, item) in notify.iter().enumerate() {
+            match item {
+                DNSRequestOwner::Socket(s) if s.is(socket) => {
+                    notify.swap_remove(i);
+                    return 1;
                 }
+                _ => {}
             }
         }
         0
     }
 
-    extern "C" fn freeaddrinfo(req: *mut Request, err: c_int) {
+    pub(crate) fn freeaddrinfo(req: ThisPtr<Request>, err: c_int) {
         let mut guard = global_cache().lock();
 
-        // SAFETY: `req` is a live cache entry; refcount/valid are only mutated
-        // under `global_cache().lock()`, which is held here.
-        unsafe {
-            if err != 0 {
-                (*req).valid = false;
-            }
-            DNS_CACHE_ERRORS.fetch_add((err != 0) as usize, Ordering::Relaxed);
+        if err != 0 {
+            req.valid.store(false, Ordering::Relaxed);
+        }
+        DNS_CACHE_ERRORS.fetch_add((err != 0) as usize, Ordering::Relaxed);
 
-            debug_assert!((*req).refcount > 0);
-            (*req).refcount -= 1;
-            if (*req).refcount == 0 && (guard.is_nearly_full() || !(*req).valid) {
-                bun_output::scoped_log!(dns, "cache --");
-                guard.remove(req);
-                Request::deinit(req);
-            }
+        debug_assert!(req.refcount() > 0);
+        let remaining = req.refcount.fetch_sub(1, Ordering::Relaxed) - 1;
+        if remaining == 0 && (guard.is_nearly_full() || !req.is_valid()) {
+            bun_output::scoped_log!(dns, "cache --");
+            guard.remove(req);
         }
     }
 
-    extern "C" fn get_request_result(req: *mut Request) -> *mut RequestResult {
-        // SAFETY: caller (usockets) only invokes this after notify, when result is set
-        unsafe { std::ptr::from_mut::<RequestResult>((*req).result.as_mut().unwrap()) }
-    }
-
-    // FFI exports.
-    #[unsafe(no_mangle)]
-    extern "C" fn Bun__addrinfo_set(request: *mut Request, socket: *mut ConnectingSocket) {
-        us_getaddrinfo_set(request, socket)
-    }
-    #[unsafe(no_mangle)]
-    extern "C" fn Bun__addrinfo_cancel(
-        request: *mut Request,
-        socket: *mut ConnectingSocket,
-    ) -> c_int {
-        us_getaddrinfo_cancel(request, socket)
-    }
-    #[unsafe(no_mangle)]
-    extern "C" fn Bun__addrinfo_get(
-        loop_: *mut Loop,
-        host: *const c_char,
-        port: u16,
-        socket: *mut *mut c_void,
-    ) -> c_int {
-        us_getaddrinfo(loop_, host, port, socket)
-    }
-    #[unsafe(no_mangle)]
-    extern "C" fn Bun__addrinfo_freeRequest(req: *mut Request, err: c_int) {
-        freeaddrinfo(req, err)
-    }
-    #[unsafe(no_mangle)]
-    extern "C" fn Bun__addrinfo_getRequestResult(req: *mut Request) -> *mut RequestResult {
-        get_request_result(req)
-    }
-    /// QUIC analogue of `Bun__addrinfo_set` — link-time export so `bun_http`
-    /// (lower-tier crate) can register without a `bun_runtime` dep cycle.
-    /// Called via `bun_dns::internal::register_quic`.
-    ///
-    /// # Safety
-    /// See [`register_quic`].
-    #[unsafe(no_mangle)]
-    unsafe extern "C" fn Bun__addrinfo_registerQuic(
-        request: *mut Request,
-        pc: *mut bun_http::H3::PendingConnect,
-    ) {
-        register_quic(request, pc)
+    pub(crate) fn get_request_result(req: ThisPtr<Request>) -> *const addrinfo_result {
+        // usockets only asks after it was notified, i.e. once `result` is set.
+        core::ptr::from_ref(req.get().result.get().expect("addrinfo result").as_c())
     }
 }
 
@@ -3353,33 +2427,18 @@ pub use internal::Request as InternalDNSRequest;
 // Resolver — JSC-exposed `dns.Resolver` (m_ctx payload of JSDNSResolver)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Field selector for the `pending_*` cache fields on `Resolver` — Rust
-/// cannot index struct fields by name string.
+/// Which of the two `GetAddrInfo` pending caches a request sits in.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum PendingCacheField {
     PendingHostCacheCares,
     PendingHostCacheNative,
-    PendingSrvCacheCares,
-    PendingSoaCacheCares,
-    PendingTxtCacheCares,
-    PendingNaptrCacheCares,
-    PendingMxCacheCares,
-    PendingCaaCacheCares,
-    PendingNsCacheCares,
-    PendingPtrCacheCares,
-    PendingCnameCacheCares,
-    PendingACacheCares,
-    PendingAaaaCacheCares,
-    PendingAnyCacheCares,
-    PendingAddrCacheCares,
-    PendingNameinfoCacheCares,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
 // CAresRecordType impls — each (struct, tag) pair is modeled as a
 // trait impl. ns/ptr/cname share `struct_hostent` and a/aaaa share
-// `hostent_with_ttls`, so those get `#[repr(transparent)]` newtype wrappers to
-// keep the per-record monomorphizations (and pending caches) distinct.
+// `hostent_with_ttls`, so those get marker types to keep the per-record
+// monomorphizations (and pending caches) distinct.
 // ──────────────────────────────────────────────────────────────────────────
 
 macro_rules! impl_cares_record_type {
@@ -3390,36 +2449,20 @@ macro_rules! impl_cares_record_type {
         impl CAresRecordType for $ty {
             const TYPE_NAME: &'static str = $tag;
             const SYSCALL: &'static str = $syscall;
-            const CACHE_FIELD: PendingCacheField = PendingCacheField::$field;
             const NS_TYPE: c_ares::NSType = c_ares::NSType::$ns_type;
-            const RAW_CALLBACK: unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int) =
-                c_ares::ares_reply_callback::<$ty, ResolveInfoRequest<$ty>>;
-            fn to_js_response(
-                &mut self,
+            type Reply = c_ares::AresBox<$ty>;
+            fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, c_ares::Error> {
+                <$ty as c_ares::AresReply>::parse(buffer)
+            }
+            fn reply_to_js(
+                reply: &Self::Reply,
                 global: &JSGlobalObject,
                 type_name: &'static str,
             ) -> JsResult<JSValue> {
-                $to_js(self, global, type_name.as_bytes())
+                $to_js(reply, global, type_name.as_bytes())
             }
-            unsafe fn destroy(this: *mut Self) {
-                // SAFETY: caller contract — `this` is the c-ares-allocated reply pointer
-                // handed to the completion callback; not aliased. All six reply structs
-                // are freed identically via `ares_free_data`.
-                unsafe { c_ares::ares_free_data(this.cast::<core::ffi::c_void>()) }
-            }
-        }
-        // Generic reply handler — forwards to `on_cares_complete`.
-        impl c_ares::ReplyHandler<$ty> for ResolveInfoRequest<$ty> {
-            fn on_reply(
-                &mut self,
-                status: Option<c_ares::Error>,
-                timeouts: i32,
-                results: *mut $ty,
-            ) {
-                // SAFETY: `ares_reply_callback` hands over the `ares_parse_*_reply`
-                // allocation, which `destroy` frees.
-                let result = NonNull::new(results).map(|reply| unsafe { OwnedReply::adopt(reply) });
-                Self::on_cares_complete(core::ptr::from_mut(self), status, timeouts, result);
+            fn pending_cache(resolver: &Resolver) -> &PendingCache<CAresLookup<Self>> {
+                &resolver.$field
             }
         }
     };
@@ -3429,7 +2472,7 @@ impl_cares_record_type!(
     c_ares::struct_ares_srv_reply,
     "srv",
     "querySrv",
-    PendingSrvCacheCares,
+    pending_srv_cache_cares,
     ns_t_srv,
     super::cares_jsc::srv_reply_to_js_response
 );
@@ -3437,7 +2480,7 @@ impl_cares_record_type!(
     c_ares::struct_ares_soa_reply,
     "soa",
     "querySoa",
-    PendingSoaCacheCares,
+    pending_soa_cache_cares,
     ns_t_soa,
     super::cares_jsc::soa_reply_to_js_response
 );
@@ -3445,7 +2488,7 @@ impl_cares_record_type!(
     c_ares::struct_ares_txt_reply,
     "txt",
     "queryTxt",
-    PendingTxtCacheCares,
+    pending_txt_cache_cares,
     ns_t_txt,
     super::cares_jsc::txt_reply_to_js_response
 );
@@ -3453,7 +2496,7 @@ impl_cares_record_type!(
     c_ares::struct_ares_naptr_reply,
     "naptr",
     "queryNaptr",
-    PendingNaptrCacheCares,
+    pending_naptr_cache_cares,
     ns_t_naptr,
     super::cares_jsc::naptr_reply_to_js_response
 );
@@ -3461,7 +2504,7 @@ impl_cares_record_type!(
     c_ares::struct_ares_mx_reply,
     "mx",
     "queryMx",
-    PendingMxCacheCares,
+    pending_mx_cache_cares,
     ns_t_mx,
     super::cares_jsc::mx_reply_to_js_response
 );
@@ -3469,448 +2512,192 @@ impl_cares_record_type!(
     c_ares::struct_ares_caa_reply,
     "caa",
     "queryCaa",
-    PendingCaaCacheCares,
+    pending_caa_cache_cares,
     ns_t_caa,
     super::cares_jsc::caa_reply_to_js_response
 );
 
-// `any` — handler receives `Option<Box<struct_any_reply>>` (parser allocates the
-// aggregate); release it via `heap::into_raw_nn` so the rest of the pipeline sees a
-// uniform `OwnedReply<T>` and `CAresRecordType::destroy` reclaims it with `heap::take`.
 impl CAresRecordType for c_ares::struct_any_reply {
     const TYPE_NAME: &'static str = "any";
     const SYSCALL: &'static str = "queryAny";
-    const CACHE_FIELD: PendingCacheField = PendingCacheField::PendingAnyCacheCares;
     const NS_TYPE: c_ares::NSType = c_ares::NSType::ns_t_any;
-    const RAW_CALLBACK: unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int) =
-        c_ares::struct_any_reply::callback_wrapper::<ResolveInfoRequest<c_ares::struct_any_reply>>;
-    fn to_js_response(
-        &mut self,
+    type Reply = Box<c_ares::struct_any_reply>;
+    fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, c_ares::Error> {
+        c_ares::struct_any_reply::parse(buffer).map(Some)
+    }
+    fn reply_to_js(
+        reply: &Self::Reply,
         global: &JSGlobalObject,
         type_name: &'static str,
     ) -> JsResult<JSValue> {
-        super::cares_jsc::any_reply_to_js_response(self, global, type_name.as_bytes())
+        super::cares_jsc::any_reply_to_js_response(reply, global, type_name.as_bytes())
     }
-    unsafe fn destroy(this: *mut Self) {
-        // SAFETY: `this` was released by `heap::into_raw_nn` in `on_any` below; Drop
-        // frees inner replies.
-        unsafe { drop(bun_core::heap::take(this)) }
-    }
-}
-impl c_ares::AnyHandler for ResolveInfoRequest<c_ares::struct_any_reply> {
-    fn on_any(
-        &mut self,
-        status: Option<c_ares::Error>,
-        timeouts: i32,
-        results: Option<Box<c_ares::struct_any_reply>>,
-    ) {
-        // SAFETY: `destroy` re-boxes the allocation released here.
-        let result =
-            results.map(|reply| unsafe { OwnedReply::adopt(bun_core::heap::into_raw_nn(reply)) });
-        Self::on_cares_complete(std::ptr::from_mut::<Self>(self), status, timeouts, result);
+    fn pending_cache(resolver: &Resolver) -> &PendingCache<CAresLookup<Self>> {
+        &resolver.pending_any_cache_cares
     }
 }
 
-/// Transparent newtype over `struct_hostent` carrying the per-record-type `type_name` tag.
-macro_rules! hostent_newtype {
-    ($name:ident, $tag:literal, $syscall:literal, $field:ident, $ns_type:ident, $wrapper:ident) => {
-        #[repr(transparent)]
-        pub(crate) struct $name(pub c_ares::struct_hostent);
+/// Marker for a record type answered with a plain `struct_hostent`.
+macro_rules! hostent_record {
+    ($name:ident, $tag:literal, $syscall:literal, $field:ident, $ns_type:ident, $parse:ident) => {
+        pub struct $name;
         impl CAresRecordType for $name {
             const TYPE_NAME: &'static str = $tag;
             const SYSCALL: &'static str = $syscall;
-            const CACHE_FIELD: PendingCacheField = PendingCacheField::$field;
             const NS_TYPE: c_ares::NSType = c_ares::NSType::$ns_type;
-            const RAW_CALLBACK: unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int) =
-                c_ares::struct_hostent::$wrapper::<ResolveInfoRequest<$name>>;
-            fn to_js_response(
-                &mut self,
+            type Reply = c_ares::AresBox<c_ares::struct_hostent>;
+            fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, c_ares::Error> {
+                c_ares::struct_hostent::$parse(buffer)
+            }
+            fn reply_to_js(
+                reply: &Self::Reply,
                 global: &JSGlobalObject,
                 type_name: &'static str,
             ) -> JsResult<JSValue> {
-                super::cares_jsc::hostent_to_js_response(&mut self.0, global, type_name.as_bytes())
+                super::cares_jsc::hostent_to_js_response(reply, global, type_name.as_bytes())
             }
-            unsafe fn destroy(this: *mut Self) {
-                // SAFETY: `#[repr(transparent)]` — `*mut Self` is `*mut struct_hostent`.
-                unsafe { c_ares::struct_hostent::destroy(this.cast::<c_ares::struct_hostent>()) }
-            }
-        }
-        impl c_ares::HostentHandler for ResolveInfoRequest<$name> {
-            fn on_hostent(
-                &mut self,
-                status: Option<c_ares::Error>,
-                timeouts: i32,
-                results: *mut c_ares::struct_hostent,
-            ) {
-                let hostent = NonNull::new(results.cast::<$name>());
-                // SAFETY: `RAW_CALLBACK` is an `ares_parse_*_reply` wrapper, so this hostent
-                // is handed over for `destroy` to free (unlike the one `ares_gethostbyaddr`
-                // lends to `GetHostByAddrInfoRequest`); `#[repr(transparent)]` makes the
-                // cast sound.
-                let result = hostent.map(|reply| unsafe { OwnedReply::adopt(reply) });
-                Self::on_cares_complete(core::ptr::from_mut(self), status, timeouts, result);
+            fn pending_cache(resolver: &Resolver) -> &PendingCache<CAresLookup<Self>> {
+                &resolver.$field
             }
         }
     };
 }
 
-/// Transparent newtype over `hostent_with_ttls` for A/AAAA records.
-macro_rules! hostent_ttls_newtype {
+/// Marker for A/AAAA, answered with a `hostent_with_ttls`.
+macro_rules! hostent_ttls_record {
     ($name:ident, $tag:literal, $syscall:literal, $field:ident, $ns_type:ident, $parse:ident) => {
-        #[repr(transparent)]
-        pub(crate) struct $name(pub c_ares::hostent_with_ttls);
+        pub struct $name;
         impl CAresRecordType for $name {
             const TYPE_NAME: &'static str = $tag;
             const SYSCALL: &'static str = $syscall;
-            const CACHE_FIELD: PendingCacheField = PendingCacheField::$field;
             const NS_TYPE: c_ares::NSType = c_ares::NSType::$ns_type;
-            const RAW_CALLBACK: unsafe extern "C" fn(*mut c_void, c_int, c_int, *mut u8, c_int) =
-                c_ares::hostent_with_ttls::callback_wrapper::<ResolveInfoRequest<$name>>;
-            fn to_js_response(
-                &mut self,
+            type Reply = Box<c_ares::hostent_with_ttls>;
+            fn parse(buffer: &[u8]) -> Result<Option<Self::Reply>, c_ares::Error> {
+                c_ares::hostent_with_ttls::$parse(buffer).map(Some)
+            }
+            fn reply_to_js(
+                reply: &Self::Reply,
                 global: &JSGlobalObject,
                 type_name: &'static str,
             ) -> JsResult<JSValue> {
                 super::cares_jsc::hostent_with_ttls_to_js_response(
-                    &mut self.0,
+                    reply,
                     global,
                     type_name.as_bytes(),
                 )
             }
-            unsafe fn destroy(this: *mut Self) {
-                // SAFETY: `#[repr(transparent)]`; released by `heap::into_raw_nn` in
-                // `on_hostent_with_ttls` below. Drop calls `ares_free_hostent`.
-                unsafe {
-                    drop(bun_core::heap::take(
-                        this.cast::<c_ares::hostent_with_ttls>(),
-                    ))
-                }
-            }
-        }
-        impl c_ares::HostentWithTtlsHandler for ResolveInfoRequest<$name> {
-            const PARSE: fn(&[u8]) -> Result<Box<c_ares::hostent_with_ttls>, c_ares::Error> =
-                c_ares::hostent_with_ttls::$parse;
-            fn on_hostent_with_ttls(
-                &mut self,
-                status: Option<c_ares::Error>,
-                timeouts: i32,
-                results: Option<Box<c_ares::hostent_with_ttls>>,
-            ) {
-                // SAFETY: `destroy` casts back and re-boxes the allocation released here;
-                // `#[repr(transparent)]` makes the cast sound.
-                let result = results.map(|reply| unsafe {
-                    OwnedReply::adopt(bun_core::heap::into_raw_nn(reply).cast::<$name>())
-                });
-                Self::on_cares_complete(core::ptr::from_mut(self), status, timeouts, result);
+            fn pending_cache(resolver: &Resolver) -> &PendingCache<CAresLookup<Self>> {
+                &resolver.$field
             }
         }
     };
 }
 
-hostent_newtype!(
+hostent_record!(
     NsHostent,
     "ns",
     "queryNs",
-    PendingNsCacheCares,
+    pending_ns_cache_cares,
     ns_t_ns,
-    callback_wrapper_ns
+    parse_ns
 );
-hostent_newtype!(
+hostent_record!(
     PtrHostent,
     "ptr",
     "queryPtr",
-    PendingPtrCacheCares,
+    pending_ptr_cache_cares,
     ns_t_ptr,
-    callback_wrapper_ptr
+    parse_ptr
 );
-hostent_newtype!(
+hostent_record!(
     CnameHostent,
     "cname",
     "queryCname",
-    PendingCnameCacheCares,
+    pending_cname_cache_cares,
     ns_t_cname,
-    callback_wrapper_cname
+    parse_cname
 );
-hostent_ttls_newtype!(
+hostent_ttls_record!(
     AHostentWithTtls,
     "a",
     "queryA",
-    PendingACacheCares,
+    pending_a_cache_cares,
     ns_t_a,
     parse_a
 );
-hostent_ttls_newtype!(
+hostent_ttls_record!(
     AaaaHostentWithTtls,
     "aaaa",
     "queryAaaa",
-    PendingAaaaCacheCares,
+    pending_aaaa_cache_cares,
     ns_t_aaaa,
     parse_aaaa
 );
 
-pub type PendingCache = HiveArray<get_addr_info_request::PendingCacheKey, 32>;
-type SrvPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_srv_reply>, 32>;
-type SoaPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_soa_reply>, 32>;
-type TxtPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_txt_reply>, 32>;
-type NaptrPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_naptr_reply>, 32>;
-type MxPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_mx_reply>, 32>;
-type CaaPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_caa_reply>, 32>;
-type NSPendingCache = HiveArray<resolve_info_request::PendingCacheKey<NsHostent>, 32>;
-type PtrPendingCache = HiveArray<resolve_info_request::PendingCacheKey<PtrHostent>, 32>;
-type CnamePendingCache = HiveArray<resolve_info_request::PendingCacheKey<CnameHostent>, 32>;
-type APendingCache = HiveArray<resolve_info_request::PendingCacheKey<AHostentWithTtls>, 32>;
-type AAAAPendingCache = HiveArray<resolve_info_request::PendingCacheKey<AaaaHostentWithTtls>, 32>;
-type AnyPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_any_reply>, 32>;
-type AddrPendingCache = HiveArray<get_host_by_addr_info_request::PendingCacheKey, 32>;
-type NameInfoPendingCache = HiveArray<get_name_info_request::PendingCacheKey, 32>;
-
+/// The c-ares socket's poll: a `FilePoll` (kqueue/epoll) or, on Windows, a
+/// libuv `uv_poll_t`.
 #[cfg(windows)]
-type PollType = UvDnsPoll;
+type PollType = libuv::SocketPoll<UvDnsPoll>;
 #[cfg(not(windows))]
-type PollType = FilePoll;
+type PollType = OwnedFilePoll;
 
-type PollsMap = ArrayHashMap<c_ares::ares_socket_t, *mut PollType>;
+type PollsMap = ArrayHashMap<c_ares::ares_socket_t, PollType>;
 
-// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
-// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). c-ares
-// completion callbacks re-enter this Resolver (e.g. `request_completed`,
-// `drain_pending_*`) while a `&self` borrow is live in `on_dns_poll` /
-// `check_timeouts`; UnsafeCell-backed fields suppress `noalias` so LLVM cannot
-// cache them across re-entrant FFI calls (the proper fix for the
-// PROVEN_CACHED ref_count miscompile previously laundered with `black_box`).
+/// Intrusively refcounted: the JS wrapper, every in-flight lookup and the
+/// armed timer each hold a ref. Methods take `ThisPtr<Self>` / `&self` with
+/// per-field interior mutability because c-ares completion callbacks re-enter
+/// the resolver (`request_completed`, `drain_pending_*`, releasing refs) from
+/// inside `on_dns_poll` / `check_timeouts`.
 #[bun_jsc::JsClass(name = "DNSResolver", no_constructor)]
 #[derive(bun_ptr::RefCounted)]
 pub struct Resolver {
     pub(crate) ref_count: bun_ptr::RefCount<Resolver>,
-    pub(crate) channel: Cell<Option<*mut c_ares::Channel>>, // FFI
-    pub(crate) vm: bun_ptr::BackRef<VirtualMachine>, // JSC_BORROW (BACKREF — VirtualMachine outlives the resolver; read-only after init)
+    pub(crate) channel: JsCell<Option<c_ares::OwnedChannel>>,
+    pub(crate) vm: BackRef<VirtualMachine>,
     pub(crate) polls: JsCell<PollsMap>,
     pub(crate) options: Cell<c_ares::ChannelOptions>,
 
     pub(crate) event_loop_timer: JsCell<EventLoopTimer>,
+    /// The ref the armed `event_loop_timer` holds on this resolver; released
+    /// when it fires (`check_timeouts`) or is removed (`remove_timer`).
+    timer_ref: Cell<Option<RefPtr<Resolver>>>,
 
-    pub(crate) pending_host_cache_cares: JsCell<PendingCache>,
-    pub(crate) pending_host_cache_native: JsCell<PendingCache>,
-    pub(crate) pending_srv_cache_cares: JsCell<SrvPendingCache>,
-    pub(crate) pending_soa_cache_cares: JsCell<SoaPendingCache>,
-    pub(crate) pending_txt_cache_cares: JsCell<TxtPendingCache>,
-    pub(crate) pending_naptr_cache_cares: JsCell<NaptrPendingCache>,
-    pub(crate) pending_mx_cache_cares: JsCell<MxPendingCache>,
-    pub(crate) pending_caa_cache_cares: JsCell<CaaPendingCache>,
-    pub(crate) pending_ns_cache_cares: JsCell<NSPendingCache>,
-    pub(crate) pending_ptr_cache_cares: JsCell<PtrPendingCache>,
-    pub(crate) pending_cname_cache_cares: JsCell<CnamePendingCache>,
-    pub(crate) pending_a_cache_cares: JsCell<APendingCache>,
-    pub(crate) pending_aaaa_cache_cares: JsCell<AAAAPendingCache>,
-    pub(crate) pending_any_cache_cares: JsCell<AnyPendingCache>,
-    pub(crate) pending_addr_cache_cares: JsCell<AddrPendingCache>,
-    pub(crate) pending_nameinfo_cache_cares: JsCell<NameInfoPendingCache>,
+    pub(crate) pending_host_cache_cares: PendingCache<DNSLookup>,
+    pub(crate) pending_host_cache_native: PendingCache<DNSLookup>,
+    pub(crate) pending_srv_cache_cares: PendingCache<CAresLookup<c_ares::struct_ares_srv_reply>>,
+    pub(crate) pending_soa_cache_cares: PendingCache<CAresLookup<c_ares::struct_ares_soa_reply>>,
+    pub(crate) pending_txt_cache_cares: PendingCache<CAresLookup<c_ares::struct_ares_txt_reply>>,
+    pub(crate) pending_naptr_cache_cares:
+        PendingCache<CAresLookup<c_ares::struct_ares_naptr_reply>>,
+    pub(crate) pending_mx_cache_cares: PendingCache<CAresLookup<c_ares::struct_ares_mx_reply>>,
+    pub(crate) pending_caa_cache_cares: PendingCache<CAresLookup<c_ares::struct_ares_caa_reply>>,
+    pub(crate) pending_ns_cache_cares: PendingCache<CAresLookup<NsHostent>>,
+    pub(crate) pending_ptr_cache_cares: PendingCache<CAresLookup<PtrHostent>>,
+    pub(crate) pending_cname_cache_cares: PendingCache<CAresLookup<CnameHostent>>,
+    pub(crate) pending_a_cache_cares: PendingCache<CAresLookup<AHostentWithTtls>>,
+    pub(crate) pending_aaaa_cache_cares: PendingCache<CAresLookup<AaaaHostentWithTtls>>,
+    pub(crate) pending_any_cache_cares: PendingCache<CAresLookup<c_ares::struct_any_reply>>,
+    pub(crate) pending_addr_cache_cares: PendingCache<CAresReverse>,
+    pub(crate) pending_nameinfo_cache_cares: PendingCache<CAresNameInfo>,
 }
 
 bun_event_loop::impl_timer_owner!(Resolver; from_timer_ptr => event_loop_timer);
 
 impl Drop for Resolver {
+    /// Last ref gone: close the channel (its pending queries fail into their
+    /// callbacks, its socket-state callbacks unregister the polls) before the
+    /// fields go.
     fn drop(&mut self) {
         self.destroy_channel();
     }
 }
 
+/// Owner data of the libuv poll on one c-ares socket (Windows).
 #[cfg(windows)]
 pub(crate) struct UvDnsPoll {
-    // BACKREF — stored mut because the poll callback hands it to
-    // `Resolver::deref`, which may write/free `*this`.
-    pub parent: *mut Resolver,
-    pub socket: c_ares::ares_socket_t,
-    pub poll: libuv::uv_poll_t,
-}
-
-#[cfg(windows)]
-impl UvDnsPoll {
-    fn new(parent: *mut Resolver, socket: c_ares::ares_socket_t) -> *mut Self {
-        bun_core::heap::into_raw(Box::new(Self {
-            parent,
-            socket,
-            poll: bun_core::ffi::zeroed(),
-        }))
-    }
-
-    fn destroy(this: *mut Self) {
-        unsafe { drop(bun_core::heap::take(this)) };
-    }
-
-    fn from_poll(poll: *mut libuv::uv_poll_t) -> *mut Self {
-        // SAFETY: poll points to UvDnsPoll.poll
-        unsafe { bun_core::from_field_ptr!(UvDnsPoll, poll, poll) }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub enum CacheHit {
-    Inflight(*mut get_addr_info_request::PendingCacheKey), // BORROW_FIELD into resolver buffer
-    New(*mut get_addr_info_request::PendingCacheKey),      // BORROW_FIELD into resolver buffer
-    Disabled,
-}
-
-pub(crate) enum LookupCacheHit<R: HasPendingCacheKey> {
-    // The request type is threaded via `R`; `PendingCacheKey` resolves
-    // through `HasPendingCacheKey`.
-    Inflight(*mut R::PendingCacheKey), // BORROW_FIELD
-    New(*mut R::PendingCacheKey),      // BORROW_FIELD
-    Disabled,
-}
-
-impl<R: HasPendingCacheKey> Clone for LookupCacheHit<R> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<R: HasPendingCacheKey> Copy for LookupCacheHit<R> {}
-
-/// Associates a request type with its `PendingCacheKey` and the matching `HiveArray`
-/// field on `Resolver`.
-pub(crate) trait HasPendingCacheKey {
-    type PendingCacheKey;
-
-    /// Return the per-request-type pending HiveArray field on `Resolver`.
-    /// `field` is the runtime tag selecting which field (some request types are reachable
-    /// via more than one field, e.g. `pending_host_cache_{cares,native}`).
-    ///
-    /// R-2: takes `&Resolver` and projects `&mut` via the field's `JsCell`.
-    /// Callers hold the borrow only for a short, non-reentrant window
-    /// (slot read/claim/unset).
-    #[allow(clippy::mut_from_ref)]
-    fn pending_cache(
-        resolver: &Resolver,
-        field: PendingCacheField,
-    ) -> &mut HiveArray<Self::PendingCacheKey, 32>;
-
-    /// `key.hash` — all `PendingCacheKey` shapes carry `{ hash: u64, len: u16, lookup: *mut _ }`.
-    fn key_hash(key: &Self::PendingCacheKey) -> u64;
-    /// `key.len`
-    fn key_len(key: &Self::PendingCacheKey) -> u16;
-    fn key_name(key: &Self::PendingCacheKey) -> &[u8];
-    /// Construct a fully-initialized `PendingCacheKey { hash, len, lookup: null }`
-    /// for `HiveArray::get_init`. `lookup` is filled in later by `*Request::init`
-    /// once the request has been heap-allocated; until then it is a defined null
-    /// rather than uninit garbage, so the `iter_set` loop in
-    /// `get_or_put_into_resolve_pending_cache` can safely materialise
-    /// `&mut PendingCacheKey` over the slot.
-    fn key_new(key: &Self::PendingCacheKey) -> Self::PendingCacheKey;
-}
-
-impl<T: CAresRecordType> HasPendingCacheKey for ResolveInfoRequest<T> {
-    type PendingCacheKey = resolve_info_request::PendingCacheKey<T>;
-
-    #[inline]
-    fn pending_cache(
-        resolver: &Resolver,
-        field: PendingCacheField,
-    ) -> &mut HiveArray<Self::PendingCacheKey, 32> {
-        resolver.pending_cache_for::<T>(field)
-    }
-    #[inline]
-    fn key_hash(key: &Self::PendingCacheKey) -> u64 {
-        key.hash
-    }
-    #[inline]
-    fn key_len(key: &Self::PendingCacheKey) -> u16 {
-        key.len
-    }
-    #[inline]
-    fn key_name(key: &Self::PendingCacheKey) -> &[u8] {
-        &key.name
-    }
-    #[inline]
-    fn key_new(key: &Self::PendingCacheKey) -> Self::PendingCacheKey {
-        resolve_info_request::PendingCacheKey {
-            hash: key.hash,
-            len: key.len,
-            name: key.name.clone(),
-            lookup: ptr::null_mut(),
-        }
-    }
-}
-
-impl HasPendingCacheKey for GetHostByAddrInfoRequest {
-    type PendingCacheKey = get_host_by_addr_info_request::PendingCacheKey;
-
-    #[inline]
-    fn pending_cache(
-        resolver: &Resolver,
-        _field: PendingCacheField,
-    ) -> &mut HiveArray<Self::PendingCacheKey, 32> {
-        // SAFETY: see `HasPendingCacheKey::pending_cache` doc — short,
-        // non-reentrant borrow on the single JS thread.
-        unsafe { resolver.pending_addr_cache_cares.get_mut() }
-    }
-    #[inline]
-    fn key_hash(key: &Self::PendingCacheKey) -> u64 {
-        key.hash
-    }
-    #[inline]
-    fn key_len(key: &Self::PendingCacheKey) -> u16 {
-        key.len
-    }
-    #[inline]
-    fn key_name(key: &Self::PendingCacheKey) -> &[u8] {
-        &key.name
-    }
-    #[inline]
-    fn key_new(key: &Self::PendingCacheKey) -> Self::PendingCacheKey {
-        get_host_by_addr_info_request::PendingCacheKey {
-            hash: key.hash,
-            len: key.len,
-            name: key.name.clone(),
-            lookup: ptr::null_mut(),
-        }
-    }
-}
-
-impl HasPendingCacheKey for GetNameInfoRequest {
-    type PendingCacheKey = get_name_info_request::PendingCacheKey;
-
-    #[inline]
-    fn pending_cache(
-        resolver: &Resolver,
-        _field: PendingCacheField,
-    ) -> &mut HiveArray<Self::PendingCacheKey, 32> {
-        // SAFETY: see `HasPendingCacheKey::pending_cache` doc — short,
-        // non-reentrant borrow on the single JS thread.
-        unsafe { resolver.pending_nameinfo_cache_cares.get_mut() }
-    }
-    #[inline]
-    fn key_hash(key: &Self::PendingCacheKey) -> u64 {
-        key.hash
-    }
-    #[inline]
-    fn key_len(key: &Self::PendingCacheKey) -> u16 {
-        key.len
-    }
-    #[inline]
-    fn key_name(key: &Self::PendingCacheKey) -> &[u8] {
-        &key.name
-    }
-    #[inline]
-    fn key_new(key: &Self::PendingCacheKey) -> Self::PendingCacheKey {
-        get_name_info_request::PendingCacheKey {
-            hash: key.hash,
-            len: key.len,
-            name: key.name.clone(),
-            lookup: ptr::null_mut(),
-        }
-    }
-}
-
-pub(crate) enum ChannelResult<'a> {
-    Err(c_ares::Error),
-    Result(&'a mut c_ares::Channel), // BORROW_FIELD — borrows the resolver's `channel` field
+    /// The resolver whose `polls` map owns this poll (so outlives it).
+    parent: BackRef<Resolver, bun_ptr::Mut>,
+    socket: c_ares::ares_socket_t,
 }
 
 // Canonical enum + parser live in `bun_dns` (lower tier so `cli` can parse
@@ -3925,8 +2712,10 @@ trait OrderJscExt {
 
 impl OrderJscExt for Order {
     fn to_js(self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        use jsc::StringJsc as _;
-        bun::String::static_(<&'static str>::from(self)).to_js(global_this)
+        bun_jsc::bun_string_jsc::create_utf8_for_js(
+            global_this,
+            <&'static str>::from(self).as_bytes(),
+        )
     }
 }
 
@@ -3965,87 +2754,43 @@ impl RecordType {
 }
 
 impl Resolver {
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
-    #[inline]
-    fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
-    }
-
     pub(crate) fn vm(&self) -> &VirtualMachine {
         self.vm.get()
-    }
-
-    // Intrusive refcount forwarders (RefCount.ref / RefCount.deref).
-    pub fn ref_(&self) {
-        // SAFETY: `self` is live; ref_count uses interior mutability.
-        unsafe { bun_ptr::RefCount::<Self>::ref_(std::ptr::from_ref::<Self>(self).cast_mut()) };
-    }
-    /// Decrement the intrusive refcount; the last ref drops the Box.
-    ///
-    /// Takes a raw `*mut Self` (not `&self`) because the final deref must write
-    /// through / deallocate `*this`; deriving a `*mut` from a `&self` borrow
-    /// and writing through it is UB under Stacked/Tree Borrows. Matches the
-    /// codebase pattern in `bun_ptr::RefCount::deref(self_: *mut T)`.
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `Resolver` originating from
-    /// `heap::alloc` (see `init`). If this call may drop the last reference,
-    /// the caller must not hold any live `&`/`&mut` borrow of `*this`.
-    pub unsafe fn deref(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; the 1→0 transition drops the Box.
-        unsafe { bun_ptr::RefCount::<Self>::deref(this) };
     }
 
     pub(crate) fn setup(vm: &VirtualMachine) -> Self {
         Self {
             ref_count: bun_ptr::RefCount::init(),
-            channel: Cell::new(None),
-            vm: bun_ptr::BackRef::new(vm),
+            channel: JsCell::new(None),
+            vm: BackRef::new(vm),
             polls: JsCell::new(PollsMap::new()),
             options: Cell::new(c_ares::ChannelOptions::default()),
             event_loop_timer: JsCell::new(EventLoopTimer::init_paused(
                 EventLoopTimerTag::DNSResolver,
             )),
-            pending_host_cache_cares: JsCell::new(PendingCache::init()),
-            pending_host_cache_native: JsCell::new(PendingCache::init()),
-            pending_srv_cache_cares: JsCell::new(HiveArray::init()),
-            pending_soa_cache_cares: JsCell::new(HiveArray::init()),
-            pending_txt_cache_cares: JsCell::new(HiveArray::init()),
-            pending_naptr_cache_cares: JsCell::new(HiveArray::init()),
-            pending_mx_cache_cares: JsCell::new(HiveArray::init()),
-            pending_caa_cache_cares: JsCell::new(HiveArray::init()),
-            pending_ns_cache_cares: JsCell::new(HiveArray::init()),
-            pending_ptr_cache_cares: JsCell::new(HiveArray::init()),
-            pending_cname_cache_cares: JsCell::new(HiveArray::init()),
-            pending_a_cache_cares: JsCell::new(HiveArray::init()),
-            pending_aaaa_cache_cares: JsCell::new(HiveArray::init()),
-            pending_any_cache_cares: JsCell::new(HiveArray::init()),
-            pending_addr_cache_cares: JsCell::new(HiveArray::init()),
-            pending_nameinfo_cache_cares: JsCell::new(HiveArray::init()),
+            timer_ref: Cell::new(None),
+            pending_host_cache_cares: PendingCache::init(),
+            pending_host_cache_native: PendingCache::init(),
+            pending_srv_cache_cares: PendingCache::init(),
+            pending_soa_cache_cares: PendingCache::init(),
+            pending_txt_cache_cares: PendingCache::init(),
+            pending_naptr_cache_cares: PendingCache::init(),
+            pending_mx_cache_cares: PendingCache::init(),
+            pending_caa_cache_cares: PendingCache::init(),
+            pending_ns_cache_cares: PendingCache::init(),
+            pending_ptr_cache_cares: PendingCache::init(),
+            pending_cname_cache_cares: PendingCache::init(),
+            pending_a_cache_cares: PendingCache::init(),
+            pending_aaaa_cache_cares: PendingCache::init(),
+            pending_any_cache_cares: PendingCache::init(),
+            pending_addr_cache_cares: PendingCache::init(),
+            pending_nameinfo_cache_cares: PendingCache::init(),
         }
-    }
-
-    pub(crate) fn init(vm: &VirtualMachine) -> *mut Self {
-        bun_output::scoped_log!(DNSResolver, "init");
-        bun_core::heap::into_raw(Box::new(Self::setup(vm)))
-    }
-
-    // ─── R-2 interior-mutability helpers ────────────────────────────────────
-
-    /// `self`'s address as `*mut Self` for c-ares / `FilePoll` / `RefPtr`
-    /// ctx slots and `Self::deref`. Callbacks deref it as `&*const` (shared) —
-    /// see `on_dns_poll`, `on_cares_complete` — so no write provenance is
-    /// required; the `*mut` spelling is purely to match the C signature. All
-    /// mutation routes through `Cell` / `JsCell` (UnsafeCell-backed).
-    #[inline]
-    pub(crate) fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
     }
 
     // ───────────── timer / pending bookkeeping ─────────────
 
-    pub(crate) fn check_timeouts(&self, now: &ElTimespec, vm: &VirtualMachine) {
+    pub(crate) fn check_timeouts(this: ThisPtr<Self>, now: &ElTimespec, vm: &VirtualMachine) {
         // Caller (`dispatch.rs::fire_timer`) hands us the event-loop's
         // local `ElTimespec`; `add_timer` works in `bun_core::timespec`. Same
         // `{ sec: i64, nsec: i64 }` layout — convert field-by-field.
@@ -4054,39 +2799,26 @@ impl Resolver {
             nsec: now.nsec,
         };
         let uws_loop = vm.uws_loop();
-        // R-2: `&self` carries no `noalias`, and every field touched below is
-        // UnsafeCell-backed, so the re-entrant `ares_process_fd` callbacks
-        // (`request_completed`, `drain_pending_*`) may freely re-derive
-        // `&Resolver` from their stored ctx without aliasing UB.
-        let deref_this = self.as_ctx_ptr();
-        scopeguard::defer! {
-            // jsc/runtime crate cycle: low-tier `VirtualMachine.timer` is `()`;
-            // resolve via the high-tier `RuntimeState` hook.
-            let state = crate::jsc_hooks::runtime_state();
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
-            unsafe { (*state).timer.increment_timer_ref(-1, uws_loop) };
-            // SAFETY: `deref_this` is the heap allocation from `init`; releases
-            // `add_timer`'s ref. May be the final release; nothing touches
-            // `*self` after this point.
-            unsafe { Self::deref(deref_this) };
-        }
+        // The ref `add_timer` took for this firing; released on the way out
+        // (after a possible re-arm has taken its own).
+        let _release = scopeguard::guard(this.timer_ref.take(), move |timer_ref| {
+            timer_all_mut().increment_timer_ref(-1, uws_loop);
+            if let Some(timer_ref) = timer_ref {
+                timer_ref.deref();
+            }
+        });
 
-        self.event_loop_timer
+        this.event_loop_timer
             .with_mut(|t| t.state = EventLoopTimerState::PENDING);
 
-        if let Ok(channel) = self.get_channel_or_error(vm.global()) {
-            if self.any_requests_pending() {
-                // SAFETY: `channel` is the live c-ares channel owned by `self`.
-                c_ares::ares_process_fd(
-                    unsafe { &mut *channel },
-                    c_ares::ARES_SOCKET_BAD,
-                    c_ares::ARES_SOCKET_BAD,
-                );
+        if let Ok(channel) = Self::get_channel_or_error(&this, vm.global()) {
+            if this.any_requests_pending() {
+                channel.process(c_ares::ARES_SOCKET_BAD, false, false);
                 // See `on_dns_poll` — c-ares detaches post-callback, so re-check.
-                if self.any_requests_pending() {
-                    let _ = self.add_timer(Some(&now));
+                if this.any_requests_pending() {
+                    let _ = Self::add_timer(this, Some(&now));
                 } else {
-                    self.remove_timer();
+                    Self::remove_timer(this);
                 }
             }
         }
@@ -4095,7 +2827,7 @@ impl Resolver {
     fn any_requests_pending(&self) -> bool {
         // Rust has no field reflection; keep this list in sync with
         // `Resolver`'s `pending_*` fields.
-        macro_rules! check { ($($f:ident),*) => { $( if self.$f.get().used.find_first_set().is_some() { return true; } )* } }
+        macro_rules! check { ($($f:ident),*) => { $( if self.$f.any_pending() { return true; } )* } }
         check!(
             pending_host_cache_cares,
             pending_host_cache_native,
@@ -4114,816 +2846,467 @@ impl Resolver {
             pending_addr_cache_cares,
             pending_nameinfo_cache_cares
         );
-        // The 32-slot caches overflow to `LookupCacheHit::Disabled`; c-ares' own
+        // The 32-slot caches overflow to `CacheHit::Disabled`; c-ares' own
         // queue length covers those too. Its channel lock is recursive, so this
         // is safe from inside a completion callback.
-        if let Some(channel) = self.channel.get() {
-            // SAFETY: `channel` is the live c-ares channel owned by `self`.
-            if c_ares::ares_queue_active_queries(unsafe { &*channel }) != 0 {
+        if let Some(channel) = self.channel.get().as_deref() {
+            if channel.active_queries() != 0 {
                 return true;
             }
         }
         false
     }
 
-    fn request_sent(&self, _vm: &VirtualMachine) {
-        let _ = self.add_timer(None);
+    fn request_sent(this: ThisPtr<Self>, _vm: &VirtualMachine) {
+        let _ = Self::add_timer(this, None);
     }
 
-    fn request_completed(&self) {
-        if self.any_requests_pending() {
-            let _ = self.add_timer(None);
+    fn request_completed(this: ThisPtr<Self>) {
+        if this.any_requests_pending() {
+            let _ = Self::add_timer(this, None);
         } else {
-            self.remove_timer();
+            Self::remove_timer(this);
         }
     }
 
-    fn add_timer(&self, now: Option<&bun::timespec>) -> bool {
-        if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+    fn add_timer(this: ThisPtr<Self>, now: Option<&bun::timespec>) -> bool {
+        if this.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
             return false;
         }
 
-        self.ref_();
+        this.timer_ref.set(Some(RefPtr::from_this(this)));
         let now_ts = now
             .copied()
             .unwrap_or_else(|| bun::timespec::now(bun::TimespecMockMode::ForceRealTime));
         let next = now_ts.add_ms(1000);
         // `EventLoopTimer.next` uses the event-loop crate's local
         // `Timespec` (distinct from `bun_core::Timespec`); convert by field.
-        self.event_loop_timer.with_mut(|t| {
+        this.event_loop_timer.with_mut(|t| {
             t.next = ElTimespec {
                 sec: next.sec,
                 nsec: next.nsec,
             }
         });
-        let uws_loop = self.vm().uws_loop();
-        let state = crate::jsc_hooks::runtime_state();
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
-        unsafe {
-            (*state).timer.increment_timer_ref(1, uws_loop);
-            // whole-struct provenance: `from_field_ptr!` recovers the container on fire
-            (*state).timer.insert(
-                core::ptr::addr_of!(self.event_loop_timer)
-                    .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                    .cast_mut(),
-            );
-        }
+        let uws_loop = this.vm().uws_loop();
+        timer_all_mut().increment_timer_ref(1, uws_loop);
+        timer_all_mut().insert(this.event_loop_timer.as_ptr());
         true
     }
 
-    fn remove_timer(&self) {
-        if self.event_loop_timer.get().state != EventLoopTimerState::ACTIVE {
+    fn remove_timer(this: ThisPtr<Self>) {
+        if this.event_loop_timer.get().state != EventLoopTimerState::ACTIVE {
             return;
         }
 
+        timer_all_mut().remove(this.event_loop_timer.as_ptr());
         // Normally checkTimeouts does this, so we have to be sure to do it ourself if we cancel the timer
-        let this = self.as_ctx_ptr();
-        scopeguard::defer! {
-            // SAFETY: `this` is the heap allocation from `init`. This releases
-            // the ref taken by `add_timer`. Every caller holds at least one
-            // other ref for the duration of this call (a `RefPtr` or the
-            // global-resolver permanent pin), so this
-            // `deref` cannot reach 0 while `&self` is live.
-            unsafe {
-                let uws_loop = (*this).vm().uws_loop();
-                let state = crate::jsc_hooks::runtime_state();
-                (*state).timer.increment_timer_ref(-1, uws_loop);
-                Self::deref(this);
-            }
+        let uws_loop = this.vm().uws_loop();
+        timer_all_mut().increment_timer_ref(-1, uws_loop);
+        // Every caller holds at least one other ref for the duration of this
+        // call (a lookup's `RefPtr`, a `ref_guard`, or the global-resolver
+        // pin), so this is never the last.
+        if let Some(timer_ref) = this.timer_ref.take() {
+            timer_ref.deref();
         }
-
-        let state = crate::jsc_hooks::runtime_state();
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
-        unsafe { (*state).timer.remove(self.event_loop_timer.as_ptr()) };
     }
 
     // ───────────── pending-cache helpers ─────────────
 
-    /// Dispatch to the GetAddrInfo PendingCache by field enum.
-    ///
-    /// R-2: returns `&mut` from `&self` via `JsCell::get_mut`. Callers hold
-    /// the borrow only for the duration of a slot read/claim/unset and never
-    /// across a re-entrant call (the c-ares callback path that re-enters the
-    /// resolver runs *after* the borrow is dropped).
-    #[allow(clippy::mut_from_ref)]
-    fn pending_host_cache(&self, field: PendingCacheField) -> &mut PendingCache {
-        // SAFETY: single-JS-thread invariant; caller holds the borrow only for
-        // a short, non-reentrant window (see fn doc).
-        unsafe {
-            match field {
-                PendingCacheField::PendingHostCacheCares => self.pending_host_cache_cares.get_mut(),
-                PendingCacheField::PendingHostCacheNative => {
-                    self.pending_host_cache_native.get_mut()
-                }
-                _ => unreachable!(),
-            }
+    /// The `GetAddrInfo` pending cache `field` names.
+    fn pending_host_cache(&self, field: PendingCacheField) -> &PendingCache<DNSLookup> {
+        match field {
+            PendingCacheField::PendingHostCacheCares => &self.pending_host_cache_cares,
+            PendingCacheField::PendingHostCacheNative => &self.pending_host_cache_native,
         }
-    }
-
-    /// Dispatch to a typed ResolveInfoRequest cache by record type.
-    // Each per-record cache is a distinct monomorphization of
-    // `HiveArray<resolve_info_request::PendingCacheKey<_>, 32>`; `PendingCacheKey<T>` is
-    // layout-identical for all `T` (only the `*mut ResolveInfoRequest<T>` payload's pointee
-    // type differs), so reinterpreting the field reference at the caller's `T` is sound when
-    // `T::CACHE_FIELD` selects the matching field.
-    #[allow(clippy::mut_from_ref)]
-    fn pending_cache_for<T: CAresRecordType>(
-        &self,
-        _field: PendingCacheField,
-    ) -> &mut HiveArray<resolve_info_request::PendingCacheKey<T>, 32> {
-        macro_rules! field {
-            ($f:ident) => {
-                // SAFETY: the matched arm guarantees `self.$f` *is*
-                // `JsCell<HiveArray<PendingCacheKey<T>, 32>>` for this `T::CACHE_FIELD`;
-                // the cast is an identity transmute (same layout, same lifetime).
-                // R-2: `JsCell::as_ptr` projects `&mut` from `&self`; caller
-                // holds the borrow only for a short, non-reentrant window
-                // (see `pending_host_cache` doc).
-                unsafe {
-                    &mut *self
-                        .$f
-                        .as_ptr()
-                        .cast::<HiveArray<resolve_info_request::PendingCacheKey<T>, 32>>()
-                }
-            };
-        }
-        match T::CACHE_FIELD {
-            PendingCacheField::PendingSrvCacheCares => field!(pending_srv_cache_cares),
-            PendingCacheField::PendingSoaCacheCares => field!(pending_soa_cache_cares),
-            PendingCacheField::PendingTxtCacheCares => field!(pending_txt_cache_cares),
-            PendingCacheField::PendingNaptrCacheCares => field!(pending_naptr_cache_cares),
-            PendingCacheField::PendingMxCacheCares => field!(pending_mx_cache_cares),
-            PendingCacheField::PendingCaaCacheCares => field!(pending_caa_cache_cares),
-            PendingCacheField::PendingNsCacheCares => field!(pending_ns_cache_cares),
-            PendingCacheField::PendingPtrCacheCares => field!(pending_ptr_cache_cares),
-            PendingCacheField::PendingCnameCacheCares => field!(pending_cname_cache_cares),
-            PendingCacheField::PendingACacheCares => field!(pending_a_cache_cares),
-            PendingCacheField::PendingAaaaCacheCares => field!(pending_aaaa_cache_cares),
-            PendingCacheField::PendingAnyCacheCares => field!(pending_any_cache_cares),
-            // host/addr/nameinfo caches use distinct key types and have their own helpers.
-            PendingCacheField::PendingHostCacheCares
-            | PendingCacheField::PendingHostCacheNative
-            | PendingCacheField::PendingAddrCacheCares
-            | PendingCacheField::PendingNameinfoCacheCares => {
-                unreachable!()
-            }
-        }
-    }
-
-    // Monomorphic helpers used by the drain* fns below.
-    fn get_key_host(
-        &self,
-        index: u8,
-        field: PendingCacheField,
-    ) -> get_addr_info_request::PendingCacheKey {
-        let cache = self.pending_host_cache(field);
-        // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
-        unsafe { cache.box_at(index as usize) }
-            .expect("pending DNS slot")
-            .into_inner()
-    }
-    fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
-        self.pending_addr_cache_cares.with_mut(|cache| {
-            // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
-            unsafe { cache.box_at(index as usize) }
-                .expect("pending DNS slot")
-                .into_inner()
-        })
-    }
-    fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
-        self.pending_nameinfo_cache_cares.with_mut(|cache| {
-            // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
-            unsafe { cache.box_at(index as usize) }
-                .expect("pending DNS slot")
-                .into_inner()
-        })
     }
 
     pub(crate) fn drain_pending_cares<T: CAresRecordType>(
-        &self,
+        this: ThisPtr<Self>,
         index: u8,
         err: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<OwnedReply<T>>,
+        result: Option<T::Reply>,
+        head: CAresLookup<T>,
     ) {
-        // cache_name = format!("pending_{}_cache_cares", T::TYPE_NAME)
-        let _guard = self.ref_guard();
+        let _g = this.ref_guard();
 
-        let key = {
-            let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
-            // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
-            unsafe { cache.box_at(index as usize) }
-                .expect("pending DNS slot")
-                .into_inner()
-        };
+        let waiters = T::pending_cache(&this).take(index);
 
-        let Some(mut addr) = result else {
-            // SAFETY: `key.lookup` is the heap-allocated request stored in the
-            // pending-cache slot; consumed via `heap::take` below.
-            unsafe {
-                let mut pending = (*key.lookup).head.next;
-                CAresLookup::<T>::process_resolve(
-                    ptr::addr_of_mut!((*key.lookup).head),
-                    err,
-                    timeout,
-                    None,
-                );
-                drop(bun_core::heap::take(key.lookup));
-
-                while let Some(value) = pending {
-                    pending = (*value.as_ptr()).next;
-                    CAresLookup::<T>::process_resolve(value.as_ptr(), err, timeout, None);
-                }
+        let Some(addr) = result else {
+            head.process_resolve(err, timeout, None);
+            for waiter in waiters {
+                waiter.process_resolve(err, timeout, None);
             }
             return;
         };
 
-        // SAFETY: `key.lookup` is the heap-allocated request stored in the
-        // pending-cache slot; consumed via `heap::take` below.
-        unsafe {
-            let mut pending = (*key.lookup).head.next;
-            let mut prev_global = (*key.lookup).head.global_this();
-            let mut array =
-                Outcome::of(prev_global, addr.to_js_response(prev_global, T::TYPE_NAME));
-            keep_alive(&array);
-            CAresLookup::<T>::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
-            drop(bun_core::heap::take(key.lookup));
+        let mut prev_global = head.global_this;
+        let mut array = Outcome::of(
+            &prev_global,
+            T::reply_to_js(&addr, &prev_global, T::TYPE_NAME),
+        );
+        keep_alive(&array);
+        head.on_complete(array);
 
-            keep_alive(&array);
+        keep_alive(&array);
 
-            while let Some(value) = pending {
-                let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
-                    array = Outcome::of(new_global, addr.to_js_response(new_global, T::TYPE_NAME));
-                    prev_global = new_global;
-                }
-                pending = (*value.as_ptr()).next;
-
-                keep_alive(&array);
-                CAresLookup::<T>::on_complete(value.as_ptr(), array);
-                keep_alive(&array);
+        for waiter in waiters {
+            let new_global = waiter.global_this;
+            if prev_global != new_global {
+                array = Outcome::of(
+                    &new_global,
+                    T::reply_to_js(&addr, &new_global, T::TYPE_NAME),
+                );
+                prev_global = new_global;
             }
+
+            keep_alive(&array);
+            waiter.on_complete(array);
+            keep_alive(&array);
         }
     }
 
     pub(crate) fn drain_pending_host_cares(
-        &self,
+        this: ThisPtr<Self>,
         index: u8,
         err: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<*mut c_ares::AddrInfo>,
+        result: Option<c_ares::AresBox<c_ares::AddrInfo>>,
+        head: DNSLookup,
     ) {
-        let key = self.get_key_host(index, PendingCacheField::PendingHostCacheCares);
+        let waiters = this
+            .pending_host_cache(PendingCacheField::PendingHostCacheCares)
+            .take(index);
 
-        let _guard = self.ref_guard();
+        let _g = this.ref_guard();
 
         let Some(addr) = result else {
-            // SAFETY: `key.lookup` is the heap-allocated request stored in the
-            // pending-cache slot; consumed via `heap::take` below.
-            unsafe {
-                let mut pending = (*key.lookup).head.next;
-                DNSLookup::process_get_addr_info(
-                    ptr::addr_of_mut!((*key.lookup).head),
-                    err,
-                    timeout,
-                    None,
-                );
-                drop(bun_core::heap::take(key.lookup));
-
-                while let Some(value) = pending {
-                    pending = (*value.as_ptr()).next;
-                    DNSLookup::process_get_addr_info(value.as_ptr(), err, timeout, None);
-                }
+            head.process_get_addr_info(err, timeout, None);
+            for waiter in waiters {
+                waiter.process_get_addr_info(err, timeout, None);
             }
             return;
         };
 
-        // SAFETY: `key.lookup` is the heap-allocated request stored in the pending-cache
-        // slot; `addr` is the c-ares-allocated AddrInfo freed by `_free_addr` below.
-        unsafe {
-            let mut pending = (*key.lookup).head.next;
-            let mut prev_global = (*key.lookup).head.global_this();
-            let mut array = Outcome::of(
-                prev_global,
-                super::cares_jsc::addr_info_to_js_array(&mut *addr, prev_global),
-            );
-            // SAFETY: addr is the c-ares-allocated AddrInfo; freed once after all consumers run.
-            // Move the raw pointer into the guard so the loop body can keep borrowing `*addr`.
-            let _free_addr = scopeguard::guard(addr, |a| c_ares::AddrInfo::destroy(a));
-            keep_alive(&array);
-            DNSLookup::on_complete_with_array(ptr::addr_of_mut!((*key.lookup).head), array);
-            drop(bun_core::heap::take(key.lookup));
+        let mut prev_global = head.global_this;
+        let mut array = Outcome::of(
+            &prev_global,
+            super::cares_jsc::addr_info_to_js_array(&addr, &prev_global),
+        );
+        keep_alive(&array);
+        head.on_complete_with_array(array);
 
-            keep_alive(&array);
+        keep_alive(&array);
 
-            while let Some(value) = pending {
-                let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
-                    array = Outcome::of(
-                        new_global,
-                        super::cares_jsc::addr_info_to_js_array(&mut *addr, new_global),
-                    );
-                    prev_global = new_global;
-                }
-                pending = (*value.as_ptr()).next;
-
-                keep_alive(&array);
-                DNSLookup::on_complete_with_array(value.as_ptr(), array);
-                keep_alive(&array);
+        for waiter in waiters {
+            let new_global = waiter.global_this;
+            if prev_global != new_global {
+                array = Outcome::of(
+                    &new_global,
+                    super::cares_jsc::addr_info_to_js_array(&addr, &new_global),
+                );
+                prev_global = new_global;
             }
+
+            keep_alive(&array);
+            waiter.on_complete_with_array(array);
+            keep_alive(&array);
         }
+        // `addr` (the c-ares `ares_addrinfo`) is freed once, after all consumers ran.
     }
 
     pub(crate) fn drain_pending_host_native(
-        &self,
+        this: ThisPtr<Self>,
         index: u8,
-        global_object: &JSGlobalObject,
         err: i32,
         result: &GetAddrInfoResultAny,
+        head: DNSLookup,
     ) {
         bun_output::scoped_log!(DNSResolver, "drainPendingHostNative");
-        let key = self.get_key_host(index, PendingCacheField::PendingHostCacheNative);
+        let global_object = head.global_this;
+        let waiters = this
+            .pending_host_cache(PendingCacheField::PendingHostCacheNative)
+            .take(index);
 
-        let _guard = self.ref_guard();
+        let _g = this.ref_guard();
 
-        let mut array: Outcome = match super::options_jsc::result_any_to_js(result, global_object)
-            .transpose()
-        {
-            Some(a) => Outcome::of(global_object, a),
-            None => {
-                // SAFETY: `key.lookup` is the heap-allocated request stored in the
-                // pending-cache slot; consumed via `heap::take` below.
-                unsafe {
-                    let mut pending = (*key.lookup).head.next;
-                    // Consume the request and move `head` out by value;
-                    // `ptr::read` + `heap::take` would double-Drop `DNSLookup`.
-                    let owned = *bun_core::heap::take(key.lookup);
-                    let mut head = owned.head;
-                    DNSLookup::process_get_addr_info_native(&raw mut head, err, ptr::null_mut());
-
-                    while let Some(value) = pending {
-                        pending = (*value.as_ptr()).next;
-                        DNSLookup::process_get_addr_info_native(
-                            value.as_ptr(),
-                            err,
-                            ptr::null_mut(),
-                        );
+        let mut array: Outcome =
+            match super::options_jsc::result_any_to_js(result, &global_object).transpose() {
+                Some(a) => Outcome::of(&global_object, a),
+                None => {
+                    head.process_get_addr_info_native(err);
+                    for waiter in waiters {
+                        waiter.process_get_addr_info_native(err);
                     }
+                    return;
                 }
-                return;
-            }
-        };
-        // SAFETY: `key.lookup` is the heap-allocated request stored in the
-        // pending-cache slot; consumed via `heap::take` below.
-        unsafe {
-            let mut pending = (*key.lookup).head.next;
-            let mut prev_global = (*key.lookup).head.global_this();
+            };
+        let mut prev_global = head.global_this;
 
-            {
-                keep_alive(&array);
-                DNSLookup::on_complete_with_array(ptr::addr_of_mut!((*key.lookup).head), array);
-                drop(bun_core::heap::take(key.lookup));
-                keep_alive(&array);
+        {
+            keep_alive(&array);
+            head.on_complete_with_array(array);
+            keep_alive(&array);
+        }
+
+        for waiter in waiters {
+            let new_global = waiter.global_this;
+            if prev_global != new_global {
+                // Non-null addrinfo (checked above): never `None`.
+                array = Outcome::of(
+                    &new_global,
+                    super::options_jsc::result_any_to_js(result, &new_global)
+                        .map(|a| a.expect("addrinfo present")),
+                );
+                prev_global = new_global;
             }
 
-            while let Some(value) = pending {
-                let new_global = (*value.as_ptr()).global_this();
-                pending = (*value.as_ptr()).next;
-                if !core::ptr::eq(prev_global, new_global) {
-                    // Non-null addrinfo (checked above): never `None`.
-                    array = Outcome::of(
-                        new_global,
-                        super::options_jsc::result_any_to_js(result, new_global)
-                            .map(|a| a.expect("addrinfo present")),
-                    );
-                    prev_global = new_global;
-                }
-
-                keep_alive(&array);
-                DNSLookup::on_complete_with_array(value.as_ptr(), array);
-                keep_alive(&array);
-            }
+            keep_alive(&array);
+            waiter.on_complete_with_array(array);
+            keep_alive(&array);
         }
     }
 
     pub(crate) fn drain_pending_addr_cares(
-        &self,
+        this: ThisPtr<Self>,
         index: u8,
         err: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<*mut c_ares::struct_hostent>,
+        result: Option<&c_ares::struct_hostent>,
+        head: CAresReverse,
     ) {
-        let key = self.get_key_addr(index);
+        let waiters = this.pending_addr_cache_cares.take(index);
 
-        let _guard = self.ref_guard();
+        let _g = this.ref_guard();
 
         let Some(addr) = result else {
-            // SAFETY: `key.lookup` is the heap-allocated request stored in the
-            // pending-cache slot; consumed via `heap::take` below.
-            unsafe {
-                let mut pending = (*key.lookup).head.next;
-                CAresReverse::process_resolve(
-                    ptr::addr_of_mut!((*key.lookup).head),
-                    err,
-                    timeout,
-                    None,
-                );
-                drop(bun_core::heap::take(key.lookup));
-
-                while let Some(value) = pending {
-                    pending = (*value.as_ptr()).next;
-                    CAresReverse::process_resolve(value.as_ptr(), err, timeout, None);
-                }
+            head.process_resolve(err, timeout, None);
+            for waiter in waiters {
+                waiter.process_resolve(err, timeout, None);
             }
             return;
         };
 
-        // SAFETY: `key.lookup` is the heap-allocated request stored in the pending-cache
-        // slot; `addr` is the c-ares-owned hostent (freed by c-ares after the callback).
-        unsafe {
-            let mut pending = (*key.lookup).head.next;
-            let mut prev_global = (*key.lookup).head.global_this();
-            //  The callback need not and should not attempt to free the memory
-            //  pointed to by hostent; the ares library will free it when the
-            //  callback returns.
-            let mut array = Outcome::of(
-                prev_global,
-                super::cares_jsc::hostent_to_js_response(&mut *addr, prev_global, b""),
-            );
-            keep_alive(&array);
-            CAresReverse::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
-            drop(bun_core::heap::take(key.lookup));
+        let mut prev_global = head.global_this;
+        //  The callback need not and should not attempt to free the memory
+        //  pointed to by hostent; the ares library will free it when the
+        //  callback returns.
+        let mut array = Outcome::of(
+            &prev_global,
+            super::cares_jsc::hostent_to_js_response(addr, &prev_global, b""),
+        );
+        keep_alive(&array);
+        head.on_complete(array);
 
-            keep_alive(&array);
+        keep_alive(&array);
 
-            while let Some(value) = pending {
-                let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
-                    array = Outcome::of(
-                        new_global,
-                        super::cares_jsc::hostent_to_js_response(&mut *addr, new_global, b""),
-                    );
-                    prev_global = new_global;
-                }
-                pending = (*value.as_ptr()).next;
-
-                keep_alive(&array);
-                CAresReverse::on_complete(value.as_ptr(), array);
-                keep_alive(&array);
+        for waiter in waiters {
+            let new_global = waiter.global_this;
+            if prev_global != new_global {
+                array = Outcome::of(
+                    &new_global,
+                    super::cares_jsc::hostent_to_js_response(addr, &new_global, b""),
+                );
+                prev_global = new_global;
             }
+
+            keep_alive(&array);
+            waiter.on_complete(array);
+            keep_alive(&array);
         }
     }
 
     pub(crate) fn drain_pending_name_info_cares(
-        &self,
+        this: ThisPtr<Self>,
         index: u8,
         err: Option<c_ares::Error>,
         timeout: i32,
-        result: Option<c_ares::struct_nameinfo>,
+        result: Option<c_ares::NameInfo<'_>>,
+        head: CAresNameInfo,
     ) {
-        let key = self.get_key_nameinfo(index);
+        let waiters = this.pending_nameinfo_cache_cares.take(index);
 
-        let _guard = self.ref_guard();
+        let _g = this.ref_guard();
 
-        let Some(mut name_info) = result else {
-            // SAFETY: `key.lookup` is the heap-allocated request stored in the
-            // pending-cache slot; consumed via `heap::take` below.
-            unsafe {
-                let mut pending = (*key.lookup).head.next;
-                CAresNameInfo::process_resolve(
-                    ptr::addr_of_mut!((*key.lookup).head),
-                    err,
-                    timeout,
-                    None,
-                );
-                drop(bun_core::heap::take(key.lookup));
-
-                while let Some(value) = pending {
-                    pending = (*value.as_ptr()).next;
-                    CAresNameInfo::process_resolve(value.as_ptr(), err, timeout, None);
-                }
+        let Some(name_info) = result else {
+            head.process_resolve(err, timeout, None);
+            for waiter in waiters {
+                waiter.process_resolve(err, timeout, None);
             }
             return;
         };
 
-        // SAFETY: `key.lookup` is the heap-allocated request stored in the
-        // pending-cache slot; consumed via `heap::take` below.
-        unsafe {
-            let mut pending = (*key.lookup).head.next;
-            let mut prev_global = (*key.lookup).head.global_this();
+        let mut prev_global = head.global_this;
 
-            let mut array = Outcome::of(
-                prev_global,
-                super::cares_jsc::nameinfo_to_js_response(&mut name_info, prev_global),
-            );
+        let mut array = Outcome::of(
+            &prev_global,
+            super::cares_jsc::nameinfo_to_js_response(&name_info, &prev_global),
+        );
+        keep_alive(&array);
+        head.on_complete(array);
+
+        keep_alive(&array);
+
+        for waiter in waiters {
+            let new_global = waiter.global_this;
+            if prev_global != new_global {
+                array = Outcome::of(
+                    &new_global,
+                    super::cares_jsc::nameinfo_to_js_response(&name_info, &new_global),
+                );
+                prev_global = new_global;
+            }
+
             keep_alive(&array);
-            CAresNameInfo::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
-            drop(bun_core::heap::take(key.lookup));
-
+            waiter.on_complete(array);
             keep_alive(&array);
-
-            while let Some(value) = pending {
-                let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
-                    array = Outcome::of(
-                        new_global,
-                        super::cares_jsc::nameinfo_to_js_response(&mut name_info, new_global),
-                    );
-                    prev_global = new_global;
-                }
-                pending = (*value.as_ptr()).next;
-
-                keep_alive(&array);
-                CAresNameInfo::on_complete(value.as_ptr(), array);
-                keep_alive(&array);
-            }
         }
     }
 
-    pub(crate) fn get_or_put_into_resolve_pending_cache<R: HasPendingCacheKey>(
-        &self,
-        key: &R::PendingCacheKey,
-        field: PendingCacheField,
-    ) -> LookupCacheHit<R> {
-        // Dispatch via `HasPendingCacheKey::pending_cache`; the body is
-        // identical across all `R`.
-        let cache = R::pending_cache(self, field);
-        let mut inflight_iter = cache.used.iter_set();
-
-        while let Some(index) = inflight_iter.next() {
-            // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.ptr_at(index) };
-            if R::key_hash(entry) == R::key_hash(key)
-                && R::key_len(entry) == R::key_len(key)
-                && R::key_name(entry) == R::key_name(key)
-            {
-                return LookupCacheHit::Inflight(std::ptr::from_mut(entry));
-            }
+    /// This resolver's c-ares channel, created on first use.
+    pub(crate) fn get_channel<'a>(
+        this: &'a ThisPtr<Self>,
+    ) -> Result<&'a c_ares::Channel, c_ares::Error> {
+        if this.channel.get().is_none() {
+            let channel = c_ares::Channel::init(*this, this.options.get())?;
+            this.channel.set(Some(channel));
+            // A live channel has sockets, timers and queries in flight whose
+            // callbacks need this VM: the stop phase closes it (any resolver,
+            // not just the VM-global one) if nobody did before. Unregistered in
+            // `destroy_channel`.
+            crate::jsc_hooks::ActiveHandle::DnsResolver(core::ptr::NonNull::from(*this)).register();
         }
-
-        if let Some(new) = cache.get_init(R::key_new(key)) {
-            return LookupCacheHit::New(new.as_ptr());
-        }
-
-        LookupCacheHit::Disabled
+        Ok(this.channel.get().as_deref().expect("channel set above"))
     }
 
-    pub(crate) fn get_or_put_into_pending_cache(
-        &self,
-        key: &get_addr_info_request::PendingCacheKey,
-        field: PendingCacheField,
-    ) -> CacheHit {
-        let cache = self.pending_host_cache(field);
-        let mut inflight_iter = cache.used.iter_set();
-
-        while let Some(index) = inflight_iter.next() {
-            // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.ptr_at(index) };
-            if entry.hash == key.hash && entry.len == key.len && entry.name == key.name {
-                return CacheHit::Inflight(std::ptr::from_mut(entry));
-            }
-        }
-
-        if let Some(new) = cache.get_init(get_addr_info_request::PendingCacheKey {
-            hash: key.hash,
-            len: key.len,
-            name: key.name.clone(),
-            lookup: ptr::null_mut(),
-        }) {
-            return CacheHit::New(new.as_ptr());
-        }
-
-        CacheHit::Disabled
+    fn get_channel_from_vm(global_this: &JSGlobalObject) -> JsResult<ThisPtr<Self>> {
+        let resolver = global_resolver(global_this);
+        Self::get_channel_or_error(&resolver, global_this)?;
+        Ok(resolver)
     }
 
-    pub(crate) fn get_channel(&self) -> ChannelResult<'_> {
-        if self.channel.get().is_none() {
-            let opts = self.options.get();
-            if let Some(err) = c_ares::Channel::init(self, opts) {
-                return ChannelResult::Err(err);
-            }
-        }
-        // SAFETY: channel set by init() on success
-        ChannelResult::Result(unsafe { &mut *self.channel.get().unwrap() })
-    }
-
-    fn get_channel_from_vm(global_this: &JSGlobalObject) -> JsResult<*mut c_ares::Channel> {
-        global_resolver(global_this).get_channel_or_error(global_this)
-    }
-
-    pub(crate) fn get_channel_or_error(
-        &self,
+    pub(crate) fn get_channel_or_error<'a>(
+        this: &'a ThisPtr<Self>,
         global_this: &JSGlobalObject,
-    ) -> JsResult<*mut c_ares::Channel> {
-        match self.get_channel() {
-            ChannelResult::Result(result) => Ok(std::ptr::from_mut(result)),
-            ChannelResult::Err(err) => {
-                let system_error = SystemError {
-                    errno: -1,
-                    code: bun_core::String::static_(err.code()),
-                    message: bun_core::String::static_(err.label()),
-                    ..Default::default()
-                };
-                Err(global_this.throw_value(system_error.to_error_instance(global_this)))
-            }
-        }
+    ) -> JsResult<&'a c_ares::Channel> {
+        Self::get_channel(this).map_err(|err| {
+            let system_error = SystemError {
+                errno: -1,
+                code: bun_core::String::static_(err.code()),
+                message: bun_core::String::static_(err.label()),
+                ..Default::default()
+            };
+            global_this.throw_value(system_error.to_error_instance(global_this))
+        })
     }
 
     // ───────────── poll callbacks ─────────────
 
-    #[cfg(windows)]
-    pub(crate) extern "C" fn on_dns_poll_uv(
-        watcher: *mut libuv::uv_poll_t,
-        status: c_int,
-        events: c_int,
-    ) {
-        let poll = UvDnsPoll::from_poll(watcher);
-        // SAFETY: `poll` is the live `UvDnsPoll` recovered from libuv's `watcher`
-        // via `from_poll` (libuv guarantees the handle outlives this callback).
-        // `parent` is the heap-allocated Resolver back-ptr (set in
-        // `on_dns_socket_state`); it is kept alive across `Channel::process` by the
-        // `_guard` below. `channel` is non-null because c-ares
-        // must have been initialized for this poll callback to fire.
-        unsafe {
-            let parent: *mut Resolver = (*poll).parent;
-            let vm = (*parent).vm.get();
-            let _exit = vm.enter_event_loop_scope();
-            // SAFETY: `parent` is the live heap-allocated Resolver back-ptr.
-            let _guard = RefPtr::init_ref(parent);
-            // channel must be non-null here as c_ares must have been initialized if we're receiving callbacks
-            let channel = (*parent).channel.get().unwrap();
-            if status < 0 {
-                // an error occurred. just pretend that the socket is both readable and writable.
-                // https://github.com/nodejs/node/blob/8a41d9b636be86350cd32847c3f89d327c4f6ff7/src/cares_wrap.cc#L93
-                (*channel).process((*poll).socket, true, true);
-            } else {
-                (*channel).process(
-                    (*poll).socket,
-                    events & libuv::UV_READABLE != 0,
-                    events & libuv::UV_WRITABLE != 0,
-                );
-            }
-
-            // See `on_dns_poll` for why this re-check follows `ares_process_fd`.
-            if !(*parent).any_requests_pending() {
-                (*parent).remove_timer();
-            }
-        }
-    }
-
-    #[cfg(windows)]
-    pub(crate) unsafe extern "C" fn on_close_uv(watcher: *mut libuv::uv_handle_t) {
-        // SAFETY: libuv invokes the close cb with the same handle pointer passed
-        // to `uv_close`, which was `&mut UvDnsPoll::poll` (a `uv_poll_t` whose
-        // header is `uv_handle_t`); `from_poll` recovers the containing struct.
-        let poll = UvDnsPoll::from_poll(watcher.cast());
-        UvDnsPoll::destroy(poll);
-    }
-
-    /// POSIX `FilePoll` callback (kqueue/epoll). Windows drives c-ares via
-    /// libuv (`on_dns_poll_uv`) instead, and the only caller
-    /// (`dispatch::__bun_run_file_poll`) is itself `#[cfg(not(windows))]`.
+    /// POSIX `FilePoll` callback (kqueue/epoll) for the c-ares socket `fd`.
+    /// Windows drives c-ares via libuv (`UvDnsPoll::on_poll`) instead.
     ///
-    /// R-2: `&self` (no `noalias`). `Channel::process` (== `ares_process_fd`)
-    /// synchronously fires c-ares completion callbacks which re-enter this
-    /// Resolver via a fresh `&Resolver` (e.g. `request_completed`,
-    /// `drain_pending_*`, `ref_`/`deref`). With every mutable field
-    /// UnsafeCell-backed, LLVM cannot cache `ref_count` across the FFI call —
-    /// the structural fix for the previously ASM-verified PROVEN_CACHED
-    /// miscompile that needed `black_box` laundering under `&mut self`.
+    /// `Channel::process` (== `ares_process_fd`) synchronously fires c-ares
+    /// completion callbacks which re-enter this Resolver (`request_completed`,
+    /// `drain_pending_*`, releasing refs).
     #[cfg(not(windows))]
-    pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll) {
-        let vm = self.vm();
-        let _exit = vm.enter_event_loop_scope();
-        let Some(channel) = self.channel.get() else {
-            self.polls.with_mut(|p| {
-                let _ = p.remove(&poll.fd.native());
-            });
-            poll.deinit();
-            return;
-        };
-
-        let _guard = self.ref_guard();
-
-        // SAFETY: `channel` is the live c-ares channel owned by `self`; no `&mut`
-        // to `*self` is held across this re-entrant call (all fields are
-        // UnsafeCell-backed).
-        unsafe {
-            (*channel).process(poll.fd.native(), poll.is_readable(), poll.is_writable());
-        }
-
-        // c-ares detaches a query only *after* its callback returns, so
-        // `request_completed` may have seen it still counted; re-check now.
-        if !self.any_requests_pending() {
-            self.remove_timer();
-        }
-    }
-
-    pub(crate) fn on_dns_socket_state(
-        &self,
+    pub(crate) fn on_dns_poll(
+        this: ThisPtr<Self>,
         fd: c_ares::ares_socket_t,
         readable: bool,
         writable: bool,
     ) {
-        #[cfg(windows)]
-        {
-            use libuv as uv;
-            if !readable && !writable {
-                // cleanup — `remove` is the ordered, value-returning variant.
-                if let Some(entry) = self.polls.with_mut(|p| p.remove(&fd)) {
-                    // SAFETY: `entry` is the heap `UvDnsPoll` we inserted below;
-                    // libuv takes ownership of the handle until `on_close_uv`
-                    // frees the allocation.
-                    unsafe {
-                        uv::uv_close(
-                            core::ptr::from_mut(&mut (*entry).poll).cast(),
-                            Some(Self::on_close_uv),
-                        )
-                    };
-                }
-                return;
-            }
-
-            // Capture `self` as a raw backref for `UvDnsPoll::parent`.
-            let this_ptr: *mut Self = self.as_ctx_ptr();
-            // SAFETY: single-JS-thread; the `&mut PollsMap` borrow does not span
-            // any re-entrant call (libuv `uv_poll_*` below do not call back into
-            // this resolver synchronously).
-            let polls = unsafe { self.polls.get_mut() };
-            let poll_entry = bun_core::handle_oom(polls.get_or_put(fd));
-            let poll: *mut UvDnsPoll = if poll_entry.found_existing {
-                *poll_entry.value_ptr
-            } else {
-                let new_poll = UvDnsPoll::new(this_ptr, fd);
-                // Publish into the map first so the `GetOrPutResult` borrow can
-                // end (NLL) before we may need to `swap_remove` on init failure.
-                *poll_entry.value_ptr = new_poll;
-                // SAFETY: `Loop::get()` is the live per-thread uws loop;
-                // `new_poll` is a fresh heap allocation with a zeroed `uv_poll_t`.
-                if unsafe {
-                    uv::uv_poll_init_socket((*Loop::get()).uv_loop, &mut (*new_poll).poll, fd as _)
-                } < 0
-                {
-                    UvDnsPoll::destroy(new_poll);
-                    let _ = polls.swap_remove(&fd);
-                    return;
-                }
-                new_poll
-            };
-
-            let uv_events = (if readable { uv::UV_READABLE } else { 0 })
-                | (if writable { uv::UV_WRITABLE } else { 0 });
-            // SAFETY: `poll` is the live entry just inserted/looked up above.
-            if unsafe {
-                uv::uv_poll_start(&mut (*poll).poll, uv_events, Some(Self::on_dns_poll_uv))
-            } < 0
-            {
-                let _ = polls.swap_remove(&fd);
-                // SAFETY: handle was successfully `uv_poll_init_socket`-ed, so
-                // `uv_close` is the required teardown path; `on_close_uv` frees
-                // the `UvDnsPoll` box.
-                unsafe {
-                    uv::uv_close(
-                        core::ptr::from_mut(&mut (*poll).poll).cast(),
-                        Some(Self::on_close_uv),
-                    )
-                };
-            }
+        let vm = this.vm();
+        let _exit = vm.enter_event_loop_scope();
+        if this.channel.get().is_none() {
+            drop(this.polls.with_mut(|p| p.remove(&fd)));
+            return;
         }
-        #[cfg(not(windows))]
-        {
-            let ctx = js_event_loop_ctx();
 
-            if !readable && !writable {
-                // read == 0 and write == 0 this is c-ares's way of notifying us that
-                // the socket is now closed. We must free the data associated with
-                // socket.
-                if let Some(value) = self.polls.with_mut(|p| p.remove(&fd)) {
-                    // SAFETY: `value` is the heap-allocated FilePoll for this fd.
-                    unsafe { (*value).deinit_with_vm(ctx) };
-                }
-                return;
+        let _guard = this.ref_guard();
+
+        if let Some(channel) = this.channel.get().as_deref() {
+            channel.process(fd, readable, writable);
+        }
+
+        // c-ares detaches a query only *after* its callback returns, so
+        // `request_completed` may have seen it still counted; re-check now.
+        if !this.any_requests_pending() {
+            Self::remove_timer(this);
+        }
+    }
+
+    #[cfg(windows)]
+    fn on_dns_socket_state(
+        this: ThisPtr<Self>,
+        fd: c_ares::ares_socket_t,
+        readable: bool,
+        writable: bool,
+    ) {
+        if !readable && !writable {
+            // cleanup — dropping the poll `uv_close`s it; libuv frees it in
+            // the close callback.
+            drop(this.polls.with_mut(|p| p.remove(&fd)));
+            return;
+        }
+
+        let uv_loop = this.vm().uv_loop();
+        this.polls.with_mut(|polls| {
+            if !polls.contains(&fd) {
+                let data = UvDnsPoll {
+                    parent: BackRef::from(this),
+                    socket: fd,
+                };
+                let Ok(poll) = libuv::SocketPoll::init(uv_loop, fd as libuv::uv_os_sock_t, data)
+                else {
+                    return;
+                };
+                bun_core::handle_oom(polls.put(fd, poll));
             }
+            let poll = polls.get(&fd).expect("inserted above");
 
-            let owner = Async::Owner::new(
-                Async::posix_event_loop::poll_tag::DNS_RESOLVER,
-                self.as_ctx_ptr().cast::<()>(),
-            );
-            // SAFETY: `event_loop_handle` is set once VM is initialized; live for VM lifetime.
-            let loop_ = unsafe { &mut *self.vm().event_loop_handle.unwrap() };
-            // SAFETY: single-JS-thread; the `&mut PollsMap` borrow does not span
-            // any re-entrant call (`FilePoll::register` is a syscall wrapper).
-            let polls = unsafe { self.polls.get_mut() };
-            let poll_entry = polls.get_or_put(fd).expect("unreachable");
-
-            if !poll_entry.found_existing {
-                *poll_entry.value_ptr =
-                    FilePoll::init(ctx, sys::Fd::from_native(fd), Default::default(), owner);
+            let uv_events = (if readable { libuv::UV_READABLE } else { 0 })
+                | (if writable { libuv::UV_WRITABLE } else { 0 });
+            if poll.start(uv_events) < 0 {
+                // Dropping the poll is the required `uv_close` teardown.
+                let _ = polls.swap_remove(&fd);
             }
+        });
+    }
 
-            // SAFETY: `value_ptr` points at a slot just initialized above (or a
-            // previously-initialized live FilePoll hive slot); JS-thread exclusive.
-            let poll = unsafe { &mut **poll_entry.value_ptr };
+    #[cfg(not(windows))]
+    fn on_dns_socket_state(
+        this: ThisPtr<Self>,
+        fd: c_ares::ares_socket_t,
+        readable: bool,
+        writable: bool,
+    ) {
+        let ctx = js_event_loop_ctx();
+
+        if !readable && !writable {
+            // read == 0 and write == 0 this is c-ares's way of notifying us that
+            // the socket is now closed. We must free the data associated with
+            // socket.
+            drop(this.polls.with_mut(|p| p.remove(&fd)));
+            return;
+        }
+
+        let owner = Async::Owner::new(
+            Async::posix_event_loop::poll_tag::DNS_RESOLVER,
+            this.as_ptr().cast::<()>(),
+        );
+        // The `&mut PollsMap` borrow does not span any re-entrant call
+        // (`FilePoll::register` is a syscall wrapper).
+        this.polls.with_mut(|polls| {
+            if !polls.contains(&fd) {
+                let poll = OwnedFilePoll::new(
+                    ctx,
+                    bun_sys::Fd::from_native(fd),
+                    Default::default(),
+                    owner,
+                );
+                bun_core::handle_oom(polls.put(fd, poll));
+            }
+            let poll = polls.get_mut(&fd).expect("inserted above");
 
             // c-ares reports the full desired (readable, writable) set for this
             // fd; sync the poll's registration to match. FilePoll now supports
@@ -4940,12 +3323,12 @@ impl Resolver {
                 // direction armed would busy-loop on level-triggered writable
                 // once the socket connects. Full resync is the simplest
                 // correct path and c-ares DNS fds are short-lived.
-                let _ = poll.unregister(loop_, false);
+                let _ = poll.unregister_on(ctx, false);
                 if readable {
-                    let _ = poll.register(loop_, Async::PollKind::Readable, false);
+                    let _ = poll.register_on(ctx, Async::PollKind::Readable, false);
                 }
                 if writable {
-                    let _ = poll.register(loop_, Async::PollKind::Writable, false);
+                    let _ = poll.register_on(ctx, Async::PollKind::Writable, false);
                 }
             } else {
                 // Only adding directions (or no change). register() issues a
@@ -4953,30 +3336,27 @@ impl Resolver {
                 // on kqueue EV_ADD creates a separate (ident, filter) knote
                 // without disturbing the existing one.
                 if readable && !have_readable {
-                    let _ = poll.register(loop_, Async::PollKind::Readable, false);
+                    let _ = poll.register_on(ctx, Async::PollKind::Readable, false);
                 }
                 if writable && !have_writable {
-                    let _ = poll.register(loop_, Async::PollKind::Writable, false);
+                    let _ = poll.register_on(ctx, Async::PollKind::Writable, false);
                 }
             }
-        }
+        });
     }
 
     // ───────────── JS host fns: resolve* family ─────────────
 
-    // JSC-ABI shim for this associated fn is emitted by `export_host_fn!` at
-    // module scope; `#[host_fn]` cannot be used here because its Free expansion
-    // calls the function by bare name, which doesn't resolve inside `impl`.
-    pub(crate) fn global_resolve(
+    pub fn global_resolve(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        global_resolver(global_this).resolve(global_this, callframe)
+        Self::resolve(global_resolver(global_this), global_this, callframe)
     }
 
     #[host_fn(method)]
-    pub(crate) fn resolve(
-        &self,
+    pub fn resolve(
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -5030,48 +3410,65 @@ impl Resolver {
         }
 
         match record_type {
-            RecordType::A => self.do_resolve_cares::<AHostentWithTtls>(name.slice(), global_this),
+            RecordType::A => {
+                Self::do_resolve_cares::<AHostentWithTtls>(this, name.slice(), global_this)
+            }
             RecordType::AAAA => {
-                self.do_resolve_cares::<AaaaHostentWithTtls>(name.slice(), global_this)
+                Self::do_resolve_cares::<AaaaHostentWithTtls>(this, name.slice(), global_this)
             }
             RecordType::ANY => {
-                self.do_resolve_cares::<c_ares::struct_any_reply>(name.slice(), global_this)
+                Self::do_resolve_cares::<c_ares::struct_any_reply>(this, name.slice(), global_this)
             }
-            RecordType::CAA => {
-                self.do_resolve_cares::<c_ares::struct_ares_caa_reply>(name.slice(), global_this)
+            RecordType::CAA => Self::do_resolve_cares::<c_ares::struct_ares_caa_reply>(
+                this,
+                name.slice(),
+                global_this,
+            ),
+            RecordType::CNAME => {
+                Self::do_resolve_cares::<CnameHostent>(this, name.slice(), global_this)
             }
-            RecordType::CNAME => self.do_resolve_cares::<CnameHostent>(name.slice(), global_this),
-            RecordType::MX => {
-                self.do_resolve_cares::<c_ares::struct_ares_mx_reply>(name.slice(), global_this)
+            RecordType::MX => Self::do_resolve_cares::<c_ares::struct_ares_mx_reply>(
+                this,
+                name.slice(),
+                global_this,
+            ),
+            RecordType::NAPTR => Self::do_resolve_cares::<c_ares::struct_ares_naptr_reply>(
+                this,
+                name.slice(),
+                global_this,
+            ),
+            RecordType::NS => Self::do_resolve_cares::<NsHostent>(this, name.slice(), global_this),
+            RecordType::PTR => {
+                Self::do_resolve_cares::<PtrHostent>(this, name.slice(), global_this)
             }
-            RecordType::NAPTR => {
-                self.do_resolve_cares::<c_ares::struct_ares_naptr_reply>(name.slice(), global_this)
-            }
-            RecordType::NS => self.do_resolve_cares::<NsHostent>(name.slice(), global_this),
-            RecordType::PTR => self.do_resolve_cares::<PtrHostent>(name.slice(), global_this),
-            RecordType::SOA => {
-                self.do_resolve_cares::<c_ares::struct_ares_soa_reply>(name.slice(), global_this)
-            }
-            RecordType::SRV => {
-                self.do_resolve_cares::<c_ares::struct_ares_srv_reply>(name.slice(), global_this)
-            }
-            RecordType::TXT => {
-                self.do_resolve_cares::<c_ares::struct_ares_txt_reply>(name.slice(), global_this)
-            }
+            RecordType::SOA => Self::do_resolve_cares::<c_ares::struct_ares_soa_reply>(
+                this,
+                name.slice(),
+                global_this,
+            ),
+            RecordType::SRV => Self::do_resolve_cares::<c_ares::struct_ares_srv_reply>(
+                this,
+                name.slice(),
+                global_this,
+            ),
+            RecordType::TXT => Self::do_resolve_cares::<c_ares::struct_ares_txt_reply>(
+                this,
+                name.slice(),
+                global_this,
+            ),
         }
     }
 
-    // JSC-ABI shim emitted by `export_host_fn!` at module scope (see `global_resolve`).
-    pub(crate) fn global_reverse(
+    pub fn global_reverse(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        global_resolver(global_this).reverse(global_this, callframe)
+        Self::reverse(global_resolver(global_this), global_this, callframe)
     }
 
     #[host_fn(method)]
-    pub(crate) fn reverse(
-        &self,
+    pub fn reverse(
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -5096,9 +3493,9 @@ impl Resolver {
         }
 
         let ip = ip_slice.slice();
-        let channel: *mut c_ares::Channel = match self.get_channel() {
-            ChannelResult::Result(res) => res,
-            ChannelResult::Err(err) => {
+        let channel = match Self::get_channel(&this) {
+            Ok(res) => res,
+            Err(err) => {
                 return Err(global_this.throw_value(
                     super::cares_jsc::error_to_js_with_syscall_and_hostname(
                         err,
@@ -5110,40 +3507,26 @@ impl Resolver {
             }
         };
 
-        let key = get_host_by_addr_info_request::PendingCacheKey::init(ip);
-        let cache = self.get_or_put_into_resolve_pending_cache::<GetHostByAddrInfoRequest>(
-            &key,
-            PendingCacheField::PendingAddrCacheCares,
-        );
-        if let LookupCacheHit::Inflight(inflight) = cache {
-            let cares_reverse = CAresReverse::init(Some(self.as_ctx_ptr()), global_this, ip);
-            // SAFETY: `inflight` points into the resolver's pending-cache HiveArray slot.
-            unsafe { (*inflight).append(cares_reverse) };
-            // SAFETY: `cares_reverse` was just heap-allocated; owned by the inflight list.
-            return Ok(unsafe { (*cares_reverse).promise.value() });
+        let key = PendingCacheKey::from_name(ip);
+        let cache = this.pending_addr_cache_cares.get_or_put(&key);
+        if let CacheHit::Inflight(inflight) = cache {
+            let cares_reverse = CAresReverse::init(Some(this), global_this, ip);
+            let promise = cares_reverse.promise.value();
+            this.pending_addr_cache_cares
+                .append(inflight, cares_reverse);
+            return Ok(promise);
         }
 
-        let request =
-            GetHostByAddrInfoRequest::init(cache, Some(self.as_ctx_ptr()), ip, global_this);
+        let request = GetHostByAddrInfoRequest::init(cache, Some(this), ip, global_this);
 
-        // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
-        let promise = unsafe { (*(*request).tail).promise.value() };
-        // SAFETY: `request` is the heap-allocated GetHostByAddrInfoRequest; channel
-        // stores it as the c-ares ctx and calls back via HostentHandler::on_hostent.
-        unsafe {
-            (*channel).get_host_by_addr(ip, &mut *request);
-        }
+        let promise = request.head.promise.value();
+        channel.get_host_by_addr(ip, request);
 
-        // SAFETY: `bun_vm()` returns the live VM back-ptr.
-        self.request_sent(global_this.bun_vm());
+        Self::request_sent(this, global_this.bun_vm());
         Ok(promise)
     }
 
-    // JSC-ABI shim emitted by `export_host_fn!` at module scope (see `global_resolve`).
-    pub(crate) fn global_lookup(
-        global_this: &JSGlobalObject,
-        callframe: &CallFrame,
-    ) -> JsResult<JSValue> {
+    pub fn global_lookup(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments_as_array::<2>();
         let arguments_len = callframe.arguments_count() as usize;
         if arguments_len < 1 {
@@ -5198,17 +3581,22 @@ impl Resolver {
 
         let resolver = global_resolver(global_this);
 
-        resolver.do_lookup(name.slice(), port, options, global_this)
+        Self::do_lookup(resolver, name.slice(), port, options, global_this)
     }
 
     pub(crate) fn do_lookup(
-        &self,
+        this: ThisPtr<Self>,
         name: &[u8],
         port: u16,
         options: GetAddrInfoOptions,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        if !bun_dns::is_valid_hostname(name) {
+        // The system backends copy the hostname into a NUL-terminated buffer.
+        // Reject anything that cannot fit a `bun.PathBuffer` (the historical
+        // bound) or embeds a NUL. RFC 1035 caps hostnames at 253 octets and
+        // NI_MAXHOST is 1025, so this never rejects a name that could have
+        // resolved.
+        if name.len() >= MAX_PATH_BYTES || strings::contains_char(name, 0) {
             let mut promise = JSPromiseStrong::init(global_this);
             let promise_value = promise.value();
             error_to_deferred(
@@ -5233,30 +3621,30 @@ impl Resolver {
 
         Ok(match opts.backend {
             GetAddrInfoBackend::CAres => {
-                self.c_ares_lookup_with_normalized_name(&query, global_this)?
+                Self::c_ares_lookup_with_normalized_name(this, &query, global_this)?
             }
             GetAddrInfoBackend::Libc => {
                 #[cfg(windows)]
                 {
-                    lib_uv_backend::lookup(self, query, global_this)?
+                    lib_uv_backend::lookup(this, query, global_this)?
                 }
                 #[cfg(not(windows))]
                 {
-                    lib_c::lookup(self, &query, global_this)
+                    lib_c::lookup(this, &query, global_this)
                 }
             }
             GetAddrInfoBackend::System => {
                 #[cfg(target_os = "macos")]
                 {
-                    dns_sd::lookup(self, &query, global_this)
+                    dns_sd::lookup(this, &query, global_this)
                 }
                 #[cfg(windows)]
                 {
-                    lib_uv_backend::lookup(self, query, global_this)?
+                    lib_uv_backend::lookup(this, query, global_this)?
                 }
                 #[cfg(all(not(target_os = "macos"), not(windows)))]
                 {
-                    lib_c::lookup(self, &query, global_this)
+                    lib_c::lookup(this, &query, global_this)
                 }
             }
         })
@@ -5268,14 +3656,13 @@ impl Resolver {
 
 macro_rules! resolve_record_fn {
     ($global:ident, $method:ident, $jsname:literal, $ty:ty, $allow_empty:expr) => {
-        // JSC-ABI shim emitted by `export_host_fn!` at module scope (see `global_resolve`).
         pub fn $global(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-            global_resolver(global_this).$method(global_this, callframe)
+            Self::$method(global_resolver(global_this), global_this, callframe)
         }
 
         #[host_fn(method)]
         pub fn $method(
-            &self,
+            this: ThisPtr<Self>,
             global_this: &JSGlobalObject,
             callframe: &CallFrame,
         ) -> JsResult<JSValue> {
@@ -5297,26 +3684,52 @@ macro_rules! resolve_record_fn {
                     "non-empty string",
                 ));
             }
-            self.do_resolve_cares::<$ty>(name.slice(), global_this)
+            Self::do_resolve_cares::<$ty>(this, name.slice(), global_this)
         }
     };
 }
 
-// `c_ares::Channel::init` requires this to wire the socket-state callback and
-// hand the allocated channel pointer back into `self.channel`.
-impl c_ares::ChannelContainer for Resolver {
+// `c_ares::Channel::init` reports socket-state changes here.
+impl c_ares::ChannelOwner for Resolver {
     #[inline]
-    fn on_dns_socket_state(&self, socket: c_ares::ares_socket_t, readable: bool, writable: bool) {
-        Resolver::on_dns_socket_state(self, socket, readable, writable);
+    fn on_socket_state(
+        this: ThisPtr<Self>,
+        socket: c_ares::ares_socket_t,
+        readable: bool,
+        writable: bool,
+    ) {
+        Resolver::on_dns_socket_state(this, socket, readable, writable);
     }
-    #[inline]
-    fn set_channel(&self, channel: *mut c_ares::Channel) {
-        self.channel.set(Some(channel));
-        // A live channel has sockets, timers and queries in flight whose
-        // callbacks need this VM: the stop phase closes it (any resolver, not
-        // just the VM-global one) if nobody did before. Unregistered in
-        // `destroy_channel`.
-        crate::jsc_hooks::ActiveHandle::DnsResolver(core::ptr::NonNull::from(self)).register();
+}
+
+#[cfg(windows)]
+impl libuv::SocketPollHandler for UvDnsPoll {
+    fn on_poll(data: &Self, status: c_int, events: c_int) {
+        let parent = data.parent.this_ptr();
+        let socket = data.socket;
+        let vm = parent.vm.get();
+        let _exit = vm.enter_event_loop_scope();
+        // Kept alive across `Channel::process` (which re-enters and may
+        // release refs) by the guard.
+        let _guard = parent.ref_guard();
+        // channel must be non-null here as c_ares must have been initialized if we're receiving callbacks
+        let channel = parent.channel.get().as_deref().expect("c-ares channel");
+        if status < 0 {
+            // an error occurred. just pretend that the socket is both readable and writable.
+            // https://github.com/nodejs/node/blob/8a41d9b636be86350cd32847c3f89d327c4f6ff7/src/cares_wrap.cc#L93
+            channel.process(socket, true, true);
+        } else {
+            channel.process(
+                socket,
+                events & libuv::UV_READABLE != 0,
+                events & libuv::UV_WRITABLE != 0,
+            );
+        }
+
+        // See `on_dns_poll` for why this re-check follows `ares_process_fd`.
+        if !parent.any_requests_pending() {
+            Resolver::remove_timer(parent);
+        }
     }
 }
 
@@ -5326,12 +3739,11 @@ impl Resolver {
     /// request's ref on this resolver) and closes the channel's sockets.
     /// Returns whether there was a channel.
     fn destroy_channel(&self) -> bool {
-        let Some(channel) = self.channel.take() else {
+        let Some(channel) = self.channel.replace(None) else {
             return false;
         };
         crate::jsc_hooks::ActiveHandle::DnsResolver(core::ptr::NonNull::from(self)).unregister();
-        // SAFETY: `channel` is the live handle from `ares_init_options`, owned by this resolver.
-        unsafe { c_ares::Channel::destroy(channel) };
+        drop(channel);
         true
     }
 }
@@ -5403,14 +3815,13 @@ impl Resolver {
     );
 
     pub(crate) fn do_resolve_cares<T: CAresRecordType>(
-        &self,
+        this: ThisPtr<Self>,
         name: &[u8],
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        let channel: *mut c_ares::Channel = match self.get_channel() {
-            ChannelResult::Result(res) => res,
-            ChannelResult::Err(err) => {
-                // syscall = "query" + ucfirst(TYPE_NAME) — precomputed per record type.
+        let channel = match Self::get_channel(&this) {
+            Ok(res) => res,
+            Err(err) => {
                 return Err(
                     global_this.throw_value(super::cares_jsc::error_to_js_with_syscall(
                         err,
@@ -5421,50 +3832,34 @@ impl Resolver {
             }
         };
 
-        let cache_field = T::CACHE_FIELD; // "pending_{TYPE_NAME}_cache_cares"
+        let key = PendingCacheKey::from_name(name);
 
-        let key = resolve_info_request::PendingCacheKey::<T>::init(name);
-
-        let cache =
-            self.get_or_put_into_resolve_pending_cache::<ResolveInfoRequest<T>>(&key, cache_field);
-        if let LookupCacheHit::Inflight(inflight) = cache {
-            // CAresLookup will have the name ownership
-            let cares_lookup = CAresLookup::<T>::init(Some(self.as_ctx_ptr()), global_this, name);
-            // SAFETY: `inflight` points into the resolver's pending-cache HiveArray slot.
-            unsafe { (*inflight).append(cares_lookup) };
-            // SAFETY: `cares_lookup` was just heap-allocated; owned by the inflight list.
-            return Ok(unsafe { (*cares_lookup).promise.value() });
+        let pending = T::pending_cache(&this);
+        let cache = pending.get_or_put(&key);
+        if let CacheHit::Inflight(inflight) = cache {
+            let cares_lookup = CAresLookup::<T>::init(Some(this), global_this, name);
+            let promise = cares_lookup.promise.value();
+            pending.append(inflight, cares_lookup);
+            return Ok(promise);
         }
 
-        let request = ResolveInfoRequest::<T>::init(
-            cache,
-            Some(self.as_ctx_ptr()),
-            name, // CAresLookup will have the ownership
-            global_this,
-            cache_field,
-        );
-        // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
-        let promise = unsafe { (*(*request).tail).promise.value() };
+        let request = ResolveInfoRequest::<T>::init(cache, Some(this), name, global_this);
+        let promise = request.head.promise.value();
 
-        // SAFETY: `channel` is the live c-ares channel owned by `self`; `request`
-        // is the freshly heap-allocated ResolveInfoRequest. c-ares stores the ctx
-        // pointer and calls `T::RAW_CALLBACK` (→ `on_cares_complete`) which
-        // consumes the request, so the `&mut` borrow is not held past this call.
-        unsafe { (*channel).resolve(name, &mut *request) };
+        channel.query(name, request);
 
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        self.request_sent(global_this.bun_vm());
+        Self::request_sent(this, global_this.bun_vm());
         Ok(promise)
     }
 
     pub(crate) fn c_ares_lookup_with_normalized_name(
-        &self,
+        this: ThisPtr<Self>,
         query: &GetAddrInfo,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        let channel: *mut c_ares::Channel = match self.get_channel() {
-            ChannelResult::Result(res) => res,
-            ChannelResult::Err(err) => {
+        let channel = match Self::get_channel(&this) {
+            Ok(res) => res,
+            Err(err) => {
                 let syscall = bun_core::String::create_atom(&query.name);
                 let system_error = SystemError {
                     errno: -1,
@@ -5477,72 +3872,52 @@ impl Resolver {
             }
         };
 
-        let key = get_addr_info_request::PendingCacheKey::init(query);
+        let key = PendingCacheKey::init(query);
 
-        let cache =
-            self.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheCares);
+        let pending = this.pending_host_cache(PendingCacheField::PendingHostCacheCares);
+        let cache = pending.get_or_put(&key);
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(self.as_ctx_ptr(), global_this);
-            // SAFETY: `inflight` points into the resolver's pending-cache HiveArray slot.
-            unsafe { (*inflight).append(dns_lookup) };
-            // SAFETY: `dns_lookup` was just heap-allocated; owned by the inflight list.
-            return Ok(unsafe { (*dns_lookup).promise.value() });
+            let dns_lookup = DNSLookup::init(Some(this), global_this);
+            let promise = dns_lookup.promise.value();
+            pending.append(inflight, dns_lookup);
+            return Ok(promise);
         }
 
         let hints_buf = [query.to_cares()];
         let request = GetAddrInfoRequest::init(
             cache,
             get_addr_info_request::Backend::CAres,
-            Some(self.as_ctx_ptr()),
+            Some(this),
             global_this,
-            PendingCacheField::PendingHostCacheCares,
         );
-        // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
-        let promise = unsafe { (*(*request).tail).promise.value() };
+        let promise = request.head.promise.value();
 
-        // SAFETY: `channel` is the live c-ares channel owned by `self`; `request`
-        // is the freshly heap-allocated GetAddrInfoRequest. c-ares stores the ctx
-        // pointer and calls `AddrInfo::callback_wrapper::<GetAddrInfoRequest>`
-        // (→ `on_cares_complete`) which consumes the request, so the `&mut`
-        // borrow is not held past this call.
-        unsafe { (*channel).get_addr_info(&query.name, query.port, &hints_buf, &mut *request) };
+        channel.get_addr_info(&query.name, query.port, &hints_buf, request);
 
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        self.request_sent(global_this.bun_vm());
+        Self::request_sent(this, global_this.bun_vm());
         Ok(promise)
     }
 
     // ───────── servers / local address ─────────
 
     fn get_channel_servers(
-        channel: *mut c_ares::Channel,
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let mut servers: *mut c_ares::struct_ares_addr_port_node = ptr::null_mut();
-        // SAFETY: `channel` is a live handle from `ares_init_options`; `servers` is a stack out-param.
-        let r = unsafe { c_ares::ares_get_servers_ports(channel, &raw mut servers) };
-        if r != c_ares::ARES_SUCCESS {
-            let err = c_ares::Error::get(r).unwrap();
-            return Err(
-                global_this.throw_value(global_this.create_error_instance(format_args!(
-                    "ares_get_servers_ports error: {}",
-                    err.label()
-                ))),
-            );
-        }
-        scopeguard::defer! {
-            // SAFETY: `servers` was allocated by ares_get_servers_ports; ares_free_data is its deallocator.
-            unsafe { c_ares::ares_free_data(servers.cast()) }
+        let channel = Self::get_channel_or_error(&this, global_this)?;
+        let servers = match channel.servers() {
+            Ok(servers) => servers,
+            Err(err) => {
+                return Err(global_this.throw_value(global_this.create_error_instance(
+                    format_args!("ares_get_servers_ports error: {}", err.label()),
+                )));
+            }
         };
 
         let values = JSValue::create_empty_array(global_this, 0)?;
 
-        let mut i: u32 = 0;
-        let mut cur = servers;
-        while !cur.is_null() {
-            // SAFETY: `cur` is non-null (loop guard) and walks the c-ares-allocated list.
-            let current = unsafe { &*cur };
+        for (i, current) in (0u32..).zip(servers.as_deref().into_iter().flat_map(|s| s.iter())) {
             // Formatting reference: https://nodejs.org/api/dns.html#dnsgetservers
             // Brackets '[' and ']' consume 2 bytes, used for IPv6 format (e.g., '[2001:4860:4860::8888]:1053').
             // Port range is 6 bytes (e.g., ':65535').
@@ -5550,10 +3925,7 @@ impl Resolver {
             let mut buf = [0u8; INET6_ADDRSTRLEN + 2 + 6 + 1];
             let family = current.family;
 
-            let addr_ptr: *const c_void = current.addr_ptr();
-            // SAFETY: `addr_ptr` type-erases the in_addr/in6_addr union arm (read-only);
-            // `dst` is the stack buffer slice starting at [1].
-            let Some(ip) = (unsafe { bun_cares_sys::ntop(family, addr_ptr, &mut buf[1..]) }) else {
+            let Some(ip_len) = current.ip_text(&mut buf[1..]).map(<[u8]>::len) else {
                 return Err(global_this.throw_value(global_this.create_error_instance(
                     format_args!(
                         "ares_inet_ntop error: no more space to convert a network format address"
@@ -5570,13 +3942,15 @@ impl Resolver {
             }
 
             // size = strlen(buf+1) + 1
-            let size = ip.len() + 1;
+            let size = ip_len + 1;
+            // The formatted bytes here are pure ASCII (IP address + optional
+            // port) — borrow as a `bun_core::String` and hand to JS.
             use jsc::StringJsc as _;
             if port == IANA_DNS_PORT {
                 values.put_index(
                     global_this,
                     i,
-                    bun_string_jsc::create_utf8_for_js(global_this, &buf[1..size])?,
+                    bun_core::String::borrow_utf8(&buf[1..size]).to_js(global_this)?,
                 )?;
             } else if family == netc::AF_INET6 {
                 buf[0] = b'[';
@@ -5605,20 +3979,15 @@ impl Resolver {
                 values.put_index(
                     global_this,
                     i,
-                    bun_string_jsc::create_utf8_for_js(global_this, &buf[1..size + port_len])?,
+                    bun_core::String::borrow_utf8(&buf[1..size + port_len]).to_js(global_this)?,
                 )?;
             }
-
-            i += 1;
-            cur = current.next;
         }
 
         Ok(values)
     }
 
-    // FFI shim emitted by `export_host_fn!` below — `#[host_fn]` (Free) cannot
-    // expand inside an `impl` block (it emits a bare `fn_name(...)` call).
-    pub(crate) fn get_global_servers(
+    pub fn get_global_servers(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -5630,33 +3999,26 @@ impl Resolver {
     }
 
     #[host_fn(method)]
-    pub(crate) fn get_servers(
-        &self,
+    pub fn get_servers(
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        Self::get_channel_servers(
-            self.get_channel_or_error(global_this)?,
-            global_this,
-            callframe,
-        )
+        Self::get_channel_servers(this, global_this, callframe)
     }
 
     #[host_fn(method)]
-    pub(crate) fn set_local_address(
-        &self,
+    pub fn set_local_address(
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        Self::set_channel_local_addresses(
-            self.get_channel_or_error(global_this)?,
-            global_this,
-            callframe,
-        )
+        let channel = Self::get_channel_or_error(&this, global_this)?;
+        Self::set_channel_local_addresses(channel, global_this, callframe)
     }
 
     fn set_channel_local_addresses(
-        channel: *mut c_ares::Channel,
+        channel: &c_ares::Channel,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -5687,36 +4049,23 @@ impl Resolver {
     }
 
     fn set_channel_local_address(
-        channel: *mut c_ares::Channel,
+        channel: &c_ares::Channel,
         global_this: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<c_int> {
-        let address = value.to_bun_string(global_this)?.to_owned_slice_z();
+        let str_ = value.to_slice(global_this)?;
+        let text = bun::ZBox::from_bytes(str_.slice());
 
         let mut addr = [0u8; 16];
 
-        // SAFETY: FFI; `address` is NUL-terminated; `addr` is a 16-byte stack buffer.
-        if unsafe {
-            c_ares::ares_inet_pton(c_ares::AF::INET, address.as_ptr(), addr.as_mut_ptr().cast())
-        } == 1
-        {
+        if c_ares::inet_pton(c_ares::AF::INET, c_str(&text), &mut addr) == 1 {
             let ip = u32::from_be_bytes([addr[0], addr[1], addr[2], addr[3]]);
-            // SAFETY: `channel` is a live handle returned by `ares_init_options`.
-            c_ares::ares_set_local_ip4(unsafe { &mut *channel }, ip);
+            channel.set_local_ip4(ip);
             return Ok(c_ares::AF::INET);
         }
 
-        // SAFETY: FFI; `address` is NUL-terminated; `addr` is a 16-byte stack buffer.
-        if unsafe {
-            c_ares::ares_inet_pton(
-                c_ares::AF::INET6,
-                address.as_ptr(),
-                addr.as_mut_ptr().cast(),
-            )
-        } == 1
-        {
-            // SAFETY: `channel` is a live handle from `ares_init_options`; `addr` is the 16-byte in6_addr.
-            unsafe { c_ares::ares_set_local_ip6(channel, addr.as_ptr()) };
+        if c_ares::inet_pton(c_ares::AF::INET6, c_str(&text), &mut addr) == 1 {
+            channel.set_local_ip6(&addr);
             return Ok(c_ares::AF::INET6);
         }
 
@@ -5724,20 +4073,20 @@ impl Resolver {
             global_this,
             format_args!(
                 "Invalid IP address: \"{}\"",
-                bstr::BStr::new(address.as_bytes())
+                bstr::BStr::new(text.as_bytes())
             ),
         ))
     }
 
     fn set_channel_servers(
-        channel: *mut c_ares::Channel,
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
+        let channel = Self::get_channel_or_error(&this, global_this)?;
         // It's okay to call dns.setServers with active queries, but not dns.Resolver.setServers
-        if channel != Self::get_channel_from_vm(global_this)?
-            // SAFETY: `channel` is a live handle returned by `ares_init_options`.
-            && c_ares::ares_queue_active_queries(unsafe { &*channel }) != 0
+        if this.as_ptr() != Self::get_channel_from_vm(global_this)?.as_ptr()
+            && channel.active_queries() != 0
         {
             return Err(global_this
                 .err(
@@ -5760,10 +4109,7 @@ impl Resolver {
         let mut triples_iterator = argument.array_iterator(global_this)?;
 
         if triples_iterator.len == 0 {
-            // SAFETY: FFI; channel is a live initialized ares_channel; null clears the server list.
-            let r = unsafe { c_ares::ares_set_servers_ports(channel, ptr::null_mut()) };
-            if r != c_ares::ARES_SUCCESS {
-                let err = c_ares::Error::get(r).unwrap();
+            if let Err(err) = channel.set_servers(&mut []) {
                 return Err(global_this.throw_value(global_this.create_error_instance(
                     format_args!("ares_set_servers_ports error: {}", err.label()),
                 )));
@@ -5800,10 +4146,7 @@ impl Resolver {
                 .get_index(global_this, 1)?
                 .to_bun_string(global_this)?;
             let address_slice = address_string.to_owned_slice();
-
-            let mut address_buffer = vec![0u8; address_slice.len() + 1];
-            let _ = strings::copy(&mut address_buffer, &address_slice);
-            address_buffer[address_slice.len()] = 0;
+            let address_z = bun::ZBox::from_bytes(&address_slice);
 
             let af: c_int = if family == 4 {
                 netc::AF_INET
@@ -5811,19 +4154,8 @@ impl Resolver {
                 netc::AF_INET6
             };
 
-            let mut node: c_ares::struct_ares_addr_port_node = bun_core::ffi::zeroed();
-            node.next = ptr::null_mut();
-            node.family = af;
-            node.udp_port = port;
-            node.tcp_port = port;
-
-            let addr_dst: *mut c_void = node.addr_mut_ptr();
-            // SAFETY: FFI; `address_buffer` is NUL-terminated above; `addr_dst` points at the
-            // in_addr/in6_addr union (16 bytes — enough for in6_addr) with write provenance.
-            if unsafe {
-                c_ares::ares_inet_pton(af, address_buffer.as_ptr().cast::<c_char>(), addr_dst)
-            } != 1
-            {
+            let mut addr = [0u8; 16];
+            if c_ares::inet_pton(af, c_str(&address_z), &mut addr) != 1 {
                 return Err(jsc::Error::INVALID_IP_ADDRESS.throw(
                     global_this,
                     format_args!(
@@ -5833,20 +4165,12 @@ impl Resolver {
                 ));
             }
 
-            entries.push(node);
-        }
-        // Link the list AFTER the Vec is fully populated (no reallocs past this point).
-        for i in 1..entries.len() {
-            // Reshaped for borrowck — raw ptr to avoid two &mut into entries.
-            let next: *mut _ = &raw mut entries[i];
-            entries[i - 1].next = next;
+            entries.push(c_ares::struct_ares_addr_port_node::new(
+                af, &addr, port, port,
+            ));
         }
 
-        // SAFETY: FFI; channel is live; entries form a valid singly-linked list (next ptrs set above)
-        // and remain alive for the duration of the call (c-ares copies them internally).
-        let r = unsafe { c_ares::ares_set_servers_ports(channel, entries.as_mut_ptr()) };
-        if r != c_ares::ARES_SUCCESS {
-            let err = c_ares::Error::get(r).unwrap();
+        if let Err(err) = channel.set_servers(&mut entries) {
             return Err(
                 global_this.throw_value(global_this.create_error_instance(format_args!(
                     "ares_set_servers_ports error: {}",
@@ -5858,8 +4182,7 @@ impl Resolver {
         Ok(JSValue::UNDEFINED)
     }
 
-    // FFI shim emitted by `export_host_fn!` below.
-    pub(crate) fn set_global_servers(
+    pub fn set_global_servers(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -5871,64 +4194,52 @@ impl Resolver {
     }
 
     #[host_fn(method)]
-    pub(crate) fn set_servers(
-        &self,
+    pub fn set_servers(
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        Self::set_channel_servers(
-            self.get_channel_or_error(global_this)?,
-            global_this,
-            callframe,
-        )
+        Self::set_channel_servers(this, global_this, callframe)
     }
 
-    // FFI shim emitted by `export_host_fn!` below (JS2Native link name).
-    pub(crate) fn new_resolver(
-        global_this: &JSGlobalObject,
-        callframe: &CallFrame,
-    ) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        let resolver = Resolver::init(global_this.bun_vm());
+    pub fn new_resolver(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let resolver = RefPtr::new(Resolver::setup(global_this.bun_vm()));
 
         let options = callframe.argument(0);
         if options.is_object() {
-            // SAFETY: `resolver` is the heap allocation from `init`; not yet
-            // wrapped in JS so exclusively owned here.
-            let opts_cell = unsafe { &(*resolver).options };
-            let mut opts = opts_cell.get();
+            let mut opts = resolver.options.get();
             if let Some(timeout) = options.get_truthy(global_this, "timeout")? {
                 opts.timeout = Some(timeout.coerce_to_i32(global_this)?);
             }
             if let Some(tries) = options.get_truthy(global_this, "tries")? {
                 opts.tries = Some(tries.coerce_to_i32(global_this)?);
             }
-            opts_cell.set(opts);
+            resolver.options.set(opts);
         }
 
-        // SAFETY: `resolver` was `heap::alloc`'d in `Resolver::init`; ownership
-        // transfers to the GC wrapper (`DNSResolver__create` → `finalize` →
-        // `Self::deref` → `heap::take`).
-        Ok(unsafe { Resolver::to_js_ptr(resolver, global_this) })
+        // Ownership of the initial ref transfers to the GC wrapper
+        // (`DNSResolver__create` → `finalize`).
+        Ok(Resolver::to_js_nonnull(
+            core::ptr::NonNull::from(resolver.into_this_ptr()),
+            global_this,
+        ))
     }
 
     #[host_fn(method)]
-    pub(crate) fn cancel(
-        &self,
+    pub fn cancel(
+        this: ThisPtr<Self>,
         global_this: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let channel = self.get_channel_or_error(global_this)?;
-        // SAFETY: `channel` is a live handle returned by `ares_init_options`.
-        c_ares::ares_cancel(unsafe { &mut *channel });
+        let channel = Self::get_channel_or_error(&this, global_this)?;
+        channel.cancel();
         Ok(JSValue::UNDEFINED)
     }
 
     // Resolves the given address and port into a host name and service using the operating system's underlying getnameinfo implementation.
     // If address is not a valid IP address, a TypeError will be thrown. The port will be coerced to a number.
     // If it is not a legal port, a TypeError will be thrown.
-    // FFI shim emitted by `export_host_fn!` below.
-    pub(crate) fn global_lookup_service(
+    pub fn global_lookup_service(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -5960,24 +4271,13 @@ impl Resolver {
         let port_value = arguments[1];
         let port: u16 = port_value.to_port_number(global_this)?;
 
-        let mut sa: SockaddrStorage = bun_core::ffi::zeroed();
-        // SAFETY: sockaddr_storage is large enough to hold any sockaddr family
-        // get_sockaddr writes (in/in6); the `&mut *` reborrow yields a
-        // `&mut sockaddr` view into that storage.
-        if c_ares::get_sockaddr(addr_s, port, unsafe {
-            // Target type inferred from `get_sockaddr`'s signature: `libc::sockaddr`
-            // on POSIX, `bun_cares_sys::winsock::sockaddr` on Windows (the latter
-            // is crate-private, so it cannot be named here).
-            &mut *(&raw mut sa).cast()
-        }) != 0
-        {
+        let Some(sa) = c_ares::get_sockaddr(addr_s, port) else {
             return Err(global_this.throw_invalid_argument_value(b"address", addr_value));
-        }
+        };
 
         let resolver = global_resolver(global_this);
-        let channel = resolver.get_channel_or_error(global_this)?;
+        let channel = Self::get_channel_or_error(&resolver, global_this)?;
 
-        // This string will be freed in `CAresNameInfo.deinit`
         let mut cache_name = Vec::new();
         {
             use std::io::Write;
@@ -5986,53 +4286,34 @@ impl Resolver {
         }
         let cache_name: Box<[u8]> = cache_name.into_boxed_slice();
 
-        let key = get_name_info_request::PendingCacheKey::init(&cache_name);
-        let cache = resolver.get_or_put_into_resolve_pending_cache::<GetNameInfoRequest>(
-            &key,
-            PendingCacheField::PendingNameinfoCacheCares,
-        );
+        let key = PendingCacheKey::from_name(&cache_name);
+        let cache = resolver.pending_nameinfo_cache_cares.get_or_put(&key);
 
-        if let LookupCacheHit::Inflight(inflight) = cache {
+        if let CacheHit::Inflight(inflight) = cache {
             let info = CAresNameInfo::init(global_this, cache_name);
-            // SAFETY: `inflight` points into the resolver's pending-cache HiveArray slot.
-            unsafe { (*inflight).append(info) };
-            // SAFETY: `info` was just heap-allocated; owned by the inflight list.
-            return Ok(unsafe { (*info).promise.value() });
+            let promise = info.promise.value();
+            resolver.pending_nameinfo_cache_cares.append(inflight, info);
+            return Ok(promise);
         }
 
         let request = GetNameInfoRequest::init(
             cache,
-            Some(resolver.as_ctx_ptr()),
+            Some(resolver),
             cache_name, // transfer ownership here
             global_this,
-            PendingCacheField::PendingNameinfoCacheCares,
         );
 
-        // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
-        let promise = unsafe { (*(*request).tail).promise.value() };
-        // SAFETY: `channel` is the live c-ares channel; `sa` is a valid
-        // sockaddr_storage reborrowed as sockaddr; `request` was just
-        // `heap::alloc`'d and is owned by c-ares until the callback fires.
-        unsafe {
-            (*channel).get_name_info(
-                // See `get_sockaddr` call above — inferred `sockaddr` type is
-                // platform-dependent and unnameable on Windows from this crate.
-                &mut *(&raw mut sa).cast(),
-                &mut *request,
-            );
-        }
+        let promise = request.head.promise.value();
+        channel.get_name_info(&sa, request);
 
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
-        resolver.request_sent(global_this.bun_vm());
+        Self::request_sent(resolver, global_this.bun_vm());
         Ok(promise)
     }
 
-    // FFI shim emitted by `export_host_fn!` below (JS2Native link name).
-    pub(crate) fn get_runtime_default_result_order_option(
+    pub fn get_runtime_default_result_order_option(
         global_this: &JSGlobalObject,
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
         // `VirtualMachine.dns_result_order` is stored as a raw `u8` (the jsc
         // crate cannot depend on this crate's `Order`); cast through Order's repr(u8).
         let raw = global_this.bun_vm().as_mut().dns_result_order;
@@ -6045,76 +4326,156 @@ impl Resolver {
     }
 }
 
-// ───────── JS host-fn FFI exports ─────────
-// The #[host_fn] attribute emits the JSC-ABI shim under the Rust function name;
-// re-export each under its `Bun__DNS__*` link name. Mirrors the proc-macro's
-// shim body (see `bun_jsc_macros::host_fn`, `HostFnKind::Free`).
-macro_rules! export_host_fn {
-    ($scope:ident :: $f:ident, $name:literal) => {
-        const _: () = {
-            #[cfg(all(windows, target_arch = "x86_64"))]
-            #[unsafe(export_name = $name)]
-            pub(crate) unsafe extern "sysv64" fn __shim(
-                g: *mut ::bun_jsc::JSGlobalObject,
-                f: *mut ::bun_jsc::CallFrame,
-            ) -> ::bun_jsc::JSValue {
-                // SAFETY: JSC guarantees both pointers are live for the call.
-                let (g, f) = unsafe { (&*g, &*f) };
-                ::bun_jsc::__macro_support::host_fn_result(g, || $scope::$f(g, f))
-            }
-            #[cfg(not(all(windows, target_arch = "x86_64")))]
-            #[unsafe(export_name = $name)]
-            pub(crate) unsafe extern "C" fn __shim(
-                g: *mut ::bun_jsc::JSGlobalObject,
-                f: *mut ::bun_jsc::CallFrame,
-            ) -> ::bun_jsc::JSValue {
-                // SAFETY: JSC guarantees both pointers are live for the call.
-                let (g, f) = unsafe { (&*g, &*f) };
-                ::bun_jsc::__macro_support::host_fn_result(g, || $scope::$f(g, f))
-            }
-        };
-    };
+// ───────── C / JS host-fn exports (thunks are generated from the `HOST_EXPORT` markers) ─────────
+
+// HOST_EXPORT(Bun__DNS__resolve)
+pub fn dns_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve(global, frame)
 }
-export_host_fn!(Resolver::global_resolve, "Bun__DNS__resolve");
-export_host_fn!(Resolver::global_lookup, "Bun__DNS__lookup");
-export_host_fn!(Resolver::global_resolve_txt, "Bun__DNS__resolveTxt");
-export_host_fn!(Resolver::global_resolve_soa, "Bun__DNS__resolveSoa");
-export_host_fn!(Resolver::global_resolve_mx, "Bun__DNS__resolveMx");
-export_host_fn!(Resolver::global_resolve_naptr, "Bun__DNS__resolveNaptr");
-export_host_fn!(Resolver::global_resolve_srv, "Bun__DNS__resolveSrv");
-export_host_fn!(Resolver::global_resolve_caa, "Bun__DNS__resolveCaa");
-export_host_fn!(Resolver::global_resolve_ns, "Bun__DNS__resolveNs");
-export_host_fn!(Resolver::global_resolve_ptr, "Bun__DNS__resolvePtr");
-export_host_fn!(Resolver::global_resolve_cname, "Bun__DNS__resolveCname");
-export_host_fn!(Resolver::global_resolve_any, "Bun__DNS__resolveAny");
-export_host_fn!(Resolver::get_global_servers, "Bun__DNS__getServers");
-export_host_fn!(Resolver::set_global_servers, "Bun__DNS__setServers");
-export_host_fn!(Resolver::global_reverse, "Bun__DNS__reverse");
-export_host_fn!(Resolver::global_lookup_service, "Bun__DNS__lookupService");
-export_host_fn!(internal::prefetch_from_js, "Bun__DNS__prefetch");
-export_host_fn!(internal::get_dns_cache_stats, "Bun__DNS__getCacheStats");
+// HOST_EXPORT(Bun__DNS__lookup)
+pub fn dns_lookup(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_lookup(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveTxt)
+pub fn dns_resolve_txt(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_txt(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveSoa)
+pub fn dns_resolve_soa(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_soa(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveMx)
+pub fn dns_resolve_mx(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_mx(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveNaptr)
+pub fn dns_resolve_naptr(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_naptr(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveSrv)
+pub fn dns_resolve_srv(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_srv(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveCaa)
+pub fn dns_resolve_caa(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_caa(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveNs)
+pub fn dns_resolve_ns(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_ns(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolvePtr)
+pub fn dns_resolve_ptr(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_ptr(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveCname)
+pub fn dns_resolve_cname(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_cname(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__resolveAny)
+pub fn dns_resolve_any(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_resolve_any(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__getServers)
+pub fn dns_get_servers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::get_global_servers(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__setServers)
+pub fn dns_set_servers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::set_global_servers(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__reverse)
+pub fn dns_reverse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_reverse(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__lookupService)
+pub fn dns_lookup_service(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::global_lookup_service(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__prefetch)
+pub fn dns_prefetch(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    internal::prefetch_from_js(global, frame)
+}
+// HOST_EXPORT(Bun__DNS__getCacheStats)
+pub fn dns_get_cache_stats(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    internal::get_dns_cache_stats(global, frame)
+}
 // JS2Native ($newRustFunction) entry points — see GeneratedJS2Native.h
-export_host_fn!(
-    Resolver::new_resolver,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver"
-);
-export_host_fn!(
-    Resolver::get_runtime_default_result_order_option,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption"
-);
-export_host_fn!(
-    internal::seed_cache_for_testing,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting"
-);
-export_host_fn!(
-    internal::is_localhost_name_for_testing,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isLocalhostNameForTesting"
-);
-export_host_fn!(
-    internal::is_all_loopback_of_one_family_for_testing,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isAllLoopbackOfOneFamilyForTesting"
-);
-export_host_fn!(
-    internal::getaddrinfo_error_for_testing,
-    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoErrorForTesting"
-);
+// HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver)
+pub fn new_resolver(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    Resolver::new_resolver(global, frame)
+}
+// HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption)
+pub fn get_runtime_default_result_order_option(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Resolver::get_runtime_default_result_order_option(global, frame)
+}
+// HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting)
+pub fn seed_cache_for_testing(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    internal::seed_cache_for_testing(global, frame)
+}
+// HOST_EXPORT(JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoErrorForTesting)
+pub fn getaddrinfo_error_for_testing(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    internal::getaddrinfo_error_for_testing(global, frame)
+}
+
+/// `bun_dns::internal::prefetch` — declared `extern "C"` in the lower-tier
+/// `bun_dns` crate so `bun_install` can prefetch registry hostnames without a
+/// crate cycle. Link-time resolved.
+// HOST_EXPORT(__bun_dns_prefetch, c)
+pub fn bun_dns_prefetch(loop_: &bun_uws::Loop, hostname: &[u8], port: u16) {
+    internal::prefetch(loop_, (!hostname.is_empty()).then_some(hostname), port)
+}
+
+// The usockets connect path (`packages/bun-usockets`, `internal.h`).
+// HOST_EXPORT(Bun__addrinfo_get, c)
+pub fn addrinfo_get(
+    loop_: &bun_uws::Loop,
+    host: Option<&CStr>,
+    port: u16,
+    request: &mut *mut c_void,
+) -> c_int {
+    internal::us_getaddrinfo(loop_, host, port, request)
+}
+// HOST_EXPORT(Bun__addrinfo_set, c)
+pub fn addrinfo_set(
+    request: ThisPtr<crate::dns_jsc::internal::Request>,
+    socket: &bun_uws::ConnectingSocket,
+) {
+    internal::us_getaddrinfo_set(request, socket)
+}
+// HOST_EXPORT(Bun__addrinfo_cancel, c)
+pub fn addrinfo_cancel(
+    request: ThisPtr<crate::dns_jsc::internal::Request>,
+    socket: &bun_uws::ConnectingSocket,
+) -> c_int {
+    internal::us_getaddrinfo_cancel(request, socket)
+}
+// HOST_EXPORT(Bun__addrinfo_freeRequest, c)
+pub fn addrinfo_free_request(request: ThisPtr<crate::dns_jsc::internal::Request>, error: c_int) {
+    internal::freeaddrinfo(request, error)
+}
+// HOST_EXPORT(Bun__addrinfo_getRequestResult, c)
+pub fn addrinfo_get_request_result(
+    request: ThisPtr<crate::dns_jsc::internal::Request>,
+) -> *const bun_uws_sys::addrinfo::addrinfo_result {
+    internal::get_request_result(request)
+}
+/// QUIC analogue of `Bun__addrinfo_set` — `bun_http` (lower-tier crate)
+/// registers through `bun_dns::internal::register_quic`, handing over its
+/// `PendingConnect` box until notification.
+// HOST_EXPORT(Bun__addrinfo_registerQuic, c)
+pub fn addrinfo_register_quic(
+    request: ThisPtr<crate::dns_jsc::internal::Request>,
+    pc: Option<Box<bun_http::H3::PendingConnect>>,
+) {
+    internal::register_quic(
+        request,
+        bun_http::H3::DnsPendingConnect::new(pc.expect("PendingConnect")),
+    )
+}

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -645,7 +645,7 @@ impl Drop for CAresNameInfo {
 pub(crate) struct GetNameInfoRequest {
     /// The VM-global resolver (pinned for the VM's lifetime, so it outlives
     /// every request).
-    resolver_for_caching: Option<BackRef<Resolver, bun_ptr::Mut>>,
+    resolver_for_caching: Option<BackRef<Resolver, bun_ptr::Root>>,
     /// See [`PendingEntry`].
     pending_slot: Option<u8>,
     head: CAresNameInfo,
@@ -1553,7 +1553,7 @@ pub mod internal {
     }
 
     struct Waiting {
-        request: BackRef<Request, bun_ptr::Mut>,
+        request: BackRef<Request, bun_ptr::Root>,
         owners: Vec<DNSRequestOwner>,
     }
 
@@ -1574,7 +1574,7 @@ pub mod internal {
         fn waiting_index(&self, request: ThisPtr<Request>) -> Option<usize> {
             self.waiting
                 .iter()
-                .position(|w| core::ptr::eq(w.request.as_ptr(), request.as_ptr()))
+                .position(|w| core::ptr::eq(w.request.as_const_ptr(), request.as_ptr().cast_const()))
         }
 
         fn add_waiter(&mut self, request: ThisPtr<Request>, owner: DNSRequestOwner) {
@@ -1879,7 +1879,7 @@ pub mod internal {
         }
     }
 
-    fn work_pool_callback(req: BackRef<Request, bun_ptr::Mut>) {
+    fn work_pool_callback(req: BackRef<Request, bun_ptr::Root>) {
         let mut service_buf = [0u8; 21];
         let port = req.key.port;
         let service: Option<&CStr> = if port > 0 {
@@ -1943,7 +1943,7 @@ pub mod internal {
 
     /// Complete an internal request: build an addrinfo chain and reuse `process_results` (happy-eyeballs order).
     #[cfg(target_os = "macos")]
-    pub(super) fn dns_sd_complete(req: BackRef<Request, bun_ptr::Mut>) {
+    pub(super) fn dns_sd_complete(req: BackRef<Request, bun_ptr::Root>) {
         let (results, empty_status) = req
             .dns_sd
             .with_mut(|query| (query.take_results(), query.empty_status()));
@@ -2218,7 +2218,7 @@ pub mod internal {
     /// per-thread mDNSResponder connection went away with its thread is
     /// finished (see `SharedConnection::close_for_terminate`). The request's
     /// in-flight `refcount` keeps it alive until `after_result`.
-    pub(super) fn run_on_work_pool(req: BackRef<Request, bun_ptr::Mut>) {
+    pub(super) fn run_on_work_pool(req: BackRef<Request, bun_ptr::Root>) {
         let _ = bun_threading::work_pool::WorkPool::go(req, work_pool_callback);
     }
 
@@ -2613,7 +2613,7 @@ impl Drop for Resolver {
 #[cfg(windows)]
 pub(crate) struct UvDnsPoll {
     /// The resolver whose `polls` map owns this poll (so outlives it).
-    parent: BackRef<Resolver, bun_ptr::Mut>,
+    parent: BackRef<Resolver, bun_ptr::Root>,
     socket: c_ares::ares_socket_t,
 }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1827,14 +1827,6 @@ pub mod internal {
                 DNSRequestOwner::Quic(pc) => pc.notify_threadsafe(),
             }
         }
-
-        pub(crate) fn notify(self, req: ThisPtr<Request>) {
-            match self {
-                DNSRequestOwner::Prefetch => freeaddrinfo(req, 0),
-                DNSRequestOwner::Socket(socket) => socket.notify(),
-                DNSRequestOwner::Quic(pc) => pc.notify(),
-            }
-        }
     }
 
     /// Register `pc` to be notified when `request` resolves. Mirrors
@@ -1842,15 +1834,19 @@ pub mod internal {
     /// no us_connecting_socket_t to hang the callback on. The .quic notify
     /// path frees the addrinfo request inline (via Bun__addrinfo_freeRequest),
     /// which re-acquires global_cache.lock — so drop it before notifying.
-    pub(crate) fn register_quic(request: ThisPtr<Request>, pc: bun_http::H3::DnsPendingConnect) {
+    pub(crate) fn register_quic(request: ThisPtr<Request>, pc: Box<bun_http::H3::PendingConnect>) {
         let guard = global_cache().lock();
-        let owner = DNSRequestOwner::Quic(pc);
         if request.has_result() {
             drop(guard);
-            owner.notify(request);
+            pc.on_dns_resolved_now();
             return;
         }
-        request.notify.lock().push(owner);
+        request
+            .notify
+            .lock()
+            .push(DNSRequestOwner::Quic(bun_http::H3::DnsPendingConnect::new(
+                pc,
+            )));
         drop(guard);
     }
 
@@ -2365,14 +2361,18 @@ pub mod internal {
 
     pub(crate) fn us_getaddrinfo_set(request: ThisPtr<Request>, socket: &ConnectingSocket) {
         let _guard = global_cache().lock();
-        // usockets keeps `socket` alive until it is notified or withdraws
-        // itself with `Bun__addrinfo_cancel`.
-        let query = DNSRequestOwner::Socket(DnsWaitingSocket::new(BackRef::new(socket)));
         if request.has_result() {
-            query.notify(request);
+            bun_uws_sys::addrinfo::dns_ready(socket);
             return;
         }
-        request.notify.lock().push(query);
+        // usockets keeps `socket` alive until it is notified or withdraws
+        // itself with `Bun__addrinfo_cancel`.
+        request
+            .notify
+            .lock()
+            .push(DNSRequestOwner::Socket(DnsWaitingSocket::new(
+                BackRef::new(socket),
+            )));
     }
 
     pub(crate) fn us_getaddrinfo_cancel(
@@ -4474,8 +4474,5 @@ pub fn addrinfo_register_quic(
     request: ThisPtr<crate::dns_jsc::internal::Request>,
     pc: Option<Box<bun_http::H3::PendingConnect>>,
 ) {
-    internal::register_quic(
-        request,
-        bun_http::H3::DnsPendingConnect::new(pc.expect("PendingConnect")),
-    )
+    internal::register_quic(request, pc.expect("PendingConnect"))
 }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -999,9 +999,7 @@ impl CAresReverse {
 impl Drop for CAresReverse {
     fn drop(&mut self) {
         self.poll_ref.unref(js_event_loop_ctx());
-        if let Some(resolver) = self.resolver.take() {
-            resolver.deref();
-        }
+        drop(self.resolver.take());
     }
 }
 
@@ -1092,9 +1090,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
 impl<T: CAresRecordType> Drop for CAresLookup<T> {
     fn drop(&mut self) {
         self.poll_ref.unref(js_event_loop_ctx());
-        if let Some(resolver) = self.resolver.take() {
-            resolver.deref();
-        }
+        drop(self.resolver.take());
     }
 }
 
@@ -1293,9 +1289,7 @@ impl Drop for DNSLookup {
         self.poll_ref.unref(Async::posix_event_loop::get_vm_ctx(
             Async::AllocatorType::Js,
         ));
-        if let Some(resolver) = self.resolver.take() {
-            resolver.deref();
-        }
+        drop(self.resolver.take());
     }
 }
 
@@ -1323,10 +1317,8 @@ impl Drop for GlobalData {
         self.resolver.destroy_channel();
         // A timer `disarm_all_for_vm_teardown` unlinked (or one still armed:
         // the timer heap goes with the VM) no longer needs its ref.
-        if let Some(timer_ref) = self.resolver.timer_ref.take() {
-            timer_ref.deref();
-        }
-        self.resolver.deref();
+        drop(self.resolver.timer_ref.take());
+        // `self.resolver` releases our ref as the field drops.
     }
 }
 
@@ -1362,7 +1354,7 @@ impl Resolver {
         use bun_jsc::virtual_machine::SweepResult;
         // Failing the pending queries releases their refs on this resolver from
         // inside `ares_destroy`; hold one so it outlives its own channel close.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         let result = if this.destroy_channel() {
             SweepResult::Stopped
         } else {
@@ -2024,7 +2016,7 @@ pub mod internal {
                 "expected (hostname: string, addresses: string[])"
             )));
         }
-        let hostname_slice = args[0].to_slice(global)?;
+        let hostname_slice = args[0].to_utf8(global)?;
         let len = args[1].get_length(global)? as usize;
         if len == 0 || len > 64 {
             return Err(
@@ -2034,7 +2026,7 @@ pub mod internal {
 
         let mut nodes: Vec<(AddrInfo, Option<SockaddrStorage>)> = Vec::with_capacity(len);
         for i in 0..len {
-            let addr_slice = args[1].get_index(global, i as u32)?.to_slice(global)?;
+            let addr_slice = args[1].get_index(global, i as u32)?.to_utf8(global)?;
             let addr_z = bun::ZBox::from_bytes(addr_slice.slice());
             let mut octets = [0u8; 16];
             let ip: std::net::IpAddr =
@@ -2235,7 +2227,7 @@ pub mod internal {
         let hostname_or_url = arguments[0];
 
         let hostname_slice = if hostname_or_url.is_string() {
-            hostname_or_url.to_slice(global_this)?
+            hostname_or_url.to_utf8(global_this)?
         } else {
             return Err(
                 global_this.throw_invalid_arguments(format_args!("hostname must be a string"))
@@ -2720,9 +2712,7 @@ impl Resolver {
         // (after a possible re-arm has taken its own).
         let _release = scopeguard::guard(this.timer_ref.take(), move |timer_ref| {
             timer_all_mut().increment_timer_ref(-1, uws_loop);
-            if let Some(timer_ref) = timer_ref {
-                timer_ref.deref();
-            }
+            drop(timer_ref);
         });
 
         this.event_loop_timer
@@ -2795,9 +2785,7 @@ impl Resolver {
         // Not ACTIVE ⇒ no ref is held (it is released when the timer fires or
         // is removed).
         debug_assert!(stale.is_none());
-        if let Some(stale) = stale {
-            stale.deref();
-        }
+        drop(stale);
         let now_ts = now
             .copied()
             .unwrap_or_else(|| bun::timespec::now(bun::TimespecMockMode::ForceRealTime));
@@ -2828,11 +2816,9 @@ impl Resolver {
         let uws_loop = this.vm().uws_loop();
         timer_all_mut().increment_timer_ref(-1, uws_loop);
         // Every caller holds at least one other ref for the duration of this
-        // call (a lookup's `RefPtr`, a `ref_guard`, or the global-resolver
+        // call (a lookup's `RefPtr`, a keep-alive guard, or the global-resolver
         // pin), so this is never the last.
-        if let Some(timer_ref) = this.timer_ref.take() {
-            timer_ref.deref();
-        }
+        drop(this.timer_ref.take());
     }
 
     // ───────────── pending-cache helpers ─────────────
@@ -2853,7 +2839,7 @@ impl Resolver {
         result: Option<T::Reply>,
         head: CAresLookup<T>,
     ) {
-        let _g = this.ref_guard();
+        let _g = RefPtr::from_this(this);
 
         let waiters = T::pending_cache(&this).take(index);
 
@@ -2903,7 +2889,7 @@ impl Resolver {
             .pending_host_cache(PendingCacheField::PendingHostCacheCares)
             .take(index);
 
-        let _g = this.ref_guard();
+        let _g = RefPtr::from_this(this);
 
         let Some(addr) = result else {
             head.process_get_addr_info(err, timeout, None);
@@ -2953,7 +2939,7 @@ impl Resolver {
             .pending_host_cache(PendingCacheField::PendingHostCacheNative)
             .take(index);
 
-        let _g = this.ref_guard();
+        let _g = RefPtr::from_this(this);
 
         let Some(result) = result else {
             head.process_get_addr_info_native(err);
@@ -3000,7 +2986,7 @@ impl Resolver {
     ) {
         let waiters = this.pending_addr_cache_cares.take(index);
 
-        let _g = this.ref_guard();
+        let _g = RefPtr::from_this(this);
 
         let Some(addr) = result else {
             head.process_resolve(err, timeout, None);
@@ -3049,7 +3035,7 @@ impl Resolver {
     ) {
         let waiters = this.pending_nameinfo_cache_cares.take(index);
 
-        let _g = this.ref_guard();
+        let _g = RefPtr::from_this(this);
 
         let Some(name_info) = result else {
             head.process_resolve(err, timeout, None);
@@ -3145,7 +3131,7 @@ impl Resolver {
             return;
         }
 
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         if let Some(channel) = this.channel.get().as_deref() {
             channel.process(fd, readable, writable);
@@ -3634,7 +3620,7 @@ impl libuv::SocketPollHandler for UvDnsPoll {
         let _exit = vm.enter_event_loop_scope();
         // Kept alive across `Channel::process` (which re-enters and may
         // release refs) by the guard.
-        let _guard = parent.ref_guard();
+        let _guard = RefPtr::from_this(parent);
         // channel must be non-null here as c_ares must have been initialized if we're receiving callbacks
         let channel = parent.channel.get().as_deref().expect("c-ares channel");
         if status < 0 {
@@ -3971,7 +3957,7 @@ impl Resolver {
         global_this: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<c_int> {
-        let str_ = value.to_slice(global_this)?;
+        let str_ = value.to_utf8(global_this)?;
         let text = bun::ZBox::from_bytes(str_.slice());
 
         let mut addr = [0u8; 16];

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -9,11 +9,10 @@ use bun_collections::ArrayHashMap;
 use bun_core::Output;
 use bun_core::strings;
 use bun_core::{self as bun, env_var, fmt as bun_fmt};
-#[cfg(not(windows))]
 use bun_dns::ResultList as GetAddrInfoResultList;
 use bun_dns::{
     self, Backend as GetAddrInfoBackend, GetAddrInfo, GetAddrInfoResult,
-    Options as GetAddrInfoOptions, ResultAny as GetAddrInfoResultAny,
+    Options as GetAddrInfoOptions,
 };
 #[cfg(not(windows))]
 use bun_io::OwnedFilePoll;
@@ -210,12 +209,7 @@ pub(crate) mod lib_uv_backend {
             return Ok(promise);
         }
 
-        let request = GetAddrInfoRequest::init(
-            cache,
-            get_addr_info_request::Backend::CAres,
-            Some(this),
-            global_this,
-        );
+        let request = GetAddrInfoRequest::init(cache, Some(this), global_this);
 
         let hints = query.options.to_libc();
         let mut port_buf = [0u8; 128];
@@ -244,18 +238,9 @@ pub(crate) mod lib_uv_backend {
                 // completion would have taken so the pending-cache slot is released
                 // and the promise is rejected with a DNSException.
                 let request = *request;
-                if let (Some(resolver), Some(pos)) = (request.head.resolver(), request.pending_slot)
-                {
-                    Resolver::drain_pending_host_native(
-                        resolver,
-                        pos,
-                        rc.int(),
-                        &GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()),
-                        request.head,
-                    );
-                    return Ok(promise);
-                }
-                request.head.process_get_addr_info_native(rc.int());
+                request
+                    .head
+                    .finish_native(request.pending_slot, rc.int(), None);
                 Ok(promise)
             }
         }
@@ -717,10 +702,9 @@ impl c_ares::NameInfoHandler for GetNameInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetAddrInfoRequest {
-    /// Backend state that must live at the request's address (the dns_sd
-    /// query); nothing for c-ares / libuv / the work pool.
-    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-    pub(crate) backend: get_addr_info_request::Backend,
+    /// The dns_sd query state (written by the reply callback at this address).
+    #[cfg(target_os = "macos")]
+    pub(crate) dns_sd: JsCell<dns_sd::QueryState>,
     /// See [`PendingEntry`].
     pub(crate) pending_slot: Option<u8>,
     pub(crate) head: DNSLookup,
@@ -789,20 +773,6 @@ pub mod get_addr_info_request {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    pub struct BackendDnsSd {
-        pub(crate) query: JsCell<dns_sd::QueryState>,
-    }
-
-    #[cfg(target_os = "macos")]
-    impl BackendDnsSd {
-        pub(crate) fn new(protocol: dns_sd::DNSServiceProtocol) -> Self {
-            Self {
-                query: JsCell::new(dns_sd::QueryState::new(protocol)),
-            }
-        }
-    }
-
     /// Non-Windows libc backend (worker-thread blocking getaddrinfo).
     #[cfg(not(windows))]
     pub enum LibcBackend {
@@ -844,26 +814,10 @@ pub mod get_addr_info_request {
                 debug_timer,
             );
             *self = match result {
-                Ok(Some(list)) => LibcBackend::Success(GetAddrInfoResult::to_list(list.first())),
+                Ok(Some(list)) => LibcBackend::Success(GetAddrInfoResult::to_list(&list)),
                 Ok(None) => LibcBackend::Err(0),
                 Err(err) => LibcBackend::Err(err),
             };
-        }
-    }
-
-    pub enum Backend {
-        CAres,
-        #[cfg(target_os = "macos")]
-        DnsSd(BackendDnsSd),
-    }
-
-    impl Backend {
-        #[cfg(target_os = "macos")]
-        pub(crate) fn dns_sd(&self) -> &BackendDnsSd {
-            match self {
-                Backend::DnsSd(l) => l,
-                _ => unreachable!(),
-            }
         }
     }
 }
@@ -871,13 +825,13 @@ pub mod get_addr_info_request {
 impl GetAddrInfoRequest {
     pub(crate) fn init(
         cache: CacheHit,
-        backend: get_addr_info_request::Backend,
         resolver: Option<ThisPtr<Resolver>>,
         global_this: &JSGlobalObject,
     ) -> Box<Self> {
         bun_output::scoped_log!(GetAddrInfoRequest, "init");
         Box::new(Self {
-            backend,
+            #[cfg(target_os = "macos")]
+            dns_sd: JsCell::new(Default::default()),
             pending_slot: cache.new_slot(),
             head: DNSLookup::init_head(resolver, global_this),
         })
@@ -886,7 +840,7 @@ impl GetAddrInfoRequest {
     /// Complete a dns_sd-backed request.
     #[cfg(target_os = "macos")]
     pub(crate) fn complete_dns_sd(self) {
-        let (results, status) = self.backend.dns_sd().query.with_mut(|query| {
+        let (results, status) = self.dns_sd.with_mut(|query| {
             let results = query.take_results();
             let status = if !results.is_empty() {
                 0
@@ -901,23 +855,8 @@ impl GetAddrInfoRequest {
             status,
             results.len()
         );
-        // Error path must be `Addrinfo(null)`: `drain_pending_host_native` keys on `result_any_to_js` == None.
-        let any = if status == 0 {
-            GetAddrInfoResultAny::List(results)
-        } else {
-            GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut())
-        };
-
-        if let (Some(resolver), Some(pos)) = (self.head.resolver(), self.pending_slot) {
-            Resolver::drain_pending_host_native(resolver, pos, status, &any, self.head);
-            return;
-        }
-
-        if status != 0 {
-            self.head.process_get_addr_info_native(status);
-        } else {
-            self.head.on_complete_native(&any);
-        }
+        self.head
+            .finish_native(self.pending_slot, status, (status == 0).then_some(&results));
     }
 
     /// The JS-thread completion of a libc (work-pool) lookup.
@@ -930,27 +869,10 @@ impl GetAddrInfoRequest {
         bun_output::scoped_log!(GetAddrInfoRequest, "then");
         match backend {
             get_addr_info_request::LibcBackend::Success(result) => {
-                // `ResultAny` impls `Drop` (frees the list) — the by-value drop
-                // at the end of whichever callee receives `any`.
-                let any = GetAddrInfoResultAny::List(result);
-                if let (Some(resolver), Some(pos)) = (head.resolver(), pending_slot) {
-                    Resolver::drain_pending_host_native(resolver, pos, 0, &any, head);
-                    return;
-                }
-                head.on_complete_native(&any);
+                head.finish_native(pending_slot, 0, Some(&result))
             }
             get_addr_info_request::LibcBackend::Err(err) => {
-                if let (Some(resolver), Some(pos)) = (head.resolver(), pending_slot) {
-                    Resolver::drain_pending_host_native(
-                        resolver,
-                        pos,
-                        err,
-                        &GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()),
-                        head,
-                    );
-                    return;
-                }
-                head.process_get_addr_info_native(err);
+                head.finish_native(pending_slot, err, None)
             }
             get_addr_info_request::LibcBackend::Query(_) => unreachable!(),
         }
@@ -976,26 +898,10 @@ impl GetAddrInfoRequest {
     pub(crate) fn on_libuv_complete(self, retcode: c_int, result: libuv::UvAddrInfo) {
         bun_output::scoped_log!(GetAddrInfoRequest, "onLibUVComplete: status={}", retcode);
 
-        // libuv re-packs the wide result into a `uv__malloc` block that
-        // `UvAddrInfo` frees with `uv_freeaddrinfo`; copy it into an owned
-        // `List` now so `ResultAny::Drop` (which calls `ws2_32!freeaddrinfo`)
-        // never sees libuv-owned memory.
-        let result_any = match result.head() {
-            None => GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()),
-            Some(head) => GetAddrInfoResultAny::List(GetAddrInfoResult::to_list(head)),
-        };
-        drop(result);
-
-        if let (Some(resolver), Some(pos)) = (self.head.resolver(), self.pending_slot) {
-            Resolver::drain_pending_host_native(resolver, pos, retcode, &result_any, self.head);
-            return;
-        }
-
-        if c_ares::Error::init_eai(retcode).is_some() {
-            self.head.process_get_addr_info_native(retcode);
-        } else {
-            self.head.on_complete_native(&result_any);
-        }
+        let result = bun_sys::net::AddrInfoList::from_uv(result)
+            .map(|list| GetAddrInfoResult::to_list(&list));
+        self.head
+            .finish_native(self.pending_slot, retcode, result.as_ref());
     }
 }
 
@@ -1235,12 +1141,32 @@ impl DNSLookup {
         }
     }
 
-    fn on_complete_native(self, result: &GetAddrInfoResultAny) {
+    /// Completion of a system-resolver lookup (libc, libuv, dns_sd): fan out
+    /// to the deduplicated waiters if this lookup owns a pending slot.
+    fn finish_native(
+        self,
+        pending_slot: Option<u8>,
+        status: c_int,
+        result: Option<&GetAddrInfoResultList>,
+    ) {
+        if let (Some(resolver), Some(pos)) = (self.resolver(), pending_slot) {
+            Resolver::drain_pending_host_native(resolver, pos, status, result, self);
+            return;
+        }
+        match result {
+            Some(_) => self.on_complete_native(result),
+            None => self.process_get_addr_info_native(status),
+        }
+    }
+
+    /// `None` (no result, no error) is an empty answer.
+    fn on_complete_native(self, result: Option<&GetAddrInfoResultList>) {
         bun_output::scoped_log!(DNSLookup, "onCompleteNative");
         let global = self.global_this();
-        // A null addrinfo with no error is an empty answer.
-        let array = super::options_jsc::result_any_to_js(result, global)
-            .and_then(|a| a.map_or_else(|| JSValue::create_empty_array(global, 0), Ok));
+        let array = match result {
+            Some(list) => super::options_jsc::result_list_to_js(list, global),
+            None => JSValue::create_empty_array(global, 0),
+        };
         let outcome = Outcome::of(global, array);
         self.on_complete_with_array(outcome);
     }
@@ -1252,7 +1178,7 @@ impl DNSLookup {
                 .reject_later(self.global_this());
             return;
         }
-        self.on_complete_native(&GetAddrInfoResultAny::Addrinfo(core::ptr::null_mut()))
+        self.on_complete_native(None)
     }
 
     fn process_get_addr_info(
@@ -1536,23 +1462,6 @@ pub mod internal {
         }
     }
 
-    /// The dns_sd query state of a connect-path lookup. Only the thread whose
-    /// `SharedConnection` issued the query touches it (from the reply callback
-    /// and completion), until `dns_sd_complete` publishes the result.
-    #[cfg(target_os = "macos")]
-    pub struct MacAsyncDNS {
-        pub(crate) query: JsCell<dns_sd::QueryState>,
-    }
-
-    #[cfg(target_os = "macos")]
-    impl Default for MacAsyncDNS {
-        fn default() -> Self {
-            Self {
-                query: JsCell::new(dns_sd::QueryState::new(0)),
-            }
-        }
-    }
-
     /// One cached lookup. usockets, the QUIC client and the work pool all hold
     /// it by address (`ThisPtr` / `BackRef`); the cache owns it and frees it
     /// only once `refcount` is back to zero.
@@ -1561,9 +1470,6 @@ pub mod internal {
         /// Set once, under the cache lock, when the lookup finishes; read
         /// lock-free by usockets after it has been notified.
         result: std::sync::OnceLock<AddrInfoResult>,
-        /// Who to notify when `result` lands; guarded by the cache lock (this
-        /// lock is only ever taken under it).
-        notify: bun_threading::Guarded<Vec<DNSRequestOwner>>,
         /// number of sockets that have a reference to result or are waiting for the result
         /// while this is non-zero, this entry cannot be freed
         refcount: AtomicU32,
@@ -1571,8 +1477,11 @@ pub mod internal {
         /// Not a precise timestamp.
         pub(crate) created_at: u32,
         valid: AtomicBool,
+        /// Only the thread whose `SharedConnection` issued the query touches it
+        /// (reply callback and completion), until `dns_sd_complete` publishes
+        /// the result.
         #[cfg(target_os = "macos")]
-        pub(crate) dns_sd: MacAsyncDNS,
+        pub(crate) dns_sd: JsCell<dns_sd::QueryState>,
     }
 
     impl Request {
@@ -1584,12 +1493,11 @@ pub mod internal {
             bun_ptr::OwnedThis::new(Self {
                 key,
                 result: std::sync::OnceLock::new(),
-                notify: bun_threading::Guarded::new(Vec::new()),
                 refcount: AtomicU32::new(refcount),
                 created_at,
                 valid: AtomicBool::new(true),
                 #[cfg(target_os = "macos")]
-                dns_sd: MacAsyncDNS::default(),
+                dns_sd: JsCell::new(Default::default()),
             })
         }
 
@@ -1629,12 +1537,6 @@ pub mod internal {
         }
     }
 
-    impl Drop for Request {
-        fn drop(&mut self) {
-            debug_assert!(self.notify.lock().is_empty());
-        }
-    }
-
     // ───────────── GlobalCache ─────────────
 
     const MAX_ENTRIES: usize = 256;
@@ -1646,6 +1548,13 @@ pub mod internal {
         /// Requests handed out while the cache had no room for them; freed
         /// like cached ones once their last holder lets go.
         orphans: Vec<bun_ptr::OwnedThis<Request>>,
+        /// Who to notify when an unfinished request's result lands.
+        waiting: Vec<Waiting>,
+    }
+
+    struct Waiting {
+        request: BackRef<Request, bun_ptr::Mut>,
+        owners: Vec<DNSRequestOwner>,
     }
 
     impl GlobalCache {
@@ -1653,12 +1562,52 @@ pub mod internal {
             Self {
                 cache: Vec::new(),
                 orphans: Vec::new(),
+                waiting: Vec::new(),
             }
         }
 
         #[inline]
         fn len(&self) -> usize {
             self.cache.len()
+        }
+
+        fn waiting_index(&self, request: ThisPtr<Request>) -> Option<usize> {
+            self.waiting
+                .iter()
+                .position(|w| core::ptr::eq(w.request.as_ptr(), request.as_ptr()))
+        }
+
+        fn add_waiter(&mut self, request: ThisPtr<Request>, owner: DNSRequestOwner) {
+            match self.waiting_index(request) {
+                Some(i) => self.waiting[i].owners.push(owner),
+                None => self.waiting.push(Waiting {
+                    request: BackRef::from(request),
+                    owners: vec![owner],
+                }),
+            }
+        }
+
+        fn take_waiters(&mut self, request: ThisPtr<Request>) -> Vec<DNSRequestOwner> {
+            match self.waiting_index(request) {
+                Some(i) => self.waiting.swap_remove(i).owners,
+                None => Vec::new(),
+            }
+        }
+
+        /// Withdraw `socket` from `request`'s waiters; whether it was waiting.
+        fn cancel_waiter(&mut self, request: ThisPtr<Request>, socket: &ConnectingSocket) -> bool {
+            let Some(i) = self.waiting_index(request) else {
+                return false;
+            };
+            let owners = &mut self.waiting[i].owners;
+            let Some(j) = owners
+                .iter()
+                .position(|o| matches!(o, DNSRequestOwner::Socket(s) if s.is(socket)))
+            else {
+                return false;
+            };
+            owners.swap_remove(j);
+            true
         }
 
         fn get(
@@ -1824,19 +1773,16 @@ pub mod internal {
     /// path frees the addrinfo request inline (via Bun__addrinfo_freeRequest),
     /// which re-acquires global_cache.lock — so drop it before notifying.
     pub(crate) fn register_quic(request: ThisPtr<Request>, pc: Box<bun_http::H3::PendingConnect>) {
-        let guard = global_cache().lock();
+        let mut guard = global_cache().lock();
         if request.has_result() {
             drop(guard);
             pc.on_dns_resolved_now();
             return;
         }
-        request
-            .notify
-            .lock()
-            .push(DNSRequestOwner::Quic(bun_http::H3::DnsPendingConnect::new(
-                pc,
-            )));
-        drop(guard);
+        guard.add_waiter(
+            request,
+            DNSRequestOwner::Quic(bun_http::H3::DnsPendingConnect::new(pc)),
+        );
     }
 
     /// The `ai_family`/`ai_socktype`/`ai_addrlen` header for a synthesized
@@ -1912,16 +1858,20 @@ pub mod internal {
     }
 
     fn after_result_entries(req: ThisPtr<Request>, result: AddrInfoResult) {
-        let guard = global_cache().lock();
+        let mut guard = global_cache().lock();
 
-        let notify = {
-            let _ = req.result.set(result);
-            let notify = core::mem::take(&mut *req.notify.lock());
-            req.refcount.fetch_sub(1, Ordering::Relaxed);
-            notify
-        };
-
-        // is this correct, or should it go after the loop?
+        // Each request is completed once (a dns_sd lookup handed to the work
+        // pool at thread teardown was never completed by dns_sd).
+        let already_set = req.result.set(result).is_err();
+        debug_assert!(!already_set);
+        let notify = guard.take_waiters(req);
+        if req.refcount.fetch_sub(1, Ordering::Relaxed) == 1 {
+            // Nobody waited (a prefetch, or every socket withdrew): an orphan
+            // has no other path to being freed.
+            debug_assert!(notify.is_empty());
+            guard.remove_orphan(req);
+            return;
+        }
         drop(guard);
 
         for query in notify {
@@ -1974,7 +1924,6 @@ pub mod internal {
         };
 
         let protocol = dns_sd::protocol_for_hints(&get_hints());
-        req.dns_sd.query.set(dns_sd::QueryState::new(protocol));
         shared
             .start(
                 dns_sd::InflightRequest::Internal(BackRef::from(req)),
@@ -1988,7 +1937,7 @@ pub mod internal {
     impl bun_sys::dns_sd::GetAddrInfoReply for Request {
         fn on_reply(&self, reply: &bun_sys::dns_sd::Reply<'_>) {
             dns_sd::SharedConnection::note_reply(core::ptr::from_ref(self).cast());
-            self.dns_sd.query.with_mut(|q| q.record_reply(reply));
+            self.dns_sd.with_mut(|q| q.record_reply(reply));
         }
     }
 
@@ -1997,7 +1946,6 @@ pub mod internal {
     pub(super) fn dns_sd_complete(req: BackRef<Request, bun_ptr::Mut>) {
         let (results, empty_status) = req
             .dns_sd
-            .query
             .with_mut(|query| (query.take_results(), query.empty_status()));
         let port = req.key.port;
         let req = req.this_ptr();
@@ -2339,43 +2287,31 @@ pub mod internal {
     }
 
     pub(crate) fn us_getaddrinfo_set(request: ThisPtr<Request>, socket: &ConnectingSocket) {
-        let _guard = global_cache().lock();
+        let mut guard = global_cache().lock();
         if request.has_result() {
             bun_uws_sys::addrinfo::dns_ready(socket);
             return;
         }
         // usockets keeps `socket` alive until it is notified or withdraws
         // itself with `Bun__addrinfo_cancel`.
-        request
-            .notify
-            .lock()
-            .push(DNSRequestOwner::Socket(DnsWaitingSocket::new(
-                BackRef::new(socket),
-            )));
+        guard.add_waiter(
+            request,
+            DNSRequestOwner::Socket(DnsWaitingSocket::new(BackRef::new(socket))),
+        );
     }
 
     pub(crate) fn us_getaddrinfo_cancel(
         request: ThisPtr<Request>,
         socket: &ConnectingSocket,
     ) -> c_int {
-        let _guard = global_cache().lock();
-        // afterResult sets result and moves the notify list out under this same
+        let mut guard = global_cache().lock();
+        // afterResult sets result and takes the waiters under this same
         // lock, so once result is non-null the socket is no longer cancellable
         // (the callback has fired or is about to fire on the worker thread).
         if request.has_result() {
             return 0;
         }
-        let mut notify = request.notify.lock();
-        for (i, item) in notify.iter().enumerate() {
-            match item {
-                DNSRequestOwner::Socket(s) if s.is(socket) => {
-                    notify.swap_remove(i);
-                    return 1;
-                }
-                _ => {}
-            }
-        }
-        0
+        guard.cancel_waiter(request, socket) as c_int
     }
 
     pub(crate) fn freeaddrinfo(req: ThisPtr<Request>, err: c_int) {
@@ -3008,7 +2944,7 @@ impl Resolver {
         this: ThisPtr<Self>,
         index: u8,
         err: i32,
-        result: &GetAddrInfoResultAny,
+        result: Option<&GetAddrInfoResultList>,
         head: DNSLookup,
     ) {
         bun_output::scoped_log!(DNSResolver, "drainPendingHostNative");
@@ -3019,17 +2955,17 @@ impl Resolver {
 
         let _g = this.ref_guard();
 
-        let mut array: Outcome =
-            match super::options_jsc::result_any_to_js(result, &global_object).transpose() {
-                Some(a) => Outcome::of(&global_object, a),
-                None => {
-                    head.process_get_addr_info_native(err);
-                    for waiter in waiters {
-                        waiter.process_get_addr_info_native(err);
-                    }
-                    return;
-                }
-            };
+        let Some(result) = result else {
+            head.process_get_addr_info_native(err);
+            for waiter in waiters {
+                waiter.process_get_addr_info_native(err);
+            }
+            return;
+        };
+        let mut array = Outcome::of(
+            &global_object,
+            super::options_jsc::result_list_to_js(result, &global_object),
+        );
         let mut prev_global = head.global_this;
 
         {
@@ -3041,11 +2977,9 @@ impl Resolver {
         for waiter in waiters {
             let new_global = waiter.global_this;
             if prev_global != new_global {
-                // Non-null addrinfo (checked above): never `None`.
                 array = Outcome::of(
                     &new_global,
-                    super::options_jsc::result_any_to_js(result, &new_global)
-                        .map(|a| a.expect("addrinfo present")),
+                    super::options_jsc::result_list_to_js(result, &new_global),
                 );
                 prev_global = new_global;
             }
@@ -3873,12 +3807,7 @@ impl Resolver {
         }
 
         let hints_buf = [query.to_cares()];
-        let request = GetAddrInfoRequest::init(
-            cache,
-            get_addr_info_request::Backend::CAres,
-            Some(this),
-            global_this,
-        );
+        let request = GetAddrInfoRequest::init(cache, Some(this), global_this);
         let promise = request.head.promise.value();
 
         channel.get_addr_info(&query.name, query.port, &hints_buf, request);

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -152,7 +152,7 @@ mod lib_c {
 // LibUVBackend (Windows uv_getaddrinfo)
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The windows implementation borrows the struct used for libc getaddrinfo
+/// Windows: `uv_getaddrinfo` on the libuv thread pool.
 #[cfg(windows)]
 pub(crate) mod lib_uv_backend {
     use super::*;
@@ -179,10 +179,6 @@ pub(crate) mod lib_uv_backend {
     }
 
     impl libuv::GetAddrInfoRequest for GetAddrInfoRequest {
-        fn uv_req(&mut self) -> &mut libuv::uv_getaddrinfo_t {
-            self.backend.as_libc_uv_mut()
-        }
-
         fn on_complete(this: Box<Self>, status: c_int, result: libuv::UvAddrInfo) {
             // TODO: We schedule a task to run because otherwise the promise will not be solved, we need to investigate this
             let vm = this.head.global_this().bun_vm();
@@ -216,7 +212,7 @@ pub(crate) mod lib_uv_backend {
 
         let request = GetAddrInfoRequest::init(
             cache,
-            get_addr_info_request::Backend::Libc(get_addr_info_request::LibcBackend::uv_uninit()),
+            get_addr_info_request::Backend::CAres,
             Some(this),
             global_this,
         );
@@ -329,8 +325,7 @@ struct PendingEntry<L> {
     /// The lookups that joined after the one that owns the slot, in order.
     waiters: Vec<L>,
     /// The in-flight `uv_getaddrinfo` (host-native cache only), so the stop
-    /// phase can cancel it. Valid while held: the slot is drained (dropping
-    /// this) by the request's completion, before the request is freed.
+    /// phase can cancel it.
     #[cfg(windows)]
     uv_inflight: Option<libuv::InflightGetAddrInfo>,
 }
@@ -722,9 +717,9 @@ impl c_ares::NameInfoHandler for GetNameInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetAddrInfoRequest {
-    /// Backend state that must live at the request's address (the libuv req,
-    /// the dns_sd query); nothing for c-ares / the work pool.
-    #[cfg_attr(not(any(windows, target_os = "macos")), allow(dead_code))]
+    /// Backend state that must live at the request's address (the dns_sd
+    /// query); nothing for c-ares / libuv / the work pool.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub(crate) backend: get_addr_info_request::Backend,
     /// See [`PendingEntry`].
     pub(crate) pending_slot: Option<u8>,
@@ -732,6 +727,7 @@ pub struct GetAddrInfoRequest {
 }
 
 pub mod get_addr_info_request {
+    #[cfg(not(windows))]
     use super::*;
 
     /// The blocking `getaddrinfo` of one libc-backend lookup, run on the pool.
@@ -855,25 +851,10 @@ pub mod get_addr_info_request {
         }
     }
 
-    /// Windows libc backend wraps a uv_getaddrinfo_t.
-    #[cfg(windows)]
-    pub struct LibcBackend {
-        pub(crate) uv: libuv::uv_getaddrinfo_t,
-    }
-    #[cfg(windows)]
-    impl LibcBackend {
-        pub(crate) fn uv_uninit() -> Self {
-            Self {
-                uv: bun_core::ffi::zeroed(),
-            }
-        }
-    }
     pub enum Backend {
         CAres,
         #[cfg(target_os = "macos")]
         DnsSd(BackendDnsSd),
-        #[cfg(windows)]
-        Libc(LibcBackend),
     }
 
     impl Backend {
@@ -881,13 +862,6 @@ pub mod get_addr_info_request {
         pub(crate) fn dns_sd(&self) -> &BackendDnsSd {
             match self {
                 Backend::DnsSd(l) => l,
-                _ => unreachable!(),
-            }
-        }
-        #[cfg(windows)]
-        pub(crate) fn as_libc_uv_mut(&mut self) -> &mut libuv::uv_getaddrinfo_t {
-            match self {
-                Backend::Libc(l) => &mut l.uv,
                 _ => unreachable!(),
             }
         }
@@ -1421,6 +1395,11 @@ impl Drop for GlobalData {
         // callbacks and release their refs) rather than whenever the last ref
         // goes; then release ours.
         self.resolver.destroy_channel();
+        // A timer `disarm_all_for_vm_teardown` unlinked (or one still armed:
+        // the timer heap goes with the VM) no longer needs its ref.
+        if let Some(timer_ref) = self.resolver.timer_ref.take() {
+            timer_ref.deref();
+        }
         self.resolver.deref();
     }
 }
@@ -1734,7 +1713,17 @@ pub mod internal {
             if let Some(i) = self.cache.iter().position(is) {
                 let len = self.cache.len();
                 self.delete_entry_at(len, i);
-            } else if let Some(i) = self.orphans.iter().position(is) {
+            } else {
+                self.remove_orphan(entry);
+            }
+        }
+
+        /// Free `entry` if it is an orphan (never findable by `get`, so nothing
+        /// can take a new reference to it).
+        fn remove_orphan(&mut self, entry: ThisPtr<Request>) {
+            let is =
+                |e: &bun_ptr::OwnedThis<Request>| core::ptr::eq(&raw const **e, entry.as_ptr());
+            if let Some(i) = self.orphans.iter().position(is) {
                 drop(self.orphans.swap_remove(i));
             }
         }
@@ -2243,32 +2232,22 @@ pub mod internal {
 
         #[cfg(target_os = "macos")]
         {
-            use bun_uws::InternalLoopDataExt as _;
             if !env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO
                 .get()
                 .unwrap_or(false)
             {
-                // The loop's parent tag (set by `EventLoopHandle::set_as_parent_of`
-                // at startup) says which of this thread's event loops owns it.
-                let (tag, _) = loop_.internal_loop_data.get_parent();
-                let ctx = match tag {
-                    1 => Some(Async::posix_event_loop::get_vm_ctx(
-                        Async::AllocatorType::Js,
-                    )),
-                    2 => Some(Async::posix_event_loop::get_vm_ctx(
-                        Async::AllocatorType::Mini,
-                    )),
-                    _ => None,
-                };
-                if let Some(ctx) = ctx {
-                    if lookup_dns_sd(req, ctx) {
-                        bun_output::scoped_log!(
-                            dns,
-                            "getaddrinfo({}) = cache miss (dns_sd)",
-                            bstr::BStr::new(host.unwrap_or(b""))
-                        );
-                        return Some(req);
-                    }
+                // The event loop driving `loop_` (set at startup) owns the
+                // dns_sd connection's poll and keep-alive.
+                let ctx = crate::api::bun::process::event_loop_handle_to_ctx(
+                    bun_event_loop::EventLoopHandle::parent_of(loop_),
+                );
+                if lookup_dns_sd(req, ctx) {
+                    bun_output::scoped_log!(
+                        dns,
+                        "getaddrinfo({}) = cache miss (dns_sd)",
+                        bstr::BStr::new(host.unwrap_or(b""))
+                    );
+                    return Some(req);
                 }
                 // if dns_sd was unavailable, fall back to the work pool
             }
@@ -2412,6 +2391,8 @@ pub mod internal {
         if remaining == 0 && (guard.is_nearly_full() || !req.is_valid()) {
             bun_output::scoped_log!(dns, "cache --");
             guard.remove(req);
+        } else if remaining == 0 {
+            guard.remove_orphan(req);
         }
     }
 
@@ -2874,7 +2855,13 @@ impl Resolver {
             return false;
         }
 
-        this.timer_ref.set(Some(RefPtr::from_this(this)));
+        let stale = this.timer_ref.replace(Some(RefPtr::from_this(this)));
+        // Not ACTIVE ⇒ no ref is held (it is released when the timer fires or
+        // is removed).
+        debug_assert!(stale.is_none());
+        if let Some(stale) = stale {
+            stale.deref();
+        }
         let now_ts = now
             .copied()
             .unwrap_or_else(|| bun::timespec::now(bun::TimespecMockMode::ForceRealTime));
@@ -2895,6 +2882,8 @@ impl Resolver {
 
     fn remove_timer(this: ThisPtr<Self>) {
         if this.event_loop_timer.get().state != EventLoopTimerState::ACTIVE {
+            // (VM teardown's `disarm_all_for_vm_teardown` can unlink an armed
+            // timer behind our back; `GlobalData::drop` releases its ref then.)
             return;
         }
 
@@ -4203,19 +4192,19 @@ impl Resolver {
     }
 
     pub fn new_resolver(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let resolver = RefPtr::new(Resolver::setup(global_this.bun_vm()));
-
+        let mut opts = c_ares::ChannelOptions::default();
         let options = callframe.argument(0);
         if options.is_object() {
-            let mut opts = resolver.options.get();
             if let Some(timeout) = options.get_truthy(global_this, "timeout")? {
                 opts.timeout = Some(timeout.coerce_to_i32(global_this)?);
             }
             if let Some(tries) = options.get_truthy(global_this, "tries")? {
                 opts.tries = Some(tries.coerce_to_i32(global_this)?);
             }
-            resolver.options.set(opts);
         }
+
+        let resolver = RefPtr::new(Resolver::setup(global_this.bun_vm()));
+        resolver.options.set(opts);
 
         // Ownership of the initial ref transfers to the GC wrapper
         // (`DNSResolver__create` → `finalize`).

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -246,7 +246,7 @@ impl InflightRequest {
     fn context(&self) -> *const () {
         match self {
             InflightRequest::Jsc(r) => core::ptr::from_ref::<GetAddrInfoRequest>(r).cast(),
-            InflightRequest::Internal(r) => r.as_ptr().cast_const().cast(),
+            InflightRequest::Internal(r) => r.as_const_ptr().cast(),
         }
     }
 
@@ -677,8 +677,8 @@ pub(crate) fn lookup(
     let promise_value = request.head.promise.value();
 
     let name_z = bun::ZBox::from_bytes(query.name.as_ref());
-    // On `None`, dns_sd never accepted it and `start` dropped the request; its
-    // slot goes with it (nothing else could have joined it yet).
+    // On `None`, dns_sd never accepted it and `start` dropped the request;
+    // release its pending slot here (nothing else could have joined it yet).
     let pending_slot = request.pending_slot;
     let Some(()) = shared.start(InflightRequest::Jsc(request), protocol, c_str(&name_z)) else {
         if let Some(pos) = pending_slot {

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -103,23 +103,26 @@ pub(crate) struct QueryState {
     stragglers: Stragglers,
     attempt: Attempt,
     /// Kept so `finish()` can reissue the query for the retry.
-    hostname: bun::ZBox,
+    hostname: Option<bun::ZBox>,
 }
 
-impl QueryState {
-    pub(crate) fn new(protocol: DNSServiceProtocol) -> Self {
+impl Default for QueryState {
+    /// Idle: nothing pending until `SharedConnection::start` issues the query.
+    fn default() -> Self {
         Self {
             results: Default::default(),
             sd_error: 0,
             saw_timeout: false,
             awaiting_more: false,
-            pending_proto: protocol,
+            pending_proto: 0,
             stragglers: Stragglers::None,
             attempt: Attempt::Plain,
-            hostname: bun::ZBox::from_bytes(b""),
+            hostname: None,
         }
     }
+}
 
+impl QueryState {
     /// Back to a fresh in-flight state for the unsuppressed reissue.
     pub(crate) fn reset_for_retry(&mut self, protocol: DNSServiceProtocol) {
         self.attempt = Attempt::Reissued;
@@ -249,8 +252,8 @@ impl InflightRequest {
 
     fn query(&self) -> &JsCell<QueryState> {
         match self {
-            InflightRequest::Jsc(r) => &r.backend.dns_sd().query,
-            InflightRequest::Internal(r) => &r.dns_sd.query,
+            InflightRequest::Jsc(r) => &r.dns_sd,
+            InflightRequest::Internal(r) => &r.dns_sd,
         }
     }
 
@@ -292,10 +295,7 @@ impl sd::GetAddrInfoReply for GetAddrInfoRequest {
     /// happens in `on_readable`.
     fn on_reply(&self, reply: &sd::Reply<'_>) {
         SharedConnection::note_reply(core::ptr::from_ref(self).cast());
-        self.backend
-            .dns_sd()
-            .query
-            .with_mut(|q| q.record_reply(reply));
+        self.dns_sd.with_mut(|q| q.record_reply(reply));
     }
 }
 
@@ -398,19 +398,21 @@ impl SharedConnection {
         hostname: &core::ffi::CStr,
     ) -> Option<()> {
         let suppress = addrconfig_flags(protocol);
+        request.query().set(QueryState {
+            pending_proto: protocol,
+            attempt: if suppress != 0 {
+                Attempt::Suppressed
+            } else {
+                Attempt::Plain
+            },
+            hostname: Some(bun::ZBox::from_bytes(hostname.to_bytes())),
+            ..Default::default()
+        });
         let sub = request.issue(&self.connection, protocol, suppress, hostname)?;
         if self.inflight.borrow().is_empty() {
             let ctx = self.ctx;
             self.with_file_poll(|p| p.enable_keeping_process_alive(ctx));
         }
-        request.query().with_mut(|q| {
-            q.attempt = if suppress != 0 {
-                Attempt::Suppressed
-            } else {
-                Attempt::Plain
-            };
-            q.hostname = bun::ZBox::from_bytes(hostname.to_bytes());
-        });
         self.inflight.borrow_mut().push(Inflight {
             request,
             sd_ref: Some(sub),
@@ -581,9 +583,11 @@ impl SharedConnection {
         let Some(this) = Self::current() else {
             return Err(inf);
         };
-        let (protocol, hostname) = {
+        let (protocol, Some(hostname)) = ({
             let q = inf.query().get();
             (protocol_for_pending(q), q.hostname.clone())
+        }) else {
+            return Err(inf);
         };
         inf.query().with_mut(|q| q.reset_for_retry(protocol));
         let Some(sub) = inf
@@ -668,12 +672,8 @@ pub(crate) fn lookup(
     };
 
     let protocol = protocol_for_family(query.options.family);
-    let request = bun_ptr::OwnedThis::new(*GetAddrInfoRequest::init(
-        cache,
-        get_addr_info_request::Backend::DnsSd(get_addr_info_request::BackendDnsSd::new(protocol)),
-        Some(this),
-        global_this,
-    ));
+    let request =
+        bun_ptr::OwnedThis::new(*GetAddrInfoRequest::init(cache, Some(this), global_this));
     let promise_value = request.head.promise.value();
 
     let name_z = bun::ZBox::from_bytes(query.name.as_ref());

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -11,20 +11,8 @@ use bun_sys::dns_sd as sd;
 pub(crate) use sd::DNSServiceProtocol;
 use sd::{DNSServiceErrorType, DNSServiceFlags};
 
-/// Map a DNSServiceErrorType to the EAI_* code the existing error paths expect.
-pub(crate) fn to_eai(err: DNSServiceErrorType) -> c_int {
-    match err {
-        sd::ERR_NO_ERROR => 0,
-        sd::ERR_NO_SUCH_NAME | sd::ERR_NO_SUCH_RECORD => libc::EAI_NONAME,
-        sd::ERR_TIMEOUT
-        | sd::ERR_NO_ROUTER
-        | sd::ERR_DEFUNCT_CONNECTION
-        | sd::ERR_SERVICE_NOT_RUNNING => libc::EAI_AGAIN,
-        sd::ERR_NO_MEMORY => libc::EAI_MEMORY,
-        sd::ERR_POLICY_DENIED | sd::ERR_NOT_PERMITTED | sd::ERR_REFUSED => libc::EAI_FAIL,
-        _ => libc::EAI_FAIL,
-    }
-}
+/// No address: libinfo's `getaddrinfo` reports this as EAI_NONAME whatever the daemon's error was.
+pub(crate) const EMPTY_STATUS: c_int = libc::EAI_NONAME;
 
 pub(crate) fn protocol_for_family(family: bun_dns::Family) -> DNSServiceProtocol {
     match family {
@@ -94,7 +82,7 @@ pub(crate) struct QueryState {
     pub(crate) results: bun_dns::ResultList,
     /// First hard error (NoSuchRecord/Timeout are per-family negatives, not errors).
     pub(crate) sd_error: DNSServiceErrorType,
-    /// A family timed out: with no results this is EAI_AGAIN, not EAI_NONAME.
+    /// A family timed out: an unsuppressed reissue would only wait out the timeout again.
     saw_timeout: bool,
     /// Last reply had `MoreComing` and no other request's reply followed: more is queued daemon-side.
     awaiting_more: bool,
@@ -202,17 +190,6 @@ impl QueryState {
         }
     }
 
-    /// EAI_* status for a completed query with no results.
-    pub(crate) fn empty_status(&self) -> c_int {
-        if self.sd_error != 0 {
-            to_eai(self.sd_error)
-        } else if self.saw_timeout {
-            libc::EAI_AGAIN
-        } else {
-            libc::EAI_NONAME
-        }
-    }
-
     pub(crate) fn take_results(&mut self) -> bun_dns::ResultList {
         let mut results = core::mem::take(&mut self.results);
         // Family arrival order races upstream; match getaddrinfo's RFC 6724 default (IPv6 first).
@@ -300,7 +277,9 @@ impl sd::GetAddrInfoReply for GetAddrInfoRequest {
 }
 
 /// One per event loop: owns the primary connection + its `FilePoll`; lookups are ShareConnection subordinates.
-/// Only ever torn down through [`destroy`](Self::destroy) (fields in that order).
+/// Held as `Rc` by [`SHARED`]; its poll owner and timer container are `Rc::as_ptr` of that same `Rc`,
+/// which dispatch.rs turns back into a counted `Rc` for the callback. `file_poll` is declared (so
+/// dropped) before `connection`: the poll is returned before its fd goes away.
 pub(crate) struct SharedConnection {
     inflight: RefCell<Vec<Inflight>>,
     file_poll: RefCell<Option<OwnedFilePoll>>,
@@ -436,11 +415,9 @@ impl SharedConnection {
         this.last_ctx.set(context);
     }
 
-    /// Socket readable: drain every buffered reply (callbacks fire inline), then finish complete queries.
-    pub(crate) fn on_readable() {
-        let Some(this) = Self::current() else {
-            return;
-        };
+    /// Socket readable (via dispatch.rs, `this` recovered from the poll owner): drain every buffered
+    /// reply (callbacks fire inline), then finish complete queries.
+    pub(crate) fn on_readable(this: Rc<Self>) {
         // One scope across `finish()` so the microtask drain runs after we let go of `this`.
         let _exit = event_loop_scope();
 
@@ -449,13 +426,13 @@ impl SharedConnection {
         let rc = this.connection.process_result();
         if rc != sd::ERR_NO_ERROR {
             bun_output::scoped_log!(dns, "DNSServiceProcessResult: {}", rc);
-            // Defunct primary: detach, fail every subordinate, destroy.
+            // Defunct primary: detach, fail every subordinate, then the last `Rc` (ours) frees it.
             let ready = core::mem::take(&mut *this.inflight.borrow_mut());
             drop(Self::detach());
             for inf in ready {
                 Self::finish(inf, Some(rc));
             }
-            Self::destroy(this);
+            drop(this);
             return;
         }
         let ready = this.take_ready(|q| q.is_ready());
@@ -515,11 +492,8 @@ impl SharedConnection {
         self.early_out_armed_for.set(deadline);
     }
 
-    /// Timer fire (via dispatch.rs): complete overdue queries.
-    pub(crate) fn on_early_out() {
-        let Some(this) = Self::current() else {
-            return;
-        };
+    /// Timer fire (via dispatch.rs, `this` recovered from the timer's container): complete overdue queries.
+    pub(crate) fn on_early_out(this: Rc<Self>) {
         let _exit = event_loop_scope();
         // The heap pops without updating state; mark FIRED so a re-arm inserts instead of removing.
         this.early_out_timer
@@ -537,19 +511,6 @@ impl SharedConnection {
         for inf in ready {
             Self::finish(inf, None);
         }
-    }
-
-    /// Free a connection already removed from `SHARED` with `inflight` empty.
-    fn destroy(this: Rc<Self>) {
-        debug_assert!(this.inflight.borrow().is_empty());
-        if this.early_out_timer.get().state == EventLoopTimerState::ACTIVE
-            && VirtualMachine::is_loaded()
-        {
-            timer_all_mut().remove(this.early_out_timer.as_ptr());
-        }
-        // Return the `FilePoll` before its fd goes away with `connection`.
-        drop(this.file_poll.borrow_mut().take());
-        drop(this);
     }
 
     /// `force_err` drops partial results so teardown rejects instead of resolving.
@@ -631,7 +592,19 @@ impl SharedConnection {
                 InflightRequest::Jsc(_) => Self::finish(inf, Some(sd::ERR_DEFUNCT_CONNECTION)),
             }
         }
-        Self::destroy(conn);
+        drop(conn);
+    }
+}
+
+impl Drop for SharedConnection {
+    /// Runs once `SHARED` and any dispatch-held `Rc` are gone, with `inflight` drained.
+    fn drop(&mut self) {
+        debug_assert!(self.inflight.get_mut().is_empty());
+        if self.early_out_timer.get().state == EventLoopTimerState::ACTIVE
+            && VirtualMachine::is_loaded()
+        {
+            timer_all_mut().remove(self.early_out_timer.as_ptr());
+        }
     }
 }
 

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -230,7 +230,7 @@ pub(crate) enum InflightRequest {
     Jsc(bun_ptr::OwnedThis<GetAddrInfoRequest>),
     /// A connect-path lookup, owned by the global cache (its in-flight
     /// refcount keeps it alive until it completes).
-    Internal(BackRef<internal::Request, bun_ptr::Mut>),
+    Internal(BackRef<internal::Request, bun_ptr::Root>),
 }
 
 /// An in-flight query: its request plus the subordinate ref, which lives and

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -233,8 +233,9 @@ pub(crate) enum InflightRequest {
 /// An in-flight query: its request plus the subordinate ref, which lives and
 /// dies on this (the connection's) thread.
 pub(crate) struct Inflight {
-    request: InflightRequest,
+    /// Declared (so dropped) before `request`, the reply context it points at.
     sd_ref: Option<sd::Query>,
+    request: InflightRequest,
 }
 
 impl InflightRequest {

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -447,7 +447,7 @@ impl SharedConnection {
         let rc = this.connection.process_result();
         if rc != sd::ERR_NO_ERROR {
             bun_output::scoped_log!(dns, "DNSServiceProcessResult: {}", rc);
-            // Defunct primary: detach, fail subordinates before freeing the parent (dns_sd.h), destroy.
+            // Defunct primary: detach, fail every subordinate, destroy.
             let ready = core::mem::take(&mut *this.inflight.borrow_mut());
             drop(Self::detach());
             for inf in ready {
@@ -545,8 +545,7 @@ impl SharedConnection {
         {
             timer_all_mut().remove(this.early_out_timer.as_ptr());
         }
-        // Return the `FilePoll` before the primary ref (and any remaining
-        // subordinates) is deallocated with `connection`.
+        // Return the `FilePoll` before its fd goes away with `connection`.
         drop(this.file_poll.borrow_mut().take());
         drop(this);
     }
@@ -612,7 +611,6 @@ impl SharedConnection {
         let Some(conn) = Self::detach() else {
             return;
         };
-        // Subordinates are dealt with (deallocating them) before the parent.
         loop {
             let Some(mut inf) = conn.inflight.borrow_mut().pop() else {
                 break;

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -1,106 +1,45 @@
 //! macOS DNSServiceGetAddrInfo backend: all lookups share one mDNSResponder connection (see dns.rs banner).
 
+use core::cell::RefCell;
+use std::rc::Rc;
+
 use super::*;
 use bun_collections::index_sort;
+use bun_io::FilePoll;
+use bun_sys::dns_sd as sd;
 
-pub(crate) type DNSServiceRef = *mut c_void;
-type DNSServiceFlags = u32;
-type DNSServiceErrorType = i32;
-pub(crate) type DNSServiceProtocol = u32;
+pub(crate) use sd::DNSServiceProtocol;
+use sd::{DNSServiceErrorType, DNSServiceFlags};
 
-pub(crate) const FLAGS_MORE_COMING: DNSServiceFlags = 0x1;
-pub(crate) const FLAGS_ADD: DNSServiceFlags = 0x2;
-const FLAGS_RETURN_INTERMEDIATES: DNSServiceFlags = 0x1000;
-const FLAGS_SHARE_CONNECTION: DNSServiceFlags = 0x4000;
-const FLAGS_SUPPRESS_UNUSABLE: DNSServiceFlags = 0x8000;
-const FLAGS_TIMEOUT: DNSServiceFlags = 0x10000;
-
-pub(crate) const PROTOCOL_IPV4: DNSServiceProtocol = 0x01;
-pub(crate) const PROTOCOL_IPV6: DNSServiceProtocol = 0x02;
-
-pub(crate) const ERR_NO_ERROR: DNSServiceErrorType = 0;
-pub(crate) const ERR_NO_SUCH_RECORD: DNSServiceErrorType = -65554;
-pub(crate) const ERR_TIMEOUT: DNSServiceErrorType = -65568;
-const ERR_DEFUNCT_CONNECTION: DNSServiceErrorType = -65569;
-
-type GetAddrInfoReply = unsafe extern "C" fn(
-    sd_ref: DNSServiceRef,
-    flags: DNSServiceFlags,
-    interface_index: u32,
-    error_code: DNSServiceErrorType,
-    hostname: *const c_char,
-    address: *const Sockaddr,
-    ttl: u32,
-    context: *mut c_void,
-);
-
-// libsystem_dnssd.dylib is part of the libSystem umbrella and always linked.
-unsafe extern "C" {
-    fn DNSServiceCreateConnection(sd_ref: *mut DNSServiceRef) -> DNSServiceErrorType;
-    fn DNSServiceRefSockFD(sd_ref: DNSServiceRef) -> c_int;
-    fn DNSServiceProcessResult(sd_ref: DNSServiceRef) -> DNSServiceErrorType;
-    fn DNSServiceRefDeallocate(sd_ref: DNSServiceRef);
-    fn DNSServiceGetAddrInfo(
-        sd_ref: *mut DNSServiceRef,
-        flags: DNSServiceFlags,
-        interface_index: u32,
-        protocol: DNSServiceProtocol,
-        hostname: *const c_char,
-        callback: GetAddrInfoReply,
-        context: *mut c_void,
-    ) -> DNSServiceErrorType;
+/// Map a DNSServiceErrorType to the EAI_* code the existing error paths expect.
+pub(crate) fn to_eai(err: DNSServiceErrorType) -> c_int {
+    match err {
+        sd::ERR_NO_ERROR => 0,
+        sd::ERR_NO_SUCH_NAME | sd::ERR_NO_SUCH_RECORD => libc::EAI_NONAME,
+        sd::ERR_TIMEOUT
+        | sd::ERR_NO_ROUTER
+        | sd::ERR_DEFUNCT_CONNECTION
+        | sd::ERR_SERVICE_NOT_RUNNING => libc::EAI_AGAIN,
+        sd::ERR_NO_MEMORY => libc::EAI_MEMORY,
+        sd::ERR_POLICY_DENIED | sd::ERR_NOT_PERMITTED | sd::ERR_REFUSED => libc::EAI_FAIL,
+        _ => libc::EAI_FAIL,
+    }
 }
-
-/// SPI: `DNSServiceGetAddrInfo` plus the attribute libinfo's getaddrinfo passes. Absent on macOS 12, so resolved at runtime.
-type GetAddrInfoExFn = unsafe extern "C" fn(
-    sd_ref: *mut DNSServiceRef,
-    flags: DNSServiceFlags,
-    interface_index: u32,
-    protocol: DNSServiceProtocol,
-    hostname: *const c_char,
-    attr: *const DNSServiceAttribute,
-    callback: GetAddrInfoReply,
-    context: *mut c_void,
-) -> DNSServiceErrorType;
-
-/// `DNSServiceGetAddrInfoEx` with `kDNSServiceAttrAllowFailover` (lets mDNSResponder fail a query over to
-/// scoped/supplemental resolvers, as getaddrinfo does), when this OS has both.
-fn getaddrinfo_ex() -> Option<(GetAddrInfoExFn, *const DNSServiceAttribute)> {
-    let f = bun_sys::dlsym_with_handle!(
-        GetAddrInfoExFn,
-        "DNSServiceGetAddrInfoEx",
-        Some(libc::RTLD_DEFAULT)
-    )?;
-    let attr = bun_sys::dlsym_with_handle!(
-        *const DNSServiceAttribute,
-        "kDNSServiceAttrAllowFailover",
-        Some(libc::RTLD_DEFAULT)
-    )?;
-    Some((f, attr))
-}
-
-#[repr(C)]
-pub(crate) struct DNSServiceAttribute {
-    _opaque: [u8; 0],
-}
-
-/// No address: libinfo's `getaddrinfo` reports this as EAI_NONAME whatever the daemon's error was.
-pub(crate) const EMPTY_STATUS: c_int = libc::EAI_NONAME;
 
 pub(crate) fn protocol_for_family(family: bun_dns::Family) -> DNSServiceProtocol {
     match family {
-        bun_dns::Family::Inet => PROTOCOL_IPV4,
-        bun_dns::Family::Inet6 => PROTOCOL_IPV6,
+        bun_dns::Family::Inet => sd::PROTOCOL_IPV4,
+        bun_dns::Family::Inet6 => sd::PROTOCOL_IPV6,
         // Both explicitly (not 0): completion tracks per-family replies.
-        _ => PROTOCOL_IPV4 | PROTOCOL_IPV6,
+        _ => sd::PROTOCOL_IPV4 | sd::PROTOCOL_IPV6,
     }
 }
 
 pub(crate) fn protocol_for_hints(hints: &AddrInfo) -> DNSServiceProtocol {
     match hints.ai_family {
-        f if f == netc::AF_INET => PROTOCOL_IPV4,
-        f if f == netc::AF_INET6 => PROTOCOL_IPV6,
-        _ => PROTOCOL_IPV4 | PROTOCOL_IPV6,
+        f if f == netc::AF_INET => sd::PROTOCOL_IPV4,
+        f if f == netc::AF_INET6 => sd::PROTOCOL_IPV6,
+        _ => sd::PROTOCOL_IPV4 | sd::PROTOCOL_IPV6,
     }
 }
 
@@ -111,14 +50,14 @@ pub(crate) fn getaddrinfo_only_flags(flags: c_int) -> bool {
 
 /// SuppressUnusable = daemon-side AI_ADDRCONFIG (localhost exempt); libinfo's getaddrinfo sets it too.
 fn addrconfig_flags(protocol: DNSServiceProtocol) -> DNSServiceFlags {
-    if protocol != (PROTOCOL_IPV4 | PROTOCOL_IPV6)
+    if protocol != (sd::PROTOCOL_IPV4 | sd::PROTOCOL_IPV6)
         || env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG
             .get()
             .unwrap_or(false)
     {
         return 0;
     }
-    FLAGS_SUPPRESS_UNUSABLE
+    sd::FLAGS_SUPPRESS_UNUSABLE
 }
 
 /// libinfo-style bound on waiting for the second family once the first has answered.
@@ -126,7 +65,7 @@ const SECOND_FAMILY_EXTRA_MS: i64 = 2000;
 
 /// The suppressed query always asked for both families.
 fn protocol_for_pending(_q: &QueryState) -> DNSServiceProtocol {
-    PROTOCOL_IPV4 | PROTOCOL_IPV6
+    sd::PROTOCOL_IPV4 | sd::PROTOCOL_IPV6
 }
 
 /// Real time: this timer lives in the real heap (`allow_fake_timers() == false`), so it must never read the mocked clock.
@@ -152,11 +91,10 @@ enum Attempt {
 
 /// Per-query state shared by the JS `dns.lookup` path and the internal connect path.
 pub(crate) struct QueryState {
-    pub(crate) sd_ref: DNSServiceRef,
     pub(crate) results: bun_dns::ResultList,
     /// First hard error (NoSuchRecord/Timeout are per-family negatives, not errors).
     pub(crate) sd_error: DNSServiceErrorType,
-    /// A family timed out: an unsuppressed reissue would only wait out the timeout again.
+    /// A family timed out: with no results this is EAI_AGAIN, not EAI_NONAME.
     saw_timeout: bool,
     /// Last reply had `MoreComing` and no other request's reply followed: more is queued daemon-side.
     awaiting_more: bool,
@@ -166,13 +104,11 @@ pub(crate) struct QueryState {
     attempt: Attempt,
     /// Kept so `finish()` can reissue the query for the retry.
     hostname: bun::ZBox,
-    callback: Option<GetAddrInfoReply>,
 }
 
 impl QueryState {
     pub(crate) fn new(protocol: DNSServiceProtocol) -> Self {
         Self {
-            sd_ref: ptr::null_mut(),
             results: Default::default(),
             sd_error: 0,
             saw_timeout: false,
@@ -181,7 +117,6 @@ impl QueryState {
             stragglers: Stragglers::None,
             attempt: Attempt::Plain,
             hostname: bun::ZBox::from_bytes(b""),
-            callback: None,
         }
     }
 
@@ -206,40 +141,33 @@ impl QueryState {
             && !self.saw_timeout
     }
 
-    /// Absorb one callback. SAFETY: `address`, if non-null, is a valid sockaddr (dnssd_clientstub guarantees it).
-    pub(crate) unsafe fn record_reply(
-        &mut self,
-        flags: DNSServiceFlags,
-        error_code: DNSServiceErrorType,
-        address: *const Sockaddr,
-        ttl: u32,
-    ) {
-        self.awaiting_more = flags & FLAGS_MORE_COMING != 0;
+    /// Absorb one callback.
+    pub(crate) fn record_reply(&mut self, reply: &sd::Reply<'_>) {
+        let (flags, error_code) = (reply.flags, reply.error_code);
+        self.awaiting_more = flags & sd::FLAGS_MORE_COMING != 0;
         // Only PolicyDenied passes a null sockaddr; A/AAAA replies (incl. negatives) are family-tagged.
-        if address.is_null() {
+        let Some(address) = reply.address else {
             if self.sd_error == 0 {
                 self.sd_error = error_code;
             }
             return;
-        }
-        // SAFETY: caller contract.
-        let fam = unsafe { (*address).sa_family } as i32;
+        };
+        let fam = address.family();
         // Any reply retires the family's bit; completeness is tracked by `awaiting_more`.
         self.pending_proto &= !if fam == netc::AF_INET6 {
-            PROTOCOL_IPV6
+            sd::PROTOCOL_IPV6
         } else {
-            PROTOCOL_IPV4
+            sd::PROTOCOL_IPV4
         };
-        if error_code == ERR_NO_ERROR && flags & FLAGS_ADD != 0 {
+        if error_code == sd::ERR_NO_ERROR && flags & sd::FLAGS_ADD != 0 {
             self.results.push(GetAddrInfoResult {
-                // SAFETY: caller contract.
-                address: unsafe { bun_dns::Address::init_posix(address.cast()) },
-                ttl: ttl as i32,
+                address,
+                ttl: reply.ttl as i32,
             });
-        } else if error_code == ERR_TIMEOUT {
+        } else if error_code == sd::ERR_TIMEOUT {
             self.saw_timeout = true;
-        } else if error_code != ERR_NO_ERROR
-            && error_code != ERR_NO_SUCH_RECORD
+        } else if error_code != sd::ERR_NO_ERROR
+            && error_code != sd::ERR_NO_SUCH_RECORD
             && self.sd_error == 0
         {
             self.sd_error = error_code;
@@ -271,6 +199,17 @@ impl QueryState {
         }
     }
 
+    /// EAI_* status for a completed query with no results.
+    pub(crate) fn empty_status(&self) -> c_int {
+        if self.sd_error != 0 {
+            to_eai(self.sd_error)
+        } else if self.saw_timeout {
+            libc::EAI_AGAIN
+        } else {
+            libc::EAI_NONAME
+        }
+    }
+
     pub(crate) fn take_results(&mut self) -> bun_dns::ResultList {
         let mut results = core::mem::take(&mut self.results);
         // Family arrival order races upstream; match getaddrinfo's RFC 6724 default (IPv6 first).
@@ -281,41 +220,93 @@ impl QueryState {
     }
 }
 
-#[derive(Clone, Copy)]
-pub(crate) enum Inflight {
-    Jsc(*mut GetAddrInfoRequest),
-    Internal(*mut internal::Request),
+/// The request an in-flight query belongs to (it owns the `QueryState` the
+/// reply callback writes).
+pub(crate) enum InflightRequest {
+    /// A `dns.lookup()`; owned here until `finish`.
+    Jsc(bun_ptr::OwnedThis<GetAddrInfoRequest>),
+    /// A connect-path lookup, owned by the global cache (its in-flight
+    /// refcount keeps it alive until it completes).
+    Internal(BackRef<internal::Request, bun_ptr::Mut>),
 }
 
-impl Inflight {
-    fn context(&self) -> *mut c_void {
-        match *self {
-            Inflight::Jsc(r) => r.cast(),
-            Inflight::Internal(r) => r.cast(),
+/// An in-flight query: its request plus the subordinate ref, which lives and
+/// dies on this (the connection's) thread.
+pub(crate) struct Inflight {
+    request: InflightRequest,
+    sd_ref: Option<sd::Query>,
+}
+
+impl InflightRequest {
+    /// The reply-callback context registered for this query (identity only).
+    fn context(&self) -> *const () {
+        match self {
+            InflightRequest::Jsc(r) => core::ptr::from_ref::<GetAddrInfoRequest>(r).cast(),
+            InflightRequest::Internal(r) => r.as_ptr().cast_const().cast(),
         }
     }
 
-    /// SAFETY: the request behind `self` is live (pinned in `inflight`);
-    /// the `&mut` derives from the stored raw pointer, not from a borrow.
-    unsafe fn query<'a>(self) -> &'a mut QueryState {
-        // SAFETY: caller contract; event-loop thread only.
-        unsafe {
-            match self {
-                Inflight::Jsc(r) => &mut (*r).backend.as_dns_sd_mut().query,
-                Inflight::Internal(r) => &mut (*r).dns_sd.query,
+    fn query(&self) -> &JsCell<QueryState> {
+        match self {
+            InflightRequest::Jsc(r) => &r.backend.dns_sd().query,
+            InflightRequest::Internal(r) => &r.dns_sd.query,
+        }
+    }
+
+    /// (Re)issue this query on `connection`.
+    fn issue(
+        &self,
+        connection: &sd::Connection,
+        protocol: DNSServiceProtocol,
+        suppress: DNSServiceFlags,
+        hostname: &core::ffi::CStr,
+    ) -> Option<sd::Query> {
+        let flags = sd::FLAGS_TIMEOUT | sd::FLAGS_RETURN_INTERMEDIATES | suppress;
+        let result = match self {
+            InflightRequest::Jsc(r) => {
+                connection.get_addr_info(flags, 0, protocol, hostname, BackRef::new(&**r))
+            }
+            InflightRequest::Internal(r) => {
+                connection.get_addr_info(flags, 0, protocol, hostname, BackRef::new(r.get()))
+            }
+        };
+        match result {
+            Ok(query) => Some(query),
+            Err(err) => {
+                bun_output::scoped_log!(dns, "DNSServiceGetAddrInfo failed: {}", err);
+                None
             }
         }
     }
 }
 
-/// One per event loop: owns the primary `DNSServiceRef` + `FilePoll`; lookups are ShareConnection subordinates.
+impl Inflight {
+    fn query(&self) -> &JsCell<QueryState> {
+        self.request.query()
+    }
+}
+
+impl sd::GetAddrInfoReply for GetAddrInfoRequest {
+    /// Reply callback (inside `process_result`): records state; completion
+    /// happens in `on_readable`.
+    fn on_reply(&self, reply: &sd::Reply<'_>) {
+        SharedConnection::note_reply(core::ptr::from_ref(self).cast());
+        self.backend
+            .dns_sd()
+            .query
+            .with_mut(|q| q.record_reply(reply));
+    }
+}
+
+/// One per event loop: owns the primary connection + its `FilePoll`; lookups are ShareConnection subordinates.
+/// Only ever torn down through [`destroy`](Self::destroy) (fields in that order).
 pub(crate) struct SharedConnection {
-    main_ref: DNSServiceRef,
-    file_poll: NonNull<FilePoll>,
+    inflight: RefCell<Vec<Inflight>>,
+    file_poll: RefCell<Option<OwnedFilePoll>>,
+    connection: sd::Connection,
     ctx: Async::EventLoopCtx,
-    inflight: Vec<Inflight>,
     /// `context` of the previous reply (a different one ends the prior request's contiguous run).
-    last_ctx: *mut c_void,
+    last_ctx: Cell<*const ()>,
     /// Early-out timer (JS threads only; the daemon timeout backstops other loops).
     pub(crate) early_out_timer: JsCell<EventLoopTimer>,
     /// Deadline the timer is currently armed for (0 = disarmed).
@@ -323,194 +314,145 @@ pub(crate) struct SharedConnection {
 }
 
 thread_local! {
-    static SHARED: Cell<*mut SharedConnection> = const { Cell::new(ptr::null_mut()) };
+    /// This thread's connection. `ManuallyDrop`: a thread that exits without
+    /// `close_for_terminate` leaves it (and mDNSResponder's fd) to the OS
+    /// rather than running teardown against a gone event loop.
+    static SHARED: RefCell<core::mem::ManuallyDrop<Option<Rc<SharedConnection>>>> =
+        const { RefCell::new(core::mem::ManuallyDrop::new(None)) };
 }
 
 impl SharedConnection {
-    /// This thread's connection; don't hold the borrow across `DNSServiceProcessResult`/`finish`.
-    fn current<'a>() -> Option<&'a mut Self> {
-        // SAFETY: SHARED is null or this thread's live heap connection.
-        unsafe { SHARED.get().as_mut() }
+    /// This thread's connection, if any.
+    fn current() -> Option<Rc<Self>> {
+        SHARED.with_borrow(|s| Option::clone(s))
     }
 
-    fn file_poll(&mut self) -> &mut FilePoll {
-        // SAFETY: `file_poll` is the live hive slot owned by this connection until `destroy`.
-        unsafe { self.file_poll.as_mut() }
+    fn detach() -> Option<Rc<Self>> {
+        SHARED.with_borrow_mut(|s| s.take())
     }
 
     /// Lazily connect; `None` (caller falls back to getaddrinfo) if mDNSResponder is unreachable.
-    pub(crate) fn get<'a>(ctx: Async::EventLoopCtx) -> Option<&'a mut Self> {
+    pub(crate) fn get(ctx: Async::EventLoopCtx) -> Option<Rc<Self>> {
         if let Some(existing) = Self::current() {
             return Some(existing);
         }
-        let mut main_ref: DNSServiceRef = ptr::null_mut();
-        // SAFETY: FFI; `main_ref` is stack-local.
-        let err = unsafe { DNSServiceCreateConnection(&raw mut main_ref) };
-        if err != ERR_NO_ERROR || main_ref.is_null() {
-            bun_output::scoped_log!(dns, "DNSServiceCreateConnection failed: {}", err);
-            return None;
-        }
-        // SAFETY: FFI; `main_ref` is the live ref just returned above.
-        let raw_fd = unsafe { DNSServiceRefSockFD(main_ref) };
+        let connection = match sd::Connection::create() {
+            Ok(c) => c,
+            Err(err) => {
+                bun_output::scoped_log!(dns, "DNSServiceCreateConnection failed: {}", err);
+                return None;
+            }
+        };
+        let raw_fd = connection.sock_fd();
         if raw_fd < 0 {
             bun_output::scoped_log!(dns, "DNSServiceRefSockFD returned {}", raw_fd);
-            // SAFETY: FFI; releasing the ref we just created.
-            unsafe { DNSServiceRefDeallocate(main_ref) };
             return None;
         }
-        let fd = sys::Fd::from_native(raw_fd);
-        let mut this = Box::new(Self {
-            main_ref,
-            file_poll: NonNull::dangling(),
+        let fd = bun_sys::Fd::from_native(raw_fd);
+        let this = Rc::new(Self {
+            inflight: RefCell::new(Vec::new()),
+            file_poll: RefCell::new(None),
+            connection,
             ctx,
-            inflight: Vec::new(),
-            last_ctx: ptr::null_mut(),
+            last_ctx: Cell::new(core::ptr::null()),
             early_out_timer: JsCell::new(EventLoopTimer::init_paused(
                 EventLoopTimerTag::DnsSdConnection,
             )),
             early_out_armed_for: Cell::new(0),
         });
-        let poll_ptr = FilePoll::init(
+        let mut poll = OwnedFilePoll::new(
             ctx,
             fd,
             Default::default(),
             Async::Owner::new(
                 Async::posix_event_loop::poll_tag::GET_ADDR_INFO_REQUEST,
-                (&raw mut *this).cast(),
+                Rc::as_ptr(&this).cast_mut().cast(),
             ),
         );
-        // SAFETY: `FilePoll::init` returned a live pool slot; exclusive here.
-        let poll = unsafe { &mut *poll_ptr };
-        // SAFETY: the event loop outlives every lookup made on it.
-        let loop_ = unsafe { ctx.platform_event_loop() };
-        let rc = poll.register_with_fd(
-            loop_,
+        let rc = poll.register_with_fd_on(
+            ctx,
             Async::PollKind::Readable,
             Async::posix_event_loop::OneShotFlag::None,
             fd,
         );
         if rc.is_err() {
-            poll.deinit();
-            // SAFETY: FFI; `main_ref` is the live connection ref.
-            unsafe { DNSServiceRefDeallocate(main_ref) };
             return None;
         }
-        this.file_poll = NonNull::new(poll_ptr).unwrap();
-        SHARED.set(bun_core::heap::into_raw(this));
-        Self::current()
+        *this.file_poll.borrow_mut() = Some(poll);
+        SHARED.with_borrow_mut(|s| **s = Some(Rc::clone(&this)));
+        Some(this)
+    }
+
+    fn with_file_poll(&self, f: impl FnOnce(&mut FilePoll)) {
+        if let Some(poll) = self.file_poll.borrow_mut().as_deref_mut() {
+            f(poll);
+        }
     }
 
     /// Start a subordinate query and track it (keeps the process alive); `None` if the daemon refused.
     pub(crate) fn start(
-        &mut self,
-        owner: Inflight,
+        &self,
+        request: InflightRequest,
         protocol: DNSServiceProtocol,
-        hostname: &ZStr,
-        callback: GetAddrInfoReply,
-        context: *mut c_void,
-    ) -> Option<DNSServiceRef> {
+        hostname: &core::ffi::CStr,
+    ) -> Option<()> {
         let suppress = addrconfig_flags(protocol);
-        let sub = self.issue(protocol, suppress, hostname, callback, context)?;
-        if self.inflight.is_empty() {
+        let sub = request.issue(&self.connection, protocol, suppress, hostname)?;
+        if self.inflight.borrow().is_empty() {
             let ctx = self.ctx;
-            self.file_poll().enable_keeping_process_alive(ctx);
+            self.with_file_poll(|p| p.enable_keeping_process_alive(ctx));
         }
-        // SAFETY: `owner` is the caller's live request, tracked here until `finish()`.
-        let q = unsafe { owner.query() };
-        q.sd_ref = sub;
-        q.attempt = if suppress != 0 {
-            Attempt::Suppressed
-        } else {
-            Attempt::Plain
-        };
-        q.hostname = bun::ZBox::from_bytes(hostname.as_bytes());
-        q.callback = Some(callback);
-        self.inflight.push(owner);
-        Some(sub)
-    }
-
-    fn issue(
-        &mut self,
-        protocol: DNSServiceProtocol,
-        suppress: DNSServiceFlags,
-        hostname: &ZStr,
-        callback: GetAddrInfoReply,
-        context: *mut c_void,
-    ) -> Option<DNSServiceRef> {
-        // ShareConnection requires `sub` to start as a copy of the primary ref.
-        let mut sub: DNSServiceRef = self.main_ref;
-        let flags = FLAGS_SHARE_CONNECTION | FLAGS_TIMEOUT | FLAGS_RETURN_INTERMEDIATES | suppress;
-        let hostname = hostname.as_ptr().cast::<c_char>();
-        // SAFETY: FFI; `hostname` is NUL-terminated (copied by dns_sd); `context` is only stored.
-        let err = unsafe {
-            match getaddrinfo_ex() {
-                Some((ex, attr)) => ex(
-                    &raw mut sub,
-                    flags,
-                    0,
-                    protocol,
-                    hostname,
-                    attr,
-                    callback,
-                    context,
-                ),
-                None => DNSServiceGetAddrInfo(
-                    &raw mut sub,
-                    flags,
-                    0,
-                    protocol,
-                    hostname,
-                    callback,
-                    context,
-                ),
-            }
-        };
-        if err != ERR_NO_ERROR {
-            bun_output::scoped_log!(dns, "DNSServiceGetAddrInfo failed: {}", err);
-            return None;
-        }
-        Some(sub)
+        request.query().with_mut(|q| {
+            q.attempt = if suppress != 0 {
+                Attempt::Suppressed
+            } else {
+                Attempt::Plain
+            };
+            q.hostname = bun::ZBox::from_bytes(hostname.to_bytes());
+        });
+        self.inflight.borrow_mut().push(Inflight {
+            request,
+            sd_ref: Some(sub),
+        });
+        Some(())
     }
 
     /// Called first from every reply callback: a different `context` ends the previous request's `MoreComing` run.
-    pub(crate) fn note_reply(context: *mut c_void) {
+    pub(crate) fn note_reply(context: *const ()) {
         let Some(this) = Self::current() else {
             return;
         };
-        let prev = this.last_ctx;
+        let prev = this.last_ctx.get();
         if !prev.is_null() && prev != context {
-            for inf in this.inflight.iter() {
-                if inf.context() == prev {
-                    // SAFETY: entries in `inflight` are live requests.
-                    unsafe { inf.query() }.awaiting_more = false;
+            for inf in this.inflight.borrow().iter() {
+                if inf.request.context() == prev {
+                    inf.query().with_mut(|q| q.awaiting_more = false);
                 }
             }
         }
-        this.last_ctx = context;
+        this.last_ctx.set(context);
     }
 
     /// Socket readable: drain every buffered reply (callbacks fire inline), then finish complete queries.
-    pub(crate) fn on_readable(this: *mut Self) {
-        // SAFETY: `this` is the live connection registered with the FilePoll.
-        let main_ref = unsafe { (*this).main_ref };
-        // One scope across `finish()` so the microtask drain runs after we let go of `this`.
-        let _exit = event_loop_scope();
-
-        // SAFETY: FFI; `main_ref` is live and no `&mut Self` is held (callbacks use `context`).
-        let rc = unsafe { DNSServiceProcessResult(main_ref) };
+    pub(crate) fn on_readable() {
         let Some(this) = Self::current() else {
             return;
         };
-        if rc != ERR_NO_ERROR {
+        // One scope across `finish()` so the microtask drain runs after we let go of `this`.
+        let _exit = event_loop_scope();
+
+        // Callbacks re-enter through `note_reply` and the requests' own cells;
+        // no `RefCell` borrow is held here.
+        let rc = this.connection.process_result();
+        if rc != sd::ERR_NO_ERROR {
             bun_output::scoped_log!(dns, "DNSServiceProcessResult: {}", rc);
             // Defunct primary: detach, fail subordinates before freeing the parent (dns_sd.h), destroy.
-            let ready = core::mem::take(&mut this.inflight);
-            let detached = SHARED.replace(ptr::null_mut());
+            let ready = core::mem::take(&mut *this.inflight.borrow_mut());
+            drop(Self::detach());
             for inf in ready {
                 Self::finish(inf, Some(rc));
             }
-            // SAFETY: `detached` was just removed from SHARED and drained.
-            unsafe { Self::destroy(detached) };
+            Self::destroy(this);
             return;
         }
         let ready = this.take_ready(|q| q.is_ready());
@@ -521,33 +463,33 @@ impl SharedConnection {
     }
 
     /// Remove every in-flight query matching `pred` (dropping the keep-alive if none remain).
-    fn take_ready(&mut self, mut pred: impl FnMut(&mut QueryState) -> bool) -> Vec<Inflight> {
+    fn take_ready(&self, mut pred: impl FnMut(&mut QueryState) -> bool) -> Vec<Inflight> {
         let mut ready = Vec::new();
+        let mut inflight = self.inflight.borrow_mut();
         let mut i = 0;
-        while i < self.inflight.len() {
-            // SAFETY: entries in `inflight` are live requests.
-            if pred(unsafe { self.inflight[i].query() }) {
-                ready.push(self.inflight.swap_remove(i));
+        while i < inflight.len() {
+            if inflight[i].query().with_mut(&mut pred) {
+                ready.push(inflight.swap_remove(i));
             } else {
                 i += 1;
             }
         }
-        if self.inflight.is_empty() {
+        if inflight.is_empty() {
+            drop(inflight);
             let ctx = self.ctx;
-            self.file_poll().disable_keeping_process_alive(ctx);
+            self.with_file_poll(|p| p.disable_keeping_process_alive(ctx));
         }
         ready
     }
 
     /// Arm the timer for the nearest early-out deadline (JS thread only; daemon timeout otherwise).
-    fn arm_early_out(&mut self) {
-        if VirtualMachine::get_or_null().is_none() {
+    fn arm_early_out(&self) {
+        if !VirtualMachine::is_loaded() {
             return;
         }
         let mut min_deadline: Option<i64> = None;
-        for inf in self.inflight.iter() {
-            // SAFETY: entries in `inflight` are live requests.
-            if let Some(d) = unsafe { inf.query() }.early_out_deadline_ms() {
+        for inf in self.inflight.borrow().iter() {
+            if let Some(d) = inf.query().get().early_out_deadline_ms() {
                 min_deadline = Some(min_deadline.map_or(d, |m| m.min(d)));
             }
         }
@@ -560,154 +502,142 @@ impl SharedConnection {
         }
         let now = bun::timespec::now(bun::TimespecMockMode::ForceRealTime);
         let next = now.add_ms((deadline - now.ms()).max(1));
-        let state = crate::jsc_hooks::runtime_state();
-        // SAFETY: this thread's live RuntimeState; the timer slot is valid until `destroy`.
-        unsafe {
-            (*state).timer.update(
-                core::ptr::addr_of!(self.early_out_timer)
-                    .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                    .cast_mut(),
-                &ElTimespec {
-                    sec: next.sec,
-                    nsec: next.nsec,
-                },
-            )
-        };
+        timer_all_mut().update(
+            self.early_out_timer.as_ptr(),
+            &ElTimespec {
+                sec: next.sec,
+                nsec: next.nsec,
+            },
+        );
         self.early_out_armed_for.set(deadline);
     }
 
-    /// Timer fire (via dispatch.rs): complete overdue queries. SAFETY: `this` is the live connection whose timer fired.
-    pub(crate) unsafe fn on_early_out(this: *mut Self) {
-        // Raw receiver like `on_readable`: `finish()` may re-derive `&mut Self`, so no borrow of `*this` outlives it.
-        let _exit = event_loop_scope();
-        // SAFETY: `this` is the live connection whose timer fired; each borrow
-        // below is scoped to its statement and ends before `finish()`.
-        let ready = unsafe {
-            // The heap pops without updating state; mark FIRED so a re-arm inserts instead of removing.
-            (*this)
-                .early_out_timer
-                .with_mut(|t| t.state = EventLoopTimerState::FIRED);
-            (*this).early_out_armed_for.set(0);
-            let now = now_ms();
-            let ready = (*this).take_ready(|q| {
-                let due = q.early_out_deadline_ms().is_some_and(|d| d <= now);
-                if due {
-                    q.give_up_on_stragglers();
-                }
-                due
-            });
-            (*this).arm_early_out();
-            ready
+    /// Timer fire (via dispatch.rs): complete overdue queries.
+    pub(crate) fn on_early_out() {
+        let Some(this) = Self::current() else {
+            return;
         };
+        let _exit = event_loop_scope();
+        // The heap pops without updating state; mark FIRED so a re-arm inserts instead of removing.
+        this.early_out_timer
+            .with_mut(|t| t.state = EventLoopTimerState::FIRED);
+        this.early_out_armed_for.set(0);
+        let now = now_ms();
+        let ready = this.take_ready(|q| {
+            let due = q.early_out_deadline_ms().is_some_and(|d| d <= now);
+            if due {
+                q.give_up_on_stragglers();
+            }
+            due
+        });
+        this.arm_early_out();
         for inf in ready {
             Self::finish(inf, None);
         }
     }
 
-    /// Free a detached connection. SAFETY: `this` is live, removed from SHARED, `inflight` empty.
-    unsafe fn destroy(this: *mut Self) {
-        // SAFETY: caller contract.
-        let conn = unsafe { bun_core::heap::take(this) };
-        debug_assert!(conn.inflight.is_empty());
-        if conn.early_out_timer.get().state == EventLoopTimerState::ACTIVE
-            && VirtualMachine::get_or_null().is_some()
+    /// Free a connection already removed from `SHARED` with `inflight` empty.
+    fn destroy(this: Rc<Self>) {
+        debug_assert!(this.inflight.borrow().is_empty());
+        if this.early_out_timer.get().state == EventLoopTimerState::ACTIVE
+            && VirtualMachine::is_loaded()
         {
-            // SAFETY: this thread's live RuntimeState owns the timer heap.
-            unsafe {
-                (*crate::jsc_hooks::runtime_state())
-                    .timer
-                    .remove(conn.early_out_timer.as_ptr())
-            };
+            timer_all_mut().remove(this.early_out_timer.as_ptr());
         }
-        // SAFETY: `file_poll` is the live hive slot; `deinit` returns it.
-        unsafe { (*conn.file_poll.as_ptr()).deinit() };
-        // SAFETY: FFI; releases the primary ref (and any remaining subordinates).
-        unsafe { DNSServiceRefDeallocate(conn.main_ref) };
-        drop(conn);
+        // Return the `FilePoll` before the primary ref (and any remaining
+        // subordinates) is deallocated with `connection`.
+        drop(this.file_poll.borrow_mut().take());
+        drop(this);
     }
 
     /// `force_err` drops partial results so teardown rejects instead of resolving.
-    fn finish(inf: Inflight, force_err: Option<DNSServiceErrorType>) {
-        // SAFETY: `inf` is a live heap request just removed from `inflight`.
-        let q = unsafe { inf.query() };
-        // SAFETY: FFI; `sd_ref` is this request's live subordinate.
-        unsafe { DNSServiceRefDeallocate(q.sd_ref) };
-        if let Some(e) = force_err {
-            q.results.clear();
-            q.sd_error = e;
-        } else if q.should_retry_unsuppressed() && Self::retry_unsuppressed(inf) {
-            return;
-        }
-        match inf {
-            Inflight::Jsc(r) => GetAddrInfoRequest::complete_dns_sd(r),
-            Inflight::Internal(r) => internal::dns_sd_complete(r),
+    fn finish(mut inf: Inflight, force_err: Option<DNSServiceErrorType>) {
+        drop(inf.sd_ref.take());
+        let retry = inf.query().with_mut(|q| {
+            if let Some(e) = force_err {
+                q.results.clear();
+                q.sd_error = e;
+                false
+            } else {
+                q.should_retry_unsuppressed()
+            }
+        });
+        let inf = if retry {
+            match Self::retry_unsuppressed(inf) {
+                Ok(()) => return,
+                Err(inf) => inf,
+            }
+        } else {
+            inf
+        };
+        match inf.request {
+            InflightRequest::Jsc(r) => GetAddrInfoRequest::complete_dns_sd(r.into_inner()),
+            InflightRequest::Internal(r) => internal::dns_sd_complete(r),
         }
     }
 
-    /// Reissue `inf`'s query without SuppressUnusable; `false` if it couldn't be reissued.
-    fn retry_unsuppressed(inf: Inflight) -> bool {
+    /// Reissue `inf`'s query without SuppressUnusable; hands it back if it couldn't be reissued.
+    fn retry_unsuppressed(mut inf: Inflight) -> Result<(), Inflight> {
         let Some(this) = Self::current() else {
-            return false;
+            return Err(inf);
         };
-        // SAFETY: `inf` is a live heap request removed from `inflight` by the caller.
-        let q = unsafe { inf.query() };
-        let (protocol, hostname) = (protocol_for_pending(q), q.hostname.clone());
-        let Some(callback) = q.callback else {
-            return false;
+        let (protocol, hostname) = {
+            let q = inf.query().get();
+            (protocol_for_pending(q), q.hostname.clone())
         };
-        q.reset_for_retry(protocol);
-        let Some(sub) = this.issue(protocol, 0, &hostname, callback, inf.context()) else {
-            return false;
+        inf.query().with_mut(|q| q.reset_for_retry(protocol));
+        let Some(sub) = inf
+            .request
+            .issue(&this.connection, protocol, 0, c_str(&hostname))
+        else {
+            return Err(inf);
         };
         bun_output::scoped_log!(
             dns,
             "retrying {} without SuppressUnusable",
             bstr::BStr::new(hostname.as_bytes())
         );
-        q.sd_ref = sub;
-        if this.inflight.is_empty() {
+        inf.sd_ref = Some(sub);
+        if this.inflight.borrow().is_empty() {
             let ctx = this.ctx;
-            this.file_poll().enable_keeping_process_alive(ctx);
+            this.with_file_poll(|p| p.enable_keeping_process_alive(ctx));
         }
-        this.inflight.push(inf);
-        true
+        this.inflight.borrow_mut().push(inf);
+        Ok(())
     }
 
     /// VM teardown: fail in-flight requests (like c-ares' EDESTRUCTION) and release the fd/FilePoll.
     pub(crate) fn close_for_terminate() {
-        let this = SHARED.replace(ptr::null_mut());
-        // SAFETY: SHARED held null or the live heap connection.
-        let Some(conn) = (unsafe { this.as_mut() }) else {
+        let Some(conn) = Self::detach() else {
             return;
         };
         // Subordinates are dealt with (deallocating them) before the parent.
-        while let Some(inf) = conn.inflight.pop() {
-            match inf {
+        loop {
+            let Some(mut inf) = conn.inflight.borrow_mut().pop() else {
+                break;
+            };
+            match &inf.request {
                 // A connect-path lookup lives in the process-wide cache and may
                 // have waiters on other threads (and its outcome is cached): this
                 // thread going away is not an answer. Finish it on the work pool.
-                Inflight::Internal(req) => {
-                    // SAFETY: `inf` is a live heap request just removed from `inflight`;
-                    // FFI releases this thread's subordinate for it.
-                    unsafe { DNSServiceRefDeallocate(inf.query().sd_ref) };
-                    internal::run_on_work_pool(req);
+                InflightRequest::Internal(req) => {
+                    drop(inf.sd_ref.take());
+                    internal::run_on_work_pool(*req);
                 }
                 // A dns.lookup() from this thread's script: only this VM waits on it.
-                Inflight::Jsc(_) => Self::finish(inf, Some(ERR_DEFUNCT_CONNECTION)),
+                InflightRequest::Jsc(_) => Self::finish(inf, Some(sd::ERR_DEFUNCT_CONNECTION)),
             }
         }
-        // SAFETY: `this` is detached and drained.
-        unsafe { Self::destroy(this) };
+        Self::destroy(conn);
     }
 }
 
 fn event_loop_scope() -> Option<bun_jsc::event_loop::EventLoopEnterGuard> {
-    // SAFETY: the current thread's VM, if any, is live for the callback.
-    VirtualMachine::get_or_null().map(|vm| unsafe { (*vm).enter_event_loop_scope() })
+    VirtualMachine::is_loaded().then(|| VirtualMachine::get().enter_event_loop_scope())
 }
 
 pub(crate) fn lookup(
-    this: &Resolver,
+    this: ThisPtr<Resolver>,
     query: &GetAddrInfo,
     global_this: &JSGlobalObject,
 ) -> JSValue {
@@ -720,62 +650,45 @@ pub(crate) fn lookup(
         return lib_c::lookup(this, query, global_this);
     }
 
-    let key = get_addr_info_request::PendingCacheKey::init(query);
-    let cache = this.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheNative);
+    let key = PendingCacheKey::init(query);
+    let pending = Resolver::pending_host_cache(&this, PendingCacheField::PendingHostCacheNative);
+    let cache = pending.get_or_put(&key);
 
     if let CacheHit::Inflight(inflight) = cache {
-        let dns_lookup = DNSLookup::init(this.as_ctx_ptr(), global_this);
-        // SAFETY: inflight points into resolver's HiveArray buffer
-        unsafe { (*inflight).append(dns_lookup) };
-        // SAFETY: `dns_lookup` was just heap-allocated by `DNSLookup::init`.
-        return unsafe { (*dns_lookup).promise.value() };
+        let dns_lookup = DNSLookup::init(Some(this), global_this);
+        let promise = dns_lookup.promise.value();
+        pending.append(inflight, dns_lookup);
+        return promise;
     }
 
     let Some(shared) = SharedConnection::get(js_event_loop_ctx()) else {
         if let CacheHit::New(new) = cache {
-            this.pending_host_cache_native.with_mut(|c| {
-                // SAFETY: `new` is the fresh HiveArray slot; no other token for it exists.
-                unsafe { c.put(new) };
-            });
+            drop(pending.take(new));
         }
         return lib_c::lookup(this, query, global_this);
     };
 
     let protocol = protocol_for_family(query.options.family);
-    let request = GetAddrInfoRequest::init(
+    let request = bun_ptr::OwnedThis::new(*GetAddrInfoRequest::init(
         cache,
         get_addr_info_request::Backend::DnsSd(get_addr_info_request::BackendDnsSd::new(protocol)),
-        Some(this.as_ctx_ptr()),
+        Some(this),
         global_this,
-        PendingCacheField::PendingHostCacheNative,
-    );
-    // SAFETY: request was just heap-allocated in init() and is exclusively owned here.
-    let promise_value = unsafe { (*request).head.promise.value() };
+    ));
+    let promise_value = request.head.promise.value();
 
     let name_z = bun::ZBox::from_bytes(query.name.as_ref());
-    let Some(_) = shared.start(
-        Inflight::Jsc(request),
-        protocol,
-        &name_z,
-        GetAddrInfoRequest::dns_sd_reply,
-        request.cast::<c_void>(),
-    ) else {
-        // SAFETY: request is exclusively owned; dns_sd never accepted it.
-        unsafe {
-            if let Some(pos) = (*request).pending_slot {
-                this.pending_host_cache_native.with_mut(|c| {
-                    let slot = c.ptr_at(pos as usize);
-                    // SAFETY: `pos` was alloc'd; no other token outstanding.
-                    c.put(slot);
-                });
-            }
-            DNSLookup::destroy(&raw mut (*request).head);
-            drop(bun_core::heap::take(request));
+    // On `None`, dns_sd never accepted it and `start` dropped the request; its
+    // slot goes with it (nothing else could have joined it yet).
+    let pending_slot = request.pending_slot;
+    let Some(()) = shared.start(InflightRequest::Jsc(request), protocol, c_str(&name_z)) else {
+        if let Some(pos) = pending_slot {
+            drop(pending.take(pos));
         }
         return lib_c::lookup(this, query, global_this);
     };
 
-    this.request_sent(this.vm());
+    Resolver::request_sent(this, this.vm());
 
     promise_value
 }

--- a/src/runtime/dns_jsc/mod.rs
+++ b/src/runtime/dns_jsc/mod.rs
@@ -2,16 +2,15 @@
 //!
 //! The full body — `Resolver` with the
 //! c-ares channel, all `resolve*`/`reverse`/`getServers`/`setServers` host
-//! functions, libinfo/libuv/system getaddrinfo backends, and the process-wide
+//! functions, dns_sd/libuv/system getaddrinfo backends, and the process-wide
 //! `internal` cache used by the usockets connect path — lives in `dns.rs`
 //! (mounted here as `dns_body`). This module is the public surface: it
 //! re-exports the real types and methods so callers (`dispatch.rs`,
 //! `repl_command.rs`, `udp_socket.rs`) name `crate::dns_jsc::Foo` directly.
 
 #[path = "dns.rs"]
-mod dns_body;
-#[cfg(windows)]
-pub(crate) use dns_body::lib_uv_backend::LibuvCompleteHolder;
+#[doc(hidden)]
+pub mod dns_body;
 pub(crate) use dns_body::netc;
 
 #[path = "cares_jsc.rs"]
@@ -21,19 +20,11 @@ pub mod cares_jsc; // c-ares reply struct → JSValue bridges
 pub mod options_jsc; // GetAddrInfo.Options ↔ JSValue
 
 // ─── public surface ──────────────────────────────────────────────────────────
-// `dns_body` is the real implementation (c-ares channel, request types,
-// Resolver method bodies, `internal` cache). The earlier erased "type-surface"
-// duplicates that lived here have been dissolved — there is one
-// `Resolver`, and `dispatch.rs`'s `from_field_ptr!`/`owner_as!` casts now resolve
-// to the same allocation `dns_body::Resolver::init` produces.
 
 #[cfg(target_os = "macos")]
 pub(crate) use dns_body::dns_sd;
+pub use dns_body::get_addr_info_request;
 pub use dns_body::{
-    CacheHit, GetAddrInfoRequest, GlobalData, InternalDNSRequest, Order, PendingCache,
-    PendingCacheField, RecordType, Resolver, internal,
-};
-pub use dns_body::{
-    get_addr_info_request, get_host_by_addr_info_request, get_name_info_request,
-    resolve_info_request,
+    CacheHit, GetAddrInfoRequest, GlobalData, InternalDNSRequest, Order, PendingCache, RecordType,
+    Resolver, internal,
 };

--- a/src/runtime/dns_jsc/options_jsc.rs
+++ b/src/runtime/dns_jsc/options_jsc.rs
@@ -5,11 +5,11 @@ use bun_jsc::{
     ComptimeStringMapExt as _, JSGlobalObject, JSValue, JsError, JsResult, StringJsc as _,
 };
 
+use bun_dns::address_to_string;
 use bun_dns::{
     BACKEND_LABEL, Backend, FAMILY_MAP, Family, GetAddrInfoResult as GaiResult, Options,
-    PROTOCOL_MAP, Protocol, ResultAny, SOCKET_TYPE_MAP, SocketType,
+    PROTOCOL_MAP, Protocol, ResultList, SOCKET_TYPE_MAP, SocketType,
 };
-use bun_dns::{addr_info_count, address_to_string};
 // `FromJSError` is the union of all the per-field `Invalid*` variants plus
 // `JSError`. The enum lives in `bun_dns` (which has no `bun_jsc` dep), so the
 // `JsError → JSError` mapping is done locally via the `js()` helper below.
@@ -188,31 +188,8 @@ fn backend_from_js(value: JSValue, global: &JSGlobalObject) -> Result<Backend, F
     Err(FromJSError::InvalidBackend)
 }
 
-pub(crate) fn result_any_to_js(
-    this: &ResultAny,
-    global: &JSGlobalObject,
-) -> JsResult<Option<JSValue>> {
-    Ok(match this {
-        ResultAny::Addrinfo(addrinfo) => {
-            // LIFETIMES.tsv: GetAddrInfo.Result.Any.addrinfo is FFI → *mut libc::addrinfo
-            // (nullable raw pointer, no Option wrapper).
-            let addrinfo: *mut super::netc::addrinfo = *addrinfo;
-            if addrinfo.is_null() {
-                return Ok(None);
-            }
-            // SAFETY: addrinfo is a non-null *mut libc::addrinfo owned by the
-            // resolver; valid for the duration of this call.
-            Some(addr_info_to_js_array(unsafe { &*addrinfo }, global)?)
-        }
-        ResultAny::List(list) => 'brk: {
-            let array = JSValue::create_empty_array(global, list.len())?;
-            let items: &[GaiResult] = list.as_slice();
-            for (i, item) in (0_u32..).zip(items.iter()) {
-                array.put_index(global, i, result_to_js(item, global)?)?;
-            }
-            break 'brk Some(array);
-        }
-    })
+pub(crate) fn result_list_to_js(list: &ResultList, global: &JSGlobalObject) -> JsResult<JSValue> {
+    JSValue::create_array_from_iter(global, list.iter(), |r| result_to_js(r, global))
 }
 
 pub(crate) fn result_to_js(this: &GaiResult, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -238,28 +215,4 @@ pub(crate) fn address_to_js(
     global: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     address_to_string(address).into_js(global)
-}
-
-fn addr_info_to_js_array(
-    addr_info: &super::netc::addrinfo,
-    global: &JSGlobalObject,
-) -> JsResult<JSValue> {
-    let array = JSValue::create_empty_array(global, addr_info_count(addr_info) as usize)?;
-
-    {
-        let mut j: u32 = 0;
-        let mut current: *const super::netc::addrinfo = addr_info;
-        // SAFETY: `current` walks the getaddrinfo(3) singly-linked result list;
-        // each node and its `ai_next` are valid until freeaddrinfo is called by
-        // the owner (which outlives this call).
-        while let Some(this_node) = unsafe { current.as_ref() } {
-            if let Some(result) = GaiResult::from_addr_info(this_node) {
-                array.put_index(global, j, result_to_js(&result, global)?)?;
-                j += 1;
-            }
-            current = this_node.ai_next;
-        }
-    }
-
-    Ok(array)
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1697,11 +1697,11 @@ fn stop_dns_for_vm_teardown() -> SweepResult {
     // SAFETY: `state` is the live per-thread `RuntimeState` box; shared borrow
     // of the `OnceCell` only (the resolver's own state is interior-mutable).
     if let Some(gd) = unsafe { &(*state).global_dns_data }.get() {
-        // SAFETY: the VM-global resolver, pinned by `GlobalData` (its own ref
-        // never drops here).
-        result = result.and(unsafe {
-            crate::dns_jsc::Resolver::close_channel_for_terminate(gd.resolver.as_ctx_ptr())
-        });
+        // The VM-global resolver, pinned by `GlobalData` (its own ref never
+        // drops here).
+        result = result.and(crate::dns_jsc::Resolver::close_channel_for_terminate(
+            gd.resolver.this_ptr(),
+        ));
         #[cfg(windows)]
         gd.resolver.cancel_pending_uv_requests_for_teardown();
     }
@@ -1820,10 +1820,13 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
                 )
             },
             // Live until it unregisters in `destroy_channel`.
-            // SAFETY: registered ⇒ live; may free itself inside, not touched after.
-            ActiveHandle::DnsResolver(r) => unsafe {
-                let _ = crate::dns_jsc::Resolver::close_channel_for_terminate(r.as_ptr());
-            },
+            ActiveHandle::DnsResolver(r) => {
+                let _ = crate::dns_jsc::Resolver::close_channel_for_terminate(
+                    // SAFETY: registered (from its `ThisPtr`) ⇒ live; may free
+                    // itself inside, not touched after.
+                    unsafe { bun_ptr::ThisPtr::new(r.as_ptr()) },
+                );
+            }
         }
     }
     for handle in kept {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -888,18 +888,12 @@ impl BunTest {
             debug_assert!(false); // shouldn't be calling runNextTick after moving on to the next file
             return; // but just in case
         };
-        let done_callback_test = bun_core::heap::into_raw(Box::new(RunTestsTask {
+        // If the task never runs (VM teardown), the queue drainer drops it.
+        let task = jsc::ManagedTask::ManagedTask::new_boxed(Box::new(RunTestsTask {
             weak: Weak::clone(weak),
             global_this: GlobalRef::from(global_this),
             phase,
         }));
-        fn call_erased(this: *mut RunTestsTask) -> bun_event_loop::JsResult<()> {
-            // `this` was `heap::into_raw`'d above (always non-null) and is
-            // invoked exactly once by `ManagedTask`.
-            RunTestsTask::call(NonNull::new(this).unwrap())
-        }
-        // `new_owned`: if the task never runs (VM teardown), the queue drainer frees `done_callback_test`.
-        let task = jsc::ManagedTask::ManagedTask::new_owned::<RunTestsTask>(done_callback_test, call_erased);
         // SAFETY: single field write through `UnsafeCell`; no other `&mut` live.
         strong.get().wants_wakeup = true;
         // we need to wake up the event loop so autoTick() doesn't wait for 16-100ms because we just enqueued a task
@@ -1518,31 +1512,22 @@ pub struct RunTestsTask {
     pub global_this: GlobalRef,
     pub(crate) phase: RefDataValue,
 }
-impl RunTestsTask {
-    /// `ManagedTask` callback ABI: `fn(*mut T) -> JsResult<()>`. The pointer
-    /// was `heap::alloc`'d in `run_next_tick`; reconstitute and drop here.
-    ///
-    /// `this` must be the pointer produced by `heap::into_raw` in
-    /// `run_next_tick`; ownership is consumed (the box is dropped on return).
-    pub fn call(this: NonNull<RunTestsTask>) -> JsResult<()> {
-        // SAFETY: `this` was produced by `heap::into_raw` in `run_next_tick` and
-        // is invoked exactly once by `ManagedTask`; ownership is reclaimed here.
-        let this = unsafe { bun_core::heap::take(this.as_ptr()) };
-        // Box drops at end of scope; the Weak drops with it.
-        let Some(strong) = this.weak.upgrade() else { return Ok(()) };
-        if let Err(e) = BunTest::run(&strong, &this.global_this) {
+impl bun_event_loop::ManagedTask::RunOnce for RunTestsTask {
+    fn run(self) -> JsResult<()> {
+        let Some(strong) = self.weak.upgrade() else { return Ok(()) };
+        if let Err(e) = BunTest::run(&strong, &self.global_this) {
             // A termination is the tick's to fold, not a test failure.
-            if this.global_this.has_pending_termination_exception() {
+            if self.global_this.has_pending_termination_exception() {
                 return Err(e);
             }
             // SAFETY: `&mut` derived via `UnsafeCell` after `run` returned; sole
             // borrow at this point.
             let bt = strong.get();
             bt.on_uncaught_exception(
-                &this.global_this,
-                Some(this.global_this.take_exception(e)),
+                &self.global_this,
+                Some(self.global_this.take_exception(e)),
                 false,
-                &this.phase,
+                &self.phase,
             );
         }
         Ok(())

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -107,7 +107,7 @@ extern "C" fn Bun__Chrome__retire() {
     chrome.retired = true;
     #[cfg(windows)]
     {
-        // Queued events from this Chrome carry its generation; `QueuedEvent::deliver` drops them.
+        // Queued events from this Chrome carry its generation; `QueuedEvent::run` drops them.
         GENERATION.fetch_add(1, Ordering::Relaxed);
         chrome.pipes.close();
     }
@@ -931,36 +931,31 @@ struct QueuedEvent {
 #[cfg(windows)]
 impl PipeEvent {
     fn post(self, generation: u32) {
-        let queued = bun_core::heap::into_raw(Box::new(QueuedEvent {
+        let queued = Box::new(QueuedEvent {
             generation,
             event: self,
-        }));
+        });
         // Not dispatched from the read callback: C++ runs JS that may spin a nested event loop (bun:test does), and libuv re-arms the read only after the callback returns.
         VirtualMachine::get()
             .as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_owned(
-                queued,
-                QueuedEvent::deliver,
-            ));
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_boxed(queued));
     }
 }
 
 #[cfg(windows)]
-impl QueuedEvent {
-    fn deliver(this: *mut QueuedEvent) -> bun_jsc::JsResult<()> {
-        // SAFETY: the box leaked by `post`; ManagedTask hands it over once.
-        let queued = unsafe { bun_core::heap::take(this) };
-        if queued.generation != GENERATION.load(Ordering::Relaxed) {
+impl bun_event_loop::ManagedTask::RunOnce for QueuedEvent {
+    fn run(self) -> bun_jsc::JsResult<()> {
+        if self.generation != GENERATION.load(Ordering::Relaxed) {
             scoped_log!(
                 Chrome,
                 "dropping event from replaced chrome (generation {})",
-                queued.generation
+                self.generation
             );
             return Ok(());
         }
         // SAFETY: plain FFI; onData copies `bytes` before returning.
         unsafe {
-            match queued.event {
+            match self.event {
                 PipeEvent::Data(bytes) => Bun__Chrome__onPipeData(bytes.as_ptr(), bytes.len()),
                 PipeEvent::Closed => Bun__Chrome__onPipeClosed(),
                 PipeEvent::Exited { signo } => Bun__Chrome__died(signo),

--- a/src/sys/Cargo.toml
+++ b/src/sys/Cargo.toml
@@ -22,6 +22,7 @@ bun_alloc.workspace = true
 bun_core.workspace = true
 bun_errno.workspace = true
 bun_paths.workspace = true
+bun_ptr.workspace = true
 bun_windows_sys.workspace = true
 bun_wyhash.workspace = true
 thiserror.workspace = true

--- a/src/sys/dns_sd.rs
+++ b/src/sys/dns_sd.rs
@@ -21,16 +21,10 @@ pub const PROTOCOL_IPV4: DNSServiceProtocol = 0x01;
 pub const PROTOCOL_IPV6: DNSServiceProtocol = 0x02;
 
 pub const ERR_NO_ERROR: DNSServiceErrorType = 0;
-pub const ERR_NO_SUCH_NAME: DNSServiceErrorType = -65538;
 pub const ERR_NO_MEMORY: DNSServiceErrorType = -65539;
-pub const ERR_REFUSED: DNSServiceErrorType = -65553;
 pub const ERR_NO_SUCH_RECORD: DNSServiceErrorType = -65554;
-pub const ERR_SERVICE_NOT_RUNNING: DNSServiceErrorType = -65563;
-pub const ERR_NO_ROUTER: DNSServiceErrorType = -65566;
 pub const ERR_TIMEOUT: DNSServiceErrorType = -65568;
 pub const ERR_DEFUNCT_CONNECTION: DNSServiceErrorType = -65569;
-pub const ERR_POLICY_DENIED: DNSServiceErrorType = -65570;
-pub const ERR_NOT_PERMITTED: DNSServiceErrorType = -65571;
 
 bun_opaque::opaque_ffi! {
     /// `struct _DNSServiceRef_t`.

--- a/src/sys/dns_sd.rs
+++ b/src/sys/dns_sd.rs
@@ -1,0 +1,251 @@
+//! `<dns_sd.h>` — the mDNSResponder client API. libsystem_dnssd is part of the
+//! libSystem umbrella and always linked on macOS.
+
+use core::ffi::{CStr, c_char, c_int, c_void};
+use core::ptr::NonNull;
+
+use crate::net::Address;
+
+pub type DNSServiceFlags = u32;
+pub type DNSServiceErrorType = i32;
+pub type DNSServiceProtocol = u32;
+
+pub const FLAGS_MORE_COMING: DNSServiceFlags = 0x1;
+pub const FLAGS_ADD: DNSServiceFlags = 0x2;
+pub const FLAGS_RETURN_INTERMEDIATES: DNSServiceFlags = 0x1000;
+pub const FLAGS_SHARE_CONNECTION: DNSServiceFlags = 0x4000;
+pub const FLAGS_SUPPRESS_UNUSABLE: DNSServiceFlags = 0x8000;
+pub const FLAGS_TIMEOUT: DNSServiceFlags = 0x10000;
+
+pub const PROTOCOL_IPV4: DNSServiceProtocol = 0x01;
+pub const PROTOCOL_IPV6: DNSServiceProtocol = 0x02;
+
+pub const ERR_NO_ERROR: DNSServiceErrorType = 0;
+pub const ERR_NO_SUCH_NAME: DNSServiceErrorType = -65538;
+pub const ERR_NO_MEMORY: DNSServiceErrorType = -65539;
+pub const ERR_REFUSED: DNSServiceErrorType = -65553;
+pub const ERR_NO_SUCH_RECORD: DNSServiceErrorType = -65554;
+pub const ERR_SERVICE_NOT_RUNNING: DNSServiceErrorType = -65563;
+pub const ERR_NO_ROUTER: DNSServiceErrorType = -65566;
+pub const ERR_TIMEOUT: DNSServiceErrorType = -65568;
+pub const ERR_DEFUNCT_CONNECTION: DNSServiceErrorType = -65569;
+pub const ERR_POLICY_DENIED: DNSServiceErrorType = -65570;
+pub const ERR_NOT_PERMITTED: DNSServiceErrorType = -65571;
+
+bun_opaque::opaque_ffi! {
+    /// `struct _DNSServiceRef_t`.
+    pub struct DNSServiceRefOpaque;
+}
+type DNSServiceRef = *mut DNSServiceRefOpaque;
+
+type DNSServiceGetAddrInfoReply = unsafe extern "C" fn(
+    sd_ref: DNSServiceRef,
+    flags: DNSServiceFlags,
+    interface_index: u32,
+    error_code: DNSServiceErrorType,
+    hostname: *const c_char,
+    address: *const crate::posix::sockaddr,
+    ttl: u32,
+    context: *mut c_void,
+);
+
+unsafe extern "C" {
+    fn DNSServiceCreateConnection(sd_ref: *mut DNSServiceRef) -> DNSServiceErrorType;
+    fn DNSServiceRefSockFD(sd_ref: DNSServiceRef) -> c_int;
+    fn DNSServiceProcessResult(sd_ref: DNSServiceRef) -> DNSServiceErrorType;
+    fn DNSServiceRefDeallocate(sd_ref: DNSServiceRef);
+    fn DNSServiceGetAddrInfo(
+        sd_ref: *mut DNSServiceRef,
+        flags: DNSServiceFlags,
+        interface_index: u32,
+        protocol: DNSServiceProtocol,
+        hostname: *const c_char,
+        callback: DNSServiceGetAddrInfoReply,
+        context: *mut c_void,
+    ) -> DNSServiceErrorType;
+}
+
+/// SPI: `DNSServiceGetAddrInfo` plus the attribute libinfo's getaddrinfo passes. Absent on macOS 12, so resolved at runtime.
+type GetAddrInfoExFn = unsafe extern "C" fn(
+    sd_ref: *mut DNSServiceRef,
+    flags: DNSServiceFlags,
+    interface_index: u32,
+    protocol: DNSServiceProtocol,
+    hostname: *const c_char,
+    attr: *const DNSServiceAttribute,
+    callback: DNSServiceGetAddrInfoReply,
+    context: *mut c_void,
+) -> DNSServiceErrorType;
+
+/// `DNSServiceGetAddrInfoEx` with `kDNSServiceAttrAllowFailover` (lets mDNSResponder fail a query over to
+/// scoped/supplemental resolvers, as getaddrinfo does), when this OS has both.
+fn getaddrinfo_ex() -> Option<(GetAddrInfoExFn, *const DNSServiceAttribute)> {
+    let f = crate::dlsym_with_handle!(
+        GetAddrInfoExFn,
+        "DNSServiceGetAddrInfoEx",
+        Some(libc::RTLD_DEFAULT)
+    )?;
+    let attr = crate::dlsym_with_handle!(
+        *const DNSServiceAttribute,
+        "kDNSServiceAttrAllowFailover",
+        Some(libc::RTLD_DEFAULT)
+    )?;
+    Some((f, attr))
+}
+
+#[repr(C)]
+struct DNSServiceAttribute {
+    _opaque: [u8; 0],
+}
+
+/// One `DNSServiceGetAddrInfo` reply, as seen inside [`Connection::process_result`].
+pub struct Reply<'a> {
+    pub flags: DNSServiceFlags,
+    pub interface_index: u32,
+    pub error_code: DNSServiceErrorType,
+    pub hostname: Option<&'a CStr>,
+    /// `None` only for replies that carry no address (e.g. `PolicyDenied`).
+    pub address: Option<Address>,
+    pub ttl: u32,
+}
+
+/// The object a query's replies are delivered to.
+pub trait GetAddrInfoReply {
+    /// Runs inside [`Connection::process_result`] on the connection's thread,
+    /// once per reply, while the [`Query`] is alive.
+    fn on_reply(&self, reply: &Reply<'_>);
+}
+
+/// The primary connection to mDNSResponder (`DNSServiceCreateConnection`).
+/// Dropping it deallocates the ref, which also invalidates every subordinate
+/// [`Query`] made on it — deallocate those first (dns_sd.h).
+pub struct Connection(NonNull<DNSServiceRefOpaque>);
+
+impl Connection {
+    pub fn create() -> Result<Self, DNSServiceErrorType> {
+        let mut sd_ref: DNSServiceRef = core::ptr::null_mut();
+        // SAFETY: `sd_ref` is a stack out-param.
+        let err = unsafe { DNSServiceCreateConnection(&raw mut sd_ref) };
+        if err != ERR_NO_ERROR {
+            return Err(err);
+        }
+        NonNull::new(sd_ref).map(Self).ok_or(ERR_NO_MEMORY)
+    }
+
+    /// The connection's socket; readable when replies are buffered.
+    #[inline]
+    pub fn sock_fd(&self) -> c_int {
+        // SAFETY: live connection ref.
+        unsafe { DNSServiceRefSockFD(self.0.as_ptr()) }
+    }
+
+    /// Read one batch of replies off the socket, running each query's
+    /// [`GetAddrInfoReply::on_reply`] inline.
+    #[inline]
+    pub fn process_result(&self) -> DNSServiceErrorType {
+        // SAFETY: live connection ref.
+        unsafe { DNSServiceProcessResult(self.0.as_ptr()) }
+    }
+
+    /// Start a `kDNSServiceFlagsShareConnection` address query (allowed to fail
+    /// over to other resolvers, as `getaddrinfo` is) whose replies go to
+    /// `*context`. The holder of `context` keeps it alive for as long as the
+    /// returned [`Query`].
+    pub fn get_addr_info<C: GetAddrInfoReply>(
+        &self,
+        flags: DNSServiceFlags,
+        interface_index: u32,
+        protocol: DNSServiceProtocol,
+        hostname: &CStr,
+        context: bun_ptr::BackRef<C>,
+    ) -> Result<Query, DNSServiceErrorType> {
+        // ShareConnection requires `sub` to start as a copy of the primary ref.
+        let mut sub: DNSServiceRef = self.0.as_ptr();
+        let flags = flags | FLAGS_SHARE_CONNECTION;
+        let context = context.as_const_ptr().cast_mut().cast::<c_void>();
+        // SAFETY: `hostname` is NUL-terminated (dns_sd copies it); `context` is
+        // only stored, and handed back to `reply_callback::<C>`.
+        let err = unsafe {
+            match getaddrinfo_ex() {
+                Some((ex, attr)) => ex(
+                    &raw mut sub,
+                    flags,
+                    interface_index,
+                    protocol,
+                    hostname.as_ptr(),
+                    attr,
+                    reply_callback::<C>,
+                    context,
+                ),
+                None => DNSServiceGetAddrInfo(
+                    &raw mut sub,
+                    flags,
+                    interface_index,
+                    protocol,
+                    hostname.as_ptr(),
+                    reply_callback::<C>,
+                    context,
+                ),
+            }
+        };
+        if err != ERR_NO_ERROR {
+            return Err(err);
+        }
+        NonNull::new(sub).map(Query).ok_or(ERR_NO_MEMORY)
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // SAFETY: the live ref `DNSServiceCreateConnection` returned.
+        unsafe { DNSServiceRefDeallocate(self.0.as_ptr()) }
+    }
+}
+
+/// A subordinate query on a [`Connection`]; deallocated on drop (on the
+/// connection's thread, like every other use of the connection), after which
+/// no more replies are delivered for it.
+pub struct Query(NonNull<DNSServiceRefOpaque>);
+
+impl Drop for Query {
+    fn drop(&mut self) {
+        // SAFETY: the live subordinate ref `DNSServiceGetAddrInfo{,Ex}` returned.
+        unsafe { DNSServiceRefDeallocate(self.0.as_ptr()) }
+    }
+}
+
+unsafe extern "C" fn reply_callback<C: GetAddrInfoReply>(
+    _sd_ref: DNSServiceRef,
+    flags: DNSServiceFlags,
+    interface_index: u32,
+    error_code: DNSServiceErrorType,
+    hostname: *const c_char,
+    address: *const crate::posix::sockaddr,
+    ttl: u32,
+    context: *mut c_void,
+) {
+    // SAFETY: `context` is the `BackRef<C>` `get_addr_info` registered, whose
+    // holder keeps `*context` alive while the `Query` is; replies are only
+    // delivered while it is.
+    let this = unsafe { &*context.cast::<C>() };
+    let hostname = if hostname.is_null() {
+        None
+    } else {
+        // SAFETY: dns_sd passes a NUL-terminated name valid for the call.
+        Some(unsafe { CStr::from_ptr(hostname) })
+    };
+    let address = if address.is_null() {
+        None
+    } else {
+        // SAFETY: dnssd_clientstub passes a sockaddr of the family it declares.
+        Some(unsafe { Address::init_posix(address.cast()) })
+    };
+    this.on_reply(&Reply {
+        flags,
+        interface_index,
+        error_code,
+        hostname,
+        address,
+        ttl,
+    });
+}

--- a/src/sys/dns_sd.rs
+++ b/src/sys/dns_sd.rs
@@ -226,7 +226,7 @@ pub struct Query {
 
 impl Drop for Query {
     fn drop(&mut self) {
-        // SAFETY: the live subordinate ref `DNSServiceGetAddrInfo` returned; its
+        // SAFETY: the live subordinate ref `DNSServiceGetAddrInfoEx` returned; its
         // primary is still alive (`_primary`, dropped after this).
         unsafe { DNSServiceRefDeallocate(self.sub.as_ptr()) }
     }

--- a/src/sys/dns_sd.rs
+++ b/src/sys/dns_sd.rs
@@ -116,10 +116,21 @@ pub trait GetAddrInfoReply {
     fn on_reply(&self, reply: &Reply<'_>);
 }
 
+/// The primary `DNSServiceCreateConnection` ref. Deallocating it invalidates
+/// every subordinate made on it (dns_sd.h), so each [`Query`] holds a share and
+/// it is deallocated only once the [`Connection`] and every `Query` are gone.
+struct PrimaryRef(NonNull<DNSServiceRefOpaque>);
+
+impl Drop for PrimaryRef {
+    fn drop(&mut self) {
+        // SAFETY: the live ref `DNSServiceCreateConnection` returned; no
+        // subordinate is left (each held an `Rc` to this).
+        unsafe { DNSServiceRefDeallocate(self.0.as_ptr()) }
+    }
+}
+
 /// The primary connection to mDNSResponder (`DNSServiceCreateConnection`).
-/// Dropping it deallocates the ref, which also invalidates every subordinate
-/// [`Query`] made on it — deallocate those first (dns_sd.h).
-pub struct Connection(NonNull<DNSServiceRefOpaque>);
+pub struct Connection(std::rc::Rc<PrimaryRef>);
 
 impl Connection {
     pub fn create() -> Result<Self, DNSServiceErrorType> {
@@ -129,14 +140,20 @@ impl Connection {
         if err != ERR_NO_ERROR {
             return Err(err);
         }
-        NonNull::new(sd_ref).map(Self).ok_or(ERR_NO_MEMORY)
+        let primary = NonNull::new(sd_ref).ok_or(ERR_NO_MEMORY)?;
+        Ok(Self(std::rc::Rc::new(PrimaryRef(primary))))
+    }
+
+    #[inline]
+    fn raw(&self) -> DNSServiceRef {
+        (self.0).0.as_ptr()
     }
 
     /// The connection's socket; readable when replies are buffered.
     #[inline]
     pub fn sock_fd(&self) -> c_int {
         // SAFETY: live connection ref.
-        unsafe { DNSServiceRefSockFD(self.0.as_ptr()) }
+        unsafe { DNSServiceRefSockFD(self.raw()) }
     }
 
     /// Read one batch of replies off the socket, running each query's
@@ -144,7 +161,7 @@ impl Connection {
     #[inline]
     pub fn process_result(&self) -> DNSServiceErrorType {
         // SAFETY: live connection ref.
-        unsafe { DNSServiceProcessResult(self.0.as_ptr()) }
+        unsafe { DNSServiceProcessResult(self.raw()) }
     }
 
     /// Start a `kDNSServiceFlagsShareConnection` address query (allowed to fail
@@ -160,7 +177,7 @@ impl Connection {
         context: bun_ptr::BackRef<C>,
     ) -> Result<Query, DNSServiceErrorType> {
         // ShareConnection requires `sub` to start as a copy of the primary ref.
-        let mut sub: DNSServiceRef = self.0.as_ptr();
+        let mut sub: DNSServiceRef = self.raw();
         let flags = flags | FLAGS_SHARE_CONNECTION;
         let context = context.as_const_ptr().cast_mut().cast::<c_void>();
         // SAFETY: `hostname` is NUL-terminated (dns_sd copies it); `context` is
@@ -191,26 +208,27 @@ impl Connection {
         if err != ERR_NO_ERROR {
             return Err(err);
         }
-        NonNull::new(sub).map(Query).ok_or(ERR_NO_MEMORY)
-    }
-}
-
-impl Drop for Connection {
-    fn drop(&mut self) {
-        // SAFETY: the live ref `DNSServiceCreateConnection` returned.
-        unsafe { DNSServiceRefDeallocate(self.0.as_ptr()) }
+        let sub = NonNull::new(sub).ok_or(ERR_NO_MEMORY)?;
+        Ok(Query {
+            sub,
+            _primary: std::rc::Rc::clone(&self.0),
+        })
     }
 }
 
 /// A subordinate query on a [`Connection`]; deallocated on drop (on the
 /// connection's thread, like every other use of the connection), after which
-/// no more replies are delivered for it.
-pub struct Query(NonNull<DNSServiceRefOpaque>);
+/// no more replies are delivered for it. Keeps the primary ref alive.
+pub struct Query {
+    sub: NonNull<DNSServiceRefOpaque>,
+    _primary: std::rc::Rc<PrimaryRef>,
+}
 
 impl Drop for Query {
     fn drop(&mut self) {
-        // SAFETY: the live subordinate ref `DNSServiceGetAddrInfo{,Ex}` returned.
-        unsafe { DNSServiceRefDeallocate(self.0.as_ptr()) }
+        // SAFETY: the live subordinate ref `DNSServiceGetAddrInfo` returned; its
+        // primary is still alive (`_primary`, dropped after this).
+        unsafe { DNSServiceRefDeallocate(self.sub.as_ptr()) }
     }
 }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5758,6 +5758,10 @@ pub mod darwin {
 #[cfg(not(target_os = "macos"))]
 pub mod darwin {}
 
+/// `<dns_sd.h>` (mDNSResponder client).
+#[cfg(target_os = "macos")]
+pub mod dns_sd;
+
 // ── Mach-O header parsing (subset). ──────────────────────────────────────
 // Just the slice that the crash handler uses to
 // walk dyld load commands and resolve a stable (ASLR-unslid) address for
@@ -8289,6 +8293,22 @@ pub mod net {
             Self { any }
         }
 
+        /// Overwrite the port (host order in, stored network order); ignored
+        /// for families other than `AF_INET`/`AF_INET6`.
+        pub fn set_port(&mut self, port: u16) {
+            match self.family() {
+                // SAFETY: `family() == AF_INET` ⇒ the storage holds a `sockaddr_in`.
+                AF_INET => unsafe {
+                    (*(&raw mut self.any).cast::<sock::sockaddr_in>()).sin_port = port.to_be()
+                },
+                // SAFETY: `family() == AF_INET6` ⇒ the storage holds a `sockaddr_in6`.
+                AF_INET6 => unsafe {
+                    (*(&raw mut self.any).cast::<sock::sockaddr_in6>()).sin6_port = port.to_be()
+                },
+                _ => {}
+            }
+        }
+
         /// The IPv6 zone index (`fe80::1%en0`); ignored for IPv4.
         pub fn set_scope_id(&mut self, scope_id: u32) {
             if self.family() == AF_INET6 {
@@ -8384,6 +8404,132 @@ pub mod net {
             } else {
                 write!(f, "<addr family={}>", self.family())
             }
+        }
+    }
+
+    impl Address {
+        /// Copy a `sockaddr` given as its raw bytes (a C API's
+        /// `(addr, addrlen)` pair). `None` if `bytes` is shorter than the
+        /// address family it declares needs.
+        pub fn from_sockaddr_bytes(bytes: &[u8]) -> Option<Self> {
+            if bytes.len() < 2 {
+                return None;
+            }
+            // SAFETY: `sockaddr_storage` is a POD C struct; all-zeros is valid.
+            let mut any: sockaddr_storage = unsafe { bun_core::ffi::zeroed_unchecked() };
+            let cap = core::mem::size_of::<sockaddr_storage>().min(bytes.len());
+            // SAFETY: `cap` bytes fit both `bytes` and `any`; distinct objects.
+            unsafe {
+                core::ptr::copy_nonoverlapping(bytes.as_ptr(), (&raw mut any).cast::<u8>(), cap)
+            };
+            let this = Self { any };
+            let need = match this.family() {
+                AF_INET => core::mem::size_of::<sockaddr_in>(),
+                AF_INET6 => core::mem::size_of::<sockaddr_in6>(),
+                _ => 2,
+            };
+            (bytes.len() >= need).then_some(this)
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // getaddrinfo(3)
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[cfg(windows)]
+    pub use bun_windows_sys::ws2_32::addrinfo;
+    #[cfg(unix)]
+    pub use libc::addrinfo;
+
+    /// The owned result list of one `getaddrinfo(3)` call; `freeaddrinfo` on drop.
+    pub struct AddrInfoList(core::ptr::NonNull<addrinfo>);
+
+    impl AddrInfoList {
+        /// Blocking `getaddrinfo(3)`. `Err` carries its non-zero return (an
+        /// `EAI_*` code); a zero return that produced no entries is `Ok(None)`.
+        pub fn lookup(
+            node: Option<&core::ffi::CStr>,
+            service: Option<&core::ffi::CStr>,
+            hints: Option<&addrinfo>,
+        ) -> Result<Option<Self>, core::ffi::c_int> {
+            #[cfg(windows)]
+            use bun_windows_sys::ws2_32::getaddrinfo;
+            #[cfg(unix)]
+            use libc::getaddrinfo;
+            // SAFETY: idempotent Winsock init; ws2_32 getaddrinfo needs WSAStartup.
+            #[cfg(windows)]
+            unsafe {
+                bun_libuv_sys::uv__winsock_ensure()
+            };
+            let mut result: *mut addrinfo = core::ptr::null_mut();
+            // SAFETY: `node`/`service` are NUL-terminated or null, `hints` is a
+            // live `addrinfo` or null, `result` is a stack out-param.
+            let rc = unsafe {
+                getaddrinfo(
+                    node.map_or(core::ptr::null(), |s| s.as_ptr()),
+                    service.map_or(core::ptr::null(), |s| s.as_ptr()),
+                    hints.map_or(core::ptr::null(), core::ptr::from_ref),
+                    &raw mut result,
+                )
+            };
+            if rc != 0 {
+                // getaddrinfo only allocates the list on success; `result` is
+                // unspecified here and must not be freed.
+                return Err(rc);
+            }
+            Ok(core::ptr::NonNull::new(result).map(Self))
+        }
+
+        /// The first entry (the list is never empty).
+        #[inline]
+        pub fn first(&self) -> &addrinfo {
+            // SAFETY: the live head node `getaddrinfo` returned; freed only on drop.
+            unsafe { self.0.as_ref() }
+        }
+
+        /// Every entry, in the order `getaddrinfo` returned them.
+        #[inline]
+        pub fn iter(&self) -> impl Iterator<Item = AddrInfoEntry<'_>> + Clone {
+            // SAFETY: `ai_next` links null or the next node of this same list,
+            // all of which live until `self` is dropped.
+            core::iter::successors(Some(self.first()), |ai| unsafe { ai.ai_next.as_ref() })
+                .map(AddrInfoEntry)
+        }
+    }
+
+    impl Drop for AddrInfoList {
+        fn drop(&mut self) {
+            #[cfg(windows)]
+            use bun_windows_sys::ws2_32::freeaddrinfo;
+            #[cfg(unix)]
+            use libc::freeaddrinfo;
+            // SAFETY: the list `getaddrinfo` allocated, freed exactly once.
+            unsafe { freeaddrinfo(self.0.as_ptr()) }
+        }
+    }
+
+    /// One node of an [`AddrInfoList`].
+    #[derive(Clone, Copy)]
+    pub struct AddrInfoEntry<'a>(&'a addrinfo);
+
+    impl<'a> AddrInfoEntry<'a> {
+        /// The C node (its `ai_next`/`ai_addr`/`ai_canonname` point into the list).
+        #[inline]
+        pub fn raw(self) -> &'a addrinfo {
+            self.0
+        }
+
+        /// The socket address, if the node has one.
+        pub fn address(self) -> Option<Address> {
+            if self.0.ai_addr.is_null() {
+                return None;
+            }
+            // SAFETY: `getaddrinfo` sets `ai_addr` to an `ai_addrlen`-byte
+            // sockaddr owned by the list for `'a`.
+            let bytes = unsafe {
+                core::slice::from_raw_parts(self.0.ai_addr.cast::<u8>(), self.0.ai_addrlen as usize)
+            };
+            Address::from_sockaddr_bytes(bytes)
         }
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8366,6 +8366,36 @@ pub mod net {
     }
     impl fmt::Display for Address {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self.ip() {
+                Some(core::net::IpAddr::V4(ip)) => {
+                    let port = self.as_in4().map_or(0, |v4| u16::from_be(v4.sin_port));
+                    write!(f, "{ip}:{port}")
+                }
+                Some(core::net::IpAddr::V6(ip)) => {
+                    let (port, flowinfo, scope_id) = self.as_in6().map_or((0, 0, 0), |v6| {
+                        (
+                            u16::from_be(v6.sin6_port),
+                            u32::from_be(v6.sin6_flowinfo),
+                            v6.sin6_scope_id,
+                        )
+                    });
+                    // `SocketAddrV6`'s Display emits `[addr]:port` (with `%scope`
+                    // when nonzero), matching Zig's `std.net.Ip6Address.format` —
+                    // the shape `bun_core::fmt::format_ip` expects to strip.
+                    fmt::Display::fmt(
+                        &std::net::SocketAddrV6::new(ip, port, flowinfo, scope_id),
+                        f,
+                    )
+                }
+                None => write!(f, "<addr family={}>", self.family()),
+            }
+        }
+    }
+
+    impl Address {
+        /// The IP this sockaddr carries; `None` for families other than
+        /// `AF_INET`/`AF_INET6`. The inverse of [`Address::from_ip`].
+        pub fn ip(&self) -> Option<core::net::IpAddr> {
             if let Some(v4) = self.as_in4() {
                 // `sin_addr` is `in_addr { s_addr: u32 }` on POSIX/ws2_32 but
                 // `[u8; 4]` in `bun_libuv_sys::sockaddr_in`; reinterpret as
@@ -8373,15 +8403,7 @@ pub mod net {
                 // SAFETY: `sin_addr` is 4 bytes of POD on every target.
                 let octets: [u8; 4] =
                     unsafe { *core::ptr::addr_of!(v4.sin_addr).cast::<[u8; 4]>() };
-                write!(
-                    f,
-                    "{}.{}.{}.{}:{}",
-                    octets[0],
-                    octets[1],
-                    octets[2],
-                    octets[3],
-                    u16::from_be(v4.sin_port)
-                )
+                Some(core::net::IpAddr::V4(core::net::Ipv4Addr::from(octets)))
             } else if let Some(v6) = self.as_in6() {
                 // `sin6_addr` is `in6_addr { s6_addr: [u8; 16] }` on every
                 // target; reinterpret as raw octets to stay independent of the
@@ -8389,20 +8411,9 @@ pub mod net {
                 // SAFETY: `sin6_addr` is 16 bytes of POD on every target.
                 let octets: [u8; 16] =
                     unsafe { *core::ptr::addr_of!(v6.sin6_addr).cast::<[u8; 16]>() };
-                // `SocketAddrV6`'s Display emits `[addr]:port` (with `%scope`
-                // when nonzero), matching Zig's `std.net.Ip6Address.format` —
-                // the shape `bun_core::fmt::format_ip` expects to strip.
-                fmt::Display::fmt(
-                    &std::net::SocketAddrV6::new(
-                        std::net::Ipv6Addr::from(octets),
-                        u16::from_be(v6.sin6_port),
-                        u32::from_be(v6.sin6_flowinfo),
-                        v6.sin6_scope_id,
-                    ),
-                    f,
-                )
+                Some(core::net::IpAddr::V6(core::net::Ipv6Addr::from(octets)))
             } else {
-                write!(f, "<addr family={}>", self.family())
+                None
             }
         }
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8441,8 +8441,13 @@ pub mod net {
     #[cfg(unix)]
     pub use libc::addrinfo;
 
-    /// The owned result list of one `getaddrinfo(3)` call; `freeaddrinfo` on drop.
-    pub struct AddrInfoList(core::ptr::NonNull<addrinfo>);
+    /// The owned result list of one `getaddrinfo(3)` call (or, on Windows, one
+    /// `uv_getaddrinfo`); freed with the matching deallocator on drop.
+    pub struct AddrInfoList {
+        head: core::ptr::NonNull<addrinfo>,
+        #[cfg(windows)]
+        from_uv: bool,
+    }
 
     impl AddrInfoList {
         /// Blocking `getaddrinfo(3)`. `Err` carries its non-zero return (an
@@ -8477,14 +8482,28 @@ pub mod net {
                 // unspecified here and must not be freed.
                 return Err(rc);
             }
-            Ok(core::ptr::NonNull::new(result).map(Self))
+            Ok(core::ptr::NonNull::new(result).map(|head| Self {
+                head,
+                #[cfg(windows)]
+                from_uv: false,
+            }))
+        }
+
+        /// Adopt the result of a completed `uv_getaddrinfo` (freed with
+        /// `uv_freeaddrinfo`); `None` if it produced nothing.
+        #[cfg(windows)]
+        pub fn from_uv(result: bun_libuv_sys::UvAddrInfo) -> Option<Self> {
+            core::ptr::NonNull::new(result.into_raw()).map(|head| Self {
+                head,
+                from_uv: true,
+            })
         }
 
         /// The first entry (the list is never empty).
         #[inline]
         pub fn first(&self) -> &addrinfo {
             // SAFETY: the live head node `getaddrinfo` returned; freed only on drop.
-            unsafe { self.0.as_ref() }
+            unsafe { self.head.as_ref() }
         }
 
         /// Every entry, in the order `getaddrinfo` returned them.
@@ -8503,8 +8522,14 @@ pub mod net {
             use bun_windows_sys::ws2_32::freeaddrinfo;
             #[cfg(unix)]
             use libc::freeaddrinfo;
+            #[cfg(windows)]
+            if self.from_uv {
+                // SAFETY: the block `uv_getaddrinfo` allocated, freed exactly once.
+                unsafe { bun_libuv_sys::uv_freeaddrinfo(self.head.as_ptr().cast()) };
+                return;
+            }
             // SAFETY: the list `getaddrinfo` allocated, freed exactly once.
-            unsafe { freeaddrinfo(self.0.as_ptr()) }
+            unsafe { freeaddrinfo(self.head.as_ptr()) }
         }
     }
 

--- a/src/uws_sys/addrinfo.rs
+++ b/src/uws_sys/addrinfo.rs
@@ -121,8 +121,8 @@ impl AddrInfoResult {
 /// A `us_connecting_socket_t` parked on a pending lookup: a back-reference
 /// whose holder obligation (usockets keeps the socket alive until it is either
 /// notified through this handle or withdraws it with `Bun__addrinfo_cancel`)
-/// is taken on where the `BackRef` is made. `us_internal_dns_callback_threadsafe`
-/// is its cross-thread entry point — hence `Send`.
+/// is taken on where the `BackRef` is made. Its only operation is the
+/// cross-thread `us_internal_dns_callback_threadsafe` — hence `Send`.
 pub struct DnsWaitingSocket(bun_ptr::BackRef<ConnectingSocket>);
 
 // SAFETY: see the type doc — the only cross-thread use is `notify_threadsafe`,
@@ -141,18 +141,20 @@ impl DnsWaitingSocket {
         core::ptr::eq(self.0.as_const_ptr(), socket)
     }
 
-    /// The lookup finished; link the socket into its loop's DNS-ready list
-    /// (the loop's thread; does not wake it).
-    #[inline]
-    pub fn notify(self) {
-        us_internal_dns_callback(self.0.get(), core::ptr::null_mut());
-    }
-
-    /// [`notify`](Self::notify) from any thread; wakes the loop.
+    /// The lookup finished (any thread): link the socket into its loop's
+    /// DNS-ready list and wake the loop.
     #[inline]
     pub fn notify_threadsafe(self) {
         us_internal_dns_callback_threadsafe(self.0.get(), core::ptr::null_mut());
     }
+}
+
+/// The lookup `socket` asked for had already finished: link it into its loop's
+/// DNS-ready list without waking the loop. `&ConnectingSocket` is `!Send`, so
+/// this is the socket's own thread.
+#[inline]
+pub fn dns_ready(socket: &ConnectingSocket) {
+    us_internal_dns_callback(socket, core::ptr::null_mut());
 }
 
 // `addrinfo_req` is unused by both (the socket already stores it).

--- a/src/uws_sys/addrinfo.rs
+++ b/src/uws_sys/addrinfo.rs
@@ -47,7 +47,7 @@ unsafe impl Sync for AddrInfoResult {}
 impl addrinfo_result_entry {
     /// An unchained entry: `info`'s pointer fields are rewritten when it is
     /// chained into an [`AddrInfoResult`] (`ai_addr` to this entry's `addr`
-    /// when `Some`, else null with `addr` zeroed).
+    /// when `Some`, else null with `addr` zeroed and `ai_addrlen` 0).
     #[inline]
     pub fn new(mut info: addrinfo, addr: Option<&sockaddr_storage>) -> Self {
         info.ai_canonname = core::ptr::null_mut();
@@ -56,6 +56,7 @@ impl addrinfo_result_entry {
         info.ai_addr = if addr.is_some() {
             NonNull::<sockaddr>::dangling().as_ptr()
         } else {
+            info.ai_addrlen = 0;
             core::ptr::null_mut()
         };
         Self {
@@ -150,15 +151,15 @@ impl DnsWaitingSocket {
 }
 
 /// The lookup `socket` asked for had already finished: link it into its loop's
-/// DNS-ready list without waking the loop. `&ConnectingSocket` is `!Send`, so
-/// this is the socket's own thread.
+/// DNS-ready list and wake the loop. The wakeup matters even on the socket's
+/// own thread: this can run inside the `dns_ready_head` drain itself (a
+/// connect issued from a connect-error callback), after the list was taken.
 #[inline]
 pub fn dns_ready(socket: &ConnectingSocket) {
-    us_internal_dns_callback(socket, core::ptr::null_mut());
+    us_internal_dns_callback_threadsafe(socket, core::ptr::null_mut());
 }
 
-// `addrinfo_req` is unused by both (the socket already stores it).
+// `addrinfo_req` is unused (the socket already stores it).
 unsafe extern "C" {
-    safe fn us_internal_dns_callback(s: &ConnectingSocket, addrinfo_req: *mut c_void);
     safe fn us_internal_dns_callback_threadsafe(s: &ConnectingSocket, addrinfo_req: *mut c_void);
 }

--- a/src/uws_sys/addrinfo.rs
+++ b/src/uws_sys/addrinfo.rs
@@ -1,0 +1,162 @@
+//! The connect path's view of Bun's process-wide DNS cache
+//! (`packages/bun-usockets/src/internal/internal.h`: `struct addrinfo_result`,
+//! `us_internal_dns_callback*`). The cache itself lives in
+//! `bun_runtime::dns_jsc::internal`; these are the C-ABI pieces usockets reads
+//! and the notify calls it takes.
+
+use core::ffi::{c_int, c_void};
+use core::ptr::NonNull;
+
+#[cfg(windows)]
+use bun_libuv_sys::{addrinfo, sockaddr, sockaddr_storage};
+#[cfg(not(windows))]
+use libc::{addrinfo, sockaddr, sockaddr_storage};
+
+use crate::ConnectingSocket;
+
+/// `struct addrinfo_result_entry`: one resolved address, its `info.ai_addr`
+/// pointing at the inline `addr` and `info.ai_next` at the next entry.
+#[repr(C)]
+pub struct addrinfo_result_entry {
+    pub info: addrinfo,
+    pub addr: sockaddr_storage,
+}
+
+/// `struct addrinfo_result`.
+#[repr(C)]
+pub struct addrinfo_result {
+    pub entries: *mut addrinfo_result_entry,
+    pub error: c_int,
+}
+
+/// A resolved (or failed) lookup in the shape usockets consumes: one boxed
+/// slice of entries chained through their `addrinfo` headers, plus the
+/// `getaddrinfo` error code.
+pub struct AddrInfoResult {
+    entries: Option<Box<[addrinfo_result_entry]>>,
+    c: addrinfo_result,
+}
+
+// SAFETY: self-contained — `c.entries` and every `info.ai_next` / `info.ai_addr`
+// point into `entries`, which this value owns and never reallocates; nothing
+// in it is thread-affine.
+unsafe impl Send for AddrInfoResult {}
+// SAFETY: as above; immutable once built.
+unsafe impl Sync for AddrInfoResult {}
+
+impl addrinfo_result_entry {
+    /// An unchained entry: `info`'s pointer fields are rewritten when it is
+    /// chained into an [`AddrInfoResult`] (`ai_addr` to this entry's `addr`
+    /// when `Some`, else null with `addr` zeroed).
+    #[inline]
+    pub fn new(mut info: addrinfo, addr: Option<&sockaddr_storage>) -> Self {
+        info.ai_canonname = core::ptr::null_mut();
+        info.ai_next = core::ptr::null_mut();
+        // Placeholder; pointed at `addr` by `AddrInfoResult::new`.
+        info.ai_addr = if addr.is_some() {
+            NonNull::<sockaddr>::dangling().as_ptr()
+        } else {
+            core::ptr::null_mut()
+        };
+        Self {
+            info,
+            addr: addr.map_or_else(bun_core::ffi::zeroed, |a| *a),
+        }
+    }
+}
+
+impl AddrInfoResult {
+    /// Chain `entries` (built with [`addrinfo_result_entry::new`]) in order.
+    pub fn new(entries: Vec<addrinfo_result_entry>, error: c_int) -> Self {
+        if entries.is_empty() {
+            return Self {
+                entries: None,
+                c: addrinfo_result {
+                    entries: core::ptr::null_mut(),
+                    error,
+                },
+            };
+        }
+        let mut boxed: Box<[addrinfo_result_entry]> = entries.into_boxed_slice();
+        // Every pointer usockets will chase derives from this one base, so no
+        // later reborrow of the slice invalidates them.
+        let len = boxed.len();
+        let base: *mut addrinfo_result_entry = boxed.as_mut_ptr();
+        for idx in 0..len {
+            // SAFETY: `idx` and `idx + 1` (when used) are in bounds of the
+            // `len`-element allocation `base` points at.
+            unsafe {
+                let entry = base.add(idx);
+                (*entry).info.ai_next = if idx + 1 < len {
+                    &raw mut (*base.add(idx + 1)).info
+                } else {
+                    core::ptr::null_mut()
+                };
+                if !(*entry).info.ai_addr.is_null() {
+                    (*entry).info.ai_addr = (&raw mut (*entry).addr).cast::<sockaddr>();
+                }
+            }
+        }
+        Self {
+            entries: Some(boxed),
+            c: addrinfo_result {
+                entries: base,
+                error,
+            },
+        }
+    }
+
+    /// What `Bun__addrinfo_getRequestResult` hands usockets.
+    #[inline]
+    pub fn as_c(&self) -> &addrinfo_result {
+        &self.c
+    }
+
+    #[inline]
+    pub fn entries(&self) -> &[addrinfo_result_entry] {
+        self.entries.as_deref().unwrap_or(&[])
+    }
+}
+
+/// A `us_connecting_socket_t` parked on a pending lookup: a back-reference
+/// whose holder obligation (usockets keeps the socket alive until it is either
+/// notified through this handle or withdraws it with `Bun__addrinfo_cancel`)
+/// is taken on where the `BackRef` is made. `us_internal_dns_callback_threadsafe`
+/// is its cross-thread entry point — hence `Send`.
+pub struct DnsWaitingSocket(bun_ptr::BackRef<ConnectingSocket>);
+
+// SAFETY: see the type doc — the only cross-thread use is `notify_threadsafe`,
+// which usockets provides for exactly that.
+unsafe impl Send for DnsWaitingSocket {}
+
+impl DnsWaitingSocket {
+    #[inline]
+    pub fn new(socket: bun_ptr::BackRef<ConnectingSocket>) -> Self {
+        Self(socket)
+    }
+
+    /// Whether this is `socket` (for `Bun__addrinfo_cancel`).
+    #[inline]
+    pub fn is(&self, socket: &ConnectingSocket) -> bool {
+        core::ptr::eq(self.0.as_const_ptr(), socket)
+    }
+
+    /// The lookup finished; link the socket into its loop's DNS-ready list
+    /// (the loop's thread; does not wake it).
+    #[inline]
+    pub fn notify(self) {
+        us_internal_dns_callback(self.0.get(), core::ptr::null_mut());
+    }
+
+    /// [`notify`](Self::notify) from any thread; wakes the loop.
+    #[inline]
+    pub fn notify_threadsafe(self) {
+        us_internal_dns_callback_threadsafe(self.0.get(), core::ptr::null_mut());
+    }
+}
+
+// `addrinfo_req` is unused by both (the socket already stores it).
+unsafe extern "C" {
+    safe fn us_internal_dns_callback(s: &ConnectingSocket, addrinfo_req: *mut c_void);
+    safe fn us_internal_dns_callback_threadsafe(s: &ConnectingSocket, addrinfo_req: *mut c_void);
+}

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -378,6 +378,8 @@ impl WindowsNamedPipe {
 pub mod error;
 pub use error::{Error, Result};
 
+#[path = "addrinfo.rs"]
+pub mod addrinfo;
 #[path = "App.rs"]
 pub mod app;
 #[path = "BodyReaderMixin.rs"]


### PR DESCRIPTION
### What

Same programme as #40055 / #40135 / #40136 / #40139 / #40187, applied to DNS: `src/runtime/dns_jsc/dns.rs` 259 → **0**, `cares_jsc.rs` 38 → 0, `dns_sd.rs` 43 → 0, by giving the C libraries typed, owning wrappers one layer down instead of open-coding pointer handling in the resolver.

- **c-ares (`bun_cares_sys`)**: `OwnedChannel` (Drop = `ares_destroy`) created with `Channel::init(ThisPtr<C: ChannelOwner>)`; queries take a `Box<H: QueryHandler | AddrInfoHandler | HostentHandler | NameInfoHandler>` and hand it back exactly once through one generic trampoline per callback shape (c-ares guarantees one callback on success / `ECANCELLED` / `EDESTRUCTION`); replies are `AresBox<T: AresAllocated>` freed with the right deallocator; `struct_hostent` / reply structs expose safe accessors and iterators instead of raw NULL-terminated arrays; `set_servers`, `get_sockaddr` (now returns a `sockaddr_storage` — the old code wrote a `sockaddr_in6` through a 16-byte `&mut sockaddr`), `inet_pton`, `parse_*` are safe.
- **Resolver ownership**: `Resolver` is `#[derive(RefCounted)]`; every in-flight lookup holds `Option<RefPtr<Resolver>>` (was `IntrusiveRc::init_ref`), the armed timeout timer's ref is a `timer_ref` slot; host fns / dispatch take `this: ThisPtr<Self>`. The per-type pending caches hold their waiters **by value** (`Vec<Option<PendingEntry<L>>>` + occupancy mask) instead of intrusive `next`/`tail` pointers into `HiveArray` slots; coalescing, the 32-entry limit, waiter order and `request_completed` points are unchanged.
- **Process-wide connect-path cache (`internal`)**: requests are `OwnedThis<Request>` in the locked global cache; C (`usockets`, QUIC) receives `ThisPtr<Request>`; cross-thread holders are `BackRef<Request, Mut>`; `refcount`/`valid` are atomics, `notify` a guarded vec, the result an `OnceLock<AddrInfoResult>`. The C-facing `addrinfo_result{,_entry}` and the `DnsWaitingSocket` / `DnsPendingConnect` notify handles live in `bun_uws_sys::addrinfo` / `bun_http::H3` (Send handles expose only the thread-safe notify; same-thread notification goes through the borrowed socket / owned box). All `Bun__addrinfo_*`, `Bun__DNS__*`, `__bun_dns_prefetch` are `HOST_EXPORT`s (the prefetch export now takes a length instead of treating install's non-terminated slice as a `ZStr`).
- **libuv (Windows)**: `bun_libuv_sys::getaddrinfo(loop, Box<T: GetAddrInfoRequest>, ..)` round-trips the box through `req.data`; `InflightGetAddrInfo::cancel`; `UvAddrInfo` (Drop = `uv_freeaddrinfo`); `SocketPoll<T>` for the c-ares fd polls. **libinfo / dns_sd (macOS)**: `bun_sys::dns_sd::{Connection, Query}` with one reply trampoline; the shared connection is a thread-local `Rc`. **POSIX**: `bun_sys::net::AddrInfoList` (owned `getaddrinfo` list), `Address::from_sockaddr_bytes`; `bun_io::OwnedFilePoll`.
- `ManagedTask::new_boxed<T: RunOnce>`; generator learns `Option<&CStr>`; `#[host_fn]` `this: ThisPtr<Self>` receiver support and `bun_ptr::OwnedThis` are cherry-picked byte-for-byte from #40139.

### Testing

Debug+ASAN: `test/js/bun/dns` (87), `test/js/node/dns` (171), all 27 `test-dns*` / `test-worker-dns*` / `test-net-dns*` node parallel tests, `socket-dns-error`, `socket.test`, `websocket`, `node-http`, `fetch` pass (fetch's root-permission cases and the 150 ms `AbortSignal.timeout` redirect case fail on any debug build here). Hand-driven: lookup via c-ares/libc/system backends + coalescing, `resolve4`/`reverse`/`lookupService`, `Resolver.cancel()` mid-query against a black-hole UDP socket (`ECANCELLED`), `prefetch` + `getCacheStats`, fetch through the connect-path cache, workers exiting/terminated with queries in flight, interior-NUL names — exit 0, no ASAN output. clippy clean on every touched crate; `rust-check-all` x86_64/aarch64-windows-msvc + aarch64-apple-darwin pass (Windows/macOS paths type-checked, not executed here). An additional adversarial review pass over the cache redesign and the cross-thread cache found no behavioural regressions; its latent findings are fixed in the second commit.

**Follow-up (review):** `bun_dns::ResultAny` is gone (native completions carry `Option<&ResultList>`; `GetAddrInfoResult::to_list` takes `&bun_sys::net::AddrInfoList`; Windows `AddrInfoList::from_uv` adopts the libuv block) — `options_jsc.rs` is now 0 unsafe too; the connect-path waiter lists live under `GlobalCache`'s single lock (no nested `Guarded`), and an orphaned request whose refcount hits 0 is freed immediately; `Backend`/`BackendDnsSd` collapsed to a `#[cfg(target_os="macos")] dns_sd: JsCell<QueryState>` field; `ManagedTask::new_owned` retired in favour of `new_boxed` (`RunTestsTask`, `QueuedEvent` implement `RunOnce`); libuv cancel handle and dns_sd parent/child ordering are structural (`Rc` token / `Rc<PrimaryRef>`).
