### PR TITLE
test(sql): prestart postgres for the LISTEN/NOTIFY file, run its suites concurrently, assert exact errors

### DIFF
--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -19,6 +19,7 @@ export const prestartMap = {
   "js/sql/postgres-binary-numeric": ["postgres_plain"],
   "js/sql/postgres-multi-statement-fields": ["postgres_plain"],
   "js/sql/postgres-simple-query-pipeline": ["postgres_plain"],
+  "js/sql/postgres-listen-notify": ["postgres_plain"],
   "js/sql/sql-onconnect-onclose-throw": ["postgres_plain", "mysql_plain"],
   "js/sql/sql-prepare-false": ["postgres_plain"],
   "js/valkey/": ["redis_unified"],

--- a/test/js/sql/postgres-listen-notify.test.ts
+++ b/test/js/sql/postgres-listen-notify.test.ts
@@ -148,6 +148,20 @@ function gate() {
   });
 }
 
+// The rejection of a promise that may still be pending, awaited plainly.
+// `expect(promise).rejects` on a pending promise re-enters the event loop
+// (#33261); from inside a socket callback, which is where a continuation
+// after `await sql.listen()` runs, the inner run drops the outer dispatch's
+// remaining events, and a subprocess test whose exit event is dropped hangs.
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("expected a rejection");
+}
+
 const connectionClosed = {
   name: "PostgresError",
   code: "ERR_POSTGRES_CONNECTION_CLOSED",
@@ -445,8 +459,8 @@ describe.concurrent("listen", () => {
     const cjk63 = Buffer.alloc(63, "字").toString(); // 21 characters
     const cjk66 = Buffer.alloc(66, "字").toString(); // 22 characters, 66 bytes
     const tooLong = (channel: string) => invalidChannel(channel, "must be at most 63 bytes");
-    await expect(sql.listen(ascii63 + "c", () => {})).rejects.toMatchObject(tooLong(ascii63 + "c"));
-    await expect(sql.listen(cjk66, () => {})).rejects.toMatchObject(tooLong(cjk66));
+    expect(await rejection(sql.listen(ascii63 + "c", () => {}))).toMatchObject(tooLong(ascii63 + "c"));
+    expect(await rejection(sql.listen(cjk66, () => {}))).toMatchObject(tooLong(cjk66));
     expect(() => sql.notify(cjk66)).toThrow(expect.objectContaining(tooLong(cjk66)));
 
     await sql.listen(ascii63, () => {});
@@ -740,7 +754,7 @@ describe.concurrent("listen/unlisten interleavings", () => {
     await using sql = client(server.url);
     await sql.listen("keep", () => {});
     server.failNextListen("bad");
-    await expect(sql.listen("bad", () => {})).rejects.toMatchObject(serverError("cannot LISTEN bad"));
+    expect(await rejection(sql.listen("bad", () => {}))).toMatchObject(serverError("cannot LISTEN bad"));
     await sql.listen("bad", () => {});
     expect(server.queries).toEqual(['LISTEN "keep"', 'LISTEN "bad"', 'LISTEN "bad"']);
   });
@@ -766,7 +780,7 @@ describe.concurrent("listen/unlisten interleavings", () => {
     const { port, server } = await listeningServer(socket => socket.destroy());
     try {
       await using sql = client(`postgres://u@127.0.0.1:${port}/db`);
-      await expect(sql.listen("ch", () => {})).rejects.toMatchObject({
+      expect(await rejection(sql.listen("ch", () => {}))).toMatchObject({
         name: "PostgresError",
         code: "ERR_POSTGRES_CONNECTION_FAILED",
         message: "Connection closed before the connection was established",
@@ -930,9 +944,9 @@ describe.concurrent("close()", () => {
     await server.untilQuery(queries => queries.includes('LISTEN "pending"'));
 
     await sql.close();
-    await expect(pending).rejects.toMatchObject(connectionClosed);
+    expect(await rejection(pending)).toMatchObject(connectionClosed);
     await server.untilClosed(1);
-    await expect(sql.listen("ch", () => {})).rejects.toMatchObject(connectionClosed);
+    expect(await rejection(sql.listen("ch", () => {}))).toMatchObject(connectionClosed);
     expect(await subscription.unlisten()).toBeUndefined();
     expect(server.queries).toEqual(['LISTEN "ch"', 'LISTEN "pending"']);
   });
@@ -960,7 +974,7 @@ describe.concurrent("close()", () => {
       const sql = new SQL(`postgres://u@127.0.0.1:${port}/db`, { max: 1, connectionTimeout: 60 });
       const listening = sql.listen("ch", () => {});
       await sql.close();
-      await expect(listening).rejects.toMatchObject(connectionClosed);
+      expect(await rejection(listening)).toMatchObject(connectionClosed);
     } finally {
       server.close();
     }
@@ -971,7 +985,7 @@ describe.concurrent("close()", () => {
     await using sql = client(server.url);
     const got = Promise.withResolvers<string>();
     await sql.listen("ch", got.resolve);
-    await expect(sql.close({ timeout: -1 })).rejects.toMatchObject({
+    expect(await rejection(sql.close({ timeout: -1 }))).toMatchObject({
       name: "TypeError",
       code: "ERR_INVALID_ARG_VALUE",
       message: "The property 'options.timeout' must be a non-negative integer less than 2^31. Received -1",
@@ -992,12 +1006,12 @@ describe.concurrent("arguments", () => {
       code: "ERR_INVALID_ARG_TYPE",
       message: `The "payload" argument must be of type string. Received ${received}`,
     });
-    await expect(sql.listen("", callback)).rejects.toMatchObject(emptyChannel);
-    await expect(sql.listen("a\0b", callback)).rejects.toMatchObject(
+    expect(await rejection(sql.listen("", callback))).toMatchObject(emptyChannel);
+    expect(await rejection(sql.listen("a\0b", callback))).toMatchObject(
       invalidChannel("a\\x00b", "must not contain null bytes"),
     );
-    await expect(sql.listen("ch", 1 as any)).rejects.toMatchObject(invalidCallback("onnotify"));
-    await expect(sql.listen("ch", callback, 1 as any)).rejects.toMatchObject(invalidCallback("onlisten"));
+    expect(await rejection(sql.listen("ch", 1 as any))).toMatchObject(invalidCallback("onnotify"));
+    expect(await rejection(sql.listen("ch", callback, 1 as any))).toMatchObject(invalidCallback("onlisten"));
     expect(() => sql.notify("", "p")).toThrow(expect.objectContaining(emptyChannel));
     expect(() => sql.notify("ch", null as any)).toThrow(expect.objectContaining(invalidPayload("null")));
     expect(() => sql.notify("ch", 1 as any)).toThrow(expect.objectContaining(invalidPayload("type number (1)")));
@@ -1006,9 +1020,9 @@ describe.concurrent("arguments", () => {
   test("non-Postgres adapters reject with a clear error", async () => {
     await using sql = new SQL("sqlite://:memory:");
     const unsupported = { name: "Error", message: "LISTEN/NOTIFY is not supported by this adapter (PostgreSQL only)" };
-    await expect(sql.listen("ch", () => {})).rejects.toMatchObject(unsupported);
-    await expect(sql.notify("ch", "p")).rejects.toMatchObject(unsupported);
-    await expect(sql.notify("ch")).rejects.toMatchObject(unsupported);
+    expect(await rejection(sql.listen("ch", () => {}))).toMatchObject(unsupported);
+    expect(await rejection(sql.notify("ch", "p"))).toMatchObject(unsupported);
+    expect(await rejection(sql.notify("ch"))).toMatchObject(unsupported);
   });
 
   test("reserved connections expose listen() on the client's shared listen connection; unlisten lives on the subscription only", async () => {
@@ -1090,12 +1104,14 @@ if (isDockerEnabled()) {
         if (payload === "barrier") barrier.open();
       });
 
-      await expect(
-        sql.begin(async tx => {
-          await tx.notify("e2e_tx", "rolled back");
-          throw new Error("abort");
-        }),
-      ).rejects.toThrow("abort");
+      expect(
+        await rejection(
+          sql.begin(async tx => {
+            await tx.notify("e2e_tx", "rolled back");
+            throw new Error("abort");
+          }),
+        ),
+      ).toMatchObject({ message: "abort" });
       await sql.begin(tx => tx.notify("e2e_tx", "committed"));
       await sql.notify("e2e_tx", "barrier");
       await barrier;

--- a/test/js/sql/postgres-listen-notify.test.ts
+++ b/test/js/sql/postgres-listen-notify.test.ts
@@ -166,6 +166,213 @@ const invalidCallback = (name: string) => ({
   message: `The "${name}" argument must be of type function. Received type number (1)`,
 });
 
+// Declared first: the runner hands out concurrency slots in declaration
+// order (5 under ASAN, 20 otherwise) and these are the slowest tests.
+describe.concurrent("in a subprocess", () => {
+  const wireFrames = path.join(import.meta.dir, "wire-frames.ts");
+  // The mock runs inside the child and is unref'd, so only the subscription
+  // under test can hold the child open. `notifyMany`, `dropConnections`,
+  // `sockets`, `pgNotificationResponse` and `sql` are in scope for `body`.
+  async function run(body: string, env: Record<string, string> = {}) {
+    using dir = tempDir("pg-listen-subprocess", {
+      "fixture.ts": `
+        import { SQL } from "bun";
+        import { listeningServer, pgAuthenticationOk, pgReadyForQuery, pgCommandComplete, pgNotificationResponse, pgReadFrontendMessages, pgRaw, pgInt32 } from ${JSON.stringify(wireFrames)};
+        const sockets = new Set();
+        const { port, server } = await listeningServer(socket => {
+          sockets.add(socket);
+          socket.unref();
+          let buffered = Buffer.alloc(0);
+          socket.once("data", () => {
+            socket.write(Buffer.concat([pgAuthenticationOk(), pgRaw("K", Buffer.concat([pgInt32(1), pgInt32(2)])), pgReadyForQuery()]));
+            socket.on("data", data => {
+              buffered = pgReadFrontendMessages(Buffer.concat([buffered, data]), (type, body) => {
+                if (type !== 0x51) return;
+                socket.write(Buffer.concat([pgCommandComplete(body.toString("utf8", 0, body.indexOf(" "))), pgReadyForQuery()]));
+              });
+            });
+          });
+          socket.on("close", () => sockets.delete(socket));
+        });
+        server.unref();
+        const notifyMany = frames => {
+          const blob = Buffer.concat(frames.map(([channel, payload]) => pgNotificationResponse(1, channel, payload)));
+          for (const socket of sockets) socket.write(blob);
+        };
+        const dropConnections = () => { for (const socket of sockets) socket.destroy(); };
+        const sql = new SQL("postgres://u@127.0.0.1:" + port + "/db", { max: 1 });
+        ${body}
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, ...env },
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      stdout,
+      stderr: stderr
+        .split("\n")
+        .filter(line => line && !line.startsWith("WARNING: ASAN"))
+        .join("\n"),
+      exitCode,
+      signal: proc.signalCode,
+    };
+  }
+  const clean = (stdout: string) => ({ stdout, stderr: "", exitCode: 0, signal: null });
+
+  test("a subscription keeps the process alive until it is removed", async () => {
+    const result = await run(`
+      const subscription = await sql.listen("ch", async payload => {
+        console.log("got " + payload);
+        await subscription.unlisten();
+        console.log("unlistened");
+      });
+      console.log("subscribed");
+      // Sent from an unref'd timer after top-level code finishes, so the
+      // subscription is the only thing keeping the process here.
+      setTimeout(() => notifyMany([["ch", "wake"]]), 20).unref();
+    `);
+    expect(result).toEqual(clean("subscribed\ngot wake\nunlistened\n"));
+  });
+
+  test("a dropped connection keeps the process alive through the backoff and reconnects", async () => {
+    const result = await run(`
+      let subscribes = 0;
+      const subscription = await sql.listen("ch", () => {}, () => {
+        if (++subscribes === 2) { console.log("reconnected"); subscription.unlisten(); }
+      });
+      console.log("subscribed");
+      dropConnections();
+    `);
+    expect(result).toEqual(clean("subscribed\nreconnected\n"));
+  });
+
+  test("sql.close() releases a subscription so the process exits", async () => {
+    const result = await run(`
+      await sql.listen("ch", () => {});
+      await sql.close();
+      console.log("closed");
+    `);
+    expect(result).toEqual(clean("closed\n"));
+  });
+
+  test("a throwing listener surfaces as uncaughtException; the channel's other listeners and later notifications are unaffected", async () => {
+    const result = await run(`
+      process.on("uncaughtException", err => console.log("uncaught: " + err.message));
+      const first = await sql.listen("ch", payload => {
+        console.log("first got " + payload);
+        if (payload === "bad") throw new Error("listener failed");
+      });
+      const second = await sql.listen("ch", payload => {
+        console.log("second got " + payload);
+        if (payload === "good") { first.unlisten(); second.unlisten(); }
+      });
+      notifyMany([["ch", "bad"], ["ch", "good"]]);
+    `);
+    expect(result).toEqual(
+      clean(
+        ["first got bad", "uncaught: listener failed", "second got bad", "first got good", "second got good", ""].join(
+          "\n",
+        ),
+      ),
+    );
+  });
+
+  test("a lone throwing listener surfaces as uncaughtException and later notifications still arrive", async () => {
+    const result = await run(`
+      process.on("uncaughtException", err => console.log("uncaught: " + err.message));
+      const subscription = await sql.listen("ch", payload => {
+        console.log("got " + payload);
+        if (payload === "bad") throw new Error("listener failed");
+        subscription.unlisten();
+      });
+      notifyMany([["ch", "bad"], ["ch", "good"]]);
+    `);
+    expect(result).toEqual(clean("got bad\nuncaught: listener failed\ngot good\n"));
+  });
+
+  test("a throwing onlisten surfaces as uncaughtException; listen() resolves and the reconnect is not retried", async () => {
+    // An empty stderr is the assertion that the reconnect sweep did not take
+    // the second throw for a failed LISTEN (which it warns about and retries).
+    const result = await run(`
+      process.on("uncaughtException", err => console.log("uncaught: " + err.message));
+      let calls = 0;
+      const subscription = await sql.listen("ch", () => {}, () => {
+        console.log("onlisten " + ++calls);
+        if (calls === 2) subscription.unlisten().then(() => console.log("unlistened"));
+        throw new Error("onlisten failed " + calls);
+      });
+      console.log("subscribed to " + subscription.channel);
+      dropConnections();
+    `);
+    expect(result).toEqual(
+      clean(
+        [
+          "onlisten 1",
+          "uncaught: onlisten failed 1",
+          "subscribed to ch",
+          "onlisten 2",
+          "uncaught: onlisten failed 2",
+          "unlistened",
+          "",
+        ].join("\n"),
+      ),
+    );
+  });
+
+  test("delivering many notifications retains nothing", async () => {
+    // Measured by RSS so a leaked native string backing (invisible to the JS
+    // heap) is caught. Each phase delivers its volume twice and reports the
+    // growth across the second pass: the first pass takes RSS to its steady
+    // state (the allocator keeps the GC's between-collection high-water mark
+    // of payload strings as free memory), after which a correct
+    // implementation shows roughly no growth and leaking one string per
+    // notification shows the pass's full payload volume.
+    //
+    // Bun.shrink() returns the heap's freed blocks to the OS at the next idle
+    // point; without it the reading drifts by up to 8 MiB from pass to pass.
+    const result = await run(
+      `
+      const channels = ["a", "b", "c", "d"];
+      let listener;
+      for (const channel of channels) await sql.listen(channel, payload => listener(payload));
+      const segment = (count, payload) => [count, Buffer.concat(Array.from({ length: count }, (_, i) => pgNotificationResponse(1, channels[i % 4], payload)))];
+      const deliver = ([count, blob]) => new Promise(done => {
+        let remaining = count;
+        listener = () => { if (--remaining === 0) done(); };
+        for (const socket of sockets) socket.write(blob);
+      });
+      const rss = async () => { Bun.gc(true); Bun.shrink(); await Bun.sleep(0); return process.memoryUsage.rss(); };
+      const measure = async (seg, rounds) => {
+        const pass = async () => { for (let i = 0; i < rounds; i++) await deliver(seg); };
+        await pass();
+        const base = await rss();
+        await pass();
+        return Math.round(((await rss()) - base) / 1024 / 1024);
+      };
+      // 256 KiB per segment, 96 segments = 24 MiB per pass.
+      const small = await measure(segment(256, Buffer.alloc(1024, 0x61).toString()), 96);
+      const large = await measure(segment(4, Buffer.alloc(64 * 1024, 0x62).toString()), 96);
+      console.log(JSON.stringify({ small, large }));
+      await sql.close();
+    `,
+      { ASAN_OPTIONS: "quarantine_size_mb=4:detect_leaks=0" },
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    const growth = JSON.parse(result.stdout);
+    // Steady state moves by a few MiB between passes; a leak adds ~24 MiB.
+    expect(growth).toEqual({ small: expect.any(Number), large: expect.any(Number) });
+    expect(growth.small, JSON.stringify(growth)).toBeLessThan(6);
+    expect(growth.large, JSON.stringify(growth)).toBeLessThan(6);
+  }, 30_000);
+});
+
 describe.concurrent("listen", () => {
   test("routes notifications to the channel's listener, in order", async () => {
     await using server = await mockServer();
@@ -489,7 +696,8 @@ describe.concurrent("unlisten", () => {
     const unlistening = subscription.unlisten();
     await server.untilQuery(queries => queries.includes('UNLISTEN "ch"'));
     server.dropConnections();
-    await expect(unlistening).resolves.toBeUndefined();
+    // Plain await: this continuation is inside the mock's data callback (see the reconnect suite).
+    expect(await unlistening).toBeUndefined();
     expect(server.queries).toEqual(['LISTEN "keep"', 'LISTEN "ch"', 'UNLISTEN "ch"']);
   });
 
@@ -685,8 +893,9 @@ describe.concurrent("reconnect", () => {
     await sql.listen("ch", got.resolve, repaired.after(2));
 
     // Plain awaits rather than expect().rejects: that one runs the event loop
-    // re-entrantly, and this code is still inside the dropped connection's
-    // data callback; on Windows the inner run frees the socket under it.
+    // re-entrantly (#33261), and this code is still inside the dropped
+    // connection's data callback; on Windows the inner run frees the socket
+    // under it (#39643).
     const outcome = (promise: Promise<unknown>) =>
       promise.then(
         () => "resolved",
@@ -724,7 +933,7 @@ describe.concurrent("close()", () => {
     await expect(pending).rejects.toMatchObject(connectionClosed);
     await server.untilClosed(1);
     await expect(sql.listen("ch", () => {})).rejects.toMatchObject(connectionClosed);
-    await expect(subscription.unlisten()).resolves.toBeUndefined();
+    expect(await subscription.unlisten()).toBeUndefined();
     expect(server.queries).toEqual(['LISTEN "ch"', 'LISTEN "pending"']);
   });
 
@@ -837,219 +1046,6 @@ describe.concurrent("notify()", () => {
     expect(server.queries).toEqual(["SELECT pg_notify($1, $2)"]);
     expect(server.liveConnections).toBe(1);
   });
-});
-
-describe.concurrent("in a subprocess", () => {
-  const wireFrames = path.join(import.meta.dir, "wire-frames.ts");
-  // The mock runs inside the child and is unref'd, so only the subscription
-  // under test can hold the child open. `notifyMany`, `dropConnections`,
-  // `sockets`, `pgNotificationResponse` and `sql` are in scope for `body`.
-  async function run(body: string, env: Record<string, string> = {}) {
-    using dir = tempDir("pg-listen-subprocess", {
-      "fixture.ts": `
-        import { SQL } from "bun";
-        import { listeningServer, pgAuthenticationOk, pgReadyForQuery, pgCommandComplete, pgNotificationResponse, pgReadFrontendMessages, pgRaw, pgInt32 } from ${JSON.stringify(wireFrames)};
-        const sockets = new Set();
-        const { port, server } = await listeningServer(socket => {
-          sockets.add(socket);
-          socket.unref();
-          let buffered = Buffer.alloc(0);
-          socket.once("data", () => {
-            socket.write(Buffer.concat([pgAuthenticationOk(), pgRaw("K", Buffer.concat([pgInt32(1), pgInt32(2)])), pgReadyForQuery()]));
-            socket.on("data", data => {
-              buffered = pgReadFrontendMessages(Buffer.concat([buffered, data]), (type, body) => {
-                if (type !== 0x51) return;
-                socket.write(Buffer.concat([pgCommandComplete(body.toString("utf8", 0, body.indexOf(" "))), pgReadyForQuery()]));
-              });
-            });
-          });
-          socket.on("close", () => sockets.delete(socket));
-        });
-        server.unref();
-        const notifyMany = frames => {
-          const blob = Buffer.concat(frames.map(([channel, payload]) => pgNotificationResponse(1, channel, payload)));
-          for (const socket of sockets) socket.write(blob);
-        };
-        const dropConnections = () => { for (const socket of sockets) socket.destroy(); };
-        const sql = new SQL("postgres://u@127.0.0.1:" + port + "/db", { max: 1 });
-        ${body}
-      `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.ts"],
-      cwd: String(dir),
-      env: { ...bunEnv, ...env },
-      stderr: "pipe",
-      timeout: 30_000,
-      killSignal: "SIGKILL",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return {
-      stdout,
-      stderr: stderr
-        .split("\n")
-        .filter(line => line && !line.startsWith("WARNING: ASAN"))
-        .join("\n"),
-      exitCode,
-      signal: proc.signalCode,
-    };
-  }
-  const clean = (stdout: string) => ({ stdout, stderr: "", exitCode: 0, signal: null });
-
-  test("a subscription keeps the process alive until it is removed", async () => {
-    const result = await run(`
-      const subscription = await sql.listen("ch", async payload => {
-        console.log("got " + payload);
-        await subscription.unlisten();
-        console.log("unlistened");
-      });
-      console.log("subscribed");
-      // Sent from an unref'd timer after top-level code finishes, so the
-      // subscription is the only thing keeping the process here.
-      setTimeout(() => notifyMany([["ch", "wake"]]), 20).unref();
-    `);
-    expect(result).toEqual(clean("subscribed\ngot wake\nunlistened\n"));
-  });
-
-  test("a dropped connection keeps the process alive through the backoff and reconnects", async () => {
-    const result = await run(`
-      let subscribes = 0;
-      const subscription = await sql.listen("ch", () => {}, () => {
-        if (++subscribes === 2) { console.log("reconnected"); subscription.unlisten(); }
-      });
-      console.log("subscribed");
-      dropConnections();
-    `);
-    expect(result).toEqual(clean("subscribed\nreconnected\n"));
-  });
-
-  test("sql.close() releases a subscription so the process exits", async () => {
-    const result = await run(`
-      await sql.listen("ch", () => {});
-      await sql.close();
-      console.log("closed");
-    `);
-    expect(result).toEqual(clean("closed\n"));
-  });
-
-  test("a throwing listener surfaces as uncaughtException; the channel's other listeners and later notifications are unaffected", async () => {
-    const result = await run(`
-      process.on("uncaughtException", err => console.log("uncaught: " + err.message));
-      const first = await sql.listen("ch", payload => {
-        console.log("first got " + payload);
-        if (payload === "bad") throw new Error("listener failed");
-      });
-      const second = await sql.listen("ch", payload => {
-        console.log("second got " + payload);
-        if (payload === "good") { first.unlisten(); second.unlisten(); }
-      });
-      notifyMany([["ch", "bad"], ["ch", "good"]]);
-    `);
-    expect(result).toEqual(
-      clean(
-        ["first got bad", "uncaught: listener failed", "second got bad", "first got good", "second got good", ""].join(
-          "\n",
-        ),
-      ),
-    );
-  });
-
-  test("a lone throwing listener surfaces as uncaughtException and later notifications still arrive", async () => {
-    const result = await run(`
-      process.on("uncaughtException", err => console.log("uncaught: " + err.message));
-      const subscription = await sql.listen("ch", payload => {
-        console.log("got " + payload);
-        if (payload === "bad") throw new Error("listener failed");
-        subscription.unlisten();
-      });
-      notifyMany([["ch", "bad"], ["ch", "good"]]);
-    `);
-    expect(result).toEqual(clean("got bad\nuncaught: listener failed\ngot good\n"));
-  });
-
-  test("a throwing onlisten surfaces as uncaughtException; listen() resolves and the reconnect is not retried", async () => {
-    // An empty stderr is the assertion that the reconnect sweep did not take
-    // the second throw for a failed LISTEN (which it warns about and retries).
-    const result = await run(`
-      process.on("uncaughtException", err => console.log("uncaught: " + err.message));
-      let calls = 0;
-      const subscription = await sql.listen("ch", () => {}, () => {
-        console.log("onlisten " + ++calls);
-        if (calls === 2) subscription.unlisten().then(() => console.log("unlistened"));
-        throw new Error("onlisten failed " + calls);
-      });
-      console.log("subscribed to " + subscription.channel);
-      dropConnections();
-    `);
-    expect(result).toEqual(
-      clean(
-        [
-          "onlisten 1",
-          "uncaught: onlisten failed 1",
-          "subscribed to ch",
-          "onlisten 2",
-          "uncaught: onlisten failed 2",
-          "unlistened",
-          "",
-        ].join("\n"),
-      ),
-    );
-  });
-
-  test("delivering many notifications retains nothing", async () => {
-    // Measured by RSS so a leaked native string backing (invisible to the JS
-    // heap) is caught. Each phase delivers its volume twice and reports the
-    // growth across the second pass: the first pass takes RSS to its steady
-    // state (the allocator keeps the GC's between-collection high-water mark
-    // of payload strings as free memory), after which a correct
-    // implementation shows roughly no growth and leaking one string per
-    // notification shows the pass's full payload volume.
-    //
-    // Steady state still drifts by several MiB from pass to pass (the allocator
-    // hands freed pages back to the OS on its own schedule), so a reading at
-    // or above the bound is checked against one more pass: a leak grows again,
-    // drift does not.
-    const bound = 12; // MiB; a leak adds ~24 per pass
-    const result = await run(
-      `
-      const channels = ["a", "b", "c", "d"];
-      let listener;
-      for (const channel of channels) await sql.listen(channel, payload => listener(payload));
-      const segment = (count, payload) => [count, Buffer.concat(Array.from({ length: count }, (_, i) => pgNotificationResponse(1, channels[i % 4], payload)))];
-      const deliver = ([count, blob]) => new Promise(done => {
-        let remaining = count;
-        listener = () => { if (--remaining === 0) done(); };
-        for (const socket of sockets) socket.write(blob);
-      });
-      const rss = () => { Bun.gc(true); return process.memoryUsage.rss(); };
-      const measure = async (seg, rounds) => {
-        const pass = async () => { for (let i = 0; i < rounds; i++) await deliver(seg); };
-        await pass();
-        const base = rss();
-        const growthMiB = () => Math.round((rss() - base) / 1024 / 1024);
-        await pass();
-        let growth = growthMiB();
-        if (growth >= ${bound}) {
-          await pass();
-          growth = Math.min(growth, growthMiB());
-        }
-        return growth;
-      };
-      // 256 KiB per segment, 96 segments = 24 MiB per pass.
-      const small = await measure(segment(256, Buffer.alloc(1024, 0x61).toString()), 96);
-      const large = await measure(segment(4, Buffer.alloc(64 * 1024, 0x62).toString()), 96);
-      console.log(JSON.stringify({ small, large }));
-      await sql.close();
-    `,
-      { ASAN_OPTIONS: "quarantine_size_mb=4:detect_leaks=0" },
-    );
-    expect(result.stderr).toBe("");
-    expect(result.exitCode).toBe(0);
-    const growth = JSON.parse(result.stdout);
-    expect(growth).toEqual({ small: expect.any(Number), large: expect.any(Number) });
-    expect(growth.small, JSON.stringify(growth)).toBeLessThan(bound);
-    expect(growth.large, JSON.stringify(growth)).toBeLessThan(bound);
-  }, 30_000);
 });
 
 if (isDockerEnabled()) {

--- a/test/js/sql/postgres-listen-notify.test.ts
+++ b/test/js/sql/postgres-listen-notify.test.ts
@@ -6,6 +6,11 @@
 // real server cannot be made to produce on demand. Behavior only observable
 // at process level (exit, uncaught exceptions, RSS) runs in a subprocess.
 // End-to-end behavior runs against the docker-compose postgres service.
+//
+// Every test owns its mock server and client (or, against the shared postgres
+// service, its channel names), so the suites run concurrently: each reconnect
+// test sits out at least one 250ms backoff, and each subprocess test pays a
+// debug-build startup.
 
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
@@ -143,7 +148,25 @@ function gate() {
   });
 }
 
-describe("listen", () => {
+const connectionClosed = {
+  name: "PostgresError",
+  code: "ERR_POSTGRES_CONNECTION_CLOSED",
+  message: "Connection closed",
+};
+/** What the mock's ErrorResponse (SQLSTATE 42601) becomes on the client. */
+const serverError = (message: string) => ({ name: "PostgresError", code: "ERR_POSTGRES_SYNTAX_ERROR", message });
+const invalidChannel = (channel: string, reason: string) => ({
+  name: "TypeError",
+  code: "ERR_INVALID_ARG_VALUE",
+  message: `The argument 'channel' ${reason}. Received '${channel}'`,
+});
+const invalidCallback = (name: string) => ({
+  name: "TypeError",
+  code: "ERR_INVALID_ARG_TYPE",
+  message: `The "${name}" argument must be of type function. Received type number (1)`,
+});
+
+describe.concurrent("listen", () => {
   test("routes notifications to the channel's listener, in order", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
@@ -214,9 +237,10 @@ describe("listen", () => {
     const ascii63 = Buffer.alloc(63, "c").toString();
     const cjk63 = Buffer.alloc(63, "字").toString(); // 21 characters
     const cjk66 = Buffer.alloc(66, "字").toString(); // 22 characters, 66 bytes
-    await expect(sql.listen(ascii63 + "c", () => {})).rejects.toThrow(/63 bytes/);
-    await expect(sql.listen(cjk66, () => {})).rejects.toThrow(/63 bytes/);
-    expect(() => sql.notify(cjk66)).toThrow(/63 bytes/);
+    const tooLong = (channel: string) => invalidChannel(channel, "must be at most 63 bytes");
+    await expect(sql.listen(ascii63 + "c", () => {})).rejects.toMatchObject(tooLong(ascii63 + "c"));
+    await expect(sql.listen(cjk66, () => {})).rejects.toMatchObject(tooLong(cjk66));
+    expect(() => sql.notify(cjk66)).toThrow(expect.objectContaining(tooLong(cjk66)));
 
     await sql.listen(ascii63, () => {});
     await sql.listen(cjk63, () => {});
@@ -244,14 +268,23 @@ describe("listen", () => {
   test("concurrent listen() calls on a new channel share its round trip", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
+    const got: string[] = [];
     const all = gate();
     const count = all.after(3);
-    const subscriptions = await Promise.all([1, 2, 3].map(() => sql.listen("ch", () => count())));
+    const subscriptions = await Promise.all(
+      [1, 2, 3].map(n =>
+        sql.listen("ch", payload => {
+          got.push(`${n}:${payload}`);
+          count();
+        }),
+      ),
+    );
     expect(server.queries).toEqual(['LISTEN "ch"']);
     expect(subscriptions.map(subscription => subscription.channel)).toEqual(["ch", "ch", "ch"]);
     expect(new Set(subscriptions).size).toBe(3);
     server.notify("ch", "x");
     await all;
+    expect(got).toEqual(["1:x", "2:x", "3:x"]);
   });
 
   test("a listener that unlistens itself mid-dispatch does not starve the others", async () => {
@@ -319,10 +352,10 @@ describe("listen", () => {
   test("registering the same callback twice is two subscriptions, each removed by its own handle", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
-    let calls = 0;
+    const got: string[] = [];
     let count = () => {};
-    const callback = () => {
-      calls++;
+    const callback = (payload: string) => {
+      got.push(payload);
       count();
     };
     const first = await sql.listen("ch", callback);
@@ -333,7 +366,7 @@ describe("listen", () => {
     count = both.after(2);
     server.notify("ch", "x");
     await both;
-    expect(calls).toBe(2);
+    expect(got).toEqual(["x", "x"]);
 
     await first.unlisten();
     const one = gate();
@@ -342,7 +375,7 @@ describe("listen", () => {
     await one;
     // This round trip is ordered after any second delivery of "y".
     await sql.listen("barrier", () => {});
-    expect(calls).toBe(3);
+    expect(got).toEqual(["x", "x", "y"]);
     expect(server.queries).toEqual(['LISTEN "ch"', 'LISTEN "barrier"']);
 
     await second.unlisten();
@@ -378,7 +411,7 @@ describe("listen", () => {
   });
 });
 
-describe("unlisten", () => {
+describe.concurrent("unlisten", () => {
   test("removing one of several listeners is local; removing the last sends UNLISTEN", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
@@ -456,7 +489,8 @@ describe("unlisten", () => {
     const unlistening = subscription.unlisten();
     await server.untilQuery(queries => queries.includes('UNLISTEN "ch"'));
     server.dropConnections();
-    await unlistening;
+    await expect(unlistening).resolves.toBeUndefined();
+    expect(server.queries).toEqual(['LISTEN "keep"', 'LISTEN "ch"', 'UNLISTEN "ch"']);
   });
 
   test("a handle from before close() is a no-op afterwards, also for a re-opened client", async () => {
@@ -476,7 +510,7 @@ describe("unlisten", () => {
   });
 });
 
-describe("listen/unlisten interleavings", () => {
+describe.concurrent("listen/unlisten interleavings", () => {
   test("a re-listen() while the UNLISTEN is in flight gets its own LISTEN, ordered after it", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
@@ -498,7 +532,7 @@ describe("listen/unlisten interleavings", () => {
     await using sql = client(server.url);
     await sql.listen("keep", () => {});
     server.failNextListen("bad");
-    await expect(sql.listen("bad", () => {})).rejects.toThrow("cannot LISTEN bad");
+    await expect(sql.listen("bad", () => {})).rejects.toMatchObject(serverError("cannot LISTEN bad"));
     await sql.listen("bad", () => {});
     expect(server.queries).toEqual(['LISTEN "keep"', 'LISTEN "bad"', 'LISTEN "bad"']);
   });
@@ -512,7 +546,11 @@ describe("listen/unlisten interleavings", () => {
     const b = sql.listen("ch", () => {});
     server.release();
     const results = await Promise.allSettled([a, b]);
-    expect(results.map(result => result.status)).toEqual(["rejected", "rejected"]);
+    expect(results).toEqual([
+      { status: "rejected", reason: expect.objectContaining(serverError("cannot LISTEN ch")) },
+      { status: "rejected", reason: expect.objectContaining(serverError("cannot LISTEN ch")) },
+    ]);
+    expect(server.queries).toEqual(['LISTEN "ch"']);
     await server.untilClosed(1);
   });
 
@@ -520,14 +558,18 @@ describe("listen/unlisten interleavings", () => {
     const { port, server } = await listeningServer(socket => socket.destroy());
     try {
       await using sql = client(`postgres://u@127.0.0.1:${port}/db`);
-      await expect(sql.listen("ch", () => {})).rejects.toThrow();
+      await expect(sql.listen("ch", () => {})).rejects.toMatchObject({
+        name: "PostgresError",
+        code: "ERR_POSTGRES_CONNECTION_FAILED",
+        message: "Connection closed before the connection was established",
+      });
     } finally {
       server.close();
     }
   });
 });
 
-describe("reconnect", () => {
+describe.concurrent("reconnect", () => {
   test("re-subscribes every channel, runs onlisten again, resumes delivery", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
@@ -592,9 +634,15 @@ describe("reconnect", () => {
   test("a channel whose re-LISTEN is rejected is retried with backoff and warns", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
+    // console.warn is process-wide and this suite is concurrent, so keep only
+    // the warnings that name this test's channel.
     const warnings: string[] = [];
     const originalWarn = console.warn;
-    console.warn = (...args: unknown[]) => void warnings.push(args.join(" "));
+    console.warn = (...args: unknown[]) => {
+      const line = args.join(" ");
+      if (line.includes('"flaky"')) warnings.push(line);
+      else originalWarn(...args);
+    };
     try {
       const resubscribed = gate();
       await sql.listen("flaky", () => {}, resubscribed.after(2));
@@ -602,7 +650,7 @@ describe("reconnect", () => {
       server.dropConnections();
       await resubscribed;
       expect(server.connections.at(-1)!.filter(query => query === 'LISTEN "flaky"')).toHaveLength(2);
-      expect(warnings).toEqual([expect.stringContaining('LISTEN "flaky" failed, retrying: cannot LISTEN flaky')]);
+      expect(warnings).toEqual(['bun:sql LISTEN "flaky" failed, retrying: cannot LISTEN flaky']);
     } finally {
       console.warn = originalWarn;
     }
@@ -649,7 +697,7 @@ describe("reconnect", () => {
     // and rejects once the client has processed the drop, which is the moment
     // the client considers "ch" unsubscribed and has armed its backoff.
     server.dropConnections();
-    expect(await outcome(sql.listen("probe", () => {}))).toMatch(/closed/i);
+    expect(await outcome(sql.listen("probe", () => {}))).toBe("Connection closed");
 
     // This listen() brings the connection back (cancelling the backoff) and is
     // the one sending LISTEN "ch"; its rejection must not strand the first listener.
@@ -663,7 +711,7 @@ describe("reconnect", () => {
   });
 });
 
-describe("close()", () => {
+describe.concurrent("close()", () => {
   test("tears down the listen connection and rejects an in-flight listen()", async () => {
     await using server = await mockServer();
     const sql = client(server.url);
@@ -673,10 +721,11 @@ describe("close()", () => {
     await server.untilQuery(queries => queries.includes('LISTEN "pending"'));
 
     await sql.close();
-    await expect(pending).rejects.toThrow();
+    await expect(pending).rejects.toMatchObject(connectionClosed);
     await server.untilClosed(1);
-    await expect(sql.listen("ch", () => {})).rejects.toThrow("Connection closed");
-    await subscription.unlisten();
+    await expect(sql.listen("ch", () => {})).rejects.toMatchObject(connectionClosed);
+    await expect(subscription.unlisten()).resolves.toBeUndefined();
+    expect(server.queries).toEqual(['LISTEN "ch"', 'LISTEN "pending"']);
   });
 
   test("in the same tick as a listen() on the live connection rejects it before any LISTEN is sent", async () => {
@@ -702,7 +751,7 @@ describe("close()", () => {
       const sql = new SQL(`postgres://u@127.0.0.1:${port}/db`, { max: 1, connectionTimeout: 60 });
       const listening = sql.listen("ch", () => {});
       await sql.close();
-      await expect(listening).rejects.toThrow();
+      await expect(listening).rejects.toMatchObject(connectionClosed);
     } finally {
       server.close();
     }
@@ -713,30 +762,44 @@ describe("close()", () => {
     await using sql = client(server.url);
     const got = Promise.withResolvers<string>();
     await sql.listen("ch", got.resolve);
-    await expect(sql.close({ timeout: -1 })).rejects.toThrow();
+    await expect(sql.close({ timeout: -1 })).rejects.toMatchObject({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_VALUE",
+      message: "The property 'options.timeout' must be a non-negative integer less than 2^31. Received -1",
+    });
     server.notify("ch", "still subscribed");
     expect(await got.promise).toBe("still subscribed");
+    expect(server.liveConnections).toBe(1);
   });
 });
 
-describe("arguments", () => {
+describe.concurrent("arguments", () => {
   test.each(["postgres", "sqlite"] as const)("%s: invalid arguments fail before any I/O", async adapter => {
     await using sql = adapter === "postgres" ? client("postgres://u@127.0.0.1:1/db") : new SQL("sqlite://:memory:");
     const callback = () => {};
-    await expect(sql.listen("", callback)).rejects.toThrow(/non-empty/);
-    await expect(sql.listen("a\0b", callback)).rejects.toThrow(/null bytes/);
-    await expect(sql.listen("ch", 1 as any)).rejects.toThrow(/onnotify/);
-    await expect(sql.listen("ch", callback, 1 as any)).rejects.toThrow(/onlisten/);
-    expect(() => sql.notify("", "p")).toThrow(/non-empty/);
-    expect(() => sql.notify("ch", null as any)).toThrow(/payload/);
-    expect(() => sql.notify("ch", 1 as any)).toThrow(/payload/);
+    const emptyChannel = invalidChannel("", "must be a non-empty string");
+    const invalidPayload = (received: string) => ({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "payload" argument must be of type string. Received ${received}`,
+    });
+    await expect(sql.listen("", callback)).rejects.toMatchObject(emptyChannel);
+    await expect(sql.listen("a\0b", callback)).rejects.toMatchObject(
+      invalidChannel("a\\x00b", "must not contain null bytes"),
+    );
+    await expect(sql.listen("ch", 1 as any)).rejects.toMatchObject(invalidCallback("onnotify"));
+    await expect(sql.listen("ch", callback, 1 as any)).rejects.toMatchObject(invalidCallback("onlisten"));
+    expect(() => sql.notify("", "p")).toThrow(expect.objectContaining(emptyChannel));
+    expect(() => sql.notify("ch", null as any)).toThrow(expect.objectContaining(invalidPayload("null")));
+    expect(() => sql.notify("ch", 1 as any)).toThrow(expect.objectContaining(invalidPayload("type number (1)")));
   });
 
   test("non-Postgres adapters reject with a clear error", async () => {
     await using sql = new SQL("sqlite://:memory:");
-    await expect(sql.listen("ch", () => {})).rejects.toThrow("PostgreSQL only");
-    await expect(sql.notify("ch", "p")).rejects.toThrow("PostgreSQL only");
-    await expect(sql.notify("ch")).rejects.toThrow("PostgreSQL only");
+    const unsupported = { name: "Error", message: "LISTEN/NOTIFY is not supported by this adapter (PostgreSQL only)" };
+    await expect(sql.listen("ch", () => {})).rejects.toMatchObject(unsupported);
+    await expect(sql.notify("ch", "p")).rejects.toMatchObject(unsupported);
+    await expect(sql.notify("ch")).rejects.toMatchObject(unsupported);
   });
 
   test("reserved connections expose listen() on the client's shared listen connection; unlisten lives on the subscription only", async () => {
@@ -757,7 +820,7 @@ describe("arguments", () => {
   });
 });
 
-describe("notify()", () => {
+describe.concurrent("notify()", () => {
   test("is sent through the pool without being awaited, and opens no listen connection", async () => {
     await using server = await mockServer();
     await using sql = client(server.url);
@@ -766,12 +829,17 @@ describe("notify()", () => {
     // to end in the docker suite.
     const settled = Promise.allSettled([sql.notify("ch", "payload"), sql.notify("signal")]);
     await server.untilQuery(queries => queries.some(query => query.includes("pg_notify($1, $2)")));
-    expect((await settled).map(result => result.status)).toEqual(["rejected", "rejected"]);
+    const rejected = {
+      status: "rejected",
+      reason: expect.objectContaining(serverError("mock rejects extended-protocol queries")),
+    };
+    expect(await settled).toEqual([rejected, rejected]);
+    expect(server.queries).toEqual(["SELECT pg_notify($1, $2)"]);
     expect(server.liveConnections).toBe(1);
   });
 });
 
-describe("in a subprocess", () => {
+describe.concurrent("in a subprocess", () => {
   const wireFrames = path.join(import.meta.dir, "wire-frames.ts");
   // The mock runs inside the child and is unref'd, so only the subscription
   // under test can hold the child open. `notifyMany`, `dropConnections`,
@@ -936,6 +1004,12 @@ describe("in a subprocess", () => {
     // of payload strings as free memory), after which a correct
     // implementation shows roughly no growth and leaking one string per
     // notification shows the pass's full payload volume.
+    //
+    // Steady state still drifts by several MiB from pass to pass (the allocator
+    // hands freed pages back to the OS on its own schedule), so a reading at
+    // or above the bound is checked against one more pass: a leak grows again,
+    // drift does not.
+    const bound = 12; // MiB; a leak adds ~24 per pass
     const result = await run(
       `
       const channels = ["a", "b", "c", "d"];
@@ -953,7 +1027,12 @@ describe("in a subprocess", () => {
         await pass();
         const base = rss();
         await pass();
-        return Math.round((rss() - base) / 1024 / 1024);
+        let growth = (rss() - base) / 1024 / 1024;
+        if (growth >= ${bound}) {
+          await pass();
+          growth = Math.min(growth, (rss() - base) / 1024 / 1024);
+        }
+        return Math.round(growth);
       };
       // 256 KiB per segment, 96 segments = 24 MiB per pass.
       const small = await measure(segment(256, Buffer.alloc(1024, 0x61).toString()), 96);
@@ -966,15 +1045,16 @@ describe("in a subprocess", () => {
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
     const growth = JSON.parse(result.stdout);
-    // Steady state drifts by a few MiB between passes; a leak adds ~24 MiB.
     expect(growth).toEqual({ small: expect.any(Number), large: expect.any(Number) });
-    expect(growth.small, JSON.stringify(growth)).toBeLessThan(6);
-    expect(growth.large, JSON.stringify(growth)).toBeLessThan(6);
+    expect(growth.small, JSON.stringify(growth)).toBeLessThan(bound);
+    expect(growth.large, JSON.stringify(growth)).toBeLessThan(bound);
   }, 30_000);
 });
 
 if (isDockerEnabled()) {
-  describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  // One postgres service for every test, so each test has its own channel
+  // names: a NOTIFY reaches every session that listens on that channel.
+  describeWithContainer("postgres", { image: "postgres_plain", concurrent: true }, container => {
     const connect = () =>
       new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max: 2 });
     // The listening backend is the session whose last statement is our LISTEN.
@@ -1031,28 +1111,33 @@ if (isDockerEnabled()) {
     // so a later delivery proves an earlier notification was or was not
     // delivered.
     describe("ported from postgres.js", () => {
-      test("listen and notify", async () => {
+      test.each(["pgjs_hello", "withUpperChar"])("listen and notify: %s", async channel => {
         await container.ready;
         await using sql = connect();
         const result = Promise.withResolvers<string>();
-        await sql.listen("pgjs_hello", result.resolve);
-        await sql.notify("pgjs_hello", "works");
+        const subscription = await sql.listen(channel, result.resolve);
+        expect(subscription.channel).toBe(channel);
+        await sql.notify(channel, "works");
         expect(await result.promise).toBe("works");
       });
 
       test("double listen", async () => {
         await container.ready;
         await using sql = connect();
-        let count = 0;
-        for (let i = 0; i < 2; i++) {
-          const received = Promise.withResolvers<string>();
-          await sql.listen("pgjs_hello", received.resolve);
-          await sql.notify("pgjs_hello", "world");
-          await received.promise;
-          count++;
+        const got: string[] = [];
+        let count = () => {};
+        for (const n of [1, 2]) {
+          const delivered = gate();
+          count = delivered.after(n); // every listener so far receives it
+          await sql.listen("pgjs_double", payload => {
+            got.push(`${n}:${payload}`);
+            count();
+          });
+          await sql.notify("pgjs_double", "world");
+          await delivered;
         }
         await sql.listen("pgjs_weee", () => {});
-        expect(count).toBe(2);
+        expect(got).toEqual(["1:world", "1:world", "2:world"]);
       });
 
       test("multiple listeners work after a reconnect", async () => {
@@ -1084,7 +1169,7 @@ if (isDockerEnabled()) {
         count = b.after(2);
         await sql.notify("pgjs_reconnect_multi", "b");
         await b;
-        expect(xs.join("")).toBe("1a2a1b2b");
+        expect(xs).toEqual(["1a", "2a", "1b", "2b"]);
       });
 
       test("listen and notify with weird name", async () => {
@@ -1102,35 +1187,31 @@ if (isDockerEnabled()) {
         await subscription.unlisten();
 
         const barrier = gate();
-        await sql.listen("pgjs_barrier", barrier.open);
+        await sql.listen("pgjs_weird_barrier", barrier.open);
         await sql.notify(channel, "after unlisten");
-        await sql.notify("pgjs_barrier", "");
+        await sql.notify("pgjs_weird_barrier", "");
         await barrier;
         expect(got).toEqual(["works"]);
-      });
-
-      test("listen and notify with upper case", async () => {
-        await container.ready;
-        await using sql = connect();
-        const result = Promise.withResolvers<string>();
-        await sql.listen("withUpperChar", result.resolve);
-        await sql.notify("withUpperChar", "works");
-        expect(await result.promise).toBe("works");
       });
 
       test("listen reconnects", async () => {
         await container.ready;
         await using sql = connect();
+        const events: string[] = [];
         const a = gate();
         const b = gate();
-        const resolvers: Record<string, () => void> = { a: a.open, b: b.open };
-        let connects = 0;
+        const arrivals: Record<string, () => void> = { a: a.open, b: b.open };
         const reconnected = gate();
+        const onlisten = reconnected.after(2);
         await sql.listen(
           "pgjs_reconnect",
-          x => resolvers[x]?.(),
+          payload => {
+            events.push("got " + payload);
+            arrivals[payload]?.();
+          },
           () => {
-            if (++connects === 2) reconnected.open();
+            events.push("onlisten");
+            onlisten();
           },
         );
         await sql.notify("pgjs_reconnect", "a");
@@ -1139,7 +1220,7 @@ if (isDockerEnabled()) {
         await reconnected;
         await sql.notify("pgjs_reconnect", "b");
         await b;
-        expect(connects).toBe(2);
+        expect(events).toEqual(["onlisten", "got a", "onlisten", "got b"]);
       });
 
       test("listen result reports correct connection state after reconnection", async () => {
@@ -1165,20 +1246,20 @@ if (isDockerEnabled()) {
         await using sql = connect();
         const xs: string[] = [];
         const a = gate();
-        const subscription = await sql.listen("pgjs_test", x => {
+        const subscription = await sql.listen("pgjs_unlisten", x => {
           xs.push(x);
           a.open();
         });
-        await sql.notify("pgjs_test", "a");
+        await sql.notify("pgjs_unlisten", "a");
         await a;
         await subscription.unlisten();
 
         const barrier = gate();
-        await sql.listen("pgjs_barrier", barrier.open);
-        await sql.notify("pgjs_test", "b");
-        await sql.notify("pgjs_barrier", "");
+        await sql.listen("pgjs_unlisten_barrier", barrier.open);
+        await sql.notify("pgjs_unlisten", "b");
+        await sql.notify("pgjs_unlisten_barrier", "");
         await barrier;
-        expect(xs.join("")).toBe("a");
+        expect(xs).toEqual(["a"]);
       });
 
       test("listen after unlisten", async () => {
@@ -1193,18 +1274,18 @@ if (isDockerEnabled()) {
 
         const a = gate();
         received = a.open;
-        const subscription = await sql.listen("pgjs_test", listener);
-        await sql.notify("pgjs_test", "a");
+        const subscription = await sql.listen("pgjs_relisten", listener);
+        await sql.notify("pgjs_relisten", "a");
         await a;
         await subscription.unlisten();
-        await sql.notify("pgjs_test", "b");
+        await sql.notify("pgjs_relisten", "b");
 
         const c = gate();
         received = c.open;
-        await sql.listen("pgjs_test", listener);
-        await sql.notify("pgjs_test", "c");
+        await sql.listen("pgjs_relisten", listener);
+        await sql.notify("pgjs_relisten", "c");
         await c;
-        expect(xs.join("")).toBe("ac");
+        expect(xs).toEqual(["a", "c"]);
       });
 
       test("multiple listeners and unlisten one", async () => {
@@ -1212,26 +1293,26 @@ if (isDockerEnabled()) {
         await using sql = connect();
         const xs: string[] = [];
         let count = () => {};
-        await sql.listen("pgjs_test", x => {
+        await sql.listen("pgjs_multi", x => {
           xs.push("1" + x);
           count();
         });
-        const s2 = await sql.listen("pgjs_test", x => {
+        const s2 = await sql.listen("pgjs_multi", x => {
           xs.push("2" + x);
           count();
         });
 
         const a = gate();
         count = a.after(2);
-        await sql.notify("pgjs_test", "a");
+        await sql.notify("pgjs_multi", "a");
         await a;
         await s2.unlisten();
 
         const b = gate();
         count = b.open;
-        await sql.notify("pgjs_test", "b");
+        await sql.notify("pgjs_multi", "b");
         await b;
-        expect(xs.join("")).toBe("1a2a1b");
+        expect(xs).toEqual(["1a", "2a", "1b"]);
       });
     });
   });

--- a/test/js/sql/postgres-listen-notify.test.ts
+++ b/test/js/sql/postgres-listen-notify.test.ts
@@ -1026,13 +1026,14 @@ describe.concurrent("in a subprocess", () => {
         const pass = async () => { for (let i = 0; i < rounds; i++) await deliver(seg); };
         await pass();
         const base = rss();
+        const growthMiB = () => Math.round((rss() - base) / 1024 / 1024);
         await pass();
-        let growth = (rss() - base) / 1024 / 1024;
+        let growth = growthMiB();
         if (growth >= ${bound}) {
           await pass();
-          growth = Math.min(growth, (rss() - base) / 1024 / 1024);
+          growth = Math.min(growth, growthMiB());
         }
-        return Math.round(growth);
+        return growth;
       };
       // 256 KiB per segment, 96 segments = 24 MiB per pass.
       const small = await measure(segment(256, Buffer.alloc(1024, 0x61).toString()), 96);


### PR DESCRIPTION
### Problem
- `test/js/sql/postgres-listen-notify.test.ts` reports 15 to 21 s per CI lane, of which 1.6 s is tests. The rest is the `postgres_plain` cold start, paid in the docker block's `beforeAll` because the file is not in `test/docker/prestart-map.mjs`.
- A local debug build takes 27.8 s: the tests run one at a time, 7 subprocess spawns (17.6 s) and a 250 ms backoff per reconnect test.

### Fix
- Add the file to `test/docker/prestart-map.mjs`: the coordinator starts `postgres_plain` at shard launch and the runner orders the file after the non-docker tests.
- Every suite is `describe.concurrent`. Each test owns its mock server and client, each docker test its channel names. The subprocess suite is declared first: slots go out in declaration order (5 under ASAN). Local debug build: 27.8 s to 10.7 s.
- Error paths assert `{ name, code, message }`, deliveries are `toEqual` logs. `Bun.shrink()` after `Bun.gc(true)` removes the leak test's RSS drift (up to 8 MiB, 4 of 42 local runs over the unchanged 6 MiB bound).
- Verified: 56 pass under `bun bd test`, docker block on. Release build under a 24-way CPU load: 0 hangs in 60 runs, 4 in 50 before the plain awaits.

### Background
- A `NOTIFY` reaches every session listening on that channel, so concurrent tests need distinct channel names.
- Consecutive `describe.concurrent` groups form one pool on one thread, filled in declaration order.
- `expect(p).rejects` on a pending promise re-enters the event loop (#33261). Inside a socket callback the inner tick drops the outer dispatch's remaining events (`src/spawn/process.rs:74`). Every rejection is awaited plainly.
- 56 tests before and after. #39850 re-indents the docker block.

<details><summary>Notes</summary>

CI attribution, this PR's build 104104, `:debian: 13 x64-asan` job `01a02e24-bd7c-4833-aa60-e4e143b2d199`, relative to the file's start: non-docker tests done at +1.6 s, `coordinator: postgres_plain ready` at +14.6 s, docker tests done at +15.1 s, reported `Ran 56 tests across 1 file. [15.15s]`. The earlier 20 s figure (build 103933) has the same shape. #39431 changes the slow-test accounting so this wait is reported separately. The other `describeWithContainer` files missing from the prestart map can be swept in a follow-up.

Build 104216 (head 57b5039f, subprocess suite declared first) hung `delivering many notifications retains nothing` for 30 s on debian 13 x64, alpine x64 and darwin aarch64, and on darwin two mock-server tests got `Connection timeout after 5s` while `notify()` hung. Build 104114 (same suites concurrent, subprocess suite declared last) passed every lane. Local A/B with the release build under 24 busy loops: suite first, 4 hangs in 50 runs; suite last, 0 in 30; suite first with every rejection awaited plainly, 0 in 60. Caught live on a hung run: the child had exited and was reaped, the parent held no pipe fds and sat in `ep_poll`, and the test ran to its timeout, so the child's exit event was dropped in the parent. The trigger is `expect(p).rejects` on a pending promise from a continuation inside a socket callback: `waitForPromise` re-enters the loop and the inner tick overwrites the ready-poll list of the outer dispatch (`src/spawn/process.rs:74`).

Local timings (debug build, 12 CPUs):

| | before | after |
|---|---|---|
| 44 tests, docker block skipped | 27.8 s | 10.7 s |
| 56 tests, docker block on | ~29.6 s | 12.4 s |
| release build (`USE_SYSTEM_BUN=1`, bun 1.4.0), 56 tests | | 0.97 s |

The docker block is gated on `isDockerEnabled()`, which is false here (no daemon). For the measurements above I ran it with the gate temporarily set to `true` and `BUN_TEST_SERVICE_postgres_plain` pointing at the local service. The committed gate is unchanged.

The backoff is `RECONNECT_MIN_MS` in `src/js/internal/sql/postgres.ts:651`. Concurrency cap: `src/options_types/context.rs:506` sets `max_concurrency` to 5 under ASAN and 20 otherwise. The runner fills slots in declaration order, so before the move the seven subprocess spawns started only after the 37 mock-server tests drained (12.2 s with the move pending, 10.7 s after).

The docker block passes `concurrent: true` to `describeWithContainer`. The two identical `listen and notify` tests are one `test.each` (same count). Shared channel names before this change: `pgjs_test` (3 tests), `pgjs_hello` (2), `pgjs_barrier` (2). The warn test patches `console.warn`, which is process-wide, so it keeps only the lines that name its channel and forwards the rest.

Assertion changes in detail:
- `a connection failure rejects listen()`: `ERR_POSTGRES_CONNECTION_FAILED`, `Connection closed before the connection was established`. Deterministic: `PostgresSQLConnection::on_close` in the `Connecting` or `SentStartupMessage` state, and the listen connection does not retry.
- `close()` suite: the in-flight `listen()`, a `listen()` after `close()`, and a `listen()` aborted during the handshake all reject with `ERR_POSTGRES_CONNECTION_CLOSED` / `Connection closed`. `close({ timeout: -1 })` rejects with `ERR_INVALID_ARG_VALUE` and the full message.
- `arguments` suite: exact `ERR_INVALID_ARG_VALUE` / `ERR_INVALID_ARG_TYPE` codes and messages for every invalid channel, callback, and payload, on both the postgres and the sqlite adapter. The sqlite `PostgreSQL only` check asserts the full message.
- Rejected `LISTEN` paths: `ERR_POSTGRES_SYNTAX_ERROR` with the mock's message, for the single caller and for both concurrent callers. The concurrent case also asserts that exactly one `LISTEN` reached the server.
- `notify()` through the pool: both rejections carry the mock's message, and the server saw exactly `SELECT pg_notify($1, $2)`.
- Delivery logs: `concurrent listen() calls` asserts `["1:x", "2:x", "3:x"]`. `registering the same callback twice` asserts `["x", "x"]` then `["x", "x", "y"]`. `double listen` asserts `["1:world", "1:world", "2:world"]`. `listen reconnects` asserts `["onlisten", "got a", "onlisten", "got b"]`. The `xs.join("")` comparisons are `toEqual` on arrays.
- `a listen() that reconnects but has its LISTEN rejected`: the probe's rejection is exactly `Connection closed` (was `/closed/i`).
- The warn test asserts the exact warning line.

Leak test. 42 serial runs of the unchanged fixture alone, `large` growth in MiB: -8, -6, -4 x3, -3 x8, -2 x10, -1 x6, 0 x6, 1, 4, 5 x2, 6 x3, 8. This drift was seen locally on the debug ASAN build only, not in CI. With `Bun.gc(true); Bun.shrink(); await Bun.sleep(0)` before each reading, 30 runs: `large` in [-3, 1], `small` in [-3, 3]. With the fixture changed to keep a reference to every payload, three runs read `{"small":26,"large":25}`, `{"small":26,"large":26}`, `{"small":27,"large":26}`. `Bun.shrink()` calls JSC's `shrinkFootprintWhenIdle()`, hence the yield.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/postgres-listen-notify.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/postgres-listen-notify.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/postgres-listen-notify.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) in a subprocess > sql.close() releases a subscription so the process exits [1566.06ms]
(pass) in a subprocess > a throwing listener surfaces as uncaughtException; the channel's other listeners and later notifications are unaffected [1616.63ms]
(pass) in a subprocess > a lone throwing listener surfaces as uncaughtException and later notifications still arrive [1702.23ms]
(pass) in a subprocess > a subscription keeps the process alive until it is removed [2236.31ms]
(pass) in a subprocess > a dropped connection keeps the process alive through the backoff and reconnects [2217.30ms]
(pass) listen > routes notifications to the channel's listener, in order [864.18ms]
(pass) listen > channel names and payloads are UTF-8 [420.79ms]
(pass) in a subprocess > a throwing onlisten surfaces as uncaughtException; listen() resolves and the reconnect is not retried [2474.20ms]
(pass) listen > thousands of notifications across channels arriving in one read [1923.09ms]
(pass) listen > channel names are quoted as identifiers [1580.22ms]
(pass) listen > channel names are limited to PostgreSQL's 63 identifier bytes, counted in UTF-8 [1604.46ms]
(pass) listen > several listeners on one channel share one LISTEN and each receives [245.75ms]
(pass) listen > concurrent listen() calls on a new channel share its round trip [241.21ms]
(pass) listen > a listener that unlistens itself mid-dispatch does not starve the others [264.35ms]
(pass) listen > a listener added from inside a callback receives the next notification, not the current one [239.61ms]
(pass) listen > onlisten runs after the LISTEN
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/docker/prestart-map.mjs               |   1 +
 test/js/sql/postgres-listen-notify.test.ts | 684 ++++++++++++++++-------------
 2 files changed, 390 insertions(+), 295 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/docker/prestart-map.mjs                    1      1      0
test/js/sql/postgres-listen-notify.test.ts     15     34      0
```

</details>

<!-- robobun:evidence:end -->