### PR TITLE
test: run bun-publish.test.ts concurrently and assert the exact requests and output

### DIFF
--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1,5 +1,5 @@
 import { file, spawn, write } from "bun";
-import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { exists, rm } from "fs/promises";
 import {
@@ -8,17 +8,21 @@ import {
   bunEnv as env,
   isLinux,
   isWindows,
+  normalizeBunSnapshot,
   pack,
   runBunInstall,
   tempDir,
-  tmpdirSync,
 } from "harness";
 import { delimiter, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
+/** The bunfig every test that publishes to verdaccio uses: the registry url and one shared token. */
+let verdaccioBunfig: string;
+
 beforeAll(async () => {
   await registry.start();
+  verdaccioBunfig = await registry.authBunfig("publish-tests");
 });
 
 afterAll(() => {
@@ -30,294 +34,435 @@ export async function publish(
   cwd: string,
   ...args: string[]
 ): Promise<{ out: string; err: string; exitCode: number }> {
-  const { stdout, stderr, exited } = spawn({
+  await using proc = spawn({
     cmd: [bunExe(), "publish", ...args],
     cwd,
     stdout: "pipe",
     stderr: "pipe",
+    stdin: "ignore",
     env,
   });
 
-  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { out, err, exitCode };
 }
 
-describe("otp", async () => {
-  const mockRegistryFetch = function (opts: {
-    token: string;
+/**
+ * A directory with `package.json` and the auth bunfig for the verdaccio registry. A previous run may have left
+ * the package in the registry storage, so that copy is removed first.
+ */
+async function verdaccioPackage(pkg: { name: string; version: string } & Record<string, unknown>, files = {}) {
+  await rm(join(registry.packagesPath, pkg.name), { recursive: true, force: true });
+  return tempDir(`publish-${pkg.name.replace(/[@/]/g, "")}`, {
+    "package.json": JSON.stringify(pkg),
+    "bunfig.toml": verdaccioBunfig,
+    ...files,
+  });
+}
+
+/**
+ * `bun publish` prints the tarball checksums and its gzip size, which depend on the platform's tar headers, and
+ * the registry port. Replace them so the rest of the output can be compared with an inline snapshot.
+ */
+function normalizePublishOutput(out: string, port?: number) {
+  return normalizeBunSnapshot(port === undefined ? out : out.replaceAll(`localhost:${port}`, "localhost:<port>"))
+    .replace(/^Shasum: [0-9a-f]{40}$/m, "Shasum: <sha1>")
+    .replace(/^Integrity: sha512-\S+$/m, "Integrity: <sha512>")
+    .replace(/^Packed size: \S+$/m, "Packed size: <size>")
+    .replace(/^\|-+\|$/gm, "|<border>|");
+}
+
+/** The files the summary lists as packed, in the order they went into the tarball. */
+function packedFiles(out: string) {
+  return out
+    .split("\n")
+    .filter(line => line.startsWith("packed "))
+    .map(line => line.split(" ").slice(2).join(" "));
+}
+
+type RegistryRequest = {
+  method: string;
+  pathname: string;
+  authorization: string | null;
+  /** the `npm-auth-type` header */
+  authType: string | null;
+  /** the `npm-otp` header */
+  otp: string | null;
+  userAgent: string | null;
+  /** the JSON body of a PUT, `null` for every other request */
+  manifest: any;
+};
+
+type MockRegistry = {
+  port: number;
+  requests: RegistryRequest[];
+  [Symbol.dispose](): void;
+};
+
+/** A registry that records what `bun publish` sends. `respond` picks the response, the default accepts everything. */
+function mockRegistry(
+  respond?: (req: Request, recorded: RegistryRequest, mock: MockRegistry) => Response | Promise<Response>,
+): MockRegistry {
+  const requests: RegistryRequest[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const recorded: RegistryRequest = {
+        method: req.method,
+        pathname: new URL(req.url).pathname,
+        authorization: req.headers.get("authorization"),
+        authType: req.headers.get("npm-auth-type"),
+        otp: req.headers.get("npm-otp"),
+        userAgent: req.headers.get("user-agent"),
+        manifest: req.method === "PUT" ? await req.json() : null,
+      };
+      requests.push(recorded);
+      return respond ? respond(req, recorded, mock) : new Response("OK", { status: 200 });
+    },
+  });
+  const mock: MockRegistry = { port: server.port, requests, [Symbol.dispose]: () => server.stop(true) };
+  return mock;
+}
+
+/** The token the mock registry tests configure. `bun publish` sends it as `authorization: Bearer <token>`. */
+const registryToken = "registry-token";
+
+function mockBunfig(mock: MockRegistry) {
+  return Bun.TOML.stringify({
+    install: { cache: false, registry: { url: `http://localhost:${mock.port}`, token: registryToken } },
+  });
+}
+
+const userAgent = expect.stringMatching(
+  new RegExp(
+    `^Bun/${Bun.version.replaceAll(".", "\\.")} ${process.platform} ${process.arch} workspaces/false( ci/\\S+)?$`,
+  ),
+);
+
+/** A request as `mockRegistry` records it, with the headers `bun publish` sends when no OTP is involved. */
+function request(method: string, pathname: string, fields: Partial<RegistryRequest> = {}) {
+  return {
+    method,
+    pathname,
+    authorization: `Bearer ${registryToken}`,
+    authType: "web",
+    otp: null,
+    userAgent,
+    manifest: method === "PUT" ? expect.any(Object) : null,
+    ...fields,
+  };
+}
+
+/** The tarball inside a PUT body: its entries and the checksums that `dist` and the printed summary must match. */
+async function attachedTarball(manifest: any) {
+  const [[filename, attachment]] = Object.entries<any>(manifest._attachments);
+  const bytes = Buffer.from(attachment.data, "base64");
+  return {
+    filename,
+    length: bytes.length,
+    files: [...(await new Bun.Archive(bytes).files()).keys()].sort(),
+    shasum: new Bun.CryptoHasher("sha1").update(bytes).digest("hex"),
+    integrity: `sha512-${new Bun.CryptoHasher("sha512").update(bytes).digest("base64")}`,
+  };
+}
+
+/** The summary prints the full sha1 and the sha512 with its middle cut out. */
+function printedChecksums({ shasum, integrity }: { shasum: string; integrity: string }) {
+  const base64 = integrity.slice("sha512-".length);
+  return `\nShasum: ${shasum}\nIntegrity: sha512-${base64.slice(0, 13)}[...]${base64.slice(-15)}\n`;
+}
+
+/**
+ * Asserts that `manifest`, the body of a PUT, is exactly what `bun publish` builds for `pkg` (the package.json
+ * that was published) when the registry listens on `port`. Returns the decoded tarball.
+ */
+async function expectPublishedManifest(
+  manifest: any,
+  pkg: { name: string; version: string } & Record<string, unknown>,
+  port: number,
+  opts: { access?: string | null; tag?: string; versionFields?: Record<string, unknown> } = {},
+) {
+  const tarball = await attachedTarball(manifest);
+  const { name, version } = pkg;
+  const tarballName = `${name}-${version}.tgz`;
+  expect(manifest).toEqual({
+    _id: name,
+    name,
+    "dist-tags": { [opts.tag ?? "latest"]: version },
+    versions: {
+      [version]: {
+        ...pkg,
+        ...opts.versionFields,
+        _id: `${name}@${version}`,
+        _integrity: tarball.integrity,
+        _nodeVersion: process.versions.node,
+        _npmVersion: "10.8.3",
+        integrity: tarball.integrity,
+        shasum: tarball.shasum,
+        dist: {
+          integrity: tarball.integrity,
+          shasum: tarball.shasum,
+          tarball: `http://localhost:${port}/${name}/-/${tarballName}`,
+        },
+      },
+    },
+    access: opts.access ?? null,
+    _attachments: {
+      [tarballName]: { content_type: "application/octet-stream", data: expect.any(String), length: tarball.length },
+    },
+  });
+  return tarball;
+}
+
+describe.concurrent("otp", () => {
+  /**
+   * The registry for the OTP tests. The first PUT is answered with a 401 that asks for a one-time password, the
+   * done url hands out `otp`, and a PUT that carries `otp` in `npm-otp` is accepted.
+   */
+  function otpRegistry(opts: {
+    otp: string;
+    /** send `www-authenticate: OTP`. Without it, the body has to mention "one-time password" */
     setAuthHeader?: boolean;
+    /** reject the PUT that carries the OTP */
     otpFail?: boolean;
+    /** add an `npm-notice` header to the 401 */
     npmNotice?: boolean;
+    /** add `x-local-cache`, which tells bun to ignore `npm-notice` */
     xLocalCache?: boolean;
-    expectedCI?: string;
   }) {
-    return async function (req: Request) {
-      const { token, setAuthHeader = true, otpFail = false, npmNotice = false, xLocalCache = false } = opts;
-      if (req.url.includes("otp-pkg")) {
-        if (opts.expectedCI) {
-          expect(req.headers.get("user-agent")).toContain("ci/" + opts.expectedCI);
-        }
-        if (req.headers.get("npm-otp") === token) {
+    const { otp, setAuthHeader = true, otpFail = false, npmNotice = false, xLocalCache = false } = opts;
+    return mockRegistry((req, recorded, mock) => {
+      if (req.method === "PUT") {
+        if (recorded.otp === otp) {
           if (otpFail) {
-            return new Response(
-              JSON.stringify({
-                error: "You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.",
-              }),
+            return Response.json(
+              { error: "You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA." },
               { status: 401 },
             );
-          } else {
-            return new Response("OK", { status: 200 });
           }
-        } else {
-          const headers = new Headers();
-          if (setAuthHeader) headers.set("www-authenticate", "OTP");
-
-          // `bun publish` won't request a url from a message in the npm-notice header, but we
-          // can test that it's displayed
-          if (npmNotice) headers.set("npm-notice", `visit http://localhost:${this.port}/auth to login`);
-
-          // npm-notice will be ignored
-          if (xLocalCache) headers.set("x-local-cache", "true");
-
-          return new Response(
-            JSON.stringify({
-              // this isn't accurate, but we just want to check that finding this string works
-              mock: setAuthHeader ? "" : "one-time password",
-
-              authUrl: `http://localhost:${this.port}/auth`,
-              doneUrl: `http://localhost:${this.port}/done`,
-            }),
-            {
-              status: 401,
-              headers,
-            },
-          );
+          return new Response("OK", { status: 200 });
         }
-      } else if (req.url.endsWith("auth")) {
-        expect.unreachable("url given to user, bun publish should not request");
-      } else if (req.url.endsWith("done")) {
-        // send a fake response saying the user has authenticated successfully with the auth url
-        return new Response(JSON.stringify({ token: token }), { status: 200 });
+        const headers = new Headers();
+        if (setAuthHeader) headers.set("www-authenticate", "OTP");
+        if (npmNotice) headers.set("npm-notice", `visit http://localhost:${mock.port}/auth to login`);
+        if (xLocalCache) headers.set("x-local-cache", "true");
+        return Response.json(
+          {
+            // this isn't accurate, but we just want to check that finding this string works
+            mock: setAuthHeader ? "" : "one-time password",
+            authUrl: `http://localhost:${mock.port}/auth`,
+            doneUrl: `http://localhost:${mock.port}/done`,
+          },
+          { status: 401, headers },
+        );
       }
-
-      expect.unreachable("unexpected url");
-    };
-  };
-
-  for (const setAuthHeader of [true, false]) {
-    test("mock web login" + (setAuthHeader ? "" : " (without auth header)"), async () => {
-      const { packageDir, packageJson } = await registry.createTestDir();
-      const token = await registry.generateUser("otp" + (setAuthHeader ? "" : "noheader"), "otp");
-
-      using mockRegistry = Bun.serve({
-        port: 0,
-        fetch: mockRegistryFetch({ token }),
-      });
-
-      const bunfig = Bun.TOML.stringify({
-        install: {
-          cache: false,
-          registry: { url: `http://localhost:${mockRegistry.port}`, token },
-        },
-      });
-      await Promise.all([
-        rm(join(registry.packagesPath, "otp-pkg-1"), { recursive: true, force: true }),
-        write(join(packageDir, "bunfig.toml"), bunfig),
-        write(
-          packageJson,
-          JSON.stringify({
-            name: "otp-pkg-1",
-            version: "2.2.2",
-            dependencies: {
-              "otp-pkg-1": "2.2.2",
-            },
-          }),
-        ),
-      ]);
-
-      const { out, err, exitCode } = await publish(env, packageDir);
-      expect(exitCode).toBe(0);
+      if (recorded.pathname === "/done") {
+        return Response.json({ token: otp });
+      }
+      // `/auth` is shown to the user. `bun publish` must never request it.
+      return new Response(`unexpected request: ${req.method} ${recorded.pathname}`, { status: 500 });
     });
   }
 
-  test("otp failure", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const token = await registry.generateUser("otp-fail", "otp");
-    using mockRegistry = Bun.serve({
-      port: 0,
-      fetch: mockRegistryFetch({ token, otpFail: true }),
-    });
+  test.each([
+    ["", { setAuthHeader: true }],
+    [" (without auth header)", { setAuthHeader: false }],
+  ])("mock web login%s", async (_, { setAuthHeader }) => {
+    const otp = "otp-1";
+    using mock = otpRegistry({ otp, setAuthHeader });
+    const pkg = { name: "otp-pkg-1", version: "2.2.2", dependencies: { "otp-pkg-1": "2.2.2" } };
+    using dir = tempDir("publish-otp", { "package.json": JSON.stringify(pkg), "bunfig.toml": mockBunfig(mock) });
 
-    const bunfig = Bun.TOML.stringify({
-      install: {
-        cache: false,
-        registry: { url: `http://localhost:${mockRegistry.port}`, token },
-      },
-    });
+    const { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
 
-    await Promise.all([
-      rm(join(registry.packagesPath, "otp-pkg-2"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(
-        packageJson,
-        JSON.stringify({
-          name: "otp-pkg-2",
-          version: "1.1.1",
-          dependencies: {
-            "otp-pkg-2": "1.1.1",
-          },
-        }),
-      ),
+      packed 97B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 97B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+      Authenticate your account at (press ENTER to open in browser):
+      |<border>|
+      | http://localhost:<port>/auth |
+      |<border>|
+
+       + otp-pkg-1@2.2.2"
+    `);
+    expect(mock.requests).toEqual([
+      request("PUT", "/otp-pkg-1"),
+      request("GET", "/done"),
+      request("PUT", "/otp-pkg-1", { authType: "legacy", otp }),
     ]);
+    const tarball = await expectPublishedManifest(mock.requests[2].manifest, pkg, mock.port);
+    expect(mock.requests[0].manifest).toEqual(mock.requests[2].manifest);
+    expect(tarball.files).toEqual(["package/package.json"]);
+    expect(out).toContain(printedChecksums(tarball));
+    expect(exitCode).toBe(0);
+  });
 
-    const { out, err, exitCode } = await publish(env, packageDir);
+  test("otp failure", async () => {
+    const otp = "otp-2";
+    using mock = otpRegistry({ otp, otpFail: true });
+    using dir = tempDir("publish-otp-failure", {
+      "package.json": JSON.stringify({ name: "otp-pkg-2", version: "1.1.1", dependencies: { "otp-pkg-2": "1.1.1" } }),
+      "bunfig.toml": mockBunfig(mock),
+    });
+
+    const { out, err, exitCode } = await publish(env, String(dir));
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 97B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 97B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+      Authenticate your account at (press ENTER to open in browser):
+      |<border>|
+      | http://localhost:<port>/auth |
+      |<border>|"
+    `);
+    expect(err).toBe(`\n401 Unauthorized: http://localhost:${mock.port}/otp-pkg-2\n\n - Received invalid OTP\n`);
+    expect(mock.requests).toEqual([
+      request("PUT", "/otp-pkg-2"),
+      request("GET", "/done"),
+      request("PUT", "/otp-pkg-2", { authType: "legacy", otp }),
+    ]);
     expect(exitCode).toBe(1);
-    expect(err).toContain(" - Received invalid OTP");
   });
 
   test("non-http auth url is shown without launching a browser and login completes via done url polling", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const token = await registry.generateUser("otp-classic-fallback", "otp");
-
-    let doneHits = 0;
-    using mockRegistry = Bun.serve({
-      port: 0,
-      fetch(req: Request) {
-        if (req.method === "PUT") {
-          if (req.headers.get("npm-otp") === token) {
-            return new Response("OK", { status: 200 });
-          }
-          return new Response(
-            JSON.stringify({
-              authUrl: "customapp://login",
-              doneUrl: `http://localhost:${mockRegistry.port}/done`,
-            }),
-            { status: 401, headers: { "www-authenticate": "OTP" } },
-          );
+    const otp = "otp-5";
+    using mock = mockRegistry((req, recorded, mock) => {
+      if (req.method === "PUT") {
+        if (recorded.otp === otp) {
+          return new Response("OK", { status: 200 });
         }
-        if (req.url.endsWith("done")) {
-          doneHits++;
-          return new Response(JSON.stringify({ token }), { status: 200 });
-        }
-        return new Response("unexpected url", { status: 500 });
-      },
+        return Response.json(
+          { authUrl: "customapp://login", doneUrl: `http://localhost:${mock.port}/done` },
+          { status: 401, headers: { "www-authenticate": "OTP" } },
+        );
+      }
+      if (recorded.pathname === "/done") {
+        return Response.json({ token: otp });
+      }
+      return new Response("unexpected url", { status: 500 });
+    });
+    using dir = tempDir("publish-otp-custom-app", {
+      "package.json": JSON.stringify({ name: "otp-pkg-5", version: "5.5.5", dependencies: { "otp-pkg-5": "5.5.5" } }),
+      "bunfig.toml": mockBunfig(mock),
     });
 
-    const bunfig = Bun.TOML.stringify({
-      install: {
-        cache: false,
-        registry: { url: `http://localhost:${mockRegistry.port}`, token },
-      },
-    });
+    const { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
 
-    await Promise.all([
-      rm(join(registry.packagesPath, "otp-pkg-5"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(
-        packageJson,
-        JSON.stringify({
-          name: "otp-pkg-5",
-          version: "5.5.5",
-          dependencies: {
-            "otp-pkg-5": "5.5.5",
-          },
-        }),
-      ),
+      packed 97B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 97B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+      Authenticate your account at:
+      |<border>|
+      | customapp://login |
+      |<border>|
+
+       + otp-pkg-5@5.5.5"
+    `);
+    expect(mock.requests).toEqual([
+      request("PUT", "/otp-pkg-5"),
+      request("GET", "/done"),
+      request("PUT", "/otp-pkg-5", { authType: "legacy", otp }),
     ]);
-
-    await using proc = spawn({
-      cmd: [bunExe(), "publish"],
-      cwd: packageDir,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-      env,
-    });
-
-    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(out).toContain("Authenticate your account at:");
-    expect(out).toContain("customapp://login");
-    expect(out).not.toContain("open in browser");
-    expect(out).not.toContain("Enter OTP: ");
-    expect(doneHits).toBeGreaterThan(0);
-    expect(out).toContain(" + otp-pkg-5@5.5.5");
     expect(exitCode).toBe(0);
   });
 
   test("done url on a different origin is not polled and login falls back to the OTP prompt", async () => {
-    const packageDir = tmpdirSync();
-    const otpCode = "424242";
-
-    let foreignDoneHits = 0;
-    using foreign = Bun.serve({
-      port: 0,
-      fetch() {
-        foreignDoneHits++;
-        return new Response(JSON.stringify({ token: otpCode }), { status: 200 });
-      },
-    });
-
-    let localDoneHits = 0;
-    using mockRegistry = Bun.serve({
-      port: 0,
-      fetch(req: Request) {
-        if (req.method === "PUT") {
-          if (req.headers.get("npm-otp") === otpCode) {
-            return new Response("OK", { status: 200 });
-          }
-          return new Response(
-            JSON.stringify({
-              authUrl: "customapp://login",
-              doneUrl: `http://127.0.0.1:${foreign.port}/done`,
-            }),
-            { status: 401, headers: { "www-authenticate": "OTP" } },
-          );
+    const otp = "424242";
+    using foreign = mockRegistry(() => Response.json({ token: otp }));
+    using mock = mockRegistry((req, recorded) => {
+      if (req.method === "PUT") {
+        if (recorded.otp === otp) {
+          return new Response("OK", { status: 200 });
         }
-        if (req.url.endsWith("done")) {
-          localDoneHits++;
-          return new Response(JSON.stringify({ token: otpCode }), { status: 200 });
-        }
-        return new Response("unexpected url", { status: 500 });
-      },
+        return Response.json(
+          { authUrl: "customapp://login", doneUrl: `http://127.0.0.1:${foreign.port}/done` },
+          { status: 401, headers: { "www-authenticate": "OTP" } },
+        );
+      }
+      if (recorded.pathname === "/done") {
+        return Response.json({ token: otp });
+      }
+      return new Response("unexpected url", { status: 500 });
     });
-
-    await Promise.all([
-      write(
-        join(packageDir, "bunfig.toml"),
-        Bun.TOML.stringify({
-          install: {
-            cache: false,
-            registry: { url: `http://localhost:${mockRegistry.port}`, token: "unused" },
-          },
-        }),
-      ),
-      write(join(packageDir, "package.json"), JSON.stringify({ name: "otp-pkg-6", version: "6.6.6" })),
-    ]);
+    using dir = tempDir("publish-otp-foreign-done", {
+      "package.json": JSON.stringify({ name: "otp-pkg-6", version: "6.6.6" }),
+      "bunfig.toml": mockBunfig(mock),
+    });
 
     await using proc = spawn({
       cmd: [bunExe(), "publish"],
-      cwd: packageDir,
+      cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
-      stdin: Buffer.from(otpCode + "\n"),
+      stdin: Buffer.from(otp + "\n"),
       env,
     });
-
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(out).toContain("Enter OTP: ");
-    expect(out).not.toContain("Authenticate your account at");
-    expect(foreignDoneHits).toBe(0);
-    expect(localDoneHits).toBe(0);
-    expect(out).toContain(" + otp-pkg-6@6.6.6");
+    expect(err).toBe("");
+    // the prompt has no line break, the typed OTP is not echoed, and the publish line starts with its own "\n"
+    expect(normalizePublishOutput(out, mock.port).split("\n")).toEqual([
+      "bun publish <version> (<revision>)",
+      "",
+      "packed 47B package.json",
+      "",
+      "Total files: 1",
+      "Shasum: <sha1>",
+      "Integrity: <sha512>",
+      "Unpacked size: 47B",
+      "Packed size: <size>",
+      "Tag: latest",
+      "Access: default",
+      "Registry: http://localhost:<port>/",
+      "",
+      "This operation requires a one-time password.",
+      "Enter OTP: ",
+      " + otp-pkg-6@6.6.6",
+    ]);
+    expect(foreign.requests).toEqual([]);
+    expect(mock.requests).toEqual([
+      request("PUT", "/otp-pkg-6"),
+      request("PUT", "/otp-pkg-6", { authType: "legacy", otp }),
+    ]);
     expect(exitCode).toBe(0);
   });
 
   test.skipIf(!isLinux)(
     "web login opens the auth url with the opener found on PATH, not one in the package directory",
     async () => {
-      const otpCode = "515151";
+      const otp = "515151";
 
       using dir = tempDir("publish-web-login-opener", {
         "package.json": JSON.stringify({ name: "otp-pkg-7", version: "7.7.7" }),
@@ -333,41 +478,27 @@ describe("otp", async () => {
       chmodSync(join(packageDir, "opener-bin", "xdg-open"), 0o755);
 
       let donePolls = 0;
-      using mockRegistry = Bun.serve({
-        port: 0,
-        fetch(req: Request) {
-          if (req.method === "PUT") {
-            if (req.headers.get("npm-otp") === otpCode) {
-              return new Response("OK", { status: 200 });
-            }
-            return new Response(
-              JSON.stringify({
-                authUrl: `http://localhost:${mockRegistry.port}/auth`,
-                doneUrl: `http://localhost:${mockRegistry.port}/done`,
-              }),
-              { status: 401, headers: { "www-authenticate": "OTP" } },
-            );
+      using mock = mockRegistry((req, recorded, mock) => {
+        if (req.method === "PUT") {
+          if (recorded.otp === otp) {
+            return new Response("OK", { status: 200 });
           }
-          if (req.url.endsWith("done")) {
-            donePolls++;
-            if (!existsSync(openedMarker) && donePolls < 40) {
-              return new Response("{}", { status: 202 });
-            }
-            return new Response(JSON.stringify({ token: otpCode }), { status: 200 });
+          return Response.json(
+            { authUrl: `http://localhost:${mock.port}/auth`, doneUrl: `http://localhost:${mock.port}/done` },
+            { status: 401, headers: { "www-authenticate": "OTP" } },
+          );
+        }
+        if (recorded.pathname === "/done") {
+          donePolls++;
+          if (!existsSync(openedMarker) && donePolls < 40) {
+            return new Response("{}", { status: 202 });
           }
-          return new Response("unexpected url", { status: 500 });
-        },
+          return Response.json({ token: otp });
+        }
+        return new Response("unexpected url", { status: 500 });
       });
 
-      await write(
-        join(packageDir, "bunfig.toml"),
-        Bun.TOML.stringify({
-          install: {
-            cache: false,
-            registry: { url: `http://localhost:${mockRegistry.port}`, token: "unused" },
-          },
-        }),
-      );
+      await write(join(packageDir, "bunfig.toml"), mockBunfig(mock));
 
       await using proc = spawn({
         cmd: [bunExe(), "publish"],
@@ -380,833 +511,832 @@ describe("otp", async () => {
           PATH: [join(packageDir, "opener-bin"), env.PATH ?? ""].join(delimiter),
         },
       });
-
       const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(out).toContain("open in browser");
-      expect(out).toContain(`http://localhost:${mockRegistry.port}/auth`);
-      expect(existsSync(openedMarker)).toBe(true);
-      expect(readFileSync(openedMarker, "utf8")).toBe(`path http://localhost:${mockRegistry.port}/auth`);
-      expect(out).toContain(" + otp-pkg-7@7.7.7");
+      expect(err).toBe("");
+      // the opener scripts embed the temp dir path, so their packed sizes differ between machines
+      expect(packedFiles(out)).toEqual(["package.json", "opener-bin/xdg-open", "xdg-open"]);
+      const authUrl = `http://localhost:${mock.port}/auth`;
+      const border = `|${Buffer.alloc(authUrl.length + 2, "-")}|`;
+      expect(out).toEndWith(
+        `\nAuthenticate your account at (press ENTER to open in browser):\n${border}\n| ${authUrl} |\n${border}\n\n + otp-pkg-7@7.7.7\n`,
+      );
+      expect(readFileSync(openedMarker, "utf8")).toBe(`path http://localhost:${mock.port}/auth`);
+      expect(mock.requests.filter(r => r.method === "PUT")).toEqual([
+        request("PUT", "/otp-pkg-7"),
+        request("PUT", "/otp-pkg-7", { authType: "legacy", otp }),
+      ]);
+      expect(donePolls).toBeGreaterThan(0);
       expect(exitCode).toBe(0);
     },
     30_000,
   );
 
-  for (const shouldIgnoreNotice of [false, true]) {
-    test(`npm-notice with login url${shouldIgnoreNotice ? " (ignored)" : ""}`, async () => {
-      const { packageDir, packageJson } = await registry.createTestDir();
-      // Situation: user has 2FA enabled account with faceid sign-in.
-      // They run `bun publish` with --auth-type=legacy, prompting them
-      // to enter their OTP. Because they have faceid sign-in, they don't
-      // have a code to enter, so npm sends a message in the npm-notice
-      // header with a url for logging in.
-      const token = await registry.generateUser(`otp-notice${shouldIgnoreNotice ? "-ignore" : ""}`, "otp");
-      using mockRegistry = Bun.serve({
-        port: 0,
-        fetch: mockRegistryFetch({ token, npmNotice: true, xLocalCache: shouldIgnoreNotice }),
-      });
-
-      const bunfig = Bun.TOML.stringify({
-        install: {
-          cache: false,
-          registry: { url: `http://localhost:${mockRegistry.port}`, token },
-        },
-      });
-
-      await Promise.all([
-        rm(join(registry.packagesPath, "otp-pkg-3"), { recursive: true, force: true }),
-        write(join(packageDir, "bunfig.toml"), bunfig),
-        write(
-          packageJson,
-          JSON.stringify({
-            name: "otp-pkg-3",
-            version: "3.3.3",
-            dependencies: {
-              "otp-pkg-3": "3.3.3",
-            },
-          }),
-        ),
-      ]);
-
-      const { out, err, exitCode } = await publish(env, packageDir);
-      expect(exitCode).toBe(0);
-      if (shouldIgnoreNotice) {
-        expect(err).not.toContain(`note: visit http://localhost:${mockRegistry.port}/auth to login`);
-      } else {
-        expect(err).toContain(`note: visit http://localhost:${mockRegistry.port}/auth to login`);
-      }
+  // Situation: user has 2FA enabled account with faceid sign-in.
+  // They run `bun publish` with --auth-type=legacy, prompting them
+  // to enter their OTP. Because they have faceid sign-in, they don't
+  // have a code to enter, so npm sends a message in the npm-notice
+  // header with a url for logging in.
+  test.each([
+    ["", false],
+    [" (ignored)", true],
+  ])("npm-notice with login url%s", async (_, shouldIgnoreNotice) => {
+    const otp = "otp-3";
+    using mock = otpRegistry({ otp, npmNotice: true, xLocalCache: shouldIgnoreNotice });
+    using dir = tempDir("publish-otp-notice", {
+      "package.json": JSON.stringify({ name: "otp-pkg-3", version: "3.3.3", dependencies: { "otp-pkg-3": "3.3.3" } }),
+      "bunfig.toml": mockBunfig(mock),
     });
-  }
 
-  const fakeCIEnvs = [
+    const { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe(shouldIgnoreNotice ? "" : `\nnote: visit http://localhost:${mock.port}/auth to login\n`);
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 97B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 97B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+      Authenticate your account at (press ENTER to open in browser):
+      |<border>|
+      | http://localhost:<port>/auth |
+      |<border>|
+
+       + otp-pkg-3@3.3.3"
+    `);
+    expect(mock.requests).toEqual([
+      request("PUT", "/otp-pkg-3"),
+      request("GET", "/done"),
+      request("PUT", "/otp-pkg-3", { authType: "legacy", otp }),
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.each([
     { ci: "expo-application-services", envs: { EAS_BUILD: "hi" } },
     { ci: "codemagic", envs: { CM_BUILD_ID: "hi" } },
-    { ci: "vercel", envs: { "NOW_BUILDER": "hi" } },
-  ];
-  for (const envInfo of fakeCIEnvs) {
-    test(`CI user agent name: ${envInfo.ci}`, async () => {
-      const { packageDir, packageJson } = await registry.createTestDir();
-      const token = await registry.generateUser(`otp-${envInfo.ci}`, "otp");
-      using mockRegistry = Bun.serve({
-        port: 0,
-        fetch: mockRegistryFetch({ token, expectedCI: envInfo.ci }),
-      });
-
-      const bunfig = Bun.TOML.stringify({
-        install: {
-          cache: false,
-          registry: { url: `http://localhost:${mockRegistry.port}`, token },
-        },
-      });
-
-      await Promise.all([
-        rm(join(registry.packagesPath, "otp-pkg-4"), { recursive: true, force: true }),
-        write(join(packageDir, "bunfig.toml"), bunfig),
-        write(
-          packageJson,
-          JSON.stringify({
-            name: "otp-pkg-4",
-            version: "4.4.4",
-            dependencies: {
-              "otp-pkg-4": "4.4.4",
-            },
-          }),
-        ),
-      ]);
-
-      const { out, err, exitCode } = await publish(
-        { ...env, ...envInfo.envs, ...{ BUILDKITE: undefined, GITHUB_ACTIONS: undefined } },
-        packageDir,
-      );
-      expect(exitCode).toBe(0);
+    { ci: "vercel", envs: { NOW_BUILDER: "hi" } },
+  ])("CI user agent name: $ci", async ({ ci, envs }) => {
+    const otp = "otp-4";
+    using mock = otpRegistry({ otp });
+    using dir = tempDir("publish-otp-ci", {
+      "package.json": JSON.stringify({ name: "otp-pkg-4", version: "4.4.4", dependencies: { "otp-pkg-4": "4.4.4" } }),
+      "bunfig.toml": mockBunfig(mock),
     });
-  }
-});
 
-test("can publish a package then install it", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const bunfig = await registry.authBunfig("basic");
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-pkg-1"), { recursive: true, force: true }),
-    write(
-      packageJson,
-      JSON.stringify({
-        name: "publish-pkg-1",
-        version: "1.1.1",
-        dependencies: {
-          "publish-pkg-1": "1.1.1",
-        },
-      }),
-    ),
-    write(join(packageDir, "bunfig.toml"), bunfig),
-  ]);
+    const { out, err, exitCode } = await publish(
+      { ...env, ...envs, BUILDKITE: undefined, GITHUB_ACTIONS: undefined },
+      String(dir),
+    );
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
 
-  const { out, err, exitCode } = await publish(env, packageDir);
-  expect(err).not.toContain("error:");
-  expect(err).not.toContain("warn:");
-  expect(exitCode).toBe(0);
+      packed 97B package.json
 
-  await runBunInstall(env, packageDir);
-  expect(await exists(join(packageDir, "node_modules", "publish-pkg-1", "package.json"))).toBeTrue();
-});
-test("can publish from a tarball", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const bunfig = await registry.authBunfig("tarball");
-  const json = {
-    name: "publish-pkg-2",
-    version: "2.2.2",
-    dependencies: {
-      "publish-pkg-2": "2.2.2",
-    },
-  };
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-pkg-2"), { recursive: true, force: true }),
-    write(packageJson, JSON.stringify(json)),
-    write(join(packageDir, "bunfig.toml"), bunfig),
-  ]);
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 97B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
 
-  await pack(packageDir, env);
+      Authenticate your account at (press ENTER to open in browser):
+      |<border>|
+      | http://localhost:<port>/auth |
+      |<border>|
 
-  let { out, err, exitCode } = await publish(env, packageDir, "./publish-pkg-2-2.2.2.tgz");
-  expect(err).not.toContain("error:");
-  expect(err).not.toContain("warn:");
-  expect(exitCode).toBe(0);
-
-  await runBunInstall(env, packageDir);
-  expect(await exists(join(packageDir, "node_modules", "publish-pkg-2", "package.json"))).toBeTrue();
-
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-pkg-2"), { recursive: true, force: true }),
-    rm(join(packageDir, "bun.lockb"), { recursive: true, force: true }),
-    rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
-  ]);
-
-  // now with an absoute path
-  ({ out, err, exitCode } = await publish(env, packageDir, join(packageDir, "publish-pkg-2-2.2.2.tgz")));
-  expect(err).not.toContain("error:");
-  expect(err).not.toContain("warn:");
-  expect(exitCode).toBe(0);
-
-  await runBunInstall(env, packageDir, { savesLockfile: false });
-  expect(await file(join(packageDir, "node_modules", "publish-pkg-2", "package.json")).json()).toEqual(json);
-});
-test("can publish scoped packages", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const bunfig = await registry.authBunfig("scoped-pkg");
-  const json = {
-    name: "@scoped/pkg-1",
-    version: "1.1.1",
-    dependencies: {
-      "@scoped/pkg-1": "1.1.1",
-    },
-  };
-  await Promise.all([
-    rm(join(registry.packagesPath, "@scoped", "pkg-1"), { recursive: true, force: true }),
-    write(packageJson, JSON.stringify(json)),
-    write(join(packageDir, "bunfig.toml"), bunfig),
-  ]);
-
-  const { out, err, exitCode } = await publish(env, packageDir);
-  expect(err).not.toContain("error:");
-  expect(err).not.toContain("warn:");
-  expect(exitCode).toBe(0);
-
-  await runBunInstall(env, packageDir);
-  expect(await file(join(packageDir, "node_modules", "@scoped", "pkg-1", "package.json")).json()).toEqual(json);
-});
-
-for (const info of [
-  { user: "bin1", bin: "bin1.js" },
-  { user: "bin2", bin: { bin1: "bin1.js", bin2: "bin2.js" } },
-  { user: "bin3", directories: { bin: "bins" } },
-]) {
-  test(`can publish and install binaries with ${JSON.stringify(info)}`, async () => {
-    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
-    const publishDir = tmpdirSync();
-    const bunfig = await registry.authBunfig("binaries-" + info.user);
-
-    await Promise.all([
-      rm(join(registry.packagesPath, "publish-pkg-" + info.user), { recursive: true, force: true }),
-      write(
-        join(publishDir, "package.json"),
-        JSON.stringify({
-          name: "publish-pkg-" + info.user,
-          version: "1.1.1",
-          ...info,
-        }),
-      ),
-      write(join(publishDir, "bunfig.toml"), bunfig),
-      write(join(publishDir, "bin1.js"), `#!/usr/bin/env bun\nconsole.log("bin1!")`),
-      write(join(publishDir, "bin2.js"), `#!/usr/bin/env bun\nconsole.log("bin2!")`),
-      write(join(publishDir, "bins", "bin3.js"), `#!/usr/bin/env bun\nconsole.log("bin3!")`),
-      write(join(publishDir, "bins", "moredir", "bin4.js"), `#!/usr/bin/env bun\nconsole.log("bin4!")`),
-
-      write(
-        packageJson,
-        JSON.stringify({
-          name: "foo",
-          dependencies: {
-            ["publish-pkg-" + info.user]: "1.1.1",
-          },
-        }),
-      ),
+       + otp-pkg-4@4.4.4"
+    `);
+    const ciUserAgent = `Bun/${Bun.version} ${process.platform} ${process.arch} workspaces/false ci/${ci}`;
+    expect(mock.requests).toEqual([
+      request("PUT", "/otp-pkg-4", { userAgent: ciUserAgent }),
+      request("GET", "/done", { userAgent: ciUserAgent }),
+      request("PUT", "/otp-pkg-4", { authType: "legacy", otp, userAgent: ciUserAgent }),
     ]);
-
-    const { out, err, exitCode } = await publish(env, publishDir);
-    expect(err).not.toContain("error:");
-    expect(err).not.toContain("warn:");
-    expect(out).toContain(`+ publish-pkg-${info.user}@1.1.1`);
     expect(exitCode).toBe(0);
-
-    await runBunInstall(env, packageDir);
-
-    const results = await Promise.all([
-      exists(join(packageDir, "node_modules", ".bin", isWindows ? "bin1.bunx" : "bin1")),
-      exists(join(packageDir, "node_modules", ".bin", isWindows ? "bin2.bunx" : "bin2")),
-      exists(join(packageDir, "node_modules", ".bin", isWindows ? "bin3.js.bunx" : "bin3.js")),
-      exists(join(packageDir, "node_modules", ".bin", isWindows ? "bin4.js.bunx" : "bin4.js")),
-      exists(join(packageDir, "node_modules", ".bin", isWindows ? "moredir" : "moredir/bin4.js")),
-      exists(
-        join(
-          packageDir,
-          "node_modules",
-          ".bin",
-          isWindows ? `publish-pkg-${info.user}.bunx` : "publish-pkg-" + info.user,
-        ),
-      ),
-    ]);
-
-    switch (info.user) {
-      case "bin1": {
-        expect(results).toEqual([false, false, false, false, false, true]);
-        break;
-      }
-      case "bin2": {
-        expect(results).toEqual([true, true, false, false, false, false]);
-        break;
-      }
-      case "bin3": {
-        expect(results).toEqual([false, false, true, true, !isWindows, false]);
-        break;
-      }
-    }
   });
-}
+});
 
-test("dependencies are installed", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const publishDir = tmpdirSync();
-  const bunfig = await registry.authBunfig("manydeps");
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-pkg-deps"), { recursive: true, force: true }),
-    write(
-      join(publishDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "publish-pkg-deps",
-          version: "1.1.1",
-          dependencies: {
-            "no-deps": "1.0.0",
-          },
-          peerDependencies: {
-            "a-dep": "1.0.1",
-          },
-          optionalDependencies: {
-            "basic-1": "1.0.0",
-          },
-        },
-        null,
-        2,
-      ),
-    ),
-    write(join(publishDir, "bunfig.toml"), bunfig),
-    write(
-      packageJson,
-      JSON.stringify({
-        name: "foo",
-        dependencies: {
-          "publish-pkg-deps": "1.1.1",
-        },
-      }),
-    ),
-  ]);
+test.concurrent("can publish a package then install it", async () => {
+  const pkg = { name: "publish-pkg-1", version: "1.1.1", dependencies: { "publish-pkg-1": "1.1.1" } };
+  using dir = await verdaccioPackage(pkg);
 
-  let { out, err, exitCode } = await publish(env, publishDir);
-  expect(err).not.toContain("error:");
-  expect(err).not.toContain("warn:");
-  expect(out).toContain("+ publish-pkg-deps@1.1.1");
+  const { out, err, exitCode } = await publish(env, String(dir));
+  expect(err).toBe("");
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 105B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 105B
+    Packed size: <size>
+    Tag: latest
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + publish-pkg-1@1.1.1"
+  `);
   expect(exitCode).toBe(0);
 
-  await runBunInstall(env, packageDir);
-
-  const results = await Promise.all([
-    exists(join(packageDir, "node_modules", "no-deps", "package.json")),
-    exists(join(packageDir, "node_modules", "a-dep", "package.json")),
-    exists(join(packageDir, "node_modules", "basic-1", "package.json")),
-  ]);
-
-  expect(results).toEqual([true, true, true]);
+  await runBunInstall(env, String(dir));
+  expect(await file(join(dir, "node_modules", "publish-pkg-1", "package.json")).json()).toEqual(pkg);
 });
 
-test("can publish workspace package", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const bunfig = await registry.authBunfig("workspace");
-  const pkgJson = {
-    name: "publish-pkg-3",
-    version: "3.3.3",
-    dependencies: {
-      "publish-pkg-3": "3.3.3",
+test.concurrent.each([
+  ["relative", "publish-pkg-2", () => "./publish-pkg-2-2.2.2.tgz"],
+  ["absolute", "publish-pkg-2-abs", (dir: string) => join(dir, "publish-pkg-2-abs-2.2.2.tgz")],
+])("can publish from a tarball (%s path)", async (_, name, tarballPath) => {
+  const pkg = { name, version: "2.2.2", dependencies: { [name]: "2.2.2" } };
+  using dir = await verdaccioPackage(pkg);
+
+  await pack(String(dir), env);
+
+  const { out, err, exitCode } = await publish(env, String(dir), tarballPath(String(dir)));
+  expect(err).toBe("");
+  expect(packedFiles(out)).toEqual(["package.json"]);
+  expect(out).toContain(
+    `\nTag: latest\nAccess: default\nRegistry: http://localhost:${registry.port}/\n\n + ${name}@2.2.2\n`,
+  );
+  expect(exitCode).toBe(0);
+
+  await runBunInstall(env, String(dir));
+  expect(await file(join(dir, "node_modules", name, "package.json")).json()).toEqual(pkg);
+});
+
+test.concurrent("can publish scoped packages", async () => {
+  const pkg = { name: "@scoped/pkg-1", version: "1.1.1", dependencies: { "@scoped/pkg-1": "1.1.1" } };
+  using dir = await verdaccioPackage(pkg);
+
+  const { out, err, exitCode } = await publish(env, String(dir));
+  expect(err).toBe("");
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 105B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 105B
+    Packed size: <size>
+    Tag: latest
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + @scoped/pkg-1@1.1.1"
+  `);
+  expect(exitCode).toBe(0);
+
+  await runBunInstall(env, String(dir));
+  expect(await file(join(dir, "node_modules", "@scoped", "pkg-1", "package.json")).json()).toEqual(pkg);
+});
+
+test.concurrent.each([
+  {
+    label: `"bin": "bin1.js"`,
+    name: "publish-pkg-bin1",
+    fields: { bin: "bin1.js" },
+    links: {
+      "bin1": false,
+      "bin2": false,
+      "bin3.js": false,
+      "bin4.js": false,
+      "moredir/bin4.js": false,
+      "publish-pkg-bin1": true,
     },
-  };
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-pkg-3"), { recursive: true, force: true }),
-    write(join(packageDir, "bunfig.toml"), bunfig),
-    write(
-      packageJson,
-      JSON.stringify({
-        name: "root",
-        workspaces: ["packages/*"],
-      }),
-    ),
-    write(join(packageDir, "packages", "publish-pkg-3", "package.json"), JSON.stringify(pkgJson)),
-  ]);
+  },
+  {
+    label: `"bin": { "bin1": "bin1.js", "bin2": "bin2.js" }`,
+    name: "publish-pkg-bin2",
+    fields: { bin: { bin1: "bin1.js", bin2: "bin2.js" } },
+    links: {
+      "bin1": true,
+      "bin2": true,
+      "bin3.js": false,
+      "bin4.js": false,
+      "moredir/bin4.js": false,
+      "publish-pkg-bin2": false,
+    },
+  },
+  {
+    label: `"directories": { "bin": "bins" }`,
+    name: "publish-pkg-bin3",
+    fields: { directories: { bin: "bins" } },
+    links: {
+      "bin1": false,
+      "bin2": false,
+      "bin3.js": true,
+      "bin4.js": true,
+      "moredir/bin4.js": !isWindows,
+      "publish-pkg-bin3": false,
+    },
+  },
+])("can publish and install binaries with $label", async ({ name, fields, links }) => {
+  const pkg = { name, version: "1.1.1", ...fields };
+  using publishDir = await verdaccioPackage(pkg, {
+    "bin1.js": `#!/usr/bin/env bun\nconsole.log("bin1!")`,
+    "bin2.js": `#!/usr/bin/env bun\nconsole.log("bin2!")`,
+    "bins/bin3.js": `#!/usr/bin/env bun\nconsole.log("bin3!")`,
+    "bins/moredir/bin4.js": `#!/usr/bin/env bun\nconsole.log("bin4!")`,
+  });
+  using dir = tempDir("publish-bins-consumer", {
+    "package.json": JSON.stringify({ name: "foo", dependencies: { [name]: "1.1.1" } }),
+    "bunfig.toml": verdaccioBunfig,
+  });
 
-  await publish(env, join(packageDir, "packages", "publish-pkg-3"));
+  const { out, err, exitCode } = await publish(env, String(publishDir));
+  expect(err).toBe("");
+  expect(packedFiles(out)).toEqual(["package.json", "bin1.js", "bin2.js", "bins/bin3.js", "bins/moredir/bin4.js"]);
+  expect(out).toContain(`\n + ${name}@1.1.1\n`);
+  expect(exitCode).toBe(0);
 
-  await write(packageJson, JSON.stringify({ name: "root", "dependencies": { "publish-pkg-3": "3.3.3" } }));
+  await runBunInstall(env, String(dir));
 
-  await runBunInstall(env, packageDir);
-
-  expect(await file(join(packageDir, "node_modules", "publish-pkg-3", "package.json")).json()).toEqual(pkgJson);
+  // Windows gets `.bunx` shims instead of symlinks.
+  const linked = (link: string) => exists(join(dir, "node_modules", ".bin", isWindows ? `${link}.bunx` : link));
+  expect({
+    "bin1": await linked("bin1"),
+    "bin2": await linked("bin2"),
+    "bin3.js": await linked("bin3.js"),
+    "bin4.js": await linked("bin4.js"),
+    "moredir/bin4.js": await exists(join(dir, "node_modules", ".bin", isWindows ? "moredir" : "moredir/bin4.js")),
+    [name]: await linked(name),
+  }).toEqual(links);
 });
 
-describe("--dry-run", async () => {
-  test("does not publish", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("dryrun");
-    await Promise.all([
-      rm(join(registry.packagesPath, "dry-run-1"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(
-        packageJson,
-        JSON.stringify({
-          name: "dry-run-1",
-          version: "1.1.1",
-          dependencies: {
-            "dry-run-1": "1.1.1",
-          },
-        }),
-      ),
-    ]);
+test.concurrent("dependencies are installed", async () => {
+  using publishDir = await verdaccioPackage({
+    name: "publish-pkg-deps",
+    version: "1.1.1",
+    dependencies: { "no-deps": "1.0.0" },
+    peerDependencies: { "a-dep": "1.0.1" },
+    optionalDependencies: { "basic-1": "1.0.0" },
+  });
+  using dir = tempDir("publish-deps-consumer", {
+    "package.json": JSON.stringify({ name: "foo", dependencies: { "publish-pkg-deps": "1.1.1" } }),
+    "bunfig.toml": verdaccioBunfig,
+  });
 
-    const { out, err, exitCode } = await publish(env, packageDir, "--dry-run");
+  const { out, err, exitCode } = await publish(env, String(publishDir));
+  expect(err).toBe("");
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 208B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 208B
+    Packed size: <size>
+    Tag: latest
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + publish-pkg-deps@1.1.1"
+  `);
+  expect(exitCode).toBe(0);
+
+  await runBunInstall(env, String(dir));
+
+  expect(
+    await Promise.all([
+      file(join(dir, "node_modules", "no-deps", "package.json")).json(),
+      file(join(dir, "node_modules", "a-dep", "package.json")).json(),
+      file(join(dir, "node_modules", "basic-1", "package.json")).json(),
+    ]),
+  ).toMatchObject([
+    { name: "no-deps", version: "1.0.0" },
+    { name: "a-dep", version: "1.0.1" },
+    { name: "basic-1", version: "1.0.0" },
+  ]);
+});
+
+test.concurrent("can publish workspace package", async () => {
+  const pkg = { name: "publish-pkg-3", version: "3.3.3", dependencies: { "publish-pkg-3": "3.3.3" } };
+  await rm(join(registry.packagesPath, pkg.name), { recursive: true, force: true });
+  using dir = tempDir("publish-workspace", {
+    "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+    "bunfig.toml": verdaccioBunfig,
+    "packages/publish-pkg-3/package.json": JSON.stringify(pkg),
+  });
+
+  const { out, err, exitCode } = await publish(env, join(dir, "packages", "publish-pkg-3"));
+  expect(err).toBe("");
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 105B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 105B
+    Packed size: <size>
+    Tag: latest
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + publish-pkg-3@3.3.3"
+  `);
+  expect(exitCode).toBe(0);
+
+  await write(join(dir, "package.json"), JSON.stringify({ name: "root", dependencies: { "publish-pkg-3": "3.3.3" } }));
+  await runBunInstall(env, String(dir));
+  expect(await file(join(dir, "node_modules", "publish-pkg-3", "package.json")).json()).toEqual(pkg);
+});
+
+describe.concurrent("--dry-run", () => {
+  test("does not publish", async () => {
+    using dir = await verdaccioPackage({ name: "dry-run-1", version: "1.1.1", dependencies: { "dry-run-1": "1.1.1" } });
+
+    const { out, err, exitCode } = await publish(env, String(dir), "--dry-run");
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 75B package.json
+
+      Total files: 1
+      Unpacked size: 75B
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + dry-run-1@1.1.1 (dry-run)"
+    `);
     expect(exitCode).toBe(0);
 
     expect(await exists(join(registry.packagesPath, "dry-run-1"))).toBeFalse();
   });
+
   test("does not publish from tarball path", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("dryruntarball");
-    await Promise.all([
-      rm(join(registry.packagesPath, "dry-run-2"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(
-        packageJson,
-        JSON.stringify({
-          name: "dry-run-2",
-          version: "2.2.2",
-          dependencies: {
-            "dry-run-2": "2.2.2",
-          },
-        }),
-      ),
-    ]);
+    using dir = await verdaccioPackage({ name: "dry-run-2", version: "2.2.2", dependencies: { "dry-run-2": "2.2.2" } });
 
-    await pack(packageDir, env);
+    await pack(String(dir), env);
 
-    const { out, err, exitCode } = await publish(env, packageDir, "./dry-run-2-2.2.2.tgz", "--dry-run");
+    const { out, err, exitCode } = await publish(env, String(dir), "./dry-run-2-2.2.2.tgz", "--dry-run");
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 97B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 97B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + dry-run-2@2.2.2 (dry-run)"
+    `);
     expect(exitCode).toBe(0);
 
     expect(await exists(join(registry.packagesPath, "dry-run-2"))).toBeFalse();
   });
+
   test("registry summary line does not print userinfo from the registry url", async () => {
-    const packageDir = tmpdirSync();
-    await write(join(packageDir, "package.json"), JSON.stringify({ name: "dry-run-3", version: "3.3.3" }));
+    using dir = tempDir("publish-dry-run-userinfo", {
+      "package.json": JSON.stringify({ name: "dry-run-3", version: "3.3.3" }),
+    });
 
     const { out, err, exitCode } = await publish(
       { ...env, npm_config_registry: "http://someuser:hunter2@127.0.0.1:1/" },
-      packageDir,
+      String(dir),
       "--dry-run",
     );
-    expect(out).toContain("Registry: http://127.0.0.1:1/\n");
-    expect(out).not.toContain("someuser");
-    expect(out).not.toContain("hunter2");
-    expect(err).not.toContain("hunter2");
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 38B package.json
+
+      Total files: 1
+      Unpacked size: 38B
+      Tag: latest
+      Access: default
+      Registry: http://127.0.0.1:1/
+
+       + dry-run-3@3.3.3 (dry-run)"
+    `);
     expect(exitCode).toBe(0);
   });
 });
 
 describe.concurrent("credentials in the registry url", () => {
-  // Records every request, so a test can assert exactly what `bun publish` sent (one authenticated PUT, or nothing).
-  function registryMock() {
-    const requests: { method: string; pathname: string; authorization: string | null }[] = [];
-    const server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        requests.push({
-          method: req.method,
-          pathname: new URL(req.url).pathname,
-          authorization: req.headers.get("authorization"),
-        });
-        return new Response("OK", { status: 200 });
-      },
-    });
-    return {
-      requests,
-      port: server.port,
-      [Symbol.dispose]: () => server.stop(true),
-    };
-  }
-
-  async function packageDirFor(name: string) {
-    const packageDir = tmpdirSync();
-    await write(join(packageDir, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
-    return packageDir;
-  }
-
   const basicAuth = `Basic ${Buffer.from("pubuser:hunter2").toString("base64")}`;
 
   test("--registry with user:pass@ publishes with Basic auth", async () => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("userinfo-flag-pkg");
+    using mock = mockRegistry();
+    const pkg = { name: "userinfo-flag-pkg", version: "1.0.0" };
+    using dir = tempDir("publish-userinfo-flag", { "package.json": JSON.stringify(pkg) });
 
     const { out, err, exitCode } = await publish(
       env,
-      packageDir,
+      String(dir),
       "--registry",
       `http://pubuser:hunter2@localhost:${mock.port}/`,
     );
-    expect(err).not.toContain("error:");
-    expect(out).toContain(`Registry: http://localhost:${mock.port}/\n`);
-    expect(out).toContain(" + userinfo-flag-pkg@1.0.0");
-    expect(out).not.toContain("hunter2");
-    expect(err).not.toContain("hunter2");
-    expect(mock.requests).toEqual([{ method: "PUT", pathname: "/userinfo-flag-pkg", authorization: basicAuth }]);
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 55B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 55B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + userinfo-flag-pkg@1.0.0"
+    `);
+    expect(mock.requests).toEqual([request("PUT", "/userinfo-flag-pkg", { authorization: basicAuth })]);
+    const tarball = await expectPublishedManifest(mock.requests[0].manifest, pkg, mock.port);
+    expect(tarball.files).toEqual(["package/package.json"]);
+    expect(out).toContain(printedChecksums(tarball));
     expect(exitCode).toBe(0);
   });
 
   test("--registry with :token@ publishes with a Bearer token", async () => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("userinfo-token-pkg");
+    using mock = mockRegistry();
+    using dir = tempDir("publish-userinfo-token", {
+      "package.json": JSON.stringify({ name: "userinfo-token-pkg", version: "1.0.0" }),
+    });
 
     const { out, err, exitCode } = await publish(
       env,
-      packageDir,
+      String(dir),
       "--registry",
       `http://:publish-token@localhost:${mock.port}/`,
     );
-    expect(err).not.toContain("error:");
-    expect(out).toContain(" + userinfo-token-pkg@1.0.0");
-    expect(out).not.toContain("publish-token");
-    expect(mock.requests).toEqual([
-      { method: "PUT", pathname: "/userinfo-token-pkg", authorization: "Bearer publish-token" },
-    ]);
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 56B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 56B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + userinfo-token-pkg@1.0.0"
+    `);
+    expect(mock.requests).toEqual([request("PUT", "/userinfo-token-pkg", { authorization: "Bearer publish-token" })]);
     expect(exitCode).toBe(0);
   });
 
   test.each(["npm_config_registry", "NPM_CONFIG_REGISTRY", "BUN_CONFIG_REGISTRY"])(
     "%s with user:pass@ publishes with Basic auth",
     async key => {
-      using mock = registryMock();
-      const packageDir = await packageDirFor("userinfo-env-pkg");
+      using mock = mockRegistry();
+      using dir = tempDir("publish-userinfo-env", {
+        "package.json": JSON.stringify({ name: "userinfo-env-pkg", version: "1.0.0" }),
+      });
 
       const { out, err, exitCode } = await publish(
         { ...env, [key]: `http://pubuser:hunter2@localhost:${mock.port}/` },
-        packageDir,
+        String(dir),
       );
-      expect(err).not.toContain("error:");
-      expect(out).toContain(`Registry: http://localhost:${mock.port}/\n`);
-      expect(out).toContain(" + userinfo-env-pkg@1.0.0");
-      expect(out).not.toContain("hunter2");
-      expect(err).not.toContain("hunter2");
-      expect(mock.requests).toEqual([{ method: "PUT", pathname: "/userinfo-env-pkg", authorization: basicAuth }]);
+      expect(err).toBe("");
+      expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+        "bun publish <version> (<revision>)
+
+        packed 54B package.json
+
+        Total files: 1
+        Shasum: <sha1>
+        Integrity: <sha512>
+        Unpacked size: 54B
+        Packed size: <size>
+        Tag: latest
+        Access: default
+        Registry: http://localhost:<port>/
+
+         + userinfo-env-pkg@1.0.0"
+      `);
+      expect(mock.requests).toEqual([request("PUT", "/userinfo-env-pkg", { authorization: basicAuth })]);
       expect(exitCode).toBe(0);
     },
   );
 
   test("no credentials at all fails before sending a request", async () => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("no-credentials-pkg");
+    using mock = mockRegistry();
+    using dir = tempDir("publish-no-credentials", {
+      "package.json": JSON.stringify({ name: "no-credentials-pkg", version: "1.0.0" }),
+    });
 
-    const { err, exitCode } = await publish(env, packageDir, "--registry", `http://localhost:${mock.port}/`);
+    const { out, err, exitCode } = await publish(env, String(dir), "--registry", `http://localhost:${mock.port}/`);
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 56B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 56B
+      Packed size: <size>"
+    `);
     expect(err).toBe("error: missing authentication (run `bunx npm login`)\n");
     expect(mock.requests).toEqual([]);
     expect(exitCode).toBe(1);
   });
 
   test("no credentials at all fails before sending a request (tarball path)", async () => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("no-credentials-tarball-pkg");
-    await pack(packageDir, env);
+    using mock = mockRegistry();
+    using dir = tempDir("publish-no-credentials-tarball", {
+      "package.json": JSON.stringify({ name: "no-credentials-tarball-pkg", version: "1.0.0" }),
+    });
+    await pack(String(dir), env);
 
-    const { err, exitCode } = await publish(
+    const { out, err, exitCode } = await publish(
       env,
-      packageDir,
+      String(dir),
       "./no-credentials-tarball-pkg-1.0.0.tgz",
       "--registry",
       `http://localhost:${mock.port}/`,
     );
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 64B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 64B
+      Packed size: <size>"
+    `);
     expect(err).toBe("error: missing authentication (run `bunx npm login`)\n");
     expect(mock.requests).toEqual([]);
     expect(exitCode).toBe(1);
   });
 });
 
-describe("lifecycle scripts", async () => {
-  const script = `const fs = require("fs");
-    fs.writeFileSync(process.argv[2] + ".txt", \`
-prepublishOnly: \${fs.existsSync("prepublishOnly.txt")}
-publish: \${fs.existsSync("publish.txt")}
-postpublish: \${fs.existsSync("postpublish.txt")}
-prepack: \${fs.existsSync("prepack.txt")}
-prepare: \${fs.existsSync("prepare.txt")}
-postpack: \${fs.existsSync("postpack.txt")}\`)`;
-  const json = {
-    name: "publish-pkg-4",
-    version: "4.4.4",
-    scripts: {
-      // should happen in this order
-      "prepublishOnly": `${bunExe()} script.js prepublishOnly`,
-      "prepack": `${bunExe()} script.js prepack`,
-      "prepare": `${bunExe()} script.js prepare`,
-      "postpack": `${bunExe()} script.js postpack`,
-      "publish": `${bunExe()} script.js publish`,
-      "postpublish": `${bunExe()} script.js postpublish`,
-    },
-    dependencies: {
-      "publish-pkg-4": "4.4.4",
-    },
-  };
+describe.concurrent("lifecycle scripts", () => {
+  // Each script appends its name, so `order.txt` records the order the scripts ran in.
+  const scripts = Object.fromEntries(
+    ["prepublishOnly", "prepack", "prepare", "postpack", "publish", "postpublish"].map(name => [
+      name,
+      `echo ${name} >> order.txt`,
+    ]),
+  );
 
-  for (const arg of [[], ["--dry-run"]]) {
-    test(`should run in order${arg.length > 0 ? " (--dry-run)" : ""}`, async () => {
-      const { packageDir, packageJson } = await registry.createTestDir();
-      const bunfig = await registry.authBunfig("lifecycle" + (arg.length > 0 ? "dry" : ""));
-      await Promise.all([
-        rm(join(registry.packagesPath, "publish-pkg-4"), { recursive: true, force: true }),
-        write(packageJson, JSON.stringify(json)),
-        write(join(packageDir, "script.js"), script),
-        write(join(packageDir, "bunfig.toml"), bunfig),
-      ]);
+  test.each([
+    ["", "publish-pkg-4", []],
+    [" (--dry-run)", "publish-pkg-4-dry", ["--dry-run"]],
+  ])("should run in order%s", async (_, name, args) => {
+    using dir = await verdaccioPackage({ name, version: "4.4.4", scripts, dependencies: { [name]: "4.4.4" } });
 
-      const { out, err, exitCode } = await publish(env, packageDir, ...arg);
-      expect(exitCode).toBe(0);
-
-      const results = await Promise.all([
-        file(join(packageDir, "prepublishOnly.txt")).text(),
-        file(join(packageDir, "prepack.txt")).text(),
-        file(join(packageDir, "prepare.txt")).text(),
-        file(join(packageDir, "postpack.txt")).text(),
-        file(join(packageDir, "publish.txt")).text(),
-        file(join(packageDir, "postpublish.txt")).text(),
-      ]);
-
-      expect(results).toEqual([
-        "\nprepublishOnly: false\npublish: false\npostpublish: false\nprepack: false\nprepare: false\npostpack: false",
-        "\nprepublishOnly: true\npublish: false\npostpublish: false\nprepack: false\nprepare: false\npostpack: false",
-        "\nprepublishOnly: true\npublish: false\npostpublish: false\nprepack: true\nprepare: false\npostpack: false",
-        "\nprepublishOnly: true\npublish: false\npostpublish: false\nprepack: true\nprepare: true\npostpack: false",
-        "\nprepublishOnly: true\npublish: false\npostpublish: false\nprepack: true\nprepare: true\npostpack: true",
-        "\nprepublishOnly: true\npublish: true\npostpublish: false\nprepack: true\nprepare: true\npostpack: true",
-      ]);
-    });
-  }
-
-  test("--ignore-scripts", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("ignorescripts");
-    await Promise.all([
-      rm(join(registry.packagesPath, "publish-pkg-5"), { recursive: true, force: true }),
-      write(packageJson, JSON.stringify(json)),
-      write(join(packageDir, "script.js"), script),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-    ]);
-
-    const { out, err, exitCode } = await publish(env, packageDir, "--ignore-scripts");
+    const { out, err, exitCode } = await publish(env, String(dir), ...args);
+    expect(err).toBe(
+      [
+        "$ echo prepublishOnly >> order.txt",
+        "$ echo prepack >> order.txt",
+        "$ echo prepare >> order.txt",
+        "$ echo postpack >> order.txt",
+        "$ echo publish >> order.txt",
+        "$ echo postpublish >> order.txt",
+        "",
+      ].join("\n"),
+    );
+    expect(out).toContain(`\n + ${name}@4.4.4${args.length ? " (dry-run)" : ""}\n`);
     expect(exitCode).toBe(0);
 
-    const results = await Promise.all([
-      exists(join(packageDir, "prepublishOnly.txt")),
-      exists(join(packageDir, "prepack.txt")),
-      exists(join(packageDir, "prepare.txt")),
-      exists(join(packageDir, "postpack.txt")),
-      exists(join(packageDir, "publish.txt")),
-      exists(join(packageDir, "postpublish.txt")),
-    ]);
+    expect(await file(join(dir, "order.txt")).text()).toBe(
+      "prepublishOnly\nprepack\nprepare\npostpack\npublish\npostpublish\n",
+    );
+  });
 
-    expect(results).toEqual([false, false, false, false, false, false]);
+  test("--ignore-scripts", async () => {
+    using dir = await verdaccioPackage({
+      name: "publish-pkg-5",
+      version: "4.4.4",
+      scripts,
+      dependencies: { "publish-pkg-5": "4.4.4" },
+    });
+
+    const { out, err, exitCode } = await publish(env, String(dir), "--ignore-scripts");
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 412B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 412B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + publish-pkg-5@4.4.4"
+    `);
+    expect(exitCode).toBe(0);
+
+    expect(await exists(join(dir, "order.txt"))).toBeFalse();
   });
 });
 
-test("prepublishOnly modifying version publishes correct version (#17195)", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const bunfig = await registry.authBunfig("version-update");
-  const updateScript = `const fs = require("fs");
+test.concurrent("prepublishOnly modifying version publishes correct version (#17195)", async () => {
+  using dir = await verdaccioPackage(
+    {
+      name: "publish-version-update",
+      version: "1.0.0",
+      scripts: { prepublishOnly: `${bunExe()} update-version.js` },
+      dependencies: { "publish-version-update": "9.9.9" },
+    },
+    {
+      "update-version.js": `const fs = require("fs");
     const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
     pkg.version = "9.9.9";
-    fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));`;
+    fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));`,
+    },
+  );
 
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-version-update"), { recursive: true, force: true }),
-    write(
-      packageJson,
-      JSON.stringify({
-        name: "publish-version-update",
-        version: "1.0.0",
-        scripts: {
-          prepublishOnly: `${bunExe()} update-version.js`,
-        },
-        dependencies: {
-          "publish-version-update": "9.9.9",
-        },
-      }),
-    ),
-    write(join(packageDir, "update-version.js"), updateScript),
-    write(join(packageDir, "bunfig.toml"), bunfig),
-  ]);
-
-  const { out, err, exitCode } = await publish(env, packageDir);
-  expect(err).not.toContain("error:");
+  const { out, err, exitCode } = await publish(env, String(dir));
+  expect(err).toBe(`$ ${bunExe()} update-version.js\n`);
+  // the package.json size depends on the path in the prepublishOnly script, so no snapshot here
+  expect(packedFiles(out)).toEqual(["package.json", "update-version.js"]);
+  expect(out).toContain(`\n + publish-version-update@9.9.9\n`);
   expect(exitCode).toBe(0);
 
   // Should be able to install the package at the UPDATED version (9.9.9), not the original (1.0.0)
-  await runBunInstall(env, packageDir);
-  const installedPkg = await file(join(packageDir, "node_modules", "publish-version-update", "package.json")).json();
+  await runBunInstall(env, String(dir));
+  const installedPkg = await file(join(dir, "node_modules", "publish-version-update", "package.json")).json();
   expect(installedPkg.version).toBe("9.9.9");
 });
 
-test("attempting to publish a private package should fail", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  const bunfig = await registry.authBunfig("privatepackage");
-  await Promise.all([
-    rm(join(registry.packagesPath, "publish-pkg-6"), { recursive: true, force: true }),
-    write(
-      packageJson,
-      JSON.stringify({
-        name: "publish-pkg-6",
-        version: "6.6.6",
-        private: true,
-        dependencies: {
-          "publish-pkg-6": "6.6.6",
-        },
-      }),
-    ),
-    write(join(packageDir, "bunfig.toml"), bunfig),
-  ]);
+test.concurrent("attempting to publish a private package should fail", async () => {
+  using dir = await verdaccioPackage({
+    name: "publish-pkg-6",
+    version: "6.6.6",
+    private: true,
+    dependencies: { "publish-pkg-6": "6.6.6" },
+  });
 
   // should fail
-  let { out, err, exitCode } = await publish(env, packageDir);
+  let { out, err, exitCode } = await publish(env, String(dir));
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`"bun publish <version> (<revision>)"`);
+  expect(err).toBe("error: attempted to publish a private package\n");
   expect(exitCode).toBe(1);
-  expect(err).toContain("error: attempted to publish a private package");
-  expect(await exists(join(registry.packagesPath, "publish-pkg-6-6.6.6.tgz"))).toBeFalse();
+  expect(await exists(join(registry.packagesPath, "publish-pkg-6"))).toBeFalse();
 
   // try tarball
-  await pack(packageDir, env);
-  ({ out, err, exitCode } = await publish(env, packageDir, "./publish-pkg-6-6.6.6.tgz"));
+  await pack(String(dir), env);
+  ({ out, err, exitCode } = await publish(env, String(dir), "./publish-pkg-6-6.6.6.tgz"));
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 124B package.json"
+  `);
+  expect(err).toBe("error: attempted to publish a private package\n");
   expect(exitCode).toBe(1);
-  expect(err).toContain("error: attempted to publish a private package");
-  expect(await exists(join(packageDir, "publish-pkg-6-6.6.6.tgz"))).toBeTrue();
+  expect(await exists(join(registry.packagesPath, "publish-pkg-6"))).toBeFalse();
+  expect(await exists(join(dir, "publish-pkg-6-6.6.6.tgz"))).toBeTrue();
 });
 
-describe("access", async () => {
+describe.concurrent("access", () => {
   test("--access", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("accessflag");
-    await Promise.all([
-      rm(join(registry.packagesPath, "publish-pkg-7"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(
-        packageJson,
-        JSON.stringify({
-          name: "publish-pkg-7",
-          version: "7.7.7",
-        }),
-      ),
-    ]);
+    using dir = await verdaccioPackage({ name: "publish-pkg-7", version: "7.7.7" });
 
     // should fail
-    let { out, err, exitCode } = await publish(env, packageDir, "--access", "restricted");
+    let { out, err, exitCode } = await publish(env, String(dir), "--access", "restricted");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`"bun publish <version> (<revision>)"`);
+    expect(err).toBe("error: unable to restrict access to unscoped package\n");
     expect(exitCode).toBe(1);
-    expect(err).toContain("error: unable to restrict access to unscoped package");
+    expect(await exists(join(registry.packagesPath, "publish-pkg-7"))).toBeFalse();
 
-    ({ out, err, exitCode } = await publish(env, packageDir, "--access", "public"));
+    ({ out, err, exitCode } = await publish(env, String(dir), "--access", "public"));
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 51B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 51B
+      Packed size: <size>
+      Tag: latest
+      Access: public
+      Registry: http://localhost:<port>/
+
+       + publish-pkg-7@7.7.7"
+    `);
     expect(exitCode).toBe(0);
 
     expect(await exists(join(registry.packagesPath, "publish-pkg-7"))).toBeTrue();
   });
 
-  for (const access of ["restricted", "public"]) {
-    test(`access ${access}`, async () => {
-      const { packageDir, packageJson } = await registry.createTestDir();
-      const bunfig = await registry.authBunfig("access" + access);
+  test.each(["restricted", "public"])("access %s", async access => {
+    const name = `@secret/publish-pkg-8-${access}`;
+    const pkg = { name, version: "8.8.8", dependencies: { [name]: "8.8.8" }, publishConfig: { access } };
+    using dir = await verdaccioPackage(pkg);
 
-      const pkgJson = {
-        name: "@secret/publish-pkg-8",
-        version: "8.8.8",
-        dependencies: {
-          "@secret/publish-pkg-8": "8.8.8",
-        },
-        publishConfig: {
-          access,
-        },
-      };
-
-      await Promise.all([
-        rm(join(registry.packagesPath, "@secret", "publish-pkg-8"), { recursive: true, force: true }),
-        write(join(packageDir, "bunfig.toml"), bunfig),
-        write(packageJson, JSON.stringify(pkgJson)),
-      ]);
-
-      let { out, err, exitCode } = await publish(env, packageDir);
-      expect(exitCode).toBe(0);
-
-      await runBunInstall(env, packageDir);
-
-      expect(await file(join(packageDir, "node_modules", "@secret", "publish-pkg-8", "package.json")).json()).toEqual(
-        pkgJson,
-      );
-    });
-  }
-});
-
-describe("tag", async () => {
-  test("can publish with a tag", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("simpletag");
-    const pkgJson = {
-      name: "publish-pkg-9",
-      version: "9.9.9",
-      dependencies: {
-        "publish-pkg-9": "simpletag",
-      },
-    };
-    await Promise.all([
-      rm(join(registry.packagesPath, "publish-pkg-9"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(packageJson, JSON.stringify(pkgJson)),
-    ]);
-
-    let { out, err, exitCode } = await publish(env, packageDir, "--tag", "simpletag");
+    const { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe("");
+    expect(out).toContain(
+      `\nTag: latest\nAccess: ${access}\nRegistry: http://localhost:${registry.port}/\n\n + ${name}@8.8.8\n`,
+    );
     expect(exitCode).toBe(0);
 
-    await runBunInstall(env, packageDir);
-    expect(await file(join(packageDir, "node_modules", "publish-pkg-9", "package.json")).json()).toEqual(pkgJson);
+    await runBunInstall(env, String(dir));
+    expect(await file(join(dir, "node_modules", name, "package.json")).json()).toEqual(pkg);
   });
 });
 
-it("$npm_command is accurate during publish", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  await write(
-    packageJson,
-    JSON.stringify({
-      name: "publish-pkg-10",
-      version: "1.0.0",
-      scripts: {
-        publish: "echo $npm_command",
-      },
-    }),
-  );
-  await write(join(packageDir, "bunfig.toml"), await registry.authBunfig("npm_command"));
-  await rm(join(registry.packagesPath, "publish-pkg-10"), { recursive: true, force: true });
-  let { out, err, exitCode } = await publish(env, packageDir, "--tag", "simpletag");
+describe.concurrent("tag", () => {
+  test("can publish with a tag", async () => {
+    const pkg = { name: "publish-pkg-9", version: "9.9.9", dependencies: { "publish-pkg-9": "simpletag" } };
+    using dir = await verdaccioPackage(pkg);
+
+    const { out, err, exitCode } = await publish(env, String(dir), "--tag", "simpletag");
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 109B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 109B
+      Packed size: <size>
+      Tag: simpletag
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + publish-pkg-9@9.9.9"
+    `);
+    expect(exitCode).toBe(0);
+
+    await runBunInstall(env, String(dir));
+    expect(await file(join(dir, "node_modules", "publish-pkg-9", "package.json")).json()).toEqual(pkg);
+  });
+});
+
+test.concurrent("$npm_command is accurate during publish", async () => {
+  using dir = await verdaccioPackage({
+    name: "publish-pkg-10",
+    version: "1.0.0",
+    scripts: { publish: "echo $npm_command" },
+  });
+
+  const { out, err, exitCode } = await publish(env, String(dir), "--tag", "simpletag");
   expect(err).toBe(`$ echo $npm_command\n`);
-  expect(out.split("\n")).toEqual([
-    `bun publish ${Bun.version_with_sha}`,
-    ``,
-    `packed 107B package.json`,
-    ``,
-    `Total files: 1`,
-    expect.stringContaining(`Shasum: `),
-    expect.stringContaining(`Integrity: sha512-`),
-    `Unpacked size: 107B`,
-    expect.stringContaining(`Packed size: `),
-    `Tag: simpletag`,
-    `Access: default`,
-    `Registry: http://localhost:${registry.port}/`,
-    ``,
-    ` + publish-pkg-10@1.0.0`,
-    `publish`,
-    ``,
-  ]);
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 107B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 107B
+    Packed size: <size>
+    Tag: simpletag
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + publish-pkg-10@1.0.0
+    publish"
+  `);
   expect(exitCode).toBe(0);
 });
 
-it("$npm_lifecycle_event is accurate during publish", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  await write(
-    packageJson,
-    `{
+test.concurrent("$npm_lifecycle_event is accurate during publish", async () => {
+  await rm(join(registry.packagesPath, "publish-pkg-11"), { recursive: true, force: true });
+  using dir = tempDir("publish-lifecycle-event", {
+    "package.json": `{
       "name": "publish-pkg-11",
       "version": "1.0.0",
       "scripts": {
@@ -1216,220 +1346,256 @@ it("$npm_lifecycle_event is accurate during publish", async () => {
       },
     }
     `,
-  );
-  await write(join(packageDir, "bunfig.toml"), await registry.authBunfig("npm_lifecycle_event"));
-  await rm(join(registry.packagesPath, "publish-pkg-11"), { recursive: true, force: true });
-  let { out, err, exitCode } = await publish(env, packageDir, "--tag", "simpletag");
+    "bunfig.toml": verdaccioBunfig,
+  });
+
+  const { out, err, exitCode } = await publish(env, String(dir), "--tag", "simpletag");
   expect(err).toBe(`$ echo 2 $npm_lifecycle_event\n$ echo 3 $npm_lifecycle_event\n`);
-  expect(out.split("\n")).toEqual([
-    `bun publish ${Bun.version_with_sha}`,
-    ``,
-    `packed 256B package.json`,
-    ``,
-    `Total files: 1`,
-    expect.stringContaining(`Shasum: `),
-    expect.stringContaining(`Integrity: sha512-`),
-    `Unpacked size: 256B`,
-    expect.stringContaining(`Packed size: `),
-    `Tag: simpletag`,
-    `Access: default`,
-    `Registry: http://localhost:${registry.port}/`,
-    ``,
-    ` + publish-pkg-11@1.0.0`,
-    `2 publish`,
-    `3 postpublish`,
-    ``,
-  ]);
+  expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 256B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 256B
+    Packed size: <size>
+    Tag: simpletag
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + publish-pkg-11@1.0.0
+    2 publish
+    3 postpublish"
+  `);
   expect(exitCode).toBe(0);
 });
 
-describe("readme", () => {
+describe.concurrent("readme", () => {
   // Regression for https://github.com/oven-sh/bun/issues/30255 — `bun publish`
   // packed the README into the tarball but never populated the version-level
   // `readme` / `readmeFilename` fields, so the registry stored an empty readme.
 
   test("workspace publish sends README contents as readme / readmeFilename", async () => {
-    let captured: any = null;
-    using mock = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        if (req.method === "PUT") captured = await req.json();
-        return new Response("OK", { status: 200 });
-      },
-    });
-
-    const packageDir = tmpdirSync();
+    using mock = mockRegistry();
+    const pkg = { name: "readme-pkg-1", version: "1.0.0" };
     const readmeContents = "# readme-pkg-1\n\nA readme.";
-    await Promise.all([
-      write(
-        join(packageDir, "bunfig.toml"),
-        Bun.TOML.stringify({
-          install: {
-            cache: false,
-            registry: { url: `http://localhost:${mock.port}`, token: "unused" },
-          },
-        }),
-      ),
-      write(join(packageDir, "package.json"), JSON.stringify({ name: "readme-pkg-1", version: "1.0.0" })),
-      write(join(packageDir, "README.md"), readmeContents),
-    ]);
-
-    const { err, exitCode } = await publish(env, packageDir);
-    expect(err).not.toContain("error:");
-    expect(exitCode).toBe(0);
-
-    expect(captured.versions["1.0.0"]).toMatchObject({
-      readme: readmeContents,
-      readmeFilename: "README.md",
+    using dir = tempDir("publish-readme", {
+      "package.json": JSON.stringify(pkg),
+      "README.md": readmeContents,
+      "bunfig.toml": mockBunfig(mock),
     });
+
+    const { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 50B package.json
+      packed 25B README.md
+
+      Total files: 2
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 75B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + readme-pkg-1@1.0.0"
+    `);
+    expect(mock.requests).toEqual([request("PUT", "/readme-pkg-1")]);
+    const tarball = await expectPublishedManifest(mock.requests[0].manifest, pkg, mock.port, {
+      versionFields: { readme: readmeContents, readmeFilename: "README.md" },
+    });
+    expect(tarball.files).toEqual(["package/README.md", "package/package.json"]);
+    expect(exitCode).toBe(0);
   });
 
   test("tarball publish sends README contents from inside the archive", async () => {
-    let captured: any = null;
-    using mock = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        if (req.method === "PUT") captured = await req.json();
-        return new Response("OK", { status: 200 });
-      },
-    });
-
-    const packageDir = tmpdirSync();
+    using mock = mockRegistry();
+    const pkg = { name: "readme-pkg-2", version: "2.0.0" };
     const readmeContents = "# readme-pkg-2\n\nFrom inside the tarball.";
-    await Promise.all([
-      write(join(packageDir, "package.json"), JSON.stringify({ name: "readme-pkg-2", version: "2.0.0" })),
-      write(join(packageDir, "README.md"), readmeContents),
-    ]);
-
-    await pack(packageDir, env);
-    await write(
-      join(packageDir, "bunfig.toml"),
-      Bun.TOML.stringify({
-        install: {
-          cache: false,
-          registry: { url: `http://localhost:${mock.port}`, token: "unused" },
-        },
-      }),
-    );
-
-    const { err, exitCode } = await publish(env, packageDir, "./readme-pkg-2-2.0.0.tgz");
-    expect(err).not.toContain("error:");
-    expect(exitCode).toBe(0);
-
-    expect(captured.versions["2.0.0"]).toMatchObject({
-      readme: readmeContents,
-      readmeFilename: "README.md",
+    using dir = tempDir("publish-readme-tarball", {
+      "package.json": JSON.stringify(pkg),
+      "README.md": readmeContents,
     });
+
+    await pack(String(dir), env);
+    await write(join(dir, "bunfig.toml"), mockBunfig(mock));
+
+    const { out, err, exitCode } = await publish(env, String(dir), "./readme-pkg-2-2.0.0.tgz");
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 50B package.json
+      packed 40B README.md
+
+      Total files: 2
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 90B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + readme-pkg-2@2.0.0"
+    `);
+    expect(mock.requests).toEqual([request("PUT", "/readme-pkg-2")]);
+    const tarball = await expectPublishedManifest(mock.requests[0].manifest, pkg, mock.port, {
+      versionFields: { readme: readmeContents, readmeFilename: "README.md" },
+    });
+    expect(tarball.files).toEqual(["package/README.md", "package/package.json"]);
+    expect(exitCode).toBe(0);
   });
 });
 
-test("dist.tarball in the published manifest does not include userinfo from the registry url", async () => {
-  let captured: any = null;
-  using mock = Bun.serve({
-    port: 0,
-    async fetch(req) {
-      if (req.method === "PUT") captured = await req.json();
-      return new Response("OK", { status: 200 });
-    },
-  });
-
-  const packageDir = tmpdirSync();
-  await write(join(packageDir, "package.json"), JSON.stringify({ name: "tarball-url-pkg", version: "1.0.0" }));
+test.concurrent("dist.tarball in the published manifest does not include userinfo from the registry url", async () => {
+  using mock = mockRegistry();
+  const pkg = { name: "tarball-url-pkg", version: "1.0.0" };
+  using dir = tempDir("publish-tarball-url", { "package.json": JSON.stringify(pkg) });
 
   const { out, err, exitCode } = await publish(
     env,
-    packageDir,
+    String(dir),
     "--registry",
     `http://pubuser:hunter2@localhost:${mock.port}/`,
   );
-  expect(err).not.toContain("error:");
-  expect(out).toContain(" + tarball-url-pkg@1.0.0");
-  const tarball: string = captured.versions["1.0.0"].dist.tarball;
-  expect(tarball).not.toContain("pubuser");
-  expect(tarball).not.toContain("hunter2");
-  expect(tarball).not.toContain("@");
-  expect(tarball).toBe(`http://localhost:${mock.port}/tarball-url-pkg/-/tarball-url-pkg-1.0.0.tgz`);
+  expect(err).toBe("");
+  expect(normalizePublishOutput(out, mock.port)).toMatchInlineSnapshot(`
+    "bun publish <version> (<revision>)
+
+    packed 53B package.json
+
+    Total files: 1
+    Shasum: <sha1>
+    Integrity: <sha512>
+    Unpacked size: 53B
+    Packed size: <size>
+    Tag: latest
+    Access: default
+    Registry: http://localhost:<port>/
+
+     + tarball-url-pkg@1.0.0"
+  `);
+  expect(mock.requests).toEqual([
+    request("PUT", "/tarball-url-pkg", {
+      authorization: `Basic ${Buffer.from("pubuser:hunter2").toString("base64")}`,
+    }),
+  ]);
+  // `expectPublishedManifest` checks `dist.tarball` against the registry url without the userinfo
+  await expectPublishedManifest(mock.requests[0].manifest, pkg, mock.port);
+  expect(JSON.stringify(mock.requests[0].manifest)).not.toContain("hunter2");
   expect(exitCode).toBe(0);
 });
 
-describe("--tolerate-republish", async () => {
+describe.concurrent("--tolerate-republish", () => {
   test("republishing normally fails", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("republish-fail");
-    const pkgJson = {
-      name: "republish-test-1",
-      version: "1.0.0",
-    };
-
-    await Promise.all([
-      rm(join(registry.packagesPath, "republish-test-1"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(packageJson, JSON.stringify(pkgJson)),
-    ]);
+    using dir = await verdaccioPackage({ name: "republish-test-1", version: "1.0.0" });
 
     // First publish should succeed
-    let { out, err, exitCode } = await publish(env, packageDir);
+    let { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe("");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 54B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 54B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/
+
+       + republish-test-1@1.0.0"
+    `);
     expect(exitCode).toBe(0);
-    expect(out).toContain("+ republish-test-1@1.0.0");
 
     // Second publish should fail
-    ({ out, err, exitCode } = await publish(env, packageDir));
+    ({ out, err, exitCode } = await publish(env, String(dir)));
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 54B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 54B
+      Packed size: <size>
+      Tag: latest
+      Access: default
+      Registry: http://localhost:<port>/"
+    `);
+    expect(err).toBe(
+      `\n409 Conflict: http://localhost:${registry.port}/republish-test-1\n\n - this package is already present\n`,
+    );
     expect(exitCode).toBe(1);
-    expect(err).toMatch(/403|409|already exists|already present|cannot publish/);
   });
 
   test("republishing with --tolerate-republish skips when version exists", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("republish-tolerate");
-    const pkgJson = {
-      name: "republish-test-2",
-      version: "1.0.0",
-    };
-
-    await Promise.all([
-      rm(join(registry.packagesPath, "republish-test-2"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(packageJson, JSON.stringify(pkgJson)),
-    ]);
+    using dir = await verdaccioPackage({ name: "republish-test-2", version: "1.0.0" });
 
     // First publish should succeed
-    let { out, err, exitCode } = await publish(env, packageDir);
+    let { out, err, exitCode } = await publish(env, String(dir));
+    expect(err).toBe("");
+    expect(out).toContain(" + republish-test-2@1.0.0\n");
     expect(exitCode).toBe(0);
-    expect(out).toContain("+ republish-test-2@1.0.0");
 
     // Second publish with --tolerate-republish should skip
-    ({ out, err, exitCode } = await publish(env, packageDir, "--tolerate-republish"));
-    expect(exitCode).toBe(0);
+    ({ out, err, exitCode } = await publish(env, String(dir), "--tolerate-republish"));
     expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n");
-    expect(err).not.toContain("error:");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 54B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 54B
+      Packed size: <size>
+
+       + republish-test-2@1.0.0"
+    `);
+    expect(exitCode).toBe(0);
   });
 
   test("republishing tarball with --tolerate-republish skips when version exists", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir();
-    const bunfig = await registry.authBunfig("republish-tarball");
-    const pkgJson = {
-      name: "republish-test-3",
-      version: "1.0.0",
-    };
-
-    await Promise.all([
-      rm(join(registry.packagesPath, "republish-test-3"), { recursive: true, force: true }),
-      write(join(packageDir, "bunfig.toml"), bunfig),
-      write(packageJson, JSON.stringify(pkgJson)),
-    ]);
+    using dir = await verdaccioPackage({ name: "republish-test-3", version: "1.0.0" });
 
     // Create tarball
-    await pack(packageDir, env);
+    await pack(String(dir), env);
 
     // First publish should succeed
-    let { out, err, exitCode } = await publish(env, packageDir, "./republish-test-3-1.0.0.tgz");
+    let { out, err, exitCode } = await publish(env, String(dir), "./republish-test-3-1.0.0.tgz");
+    expect(err).toBe("");
+    expect(out).toContain(" + republish-test-3@1.0.0\n");
     expect(exitCode).toBe(0);
-    expect(out).toContain("+ republish-test-3@1.0.0");
 
     // Second publish with --tolerate-republish should skip
-    ({ out, err, exitCode } = await publish(env, packageDir, "./republish-test-3-1.0.0.tgz", "--tolerate-republish"));
-    expect(exitCode).toBe(0);
+    ({ out, err, exitCode } = await publish(env, String(dir), "./republish-test-3-1.0.0.tgz", "--tolerate-republish"));
     expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n");
-    expect(err).not.toContain("error:");
+    expect(normalizePublishOutput(out, registry.port)).toMatchInlineSnapshot(`
+      "bun publish <version> (<revision>)
+
+      packed 54B package.json
+
+      Total files: 1
+      Shasum: <sha1>
+      Integrity: <sha512>
+      Unpacked size: 54B
+      Packed size: <size>
+
+       + republish-test-3@1.0.0"
+    `);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Stacked on #40219. Merge that first. GitHub retargets this PR to `main` when the base branch is deleted.

### Problem
- The 46 cases of `test/cli/install/bun-publish.test.ts` ran one after another. Each one called `registry.createTestDir()` and `registry.generateUser()` before it spawned `bun publish`, so each paid for a registry round trip and a new verdaccio user. Locally (`bun bd test`) the file took 20 s.
- Most assertions were weak: `expect(exitCode).toBe(0)` alone, `not.toContain("error:")`, or a few `toContain` checks. The workspace case did not check the exit code. The `--ignore-scripts` case published `publish-pkg-4` but removed `publish-pkg-5` from the registry storage, so it failed with a 409 when run on its own after the lifecycle case.

### Fix
- All cases run concurrently. Each case owns a `tempDir` and a unique package name. The verdaccio cases share one token from `beforeAll` (#40219 makes `createTestDir()` safe next to them). The OTP cases use the mock registry only. The lifecycle cases append to one `order.txt` with shell `echo` instead of spawning `bun script.js` six times. "can publish from a tarball" is split into a relative and an absolute path case: 47 cases, was 46.
- The mock registry records every request. Cases compare the request list (method, path, authorization, npm-auth-type, npm-otp, user-agent) and the full PUT manifest with `toEqual`. The tarball in `_attachments` is decoded: its file list, sha1 and sha512 must match `dist` and the printed summary. stdout is an inline snapshot in 38 places, stderr is compared exactly everywhere.
- Verified: `bun bd test test/cli/install/bun-publish.test.ts`, 47 pass, five runs in a row. Local: 20.05 s before, 6.0 to 6.4 s after. CI: a modified test file runs first in its shard and pays the cold start of the machine, so compare PR builds that modified this file. asan 22.4 to 25.2 s before, 18.1 and 14.0 s after. windows x64 7.6 to 8.4 s before, 6.0 and 5.8 s after. The table is in the notes.

### Background
- `VerdaccioRegistry` (test/harness.ts) forks a verdaccio registry per file. Published packages land in `test/cli/install/registry/packages`, so each case removes its own package from there first. The names are covered by the `.gitignore` in that directory.
- The OTP flow: the registry answers the first PUT with 401 and `www-authenticate: OTP` (or a body that mentions "one-time password"). `bun publish` polls the `doneUrl` for a token and repeats the PUT with `npm-otp` and `npm-auth-type: legacy`.
- `scripts/runner.node.mjs` runs the test files a PR modified first in their shard. The first file on a fresh machine pays for the cold disk cache, and this file also starts verdaccio under the lane's bun, which is the debug build on the asan lane.

<details><summary>Notes</summary>

CI durations of this file (from the job logs, `Ran N tests across 1 file`):

| lane | old file, not modified, ran 9th or later (builds 103933, 104185, 104187, 104190, 104193, 104195) | old file, modified, ran first (builds 97133, 100321, 101544) | new file, modified, ran first (builds 104115, 104208) |
| --- | --- | --- | --- |
| linux x64 asan | 14.9 to 17.0 s | 25.2, 23.6, 22.4 s | 18.1, 14.0 s |
| windows x64 | 2.4 to 3.4 s | 8.4, 7.6, 7.7 s | 6.0, 5.8 s |
| linux x64 | 6.3 to 10.6 s | 9.2, 7.9, 10.1 s | 7.8, 7.9 s |
| linux aarch64 | 7.0 to 8.9 s | 5.6, 4.2, 8.1 s | 5.8, 5.9 s |
| darwin aarch64 | 1.3 s | 3.9, 4.9 s | 1.3, 2.7 s |

The three "modified" baseline builds come from #38704, #38813 and #39724, which each add a case to this file (42 to 48 cases). The asan lane starts verdaccio under the ASAN build: locally that takes 33 s before the first case runs, in CI about 5 s warm and more when the machine is cold.

Local CI-like run (`CI=1`, which makes the harness run verdaccio under the debug build, with `--timeout=270000` like the asan lane, pinned to 8 cpus like the r7i.2xlarge runner): old file 73.7 s, new file 52.1 s at the default ASAN concurrency of 5, 57.1 s at 2, 64.8 s at 1. With the release build pinned to 4 cpus: old 2.25 s, new 1.16 s. On a 16 vCPU Windows machine with the canary build: old 3.1 s, new 1.16 s, and 2.45 s against 1.45 s when pinned to 4 cpus like the Azure D4ds_v6 runner. So the concurrency does not hurt the small CI runners.

Assertion changes, case by case:

- OTP cases: the exact request sequence `PUT` (401) -> `GET /done` -> `PUT` with `npm-otp` and `npm-auth-type: legacy`, with the Bearer token on every request. The `/auth` url is never requested (it would show up in the list). The first and the retried PUT carry the same manifest. "otp failure": stderr is exactly the 401 line plus ` - Received invalid OTP`. "npm-notice": stderr is exactly the `note:` line, or empty with `x-local-cache`. CI user agent: the exact `user-agent` value on all three requests. "different origin": the foreign server recorded zero requests, the local registry got no `/done` poll, the prompt line is in the output. Opener: the two PUTs, the marker file content, the packed file list, the auth box in the output.
- Credentials cases: the exact request with `Basic`/`Bearer` authorization, plus the full manifest and `Shasum`/`Integrity` lines for the Basic auth case. Output snapshots show the summary stops at `Packed size` when no credentials exist.
- Verdaccio cases: stderr `toBe("")`, output snapshot (checksums, gzip size and port normalized), and the installed `package.json` compared with `toEqual` to the published one (publish then install, tarball, scoped, access, tag). The deps case checks name and version of `no-deps`, `a-dep`, `basic-1`. The bins case checks the packed file list and the `.bin` links as one object.
- Lifecycle: `order.txt` holds `prepublishOnly prepack prepare postpack publish postpublish`, and stderr lists the six `$ echo ...` lines in that order. `--ignore-scripts`: `order.txt` does not exist.
- Errors compared exactly: `error: attempted to publish a private package`, `error: unable to restrict access to unscoped package`, `error: missing authentication (run \`bunx npm login\`)`, the verdaccio `409 Conflict` with ` - this package is already present`, and the `--tolerate-republish` warning.
- `--dry-run`: the snapshot shows the directory dry run prints no checksums (no tarball is built) while the tarball dry run does.
- Removed: `not.toContain("error:")`, `not.toContain("warn:")`, and `expect.unreachable` inside a `Bun.serve` fetch handler (a throw there only produces a 500).

Snapshot stability: the `packed <size> package.json` and `Unpacked size` lines come from `JSON.stringify` of literal objects. Two cases where a size depends on a machine path (the prepublishOnly script contains `bunExe()`, the fake `xdg-open` scripts contain the temp dir) assert the packed file list instead. Checksums, gzip size and the port are normalized. The auth box border width follows the url length, so it is normalized too.

Also ran: `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-publish.test.ts` (bun 1.4.0): 47 pass in 1.4 s.

Open PRs that add cases to this file and will need a rebase: #39403 (the install fold), #38776, #36556, #38322, #38753, #38704, #38813, #38788, #38720, #39063, #39724, #35667. With #40219 in, an appended case in the old style (`createTestDir()` plus `generateUser()`) keeps working next to the concurrent cases. It is still better to express new cases with `verdaccioPackage()`, `mockRegistry()` and `request()`. #36556 changes the behavior that "done url on a different origin is not polled" pins, so that case needs an update in whichever PR lands second.
</details>
