### PR TITLE
test(http2): run the six Client Basics groups of node-http2.test.js as one concurrent pool

### DIFF
--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -14,7 +14,7 @@ import tls from "node:tls";
 import { Duplex, duplexPair } from "stream";
 import http2utils from "./helpers";
 import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
-const { describe, expect, it, beforeAll, afterAll, createCallCheckCtx } = createTest(import.meta.path);
+const { describe, expect, it, beforeAll, afterAll, beforeEach, createCallCheckCtx } = createTest(import.meta.path);
 // bun-debug ships with ASAN but isn't named bun-asan, so isASAN is false
 // there; the 10k-request maxSessionMemory stress test takes ~105s under
 // debug+ASAN vs ~2s release, so scale for either.
@@ -41,12 +41,31 @@ function paddingStrategyName(paddingStrategy) {
   }
 }
 
+const PADDING_STRATEGIES = [
+  http2.constants.PADDING_STRATEGY_NONE,
+  http2.constants.PADDING_STRATEGY_MAX,
+  http2.constants.PADDING_STRATEGY_ALIGNED,
+];
+
+// One echo server per padding strategy, shared by the node and the bun "Client Basics" groups
+// below (the server is stateless and does not depend on nodeExecutable). They start here, in the
+// file-level beforeAll, and not in a beforeAll of each group: the runner completes a describe that
+// has beforeAll/afterAll hooks before it starts the next one, which made the six groups run one
+// after another. Without hooks of their own, their tests form one concurrent run.
+const echoServers = new Map();
+beforeAll(async () => {
+  await Promise.all(
+    PADDING_STRATEGIES.map(async paddingStrategy => {
+      echoServers.set(paddingStrategy, await nodeEchoServer(paddingStrategy));
+    }),
+  );
+});
+afterAll(() => {
+  for (const server of echoServers.values()) server.subprocess.kill(9);
+});
+
 for (const nodeExecutable of [nodeExe(), bunExe()]) {
-  for (const paddingStrategy of [
-    http2.constants.PADDING_STRATEGY_NONE,
-    http2.constants.PADDING_STRATEGY_MAX,
-    http2.constants.PADDING_STRATEGY_ALIGNED,
-  ]) {
+  for (const paddingStrategy of PADDING_STRATEGIES) {
     describe.concurrent(`${path.basename(nodeExecutable)} ${paddingStrategyName(paddingStrategy)}`, () => {
       async function nodeDynamicServer(test_name, code) {
         if (!nodeExecutable) throw new Error("node executable not found");
@@ -170,16 +189,11 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
       }
 
       describe("Client Basics", () => {
-        // The echo server is stateless; share one instance across all tests in
-        // this describe block instead of spawning a fresh subprocess per test.
-        let sharedEchoServer;
+        // The shared echo server is started by the file-level beforeAll above. Its URL is read
+        // here, per test, because a beforeAll in this group would serialize the groups again.
         let HTTPS_SERVER;
-        beforeAll(async () => {
-          sharedEchoServer = await nodeEchoServer(paddingStrategy);
-          HTTPS_SERVER = sharedEchoServer.url;
-        });
-        afterAll(() => {
-          sharedEchoServer?.subprocess?.kill?.(9);
+        beforeEach(() => {
+          HTTPS_SERVER = echoServers.get(paddingStrategy).url;
         });
 
         // we dont support server yet but we support client
@@ -188,8 +202,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             ":path": "/get",
             "test-header": "test-value",
           });
-          let parsed;
-          expect(() => (parsed = JSON.parse(result.data))).not.toThrow();
+          const parsed = JSON.parse(result.data);
           expect(parsed.url).toBe(`${HTTPS_SERVER}/get`);
           expect(parsed.headers["test-header"]).toBe("test-value");
         });
@@ -201,8 +214,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             { ":path": "/post", "test-header": "test-value", ":method": "POST" },
             payload,
           );
-          let parsed;
-          expect(() => (parsed = JSON.parse(result.data))).not.toThrow();
+          const parsed = JSON.parse(result.data);
           expect(parsed.url).toBe(`${HTTPS_SERVER}/post`);
           expect(parsed.headers["test-header"]).toBe("test-value");
           expect(parsed.json).toEqual({ "hello": "bun" });
@@ -229,8 +241,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           });
           req.end(payload);
           const result = await promise;
-          let parsed;
-          expect(() => (parsed = JSON.parse(result.data))).not.toThrow();
+          const parsed = JSON.parse(result.data);
           expect(parsed.url).toBe(`${HTTPS_SERVER}/post`);
           expect(parsed.headers["test-header"]).toBe("test-value");
           expect(parsed.json).toEqual({ "hello": "bun" });
@@ -244,12 +255,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             { headers: { ":path": "/get" } },
             { headers: { ":path": "/get" } },
           ]);
-          expect(results.length).toBe(5);
-          for (let i = 0; i < results.length; i++) {
-            let parsed;
-            expect(() => (parsed = JSON.parse(results[i].data))).not.toThrow();
-            expect(parsed.url).toBe(`${HTTPS_SERVER}/get`);
-          }
+          expect(results.map(result => JSON.parse(result.data).url)).toEqual(Array(5).fill(`${HTTPS_SERVER}/get`));
         });
         it("http2 should receive remoteSettings when receiving default settings frame", async () => {
           const { promise, resolve, reject } = Promise.withResolvers();
@@ -284,13 +290,10 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             { headers: { ":path": "/post", ":method": "POST" }, payload: JSON.stringify({ "request": 4 }) },
             { headers: { ":path": "/post", ":method": "POST" }, payload: JSON.stringify({ "request": 5 }) },
           ]);
-          expect(results.length).toBe(5);
-          for (let i = 0; i < results.length; i++) {
-            let parsed;
-            expect(() => (parsed = JSON.parse(results[i].data))).not.toThrow();
-            expect(parsed.url).toBe(`${HTTPS_SERVER}/post`);
-            expect([1, 2, 3, 4, 5]).toContain(parsed.json?.request);
-          }
+          const parsed = results.map(result => JSON.parse(result.data));
+          expect(parsed.map(p => p.url)).toEqual(Array(5).fill(`${HTTPS_SERVER}/post`));
+          // Every request is answered exactly once; the responses may complete in any order.
+          expect(parsed.map(p => p.json.request).sort()).toEqual([1, 2, 3, 4, 5]);
         });
         it("constants", () => {
           expect(http2.constants).toEqual({
@@ -686,9 +689,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             )
             .on("error", reject);
           const result = await promise;
-          let parsed;
-          expect(() => (parsed = JSON.parse(result.data))).not.toThrow();
-          expect(parsed.url).toBe(`${HTTPS_SERVER}/get`);
+          expect(JSON.parse(result.data).url).toBe(`${HTTPS_SERVER}/get`);
           socket.destroy();
         });
         it("close callback", async () => {
@@ -1066,8 +1067,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           });
           req.end("hello");
           const response = await promise;
-          let parsed;
-          expect(() => (parsed = JSON.parse(response.data))).not.toThrow();
+          const parsed = JSON.parse(response.data);
           expect(parsed.headers[":method"]).toEqual(headers[":method"]);
           expect(parsed.headers[":path"]).toEqual(headers[":path"]);
           expect(parsed.headers["x-wait-trailer"]).toEqual(headers["x-wait-trailer"]);
@@ -1094,12 +1094,16 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
                 HTTP2_SERVER_INFO: JSON.stringify(server),
                 HTTP2_SERVER_TLS: JSON.stringify(TLS_OPTIONS),
               },
-              stderr: "inherit",
+              stderr: "pipe",
               stdin: "inherit",
-              stdout: "inherit",
+              stdout: "pipe",
             });
-            const exitCode = await proc.exited;
-            expect(exitCode || 0).toBe(0);
+            const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+            // The script logs a wrong echo response or a failed write to stdout and carries on, so
+            // such a run still exited 0. On success its only output is the RSS delta, on stderr.
+            expect(stdout).toBe("");
+            expect(stderr).toMatch(/^Memory delta -?\d+ MB\n$/);
+            expect(exitCode).toBe(0);
           },
           100000,
         );
@@ -2853,10 +2857,7 @@ it("http2 client.request() rejects header names longer than 4096 bytes with a ca
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(stdout).toContain("CODE:ERR_INVALID_HTTP_TOKEN");
-  expect(stdout).toContain("NAME:TypeError");
-  expect(stdout).not.toContain("NO_ERROR");
-  expect(stdout).toContain("STATUS:200");
+  expect(stdout).toBe("CODE:ERR_INVALID_HTTP_TOKEN\nNAME:TypeError\nSTATUS:200\n");
   expect(exitCode).toBe(0);
 });
 
@@ -3300,8 +3301,8 @@ it("http2 client survives session teardown from a socket write while flushing qu
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain("DATA_QUEUED");
-  expect(stdout).toContain("TEARDOWN_DURING_FLUSH_OK");
+  expect(stderr).toBe("");
+  expect(stdout).toBe("DATA_QUEUED\nTEARDOWN_DURING_FLUSH_OK\n");
   expect(exitCode).toBe(0);
 });
 
@@ -3384,7 +3385,8 @@ it("http2 client keeps parsing a socket chunk whose ArrayBuffer is transferred b
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain('PINGS:["4141414141414141","4242424242424242"]');
+  expect(stderr).toBe("");
+  expect(stdout).toBe('PINGS:["4141414141414141","4242424242424242"]\n');
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- The six `Client Basics` groups of `node-http2.test.js` ran one after another. Each started its echo server in its own `beforeAll`, and the runner completes a describe with `beforeAll`/`afterAll` hooks before it starts the next one, so `describe.concurrent` only overlapped the tests inside a group.
- On the debian 13 x64-asan lane (build 103933) one group completed every 0.65 s. On a debug build with `CI=1` the groups take 35 s, each waiting for its own 4 s `should not leak memory` case.
- `should not leak memory` only checked the exit code. The script logs a wrong echo response or a failed write to stdout and carries on, so such a run still passed.

### Fix
- One echo server per padding strategy starts in a file-level `beforeAll` and serves both the node and the bun groups (the server does not depend on `nodeExecutable`). Each group reads its URL in a `beforeEach`, which does not split the run. The 270 group tests now run as one pool.
- `should not leak memory` requires an empty stdout, the `Memory delta N MB` stderr line, and exit code 0. Three other subprocess cases compare the exact stdout and stderr. The multiplex cases check that all five requests are answered exactly once.
- Verified: 368 tests before and after, 0 fail, 4 runs with `CI=1`. Asan lane (build 104213): the groups and the 15 cases after them finish at 3.65 s instead of 4.25 s, the file at 22.1 s instead of 22.8 s. Debug build with `CI=1`: 93.0 s to 75.4 s.
- The 16 s that remain on the asan lane are the `maxSessionMemory` case, which #31354 fixes. This PR leaves it alone.

### Background
- `bun test` runs consecutive concurrent tests as one group, `--max-concurrency` at a time (5 on ASAN builds, 20 otherwise). A `beforeAll` or `afterAll` hook forms a serial group of its own and splits the run. A `beforeEach` runs inside each test's sequence.
- `Client Basics` is instantiated for `[node, bun] x [none, max, aligned]` padding. Only the two `goaway` cases use `nodeExecutable`. The echo server is always node.
- `isCI` enables `should not leak memory`: a dedicated echo server plus a `bun` child running `node-http2-memory-leak.js`.

<details><summary>Notes</summary>

Asan lane timeline, from the shard logs (dots are completed tests, `t` is seconds after the file started):

| | build 103933 (main) | build 104213 (this PR) | build 104113 (first version) |
| --- | --- | --- | --- |
| six groups done | t=3.62 | folded into one pool | folded into one pool |
| groups + 15 top-level cases done | t=4.25 | t=3.65 | t=2.48 |
| `maxSessionMemory` done | t=20.08 | t=19.32 | t=18.92 |
| file done | 22.83 s | 22.08 s | 20.82 s |

The other lanes are within their noise band (for example debian 13 x64 7.34 s to 7.84 s, alpine x64 8.54 s to 8.48 s). A PR build runs the changed file first, on a cold machine, so lane totals are not directly comparable: on darwin aarch64 the untouched `maxSessionMemory` case alone took 15.0 s in the PR build and 9.5 s on main.

The first version of this PR also turned 54 top-level cases into `it.concurrent`. That part was worth about 1 s on the asan lane, reflowed 14 cases through prettier and conflicted with about ten open PRs on this file, so it was dropped after review. The seven subprocess cases can be made concurrent once the open http2 PR batch on this file has landed.

Debug build timings (12-core container, `bun bd test test/js/node/http2/node-http2.test.js`):

| run | before | after |
| --- | --- | --- |
| full file, `CI=1` | 93.0 s | 75.4 s |
| full file | 75.3 s | 71.4 s |
| `-t "Client Basics"`, `CI=1` | 35.4 s | about 19 s |
| `-t "minimal maxSessionMemory"` (unchanged) | 32.5 s | 29 s |

Before the change, the six `should not leak memory` cases took 4.2 to 4.4 s each on a debug build and the six `bun-debug ... should receive goaway` cases 1.9 s each. They now overlap with the rest of the pool.

Assertion changes:
- `should not leak memory`: `expect(exitCode || 0).toBe(0)` with inherited stdio, to exact stdout (`""`), stderr (`/^Memory delta -?\d+ MB\n$/`), exit code 0. Bun resolves `exited` to 128 plus the signal number when a child dies from a signal, so the `|| 0` never masked a signal death. The gap was the script's stdout: `runRequests` catches a rejected request, logs it, and continues.
- `rejects header names longer than 4096 bytes`: four `toContain`/`not.toContain` checks, to the exact three-line stdout.
- `survives session teardown from a socket write` and `keeps parsing a socket chunk`: added `expect(stderr).toBe("")` and exact stdout instead of `toContain`.
- `should be able to mutiplex POST requests`: `toContain` per response, to "every request is answered exactly once" (`[1, 2, 3, 4, 5]`).
- `should be able to mutiplex GET requests`: length plus per-item url, to one `toEqual` on the five urls.
- Seven `expect(() => (parsed = JSON.parse(...))).not.toThrow()` wrappers replaced by a direct parse. A parse error still fails the test. The expect count drops from 12562 to 12398 because of these.

Concurrency of the memory-leak cases: each still spawns its own echo server and child. On release lanes (no `ASAN_OPTIONS`) up to six children can now run at the same time, each with its own server. The RSS delta each child measures is per process.

Open PRs that edit single cases in this file were left alone: #37832 and #38078 (the `DATA payload` describe), #31354 (`maxSessionMemory`), #34307 (`test/expectations.txt`).

Also ran: `test/js/node/http2/h2-conformance.test.ts`, `node-http2-continuation.test.ts`, `node-http2-upgrade.test.mts` (91 pass).
</details>
