### PR TITLE
bun_ptr: only a BackRef minted from a ThisPtr can hand a ThisPtr back

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -19,7 +19,7 @@ use bun_core::{ZigString, strings};
 use bun_http::websocket::{Opcode, WebsocketHeader};
 use bun_io::KeepAlive;
 use bun_jsc::{self as jsc, GlobalRef, JSGlobalObject, JSValue};
-use bun_ptr::{BackRef, JsCell, Mut, RefPtr, ThisPtr};
+use bun_ptr::{BackRef, JsCell, RefPtr, Root, ThisPtr};
 use bun_uws::{self as uws, NewSocketHandler, us_bun_verify_error_t};
 use bun_uws_sys::us_socket_t;
 
@@ -106,7 +106,7 @@ pub struct WebSocket<const SSL: bool> {
     /// The queued `InitialDataTask` (handshake-overflow bytes) until it runs or
     /// `handle_data` drains it first; detached in `Drop` so a task that
     /// outlives us does nothing.
-    pending_initial_task: Cell<Option<BackRef<InitialDataTask<SSL>, Mut>>>,
+    pending_initial_task: Cell<Option<BackRef<InitialDataTask<SSL>, Root>>>,
     pub(crate) deflate: RefCell<Option<Box<WebSocketDeflate>>>,
 
     /// Track if current message is compressed
@@ -1860,7 +1860,7 @@ impl InitialDataHandler {
 pub(crate) struct InitialDataTask<const SSL: bool> {
     /// Detached by `WebSocket`'s `Drop` (or by `handle_data` draining `data`
     /// first) so a task that outlives its client does nothing.
-    ws: Cell<Option<BackRef<WebSocket<SSL>, Mut>>>,
+    ws: Cell<Option<BackRef<WebSocket<SSL>, Root>>>,
     data: JsCell<Option<InitialDataHandler>>,
 }
 

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -27,7 +27,7 @@ use core::cell::{Cell, OnceCell};
 
 use bun_boringssl as boringssl;
 use bun_io::StreamBuffer;
-use bun_ptr::{BackRef, JsCell, Mut, RefPtr, ThisPtr};
+use bun_ptr::{BackRef, JsCell, RefPtr, Root, ThisPtr};
 use bun_uws::ssl_wrapper::{Handlers as SslHandlers, SslWrapper};
 use bun_uws::{NewSocketHandler, us_bun_verify_error_t};
 
@@ -46,8 +46,8 @@ use super::websocket_upgrade_client::{HttpUpgradeClient, HttpsUpgradeClient};
 /// holding a borrow of the tunnel across the re-entrant call.
 #[derive(Clone, Copy)]
 pub enum UpgradeClientRef {
-    Http(BackRef<HttpUpgradeClient, Mut>),
-    Https(BackRef<HttpsUpgradeClient, Mut>),
+    Http(BackRef<HttpUpgradeClient, Root>),
+    Https(BackRef<HttpsUpgradeClient, Root>),
 }
 
 /// Builds the [`UpgradeClientRef`] variant for a concrete `HTTPClient<SSL>`.
@@ -109,7 +109,7 @@ pub struct WebSocketProxyTunnel {
     /// Back-reference to the connected WebSocket client - used after
     /// successful upgrade. The client clears it (`clear_connected_web_socket`)
     /// before it can be freed.
-    connected_websocket: Cell<Option<BackRef<WebSocketClient, Mut>>>,
+    connected_websocket: Cell<Option<BackRef<WebSocketClient, Root>>>,
     /// SSL wrapper for TLS inside tunnel; set once in `start()`.
     wrapper: OnceCell<SslWrapperType>,
     /// Socket reference (the proxy connection)

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -863,7 +863,7 @@ impl JSGlobalObject {
     pub fn queue_microtask_boxed<T: MicrotaskCallback>(
         &self,
         task: Box<T>,
-    ) -> bun_ptr::BackRef<T, bun_ptr::Mut> {
+    ) -> bun_ptr::BackRef<T, bun_ptr::Root> {
         unsafe extern "C" fn run<T: MicrotaskCallback>(ctx: *mut c_void) {
             // SAFETY: `ctx` is the `Box<T>` leaked below; the microtask queue
             // invokes each callback exactly once.
@@ -873,7 +873,7 @@ impl JSGlobalObject {
         self.queue_microtask_callback(task, run::<T>);
         // SAFETY: `task` is the live leaked box; see the doc comment for the
         // holder's obligation.
-        unsafe { bun_ptr::BackRef::from_raw_mut(task) }
+        unsafe { bun_ptr::BackRef::from_root(task) }
     }
 
     pub fn queue_microtask(&self, function: JSValue, args: &[JSValue]) {

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -89,6 +89,10 @@ pub use bun_core::callback_ctx;
 
 pub struct Shared;
 pub struct Mut;
+/// Provenance marker: the back-reference was minted from a [`ThisPtr`] (or a
+/// leaked `Box`), i.e. it is the root pointer of a live heap allocation, so it
+/// may hand a [`ThisPtr`] back out. `BackRef<T, Mut>` (any `&mut T`) may not.
+pub struct Root;
 
 /// Non-owning, non-null back-reference to an object that outlives `self`.
 /// For struct fields where the pointee is the owner/parent and is
@@ -196,24 +200,35 @@ impl<T: ?Sized, P> BackRef<T, P> {
     }
 }
 
-impl<T: AnyRefCounted> BackRef<T, Mut>
-where
-    T::DestructorCtx: Default,
-{
-    /// View the pointee as a [`ThisPtr`] for the refcounted-dispatch entry
-    /// points that take one. Safe under the `BackRef` invariant: the pointee is
-    /// live for as long as this back-reference is held, which is exactly
-    /// [`ThisPtr::new`]'s precondition; `Mut` records that the pointer carries
-    /// the allocation's root provenance (it came from a `ThisPtr`), so the
-    /// callee may release refs through it.
+impl<T> BackRef<T, Root> {
+    /// View the pointee as a [`ThisPtr`] again for the dispatch entry points
+    /// that take one. Safe under the `BackRef` invariant (the pointee is live
+    /// for as long as this back-reference is held — [`ThisPtr::new`]'s
+    /// precondition) plus what `Root` records: this pointer *is* a heap
+    /// allocation's root, so the callee may release refs through it.
     #[inline]
     pub fn this_ptr(&self) -> ThisPtr<T> {
-        // SAFETY: BackRef invariant — pointee is live and non-null.
+        // SAFETY: see above.
         unsafe { ThisPtr::new(self.0.as_ptr()) }
+    }
+
+    /// Wrap the root pointer of a live heap allocation.
+    ///
+    /// # Safety
+    /// [`BackRef::from_raw`]'s contract, and `p` is what `Box::into_raw` /
+    /// `heap::into_raw` returned for an allocation that stays live while the
+    /// result is held.
+    #[inline]
+    pub const unsafe fn from_root(p: *mut T) -> Self {
+        // SAFETY: caller contract — `p` is non-null.
+        BackRef(
+            unsafe { core::ptr::NonNull::new_unchecked(p) },
+            core::marker::PhantomData,
+        )
     }
 }
 
-impl<T> From<ThisPtr<T>> for BackRef<T, Mut> {
+impl<T> From<ThisPtr<T>> for BackRef<T, Root> {
     /// Record a dispatch-time [`ThisPtr`] as a back-reference. The holder takes
     /// on the `BackRef` invariant: it must drop/clear this before the pointee
     /// can be freed.

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1374,7 +1374,7 @@ pub struct CronJob {
     ref_count: Cell<u32>,
     /// Set from the allocating `RefPtr` so `&self` host fns can reach the
     /// `ThisPtr`-taking paths that may release refs.
-    self_ref: Cell<BackRef<CronJob, bun_ptr::Mut>>,
+    self_ref: Cell<BackRef<CronJob, bun_ptr::Root>>,
     // pub: `bun_core::from_field_ptr!(CronJob, event_loop_timer)` needs `offset_of!` visibility.
     // `JsCell` is `#[repr(transparent)]`, so the byte offset of the inner
     // `EventLoopTimer` is identical and the dispatch.rs `owner!` macro works

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -6157,9 +6157,9 @@ impl EntryPointList {
 /// `<'a>` retained only for the owning `DevServer<'a>`'s `Transpiler` borrows.
 #[derive(Default)]
 pub struct HTMLRouter {
-    pub(crate) map: StringHashMap<bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Mut>>,
+    pub(crate) map: StringHashMap<bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Root>>,
     /// If a catch-all route exists, it is not stored in map, but here.
-    pub(crate) fallback: Option<bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Mut>>,
+    pub(crate) fallback: Option<bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Root>>,
 }
 
 impl HTMLRouter {
@@ -6181,7 +6181,7 @@ impl HTMLRouter {
     pub(crate) fn put(
         &mut self,
         path: &[u8],
-        route: bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Mut>,
+        route: bun_ptr::BackRef<HTMLBundleRoute, bun_ptr::Root>,
     ) -> crate::Result<()> {
         if path == b"/*" {
             self.fallback = Some(route);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -856,7 +856,7 @@ impl AnyRoute {
 
 pub struct ServerInitContext<'a> {
     pub(crate) dedupe_html_bundle_map:
-        HashMap<*const HTMLBundle, bun_ptr::BackRef<html_bundle::Route, bun_ptr::Mut>>,
+        HashMap<*const HTMLBundle, bun_ptr::BackRef<html_bundle::Route, bun_ptr::Root>>,
     pub(crate) js_string_allocations: bake::StringRefList,
     pub global: &'a JSGlobalObject,
     pub(crate) framework_router_list: Vec<bake::FileSystemRouterType>,


### PR DESCRIPTION
### What

Closes a hole a reviewer spotted on #40190 (present on main since #40055): `BackRef<T, Mut>::this_ptr()` was callable on any `BackRef::new_mut(&mut t)`, so safe code could mint a `ThisPtr` to a stack value and then `RefPtr::from_this(..).deref()` it into the destructor.

`bun_ptr::Root` is a third provenance marker meaning "this back-reference *is* the root pointer of a live heap allocation": it is built `From<ThisPtr<T>>` (or `unsafe from_root` for a leaked `Box`, used by `queue_microtask_boxed`) and is the only `BackRef` flavour with `this_ptr()`. `Mut` keeps `new_mut`/`get_mut`/`as_ptr` and loses `this_ptr`. Every existing user (`CronJob::self_ref`, the websocket tunnel's `UpgradeClientRef`/`connected_websocket`, `InitialDataTask`, the HTMLBundle route maps in `server_body`/`DevServer`) was already minted from a `ThisPtr` and just changes its type parameter. No runtime behaviour change.

The open unsafe-removal PRs (#40139, #40187, #40190) will pick this up on rebase.

### Testing

`cargo clippy -p bun_ptr -p bun_jsc -p bun_http_jsc -p bun_runtime -D warnings` clean; type-level change only.