### PR TITLE
fs.watch/fs.watchFile: remove unsafe from the watcher modules

### DIFF
--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -73,7 +73,55 @@ pub trait AbortListener {
     fn on_abort(&mut self, reason: JSValue);
 }
 
+/// Abort callback for [`AbortSignal::subscribe`]: runs on the JS thread when
+/// the signal aborts, and may re-enter the subscriber (hence `&self`).
+pub trait OnAbort {
+    fn on_abort(&self, reason: JSValue);
+}
+
+/// A native listener registered on a JS `AbortSignal` by
+/// [`AbortSignal::subscribe`]. Holds its own ref on the signal and removes the
+/// listener when dropped, so the subscriber it points back to only has to keep
+/// this value for as long as it lives at that address.
+pub struct AbortSubscription {
+    signal: AbortSignalRef,
+    ctx: *mut c_void,
+}
+
+impl AbortSubscription {
+    /// The signal this listener is registered on.
+    #[inline]
+    pub fn signal(&self) -> &AbortSignal {
+        &self.signal
+    }
+}
+
+impl Drop for AbortSubscription {
+    fn drop(&mut self) {
+        self.signal.clean_native_bindings(self.ctx);
+    }
+}
+
 impl AbortSignal {
+    /// Call `subscriber.on_abort(reason)` when this signal aborts, until the
+    /// returned subscription is dropped. `subscriber` is the holder of the
+    /// subscription (the [`BackRef`](bun_ptr::BackRef) obligation): it must
+    /// drop it before it moves or goes away.
+    pub fn subscribe<C: OnAbort>(&self, subscriber: bun_ptr::BackRef<C>) -> AbortSubscription {
+        extern "C" fn callback<C: OnAbort>(ptr: *mut c_void, reason: JSValue) {
+            // SAFETY: `ptr` is the `BackRef<C>` registered below; the
+            // `AbortSubscription` its pointee holds unregisters this callback
+            // before the pointee goes away, so it is live here (JS thread).
+            C::on_abort(unsafe { &*ptr.cast::<C>() }, reason);
+        }
+        let ctx = subscriber.as_const_ptr().cast_mut().cast::<c_void>();
+        self.add_listener(ctx, callback::<C>);
+        AbortSubscription {
+            signal: self.ref_(),
+            ctx,
+        }
+    }
+
     pub fn listen<C: AbortListener>(&self, ctx: *mut C) -> &AbortSignal {
         extern "C" fn callback<C: AbortListener>(ptr: *mut c_void, reason: JSValue) {
             // SAFETY: ptr was registered below as `*mut C`; C++ calls back on

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -344,6 +344,28 @@ impl VmHandle {
         })
     }
 
+    /// Queue an owned `T` on the VM's `kind` loop (dispatched under `T::TAG`,
+    /// whose arm reclaims the box), or hand it back if the VM is closed.
+    pub fn post_boxed<T: bun_event_loop::Taskable>(
+        &self,
+        kind: LoopKind,
+        task: Box<T>,
+    ) -> Result<(), Box<T>> {
+        let raw: *mut T = bun_core::heap::into_raw(task);
+        let ct = ConcurrentTaskItem::create(bun_event_loop::Task::init(raw));
+        match self.post(kind, ct) {
+            Posted::Queued => Ok(()),
+            Posted::Refused(ct) => {
+                // SAFETY: refused ⇒ nothing else holds the carrier `create` boxed
+                // or the payload we boxed into it two lines up.
+                unsafe {
+                    drop(bun_core::heap::take(ct.as_ptr()));
+                    Err(bun_core::heap::take(raw))
+                }
+            }
+        }
+    }
+
     /// Queue a C++ `EventLoopTask` on the VM's `kind` loop from another
     /// thread (WebCore's `postTaskTo` / `postTaskConcurrently`), or delete it
     /// unrun if the VM is closed.

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -32,7 +32,7 @@ use super::uuid::UUID;
 //   - `mysql_context` / `postgresql_context` / `ssl_ctx_cache` / `editor_context`
 //     → moved to `bun_runtime::jsc_hooks::RuntimeState` (already there).
 //   - `node_fs_stat_watcher_scheduler`
-//     → erased `*mut c_void` slot; high tier lazy-inits.
+//     → moved to `bun_runtime::jsc_hooks::RuntimeState` (typed `RefPtr`).
 //   - the `bun test --isolate` watcher/server registries → moved to
 //     `bun_runtime::jsc_hooks::ActiveHandles` so the entries keep their
 //     concrete types.
@@ -249,10 +249,6 @@ pub struct RareData {
     /// Held for the VM's lifetime so the weak-cache entry never tombstones.
     pub default_client_ssl_ctx: Option<boring::OwnedSslCtx>,
 
-    /// `bun_runtime::node::StatWatcherScheduler` — erased `RefPtr` payload;
-    /// lazy-init in `bun_runtime::node::node_fs_stat_watcher`.
-    pub(crate) node_fs_stat_watcher_scheduler: Option<NonNull<c_void>>,
-
     /// `bun_runtime::node::memory_pressure::MemoryPressureWatcher` — erased
     /// `Box`; lazy-init on the first `process.on("memoryPressure", ...)` listener.
     pub(crate) memory_pressure_watcher: Option<NonNull<c_void>>,
@@ -326,7 +322,6 @@ impl Default for RareData {
             ws_client_group_: SocketGroup::default(),
             ws_client_tls_group: SocketGroup::default(),
             default_client_ssl_ctx: None,
-            node_fs_stat_watcher_scheduler: None,
             memory_pressure_watcher: None,
             listening_sockets_for_watch_mode: Mutex::new(Vec::new()),
             pipe_read_scratch: Box::new(bun_event_loop::PipeReadScratch::new()),
@@ -662,13 +657,6 @@ impl RareData {
     }
 
     // ── trivial field accessors ────────────────────────────────────────────
-
-    /// Raw slot — lazy-init body lives in `bun_runtime::node::node_fs_stat_watcher`
-    /// (`StatWatcherScheduler::init` is higher-tier).
-    #[inline]
-    pub fn node_fs_stat_watcher_scheduler_slot(&mut self) -> &mut Option<NonNull<c_void>> {
-        &mut self.node_fs_stat_watcher_scheduler
-    }
 
     /// Raw slot — lazy-init body lives in `bun_runtime::node::memory_pressure`.
     #[inline]

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -655,6 +655,90 @@ unsafe impl<T: ?Sized + Sync, P> Send for BackRef<T, P> {}
 unsafe impl<T: ?Sized + Sync, P> Sync for BackRef<T, P> {}
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ThreadBound<T> — a back-reference other threads may carry but not follow.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A [`BackRef`] to a thread-affine `T` that any thread may hold, copy and
+/// pass along, but that only the thread it was created on can dereference:
+/// [`get`](Self::get) panics everywhere else.
+///
+/// This is the typed way to hand a JS-thread object's address to machinery
+/// that runs on another thread (a watcher thread's registration, a task it
+/// queues back) purely so that it can be handed back to the owning thread.
+/// Liveness is the usual `BackRef` holder obligation, stated where the value
+/// is constructed; thread affinity is enforced here, which is what makes the
+/// `Send`/`Sync` impls below hold for every `T`.
+pub struct ThreadBound<T: ?Sized> {
+    ptr: BackRef<T>,
+    /// `std`'s id (a process-unique counter, never reused) rather than the OS
+    /// thread id, so a later thread cannot pass for the owner.
+    owner: std::thread::ThreadId,
+}
+
+impl<T: ?Sized> ThreadBound<T> {
+    /// Bind `r`'s address to the calling thread.
+    #[inline]
+    pub fn new(r: &T) -> Self {
+        ThreadBound {
+            ptr: BackRef::new(r),
+            owner: std::thread::current().id(),
+        }
+    }
+
+    /// Whether the calling thread is the one this reference was created on.
+    #[inline]
+    pub fn is_owner_thread(&self) -> bool {
+        std::thread::current().id() == self.owner
+    }
+
+    /// Borrow the pointee. Panics when called from any thread other than the
+    /// one that created this reference.
+    #[inline]
+    #[track_caller]
+    pub fn get(&self) -> &T {
+        assert!(
+            self.is_owner_thread(),
+            "ThreadBound: dereferenced on a thread other than its owner"
+        );
+        self.ptr.get()
+    }
+
+    /// The pointee's address, for identity comparisons on any thread.
+    #[inline]
+    pub fn addr(&self) -> usize {
+        self.ptr.as_const_ptr().cast::<()>() as usize
+    }
+}
+
+impl<T: ?Sized> Clone for ThreadBound<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        ThreadBound {
+            ptr: self.ptr,
+            owner: self.owner,
+        }
+    }
+}
+
+impl<T: ?Sized> core::fmt::Debug for ThreadBound<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ThreadBound")
+            .field("ptr", &self.ptr)
+            .field("owner", &self.owner)
+            .finish()
+    }
+}
+
+// SAFETY: the pointee is reachable only through `get`, which refuses every
+// thread but the one the reference was created on (where a `&T` already
+// existed), so moving the handle to another thread exposes no `T` state there.
+unsafe impl<T: ?Sized> Send for ThreadBound<T> {}
+// SAFETY: as above — a shared `&ThreadBound<T>` on a foreign thread yields
+// nothing but the address; on the owner thread it yields aliased `&T`s, which
+// is ordinary same-thread sharing.
+unsafe impl<T: ?Sized> Sync for ThreadBound<T> {}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // DetachablePtr<T> — scoped `&mut T` parked behind `&self` for re-entrant reads.
 //
 // Pattern: a Rust/C library hands a handler closure `&mut X` for the duration

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -118,8 +118,7 @@ pub(crate) extern "C" fn __lsan_default_suppressions() -> *const core::ffi::c_ch
         // and the per-process `FSEventStream` / `CFRunLoop` they require.
         // These are platform singletons by design (CF objects are not safely
         // disposable while the dylib remains loaded).
-        "leak:bun_runtime::node::fs_events::init_core_foundation\n",
-        "leak:bun_runtime::node::fs_events::init_core_services\n",
+        "leak:bun_sys::core_foundation::load\n",
         "leak:bun_runtime::node::fs_events::FSEventsLoop\n",
         // Process-lifetime inspector thread. The debugger handles SIGINT and
         // serves the WebSocket protocol up to (and during) `process.exit()`;

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -302,12 +302,11 @@ pub(crate) fn run_task(
             };
         }
         task_tag::StatWatcherHop => {
-            // SAFETY: posted by `StatWatcher::post_to_js_thread` with a ref held.
+            // SAFETY: boxed in `StatWatcher::post_to_js_thread`; the arm consumes it.
             unsafe {
-                crate::node::node_fs_stat_watcher::StatWatcher::run_hop(cast_ptr!(
-                    crate::node::node_fs_stat_watcher::StatWatcher
-                ))
-            }?;
+                bun_core::heap::take(cast_ptr!(crate::node::node_fs_stat_watcher::StatWatcherHop))
+            }
+            .run()?;
         }
         task_tag::ManagedTask => {
             // SAFETY: `task.ptr` was produced by `heap::alloc` in `ManagedTask::new`
@@ -398,16 +397,9 @@ pub(crate) fn run_task(
         // ── bake dev-server (cold — hoisted to `run_task_cold`) ──────────
         task_tag::BakeHotReloadEvent => run_task_cold(task),
         task_tag::FSWatchTask => {
-            // The task is heap-allocated
-            // (cloned from `FSWatcher.current_task` at enqueue). `deinit` is
-            // explicit (not `Drop`) so the embedded `current_task` field never
-            // runs it.
-            let t = cast_ptr!(FSWatchTask);
-            // SAFETY: tag identifies pointee; live Box'd FSWatchTask.
-            let ran = unsafe { (*t).run() };
-            // SAFETY: paired with heap::alloc in `FSWatchTask::enqueue`.
-            unsafe { FSWatchTask::deinit(t) };
-            ran?;
+            // SAFETY: boxed by the watcher's `EventSink` / `enqueue_one`; the
+            // arm consumes it.
+            unsafe { bun_core::heap::take(cast_ptr!(FSWatchTask)) }.run()?;
         }
 
         // ── node:fs libuv-request ops (Windows) ──────────────────────────
@@ -592,6 +584,34 @@ const _: () = assert!(
     task_tag::COUNT == 61,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
+
+// ── tag ↔ payload for the boxed fs watcher tasks ────────────────────────────
+// The payload types are plain owned boxes with safe `run`/`release_unrun`; the
+// raw-pointer reclaim lives here next to the arms that do the same.
+
+impl bun_event_loop::Taskable for FSWatchTask {
+    const TAG: bun_event_loop::TaskTag = task_tag::FSWatchTask;
+    unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: fn contract — the box queued under this tag.
+        FSWatchTask::release_unrun(unsafe { bun_core::heap::take(this) });
+    }
+}
+
+impl bun_event_loop::Taskable for crate::node::node_fs_stat_watcher::StatWatcherHop {
+    const TAG: bun_event_loop::TaskTag = task_tag::StatWatcherHop;
+    unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: fn contract — the box queued under this tag.
+        Self::release_unrun(unsafe { bun_core::heap::take(this) });
+    }
+}
+
+impl bun_event_loop::Taskable for crate::node::node_fs_stat_watcher::StatWatcherTimerUpdate {
+    const TAG: bun_event_loop::TaskTag = task_tag::StatWatcherTimerUpdate;
+    unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: fn contract — the box queued under this tag.
+        Self::release_unrun(unsafe { bun_core::heap::take(this) });
+    }
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // `tick_queue_with_count` — the full drain loop.
@@ -995,9 +1015,12 @@ pub(crate) unsafe fn __bun_fire_timer(
                 (*c).on_fire(&mut *vm, &*now)
             })
         }
+        // `timer_callback` takes refs on the scheduler for the pass it starts,
+        // hence the `ThisPtr`.
         EventLoopTimerTag::StatWatcherScheduler => {
-            timer_arm!(StatWatcherScheduler, event_loop_timer, |c, _now, _vm| (*c)
-                .timer_callback())
+            timer_arm!(StatWatcherScheduler, event_loop_timer, |c, _now, _vm| {
+                StatWatcherScheduler::timer_callback(bun_ptr::ThisPtr::new(c))
+            })
         }
         EventLoopTimerTag::UpgradedDuplex => {
             timer_arm!(UpgradedDuplex, event_loop_timer, |c, _now, _vm| (*c)
@@ -1285,7 +1308,7 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::StatWatcherTimerUpdate => {
             release!(crate::node::node_fs_stat_watcher::StatWatcherTimerUpdate)
         }
-        task_tag::StatWatcherHop => release!(crate::node::node_fs_stat_watcher::StatWatcher),
+        task_tag::StatWatcherHop => release!(crate::node::node_fs_stat_watcher::StatWatcherHop),
         task_tag::AsyncCpTask => release!(crate::node::fs::AsyncCpTask),
         task_tag::ShellAsyncCpTask => release!(crate::node::fs::ShellAsyncCpTask),
         task_tag::StreamPending => release!(StreamPending),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -102,6 +102,11 @@ pub(crate) struct RuntimeState {
     /// stop; one ref per entry, released by `CronJob::remove_from_list` /
     /// `clear_all_for_vm`.
     pub(crate) cron_jobs: Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>,
+    /// The `fs.watchFile` re-stat scheduler, created by the first
+    /// `fs.watchFile` on this thread. One ref, released by
+    /// `StatWatcherScheduler::shutdown_for_exit`.
+    pub(crate) stat_watcher_scheduler:
+        Option<bun_ptr::RefPtr<crate::node::node_fs_stat_watcher::StatWatcherScheduler>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -214,6 +219,25 @@ pub(crate) fn active_handles() -> Option<&'static mut ActiveHandles> {
     }
     // SAFETY: live boxed per-thread `RuntimeState`.
     Some(unsafe { &mut (*state).active_handles })
+}
+
+/// Runs `f` against this thread's `fs.watchFile` scheduler slot (`None` before
+/// the runtime state exists). A callback rather than a `&'static mut`, which
+/// two callers could hold at once; `f` must not re-enter anything that reaches
+/// the slot.
+#[inline]
+pub(crate) fn with_stat_watcher_scheduler<R>(
+    f: impl FnOnce(
+        &mut Option<bun_ptr::RefPtr<crate::node::node_fs_stat_watcher::StatWatcherScheduler>>,
+    ) -> R,
+) -> Option<R> {
+    let state = runtime_state();
+    if state.is_null() {
+        return None;
+    }
+    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread; the
+    // borrow ends when `f` returns.
+    Some(f(unsafe { &mut (*state).stat_watcher_scheduler }))
 }
 
 impl ActiveHandle {
@@ -409,6 +433,7 @@ unsafe fn init_runtime_state(
         active_handles: ActiveHandles::default(),
         wake_ctx: None,
         cron_jobs: Vec::new(),
+        stat_watcher_scheduler: None,
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 
@@ -1639,10 +1664,7 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     // watcher still queued at exit forms a cycle and leaks. Runs before
     // `cancel_all_timeout_objects` so the scheduler's `EventLoopTimer` is still
     // linked when `set_timer(0)` removes it.
-    // SAFETY: `vm` per fn contract; JS thread, before JSC teardown.
-    unsafe {
-        crate::node::node_fs_stat_watcher::StatWatcherScheduler::shutdown_for_exit(vm);
-    }
+    crate::node::node_fs_stat_watcher::StatWatcherScheduler::shutdown_for_exit();
     // SAFETY: `state` is the live boxed per-thread `RuntimeState`; `vm` per fn
     // contract. `addr_of_mut!` does not materialize a `&mut RuntimeState`.
     unsafe {

--- a/src/runtime/node/fs_events.rs
+++ b/src/runtime/node/fs_events.rs
@@ -1,554 +1,118 @@
-use core::cell::UnsafeCell;
-use core::ffi::{c_char, c_int, c_long, c_void};
-use core::ptr::{self, NonNull};
-use core::sync::atomic::{AtomicPtr, Ordering};
+//! macOS FSEvents backend for `fs.watch()`: one `CFRunLoop` thread running one
+//! `FSEventStream` that covers every watched path; `path_watcher.rs` fans the
+//! events out to the JS watchers.
 
-use bun_collections::VecExt;
-use bun_core::zstr;
-use bun_threading::{Mutex, Semaphore, UnboundedQueue};
+use core::sync::atomic::{AtomicU8, Ordering};
+use std::sync::OnceLock;
 
-// Both siblings are wired into `crate::node`, and intra-crate module cycles
-// are fine in Rust, so import the real shapes instead of mirroring them.
-use super::node_fs_watcher::Event;
+use bun_core::{ZBox, zstr};
+use bun_sys::core_foundation as cf;
+use bun_threading::{Guarded, Mutex, Semaphore};
+
 use super::node_fs_watcher::WatchEventKind;
+use super::path_watcher::WatcherId;
 
-type CFAbsoluteTime = f64;
-pub(crate) type CFTimeInterval = f64;
+const K_FS_EVENTS_MODIFIED: u32 = cf::event_flags::ITEM_CHANGE_OWNER
+    | cf::event_flags::ITEM_FINDER_INFO_MOD
+    | cf::event_flags::ITEM_INODE_META_MOD
+    | cf::event_flags::ITEM_MODIFIED
+    | cf::event_flags::ITEM_XATTR_MOD;
 
-pub(crate) type FSEventStreamEventFlags = c_int;
-pub(crate) type CFIndex = c_long;
-
-pub(crate) type FSEventStreamCreateFlags = u32;
-pub(crate) type FSEventStreamEventId = u64;
-
-pub(crate) type CFArrayRef = *mut c_void;
-pub(crate) type CFAllocatorRef = *mut c_void;
-pub(crate) type CFRunLoopRef = *mut c_void;
-pub(crate) type CFRunLoopSourceRef = *mut c_void;
-pub(crate) type CFStringRef = *mut c_void;
-pub(crate) type CFTypeRef = *mut c_void;
-pub(crate) type FSEventStreamRef = *mut c_void;
-pub(crate) type FSEventStreamCallback = unsafe extern "C" fn(
-    FSEventStreamRef,
-    *mut c_void,
-    usize,
-    *mut c_void,
-    *mut FSEventStreamEventFlags,
-    *mut FSEventStreamEventId,
-);
-
-// we only care about info and perform
-#[repr(C)]
-pub struct CFRunLoopSourceContext {
-    pub(crate) version: CFIndex,
-    pub(crate) info: *mut c_void,
-    pub(crate) retain: Option<unsafe extern "C" fn(*const c_void) -> *const c_void>,
-    pub(crate) release: Option<unsafe extern "C" fn(*const c_void)>,
-    pub(crate) copy_description: Option<unsafe extern "C" fn(*const c_void) -> *mut c_void>,
-    pub(crate) equal: Option<unsafe extern "C" fn(*const c_void, *const c_void) -> u8>,
-    pub(crate) hash: Option<unsafe extern "C" fn(*const c_void) -> usize>,
-    pub(crate) schedule: Option<unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void)>,
-    pub(crate) cancel: Option<unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void)>,
-    pub(crate) perform: unsafe extern "C" fn(*mut c_void),
-}
-
-#[repr(C)]
-pub struct FSEventStreamContext {
-    pub(crate) version: CFIndex,
-    pub(crate) info: *mut c_void,
-    pub(crate) pad: [*mut c_void; 3],
-}
-
-impl Default for FSEventStreamContext {
-    fn default() -> Self {
-        Self {
-            version: 0,
-            info: ptr::null_mut(),
-            pad: [ptr::null_mut(); 3],
-        }
-    }
-}
-
-const K_FS_EVENT_STREAM_CREATE_FLAG_NO_DEFER: c_int = 2;
-const K_FS_EVENT_STREAM_CREATE_FLAG_FILE_EVENTS: c_int = 16;
-
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CHANGE_OWNER: c_int = 0x4000;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CREATED: c_int = 0x100;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_FINDER_INFO_MOD: c_int = 0x2000;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_INODE_META_MOD: c_int = 0x400;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_DIR: c_int = 0x20000;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_MODIFIED: c_int = 0x1000;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_REMOVED: c_int = 0x200;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_RENAMED: c_int = 0x800;
-const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_XATTR_MOD: c_int = 0x8000;
-
-const K_FS_EVENTS_MODIFIED: c_int = K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CHANGE_OWNER
-    | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_FINDER_INFO_MOD
-    | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_INODE_META_MOD
-    | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_MODIFIED
-    | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_XATTR_MOD;
-
-const K_FS_EVENTS_RENAMED: c_int = K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CREATED
-    | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_REMOVED
-    | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_RENAMED;
+const K_FS_EVENTS_RENAMED: u32 =
+    cf::event_flags::ITEM_CREATED | cf::event_flags::ITEM_REMOVED | cf::event_flags::ITEM_RENAMED;
 
 static FSEVENTS_DEFAULT_LOOP_MUTEX: Mutex = Mutex::new();
-static FSEVENTS_DEFAULT_LOOP: std::sync::OnceLock<&'static FSEventsLoop> =
-    std::sync::OnceLock::new();
+static FSEVENTS_DEFAULT_LOOP: OnceLock<&'static FSEventsLoop> = OnceLock::new();
 
-fn dlsym<T>(handle: *mut c_void, symbol: &core::ffi::CStr) -> Option<T> {
-    const { assert!(core::mem::size_of::<T>() == core::mem::size_of::<*mut c_void>()) };
-    // SAFETY: handle is a valid dlopen handle; symbol is NUL-terminated
-    let ptr = unsafe { bun_sys::c::dlsym(handle, symbol.as_ptr()) };
-    if ptr.is_null() {
-        return None;
-    }
-    // SAFETY: genuine FFI — dlsym yields an opaque address that must be reinterpreted
-    // as the symbol's true type. Callers monomorphise T to the matching `extern "C" fn`
-    // (or pointer-sized data symbol) declared by CoreFoundation/CoreServices; the const
-    // assert above enforces size parity, and the null check rules out the absent-symbol
-    // case so the resulting fn pointer is always non-null. Not expressible via
-    // bytemuck/as: fn pointers are not Pod and `as` can't cast data→fn pointers.
-    Some(unsafe { core::mem::transmute_copy::<*mut c_void, T>(&ptr) })
+/// Work for the CF thread, requested from any thread by [`FSEventsLoop::request`]
+/// and picked up by the run loop source's `perform`.
+mod request {
+    /// Rebuild the FSEventStream from the current watcher list.
+    pub(super) const SCHEDULE: u8 = 1 << 0;
+    /// Stop the run loop (shutdown).
+    pub(super) const STOP: u8 = 1 << 1;
 }
 
-// Clone/Copy: bitwise OK — resolved fn pointers plus a framework-static
-// `*const CFStringRef`; the dlopen handle they came from is leaked (never
-// dlclosed), so copies stay valid for the process lifetime.
-#[derive(Clone, Copy)]
-pub struct CoreFoundation {
-    pub(crate) array_create: unsafe extern "C" fn(
-        CFAllocatorRef,
-        *mut *mut c_void,
-        CFIndex,
-        *const c_void,
-    ) -> CFArrayRef,
-    pub(crate) retain: unsafe extern "C" fn(CFTypeRef) -> CFTypeRef,
-    pub(crate) release: unsafe extern "C" fn(CFTypeRef),
-
-    pub(crate) run_loop_add_source:
-        unsafe extern "C" fn(CFRunLoopRef, CFRunLoopSourceRef, CFStringRef),
-    pub(crate) run_loop_get_current: unsafe extern "C" fn() -> CFRunLoopRef,
-    pub(crate) run_loop_remove_source:
-        unsafe extern "C" fn(CFRunLoopRef, CFRunLoopSourceRef, CFStringRef),
-    pub(crate) run_loop_run: unsafe extern "C" fn(),
-    pub(crate) run_loop_source_create: unsafe extern "C" fn(
-        CFAllocatorRef,
-        CFIndex,
-        *mut CFRunLoopSourceContext,
-    ) -> CFRunLoopSourceRef,
-    pub(crate) run_loop_source_signal: unsafe extern "C" fn(CFRunLoopSourceRef),
-    pub(crate) run_loop_stop: unsafe extern "C" fn(CFRunLoopRef),
-    pub(crate) run_loop_wake_up: unsafe extern "C" fn(CFRunLoopRef),
-    pub(crate) string_create_with_file_system_representation:
-        unsafe extern "C" fn(CFAllocatorRef, *const u8) -> CFStringRef,
-    pub(crate) run_loop_default_mode: *const CFStringRef,
-}
-
-// SAFETY: `run_loop_default_mode` points at a process-static CFStringRef
-// inside the loaded (never-dlclosed) framework; every other field is a
-// resolved fn pointer. Sharing/sending bitwise copies across threads is sound.
-unsafe impl Send for CoreFoundation {}
-// SAFETY: all fields are immutable process-lifetime data (framework-static
-// `*const CFStringRef`, resolved fn pointers); none provide interior
-// mutability, so concurrent `&CoreFoundation` access is sound.
-unsafe impl Sync for CoreFoundation {}
-
-impl CoreFoundation {
-    pub fn get() -> CoreFoundation {
-        *FSEVENTS_CF.get_or_init(init_core_foundation)
-    }
-}
-
-// Clone/Copy: bitwise OK — resolved fn pointers (from a leaked, never-dlclosed
-// dlopen handle) plus a `u64` sentinel.
-#[derive(Clone, Copy)]
-pub struct CoreServices {
-    pub(crate) fs_event_stream_create: unsafe extern "C" fn(
-        CFAllocatorRef,
-        FSEventStreamCallback,
-        *mut FSEventStreamContext,
-        CFArrayRef,
-        FSEventStreamEventId,
-        CFTimeInterval,
-        FSEventStreamCreateFlags,
-    ) -> FSEventStreamRef,
-    pub(crate) fs_event_stream_invalidate: unsafe extern "C" fn(FSEventStreamRef),
-    pub(crate) fs_event_stream_release: unsafe extern "C" fn(FSEventStreamRef),
-    pub(crate) fs_event_stream_schedule_with_run_loop:
-        unsafe extern "C" fn(FSEventStreamRef, CFRunLoopRef, CFStringRef),
-    pub(crate) fs_event_stream_start: unsafe extern "C" fn(FSEventStreamRef) -> c_int,
-    pub(crate) fs_event_stream_stop: unsafe extern "C" fn(FSEventStreamRef),
-    // libuv set it to -1 so the actual value is this
-    pub(crate) k_fs_event_stream_event_id_since_now: FSEventStreamEventId,
-}
-
-impl CoreServices {
-    pub fn get() -> CoreServices {
-        *FSEVENTS_CS.get_or_init(init_core_services)
-    }
-}
-
-// Write-once fn-ptr tables; `OnceLock` provides the one-init + acquire/release
-// publish that the prior RacyCell + hand-rolled double-checked-lock encoded.
-static FSEVENTS_CF: std::sync::OnceLock<CoreFoundation> = std::sync::OnceLock::new();
-static FSEVENTS_CS: std::sync::OnceLock<CoreServices> = std::sync::OnceLock::new();
-
-fn init_core_foundation() -> CoreFoundation {
-    let fsevents_cf_handle = bun_sys::dlopen(
-        zstr!("/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"),
-        bun_sys::RTLD::LAZY | bun_sys::RTLD::LOCAL,
-    );
-    let Some(fsevents_cf_handle) = fsevents_cf_handle else {
-        panic!("Cannot Load CoreFoundation");
-    };
-
-    CoreFoundation {
-        array_create: dlsym(fsevents_cf_handle, c"CFArrayCreate")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        retain: dlsym(fsevents_cf_handle, c"CFRetain")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        release: dlsym(fsevents_cf_handle, c"CFRelease")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_add_source: dlsym(fsevents_cf_handle, c"CFRunLoopAddSource")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_get_current: dlsym(fsevents_cf_handle, c"CFRunLoopGetCurrent")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_remove_source: dlsym(fsevents_cf_handle, c"CFRunLoopRemoveSource")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_run: dlsym(fsevents_cf_handle, c"CFRunLoopRun")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_source_create: dlsym(fsevents_cf_handle, c"CFRunLoopSourceCreate")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_source_signal: dlsym(fsevents_cf_handle, c"CFRunLoopSourceSignal")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_stop: dlsym(fsevents_cf_handle, c"CFRunLoopStop")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_wake_up: dlsym(fsevents_cf_handle, c"CFRunLoopWakeUp")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        string_create_with_file_system_representation: dlsym(
-            fsevents_cf_handle,
-            c"CFStringCreateWithFileSystemRepresentation",
-        )
-        .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-        run_loop_default_mode: dlsym(fsevents_cf_handle, c"kCFRunLoopDefaultMode")
-            .unwrap_or_else(|| panic!("Cannot Load CoreFoundation")),
-    }
-}
-
-fn init_core_services() -> CoreServices {
-    let fsevents_cs_handle = bun_sys::dlopen(
-        zstr!("/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices"),
-        bun_sys::RTLD::LAZY | bun_sys::RTLD::LOCAL,
-    );
-    let Some(fsevents_cs_handle) = fsevents_cs_handle else {
-        panic!("Cannot Load CoreServices");
-    };
-
-    CoreServices {
-        fs_event_stream_create: dlsym(fsevents_cs_handle, c"FSEventStreamCreate")
-            .unwrap_or_else(|| panic!("Cannot Load CoreServices")),
-        fs_event_stream_invalidate: dlsym(fsevents_cs_handle, c"FSEventStreamInvalidate")
-            .unwrap_or_else(|| panic!("Cannot Load CoreServices")),
-        fs_event_stream_release: dlsym(fsevents_cs_handle, c"FSEventStreamRelease")
-            .unwrap_or_else(|| panic!("Cannot Load CoreServices")),
-        fs_event_stream_schedule_with_run_loop: dlsym(
-            fsevents_cs_handle,
-            c"FSEventStreamScheduleWithRunLoop",
-        )
-        .unwrap_or_else(|| panic!("Cannot Load CoreServices")),
-        fs_event_stream_start: dlsym(fsevents_cs_handle, c"FSEventStreamStart")
-            .unwrap_or_else(|| panic!("Cannot Load CoreServices")),
-        fs_event_stream_stop: dlsym(fsevents_cs_handle, c"FSEventStreamStop")
-            .unwrap_or_else(|| panic!("Cannot Load CoreServices")),
-        k_fs_event_stream_event_id_since_now: 18446744073709551615,
-    }
-}
-
-pub struct FSEventsLoop {
-    signal_source: AtomicPtr<c_void>,
-    loop_: AtomicPtr<c_void>,
-    mutex: Mutex,
+pub(crate) struct FSEventsLoop {
+    /// The source that wakes the CF thread for `pending`, and the CF thread's
+    /// run loop (set by that thread before `sem` is posted). Both are taken and
+    /// released by `shutdown()` after the thread is joined.
+    handles: Guarded<Handles>,
+    /// `request::*` bits not yet performed by the CF thread.
+    pending: AtomicU8,
     sem: Semaphore,
-    tasks: UnboundedQueue<ConcurrentTask>,
-    thread: UnsafeCell<Option<std::thread::JoinHandle<()>>>,
-    state: UnsafeCell<FSEventsLoopState>,
+    /// Only touched by `init()`/`shutdown()`, under `FSEVENTS_DEFAULT_LOOP_MUTEX`.
+    thread: Guarded<Option<std::thread::JoinHandle<()>>>,
+    state: Guarded<FSEventsLoopState>,
 }
 
+#[derive(Default)]
+struct Handles {
+    source: Option<cf::RunLoopSource>,
+    run_loop: Option<cf::RunLoop>,
+}
+
+#[derive(Default)]
 struct FSEventsLoopState {
-    watchers: Vec<Option<NonNull<FSEventsWatcher>>>,
+    watchers: Vec<Option<Registered>>,
     watcher_count: u32,
+    next_id: u64,
     has_scheduled_watchers: bool,
-    fsevent_stream: FSEventStreamRef,
-    paths: Option<Box<[*mut c_void]>>,
-    cf_paths: CFArrayRef,
+    /// The live stream and the path array it was created with (kept alive for
+    /// the stream's lifetime, released together when the stream is rebuilt).
+    stream: Option<(cf::EventStream, cf::CFStringArray)>,
 }
 
-// SAFETY: cross-thread pointers are `AtomicPtr`; `state` is only accessed under `mutex`; `thread` is only touched by `init()`/`shutdown()` on the JS thread.
-unsafe impl Sync for FSEventsLoop {}
-// SAFETY: no thread-affine data; the loop is a leaked `&'static` singleton and all shared access is synchronized per the `Sync` impl above.
-unsafe impl Send for FSEventsLoop {}
-
-impl FSEventsLoop {
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn state(&self) -> &mut FSEventsLoopState {
-        // SAFETY: the caller holds `self.mutex`, so this is the only live reference to `state`.
-        unsafe { &mut *self.state.get() }
-    }
+/// One registered watch: what `on_events` matches event paths against and
+/// where it sends the ones that match.
+struct Registered {
+    id: u64,
+    /// Canonical path of the watched file/directory (NUL-terminated for
+    /// `CFStringCreateWithFileSystemRepresentation`).
+    path: ZBox,
+    recursive: bool,
+    callback: Callback,
+    flush: UpdateEndCallback,
+    ctx: WatcherId,
 }
 
-pub struct Task {
-    pub ctx: *mut (),
-    pub callback: fn(*mut ()),
-}
+pub(crate) type Callback =
+    fn(ctx: WatcherId, event_type: WatchEventKind, path: &[u8], is_file: bool);
+pub(crate) type UpdateEndCallback = fn(ctx: WatcherId);
 
-impl Task {
-    pub(crate) fn run(&mut self) {
-        let callback = self.callback;
-        let ctx = self.ctx;
-        debug_assert!(!ctx.is_null());
-        callback(ctx);
-    }
-
-    pub(crate) fn new<T>(ctx: &'static T, callback: fn(&T)) -> Task {
-        Task {
-            // SAFETY: `fn(&T)` and `fn(*mut ())` have identical single-pointer ABI, and `ctx` is a valid `&T` at call time.
-            callback: unsafe { bun_ptr::cast_fn_ptr::<fn(&T), fn(*mut ())>(callback) },
-            ctx: core::ptr::from_ref::<T>(ctx).cast_mut().cast::<()>(),
+impl cf::RunLoopSourceHandler for FSEventsLoop {
+    /// Runs on the CF thread after `request()` signalled the source.
+    fn perform(&'static self) {
+        let pending = self.pending.swap(0, Ordering::AcqRel);
+        if pending & request::SCHEDULE != 0 {
+            self.schedule();
+        }
+        if pending & request::STOP != 0 {
+            self.stop();
         }
     }
 }
 
-pub struct ConcurrentTask {
-    pub task: Task,
-    pub(crate) next: bun_threading::Link<ConcurrentTask>,
-    pub(crate) auto_delete: bool,
-}
+impl cf::EventStreamHandler for FSEventsLoop {
+    /// Runs on the CF thread when there are events in the FSEventStream.
+    fn on_events(&'static self, events: cf::Events<'_>) {
+        // Hold the lock for the whole iteration: `unregister_watcher` on the
+        // main thread removes the entry under this same lock and its caller
+        // then drops the watcher, and `register_watcher` may reallocate
+        // `watchers`.
+        let state = self.state.lock();
 
-// SAFETY: `next` is the sole intrusive link for `UnboundedQueue<ConcurrentTask>`.
-unsafe impl bun_threading::Linked for ConcurrentTask {
-    #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
-    }
-}
+        for handle in state.watchers.iter().flatten() {
+            let handle_path: &[u8] = handle.path.as_bytes();
 
-impl ConcurrentTask {
-    fn from(this: &mut ConcurrentTask, task: Task, auto_delete: bool) -> &mut ConcurrentTask {
-        *this = ConcurrentTask {
-            task,
-            next: bun_threading::Link::new(),
-            auto_delete,
-        };
-        this
-    }
-}
-
-impl FSEventsLoop {
-    fn cf_thread_loop(&'static self) {
-        bun_core::Output::Source::configure_named_thread(zstr!("CFThreadLoop"));
-
-        let cf = CoreFoundation::get();
-        let signal_source = self.signal_source.load(Ordering::Relaxed);
-
-        // SAFETY: CF fn pointers loaded via dlsym; signal_source is valid
-        unsafe {
-            // Retain the run loop so it outlives this thread's pthread-TSD destructor; `shutdown()` releases it after `thread.join()`.
-            let loop_ = (cf.retain)((cf.run_loop_get_current)());
-            self.loop_.store(loop_, Ordering::Release);
-
-            (cf.run_loop_add_source)(loop_, signal_source, *cf.run_loop_default_mode);
-
-            self.sem.post();
-
-            (cf.run_loop_run)();
-            (cf.run_loop_remove_source)(loop_, signal_source, *cf.run_loop_default_mode);
-        }
-    }
-
-    // Runs in CF thread, executed after `enqueueTaskConcurrent()`. Body
-    // discharges its own preconditions; safe `extern "C" fn` coerces to the
-    // `CFRunLoopSourceContext.perform` fn-pointer slot.
-    extern "C" fn cf_loop_callback(arg: *mut c_void) {
-        if arg.is_null() {
-            return;
-        }
-        // SAFETY: `arg` is the leaked `&'static FSEventsLoop` set as `ctx.info` in `init()`.
-        let this: &FSEventsLoop = unsafe { &*arg.cast::<FSEventsLoop>() };
-
-        let concurrent = this.tasks.pop_batch();
-        let count = concurrent.count;
-        if count == 0 {
-            return;
-        }
-
-        let mut iter = concurrent.iterator();
-        loop {
-            let task = iter.next();
-            if task.is_null() {
-                break;
-            }
-            // SAFETY: task is a valid *mut ConcurrentTask from the queue; this
-            // thread owns it exclusively once popped. Scoped accesses so no
-            // reference is live when the node is freed below.
-            let auto_delete = unsafe {
-                (*task).task.run();
-                (*task).auto_delete
-            };
-            if auto_delete {
-                // SAFETY: was heap-allocated in enqueue_task_concurrent; freed
-                // through the queue pointer (allocation provenance).
-                drop(unsafe { bun_core::heap::take(task) });
-            }
-        }
-    }
-
-    pub(crate) fn init() -> crate::Result<&'static FSEventsLoop> {
-        // Owning raw pointer first, shared view second: the error paths below reclaim
-        // through `this_ptr`, which must not be derived from a shared reference.
-        let this_ptr: *mut FSEventsLoop = bun_core::heap::into_raw(Box::new(FSEventsLoop {
-            signal_source: AtomicPtr::new(ptr::null_mut()),
-            loop_: AtomicPtr::new(ptr::null_mut()),
-            mutex: Mutex::new(),
-            sem: Semaphore::default(),
-            tasks: UnboundedQueue::default(),
-            thread: UnsafeCell::new(None),
-            state: UnsafeCell::new(FSEventsLoopState {
-                watchers: Vec::new(),
-                watcher_count: 0,
-                has_scheduled_watchers: false,
-                fsevent_stream: ptr::null_mut(),
-                paths: None,
-                cf_paths: ptr::null_mut(),
-            }),
-        }));
-        // SAFETY: just allocated and exclusively owned; the CF thread only sees it after spawn.
-        let this: &'static FSEventsLoop = unsafe { &*this_ptr };
-
-        let cf = CoreFoundation::get();
-
-        let mut ctx = CFRunLoopSourceContext {
-            version: 0,
-            info: core::ptr::from_ref::<FSEventsLoop>(this)
-                .cast_mut()
-                .cast::<c_void>(),
-            retain: None,
-            release: None,
-            copy_description: None,
-            equal: None,
-            hash: None,
-            schedule: None,
-            cancel: None,
-            perform: Self::cf_loop_callback,
-        };
-
-        // SAFETY: ctx is stack-local and outlives the call; CF copies it
-        let signal_source =
-            unsafe { (cf.run_loop_source_create)(ptr::null_mut(), 0, &raw mut ctx) };
-        if signal_source.is_null() {
-            // SAFETY: nothing else has seen the allocation (published only on Ok).
-            drop(unsafe { bun_core::heap::take(this_ptr) });
-            return Err(crate::Error::FailedToCreateCoreFoudationSourceLoop);
-        }
-        this.signal_source.store(signal_source, Ordering::Relaxed);
-
-        let handle = match std::thread::Builder::new()
-            .name("CFThreadLoop".into())
-            .spawn(move || this.cf_thread_loop())
-        {
-            Ok(handle) => handle,
-            Err(_) => {
-                // SAFETY: the source was never scheduled on a run loop and the allocation
-                // was never published, so both are exclusively owned here.
-                unsafe {
-                    (cf.release)(signal_source.cast());
-                    drop(bun_core::heap::take(this_ptr));
-                }
-                return Err(crate::Error::FailedToSpawnFSEventsThread);
-            }
-        };
-        // SAFETY: `thread` is only touched by `init()`/`shutdown()` on the JS thread; the CF thread never accesses it.
-        unsafe {
-            *this.thread.get() = Some(handle);
-        }
-
-        // sync threads
-        this.sem.wait();
-        Ok(this)
-    }
-
-    fn enqueue_task_concurrent(&self, task: Task) {
-        let cf = CoreFoundation::get();
-        let concurrent = bun_core::heap::into_raw(Box::new(ConcurrentTask {
-            task: Task {
-                ctx: ptr::null_mut(),
-                callback: |_| {},
-            },
-            next: bun_threading::Link::new(),
-            auto_delete: false,
-        }));
-        // SAFETY: concurrent is a valid freshly-boxed non-null pointer
-        unsafe {
-            ConcurrentTask::from(&mut *concurrent, task, true);
-            self.tasks.push(NonNull::new_unchecked(concurrent));
-        }
-        let signal_source = self.signal_source.load(Ordering::Relaxed);
-        let loop_ = self.loop_.load(Ordering::Acquire);
-        // SAFETY: CF fn pointers loaded via dlsym; handles valid per above.
-        unsafe {
-            (cf.run_loop_source_signal)(signal_source);
-            (cf.run_loop_wake_up)(loop_);
-        }
-    }
-
-    // Runs in CF thread, when there're events in FSEventStream. Body discharges
-    // its own preconditions; safe `extern "C" fn` coerces to the
-    // `FSEventStreamCallback` pointer type.
-    extern "C" fn events_cb(
-        _: FSEventStreamRef,
-        info: *mut c_void,
-        num_events: usize,
-        event_paths: *mut c_void,
-        event_flags: *mut FSEventStreamEventFlags,
-        _: *mut FSEventStreamEventId,
-    ) {
-        let paths_ptr = event_paths as *const *const c_char;
-        // SAFETY: event_paths is a `char **` of length num_events per FSEvents API
-        let paths = unsafe { bun_core::ffi::slice(paths_ptr, num_events) };
-        // SAFETY: `info` is the leaked `&'static FSEventsLoop` set as `ctx.info` in `schedule()`.
-        let loop_: &FSEventsLoop = unsafe { &*info.cast::<FSEventsLoop>() };
-        // SAFETY: event_flags is an array of length num_events per FSEvents API
-        let event_flags = unsafe { bun_core::ffi::slice(event_flags.cast_const(), num_events) };
-
-        // Hold the mutex for the whole iteration. `unregisterWatcher` on the
-        // main thread nulls the entry under this same mutex and then the
-        // caller immediately frees the FSEventsWatcher (and its path buffer),
-        // so without this lock we can read `handle.path` / call `handle.emit`
-        // on freed memory. Holding the lock also prevents `registerWatcher`
-        // from reallocating the `watchers` buffer mid-iteration.
-        let _guard = loop_.mutex.lock_guard();
-        // SAFETY: holding `mutex` — see `FSEventsLoop::state`.
-        let state = unsafe { loop_.state() };
-
-        for watcher in state.watchers.slice() {
-            let Some(handle) = *watcher else { continue };
-            // `handle` is alive while held under the mutex (see comment above);
-            // `BackRef` invariant (pointee outlives holder) holds for this
-            // scope. `emit`/`flush` take `&self`, so a shared borrow suffices.
-            let handle = bun_ptr::BackRef::from(handle);
-            let handle_path = handle.path.slice();
-
-            for (i, path_ptr) in paths.iter().enumerate() {
-                let mut flags = event_flags[i];
-                // SAFETY: each path_ptr is a NUL-terminated C string from FSEvents
-                let mut path = unsafe { bun_core::ffi::cstr(*path_ptr) }.to_bytes();
+            for (event_path, event_flags) in events.iter() {
+                let mut flags = event_flags;
+                let mut path = event_path;
                 // Filter out paths that are outside handle's request
                 if path.len() < handle_path.len() || !path.starts_with(handle_path) {
                     continue;
                 }
-                let is_file = (flags & K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_DIR) == 0;
+                let is_file = (flags & cf::event_flags::ITEM_IS_DIR) == 0;
 
                 // Remove common prefix, unless the watched folder is "/"
                 if !(handle_path.len() == 1 && handle_path[0] == b'/') {
@@ -595,318 +159,282 @@ impl FSEventsLoop {
                 } else {
                     WatchEventKind::Change
                 };
-                handle.emit(event_type.to_event(path.into()), is_file);
+                (handle.callback)(handle.ctx, event_type, path, is_file);
             }
-            handle.flush();
+            (handle.flush)(handle.ctx);
+        }
+    }
+}
+
+impl FSEventsLoop {
+    fn cf_thread_loop(&'static self) {
+        bun_core::Output::Source::configure_named_thread(zstr!("CFThreadLoop"));
+
+        {
+            let mut handles = self.handles.lock();
+            // Retained so it outlives this thread's pthread-TSD destructor;
+            // `shutdown()` releases it after `thread.join()`.
+            let run_loop = cf::RunLoop::current();
+            if let Some(source) = &handles.source {
+                run_loop.add_source(source);
+            }
+            handles.run_loop = Some(run_loop);
+        }
+
+        self.sem.post();
+
+        cf::RunLoop::run_current();
+
+        let handles = self.handles.lock();
+        if let (Some(run_loop), Some(source)) = (&handles.run_loop, &handles.source) {
+            run_loop.remove_source(source);
+        }
+    }
+
+    pub(crate) fn init() -> crate::Result<&'static FSEventsLoop> {
+        cf::ensure_loaded();
+
+        // Leaked up front: the run loop source and the event stream carry
+        // `&'static self` as their context. (If source creation or the thread
+        // spawn fails below, this allocation is abandoned.)
+        let this: &'static FSEventsLoop = Box::leak(Box::new(FSEventsLoop {
+            handles: Guarded::init(Handles::default()),
+            pending: AtomicU8::new(0),
+            sem: Semaphore::default(),
+            thread: Guarded::init(None),
+            state: Guarded::init(FSEventsLoopState::default()),
+        }));
+
+        let Some(source) = cf::RunLoopSource::new(this) else {
+            return Err(crate::Error::FailedToCreateCoreFoudationSourceLoop);
+        };
+        this.handles.lock().source = Some(source);
+
+        let handle = match std::thread::Builder::new()
+            .name("CFThreadLoop".into())
+            .spawn(move || this.cf_thread_loop())
+        {
+            Ok(handle) => handle,
+            Err(_) => {
+                this.handles.lock().source = None;
+                return Err(crate::Error::FailedToSpawnFSEventsThread);
+            }
+        };
+        *this.thread.lock() = Some(handle);
+
+        // sync threads
+        this.sem.wait();
+        Ok(this)
+    }
+
+    /// Ask the CF thread to perform `request::*` work.
+    fn request(&self, what: u8) {
+        self.pending.fetch_or(what, Ordering::AcqRel);
+        let handles = self.handles.lock();
+        if let Some(source) = &handles.source {
+            source.signal();
+        }
+        if let Some(run_loop) = &handles.run_loop {
+            run_loop.wake_up();
         }
     }
 
     // Runs on CF Thread
-    fn schedule(&self) {
-        let _guard = self.mutex.lock_guard();
-        // SAFETY: holding `mutex` — see `FSEventsLoop::state`.
-        let state = unsafe { self.state() };
+    fn schedule(&'static self) {
+        let mut state = self.state.lock();
         state.has_scheduled_watchers = false;
         let watcher_count = state.watcher_count;
 
-        let cf = CoreFoundation::get();
-        let cs = CoreServices::get();
-
-        // SAFETY: all CF/CS calls below operate on handles we own
-        unsafe {
-            if !state.fsevent_stream.is_null() {
-                let stream = state.fsevent_stream;
-                // Stop emitting events
-                (cs.fs_event_stream_stop)(stream);
-
-                // Release stream
-                (cs.fs_event_stream_invalidate)(stream);
-                (cs.fs_event_stream_release)(stream);
-                state.fsevent_stream = ptr::null_mut();
-            }
-            // clean old paths
-            if let Some(p) = state.paths.take() {
-                for s in p.iter() {
-                    if !s.is_null() {
-                        (cf.release)(*s);
-                    }
-                }
-                drop(p);
-            }
-            if !state.cf_paths.is_null() {
-                let cfp = state.cf_paths;
-                state.cf_paths = ptr::null_mut();
-                (cf.release)(cfp);
-            }
-
-            if watcher_count == 0 {
-                return;
-            }
-
-            let mut paths: Box<[*mut c_void]> =
-                vec![ptr::null_mut(); watcher_count as usize].into_boxed_slice();
-            let mut count: u32 = 0;
-            for w in state.watchers.slice() {
-                if let Some(watcher) = *w {
-                    // SAFETY: watcher alive under mutex; its `path` borrows from the
-                    // owning PathWatcher, whose `ZBox` storage is NUL-terminated, so
-                    // `as_ptr()` yields a valid C string for CF.
-                    let watcher = &*watcher.as_ptr();
-                    let path = (cf.string_create_with_file_system_representation)(
-                        ptr::null_mut(),
-                        watcher.path.slice().as_ptr().cast(),
-                    );
-                    paths[count as usize] = path;
-                    count += 1;
-                }
-            }
-
-            let cf_paths = (cf.array_create)(
-                ptr::null_mut(),
-                paths.as_mut_ptr(),
-                count as CFIndex,
-                ptr::null(),
-            );
-            let mut ctx = FSEventStreamContext {
-                info: core::ptr::from_ref::<FSEventsLoop>(self)
-                    .cast_mut()
-                    .cast::<c_void>(),
-                ..Default::default()
-            };
-
-            let latency: CFAbsoluteTime = 0.05;
-            // Explanation of selected flags:
-            // 1. NoDefer - without this flag, events that are happening continuously
-            //    (i.e. each event is happening after time interval less than `latency`,
-            //    counted from previous event), will be deferred and passed to callback
-            //    once they'll either fill whole OS buffer, or when this continuous stream
-            //    will stop (i.e. there'll be delay between events, bigger than
-            //    `latency`).
-            //    Specifying this flag will invoke callback after `latency` time passed
-            //    since event.
-            // 2. FileEvents - fire callback for file changes too (by default it is firing
-            //    it only for directory changes).
-            //
-            let flags: FSEventStreamCreateFlags = (K_FS_EVENT_STREAM_CREATE_FLAG_NO_DEFER
-                | K_FS_EVENT_STREAM_CREATE_FLAG_FILE_EVENTS)
-                as FSEventStreamCreateFlags;
-
-            //
-            // NOTE: It might sound like a good idea to remember last seen StreamEventId,
-            // but in reality one dir might have last StreamEventId less than, the other,
-            // that is being watched now. Which will cause FSEventStream API to report
-            // changes to files from the past.
-            //
-            let r#ref = (cs.fs_event_stream_create)(
-                ptr::null_mut(),
-                Self::events_cb,
-                &raw mut ctx,
-                cf_paths,
-                cs.k_fs_event_stream_event_id_since_now,
-                latency,
-                flags,
-            );
-            if r#ref.is_null() {
-                // FSEventStreamCreate can fail under rapid stream churn (resource
-                // exhaustion); passing NULL into ScheduleWithRunLoop crashes the CF thread.
-                for s in &paths[..count as usize] {
-                    if !s.is_null() {
-                        (cf.release)(*s);
-                    }
-                }
-                drop(paths);
-                (cf.release)(cf_paths);
-                return;
-            }
-
-            (cs.fs_event_stream_schedule_with_run_loop)(
-                r#ref,
-                self.loop_.load(Ordering::Relaxed),
-                *cf.run_loop_default_mode,
-            );
-            if (cs.fs_event_stream_start)(r#ref) == 0 {
-                //clean in case of failure
-                for s in &paths[..count as usize] {
-                    if !s.is_null() {
-                        (cf.release)(*s);
-                    }
-                }
-                drop(paths);
-                (cf.release)(cf_paths);
-                (cs.fs_event_stream_invalidate)(r#ref);
-                (cs.fs_event_stream_release)(r#ref);
-                return;
-            }
-            state.fsevent_stream = r#ref;
-            state.paths = Some(paths);
-            state.cf_paths = cf_paths;
+        if let Some((stream, paths)) = state.stream.take() {
+            // Stop emitting events
+            stream.stop();
+            // Release stream (invalidate + release), then the old paths
+            drop(stream);
+            drop(paths);
         }
+
+        if watcher_count == 0 {
+            return;
+        }
+
+        let strings: Vec<cf::CFString> = state
+            .watchers
+            .iter()
+            .flatten()
+            .filter_map(|w| cf::CFString::from_file_system_path(&w.path))
+            .collect();
+        let Some(paths) = cf::CFStringArray::new(strings) else {
+            return;
+        };
+
+        let latency: f64 = 0.05;
+        // Explanation of selected flags:
+        // 1. NoDefer - without this flag, events that are happening continuously
+        //    (i.e. each event is happening after time interval less than `latency`,
+        //    counted from previous event), will be deferred and passed to callback
+        //    once they'll either fill whole OS buffer, or when this continuous stream
+        //    will stop (i.e. there'll be delay between events, bigger than
+        //    `latency`).
+        //    Specifying this flag will invoke callback after `latency` time passed
+        //    since event.
+        // 2. FileEvents - fire callback for file changes too (by default it is firing
+        //    it only for directory changes).
+        //
+        let flags: cf::FSEventStreamCreateFlags =
+            cf::create_flags::NO_DEFER | cf::create_flags::FILE_EVENTS;
+
+        //
+        // NOTE: It might sound like a good idea to remember last seen StreamEventId,
+        // but in reality one dir might have last StreamEventId less than, the other,
+        // that is being watched now. Which will cause FSEventStream API to report
+        // changes to files from the past.
+        //
+        // FSEventStreamCreate can fail under rapid stream churn (resource
+        // exhaustion); in that case (or if start fails) everything created here
+        // is released again and the next register/unregister retries. The
+        // stream is scheduled on this (the CF) thread's run loop.
+        let Some(stream) =
+            cf::EventStream::new_scheduled(self, &paths, cf::EVENT_ID_SINCE_NOW, latency, flags)
+        else {
+            return;
+        };
+        if !stream.start() {
+            //clean in case of failure
+            drop(paths);
+            drop(stream);
+            return;
+        }
+        state.stream = Some((stream, paths));
     }
 
-    fn register_watcher(&'static self, watcher: *mut FSEventsWatcher) {
-        let _guard = self.mutex.lock_guard();
-        // SAFETY: holding `mutex` — see `FSEventsLoop::state`.
-        let state = unsafe { self.state() };
+    fn register_watcher(&self, mut watcher: Registered) -> u64 {
+        let mut state = self.state.lock();
+        state.next_id += 1;
+        let id = state.next_id;
+        watcher.id = id;
         if state.watcher_count as usize == state.watchers.len() {
             state.watcher_count += 1;
-            state.watchers.push(NonNull::new(watcher));
+            state.watchers.push(Some(watcher));
         } else {
-            for w in state.watchers.slice_mut() {
-                if w.is_none() {
-                    *w = NonNull::new(watcher);
-                    state.watcher_count += 1;
-                    break;
-                }
-            }
+            let slot = state
+                .watchers
+                .iter_mut()
+                .find(|w| w.is_none())
+                .expect("watcher_count < len implies a free slot");
+            *slot = Some(watcher);
+            state.watcher_count += 1;
         }
 
         if !state.has_scheduled_watchers {
             state.has_scheduled_watchers = true;
         } else {
-            return;
+            return id;
         }
-        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::schedule));
+        self.request(request::SCHEDULE);
+        id
     }
 
-    fn unregister_watcher(&'static self, watcher: *mut FSEventsWatcher) {
-        let _guard = self.mutex.lock_guard();
-        // SAFETY: holding `mutex` — see `FSEventsLoop::state`.
-        let state = unsafe { self.state() };
-        let len = state.watchers.len() as usize;
+    fn unregister_watcher(&self, id: u64) {
+        let mut state = self.state.lock();
+        let len = state.watchers.len();
         for i in 0..len {
-            if let Some(item) = state.watchers.slice_mut()[i] {
-                if item.as_ptr() == watcher {
-                    state.watchers.slice_mut()[i] = None;
-                    // if is the last one just pop
-                    if i == len - 1 {
-                        let _ = state.watchers.pop();
-                    }
-                    state.watcher_count -= 1;
-                    break;
+            if state.watchers[i].as_ref().is_some_and(|item| item.id == id) {
+                state.watchers[i] = None;
+                // if is the last one just pop
+                if i == len - 1 {
+                    let _ = state.watchers.pop();
                 }
+                state.watcher_count -= 1;
+                break;
             }
         }
 
         // Rebuild the FSEventStream on the CF thread so it stops firing for
         // the path we just removed. Without this the stream keeps delivering
-        // events for freed paths until another register happens to
-        // reschedule. `events_cb` tolerates the interim (it sees `null` and
-        // skips) because both sides hold `this.mutex`.
+        // events for removed paths until another register happens to
+        // reschedule. `on_events` tolerates the interim (the entry is gone)
+        // because both sides hold `state`.
         if !state.has_scheduled_watchers {
             state.has_scheduled_watchers = true;
         } else {
             return;
         }
-        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::schedule));
+        self.request(request::SCHEDULE);
     }
 
     // Runs on CF loop to close the loop
     fn stop(&self) {
-        let cf = CoreFoundation::get();
-        // SAFETY: runs on the CF thread — this is our own run loop.
-        unsafe { (cf.run_loop_stop)(self.loop_.load(Ordering::Relaxed)) };
+        if let Some(run_loop) = &self.handles.lock().run_loop {
+            run_loop.stop();
+        }
     }
 
     fn shutdown(&'static self) {
-        // SAFETY: `thread` is only touched here and in `init()`, always on the JS thread under `FSEVENTS_DEFAULT_LOOP_MUTEX`.
-        let Some(thread) = (unsafe { (*self.thread.get()).take() }) else {
+        let Some(thread) = self.thread.lock().take() else {
             return; // already shut down
         };
         // signal close and wait
-        self.enqueue_task_concurrent(Task::new(self, FSEventsLoop::stop));
+        self.request(request::STOP);
         let _ = thread.join();
 
-        let cf = CoreFoundation::get();
-        let loop_ = self.loop_.swap(ptr::null_mut(), Ordering::Relaxed);
-        debug_assert!(!loop_.is_null());
-        // SAFETY: retained in `cf_thread_loop`; sole owner after join.
-        unsafe { (cf.release)(loop_) };
-
-        let signal_source = self.signal_source.swap(ptr::null_mut(), Ordering::Relaxed);
-        debug_assert!(!signal_source.is_null());
-        // SAFETY: signal_source is a valid CF object until released here
-        unsafe { (cf.release)(signal_source) };
-
-        let _guard = self.mutex.lock_guard();
-        // SAFETY: holding `mutex` — see `FSEventsLoop::state`.
-        let state = unsafe { self.state() };
-        if state.watcher_count > 0 {
-            while let Some(watcher) = state.watchers.pop() {
-                if let Some(w) = watcher {
-                    // `w` is a registered, not-yet-freed watcher; `BackRef`
-                    // invariant holds. `loop_` is a `Cell`, so the write goes
-                    // through a shared `&FSEventsWatcher` safely.
-                    bun_ptr::BackRef::from(w).loop_.set(None);
-                }
-            }
+        {
+            let mut handles = self.handles.lock();
+            let run_loop = handles.run_loop.take();
+            debug_assert!(run_loop.is_some());
+            drop(run_loop);
+            let source = handles.source.take();
+            debug_assert!(source.is_some());
+            drop(source);
         }
+
+        // Forget the remaining registrations; their owners' later unregister
+        // finds nothing and, with the handles gone, wakes nothing.
+        let mut state = self.state.lock();
+        state.watchers.clear();
+        state.watcher_count = 0;
     }
 }
 
-pub struct FSEventsWatcher {
-    /// Borrowed from the owning `PathWatcher`. The
-    /// PathWatcher heap-allocates this watcher and only frees it after `Drop`
-    /// (→ `unregister_watcher`) has run, so the bytes outlive every read in
-    /// `events_cb` / `schedule` — `RawSlice` invariant. The backing buffer is
-    /// a `ZBox`, so `path.slice().as_ptr()` is NUL-terminated (required by
-    /// `CFStringCreateWithFileSystemRepresentation`).
-    pub path: bun_ptr::RawSlice<u8>,
-    pub callback: Callback,
-    pub(crate) flush_callback: UpdateEndCallback,
-    pub(crate) loop_: core::cell::Cell<Option<&'static FSEventsLoop>>,
-    pub(crate) recursive: bool,
-    pub ctx: *mut c_void,
+/// A registration on the FSEvents loop; dropping it unregisters.
+pub(crate) struct FSEventsWatcher {
+    loop_: &'static FSEventsLoop,
+    id: u64,
 }
-
-pub type Callback = fn(ctx: *mut c_void, event: Event, is_file: bool);
-pub(crate) type UpdateEndCallback = fn(ctx: *mut c_void);
 
 impl FSEventsWatcher {
     fn init(
         loop_: &'static FSEventsLoop,
-        path: &[u8],
+        path: ZBox,
         recursive: bool,
         callback: Callback,
         update_end: UpdateEndCallback,
-        ctx: *mut c_void,
-    ) -> Box<FSEventsWatcher> {
-        let mut this = Box::new(FSEventsWatcher {
-            path: bun_ptr::RawSlice::new(path),
-            callback,
-            flush_callback: update_end,
-            loop_: core::cell::Cell::new(Some(loop_)),
+        ctx: WatcherId,
+    ) -> FSEventsWatcher {
+        let id = loop_.register_watcher(Registered {
+            id: 0,
+            path,
             recursive,
+            callback,
+            flush: update_end,
             ctx,
         });
-
-        loop_.register_watcher(&raw mut *this);
-        this
-    }
-
-    fn emit(&self, event: Event, is_file: bool) {
-        (self.callback)(self.ctx, event, is_file);
-    }
-
-    fn flush(&self) {
-        (self.flush_callback)(self.ctx);
+        FSEventsWatcher { loop_, id }
     }
 }
 
 impl Drop for FSEventsWatcher {
     fn drop(&mut self) {
-        if let Some(loop_) = self.loop_.get() {
-            loop_.unregister_watcher(std::ptr::from_mut(self));
-        }
+        self.loop_.unregister_watcher(self.id);
     }
 }
 
 pub(crate) fn watch(
-    path: &[u8],
+    path: ZBox,
     recursive: bool,
     callback: Callback,
     update_end: UpdateEndCallback,
-    ctx: *mut c_void,
-) -> crate::Result<Box<FSEventsWatcher>> {
+    ctx: WatcherId,
+) -> crate::Result<FSEventsWatcher> {
     if let Some(&loop_) = FSEVENTS_DEFAULT_LOOP.get() {
         return Ok(FSEventsWatcher::init(
             loop_, path, recursive, callback, update_end, ctx,

--- a/src/runtime/node/fs_events.rs
+++ b/src/runtime/node/fs_events.rs
@@ -185,6 +185,14 @@ impl FSEventsLoop {
 
         cf::RunLoop::run_current();
 
+        // The stream was created and scheduled on this thread and must be
+        // stopped and released here too; `shutdown()` runs on another thread.
+        if let Some((stream, paths)) = self.state.lock().stream.take() {
+            stream.stop();
+            drop(stream);
+            drop(paths);
+        }
+
         let handles = self.handles.lock();
         if let (Some(run_loop), Some(source)) = (&handles.run_loop, &handles.source) {
             run_loop.remove_source(source);

--- a/src/runtime/node/fs_events.rs
+++ b/src/runtime/node/fs_events.rs
@@ -300,8 +300,8 @@ impl FSEventsLoop {
         };
         if !stream.start() {
             //clean in case of failure
-            drop(paths);
             drop(stream);
+            drop(paths);
             return;
         }
         state.stream = Some((stream, paths));

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7867,13 +7867,7 @@ impl NodeFS {
     }
 
     pub(crate) fn watch(&mut self, args: &args::Watch<'_>, _: Flavor) -> Maybe<ret::Watch> {
-        match args.create_fs_watcher() {
-            // SAFETY: `create_fs_watcher` returns a freshly-heap-allocated
-            // `*mut FSWatcher` whose ownership is held by the JS wrapper
-            // (`js_this`); only `js_this` is read here.
-            Ok(result) => Ok(unsafe { (*result).js_this() }),
-            Err(err) => Err(err),
-        }
+        args.create_fs_watcher()
     }
 
     /// This function is `cpSync`, but only if you pass `{ recursive: ..., force: ..., errorOnExist: ..., mode: ... }'

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -16,10 +16,10 @@ use bun_jsc::{
     WorkPoolTask,
 };
 use bun_paths::resolve_path::{self as Path, platform};
-use bun_ptr::{BackRef, ParentRef, RefPtr, ThreadSafeRefCount};
+use bun_ptr::{BackRef, RefPtr, ThisPtr, ThreadSafeRefCount};
 use bun_resolver::fs;
 use bun_sys::{self, PosixStat};
-use bun_threading::{Guarded, UnboundedQueue};
+use bun_threading::Guarded;
 
 use crate::generated_classes::js_StatWatcher as js;
 use crate::node::stat::{StatsBig, StatsSmall};
@@ -48,135 +48,72 @@ fn stat_to_js_stats(
 #[derive(bun_ptr::ThreadSafeRefCounted)]
 pub struct StatWatcherScheduler {
     current_interval: AtomicI32,
-    /// Set by `timer_callback` immediately before scheduling `work_pool_callback`
-    /// on the thread pool, cleared by `work_pool_callback` once it has finished
-    /// touching `watchers`. `shutdown_for_exit` spin-waits on this so it never
-    /// races the work-pool thread for the queue.
+    /// Set by `timer_callback` immediately before scheduling a [`StatPassTask`]
+    /// on the thread pool, cleared by that task once it has finished touching
+    /// `watchers`. `shutdown_for_exit` spin-waits on this so it never races the
+    /// work-pool thread for the queue.
     work_pool_in_flight: AtomicBool,
-    /// Set by `shutdown_for_exit`. Once true, `work_pool_callback` stops
-    /// rescheduling the timer (so no `Holder` task is left stranded in the
-    /// concurrent-task queue at process exit).
+    /// Set by `shutdown_for_exit`. Once true, the stat pass stops
+    /// rescheduling the timer (so no `StatWatcherTimerUpdate` is left stranded
+    /// in the concurrent-task queue at process exit).
     is_shutdown: AtomicBool,
-    task: WorkPoolTask,
     main_thread: ThreadId,
     /// JS-thread uses only (`timer_callback`).
     vm: BackRef<VirtualMachine>,
-    /// Held while the periodic stat pass is out on the pool (set in
-    /// `timer_callback`, moved out by `work_pool_callback`).
-    ticket: Cell<Option<bun_jsc::Ticket>>,
-    watchers: WatcherQueue,
+    /// The watchers waiting for their next re-stat. One ref each, taken by
+    /// `append`; released by the stat pass that finds the watcher closed, or by
+    /// `shutdown_for_exit`.
+    watchers: Guarded<Vec<RefPtr<StatWatcher>>>,
 
-    pub(crate) event_loop_timer: EventLoopTimer,
+    pub(crate) event_loop_timer: JsCell<EventLoopTimer>,
 
     ref_count: ThreadSafeRefCount<StatWatcherScheduler>,
 }
 
 bun_event_loop::impl_timer_owner!(StatWatcherScheduler; from_timer_ptr => event_loop_timer);
 
-type WatcherQueue = UnboundedQueue<StatWatcher>;
-
-// Intrusive `next`-link accessors for `UnboundedQueue<StatWatcher>`.
-//
-// SAFETY: all four route through the same `next: *mut StatWatcher` field; the
-// atomic variants reinterpret it as `AtomicPtr<StatWatcher>` (same size/align,
-// `addr_of!` preserves provenance).
-unsafe impl bun_threading::Linked for StatWatcher {
-    #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
-    }
-}
-
 impl Drop for StatWatcherScheduler {
     fn drop(&mut self) {
         assert!(
-            self.watchers.is_empty(),
+            self.watchers.get_mut().is_empty(),
             "destroying StatWatcherScheduler while it still has watchers",
         );
     }
 }
 
 impl StatWatcherScheduler {
-    /// # Safety
-    /// `this` must point to a live `StatWatcherScheduler`.
-    // Forwards `this` to the unsafe `ThreadSafeRefCount` helper without
-    // dereferencing; not_unsafe_ptr_arg_deref is a false positive on
-    // opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[inline]
-    pub fn ref_(this: *mut Self) {
-        // SAFETY: per fn contract.
-        unsafe { ThreadSafeRefCount::<Self>::ref_(this) };
-    }
-    /// # Safety
-    /// `this` must point to a live `StatWatcherScheduler` and the caller must
-    /// own one outstanding ref, which is released.
-    // Forwards `this` to the unsafe `ThreadSafeRefCount` helper without
-    // dereferencing; not_unsafe_ptr_arg_deref is a false positive on
-    // opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[inline]
-    pub fn deref(this: *mut Self) {
-        // SAFETY: per fn contract.
-        unsafe { ThreadSafeRefCount::<Self>::deref(this) };
-    }
-
-    /// Borrow the per-thread `VirtualMachine` this scheduler is bound to.
-    ///
-    /// `vm` is a `BackRef` (JSC_BORROW): the VM owns the event loop / timer
-    /// heap that drives this scheduler and outlives it.
-    #[inline]
-    fn vm(&self) -> &VirtualMachine {
-        self.vm.get()
-    }
-
-    pub(crate) fn init(vm: *mut VirtualMachine) -> RefPtr<StatWatcherScheduler> {
+    pub(crate) fn init(vm: &VirtualMachine) -> RefPtr<StatWatcherScheduler> {
         RefPtr::new(StatWatcherScheduler {
             current_interval: AtomicI32::new(0),
             work_pool_in_flight: AtomicBool::new(false),
             is_shutdown: AtomicBool::new(false),
-            task: WorkPoolTask {
-                node: Default::default(),
-                callback: Self::work_pool_callback,
-            },
             main_thread: thread::current().id(),
-            // JSC_BORROW: `vm` is the live per-thread VM (never null).
-            vm: BackRef::from(core::ptr::NonNull::new(vm).expect("vm")),
-            ticket: Cell::new(None),
-            watchers: WatcherQueue::default(),
-            event_loop_timer: EventLoopTimer::init_paused(EventLoopTimerTag::StatWatcherScheduler),
+            vm: BackRef::new(vm),
+            watchers: Guarded::init(Vec::new()),
+            event_loop_timer: JsCell::new(EventLoopTimer::init_paused(
+                EventLoopTimerTag::StatWatcherScheduler,
+            )),
             ref_count: ThreadSafeRefCount::init(),
         })
     }
 
-    /// # Safety
-    /// `this` must point to a live `StatWatcherScheduler` (caller holds a ref)
-    /// and `watcher` must point to a live `StatWatcher`.
-    pub(crate) fn append(this: *mut Self, watcher: *mut StatWatcher) {
-        // BACKREF — `watcher` is a live ref-counted StatWatcher (we ref() it
-        // below). R-2: shared `&` only — all field access goes through
-        // Cell/Atomic. `ParentRef` Deref collapses the per-site raw deref.
-        let watcher = NonNull::new(watcher).expect("append: watcher");
-        let w = ParentRef::from(watcher);
-        log!("append new watcher {}", bstr::BStr::new(w.path.as_bytes()));
-        debug_assert!(!w.closed.load(Ordering::Relaxed));
-        debug_assert!(w.next.is_null());
-
-        // SAFETY: per fn contract — `watcher` is live.
-        StatWatcher::ref_(watcher.as_ptr());
-        // BACKREF — `this` is live (caller holds a ref).
-        let this_ref = ParentRef::from(NonNull::new(this).expect("append: scheduler"));
-        debug_assert_eq!(this_ref.main_thread, thread::current().id());
-        this_ref.watchers.push(watcher);
+    /// JS thread. Takes over `watcher` (one ref) until a stat pass finds it
+    /// closed.
+    pub(crate) fn append(&self, watcher: RefPtr<StatWatcher>) {
+        log!(
+            "append new watcher {}",
+            bstr::BStr::new(watcher.path.as_bytes())
+        );
+        debug_assert!(!watcher.closed.load(Ordering::Relaxed));
+        debug_assert_eq!(self.main_thread, thread::current().id());
+        let interval = watcher.interval;
         log!("push watcher {:x}", watcher.as_ptr() as usize);
-        let current = this_ref.get_interval();
-        if current == 0 || current > w.interval {
+        self.watchers.lock().push(watcher);
+        let current = self.get_interval();
+        if current == 0 || current > interval {
             // we are not running or the new watcher has a smaller interval
-            this_ref
-                .current_interval
-                .store(w.interval, Ordering::Relaxed);
-            Self::set_timer(this, w.interval);
+            self.current_interval.store(interval, Ordering::Relaxed);
+            self.set_timer(interval);
         }
     }
 
@@ -185,26 +122,14 @@ impl StatWatcherScheduler {
     }
 
     /// Set the timer (this function is not thread safe, should be called only from the main thread)
-    fn set_timer(this: *mut Self, interval: i32) {
-        // jsc/runtime crate cycle: `vm.timer: api.Timer.All` lives in `RuntimeState` (this crate),
-        // not as a value field on the low-tier `VirtualMachine`. Recover it via
-        // the per-thread `runtime_state()` (single JS thread; see jsc_hooks.rs).
-        // SAFETY: main-thread-only per fn contract; `runtime_state()` is non-null
-        // after `bun_runtime::init()`. Raw-ptr-per-field re-entry pattern.
-        let timer_all = unsafe { &mut (*crate::jsc_hooks::runtime_state()).timer };
-        // SAFETY: `this` is live: a scheduler ref is held for the whole call by
-        // every caller (`set_interval`'s caller, `timer_callback`'s `&mut self`,
-        // `shutdown_for_exit`'s `RareData` ref) or, for `StatWatcherTimerUpdate`
-        // (whose `scheduler` is a non-owning `ParentRef`), by the watcher's
-        // `RefPtr<StatWatcherScheduler>` held across the hop.
-        let elt = unsafe { core::ptr::addr_of_mut!((*this).event_loop_timer) };
+    fn set_timer(&self, interval: i32) {
+        let timer_all = crate::jsc_hooks::timer_all_mut();
 
         // if the interval is 0 means that we stop the timer
         if interval == 0 {
             // if the timer is active we need to remove it
-            // SAFETY: `elt` is the live embedded EventLoopTimer.
-            if unsafe { (*elt).state } == EventLoopTimerState::ACTIVE {
-                timer_all.remove(elt);
+            if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+                timer_all.remove(self.event_loop_timer.as_ptr());
             }
             return;
         }
@@ -212,245 +137,196 @@ impl StatWatcherScheduler {
         // reschedule the timer — this tag opts out of fake timers, so the
         // deadline lives in the real heap and must be in real-clock units.
         timer_all.update(
-            elt,
+            self.event_loop_timer.as_ptr(),
             &Timespec::ms_from_now(TimespecMockMode::ForceRealTime, i64::from(interval)),
         );
     }
 
-    /// Schedule a task to set the timer in the main thread
-    fn schedule_timer_update(this: *mut Self, ticket: &bun_jsc::Ticket) {
+    /// Pool thread: schedule a task to set the timer in the main thread.
+    fn schedule_timer_update(this: &RefPtr<StatWatcherScheduler>, ticket: &bun_jsc::Ticket) {
         let holder = Box::new(StatWatcherTimerUpdate {
-            // SAFETY: `this` is the live ref'd scheduler (write provenance for
-            // `set_timer`), kept alive across the hop by the watcher's RefPtr.
-            scheduler: unsafe { ParentRef::from_raw_mut(this) },
+            scheduler: this.clone(),
         });
-        let holder = bun_core::heap::into_raw(holder);
-        ticket.post(ConcurrentTask::create_from(holder));
+        ticket.post(ConcurrentTask::create(Task::from_boxed(holder)));
     }
 
-    pub(crate) fn timer_callback(&mut self) {
-        let has_been_cleared = self.event_loop_timer.state == EventLoopTimerState::CANCELLED
-            || self.vm().script_execution_status() != jsc::ScriptExecutionStatus::Running;
+    pub(crate) fn timer_callback(this: ThisPtr<StatWatcherScheduler>) {
+        let has_been_cleared = this.event_loop_timer.get().state == EventLoopTimerState::CANCELLED
+            || this.vm.script_execution_status() != jsc::ScriptExecutionStatus::Running;
 
-        self.event_loop_timer.state = EventLoopTimerState::FIRED;
-        self.event_loop_timer.heap = Default::default();
+        this.event_loop_timer.with_mut(|t| {
+            t.state = EventLoopTimerState::FIRED;
+            t.heap = Default::default();
+        });
 
-        if has_been_cleared || self.is_shutdown.load(Ordering::Relaxed) {
+        if has_been_cleared || this.is_shutdown.load(Ordering::Relaxed) {
             return;
         }
 
-        // `self.task` is an *intrusive* node in the WorkPool's Treiber stack.
-        // Pushing it while a prior push is still linked (or `work_pool_callback`
-        // is mid-run and has not yet cleared the flag) would overwrite
-        // `self.task.node.next` and, with any other task interleaved between
-        // the two pushes, form a cycle in the run queue. `Buffer::consume`
-        // then fills a worker's 256-slot ring with repeated copies of every
-        // node in the cycle, so any `AsyncFSTask` caught in it is dispatched
-        // many times and runs on freed memory after the first completion
-        // reaches `destroy()` on the JS thread (observed as a null-deref in
-        // `NodeFS::rm` → `PathLike::slice`). `append()` can re-arm this timer
-        // from `initial_stat_success_on_main_thread` while `self.task` is
-        // still in flight, so guard here: if already in flight, re-arm the
-        // one-shot timer and try again next fire. `work_pool_callback` clears
-        // the flag on exit; the re-arm must be unconditional because its
-        // `!contain_watchers` branch stores `current_interval = 0` directly
-        // (no `set_interval` / no timer update) and can race an `append()`
-        // that landed after its `pop_batch()`, which would otherwise leave a
-        // live watcher with the timer disarmed. `.max(5)` matches the clamp
-        // applied to every watcher interval in `StatWatcher::init`.
-        if self.work_pool_in_flight.swap(true, Ordering::AcqRel) {
-            let this = core::ptr::from_mut(self);
-            Self::set_timer(this, self.get_interval().max(5));
+        // Only one stat pass may be out on the pool at a time: a second pass
+        // would race the first for `watchers` and post a second timer update.
+        // `append()` can re-arm this timer from
+        // `initial_stat_success_on_main_thread` while a pass is still in
+        // flight, so guard here: if one is, re-arm the one-shot timer and try
+        // again next fire. The pass clears the flag on exit; the re-arm must be
+        // unconditional because its `!contain_watchers` branch stores
+        // `current_interval = 0` directly (no timer update) and can race an
+        // `append()` that landed after it took the queue, which would otherwise
+        // leave a live watcher with the timer disarmed. `.max(5)` matches the
+        // clamp applied to every watcher interval in `StatWatcher::init`.
+        if this.work_pool_in_flight.swap(true, Ordering::AcqRel) {
+            this.set_timer(this.get_interval().max(5));
             return;
         }
 
-        // One ref is held across the work-pool hop (released by the
-        // `RefPtr::from_raw` in `work_pool_callback`). Taken here — not in
-        // `set_interval` — so the count exactly tracks "task in flight" instead
-        // of accumulating one leak per `set_interval(0)` / re-arm.
-        // SAFETY: `self` is live (`&mut self`).
-        Self::ref_(core::ptr::from_mut(self));
-        self.ticket.set(Some(self.vm().ticket()));
-        WorkPool::schedule(&raw mut self.task);
+        // One ref is held across the work-pool hop by the pass itself, so the
+        // count exactly tracks "task in flight".
+        WorkPool::schedule_new(StatPassTask {
+            scheduler: RefPtr::from_this(this),
+            ticket: this.vm.ticket(),
+            task: WorkPoolTask::default(),
+        });
     }
 
-    /// Thread-pool callback (safe fn — coerces to the `WorkPoolTask.callback`
-    /// field type at the struct-init site in `init`).
-    fn work_pool_callback(task: *mut WorkPoolTask) {
-        // SAFETY: `task` points to `StatWatcherScheduler.task` — only ever
-        // invoked by the thread pool against a scheduler it scheduled in
-        // `timer_callback`, so provenance covers the full allocation.
-        let this: *mut StatWatcherScheduler =
-            unsafe { bun_core::from_field_ptr!(StatWatcherScheduler, task, task) };
-        // ref'd when the work-pool task was scheduled
-        // SAFETY: `this` is live; one ref (taken in `timer_callback`) is owned
-        // by this callback and adopted here.
-        let guard = unsafe { RefPtr::from_raw(this) };
-        // BACKREF — `this` is alive (ref'd when the timer was scheduled);
-        // `ParentRef` Deref gives safe `&Self` for the queue/interval reads.
-        let this_ref = ParentRef::from(NonNull::new(this).expect("work_pool_callback: scheduler"));
-        // Moved out before anything is posted: the JS thread may re-arm (and
-        // store the next pass's ticket) as soon as it hears from this pass.
-        let ticket = this_ref
-            .ticket
-            .take()
-            .expect("stat scheduler pass holds a ticket");
-
-        // Instant.now will not fail on our target platforms.
-        let now = Instant::now();
-
-        let batch = this_ref.watchers.pop_batch();
-        log!("pop batch of {} watchers", batch.count);
-        let mut iter = batch.iterator();
-        let mut min_interval: i32 = i32::MAX;
-        let mut closest_next_check: u64 = u64::try_from(min_interval).expect("int cast");
-        let mut contain_watchers = false;
-        loop {
-            let watcher_raw = iter.next();
-            // BACKREF — `watcher` is a live `*mut StatWatcher` from the intrusive
-            // queue; alive because we hold a ref on it (taken in `append`).
-            // R-2: shared `&` only — `restat()` may enqueue a main-thread task
-            // that derefs the same `StatWatcher` concurrently; aliased `&` is
-            // sound where `&mut` would not be. `ParentRef` Deref gives that `&`.
-            let Some(watcher) = NonNull::new(watcher_raw) else {
-                break;
-            };
-            let w = ParentRef::from(watcher);
-            if w.closed.load(Ordering::Relaxed) {
-                // SAFETY: we own the ref taken in `append`.
-                unsafe { ThreadSafeRefCount::<StatWatcher>::deref(watcher.as_ptr()) };
-                continue;
-            }
-            contain_watchers = true;
-
-            let time_since =
-                u64::try_from(now.duration_since(w.last_check.get()).as_nanos()).expect("int cast");
-            let interval = u64::try_from(w.interval).expect("int cast") * 1_000_000;
-
-            if time_since >= interval.saturating_sub(500) {
-                w.last_check.set(now);
-                w.restat(&ticket);
-            } else {
-                closest_next_check = (interval - time_since).min(closest_next_check);
-            }
-            min_interval = min_interval.min(w.interval);
-            this_ref.watchers.push(watcher);
-            log!("reinsert watcher {:x}", watcher.as_ptr() as usize);
-        }
-
-        if this_ref.is_shutdown.load(Ordering::Relaxed) {
-            // Do not enqueue a `StatWatcherTimerUpdate` onto a JS-thread queue
-            // that will never tick again.
-            this_ref.current_interval.store(0, Ordering::Relaxed);
-        } else if contain_watchers {
-            // choose the smallest interval or the closest time to the next check
-            let interval = min_interval.min(i32::try_from(closest_next_check).expect("int cast"));
-            this_ref.current_interval.store(interval, Ordering::Relaxed);
-            Self::schedule_timer_update(this, &ticket);
-        } else {
-            // we do not have watchers, we can stop the timer
-            this_ref.current_interval.store(0, Ordering::Relaxed);
-        }
-        // Publish the queue writes above before declaring the work-pool hop
-        // finished; `shutdown_for_exit` Acquire-loads this and then drains.
-        this_ref.work_pool_in_flight.store(false, Ordering::Release);
-        drop(guard);
-        drop(ticket);
-    }
-
-    /// Drain every queued [`StatWatcher`] and release the per-VM scheduler ref
-    /// stored in `RareData`. Runs on the JS thread during `global_exit` /
-    /// worker shutdown, before JSC teardown, so each watcher can still be
-    /// `close()`'d (downgrades its `JsRef` Strong) and so `finalize()` —
-    /// reached from `lastChanceToFinalize` — drops the last ref.
+    /// Drain every queued [`StatWatcher`] and release the per-thread scheduler
+    /// ref stored in the runtime state. Runs on the JS thread during
+    /// `global_exit` / worker shutdown, before JSC teardown, so each watcher
+    /// can still be `close()`'d (downgrades its `JsRef` Strong) and so
+    /// `finalize()` — reached from `lastChanceToFinalize` — drops the last ref.
     ///
     /// Without this the queue forms a refcount cycle at exit
     /// (`scheduler.watchers` → `StatWatcher` → `StatWatcher.scheduler`) and
     /// every still-queued watcher leaks.
-    ///
-    /// # Safety
-    /// `vm` is the live per-thread VM. Must be called on the JS thread.
-    pub(crate) unsafe fn shutdown_for_exit(vm: *mut VirtualMachine) {
-        // SAFETY: per fn contract; main-thread only. Touch the raw `rare_data`
-        // option directly so a never-used VM does not lazy-allocate `RareData`
-        // here just to find an empty slot.
-        let Some(rare) = (unsafe { &mut (*vm).rare_data }).as_deref_mut() else {
+    pub(crate) fn shutdown_for_exit() {
+        let Some(Some(this)) = crate::jsc_hooks::with_stat_watcher_scheduler(Option::take) else {
             return;
         };
-        let Some(raw) = core::mem::take(rare.node_fs_stat_watcher_scheduler_slot()) else {
-            return;
-        };
-        let this: *mut StatWatcherScheduler = raw.as_ptr().cast();
-        let this_ref = ParentRef::from(NonNull::new(this).expect("shutdown: scheduler"));
-        debug_assert_eq!(this_ref.main_thread, thread::current().id());
+        debug_assert_eq!(this.main_thread, thread::current().id());
 
-        this_ref.is_shutdown.store(true, Ordering::Relaxed);
+        this.is_shutdown.store(true, Ordering::Relaxed);
         // Disarm the event-loop timer so `timer_callback` cannot schedule a new
         // work-pool task after we've waited below.
-        Self::set_timer(this, 0);
+        this.set_timer(0);
 
         // Wait for any in-flight work-pool task to finish touching `watchers`.
         // The task is bounded (one stat per queued watcher) so this is a short
         // spin in the rare case it overlaps.
-        while this_ref.work_pool_in_flight.load(Ordering::Acquire) {
+        while this.work_pool_in_flight.load(Ordering::Acquire) {
             core::hint::spin_loop();
         }
 
-        let batch = this_ref.watchers.pop_batch();
-        let mut iter = batch.iterator();
-        loop {
-            let watcher = iter.next();
-            if watcher.is_null() {
-                break;
-            }
-            let w = ParentRef::from(NonNull::new(watcher).expect("shutdown: watcher"));
-            if !w.closed.load(Ordering::Relaxed) {
+        let batch = core::mem::take(&mut *this.watchers.lock());
+        for watcher in batch {
+            if !watcher.closed.load(Ordering::Relaxed) {
                 // Downgrade the `JsRef` Strong so the JS wrapper becomes
                 // collectible at `lastChanceToFinalize`.
-                w.close();
+                watcher.close();
             }
-            // SAFETY: we own the queue ref taken in `append`.
-            unsafe { ThreadSafeRefCount::<StatWatcher>::deref(watcher) };
         }
 
-        // Release the RareData ref (`into_raw()` in `lazy_scheduler`). The
-        // scheduler stays alive until the last remaining `StatWatcher` (each
-        // holds a `scheduler` ref) is freed.
-        // SAFETY: `this` is live and we own the RareData ref.
-        Self::deref(this);
+        // The scheduler stays alive until the last remaining `StatWatcher`
+        // (each holds a `scheduler` ref) is freed.
+        drop(this);
     }
 }
 
-// TODO: make this a top-level struct
-//
+/// One periodic stat pass over the scheduler's watchers, run on the work pool.
+/// Owns the scheduler ref that marks "pass in flight".
+struct StatPassTask {
+    scheduler: RefPtr<StatWatcherScheduler>,
+    ticket: bun_jsc::Ticket,
+    task: WorkPoolTask,
+}
+
+bun_threading::owned_task!(StatPassTask, task);
+
+impl StatPassTask {
+    #[allow(clippy::boxed_local)]
+    fn run_owned(self: Box<Self>) {
+        let StatPassTask {
+            scheduler: this,
+            ticket,
+            task: _,
+        } = *self;
+
+        // Instant.now will not fail on our target platforms.
+        let now = Instant::now();
+
+        let batch = core::mem::take(&mut *this.watchers.lock());
+        log!("pop batch of {} watchers", batch.len());
+        let mut min_interval: i32 = i32::MAX;
+        let mut closest_next_check: u64 = u64::try_from(min_interval).expect("int cast");
+        let mut contain_watchers = false;
+        let mut kept: Vec<RefPtr<StatWatcher>> = Vec::with_capacity(batch.len());
+        for watcher in batch {
+            if watcher.closed.load(Ordering::Relaxed) {
+                continue;
+            }
+            contain_watchers = true;
+
+            let time_since = u64::try_from(now.duration_since(watcher.last_check.get()).as_nanos())
+                .expect("int cast");
+            let interval = u64::try_from(watcher.interval).expect("int cast") * 1_000_000;
+
+            if time_since >= interval.saturating_sub(500) {
+                watcher.last_check.set(now);
+                StatWatcher::restat(&watcher, &ticket);
+            } else {
+                closest_next_check = (interval - time_since).min(closest_next_check);
+            }
+            min_interval = min_interval.min(watcher.interval);
+            log!("reinsert watcher {:x}", watcher.as_ptr() as usize);
+            kept.push(watcher);
+        }
+        {
+            let mut queue = this.watchers.lock();
+            kept.append(&mut queue);
+            *queue = kept;
+        }
+
+        if this.is_shutdown.load(Ordering::Relaxed) {
+            // Do not enqueue a `StatWatcherTimerUpdate` onto a JS-thread queue
+            // that will never tick again.
+            this.current_interval.store(0, Ordering::Relaxed);
+        } else if contain_watchers {
+            // choose the smallest interval or the closest time to the next check
+            let interval = min_interval.min(i32::try_from(closest_next_check).expect("int cast"));
+            this.current_interval.store(interval, Ordering::Relaxed);
+            StatWatcherScheduler::schedule_timer_update(&this, &ticket);
+        } else {
+            // we do not have watchers, we can stop the timer
+            this.current_interval.store(0, Ordering::Relaxed);
+        }
+        // Publish the queue writes above before declaring the work-pool hop
+        // finished; `shutdown_for_exit` Acquire-loads this and then drains.
+        this.work_pool_in_flight.store(false, Ordering::Release);
+        drop(this);
+        drop(ticket);
+    }
+}
+
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). `closed` is
 // `AtomicBool` because it is genuinely cross-thread (written by `close()` on
-// the JS thread, read by the work-pool callback). `last_check` is `Cell`
+// the JS thread, read by the stat pass). `last_check` is `Cell`
 // (worker-thread-only after init); `persistent`/`poll_ref`/`this_value` are
 // JS-thread-only. Read-only-after-construction fields stay bare.
 #[bun_jsc::JsClass(no_constructor)]
 #[derive(bun_ptr::ThreadSafeRefCounted)]
 pub struct StatWatcher {
-    pub(crate) next: bun_threading::Link<StatWatcher>, // INTRUSIVE link for UnboundedQueue
-
     /// JS-thread uses only.
-    ctx: BackRef<VirtualMachine, bun_ptr::Mut>,
-    /// The pending pool→JS hop, if any (one at a time: the initial stat, then restats).
-    pending_hop: Cell<u8>,
+    ctx: BackRef<VirtualMachine>,
 
     ref_count: ThreadSafeRefCount<StatWatcher>,
 
     /// Closed is set to true to tell the scheduler to remove from list and deref.
     closed: AtomicBool,
-    path: ZBox, // owned NUL-terminated path; was `[:0]u8` allocSentinel'd + freed in deinit (Drop frees)
+    path: ZBox,
     persistent: Cell<bool>,
     bigint: bool,
     interval: i32,
     last_check: Cell<Instant>,
 
-    // JSC_BORROW per LIFETIMES.tsv — global outlives every watcher; `BackRef`
-    // gives safe `&JSGlobalObject` projection (Deref) at every read site.
     global_this: BackRef<JSGlobalObject>,
 
     this_value: JsCell<JsRef>,
@@ -459,130 +335,57 @@ pub struct StatWatcher {
 
     last_stat: Guarded<PosixStat>,
 
+    /// One ref on the per-thread scheduler; released when the watcher is freed.
     scheduler: RefPtr<StatWatcherScheduler>,
 }
 
 impl Drop for StatWatcher {
+    /// Runs when the last ref goes — possibly on the work-pool thread (a stat
+    /// pass or `InitialStatTask` dropping the ref it held). Isolation-registry
+    /// removal and the poll unref therefore live in `close()`, which every
+    /// registered watcher reaches on the JS thread first: the Strong
+    /// `this_value` self-ref keeps the wrapper alive until `close()`
+    /// downgrades it, so `finalize` cannot drop the wrapper ref before then.
     fn drop(&mut self) {
-        log!("deinit {:x}", std::ptr::from_ref(self) as usize);
-        // Isolation-registry removal lives in `close()`, NOT here: the last
-        // `deref` can happen on the work-pool thread (queue ref dropped in
-        // `work_pool_callback` / `InitialStatTask`), where the thread-local
-        // `active_handles()` is null and the removal would silently no-op,
-        // leaving a dangling registry pointer. Every drop of a registered
-        // watcher is preceded by a JS-thread `close()` (the Strong `this_value`
-        // self-ref keeps the wrapper alive until `close()` downgrades it, so
-        // `finalize` cannot drop the wrapper ref first).
-        if cfg!(debug_assertions) && self.poll_ref.get().is_active() {
-            debug_assert!(core::ptr::eq(VirtualMachine::get(), self.ctx.as_ptr())); // We cannot unref() on another thread this way.
+        log!("deinit {:x}", core::ptr::from_ref(self) as usize);
+        self.persistent.set(false);
+        if self.poll_ref.get().is_active() {
+            // We cannot unref() on another thread this way.
+            debug_assert!(core::ptr::eq(
+                VirtualMachine::get(),
+                self.ctx.as_const_ptr()
+            ));
+            let el_ctx = self.ctx.loop_ctx();
+            self.poll_ref.with_mut(|p| p.unref(el_ctx));
         }
-        let el_ctx = self.ctx_el_ctx();
-        self.poll_ref.with_mut(|p| p.unref(el_ctx));
+        self.closed.store(true, Ordering::Relaxed);
+        self.this_value.set(JsRef::empty());
     }
 }
 
 impl StatWatcher {
-    /// Safe `&JSGlobalObject` accessor for the JSC_BORROW `global_this` back-pointer.
-    #[inline]
-    fn global_this(&self) -> &JSGlobalObject {
-        // `BackRef` invariant: global outlives every `StatWatcher` (JSC_BORROW).
-        self.global_this.get()
+    /// The per-thread scheduler, created on first use; the returned ref is the
+    /// caller's.
+    fn lazy_scheduler(vm: &VirtualMachine) -> RefPtr<StatWatcherScheduler> {
+        crate::jsc_hooks::with_stat_watcher_scheduler(|slot| {
+            slot.get_or_insert_with(|| StatWatcherScheduler::init(vm))
+                .clone()
+        })
+        .expect("fs.watchFile before the runtime state is installed")
     }
 
-    /// Spec `RareData.nodeFSStatWatcherScheduler`. Body lives here (high tier)
-    /// because `StatWatcherScheduler` cannot be named from `bun_jsc::rare_data`
-    /// without a crate cycle; the slot in `RareData` is an erased
-    /// `Option<NonNull<c_void>>` (§Dispatch).
-    fn lazy_scheduler(vm: *mut VirtualMachine) -> RefPtr<StatWatcherScheduler> {
-        // SAFETY: `vm` is the live per-thread VM; called only from the JS thread.
-        let slot = unsafe { (*vm).rare_data() }.node_fs_stat_watcher_scheduler_slot();
-        let raw = match *slot {
-            Some(p) => p.as_ptr().cast::<StatWatcherScheduler>(),
-            None => {
-                let arc = StatWatcherScheduler::init(vm);
-                let raw = arc.into_raw(); // VM owns this ref forever (never deref'd)
-                // SAFETY: `vm` is live; reborrow rare_data after `init` to avoid
-                // an aliasing `&mut RareData` across the call.
-                *unsafe { (*vm).rare_data() }.node_fs_stat_watcher_scheduler_slot() =
-                    core::ptr::NonNull::new(raw.cast());
-                raw
-            }
-        };
-        // SAFETY: `raw` was produced by `into_raw` above (or on a prior call) and
-        // the VM ref keeps it alive; bump the count for the caller's `RefPtr`.
-        unsafe { RefPtr::init_ref(raw) }
-    }
-
-    /// # Safety
-    /// `this` must point to a live `StatWatcher`.
-    // Forwards `this` to the unsafe `ThreadSafeRefCount` helper without
-    // dereferencing; not_unsafe_ptr_arg_deref is a false positive on
-    // opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[inline]
-    fn ref_(this: *mut Self) {
-        // SAFETY: per fn contract.
-        unsafe { ThreadSafeRefCount::<Self>::ref_(this) };
-    }
-    /// # Safety
-    /// `this` must point to a live `StatWatcher` and the caller must own one
-    /// outstanding ref, which is released.
-    // Forwards `this` to the unsafe `ThreadSafeRefCount` helper without
-    // dereferencing; not_unsafe_ptr_arg_deref is a false positive on
-    // opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    #[inline]
-    fn deref(this: *mut Self) {
-        // SAFETY: per fn contract.
-        unsafe { ThreadSafeRefCount::<Self>::deref(this) };
-    }
-
-    #[inline]
-    fn ctx_el_ctx(&self) -> bun_io::EventLoopCtx {
-        // SAFETY: `self.ctx` is the live per-thread VM singleton backref.
-        unsafe { VirtualMachine::event_loop_ctx(self.ctx.as_ptr()) }
-    }
-
-    /// `self`'s address as `*mut Self` for `ConcurrentTask` ctx slots. The
-    /// callbacks deref it as `&*const` (shared) — see
-    /// `swap_and_call_listener_on_main_thread` etc. — so no write provenance
-    /// is required; the `*mut` spelling is purely to match the C ABI.
-    #[inline]
-    fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
-    }
-
-    /// Pool thread → JS thread: `hop` runs there and consumes one ref on
-    /// `self`; a VM tearing down releases the ref from its queue instead.
-    fn post_to_js_thread(&self, hop: StatWatcherHop, ticket: &bun_jsc::Ticket) {
-        self.pending_hop.set(hop as u8);
-        ticket.post(ConcurrentTask::create(Task::init(self.as_ctx_ptr())));
-    }
-
-    /// JS thread dispatch of a [`post_to_js_thread`](Self::post_to_js_thread) hop.
-    ///
-    /// # Safety
-    /// `this` is the watcher the pool posted (ref held for the hop).
-    pub(crate) unsafe fn run_hop(this: *mut StatWatcher) -> bun_event_loop::JsResult<()> {
-        // SAFETY: fn contract.
-        let hop = unsafe { (*this).pending_hop.get() };
-        match hop {
-            x if x == StatWatcherHop::InitialStatSuccess as u8 => {
-                Self::initial_stat_success_on_main_thread(this)
-            }
-            x if x == StatWatcherHop::InitialStatError as u8 => {
-                Self::initial_stat_error_on_main_thread(this)
-            }
-            _ => Self::swap_and_call_listener_on_main_thread(this),
-        }
-    }
-
-    /// VM teardown release of a queued hop (JS thread): drop the hop's ref.
-    ///
-    /// # Safety
-    /// As [`run_hop`](Self::run_hop).
-    pub(crate) unsafe fn release_hop(this: *mut StatWatcher) {
-        Self::deref(this);
+    /// Pool thread → JS thread: `hop` runs there and consumes `this`; a VM
+    /// tearing down releases it from its queue instead.
+    fn post_to_js_thread(
+        this: RefPtr<StatWatcher>,
+        hop: StatWatcherHopKind,
+        ticket: &bun_jsc::Ticket,
+    ) {
+        let hop = Box::new(StatWatcherHop {
+            watcher: this,
+            kind: hop,
+        });
+        ticket.post(ConcurrentTask::create(Task::from_boxed(hop)));
     }
 
     /// Copy the last stat by value.
@@ -590,16 +393,12 @@ impl StatWatcher {
     /// This field is sometimes set from aonther thread, so we should copy by
     /// value instead of referencing by pointer.
     fn get_last_stat(&self) -> PosixStat {
-        let value = self.last_stat.lock();
-        *value
-        // unlock on Drop of guard
+        *self.last_stat.lock()
     }
 
     /// Set the last stat.
     fn set_last_stat(&self, stat: &PosixStat) {
-        let mut value = self.last_stat.lock();
-        *value = *stat;
-        // unlock on Drop of guard
+        *self.last_stat.lock() = *stat;
     }
 
     #[bun_jsc::host_fn(method)]
@@ -610,7 +409,7 @@ impl StatWatcher {
     ) -> JsResult<JSValue> {
         if !this.closed.load(Ordering::Relaxed) && !this.persistent.get() {
             this.persistent.set(true);
-            let el_ctx = this.ctx_el_ctx();
+            let el_ctx = this.ctx.loop_ctx();
             this.poll_ref.with_mut(|p| p.ref_(el_ctx));
         }
         Ok(JSValue::UNDEFINED)
@@ -624,7 +423,7 @@ impl StatWatcher {
     ) -> JsResult<JSValue> {
         if this.persistent.get() {
             this.persistent.set(false);
-            let el_ctx = this.ctx_el_ctx();
+            let el_ctx = this.ctx.loop_ctx();
             this.poll_ref.with_mut(|p| p.unref(el_ctx));
         }
         Ok(JSValue::UNDEFINED)
@@ -634,10 +433,9 @@ impl StatWatcher {
     ///
     /// Always runs on the JS thread (`do_close`, `stop_active_handles_for_vm_teardown`,
     /// `shutdown_for_exit`), so this is where the watcher leaves the
-    /// isolation registry — `deinit` can fire on the work-pool thread where
+    /// isolation registry — the last ref can go on the work-pool thread where
     /// the thread-local registry is unreachable.
     pub(crate) fn close(&self) {
-        // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
         if let Some(handles) = crate::jsc_hooks::active_handles() {
             handles.swap_remove(&crate::jsc_hooks::ActiveHandle::StatWatcher(NonNull::from(
                 self,
@@ -646,7 +444,7 @@ impl StatWatcher {
         if self.persistent.get() {
             self.persistent.set(false);
         }
-        let el_ctx = self.ctx_el_ctx();
+        let el_ctx = self.ctx.loop_ctx();
         self.poll_ref.with_mut(|p| p.unref(el_ctx));
         self.closed.store(true, Ordering::Relaxed);
         self.this_value.with_mut(|r| r.downgrade());
@@ -669,52 +467,43 @@ impl StatWatcher {
         self.closed.store(true, Ordering::Relaxed);
     }
 
-    fn initial_stat_success_on_main_thread(this: *mut StatWatcher) -> bun_event_loop::JsResult<()> {
-        // SAFETY: balance the ref from createAndSchedule(); raw ptr captured (not `&self`).
-        let _guard = unsafe { RefPtr::from_raw(this) };
-        // BACKREF — `this` is alive (ref'd in
-        // InitialStatTask::create_and_schedule). R-2: all field access via
-        // Cell/JsCell/Atomic; `ParentRef` Deref gives safe `&Self`.
-        let this_ref = ParentRef::from(NonNull::new(this).expect("initial_stat_success: watcher"));
-        if this_ref.closed.load(Ordering::Relaxed) {
+    fn initial_stat_success_on_main_thread(
+        this: &RefPtr<StatWatcher>,
+    ) -> bun_event_loop::JsResult<()> {
+        if this.closed.load(Ordering::Relaxed) {
             return Ok(());
         }
 
-        let Some(js_this) = this_ref.this_value.get().try_get() else {
+        let Some(js_this) = this.this_value.get().try_get() else {
             return Ok(());
         };
-        let global_this = this_ref.global_this();
+        let global_this = this.global_this.get();
 
         // Propagated to the task fold: reporting here would leave a
         // termination pending for the next queued task's JS entry.
-        let jsvalue = stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)?;
+        let jsvalue = stat_to_js_stats(global_this, &this.get_last_stat(), this.bigint)?;
         js::prev_stat_set_cached(js_this, global_this, jsvalue);
 
-        // SAFETY: scheduler is live (`RefPtr`); `this` is live (ref'd, guard above).
-        StatWatcherScheduler::append(this_ref.scheduler.as_ptr(), this);
+        this.scheduler.append(this.clone());
         Ok(())
     }
 
-    fn initial_stat_error_on_main_thread(this: *mut StatWatcher) -> bun_event_loop::JsResult<()> {
-        // SAFETY: balance the ref from createAndSchedule(); raw ptr captured (not `&self`).
-        let _guard = unsafe { RefPtr::from_raw(this) };
-        // BACKREF — `this` is alive (ref'd in
-        // InitialStatTask::create_and_schedule). R-2: `cb.call()` below
-        // re-enters JS, which may call `do_close()` → fresh `&Self` from
-        // m_ctx; aliased `&` is sound, aliased `&mut` is not. `ParentRef`
-        // Deref gives that shared `&`.
-        let this_ref = ParentRef::from(NonNull::new(this).expect("initial_stat_error: watcher"));
-        if this_ref.closed.load(Ordering::Relaxed) {
+    fn initial_stat_error_on_main_thread(
+        this: &RefPtr<StatWatcher>,
+    ) -> bun_event_loop::JsResult<()> {
+        if this.closed.load(Ordering::Relaxed) {
             return Ok(());
         }
 
-        let Some(js_this) = this_ref.this_value.get().try_get() else {
+        let Some(js_this) = this.this_value.get().try_get() else {
             return Ok(());
         };
-        let global_this = this_ref.global_this();
-        let jsvalue = stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)?;
+        let global_this = this.global_this.get();
+        let jsvalue = stat_to_js_stats(global_this, &this.get_last_stat(), this.bigint)?;
         js::prev_stat_set_cached(js_this, global_this, jsvalue);
 
+        // R-2: `call()` re-enters JS, which may call `do_close()` → fresh
+        // `&Self` from m_ctx; everything here is shared access.
         let result = js::listener_get_cached(js_this).unwrap().call(
             global_this,
             JSValue::UNDEFINED,
@@ -724,9 +513,8 @@ impl StatWatcher {
         // Append to the scheduler before propagating a listener error so the
         // watcher keeps running after a throwing listener (Node semantics).
         // `append` does not enter JS, so it is safe with an exception pending.
-        if !this_ref.closed.load(Ordering::Relaxed) {
-            // SAFETY: scheduler is live (`RefPtr`); `this` is live (ref'd, guard above).
-            StatWatcherScheduler::append(this_ref.scheduler.as_ptr(), this);
+        if !this.closed.load(Ordering::Relaxed) {
+            this.scheduler.append(this.clone());
         }
 
         // Propagate to the dispatcher: `report_error_or_terminate` reports a
@@ -738,16 +526,15 @@ impl StatWatcher {
     }
 
     /// Pool thread (the scheduler's pass).
-    fn restat(&self, ticket: &bun_jsc::Ticket) {
+    fn restat(this: &RefPtr<StatWatcher>, ticket: &bun_jsc::Ticket) {
         log!("recalling stat");
-        let stat = restat_impl(&self.path);
+        let stat = restat_impl(&this.path);
         let res = match stat {
             Ok(res) => res,
-            // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
             Err(_) => bun_core::ffi::zeroed::<PosixStat>(),
         };
 
-        let last_stat = self.get_last_stat();
+        let last_stat = this.get_last_stat();
 
         // Ignore atime changes when comparing stats
         // Compare field-by-field to avoid false positives from padding bytes
@@ -771,36 +558,23 @@ impl StatWatcher {
             return;
         }
 
-        self.set_last_stat(&res);
-        // R-2: derive the ctx pointer from `&self` — the callback derefs it as
-        // shared (`&*const`), so no write provenance is required.
-        let this_ptr: *mut StatWatcher = self.as_ctx_ptr();
-        Self::ref_(this_ptr);
-        self.post_to_js_thread(StatWatcherHop::Changed, ticket);
+        this.set_last_stat(&res);
+        Self::post_to_js_thread(this.clone(), StatWatcherHopKind::Changed, ticket);
     }
 
     /// After a restat found the file changed, this calls the listener function.
     fn swap_and_call_listener_on_main_thread(
-        this: *mut StatWatcher,
+        this: &RefPtr<StatWatcher>,
     ) -> bun_event_loop::JsResult<()> {
-        // SAFETY: balance the ref from restat(); raw ptr captured (not `&self`).
-        let _guard = unsafe { RefPtr::from_raw(this) };
-        // BACKREF — `this` is alive (ref'd in restat()). R-2: `cb.call()`
-        // below re-enters JS, which may call `do_close()` → fresh `&Self` from
-        // m_ctx; aliased `&` is sound, aliased `&mut` is not (and the
-        // work-pool thread may still hold `&*watcher`). `ParentRef` Deref
-        // gives that shared `&`.
-        let this_ref = ParentRef::from(NonNull::new(this).expect("swap_and_call: watcher"));
-        if this_ref.closed.load(Ordering::Relaxed) {
+        if this.closed.load(Ordering::Relaxed) {
             return Ok(());
         }
-        let Some(js_this) = this_ref.this_value.get().try_get() else {
+        let Some(js_this) = this.this_value.get().try_get() else {
             return Ok(());
         };
-        let global_this = this_ref.global_this();
+        let global_this = this.global_this.get();
         let prev_jsvalue = js::prev_stat_get_cached(js_this).unwrap_or(JSValue::UNDEFINED);
-        let current_jsvalue =
-            stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)?;
+        let current_jsvalue = stat_to_js_stats(global_this, &this.get_last_stat(), this.bigint)?;
         js::prev_stat_set_cached(js_this, global_this, current_jsvalue);
 
         // Propagate to the dispatcher: `report_error_or_terminate` reports a
@@ -808,6 +582,8 @@ impl StatWatcher {
         // Swallowing the error here leaves a termination exception on the VM
         // and the next queued task re-enters JS under a
         // `scope.assertNoException()` RELEASE_ASSERT.
+        // R-2: `call()` re-enters JS, which may call `do_close()`; shared
+        // access only.
         js::listener_get_cached(js_this)
             .unwrap()
             .call(
@@ -818,36 +594,26 @@ impl StatWatcher {
             .map(drop)
     }
 
-    fn init(args: &Arguments) -> Result<*mut StatWatcher, crate::Error> {
+    fn init(args: &Arguments) -> Result<JSValue, crate::Error> {
         log!("init");
 
         let mut buf = bun_paths::path_buffer_pool::get();
-        // guard puts back on Drop
         let mut slice = args.path.slice();
         if strings::starts_with(slice, b"file://") {
             slice = &slice[b"file://".len()..];
         }
 
-        // SAFETY: `FileSystem::instance()` is initialized at process start
-        // (`FileSystem::init` runs before any JS module loads).
         let top_level_dir = fs::FileSystem::get().top_level_dir;
         let parts: [&[u8]; 1] = [slice];
         let file_path =
             Path::join_abs_string_buf::<platform::Auto>(top_level_dir, &mut buf[..], &parts);
 
-        // allocSentinel + memcpy → owned NUL-terminated copy (ZBox)
         let alloc_file_path = ZBox::from_bytes(file_path);
-        // errdefer free → Drop handles it
 
-        // `args.global_this` is a `BackRef` (JSC_BORROW); safe Deref.
-        let vm = args.global_this.bun_vm_ptr();
-        let this = Box::new(StatWatcher {
-            next: bun_threading::Link::new(),
-            // JSC_BORROW: `vm` is the live per-thread VM (never null); write provenance
-            // for the `rare_data()` call in `deinit`.
-            // SAFETY: `bun_vm_ptr()` is the live per-thread VM, non-null, outlives the watcher.
-            ctx: unsafe { BackRef::from_raw_mut(vm) },
-            pending_hop: Cell::new(0),
+        let global_this: &JSGlobalObject = &args.global_this;
+        let vm = global_this.bun_vm();
+        let watcher = RefPtr::new(StatWatcher {
+            ctx: BackRef::new(vm),
             ref_count: ThreadSafeRefCount::init(),
             closed: AtomicBool::new(false),
             path: alloc_file_path,
@@ -860,51 +626,42 @@ impl StatWatcher {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             // InitStatTask is responsible for setting this
-            // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
             last_stat: Guarded::init(bun_core::ffi::zeroed::<PosixStat>()),
             scheduler: Self::lazy_scheduler(vm),
         });
-        let this_ptr = bun_core::heap::into_raw(this);
-        // errdefer: on the error path we own the only reference.
-        // SAFETY: sole owner on that path.
-        let guard = scopeguard::guard(this_ptr, |p| drop(unsafe { bun_core::heap::take(p) }));
-        // BACKREF — `this_ptr` just leaked from Box; alive until deref drops
-        // it. R-2: all field mutation goes through Cell/JsCell so shared `&`
-        // suffices (and `to_js_ptr` below creates the JS wrapper, after which
-        // the codegen shim may form its own `&Self`). `ParentRef` Deref gives
-        // that shared `&`.
-        let this_ref = ParentRef::from(NonNull::new(this_ptr).expect("init: watcher"));
 
-        if this_ref.persistent.get() {
-            let el_ctx = this_ref.ctx_el_ctx();
-            this_ref.poll_ref.with_mut(|p| p.ref_(el_ctx));
+        if watcher.persistent.get() {
+            let el_ctx = watcher.ctx.loop_ctx();
+            watcher.poll_ref.with_mut(|p| p.ref_(el_ctx));
         }
 
-        // SAFETY: `this_ptr` ownership transfers to the C++ wrapper (freed via
-        // `StatWatcherClass__finalize`). `args.global_this` is a `BackRef`
-        // (JSC_BORROW) — safe Deref to `&JSGlobalObject`.
-        let js_this = unsafe { StatWatcher::to_js_ptr(this_ptr, &args.global_this) };
-        this_ref
-            .this_value
-            .set(JsRef::init_strong(js_this, &args.global_this));
-        js::listener_set_cached(js_this, &args.global_this, args.listener);
-        // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
+        // The initial ref becomes the JS wrapper's (released by
+        // `StatWatcherClass__finalize` → `finalize`). R-2: from here on the
+        // codegen shim may form its own `&Self`, so everything below is shared
+        // access through `this`.
+        let this: ThisPtr<StatWatcher> = watcher.into_this_ptr();
+        let js_this = StatWatcher::to_js_nonnull(
+            NonNull::new(this.as_ptr()).expect("RefPtr is non-null"),
+            global_this,
+        );
+        this.this_value
+            .set(JsRef::init_strong(js_this, global_this));
+        js::listener_set_cached(js_this, global_this, args.listener);
         if let Some(handles) = crate::jsc_hooks::active_handles() {
             bun_core::handle_oom(handles.put(
                 crate::jsc_hooks::ActiveHandle::StatWatcher(
-                    NonNull::new(this_ptr).expect("init: watcher"),
+                    NonNull::new(this.as_ptr()).expect("RefPtr is non-null"),
                 ),
                 (),
             ));
         }
-        // SAFETY: `this_ptr` was just leaked from `Box`; live with refcount 1.
-        InitialStatTask::create_and_schedule(this_ptr);
+        InitialStatTask::create_and_schedule(RefPtr::from_this(this));
 
-        Ok(scopeguard::ScopeGuard::into_inner(guard))
+        Ok(js_this)
     }
 }
 
-// Shared by InitialStatTask::work_pool_callback and StatWatcher::restat — identical logic.
+// Shared by InitialStatTask::run_owned and StatWatcher::restat — identical logic.
 fn restat_impl(path: &ZStr) -> bun_sys::Maybe<PosixStat> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
@@ -923,8 +680,8 @@ pub struct Arguments {
     pub(crate) bigint: bool,
     pub(crate) interval: i32,
 
-    // JSC_BORROW per LIFETIMES.tsv — global outlives the parsed `Arguments`;
-    // `BackRef` gives safe `&JSGlobalObject` projection at every read site.
+    // JSC_BORROW — global outlives the parsed `Arguments`; `BackRef` gives
+    // safe `&JSGlobalObject` projection at every read site.
     pub global_this: BackRef<JSGlobalObject>,
 }
 
@@ -986,38 +743,55 @@ impl Arguments {
     }
 
     pub(crate) fn create_stat_watcher(self) -> Result<JSValue, crate::Error> {
-        // BACKREF — `init` returns the live heap watcher (refcount==1);
-        // `ParentRef` Deref gives safe field access for the `this_value` read.
-        let obj = ParentRef::from(
-            NonNull::new(StatWatcher::init(&self)?).expect("create_stat_watcher: init"),
-        );
-        Ok(obj.this_value.get().try_get().unwrap_or(JSValue::UNDEFINED))
+        StatWatcher::init(&self)
     }
 }
 
-/// Which JS-thread continuation a posted [`StatWatcher`] hop runs.
-#[repr(u8)]
+/// Which JS-thread continuation a posted [`StatWatcherHop`] runs.
 #[derive(Clone, Copy)]
-pub(crate) enum StatWatcherHop {
-    InitialStatSuccess = 1,
-    InitialStatError = 2,
-    Changed = 3,
+pub(crate) enum StatWatcherHopKind {
+    InitialStatSuccess,
+    InitialStatError,
+    Changed,
 }
 
-impl bun_event_loop::Taskable for StatWatcher {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::StatWatcherHop;
-    /// A continuation the pool posted: drop the ref it carries.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract.
-        unsafe { StatWatcher::release_hop(this) }
+/// A pool → JS thread continuation for one watcher (`task_tag::StatWatcherHop`).
+/// Owns one ref on the watcher, released when it has run or is released unrun.
+pub(crate) struct StatWatcherHop {
+    watcher: RefPtr<StatWatcher>,
+    kind: StatWatcherHopKind,
+}
+
+impl StatWatcherHop {
+    /// JS thread dispatch of the hop.
+    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+    pub(crate) fn run(self: Box<Self>) -> bun_event_loop::JsResult<()> {
+        let result = match self.kind {
+            StatWatcherHopKind::InitialStatSuccess => {
+                StatWatcher::initial_stat_success_on_main_thread(&self.watcher)
+            }
+            StatWatcherHopKind::InitialStatError => {
+                StatWatcher::initial_stat_error_on_main_thread(&self.watcher)
+            }
+            StatWatcherHopKind::Changed => {
+                StatWatcher::swap_and_call_listener_on_main_thread(&self.watcher)
+            }
+        };
+        drop(self);
+        result
+    }
+
+    /// VM teardown release of a queued hop (JS thread): drop the hop's ref.
+    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+    pub(crate) fn release_unrun(self: Box<Self>) {
+        drop(self);
     }
 }
 
 pub(crate) struct InitialStatTask {
-    // StatWatcher is intrusively ref-counted (ThreadSafeRefCount m_ctx
-    // payload). We hold the strong ref via `ref_()`/`deref()` and keep the
-    // raw `*mut`.
-    watcher: *mut StatWatcher,
+    /// One ref, handed on to the JS-thread hop (or released here if the
+    /// watcher was closed before the pool got to it).
+    watcher: RefPtr<StatWatcher>,
     ticket: bun_jsc::Ticket,
     task: WorkPoolTask,
 }
@@ -1025,18 +799,13 @@ pub(crate) struct InitialStatTask {
 bun_threading::owned_task!(InitialStatTask, task);
 
 impl InitialStatTask {
-    /// # Safety
-    /// `watcher` must point to a live `StatWatcher`.
-    fn create_and_schedule(watcher: *mut StatWatcher) {
-        // SAFETY: per fn contract; we bump its intrusive refcount, held across
-        // the task lifetime (balanced by `deref()` in run_owned's closed path or
-        // by the main-thread `initial_stat_*_on_main_thread` callbacks).
-        StatWatcher::ref_(watcher);
+    /// JS thread.
+    fn create_and_schedule(watcher: RefPtr<StatWatcher>) {
+        // The watcher is a JS-owned m_ctx; its VM waits for this ticket.
+        let ticket = watcher.ctx.ticket();
         WorkPool::schedule_new(InitialStatTask {
             watcher,
-            // The watcher is a JS-owned m_ctx; its VM waits for this ticket.
-            // SAFETY: per fn contract; JS thread.
-            ticket: unsafe { (*watcher).ctx.get() }.ticket(),
+            ticket,
             task: WorkPoolTask::default(),
         });
     }
@@ -1045,69 +814,56 @@ impl InitialStatTask {
     // is a false positive on this macro contract.
     #[allow(clippy::boxed_local)]
     fn run_owned(self: Box<Self>) {
-        // `watcher` is a raw `*mut` (Copy), so dropping the Box does not touch
-        // the refcount.
-        let this: *mut StatWatcher = self.watcher;
-        // BACKREF — `this` is kept alive by the intrusive ref taken in
-        // `create_and_schedule`. We only need shared access here — `closed` is
-        // read-only, `path` is borrowed, and `set_last_stat`/
-        // `enqueue_task_concurrent` take `&self` (mutation goes through
-        // `Guarded`/atomics). The main thread may concurrently run
-        // `close()`/`finalize()` after `init()` returns the watcher to JS;
-        // both also deref as shared (R-2), so aliased `&` is sound.
-        // `ParentRef` Deref gives that shared `&`.
-        let this_ref = ParentRef::from(NonNull::new(this).expect("run_owned: watcher"));
-        let ticket = self.ticket;
+        let InitialStatTask {
+            watcher: this,
+            ticket,
+            task: _,
+        } = *self;
+        // The main thread may concurrently run `close()`/`finalize()` after
+        // `init()` returned the watcher to JS; both are shared access (R-2), as
+        // is everything here (`closed` is atomic, `set_last_stat` locks).
 
-        if this_ref.closed.load(Ordering::Relaxed) {
-            // Balance the ref() from createAndSchedule().
-            // SAFETY: `this` is live (ref'd in `create_and_schedule`); we own that ref.
-            StatWatcher::deref(this);
+        if this.closed.load(Ordering::Relaxed) {
             return;
         }
 
-        let stat = restat_impl(&this_ref.path);
+        let stat = restat_impl(&this.path);
         match stat {
             Ok(ref res) => {
                 // we store the stat, but do not call the callback
-                this_ref.set_last_stat(res);
-                this_ref.post_to_js_thread(StatWatcherHop::InitialStatSuccess, &ticket);
+                this.set_last_stat(res);
+                StatWatcher::post_to_js_thread(
+                    this,
+                    StatWatcherHopKind::InitialStatSuccess,
+                    &ticket,
+                );
             }
             Err(_) => {
                 // on enoent, eperm, we call cb with two zeroed stat objects
                 // and store previous stat as a zeroed stat object, and then call the callback.
-                // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
-                this_ref.set_last_stat(&bun_core::ffi::zeroed::<PosixStat>());
-                this_ref.post_to_js_thread(StatWatcherHop::InitialStatError, &ticket);
+                this.set_last_stat(&bun_core::ffi::zeroed::<PosixStat>());
+                StatWatcher::post_to_js_thread(this, StatWatcherHopKind::InitialStatError, &ticket);
             }
         }
-        // ref ownership transferred to main-thread callback
-        // (`initial_stat_*_on_main_thread` calls deref()). Nothing to forget —
-        // `watcher` is a raw pointer.
     }
 }
 
+/// Pool → JS thread: re-arm the scheduler's timer for its current interval
+/// (`task_tag::StatWatcherTimerUpdate`). Owns one scheduler ref.
 pub(crate) struct StatWatcherTimerUpdate {
-    // BACKREF — `scheduler` is the refcounted singleton, kept alive by
-    // every `StatWatcher`'s `RefPtr<StatWatcherScheduler>`; the watcher
-    // that drove this `set_interval` still holds one across the hop.
-    scheduler: bun_ptr::ParentRef<StatWatcherScheduler, bun_ptr::Mut>,
+    scheduler: RefPtr<StatWatcherScheduler>,
 }
 
 impl StatWatcherTimerUpdate {
     #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
     pub(crate) fn run(self: Box<Self>) {
         let interval = self.scheduler.get_interval();
-        StatWatcherScheduler::set_timer(self.scheduler.as_mut_ptr(), interval);
+        self.scheduler.set_timer(interval);
     }
-}
 
-impl bun_event_loop::Taskable for StatWatcherTimerUpdate {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::StatWatcherTimerUpdate;
-    /// The holder owns nothing (a non-owning scheduler ref); timers are
-    /// already disarmed, so just drop it.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box `schedule_timer_update` posted.
-        drop(unsafe { bun_core::heap::take(this) });
+    /// Timers are already disarmed; just drop the ref.
+    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+    pub(crate) fn release_unrun(self: Box<Self>) {
+        drop(self);
     }
 }

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -210,9 +210,9 @@ impl StatWatcherScheduler {
 
         // Wait for any in-flight work-pool task to finish touching `watchers`.
         // The task is bounded (one stat per queued watcher) so this is a short
-        // spin in the rare case it overlaps.
+        // wait in the rare case it overlaps.
         while this.work_pool_in_flight.load(Ordering::Acquire) {
-            core::hint::spin_loop();
+            thread::yield_now();
         }
 
         let batch = core::mem::take(&mut *this.watchers.lock());

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -1,25 +1,23 @@
 use core::cell::Cell;
-use core::ffi::c_void;
-#[cfg(not(windows))]
-use core::mem::MaybeUninit;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
 
+use bun_collections::smallvec::SmallVec;
 use bun_core::Output;
 use bun_core::strings;
-#[cfg(not(windows))]
-use bun_event_loop::ConcurrentTask::ConcurrentTask;
-use bun_event_loop::{Task, TaskTag, Taskable, task_tag};
+#[cfg(windows)]
+use bun_event_loop::Task;
 use bun_io::KeepAlive;
-use bun_jsc::abort_signal::AbortListener;
+use bun_jsc::abort_signal::{AbortSubscription, OnAbort};
 use bun_jsc::bun_string_jsc;
 use bun_jsc::node::PathLike;
 use bun_jsc::{
     self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, CommonAbortReason,
     CommonAbortReasonExt as _, GlobalRef, JSGlobalObject, JSValue, JsRef, JsResult, SysErrorJsc,
-    VirtualMachineRef as VirtualMachine,
 };
 use bun_jsc::{JsCell, JsCellRefExt as _};
 use bun_paths::resolve_path::{self as Path, platform};
+use bun_ptr::{BackRef, ThreadBound};
 use bun_sys::{self, SystemErrno};
 use bun_threading::Mutex;
 
@@ -33,48 +31,82 @@ use super::path_watcher;
 #[cfg(windows)]
 use super::win_watcher as path_watcher;
 
-// TODO: make this a top-level struct
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
-// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). `&mut Self`
-// carried LLVM `noalias`, so a host-fn that re-entered JS while holding it let
-// the optimiser cache `self.closed` etc. across the FFI call — the `*mut Self`
-// dance in the old `emit_abort`/`emit_error` was a manual workaround for
-// exactly that. With `Cell`/`JsCell` (UnsafeCell-backed) the miscompile is
-// structurally impossible and those methods are now plain `&self`.
+// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy), so a listener
+// that re-enters (`watcher.close()` from inside the callback) is observed by
+// the code after the call instead of being miscompiled away under `noalias`.
 #[bun_jsc::JsClass(no_constructor)]
 pub struct FSWatcher {
-    // codegen: jsc.Codegen.JSFSWatcher provides toJS/fromJS/fromJSDirect
-    /// JS-thread uses only.
-    ctx: *mut VirtualMachine,
-    /// How the (process-wide) watcher thread delivers event batches to the
-    /// VM while this watcher is attached (POSIX; on Windows libuv delivers fs
-    /// events on the JS thread). Weak: `detach()` — close, the VM's stop
-    /// phase, or finalize — is what ends the thread's access to `self`.
-    #[cfg(not(windows))]
-    handle: bun_jsc::VmHandle,
-    #[cfg(not(windows))]
-    loop_kind: bun_jsc::LoopKind,
     verbose: bool,
-
-    mutex: Mutex,
-    signal: JsCell<Option<AbortSignalRef>>,
-    persistent: Cell<bool>,
-    path_watcher: Cell<Option<*mut path_watcher::PathWatcher>>,
-    poll_ref: JsCell<KeepAlive>,
+    // pub(super): read by `win_watcher::PathWatcher::emit`.
+    pub(super) encoding: Encoding,
     global_this: GlobalRef,
     /// JS wrapper object, held weak: the wrapper is rooted by
     /// `has_pending_activity()` while the watcher is open; a strong ref here
     /// would self-pin it forever. Cleared by `detach()`.
     js_this: JsCell<JsRef>,
-    // pub(super): read directly by `win_watcher::PathWatcher::emit`.
-    pub(super) encoding: Encoding,
+    persistent: Cell<bool>,
+    poll_ref: JsCell<KeepAlive>,
+    /// Counted ref on the `AbortSignal` from `options.signal`, for reading its
+    /// state and reason. Cleared by `detach()`.
+    signal: JsCell<Option<AbortSignalRef>>,
+    /// Our abort listener on `signal`; dropping it unregisters. Cleared by
+    /// `detach()`.
+    abort_subscription: JsCell<Option<AbortSubscription>>,
+    /// Our handler on the (shared, per-path) OS watch; dropping it detaches it
+    /// and tears the watch down if it was the last. Cleared by `detach()` —
+    /// close, the VM's stop phase, or finalize — which is what ends the
+    /// watcher thread's access to this object.
+    watch: JsCell<Option<path_watcher::Registration>>,
+    /// Open/closed state and the pending-activity count that roots the JS
+    /// wrapper. Shared with the watcher thread's [`EventSink`] and every
+    /// queued [`FSWatchTask`], which only touch this part.
+    activity: Arc<Activity>,
+}
 
-    /// User can call close and pre-detach so we need to track this
-    closed: Cell<bool>,
-
+/// The part of an [`FSWatcher`] the watcher thread and the GC thread reach.
+pub(crate) struct Activity {
+    /// Serialises `closed` against `ref_task` (watcher thread) so no new
+    /// activity is taken once `close()` has decided.
+    mutex: Mutex,
+    /// User can call close and pre-detach so we need to track this.
+    closed: AtomicBool,
     /// While it's not closed, the pending activity
-    pending_activity_count: AtomicU32,
-    current_task: JsCell<FSWatchTask>,
+    pending: AtomicU32,
+}
+
+impl Activity {
+    // this can be called from Watcher Thread or JS Context Thread
+    pub(crate) fn ref_task(&self) -> bool {
+        let _guard = self.mutex.lock_guard();
+        if self.closed.load(Ordering::Relaxed) {
+            return false;
+        }
+        self.pending.fetch_add(1, Ordering::Relaxed);
+        true
+    }
+
+    pub(crate) fn unref_task(&self) {
+        let _guard = self.mutex.lock_guard();
+        // JSC eventually will free it
+        let prev = self.pending.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(prev > 0);
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Relaxed)
+    }
+
+    /// `true` if this call moved the watcher from open to closed.
+    fn close(&self) -> bool {
+        let _guard = self.mutex.lock_guard();
+        if self.closed.load(Ordering::Relaxed) {
+            return false;
+        }
+        self.closed.store(true, Ordering::Relaxed);
+        true
+    }
 }
 
 /// `jsc.Codegen.JSFSWatcher` cached-slot accessors (`values: ["listener"]` in
@@ -83,229 +115,168 @@ pub mod js {
     bun_jsc::codegen_cached_accessors!("FSWatcher"; listener);
 }
 
-impl FSWatcher {
-    /// JS thread only (Windows delivers fs events on the loop thread).
-    #[cfg(windows)]
-    #[inline]
-    fn vm(&self) -> &mut VirtualMachine {
-        // SAFETY: `ctx` is the live per-thread VM (set in `init`); every caller
-        // is on its JS thread.
-        unsafe { &mut *self.ctx }
-    }
-
-    #[inline]
-    fn vm_ctx(&self) -> bun_io::EventLoopCtx {
-        // SAFETY: `self.ctx` is the live per-thread VM singleton backref.
-        unsafe { VirtualMachine::event_loop_ctx(self.ctx) }
-    }
-
-    /// Watcher thread → JS thread. `task` is the intrusive node of a heap batch
-    /// task; the queue takes ownership unless the VM has been torn down, in
-    /// which case the caller gets it back.
-    #[cfg(not(windows))]
-    pub(crate) fn post(
-        &self,
-        task: core::ptr::NonNull<ConcurrentTask>,
-    ) -> bun_jsc::vm_handle::Posted {
-        self.handle.post(self.loop_kind, task)
-    }
-
-    /// `self`'s address as `*mut Self` for path-watcher / abort-signal /
-    /// rare-data ctx slots. Callbacks deref it as `&*const` (shared) — all
-    /// mutation goes through `Cell`/`JsCell` — so no write provenance is
-    /// required; the `*mut` spelling is purely to match the C signature.
-    #[inline]
-    fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
-    }
-
-    /// Codegen `finalize: true` entry point. Runs on the mutator thread during lazy sweep.
-    #[allow(clippy::boxed_local)] // codegen's signature
-    pub fn finalize(self: Box<Self>) {
-        // stop all managers and signals
-        self.detach();
-    }
+/// A batch of events for one watcher, queued to its JS thread
+/// (`task_tag::FSWatchTask`). Holds one unit of the watcher's pending
+/// activity, which is what keeps `owner` alive until it runs or is released.
+pub struct FSWatchTask {
+    owner: ThreadBound<FSWatcher>,
+    activity: Arc<Activity>,
+    entries: EventBatch,
 }
 
-#[cfg(windows)]
-pub type FSWatchTask = FSWatchTaskWindows;
-#[cfg(not(windows))]
-pub type FSWatchTask = FSWatchTaskPosix;
+type EventBatch = SmallVec<[Event; 8]>;
 
-// `Event::Rename`/`Change` carry `StringOrBytesToDecode` on Windows, which
-// does not coerce to the `&[u8]` `emit()` expects — gate the whole posix task
-// to keep the Windows build sound.
-#[cfg(not(windows))]
-pub struct FSWatchTaskPosix {
-    /// `None` only during `FSWatcher::init` two-phase construction (the task is
-    /// embedded as `current_task` before the boxed `FSWatcher` address is
-    /// known); patched to `Some` immediately after.
-    ctx: Option<bun_ptr::ParentRef<FSWatcher>>,
-    count: u8,
-
-    entries: [MaybeUninit<Entry>; 8],
-    concurrent_task: ConcurrentTask,
-}
-
-#[cfg(not(windows))]
-impl Taskable for FSWatchTaskPosix {
-    const TAG: TaskTag = task_tag::FSWatchTask;
-    /// A batch of events the watcher thread posted that nobody will emit:
-    /// free it (its entries own their paths) and drop the activity unit it
-    /// took — as the refused-post path in `enqueue` does.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract; the FSWatcher outlives its tasks.
-        unsafe {
-            let ctx = (*this).ctx;
-            Self::deinit(this);
-            ctx.expect("FSWatchTask.ctx unset").get().unref_task();
-        }
-    }
-}
-
-#[cfg(not(windows))]
-pub struct Entry {
-    event: Event,
-    needs_free: bool,
-}
-
-#[cfg(not(windows))]
-impl FSWatchTaskPosix {
-    fn ctx(&self) -> &FSWatcher {
-        // BACKREF — `ctx` is the live owning FSWatcher (set right after
-        // boxing in `init`); FSWatcher outlives all its tasks.
-        // R-2: `ParentRef: Deref<Target=FSWatcher>` yields `&FSWatcher`; all
-        // FSWatcher host-fns take `&self` (Cell/JsCell-backed).
-        self.ctx.as_ref().expect("FSWatchTask.ctx unset").get()
-    }
-
-    pub(crate) fn append(&mut self, event: Event, needs_free: bool) {
-        if self.count == 8 {
-            self.enqueue();
-            let ctx = self.ctx;
-            *self = Self {
-                ctx,
-                count: 0,
-                entries: [const { MaybeUninit::uninit() }; 8],
-                concurrent_task: ConcurrentTask::default(),
-            };
-        }
-
-        self.entries[self.count as usize].write(Entry { event, needs_free });
-        self.count += 1;
+impl FSWatchTask {
+    fn new(
+        owner: ThreadBound<FSWatcher>,
+        activity: Arc<Activity>,
+        entries: EventBatch,
+    ) -> Box<Self> {
+        Box::new(FSWatchTask {
+            owner,
+            activity,
+            entries,
+        })
     }
 
     /// JS thread: deliver each batched event to the listener.
-    pub(crate) fn run(&mut self) -> JsResult<()> {
-        let ctx: *const FSWatcher = self.ctx();
-        // SAFETY: BACKREF — the FSWatcher outlives its tasks.
-        let _unref = scopeguard::guard((), |()| unsafe { (*ctx).unref_task() });
-        for i in 0..self.count as usize {
-            // SAFETY: entries [0..count) were written by `append`.
-            let entry = unsafe { self.entries[i].assume_init_ref() };
-            let emitted = match &entry.event {
-                Event::Rename(file_path) => self.ctx().emit::<{ EventType::Rename }>(file_path),
-                Event::Change(file_path) => self.ctx().emit::<{ EventType::Change }>(file_path),
-                Event::Error { err, close } => {
-                    self.ctx().emit_error(err, *close);
-                    Ok(())
+    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+    pub(crate) fn run(self: Box<Self>) -> JsResult<()> {
+        let FSWatchTask {
+            owner,
+            activity,
+            entries,
+        } = *self;
+        let this = owner.get();
+        let result = (|| {
+            for event in entries {
+                match event {
+                    #[cfg(not(windows))]
+                    Event::Rename(file_path) => this.emit::<{ EventType::Rename }>(&file_path)?,
+                    #[cfg(not(windows))]
+                    Event::Change(file_path) => this.emit::<{ EventType::Change }>(&file_path)?,
+                    #[cfg(windows)]
+                    Event::Rename(mut path) => {
+                        this.emit_decoded::<{ EventType::Rename }>(&mut path)?
+                    }
+                    #[cfg(windows)]
+                    Event::Change(mut path) => {
+                        this.emit_decoded::<{ EventType::Change }>(&mut path)?
+                    }
+                    Event::Error { err, close } => this.emit_error(&err, close),
+                    Event::NoFilename(event_type) => this.emit_null_filename(event_type),
+                    Event::Abort => this.emit_if_aborted(),
                 }
-                Event::NoFilename(event_type) => {
-                    self.ctx().emit_null_filename(*event_type);
-                    Ok(())
-                }
-                Event::Abort => {
-                    self.ctx().emit_if_aborted();
-                    Ok(())
-                }
-            };
-            // A filename that could not be built (allocation failure, or the
-            // VM is stopping): the rest of the batch is dropped with the task.
-            emitted?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn append_abort(&mut self) {
-        self.append(Event::Abort, false);
-        self.enqueue();
-    }
-
-    pub(crate) fn enqueue(&mut self) {
-        if self.count == 0 {
-            return;
-        }
-
-        // if false is closed or detached (can still contain valid refs but will not create a new one)
-        if self.ctx().ref_task() {
-            // Reshaped for borrowck — clone self into a heap task, then reset.
-            let that = bun_core::heap::into_raw(Box::new(FSWatchTaskPosix {
-                ctx: self.ctx,
-                count: self.count,
-                entries: core::mem::replace(
-                    &mut self.entries,
-                    [const { MaybeUninit::uninit() }; 8],
-                ),
-                concurrent_task: ConcurrentTask::default(),
-            }));
-            self.count = 0;
-            // SAFETY: `that` is a freshly-boxed task; the concurrent queue takes
-            // ownership of the `ConcurrentTask` node (and transitively the box)
-            // until the JS thread drains and `heap::take`s it in `dispatch`.
-            unsafe {
-                (*that).concurrent_task.task = Task::init(that);
-                let node = core::ptr::NonNull::new_unchecked(core::ptr::addr_of_mut!(
-                    (*that).concurrent_task
-                ));
-                if let bun_jsc::vm_handle::Posted::Refused(_) = self.ctx().post(node) {
-                    // VM torn down: nobody will emit these events. Free the batch
-                    // (its entries own their paths) and drop the activity ref.
-                    let mut task = bun_core::heap::take(that);
-                    task.clean_entries();
-                    self.ctx().unref_task();
-                }
+                // A filename that could not be built (allocation failure, or
+                // the VM is stopping): the rest of the batch is dropped with
+                // the task.
             }
-            return;
-        }
-        // closed or detached so just cleanEntries
-        self.clean_entries();
+            Ok(())
+        })();
+        activity.unref_task();
+        result
     }
 
-    pub(crate) fn clean_entries(&mut self) {
-        for i in 0..self.count as usize {
-            // SAFETY: entries [0..count) were written by `append`.
-            let needs_free = unsafe { self.entries[i].assume_init_ref() }.needs_free;
-            if needs_free {
-                // SAFETY: entries [0..count) were written by `append`; dropped at most once
-                // (count is reset to 0 below).
-                unsafe { self.entries[i].assume_init_drop() };
-            }
-        }
-        self.count = 0;
+    /// The VM is tearing down and nobody will emit these events: drop them and
+    /// the activity unit the batch took.
+    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+    pub(crate) fn release_unrun(self: Box<Self>) {
+        self.activity.unref_task();
     }
 }
 
+/// One `FSWatcher`'s end of a shared POSIX path watch: what the watcher
+/// thread holds (under the manager lock) to batch events and hand them to the
+/// owner's JS thread.
 #[cfg(not(windows))]
-impl FSWatchTaskPosix {
-    /// `FSWatchTaskPosix.deinit`. **Not** `impl Drop`:
-    /// this is only ever called on heap clones produced by `enqueue()` (via the
-    /// task dispatcher), never on the embedded `FSWatcher.current_task` field —
-    /// the assert below enforces that. A `Drop` impl would also fire on
-    /// `*self = Self{..}` in `append()` and on `heap::take` in `finalize`,
-    /// where `self` *is* `current_task`, which would always trip the assert.
-    ///
-    /// # Safety
-    /// `this` must be the unique `heap::alloc` pointer produced by
-    /// `enqueue()`; called from the JS-thread task dispatcher only.
-    pub(crate) unsafe fn deinit(this: *mut Self) {
-        // SAFETY: caller contract — `this` is the unique live heap clone from
-        // `enqueue()`; reclaim ownership (paired with its `heap::alloc`).
-        let mut task = unsafe { bun_core::heap::take(this) };
-        task.clean_entries();
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(!core::ptr::eq(task.ctx().current_task.as_ptr(), this));
+pub(crate) struct EventSink {
+    /// Deref'd only by the queued [`FSWatchTask`] on the JS thread; here it is
+    /// just carried. The owner drops its `Registration` (which drops this sink)
+    /// before it goes away.
+    owner: ThreadBound<FSWatcher>,
+    activity: Arc<Activity>,
+    vm: bun_jsc::VmHandle,
+    loop_kind: bun_jsc::LoopKind,
+    verbose: bool,
+    batch: EventBatch,
+}
+
+#[cfg(not(windows))]
+impl EventSink {
+    /// JS thread.
+    fn new(owner: &FSWatcher) -> EventSink {
+        let vm = owner.global_this.bun_vm();
+        EventSink {
+            owner: ThreadBound::new(owner),
+            activity: Arc::clone(&owner.activity),
+            vm: vm.handle(),
+            loop_kind: vm.current_loop_kind(),
+            verbose: owner.verbose,
+            batch: EventBatch::new(),
         }
+    }
+
+    /// Identity of the owning `FSWatcher`, for logs.
+    pub(crate) fn owner_addr(&self) -> usize {
+        self.owner.addr()
+    }
+
+    pub(crate) fn on_path_update(&mut self, event: Event, is_file: bool) {
+        if self.verbose {
+            match &event {
+                Event::Rename(value) | Event::Change(value) => {
+                    if is_file {
+                        bun_core::pretty_errorln!(
+                            "<r> <d>File changed: {}<r>",
+                            bstr::BStr::new(value)
+                        );
+                    } else {
+                        bun_core::pretty_errorln!(
+                            "<r> <d>Dir changed: {}<r>",
+                            bstr::BStr::new(value)
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if self.batch.len() == self.batch.inline_size() {
+            self.enqueue();
+        }
+        self.batch.push(event);
+    }
+
+    /// End of one batch of OS events: hand what was collected to the JS thread.
+    pub(crate) fn on_update_end(&mut self) {
+        if self.verbose {
+            Output::flush();
+        }
+        // we only enqueue after all events are processed
+        self.enqueue();
+    }
+
+    fn enqueue(&mut self) {
+        if self.batch.is_empty() {
+            return;
+        }
+
+        // false once closed or detached: batches already queued keep their
+        // activity unit, but no new one is taken.
+        if self.activity.ref_task() {
+            let task = FSWatchTask::new(
+                self.owner.clone(),
+                Arc::clone(&self.activity),
+                core::mem::take(&mut self.batch),
+            );
+            if let Err(task) = self.vm.post_boxed(self.loop_kind, task) {
+                // VM torn down: nobody will emit these events.
+                task.release_unrun();
+            }
+            return;
+        }
+        // closed or detached so just drop the events
+        self.batch.clear();
     }
 }
 
@@ -367,43 +338,6 @@ unsafe extern "C" {
     safe fn Bun__domEventNameToJS(global: &JSGlobalObject, event_type: EventType) -> JSValue;
 }
 
-#[cfg(windows)]
-pub struct FSWatchTaskWindows {
-    event: Event,
-    ctx: Option<bun_ptr::ParentRef<FSWatcher>>,
-}
-
-#[cfg(windows)]
-impl Taskable for FSWatchTaskWindows {
-    const TAG: TaskTag = task_tag::FSWatchTask;
-    /// As the POSIX task: free the batch, drop the activity unit.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract; the FSWatcher outlives its tasks.
-        unsafe {
-            let ctx = (*this).ctx;
-            Self::deinit(this);
-            ctx.expect("FSWatchTask.ctx unset").get().unref_task();
-        }
-    }
-}
-
-#[cfg(windows)]
-impl Default for FSWatchTaskWindows {
-    fn default() -> Self {
-        Self {
-            event: Event::Error {
-                err: bun_sys::Error {
-                    errno: SystemErrno::EINVAL as _,
-                    syscall: bun_sys::Tag::watch,
-                    ..Default::default()
-                },
-                close: true,
-            },
-            ctx: None,
-        }
-    }
-}
-
 pub enum StringOrBytesToDecode {
     String(bun_core::String),
     BytesToFree(Box<[u8]>),
@@ -430,143 +364,28 @@ impl core::fmt::Display for StringOrBytesToDecode {
     }
 }
 
-#[cfg(windows)]
-impl FSWatchTaskWindows {
-    pub(crate) fn append_abort(&mut self) {
-        let ctx = self.ctx;
-        // Balance the `ctx.unrefTask()` at the end of `run()` (matches
-        // `onPathUpdateWindows` and the posix `enqueue()` path).
-        // SAFETY: ParentRef — `ctx` is the live owning FSWatcher set at
-        // construction; FSWatcher outlives every task it enqueues.
-        // R-2: `ref_task` takes `&self`; ParentRef Derefs to `&FSWatcher`.
-        if !ctx.expect("FSWatchTask.ctx unset").ref_task() {
+impl FSWatcher {
+    /// Queue `event` alone to this watcher's JS thread (from the JS thread).
+    fn enqueue_one(&self, event: Event) {
+        if !self.activity.ref_task() {
             return;
         }
-        let task = bun_core::heap::into_raw(Box::new(FSWatchTaskWindows {
-            ctx,
-            event: Event::Abort,
-        }));
-
-        // `ctx` is the live owning `ParentRef<FSWatcher>` (BACKREF); `vm()` →
-        // `event_loop_mut()` is the audited safe `&mut EventLoop` accessor.
-        // Ownership of `task` transfers to the queue (drained on the same thread).
-        ctx.expect("FSWatchTask.ctx unset")
-            .vm()
-            .event_loop_mut()
-            .enqueue_task(Task::init(task));
-    }
-
-    /// this runs on JS Context Thread
-    pub(crate) fn run(&mut self) -> JsResult<()> {
-        // BACKREF — `self.ctx` is the live owning FSWatcher (set at
-        // construction), outliving every task it enqueues. R-2: all FSWatcher
-        // methods below take `&self`, so a single `&FSWatcher` held across the
-        // match is sound (aliased shared borrows are fine; the old `*mut Self`
-        // re-derive dance is no longer needed). `ParentRef` Derefs to `&T`.
-        let ctx: &FSWatcher = &self.ctx.expect("FSWatchTask.ctx unset");
-        let _unref = scopeguard::guard((), |()| ctx.unref_task());
-        match &mut self.event {
-            Event::Rename(path) => Self::run_path::<{ EventType::Rename }>(ctx, path),
-            Event::Change(path) => Self::run_path::<{ EventType::Change }>(ctx, path),
-            Event::Error { err, close } => {
-                ctx.emit_error(err, *close);
-                Ok(())
-            }
-            Event::NoFilename(event_type) => {
-                ctx.emit_null_filename(*event_type);
-                Ok(())
-            }
-            Event::Abort => {
-                ctx.emit_if_aborted();
-                Ok(())
-            }
+        let mut entries = EventBatch::new();
+        entries.push(event);
+        let task = FSWatchTask::new(ThreadBound::new(self), Arc::clone(&self.activity), entries);
+        let vm = self.global_this.bun_vm();
+        #[cfg(not(windows))]
+        if let Err(task) = vm.handle().post_boxed(vm.current_loop_kind(), task) {
+            task.release_unrun();
         }
+        #[cfg(windows)]
+        vm.event_loop_mut().enqueue_task(Task::from_boxed(task));
     }
 
-    fn run_path<const EVENT_TYPE: EventType>(
-        ctx: &FSWatcher,
-        path: &mut StringOrBytesToDecode,
-    ) -> JsResult<()> {
-        use bun_jsc::StringJsc;
-        if ctx.encoding == Encoding::Utf8 {
-            let StringOrBytesToDecode::String(s) = path else {
-                // Producer invariant (win_watcher::on_path_update_windows): when
-                // `ctx.encoding == Utf8` the payload is always the `String`
-                // variant, and `encoding` is immutable after init.
-                unreachable!()
-            };
-            let js = core::mem::take(s).into_js(&ctx.global_this)?;
-            ctx.emit_with_filename::<EVENT_TYPE>(js);
-            Ok(())
-        } else {
-            let StringOrBytesToDecode::BytesToFree(bytes_ref) = path else {
-                unreachable!()
-            };
-            let bytes = core::mem::take(bytes_ref);
-            ctx.emit::<EVENT_TYPE>(&bytes)
-        }
-    }
-
-    /// `FSWatchTaskWindows.deinit`. Explicit, not
-    /// `impl Drop`, to mirror `FSWatchTaskPosix::deinit` so the dispatcher can
-    /// call `FSWatchTask::deinit` uniformly.
-    ///
-    /// # Safety
-    /// `this` must be the unique `heap::alloc` pointer produced by
-    /// `append_abort()` / `on_path_update_windows()`.
-    pub(crate) unsafe fn deinit(this: *mut Self) {
-        // SAFETY: paired with `heap::alloc` at the enqueue site.
-        drop(unsafe { bun_core::heap::take(this) });
-    }
-}
-
-impl FSWatcher {
-    /// Recover `&FSWatcher` from the `*mut c_void` userdata stashed in `init`.
-    ///
-    /// Centralises the set-once `Option<*mut c_void> → &FSWatcher` deref so the
-    /// three watcher-backend callbacks (`on_path_update_*`, `on_update_end`)
-    /// stay safe at the call site. R-2: deref as shared — all `FSWatcher`
-    /// mutation goes through `Cell`/`JsCell`.
-    #[inline]
-    fn from_ctx<'a>(ctx: Option<*mut c_void>) -> &'a FSWatcher {
-        // SAFETY: ctx was registered as `*mut FSWatcher` cast to `*mut c_void`
-        // in `init`. The FSWatcher is heap-stable (`heap::into_raw`) and
-        // outlives every watcher callback — it owns the `path_watcher`
-        // registration, which is dropped before the FSWatcher in `finalize`.
-        unsafe { &*ctx.unwrap().cast::<FSWatcher>() }
-    }
-
-    #[cfg(not(windows))]
-    pub(crate) fn on_path_update_posix(ctx: Option<*mut c_void>, event: Event, is_file: bool) {
-        let this = Self::from_ctx(ctx);
-
-        if this.verbose {
-            match &event {
-                Event::Rename(value) | Event::Change(value) => {
-                    if is_file {
-                        bun_core::pretty_errorln!(
-                            "<r> <d>File changed: {}<r>",
-                            bstr::BStr::new(value)
-                        );
-                    } else {
-                        bun_core::pretty_errorln!(
-                            "<r> <d>Dir changed: {}<r>",
-                            bstr::BStr::new(value)
-                        );
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        this.current_task.with_mut(|t| t.append(event, true));
-    }
-
+    /// libuv delivers fs events on the JS thread; each becomes its own task.
     #[cfg(windows)]
-    pub(crate) fn on_path_update_windows(ctx: Option<*mut c_void>, event: Event, is_file: bool) {
-        let this = Self::from_ctx(ctx);
-
-        if this.verbose {
+    pub(crate) fn on_path_update_windows(&self, event: Event, is_file: bool) {
+        if self.verbose {
             match &event {
                 Event::Rename(value) | Event::Change(value) => {
                     if is_file {
@@ -579,39 +398,13 @@ impl FSWatcher {
             }
         }
 
-        if !this.ref_task() {
-            return;
-        }
-
-        let task = bun_core::heap::into_raw(Box::new(FSWatchTaskWindows {
-            // SAFETY: `this` is the live owning `&FSWatcher` (BACKREF) recovered
-            // from the registered userdata; outlives every task it enqueues.
-            ctx: Some(unsafe { bun_ptr::ParentRef::from_raw(this.as_ctx_ptr()) }),
-            event,
-        }));
-        // `vm()` is the BACKREF accessor; `event_loop_mut()` is the audited
-        // safe `&mut EventLoop` accessor. Ownership of `task` transfers to the
-        // queue.
-        this.vm().event_loop_mut().enqueue_task(Task::init(task));
-        let _ = is_file;
+        self.enqueue_one(event);
     }
 
     #[cfg(windows)]
-    pub(crate) const ON_PATH_UPDATE: fn(Option<*mut c_void>, Event, bool) =
-        Self::on_path_update_windows;
-    #[cfg(not(windows))]
-    pub(crate) const ON_PATH_UPDATE: fn(Option<*mut c_void>, Event, bool) =
-        Self::on_path_update_posix;
-
-    pub(crate) fn on_update_end(ctx: Option<*mut c_void>) {
-        let this = Self::from_ctx(ctx);
-        if this.verbose {
+    pub(crate) fn on_update_end(&self) {
+        if self.verbose {
             Output::flush();
-        }
-        #[cfg(unix)]
-        {
-            // we only enqueue after all events are processed
-            this.current_task.with_mut(|t| t.enqueue());
         }
     }
 }
@@ -732,68 +525,19 @@ impl<'a> Arguments<'a> {
         })
     }
 
-    pub(crate) fn create_fs_watcher(&self) -> bun_sys::Result<*mut FSWatcher> {
+    /// Start the watch and return the JS `FSWatcher` object.
+    pub(crate) fn create_fs_watcher(&self) -> bun_sys::Result<JSValue> {
         FSWatcher::init(self)
     }
 }
 
-impl AbortListener for FSWatcher {
-    // R-2: trait sig is fixed at `&mut self`; body just reborrows as `&self`
-    // (auto-deref) and calls the interior-mutable `emit_abort`.
-    fn on_abort(&mut self, reason: JSValue) {
-        (*self).emit_abort(reason);
+impl OnAbort for FSWatcher {
+    fn on_abort(&self, reason: JSValue) {
+        self.emit_abort(reason);
     }
 }
 
 impl FSWatcher {
-    /// Read access to the JS wrapper value. Exposed for `NodeFS::watch`.
-    /// Returns `UNDEFINED` if the wrapper reference has been cleared.
-    #[inline]
-    pub(crate) fn js_this(&self) -> JSValue {
-        self.js_this.get_or_undefined()
-    }
-
-    /// `FSWatcher.initJS`. Takes `*mut Self` so the
-    /// already-heap-allocated payload can be handed to `${T}__create` via
-    /// `to_js_ptr` without re-boxing (see jsc_macros::JsClass).
-    ///
-    /// # Safety
-    /// `this` must be the unique `heap::alloc` pointer produced by `init`;
-    /// JS-thread only.
-    pub(crate) unsafe fn init_js(this: *mut Self, listener: JSValue) {
-        // SAFETY: caller contract — `this` is uniquely owned and live.
-        // R-2: deref as shared; mutation goes through `Cell`/`JsCell`.
-        let this_ref = unsafe { &*this };
-        if this_ref.persistent.get() {
-            let vm_ctx = this_ref.vm_ctx();
-            this_ref.poll_ref.with_mut(|r| r.ref_(vm_ctx));
-        }
-
-        // SAFETY: ownership of `this` transfers to the GC wrapper here; the
-        // wrapper's finalize hook is `FSWatcher::finalize` which calls
-        // `heap::take(this)`.
-        let js_this = unsafe { Self::to_js_ptr(this, &this_ref.global_this) };
-        js_this.ensure_still_alive();
-        this_ref.js_this.set(JsRef::init_weak(js_this));
-        js::listener_set_cached(js_this, &this_ref.global_this, listener);
-
-        if let Some(s) = this_ref.signal.get() {
-            // already aborted?
-            if s.aborted() {
-                // safely abort next tick
-                this_ref.current_task.set(FSWatchTask {
-                    // SAFETY: `this` is the live boxed FSWatcher (shared; the task only reads).
-                    ctx: Some(unsafe { bun_ptr::ParentRef::from_raw(this) }),
-                    ..Default::default()
-                });
-                this_ref.current_task.with_mut(|t| t.append_abort());
-            } else {
-                // watch for abortion
-                s.listen::<FSWatcher>(this);
-            }
-        }
-    }
-
     pub(crate) fn emit_if_aborted(&self) {
         let reason = match self.signal.get() {
             Some(s) if s.aborted() => Some(s.js_reason(&self.global_this)),
@@ -804,18 +548,14 @@ impl FSWatcher {
         }
     }
 
-    /// R-2: `&self` + `Cell<bool>` for `closed` makes the old `*mut Self`
-    /// re-derive dance unnecessary. `listener.call_with_global_this(...)`
-    /// re-enters JS, which can call `watcher.close()` on this same object via
-    /// the wrapper's `m_ptr` — setting `closed = true` and `detach()`-ing.
-    /// `Cell::get()` after the callback observes that write because
-    /// `UnsafeCell` suppresses `noalias` on `&Self`; the trailing
-    /// `self.close()` then no-ops.
+    /// `listener` re-enters JS, which can call `watcher.close()` on this same
+    /// object via the wrapper's `m_ctx` — closing and `detach()`-ing. The
+    /// trailing `self.close()` observes that and no-ops.
     pub(crate) fn emit_abort(&self, err: JSValue) {
-        if self.closed.get() {
+        if self.activity.is_closed() {
             return;
         }
-        self.pending_activity_count.fetch_add(1, Ordering::Relaxed);
+        self.activity.pending.fetch_add(1, Ordering::Relaxed);
         // unref_task() must execute before close(). No early returns below,
         // so both calls are inlined at the end of this function.
 
@@ -848,17 +588,16 @@ impl FSWatcher {
             }
         }
 
-        self.unref_task();
+        self.activity.unref_task();
         self.close();
     }
 
-    /// R-2: see `emit_abort` — `&self` + `Cell` so the trailing `close()`
-    /// observes a re-entrant `watcher.close()` from inside the listener.
+    /// See `emit_abort` — the trailing `close()` observes a re-entrant
+    /// `watcher.close()` from inside the listener.
     pub(crate) fn emit_error(&self, err: &bun_sys::Error, close: bool) {
-        if self.closed.get() {
+        if self.activity.is_closed() {
             return;
         }
-        // Reshaped for borrowck — `defer this.close()` moved to fn end.
 
         let js_this = self.js_this.try_get();
         if let Some(js_this) = js_this {
@@ -929,6 +668,33 @@ impl FSWatcher {
         emit_js::<EVENT_TYPE>(listener, &global_object, filename);
         Ok(())
     }
+
+    /// Windows: the path arrives either as a ready-made WTF string (utf8
+    /// watchers) or as bytes to encode.
+    #[cfg(windows)]
+    fn emit_decoded<const EVENT_TYPE: EventType>(
+        &self,
+        path: &mut StringOrBytesToDecode,
+    ) -> JsResult<()> {
+        use bun_jsc::StringJsc;
+        if self.encoding == Encoding::Utf8 {
+            let StringOrBytesToDecode::String(s) = path else {
+                // Producer invariant (win_watcher::PathWatcher::emit): when
+                // `encoding == Utf8` the payload is always the `String`
+                // variant, and `encoding` is immutable after init.
+                unreachable!()
+            };
+            let js = core::mem::take(s).into_js(&self.global_this)?;
+            self.emit_with_filename::<EVENT_TYPE>(js);
+            Ok(())
+        } else {
+            let StringOrBytesToDecode::BytesToFree(bytes_ref) = path else {
+                unreachable!()
+            };
+            let bytes = core::mem::take(bytes_ref);
+            self.emit::<EVENT_TYPE>(&bytes)
+        }
+    }
 }
 
 /// Each event's listener call is a top-level call of its own: what it throws
@@ -949,9 +715,14 @@ fn emit_js<const EVENT_TYPE: EventType>(
 }
 
 impl FSWatcher {
+    #[inline]
+    fn vm_ctx(&self) -> bun_io::EventLoopCtx {
+        self.global_this.bun_vm().loop_ctx()
+    }
+
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_ref(&self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-        if !self.closed.get() && !self.persistent.get() {
+        if !self.activity.is_closed() && !self.persistent.get() {
             self.persistent.set(true);
             let vm_ctx = self.vm_ctx();
             self.poll_ref.with_mut(|r| r.ref_(vm_ctx));
@@ -973,52 +744,25 @@ impl FSWatcher {
         Ok(JSValue::UNDEFINED)
     }
 
-    // this can be called from Watcher Thread or JS Context Thread
-    pub(crate) fn ref_task(&self) -> bool {
-        let _guard = self.mutex.lock_guard();
-        // R-2: `closed: Cell<bool>` is `!Sync`, but `FSWatcher` itself is
-        // `!Sync` (raw-pointer fields, no `unsafe impl Sync`); cross-thread
-        // access goes through `*mut FSWatcher` in `FSWatchTask.ctx` exactly as
-        // before. The mutex serialises this read against the JS-thread
-        // `close()` write — same soundness profile as the bare `bool` it
-        // replaced.
-        if self.closed.get() {
-            return false;
-        }
-        self.pending_activity_count.fetch_add(1, Ordering::Relaxed);
-
-        true
-    }
-
     /// Called from the GC thread via the codegen `FSWatcher__hasPendingActivity`
-    /// thunk; only touches the atomic field so `&self` is sound across threads.
+    /// thunk; only touches the atomic count so `&self` is sound across threads.
     pub(crate) fn has_pending_activity(&self) -> bool {
-        self.pending_activity_count.load(Ordering::Acquire) > 0
-    }
-
-    pub(crate) fn unref_task(&self) {
-        let _guard = self.mutex.lock_guard();
-        // JSC eventually will free it
-        let prev = self.pending_activity_count.fetch_sub(1, Ordering::Relaxed);
-        debug_assert!(prev > 0);
+        self.activity.pending.load(Ordering::Acquire) > 0
     }
 
     pub fn close(&self) {
-        self.mutex.lock();
-        if !self.closed.get() {
-            self.closed.set(true);
+        if self.activity.close() {
             // Read before `detach()` clears the ref; pending activity still
             // roots the wrapper for the close-event emit below.
             let js_this = self.js_this.try_get();
-            self.mutex.unlock();
             self.detach();
 
             if let Some(js_this) = js_this {
                 if let Some(listener) = js::listener_get_cached(js_this) {
-                    // `closed` is already true so `refTask()` would return false without
-                    // incrementing; bump the counter directly so the `unrefTask()` below is
+                    // `closed` is already true so `ref_task()` would return false without
+                    // incrementing; bump the counter directly so the `unref_task()` below is
                     // balanced and the count stays > 0 while the close event is emitted.
-                    self.pending_activity_count.fetch_add(1, Ordering::Relaxed);
+                    self.activity.pending.fetch_add(1, Ordering::Relaxed);
                     bun_output::scoped_log!(fs_watch, "emit('close')");
                     // Reported here rather than returned: `close()` runs from
                     // host functions and error paths that must finish releasing
@@ -1031,54 +775,39 @@ impl FSWatcher {
                         global.to_js_value(),
                         &[EventType::Close.to_js(&global), JSValue::UNDEFINED],
                     );
-                    self.unref_task();
+                    self.activity.unref_task();
                 }
             }
 
-            self.unref_task();
-        } else {
-            self.mutex.unlock();
+            self.activity.unref_task();
         }
-        // Manual lock/unlock: the lock is released
-        // before `detach()` on the not-closed path and in the else branch — every
-        // path unlocks exactly once. `ref_task`/`unref_task` use the RAII guard.
     }
 
     /// `bun test --isolate` teardown: `close()` minus the `'close'` event (no
     /// user JS mid-swap; parity with `StatWatcher::close`). Dropping the
     /// initial pending-activity ref is the load-bearing part — `detach()`
-    /// alone leaves `pending_activity_count` at 1, so `has_pending_activity()`
-    /// stays true forever and the GC can never collect the wrapper, pinning
-    /// the cached listener (and the outgoing file's entire global) for the
-    /// rest of the run.
+    /// alone leaves the count at 1, so `has_pending_activity()` stays true
+    /// forever and the GC can never collect the wrapper, pinning the cached
+    /// listener (and the outgoing file's entire global) for the rest of the
+    /// run.
     pub(crate) fn close_for_isolation(&self) {
-        self.mutex.lock();
-        if !self.closed.get() {
-            self.closed.set(true);
-            self.mutex.unlock();
+        if self.activity.close() {
             self.detach();
-            self.unref_task();
-        } else {
-            self.mutex.unlock();
+            self.activity.unref_task();
         }
     }
 
     // this can be called multiple times
     pub(crate) fn detach(&self) {
-        let ctx_ptr = self.as_ctx_ptr().cast::<c_void>();
         if let Some(handles) = crate::jsc_hooks::active_handles() {
             handles.swap_remove(&crate::jsc_hooks::ActiveHandle::FsWatcher(
                 core::ptr::NonNull::from(self),
             ));
         }
 
-        if let Some(watcher) = self.path_watcher.take() {
-            // Both backends expose `detach` as an associated fn over `*mut PathWatcher`
-            // (it self-destroys via `heap::take` on the last handler, so it cannot
-            // soundly take `&mut self`). `watcher` is the live pointer returned by
-            // `path_watcher::watch`.
-            path_watcher::PathWatcher::detach(watcher, ctx_ptr);
-        }
+        // Detaches our handler from the shared OS watch (the last one out
+        // tears it down).
+        self.watch.set(None);
 
         if self.persistent.get() {
             self.persistent.set(false);
@@ -1086,14 +815,19 @@ impl FSWatcher {
             self.poll_ref.with_mut(|r| r.unref(vm_ctx));
         }
 
-        if let Some(signal) = self.signal.replace(None) {
-            // `AbortSignalRef::Drop` already does the `unref`, so only
-            // remove the listener here to avoid a double-unref.
-            signal.clean_native_bindings(ctx_ptr);
-        }
+        self.abort_subscription.set(None);
+        self.signal.set(None);
 
         // Idempotent: `detach()` can run more than once (close + finalize).
         self.js_this.set(JsRef::empty());
+    }
+
+    /// codegen `finalize: true` entry point; runs on the mutator thread during
+    /// lazy sweep.
+    #[allow(clippy::boxed_local)] // codegen's signature
+    pub fn finalize(self: Box<Self>) {
+        // stop all managers and signals
+        self.detach();
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1106,7 +840,7 @@ impl FSWatcher {
         Ok(JSValue::UNDEFINED)
     }
 
-    pub(crate) fn init(args: &Arguments<'_>) -> bun_sys::Result<*mut FSWatcher> {
+    pub(crate) fn init(args: &Arguments<'_>) -> bun_sys::Result<JSValue> {
         let mut joined_buf = bun_paths::path_buffer_pool::get();
         let slice = {
             let mut s = args.path.slice();
@@ -1115,8 +849,6 @@ impl FSWatcher {
             }
             s
         };
-        // SAFETY: `FileSystem::instance()` returns the process-global singleton
-        // initialized at startup; never null once init has run.
         let cwd = bun_resolver::fs::FileSystem::get().top_level_dir;
         let joined_buf_len = joined_buf.len();
         let Some(joined) = Path::join_abs_string_buf_checked::<platform::Auto>(
@@ -1135,102 +867,89 @@ impl FSWatcher {
         joined_buf[joined_len] = 0;
         let file_path: &bun_core::ZStr = bun_core::ZStr::from_buf(&joined_buf[..], joined_len);
 
-        let vm = args.global_this.bun_vm_ptr();
-        // `bun_vm()` is the audited safe `&'static VirtualMachine` accessor —
-        // single deref site so the four uses below stay safe.
-        let vm_ref = args.global_this.bun_vm();
+        let global: &JSGlobalObject = args.global_this;
 
-        let ctx = bun_core::heap::into_raw(Box::new(FSWatcher {
-            ctx: vm,
-            #[cfg(not(windows))]
-            handle: vm_ref.handle(),
-            #[cfg(not(windows))]
-            loop_kind: vm_ref.current_loop_kind(),
-            current_task: JsCell::new(FSWatchTask {
-                ctx: None,
-                ..Default::default()
-            }),
-            mutex: Mutex::default(),
-            signal: JsCell::new(args.signal.map(|s| s.ref_())),
-            persistent: Cell::new(args.persistent),
-            path_watcher: Cell::new(None),
-            global_this: GlobalRef::from(args.global_this),
-            js_this: JsCell::new(JsRef::empty()),
-            encoding: args.encoding,
-            closed: Cell::new(false),
+        let watcher = Box::new(FSWatcher {
             verbose: args.verbose,
+            encoding: args.encoding,
+            global_this: GlobalRef::from(global),
+            js_this: JsCell::new(JsRef::empty()),
+            persistent: Cell::new(args.persistent),
             poll_ref: JsCell::new(KeepAlive::default()),
-            pending_activity_count: AtomicU32::new(1),
-        }));
-        // SAFETY: `ctx` is the freshly-boxed payload; uniquely owned here.
-        // R-2: deref as shared; mutation goes through `JsCell`.
-        let ctx_ref = unsafe { &*ctx };
-        // SAFETY: `ctx` is the heap-stable Box address (shared; the task only reads).
-        let parent = unsafe { bun_ptr::ParentRef::from_raw(ctx) };
-        ctx_ref.current_task.with_mut(|t| t.ctx = Some(parent));
+            signal: JsCell::new(args.signal.map(AbortSignal::ref_)),
+            abort_subscription: JsCell::new(None),
+            watch: JsCell::new(None),
+            activity: Arc::new(Activity {
+                mutex: Mutex::default(),
+                closed: AtomicBool::new(false),
+                pending: AtomicU32::new(1),
+            }),
+        });
 
-        ctx_ref
-            .path_watcher
-            .set(if args.signal.is_none_or(|s| !s.aborted()) {
-                // The two backends take different arities (the Windows
-                // backend dropped the callback parameters — only one valid
-                // value each), so the call is cfg-split.
-                #[cfg(windows)]
-                let r = path_watcher::watch(vm_ref, file_path, args.recursive, ctx as *mut c_void);
-                #[cfg(not(windows))]
-                let r = path_watcher::watch(
-                    vm_ref,
-                    file_path,
-                    args.recursive,
-                    FSWatcher::ON_PATH_UPDATE,
-                    FSWatcher::on_update_end,
-                    ctx.cast::<c_void>(),
-                );
-                match r {
-                    Ok(r) => Some(r),
-                    Err(err) => {
-                        // SAFETY: `ctx` was produced by `heap::into_raw` above and
-                        // never handed to a JS wrapper; reclaim ownership.
-                        FSWatcher::finalize(unsafe { Box::from_raw(ctx) });
-                        return Err(bun_sys::Error {
-                            errno: err.errno,
-                            syscall: bun_sys::Tag::watch,
-                            path: args.path.slice().into(),
-                            ..Default::default()
-                        });
-                    }
+        if args.signal.is_none_or(|s| !s.aborted()) {
+            // The box gives the watcher its final address before anything
+            // (the sink, the wrapper) records it.
+            #[cfg(not(windows))]
+            let r = path_watcher::watch(file_path, args.recursive, EventSink::new(&watcher));
+            #[cfg(windows)]
+            let r = path_watcher::watch(
+                global.bun_vm(),
+                file_path,
+                args.recursive,
+                BackRef::new(&*watcher),
+            );
+            match r {
+                Ok(registration) => watcher.watch.set(Some(registration)),
+                Err(err) => {
+                    // Nothing else holds the watcher yet; dropping it releases
+                    // the signal ref.
+                    drop(watcher);
+                    return Err(bun_sys::Error {
+                        errno: err.errno,
+                        syscall: bun_sys::Tag::watch,
+                        path: args.path.slice().into(),
+                        ..Default::default()
+                    });
                 }
+            }
+        }
+
+        if watcher.persistent.get() {
+            let vm_ctx = watcher.vm_ctx();
+            watcher.poll_ref.with_mut(|r| r.ref_(vm_ctx));
+        }
+
+        // Ownership of the box moves to the JS wrapper (`FSWatcherClass__finalize`
+        // hands it back to `finalize`).
+        let js_this = FSWatcher::to_js_boxed(watcher, global);
+        js_this.ensure_still_alive();
+        let this: &FSWatcher = js_this
+            .as_class_ref::<FSWatcher>()
+            .expect("FSWatcher wrapper just created");
+        this.js_this.set(JsRef::init_weak(js_this));
+        js::listener_set_cached(
+            js_this,
+            global,
+            args.listener.with_async_context_if_needed(global),
+        );
+
+        if let Some(s) = args.signal {
+            if s.aborted() {
+                // safely abort next tick
+                this.enqueue_one(Event::Abort);
             } else {
-                None
-            });
-        // SAFETY: `ctx` is the unique heap pointer; `init_js` hands ownership to
-        // the GC wrapper via `to_js_ptr`.
-        unsafe {
-            FSWatcher::init_js(
-                ctx,
-                args.listener.with_async_context_if_needed(args.global_this),
-            )
-        };
+                // watch for abortion
+                this.abort_subscription
+                    .set(Some(s.subscribe(BackRef::new(this))));
+            }
+        }
+
         if let Some(handles) = crate::jsc_hooks::active_handles() {
             bun_core::handle_oom(handles.put(
-                crate::jsc_hooks::ActiveHandle::FsWatcher(
-                    core::ptr::NonNull::new(ctx).expect("init: watcher"),
-                ),
+                crate::jsc_hooks::ActiveHandle::FsWatcher(core::ptr::NonNull::from(this)),
                 (),
             ));
         }
-        Ok(ctx)
-    }
-}
-
-#[cfg(not(windows))]
-impl Default for FSWatchTaskPosix {
-    fn default() -> Self {
-        Self {
-            ctx: None,
-            count: 0,
-            entries: [const { MaybeUninit::uninit() }; 8],
-            concurrent_task: ConcurrentTask::default(),
-        }
+        Ok(js_this)
     }
 }

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -89,7 +89,9 @@ pub(crate) struct PathWatcherManager {
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     fd: Fd,
 
-    /// Reader-thread loop flag. Initialized `true`, never cleared (no teardown).
+    /// Reader-thread loop flag. Initialized `true`; cleared only by the reader
+    /// thread itself when it exits on a fatal read error, after which
+    /// `watch()` refuses new registrations (no teardown otherwise).
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     running: AtomicBool,
 }
@@ -398,6 +400,12 @@ pub(crate) fn watch(path: &ZStr, recursive: bool, sink: EventSink) -> sys::Resul
     let key = PathWatcherManager::make_key(key_buf.as_mut_slice(), resolved.as_bytes(), recursive);
 
     let mut state = manager.state.lock();
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    if !manager.running.load(Ordering::Acquire) {
+        // The reader thread hit a fatal error and exited; nothing would ever
+        // deliver events for a new registration.
+        return Err(sys::Error::from_code(E::EBADF, Tag::watch));
+    }
     let handler = state.next_handler_id();
 
     if let Some(&existing) = state.by_key.get(key) {
@@ -880,6 +888,10 @@ impl Linux {
                                 w.handlers.flush();
                             }
                         }
+                        // Under the state lock, so a concurrent `watch()` either
+                        // registered before this (and got the error above) or
+                        // sees the reader gone.
+                        manager.running.store(false, Ordering::Release);
                         return;
                     }
                 },

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -18,21 +18,19 @@
 //!     └─ FreeBSD: one kqueue fd + one reader thread, fd → PathWatcher map
 //!
 //!   PathWatcher               one per unique (realpath, recursive) — deduped
-//!     └─ handlers[]           the JS FSWatcher contexts sharing this watch
+//!     └─ handlers[]           the JS FSWatchers' event sinks sharing this watch
 //!
-//! A second `fs.watch()` on the same path returns the existing PathWatcher with a
-//! new handler appended. `detach()` removes a handler; the last one out tears down
-//! the OS watch.
+//! A second `fs.watch()` on the same path finds the existing PathWatcher and
+//! appends a handler. Dropping the returned [`Registration`] removes it; the
+//! last one out tears down the OS watch.
 
-use core::cell::{Cell, UnsafeCell};
-use core::ffi::c_void;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use bun_collections::HashMap;
-use bun_collections::{ArrayHashMap, StringArrayHashMap};
-#[cfg(not(windows))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+use bun_collections::ArrayHashMap;
+use bun_collections::{HashMap, StringArrayHashMap};
 use bun_core::ZBox;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use bun_core::strings;
@@ -47,13 +45,10 @@ use bun_paths::resolve_path::join_z_buf_spill;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use bun_sys::FdExt;
 use bun_sys::{self as sys, E, Fd, Tag};
-use bun_threading::Mutex;
-#[cfg(not(windows))]
+use bun_threading::{Guarded, Mutex};
 use bun_wyhash::hash;
 
-use bun_jsc::VirtualMachineRef as VirtualMachine;
-
-use crate::node::node_fs_watcher::{Event, FSWatcher, WatchEventKind};
+use crate::node::node_fs_watcher::{Event, EventSink, WatchEventKind};
 
 #[cfg(target_os = "macos")]
 use crate::node::fs_events as fsevents;
@@ -61,97 +56,91 @@ use crate::node::fs_events as fsevents;
 bun_output::define_scoped_log!(log, fs_watch, hidden);
 
 /// Process-global manager. Created on first `fs.watch()`, never destroyed (matches
-/// the FSEvents loop and Windows libuv loop lifetimes).
-// PORTING.md §Global mutable state: init-once-then-read-only → `OnceLock`.
-// `DEFAULT_MANAGER_MUTEX` still serializes the *fallible* init path so a failed
-// `Platform::init` can be retried on a later `get()` without two threads
-// racing to allocate; `OnceLock` provides the Acquire/Release publish so the
-// FSEvents-thread reads in `on_fs_event` need no `unsafe`.
-static DEFAULT_MANAGER: std::sync::OnceLock<&'static PathWatcherManager> =
-    std::sync::OnceLock::new();
+/// the FSEvents loop and Windows libuv loop lifetimes). `DEFAULT_MANAGER_MUTEX`
+/// serializes the *fallible* init path so a failed `Platform::init` can be
+/// retried on a later `get()` without two threads racing to create one;
+/// `OnceLock` provides the publish so the FSEvents-thread read in
+/// `on_fs_event` needs no lock.
+static DEFAULT_MANAGER: std::sync::OnceLock<Arc<PathWatcherManager>> = std::sync::OnceLock::new();
 static DEFAULT_MANAGER_MUTEX: Mutex = Mutex::new();
+
+/// Identity of one [`PathWatcher`] within its manager. Never reused, so a stale
+/// id (an FSEvents callback racing a detach) simply finds nothing.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct WatcherId(u64);
+
+/// Identity of one handler (one `FSWatcher`'s sink) on a [`PathWatcher`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HandlerId(u64);
 
 // ────────────────────────────────────────────────────────────────────────────────
 // PathWatcherManager
 // ────────────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct PathWatcherManager {
-    /// Guards `watchers` and all per-platform dispatch maps. The reader thread holds
-    /// this while dispatching, so `detach()` on the JS thread cannot free a PathWatcher
-    /// mid-emit. A single lock here replaces the three interacting mutexes of the old
-    /// design.
-    mutex: Mutex,
+    /// Every watcher, the dedup map and the per-platform dispatch maps. The
+    /// reader thread holds this while dispatching, so a detach on the JS
+    /// thread cannot tear a PathWatcher down mid-emit. A single lock here
+    /// replaces the three interacting mutexes of the old design.
+    state: Guarded<State>,
 
-    /// Dedup map: dedup key → PathWatcher. The key is the resolved path with a one-byte
-    /// suffix encoding `recursive` (so `fs.watch(p)` and `fs.watch(p, {recursive:true})`
-    /// don't share — they want different OS registrations on every platform).
-    ///
-    /// Interior-mutable: written through `&'static PathWatcherManager` while holding
-    /// `mutex`. The field must be `UnsafeCell` so deriving `&mut` from a shared
-    /// manager reference is defined.
-    watchers: UnsafeCell<StringArrayHashMap<*mut PathWatcher>>,
-
-    /// Platform-specific dispatch maps (inotify wd_map / kqueue entries).
-    /// On macOS this is empty — FSEvents owns its own thread via `fs_events.rs`.
-    /// Interior-mutable for the same reason as `watchers`.
+    /// inotify/kqueue fd. Set before the reader thread spawns, never
+    /// reassigned (process-lifetime singleton, no teardown).
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-    platform: UnsafeCell<Platform>,
-
-    /// inotify/kqueue fd. Set once in `Platform::init` *before* the reader thread
-    /// spawns, never reassigned (process-lifetime singleton, no teardown). Hoisted
-    /// out of `UnsafeCell<Platform>` so reads are safe `Cell::get()` instead of
-    /// raw deref; thread-spawn happens-before makes the cross-thread read sound.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-    platform_fd: Cell<Fd>,
+    fd: Fd,
 
     /// Reader-thread loop flag. Initialized `true`, never cleared (no teardown).
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     running: AtomicBool,
-
-    /// Monotonic kevent generation counter (FreeBSD). Bumped under `mutex`.
-    /// `Cell` so the bump is a safe `.get()/.set()` instead of a raw deref.
-    #[cfg(target_os = "freebsd")]
-    next_gen: Cell<usize>,
 }
 
-// SAFETY: all interior-mutable state (`watchers`, `platform` dispatch maps,
-// `next_gen`) is only accessed while holding `mutex`. `running` is atomic.
-// `platform_fd` is set once in `init()` before the reader thread spawns and is
-// never written afterwards, so cross-thread `Cell::get()` reads observe only the
-// publish ordered by the spawn happens-before — no data race. The manager is a
-// process-global singleton shared between the JS thread(s) and the reader thread.
-unsafe impl Sync for PathWatcherManager {}
-// SAFETY: same field invariants as `Sync` above; the manager is constructed on
-// one thread and only ever crosses threads as `&'static PathWatcherManager`,
-// whose `Send` bound reduces to `PathWatcherManager: Sync`.
-unsafe impl Send for PathWatcherManager {}
+#[derive(Default)]
+struct State {
+    /// Dedup map: dedup key → watcher. The key is the resolved path with a one-byte
+    /// suffix encoding `recursive` (so `fs.watch(p)` and `fs.watch(p, {recursive:true})`
+    /// don't share — they want different OS registrations on every platform).
+    by_key: StringArrayHashMap<WatcherId>,
+    watchers: HashMap<WatcherId, PathWatcher>,
+    next_watcher_id: u64,
+    next_handler_id: u64,
 
-impl Default for PathWatcherManager {
-    fn default() -> Self {
-        Self {
-            mutex: Mutex::new(),
-            watchers: UnsafeCell::new(StringArrayHashMap::default()),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-            platform: UnsafeCell::new(Platform::default()),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-            platform_fd: Cell::new(Fd::INVALID),
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-            running: AtomicBool::new(true),
-            #[cfg(target_os = "freebsd")]
-            next_gen: Cell::new(1),
+    /// Platform-specific dispatch maps (inotify wd_map / kqueue entries).
+    /// On macOS there is none — FSEvents owns its own thread via `fs_events.rs`.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    platform: Platform,
+
+    /// Monotonic kevent generation counter (FreeBSD).
+    #[cfg(target_os = "freebsd")]
+    next_gen: usize,
+}
+
+impl State {
+    fn next_watcher_id(&mut self) -> WatcherId {
+        self.next_watcher_id += 1;
+        WatcherId(self.next_watcher_id)
+    }
+
+    fn next_handler_id(&mut self) -> HandlerId {
+        self.next_handler_id += 1;
+        HandlerId(self.next_handler_id)
+    }
+
+    /// Remove `id` from the dedup map (the watcher itself stays in `watchers`
+    /// until its last handler goes).
+    fn unlink(&mut self, id: WatcherId) {
+        if let Some(i) = self.by_key.values().iter().position(|&w| w == id) {
+            self.by_key.swap_remove_at(i);
         }
     }
 }
 
 impl PathWatcherManager {
     fn get() -> sys::Result<&'static PathWatcherManager> {
-        // No unlocked fast path: `default_manager` is a plain global and an unsynchronized
-        // read here would be textbook broken DCLP (a concurrent Worker's first `fs.watch()`
-        // on ARM64 could observe the non-null pointer before `m.* = .{}` is visible and
-        // lock a garbage `m.mutex`). `get()` runs once per `fs.watch()` call; the mutex is
-        // uncontended after initialization.
+        // No unlocked fast path for creation: two Workers' first `fs.watch()`
+        // must not both run `Platform::init`. `get()` runs once per `fs.watch()`
+        // call; the mutex is uncontended after initialization.
         let _g = DEFAULT_MANAGER_MUTEX.lock_guard();
-        if let Some(&m) = DEFAULT_MANAGER.get() {
+        if let Some(m) = DEFAULT_MANAGER.get() {
             return Ok(m);
         }
 
@@ -159,7 +148,7 @@ impl PathWatcherManager {
         // Holding DEFAULT_MANAGER_MUTEX with `.get()` having returned `None`
         // above, so this is the first publish; `set` cannot fail.
         let _ = DEFAULT_MANAGER.set(m);
-        Ok(m)
+        Ok(DEFAULT_MANAGER.get().expect("just set"))
     }
 
     /// Build the dedup key into `buf`. Not null-terminated; only used as a hashmap key.
@@ -169,17 +158,53 @@ impl PathWatcherManager {
         &buf[..resolved_path.len() + 1]
     }
 
-    /// Remove `watcher` from the dedup map. Caller holds `mutex`.
-    fn unlink_watcher_locked(&self, watcher: *mut PathWatcher) {
-        // SAFETY: caller holds self.mutex; exclusive access to self.watchers
-        // for the duration of this block (nothing here re-enters the map).
-        unsafe {
-            let watchers = &mut *self.watchers.get();
-            if let Some(i) = watchers.values().iter().position(|&w| w == watcher) {
-                // Key is an owned Box<[u8]>; swap_remove_at drops it.
-                watchers.swap_remove_at(i);
+    /// JS-thread entry point from [`Registration`]'s drop. Removes one handler;
+    /// if it was the last, tears down the OS watch and drops the watcher.
+    ///
+    /// All bookkeeping (handlers, dedup map, platform dispatch maps) happens in
+    /// one critical section so a concurrent `watch()` from another Worker cannot
+    /// observe a zero-handler PathWatcher still present in the dedup map.
+    ///
+    /// On macOS the FSEvents unregister happens *after* releasing the lock (by
+    /// dropping the watcher outside it): `FSEventsWatcher`'s drop takes the
+    /// FSEvents loop lock, and the CF thread's event callback holds that lock while
+    /// calling into `on_fs_event` (which takes ours). Holding both here would be
+    /// AB/BA with the CF thread. In the window between the two, `on_fs_event`
+    /// finds no watcher for the id and drops the event.
+    fn detach(&self, watcher: WatcherId, handler: HandlerId) {
+        let removed: PathWatcher = {
+            let mut state = self.state.lock();
+            let Some(w) = state.watchers.get_mut(&watcher) else {
+                return;
+            };
+            w.handlers.remove(handler);
+            if !w.handlers.is_empty() {
+                return;
             }
-        }
+            // Last handler gone — make this watcher unreachable before dropping the lock.
+            state.unlink(watcher);
+            #[allow(unused_mut)]
+            let mut w = state.watchers.remove(&watcher).expect("present above");
+            #[cfg(not(target_os = "macos"))]
+            Platform::remove_watch(self, &mut state, watcher, &mut w);
+            w
+        };
+        drop(removed);
+    }
+}
+
+/// One `FSWatcher`'s handler on a shared [`PathWatcher`]. Dropping it detaches
+/// the handler (and with the last handler, the OS watch), which is what ends
+/// the watcher thread's use of the handler's [`EventSink`].
+pub(crate) struct Registration {
+    manager: &'static PathWatcherManager,
+    watcher: WatcherId,
+    handler: HandlerId,
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        self.manager.detach(self.watcher, self.handler);
     }
 }
 
@@ -188,27 +213,32 @@ impl PathWatcherManager {
 // ────────────────────────────────────────────────────────────────────────────────
 
 pub struct PathWatcher {
-    manager: Option<&'static PathWatcherManager>,
-
     /// Canonical absolute path (realpath of the user-supplied path). Owned.
-    #[cfg(not(windows))]
     path: ZBox,
-    #[cfg(not(windows))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     recursive: bool,
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     is_file: bool,
 
-    /// JS `FSWatcher` contexts sharing this OS watch. Each gets its own ChangeEvent
-    /// for per-handler duplicate suppression (same as `win_watcher.rs`). Guarded by
-    /// `manager.mutex` on all platforms — every emit path (inotify/kqueue reader
-    /// threads and the Darwin FSEvents callback) holds it while iterating, so
-    /// attach/detach can never race with dispatch.
-    handlers: ArrayHashMap<*mut c_void, ChangeEvent>,
+    /// The JS `FSWatcher` sinks sharing this OS watch. Each gets its own
+    /// ChangeEvent for per-handler duplicate suppression (same as
+    /// `win_watcher.rs`). Only touched with the manager lock held — every emit
+    /// path (inotify/kqueue reader threads and the Darwin FSEvents callback)
+    /// holds it while iterating, so attach/detach can never race with dispatch.
+    handlers: Handlers,
 
     /// Per-platform per-watch state (inotify wds, kqueue fds, or the FSEventsWatcher).
-    #[cfg(not(windows))]
     platform: PlatformWatch,
 }
+
+struct Handler {
+    id: HandlerId,
+    change: ChangeEvent,
+    sink: EventSink,
+}
+
+#[derive(Default)]
+struct Handlers(Vec<Handler>);
 
 /// Per-handler duplicate suppression.
 ///
@@ -217,61 +247,59 @@ pub struct PathWatcher {
 /// each emit — node delivers both (see test/js/node/test/parallel
 /// fs-watch tests that write two files back-to-back). Kept identical to
 /// `win_watcher.rs` so POSIX and Windows agree on which bursts are coalesced.
-///
-/// Fields are `Cell` so `should_emit` takes `&self` — the emit paths then only
-/// ever need shared access to a `PathWatcher`.
 #[derive(Default)]
 pub(crate) struct ChangeEvent {
-    #[cfg(not(windows))]
-    hash: Cell<u64>,
-    #[cfg(not(windows))]
-    event_type: Cell<WatchEventKind>,
-    #[cfg(not(windows))]
-    timestamp: Cell<i64>,
+    hash: u64,
+    event_type: WatchEventKind,
+    timestamp: i64,
 }
 
-#[cfg(not(windows))]
 impl ChangeEvent {
-    fn should_emit(&self, hash: u64, timestamp: i64, event_type: WatchEventKind) -> bool {
-        let time_diff = timestamp - self.timestamp.get();
-        if self.timestamp.get() == 0
+    fn should_emit(&mut self, hash: u64, timestamp: i64, event_type: WatchEventKind) -> bool {
+        let time_diff = timestamp - self.timestamp;
+        if self.timestamp == 0
             || time_diff > 1
-            || self.event_type.get() != event_type
-            || self.hash.get() != hash
+            || self.event_type != event_type
+            || self.hash != hash
         {
-            self.timestamp.set(timestamp);
-            self.event_type.set(event_type);
-            self.hash.set(hash);
+            self.timestamp = timestamp;
+            self.event_type = event_type;
+            self.hash = hash;
             return true;
         }
         false
     }
 }
 
-pub(crate) type Callback = fn(ctx: Option<*mut c_void>, event: Event, is_file: bool);
-pub(crate) type UpdateEndCallback = fn(ctx: Option<*mut c_void>);
-
-impl PathWatcher {
-    /// Heap-allocate and return a raw pointer.
-    fn new(init: PathWatcher) -> *mut PathWatcher {
-        bun_core::heap::into_raw(Box::new(init))
+impl Handlers {
+    fn push(&mut self, id: HandlerId, sink: EventSink) {
+        self.0.push(Handler {
+            id,
+            change: ChangeEvent::default(),
+            sink,
+        });
     }
 
-    /// Called from the platform reader thread with `manager.mutex` held.
-    /// `rel_path` is borrowed — `onPathUpdatePosix` dupes it before enqueuing.
-    /// `&self`: per-handler state is `Cell`-based, so the emit paths never
-    /// need an exclusive `PathWatcher` borrow.
-    #[cfg(not(windows))]
-    fn emit(&self, event_type: WatchEventKind, rel_path: &[u8], is_file: bool) {
+    fn remove(&mut self, id: HandlerId) {
+        if let Some(i) = self.0.iter().position(|h| h.id == id) {
+            self.0.swap_remove(i);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Called from the platform reader thread with the manager lock held.
+    /// `rel_path` is borrowed — the sink copies it before queueing.
+    fn emit(&mut self, event_type: WatchEventKind, rel_path: &[u8], is_file: bool) {
         let timestamp = bun_core::time::milli_timestamp();
         let h = hash(rel_path);
-        for (&ctx, ev) in self.handlers.iter() {
-            if ev.should_emit(h, timestamp, event_type) {
-                (FSWatcher::ON_PATH_UPDATE)(
-                    Some(ctx),
-                    event_type.to_event(rel_path.into()),
-                    is_file,
-                );
+        for handler in self.0.iter_mut() {
+            if handler.change.should_emit(h, timestamp, event_type) {
+                handler
+                    .sink
+                    .on_path_update(event_type.to_event(rel_path.into()), is_file);
             }
         }
     }
@@ -280,33 +308,30 @@ impl PathWatcher {
     /// The `IN_IGNORED` retiring a deleted inode's wd lands in the same
     /// millisecond as its `IN_DELETE_SELF`, with the same path and type, so
     /// `should_emit` would fold the two into one; node (libuv) delivers both.
-    /// Caller holds `manager.mutex`.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn emit_unsuppressed(&self, event_type: WatchEventKind, rel_path: &[u8], is_file: bool) {
-        for &ctx in self.handlers.keys() {
-            (FSWatcher::ON_PATH_UPDATE)(Some(ctx), event_type.to_event(rel_path.into()), is_file);
+    fn emit_unsuppressed(&mut self, event_type: WatchEventKind, rel_path: &[u8], is_file: bool) {
+        for handler in self.0.iter_mut() {
+            handler
+                .sink
+                .on_path_update(event_type.to_event(rel_path.into()), is_file);
         }
     }
 
     /// The shared inotify queue overflowed and events were lost; every handler
     /// gets `('change', null)`. No duplicate suppression — a loss signal must
-    /// always be delivered. Caller holds `manager.mutex`.
+    /// always be delivered.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn emit_overflow(&self) {
-        for &ctx in self.handlers.keys() {
-            (FSWatcher::ON_PATH_UPDATE)(
-                Some(ctx),
-                Event::NoFilename(WatchEventKind::Change),
-                false,
-            );
+    fn emit_overflow(&mut self) {
+        for handler in self.0.iter_mut() {
+            handler
+                .sink
+                .on_path_update(Event::NoFilename(WatchEventKind::Change), false);
         }
     }
 
-    #[cfg(not(windows))]
-    fn emit_error(&self, err: &sys::Error, close: bool) {
-        for &ctx in self.handlers.keys() {
-            (FSWatcher::ON_PATH_UPDATE)(
-                Some(ctx),
+    fn emit_error(&mut self, err: &sys::Error, close: bool) {
+        for handler in self.0.iter_mut() {
+            handler.sink.on_path_update(
                 Event::Error {
                     err: err.clone(),
                     close,
@@ -316,101 +341,12 @@ impl PathWatcher {
         }
     }
 
-    /// Signals end-of-batch so `FSWatcher` can flush its queued events to the JS thread.
-    /// Caller holds `manager.mutex`.
-    #[cfg(not(windows))]
-    fn flush(&self) {
-        for &ctx in self.handlers.keys() {
-            FSWatcher::on_update_end(Some(ctx));
+    /// Signals end-of-batch so each sink can flush its queued events to its JS
+    /// thread.
+    fn flush(&mut self) {
+        for handler in self.0.iter_mut() {
+            handler.sink.on_update_end();
         }
-    }
-
-    /// JS-thread entry point from `FSWatcher.detach()`. Removes one handler; if it was
-    /// the last, tears down the OS watch and frees.
-    ///
-    /// All bookkeeping (handlers, dedup map, platform dispatch maps) happens under
-    /// `manager.mutex` in one critical section so a concurrent `watch()` from another
-    /// Worker cannot observe a zero-handler PathWatcher still present in the dedup map.
-    ///
-    /// On macOS the FSEvents unregister happens *after* releasing `manager.mutex`:
-    /// `FSEventsWatcher.deinit()` takes the FSEvents loop mutex, and the CF thread's
-    /// `events_cb` holds that mutex while calling into `onFSEvent` (which takes
-    /// `manager.mutex`). Holding both here would be AB/BA with the CF thread. Once
-    /// `fse.deinit()` returns, `events_cb` has released the loop mutex and nulled our
-    /// slot, so no further callbacks will fire and `destroy()` is safe.
-    ///
-    /// # Safety
-    /// `this` must be a live `PathWatcher` produced by [`PathWatcher::new`] whose
-    /// `handlers` still contains `ctx`. Called from the JS thread only.
-    // The param must stay `*mut PathWatcher`: on macOS the CF thread may
-    // concurrently raw-read the disjoint `manager` field while we're between
-    // `unlock()` and `remove_watch()` (see the SAFETY notes below), so no
-    // whole-struct reference may span that window — every access below is
-    // scoped to a single statement.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn detach(this: *mut PathWatcher, ctx: *mut c_void) {
-        // SAFETY: `this` is a live PathWatcher created via `PathWatcher::new`. Read
-        // `manager` via the raw pointer so no reference is asserted before
-        // we hold `manager.mutex` — on macOS the CF thread may concurrently raw-read
-        // the same field inside `on_fs_event` (see that fn's SAFETY note).
-        let Some(manager) = (unsafe { (*this).manager }) else {
-            // No manager → never registered (or already unlinked); we are sole owner.
-            // SAFETY: sole owner; no other thread can reach `this`.
-            unsafe {
-                (*this).handlers.swap_remove(&ctx);
-                if (*this).handlers.len() == 0 {
-                    Self::destroy(this);
-                }
-            }
-            return;
-        };
-
-        manager.mutex.lock();
-        {
-            // SAFETY: holding manager.mutex; the reader/CF threads only touch this
-            // watcher under the same lock, so these scoped accesses are exclusive.
-            let remaining = unsafe {
-                (*this).handlers.swap_remove(&ctx);
-                (*this).handlers.len()
-            };
-            if remaining > 0 {
-                manager.mutex.unlock();
-                return;
-            }
-
-            // Last handler gone — make this watcher unreachable before dropping the lock.
-            manager.unlink_watcher_locked(this);
-            // SAFETY: raw place write under manager.mutex; see above.
-            unsafe { (*this).manager = None };
-            #[cfg(not(target_os = "macos"))]
-            {
-                // SAFETY: exclusive under manager.mutex; the borrow ends at the call.
-                Platform::remove_watch(manager, unsafe { &mut *this });
-            }
-        }
-        manager.mutex.unlock();
-
-        #[cfg(target_os = "macos")]
-        {
-            // Takes fsevents_loop.mutex; must not hold manager.mutex (see doc comment).
-            // Pass the raw pointer: the CF thread (holding the FSEvents loop mutex
-            // that `deinit` is about to block on) may concurrently take
-            // `manager.mutex`, raw-read `(*this).manager`, observe `None`, and bail
-            // — so no `&mut PathWatcher` may be live across that call.
-            Platform::remove_watch(manager, this);
-        }
-        // SAFETY: `this` was created via PathWatcher::new (heap::alloc); no other thread
-        // can reach it after unlink + remove_watch above.
-        unsafe { Self::destroy(this) };
-    }
-
-    /// # Safety
-    /// `this` must have been produced by `PathWatcher::new` and have no remaining
-    /// references (handlers empty, removed from manager maps).
-    unsafe fn destroy(this: *mut PathWatcher) {
-        // SAFETY: caller contract — `this` came from `heap::into_raw` in
-        // `PathWatcher::new` and has no remaining references.
-        drop(unsafe { bun_core::heap::take(this) });
     }
 }
 
@@ -418,21 +354,9 @@ impl PathWatcher {
 // watch()
 // ────────────────────────────────────────────────────────────────────────────────
 
-pub(crate) fn watch(
-    vm: &VirtualMachine,
-    path: &ZStr,
-    recursive: bool,
-    callback: Callback,
-    update_end: UpdateEndCallback,
-    ctx: *mut c_void,
-) -> sys::Result<*mut PathWatcher> {
-    // Assert the callback/updateEnd are what node_fs_watcher passes.
-    // Compare against the *exact* fn pointers `FSWatcher` passes (not local wrappers,
-    // which would be distinct fn items with distinct addresses).
-    debug_assert!(callback as usize == FSWatcher::ON_PATH_UPDATE as usize);
-    debug_assert!(update_end as usize == (FSWatcher::on_update_end as UpdateEndCallback) as usize);
-    let _ = vm;
-
+/// Attach `sink` to the (shared, per canonical path) OS watch for `path`,
+/// creating it if this is the first. JS thread.
+pub(crate) fn watch(path: &ZStr, recursive: bool, sink: EventSink) -> sys::Result<Registration> {
     let manager = PathWatcherManager::get()?;
 
     // Resolve to a canonical path so `fs.watch("./x")` and `fs.watch("/abs/x")` dedup;
@@ -466,7 +390,6 @@ pub(crate) fn watch(
         Ok(r) => {
             let len = r.len();
             resolve_buf[len] = 0;
-            // SAFETY: resolve_buf[len] == 0 written above; buf lives for the rest of this fn.
             ZStr::from_buf(&resolve_buf[..], len)
         }
     };
@@ -474,106 +397,127 @@ pub(crate) fn watch(
     let mut key_buf = path::path_buffer_pool::get();
     let key = PathWatcherManager::make_key(key_buf.as_mut_slice(), resolved.as_bytes(), recursive);
 
-    manager.mutex.lock();
+    let mut state = manager.state.lock();
+    let handler = state.next_handler_id();
 
-    // SAFETY: holding manager.mutex; exclusive access to manager.watchers,
-    // scoped to this lookup.
-    if let Some(&existing) = unsafe { (*manager.watchers.get()).get(key) } {
-        // SAFETY: existing is a live PathWatcher under manager.mutex.
-        unsafe { handle_oom((*existing).handlers.put(ctx, ChangeEvent::default())) };
-        manager.mutex.unlock();
-        return Ok(existing);
+    if let Some(&existing) = state.by_key.get(key) {
+        log!(
+            "watch('{}') → existing watcher, sink {:#x}",
+            bstr::BStr::new(resolved.as_bytes()),
+            sink.owner_addr()
+        );
+        state
+            .watchers
+            .get_mut(&existing)
+            .expect("dedup map and watcher map agree")
+            .handlers
+            .push(handler, sink);
+        drop(state);
+        return Ok(Registration {
+            manager,
+            watcher: existing,
+            handler,
+        });
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
     let _ = is_file;
-    // New watcher: own the key and path.
-    let watcher = PathWatcher::new(PathWatcher {
-        manager: Some(manager),
-        #[cfg(not(windows))]
+    log!(
+        "watch('{}') → new watcher, sink {:#x}",
+        bstr::BStr::new(resolved.as_bytes()),
+        sink.owner_addr()
+    );
+    let id = state.next_watcher_id();
+    let mut watcher = PathWatcher {
         path: ZBox::from_bytes(resolved.as_bytes()),
-        #[cfg(not(windows))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         recursive,
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         is_file,
-        handlers: ArrayHashMap::default(),
-        #[cfg(not(windows))]
+        handlers: Handlers::default(),
         platform: PlatformWatch::default(),
-    });
-    // SAFETY: watcher just allocated; we hold the only reference.
-    unsafe { handle_oom((*watcher).handlers.put(ctx, ChangeEvent::default())) };
-    // SAFETY: holding manager.mutex; exclusive access to manager.watchers.
-    unsafe { handle_oom((*manager.watchers.get()).put(key, watcher)) };
+    };
+    watcher.handlers.push(handler, sink);
+    #[cfg(target_os = "macos")]
+    let fsevents_path = watcher.path.clone();
+    handle_oom(state.by_key.put(key, id));
+    state.watchers.insert(id, watcher);
+    let registration = move || Registration {
+        manager,
+        watcher: id,
+        handler,
+    };
 
-    // Linux/FreeBSD: `addWatch` mutates the platform dispatch maps (wd_map/entries)
-    // which live under `manager.mutex`, so call it while still locked.
+    // Linux/FreeBSD: `add_watch` mutates the platform dispatch maps (wd_map/entries)
+    // which live under the manager lock, so call it while still locked.
     //
-    // macOS: `addWatch` calls `FSEvents.watch()` which takes the FSEvents loop mutex.
-    // The CF thread holds that mutex while calling `onFSEvent`, which in turn takes
-    // `manager.mutex`. To keep lock order one-way (fsevents → manager), release ours
-    // first. Another Worker's `watch()` finding this PathWatcher in the interim is
-    // fine — it just appends a handler; events won't deliver until the FSEventStream
-    // is scheduled anyway.
+    // macOS: `add_watch` calls `FSEvents.watch()` which takes the FSEvents loop lock.
+    // The CF thread holds that lock while calling `on_fs_event`, which in turn takes
+    // ours. To keep lock order one-way (fsevents → manager), release ours first.
+    // Another Worker's `watch()` finding this PathWatcher in the interim is fine —
+    // it just appends a handler; events won't deliver until the FSEventStream is
+    // scheduled anyway.
     #[cfg(not(target_os = "macos"))]
     {
-        // SAFETY: watcher live under manager.mutex.
-        if let Err(err) = Platform::add_watch(manager, unsafe { &mut *watcher }) {
+        if let Err(err) = Platform::add_watch(manager, &mut state, id) {
             // Still under the same lock as the map insertion, so no other thread
-            // can have observed `watcher` yet — unconditional destroy is safe.
-            manager.unlink_watcher_locked(watcher);
-            manager.mutex.unlock();
-            // SAFETY: no other thread observed watcher.
-            unsafe {
-                (*watcher).manager = None;
-                PathWatcher::destroy(watcher);
-            }
-            // `Linux.addOne` builds the error with `.path = watcher.path`, which we
-            // just freed; strip it like every other return in this function.
+            // can have observed the watcher yet — dropping it is all there is to undo.
+            state.unlink(id);
+            let watcher = state.watchers.remove(&id);
+            drop(state);
+            drop(watcher);
+            // `Linux::add_one` builds the error with `.path = watcher.path`;
+            // strip it like every other return in this function.
             return Err(err.without_path());
         }
-        manager.mutex.unlock();
-        return Ok(watcher);
+        drop(state);
+        Ok(registration())
     }
 
     #[cfg(target_os = "macos")]
     {
-        manager.mutex.unlock();
+        drop(state);
 
-        // SAFETY: watcher heap-allocated; reachable via dedup map but FSEvents not yet
-        // scheduled so no concurrent emit.
-        if let Err(err) = Platform::add_watch(manager, unsafe { &mut *watcher }) {
-            // `watcher` was visible in the dedup map while we were unlocked above; a
-            // concurrent Worker's `fs.watch()` on the same path may have attached a
-            // handler and already returned `watcher` to its caller. Only destroy if
-            // ours was the last handler; otherwise surface the error to the survivors
-            // and leave `watcher.manager` set so their `detach()` takes the locked path
-            // (→ `unlinkWatcherLocked` no-ops, `removeWatch` no-ops on null `fsevents`,
-            // then frees). Never free memory another thread holds.
-            manager.mutex.lock();
-            manager.unlink_watcher_locked(watcher);
-            // SAFETY: holding manager.mutex; scoped accesses only.
-            let remaining = unsafe {
-                (*watcher).handlers.swap_remove(&ctx);
-                (*watcher).handlers.len()
-            };
-            if remaining > 0 {
-                // SAFETY: watcher live under manager.mutex; `emit_error`/`flush`
-                // take `&self`.
-                unsafe {
-                    (*watcher).emit_error(&err, true);
-                    (*watcher).flush();
+        match Darwin::add_watch(fsevents_path, recursive, id) {
+            Ok(fse) => {
+                let mut state = manager.state.lock();
+                if let Some(w) = state.watchers.get_mut(&id) {
+                    w.platform.fsevents = Some(fse);
+                } else {
+                    // Cannot happen — our own handler keeps the watcher present
+                    // until `registration` drops — but tearing the stream down
+                    // (outside the lock) is the right response either way.
+                    drop(state);
+                    drop(fse);
                 }
-                manager.mutex.unlock();
-                return Err(err.without_path());
+                Ok(registration())
             }
-            // SAFETY: holding manager.mutex.
-            unsafe { (*watcher).manager = None };
-            manager.mutex.unlock();
-            // SAFETY: last handler removed; no other thread holds watcher.
-            unsafe { PathWatcher::destroy(watcher) };
-            return Err(err.without_path());
+            Err(err) => {
+                // The watcher was visible in the dedup map while we were unlocked; a
+                // concurrent Worker's `fs.watch()` on the same path may have attached a
+                // handler and already returned. Only drop it if ours was the last
+                // handler; otherwise surface the error to the survivors and leave
+                // the (unlinked, stream-less) watcher for their registrations to
+                // release.
+                let mut state = manager.state.lock();
+                state.unlink(id);
+                let w = state
+                    .watchers
+                    .get_mut(&id)
+                    .expect("our handler keeps the watcher present");
+                w.handlers.remove(handler);
+                if !w.handlers.is_empty() {
+                    w.handlers.emit_error(&err, true);
+                    w.handlers.flush();
+                    drop(state);
+                    return Err(err.without_path());
+                }
+                let w = state.watchers.remove(&id);
+                drop(state);
+                drop(w);
+                Err(err.without_path())
+            }
         }
-        return Ok(watcher);
     }
 }
 
@@ -682,11 +626,9 @@ pub(crate) struct Linux {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 struct WdOwner {
-    /// Raw `*mut`. Stored in a long-lived map; `platform.wds` is written through
-    /// it under `manager.mutex`, so a `&PathWatcher` here would make every
-    /// write-through a const→mut cast (UB). Lifetime: outlives the entry
-    /// because `remove_watch` drops all of a watcher's wd entries before `destroy()`.
-    watcher: *mut PathWatcher,
+    /// The owning watcher; `remove_watch` drops all of a watcher's wd entries
+    /// before the watcher itself is dropped.
+    watcher: WatcherId,
     /// Path of the watched directory/file relative to `watcher.path`. Empty for
     /// the root. Owned; freed when this owner is removed from the wd.
     subpath: ZBox,
@@ -698,19 +640,6 @@ pub(crate) struct LinuxWatch {
     /// All wds belonging to this PathWatcher (one for a file/non-recursive dir,
     /// many for a recursive dir).
     wds: Vec<i32>,
-}
-// Drop: Vec frees automatically.
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
-impl PathWatcherManager {
-    /// Set-once inotify fd. Assigned exactly once in [`Linux::init`] *before*
-    /// the reader thread is spawned and never reassigned afterwards (the
-    /// manager is a process-lifetime singleton with no teardown), so reading it
-    /// from either thread races with nothing.
-    #[inline]
-    fn inotify_fd(&self) -> Fd {
-        self.platform_fd.get()
-    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -729,68 +658,105 @@ mod inotify_masks {
         | IN::ONLYDIR;
 }
 
+/// One `struct inotify_event` decoded from the read buffer.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+struct InotifyEvent<'a> {
+    wd: i32,
+    mask: u32,
+    /// The entry name (NUL padding stripped); empty for events about the watched
+    /// inode itself.
+    name: &'a [u8],
+}
+
+/// Iterate the whole `inotify_event`s the kernel wrote into `buf` (inotify never
+/// splits an event across reads).
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn inotify_events(buf: &[u8]) -> impl Iterator<Item = InotifyEvent<'_>> {
+    const HEADER: usize = 16;
+    let mut i = 0usize;
+    core::iter::from_fn(move || {
+        if i + HEADER > buf.len() {
+            return None;
+        }
+        let field =
+            |off: usize| -> [u8; 4] { buf[i + off..i + off + 4].try_into().expect("4 bytes") };
+        let wd = i32::from_ne_bytes(field(0));
+        let mask = u32::from_ne_bytes(field(4));
+        let name_len = u32::from_ne_bytes(field(12)) as usize;
+        let padded = &buf[i + HEADER..(i + HEADER + name_len).min(buf.len())];
+        let name = match strings::index_of_char_usize(padded, 0) {
+            Some(nul) => &padded[..nul],
+            None => padded,
+        };
+        i += HEADER + name_len;
+        Some(InotifyEvent { wd, mask, name })
+    })
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 impl Linux {
-    fn init() -> sys::Result<&'static PathWatcherManager> {
+    fn init() -> sys::Result<Arc<PathWatcherManager>> {
         use bun_sys::linux::IN;
         let rc = sys::linux::inotify_init1(IN::CLOEXEC);
         if rc < 0 {
             return Err(sys::Error::from_code_int(sys::last_errno(), Tag::watch));
         }
-        // Owning raw pointer first, shared view second: the spawn error arm reclaims
-        // through `manager_ptr`, which must not be derived from a shared reference.
-        let manager_ptr = bun_core::heap::into_raw(Box::new(PathWatcherManager::default()));
-        // SAFETY: just allocated and exclusively owned; published only on Ok.
-        let manager: &'static PathWatcherManager = unsafe { &*manager_ptr };
-        manager.platform_fd.set(Fd::from_native(rc));
+        let manager = Arc::new(PathWatcherManager {
+            state: Guarded::init(State::default()),
+            fd: Fd::from_native(rc),
+            running: AtomicBool::new(true),
+        });
         // The manager is process-global and never torn down, so the reader thread is
         // a daemon — detach it instead of stashing a handle we'd never join.
-        match std::thread::Builder::new().spawn(move || Linux::thread_main(manager)) {
+        let reader = Arc::clone(&manager);
+        match std::thread::Builder::new().spawn(move || Linux::thread_main(&reader)) {
             Ok(handle) => drop(handle), // detach
             Err(_) => {
-                manager.platform_fd.get().close();
-                // SAFETY: the thread never started and the manager was never published.
-                drop(unsafe { bun_core::heap::take(manager_ptr) });
+                manager.fd.close();
                 return Err(sys::Error::from_code(E::ENOMEM, Tag::watch));
             }
         }
         Ok(manager)
     }
 
-    /// Caller holds `manager.mutex`.
+    /// Caller holds the manager lock (`state`).
     fn add_watch(
-        manager: &'static PathWatcherManager,
-        watcher: &mut PathWatcher,
+        manager: &PathWatcherManager,
+        state: &mut State,
+        id: WatcherId,
     ) -> sys::Result<()> {
+        let State {
+            watchers, platform, ..
+        } = state;
+        let watcher = watchers.get_mut(&id).expect("just inserted");
         // Borrowck: clone path to avoid &/&mut overlap on watcher.
         let root = watcher.path.clone();
-        Linux::add_one(manager, watcher, &root, b"")?;
+        Linux::add_one(manager.fd, platform, id, watcher, &root, b"")?;
         if watcher.recursive && !watcher.is_file {
-            if let Some(err) = Linux::walk_and_add(manager, watcher, &root, b"") {
+            if let Some(err) = Linux::walk_and_add(manager.fd, platform, id, watcher, &root, b"") {
                 // Partial coverage: emit 'error' but keep the watcher, like node.
-                watcher.emit_error(&err, false);
-                watcher.flush();
+                watcher.handlers.emit_error(&err, false);
+                watcher.handlers.flush();
             }
         }
         Ok(())
     }
 
-    /// Add a single inotify watch and record ownership. Caller holds `manager.mutex`.
+    /// Add a single inotify watch and record ownership. Caller holds the manager lock.
     fn add_one(
-        manager: &'static PathWatcherManager,
+        fd: Fd,
+        platform: &mut Linux,
+        id: WatcherId,
         watcher: &mut PathWatcher,
         abs_path: &ZStr,
         subpath: &[u8],
     ) -> sys::Result<()> {
-        let plat: *mut Linux = manager.platform.get();
         let mask: u32 = if watcher.is_file && subpath.is_empty() {
             inotify_masks::WATCH_FILE_MASK
         } else {
             inotify_masks::WATCH_DIR_MASK
         };
-        let fd = manager.inotify_fd();
-        // SAFETY: thin wrapper over libc::inotify_add_watch; abs_path is NUL-terminated.
-        let rc = unsafe { sys::linux::inotify_add_watch(fd.native(), abs_path.as_ptr(), mask) };
+        let rc = sys::linux::inotify_add_watch_z(fd.native(), abs_path, mask);
         if rc < 0 {
             let err = sys::Error::from_code_int(sys::last_errno(), Tag::watch);
             // ENOENT/ENOTDIR during a recursive walk just means we raced; skip.
@@ -800,8 +766,7 @@ impl Linux {
             return Err(err.with_path(abs_path.as_bytes()));
         }
         let wd: i32 = rc;
-        // SAFETY: caller holds manager.mutex; exclusive access to `wd_map`.
-        let owners = unsafe { (*plat).wd_map.entry(wd).or_default() };
+        let owners = platform.wd_map.entry(wd).or_default();
         // This wd may already have this watcher as an owner:
         //   - IN_CREATE raced the initial walk (same subpath → the reassign is a no-op)
         //   - a subdirectory was *renamed* within the tree: IN_MOVED_TO re-adds it,
@@ -810,7 +775,7 @@ impl Linux {
         //     new name. `walkAndAdd` never follows symlinks (`entry.kind == .directory`,
         //     not `.sym_link`), so this can't pick a longer alias via a cycle.
         for o in owners.iter_mut() {
-            if core::ptr::eq(o.watcher, watcher) {
+            if o.watcher == id {
                 if !strings::eql(o.subpath.as_bytes(), subpath) {
                     o.subpath = ZBox::from_bytes(subpath);
                 }
@@ -818,7 +783,7 @@ impl Linux {
             }
         }
         owners.push(WdOwner {
-            watcher: std::ptr::from_mut::<PathWatcher>(watcher),
+            watcher: id,
             subpath: ZBox::from_bytes(subpath),
         });
         watcher.platform.wds.push(wd);
@@ -836,14 +801,16 @@ impl Linux {
     /// for files arrive on their parent's wd), so only descend into subdirectories.
     /// Returns the first `inotify_add_watch` failure without stopping the walk.
     fn walk_and_add(
-        manager: &'static PathWatcherManager,
+        fd: Fd,
+        platform: &mut Linux,
+        id: WatcherId,
         watcher: &mut PathWatcher,
         abs_dir: &ZStr,
         rel_dir: &[u8],
     ) -> Option<sys::Error> {
         let mut first_err: Option<sys::Error> = None;
         walk_subtree::<true>(abs_dir, rel_dir, &mut |abs, rel, _is_file| {
-            if let Err(e) = Linux::add_one(manager, watcher, abs, rel) {
+            if let Err(e) = Linux::add_one(fd, platform, id, watcher, abs, rel) {
                 if first_err.is_none() {
                     first_err = Some(e);
                 }
@@ -852,20 +819,22 @@ impl Linux {
         first_err
     }
 
-    /// Caller holds `manager.mutex`. Drops this watcher's ownership of each of its
-    /// wds; only issues `inotify_rm_watch` once a wd has no remaining owners.
-    fn remove_watch(manager: &'static PathWatcherManager, watcher: &mut PathWatcher) {
-        let plat: *mut Linux = manager.platform.get();
-        let fd = manager.inotify_fd();
-        // SAFETY: caller holds manager.mutex; exclusive access to `wd_map`.
-        let wd_map = unsafe { &mut (*plat).wd_map };
+    /// Caller holds the manager lock. Drops this watcher's ownership of each of
+    /// its wds; only issues `inotify_rm_watch` once a wd has no remaining owners.
+    fn remove_watch(
+        manager: &PathWatcherManager,
+        state: &mut State,
+        id: WatcherId,
+        watcher: &mut PathWatcher,
+    ) {
+        let wd_map = &mut state.platform.wd_map;
         for &wd in watcher.platform.wds.iter() {
             let Some(owners) = wd_map.get_mut(&wd) else {
                 continue;
             };
             let mut j: usize = 0;
             while j < owners.len() {
-                if core::ptr::eq(owners[j].watcher, watcher) {
+                if owners[j].watcher == id {
                     owners.swap_remove(j);
                 } else {
                     j += 1;
@@ -873,95 +842,75 @@ impl Linux {
             }
             if owners.is_empty() {
                 wd_map.remove(&wd);
-                sys::linux::inotify_rm_watch(fd.native(), wd);
+                sys::linux::inotify_rm_watch(manager.fd.native(), wd);
             }
         }
         watcher.platform.wds.clear();
     }
 
-    fn thread_main(manager: &'static PathWatcherManager) {
+    fn thread_main(manager: &PathWatcherManager) {
         use bun_sys::linux::IN;
         Output::Source::configure_named_thread(zstr!("fs.watch"));
-        let plat: *mut Linux = manager.platform.get();
-        let fd = manager.inotify_fd();
-        let running: &AtomicBool = &manager.running;
+        let fd = manager.fd;
         // Large enough for a burst of events; inotify guarantees whole events per read.
-        // `align(InotifyEvent)`: stack array `[u8; N]` is 1-aligned; box for 4-byte
-        // alignment so the `&InotifyEvent` cast is valid.
-        #[repr(C, align(4))]
-        struct AlignedBuf([u8; 64 * 1024]);
-        let mut buf = {
-            let mut b = Box::<AlignedBuf>::new_uninit();
-            // SAFETY: `AlignedBuf` is `repr(C)` over `[u8; N]`; `write_bytes`
-            // fully zero-initializes it before `assume_init`.
-            unsafe {
-                core::ptr::write_bytes(b.as_mut_ptr(), 0, 1);
-                b.assume_init()
-            }
-        };
-        let mut path_buf = bun_paths::path_buffer_pool::get();
+        let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
+        let mut path_buf = path::path_buffer_pool::get();
         let mut rel_spill: Vec<u8> = Vec::new();
 
-        while running.load(Ordering::Acquire) {
-            // SAFETY: buf is valid for buf.0.len() bytes; fd is a plain c_int.
-            let rc = unsafe { sys::linux::read(fd.native(), buf.0.as_mut_ptr(), buf.0.len()) };
-            match sys::get_errno(rc) {
-                E::SUCCESS => {}
-                E::EAGAIN | E::EINTR => continue,
-                errno => {
-                    // Fatal: surface to every watcher, then exit the thread.
-                    let err = sys::Error {
-                        errno: errno as u16,
-                        syscall: Tag::read,
-                        ..Default::default()
-                    };
-                    manager.mutex.lock();
-                    // SAFETY: holding manager.mutex.
-                    let watchers = unsafe { &*manager.watchers.get() };
-                    for &w in watchers.values() {
-                        // SAFETY: holding manager.mutex; w is live.
-                        unsafe {
-                            (*w).emit_error(&err, true);
-                            (*w).flush();
+        while manager.running.load(Ordering::Acquire) {
+            let n = match sys::read(fd, &mut buf) {
+                Ok(n) => n,
+                Err(err) => match err.get_errno() {
+                    E::EAGAIN | E::EINTR => continue,
+                    errno => {
+                        // Fatal: surface to every watcher, then exit the thread.
+                        let err = sys::Error {
+                            errno: errno as u16,
+                            syscall: Tag::read,
+                            ..Default::default()
+                        };
+                        let mut guard = manager.state.lock();
+                        let State {
+                            by_key, watchers, ..
+                        } = &mut *guard;
+                        // Registration order (the dedup map), like every other fan-out.
+                        for id in by_key.values() {
+                            if let Some(w) = watchers.get_mut(id) {
+                                w.handlers.emit_error(&err, true);
+                                w.handlers.flush();
+                            }
                         }
+                        return;
                     }
-                    manager.mutex.unlock();
-                    return;
-                }
-            }
-            let n = rc as usize;
+                },
+            };
             if n == 0 {
                 continue;
             }
 
-            manager.mutex.lock();
+            let mut guard = manager.state.lock();
+            let State {
+                by_key,
+                watchers,
+                platform,
+                ..
+            } = &mut *guard;
             // Track which PathWatchers got at least one event so we flush() each once.
-            let mut touched: ArrayHashMap<*mut PathWatcher, ()> = ArrayHashMap::default();
+            let mut touched: ArrayHashMap<WatcherId, ()> = ArrayHashMap::default();
 
-            let mut i: usize = 0;
-            while i < n {
-                // SAFETY: inotify guarantees whole events and pads `name` so each
-                // header stays 4-byte aligned; `buf` is 4-byte aligned via
-                // `AlignedBuf`, so byte offset `i` always lands on an aligned
-                // event header within the `n` bytes the kernel just wrote.
-                let ev: &InotifyEvent = unsafe {
-                    &*core::ptr::from_ref(&*buf)
-                        .cast::<InotifyEvent>()
-                        .byte_add(i)
-                };
-                i += core::mem::size_of::<InotifyEvent>() + ev.name_len as usize;
-                let wd = ev.watch_descriptor;
+            for ev in inotify_events(&buf[..n]) {
+                let wd = ev.wd;
+                let name = ev.name;
 
                 // Queue hit fs.inotify.max_queued_events and the kernel dropped
                 // events (wd == -1 matches no watch). Every watcher on this fd
                 // is affected — notify all, like node on Windows does.
                 if ev.mask & IN::Q_OVERFLOW != 0 {
-                    // SAFETY: holding manager.mutex.
-                    let watchers = unsafe { &*manager.watchers.get() };
-                    for &w in watchers.values() {
-                        // SAFETY: w live under manager.mutex.
-                        unsafe { (*w).emit_overflow() };
-                        let _ = handle_oom(touched.get_or_put(w));
+                    for &id in by_key.values() {
+                        if let Some(w) = watchers.get_mut(&id) {
+                            w.handlers.emit_overflow();
+                            let _ = handle_oom(touched.get_or_put(id));
+                        }
                     }
                     continue;
                 }
@@ -973,49 +922,31 @@ impl Linux {
                 // so a deleted watch root reports two. Recursive sub-wds stay
                 // silent; their parent directory's IN_DELETE already reported it.
                 if ev.mask & IN::IGNORED != 0 {
-                    // SAFETY: holding manager.mutex; exclusive access to `wd_map`.
-                    let wd_map = unsafe { &mut (*plat).wd_map };
-                    if let Some(owners) = wd_map.get_mut(&wd) {
+                    if let Some(owners) = platform.wd_map.get_mut(&wd) {
                         for o in owners.drain(..) {
-                            // SAFETY: o.watcher live under manager.mutex; shared
-                            // access only — `emit_unsuppressed` takes `&self`.
-                            let w = unsafe { &*o.watcher };
+                            let Some(w) = watchers.get_mut(&o.watcher) else {
+                                continue;
+                            };
                             if o.subpath.as_bytes().is_empty() && (w.is_file || !w.recursive) {
-                                w.emit_unsuppressed(
+                                w.handlers.emit_unsuppressed(
                                     WatchEventKind::Rename,
                                     path::basename(w.path.as_bytes()),
                                     w.is_file,
                                 );
                                 let _ = handle_oom(touched.get_or_put(o.watcher));
                             }
-                            // SAFETY: exclusive scoped access to this watcher's wd
-                            // list under manager.mutex; the shared borrow above is
-                            // no longer used.
-                            unsafe {
-                                let wds = &mut (*o.watcher).platform.wds;
-                                if let Some(idx) = wds.iter().position(|&x| x == wd) {
-                                    wds.swap_remove(idx);
-                                }
+                            if let Some(idx) = w.platform.wds.iter().position(|&x| x == wd) {
+                                w.platform.wds.swap_remove(idx);
                             }
                         }
-                        wd_map.remove(&wd);
+                        platform.wd_map.remove(&wd);
                     }
                     continue;
                 }
 
-                // SAFETY: holding manager.mutex.
-                if unsafe { (*plat).wd_map.get(&wd).is_none() } {
+                if platform.wd_map.get(&wd).is_none() {
                     continue;
                 }
-
-                let name: &[u8] = if ev.name_len > 0 {
-                    // SAFETY: i was just advanced past this event's name_len bytes; offset is within buf[0..n].
-                    let name_ptr = unsafe { buf.0.as_ptr().add(i - ev.name_len as usize) };
-                    // SAFETY: kernel NUL-pads name within name_len bytes.
-                    unsafe { bun_core::ffi::cstr(name_ptr.cast()).to_bytes() }
-                } else {
-                    b""
-                };
 
                 let is_dir_child = ev.mask & IN::ISDIR != 0;
                 let event_type: WatchEventKind = if ev.mask
@@ -1033,51 +964,29 @@ impl Linux {
                 };
 
                 // Dispatch to every owner of this wd. The recursive branch below calls
-                // `addOne`/`walkAndAdd`, which insert into `wd_map` via `getOrPut` and
-                // may rehash — that would invalidate any pointer into the map's value
-                // storage. Re-fetch the owners list by key each iteration rather than
-                // caching `getPtr(wd)` across the loop.
+                // `add_one`/`walk_and_add`, which insert into `wd_map` and may rehash
+                // or grow this wd's owner list, so re-fetch the owners by key each
+                // iteration rather than holding a borrow across the loop.
                 let mut oi: usize = 0;
                 loop {
-                    // SAFETY: holding manager.mutex. Re-project `wd_map` each iteration
-                    // (raw-ptr access, no long-lived `&mut`): the recursive branch below
-                    // calls `add_one`/`walk_and_add`, which take their own `&mut wd_map`
-                    // and may rehash. Extract the owner's watcher ptr and subpath bytes,
-                    // then drop the map borrow before any of that runs.
-                    let (owner_watcher, owner_subpath): (*mut PathWatcher, &[u8]) = unsafe {
-                        let Some(owners) = (*plat).wd_map.get(&wd) else {
-                            break;
-                        };
-                        if oi >= owners.len() {
-                            break;
-                        }
-                        let o = &owners[oi];
-                        // `o.subpath` is a `ZBox` — its heap bytes do not move when
-                        // `wd_map` rehashes (only the Vec header does). Launder the slice
-                        // through a raw ptr so its provenance is decoupled from the map
-                        // borrow that `add_one` will invalidate.
-                        (
-                            o.watcher,
-                            &*std::ptr::from_ref::<[u8]>(o.subpath.as_bytes()),
-                        )
+                    let Some(owners) = platform.wd_map.get(&wd) else {
+                        break;
                     };
-                    // SAFETY: owner_watcher live under manager.mutex. Copy the
-                    // scalars and launder the path bytes via a raw ptr so `rel`
-                    // (which may borrow them) is decoupled from the scoped `&mut`
-                    // temporaries `add_one` takes below. `path` is a `ZBox`; its
-                    // heap bytes are a separate allocation, so this mirrors the
-                    // `owner_subpath` raw-ptr laundering above.
-                    let (watcher_is_file, watcher_recursive, watcher_path): (bool, bool, &[u8]) = unsafe {
-                        (
-                            (*owner_watcher).is_file,
-                            (*owner_watcher).recursive,
-                            &*std::ptr::from_ref::<[u8]>((*owner_watcher).path.as_bytes()),
-                        )
+                    let Some(owner) = owners.get(oi) else {
+                        break;
                     };
+                    let owner_id = owner.watcher;
+                    let owner_subpath: &[u8] = owner.subpath.as_bytes();
+                    let Some(w) = watchers.get_mut(&owner_id) else {
+                        oi += 1;
+                        continue;
+                    };
+                    let watcher_is_file = w.is_file;
+                    let watcher_recursive = w.recursive;
 
                     // Build the path relative to this owner's root.
                     let rel: &[u8] = if watcher_is_file {
-                        path::basename(watcher_path)
+                        path::basename(w.path.as_bytes())
                     } else if owner_subpath.is_empty() {
                         if name.is_empty() && !watcher_recursive {
                             // A nameless event on the root wd is about the watched
@@ -1085,7 +994,7 @@ impl Linux {
                             // IN_ATTRIB); libuv reports basename(watched path),
                             // same as for a file. node's recursive watcher uses
                             // root-relative paths instead, so those keep "".
-                            path::basename(watcher_path)
+                            path::basename(w.path.as_bytes())
                         } else {
                             name
                         }
@@ -1100,17 +1009,14 @@ impl Linux {
                         .as_bytes()
                     };
 
-                    // SAFETY: owner_watcher live under manager.mutex; `emit` takes `&self`.
-                    unsafe {
-                        (*owner_watcher).emit(
-                            event_type,
-                            rel,
-                            !is_dir_child
-                                && !((ev.mask & (IN::DELETE_SELF | IN::MOVE_SELF) != 0)
-                                    && !watcher_is_file),
-                        );
-                    }
-                    let _ = handle_oom(touched.get_or_put(owner_watcher));
+                    w.handlers.emit(
+                        event_type,
+                        rel,
+                        !is_dir_child
+                            && !((ev.mask & (IN::DELETE_SELF | IN::MOVE_SELF) != 0)
+                                && !watcher_is_file),
+                    );
+                    let _ = handle_oom(touched.get_or_put(owner_id));
 
                     // Recursive: a new directory appeared under this owner's tree —
                     // start watching it so future events inside it are delivered.
@@ -1126,21 +1032,14 @@ impl Linux {
                         let child_abs = join_z_buf_spill::<platform::Posix>(
                             abs_buf.as_mut_slice(),
                             &mut abs_spill,
-                            &[watcher_path, owner_subpath, name],
+                            &[w.path.as_bytes(), owner_subpath, name],
                         );
-                        // Borrowck: `rel` may borrow `path_buf`,
-                        // which `walk_subtree` also borrows. Own it for the call.
+                        // `rel` may borrow `path_buf` (which `walk_subtree`
+                        // also needs) or this wd's owner list (which `add_one`
+                        // is about to grow); own it for the calls below.
                         let rel_owned: Box<[u8]> = Box::from(rel);
-                        // These may rehash `wd_map`; `owners` is re-fetched next iteration.
-                        // SAFETY: owner_watcher live under manager.mutex; the `&mut`
-                        // is scoped to the call.
-                        let mut add_err = Linux::add_one(
-                            manager,
-                            unsafe { &mut *owner_watcher },
-                            child_abs,
-                            &rel_owned,
-                        )
-                        .err();
+                        let mut add_err =
+                            Linux::add_one(fd, platform, owner_id, w, child_abs, &rel_owned).err();
                         // Entries created inside the new directory before our watch
                         // attached never get their own IN_CREATE on this fd. Walk the
                         // subtree: watch nested directories and synthesize a "rename"
@@ -1154,31 +1053,20 @@ impl Linux {
                             &rel_owned,
                             &mut |abs, entry_rel, entry_is_file| {
                                 if !entry_is_file {
-                                    // SAFETY: owner_watcher live under manager.mutex;
-                                    // the `&mut` is scoped to the call.
-                                    let watcher = unsafe { &mut *owner_watcher };
-                                    if let Err(e) = Linux::add_one(manager, watcher, abs, entry_rel)
+                                    if let Err(e) =
+                                        Linux::add_one(fd, platform, owner_id, w, abs, entry_rel)
                                     {
                                         if add_err.is_none() {
                                             add_err = Some(e);
                                         }
                                     }
                                 }
-                                // SAFETY: owner_watcher live under manager.mutex;
-                                // `emit` takes `&self`.
-                                unsafe {
-                                    (*owner_watcher).emit(
-                                        WatchEventKind::Rename,
-                                        entry_rel,
-                                        entry_is_file,
-                                    );
-                                }
+                                w.handlers
+                                    .emit(WatchEventKind::Rename, entry_rel, entry_is_file);
                             },
                         );
                         if let Some(err) = add_err {
-                            // SAFETY: owner_watcher live under manager.mutex;
-                            // `emit_error` takes `&self`.
-                            unsafe { (*owner_watcher).emit_error(&err, false) };
+                            w.handlers.emit_error(&err, false);
                         }
                     }
 
@@ -1186,164 +1074,100 @@ impl Linux {
                 }
             }
 
-            for &w in touched.keys() {
-                // SAFETY: w live under manager.mutex.
-                unsafe { (*w).flush() };
+            for &id in touched.keys() {
+                if let Some(w) = watchers.get_mut(&id) {
+                    w.handlers.flush();
+                }
             }
-            manager.mutex.unlock();
+            drop(guard);
         }
     }
 }
-
-/// The kernel `struct inotify_event` header. Shared with the bundler watcher;
-/// field naming there is `watch_descriptor` / `name_len`.
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use bun_watcher::inotify_watcher::Event as InotifyEvent;
 
 // ────────────────────────────────────────────────────────────────────────────────
 // Darwin
 // ────────────────────────────────────────────────────────────────────────────────
 
-/// macOS: delegate to `fs_events.rs`, which already runs one CFRunLoop thread with
-/// one FSEventStream covering every watched path. The PathWatcher itself is the
-/// FSEventsWatcher's opaque ctx — `fs_events.rs` calls back via `onFSEvent` below,
+/// macOS: delegate to `fs_events.rs`, which runs one CFRunLoop thread with one
+/// FSEventStream covering every watched path. The PathWatcher's id is the
+/// FSEventsWatcher's context — `fs_events.rs` calls back via `on_fs_event` below,
 /// and we fan out to the JS handlers.
 ///
-/// Unlike the old design, FSEvents is used for both files and directories (same as
-/// libuv), so `fs.watch()` no longer spins up a second kqueue thread.
+/// FSEvents is used for both files and directories (same as libuv), so
+/// `fs.watch()` never spins up a second kqueue thread.
 #[cfg(target_os = "macos")]
 #[derive(Default)]
 pub struct Darwin {
     // No manager-level state — FSEvents has its own process-global loop.
 }
 
+/// Dropping this (with the watcher, outside the manager lock) unregisters from
+/// the FSEvents loop; see [`PathWatcherManager::detach`].
 #[cfg(target_os = "macos")]
 #[derive(Default)]
 pub(crate) struct DarwinWatch {
-    fsevents: Option<*mut fsevents::FSEventsWatcher>,
-}
-
-#[cfg(target_os = "macos")]
-impl Drop for DarwinWatch {
-    fn drop(&mut self) {
-        if let Some(fse) = self.fsevents.take() {
-            // SAFETY: fse came from `heap::alloc` in `add_watch`; reconstitute
-            // to run `FSEventsWatcher::drop` (→ `unregister_watcher`).
-            drop(unsafe { bun_core::heap::take(fse) });
-        }
-    }
+    fsevents: Option<fsevents::FSEventsWatcher>,
 }
 
 #[cfg(target_os = "macos")]
 impl Darwin {
-    fn init() -> sys::Result<&'static PathWatcherManager> {
-        // SAFETY: just allocated; nothing after this can fail.
-        Ok(unsafe { &*bun_core::heap::into_raw(Box::new(PathWatcherManager::default())) })
+    fn init() -> sys::Result<Arc<PathWatcherManager>> {
+        Ok(Arc::new(PathWatcherManager {
+            state: Guarded::init(State::default()),
+        }))
     }
 
-    /// Caller does NOT hold `manager.mutex` — `FSEvents.watch()` takes the FSEvents
-    /// loop mutex, and the CF thread holds that while calling `onFSEvent` (which
-    /// takes `manager.mutex`). Keeping this call outside `manager.mutex` makes the
-    /// lock order one-way: fsevents_loop.mutex → manager.mutex.
-    fn add_watch(_: &'static PathWatcherManager, watcher: &mut PathWatcher) -> sys::Result<()> {
-        // Borrowck: capture the raw ctx pointer before the
-        // shared borrow of `watcher.path` so the two don't overlap at the call site.
-        let ctx = core::ptr::from_mut::<PathWatcher>(watcher).cast::<c_void>();
-        match fsevents::watch(
-            // `FSEventsWatcher` borrows this slice for its whole lifetime; the
-            // backing `ZBox` is NUL-terminated for CF's C-string consumer.
-            watcher.path.as_bytes(),
-            watcher.recursive,
+    /// Caller does NOT hold the manager lock — `fsevents::watch()` takes the
+    /// FSEvents loop lock, and the CF thread holds that while calling
+    /// `on_fs_event` (which takes the manager lock). Keeping this call outside
+    /// makes the lock order one-way: fsevents loop → manager.
+    fn add_watch(
+        path: ZBox,
+        recursive: bool,
+        id: WatcherId,
+    ) -> sys::Result<fsevents::FSEventsWatcher> {
+        fsevents::watch(
+            path,
+            recursive,
             Darwin::on_fs_event,
             Darwin::on_fs_event_flush,
-            ctx,
-        ) {
-            Ok(fse) => {
-                watcher.platform.fsevents = Some(bun_core::heap::into_raw(fse));
-                Ok(())
-            }
-            Err(e) => Err(sys::Error::from_code(
+            id,
+        )
+        .map_err(|e| {
+            sys::Error::from_code(
                 if matches!(e, crate::Error::FailedToCreateCoreFoudationSourceLoop) {
                     E::EINVAL
                 } else {
                     E::ENOMEM
                 },
                 Tag::watch,
-            )),
-        }
+            )
+        })
     }
 
-    /// Caller does NOT hold `manager.mutex` (same lock-order reasoning as `addWatch`).
-    /// `FSEventsWatcher.deinit()` → `unregisterWatcher()` blocks on the FSEvents loop
-    /// mutex, which `events_cb` holds for the whole dispatch; once this returns no
-    /// further `onFSEvent` calls will arrive for `watcher`.
-    ///
-    /// Takes a raw `*mut PathWatcher`: while we block on the FSEvents loop mutex
-    /// inside `deinit`, the CF thread may concurrently take `manager.mutex` and
-    /// raw-read `(*watcher).manager` (to bail on `None`). Holding a `&mut PathWatcher`
-    /// across that would be aliased-`&mut` UB under Stacked Borrows.
-    fn remove_watch(_: &'static PathWatcherManager, watcher: *mut PathWatcher) {
-        // SAFETY: caller is the sole logical owner (last handler detached, watcher
-        // unlinked from the dedup map, `manager` already nulled). Project only the
-        // `platform.fsevents` sub-place via the raw pointer; the CF thread's
-        // concurrent raw read targets the disjoint `manager` field.
-        if let Some(fse) = unsafe { (*watcher).platform.fsevents.take() } {
-            // SAFETY: fse came from `heap::alloc` in `add_watch`; reconstitute to
-            // run `FSEventsWatcher::drop` (→ `unregister_watcher`).
-            drop(unsafe { bun_core::heap::take(fse) });
-        }
-    }
-
-    /// Called from the CFRunLoop thread (`fs_events.rs`'s `events_cb`) with the
-    /// FSEvents loop mutex held. Take `manager.mutex` so iterating `handlers` can't
-    /// race with `watch()`/`detach()` mutating it. The JS thread never holds
-    /// `manager.mutex` across a call into FSEvents, so this is deadlock-free.
-    ///
-    /// `watcher` itself is kept alive by the FSEvents loop mutex: `detach()` →
-    /// `removeWatch()` → `fse.deinit()` → `unregisterWatcher()` blocks until
-    /// `events_cb` releases it, so `destroy()` cannot run under us. The
-    /// `watcher.manager == null` check catches the window where detach has already
-    /// unlinked us but hasn't yet called `fse.deinit()`.
-    fn on_fs_event(ctx: *mut c_void, event: Event, is_file: bool) {
-        // SAFETY: ctx is the *mut PathWatcher passed in add_watch above. Keep it raw
-        // until `manager.mutex` is held and the `manager.is_none()` bail-out has run:
-        // `detach()` on the JS thread may concurrently be between its `unlock()` and
-        // `remove_watch()` (blocked on the FSEvents loop mutex we hold), with the
-        // watcher already unlinked. Forming a reference here before that check would
-        // alias detach's access; raw-ptr reads have no exclusivity assertion.
-        let watcher_ptr = ctx.cast::<PathWatcher>();
-        let Some(&manager) = DEFAULT_MANAGER.get() else {
+    /// Called from the CFRunLoop thread (`fs_events.rs`'s `on_events`) with the
+    /// FSEvents loop lock held. Takes the manager lock so iterating `handlers`
+    /// can't race with `watch()`/`detach()` mutating it. The JS thread never holds
+    /// the manager lock across a call into FSEvents, so this is deadlock-free.
+    /// A watcher whose last handler already detached is simply not found.
+    fn on_fs_event(id: WatcherId, event_type: WatchEventKind, path: &[u8], is_file: bool) {
+        let Some(manager) = DEFAULT_MANAGER.get() else {
             return;
         };
-        let _g = manager.mutex.lock_guard();
-        // SAFETY: raw read under manager.mutex; see above.
-        if unsafe { (*watcher_ptr).manager.is_none() } {
-            return;
-        }
-        // SAFETY: holding manager.mutex with `manager` still set → detach() has not
-        // yet unlinked us. Shared access only — `emit`/`emit_error` take `&self`.
-        let watcher = unsafe { &*watcher_ptr };
-        match event {
-            Event::Rename(path) => watcher.emit(WatchEventKind::Rename, &path, is_file),
-            Event::Change(path) => watcher.emit(WatchEventKind::Change, &path, is_file),
-            Event::Error { err, close } => watcher.emit_error(&err, close),
-            _ => {}
+        let mut state = manager.state.lock();
+        if let Some(w) = state.watchers.get_mut(&id) {
+            w.handlers.emit(event_type, path, is_file);
         }
     }
 
-    fn on_fs_event_flush(ctx: *mut c_void) {
-        // SAFETY: see on_fs_event — keep raw until locked + manager-is-none checked.
-        let watcher_ptr = ctx.cast::<PathWatcher>();
-        let Some(&manager) = DEFAULT_MANAGER.get() else {
+    fn on_fs_event_flush(id: WatcherId) {
+        let Some(manager) = DEFAULT_MANAGER.get() else {
             return;
         };
-        let _g = manager.mutex.lock_guard();
-        // SAFETY: raw read under manager.mutex.
-        if unsafe { (*watcher_ptr).manager.is_none() } {
-            return;
+        let mut state = manager.state.lock();
+        if let Some(w) = state.watchers.get_mut(&id) {
+            w.handlers.flush();
         }
-        // SAFETY: holding manager.mutex with `manager` still set; exclusive.
-        unsafe { (*watcher_ptr).flush() };
     }
 }
 
@@ -1366,10 +1190,9 @@ pub(crate) struct Kqueue {
 
 #[cfg(target_os = "freebsd")]
 struct KqEntry {
-    /// Raw `*mut`. See `WdOwner.watcher` — stored long-lived, dereferenced
-    /// under `manager.mutex`; outlives the entry because
-    /// `remove_watch` clears all of a watcher's entries before `destroy()`.
-    watcher: *mut PathWatcher,
+    /// The owning watcher; `remove_watch` clears all of a watcher's entries
+    /// before the watcher itself is dropped.
+    watcher: WatcherId,
     fd: Fd,
     /// Relative to watcher.path; empty for the root. Owned.
     subpath: ZBox,
@@ -1382,57 +1205,54 @@ struct KqEntry {
 pub(crate) struct KqueueWatch {
     fds: Vec<i32>,
 }
-// Drop: Vec frees automatically.
-
-#[cfg(target_os = "freebsd")]
-impl PathWatcherManager {
-    /// Set-once kqueue fd. Assigned exactly once in [`Kqueue::init`] *before*
-    /// the reader thread is spawned and never reassigned afterwards (the
-    /// manager is a process-lifetime singleton with no teardown), so reading it
-    /// from either thread races with nothing.
-    #[inline]
-    fn kq_fd(&self) -> Fd {
-        self.platform_fd.get()
-    }
-}
 
 #[cfg(target_os = "freebsd")]
 impl Kqueue {
-    fn init() -> sys::Result<&'static PathWatcherManager> {
+    fn init() -> sys::Result<Arc<PathWatcherManager>> {
         let kq = sys::kqueue()?;
-        // Owning raw pointer first, shared view second: the spawn error arm reclaims
-        // through `manager_ptr`, which must not be derived from a shared reference.
-        let manager_ptr = bun_core::heap::into_raw(Box::new(PathWatcherManager::default()));
-        // SAFETY: just allocated and exclusively owned; published only on Ok.
-        let manager: &'static PathWatcherManager = unsafe { &*manager_ptr };
-        manager.platform_fd.set(kq);
+        let manager = Arc::new(PathWatcherManager {
+            state: Guarded::init(State::default()),
+            fd: kq,
+            running: AtomicBool::new(true),
+        });
         // Daemon reader — the manager is process-global and never torn down.
-        match std::thread::Builder::new().spawn(move || Kqueue::thread_main(manager)) {
+        let reader = Arc::clone(&manager);
+        match std::thread::Builder::new().spawn(move || Kqueue::thread_main(&reader)) {
             Ok(handle) => drop(handle), // detach
             Err(_) => {
-                manager.platform_fd.get().close();
-                // SAFETY: the thread never started and the manager was never published.
-                drop(unsafe { bun_core::heap::take(manager_ptr) });
+                manager.fd.close();
                 return Err(sys::Error::from_code(E::ENOMEM, Tag::watch));
             }
         }
         Ok(manager)
     }
 
-    /// Caller holds `manager.mutex`.
+    /// Caller holds the manager lock (`state`).
     fn add_watch(
-        manager: &'static PathWatcherManager,
-        watcher: &mut PathWatcher,
+        manager: &PathWatcherManager,
+        state: &mut State,
+        id: WatcherId,
     ) -> sys::Result<()> {
+        let State {
+            watchers,
+            platform,
+            next_gen,
+            ..
+        } = state;
+        let watcher = watchers.get_mut(&id).expect("just inserted");
         // Borrowck: clone path to avoid &/&mut overlap.
         let root = watcher.path.clone();
         let is_file = watcher.is_file;
-        Kqueue::add_one(manager, watcher, &root, b"", is_file)?;
+        Kqueue::add_one(
+            manager.fd, platform, next_gen, id, watcher, &root, b"", is_file,
+        )?;
         if watcher.recursive && !watcher.is_file {
             // kqueue needs an open fd per *file* as well as per directory.
             let mut first_err: Option<sys::Error> = None;
             walk_subtree::<false>(&root, b"", &mut |abs, rel, is_file| {
-                if let Err(e) = Kqueue::add_one(manager, watcher, abs, rel, is_file) {
+                if let Err(e) = Kqueue::add_one(
+                    manager.fd, platform, next_gen, id, watcher, abs, rel, is_file,
+                ) {
                     if first_err.is_none() {
                         first_err = Some(e);
                     }
@@ -1440,22 +1260,25 @@ impl Kqueue {
             });
             if let Some(err) = first_err {
                 // Partial coverage: emit 'error' but keep the watcher, like node.
-                watcher.emit_error(&err, false);
-                watcher.flush();
+                watcher.handlers.emit_error(&err, false);
+                watcher.handlers.flush();
             }
         }
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_one(
-        manager: &'static PathWatcherManager,
+        kq: Fd,
+        platform: &mut Kqueue,
+        next_gen: &mut usize,
+        id: WatcherId,
         watcher: &mut PathWatcher,
         abs_path: &ZStr,
         subpath: &[u8],
         is_file: bool,
     ) -> sys::Result<()> {
-        use bun_sys::freebsd::{EV, EVFILT, Kevent, NOTE, kevent};
-        let plat: *mut Kqueue = manager.platform.get();
+        use bun_sys::freebsd::{EV, EVFILT, Kevent, NOTE};
         // O_EVTONLY: we only need the fd for kevent registration, never for I/O.
         // (No-op on FreeBSD where EVTONLY is 0; semantic here for kqueue-on-macOS.)
         let fd = match sys::open(
@@ -1472,15 +1295,12 @@ impl Kqueue {
             Ok(f) => f,
         };
 
-        // Caller holds manager.mutex; exclusive access to `next_gen`.
         let generation = {
-            let g = manager.next_gen.get();
-            manager.next_gen.set(g.wrapping_add(1));
+            let g = *next_gen;
+            *next_gen = g.wrapping_add(1);
             g
         };
-        let kq = manager.kq_fd();
 
-        // SAFETY: all-zero is a valid Kevent (#[repr(C)] POD).
         let mut kev: Kevent = bun_core::ffi::zeroed();
         kev.ident = fd.native() as usize;
         kev.filter = EVFILT::VNODE;
@@ -1493,52 +1313,40 @@ impl Kqueue {
             | NOTE::LINK
             | NOTE::REVOKE;
         kev.udata = generation as _;
-        let mut changes = [kev];
-        // SAFETY: thin wrapper over libc::kevent.
-        let krc = unsafe {
-            kevent(
-                kq.native(),
-                changes.as_ptr(),
-                1,
-                changes.as_mut_ptr(),
-                0,
-                core::ptr::null(),
-            )
-        };
-        if krc < 0 {
+        if let Err(err) = sys::kevent(kq, core::slice::from_ref(&kev), &mut [], None) {
             // Registration failed (ENOMEM/EINVAL on a bad fd, etc.). Don't leave a
             // dead entry in the map that will never deliver events.
-            let errno = sys::get_errno(krc);
             fd.close();
             return Err(sys::Error {
-                errno: errno as u16,
+                errno: err.errno,
                 syscall: Tag::watch,
                 ..Default::default()
             }
             .with_path(abs_path.as_bytes()));
         }
 
-        // SAFETY: caller holds manager.mutex; exclusive access to `entries`.
-        unsafe {
-            handle_oom((*plat).entries.put(
-                fd.native() as i32,
-                KqEntry {
-                    watcher: core::ptr::from_mut(watcher),
-                    fd,
-                    subpath: ZBox::from_bytes(subpath),
-                    generation,
-                    is_file,
-                },
-            ));
-        }
+        handle_oom(platform.entries.put(
+            fd.native() as i32,
+            KqEntry {
+                watcher: id,
+                fd,
+                subpath: ZBox::from_bytes(subpath),
+                generation,
+                is_file,
+            },
+        ));
         watcher.platform.fds.push(fd.native() as i32);
         Ok(())
     }
 
-    /// Caller holds `manager.mutex`.
-    fn remove_watch(manager: &'static PathWatcherManager, watcher: &mut PathWatcher) {
-        // SAFETY: caller holds manager.mutex; exclusive access to `entries`.
-        let entries = unsafe { &mut (*manager.platform.get()).entries };
+    /// Caller holds the manager lock.
+    fn remove_watch(
+        _: &PathWatcherManager,
+        state: &mut State,
+        _: WatcherId,
+        watcher: &mut PathWatcher,
+    ) {
+        let entries = &mut state.platform.entries;
         for &ident in watcher.platform.fds.iter() {
             if let Some((_, entry)) = entries.fetch_swap_remove(&ident) {
                 // Closing the fd auto-removes the kevent.
@@ -1549,37 +1357,27 @@ impl Kqueue {
         watcher.platform.fds.clear();
     }
 
-    fn thread_main(manager: &'static PathWatcherManager) {
-        use bun_sys::freebsd::{Kevent, NOTE, kevent};
+    fn thread_main(manager: &PathWatcherManager) {
+        use bun_sys::freebsd::{Kevent, NOTE};
         Output::Source::configure_named_thread(zstr!("fs.watch"));
-        let plat: *mut Kqueue = manager.platform.get();
-        let kq = manager.kq_fd();
-        let running: &AtomicBool = &manager.running;
-        // SAFETY: Kevent is POD; uninitialized array filled by kernel before read.
+        let kq = manager.fd;
         let mut events: [Kevent; 128] = bun_core::ffi::zeroed();
-        while running.load(Ordering::Acquire) {
-            // SAFETY: thin wrapper over libc::kevent.
-            let count = unsafe {
-                kevent(
-                    kq.native(),
-                    events.as_ptr(),
-                    0,
-                    events.as_mut_ptr(),
-                    events.len() as _,
-                    core::ptr::null(),
-                )
+        while manager.running.load(Ordering::Acquire) {
+            let count = match sys::kevent(kq, &[], &mut events, None) {
+                Ok(n) => n,
+                Err(_) => continue,
             };
-            if count <= 0 {
+            if count == 0 {
                 continue;
             }
 
-            manager.mutex.lock();
-            // SAFETY: holding manager.mutex; exclusive access to `entries`. This loop
-            // never mutates `entries`, so a shared borrow suffices.
-            let entries = unsafe { &(*plat).entries };
-            let mut touched: ArrayHashMap<*mut PathWatcher, ()> = ArrayHashMap::default();
+            let mut guard = manager.state.lock();
+            let State {
+                watchers, platform, ..
+            } = &mut *guard;
+            let mut touched: ArrayHashMap<WatcherId, ()> = ArrayHashMap::default();
 
-            for kev in &events[..count as usize] {
+            for kev in &events[..count] {
                 // Validate via the map — the entry may have been freed by a racing
                 // removeWatch between kevent() returning and us taking the lock. POSIX
                 // recycles the lowest fd on open(), so the ident could also now belong
@@ -1587,17 +1385,15 @@ impl Kqueue {
                 // set to a monotonic generation at registration and survives in the
                 // already-delivered event, so compare it to the current entry's gen
                 // to reject stale fd-reuse hits.
-                let Some(entry) = entries.get(&(kev.ident as i32)) else {
+                let Some(entry) = platform.entries.get(&(kev.ident as i32)) else {
                     continue;
                 };
                 if entry.generation != kev.udata as usize {
                     continue;
                 }
-                // SAFETY: entry.watcher live under manager.mutex; PathWatcher is a
-                // separate heap allocation, disjoint from the `entries` borrow above.
-                // Shared access only — `emit` takes `&self`.
-                let watcher = unsafe { &*entry.watcher };
-                let watcher_path: &[u8] = watcher.path.as_bytes();
+                let Some(watcher) = watchers.get_mut(&entry.watcher) else {
+                    continue;
+                };
 
                 let event_type: WatchEventKind = if kev.fflags
                     & (NOTE::DELETE | NOTE::RENAME | NOTE::REVOKE | NOTE::LINK)
@@ -1611,20 +1407,21 @@ impl Kqueue {
                 // kqueue has no filenames. For a file watch, report the basename; for a
                 // directory, report the subpath (empty for root → caller re-scans).
                 let rel: &[u8] = if entry.is_file && entry.subpath.is_empty() {
-                    path::basename(watcher_path)
+                    path::basename(watcher.path.as_bytes())
                 } else {
                     entry.subpath.as_bytes()
                 };
 
-                watcher.emit(event_type, rel, entry.is_file);
+                watcher.handlers.emit(event_type, rel, entry.is_file);
                 let _ = handle_oom(touched.get_or_put(entry.watcher));
             }
 
-            for &w in touched.keys() {
-                // SAFETY: w live under manager.mutex.
-                unsafe { (*w).flush() };
+            for &id in touched.keys() {
+                if let Some(w) = watchers.get_mut(&id) {
+                    w.handlers.flush();
+                }
             }
-            manager.mutex.unlock();
+            drop(guard);
         }
     }
 }

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -17,12 +17,8 @@ use bun_sys::windows::libuv::UvHandle as _;
 use bun_threading::Mutex;
 
 use super::node_fs_watcher::WatchEventKind;
-// The callbacks are *associated functions* on `FSWatcher`, not free fns.
 use crate::node::node_fs_watcher::{Event, FSWatcher, StringOrBytesToDecode};
-#[allow(non_upper_case_globals)]
-const on_path_update_fn: fn(Option<*mut c_void>, Event, bool) = FSWatcher::ON_PATH_UPDATE;
-#[allow(non_upper_case_globals)]
-const on_update_end_fn: fn(Option<*mut c_void>) = FSWatcher::on_update_end;
+use bun_ptr::BackRef;
 
 bun_output::declare_scope!(PathWatcherManager, visible);
 // Rust identifiers cannot contain '.', so
@@ -147,7 +143,14 @@ pub struct PathWatcher {
     // LIFETIMES.tsv: BACKREF → Option<*mut PathWatcherManager>
     manager: Cell<Option<*mut PathWatcherManager>>,
     emit_in_progress: Cell<bool>,
-    handlers: JsCell<ArrayHashMap<*mut c_void, ChangeEvent>>,
+    /// The JS `FSWatcher`s sharing this watch, keyed by address. Each removes
+    /// itself (drops its [`Registration`]) before it goes away.
+    handlers: JsCell<ArrayHashMap<usize, (BackRef<FSWatcher>, ChangeEvent)>>,
+}
+
+#[inline]
+fn handler_key(owner: &FSWatcher) -> usize {
+    core::ptr::from_ref(owner) as usize
 }
 
 #[derive(Clone, Copy)]
@@ -221,19 +224,18 @@ impl PathWatcher {
             me.emit_in_progress.set(true);
 
             let keys: Vec<_> = me.handlers.get().keys().iter().copied().collect();
-            for ctx in keys {
-                if !me.handlers.get().contains_key(&ctx) {
+            for key in keys {
+                let Some(owner) = me.handlers.get().get(&key).map(|(owner, _)| *owner) else {
                     continue;
-                }
-                on_path_update_fn(
-                    Some(ctx),
+                };
+                owner.on_path_update_windows(
                     Event::Error {
                         err: err.clone(),
                         close: true,
                     },
                     false,
                 );
-                on_update_end_fn(Some(ctx));
+                owner.on_update_end();
             }
 
             me.emit_in_progress.set(false);
@@ -253,12 +255,12 @@ impl PathWatcher {
             // Forward `(event, null)` to every handler like node, unsuppressed.
             me.emit_in_progress.set(true);
             let keys: Vec<_> = me.handlers.get().keys().iter().copied().collect();
-            for ctx in keys {
-                if !me.handlers.get().contains_key(&ctx) {
+            for key in keys {
+                let Some(owner) = me.handlers.get().get(&key).map(|(owner, _)| *owner) else {
                     continue;
-                }
-                on_path_update_fn(Some(ctx), Event::NoFilename(event_type), false);
-                on_update_end_fn(Some(ctx));
+                };
+                owner.on_path_update_windows(Event::NoFilename(event_type), false);
+                owner.on_update_end();
             }
             me.emit_in_progress.set(false);
             Self::maybe_deinit(this);
@@ -291,30 +293,26 @@ impl PathWatcher {
 
             let keys: Vec<_> = me.handlers.get().keys().iter().copied().collect();
             for key in keys {
-                let Some(fire) = me
-                    .handlers
-                    .with_mut(|h| h.get_mut(&key).map(|v| v.emit(hash, timestamp, event_type)))
-                else {
+                let Some(owner) = me.handlers.with_mut(|h| {
+                    h.get_mut(&key).and_then(|(owner, change)| {
+                        change.emit(hash, timestamp, event_type).then_some(*owner)
+                    })
+                }) else {
                     continue;
                 };
-                if fire {
-                    let ctx: *mut FSWatcher = key.cast::<FSWatcher>();
-                    // SAFETY: handlers keys are `*mut FSWatcher` erased to `*mut c_void` in `watch()`.
-                    let encoding = unsafe { (*ctx).encoding };
-                    // `EventPathString` on Windows is `StringOrBytesToDecode`.
-                    let payload = match encoding {
-                        crate::node::Encoding::Utf8 => {
-                            StringOrBytesToDecode::String(BunString::clone_utf8(path))
-                        }
-                        _ => StringOrBytesToDecode::BytesToFree(Box::<[u8]>::from(path)),
-                    };
-                    on_path_update_fn(Some(ctx.cast()), event_type.to_event(payload), is_file);
-                    #[cfg(debug_assertions)]
-                    {
-                        debug_count += 1;
+                // `EventPathString` on Windows is `StringOrBytesToDecode`.
+                let payload = match owner.encoding {
+                    crate::node::Encoding::Utf8 => {
+                        StringOrBytesToDecode::String(BunString::clone_utf8(path))
                     }
-                    on_update_end_fn(Some(ctx.cast()));
+                    _ => StringOrBytesToDecode::BytesToFree(Box::<[u8]>::from(path)),
+                };
+                owner.on_path_update_windows(event_type.to_event(payload), is_file);
+                #[cfg(debug_assertions)]
+                {
+                    debug_count += 1;
                 }
+                owner.on_update_end();
             }
 
             #[cfg(debug_assertions)]
@@ -438,10 +436,8 @@ impl PathWatcher {
         drop(unsafe { bun_core::heap::take(this) });
     }
 
-    /// JS-thread entry point from `FSWatcher.detach()`. Signature matches the posix
-    /// `path_watcher::PathWatcher::detach` (associated fn over `*mut Self`) so the
-    /// caller in `node_fs_watcher.rs` is platform-agnostic.
-    pub(crate) fn detach(this: *mut PathWatcher, handler: *mut c_void) {
+    /// JS-thread entry point from [`Registration`]'s drop.
+    fn detach(this: *mut PathWatcher, handler: usize) {
         // SAFETY: `this` is the live `heap::alloc`'d pointer returned from `watch()`;
         // it stays valid until `maybe_deinit` self-destroys on the last handler.
         let removed = unsafe { &*this }
@@ -506,12 +502,28 @@ impl PathWatcher {
 
 // ──────────────────────────────────────────────────────────────────────────
 
+/// One `FSWatcher`'s handler on a shared [`PathWatcher`]. Dropping it detaches
+/// the handler (and with the last handler, the libuv watch).
+pub(crate) struct Registration {
+    watcher: *mut PathWatcher,
+    handler: usize,
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        PathWatcher::detach(self.watcher, self.handler);
+    }
+}
+
+/// Attach `owner` to the (shared, per path) libuv watch for `path`, creating
+/// it if this is the first. `owner` keeps the returned registration for as
+/// long as — and no longer than — it lives at that address.
 pub(crate) fn watch(
     vm: &'static jsc::VirtualMachineRef,
     path: &ZStr,
     recursive: bool,
-    ctx: *mut c_void,
-) -> sys::Result<*mut PathWatcher> {
+    owner: BackRef<FSWatcher>,
+) -> sys::Result<Registration> {
     #[cfg(not(windows))]
     compile_error!("win_watcher should only be used on Windows");
 
@@ -542,9 +554,10 @@ pub(crate) fn watch(
         sys::Result::Err(err) => return sys::Result::Err(err),
         sys::Result::Ok(w) => w,
     };
+    let handler = handler_key(&owner);
     // SAFETY: watcher is a valid freshly-returned heap pointer.
     unsafe { &*watcher }.handlers.with_mut(|h| {
-        h.insert(ctx, ChangeEvent::default());
+        h.insert(handler, (owner, ChangeEvent::default()));
     });
-    sys::Result::Ok(watcher)
+    sys::Result::Ok(Registration { watcher, handler })
 }

--- a/src/sys/core_foundation.rs
+++ b/src/sys/core_foundation.rs
@@ -1,0 +1,574 @@
+//! The CoreFoundation / FSEvents (CoreServices) entry points `fs.watch()` uses
+//! on macOS, resolved once with `dlopen`/`dlsym` (Bun does not link the
+//! frameworks), behind owned handle types and typed callbacks so callers need
+//! no `unsafe`.
+//!
+//! Only the surface `bun_runtime::node::fs_events` needs is here: a run loop
+//! with one custom source to wake it, and one `FSEventStream` at a time.
+
+use core::ffi::{CStr, c_char, c_long, c_void};
+use core::ptr::{self, NonNull};
+use std::sync::OnceLock;
+
+use bun_core::{ZStr, zstr};
+
+type CFIndex = c_long;
+type CFTimeInterval = f64;
+type CFTypeRef = *mut c_void;
+type CFAllocatorRef = *mut c_void;
+type CFArrayRef = *mut c_void;
+type CFStringRef = *mut c_void;
+type CFRunLoopRef = *mut c_void;
+type CFRunLoopSourceRef = *mut c_void;
+type FSEventStreamRef = *mut c_void;
+
+pub type FSEventStreamEventFlags = u32;
+pub type FSEventStreamCreateFlags = u32;
+pub type FSEventStreamEventId = u64;
+
+/// `kFSEventStreamEventIdSinceNow`.
+pub const EVENT_ID_SINCE_NOW: FSEventStreamEventId = u64::MAX;
+
+/// `kFSEventStreamCreateFlag*`.
+pub mod create_flags {
+    pub const NO_DEFER: u32 = 0x2;
+    pub const FILE_EVENTS: u32 = 0x10;
+}
+
+/// `kFSEventStreamEventFlagItem*`.
+pub mod event_flags {
+    pub const ITEM_CREATED: u32 = 0x100;
+    pub const ITEM_REMOVED: u32 = 0x200;
+    pub const ITEM_INODE_META_MOD: u32 = 0x400;
+    pub const ITEM_RENAMED: u32 = 0x800;
+    pub const ITEM_MODIFIED: u32 = 0x1000;
+    pub const ITEM_FINDER_INFO_MOD: u32 = 0x2000;
+    pub const ITEM_CHANGE_OWNER: u32 = 0x4000;
+    pub const ITEM_XATTR_MOD: u32 = 0x8000;
+    pub const ITEM_IS_DIR: u32 = 0x20000;
+}
+
+type FSEventStreamCallback = extern "C" fn(
+    FSEventStreamRef,
+    *mut c_void,
+    usize,
+    *mut c_void,
+    *const FSEventStreamEventFlags,
+    *const FSEventStreamEventId,
+);
+
+#[repr(C)]
+struct CFRunLoopSourceContext {
+    version: CFIndex,
+    info: *mut c_void,
+    retain: Option<extern "C" fn(*const c_void) -> *const c_void>,
+    release: Option<extern "C" fn(*const c_void)>,
+    copy_description: Option<extern "C" fn(*const c_void) -> *mut c_void>,
+    equal: Option<extern "C" fn(*const c_void, *const c_void) -> u8>,
+    hash: Option<extern "C" fn(*const c_void) -> usize>,
+    schedule: Option<extern "C" fn(*mut c_void, *mut c_void, *mut c_void)>,
+    cancel: Option<extern "C" fn(*mut c_void, *mut c_void, *mut c_void)>,
+    perform: extern "C" fn(*mut c_void),
+}
+
+#[repr(C)]
+struct FSEventStreamContext {
+    version: CFIndex,
+    info: *mut c_void,
+    retain: *mut c_void,
+    release: *mut c_void,
+    copy_description: *mut c_void,
+}
+
+struct Fns {
+    array_create: unsafe extern "C" fn(
+        CFAllocatorRef,
+        *const *const c_void,
+        CFIndex,
+        *const c_void,
+    ) -> CFArrayRef,
+    retain: unsafe extern "C" fn(CFTypeRef) -> CFTypeRef,
+    release: unsafe extern "C" fn(CFTypeRef),
+    run_loop_add_source: unsafe extern "C" fn(CFRunLoopRef, CFRunLoopSourceRef, CFStringRef),
+    run_loop_get_current: unsafe extern "C" fn() -> CFRunLoopRef,
+    run_loop_remove_source: unsafe extern "C" fn(CFRunLoopRef, CFRunLoopSourceRef, CFStringRef),
+    run_loop_run: unsafe extern "C" fn(),
+    run_loop_source_create: unsafe extern "C" fn(
+        CFAllocatorRef,
+        CFIndex,
+        *mut CFRunLoopSourceContext,
+    ) -> CFRunLoopSourceRef,
+    run_loop_source_signal: unsafe extern "C" fn(CFRunLoopSourceRef),
+    run_loop_stop: unsafe extern "C" fn(CFRunLoopRef),
+    run_loop_wake_up: unsafe extern "C" fn(CFRunLoopRef),
+    string_create_with_file_system_representation:
+        unsafe extern "C" fn(CFAllocatorRef, *const c_char) -> CFStringRef,
+    run_loop_default_mode: *const CFStringRef,
+
+    fs_event_stream_create: unsafe extern "C" fn(
+        CFAllocatorRef,
+        FSEventStreamCallback,
+        *const FSEventStreamContext,
+        CFArrayRef,
+        FSEventStreamEventId,
+        CFTimeInterval,
+        FSEventStreamCreateFlags,
+    ) -> FSEventStreamRef,
+    fs_event_stream_invalidate: unsafe extern "C" fn(FSEventStreamRef),
+    fs_event_stream_release: unsafe extern "C" fn(FSEventStreamRef),
+    fs_event_stream_schedule_with_run_loop:
+        unsafe extern "C" fn(FSEventStreamRef, CFRunLoopRef, CFStringRef),
+    fs_event_stream_start: unsafe extern "C" fn(FSEventStreamRef) -> u8,
+    fs_event_stream_stop: unsafe extern "C" fn(FSEventStreamRef),
+}
+
+// SAFETY: a table of resolved function pointers plus `kCFRunLoopDefaultMode`'s
+// address inside the (never unloaded) framework image; immutable once built.
+unsafe impl Send for Fns {}
+// SAFETY: as above.
+unsafe impl Sync for Fns {}
+
+static FNS: OnceLock<Fns> = OnceLock::new();
+
+fn fns() -> &'static Fns {
+    FNS.get_or_init(load)
+}
+
+/// Resolve `name` in `handle` as a `T`.
+///
+/// # Safety
+/// `T` is the (pointer-sized) C type the framework declares for `name`.
+unsafe fn sym<T>(handle: *mut c_void, name: &CStr, framework: &str) -> T {
+    const { assert!(core::mem::size_of::<T>() == core::mem::size_of::<*mut c_void>()) };
+    let Some(p) = crate::dlsym_impl(Some(handle), ZStr::from_cstr(name)) else {
+        panic!("Cannot Load {framework}");
+    };
+    // SAFETY: `p` is the non-null address `dlsym` resolved for `name`, and the
+    // caller vouches that `T` is that symbol's type.
+    unsafe { core::mem::transmute_copy::<*mut c_void, T>(&p) }
+}
+
+fn load() -> Fns {
+    let Some(cf) = crate::dlopen(
+        zstr!("/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"),
+        crate::RTLD::LAZY | crate::RTLD::LOCAL,
+    ) else {
+        panic!("Cannot Load CoreFoundation");
+    };
+    let Some(cs) = crate::dlopen(
+        zstr!("/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices"),
+        crate::RTLD::LAZY | crate::RTLD::LOCAL,
+    ) else {
+        panic!("Cannot Load CoreServices");
+    };
+    const CF: &str = "CoreFoundation";
+    const CS: &str = "CoreServices";
+    // SAFETY: each field's type is the signature CFRunLoop.h / CFArray.h /
+    // CFString.h / FSEvents.h declare for the symbol it is loaded from.
+    unsafe {
+        Fns {
+            array_create: sym(cf, c"CFArrayCreate", CF),
+            retain: sym(cf, c"CFRetain", CF),
+            release: sym(cf, c"CFRelease", CF),
+            run_loop_add_source: sym(cf, c"CFRunLoopAddSource", CF),
+            run_loop_get_current: sym(cf, c"CFRunLoopGetCurrent", CF),
+            run_loop_remove_source: sym(cf, c"CFRunLoopRemoveSource", CF),
+            run_loop_run: sym(cf, c"CFRunLoopRun", CF),
+            run_loop_source_create: sym(cf, c"CFRunLoopSourceCreate", CF),
+            run_loop_source_signal: sym(cf, c"CFRunLoopSourceSignal", CF),
+            run_loop_stop: sym(cf, c"CFRunLoopStop", CF),
+            run_loop_wake_up: sym(cf, c"CFRunLoopWakeUp", CF),
+            string_create_with_file_system_representation: sym(
+                cf,
+                c"CFStringCreateWithFileSystemRepresentation",
+                CF,
+            ),
+            run_loop_default_mode: sym(cf, c"kCFRunLoopDefaultMode", CF),
+
+            fs_event_stream_create: sym(cs, c"FSEventStreamCreate", CS),
+            fs_event_stream_invalidate: sym(cs, c"FSEventStreamInvalidate", CS),
+            fs_event_stream_release: sym(cs, c"FSEventStreamRelease", CS),
+            fs_event_stream_schedule_with_run_loop: sym(
+                cs,
+                c"FSEventStreamScheduleWithRunLoop",
+                CS,
+            ),
+            fs_event_stream_start: sym(cs, c"FSEventStreamStart", CS),
+            fs_event_stream_stop: sym(cs, c"FSEventStreamStop", CS),
+        }
+    }
+}
+
+impl Fns {
+    #[inline]
+    fn default_mode(&self) -> CFStringRef {
+        // SAFETY: `run_loop_default_mode` is the address of the framework's
+        // `kCFRunLoopDefaultMode` constant, valid for the life of the process.
+        unsafe { *self.run_loop_default_mode }
+    }
+}
+
+/// Resolve every entry point now (the first use does this lazily otherwise).
+/// Panics if either framework cannot be loaded.
+pub fn ensure_loaded() {
+    let _ = fns();
+}
+
+// ─── CFString / CFArray ─────────────────────────────────────────────────────
+
+/// An owned reference to a `CFString`.
+pub struct CFString(NonNull<c_void>);
+
+impl CFString {
+    /// `CFStringCreateWithFileSystemRepresentation`.
+    pub fn from_file_system_path(path: &ZStr) -> Option<CFString> {
+        // SAFETY: `path` is NUL-terminated; a NULL allocator selects the default.
+        let s = unsafe {
+            (fns().string_create_with_file_system_representation)(
+                ptr::null_mut(),
+                path.as_ptr().cast::<c_char>(),
+            )
+        };
+        NonNull::new(s).map(CFString)
+    }
+}
+
+impl Drop for CFString {
+    fn drop(&mut self) {
+        // SAFETY: we own the +1 `Create` returned.
+        unsafe { (fns().release)(self.0.as_ptr()) }
+    }
+}
+
+// SAFETY: an immutable CFString is safe to use and release from any thread.
+unsafe impl Send for CFString {}
+
+/// An owned `CFArray` of [`CFString`]s. The array is created without retain
+/// callbacks, so the strings are kept alive alongside it and released with it.
+pub struct CFStringArray {
+    array: NonNull<c_void>,
+    _strings: Vec<CFString>,
+}
+
+impl CFStringArray {
+    pub fn new(strings: Vec<CFString>) -> Option<CFStringArray> {
+        let values: Vec<*const c_void> =
+            strings.iter().map(|s| s.0.as_ptr().cast_const()).collect();
+        // SAFETY: `values` holds `values.len()` valid CFStringRefs; NULL
+        // callbacks make the array a plain pointer vector (no retain/release).
+        let array = unsafe {
+            (fns().array_create)(
+                ptr::null_mut(),
+                values.as_ptr(),
+                values.len() as CFIndex,
+                ptr::null(),
+            )
+        };
+        NonNull::new(array).map(|array| CFStringArray {
+            array,
+            _strings: strings,
+        })
+    }
+}
+
+impl Drop for CFStringArray {
+    fn drop(&mut self) {
+        // SAFETY: we own the +1 `CFArrayCreate` returned; the element strings
+        // are released afterwards by `_strings`.
+        unsafe { (fns().release)(self.array.as_ptr()) }
+    }
+}
+
+// SAFETY: an immutable CFArray of immutable CFStrings; usable from any thread.
+unsafe impl Send for CFStringArray {}
+
+// ─── CFRunLoop / CFRunLoopSource ────────────────────────────────────────────
+
+/// A retained reference to a thread's `CFRunLoop`.
+pub struct RunLoop(NonNull<c_void>);
+
+impl RunLoop {
+    /// The calling thread's run loop, retained so the reference outlives the
+    /// thread's own teardown of it.
+    pub fn current() -> RunLoop {
+        let f = fns();
+        // SAFETY: `CFRunLoopGetCurrent` never returns NULL; `CFRetain` on it
+        // gives us our own reference.
+        let rl = unsafe { (f.retain)((f.run_loop_get_current)()) };
+        RunLoop(NonNull::new(rl).expect("CFRunLoopGetCurrent"))
+    }
+
+    /// `CFRunLoopRun` on the calling thread; returns once the loop is stopped.
+    pub fn run_current() {
+        // SAFETY: no preconditions.
+        unsafe { (fns().run_loop_run)() }
+    }
+
+    /// `CFRunLoopStop` (callable from any thread).
+    pub fn stop(&self) {
+        // SAFETY: `self.0` is a live run loop we hold a reference to.
+        unsafe { (fns().run_loop_stop)(self.0.as_ptr()) }
+    }
+
+    /// `CFRunLoopWakeUp` (callable from any thread).
+    pub fn wake_up(&self) {
+        // SAFETY: as `stop`.
+        unsafe { (fns().run_loop_wake_up)(self.0.as_ptr()) }
+    }
+
+    /// Add `source` to this run loop's default mode.
+    pub fn add_source(&self, source: &RunLoopSource) {
+        let f = fns();
+        // SAFETY: both handles are live references we hold.
+        unsafe { (f.run_loop_add_source)(self.0.as_ptr(), source.0.as_ptr(), f.default_mode()) }
+    }
+
+    /// Remove `source` from this run loop's default mode.
+    pub fn remove_source(&self, source: &RunLoopSource) {
+        let f = fns();
+        // SAFETY: both handles are live references we hold.
+        unsafe { (f.run_loop_remove_source)(self.0.as_ptr(), source.0.as_ptr(), f.default_mode()) }
+    }
+}
+
+impl Drop for RunLoop {
+    fn drop(&mut self) {
+        // SAFETY: releases the reference `current` retained.
+        unsafe { (fns().release)(self.0.as_ptr()) }
+    }
+}
+
+// SAFETY: `CFRunLoopStop`, `CFRunLoopWakeUp` and `CFRunLoopAddSource` are the
+// documented cross-thread operations on a run loop, and the reference itself is
+// a thread-safe retain count.
+unsafe impl Send for RunLoop {}
+// SAFETY: as above.
+unsafe impl Sync for RunLoop {}
+
+/// The `perform` callback of a [`RunLoopSource`]: runs on the run loop's
+/// thread after the source is signalled and the loop woken.
+pub trait RunLoopSourceHandler: Sync + 'static {
+    fn perform(&'static self);
+}
+
+/// An owned version-0 `CFRunLoopSource` whose `perform` calls a
+/// [`RunLoopSourceHandler`].
+pub struct RunLoopSource(NonNull<c_void>);
+
+impl RunLoopSource {
+    pub fn new<H: RunLoopSourceHandler>(handler: &'static H) -> Option<RunLoopSource> {
+        extern "C" fn perform<H: RunLoopSourceHandler>(info: *mut c_void) {
+            // SAFETY: `info` is the `&'static H` stored in the context below.
+            let handler: &'static H = unsafe { &*info.cast::<H>() };
+            handler.perform();
+        }
+        let mut ctx = CFRunLoopSourceContext {
+            version: 0,
+            info: ptr::from_ref::<H>(handler).cast_mut().cast::<c_void>(),
+            retain: None,
+            release: None,
+            copy_description: None,
+            equal: None,
+            hash: None,
+            schedule: None,
+            cancel: None,
+            perform: perform::<H>,
+        };
+        // SAFETY: `ctx` is a valid version-0 context for the duration of the
+        // call (CF copies it).
+        let source = unsafe { (fns().run_loop_source_create)(ptr::null_mut(), 0, &raw mut ctx) };
+        NonNull::new(source).map(RunLoopSource)
+    }
+
+    /// `CFRunLoopSourceSignal` (callable from any thread; wake the run loop
+    /// afterwards to have `perform` run promptly).
+    pub fn signal(&self) {
+        // SAFETY: `self.0` is the live source we own.
+        unsafe { (fns().run_loop_source_signal)(self.0.as_ptr()) }
+    }
+}
+
+impl Drop for RunLoopSource {
+    fn drop(&mut self) {
+        // SAFETY: releases the +1 `CFRunLoopSourceCreate` returned.
+        unsafe { (fns().release)(self.0.as_ptr()) }
+    }
+}
+
+// SAFETY: `CFRunLoopSourceSignal` is the documented way to poke a run loop
+// from another thread; the handler is `Sync` and the reference is a
+// thread-safe retain count.
+unsafe impl Send for RunLoopSource {}
+// SAFETY: as above.
+unsafe impl Sync for RunLoopSource {}
+
+// ─── FSEventStream ──────────────────────────────────────────────────────────
+
+/// One `FSEventStream` callback's batch of events.
+pub struct Events<'a> {
+    paths: &'a [*const c_char],
+    flags: &'a [FSEventStreamEventFlags],
+}
+
+impl<'a> Events<'a> {
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    /// The `i`th event's path (as reported: absolute, by realpath) and flags.
+    #[inline]
+    pub fn get(&self, i: usize) -> (&'a [u8], FSEventStreamEventFlags) {
+        // SAFETY: without `kFSEventStreamCreateFlagUseCFTypes`, `eventPaths`
+        // is an array of NUL-terminated C strings valid for the callback.
+        let path = unsafe { CStr::from_ptr(self.paths[i]) }.to_bytes();
+        (path, self.flags[i])
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'a [u8], FSEventStreamEventFlags)> + '_ {
+        (0..self.len()).map(move |i| self.get(i))
+    }
+}
+
+/// Receives an [`EventStream`]'s events on the run loop thread it was
+/// scheduled on.
+pub trait EventStreamHandler: Sync + 'static {
+    fn on_events(&'static self, events: Events<'_>);
+}
+
+/// An owned `FSEventStream`, created and scheduled on the calling thread's run
+/// loop in one step and from then on used only on that thread (checked);
+/// dropping it invalidates (unschedules) and releases it.
+pub struct EventStream {
+    stream: NonNull<c_void>,
+    /// The run loop (thread) the stream is scheduled on; compared, never
+    /// dereferenced.
+    run_loop: CFRunLoopRef,
+}
+
+/// `kFSEventStreamCreateFlagUseCFTypes` / `kFSEventStreamCreateFlagUseExtendedData`:
+/// both change what the callback's `eventPaths` points at, which [`Events`]
+/// reads as C strings, so [`EventStream::new_scheduled`] refuses them.
+const CALLBACK_SHAPE_FLAGS: FSEventStreamCreateFlags = 0x1 | 0x40;
+
+impl EventStream {
+    /// `FSEventStreamCreate` + `FSEventStreamScheduleWithRunLoop` on the
+    /// calling thread's run loop (default mode). `None` if the stream could
+    /// not be created.
+    pub fn new_scheduled<H: EventStreamHandler>(
+        handler: &'static H,
+        paths: &CFStringArray,
+        since: FSEventStreamEventId,
+        latency: f64,
+        flags: FSEventStreamCreateFlags,
+    ) -> Option<EventStream> {
+        extern "C" fn callback<H: EventStreamHandler>(
+            _stream: FSEventStreamRef,
+            info: *mut c_void,
+            num_events: usize,
+            event_paths: *mut c_void,
+            event_flags: *const FSEventStreamEventFlags,
+            _event_ids: *const FSEventStreamEventId,
+        ) {
+            // SAFETY: `info` is the `&'static H` stored in the context below.
+            let handler: &'static H = unsafe { &*info.cast::<H>() };
+            let events = if num_events == 0 {
+                Events {
+                    paths: &[],
+                    flags: &[],
+                }
+            } else {
+                // SAFETY: FSEvents passes `num_events`-long arrays of C-string
+                // pointers and flags, valid for the duration of the callback.
+                unsafe {
+                    Events {
+                        paths: core::slice::from_raw_parts(
+                            event_paths.cast::<*const c_char>(),
+                            num_events,
+                        ),
+                        flags: core::slice::from_raw_parts(event_flags, num_events),
+                    }
+                }
+            };
+            handler.on_events(events);
+        }
+        debug_assert_eq!(flags & CALLBACK_SHAPE_FLAGS, 0);
+        let flags = flags & !CALLBACK_SHAPE_FLAGS;
+        let f = fns();
+        let ctx = FSEventStreamContext {
+            version: 0,
+            info: ptr::from_ref::<H>(handler).cast_mut().cast::<c_void>(),
+            retain: ptr::null_mut(),
+            release: ptr::null_mut(),
+            copy_description: ptr::null_mut(),
+        };
+        // SAFETY: `ctx` is a valid version-0 context (copied by the call);
+        // `paths` is a live CFArray of CFStrings.
+        let stream = unsafe {
+            (f.fs_event_stream_create)(
+                ptr::null_mut(),
+                callback::<H>,
+                &raw const ctx,
+                paths.array.as_ptr(),
+                since,
+                latency,
+                flags,
+            )
+        };
+        let stream = NonNull::new(stream)?;
+        // SAFETY: no preconditions; never NULL.
+        let run_loop = unsafe { (f.run_loop_get_current)() };
+        // SAFETY: `stream` was just created; `run_loop` is this thread's.
+        unsafe {
+            (f.fs_event_stream_schedule_with_run_loop)(stream.as_ptr(), run_loop, f.default_mode())
+        };
+        Some(EventStream { stream, run_loop })
+    }
+
+    #[track_caller]
+    fn assert_on_run_loop_thread(&self) {
+        // SAFETY: no preconditions.
+        let current = unsafe { (fns().run_loop_get_current)() };
+        assert!(
+            ptr::eq(current, self.run_loop),
+            "FSEventStream used off the thread it is scheduled on"
+        );
+    }
+
+    /// `FSEventStreamStart`; `false` if it failed.
+    pub fn start(&self) -> bool {
+        self.assert_on_run_loop_thread();
+        // SAFETY: the live, scheduled stream we own, on its run loop's thread.
+        unsafe { (fns().fs_event_stream_start)(self.stream.as_ptr()) != 0 }
+    }
+
+    /// `FSEventStreamStop`.
+    pub fn stop(&self) {
+        self.assert_on_run_loop_thread();
+        // SAFETY: as `start`.
+        unsafe { (fns().fs_event_stream_stop)(self.stream.as_ptr()) }
+    }
+}
+
+impl Drop for EventStream {
+    fn drop(&mut self) {
+        self.assert_on_run_loop_thread();
+        let f = fns();
+        // SAFETY: the live, scheduled stream we own, on its run loop's thread;
+        // invalidate unschedules it, release drops our +1.
+        unsafe {
+            (f.fs_event_stream_invalidate)(self.stream.as_ptr());
+            (f.fs_event_stream_release)(self.stream.as_ptr());
+        }
+    }
+}
+
+// SAFETY: every operation (start/stop/drop) checks it runs on the thread whose
+// run loop the stream was scheduled on, so holding or moving the handle
+// elsewhere cannot drive the stream from another thread.
+unsafe impl Send for EventStream {}

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5382,6 +5382,14 @@ pub mod linux {
         // valid NUL-terminated C string.
         unsafe { libc::inotify_add_watch(fd, path, mask) }
     }
+    /// [`inotify_add_watch`] for a `&ZStr` path; returns the raw rc (`-1` +
+    /// `errno` on failure, else the watch descriptor).
+    #[inline]
+    pub fn inotify_add_watch_z(fd: c_int, path: &bun_core::ZStr, mask: u32) -> c_int {
+        // SAFETY: `ZStr` is NUL-terminated by construction; a stale/invalid
+        // `fd` is reported as `EBADF`/`EINVAL`, not UB.
+        unsafe { libc::inotify_add_watch(fd, path.as_ptr().cast::<c_char>(), mask) }
+    }
     #[inline]
     pub fn inotify_rm_watch(fd: c_int, wd: c_int) -> c_int {
         // bionic declares `wd` as `uint32_t`, glibc/musl as `int`; the kernel
@@ -5503,6 +5511,10 @@ pub mod linux {
     // Empty on non-Linux; callers gate on `cfg(target_os = "linux")` (or
     // `linux | android` for the Linux-kernel surface).
 }
+
+/// CoreFoundation run loop + FSEvents, dlopen'd (macOS `fs.watch()` backend).
+#[cfg(target_os = "macos")]
+pub mod core_foundation;
 
 // ── `bun.darwin` — Darwin-only platform surface. ──
 #[cfg(target_os = "macos")]

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -126,15 +126,7 @@
     ]
   },
   "src/runtime/node/fs_events.rs": {
-    "thread spawn": 1,
-    "unsafe impl Send": [
-      "CoreFoundation",
-      "FSEventsLoop"
-    ],
-    "unsafe impl Sync": [
-      "CoreFoundation",
-      "FSEventsLoop"
-    ]
+    "thread spawn": 1
   },
   "src/runtime/node/memory_pressure.rs": {
     "thread spawn": 1
@@ -158,7 +150,8 @@
   "src/runtime/node/node_fs_stat_watcher.rs": {
     "WorkPool::schedule*": 2,
     "owned_task!": [
-      "InitialStatTask"
+      "InitialStatTask",
+      "StatPassTask"
     ]
   },
   "src/runtime/node/node_process.rs": {
@@ -170,13 +163,7 @@
     "WorkPool::schedule*": 1
   },
   "src/runtime/node/path_watcher.rs": {
-    "thread spawn": 2,
-    "unsafe impl Send": [
-      "PathWatcherManager"
-    ],
-    "unsafe impl Sync": [
-      "PathWatcherManager"
-    ]
+    "thread spawn": 2
   },
   "src/runtime/node/types.rs": {
     "unsafe impl Send": [


### PR DESCRIPTION
### What

Same programme as #40055 / #40135 / #40136 / #40139 / #40187 / #40190, applied to the `fs.watch` / `fs.watchFile` machinery: `path_watcher.rs` 66 → 0, `fs_events.rs` 64 → 0, `node_fs_stat_watcher.rs` 44 → 0, `node_fs_watcher.rs` 28 → 0 (one `unsafe extern "C" { safe fn }` decl for a C++ symbol that takes this file's `EventType`).

- **Registrations, not pointers.** A `PathWatcher` is owned by the manager's `Guarded<State>` and addressed by a never-reused `WatcherId`; inotify wds / kqueue entries / FSEvents streams carry ids. `fs.watch` gets a `path_watcher::Registration` (RAII; drop = detach). The reader thread's per-handler state is a typed `EventSink` (batch of ≤8 events, `Arc<Activity>`, `VmHandle`) inside the locked state; batches reach the JS thread as owned `Box<FSWatchTask>` via a new `VmHandle::post_boxed` (refused ⇒ box handed back).
- **`FSWatcher`**: `Activity { mutex, closed, pending }` in an `Arc` shared with sinks/tasks/GC thread; the abort listener is a new `bun_jsc::AbortSubscription` (holds a signal ref, unregisters on drop; subscriber passed as `BackRef`); wrapper via `to_js_boxed`; `finalize_js_box`.
- **`StatWatcher` / scheduler**: queue is `Guarded<Vec<RefPtr<StatWatcher>>>`; the stat pass is an owned, ticketed `StatPassTask` holding the scheduler ref; timer hops are boxed payloads owning their `RefPtr`; the per-thread scheduler slot moves from `RareData` (erased pointer) to `RuntimeState` with a scoped `with_stat_watcher_scheduler(|slot| ..)`; `deinit` → `Drop`.
- **FSEvents (macOS)**: new `bun_sys::core_foundation` — dlsym'd typed function table, owned `CFString`/`CFStringArray`/`RunLoop`/`RunLoopSource`/`EventStream` (created and scheduled on the calling thread's run loop; start/stop/drop assert that thread), typed `&'static H` handler trampolines. Cross-thread requests are two atomic bits + `RunLoopSourceHandler::perform`; state under `Guarded`; registrations by id.
- **`bun_ptr::ThreadBound<T>`**: a `BackRef` plus the owning `std` thread id; any thread may carry it, only the owner thread may `get()` (asserted) — the typed way to hand a JS-thread object's address to a watcher thread purely so it can be handed back. `bun_sys::linux::inotify_add_watch_z`.

Pre-existing issue fixed in passing: the old `FSWatchTaskPosix::release_unrun` dereferenced the `FSWatcher` (which may already be finalized at teardown); the new one only touches the shared `Arc<Activity>`.

### Testing

Debug+ASAN (Linux): `test/js/node/watch/*.test.ts`, all 38 `test-fs-watch*` / `test-fs-watchfile*` node parallel tests, `fs.test.ts -t watch`, `test/cli/hot/{hot,watch,watch-many-dirs}`, `test/cli/watch/{watch,watcher-trace}`, source lints. Hand-driven: recursive watch with create/rename/delete and close inside the listener; watchFile + unwatchFile mid-poll and immediately; 200 watchers on one path then GC; an unclosed unref'd watcher collected; a worker with fs.watch/fs.watchFile terminated while main keeps watching — exit 0, no ASAN output, outputs match 1.4.0. clippy clean on every touched crate (host + aarch64-apple-darwin); `rust-check-all` x86_64-pc-windows-msvc + aarch64-apple-darwin pass (macOS FSEvents / Windows ReadDirectoryChangesW paths are type-checked, not executed here).