### PR TITLE
test(bake): run the css dev server cases against one shared dev server

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -139,6 +139,9 @@ export interface DevServerTest {
   env?: Record<string, string>;
 }
 
+/** A `DevServerTest` without its body: what one dev server serves. */
+type DevServerProject = Omit<DevServerTest, "test">;
+
 let interactive = false;
 let activeClient: Client | null = null;
 const interactive_timeout = 24 * 60 * 60 * 1000; // 24 hours
@@ -216,7 +219,7 @@ export class Dev extends EventEmitter {
     process: Subprocess<"pipe", "pipe", "pipe">,
     stream: OutputLineStream,
     nodeEnv: "development" | "production",
-    options: DevServerTest,
+    options: DevServerProject,
   ) {
     super();
     this.rootDir = realpathSync(root);
@@ -1926,20 +1929,8 @@ export function indexHtmlScript(htmlFiles: string[]) {
 
 const skipTargets = [process.platform, isCI ? "ci" : null].filter(Boolean);
 
-function testImpl<T extends DevServerTest>(
-  description: string,
-  options: T,
-  NODE_ENV: "development" | "production",
-  caller: string,
-): T {
-  if (interactive) return options;
-
-  const jest = (Bun as any).jest(caller);
-
-  const basename = path.basename(caller, ".test" + path.extname(caller));
-  const count = (counts[basename] = (counts[basename] ?? 0) + 1);
-
-  const name = `${
+function testName(NODE_ENV: "development" | "production", basename: string, count: number, description: string) {
+  return `${
     NODE_ENV === "development" //
       ? Bun.enableANSIColors
         ? " \x1b[35mDEV\x1b[0m"
@@ -1948,36 +1939,42 @@ function testImpl<T extends DevServerTest>(
         ? "\x1b[36mPROD\x1b[0m"
         : "PROD"
   }:${basename}-${count}: ${description}`;
+}
 
-  const isStressTest = stressTestSelect === "ALL" || (stressTestSelect && name.includes(stressTestSelect));
+function testTimeout(options: Pick<DevServerTest, "timeoutMultiplier">) {
+  return (options.timeoutMultiplier ?? 1) * (isWindows ? 45_000 : 30_000) * WAIT_MULTIPLIER;
+}
 
-  async function run() {
-    const root = path.join(tempDir, basename + count);
+/**
+ * Writes the project one dev server serves under `root`: `options.files` (or
+ * the fixture), the `bun.app.ts` that routes its HTML files, and the
+ * `harness_start.ts` entry point the harness drives.
+ */
+async function writeProject(root: string, options: DevServerProject): Promise<void> {
+  // Clean the test directory if it exists
+  cleanTestDir(root);
 
-    // Clean the test directory if it exists
-    cleanTestDir(root);
-
-    const mainDir = path.resolve(root, options.mainDir ?? ".");
-    if (options.files) {
-      const htmlFiles = (options.htmlFiles ?? Object.keys(options.files).filter(file => file.endsWith(".html"))).map(
-        x => path.join(root, x),
-      );
-      await writeAll(root, options.files);
-      const runInstall = options.framework === "react";
-      if (runInstall) {
-        // await copyCachedReactDeps(root);
-        await installReactWithCache(root);
+  const mainDir = path.resolve(root, options.mainDir ?? ".");
+  if (options.files) {
+    const htmlFiles = (options.htmlFiles ?? Object.keys(options.files).filter(file => file.endsWith(".html"))).map(x =>
+      path.join(root, x),
+    );
+    await writeAll(root, options.files);
+    const runInstall = options.framework === "react";
+    if (runInstall) {
+      // await copyCachedReactDeps(root);
+      await installReactWithCache(root);
+    }
+    if (options.files["bun.app.ts"] == undefined && htmlFiles.length === 0) {
+      if (!options.framework) {
+        throw new Error("Must specify one of: `options.framework`, `*.html`, or `bun.app.ts`");
       }
-      if (options.files["bun.app.ts"] == undefined && htmlFiles.length === 0) {
-        if (!options.framework) {
-          throw new Error("Must specify one of: `options.framework`, `*.html`, or `bun.app.ts`");
-        }
-        if (options.pluginFile) {
-          fs.writeFileSync(path.join(root, "pluginFile.ts"), dedent(options.pluginFile));
-        }
-        fs.writeFileSync(
-          path.join(root, "bun.app.ts"),
-          dedent`
+      if (options.pluginFile) {
+        fs.writeFileSync(path.join(root, "pluginFile.ts"), dedent(options.pluginFile));
+      }
+      fs.writeFileSync(
+        path.join(root, "bun.app.ts"),
+        dedent`
             ${options.pluginFile ? `import plugins from './pluginFile.ts';` : "let plugins = undefined;"}
             export default {
               app: {
@@ -1986,48 +1983,48 @@ function testImpl<T extends DevServerTest>(
               },
             };
           `,
-        );
-      } else if (htmlFiles.length > 0) {
-        if (options.files["bun.app.ts"]) {
-          throw new Error("Cannot provide both bun.app.ts and index.html");
-        }
-        await Bun.write(
-          path.join(mainDir, "bun.app.ts"),
-          indexHtmlScript(htmlFiles.map(file => path.relative(mainDir, file))),
-        );
+      );
+    } else if (htmlFiles.length > 0) {
+      if (options.files["bun.app.ts"]) {
+        throw new Error("Cannot provide both bun.app.ts and index.html");
       }
-    } else {
-      if (!options.fixture) {
-        throw new Error("Must provide either `fixture` or `files`");
-      }
-      const fixture = path.join(devTestRoot, "../fixtures", options.fixture);
-      fs.cpSync(fixture, root, { recursive: true });
+      await Bun.write(
+        path.join(mainDir, "bun.app.ts"),
+        indexHtmlScript(htmlFiles.map(file => path.relative(mainDir, file))),
+      );
+    }
+  } else {
+    if (!options.fixture) {
+      throw new Error("Must provide either `fixture` or `files`");
+    }
+    const fixture = path.join(devTestRoot, "../fixtures", options.fixture);
+    fs.cpSync(fixture, root, { recursive: true });
 
-      if (!fs.existsSync(path.join(mainDir, "bun.app.ts"))) {
-        if (!fs.existsSync(path.join(mainDir, "index.html"))) {
-          throw new Error(`Fixture ${fixture} must contain a bun.app.ts or index.html file.`);
-        } else {
-          await Bun.write(path.join(root, "bun.app.ts"), indexHtmlScript(["index.html"]));
-        }
-      }
-      if (!fs.existsSync(path.join(root, "node_modules"))) {
-        if (fs.existsSync(path.join(root, "bun.lock"))) {
-          // run bun install
-          Bun.spawnSync({
-            cmd: [process.execPath, "install", "--linker=hoisted"],
-            cwd: root,
-            stdio: ["inherit", "inherit", "inherit"],
-            env: bunEnv,
-          });
-        } else {
-          // link the node_modules directory from test/node_modules to the temp directory
-          fs.symlinkSync(path.join(devTestRoot, "../../node_modules"), path.join(root, "node_modules"), "junction");
-        }
+    if (!fs.existsSync(path.join(mainDir, "bun.app.ts"))) {
+      if (!fs.existsSync(path.join(mainDir, "index.html"))) {
+        throw new Error(`Fixture ${fixture} must contain a bun.app.ts or index.html file.`);
+      } else {
+        await Bun.write(path.join(root, "bun.app.ts"), indexHtmlScript(["index.html"]));
       }
     }
-    fs.writeFileSync(
-      path.join(root, "harness_start.ts"),
-      dedent`
+    if (!fs.existsSync(path.join(root, "node_modules"))) {
+      if (fs.existsSync(path.join(root, "bun.lock"))) {
+        // run bun install
+        Bun.spawnSync({
+          cmd: [process.execPath, "install", "--linker=hoisted"],
+          cwd: root,
+          stdio: ["inherit", "inherit", "inherit"],
+          env: bunEnv,
+        });
+      } else {
+        // link the node_modules directory from test/node_modules to the temp directory
+        fs.symlinkSync(path.join(devTestRoot, "../../node_modules"), path.join(root, "node_modules"), "junction");
+      }
+    }
+  }
+  fs.writeFileSync(
+    path.join(root, "harness_start.ts"),
+    dedent`
         import appConfig from ${JSON.stringify(path.join(mainDir, "bun.app.ts"))};
         import { fullGC } from "bun:jsc";
 
@@ -2069,47 +2066,67 @@ function testImpl<T extends DevServerTest>(
           }
         });
       `,
-    );
+  );
+}
 
-    using _ = {
-      [Symbol.dispose]: () => {
-        for (const proc of danglingProcesses) {
-          proc.kill("SIGKILL");
-        }
-      },
-    };
+/** Kills every client and dev server subprocess that is still running. */
+function killDanglingProcesses() {
+  for (const proc of danglingProcesses) {
+    proc.kill("SIGKILL");
+  }
+}
 
-    await using devProcess = Bun.spawn({
-      cwd: root,
-      cmd: [process.execPath, "./harness_start.ts"],
-      env: mergeWindowEnvs([
-        bunEnv,
-        {
-          FORCE_COLOR: "1",
-          BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
-          BUN_DEV_SERVER_TEST_RUNNER: "1",
-          BUN_DUMP_STATE_ON_CRASH: "1",
-          NODE_ENV,
-          // BUN_DEBUG_QUIET_LOGS: "0",
-          // BUN_DEBUG_DEVSERVER: isDebugBuild && interactive ? "1" : undefined,
-          // BUN_DEBUG_INCREMENTALGRAPH: isDebugBuild && interactive ? "1" : undefined,
-          // BUN_DEBUG_WATCHER: isDebugBuild && interactive ? "1" : undefined,
-          BUN_ASSUME_PERFECT_INCREMENTAL: "0",
-          ...options.env,
-        },
-      ]),
-      stdio: ["pipe", "pipe", "pipe"],
-      onExit: (subprocess, exitCode, signalCode, error) => {
-        danglingProcesses.delete(subprocess);
+interface DevServerHandle extends AsyncDisposable {
+  dev: Dev;
+}
+
+/**
+ * Spawns the dev server for a project that `writeProject` wrote, and resolves
+ * once it listens and the harness's HMR socket is connected. Disposing the
+ * handle kills the process; call `dev.gracefulExit()` first for a clean exit.
+ */
+async function spawnDevServer(
+  root: string,
+  options: DevServerProject,
+  NODE_ENV: "development" | "production",
+  isStressTest: boolean,
+): Promise<DevServerHandle> {
+  const devProcess = Bun.spawn({
+    cwd: root,
+    cmd: [process.execPath, "./harness_start.ts"],
+    env: mergeWindowEnvs([
+      bunEnv,
+      {
+        FORCE_COLOR: "1",
+        BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+        BUN_DEV_SERVER_TEST_RUNNER: "1",
+        BUN_DUMP_STATE_ON_CRASH: "1",
+        NODE_ENV,
+        // BUN_DEBUG_QUIET_LOGS: "0",
+        // BUN_DEBUG_DEVSERVER: isDebugBuild && interactive ? "1" : undefined,
+        // BUN_DEBUG_INCREMENTALGRAPH: isDebugBuild && interactive ? "1" : undefined,
+        // BUN_DEBUG_WATCHER: isDebugBuild && interactive ? "1" : undefined,
+        BUN_ASSUME_PERFECT_INCREMENTAL: "0",
+        ...options.env,
       },
-      ipc(message, subprocess) {},
-    });
-    danglingProcesses.add(devProcess);
-    if (interactive) {
-      console.log("\x1b[35mDev Server PID: " + devProcess.pid + "\x1b[0m");
-    }
-    using stream = new OutputLineStream("dev", devProcess.stdout, devProcess.stderr);
-    devProcess.exited.then(exitCode => (stream.exitCode = exitCode));
+    ]),
+    stdio: ["pipe", "pipe", "pipe"],
+    onExit: (subprocess, exitCode, signalCode, error) => {
+      danglingProcesses.delete(subprocess);
+    },
+    ipc(message, subprocess) {},
+  });
+  danglingProcesses.add(devProcess);
+  if (interactive) {
+    console.log("\x1b[35mDev Server PID: " + devProcess.pid + "\x1b[0m");
+  }
+  const stream = new OutputLineStream("dev", devProcess.stdout, devProcess.stderr);
+  devProcess.exited.then(exitCode => (stream.exitCode = exitCode));
+  const dispose = async () => {
+    stream[Symbol.dispose]();
+    await devProcess[Symbol.asyncDispose]();
+  };
+  try {
     const port = parseInt((await stream.waitForLine(/localhost:(\d+)/))[1], 10);
     const dev = new Dev(root, port, devProcess, stream, NODE_ENV, options);
     if (dev.nodeEnv === "development") {
@@ -2118,35 +2135,96 @@ function testImpl<T extends DevServerTest>(
     if (isStressTest) {
       dev.stressTestEndurance = true;
     }
-
-    await maybeWaitInteractive("start");
-
-    try {
-      await options.test(dev);
-    } catch (err: any) {
-      while (err instanceof SuppressedError) {
-        logErr(err.suppressed);
-        err = err.error;
-      }
-      if (interactive) {
-        logErr(err);
-        await maybeWaitInteractive("exit");
-        process.exit(1);
-      }
-      logErr(err);
-      console.log("\x1b[31mFailed\x1b[0;2m. Files in " + root + "\x1b[0m\r");
-      throw "\r\x1b[K\x1b[A";
-    }
-
-    if (interactive) {
-      console.log("\x1b[32mPASS\x1b[0m");
-      await maybeWaitInteractive("exit");
-      await dev.gracefulExit();
-      process.exit(0);
-    }
-
-    await dev.gracefulExit();
+    return { dev, [Symbol.asyncDispose]: dispose };
+  } catch (e) {
+    await dispose();
+    throw e;
   }
+}
+
+/**
+ * Runs one case against `dev`. A failure is reported with the case's annotated
+ * stack line, and the project is left in `root` for inspection.
+ */
+async function runCase(root: string, dev: Dev, test: (dev: Dev) => Promise<void>): Promise<void> {
+  try {
+    await test(dev);
+  } catch (err: any) {
+    while (err instanceof SuppressedError) {
+      logErr(err.suppressed);
+      err = err.error;
+    }
+    if (interactive) {
+      logErr(err);
+      await maybeWaitInteractive("exit");
+      process.exit(1);
+    }
+    logErr(err);
+    console.log("\x1b[31mFailed\x1b[0;2m. Files in " + root + "\x1b[0m\r");
+    throw "\r\x1b[K\x1b[A";
+  }
+}
+
+/** Runs one `devTest` case on its own dev server, from writing the project to the server's exit. */
+async function runStandalone(
+  root: string,
+  options: DevServerTest,
+  NODE_ENV: "development" | "production",
+  isStressTest: boolean,
+): Promise<void> {
+  await writeProject(root, options);
+
+  using _ = { [Symbol.dispose]: killDanglingProcesses };
+  await using server = await spawnDevServer(root, options, NODE_ENV, isStressTest);
+  const dev = server.dev;
+
+  await maybeWaitInteractive("start");
+
+  await runCase(root, dev, options.test);
+
+  if (interactive) {
+    console.log("\x1b[32mPASS\x1b[0m");
+    await maybeWaitInteractive("exit");
+    await dev.gracefulExit();
+    process.exit(0);
+  }
+
+  await dev.gracefulExit();
+}
+
+/** The `-t` filter of an interactive run (`bun test/bake/dev/foo.test.ts <filter>`), or exits with usage. */
+function interactiveFilter(): string {
+  let arg = process.argv.slice(2).join(" ").trim();
+  if (arg.startsWith("-t")) {
+    arg = arg.slice(2).trim();
+  }
+  if (!arg) {
+    const mainFile = Bun.$.escape(path.relative(process.cwd(), process.argv[1]));
+    console.error("Options for running Dev Server tests:");
+    console.error(" - automated:   bun test " + mainFile);
+    console.error(" - interactive: bun " + mainFile + " [-t] <filter or number for test>");
+    process.exit(1);
+  }
+  return arg;
+}
+
+function testImpl<T extends DevServerTest>(
+  description: string,
+  options: T,
+  NODE_ENV: "development" | "production",
+  caller: string,
+): T {
+  if (interactive) return options;
+
+  const jest = (Bun as any).jest(caller);
+
+  const basename = path.basename(caller, ".test" + path.extname(caller));
+  const count = (counts[basename] = (counts[basename] ?? 0) + 1);
+  const name = testName(NODE_ENV, basename, count, description);
+  const isStressTest = stressTestSelect === "ALL" || (stressTestSelect && name.includes(stressTestSelect));
+  const root = path.join(tempDir, basename + count);
+
+  const run = () => runStandalone(root, options, NODE_ENV, !!isStressTest);
 
   try {
     if (options.skip && options.skip.some(x => skipTargets.includes(x))) {
@@ -2157,26 +2235,12 @@ function testImpl<T extends DevServerTest>(
     (options.only ? jest.test.only : jest.test)(
       name,
       run,
-      isStressTest
-        ? 11 * 60 * 1000
-        : interactive
-          ? interactive_timeout
-          : (options.timeoutMultiplier ?? 1) * (isWindows ? 45_000 : 30_000) * WAIT_MULTIPLIER,
+      isStressTest ? 11 * 60 * 1000 : interactive ? interactive_timeout : testTimeout(options),
     );
     return options;
   } catch {
     // not in bun test. allow interactive use
-    let arg = process.argv.slice(2).join(" ").trim();
-    if (arg.startsWith("-t")) {
-      arg = arg.slice(2).trim();
-    }
-    if (!arg) {
-      const mainFile = Bun.$.escape(path.relative(process.cwd(), process.argv[1]));
-      console.error("Options for running Dev Server tests:");
-      console.error(" - automated:   bun test " + mainFile);
-      console.error(" - interactive: bun " + mainFile + " [-t] <filter or number for test>");
-      process.exit(1);
-    }
+    const arg = interactiveFilter();
     if (name.includes(arg)) {
       interactive = true;
       console.log("\x1b[32;1m" + name + " (Interactive)\x1b[0m");
@@ -2185,6 +2249,125 @@ function testImpl<T extends DevServerTest>(
     }
   }
   return options;
+}
+
+export interface DevServerTestCase {
+  /** Starting files. Every path must be unique across the group's cases. */
+  files: FileObject;
+  /** Execute the case */
+  test: (dev: Dev) => Promise<void>;
+}
+
+export type DevServerTestGroupOptions = Omit<DevServerProject, "files" | "htmlFiles" | "fixture">;
+
+/**
+ * Declares cases that share one dev server. The server starts before the first
+ * case and exits after the last one, so the cost of a dev server process
+ * (startup, and on the ASAN lane the leak check at exit) is paid once per group
+ * instead of once per case. Each case is still its own test.
+ *
+ * The cases share one project and one incremental graph. So each case must use
+ * its own HTML route and its own files, and must leave them building without
+ * errors: the dev server reports every failure it still holds on the next error
+ * page, whichever route the failing file belongs to.
+ */
+export function devTestGroup(
+  description: string,
+  options: DevServerTestGroupOptions,
+  define: (test: (description: string, testCase: DevServerTestCase) => void) => void,
+): void {
+  const callerLocation = snapshotCallerLocation();
+  const caller = stackTraceFileName(callerLocation);
+  assert(caller.startsWith(devTestRoot), "dev server tests must be in test/bake/dev, not " + caller);
+  groupImpl(description, options, define, "development", caller);
+}
+
+function groupImpl(
+  description: string,
+  options: DevServerTestGroupOptions,
+  define: (test: (description: string, testCase: DevServerTestCase) => void) => void,
+  NODE_ENV: "development" | "production",
+  caller: string,
+): void {
+  if (interactive) return;
+
+  const jest = (Bun as any).jest(caller);
+
+  const basename = path.basename(caller, ".test" + path.extname(caller));
+  const count = (counts[basename] = (counts[basename] ?? 0) + 1);
+  const name = testName(NODE_ENV, basename, count, description);
+  const root = path.join(tempDir, basename + count);
+  const timeout = testTimeout(options);
+
+  const files: FileObject = {};
+  const cases: { name: string; testCase: DevServerTestCase }[] = [];
+  const addCase = (caseName: string, testCase: DevServerTestCase) => {
+    for (const [file, contents] of Object.entries(testCase.files)) {
+      if (file in files) {
+        throw new Error(
+          `devTestGroup ${JSON.stringify(description)}: two cases declare the file ${JSON.stringify(file)}`,
+        );
+      }
+      files[file] = contents;
+    }
+    cases.push({ name: caseName, testCase });
+  };
+  const project: DevServerProject = { ...options, files };
+
+  try {
+    if (options.skip && options.skip.some(x => skipTargets.includes(x))) {
+      jest.describe(name, () => {
+        define((caseName, testCase) => {
+          addCase(caseName, testCase);
+          jest.test.todo(caseName);
+        });
+      });
+      return;
+    }
+
+    (options.only ? jest.describe.only : jest.describe)(name, () => {
+      let server: DevServerHandle | null = null;
+
+      jest.beforeAll(async () => {
+        await writeProject(root, project);
+        server = await spawnDevServer(root, project, NODE_ENV, false);
+      }, timeout);
+
+      define((caseName, testCase) => {
+        addCase(caseName, testCase);
+        jest.test(
+          caseName,
+          async () => {
+            if (!server) throw new Error("The group's dev server did not start");
+            await runCase(root, server.dev, testCase.test);
+          },
+          timeout,
+        );
+      });
+
+      jest.afterAll(async () => {
+        if (!server) return;
+        try {
+          await server.dev.gracefulExit();
+        } finally {
+          await server[Symbol.asyncDispose]();
+          killDanglingProcesses();
+        }
+      }, timeout);
+    });
+  } catch {
+    // not in bun test. allow interactive use
+    const arg = interactiveFilter();
+    cases.length = 0;
+    for (const file of Object.keys(files)) delete files[file];
+    define(addCase);
+    const match = cases.find(c => `${name} > ${c.name}`.includes(arg));
+    if (match) {
+      interactive = true;
+      console.log("\x1b[32;1m" + name + " > " + match.name + " (Interactive)\x1b[0m");
+      runStandalone(root, { ...project, test: match.testCase.test }, NODE_ENV, false);
+    }
+  }
 }
 
 function logErr(err: any) {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -324,28 +324,34 @@ export class Dev extends EventEmitter {
     const b = {
       write: resetSeenFilesWithResolvers,
       [Symbol.asyncDispose]: async () => {
-        if (wantsHmrEvent && interactive) {
-          await seenFiles.promise;
-        } else if (wantsHmrEvent) {
-          await Promise.race([seenFiles.promise]);
-        }
-        // One Bun.write can surface as several watcher events (notably on
-        // Windows); let them coalesce so releasing the batch bundles once.
-        await Bun.sleep(50);
-
-        dev.off("watch_synchronization", onSeenFiles);
-
-        this.socket!.send("H");
-        await wait;
-
-        let errors = options.errors;
-        if (errors !== null) {
-          errors ??= [];
-          for (const client of this.connectedClients) {
-            await client.expectErrorOverlay(errors, options.snapshot);
+        // The batch ends even when an assertion below throws. Otherwise the
+        // next write on this `Dev` (the next case of a `devTestGroup`) would
+        // see an open batch and skip its own synchronization.
+        try {
+          if (wantsHmrEvent && interactive) {
+            await seenFiles.promise;
+          } else if (wantsHmrEvent) {
+            await Promise.race([seenFiles.promise]);
           }
+          // One Bun.write can surface as several watcher events (notably on
+          // Windows); let them coalesce so releasing the batch bundles once.
+          await Bun.sleep(50);
+
+          dev.off("watch_synchronization", onSeenFiles);
+
+          this.socket!.send("H");
+          await wait;
+
+          let errors = options.errors;
+          if (errors !== null) {
+            errors ??= [];
+            for (const client of this.connectedClients) {
+              await client.expectErrorOverlay(errors, options.snapshot);
+            }
+          }
+        } finally {
+          this.batchingChanges = null;
         }
-        this.batchingChanges = null;
       },
     };
     this.batchingChanges = b;
@@ -2342,6 +2348,8 @@ function groupImpl(
           caseName,
           async () => {
             if (!server) throw new Error("The group's dev server did not start");
+            // A case that timed out inside a write leaves its batch open.
+            server.dev.batchingChanges = null;
             await runCase(root, server.dev, testCase.test);
           },
           timeout,

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1903,13 +1903,16 @@ class OutputLineStream extends EventEmitter {
 }
 
 export function indexHtmlScript(htmlFiles: string[]) {
+  // `htmlFiles` are platform-relative paths; both the import specifier and the
+  // route key need forward slashes.
+  const posixFiles = htmlFiles.map(file => file.replaceAll(path.sep, "/"));
   return [
-    ...htmlFiles.map((file, i) => `import html${i} from ${JSON.stringify("./" + file.replaceAll(path.sep, "/"))};`),
+    ...posixFiles.map((file, i) => `import html${i} from ${JSON.stringify("./" + file)};`),
     "export default {",
     "  static: {",
-    ...(htmlFiles.length === 1
+    ...(posixFiles.length === 1
       ? [`    '/*': html0,`]
-      : htmlFiles.map(
+      : posixFiles.map(
           (file, i) =>
             `    ${JSON.stringify(
               "/" +

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -350,7 +350,7 @@ export class Dev extends EventEmitter {
             }
           }
         } finally {
-          this.batchingChanges = null;
+          if (this.batchingChanges === b) this.batchingChanges = null;
         }
       },
     };
@@ -2078,6 +2078,10 @@ async function writeProject(root: string, options: DevServerProject): Promise<vo
   );
 }
 
+function hasExited(proc: Subprocess): boolean {
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
+
 /** Kills every client and dev server subprocess that is still running. */
 function killDanglingProcesses() {
   for (const proc of danglingProcesses) {
@@ -2342,15 +2346,25 @@ function groupImpl(
         server = await spawnDevServer(root, project, NODE_ENV, false);
       }, timeout);
 
+      // `bun test` kills every subprocess of a test that timed out, the shared
+      // server included. That case reported the failure; the cases after it
+      // get a new server on the same project.
+      const serverForCase = async (): Promise<DevServerHandle> => {
+        if (!server) throw new Error("The group's dev server did not start");
+        if (hasExited(server.dev.devProcess)) {
+          await server[Symbol.asyncDispose]();
+          server = await spawnDevServer(root, project, NODE_ENV, false);
+        }
+        return server;
+      };
+
       define((caseName, testCase) => {
         addCase(caseName, testCase);
         jest.test(
           caseName,
           async () => {
-            if (!server) throw new Error("The group's dev server did not start");
-            // A case that timed out inside a write leaves its batch open.
-            server.dev.batchingChanges = null;
-            await runCase(root, server.dev, testCase.test);
+            const { dev } = await serverForCase();
+            await runCase(root, dev, testCase.test);
           },
           timeout,
         );
@@ -2359,7 +2373,11 @@ function groupImpl(
       jest.afterAll(async () => {
         if (!server) return;
         try {
-          await server.dev.gracefulExit();
+          if (hasExited(server.dev.devProcess)) {
+            if (server.dev.panicked) throw new Error("DevServer panicked");
+          } else {
+            await server.dev.gracefulExit();
+          }
         } finally {
           await server[Symbol.asyncDispose]();
           killDanglingProcesses();

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -337,6 +337,12 @@ devTestGroup("shared dev server", {}, test => {
     // with `swapRemoveAt`, which moves the last entry into the first slot.
     // The second CSS file's `path_map` entry must be patched to the new slot
     // so the next edit does not read past the end of the asset array.
+    //
+    // The case controls that order itself: it appends `first.css`, then
+    // `second.css`, then frees `first.css` before anything else is appended,
+    // so `second.css` is the entry that moves. Entries from earlier cases sit
+    // at lower indices, and CSS roots are keyed by path, so sharing the server
+    // does not change which entry moves.
     files: {
       "asset-index/first.html": emptyHtmlFile({
         styles: ["first.css"],

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,367 +1,684 @@
 // CSS tests concern bundling bugs with CSS files
 import { expect } from "bun:test";
 import assert from "node:assert";
-import { devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
+import { devTest, devTestGroup, emptyHtmlFile, imageFixtures } from "../bake-harness";
 
-devTest("css file with syntax error does not kill old styles", {
-  files: {
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+// Every case below gets its own route and directory on one dev server, so the
+// file pays for one dev server process instead of one per case. A case must
+// leave its files valid: the server reports every failure it still holds on
+// the next error page, whichever route the failing file belongs to.
+devTestGroup("shared dev server", {}, test => {
+  test("css file with syntax error does not kill old styles", {
+    files: {
+      "syntax-error/styles.css": `
         body {
           color: red;
-          background-color
         }
       `,
-      {
-        errors: ["styles.css:4:1: error: Unexpected end of input"],
-      },
-    );
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          color: red;
-          background-color: blue;
-        }
-      `,
-    );
-    await c.style("body").backgroundColor.expect.toBe("#00f");
-    await dev.write("styles.css", ` `, { dedent: false });
-    await c.style("body").notFound();
-  },
-});
-devTest("css file with initial syntax error gets recovered", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-    "styles.css": `
-      body {
-        color: red;
-      }}
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ["styles.css:3:3: error: Unexpected end of input"],
-    });
-    // hard reload to dismiss the error overlay
-    await c.expectReload(async () => {
+      "syntax-error/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+        body: `hello world`,
+      }),
+    },
+    async test(dev) {
+      await using c = await dev.client("/syntax-error");
+      await c.style("body").color.expect.toBe("red");
       await dev.write(
-        "styles.css",
+        "syntax-error/styles.css",
         `
           body {
             color: red;
-          }
-        `,
-      );
-    });
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          color: blue;
-        }
-      `,
-    );
-    await c.style("body").color.expect.toBe("#00f");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          color: blue;
-        }}
-      `,
-      {
-        errors: ["styles.css:3:3: error: Unexpected end of input"],
-      },
-    );
-  },
-});
-devTest("add new css import later", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-      body: `hello world`,
-    }),
-    "index.ts": `
-      // import "./styles.css";
-      export default function () {
-        return "hello world";
-      }
-      import.meta.hot.accept();
-    `,
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style("body").notFound();
-    await dev.patch("index.ts", { find: "// import", replace: "import" });
-    await c.style("body").color.expect.toBe("red");
-    await dev.patch("index.ts", { find: "import", replace: "// import" });
-    await c.style("body").notFound();
-  },
-});
-devTest("css import another css file", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      @import "./second.css";
-      body {
-        color: red;
-      }
-    `,
-    "second.css": `
-      h1 {
-        color: blue;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    // Verify initial build
-    await c.style("h1").color.expect.toBe("#00f");
-    await c.style("body").color.expect.toBe("red");
-
-    // Hot reload
-    await dev.write(
-      "second.css",
-      `
-        h1 {
-          color: green;
-        }
-      `,
-    );
-    await c.style("h1").color.expect.toBe("green");
-    await c.style("body").color.expect.toBe("red");
-
-    // Check that the styles still work after a reload
-    await c.hardReload();
-    await c.style("h1").color.expect.toBe("green");
-    await c.style("body").color.expect.toBe("red");
-  },
-});
-devTest("asset referenced in css", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      body {
-        background-image: url(./bun.png);
-      }
-    `,
-    "bun.png": imageFixtures.bun,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    let backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    // The served stylesheet is the chunk with the asset reference resolved and
-    // nothing else: CSS never gets a source map, so no debugId trailer either.
-    const stylesheetHref = (await (await dev.fetch("/")).text()).match(/<link rel="stylesheet"[^>]*href="([^"]+)"/)![1];
-    const stylesheet = await (await dev.fetch(stylesheetHref)).text();
-    expect(stylesheet).toContain("background-image:");
-    expect(stylesheet).not.toContain("debugId");
-    await dev.write("bun.png", imageFixtures.bun2);
-    backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun2);
-  },
-});
-devTest("syntax error crash", {
-  files: {
-    "styles.css": `
-      body {
-        background-image: url
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
-    expect((await dev.fetch("/")).status).toBe(200);
-    // previously: panic(main thread): Asset double unref: 0000000000000000
-    await dev.patch("styles.css", { find: "url\n", replace: "url(\n" });
-    expect((await dev.fetch("/")).status).toBe(500);
-  },
-});
-devTest("css url resolve error on hot reload is recoverable", {
-  files: {
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
-    {
-      await using c = await dev.client("/");
-      await c.style("body").color.expect.toBe("red");
-      // A CSS file that parses but fails import resolution must fail the
-      // rebuild with an error instead of being treated as a valid CSS chunk.
-      // previously: panic: assertion failed: !chunk.content.is_css()
-      await dev.write(
-        "styles.css",
-        `
-          body {
-            background-image: url(./missing.png);
+            background-color
           }
         `,
         {
-          errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
+          errors: ["syntax-error/styles.css:4:1: error: Unexpected end of input"],
         },
       );
-    }
-    // The failing route is fetched and recovered without a connected client: a
-    // fetch re-bundles the route, and both that and the recovery ship the HTML
-    // route as a JS module without the route-reload flag, which trips a
-    // client-side debug assert (tracked in https://github.com/oven-sh/bun/issues/31908).
-    expect((await dev.fetch("/")).status).toBe(500);
-    await dev.write(
-      "styles.css",
-      `
+      // The old stylesheet stays in place, including the absence of the new rule.
+      await c.style("body").color.expect.toBe("red");
+      await c.style("body").backgroundColor.expect.toBeUndefined();
+      await dev.write(
+        "syntax-error/styles.css",
+        `
+          body {
+            color: red;
+            background-color: blue;
+          }
+        `,
+      );
+      await c.style("body").backgroundColor.expect.toBe("#00f");
+      await dev.write("syntax-error/styles.css", ` `, { dedent: false });
+      await c.style("body").notFound();
+    },
+  });
+  test("css file with initial syntax error gets recovered", {
+    files: {
+      "initial-syntax-error/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+        body: `hello world`,
+      }),
+      "initial-syntax-error/styles.css": `
         body {
+          color: red;
+        }}
+      `,
+    },
+    async test(dev) {
+      await using c = await dev.client("/initial-syntax-error", {
+        errors: ["initial-syntax-error/styles.css:3:3: error: Unexpected end of input"],
+      });
+      // hard reload to dismiss the error overlay
+      await c.expectReload(async () => {
+        await dev.write(
+          "initial-syntax-error/styles.css",
+          `
+            body {
+              color: red;
+            }
+          `,
+        );
+      });
+      await c.style("body").color.expect.toBe("red");
+      await dev.write(
+        "initial-syntax-error/styles.css",
+        `
+          body {
+            color: blue;
+          }
+        `,
+      );
+      await c.style("body").color.expect.toBe("#00f");
+      await dev.write(
+        "initial-syntax-error/styles.css",
+        `
+          body {
+            color: blue;
+          }}
+        `,
+        {
+          errors: ["initial-syntax-error/styles.css:3:3: error: Unexpected end of input"],
+        },
+      );
+      // A second recovery, this time on a page that is already loaded, is a
+      // hot update rather than a reload.
+      await c.style("body").color.expect.toBe("#00f");
+      await dev.write(
+        "initial-syntax-error/styles.css",
+        `
+          body {
+            color: green;
+          }
+        `,
+      );
+      await c.style("body").color.expect.toBe("green");
+    },
+  });
+  test("add new css import later", {
+    files: {
+      "add-import-later/index.html": emptyHtmlFile({
+        scripts: ["index.ts"],
+        body: `hello world`,
+      }),
+      "add-import-later/index.ts": `
+        // import "./styles.css";
+        export default function () {
+          return "hello world";
+        }
+        import.meta.hot.accept();
+      `,
+      "add-import-later/styles.css": `
+        body {
+          color: red;
+        }
+      `,
+    },
+    async test(dev) {
+      await using c = await dev.client("/add-import-later");
+      await c.style("body").notFound();
+      await dev.patch("add-import-later/index.ts", { find: "// import", replace: "import" });
+      await c.style("body").color.expect.toBe("red");
+      await dev.patch("add-import-later/index.ts", { find: "import", replace: "// import" });
+      await c.style("body").notFound();
+    },
+  });
+  test("css import another css file", {
+    files: {
+      "import-another/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+      }),
+      "import-another/styles.css": `
+        @import "./second.css";
+        body {
+          color: red;
+        }
+      `,
+      "import-another/second.css": `
+        h1 {
           color: blue;
         }
       `,
-    );
-    expect((await dev.fetch("/")).status).toBe(200);
-  },
-});
-devTest("circular css imports handle hot reload", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["a.css"],
-      body: `
-        <div class="a">hello</div>
-        <div class="b">hello</div>
-      `,
-    }),
-    "a.css": `
-      @import "./b.css";
-      .a { color: red; }
-    `,
-    "b.css": `
-      @import "./a.css";
-      .b { color: blue; }
-    `,
-  },
-  async test(dev) {
-    await using client = await dev.client("/");
-    await client.style(".a").color.expect.toBe("red");
-    await client.style(".b").color.expect.toBe("#00f");
+    },
+    async test(dev) {
+      await using c = await dev.client("/import-another");
+      // Verify initial build
+      await c.style("h1").color.expect.toBe("#00f");
+      await c.style("body").color.expect.toBe("red");
 
-    // Modify one of the circular dependencies
-    await dev.write(
-      "a.css",
-      `
+      // Hot reload
+      await dev.write(
+        "import-another/second.css",
+        `
+          h1 {
+            color: green;
+          }
+        `,
+      );
+      await c.style("h1").color.expect.toBe("green");
+      await c.style("body").color.expect.toBe("red");
+
+      // Check that the styles still work after a reload
+      await c.hardReload();
+      await c.style("h1").color.expect.toBe("green");
+      await c.style("body").color.expect.toBe("red");
+    },
+  });
+  test("asset referenced in css", {
+    files: {
+      "asset-in-css/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+      }),
+      "asset-in-css/styles.css": `
+        body {
+          background-image: url(./bun.png);
+        }
+      `,
+      "asset-in-css/bun.png": imageFixtures.bun,
+    },
+    async test(dev) {
+      await using c = await dev.client("/asset-in-css");
+      let backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      // The served stylesheet is the chunk with the asset reference resolved and
+      // nothing else: CSS never gets a source map, so no debugId trailer either.
+      const stylesheetHref = (await dev.fetch("/asset-in-css").text()).match(
+        /<link rel="stylesheet"[^>]*href="([^"]+)"/,
+      )![1];
+      await dev
+        .fetch(stylesheetHref)
+        .expect.toBe(
+          `/* asset-in-css/styles.css */\nbody {\n  background-image: url(${JSON.stringify(extractCssUrl(backgroundImage))});\n}\n`,
+        );
+      await dev.write("asset-in-css/bun.png", imageFixtures.bun2);
+      const updatedBackgroundImage = await c.style("body").backgroundImage;
+      assert(updatedBackgroundImage);
+      expect(updatedBackgroundImage).not.toBe(backgroundImage);
+      await dev.fetch(extractCssUrl(updatedBackgroundImage)).expectFile(imageFixtures.bun2);
+    },
+  });
+  test("syntax error crash", {
+    files: {
+      "syntax-error-crash/styles.css": `
+        body {
+          background-image: url
+        }
+      `,
+      "syntax-error-crash/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+        body: `hello world`,
+      }),
+    },
+    async test(dev) {
+      const initial = await dev.fetch("/syntax-error-crash");
+      expect(initial.status).toBe(200);
+      expect(await initial.text()).toContain("hello world");
+      // previously: panic(main thread): Asset double unref: 0000000000000000
+      await dev.patch("syntax-error-crash/styles.css", { find: "url\n", replace: "url(\n" });
+      const failed = await dev.fetch("/syntax-error-crash");
+      expect(failed.status).toBe(500);
+      expect(await failed.text()).toContain("<title>Bun - Build Failed</title>");
+      // The route recovers once the file parses again.
+      await dev.patch("syntax-error-crash/styles.css", { find: "url(\n", replace: "url\n" });
+      const recovered = await dev.fetch("/syntax-error-crash");
+      expect(recovered.status).toBe(200);
+      expect(await recovered.text()).toContain("hello world");
+    },
+  });
+  test("css url resolve error on hot reload is recoverable", {
+    files: {
+      "url-resolve-error/styles.css": `
+        body {
+          color: red;
+        }
+      `,
+      "url-resolve-error/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+        body: `hello world`,
+      }),
+    },
+    async test(dev) {
+      {
+        await using c = await dev.client("/url-resolve-error");
+        await c.style("body").color.expect.toBe("red");
+        // A CSS file that parses but fails import resolution must fail the
+        // rebuild with an error instead of being treated as a valid CSS chunk.
+        // previously: panic: assertion failed: !chunk.content.is_css()
+        await dev.write(
+          "url-resolve-error/styles.css",
+          `
+            body {
+              background-image: url(./missing.png);
+            }
+          `,
+          {
+            errors: ['url-resolve-error/styles.css:2:21: error: Could not resolve: "./missing.png"'],
+          },
+        );
+      }
+      // The failing route is fetched and recovered without a connected client: a
+      // fetch re-bundles the route, and both that and the recovery ship the HTML
+      // route as a JS module without the route-reload flag, which trips a
+      // client-side debug assert (tracked in https://github.com/oven-sh/bun/issues/31908).
+      const failed = await dev.fetch("/url-resolve-error");
+      expect(failed.status).toBe(500);
+      expect(await failed.text()).toContain("<title>Bun - Build Failed</title>");
+      await dev.write(
+        "url-resolve-error/styles.css",
+        `
+          body {
+            color: blue;
+          }
+        `,
+      );
+      const recovered = await dev.fetch("/url-resolve-error");
+      expect(recovered.status).toBe(200);
+      expect(await recovered.text()).toContain("hello world");
+    },
+  });
+  test("circular css imports handle hot reload", {
+    files: {
+      "circular/index.html": emptyHtmlFile({
+        styles: ["a.css"],
+        body: `
+          <div class="a">hello</div>
+          <div class="b">hello</div>
+        `,
+      }),
+      "circular/a.css": `
         @import "./b.css";
-        .a { color: green; }
+        .a { color: red; }
       `,
-    );
-    await client.style(".a").color.expect.toBe("green");
-    await client.style(".b").color.expect.toBe("#00f");
-  },
-});
-devTest("asset index stays valid after another css root is freed", {
-  // Two independent CSS roots each get an entry in `DevServer.Assets`.
-  // When the first one is freed (via a syntax error), its slot is removed
-  // with `swapRemoveAt`, which moves the second entry into the first slot.
-  // The second CSS file's `path_map` entry must be patched to the new slot
-  // so the next edit does not read past the end of the asset array.
-  files: {
-    "first.html": emptyHtmlFile({
-      styles: ["first.css"],
-      body: `<div class="first">hello</div>`,
-    }),
-    "second.html": emptyHtmlFile({
-      styles: ["second.css"],
-      body: `<div class="second">hello</div>`,
-    }),
-    "first.css": `
-      .first { color: red; }
-    `,
-    "second.css": `
-      .second { color: blue; }
-    `,
-  },
-  async test(dev) {
-    // Bundle /first before /second so that `first.css` is registered at
-    // a lower asset index than `second.css`.
-    {
-      await using c1 = await dev.client("/first");
+      "circular/b.css": `
+        @import "./a.css";
+        .b { color: blue; }
+      `,
+    },
+    async test(dev) {
+      await using client = await dev.client("/circular");
+      await client.style(".a").color.expect.toBe("red");
+      await client.style(".b").color.expect.toBe("#00f");
+
+      // Modify one of the circular dependencies
+      await dev.write(
+        "circular/a.css",
+        `
+          @import "./b.css";
+          .a { color: green; }
+        `,
+      );
+      await client.style(".a").color.expect.toBe("green");
+      await client.style(".b").color.expect.toBe("#00f");
+    },
+  });
+  test("asset index stays valid after another css root is freed", {
+    // Two independent CSS roots each get an entry in `DevServer.Assets`.
+    // When the first one is freed (via a syntax error), its slot is removed
+    // with `swapRemoveAt`, which moves the last entry into the first slot.
+    // The second CSS file's `path_map` entry must be patched to the new slot
+    // so the next edit does not read past the end of the asset array.
+    files: {
+      "asset-index/first.html": emptyHtmlFile({
+        styles: ["first.css"],
+        body: `<div class="first">hello</div>`,
+      }),
+      "asset-index/second.html": emptyHtmlFile({
+        styles: ["second.css"],
+        body: `<div class="second">hello</div>`,
+      }),
+      "asset-index/first.css": `
+        .first { color: red; }
+      `,
+      "asset-index/second.css": `
+        .second { color: blue; }
+      `,
+    },
+    async test(dev) {
+      // Bundle /first before /second so that `first.css` is registered at
+      // a lower asset index than `second.css`, and `second.css` is the last
+      // asset when `first.css` is freed.
+      {
+        await using c1 = await dev.client("/asset-index/first");
+        await c1.style(".first").color.expect.toBe("red");
+      }
+      await using c2 = await dev.client("/asset-index/second");
+      await c2.style(".second").color.expect.toBe("#00f");
+
+      // Failing `first.css` frees its asset slot via `unrefByPath`, which
+      // swap-removes it and moves the data for `second.css` into its slot.
+      await dev.write(
+        "asset-index/first.css",
+        `
+          .first { color: red; }}
+        `,
+        { errors: null },
+      );
+
+      // Editing `second.css` now goes through `replacePath`, which looks up
+      // its `path_map` entry. Previously this index was stale (pointed at
+      // `files.len`), causing an out-of-bounds read into `refs`/`files`.
+      await dev.write(
+        "asset-index/second.css",
+        `
+          .second { color: green; }
+        `,
+        { errors: null },
+      );
+      await c2.style(".second").color.expect.toBe("green");
+
+      // Fix the first file and ensure both pages still work afterwards.
+      await dev.write(
+        "asset-index/first.css",
+        `
+          .first { color: yellow; }
+        `,
+      );
+      await c2.style(".second").color.expect.toBe("green");
+      {
+        await using c1 = await dev.client("/asset-index/first");
+        await c1.style(".first").color.expect.toBe("#ff0");
+      }
+    },
+  });
+  test("multiple stylesheets importing same dependency", {
+    files: {
+      "shared-dep/first.html": emptyHtmlFile({
+        styles: ["first.css"],
+        body: `
+          <div class="first">hello</div>
+          <div class="shared">hello</div>
+        `,
+      }),
+      "shared-dep/second.html": emptyHtmlFile({
+        styles: ["second.css"],
+        body: `
+          <div class="second">hello</div>
+          <div class="shared">hello</div>
+        `,
+      }),
+      "shared-dep/first.css": `
+        @import "./shared.css";
+        .first { color: red; }
+      `,
+      "shared-dep/second.css": `
+        @import "./shared.css";
+        .second { color: blue; }
+      `,
+      "shared-dep/shared.css": `
+        .shared { color: green; }
+      `,
+    },
+    async test(dev) {
+      await using c1 = await dev.client("/shared-dep/first");
+      await using c2 = await dev.client("/shared-dep/second");
       await c1.style(".first").color.expect.toBe("red");
-    }
-    await using c2 = await dev.client("/second");
-    await c2.style(".second").color.expect.toBe("#00f");
+      await c2.style(".second").color.expect.toBe("#00f");
+      await c1.style(".shared").color.expect.toBe("green");
+      await c2.style(".shared").color.expect.toBe("green");
 
-    // Failing `first.css` frees its asset slot via `unrefByPath`, which
-    // swap-removes it and moves the data for `second.css` into its slot.
-    await dev.write(
-      "first.css",
-      `
-        .first { color: red; }}
-      `,
-      { errors: null },
-    );
+      await dev.write(
+        "shared-dep/shared.css",
+        `
+          .shared { color: yellow; }
+        `,
+      );
 
-    // Editing `second.css` now goes through `replacePath`, which looks up
-    // its `path_map` entry. Previously this index was stale (pointed at
-    // `files.len`), causing an out-of-bounds read into `refs`/`files`.
-    await dev.write(
-      "second.css",
-      `
-        .second { color: green; }
+      // Both importers pick up the change and keep their own rules.
+      await c1.style(".shared").color.expect.toBe("#ff0");
+      await c2.style(".shared").color.expect.toBe("#ff0");
+      await c1.style(".first").color.expect.toBe("red");
+      await c2.style(".second").color.expect.toBe("#00f");
+    },
+  });
+  test("removing and re-adding css import", {
+    files: {
+      "readd-import/index.html": emptyHtmlFile({
+        styles: ["main.css"],
+      }),
+      "readd-import/main.css": `
+        @import "./colors.css";
+        .main { background: white; }
       `,
-      { errors: null },
-    );
-    await c2.style(".second").color.expect.toBe("green");
+      "readd-import/colors.css": `
+        .colored { color: blue; }
+      `,
+    },
+    async test(dev) {
+      await using c = await dev.client("/readd-import");
+      await c.style(".colored").color.expect.toBe("#00f");
 
-    // Fix the first file and ensure both pages still work afterwards.
-    await dev.write(
-      "first.css",
-      `
-        .first { color: yellow; }
+      // Remove the import
+      await dev.write(
+        "readd-import/main.css",
+        `
+          /* @import "./colors.css"; */
+          .main { background: white; }
+        `,
+      );
+      await c.style(".colored").notFound();
+
+      // A change to 'colors.css' should not trigger a rebuild of 'main.css', nor notify any clients.
+      await c.expectNoWebSocketActivity(async () => {
+        await dev.write(
+          "readd-import/colors.css",
+          `
+            .colored { color: yellow; }
+          `,
+        );
+        await dev.write(
+          "readd-import/colors.css",
+          `
+            .colored { color: blue; }
+          `,
+        );
+      });
+      await c.style(".colored").notFound();
+
+      // Re-add the import
+      await dev.write(
+        "readd-import/main.css",
+        `
+          @import "./colors.css";
+          .main { background: white; }
+        `,
+      );
+      await c.style(".colored").color.expect.toBe("#00f");
+      await c.style(".main").backgroundColor.expect.toBe("#fff");
+    },
+  });
+  test("changing html file with link tag works", {
+    files: {
+      "link-tag/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+      }),
+      "link-tag/styles.css": `
+        .test {
+          color: blue;
+          font-size: 24px;
+        }
       `,
-    );
-    await c2.style(".second").color.expect.toBe("green");
-    {
-      await using c1 = await dev.client("/first");
-      await c1.style(".first").color.expect.toBe("#ff0");
-    }
-  },
+    },
+    async test(dev) {
+      await using c = await dev.client("/link-tag");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+
+      await c.expectReload(async () => {
+        await dev.writeNoChanges("link-tag/index.html");
+      });
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+
+      await c.hardReload();
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+
+      await dev.write(
+        "link-tag/index.html",
+        emptyHtmlFile({
+          styles: ["other.css"],
+        }),
+        {
+          errors: ['link-tag/index.html: error: Could not resolve: "other.css". Maybe you need to "bun install"?'],
+        },
+      );
+      await c.expectReload(async () => {
+        await dev.write(
+          "link-tag/other.css",
+          `
+            .other {
+              color: red;
+            }
+          `,
+        );
+      });
+      await c.style(".other").color.expect.toBe("red");
+      await c.style(".test").notFound();
+      await c.expectReload(async () => {
+        await dev.write(
+          "link-tag/index.html",
+          emptyHtmlFile({
+            styles: ["styles.css"],
+          }),
+        );
+      });
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      await c.style(".other").notFound();
+      await c.expectReload(async () => {
+        await dev.write(
+          "link-tag/index.html",
+          emptyHtmlFile({
+            styles: ["other.css", "styles.css"],
+          }),
+        );
+      });
+      await c.style(".other").color.expect.toBe("red");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+    },
+  });
+  test("css import before create", {
+    files: {
+      "before-create/index.html": emptyHtmlFile({
+        styles: ["styles.css"],
+        body: `
+          <div>HELLO</div>
+        `,
+      }),
+    },
+    async test(dev) {
+      await using c = await dev.client("/before-create", {
+        errors: ['before-create/index.html: error: Could not resolve: "styles.css". Maybe you need to "bun install"?'],
+      });
+      const failed = await dev.fetch("/before-create");
+      expect(failed.status).toBe(500);
+      expect(await failed.text()).not.toContain("HELLO");
+      await dev.write(
+        "before-create/styles.css",
+        `
+          body {
+            background-image: url(bun.png);
+          }
+        `,
+        {
+          errors: [
+            'before-create/styles.css:2:21: error: Could not resolve: "bun.png". Maybe you need to "bun install"?',
+          ],
+        },
+      );
+      await c.expectReload(async () => {
+        await dev.write("before-create/bun.png", imageFixtures.bun);
+      });
+      const backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      const recovered = await dev.fetch("/before-create");
+      expect(recovered.status).toBe(200);
+      expect(await recovered.text()).toContain("HELLO");
+    },
+  });
+  test("css import before create project relative", {
+    files: {
+      "project-relative/html/index.html": emptyHtmlFile({
+        styles: ["/project-relative/style/styles.css"],
+        body: `
+          <div>HELLO</div>
+        `,
+      }),
+    },
+    async test(dev) {
+      dev.mkdir("project-relative/style"); // (See DevServer "BUN-10968")
+      await using c = await dev.client("/project-relative/html", {
+        errors: ['project-relative/html/index.html: error: Could not resolve: "/project-relative/style/styles.css"'],
+      });
+      const failed = await dev.fetch("/project-relative/html");
+      expect(failed.status).toBe(500);
+      expect(await failed.text()).not.toContain("HELLO");
+      await dev.write(
+        "project-relative/style/styles.css",
+        `
+          body {
+            background-image: url(/project-relative/assets/bun.png);
+          }
+        `,
+        {
+          errors: [
+            'project-relative/style/styles.css:2:21: error: Could not resolve: "/project-relative/assets/bun.png"',
+          ],
+        },
+      );
+      await c.expectNoWebSocketActivity(async () => {
+        await dev.write("project-relative/assets/bun.png", imageFixtures.bun, { errors: null });
+        await dev.delete("project-relative/assets/bun.png", { errors: null });
+      });
+      await dev.fetch("/project-relative/html").expect.not.toContain("HELLO");
+      await dev.write(
+        "project-relative/style/styles.css",
+        `
+          body {
+            background-image: url(../assets/bun.png);
+          }
+        `,
+        {
+          errors: ['project-relative/style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
+        },
+      );
+      await c.expectReload(async () => {
+        await dev.write("project-relative/assets/bun.png", imageFixtures.bun);
+      });
+      const backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      const recovered = await dev.fetch("/project-relative/html");
+      expect(recovered.status).toBe(200);
+      expect(await recovered.text()).toContain("HELLO");
+    },
+  });
 });
+
+// The resolver plugin applies to every route of a server, so this case keeps
+// its own server.
 devTest("css hot update carries the edited stylesheet when another root fails in the same rebuild", {
   files: {
     "bunfig.toml": `
@@ -435,266 +752,6 @@ devTest("css hot update carries the edited stylesheet when another root fails in
       await using c1 = await dev.client("/first");
       await c1.style(".first").color.expect.toBe("#ff0");
     }
-  },
-});
-devTest("multiple stylesheets importing same dependency", {
-  files: {
-    "first.html": emptyHtmlFile({
-      styles: ["first.css"],
-      body: `
-        <div class="first">hello</div>
-        <div class="shared">hello</div>
-      `,
-    }),
-    "second.html": emptyHtmlFile({
-      styles: ["second.css"],
-      body: `
-        <div class="second">hello</div>
-        <div class="shared">hello</div>
-      `,
-    }),
-    "first.css": `
-      @import "./shared.css";
-      .first { color: red; }
-    `,
-    "second.css": `
-      @import "./shared.css";
-      .second { color: blue; }
-    `,
-    "shared.css": `
-      .shared { color: green; }
-    `,
-  },
-  async test(dev) {
-    await using c1 = await dev.client("/first");
-    await using c2 = await dev.client("/second");
-    await c1.style(".first").color.expect.toBe("red");
-    await c2.style(".second").color.expect.toBe("#00f");
-    await c1.style(".shared").color.expect.toBe("green");
-    await c2.style(".shared").color.expect.toBe("green");
-
-    await dev.write(
-      "shared.css",
-      `
-        .shared { color: yellow; }
-      `,
-    );
-
-    await c1.style(".shared").color.expect.toBe("#ff0");
-    await c2.style(".shared").color.expect.toBe("#ff0");
-  },
-});
-devTest("removing and re-adding css import", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["main.css"],
-    }),
-    "main.css": `
-      @import "./colors.css";
-      .main { background: white; }
-    `,
-    "colors.css": `
-      .colored { color: blue; }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style(".colored").color.expect.toBe("#00f");
-
-    // Remove the import
-    await dev.write(
-      "main.css",
-      `
-        /* @import "./colors.css"; */
-        .main { background: white; }
-      `,
-    );
-    await c.style(".colored").notFound();
-
-    // A change to 'colors.css' should not trigger a rebuild of 'main.css', nor notify any clients.
-    await c.expectNoWebSocketActivity(async () => {
-      await dev.write(
-        "colors.css",
-        `
-          .colored { color: yellow; }
-        `,
-      );
-      await dev.write(
-        "colors.css",
-        `
-          .colored { color: blue; }
-        `,
-      );
-    });
-    await c.style(".colored").notFound();
-
-    // Re-add the import
-    await dev.write(
-      "main.css",
-      `
-        @import "./colors.css";
-        .main { background: white; }
-      `,
-    );
-    await c.style(".colored").color.expect.toBe("#00f");
-    await c.style(".main").backgroundColor.expect.toBe("#fff");
-  },
-});
-devTest("changing html file with link tag works", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      .test {
-        color: blue;
-        font-size: 24px;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await c.expectReload(async () => {
-      await dev.writeNoChanges("index.html");
-    });
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await c.hardReload();
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await dev.write(
-      "index.html",
-      emptyHtmlFile({
-        styles: ["other.css"],
-      }),
-      {
-        errors: ['index.html: error: Could not resolve: "other.css". Maybe you need to "bun install"?'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write(
-        "other.css",
-        `
-          .other {
-            color: red;
-          }
-        `,
-      );
-    });
-    await c.style(".other").color.expect.toBe("red");
-    await c.style(".test").notFound();
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.html",
-        emptyHtmlFile({
-          styles: ["styles.css"],
-        }),
-      );
-    });
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-    await c.style(".other").notFound();
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.html",
-        emptyHtmlFile({
-          styles: ["other.css", "styles.css"],
-        }),
-      );
-    });
-    await c.style(".other").color.expect.toBe("red");
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-  },
-});
-devTest("css import before create", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ['index.html: error: Could not resolve: "styles.css". Maybe you need to "bun install"?'],
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          background-image: url(bun.png);
-        }
-      `,
-      {
-        errors: ['styles.css:2:21: error: Could not resolve: "bun.png". Maybe you need to "bun install"?'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write("bun.png", imageFixtures.bun);
-    });
-    const backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.fetch("/").expect.toContain("HELLO");
-  },
-});
-devTest("css import before create project relative", {
-  files: {
-    "html/index.html": emptyHtmlFile({
-      styles: ["/style/styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
-  },
-  async test(dev) {
-    dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
-    await using c = await dev.client("/", {
-      errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "style/styles.css",
-      `
-        body {
-          background-image: url(/assets/bun.png);
-        }
-      `,
-      {
-        errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
-      },
-    );
-    await c.expectNoWebSocketActivity(async () => {
-      await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
-      await dev.delete("assets/bun.png", { errors: null });
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "style/styles.css",
-      `
-        body {
-          background-image: url(../assets/bun.png);
-        }
-      `,
-      {
-        errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write("assets/bun.png", imageFixtures.bun);
-    });
-    const backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.fetch("/").expect.toContain("HELLO");
   },
 });
 


### PR DESCRIPTION
### Problem
- `test/bake/dev/css.test.ts` takes 68 s on the debian 13 x64-asan lane (build #103933) for 15 tests.
- Each case starts its own dev server process. The runner leak-checks this file on that lane, so each process spends about 3.9 s in its exit. Bodies take 0.1 s to 1.1 s. 15 exits are about 57 s of the 68 s.

### Fix
- Add `devTestGroup` to `test/bake/bake-harness.ts`. Its cases share one dev server, started in `beforeAll` and exited in `afterAll`. Each case is still its own `test()`. `devTest` behaves as before. Both run the same extracted steps (`writeProject`, `spawnDevServer`, `runCase`).
- Move 14 of the 15 cases onto one group. Each case has its own route and directory (`syntax-error/`, `asset-index/first.html`) and ends with its files building. The bunfig plugin case keeps its own server, because a resolver plugin applies to every route.
- The leak check still covers every case, once, at the group's exit.
- Verified: `bun bd test test/bake/dev/css.test.ts`, 15 tests before and after, `expect()` calls 78 to 93. Local debug ASAN build: 39.7 s before, 22.6 s after. With the asan lane environment: 47.4 s before, 24.4 s after. Also `html.test.ts` and `dev-and-prod.test.ts` in `test/bake`, and this file on a Windows Server 2019 x64 debug build (15 of 15, twice).

### Background
- `scripts/runner.node.mjs` runs a file not listed in `test/no-validate-leaksan.txt` with `ASAN_OPTIONS=detect_leaks=1` and `BUN_DESTRUCT_VM_ON_EXIT=1`. The dev server child inherits both, so its exit scans the whole heap. The listed `html.test.ts` exits each server in 0.1 s.
- The dev server keeps one set of bundling failures for the whole project. An error page lists all of them, whichever route owns the failing file. So every case must end with valid files.

<details><summary>Notes</summary>

Assertion changes, per case:

- "css file with syntax error does not kill old styles": after the failed write, also asserts the new `background-color` rule did not appear. The old stylesheet is intact, not partially applied.
- "css file with initial syntax error gets recovered": adds a second error and recovery on the loaded page, which is the hot update path and not the reload path. Asserts the color holds during the error and updates after the fix. This also leaves the file valid for the next case.
- "asset referenced in css": asserts the full served stylesheet text (the path comment, the rule with the resolved asset URL, nothing else) instead of `toContain("background-image:")`, and asserts the URL changes with the image.
- "syntax error crash": asserts the 200 body has the page content and the 500 body is the "Bun - Build Failed" page. Adds the recovery step: after the file parses again the route serves 200 with the content.
- "css url resolve error on hot reload is recoverable": the same body assertions for the 500 and 200 responses.
- "multiple stylesheets importing same dependency": after the shared file changes, asserts each importer's own rule is still present.
- "css import before create" and "... project relative": assert status 500 while the import is unresolved and 200 after recovery.

Interaction with #40092: after a failed CSS build recovers, the stored HTML keeps the source `<link href="styles.css">` tag. On `main` the catch-all `/*` route served HTML for that href, which hid it. With one route per case the href is a 404, so the client fixture waits its 1 s cap for that link on three page loads ("Reached maximum CSS load check attempts" in the log). #40092 removes the tag and with it the wait. Its one new assertion needs a one-line rebase onto the new route and href.

Other open PRs that append `devTest` cases to this file (#37051, #39251, #33405) still apply: `devTest` and `extractCssUrl` keep their places at the top and bottom of the file. #39488 rewrites this file and the harness and will conflict.

Timing source: the asan lane log of build #103933. For each case the gap between its last dev server line and the test's pass marker is 3.8 s to 4.0 s. Locally the same gap is 1.1 s on a debug build, 1.0 s of which is `require("bun:internal-for-testing")` in the graceful-exit handler (19 ms on a release build).

Not changed: the 50 ms coalesce sleep per `dev.write` and the client fixture's CSS load wait, both harness-wide.

Failure modes of a group: a failing case leaves its files in whatever state it reached, so a later case that loads an error page can see its failure too. The first failure is the real one. A `dev.write()` that fails its assertion still closes its batch (`batchChanges` resets `batchingChanges` in a `finally` block), so later cases keep synchronizing their writes. A case that times out takes the shared server with it (`bun test` kills every subprocess of a timed-out test), so the next case starts a new server on the same project, and `afterAll` skips the graceful exit of a server that is already gone. A leak in any case fails the group's `afterAll` with the LeakSanitizer report, the same report a `devTest` case would get.

</details>
