### PR TITLE
server: remove unsafe from RequestContext

### DIFF
--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -405,6 +405,16 @@ impl<T, const CAPACITY: usize> Drop for HiveArray<T, CAPACITY> {
 // HiveSlot
 // ──────────────────────────────────────────────────────────────────────────
 
+/// A refcounted type whose last-ref destructor (`#[ref_count(destroy = …)]`)
+/// returns its storage to the [`Fallback`] pool it was claimed from via
+/// [`Fallback::put`], never through `Box` deallocation.
+///
+/// # Safety
+/// Implement only if that is true for every value handed to
+/// [`HiveSlot::write_ref`]; a `Box`-freeing destructor on an inline pool slot
+/// is an invalid free.
+pub unsafe trait PoolReclaimed {}
+
 /// Linear reservation token for a claimed-but-uninitialized hive slot.
 ///
 /// `HiveArray` slots are `[MaybeUninit<T>; CAP]`. A two-phase claim-then-
@@ -455,13 +465,12 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     }
 
     /// [`write`](Self::write) an intrusively refcounted `value` (constructed with
-    /// its count at 1) and return that first ref. `T`'s refcount destructor
-    /// must be one that returns the slot to *this* pool ([`Fallback::put`]),
-    /// not the default `Box` reclaim.
+    /// its count at 1) and return that first ref. [`PoolReclaimed`] is the
+    /// proof that dropping the last ref hands the slot back to this pool.
     #[inline]
     pub fn write_ref(self, value: T) -> bun_ptr::RefPtr<T>
     where
-        T: bun_ptr::AnyRefCounted,
+        T: bun_ptr::AnyRefCounted + PoolReclaimed,
     {
         let p = self.write(value);
         // SAFETY: `p` is the just-initialized slot; its only ref is the one

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -465,9 +465,9 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     {
         let p = self.write(value);
         // SAFETY: `p` is the just-initialized slot; its only ref is the one
-        // adopted here.
+        // adopted here (checked), so the `RefPtr`'s release returns the slot.
         unsafe {
-            debug_assert!(T::rc_has_one_ref(p.as_ptr()));
+            assert!(T::rc_has_one_ref(p.as_ptr()), "write_ref: value must start with one ref");
             bun_ptr::RefPtr::from_raw(p.as_ptr())
         }
     }

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -454,6 +454,24 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
         p
     }
 
+    /// [`write`](Self::write) an intrusively refcounted `value` (constructed with
+    /// its count at 1) and return that first ref. `T`'s refcount destructor
+    /// must be one that returns the slot to *this* pool ([`Fallback::put`]),
+    /// not the default `Box` reclaim.
+    #[inline]
+    pub fn write_ref(self, value: T) -> bun_ptr::RefPtr<T>
+    where
+        T: bun_ptr::AnyRefCounted,
+    {
+        let p = self.write(value);
+        // SAFETY: `p` is the just-initialized slot; its only ref is the one
+        // adopted here.
+        unsafe {
+            debug_assert!(T::rc_has_one_ref(p.as_ptr()));
+            bun_ptr::RefPtr::from_raw(p.as_ptr())
+        }
+    }
+
     /// Caller has fully initialized the slot by writing through
     /// [`addr`](Self::addr). Consumes the token.
     ///

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -467,7 +467,10 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
         // SAFETY: `p` is the just-initialized slot; its only ref is the one
         // adopted here (checked), so the `RefPtr`'s release returns the slot.
         unsafe {
-            assert!(T::rc_has_one_ref(p.as_ptr()), "write_ref: value must start with one ref");
+            assert!(
+                T::rc_has_one_ref(p.as_ptr()),
+                "write_ref: value must start with one ref"
+            );
             bun_ptr::RefPtr::from_raw(p.as_ptr())
         }
     }

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -33,7 +33,7 @@ pub use static_hash_map::StaticHashMap;
 
 pub use bounded_array::BoundedArray;
 pub use hive_array::{
-    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot,
+    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot, PoolReclaimed,
 };
 pub use linear_fifo::LinearFifo;
 pub use multi_array_list::MultiArrayList;

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -33,7 +33,8 @@ pub use static_hash_map::StaticHashMap;
 
 pub use bounded_array::BoundedArray;
 pub use hive_array::{
-    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot, PoolReclaimed,
+    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot,
+    PoolReclaimed,
 };
 pub use linear_fifo::LinearFifo;
 pub use multi_array_list::MultiArrayList;

--- a/src/jsc/NativePromiseContext.rs
+++ b/src/jsc/NativePromiseContext.rs
@@ -1,0 +1,92 @@
+//! Typed side of the `NativePromiseContext` JSCell
+//! (src/jsc/bindings/NativePromiseContext.h): a GC cell that owns one ref on
+//! an intrusively refcounted native object while a promise reaction that needs
+//! it is pending. If the promise settles, the reaction [`take`]s the ref back;
+//! if it is collected unsettled, the cell's destructor releases it (through
+//! `Bun__NativePromiseContext__destroy`, which the runtime dispatches on the
+//! tag).
+
+use core::ffi::c_void;
+
+use bun_ptr::{AnyRefCounted, RefPtr};
+
+use crate::{JSGlobalObject, JSValue};
+
+/// A tag no cell carries: for type-level combinations that are never
+/// instantiated. [`create`] refuses it.
+pub const INVALID_TAG: u8 = u8::MAX;
+
+/// A native type a `NativePromiseContext` cell can hold a ref on.
+///
+/// # Safety
+/// `TAG` is the `Bun::NativePromiseContext::Tag` value whose destructor arm
+/// releases a ref on a `Self`, no other type maps to it (or it is
+/// [`INVALID_TAG`]), and cells carrying it are only made by [`create`].
+/// Implement through [`native_promise_context_type!`], next to the destructor
+/// dispatch that defines the mapping.
+pub unsafe trait NativePromiseContextType: AnyRefCounted {
+    const TAG: u8;
+}
+
+/// `unsafe impl NativePromiseContextType`; see the trait for the obligation.
+#[macro_export]
+macro_rules! native_promise_context_type {
+    (impl $([$($generics:tt)*])? for $ty:ty => $tag:expr) => {
+        unsafe impl $(<$($generics)*>)? $crate::native_promise_context::NativePromiseContextType
+            for $ty
+        {
+            const TAG: u8 = $tag;
+        }
+    };
+}
+
+// `ctx` is stored opaquely by the C++ side; `&JSGlobalObject` is ABI-identical
+// to a non-null pointer.
+unsafe extern "C" {
+    safe fn Bun__NativePromiseContext__create(
+        global: &JSGlobalObject,
+        ctx: *mut c_void,
+        tag: u8,
+        held: JSValue,
+    ) -> JSValue;
+    safe fn Bun__NativePromiseContext__take(value: JSValue, tag: u8) -> *mut c_void;
+}
+
+/// A new cell owning `ctx`'s ref. `held` is visited by the cell, so whatever
+/// GC object keeps the native object reachable can ride along for as long as
+/// the promise can settle; pass `JSValue::ZERO` when nothing needs rooting.
+pub fn create<T: NativePromiseContextType>(
+    global: &JSGlobalObject,
+    ctx: RefPtr<T>,
+    held: JSValue,
+) -> JSValue {
+    assert_ne!(T::TAG, INVALID_TAG, "NativePromiseContext: type has no tag");
+    Bun__NativePromiseContext__create(global, ctx.into_raw().cast::<c_void>(), T::TAG, held)
+}
+
+/// The ref `cell` was created with, leaving the cell empty so its destructor
+/// is a no-op. `None` if it was already taken (or released by a termination
+/// path), or if `cell` is not a `NativePromiseContext` holding a `T`.
+pub fn take<T: NativePromiseContextType>(cell: JSValue) -> Option<RefPtr<T>> {
+    if cell.is_empty() || T::TAG == INVALID_TAG {
+        return None;
+    }
+    let ptr = Bun__NativePromiseContext__take(cell, T::TAG);
+    if ptr.is_null() {
+        return None;
+    }
+    // SAFETY: a cell tagged `T::TAG` was made by `create::<T>` from
+    // `RefPtr::<T>::into_raw` (trait contract: the tag names `T` alone), and
+    // the C++ side nulled its slot, so that ref is handed back exactly once.
+    Some(unsafe { RefPtr::from_raw(ptr.cast::<T>()) })
+}
+
+/// For the destructor dispatch: the ref a collected, never-taken cell owned.
+///
+/// # Safety
+/// `ctx` and `tag` are the pair `Bun__NativePromiseContext__destroy` received,
+/// with `tag == T::TAG`, and this is the only release of that ref.
+pub unsafe fn destroyed_ref<T: NativePromiseContextType>(ctx: *mut c_void) -> RefPtr<T> {
+    // SAFETY: caller contract — as for `take`.
+    unsafe { RefPtr::from_raw(ctx.cast::<T>()) }
+}

--- a/src/jsc/bindings/NativePromiseContext.cpp
+++ b/src/jsc/bindings/NativePromiseContext.cpp
@@ -66,8 +66,18 @@ extern "C" JSC::EncodedJSValue Bun__NativePromiseContext__create(Zig::GlobalObje
     return JSC::JSValue::encode(cell);
 }
 
-extern "C" void* Bun__NativePromiseContext__take(JSC::EncodedJSValue encodedValue)
+// Returns null (leaving the cell to its destructor) unless `encodedValue` is a
+// NativePromiseContext created with `expectedTag`, so the Rust side can hand
+// the pointer back as the type that tag names.
+extern "C" void* Bun__NativePromiseContext__take(JSC::EncodedJSValue encodedValue, uint8_t expectedTag)
 {
-    auto* cell = uncheckedDowncast<Bun::NativePromiseContext>(JSC::JSValue::decode(encodedValue));
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+    auto* cell = value ? dynamicDowncast<Bun::NativePromiseContext>(value) : nullptr;
+    ASSERT_WITH_MESSAGE(cell, "NativePromiseContext::take on a foreign cell");
+    if (!cell) [[unlikely]]
+        return nullptr;
+    ASSERT_WITH_MESSAGE(cell->tag() == static_cast<Bun::NativePromiseContext::Tag>(expectedTag), "NativePromiseContext::take with the wrong tag");
+    if (cell->tag() != static_cast<Bun::NativePromiseContext::Tag>(expectedTag)) [[unlikely]]
+        return nullptr;
     return cell->take();
 }

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -159,6 +159,8 @@ pub mod js_ref;
 pub mod js_type;
 #[path = "JSValue.rs"]
 pub mod js_value;
+#[path = "NativePromiseContext.rs"]
+pub mod native_promise_context;
 #[path = "rare_data.rs"]
 pub mod rare_data;
 #[path = "StringBuilder.rs"]

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -42,7 +42,7 @@ pub use tagged_pointer::TaggedPtr;
 pub mod ref_count;
 pub use ref_count::{
     AnyRefCounted, CellRefCounted, RefCount, RefCounted, RefPtr, ThreadSafeRefCount,
-    ThreadSafeRefCounted,
+    ThreadSafeRefCounted, destroy_with,
 };
 // Derive macros — same names as the traits (separate namespace). The derives
 // expand to `::bun_ptr::…` paths, so this crate is the canonical re-export
@@ -232,6 +232,13 @@ impl<T> From<ThisPtr<T>> for BackRef<T, Root> {
     #[inline]
     fn from(p: ThisPtr<T>) -> Self {
         BackRef(p.0, core::marker::PhantomData)
+    }
+}
+
+impl<T> From<ThisPtr<T>> for core::ptr::NonNull<T> {
+    #[inline]
+    fn from(p: ThisPtr<T>) -> Self {
+        p.0
     }
 }
 

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -494,6 +494,29 @@ pub unsafe trait CellRefCounted: Sized {
     }
 }
 
+/// Destroy hook body for a `T` whose storage is not a `Box` (a pool slot, a
+/// C-side owner): run `finalize(&*this)`, then — once that borrow has ended —
+/// hand the root pointer and whatever `finalize` returned to `release`, which
+/// gives the storage back.
+///
+/// Only a `#[ref_count(destroy = …)]` target may call this, forwarding the
+/// pointer the generated [`CellRefCounted::destroy`] received (sole owner,
+/// refcount zero).
+#[inline]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn destroy_with<T, R>(
+    this: *mut T,
+    finalize: impl FnOnce(&T) -> R,
+    release: impl FnOnce(NonNull<T>, R),
+) {
+    let ptr = NonNull::new(this).expect("destroy_with: null");
+    // SAFETY: `CellRefCounted::destroy` contract — `this` is the sole live
+    // owner of an initialized `T`; `finalize` only observes it shared, and that
+    // borrow ends before `release` may free the storage.
+    let r = finalize(unsafe { ptr.as_ref() });
+    release(ptr, r);
+}
+
 // A blanket `impl<T: ThreadSafeRefCounted> AnyRefCounted for T` would overlap
 // with the `RefCounted` blanket above (Rust forbids overlapping blanket impls).
 // Instead, thread-safe hosts opt in via `#[derive(ThreadSafeRefCounted)]`,

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -499,20 +499,20 @@ pub unsafe trait CellRefCounted: Sized {
 /// hand the root pointer and whatever `finalize` returned to `release`, which
 /// gives the storage back.
 ///
-/// Only a `#[ref_count(destroy = …)]` target may call this, forwarding the
-/// pointer the generated [`CellRefCounted::destroy`] received (sole owner,
-/// refcount zero).
+/// # Safety
+/// `this` is the pointer the generated [`CellRefCounted::destroy`] received:
+/// non-null, the allocation root of an initialized `T` whose refcount just
+/// reached zero, with no other live borrow. Only a `#[ref_count(destroy = …)]`
+/// target should call this.
 #[inline]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn destroy_with<T, R>(
+pub unsafe fn destroy_with<T, R>(
     this: *mut T,
     finalize: impl FnOnce(&T) -> R,
     release: impl FnOnce(NonNull<T>, R),
 ) {
     let ptr = NonNull::new(this).expect("destroy_with: null");
-    // SAFETY: `CellRefCounted::destroy` contract — `this` is the sole live
-    // owner of an initialized `T`; `finalize` only observes it shared, and that
-    // borrow ends before `release` may free the storage.
+    // SAFETY: fn contract — sole owner of an initialized `T`; `finalize` only
+    // observes it shared, and that borrow ends before `release` frees storage.
     let r = finalize(unsafe { ptr.as_ref() });
     release(ptr, r);
 }

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -104,6 +104,44 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
         }
     }
 
+    /// Take a weak reference to the pointee of a dispatch-time
+    /// [`ThisPtr`](crate::ThisPtr). Safe: the `ThisPtr` invariant (a live `T`
+    /// behind the allocation's root pointer) is [`init_ref`](Self::init_ref)'s
+    /// contract.
+    #[inline]
+    pub fn from_this(this: crate::ThisPtr<T>) -> Self {
+        // SAFETY: see above.
+        unsafe { Self::init_ref(this.as_ptr()) }
+    }
+
+    /// Borrow the pointee, or `None` once the owner has finalized it (or this
+    /// handle is empty). Unlike [`get`](Self::get) this does not release the
+    /// weak ref on observing finalization; dropping the handle still does.
+    ///
+    /// The allocation is not freed while this handle holds its weak count.
+    /// The owner may still *finalize* the value (through its own pointer) if
+    /// the caller lets that happen while the borrow is live, exactly as with
+    /// [`get`](Self::get): do not hold the result across anything that can
+    /// finalize the owner (for GC-owned payloads: a JS allocation or
+    /// collection).
+    #[inline]
+    pub fn get_ref(&self) -> Option<&T> {
+        let value = self.raw_ptr?;
+        // SAFETY: allocation is live while any WeakPtr holds it (see above).
+        unsafe {
+            if (*T::weak_ptr_data(value.as_ptr())).finalized() {
+                return None;
+            }
+            Some(&*value.as_ptr())
+        }
+    }
+
+    /// Whether this handle refers to `this`'s allocation.
+    #[inline]
+    pub fn is(&self, this: crate::ThisPtr<T>) -> bool {
+        self.raw_ptr.is_some_and(|p| p.as_ptr() == this.as_ptr())
+    }
+
     /// Borrow the pointee, or `None` once the owner has finalized it (which
     /// also releases this handle's weak ref).
     ///

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -143,17 +143,15 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
     }
 
     /// Borrow the pointee, or `None` once the owner has finalized it (which
-    /// also releases this handle's weak ref).
-    ///
-    /// The returned `&mut T` is a fresh reborrow of the allocation pointer, so
-    /// it must not overlap any other borrow of the same object — including one
-    /// handed out by a second `WeakPtr`. Finish with it before the next `get`.
-    pub fn get(&mut self) -> Option<&mut T> {
+    /// also releases this handle's weak ref). Shared access only: several
+    /// handles (and the owner) may observe the same allocation at once, so no
+    /// accessor hands out `&mut T`; mutate through the pointee's own `Cell`s.
+    pub fn get(&mut self) -> Option<&T> {
         if let Some(value) = self.raw_ptr {
             // SAFETY: allocation is live while any WeakPtr holds it (see above).
             unsafe {
                 if !(*T::weak_ptr_data(value.as_ptr())).finalized() {
-                    return Some(&mut *value.as_ptr());
+                    return Some(&*value.as_ptr());
                 }
                 self.deref_internal(value);
             }

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -9,14 +9,12 @@
 //! Usage pattern:
 //!
 //! ```ignore
-//! ctx.ref_();
-//! let cell = native_promise_context::create(global, ctx);
+//! let cell = bun_jsc::native_promise_context::create(global, RefPtr::from_this(ctx), JSValue::ZERO);
 //! promise.then_with_value(global, cell, on_resolve, on_reject)?;
 //!
 //! // In on_resolve/on_reject:
-//! let Some(ctx) = native_promise_context::take::<RequestContext>(arguments[1]) else { return; };
-//! // ... process ...
-//! ctx.deref_();
+//! let Some(ctx) = bun_jsc::native_promise_context::take::<RequestContext>(arguments[1]) else { return; };
+//! // ... process; the ref is released when `ctx` drops.
 //! ```
 
 use core::ffi::c_void;
@@ -89,17 +87,14 @@ impl Tag {
     }
 }
 
-/// Maps a concrete native type to its `Tag`, expressed as a compile-time
-/// mapping via a trait impl per type.
-pub(crate) trait NativePromiseContextType {
-    const TAG: Tag;
-}
-
-// Layering note: blanket-impl over `ThisServer` so that ANY server
-// type (mod.rs::NewServer or server_body::NewServer) yields the same Tag —
-// the tag depends only on (SSL, DBG, MUX), never on the server type.
-const fn npc_tag_for(ssl: bool, dbg: bool, mux: bool) -> Tag {
-    match (ssl, dbg, mux) {
+// The tag depends only on (SSL, DBG, MUX): `ServerLike` is sealed to
+// `NewServer<SSL, DBG>` and a context whose server's `(SSL, DEBUG)` differ from
+// its own gets no tag, so each tag names exactly one type.
+const fn npc_tag_for(server_ssl: bool, server_dbg: bool, ssl: bool, dbg: bool, mux: bool) -> u8 {
+    if server_ssl != ssl || server_dbg != dbg {
+        return bun_jsc::native_promise_context::INVALID_TAG;
+    }
+    (match (ssl, dbg, mux) {
         (false, false, false) => Tag::HTTPServerRequestContext,
         (true, false, false) => Tag::HTTPSServerRequestContext,
         (false, true, false) => Tag::DebugHTTPServerRequestContext,
@@ -108,21 +103,18 @@ const fn npc_tag_for(ssl: bool, dbg: bool, mux: bool) -> Tag {
         (true, false, true) => Tag::HTTPSServerMuxRequestContext,
         (false, true, true) => Tag::DebugHTTPServerMuxRequestContext,
         (true, true, true) => Tag::DebugHTTPSServerMuxRequestContext,
-    }
+    }) as u8
 }
-impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> NativePromiseContextType
-    for server::NewRequestContext<ThisServer, SSL, DBG, MUX>
-{
-    const TAG: Tag = npc_tag_for(SSL, DBG, MUX);
-}
-impl NativePromiseContextType for html_rewriter::RewriterPipe {
-    const TAG: Tag = Tag::HTMLRewriterSuspension;
-}
+bun_jsc::native_promise_context_type!(
+    impl [ThisServer: server::ServerLike + 'static, const SSL: bool, const DBG: bool, const MUX: bool]
+    for server::NewRequestContext<ThisServer, SSL, DBG, MUX> =>
+        npc_tag_for(ThisServer::SSL, ThisServer::DEBUG, SSL, DBG, MUX)
+);
 
 // `&JSGlobalObject` is ABI-identical to a non-null pointer. `ctx` is stored
 // opaquely (never dereferenced by the C++ side), so the FFI itself has no
 // pointer-validity precondition — the ref-count contract is documented on
-// `create()` below, not on the FFI call.
+// `create_html_rewriter_suspension()` below, not on the FFI call.
 unsafe extern "C" {
     safe fn Bun__NativePromiseContext__create(
         global: &JSGlobalObject,
@@ -130,27 +122,41 @@ unsafe extern "C" {
         tag: u8,
         held: JSValue,
     ) -> JSValue;
-    safe fn Bun__NativePromiseContext__take(value: JSValue) -> *mut c_void;
+    safe fn Bun__NativePromiseContext__take(value: JSValue, tag: u8) -> *mut c_void;
 }
 
-/// The cell owns the caller's claim on `ctx` until `take()` transfers it back
-/// or GC runs the destructor (which defers to [`DeferredDerefTask`]). `held`
-/// is visited by the cell, so whatever GC object keeps `ctx` alive can ride
-/// along for as long as the promise can settle; pass `JSValue::ZERO` when
-/// nothing needs rooting.
-pub(crate) fn create<T: NativePromiseContextType>(
+/// A `Tag::HTMLRewriterSuspension` cell. The cell owns the caller's claim on
+/// `pipe` until `take_html_rewriter_suspension()` transfers it back or GC runs
+/// the destructor (which defers to [`DeferredDerefTask`]). `held` is visited
+/// by the cell, so whatever GC object keeps `pipe` alive can ride along for as
+/// long as the promise can settle. (Request contexts use the typed
+/// [`bun_jsc::native_promise_context::create`], whose cell owns a `RefPtr`.)
+pub(crate) fn create_html_rewriter_suspension(
     global: &JSGlobalObject,
-    ctx: *mut T,
+    pipe: NonNull<html_rewriter::RewriterPipe>,
     held: JSValue,
 ) -> JSValue {
-    Bun__NativePromiseContext__create(global, ctx.cast::<c_void>(), T::TAG as u8, held)
+    Bun__NativePromiseContext__create(
+        global,
+        pipe.as_ptr().cast::<c_void>(),
+        Tag::HTMLRewriterSuspension as u8,
+        held,
+    )
 }
 
-/// Transfers the ref back to the caller and nulls the cell so the destructor
-/// is a no-op. Returns null if already taken (e.g., the connection aborted
-/// and the ref was released via the destructor on a prior GC cycle).
-pub(crate) fn take<T>(cell: JSValue) -> Option<NonNull<T>> {
-    NonNull::new(Bun__NativePromiseContext__take(cell).cast::<T>())
+/// Transfers the claim back to the caller and nulls the cell so the destructor
+/// is a no-op. Returns null if already taken (the suspension was abandoned) or
+/// if `cell` is not an HTMLRewriter suspension cell.
+pub(crate) fn take_html_rewriter_suspension(
+    cell: JSValue,
+) -> Option<NonNull<html_rewriter::RewriterPipe>> {
+    if cell.is_empty() {
+        return None;
+    }
+    NonNull::new(
+        Bun__NativePromiseContext__take(cell, Tag::HTMLRewriterSuspension as u8)
+            .cast::<html_rewriter::RewriterPipe>(),
+    )
 }
 
 /// Called from the C++ destructor when a cell is collected with a non-null
@@ -285,34 +291,38 @@ impl DeferredDerefTask {
     pub(crate) fn run_from_js_thread(packed_ptr: usize) {
         let tag = Tag::from_raw((packed_ptr & Self::TAG_MASK) as u8);
         let ctx = (packed_ptr & !Self::TAG_MASK) as *mut c_void;
+        use bun_jsc::native_promise_context::destroyed_ref;
         // SAFETY: ctx was packed in `schedule` from a live, non-null pointer
         // of the type indicated by `tag`, and this task owns one ref on it,
-        // released below (for the HTMLRewriter tags: the ref taken in
+        // released below (for the request contexts: the `RefPtr` the cell was
+        // created with; for the HTMLRewriter tags: the ref taken in
         // `begin_suspension`, or the last ref handed over by
         // `deref_outside_caller`). We are on the JS thread.
         unsafe {
             match tag {
-                Tag::HTTPServerRequestContext => (*ctx.cast::<HTTPServerRequestContext>()).deref(),
+                Tag::HTTPServerRequestContext => {
+                    drop(destroyed_ref::<HTTPServerRequestContext>(ctx))
+                }
                 Tag::HTTPSServerRequestContext => {
-                    (*ctx.cast::<HTTPSServerRequestContext>()).deref()
+                    drop(destroyed_ref::<HTTPSServerRequestContext>(ctx))
                 }
                 Tag::DebugHTTPServerRequestContext => {
-                    (*ctx.cast::<DebugHTTPServerRequestContext>()).deref()
+                    drop(destroyed_ref::<DebugHTTPServerRequestContext>(ctx))
                 }
                 Tag::DebugHTTPSServerRequestContext => {
-                    (*ctx.cast::<DebugHTTPSServerRequestContext>()).deref()
+                    drop(destroyed_ref::<DebugHTTPSServerRequestContext>(ctx))
                 }
                 Tag::HTTPServerMuxRequestContext => {
-                    (*ctx.cast::<HTTPServerMuxRequestContext>()).deref()
+                    drop(destroyed_ref::<HTTPServerMuxRequestContext>(ctx))
                 }
                 Tag::HTTPSServerMuxRequestContext => {
-                    (*ctx.cast::<HTTPSServerMuxRequestContext>()).deref()
+                    drop(destroyed_ref::<HTTPSServerMuxRequestContext>(ctx))
                 }
                 Tag::DebugHTTPServerMuxRequestContext => {
-                    (*ctx.cast::<DebugHTTPServerMuxRequestContext>()).deref()
+                    drop(destroyed_ref::<DebugHTTPServerMuxRequestContext>(ctx))
                 }
                 Tag::DebugHTTPSServerMuxRequestContext => {
-                    (*ctx.cast::<DebugHTTPSServerMuxRequestContext>()).deref()
+                    drop(destroyed_ref::<DebugHTTPSServerMuxRequestContext>(ctx))
                 }
                 Tag::HTMLRewriterSuspension => {
                     let back = bun_ptr::BackRef::from(NonNull::new_unchecked(

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1684,8 +1684,11 @@ impl RewriterPipe {
         let cell = self.cell.get();
         let promise = js_HTMLRewriterTransform::suspension_promise_get_cached(cell)
             .expect("suspension promise slot empty");
-        let pipe = core::ptr::from_ref(self).cast_mut();
-        let context = native_promise_context::create(&self.global, pipe, cell);
+        let context = native_promise_context::create_html_rewriter_suspension(
+            &self.global,
+            NonNull::from(self),
+            cell,
+        );
         // The context destructor (promise GC'd unsettled) queues
         // `abandon_suspension` (`DeferredDerefTask::schedule` runs it inline
         // once the VM's task queue has closed); this ref keeps the pipe alive
@@ -1896,7 +1899,8 @@ fn on_handler_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
     let args = frame.arguments();
     // `take` nulls the context so its destructor is a no-op; `None` means the
     // suspension was already abandoned.
-    let Some(pipe) = native_promise_context::take::<RewriterPipe>(args[args.len() - 1]) else {
+    let Some(pipe) = native_promise_context::take_html_rewriter_suspension(args[args.len() - 1])
+    else {
         return Ok(JSValue::UNDEFINED);
     };
     let pipe = BackRef::from(pipe);
@@ -1916,7 +1920,8 @@ fn on_handler_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
 fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
     let reason = args[0];
-    let Some(pipe) = native_promise_context::take::<RewriterPipe>(args[args.len() - 1]) else {
+    let Some(pipe) = native_promise_context::take_html_rewriter_suspension(args[args.len() - 1])
+    else {
         return Ok(JSValue::UNDEFINED);
     };
     let pipe = BackRef::from(pipe);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -6510,7 +6510,7 @@ fn bundle_new_route_js_function_impl(
 
     // SAFETY: request_ptr is a *bun.webcore.Request from C++
     let request: &mut WebRequest = unsafe { &mut *request_ptr.cast::<WebRequest>() };
-    let Some(dev) = request.request_context.dev_server() else {
+    let Some(dev) = request.request_context.get().dev_server() else {
         return Err(global.throw(format_args!(
             "Request context does not belong to dev server"
         )));
@@ -6536,7 +6536,7 @@ fn bundle_new_route_js_function_impl(
     let _exit = dev.vm().enter_event_loop_scope();
 
     let _ = dev;
-    let Some(dev_ptr) = request.request_context.dev_server_mut() else {
+    let Some(dev_ptr) = request.request_context.get().dev_server_mut() else {
         return Err(global.throw(format_args!(
             "Request context does not belong to dev server"
         )));
@@ -6650,7 +6650,7 @@ fn new_route_params_for_bundle_promise_for_js(
     };
     // SAFETY: `from_js` returned a live native pointer; JS holds the GC ref.
     let request: &mut WebRequest = unsafe { &mut *request_ptr };
-    let Some(dev_ptr) = request.request_context.dev_server_mut() else {
+    let Some(dev_ptr) = request.request_context.get().dev_server_mut() else {
         return Err(global.throw(format_args!(
             "Request context does not belong to dev server"
         )));

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -1,8 +1,9 @@
 //! A generic wrapper for the HTTP(s) Server `RequestContext`s.
 //! Only really exists because of `NewServer()` and `NewRequestContext()` generics.
 
-use core::ffi::{c_uint, c_void};
+use core::ffi::c_uint;
 
+use bun_ptr::ThisPtr;
 use bun_uws as uws;
 
 use crate::webcore::CookieMap;
@@ -13,14 +14,14 @@ use super::{DebugHTTPSServer, DebugHTTPServer, HTTPSServer, HTTPServer};
 
 // The eight monomorphizations of `NewRequestContext` (ssl × debug × mux),
 // where mux = HTTP/2 or HTTP/3 (see `request_context::Req`).
-type HttpCtx = RequestContext<HTTPServer, false, false, false>;
-type HttpsCtx = RequestContext<HTTPSServer, true, false, false>;
-type DebugHttpCtx = RequestContext<DebugHTTPServer, false, true, false>;
-type DebugHttpsCtx = RequestContext<DebugHTTPSServer, true, true, false>;
-type HttpMuxCtx = RequestContext<HTTPServer, false, false, true>;
-type HttpsMuxCtx = RequestContext<HTTPSServer, true, false, true>;
-type DebugHttpMuxCtx = RequestContext<DebugHTTPServer, false, true, true>;
-type DebugHttpsMuxCtx = RequestContext<DebugHTTPSServer, true, true, true>;
+pub(crate) type HttpCtx = RequestContext<HTTPServer, false, false, false>;
+pub(crate) type HttpsCtx = RequestContext<HTTPSServer, true, false, false>;
+pub(crate) type DebugHttpCtx = RequestContext<DebugHTTPServer, false, true, false>;
+pub(crate) type DebugHttpsCtx = RequestContext<DebugHTTPSServer, true, true, false>;
+pub(crate) type HttpMuxCtx = RequestContext<HTTPServer, false, false, true>;
+pub(crate) type HttpsMuxCtx = RequestContext<HTTPSServer, true, false, true>;
+pub(crate) type DebugHttpMuxCtx = RequestContext<DebugHTTPServer, false, true, true>;
+pub(crate) type DebugHttpsMuxCtx = RequestContext<DebugHTTPSServer, true, true, true>;
 
 // The `bun_ptr::impl_tagged_ptr_union!` macro hits the orphan rule from
 // outside `bun_ptr`, so store `(tag: u8, ptr: *mut ())` as two fields.
@@ -42,6 +43,10 @@ pub enum CtxTag {
     DebugHttpsMux,
 }
 
+/// A tagged, non-owning [`ThisPtr`] to one of the eight `RequestContext` types.
+/// Every holder is something the context outlives (its `Request`, its body
+/// producer/consumer hooks, its response sink, its file stream) or that holds
+/// a ref on it (`SavedRequest`).
 #[derive(Copy, Clone)]
 pub struct AnyRequestContext {
     pub(crate) tag: CtxTag,
@@ -55,13 +60,28 @@ impl AnyRequestContext {
     };
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl<S: crate::server::ServerLike + 'static, const SSL: bool, const DBG: bool, const MUX: bool>
+        Sealed for super::RequestContext<S, SSL, DBG, MUX>
+    {
+    }
+}
+
 /// Internal: maps each `RequestContext` monomorphization to its tag so
 /// `AnyRequestContext::init` is generic over the eight types without `TypeList`.
-pub trait CtxKind {
+/// Sealed: `dispatch!` trusts `TAG` to name the type.
+pub trait CtxKind: sealed::Sealed {
     const TAG: CtxTag;
 }
 
-const fn ctx_tag_for(ssl: bool, dbg: bool, mux: bool) -> CtxTag {
+/// `CtxTag::None` for combinations that are never instantiated (a server
+/// whose `(SSL, DEBUG)` differ from the context's), so each tag names exactly
+/// one type.
+const fn ctx_tag_for(server_ssl: bool, server_dbg: bool, ssl: bool, dbg: bool, mux: bool) -> CtxTag {
+    if server_ssl != ssl || server_dbg != dbg {
+        return CtxTag::None;
+    }
     match (ssl, dbg, mux) {
         (false, false, false) => CtxTag::Http,
         (true, false, false) => CtxTag::Https,
@@ -77,17 +97,17 @@ const fn ctx_tag_for(ssl: bool, dbg: bool, mux: bool) -> CtxTag {
 // Blanket impl over the const-generic params so any `Ctx: RequestCtx` (which
 // is always a `RequestContext<_, SSL, DBG, MUX>`) also satisfies `CtxKind`
 // without callers having to spell the eight concrete types.
-impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> CtxKind
-    for RequestContext<ThisServer, SSL, DBG, MUX>
+impl<ThisServer: super::ServerLike + 'static, const SSL: bool, const DBG: bool, const MUX: bool>
+    CtxKind for RequestContext<ThisServer, SSL, DBG, MUX>
 {
-    const TAG: CtxTag = ctx_tag_for(SSL, DBG, MUX);
+    const TAG: CtxTag = ctx_tag_for(ThisServer::SSL, ThisServer::DEBUG, SSL, DBG, MUX);
 }
 
 impl AnyRequestContext {
-    pub(crate) fn init<T: CtxKind>(request_ctx: *const T) -> Self {
+    pub(crate) fn init<T: CtxKind>(request_ctx: ThisPtr<T>) -> Self {
         Self {
             tag: T::TAG,
-            ptr: request_ctx as *mut (),
+            ptr: request_ctx.as_ptr().cast::<()>(),
         }
     }
 }
@@ -104,36 +124,11 @@ macro_rules! dispatch {
         let this = $self;
         macro_rules! arm {
             ($Ty:ty) => {{
-                // SAFETY: tag matched; ptr is non-null and live for the
-                // duration of the dispatch arm. `RequestContext` is
-                // interior-mutable, so a shared reborrow suffices.
-                let $ctx = unsafe { &*this.ptr.cast::<$Ty>() };
                 type $T = $Ty;
-                let _ = core::marker::PhantomData::<$T>;
-                $body
-            }};
-        }
-        match this.tag {
-            CtxTag::None => $default,
-            CtxTag::Http => arm!(HttpCtx),
-            CtxTag::Https => arm!(HttpsCtx),
-            CtxTag::DebugHttp => arm!(DebugHttpCtx),
-            CtxTag::DebugHttps => arm!(DebugHttpsCtx),
-            CtxTag::HttpMux => arm!(HttpMuxCtx),
-            CtxTag::HttpsMux => arm!(HttpsMuxCtx),
-            CtxTag::DebugHttpMux => arm!(DebugHttpMuxCtx),
-            CtxTag::DebugHttpsMux => arm!(DebugHttpsMuxCtx),
-        }
-    }};
-    // Raw-pointer variant: hands the typed `*mut T` to `$body` without forming
-    // a `&mut` reborrow. Use when the callee may re-enter while an outer frame
-    // already holds `&mut Self` (borrow = ptr).
-    ($self:expr, $default:expr, ptr |$T:ident, $ptr:ident| $body:expr) => {{
-        let this = $self;
-        macro_rules! arm {
-            ($Ty:ty) => {{
-                type $T = $Ty;
-                let $ptr = this.ptr.cast::<$T>();
+                // SAFETY: tag matched, so `ptr` is the `ThisPtr<$Ty>` `init`
+                // recorded; the holder's contract (see the type doc) keeps the
+                // context live while this handle is used.
+                let $ctx: ThisPtr<$T> = unsafe { ThisPtr::new(this.ptr.cast::<$T>()) };
                 $body
             }};
         }
@@ -165,9 +160,10 @@ impl AnyRequestContext {
         dispatch!(self, 0, |_T, ctx| ctx.memory_cost())
     }
 
-    pub fn get<T: CtxKind>(self) -> Option<*mut T> {
-        if self.tag == T::TAG {
-            Some(self.ptr.cast::<T>())
+    pub fn get<T: CtxKind>(self) -> Option<ThisPtr<T>> {
+        if self.tag != CtxTag::None && self.tag == T::TAG {
+            // SAFETY: as for `dispatch!` — the tag names `T`.
+            Some(unsafe { ThisPtr::new(self.ptr.cast::<T>()) })
         } else {
             None
         }
@@ -198,22 +194,20 @@ impl AnyRequestContext {
                 // HTTP/2 and HTTP/3 populate url/headers eagerly
                 return;
             }
-            // `Req<_,_> = c_void` (erased handle). For non-mux the underlying
-            // type is always `uws::Request`, so the cast is purely nominal.
-            ctx.req.set(Some(req.cast::<c_void>()));
+            ctx.req.set(Some(uws::AnyRequest::H1(req)));
         })
     }
 
     pub(crate) fn get_request(self) -> Option<*mut uws::Request> {
-        dispatch!(self, None, |T, ctx| {
-            if T::IS_MUX {
-                // url/headers already on the Request
-                return None;
-            }
-            ctx.req.get().map(|p| p.cast::<uws::Request>())
+        dispatch!(self, None, |_T, ctx| match ctx.req.get()? {
+            // url/headers already on the Request for H2/H3
+            uws::AnyRequest::H1(req) => Some(req),
+            uws::AnyRequest::H3(_) => None,
         })
     }
 
+    /// A ref for a holder that stores this handle past the request callback
+    /// (`SavedRequest`); paired with [`deref`](Self::deref).
     pub fn ref_(self) {
         dispatch!(self, (), |_T, ctx| ctx.ref_())
     }
@@ -222,13 +216,8 @@ impl AnyRequestContext {
         dispatch!(self, (), |_T, ctx| ctx.set_signal_aborted(reason))
     }
 
-    pub(crate) fn dev_server(self) -> Option<&'static crate::bake::DevServer::DevServer> {
-        dispatch!(self, None, |_T, ctx| ctx.dev_server().map(|r| {
-            // SAFETY: the server backref outlives any AnyRequestContext (held only
-            // for the duration of a request callback); `self` is a by-value tagged
-            // pointer, so there is no input lifetime to tie the borrow to.
-            unsafe { bun_ptr::detach_lifetime_ref(r) }
-        }))
+    pub(crate) fn dev_server(self) -> Option<bun_ptr::BackRef<crate::bake::DevServer::DevServer>> {
+        dispatch!(self, None, |_T, ctx| ctx.dev_server())
     }
 
     /// Mutable access to the attached DevServer. The accessor above hands out
@@ -247,32 +236,62 @@ impl AnyRequestContext {
         })
     }
 
+    /// Releases the ref [`ref_`](Self::ref_) took.
     pub fn deref(self) {
-        dispatch!(self, (), |_T, ctx| ctx.deref())
+        dispatch!(self, (), |T, ctx| <T as bun_ptr::CellRefCounted>::deref_nn(
+            ctx.into()
+        ))
     }
 
     pub fn on_request_body_stream_drained(self) {
-        dispatch!(
-            self,
-            (),
-            ptr | T,
-            ptr | T::on_request_body_stream_drained(ptr)
-        )
+        dispatch!(self, (), |_T, ctx| ctx.on_request_body_stream_drained())
     }
 
     pub fn write_chunk(
         self,
         data: &crate::webcore::streams::Result,
     ) -> crate::webcore::streams::Writable {
-        dispatch!(
-            self,
-            crate::webcore::streams::Writable::Done,
-            ptr | T,
-            ptr | T::write_chunk(ptr, data)
-        )
+        dispatch!(self, crate::webcore::streams::Writable::Done, |T, ctx| {
+            T::write_chunk(ctx, data)
+        })
     }
 
     pub fn end_chunk(self, err: Option<&crate::webcore::streams::StreamError>) {
-        dispatch!(self, (), ptr | T, ptr | T::end_chunk(ptr, err))
+        dispatch!(self, (), |T, ctx| T::end_chunk(ctx, err))
+    }
+
+    /// The response sink's first write: flush status and headers ahead of it.
+    pub(crate) fn on_first_stream_write(self) {
+        dispatch!(self, (), |_T, ctx| ctx.handle_first_stream_write())
+    }
+
+    /// `Body::ReceiveValue::Server`: the pending response body resolved.
+    pub(crate) fn render_pending_body_value(self, value: &mut crate::webcore::body::Value) {
+        dispatch!(self, (), |T, ctx| T::render_pending_body_value(ctx, value))
+    }
+
+    /// `FileResponseStream` finished sending the body, or failed with `err`
+    /// (after force-closing the socket).
+    pub(crate) fn on_file_stream_complete(
+        self,
+        resp: uws::AnyResponse,
+        err: Option<bun_sys::Error>,
+    ) {
+        dispatch!(self, (), |T, ctx| T::on_file_stream_complete(
+            ctx, resp, err
+        ))
+    }
+
+    /// The client went away while `FileResponseStream` was sending the body.
+    pub(crate) fn on_file_stream_abort(self, resp: uws::AnyResponse) {
+        dispatch!(self, (), |T, ctx| T::on_abort(ctx, resp))
+    }
+
+    /// `S3::client::stat` for a HEAD response with an S3 body completed.
+    pub(crate) fn on_s3_size_resolved(
+        self,
+        result: crate::webcore::s3::simple_request::S3StatResult<'_>,
+    ) {
+        dispatch!(self, (), |T, ctx| T::on_s3_size_resolved(ctx, result))
     }
 }

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -78,7 +78,13 @@ pub trait CtxKind: sealed::Sealed {
 /// `CtxTag::None` for combinations that are never instantiated (a server
 /// whose `(SSL, DEBUG)` differ from the context's), so each tag names exactly
 /// one type.
-const fn ctx_tag_for(server_ssl: bool, server_dbg: bool, ssl: bool, dbg: bool, mux: bool) -> CtxTag {
+const fn ctx_tag_for(
+    server_ssl: bool,
+    server_dbg: bool,
+    ssl: bool,
+    dbg: bool,
+    mux: bool,
+) -> CtxTag {
     if server_ssl != ssl || server_dbg != dbg {
         return CtxTag::None;
     }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -120,14 +120,10 @@ pub(crate) enum StreamOwner {
     FileRoute(RefPtr<FileRoute>),
     /// Likewise for `DirectoryRoute::on`.
     DirectoryRoute(RefPtr<DirectoryRoute>),
-    Ctx {
-        ctx: *mut c_void,
-        on_complete: fn(*mut c_void, AnyResponse),
-        /// Fires instead of `on_complete` when the client disconnects
-        /// mid-stream. If `None`, abort is reported via `on_complete`.
-        on_abort: Option<fn(*mut c_void, AnyResponse)>,
-        on_error: fn(*mut c_void, AnyResponse, sys::Error),
-    },
+    /// A `Bun.serve` request whose response body is a file. The context's
+    /// in-flight ref (`RequestContext::in_flight`) is what the delivered
+    /// completion releases; an abort is routed through its `on_abort`.
+    RequestContext(crate::server::AnyRequestContext),
 }
 
 enum StreamEnd {
@@ -141,15 +137,10 @@ impl StreamOwner {
         match self {
             StreamOwner::FileRoute(route) => route.on_response_complete(resp),
             StreamOwner::DirectoryRoute(route) => route.on_response_complete(resp),
-            StreamOwner::Ctx {
-                ctx,
-                on_complete,
-                on_abort,
-                on_error,
-            } => match end {
-                StreamEnd::Complete => on_complete(ctx, resp),
-                StreamEnd::Abort => on_abort.unwrap_or(on_complete)(ctx, resp),
-                StreamEnd::Error(err) => on_error(ctx, resp, err),
+            StreamOwner::RequestContext(ctx) => match end {
+                StreamEnd::Complete => ctx.on_file_stream_complete(resp, None),
+                StreamEnd::Abort => ctx.on_file_stream_abort(resp),
+                StreamEnd::Error(err) => ctx.on_file_stream_complete(resp, Some(err)),
             },
         }
     }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -258,6 +258,14 @@ where
     }
 }
 
+// SAFETY: `#[ref_count(destroy = Self::destroy)]` above — the last ref runs
+// `destroy` → `release` → `ThisServer::release_request_context`, which returns
+// the slot to the server's `HiveArray` pool; nothing `Box`-frees a context.
+unsafe impl<ThisServer: ServerLike + 'static, const SSL: bool, const DBG: bool, const MUX: bool>
+    bun_collections::PoolReclaimed for RequestContext<ThisServer, SSL, DBG, MUX>
+{
+}
+
 impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const MUX: bool>
     RequestContext<ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>
 where

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -873,19 +873,26 @@ where
     }
 
     /// `CellRefCounted` destructor: the last ref was released.
-    fn destroy(this: *mut Self) {
-        bun_ptr::destroy_with(
-            this,
-            |ctx| {
-                ctx.finalize_without_deinit();
-                ctx.teardown()
-            },
-            |ctx, server| {
-                if let Some(server) = server {
-                    Self::release(ctx, server);
-                }
-            },
-        );
+    ///
+    /// # Safety
+    /// Called only by the generated `CellRefCounted::destroy` with the
+    /// allocation root of a context whose refcount just reached zero.
+    unsafe fn destroy(this: *mut Self) {
+        // SAFETY: forwarded from the fn contract.
+        unsafe {
+            bun_ptr::destroy_with(
+                this,
+                |ctx| {
+                    ctx.finalize_without_deinit();
+                    ctx.teardown()
+                },
+                |ctx, server| {
+                    if let Some(server) = server {
+                        Self::release(ctx, server);
+                    }
+                },
+            );
+        }
     }
 
     /// A new `NativePromiseContext` cell owning a ref on this context,

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -7,6 +7,7 @@ use bun_sys::FdExt as _;
 use bun_core::String as BunString;
 use bun_http_types::Method::Method;
 use bun_jsc::JsCell;
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_uws::{self as uws, WebSocketUpgradeContext};
 
 use crate::server::jsc::{self, JSGlobalObject, JSValue, JsResult};
@@ -43,18 +44,12 @@ impl AdditionalOnAbortCallback {
 // const-generic `bool` without specialization, and an early `Transport`
 // helper-trait approach forced `where TransportFor<SSL,MUX>: Transport` bounds
 // onto every generic that named `RequestContext` (which Rust then *cannot*
-// discharge for a generic `const SSL: bool` — only the concrete combos have
-// impls). So instead the `resp` field stores `uws::AnyResponse` (a Copy enum
-// over the concrete handles) and dispatches at runtime — same shape as
-// `AnyRequestContext` / `AnyServer`.
-//
-// `MUX` = the request arrived on a stream-multiplexed transport (HTTP/2 or
-// HTTP/3): headers come pre-decoded as a list (`uws::H3::Request` serves
-// both), the body ends at END_STREAM/FIN rather than by Content-Length or
-// chunking, a response never owns the connection (no `Connection: close`,
-// no `Transfer-Encoding`, no upgrade), and the response handle stays valid
-// after `end()` until its `onAborted` fires to say the stream is gone.
-pub type Req<const SSL_ENABLED: bool, const MUX: bool> = c_void;
+// discharge for a generic `const SSL: bool` — only the four concrete combos
+// have impls). So instead the `resp` field stores `uws::AnyResponse` (a Copy
+// enum over the three concrete handles) and dispatches at runtime — same shape
+// as `AnyRequestContext` / `AnyServer`. The const params still pick which
+// variant `create()` constructs and gate MUX-specific code paths; `req` is the
+// matching `uws::AnyRequest`.
 
 /// Back-reference to a stack-local "should this RequestContext defer its
 /// deinit until the JS callback returns" flag. The dispatching frame owns the
@@ -66,12 +61,14 @@ pub(crate) type ResponseStream<const SSL_ENABLED: bool> =
     crate::webcore::streams::HTTPServerWritable<SSL_ENABLED>;
 type ResponseStreamJSSink<const SSL_ENABLED: bool> =
     crate::webcore::streams::HTTPServerWritableJSSink<SSL_ENABLED>;
+type OwnedResponseStream<const SSL_ENABLED: bool> =
+    crate::webcore::streams::OwnedHTTPServerWritable<SSL_ENABLED>;
 
-/// This pre-allocates up to 2,048 RequestContext structs.
-/// It costs about 655,632 bytes.
+/// This pre-allocates up to 2,048 RequestContext structs (several hundred KB
+/// per pool).
 // Capacity 0 when heap-breakdown is enabled routes every allocation through
 // the fallback heap path so the per-type malloc zones can attribute them.
-const REQUEST_CONTEXT_POOL_CAPACITY: usize = if bun_alloc::heap_breakdown::ENABLED {
+pub(crate) const REQUEST_CONTEXT_POOL_CAPACITY: usize = if bun_alloc::heap_breakdown::ENABLED {
     0
 } else {
     2048
@@ -98,11 +95,22 @@ pub(crate) enum UpgradeState {
     Upgraded,
 }
 
+/// Pool-allocated (the server's `RequestContextStackAllocator`) and
+/// intrusively refcounted; the last ref returns the slot (`destroy`). Every
+/// ref is a `RefPtr` held in a named slot: [`in_flight`](Self::in_flight) for
+/// the open response, the `NativePromiseContext` cell
+/// ([`promise_cell`](Self::promise_cell)) for a parked handler promise, [`body_value_ref`](Self::body_value_ref),
+/// [`byte_stream_ref`](Self::byte_stream_ref), [`s3_stat_ref`](Self::s3_stat_ref),
+/// `SavedRequest`'s (through `AnyRequestContext::ref_`), and the guard each
+/// callback entry holds for its frame.
+///
 /// `align(16)`: `NativePromiseContext`'s deferred-deref task packs a 4-bit
 /// type tag into the low bits of a pointer to this.
+#[derive(bun_ptr::CellRefCounted)]
+#[ref_count(destroy = Self::destroy)]
 #[repr(align(16))]
 pub struct RequestContext<
-    ThisServer,
+    ThisServer: ServerLike + 'static,
     const SSL_ENABLED: bool,
     const DEBUG_MODE: bool,
     const MUX: bool,
@@ -110,9 +118,10 @@ pub struct RequestContext<
     /// BACKREF to the embedding `Server` — the server owns this request
     /// context (allocated from its `HiveArray` pool) and outlives it, so the
     /// pointee is live for the holder's entire lifetime. `None` once detached.
-    pub(crate) server: Cell<Option<bun_ptr::BackRef<ThisServer, bun_ptr::Mut>>>,
+    pub(crate) server: Cell<Option<BackRef<ThisServer, bun_ptr::Mut>>>,
     pub(crate) resp: Cell<Option<uws::AnyResponse>>,
-    pub(crate) req: Cell<Option<*mut Req<SSL_ENABLED, MUX>>>,
+    /// The uWS request, while the dispatching frame that owns it is on the stack.
+    pub(crate) req: Cell<Option<uws::AnyRequest>>,
     pub(crate) request_weakref: JsCell<request::WeakRef>,
     // NOTE: `Arc<AbortSignal>` was wrong —
     // `AbortSignal` is an opaque ZST FFI handle; an `Arc` of a ZST never owns
@@ -138,9 +147,25 @@ pub struct RequestContext<
     // fall back to `response_weakref` (see its doc below), so a `Strong`
     // here would root the Response unconditionally and change GC behavior.
     pub(crate) response_jsvalue: Cell<JSValue>,
-    root: Cell<*mut Self>,
-    pub(crate) ref_count: Cell<u8>,
+    /// This slot's own root pointer, recorded at creation so `&self` methods
+    /// can hand a `ThisPtr<Self>` to the callbacks they register.
+    root: Cell<Option<BackRef<Self, bun_ptr::Root>>>,
+    pub(crate) ref_count: Cell<u32>,
     pub(crate) pin_count: Cell<u8>,
+    /// The ref the open response holds on this context: taken at creation,
+    /// released when the response is ended, aborted or handed off
+    /// (`release_in_flight`).
+    in_flight: Cell<Option<RefPtr<Self>>>,
+    /// The ref a `Body::ReceiveValue::Server` registration holds while this
+    /// context waits for a pending response body; released by
+    /// `render_pending_body_value`.
+    body_value_ref: Cell<Option<RefPtr<Self>>>,
+    /// The ref the natively piped response body (`byte_stream`) holds; released
+    /// by `end_chunk`, or by `on_abort` when the pipe can no longer finish.
+    byte_stream_ref: Cell<Option<RefPtr<Self>>>,
+    /// The ref an in-flight `S3::client::stat` (HEAD on an S3 body) holds;
+    /// released by `on_s3_size_resolved`.
+    s3_stat_ref: Cell<Option<RefPtr<Self>>>,
 
     /// Weak: for plain Blob/InternalBlob bodies the Response JSValue is
     /// not protected (hot path), so GC may finalize it while we're parked
@@ -166,8 +191,13 @@ pub struct RequestContext<
     /// chunked / H3 bodies consumed as a stream are capped against this.
     pub(crate) request_body_streamed_len: Cell<usize>,
 
-    pub sink: Cell<Option<NonNull<ResponseStreamJSSink<SSL_ENABLED>>>>,
-    pub(crate) byte_stream: Cell<Option<NonNull<ByteStream>>>,
+    /// The streaming-response sink, from `do_render_stream` until a settle
+    /// path, `discard_stream_after_abort` or `teardown` destroys it. The JS
+    /// controller holds its address until `JSSink::detach`.
+    pub sink: JsCell<Option<OwnedResponseStream<SSL_ENABLED>>>,
+    /// The `ByteStream` a native response body is piped from; kept alive by
+    /// `response_body_readable_stream_ref`.
+    pub(crate) byte_stream: Cell<Option<BackRef<ByteStream>>>,
     /// This keeps the Response body's ReadableStream alive.
     pub(crate) response_body_readable_stream_ref: JsCell<readable_stream::Strong>,
 
@@ -188,13 +218,44 @@ pub struct RequestContext<
 
     pub(crate) additional_on_abort: JsCell<Option<AdditionalOnAbortCallback>>,
 
-    /// The `NativePromiseContext` cell whose claim (one ref on this context)
-    /// is still outstanding, or `ZERO`. Not visited by GC: the promise
+    /// The `NativePromiseContext` cell that owns a ref on this context for a
+    /// parked promise reaction, or `ZERO`. Not visited by GC: the promise
     /// reaction keeps the cell alive, and the cell's destructor clears this
     /// field before the value can dangle. `on_abort` reclaims the ref through
     /// it so an aborted request is torn down without waiting for GC.
     promise_cell: Cell<JSValue>,
     // TODO: support builtin compression
+}
+
+/// Keeps a [`RequestContext`] alive across a callback frame without counting
+/// as a holder in `should_render_missing` / `is_dead_request` (which ask
+/// whether anything *other than the current frame* still needs the context).
+struct Pin<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>(
+    RefPtr<RequestContext<ThisServer, SSL, DBG, MUX>>,
+)
+where
+    ThisServer: ServerLike + 'static;
+
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> Pin<ThisServer, SSL, DBG, MUX>
+where
+    ThisServer: ServerLike + 'static,
+{
+    #[inline]
+    fn new(this: ThisPtr<RequestContext<ThisServer, SSL, DBG, MUX>>) -> Self {
+        this.pin_count.set(this.pin_count.get() + 1);
+        Self(RefPtr::from_this(this))
+    }
+}
+
+impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> Drop
+    for Pin<ThisServer, SSL, DBG, MUX>
+where
+    ThisServer: ServerLike + 'static,
+{
+    #[inline]
+    fn drop(&mut self) {
+        self.0.pin_count.set(self.0.pin_count.get() - 1);
+    }
 }
 
 impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const MUX: bool>
@@ -204,15 +265,29 @@ where
 {
     pub(crate) const IS_MUX: bool = MUX;
 
+    /// This context as the `ThisPtr` its callbacks are registered with.
     #[inline]
-    pub(crate) fn as_ctx_ptr(&self) -> *mut Self {
-        let p = self.root.get();
-        debug_assert!(!p.is_null(), "RequestContext root not recorded");
-        p
+    pub(crate) fn this(&self) -> ThisPtr<Self> {
+        self.root
+            .get()
+            .expect("RequestContext root not recorded")
+            .this_ptr()
+    }
+
+    #[inline]
+    fn pin(this: ThisPtr<Self>) -> Pin<ThisServer, SSL_ENABLED, DEBUG_MODE, MUX> {
+        Pin::new(this)
+    }
+
+    /// Release the open response's ref (see [`in_flight`](Self::in_flight)).
+    /// The caller's frame holds its own ref, so this never frees `self`.
+    #[inline]
+    pub(crate) fn release_in_flight(&self) {
+        drop(self.in_flight.take());
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
-        // The Sink and ByteStream aren't owned by this.
+        // The sink's buffer and the ByteStream aren't counted here.
         core::mem::size_of::<Self>()
             + self.request_body_buf.get().capacity()
             + self.response_buf_owned.get().capacity()
@@ -224,10 +299,10 @@ where
         self.defer_deinit_until_callback_completes.get().is_none()
     }
 
-    pub(crate) fn dev_server(&self) -> Option<&crate::bake::DevServer::DevServer> {
+    /// The server's `DevServer`, which it keeps for as long as it has requests.
+    pub(crate) fn dev_server(&self) -> Option<BackRef<crate::bake::DevServer::DevServer>> {
         let server = self.server.get()?;
-        // SAFETY: BACKREF — the server outlives every context it allocates.
-        unsafe { &*server.as_ptr() }.dev_server()
+        server.dev_server().map(BackRef::new)
     }
 }
 
@@ -235,129 +310,35 @@ where
 // Everything below until the helper structs at the bottom is the request
 // state machine: render(), on_abort(), on_resolve(), do_render_*, sendfile,
 // stream handling, error handling.
-use bun_collections::VecExt;
-use bun_core::Output;
-use bun_core::strings;
-use bun_http_types as HTTP;
-use bun_http_types::MimeType::MimeType;
-use std::io::Write as _;
-#[allow(non_snake_case)]
-mod NativePromiseContext {
-    use super::{JSGlobalObject, JSValue};
-    use crate::api::native_promise_context as npc;
-    use core::ptr::NonNull;
-    pub(super) use npc::NativePromiseContextType;
-
-    #[inline]
-    pub(super) fn create<T: NativePromiseContextType>(
-        global: &JSGlobalObject,
-        ctx: *mut T,
-    ) -> JSValue {
-        npc::create(global, ctx, JSValue::ZERO)
-    }
-    #[inline]
-    pub(super) fn take<T>(cell: JSValue) -> Option<NonNull<T>> {
-        npc::take::<T>(cell)
-    }
-}
 use crate::node::types::PathLikeExt as _;
 use crate::server::jsc::CallFrame;
 use crate::server::{AnyRequestContext, FileResponseStream, HTTPStatusText, file_response_stream};
 use crate::webcore::blob::BlobExt as _;
 use crate::webcore::{Blob, ReadableStream, body as Body, s3 as S3};
+use bun_collections::VecExt;
+use bun_core::Output;
+use bun_core::strings;
+use bun_http_types as HTTP;
+use bun_http_types::MimeType::MimeType;
 use bun_jsc::SysErrorJsc as _;
+use bun_jsc::native_promise_context;
+use std::io::Write as _;
 
-/// RAII: releases one intrusive ref on a [`RequestContext`] at scope exit.
-///
-/// Every callback entry that can reach a `deref()` (uWS handlers, promise
-/// reactions, task callbacks) constructs one of these from its raw entry
-/// pointer as the first statement: the guard's ref keeps the pooled context
-/// alive for the whole frame even if the body drops the base ref, and the
-/// actual pool release happens here at drop.
-struct RequestContextRef<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>
-where
-    ThisServer: ServerLike + 'static,
-{
-    ctx: *mut RequestContext<ThisServer, SSL, DBG, MUX>,
-    is_pin: bool,
-}
-
-impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>
-    RequestContextRef<ThisServer, SSL, DBG, MUX>
-where
-    ThisServer: ServerLike + 'static,
-{
-    #[inline]
-    fn pin(this: *mut RequestContext<ThisServer, SSL, DBG, MUX>) -> Self {
-        // SAFETY: `this` is a live context registered as the callback's
-        // user-data; the base ref cannot be released before this returns.
-        unsafe {
-            (*this).ref_();
-            (*this).pin_count.set((*this).pin_count.get() + 1);
-        }
-        Self {
-            ctx: this,
-            is_pin: true,
-        }
-    }
-
-    #[inline]
-    fn adopt(this: *mut RequestContext<ThisServer, SSL, DBG, MUX>) -> Self {
-        Self {
-            ctx: this,
-            is_pin: false,
-        }
-    }
-
-    #[inline]
-    fn ctx(&self) -> &RequestContext<ThisServer, SSL, DBG, MUX> {
-        // SAFETY: this guard owns a ref, so `*self.ctx` is live for `&self`.
-        unsafe { &*self.ctx }
-    }
-}
-
-impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> Drop
-    for RequestContextRef<ThisServer, SSL, DBG, MUX>
-where
-    ThisServer: ServerLike + 'static,
-{
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: pointer was live when wrapped (this guard owns one ref) and
-        // `deref()` itself handles the pool release when count hits zero.
-        unsafe {
-            if self.is_pin {
-                (*self.ctx).pin_count.set((*self.ctx).pin_count.get() - 1);
-            }
-            (*self.ctx).deref()
-        };
-    }
-}
-
-// `Response` doesn't yet implement `JsClass` (codegen-gated). Route the
-// downcast through the codegen stub so the call sites type-check; the stub
-// returns `None` until codegen lands.
-//
-/// The C++-owned cell pointer for `value`, or `None` if it is not a `Response`.
-///
-/// Returns a raw pointer rather than `&mut Response` so it keeps the wrapper
-/// allocation's provenance: `RequestContext::set_response` stores it in a
-/// `WeakPtr<Response>`, which outlives any reborrow and is read again after
-/// the Response has been written through other pointers.
-///
-/// Callers must keep `value` GC-rooted (ensure_still_alive / protect()) for as
-/// long as they use the pointer, so the JSC-owned allocation outlives it, and
-/// must not form two overlapping `&mut Response` from it.
+/// The `Response` payload of the JS wrapper `value`, or `None` if it is not a
+/// `Response`. The pointer is the wrapper allocation's root (what
+/// `set_response`'s `WeakPtr` needs); it is valid while `value` is GC-rooted
+/// (ensure_still_alive / protect()), which callers arrange for as long as
+/// they use it.
 #[inline]
-fn as_response(value: JSValue) -> Option<*mut Response> {
-    response::from_js(value).map(|p| p.cast::<Response>())
+fn as_response(value: JSValue) -> Option<ThisPtr<Response>> {
+    value.as_class_this_ptr::<Response>()
 }
 
 /// Release the body's hold on a stream the sink is done with, and mark a
 /// `Locked` body used. Non-generic and out of line: the eight `RequestContext`
 /// monomorphizations share one copy.
 #[inline(never)]
-fn release_body_stream(response: &mut Response, global_this: &JSGlobalObject) {
+fn release_body_stream(response: &Response, global_this: &JSGlobalObject) {
     if let Some(stream) = response.get_body_readable_stream() {
         stream.value.ensure_still_alive();
         response.detach_readable_stream(global_this);
@@ -378,11 +359,11 @@ mod shim {
     use super::*;
 
     #[inline]
-    pub(super) fn response_body_stream(r: &mut Response) -> Option<ReadableStream> {
+    pub(super) fn response_body_stream(r: &Response) -> Option<ReadableStream> {
         r.get_body_readable_stream()
     }
     #[inline]
-    pub(super) fn response_detach_stream(r: &mut Response, g: &JSGlobalObject) {
+    pub(super) fn response_detach_stream(r: &Response, g: &JSGlobalObject) {
         r.detach_readable_stream(g)
     }
     #[inline]
@@ -434,10 +415,10 @@ mod shim {
     /// The response is done with its natively piped body. A body still mid-stream is
     /// cancelled: it stayed locked to this response, so nothing else can read it.
     #[inline]
-    pub(super) fn byte_stream_unpipe(s: NonNull<ByteStream>) {
+    pub(super) fn byte_stream_unpipe(s: BackRef<ByteStream>) {
         // The caller has just `take()`n `self.byte_stream` and still holds
         // `response_body_readable_stream_ref`, which keeps the pointee alive.
-        bun_ptr::BackRef::from(s).detach_finished_sink()
+        s.detach_finished_sink()
     }
 }
 use crate::server::DevErrorPage;
@@ -454,10 +435,10 @@ macro_rules! stream_log { ($($t:tt)*) => { bun_core::scoped_log!(ReadableStream,
 /// `GlobalObject::promiseHandlerID` compares against.
 ///
 /// The `#[no_mangle]` exports cannot live on a generic fn, so they are
-/// emitted as concrete wrappers by `request_ctx_exports!` below. The trait
-/// impls — also emitted by that macro — point at those *exported* wrappers
-/// (not the inner generic shims), so `Self::ON_RESOLVE` and the C++ side agree
-/// on the function-pointer identity and `promiseHandlerID` resolves.
+/// emitted as concrete wrappers by `request_ctx_exports!` below (through
+/// `bun_jsc::jsc_promise_handler!`). This impl points at those *exported*
+/// wrappers, so `Self::ON_RESOLVE` and the C++ side agree on the
+/// function-pointer identity and `promiseHandlerID` resolves.
 ///
 /// NOTE (layering): expressed as a trait (not inherent consts) so
 /// downstream `where`-clauses that already name it keep type-checking.
@@ -468,79 +449,14 @@ pub trait RequestContextHostFns {
     const ON_REJECT_STREAM: bun_jsc::JSHostFn;
 }
 
-// Plain safe Rust helpers — only ever called Rust→Rust by the `#[no_mangle]`
-// ABI wrappers in `request_ctx_exports!`, so they need no `extern` ABI and
-// have no caller preconditions (bodies use safe `opaque_deref`). The wrappers
-// carry `#[bun_jsc::host_call]` for the C++-visible symbol.
-fn host_on_resolve<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>(
-    g: *mut JSGlobalObject,
-    f: *mut CallFrame,
-) -> JSValue
-where
-    ThisServer: ServerLike + 'static,
-{
-    // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-    // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-    let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
-    bun_jsc::to_js_host_fn_result(
-        g,
-        RequestContext::<ThisServer, SSL, DBG, MUX>::on_resolve(g, f),
-    )
-}
-fn host_on_reject<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>(
-    g: *mut JSGlobalObject,
-    f: *mut CallFrame,
-) -> JSValue
-where
-    ThisServer: ServerLike + 'static,
-{
-    // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-    // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-    let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
-    bun_jsc::to_js_host_fn_result(
-        g,
-        RequestContext::<ThisServer, SSL, DBG, MUX>::on_reject(g, f),
-    )
-}
-fn host_on_resolve_stream<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>(
-    g: *mut JSGlobalObject,
-    f: *mut CallFrame,
-) -> JSValue
-where
-    ThisServer: ServerLike + 'static,
-{
-    // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-    // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-    let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
-    bun_jsc::to_js_host_fn_result(
-        g,
-        RequestContext::<ThisServer, SSL, DBG, MUX>::on_resolve_stream(g, f),
-    )
-}
-fn host_on_reject_stream<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool>(
-    g: *mut JSGlobalObject,
-    f: *mut CallFrame,
-) -> JSValue
-where
-    ThisServer: ServerLike + 'static,
-{
-    // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-    // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-    let (g, f) = (bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(f));
-    bun_jsc::to_js_host_fn_result(
-        g,
-        RequestContext::<ThisServer, SSL, DBG, MUX>::on_reject_stream(g, f),
-    )
-}
-
 impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> RequestContextHostFns
     for RequestContext<ThisServer, SSL, DBG, MUX>
 where
     ThisServer: ServerLike + 'static,
 {
     // These consts must resolve to the *exported* `#[no_mangle]` symbols
-    // (`Bun__HTTPRequestContext*__on*`), not the inner generic
-    // `host_on_*::<..>` shims: the function-pointer value is what C++'s
+    // (`Bun__HTTPRequestContext*__on*`), not the generic `on_*::<..>` bodies:
+    // the function-pointer value is what C++'s
     // `GlobalObject::promiseHandlerID` compares against (ZigGlobalObject.cpp),
     // and the exported wrapper has a different address from the generic it
     // forwards to. We route through a const-fn lookup keyed on the
@@ -556,91 +472,39 @@ impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const MUX: boo
 where
     ThisServer: ServerLike + 'static,
 {
-    /// Reborrow the owning server. `server` is a BACKREF (LIFETIMES.tsv): set
-    /// at construction in `init()` from the `NewServer` that owns the request
-    /// pool, never null while the `RequestContext` is live, and the server
-    /// outlives every `RequestContext` it allocates. Centralises the
-    /// per-call-site backref deref behind the `bun_ptr::BackRef` field.
-    ///
-    /// Returned lifetime is **decoupled** from `&self` (unbounded `'r`): the
-    /// server is not a sub-field of `RequestContext` (it owns the pool the
-    /// context lives in), so callers may hold `&ThisServer` past calls that
-    /// end or recycle this context.
+    /// The owning server. `server` is a BACKREF (LIFETIMES.tsv): set at
+    /// construction from the `NewServer` that owns the request pool, never
+    /// null while the `RequestContext` is live, and the server outlives every
+    /// `RequestContext` it allocates. Returned by value (it is `Copy`) so
+    /// callers may keep using it past calls that end or recycle this context.
     #[inline]
-    pub(crate) fn server<'r>(&self) -> &'r ThisServer {
-        // SAFETY: BACKREF — `server` is `Some(non-null)` after `init()` and
-        // the pointee `NewServer` outlives this context (it owns the pool).
-        // `'r` may exceed `&self` because the server is not borrowed from
-        // `*self`; it lives independently and outlives every context.
-        unsafe {
-            &*self
-                .server
-                .get()
-                .expect("infallible: server bound")
-                .as_ptr()
-        }
+    pub(crate) fn server(&self) -> BackRef<ThisServer, bun_ptr::Mut> {
+        self.server.get().expect("infallible: server bound")
     }
 
-    /// Mutably borrow the pooled request-body slot, if attached.
-    ///
-    /// Returns an unbounded `&'r mut` because the slot is a separate
-    /// `HiveArray` allocation, **not** a sub-field of `*self`, so callers may
-    /// hold it across disjoint reborrows of other `RequestContext` fields
-    /// (same pattern as [`server()`]).
+    /// The pooled request-body slot, if attached. Shared with `Request.body`;
+    /// keep `with_mut` borrows short and off any path that reaches the slot
+    /// again (`end_request_streaming`).
     #[inline]
-    #[allow(
-        clippy::mut_from_ref,
-        reason = "the body slot is a separate pooled allocation, not a field of *self (R-2)"
-    )]
-    fn request_body_mut(&self) -> Option<&mut Body::Value> {
-        // SAFETY: R-2 invariant — the slot is shared with `Request.body` but
-        // never `&mut`-borrowed concurrently (single-threaded event loop).
-        self.request_body
-            .get()
-            .as_ref()
-            .map(|h| unsafe { &mut (*h.as_ptr()).value })
+    fn request_body_slot(&self) -> Option<&JsCell<Body::Value>> {
+        self.request_body.get().as_deref()
     }
 
-    /// Exclusive borrow of the heap [`ResponseStreamJSSink`] this context owns.
-    ///
-    /// Returns an unbounded `&'r mut` because the sink is a separate heap
-    /// allocation (`heap::alloc` in [`do_render_stream`]), **not** a sub-field
-    /// of `*self` (same pattern as [`request_body_mut`]).
-    ///
-    /// # Safety (encapsulated)
-    /// While `Some`, `sink` points to the JSSink allocated by
-    /// `do_render_stream`; this `RequestContext` is its sole owner until
-    /// [`destroy_sink`] consumes it. Single-threaded — no other `&mut` alias.
+    /// The streaming-response sink (see [`sink`](Self::sink)).
     #[inline]
-    #[allow(
-        clippy::mut_from_ref,
-        reason = "the sink is a separate heap allocation owned by this ctx, not a field of *self"
-    )]
-    fn sink_mut(&self) -> Option<&mut ResponseStreamJSSink<SSL_ENABLED>> {
-        // SAFETY: see fn doc — heap JSSink owned by this ctx, sole live
-        // mutable view, single-threaded.
-        self.sink.get().map(|p| unsafe { &mut *p.as_ptr() })
+    fn sink(&self) -> Option<&JsCell<ResponseStream<SSL_ENABLED>>> {
+        self.sink.get().as_deref()
     }
 
-    ///
+    /// The tracked `Response`, unless GC already finalized it.
     #[inline]
-    fn response_mut<'r>(&self) -> Option<&'r mut Response> {
-        let ptr = self
-            .response_weakref
-            .with_mut(|w| w.get().map(std::ptr::from_mut::<Response>));
-        // SAFETY: weak handle just reported the allocation live; the pointee
-        // is disjoint from `*self`.
-        ptr.map(|p| unsafe { &mut *p })
+    fn response(&self) -> Option<&Response> {
+        self.response_weakref.get().get_ref()
     }
 
     #[inline]
-    fn request_mut<'r>(&self) -> Option<&'r mut Request> {
-        let ptr = self
-            .request_weakref
-            .with_mut(|w| w.get().map(std::ptr::from_mut::<Request>));
-        // SAFETY: weak handle just reported the allocation live; the pointee
-        // is disjoint from `*self`.
-        ptr.map(|p| unsafe { &mut *p })
+    fn request(&self) -> Option<&Request> {
+        self.request_weakref.get().get_ref()
     }
 
     /// Take the pooled request-body slot out of `self`; the handle's `Drop`
@@ -648,6 +512,14 @@ where
     #[inline]
     fn request_body_take_unref(&self) {
         drop(self.request_body.replace(None));
+    }
+
+    /// The dispatching frame arms the request body it will feed through
+    /// `on_buffered_body_chunk`.
+    pub(crate) fn set_pending_request_body(&self, pending: Body::PendingValue) {
+        self.request_body_slot()
+            .expect("request_body attached at creation")
+            .set(Body::Value::Locked(pending));
     }
 
     pub(crate) fn set_signal_aborted(&self, reason: jsc::CommonAbortReason) {
@@ -683,14 +555,13 @@ where
         self.flags.set_has_abort_handler(true);
         if resp.is_closed() {
             // `req` is still set only while the dispatch is on the stack: snapshot as `to_async` would have.
-            if let (Some(req), Some(request)) = (self.req.get(), self.request_mut()) {
+            if let (Some(req), Some(request)) = (self.req.get(), self.request()) {
                 self.to_async_without_abort_handler(req, request);
             }
-            Self::on_abort(self.as_ctx_ptr(), resp);
+            Self::on_abort(self.this(), resp);
             return;
         }
-        // SAFETY: FFI handle valid while resp is Some
-        resp.on_aborted(|this, resp| Self::on_abort(this, resp), self.as_ctx_ptr());
+        resp.on_aborted_this(Self::on_abort, self.this());
     }
 
     pub(crate) fn set_cookies(&self, cookie_map: Option<*mut CookieMap>) {
@@ -706,19 +577,20 @@ where
         ctx_log!("onResolve");
 
         let arguments = callframe.arguments_as_array::<2>();
-        let Some(ctx) = NativePromiseContext::take::<Self>(arguments[1]) else {
+        let Some(claim) = native_promise_context::take::<Self>(arguments[1]) else {
             // A termination path (abort, end, upgrade) reclaimed the cell's
-            // claim; the context may already be gone.
+            // ref; the context may already be gone.
             Self::discard_response_body(global, arguments[0]);
             return Ok(JSValue::UNDEFINED);
         };
-        let ctx = RequestContextRef::adopt(ctx.as_ptr());
-        ctx.ctx().promise_cell.set(JSValue::ZERO);
+        let ctx = claim.this_ptr();
+        let _claim = claim;
+        ctx.promise_cell.set(JSValue::ZERO);
 
         let result = arguments[0];
         result.ensure_still_alive();
 
-        ctx.ctx().handle_resolve(global, result);
+        ctx.handle_resolve(global, result);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -808,7 +680,7 @@ where
         // The formatter and `write_trace` above re-enter JS (getters, proxy
         // traps, Error.prepareStackTrace), which can synchronously abort or
         // end this request (e.g. AbortController.abort() inside a getter).
-        // The `RequestContextRef` guard taken in `on_resolve` keeps the
+        // The ref the caller's frame holds (`on_resolve`'s claim) keeps the
         // allocation alive across the re-entry; re-check the request state so
         // we never render onto a response that was ended underneath us.
         if self.is_aborted_or_ended() {
@@ -832,9 +704,8 @@ where
             self.render_missing_invalid_response(value);
             return;
         };
-        // SAFETY: `response` is the live cell pointer; `value` is rooted by the
-        // caller's frame and protect()'d below.
-        if self.reject_unsendable_response(unsafe { (*response).status_code() }) {
+        // `value` is rooted by the caller's frame and protect()'d below.
+        if self.reject_unsendable_response(response.status_code()) {
             return;
         }
         // An async error() Response may replace a still-protected streaming
@@ -849,22 +720,17 @@ where
 
         if self.method == Method::HEAD {
             if let Some(resp) = self.resp.get() {
-                let mut pair = HeaderResponsePair {
-                    this: self,
-                    response,
-                };
-                resp.run_corked_with_type(Self::do_render_head_response, &raw mut pair);
+                resp.corked(|| self.do_render_head_response(response));
             }
             return;
         }
 
-        // SAFETY: `response` is the live, protect()'d cell pointer.
-        unsafe { self.render(response) };
+        self.render(response);
     }
 
     #[inline]
-    fn unpinned_ref_count(&self) -> u8 {
-        self.ref_count.get() - self.pin_count.get()
+    fn unpinned_ref_count(&self) -> u32 {
+        self.ref_count.get() - u32::from(self.pin_count.get())
     }
 
     pub(crate) fn should_render_missing(&self) -> bool {
@@ -931,8 +797,8 @@ where
             return false;
         }
         // check if the body is Locked (streaming)
-        if let Some(body) = self.request_body.get() {
-            if matches!(&**body, Body::Value::Locked(_)) {
+        if let Some(body) = self.request_body_slot() {
+            if matches!(body.get(), Body::Value::Locked(_)) {
                 return false;
             }
         }
@@ -940,8 +806,12 @@ where
         true
     }
 
-    /// destroy RequestContext, should be only called by deref or if defer_deinit_until_callback_completes is ref is set to true
-    pub(crate) fn deinit(&self) {
+    /// Everything the last ref's release does short of returning the slot,
+    /// which is the caller's to do with the server this returns. `None`: the
+    /// dispatching frame is still on the stack (`defer_deinit_until_callback_completes`)
+    /// and finishes the job through [`deinit`](Self::deinit) once its callback
+    /// returns, or the slot was already returned.
+    fn teardown(&self) -> Option<BackRef<ThisServer, bun_ptr::Mut>> {
         ctx_log!("deinit");
         self.detach_response();
         self.end_request_streaming_and_drain();
@@ -951,7 +821,7 @@ where
         if let Some(defer_deinit) = self.defer_deinit_until_callback_completes.get() {
             defer_deinit.set(true);
             ctx_log!("deferred deinit <d> ({:p})<r>", self);
-            return;
+            return None;
         }
 
         ctx_log!("deinit<d> ({:p})<r>", self);
@@ -961,15 +831,20 @@ where
         // whose reactions consume the sink (`handleResolveStream` / `handleRejectStream`),
         // so a client abort in that state reaches deinit with the sink still owned here.
         // This is the owner's last exit: release it exactly like the settle paths do.
-        if let Some(wrapper_ptr) = self.sink.take() {
-            // SAFETY: deinit runs once, after `detach_response()` removed the uWS callbacks;
-            // the context is the sink's sole owner (see the `sink` field's doc comment).
-            let wrapper = unsafe { &mut *wrapper_ptr.as_ptr() };
-            wrapper.sink.finalize();
-            if let Some(sink_global) = wrapper.sink.global_this {
-                ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut wrapper.sink.source, &sink_global);
+        if let Some(sink) = self.sink.replace(None) {
+            let sink_global = sink.with_mut(|sink| {
+                sink.finalize();
+                sink.global_this
+            });
+            if let Some(sink_global) = sink_global {
+                sink.with_mut(|sink| {
+                    ResponseStreamJSSink::<SSL_ENABLED>::detach(
+                        &mut sink.source,
+                        &sink_global,
+                    )
+                });
             }
-            Self::destroy_sink(wrapper_ptr);
+            ResponseStream::destroy(sink);
         }
 
         self.request_body_buf.set(Vec::new());
@@ -982,44 +857,54 @@ where
             cb.deref();
         }
 
-        if let Some(server) = self.server.take() {
-            server.release_request_context(self.as_ctx_ptr().cast::<c_void>(), MUX);
-            // SAFETY: `&mut` through the backref — the server outlives this
-            // context and no other borrow of it is live here.
-            unsafe { (*server.as_ptr()).on_request_complete() };
+        self.server.take()
+    }
+
+    fn release(this: NonNull<Self>, server: BackRef<ThisServer, bun_ptr::Mut>) {
+        server.release_request_context(this.as_ptr().cast::<c_void>(), MUX);
+        ThisServer::on_request_complete(server);
+    }
+
+    /// The dispatching frame's deferred teardown (its
+    /// `defer_deinit_until_callback_completes` flag came back set): the last
+    /// ref was released during the callback, so finish releasing the context.
+    pub(crate) fn deinit(this: ThisPtr<Self>) {
+        debug_assert_eq!(this.ref_count.get(), 0);
+        if let Some(server) = this.get().teardown() {
+            Self::release(this.into(), server);
         }
     }
 
-    pub fn deref(&self) {
-        let ref_count = self.ref_count.get();
-        stream_log!("deref {} -> {}", ref_count, ref_count - 1);
-        debug_assert!(ref_count > 0);
-        self.ref_count.set(ref_count - 1);
-        if ref_count == 1 {
-            self.finalize_without_deinit();
-            self.deinit();
-        }
+    /// `CellRefCounted` destructor: the last ref was released.
+    fn destroy(this: *mut Self) {
+        bun_ptr::destroy_with(
+            this,
+            |ctx| {
+                ctx.finalize_without_deinit();
+                ctx.teardown()
+            },
+            |ctx, server| {
+                if let Some(server) = server {
+                    Self::release(ctx, server);
+                }
+            },
+        );
     }
 
-    pub fn ref_(&self) {
-        let ref_count = self.ref_count.get();
-        stream_log!("ref {} -> {}", ref_count, ref_count + 1);
-        self.ref_count.set(ref_count + 1);
-    }
-
-    /// Takes one ref as the cell's claim on this context and remembers the
-    /// cell in `promise_cell`. The settle reactions (`take()` + a field
-    /// clear), `on_abort`, or the cell's destructor release the claim.
+    /// A new `NativePromiseContext` cell owning a ref on this context,
+    /// remembered in `promise_cell`. The settle reactions (`take()` + a field
+    /// clear), `on_abort` (`reclaim_promise_cell`), or the cell's destructor
+    /// release it.
     fn create_promise_cell(&self, global: &JSGlobalObject) -> JSValue {
         debug_assert!(self.promise_cell.get().is_empty());
-        self.ref_();
-        let cell = NativePromiseContext::create(global, self.as_ctx_ptr());
+        let cell =
+            native_promise_context::create(global, RefPtr::from_this(self.this()), JSValue::ZERO);
         self.promise_cell.set(cell);
         cell
     }
 
-    /// Called from the cell's destructor (GC sweep) when the claim was never
-    /// taken: the deref is deferred (or skipped at VM teardown), but the field
+    /// Called from the cell's destructor (GC sweep) when its ref was never
+    /// taken: the release is deferred (or skipped at VM teardown), but the field
     /// must stop pointing at the dying cell now. A plain field write, safe
     /// during sweep.
     pub(crate) fn promise_cell_collected(&self) {
@@ -1028,14 +913,16 @@ where
 
     /// Once the response is detached or ended, the promise this context
     /// subscribed to can no longer do anything for the request. Reclaim the
-    /// cell's claim so the context is torn down now instead of when GC
+    /// cell's ref so the context is torn down now instead of when GC
     /// collects the promise; the settle reactions then see a null `take()`
-    /// and no-op. A no-op when no claim is outstanding (the common case on
+    /// and no-op. A no-op when no cell is outstanding (the common case on
     /// paths reached from a settle reaction, which already cleared the field).
     pub(crate) fn reclaim_promise_cell(&self) {
         let cell = self.promise_cell.replace(JSValue::ZERO);
-        if !cell.is_empty() && NativePromiseContext::take::<Self>(cell).is_some() {
-            self.deref();
+        if !cell.is_empty()
+            && let Some(claim) = native_promise_context::take::<Self>(cell)
+        {
+            drop(claim);
         }
     }
 
@@ -1043,19 +930,20 @@ where
         ctx_log!("onReject");
 
         let arguments = callframe.arguments_as_array::<2>();
-        let Some(ctx) = NativePromiseContext::take::<Self>(arguments[1]) else {
+        let Some(claim) = native_promise_context::take::<Self>(arguments[1]) else {
             // A termination path (abort, end, upgrade) reclaimed the cell's
-            // claim; the context may already be gone.
+            // ref; the context may already be gone.
             return Ok(JSValue::UNDEFINED);
         };
-        let ctx = RequestContextRef::adopt(ctx.as_ptr());
-        ctx.ctx().promise_cell.set(JSValue::ZERO);
+        let ctx = claim.this_ptr();
+        let _claim = claim;
+        ctx.promise_cell.set(JSValue::ZERO);
 
         let err = arguments[0];
         // Pass the rejection reason through verbatim (including `null` and
         // `undefined`) so `error()` sees the same value the already-settled
         // path delivers. Only an empty JSValue is normalized.
-        ctx.ctx().handle_reject(if err.is_empty() {
+        ctx.handle_reject(if err.is_empty() {
             JSValue::UNDEFINED
         } else {
             err
@@ -1069,7 +957,6 @@ where
         }
 
         let resp = self.resp.get().expect("infallible: resp bound");
-        // SAFETY: FFI handle, just checked Some
         let has_responded = resp.has_responded();
 
         // The status line is already committed (a direct stream's pull() threw
@@ -1098,7 +985,7 @@ where
                 .set(original_state);
             // we try to deinit inside runErrorHandler so we just return here and let it deinit
             if should_deinit_context.get() {
-                self.deinit();
+                Self::deinit(self.this());
                 return;
             }
         }
@@ -1112,7 +999,6 @@ where
             return;
         }
 
-        // SAFETY: FFI handle
         if !resp.has_responded()
             && !self.flags.has_marked_pending()
             && !self.flags.is_error_promise_pending()
@@ -1124,14 +1010,12 @@ where
 
     pub(crate) fn render_missing(&self) {
         if let Some(resp) = self.resp.get() {
-            resp.run_corked_with_type(|ctx| Self::render_missing_corked(ctx), self.as_ctx_ptr());
+            resp.corked(|| self.render_missing_corked());
         }
     }
 
-    fn render_missing_corked(ctx: *mut Self) {
-        // SAFETY: `ctx` is the live `RequestContext` threaded through the
-        // synchronous cork call; only a shared view is formed.
-        let ctx = unsafe { &*ctx };
+    fn render_missing_corked(&self) {
+        let ctx = self;
         if let Some(resp) = ctx.resp.get() {
             if !DEBUG_MODE {
                 if !ctx.flags.has_written_status() {
@@ -1212,7 +1096,7 @@ where
             self.detach_response();
             self.end_request_streaming_and_drain();
             self.finalize_without_deinit();
-            self.deref();
+            self.release_in_flight();
             return;
         }
 
@@ -1220,17 +1104,8 @@ where
         self.response_buf_owned.set(bb);
 
         if let Some(resp) = self.resp.get() {
-            // SAFETY: FFI handle
-            resp.on_writable(
-                |this, off, resp| Self::on_writable_complete_response_buffer(this, off, resp),
-                self.as_ctx_ptr(),
-            );
+            resp.on_writable_this(Self::on_writable_complete_response_buffer, self.this());
         }
-    }
-
-    fn drain_response_buffer_and_metadata_corked(this: *mut Self) {
-        // SAFETY: this is the live RequestContext threaded through cork user-data.
-        unsafe { (*this).drain_response_buffer_and_metadata() };
     }
 
     /// Drain a partial response buffer
@@ -1239,7 +1114,6 @@ where
             self.render_metadata();
 
             let mut buffer = self.response_buf_owned.replace(Vec::new());
-            // SAFETY: FFI handle
             resp.write(&buffer);
             buffer.clear();
             self.response_buf_owned.set(buffer);
@@ -1253,13 +1127,12 @@ where
         if let Some(resp) = self.resp.get() {
             self.detach_response();
             self.reclaim_promise_cell();
-            // SAFETY: FFI handle
             resp.end(data, close_connection);
             // end_request_streaming_and_drain() must run after the last
             // `resp` access: its drain_microtasks() can re-enter lsquic (H3)
             // and free the stream out from under the local `resp` copy.
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
         }
     }
 
@@ -1278,7 +1151,7 @@ where
             // `resp` access: its drain_microtasks() can re-enter lsquic (H3)
             // and free the stream out from under the local `resp` copy.
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
         }
     }
 
@@ -1311,7 +1184,7 @@ where
             self.request_body_buf.set(Vec::new());
             self.reclaim_promise_cell();
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
         }
     }
 
@@ -1321,9 +1194,8 @@ where
             self.detach_response();
             // uWS markDone() clears onAborted on end, so on_abort can never
             // run for this request; this is the last chance to reclaim an
-            // outstanding claim (e.g. a 413 while the handler promise parks).
+            // outstanding cell (e.g. a 413 while the handler promise parks).
             self.reclaim_promise_cell();
-            // SAFETY: FFI handle
             resp.end_without_body(close_connection);
             // This end can run uncorked (e.g. render_production_error from a
             // rejection microtask), where no cork or parser gate runs the
@@ -1335,7 +1207,7 @@ where
             // `resp` access: its drain_microtasks() can re-enter lsquic (H3)
             // and free the stream out from under the local `resp` copy.
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
         }
     }
 
@@ -1343,13 +1215,12 @@ where
         if let Some(resp) = self.resp.get() {
             self.detach_response();
             self.reclaim_promise_cell();
-            // SAFETY: FFI handle
             resp.force_close();
             // end_request_streaming_and_drain() must run after the last
             // `resp` access: its drain_microtasks() can re-enter lsquic (H3)
             // and free the stream out from under the local `resp` copy.
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
         }
     }
 
@@ -1366,13 +1237,12 @@ where
     }
 
     fn on_writable_complete_response_buffer(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         write_offset: u64,
         resp: uws::AnyResponse,
     ) -> bool {
         ctx_log!("onWritableCompleteResponseBuffer");
-        let pinned = RequestContextRef::pin(this);
-        let this = pinned.ctx();
+        let _pin = Self::pin(this);
         debug_assert!(this.resp.get().is_some());
         if this.is_aborted_or_ended() {
             return false;
@@ -1380,92 +1250,73 @@ where
         this.send_writable_bytes_for_complete_response_buffer(write_offset, resp)
     }
 
-    #[inline]
-    fn any_request(r: *mut Req<SSL_ENABLED, MUX>) -> uws::AnyRequest {
-        if MUX {
-            uws::AnyRequest::H3(r.cast::<bun_uws_sys::h3::Request>())
-        } else {
-            uws::AnyRequest::H1(r.cast::<bun_uws_sys::Request>())
-        }
-    }
-
-    #[inline]
-    fn req_method(r: *mut Req<SSL_ENABLED, MUX>) -> &'static [u8] {
-        // SAFETY: r is a live uWS/lsquic request handle for the duration of
-        // the request callback; both surfaces return request-owned slices.
-        unsafe {
-            if MUX {
-                (*r.cast::<bun_uws_sys::h3::Request>()).method()
-            } else {
-                (*r.cast::<bun_uws_sys::Request>()).method()
-            }
-        }
-    }
-
+    /// Construct a context in `slot` (claimed from `server`'s pool for this
+    /// transport) and return it; its first ref is [`in_flight`](Self::in_flight).
     pub(crate) fn create(
-        this: &mut core::mem::MaybeUninit<Self>,
-        server: *mut ThisServer,
-        req: *mut Req<SSL_ENABLED, MUX>,
+        slot: bun_collections::hive_array::HiveSlot<'_, Self, REQUEST_CONTEXT_POOL_CAPACITY>,
+        server: BackRef<ThisServer, bun_ptr::Mut>,
+        req: uws::AnyRequest,
         resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<Method>,
-    ) {
+    ) -> ThisPtr<Self> {
+        debug_assert_eq!(matches!(req, uws::AnyRequest::H3(_)), MUX);
         let resolved_method = method
-            .or_else(|| Method::which(Self::req_method(req)))
+            .or_else(|| Method::which(req.method()))
             .unwrap_or(Method::GET);
-        let slot: *mut Self = this.as_mut_ptr();
-        // SAFETY: writing to MaybeUninit slot
-        unsafe {
-            slot.write(Self {
-                root: Cell::new(slot),
-                resp: Cell::new(Some(resp)),
-                req: Cell::new(Some(req)),
-                method: resolved_method,
-                server: Cell::new(
-                    NonNull::new(server).map(|p| bun_ptr::BackRef::from_raw_mut(p.as_ptr())),
-                ),
-                defer_deinit_until_callback_completes: Cell::new(should_deinit_context),
-                range: RangeRequest::raw_from_request(&Self::any_request(req)),
-                request_weakref: JsCell::new(request::WeakRef::EMPTY),
-                signal: Cell::new(None),
-                cookies: JsCell::new(None),
-                flags: Flags::<DEBUG_MODE>::default(),
-                upgrade_context: Cell::new(UpgradeState::None),
-                response_jsvalue: Cell::new(JSValue::ZERO),
-                ref_count: Cell::new(1),
-                pin_count: Cell::new(0),
-                response_weakref: JsCell::new(response::WeakRef::EMPTY),
-                blob: JsCell::new(AnyBlob::Blob(Blob::default())),
-                sendfile: Cell::new(SendfileContext::default()),
-                request_body_readable_stream_ref: JsCell::new(readable_stream::Strong::default()),
-                request_body: JsCell::new(None),
-                request_body_buf: JsCell::new(Vec::new()),
-                request_body_content_len: Cell::new(0),
-                request_body_streamed_len: Cell::new(0),
-                sink: Cell::new(None),
-                byte_stream: Cell::new(None),
-                response_body_readable_stream_ref: JsCell::new(readable_stream::Strong::default()),
-                pathname: JsCell::new(BunString::EMPTY),
-                response_buf_owned: JsCell::new(Vec::new()),
-                additional_on_abort: JsCell::new(None),
-                promise_cell: Cell::new(JSValue::ZERO),
-            });
-        }
+        let in_flight = slot.write_ref(Self {
+            root: Cell::new(None),
+            resp: Cell::new(Some(resp)),
+            req: Cell::new(Some(req)),
+            method: resolved_method,
+            server: Cell::new(Some(server)),
+            defer_deinit_until_callback_completes: Cell::new(should_deinit_context),
+            range: RangeRequest::raw_from_request(&req),
+            request_weakref: JsCell::new(request::WeakRef::EMPTY),
+            signal: Cell::new(None),
+            cookies: JsCell::new(None),
+            flags: Flags::<DEBUG_MODE>::default(),
+            upgrade_context: Cell::new(UpgradeState::None),
+            response_jsvalue: Cell::new(JSValue::ZERO),
+            ref_count: Cell::new(1),
+            pin_count: Cell::new(0),
+            in_flight: Cell::new(None),
+            body_value_ref: Cell::new(None),
+            byte_stream_ref: Cell::new(None),
+            s3_stat_ref: Cell::new(None),
+            response_weakref: JsCell::new(response::WeakRef::EMPTY),
+            blob: JsCell::new(AnyBlob::Blob(Blob::default())),
+            sendfile: Cell::new(SendfileContext::default()),
+            request_body_readable_stream_ref: JsCell::new(readable_stream::Strong::default()),
+            request_body: JsCell::new(None),
+            request_body_buf: JsCell::new(Vec::new()),
+            request_body_content_len: Cell::new(0),
+            request_body_streamed_len: Cell::new(0),
+            sink: JsCell::new(None),
+            byte_stream: Cell::new(None),
+            response_body_readable_stream_ref: JsCell::new(readable_stream::Strong::default()),
+            pathname: JsCell::new(BunString::EMPTY),
+            response_buf_owned: JsCell::new(Vec::new()),
+            additional_on_abort: JsCell::new(None),
+            promise_cell: Cell::new(JSValue::ZERO),
+        });
+        let this = in_flight.this_ptr();
+        this.root.set(Some(BackRef::from(this)));
+        this.in_flight.set(Some(in_flight));
 
         ctx_log!("create<d> ({:p})<r>", this.as_ptr());
+        this
     }
 
-    fn on_abort(this: *mut Self, resp: uws::AnyResponse) {
+    pub(crate) fn on_abort(this: ThisPtr<Self>, resp: uws::AnyResponse) {
         ctx_log!("onAbort");
-        let pinned = RequestContextRef::pin(this);
-        let this = pinned.ctx();
+        let _pin = Self::pin(this);
         debug_assert!(this.resp.get().is_some());
         // An HTTP/2 or HTTP/3 stream is destroyed once both sides finish,
         // so this also fires after a successful end(). HTTP/1 sockets persist
         // for keep-alive, so the equivalent never happens there. Drop the
         // pointer; everything else cleans up via the resolve/reject path.
         if MUX {
-            // SAFETY: FFI handle
             if resp.has_responded() {
                 this.resp.set(None);
                 this.flags.set_has_abort_handler(false);
@@ -1488,9 +1339,10 @@ where
         let vm = server.vm();
         let global_this = server.global_this();
         // Entered for the abort listeners below, and (dropped last) for the
-        // drains below and in the release of `_ref`.
+        // drains below and in the release of `_in_flight`.
         let _entered = vm.enter_event_loop_scope_without_checkpoint();
-        let _ref = RequestContextRef::adopt(this.as_ctx_ptr());
+        // The response is gone: its ref is this frame's to release.
+        let _in_flight = this.in_flight.take();
         // This is a task in the event loop.
         // If we called into JavaScript, we must drain the microtask queue.
         scopeguard::defer! {
@@ -1499,10 +1351,10 @@ where
             }
         }
 
-        if let Some(request) = this.request_mut() {
-            request.request_context = AnyRequestContext::NULL;
-            this.request_weakref.set(request::WeakRef::EMPTY);
+        if let Some(request) = this.request() {
+            request.request_context.set(AnyRequestContext::NULL);
         }
+        this.request_weakref.set(request::WeakRef::EMPTY);
         // if signal is not aborted, abort the signal
         if let Some(signal) = this.signal.take() {
             if !shim::signal_aborted(signal) {
@@ -1517,17 +1369,12 @@ where
         }
 
         // if have sink, call onAborted on sink
-        if let Some(sink_ptr) = this.sink.get() {
-            // The sink abort runs the stream's JS onClose through its signal.
+        if let Some(mut source) = this.sink().map(|sink| sink.with_mut(|sink| sink.abort())) {
+            // The close runs the stream's JS onClose through its signal, and
+            // the teardown that can re-enter frees the sink: no borrow of it
+            // is live here.
             any_js_calls.set(true);
-            // SAFETY: `sink_ptr` is the live JSSink allocated by do_render_stream
-            // (repr(transparent) over the sink). `abort` takes the raw pointer
-            // because the teardown it can re-enter frees the sink.
-            unsafe {
-                ResponseStream::<SSL_ENABLED>::abort(
-                    sink_ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED>>(),
-                );
-            }
+            source.close(None);
             // End request streaming here, not in deinit: a `Used` body
             // (textStream) can only be rejected through
             // request_body_readable_stream_ref, and finalize_without_deinit
@@ -1537,12 +1384,12 @@ where
             return;
         }
 
-        // A natively piped body has nobody left to take it. The deref balances the ref
+        // A natively piped body has nobody left to take it. Release the ref
         // `do_render_with_body` took for the pipe: `end_chunk`, which releases it otherwise,
         // cannot run once the response is gone.
         if let Some(stream) = this.byte_stream.take() {
             shim::byte_stream_unpipe(stream);
-            this.deref();
+            drop(this.byte_stream_ref.take());
         }
 
         // if we can, free the request now.
@@ -1554,7 +1401,7 @@ where
                 any_js_calls.set(true);
             }
 
-            if let Some(response) = this.response_mut() {
+            if let Some(response) = this.response() {
                 if let Some(stream) = shim::response_body_stream(response) {
                     let _keep = jsc::EnsureStillAlive(stream.value);
                     shim::response_detach_stream(response, global_this);
@@ -1564,7 +1411,7 @@ where
             }
         }
 
-        // Reclaim only after the block above: the claim's ref must still
+        // Reclaim only after the block above: the cell's ref must still
         // count in `is_dead_request`, so a parked request-body read goes
         // through `end_request_streaming` and rejects instead of being
         // silently dropped by `finalize_without_deinit`.
@@ -1591,7 +1438,7 @@ where
         // A stream pump that settles after this point finds no context
         // (`reclaim_promise_cell`), so its `handle_*_stream` cleanup never
         // runs: release the body's hold on the stream here.
-        if let Some(resp) = self.response_mut() {
+        if let Some(resp) = self.response() {
             release_body_stream(resp, global_this);
         }
 
@@ -1613,10 +1460,10 @@ where
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
         drop(self.cookies.replace(None));
 
-        if let Some(request) = self.request_mut() {
-            request.request_context = AnyRequestContext::NULL;
-            self.request_weakref.set(request::WeakRef::EMPTY);
+        if let Some(request) = self.request() {
+            request.request_context.set(AnyRequestContext::NULL);
         }
+        self.request_weakref.set(request::WeakRef::EMPTY);
 
         // if signal is not aborted, abort the signal
         if let Some(signal) = self.signal.take() {
@@ -1651,23 +1498,20 @@ where
         self.pathname.set(BunString::EMPTY);
     }
 
-    fn on_file_stream_complete(ctx: *mut c_void, _resp: uws::AnyResponse) {
-        let pinned = RequestContextRef::pin(ctx.cast::<Self>());
-        let this = pinned.ctx();
+    /// `FileResponseStream` finished, or failed with `err` after force-closing
+    /// the socket, which needs the same cleanup.
+    pub(crate) fn on_file_stream_complete(
+        this: ThisPtr<Self>,
+        _resp: uws::AnyResponse,
+        err: Option<bun_sys::Error>,
+    ) {
+        if let Some(err) = err {
+            ctx_log!("file stream error: {:?}", err);
+        }
+        let _pin = Self::pin(this);
         this.detach_response();
         this.end_request_streaming_and_drain();
-        this.deref();
-    }
-
-    fn on_file_stream_abort(ctx: *mut c_void, resp: uws::AnyResponse) {
-        // Route through the real onAbort so flags.aborted, request.signal,
-        // and additional_on_abort fire exactly as they did pre-consolidation.
-        Self::on_abort(ctx.cast::<Self>(), resp);
-    }
-
-    fn on_file_stream_error(ctx: *mut c_void, resp: uws::AnyResponse, _err: bun_sys::Error) {
-        // FileResponseStream already force-closed the socket; just clean up.
-        Self::on_file_stream_complete(ctx, resp);
+        this.release_in_flight();
     }
 
     /// Forward uWS's drain notification to the streaming response sink so it
@@ -1679,33 +1523,28 @@ where
     /// invokes the handler once its own send buffer has fully drained, so an
     /// always-armed registration costs nothing on the no-backpressure path.
     fn on_writable_response_stream(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         write_offset: u64,
         _resp: uws::AnyResponse,
     ) -> bool {
         ctx_log!("onWritableResponseStream({})", write_offset);
-        let pinned = RequestContextRef::pin(this);
-        let this = pinned.ctx();
-        if let Some(wrapper) = this.sink_mut() {
-            return wrapper.sink.on_writable(write_offset, _resp);
+        let _pin = Self::pin(this);
+        if let Some(sink) = this.sink() {
+            return sink.with_mut(|sink| sink.on_writable(write_offset, _resp));
         }
         true
     }
 
-    fn on_writable_bytes(this: *mut Self, write_offset: u64, resp: uws::AnyResponse) -> bool {
+    fn on_writable_bytes(this: ThisPtr<Self>, write_offset: u64, resp: uws::AnyResponse) -> bool {
         ctx_log!("onWritableBytes");
-        let pinned = RequestContextRef::pin(this);
-        let this = pinned.ctx();
+        let _pin = Self::pin(this);
         debug_assert!(this.resp.get().is_some());
         if this.is_aborted_or_ended() {
             return false;
         }
 
-        // SAFETY: `this.blob`'s backing bytes are owned by the (pinned)
-        // context and outlive `send_writable_bytes_for_blob`; the cell borrow
-        // ends here.
-        let bytes: &[u8] = unsafe { bun_ptr::detach_lifetime(this.blob.get().slice()) };
-
+        let this = this.get();
+        let bytes = this.blob.get().slice();
         let _ = this.send_writable_bytes_for_blob(bytes, write_offset, resp);
         true
     }
@@ -1720,19 +1559,14 @@ where
         let write_offset: usize = write_offset_ as usize;
 
         let bytes = &bytes_[bytes_.len().min(write_offset)..];
-        // SAFETY: FFI handle
         if resp.try_end(bytes, bytes_.len(), self.should_close_connection()) {
             self.detach_response();
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
             true
         } else {
             self.flags.set_has_marked_pending(true);
-            // SAFETY: FFI handle
-            resp.on_writable(
-                |this, off, resp| Self::on_writable_bytes(this, off, resp),
-                self.as_ctx_ptr(),
-            );
+            resp.on_writable_this(Self::on_writable_bytes, self.this());
             true
         }
     }
@@ -1749,21 +1583,16 @@ where
         let buffer = self.response_buf_owned.replace(Vec::new());
         let total_len = buffer.len();
         let bytes = &buffer[total_len.min(write_offset)..];
-        // SAFETY: FFI handle
         let done = resp.try_end(bytes, total_len, close_connection);
         if done {
             drop(buffer);
             self.detach_response();
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
         } else {
             self.response_buf_owned.set(buffer);
             self.flags.set_has_marked_pending(true);
-            // SAFETY: FFI handle
-            resp.on_writable(
-                |this, off, resp| Self::on_writable_complete_response_buffer(this, off, resp),
-                self.as_ctx_ptr(),
-            );
+            resp.on_writable_this(Self::on_writable_complete_response_buffer, self.this());
         }
 
         true
@@ -1905,7 +1734,7 @@ where
         // `.slice(0, n)` blob has `n < stat_size`. Skip if the user
         // already set Content-Range or a non-200 status — they're
         // managing partial responses themselves.
-        let user_handles_range = if let Some(r) = self.response_mut() {
+        let user_handles_range = if let Some(r) = self.response() {
             r.status_code() != 200
                 || r.get_init_headers_mut()
                     .map(|h| h.fast_has(jsc::HTTPHeaderName::ContentRange))
@@ -1939,7 +1768,7 @@ where
                     }
                     let mut crbuf = [0u8; RangeRequest::CONTENT_RANGE_BUF];
                     self.do_write_status(416);
-                    if let Some(response) = self.response_mut() {
+                    if let Some(response) = self.response() {
                         if let Some(mut headers_) = response.swap_init_headers() {
                             self.do_write_headers(&mut headers_);
                             // `HeadersRef` releases the +1 ref in Drop; do NOT
@@ -1958,26 +1787,24 @@ where
                     self.detach_response();
                     resp.end(b"", close);
                     self.end_request_streaming_and_drain();
-                    self.deref();
+                    self.release_in_flight();
                     return;
                 }
             }
         }
 
-        resp.run_corked_with_type(Self::render_metadata_corked, self.as_ctx_ptr());
+        resp.corked(|| self.render_metadata());
 
         let sendfile = self.sendfile.get();
         if (is_regular && sendfile.remain == 0) || !self.method.has_body() {
             if auto_close {
                 fd.close();
             }
-            // SAFETY: FFI handle
             let close = resp.should_close_connection();
             self.detach_response();
-            // SAFETY: FFI handle
             resp.end(b"", close);
             self.end_request_streaming_and_drain();
-            self.deref();
+            self.release_in_flight();
             return;
         }
 
@@ -2009,21 +1836,17 @@ where
                 None
             },
             idle_timeout: server.config().idle_timeout,
-            owner: file_response_stream::StreamOwner::Ctx {
-                ctx: self.as_ctx_ptr().cast::<c_void>(),
-                on_complete: Self::on_file_stream_complete,
-                on_abort: Some(Self::on_file_stream_abort),
-                on_error: Self::on_file_stream_error,
-            },
+            owner: file_response_stream::StreamOwner::RequestContext(AnyRequestContext::init(
+                self.this(),
+            )),
         });
     }
 
-    fn do_render_with_body_locked(this: NonNull<c_void>, value: &mut Body::Value) {
-        // Consumes the +1 taken at the `on_receive_value` registration site.
-        let pinned = RequestContextRef::adopt(this.cast::<Self>().as_ptr());
-        pinned
-            .ctx()
-            .do_render_with_body(std::ptr::from_mut(value), None);
+    /// `Body::ReceiveValue::Server`: the pending response body resolved.
+    /// Releases the ref the registration in `do_render_with_body` took.
+    pub(crate) fn render_pending_body_value(this: ThisPtr<Self>, value: &mut Body::Value) {
+        let _registration = this.body_value_ref.take();
+        this.do_render_with_body(value, None);
     }
 
     fn render_with_blob_from_body_value(&self) {
@@ -2045,34 +1868,32 @@ where
         self.do_render_blob();
     }
 
-    fn handle_first_stream_write(&self) {
+    /// The response sink's first write (`HTTPServerWritable::first_write_ctx`).
+    pub(crate) fn handle_first_stream_write(&self) {
         if !self.flags.has_written_status() {
             self.render_metadata();
         }
     }
 
-    /// C-ABI thunk for `HTTPServerWritable::on_first_write` (`fn(?*anyopaque)`).
-    fn handle_first_stream_write_thunk(ctx: Option<*mut c_void>) {
-        let Some(ctx) = ctx else { return };
-        // SAFETY: ctx is the `*mut Self` stashed in `sink.ctx` by
-        // do_render_stream; the sink (and so this context) is live for the
-        // synchronous write that fires this.
-        Self::handle_first_stream_write(unsafe { &*ctx.cast::<Self>() });
-    }
-
-    /// Tear down a heap `ResponseStreamJSSink` allocated by `do_render_stream`.
-    /// JSSink<T> is `repr(transparent)` so the inner-ptr free matches the
-    /// outer allocation.
-    fn destroy_sink(ptr: NonNull<ResponseStreamJSSink<SSL_ENABLED>>) {
-        // `ptr` was `heap::alloc`'d in do_render_stream and is being consumed
-        // exactly once here. `JSSink<T>` is repr(transparent), so the inner
-        // `HTTPServerWritable` shares the allocation Layout.
-        ResponseStream::<SSL_ENABLED>::destroy(ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED>>());
+    /// Detach the JS controller from the sink and free it. `finish` runs on
+    /// the sink in between (the settle paths finalize it there).
+    fn destroy_sink(
+        &self,
+        global_this: &JSGlobalObject,
+        finish: impl FnOnce(&mut ResponseStream<SSL_ENABLED>),
+    ) {
+        if let Some(sink) = self.sink.replace(None) {
+            sink.with_mut(|sink| {
+                ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut sink.source, global_this);
+                finish(sink);
+            });
+            ResponseStream::destroy(sink);
+        }
     }
 
     /// `on_abort` ran from inside the user code `do_render_stream` invoked
     /// (`server.stop(true)` in `pull()`): it aborted the sink, detached `resp`
-    /// and took over the base ref, leaving only the sink and stream to drop.
+    /// and took over the in-flight ref, leaving only the sink and stream to drop.
     /// Keyed on `resp` being gone, not on `is_aborted_or_ended()`: a stop that
     /// found the response already complete never reaches `on_abort`, and that
     /// request still owns its ref, which the regular arms release.
@@ -2085,26 +1906,26 @@ where
         let mut readable_ref = self
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
-        if let Some(wrapper_ptr) = self.sink.take() {
-            // SAFETY: this context is the sink's sole owner until `destroy_sink`
-            // below (see the `sink` field); `on_abort` leaves it allocated.
-            let wrapper = unsafe { &mut *wrapper_ptr.as_ptr() };
-            ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut wrapper.sink.source, global_this);
+        if let Some(sink) = self.sink.replace(None) {
+            sink.with_mut(|sink| {
+                ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut sink.source, global_this)
+            });
             crate::dispatch::fold(stream.cancel(global_this));
-            wrapper.sink.mark_done();
-            wrapper.sink.on_first_write = None;
-            wrapper.sink.finalize();
-            Self::destroy_sink(wrapper_ptr);
+            sink.with_mut(|sink| {
+                sink.mark_done();
+                sink.first_write_ctx = None;
+                sink.finalize();
+            });
+            ResponseStream::destroy(sink);
         }
         readable_ref.deinit();
     }
 
-    fn do_render_stream(pair: *mut StreamPair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>) {
+    /// Runs corked.
+    fn do_render_stream(&self, mut stream: WebCore::ReadableStream) {
         ctx_log!("doRenderStream");
-        // SAFETY: pair is a stack local threaded through cork user-data.
-        let pair = unsafe { &mut *pair };
-        let this: &Self = pair.this;
-        let stream = &mut pair.stream;
+        let this = self;
+        let stream = &mut stream;
         debug_assert!(this.server.get().is_some());
         let global_this = this.server().global_this();
 
@@ -2121,20 +1942,16 @@ where
 
         stream.value.ensure_still_alive();
 
-        let response_stream_box = Box::new(ResponseStreamJSSink::<SSL_ENABLED> {
-            sink: ResponseStream::<SSL_ENABLED> {
-                res: Some(resp),
-                buffer: Vec::<u8>::default(),
-                on_first_write: Some(Self::handle_first_stream_write_thunk),
-                ctx: Some(this.as_ctx_ptr().cast::<c_void>()),
-                global_this: Some(bun_ptr::BackRef::new(global_this)),
-                ..Default::default()
-            },
-        });
-        let response_stream_ptr = bun_core::heap::into_raw_nn(response_stream_box);
-        this.sink.set(Some(response_stream_ptr));
-        // SAFETY: just allocated; sole live mutable view (this.sink only stores the ptr).
-        let response_stream = unsafe { &mut *response_stream_ptr.as_ptr() };
+        this.sink.set(Some(Box::new(JsCell::new(ResponseStream::<SSL_ENABLED> {
+            res: Some(resp),
+            buffer: Vec::<u8>::default(),
+            first_write_ctx: Some(AnyRequestContext::init(this.this())),
+            global_this: Some(BackRef::new(global_this)),
+            ..Default::default()
+        }))));
+        // Re-fetched after every call that runs user code: `on_abort` may run
+        // in there, but it leaves the sink to `discard_stream_after_abort`.
+        let sink = || this.sink().expect("sink set above");
 
         // we need to render metadata before assignToStream because the stream can call res.end
         // and this would auto write an 200 status
@@ -2142,24 +1959,22 @@ where
             this.render_metadata();
         }
 
-        resp.on_writable(
-            |this, off, resp| Self::on_writable_response_stream(this, off, resp),
-            this.as_ctx_ptr(),
-        );
+        resp.on_writable_this(Self::on_writable_response_stream, this.this());
 
         // We are already corked!
-        let assignment_result: JSValue = ResponseStreamJSSink::<SSL_ENABLED>::assign_to_stream(
-            global_this,
-            stream.value,
-            NonNull::from(&mut response_stream.sink),
-        );
+        let assignment_result: JSValue =
+            ResponseStreamJSSink::<SSL_ENABLED>::assign_to_stream(
+                global_this,
+                stream.value,
+                NonNull::new(sink().as_ptr()).expect("JsCell::as_ptr is non-null"),
+            );
 
         assignment_result.ensure_still_alive();
 
         // assignToStream stored the controller in `sink.source`; a sync-finished stream's
         // `__controllerDetached` may already have cleared it again (handled below).
 
-        let aborted = this.flags.aborted() || response_stream.sink.is_aborted();
+        let aborted = this.flags.aborted() || sink().get().is_aborted();
         this.flags.set_aborted(aborted);
 
         if this.resp.get().is_none() {
@@ -2174,23 +1989,13 @@ where
 
         if let Some(err_value) = assignment_result.to_error() {
             stream_log!("returned an error");
-            ResponseStreamJSSink::<SSL_ENABLED>::detach(
-                &mut response_stream.sink.source,
-                global_this,
-            );
-            this.sink.set(None);
-            Self::destroy_sink(response_stream_ptr);
+            this.destroy_sink(global_this, |_| {});
             return this.handle_reject(err_value);
         }
 
         if resp.has_responded() {
             stream_log!("done");
-            ResponseStreamJSSink::<SSL_ENABLED>::detach(
-                &mut response_stream.sink.source,
-                global_this,
-            );
-            this.sink.set(None);
-            Self::destroy_sink(response_stream_ptr);
+            this.destroy_sink(global_this, |_| {});
             stream.done();
             this.response_body_readable_stream_ref
                 .with_mut(|s| s.deinit());
@@ -2207,7 +2012,7 @@ where
         // above resolves it) instead of falling through to the cancel path.
         let mut effective_result = assignment_result;
         if effective_result.is_empty_or_undefined_or_null() {
-            if let Some(flush) = response_stream.sink.pending_flush {
+            if let Some(flush) = sink().get().pending_flush {
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 effective_result = jsc::JSPromise::opaque_ref(flush).to_js();
             }
@@ -2240,13 +2045,12 @@ where
                         // from under the sink while the stream is in flight.
                         this.flags.set_has_marked_pending(true);
                         if !this.flags.has_written_status() {
-                            response_stream.sink.on_first_write = None;
-                            response_stream.sink.ctx = None;
+                            sink().with_mut(|s| s.first_write_ctx = None);
                             this.render_metadata();
                         }
 
                         // TODO: should this timeout?
-                        let body_value = this.response_mut().unwrap().get_body_value();
+                        let body_value = this.response().unwrap().get_body_value();
                         *body_value = Body::Value::Locked(Body::PendingValue {
                             readable: readable_stream::Strong::init(*stream, global_this),
                             global: std::ptr::from_ref(global_this),
@@ -2295,12 +2099,7 @@ where
             } else {
                 // if is not a promise we treat it as Error
                 stream_log!("returned an error");
-                ResponseStreamJSSink::<SSL_ENABLED>::detach(
-                    &mut response_stream.sink.source,
-                    global_this,
-                );
-                this.sink.set(None);
-                Self::destroy_sink(response_stream_ptr);
+                this.destroy_sink(global_this, |_| {});
                 return this.handle_reject(effective_result);
             }
         }
@@ -2309,24 +2108,21 @@ where
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
 
-        let is_in_progress = response_stream.sink.has_backpressure
-            || !(response_stream.sink.wrote == 0 && response_stream.sink.buffer.len() == 0);
+        let is_in_progress = {
+            let s = sink().get();
+            s.has_backpressure || !(s.wrote == 0 && s.buffer.len() == 0)
+        };
 
         if !stream.is_locked(global_this) && !is_in_progress {
             if let Some(comparator) = WebCore::ReadableStream::from_js_direct(stream.value) {
                 if core::mem::discriminant(&comparator.ptr) == core::mem::discriminant(&stream.ptr)
                 {
                     stream_log!("is not locked");
-                    response_stream.sink.on_first_write = None;
-                    response_stream.sink.ctx = None;
-                    ResponseStreamJSSink::<SSL_ENABLED>::detach(
-                        &mut response_stream.sink.source,
-                        global_this,
-                    );
-                    response_stream.sink.mark_done();
-                    response_stream.sink.finalize();
-                    this.sink.set(None);
-                    Self::destroy_sink(response_stream_ptr);
+                    sink().with_mut(|s| s.first_write_ctx = None);
+                    this.destroy_sink(global_this, |s| {
+                        s.mark_done();
+                        s.finalize();
+                    });
                     readable_ref.deinit();
                     this.render_missing();
                     return;
@@ -2335,14 +2131,18 @@ where
         }
 
         stream_log!("is in progress, but did not return a Promise. Finalizing request context");
-        response_stream.sink.on_first_write = None;
-        response_stream.sink.ctx = None;
-        ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut response_stream.sink.source, global_this);
-        crate::dispatch::fold(stream.cancel(global_this));
-        response_stream.sink.mark_done();
-        response_stream.sink.finalize();
-        this.sink.set(None);
-        Self::destroy_sink(response_stream_ptr);
+        sink().with_mut(|s| s.first_write_ctx = None);
+        if let Some(owned) = this.sink.replace(None) {
+            owned.with_mut(|s| {
+                ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut s.source, global_this)
+            });
+            crate::dispatch::fold(stream.cancel(global_this));
+            owned.with_mut(|s| {
+                s.mark_done();
+                s.finalize();
+            });
+            ResponseStream::destroy(owned);
+        }
         readable_ref.deinit();
         this.render_missing();
     }
@@ -2351,22 +2151,14 @@ where
         matches!(self.upgrade_context.get(), UpgradeState::Upgraded)
     }
 
-    fn to_async_without_abort_handler(
-        &self,
-        req: *mut Req<SSL_ENABLED, MUX>,
-        request_object: &mut Request,
-    ) {
+    fn to_async_without_abort_handler(&self, req: uws::AnyRequest, request_object: &Request) {
         debug_assert!(self.server.get().is_some());
 
         // For HTTP/3, prepareJsRequestContextFor() already eagerly
         // populated url+headers (the lazy getRequest() path is H1-only),
         // so the guards below short-circuit and `req` is never read.
-        if !MUX {
-            // `Req<SSL,H3>` is erased to `c_void`; for !MUX the concrete
-            // type is `uws::Request`, so the cast is nominal.
-            request_object
-                .request_context
-                .set_request(req.cast::<uws::Request>());
+        if let uws::AnyRequest::H1(req) = req {
+            request_object.request_context.get().set_request(req);
         }
 
         if request_object.ensure_url().is_err() {
@@ -2375,18 +2167,20 @@ where
 
         // we have to clone the request headers here since they will soon belong to a different request
         if !request_object.has_fetch_headers() {
-            if !MUX {
+            if let uws::AnyRequest::H1(req) = req {
                 // `HeadersRef::create_from_uws` adopts the freshly-allocated +1 ref.
-                request_object.set_fetch_headers(Some(response::HeadersRef::create_from_uws(req)));
+                request_object.set_fetch_headers(Some(response::HeadersRef::create_from_uws(
+                    req.cast::<c_void>(),
+                )));
             }
         }
 
         // This object dies after the stack frame is popped
         // so we have to clear it in here too
-        request_object.request_context.detach_request();
+        request_object.request_context.get().detach_request();
     }
 
-    pub(crate) fn to_async(&self, req: *mut Req<SSL_ENABLED, MUX>, request_object: &mut Request) {
+    pub(crate) fn to_async(&self, req: uws::AnyRequest, request_object: &Request) {
         ctx_log!("toAsync");
         self.to_async_without_abort_handler(req, request_object);
         if DEBUG_MODE {
@@ -2411,17 +2205,19 @@ where
 
         // if we cannot, we have to reject pending promises
         // first, we reject the request body promise
-        if let Some(body) = self.request_body_mut() {
+        if let Some(body) = self.request_body_slot()
+            && matches!(body.get(), Body::Value::Locked(_))
+        {
             // User called .blob(), .json(), text(), or .arrayBuffer() on the Request object
             // but we received nothing or the connection was aborted
-            if matches!(body, Body::Value::Locked(_)) {
-                let global_this = self.server().global_this();
+            let global_this = self.server().global_this();
+            body.with_mut(|body| {
                 body.to_error_instance(
                     Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed),
                     global_this,
-                )?;
-                return Ok(true);
-            }
+                )
+            })?;
+            return Ok(true);
         }
 
         // `req.textStream()` transitions the body to `Value::Used`, so the
@@ -2476,56 +2272,40 @@ where
             || self.server().terminated()
     }
 
-    fn do_render_head_response_after_s3_size_resolved(
-        pair: *mut HeaderResponseSizePair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>,
-    ) {
-        // SAFETY: `pair` is the live stack-local threaded through the
-        // synchronous cork call.
-        let pair = unsafe { &*pair };
-        let this = pair.this;
+    /// Runs corked.
+    fn do_render_head_response_after_s3_size_resolved(&self, size: usize) {
+        let this = self;
         this.render_metadata();
 
         if let Some(resp) = this.resp.get() {
-            // SAFETY: FFI handle
-            resp.write_header_int(b"content-length", pair.size as u64);
+            resp.write_header_int(b"content-length", size as u64);
         }
         this.end_without_body(this.should_close_connection());
-        // `end_without_body` released the base ref; the caller
+        // `end_without_body` released the in-flight ref; the caller
         // (`on_s3_size_resolved`) releases the ref taken for the S3 stat.
     }
 
-    /// `S3::client::stat` callback shape: `fn(S3StatResult, *mut c_void) -> JsResult<()>`.
-    fn on_s3_size_resolved_thunk(
+    /// `S3::client::stat` for a HEAD response with an S3 body completed.
+    /// Releases [`s3_stat_ref`](Self::s3_stat_ref).
+    pub(crate) fn on_s3_size_resolved(
+        this: ThisPtr<Self>,
         result: S3::simple_request::S3StatResult<'_>,
-        this: *mut c_void,
-    ) -> JsResult<()> {
-        let stat_ref = RequestContextRef::adopt(this.cast::<Self>());
-        stat_ref.ctx().on_s3_size_resolved(result);
-        Ok(())
-    }
-
-    pub(crate) fn on_s3_size_resolved(&self, result: S3::simple_request::S3StatResult<'_>) {
-        if let Some(resp) = self.resp.get() {
+    ) {
+        let _stat_ref = this.s3_stat_ref.take();
+        if let Some(resp) = this.resp.get() {
             let size = match result {
                 S3::simple_request::S3StatResult::Failure(_)
                 | S3::simple_request::S3StatResult::NotFound(_) => 0,
                 S3::simple_request::S3StatResult::Success(stat) => stat.size,
             };
-            let mut pair = HeaderResponseSizePair { this: self, size };
-            resp.run_corked_with_type(
-                |p| Self::do_render_head_response_after_s3_size_resolved(p),
-                &raw mut pair,
-            );
+            resp.corked(|| this.do_render_head_response_after_s3_size_resolved(size));
         }
     }
 
-    fn do_render_head_response(
-        pair: *mut HeaderResponsePair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, MUX>,
-    ) {
-        // SAFETY: pair is a stack local threaded through the synchronous cork call.
-        let pair = unsafe { &*pair };
-        let this = pair.this;
-        let response_ptr = pair.response;
+    /// Runs corked. `response` is the payload of the JS wrapper the calling
+    /// frame keeps GC-rooted.
+    fn do_render_head_response(&self, response: ThisPtr<Response>) {
+        let this = self;
         if this.resp.get().is_none() {
             return;
         }
@@ -2534,24 +2314,20 @@ where
         // Always this.renderMetadata() before sending the content-length or transfer-encoding header so status is sent first
 
         let resp = this.resp.get().expect("infallible: resp bound");
-        // SAFETY: `response_ptr` is the live, GC-rooted cell pointer the
-        // constructing frame put in the pair; it carries the cell's provenance.
-        unsafe { this.set_response(response_ptr) };
-        // SAFETY: sole `&mut Response` for this cell in this frame.
-        let response = unsafe { &mut *response_ptr };
+        this.set_response(response);
+        let response = response.get();
 
         // `render` drops the body for a null-body status on GET, so HEAD must
         // not derive framing from that body (or the user headers) either
         // (RFC 9110 §9.3.2): render the exact metadata+framing GET would.
         if HTTPStatusText::is_null_body(response.status_code()) {
-            Self::do_render_null_body_status_corked(this.as_ctx_ptr());
+            this.do_render_null_body_status_corked();
             return;
         }
 
         let Some(server) = this.server.get() else {
             // server detached?
             this.render_metadata();
-            // SAFETY: FFI handle
             resp.write_header_int(b"content-length", 0);
             this.end_without_body(this.should_close_connection());
             return;
@@ -2598,7 +2374,6 @@ where
                     drop(content_length_str);
 
                     this.render_metadata();
-                    // SAFETY: FFI handle
                     resp.write_header_int(b"content-length", len as u64);
                     this.end_without_body(this.should_close_connection());
                     return;
@@ -2627,9 +2402,11 @@ where
                 if shim::blob_is_s3(blob) {
                     // we need to read the size asynchronously
                     // in this case should always be a redirect so should not hit this path, but in case we change it in the future lets handle it
-                    // Ref for the S3 stat; adopted and released by
-                    // `on_s3_size_resolved_thunk`.
-                    this.ref_();
+                    // Ref for the S3 stat; released by `on_s3_size_resolved`.
+                    let prev = this
+                        .s3_stat_ref
+                        .replace(Some(RefPtr::from_this(this.this())));
+                    debug_assert!(prev.is_none());
 
                     let crate::webcore::blob::store::Data::S3(s3) =
                         &blob.store.get().as_ref().unwrap().data
@@ -2648,11 +2425,10 @@ where
                         .get_http_proxy(true, None, None)
                         .map(|proxy| proxy.href);
 
-                    let _ = S3::client::stat(
+                    let _ = S3::client::stat_for_request_context(
                         credentials,
                         path,
-                        Self::on_s3_size_resolved_thunk,
-                        this.as_ctx_ptr().cast::<c_void>(),
+                        AnyRequestContext::init(this.this()),
                         proxy_url,
                         s3.request_payer,
                     ); // TODO: properly propagate exception upwards
@@ -2676,18 +2452,14 @@ where
             Body::Value::Locked(_) => {
                 this.render_metadata();
                 if !MUX {
-                    // SAFETY: FFI handle
                     resp.write_header(b"transfer-encoding", b"chunked");
                 }
                 // HEAD never transmits the body.
-                if let Some(response) = this.response_mut() {
-                    Self::cancel_unread_body(response, global_this);
-                }
+                Self::cancel_unread_body(&response, global_this);
                 this.end_without_body(this.should_close_connection());
             }
             Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_) => {
                 this.render_metadata();
-                // SAFETY: FFI handle
                 resp.write_header_int(b"content-length", 0);
                 this.end_without_body(this.should_close_connection());
             }
@@ -2760,8 +2532,7 @@ where
         // `response_value` is rooted via ensure_still_alive() / protect() below
         // for as long as `response` is used.
         if let Some(response) = as_response(response_value) {
-            // SAFETY: `response` is the live, rooted cell pointer.
-            if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
+            if ctx.reject_unsendable_response(response.status_code()) {
                 return;
             }
             ctx.response_jsvalue.set(response_value);
@@ -2769,16 +2540,11 @@ where
             ctx.flags.set_response_protected(false);
             if ctx.method == Method::HEAD {
                 if let Some(resp) = ctx.resp.get() {
-                    let mut pair = HeaderResponsePair {
-                        this: ctx,
-                        response,
-                    };
-                    resp.run_corked_with_type(Self::do_render_head_response, &raw mut pair);
+                    resp.corked(|| ctx.do_render_head_response(response));
                 }
                 return;
             } else {
-                // SAFETY: `response` is the live, rooted cell pointer.
-                unsafe { ctx.protect_for_body_and_render(response_value, response) };
+                ctx.protect_for_body_and_render(response_value, response);
             }
             return;
         }
@@ -2818,8 +2584,7 @@ where
                         return;
                     };
 
-                    // SAFETY: `response` is the live, rooted cell pointer.
-                    if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
+                    if ctx.reject_unsendable_response(response.status_code()) {
                         return;
                     }
 
@@ -2828,16 +2593,11 @@ where
                     ctx.flags.set_response_protected(false);
                     if ctx.method == Method::HEAD {
                         if let Some(resp) = ctx.resp.get() {
-                            let mut pair = HeaderResponsePair {
-                                this: ctx,
-                                response,
-                            };
-                            resp.run_corked_with_type(Self::do_render_head_response, &raw mut pair);
+                            resp.corked(|| ctx.do_render_head_response(response));
                         }
                         return;
                     }
-                    // SAFETY: `response` is the live, rooted cell pointer.
-                    unsafe { ctx.protect_for_body_and_render(fulfilled_value, response) };
+                    ctx.protect_for_body_and_render(fulfilled_value, response);
                     return;
                 }
                 jsc::PromiseResult::Rejected(err) => {
@@ -2863,14 +2623,14 @@ where
         // the flush to settle and re-enter. On abort, flushPromise() has
         // already settled pending_flush, so this never waits on a dead
         // socket.
-        if let Some(wrapper) = self.sink_mut() {
-            if !self.flags.aborted() && !wrapper.sink.is_aborted() {
+        if let Some(sink) = self.sink().map(JsCell::get) {
+            if !self.flags.aborted() && !sink.is_aborted() {
                 // Only defer when there is still a live response to drain the
                 // flush through: on_writable (which resolves the flush via
                 // flush_promise) is armed on `resp`. With no response the flush
                 // can never settle, so taking a ref and attaching here would
                 // leak the ref and hang the request; fall through to teardown.
-                if let Some(flush) = wrapper.sink.pending_flush
+                if let Some(flush) = sink.pending_flush
                     && self.resp.get().is_some()
                 {
                     stream_log!("handleResolveStream: waiting for pending flush");
@@ -2891,15 +2651,11 @@ where
 
         let mut wrote_anything = false;
         let mut ended_response = false;
-        if let Some(wrapper) = self.sink_mut() {
-            let wrapper_ptr = self
-                .sink
-                .take()
-                .expect("infallible: sink_mut returned Some");
-            let aborted = self.flags.aborted() || wrapper.sink.is_aborted();
+        if let Some(sink) = self.sink.replace(None) {
+            let aborted = self.flags.aborted() || sink.get().is_aborted();
             self.flags.set_aborted(aborted);
-            wrote_anything = wrapper.sink.wrote > 0;
-            ended_response = wrapper.sink.ended_response;
+            wrote_anything = sink.get().wrote > 0;
+            ended_response = sink.get().ended_response;
             if ended_response {
                 // `resp` may be freed; the sink already resumed it. Clear these
                 // before `detach()` below re-enters JS so any drain callback /
@@ -2908,20 +2664,22 @@ where
                 self.detach_request_body_producer();
             }
 
-            wrapper.sink.finalize();
-            let sink_global = wrapper
-                .sink
-                .global_this
-                .expect("sink.global_this set in do_render_stream");
-            ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut wrapper.sink.source, &sink_global);
-            Self::destroy_sink(wrapper_ptr);
+            let sink_global = sink.with_mut(|sink| {
+                sink.finalize();
+                sink.global_this
+                    .expect("sink.global_this set in do_render_stream")
+            });
+            sink.with_mut(|sink| {
+                ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut sink.source, &sink_global)
+            });
+            ResponseStream::destroy(sink);
         }
 
         debug_assert!(self.server.get().is_some());
         // server is a BACKREF; `global_this()` returns a lifetime decoupled
         // from `&self`.
         let global_this = self.server().global_this();
-        if let Some(resp) = self.response_mut() {
+        if let Some(resp) = self.response() {
             if let Some(stream) = resp.get_body_readable_stream() {
                 stream.value.ensure_still_alive();
                 resp.detach_readable_stream(global_this);
@@ -2964,12 +2722,13 @@ where
     ) -> JsResult<JSValue> {
         stream_log!("onResolveStream");
         let args = callframe.arguments();
-        let Some(req) = NativePromiseContext::take::<Self>(args[args.len() - 1]) else {
+        let Some(claim) = native_promise_context::take::<Self>(args[args.len() - 1]) else {
             return Ok(JSValue::UNDEFINED);
         };
-        let req = RequestContextRef::adopt(req.as_ptr());
-        req.ctx().promise_cell.set(JSValue::ZERO);
-        req.ctx().handle_resolve_stream();
+        let req = claim.this_ptr();
+        let _claim = claim;
+        req.promise_cell.set(JSValue::ZERO);
+        req.handle_resolve_stream();
         Ok(JSValue::UNDEFINED)
     }
 
@@ -2979,14 +2738,15 @@ where
     ) -> JsResult<JSValue> {
         stream_log!("onRejectStream");
         let args = callframe.arguments();
-        let Some(req) = NativePromiseContext::take::<Self>(args[args.len() - 1]) else {
+        let Some(claim) = native_promise_context::take::<Self>(args[args.len() - 1]) else {
             return Ok(JSValue::UNDEFINED);
         };
         let err = args[0];
-        let req = RequestContextRef::adopt(req.as_ptr());
-        req.ctx().promise_cell.set(JSValue::ZERO);
+        let req = claim.this_ptr();
+        let _claim = claim;
+        req.promise_cell.set(JSValue::ZERO);
 
-        req.ctx().handle_reject_stream(global_this, err);
+        req.handle_reject_stream(global_this, err);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -2994,38 +2754,36 @@ where
         stream_log!("handleRejectStream");
 
         let mut ended_response = false;
-        if let Some(wrapper) = self.sink_mut() {
-            let wrapper_ptr = self
-                .sink
-                .take()
-                .expect("infallible: sink_mut returned Some");
-            ended_response = wrapper.sink.ended_response;
+        if let Some(sink) = self.sink.replace(None) {
+            ended_response = sink.get().ended_response;
             if ended_response {
                 // `resp` may be freed; the sink already resumed it. Clear before JS below.
                 self.flags.set_request_body_paused(false);
                 self.detach_request_body_producer();
             }
-            if let Some(prom) = wrapper.sink.pending_flush.take() {
-                // The promise value was protected when pending_flush was
-                // assigned (flushFromJS / endFromJS). Drop that root before
-                // abandoning the pointer, otherwise it leaks for the
-                // lifetime of the VM.
-                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe deref.
-                bun_opaque::opaque_deref_mut(prom).to_js().unprotect();
-            }
-            wrapper.sink.set_done();
-            let aborted = self.flags.aborted() || wrapper.sink.is_aborted();
-            self.flags.set_aborted(aborted);
-            wrapper.sink.finalize();
-            let sink_global = wrapper
-                .sink
-                .global_this
-                .expect("sink.global_this set in do_render_stream");
-            ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut wrapper.sink.source, &sink_global);
-            Self::destroy_sink(wrapper_ptr);
+            let sink_global = sink.with_mut(|sink| {
+                if let Some(prom) = sink.pending_flush.take() {
+                    // The promise value was protected when pending_flush was
+                    // assigned (flushFromJS / endFromJS). Drop that root before
+                    // abandoning the pointer, otherwise it leaks for the
+                    // lifetime of the VM.
+                    // S008: `JSPromise` is an `opaque_ffi!` ZST — safe deref.
+                    bun_opaque::opaque_deref_mut(prom).to_js().unprotect();
+                }
+                sink.set_done();
+                let aborted = self.flags.aborted() || sink.is_aborted();
+                self.flags.set_aborted(aborted);
+                sink.finalize();
+                sink.global_this
+                    .expect("sink.global_this set in do_render_stream")
+            });
+            sink.with_mut(|sink| {
+                ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut sink.source, &sink_global)
+            });
+            ResponseStream::destroy(sink);
         }
 
-        if let Some(resp) = self.response_mut() {
+        if let Some(resp) = self.response() {
             release_body_stream(resp, global_this);
         }
 
@@ -3097,13 +2855,12 @@ where
         true
     }
 
+    /// `value` is the body of the `Response` being rendered.
     pub(crate) fn do_render_with_body(
         &self,
-        value: *mut Body::Value,
+        value: &mut Body::Value,
         owned_readable: Option<WebCore::ReadableStream>,
     ) {
-        // SAFETY: `value` is the live body slot of the response being rendered.
-        let value = unsafe { &mut *value };
         let this = self;
         if this.drain_microtasks().is_err() {
             return;
@@ -3201,20 +2958,18 @@ where
                         // These are the common scenario:
                         | readable_stream::Source::JavaScript => {
                             if let Some(resp) = this.resp.get() {
-                                let mut pair = StreamPair { stream, this };
-                                resp.run_corked_with_type(Self::do_render_stream, &raw mut pair);
+                                resp.corked(|| this.do_render_stream(stream));
                             }
                             return;
                         }
 
-                        readable_stream::Source::Bytes(byte_stream_ptr) => {
+                        readable_stream::Source::Bytes(_) => {
                             // BACKREF: `Source::Bytes` stores a live non-null
                             // `*mut ByteStream` (the JS wrapper's `m_ctx` heap
                             // payload, kept alive by `stream`). R-2: all touched
                             // ByteStream methods/fields are `&self`/interior-mutable.
-                            let byte_stream_nn = NonNull::new(byte_stream_ptr)
-                                .expect("Source::Bytes payload is non-null");
-                            let byte_stream = bun_ptr::BackRef::from(byte_stream_nn);
+                            let byte_stream =
+                                stream.ptr.bytes().expect("Source::Bytes payload is non-null");
                             debug_assert!(byte_stream.sink.get().is_none());
                             debug_assert!(this.byte_stream.get().is_none());
                             if this.resp.get().is_none() {
@@ -3237,13 +2992,18 @@ where
                                 this.do_render_blob();
                                 return;
                             }
-                            this.ref_();
+                            // The pipe's ref; released by `end_chunk`, or by
+                            // `on_abort` when the pipe can no longer finish.
+                            let prev = this
+                                .byte_stream_ref
+                                .replace(Some(RefPtr::from_this(this.this())));
+                            debug_assert!(prev.is_none());
                             // Same as do_render_stream's Pending branch: the
                             // body is in flight, so `handle_reject` must not
                             // fall through to render_missing() and end it.
                             this.flags.set_has_marked_pending(true);
                             byte_stream.sink.set(WebCore::SinkHandle::ServerResponse(
-                                AnyRequestContext::init(this.as_ctx_ptr()),
+                                AnyRequestContext::init(this.this()),
                             ));
                             stream.lock_native(global_this);
                             byte_stream.signal_consumer_attached();
@@ -3254,7 +3014,7 @@ where
                             this.response_body_readable_stream_ref
                                 .set(readable_stream::Strong::init(stream, global_this));
 
-                            this.byte_stream.set(Some(byte_stream_nn));
+                            this.byte_stream.set(Some(byte_stream));
                             let mut response_buf = byte_stream.take_buffer();
                             let buffer = response_buf.move_to_list();
                             let has_body_bytes = !buffer.is_empty();
@@ -3266,10 +3026,7 @@ where
 
                             // if we've received metadata and part of the body, send everything we can and drain
                             if has_body_bytes {
-                                resp.run_corked_with_type(
-                                    Self::drain_response_buffer_and_metadata_corked,
-                                    this.as_ctx_ptr(),
-                                );
+                                resp.corked(|| this.drain_response_buffer_and_metadata());
                             } else if matches!(
                                 byte_stream.parent_const().producer.get(),
                                 WebCore::streams::SourceHandle::HTMLRewriter(_)
@@ -3279,10 +3036,7 @@ where
                                 // still reach `error()`.
                             } else {
                                 // if we only have metadata to send, send it now
-                                resp.run_corked_with_type(
-                                    Self::render_metadata_corked,
-                                    this.as_ctx_ptr(),
-                                );
+                                resp.corked(|| this.render_metadata());
                             }
                             // Wake the producer after the older bytes are queued.
                             byte_stream.signal_drained();
@@ -3301,18 +3055,21 @@ where
                         }
                     };
                     readable.ensure_still_alive();
-                    this.do_render_with_body(std::ptr::from_mut(value), None);
+                    this.do_render_with_body(value, None);
                     return;
                 }
 
                 // No stream and no other consumer: wait for `Value::resolve`.
-                // The registered callback owns a +1 on `this`, released by
-                // `do_render_with_body_locked`.
-                this.ref_();
+                // The registration holds a ref on `this`, released by
+                // `render_pending_body_value`.
+                let prev = this
+                    .body_value_ref
+                    .replace(Some(RefPtr::from_this(this.this())));
+                debug_assert!(prev.is_none());
                 this.flags.set_has_marked_pending(true);
-                lock.on_receive_value =
-                    Some(|ctx, value| Self::do_render_with_body_locked(ctx, value));
-                lock.task = Some(NonNull::new(this.as_ctx_ptr().cast::<c_void>()).unwrap());
+                lock.on_receive_value = Some(Body::ReceiveValue::Server(AnyRequestContext::init(
+                    this.this(),
+                )));
 
                 return;
             }
@@ -3322,13 +3079,12 @@ where
         this.do_render_blob();
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    /// `ByteStream`'s sink (`SinkHandle::ServerResponse`) delivering a chunk of
+    /// the natively piped response body.
     pub(crate) fn write_chunk(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         stream: &WebCore::streams::Result,
     ) -> WebCore::streams::Writable {
-        // SAFETY: caller passes the live `*mut RequestContext` stored as the sink ctx.
-        let this = unsafe { &*this };
         if this.is_aborted_or_ended() {
             return WebCore::streams::Writable::Done;
         }
@@ -3338,7 +3094,7 @@ where
         // first chunk so a pre-first-byte failure can still reach the
         // server's `error()` hook. Flush it now, corked.
         if !this.flags.has_written_status() {
-            resp.run_corked_with_type(Self::render_metadata_corked, this.as_ctx_ptr());
+            resp.corked(|| this.render_metadata());
         }
 
         let chunk = stream.slice();
@@ -3346,28 +3102,21 @@ where
         // we can't do buffering ourselves here or it won't work
         // uSockets will append and manage the buffer
         // so any write will buffer if the write fails
-        // SAFETY: FFI handle
         match resp.write(chunk) {
             uws::WriteResult::WantMore(n) => WebCore::streams::Writable::Owned(n as BlobSizeType),
             uws::WriteResult::Backpressure(n) => {
                 this.flags.set_has_marked_pending(true);
-                // SAFETY: FFI handle
-                resp.on_writable(
-                    |this, off, resp| Self::on_writable_byte_stream(this, off, resp),
-                    this.as_ctx_ptr(),
-                );
+                resp.on_writable_this(Self::on_writable_byte_stream, this);
                 WebCore::streams::Writable::Backpressure(n as BlobSizeType)
             }
         }
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn end_chunk(this: *mut Self, err: Option<&WebCore::streams::StreamError>) {
-        let _ref = RequestContextRef::adopt(this);
-        // SAFETY: caller passes the live `*mut RequestContext` stored as the
-        // sink ctx; `_ref` keeps it alive for this call.
-        let this = unsafe { &*this };
-        // The stream has already dropped this sink; `_ref` is the pipe's ref.
+    /// `ByteStream`'s sink (`SinkHandle::ServerResponse`) reporting the end of
+    /// the natively piped response body. Releases [`byte_stream_ref`](Self::byte_stream_ref).
+    pub(crate) fn end_chunk(this: ThisPtr<Self>, err: Option<&WebCore::streams::StreamError>) {
+        // The stream has already dropped this sink; the pipe's ref is this frame's.
+        let _pipe_ref = this.byte_stream_ref.take();
         this.byte_stream.set(None);
 
         if this.is_aborted_or_ended() {
@@ -3398,27 +3147,25 @@ where
             // Upstream ended cleanly before any chunk: flush the deferred
             // status/headers so the client sees them before the terminator.
             if let Some(resp) = this.resp.get() {
-                resp.run_corked_with_type(Self::render_metadata_corked, this.as_ctx_ptr());
+                resp.corked(|| this.render_metadata());
             }
         }
         this.end_stream(this.should_close_connection());
     }
 
     pub(crate) fn on_writable_byte_stream(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         _write_offset: u64,
         _resp: uws::AnyResponse,
     ) -> bool {
         ctx_log!("onWritableByteStream");
-        // SAFETY: `this` is live for the callback; only a shared view is
-        // formed, so the `resume()` re-entry into `write_chunk` is fine.
-        let this = unsafe { &*this };
         debug_assert!(this.resp.get().is_some());
         if this.is_aborted_or_ended() {
             return false;
         }
+        // `resume()` re-enters `write_chunk`.
         if let Some(bs) = this.byte_stream.get() {
-            bun_ptr::BackRef::from(bs).resume();
+            bs.resume();
         }
         true
     }
@@ -3431,34 +3178,25 @@ where
         // This is an important performance optimization
         if self.flags.has_abort_handler() && self.blob.get().fast_size() < 16384 - 1024 {
             if let Some(resp) = self.resp.get() {
-                resp.run_corked_with_type(
-                    |ctx| Self::do_render_blob_corked(ctx),
-                    self.as_ctx_ptr(),
-                );
+                resp.corked(|| self.do_render_blob_corked());
             }
         } else {
-            Self::do_render_blob_corked(self.as_ctx_ptr());
+            self.do_render_blob_corked();
         }
     }
 
-    fn do_render_blob_corked(this: *mut Self) {
-        // SAFETY: `this` is live for the synchronous cork call; only a shared
-        // view is formed.
-        let this = unsafe { &*this };
-        this.render_metadata();
-        this.render_bytes();
+    fn do_render_blob_corked(&self) {
+        self.render_metadata();
+        self.render_bytes();
     }
 
     pub(crate) fn do_render_null_body_status(&self) {
         if self.flags.has_abort_handler() {
             if let Some(resp) = self.resp.get() {
-                resp.run_corked_with_type(
-                    Self::do_render_null_body_status_corked,
-                    self.as_ctx_ptr(),
-                );
+                resp.corked(|| self.do_render_null_body_status_corked());
             }
         } else {
-            Self::do_render_null_body_status_corked(self.as_ctx_ptr());
+            self.do_render_null_body_status_corked();
         }
     }
 
@@ -3466,16 +3204,11 @@ where
     /// would put `Content-Length: 0` on a 304 (uWS only suppresses it for
     /// 1xx/204); RFC 9110 §8.6 only allows the 200's length, so forward the
     /// handler's value or emit none.
-    ///
-    /// # Safety
-    /// `this` must point to a live `RequestContext` threaded through cork user-data.
-    fn do_render_null_body_status_corked(this: *mut Self) {
-        // SAFETY: `this` is live for the synchronous cork call; only a shared
-        // view is formed.
-        let this = unsafe { &*this };
+    fn do_render_null_body_status_corked(&self) {
+        let this = self;
 
         let (status, app_content_length) = {
-            let response: &mut Response = this.response_mut().unwrap();
+            let response: &Response = this.response().unwrap();
             let status = response.status_code();
             // Parsed before render_metadata() fast_remove()s it and derefs the headers.
             let app_cl = (status == 304)
@@ -3494,7 +3227,7 @@ where
 
         // A null-body status never transmits the body.
         if let Some(server) = this.server.get()
-            && let Some(response) = this.response_mut()
+            && let Some(response) = this.response()
             && matches!(response.get_body_value(), Body::Value::Locked(_))
         {
             Self::cancel_unread_body(response, server.global_this());
@@ -3511,14 +3244,8 @@ where
                 return;
             }
         }
-        // render_bytes releases the base ref on every path (resp gone included).
+        // render_bytes releases the in-flight ref on every path (resp gone included).
         this.render_bytes();
-    }
-
-    /// `render_metadata` adapter for `run_corked_with_type` (takes `fn(*mut U)`).
-    fn render_metadata_corked(this: *mut Self) {
-        // SAFETY: this is the live RequestContext threaded through cork user-data.
-        unsafe { (*this).render_metadata() };
     }
 
     pub(crate) fn do_render(&self) {
@@ -3528,12 +3255,9 @@ where
             return;
         }
         let (value, owned_readable) = {
-            let response: &mut Response = self.response_mut().unwrap();
+            let response: &Response = self.response().unwrap();
             let owned_readable = response.get_body_readable_stream();
-            (
-                std::ptr::from_mut(response.get_body_value()),
-                owned_readable,
-            )
+            (response.get_body_value(), owned_readable)
         };
         self.do_render_with_body(value, owned_readable);
     }
@@ -3600,7 +3324,6 @@ where
     #[inline]
     pub(crate) fn should_close_connection(&self) -> bool {
         if let Some(resp) = self.resp.get() {
-            // SAFETY: FFI handle
             return resp.should_close_connection();
         }
         false
@@ -3681,8 +3404,7 @@ where
                     } else if let Some(response) = as_response(result) {
                         // An unsendable Response from the error handler itself
                         // falls through to the default error page below.
-                        // SAFETY: `response` is the live, rooted cell pointer.
-                        if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                        if HTTPStatusText::is_sendable(response.status_code()) {
                             // A file or streaming body defers `render_metadata`
                             // past this frame, where `_keep` is the only root,
                             // so root the Response the way the async error
@@ -3693,8 +3415,7 @@ where
                             }
                             self.response_jsvalue.set(result);
                             self.flags.set_response_protected(false);
-                            // SAFETY: as above.
-                            unsafe { self.protect_for_body_and_render(result, response) };
+                            self.protect_for_body_and_render(result, response);
                             return;
                         }
                     }
@@ -3736,8 +3457,7 @@ where
                     return;
                 };
 
-                // SAFETY: `response` is the live, rooted cell pointer.
-                if !HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                if !HTTPStatusText::is_sendable(response.status_code()) {
                     ctx.finish_running_error_handler(value, status);
                     return;
                 }
@@ -3750,8 +3470,7 @@ where
                 fulfilled_value.ensure_still_alive();
                 ctx.flags.set_response_protected(false);
 
-                // SAFETY: `response` is the live, rooted cell pointer.
-                unsafe { ctx.protect_for_body_and_render(fulfilled_value, response) };
+                ctx.protect_for_body_and_render(fulfilled_value, response);
                 return;
             }
             jsc::PromiseResult::Rejected(err) => {
@@ -3786,7 +3505,7 @@ where
         // render() before any backpressure gap, so the Response is
         // always live here. File / stream bodies that call this after
         // an async hop keep the Response rooted via response_protected.
-        let response: &mut Response = self.response_mut().unwrap();
+        let response: &Response = self.response().unwrap();
         let sendfile = self.sendfile.get();
         let mut status = response.status_code();
         let blob = self.blob.get();
@@ -3947,51 +3666,34 @@ where
     }
 
     pub(crate) fn render_bytes(&self) {
-        // SAFETY: `self.blob`'s backing bytes are owned by the context and
-        // outlive the `try_end`/`on_writable` calls below; the cell read ends
-        // here, before the (self-releasing) tail.
-        let bytes: &[u8] = unsafe { bun_ptr::detach_lifetime(self.blob.get().slice()) };
+        let bytes = self.blob.get().slice();
         if let Some(resp) = self.resp.get() {
-            // SAFETY: FFI handle
             if !resp.try_end(bytes, bytes.len(), self.should_close_connection()) {
                 self.flags.set_has_marked_pending(true);
-                // SAFETY: FFI handle
-                resp.on_writable(
-                    |this, off, resp| Self::on_writable_bytes(this, off, resp),
-                    self.as_ctx_ptr(),
-                );
+                resp.on_writable_this(Self::on_writable_bytes, self.this());
                 return;
             }
         }
         self.detach_response();
         self.end_request_streaming_and_drain();
-        self.deref();
+        self.release_in_flight();
     }
 
     /// Replace the tracked Response. Drops the previous weak ref (if any)
     /// before taking a new one so the old Response's allocation can be
-    /// freed once its own strong refs go to zero.
-    ///
-    /// # Safety
-    /// `response` must be the live JS wrapper's cell pointer (as returned by
-    /// [`as_response`]), carrying the allocation's provenance — `WeakPtr` keeps
-    /// it past any reborrow.
-    unsafe fn set_response(&self, response: *mut Response) {
-        if self
-            .response_weakref
-            .with_mut(|weak| weak.get().map(std::ptr::from_mut::<Response>))
-            == Some(response)
-        {
-            return;
-        }
-        // SAFETY: caller contract — `response` is live and root-provenanced.
-        self.response_weakref
-            .set(unsafe { response::WeakRef::init_ref(response) });
+    /// freed once its own strong refs go to zero. `response` is the payload of
+    /// a JS wrapper the caller keeps GC-rooted (see [`as_response`]).
+    fn set_response(&self, response: ThisPtr<Response>) {
+        self.response_weakref.with_mut(|weak| {
+            if weak.get_ref().is_some() && weak.is(response) {
+                return;
+            }
+            *weak = response::WeakRef::from_this(response);
+        });
     }
 
-    /// # Safety
-    /// Same contract as [`Self::set_response`].
-    pub(crate) unsafe fn render(&self, response: *mut Response) {
+    /// `response`: as for [`Self::set_response`].
+    pub(crate) fn render(&self, response: ThisPtr<Response>) {
         ctx_log!("render");
 
         // A HEAD response never carries content (RFC 9110 §9.3.2). The normal
@@ -3999,20 +3701,14 @@ where
         // here, but the `error()` handler paths call `render()` directly.
         if self.method == Method::HEAD {
             if let Some(resp) = self.resp.get() {
-                let mut pair = HeaderResponsePair {
-                    this: self,
-                    response,
-                };
-                resp.run_corked_with_type(Self::do_render_head_response, &raw mut pair);
+                resp.corked(|| self.do_render_head_response(response));
             }
             return;
         }
 
-        // SAFETY: caller contract.
-        unsafe { self.set_response(response) };
+        self.set_response(response);
 
-        // SAFETY: caller contract — `response` is live.
-        if HTTPStatusText::is_null_body(unsafe { (*response).status_code() }) {
+        if HTTPStatusText::is_null_body(response.status_code()) {
             self.do_render_null_body_status();
             return;
         }
@@ -4025,13 +3721,9 @@ where
     /// file or streaming body is still being sent after this frame returns,
     /// so for those the wrapper is protected first; in-memory bodies leave it
     /// unprotected (see `response_jsvalue`).
-    ///
-    /// # Safety
-    /// Same contract as [`Self::render`].
-    unsafe fn protect_for_body_and_render(&self, response_value: JSValue, response: *mut Response) {
-        // SAFETY: caller contract: `response` is live. This is the only borrow
-        // of its body, and it ends before `render` reborrows the cell.
-        let body_value = unsafe { (*response).get_body_value() };
+    fn protect_for_body_and_render(&self, response_value: JSValue, response: ThisPtr<Response>) {
+        // The only borrow of the body; it ends before `render` reborrows it.
+        let body_value = response.get().get_body_value();
         body_value.to_blob_if_possible();
         let sent_after_return = match body_value {
             Body::Value::Blob(blob) => shim::blob_needs_to_read_file(blob),
@@ -4042,14 +3734,13 @@ where
             response_value.protect();
             self.flags.set_response_protected(true);
         }
-        // SAFETY: caller contract.
-        unsafe { self.render(response) };
+        self.render(response);
     }
 
-    pub(crate) fn on_buffered_body_chunk(this: *mut Self, chunk: &[u8], last: bool) {
+    /// uWS `on_data`: a chunk of the request body arrived.
+    pub(crate) fn on_buffered_body_chunk(this: ThisPtr<Self>, chunk: &[u8], last: bool) {
         ctx_log!("onBufferedBodyChunk {} {}", chunk.len(), last);
-        let pinned = RequestContextRef::pin(this);
-        let this = pinned.ctx();
+        let _pin = Self::pin(this);
         debug_assert!(this.resp.get().is_some());
 
         this.flags.set_is_waiting_for_request_body(!last);
@@ -4110,12 +3801,10 @@ where
                 }
 
                 // Route through the normal end path so this.resp is detached
-                // and the base ref released (see the buffering branch below).
-                // SAFETY: FFI handle
+                // and the in-flight ref released (see the buffering branch below).
                 if let Some(resp) = this.resp.get() {
                     if !resp.has_responded() {
                         this.flags.set_has_written_status(true);
-                        // SAFETY: FFI handle
                         resp.write_status(b"413 Payload Too Large");
                     }
                 }
@@ -4129,14 +3818,11 @@ where
             // caller for the duration of the synchronous `on_data` call.
             let borrowed = bun_ptr::RawSlice::new(chunk);
             if !last {
-                let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr else {
-                    return;
-                };
                 // BACKREF: `Source::Bytes` payload is the live non-null `m_ctx`
                 // heap `ByteStream` kept alive by `readable` for this call.
-                let bytes = bun_ptr::BackRef::from(
-                    NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
-                );
+                let Some(bytes) = readable.ptr.bytes() else {
+                    return;
+                };
                 bytes.on_data(WebCore::streams::Result::Temporary(borrowed));
 
                 // What `on_data` buffered; `on_stream_drained` resumes once it empties.
@@ -4159,14 +3845,11 @@ where
                 this.request_body_take_unref();
 
                 readable.value.ensure_still_alive();
-                let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr else {
-                    return;
-                };
                 // BACKREF: `Source::Bytes` payload is the live non-null `m_ctx`
                 // heap `ByteStream` kept alive by `readable` for this call.
-                let bytes = bun_ptr::BackRef::from(
-                    NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
-                );
+                let Some(bytes) = readable.ptr.bytes() else {
+                    return;
+                };
                 let source = bytes.parent_const();
                 source.producer.set(WebCore::streams::SourceHandle::None);
                 bytes.on_data(WebCore::streams::Result::TemporaryAndDone(borrowed));
@@ -4176,8 +3859,7 @@ where
         }
 
         // This is the start of a task, so it's a good time to drain
-        // The pooled body slot is a separate allocation decoupled from `*this`.
-        if let Some(body) = this.request_body_mut() {
+        if let Some(body) = this.request_body_slot() {
             // The up-front maxRequestBodySize check in the server only
             // sees Content-Length. HTTP/3 (and H1 chunked) bodies may
             // omit it, so cap accumulated bytes here too — otherwise a
@@ -4203,25 +3885,25 @@ where
                 // generic ConnectionClosed. toErrorInstance handles
                 // .Locked itself (rejects the promise, deinits the
                 // readable, calls onReceiveValue).
-                let _ = body.to_error_instance(
-                    Body::ValueError::Message(BunString::static_(
-                        "Request body exceeded maxRequestBodySize",
-                    )),
-                    global_this,
-                );
+                let _ = body.with_mut(|body| {
+                    body.to_error_instance(
+                        Body::ValueError::Message(BunString::static_(
+                            "Request body exceeded maxRequestBodySize",
+                        )),
+                        global_this,
+                    )
+                });
 
                 // Route through the normal end path so this.resp is
-                // detached and the base ref released. Writing directly on
+                // detached and the in-flight ref released. Writing directly on
                 // the raw uWS response left this.resp pointing at a
                 // completed (and soon freed) response — uWS markDone()
                 // clears onAborted so no abort ever fires to release the
                 // ref, and a later handleResolve()/handleReject() from an
                 // async handler would dereference the stale pointer.
-                // SAFETY: FFI handle
                 if let Some(resp) = this.resp.get() {
                     if !resp.has_responded() {
                         this.flags.set_has_written_status(true);
-                        // SAFETY: FFI handle
                         resp.write_status(b"413 Payload Too Large");
                     }
                 }
@@ -4231,24 +3913,26 @@ where
 
             if last {
                 let mut bytes = this.request_body_buf.replace(Vec::new());
-
-                let mut old = core::mem::replace(body, Body::Value::Null);
-
                 let total = bytes.len() + chunk.len();
                 // Vec aborts on OOM (repo-wide abort-on-OOM policy).
                 bytes.reserve_exact(total.saturating_sub(bytes.len()));
                 bytes.extend_from_slice(chunk);
                 debug_assert_eq!(bytes.len(), total);
-                *body = Body::Value::InternalBlob(WebCore::InternalBlob {
-                    bytes,
-                    was_string: false,
+
+                body.with_mut(|body| {
+                    let mut old = core::mem::replace(
+                        body,
+                        Body::Value::InternalBlob(WebCore::InternalBlob {
+                            bytes,
+                            was_string: false,
+                        }),
+                    );
+                    if matches!(old, Body::Value::Locked(_)) {
+                        let _exit = vm.enter_event_loop_scope();
+
+                        let _ = Body::Value::resolve(&mut old, body, global_this, None); // TODO: properly propagate exception upwards
+                    }
                 });
-
-                if matches!(old, Body::Value::Locked(_)) {
-                    let _exit = vm.enter_event_loop_scope();
-
-                    let _ = Body::Value::resolve(&mut old, body, global_this, None); // TODO: properly propagate exception upwards
-                }
                 return;
             }
 
@@ -4305,11 +3989,8 @@ where
     /// `us_socket_t` (see `end_already_responded_stream`; the sink resumed it).
     #[inline]
     fn live_resp(&self) -> Option<uws::AnyResponse> {
-        if let Some(sink) = self.sink.get() {
-            // SAFETY: `sink` is owned by this context and freed in `handle_resolve_stream`/`deinit`.
-            if unsafe { (*sink.as_ptr()).sink.ended_response } {
-                return None;
-            }
+        if self.sink().is_some_and(|sink| sink.get().ended_response) {
+            return None;
         }
         self.resp.get()
     }
@@ -4325,10 +4006,9 @@ where
         }
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn on_request_body_stream_drained(this: *mut Self) {
-        // SAFETY: `this` is the registered live `*mut RequestContext`.
-        let this = unsafe { &*this };
+    /// `SourceHandle::ServerRequestBody`: the request-body stream's buffer emptied.
+    pub(crate) fn on_request_body_stream_drained(&self) {
+        let this = self;
         if !this.flags.request_body_paused() {
             return;
         }
@@ -4399,49 +4079,53 @@ where
             {
                 // no content-length or 0 content-length
                 // no transfer-encoding
-                if let Some(body) = self.request_body_mut() {
-                    let mut old = core::mem::replace(body, Body::Value::Null);
+                if let Some(body) = self.request_body_slot() {
+                    let mut old = body.replace(Body::Value::Null);
                     if let Body::Value::Locked(l) = &mut old {
                         l.on_receive_value = None;
                     }
                     let mut new_body: Body::Value = Body::Value::Null;
                     let global_this = server.global_this();
                     let _ = Body::Value::resolve(&mut old, &mut new_body, global_this, None); // TODO: properly propagate exception upwards
-                    *body = new_body;
+                    body.set(new_body);
                 }
             }
         }
     }
 
+    /// `Body::PendingValue` producer hooks. `task` is the context the server
+    /// installed as the pending request body's producer; the context errors a
+    /// still-pending body (`end_request_streaming`), which drops these hooks,
+    /// before it is released.
+    fn from_body_task(task: NonNull<c_void>) -> BackRef<Self> {
+        BackRef::from(task.cast::<Self>())
+    }
+
     pub(crate) fn on_request_body_readable_stream_available(
-        ptr: NonNull<c_void>,
+        task: NonNull<c_void>,
         global_this: &JSGlobalObject,
         readable: WebCore::ReadableStream,
     ) {
-        // SAFETY: `ptr` is the registered live body-callback context.
-        let this = unsafe { ptr.cast::<Self>().as_ref() };
+        let this = Self::from_body_task(task);
         debug_assert!(!this.request_body_readable_stream_ref.with_mut(|s| s.has()));
         this.request_body_readable_stream_ref
             .set(readable_stream::Strong::init(readable, global_this));
     }
 
-    pub(crate) fn on_start_buffering_callback(this: NonNull<c_void>) {
-        // SAFETY: `this` is the registered live body-callback context.
-        unsafe { this.cast::<Self>().as_ref() }.on_start_buffering();
+    pub(crate) fn on_start_buffering_callback(task: NonNull<c_void>) {
+        Self::from_body_task(task).on_start_buffering();
     }
 
     pub(crate) fn on_start_streaming_request_body_callback(
-        this: NonNull<c_void>,
+        task: NonNull<c_void>,
     ) -> WebCore::DrainResult {
-        // SAFETY: `this` is the registered live body-callback context.
-        unsafe { this.cast::<Self>().as_ref() }.on_start_streaming_request_body()
+        Self::from_body_task(task).on_start_streaming_request_body()
     }
 
     pub(crate) fn get_remote_socket_info(&self) -> Option<uws::SocketAddress> {
         let resp = self.live_resp()?;
         // `AnyResponse::get_remote_socket_info` returns the uws_sys
         // variant; convert to the owned `bun_uws::SocketAddress`.
-        // SAFETY: FFI handle
         let info = resp.get_remote_socket_info()?;
         Some(uws::SocketAddress {
             ip: info.ip().to_vec().into_boxed_slice(),
@@ -4452,10 +4136,8 @@ where
 
     pub(crate) fn set_timeout(&self, seconds: c_uint) -> bool {
         if let Some(resp) = self.live_resp() {
-            // SAFETY: FFI handle
             resp.timeout(seconds.min(255) as u8);
             if seconds == 0 {
-                // SAFETY: FFI handle
                 resp.clear_timeout();
             }
             return true;
@@ -4477,36 +4159,26 @@ const REQUEST_BODY_HIGH_WATER_MARK: usize = 1024 * 1024;
 // instantiations × 4 callbacks is spelled out via `request_ctx_exports!`. The
 // generic body lives on the `impl<ThisServer, ..> RequestContext` block above
 // (`on_resolve` / `on_reject` / `on_resolve_stream` / `on_reject_stream`); each
-// shim is the result-mapping (`JsResult<JSValue>` → raw `JSValue`,
-// `.zero` on error) over the monomorphic associated fn.
+// shim (`bun_jsc::jsc_promise_handler!`) is the result-mapping
+// (`JsResult<JSValue>` → raw `JSValue`, `.zero` on error) over the
+// monomorphic associated fn.
 macro_rules! request_ctx_exports {
     ($(
         ($srv:ty, $ssl:literal, $dbg:literal, $mux:literal) =>
         $on_resolve:ident, $on_reject:ident, $on_resolve_stream:ident, $on_reject_stream:ident
     );* $(;)?) => {$(
-        // Named C-ABI symbols for the C++ side. The bodies forward to the
-        // generic `host_on_*` shims monomorphized at this tuple — `#[no_mangle]`
-        // pins the link name.
-        #[unsafe(no_mangle)]
-        #[bun_jsc::host_call]
-        pub fn $on_resolve(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_resolve::<$srv, $ssl, $dbg, $mux>(g, f)
-        }
-        #[unsafe(no_mangle)]
-        #[bun_jsc::host_call]
-        pub fn $on_reject(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_reject::<$srv, $ssl, $dbg, $mux>(g, f)
-        }
-        #[unsafe(no_mangle)]
-        #[bun_jsc::host_call]
-        pub fn $on_resolve_stream(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_resolve_stream::<$srv, $ssl, $dbg, $mux>(g, f)
-        }
-        #[unsafe(no_mangle)]
-        #[bun_jsc::host_call]
-        pub fn $on_reject_stream(g: *mut JSGlobalObject, f: *mut CallFrame) -> JSValue {
-            host_on_reject_stream::<$srv, $ssl, $dbg, $mux>(g, f)
-        }
+        bun_jsc::jsc_promise_handler!(
+            pub fn $on_resolve => RequestContext::<$srv, $ssl, $dbg, $h3>::on_resolve
+        );
+        bun_jsc::jsc_promise_handler!(
+            pub fn $on_reject => RequestContext::<$srv, $ssl, $dbg, $h3>::on_reject
+        );
+        bun_jsc::jsc_promise_handler!(
+            pub fn $on_resolve_stream => RequestContext::<$srv, $ssl, $dbg, $h3>::on_resolve_stream
+        );
+        bun_jsc::jsc_promise_handler!(
+            pub fn $on_reject_stream => RequestContext::<$srv, $ssl, $dbg, $h3>::on_reject_stream
+        );
     )*
 
     /// Map the `(SSL, DEBUG, MUX)` const-generic tuple to the concrete
@@ -4579,25 +4251,13 @@ request_ctx_exports! {
         Bun__HTTPRequestContextDebugMuxTLS__onRejectStream;
 }
 
-struct StreamPair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
-    pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
-    pub stream: WebCore::ReadableStream,
-}
-
-struct HeaderResponseSizePair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
-    pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
-    pub(crate) size: usize,
-}
-
-struct HeaderResponsePair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
-    pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
-    /// The JS wrapper's cell pointer, not a `&mut Response`: the receiving
-    /// frame hands it to `set_response`, which stores it in a `WeakPtr` that
-    /// outlives any reborrow. The cell is GC-rooted by the constructing frame.
-    pub(crate) response: *mut Response,
-}
-
-struct PathnameFormatter<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
+struct PathnameFormatter<
+    'a,
+    ThisServer: ServerLike + 'static,
+    const SSL: bool,
+    const DBG: bool,
+    const MUX: bool,
+> {
     ctx: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
 }
 
@@ -4616,18 +4276,7 @@ where
 
         if !this.flags.has_abort_handler() {
             if let Some(req) = this.req.get() {
-                // Inlined `req_url` body to avoid carrying the
-                // `Transport`/`NativePromiseContextType` bounds onto this
-                // formatter impl.
-                // SAFETY: req is the live uWS request handle.
-                let url: &[u8] = unsafe {
-                    if MUX {
-                        (*req.cast::<bun_uws_sys::h3::Request>()).url()
-                    } else {
-                        (*req.cast::<bun_uws_sys::Request>()).url()
-                    }
-                };
-                return write!(writer, "{}", bstr::BStr::new(url));
+                return write!(writer, "{}", bstr::BStr::new(req.url()));
             }
         }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -838,10 +838,7 @@ where
             });
             if let Some(sink_global) = sink_global {
                 sink.with_mut(|sink| {
-                    ResponseStreamJSSink::<SSL_ENABLED>::detach(
-                        &mut sink.source,
-                        &sink_global,
-                    )
+                    ResponseStreamJSSink::<SSL_ENABLED>::detach(&mut sink.source, &sink_global)
                 });
             }
             ResponseStream::destroy(sink);
@@ -1942,13 +1939,14 @@ where
 
         stream.value.ensure_still_alive();
 
-        this.sink.set(Some(Box::new(JsCell::new(ResponseStream::<SSL_ENABLED> {
-            res: Some(resp),
-            buffer: Vec::<u8>::default(),
-            first_write_ctx: Some(AnyRequestContext::init(this.this())),
-            global_this: Some(BackRef::new(global_this)),
-            ..Default::default()
-        }))));
+        this.sink
+            .set(Some(Box::new(JsCell::new(ResponseStream::<SSL_ENABLED> {
+                res: Some(resp),
+                buffer: Vec::<u8>::default(),
+                first_write_ctx: Some(AnyRequestContext::init(this.this())),
+                global_this: Some(BackRef::new(global_this)),
+                ..Default::default()
+            }))));
         // Re-fetched after every call that runs user code: `on_abort` may run
         // in there, but it leaves the sink to `discard_stream_after_abort`.
         let sink = || this.sink().expect("sink set above");
@@ -1962,12 +1960,11 @@ where
         resp.on_writable_this(Self::on_writable_response_stream, this.this());
 
         // We are already corked!
-        let assignment_result: JSValue =
-            ResponseStreamJSSink::<SSL_ENABLED>::assign_to_stream(
-                global_this,
-                stream.value,
-                NonNull::new(sink().as_ptr()).expect("JsCell::as_ptr is non-null"),
-            );
+        let assignment_result: JSValue = ResponseStreamJSSink::<SSL_ENABLED>::assign_to_stream(
+            global_this,
+            stream.value,
+            NonNull::new(sink().as_ptr()).expect("JsCell::as_ptr is non-null"),
+        );
 
         assignment_result.ensure_still_alive();
 
@@ -4168,16 +4165,16 @@ macro_rules! request_ctx_exports {
         $on_resolve:ident, $on_reject:ident, $on_resolve_stream:ident, $on_reject_stream:ident
     );* $(;)?) => {$(
         bun_jsc::jsc_promise_handler!(
-            pub fn $on_resolve => RequestContext::<$srv, $ssl, $dbg, $h3>::on_resolve
+            pub fn $on_resolve => RequestContext::<$srv, $ssl, $dbg, $mux>::on_resolve
         );
         bun_jsc::jsc_promise_handler!(
-            pub fn $on_reject => RequestContext::<$srv, $ssl, $dbg, $h3>::on_reject
+            pub fn $on_reject => RequestContext::<$srv, $ssl, $dbg, $mux>::on_reject
         );
         bun_jsc::jsc_promise_handler!(
-            pub fn $on_resolve_stream => RequestContext::<$srv, $ssl, $dbg, $h3>::on_resolve_stream
+            pub fn $on_resolve_stream => RequestContext::<$srv, $ssl, $dbg, $mux>::on_resolve_stream
         );
         bun_jsc::jsc_promise_handler!(
-            pub fn $on_reject_stream => RequestContext::<$srv, $ssl, $dbg, $h3>::on_reject_stream
+            pub fn $on_reject_stream => RequestContext::<$srv, $ssl, $dbg, $mux>::on_reject_stream
         );
     )*
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2467,7 +2467,7 @@ where
                     resp.write_header(b"transfer-encoding", b"chunked");
                 }
                 // HEAD never transmits the body.
-                Self::cancel_unread_body(&response, global_this);
+                Self::cancel_unread_body(response, global_this);
                 this.end_without_body(this.should_close_connection());
             }
             Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_) => {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -359,7 +359,9 @@ pub enum CreateJsRequest {
 pub struct PreparedRequest<const SSL: bool, const DEBUG: bool> {
     pub(crate) js_request: JSValue,
     pub(crate) request_object: *mut crate::webcore::Request,
-    pub ctx: *mut ServerRequestContext<SSL, DEBUG>,
+    /// Live for the dispatching frame: the context's in-flight ref cannot be
+    /// released past `defer_deinit_until_callback_completes` while it runs.
+    pub ctx: bun_ptr::ThisPtr<ServerRequestContext<SSL, DEBUG>>,
 }
 
 impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
@@ -374,15 +376,10 @@ impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
         // By saving a request, all information from `req` must be
         // copied since the provided uws.Request will be re-used for
         // future requests (stack allocated).
-        // SAFETY: `ctx`/`request_object` are the freshly-allocated
-        // `RequestContext` slot and heap `Request` produced by
-        // `prepare_js_request_context` for this frame.
-        unsafe {
-            (*self.ctx).to_async(
-                std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-                &mut *self.request_object,
-            );
-        }
+        // SAFETY: `request_object` is the freshly-allocated heap `Request`
+        // produced by `prepare_js_request_context` for this frame.
+        self.ctx
+            .to_async(uws::AnyRequest::H1(req), unsafe { &*self.request_object });
 
         SavedRequest {
             js_request: jsc::StrongOptional::create(self.js_request, global),
@@ -414,8 +411,8 @@ impl Drop for DetachRequestOnDrop {
     fn drop(&mut self) {
         // SAFETY: per `new()` contract — `self.0` is the heap allocation
         // produced by `Request::new`; kept alive by `ctx.request_weakref`
-        // until `RequestContext::deinit` releases it.
-        unsafe { (*self.0).request_context.detach_request() };
+        // until the context's teardown releases it.
+        unsafe { &*self.0 }.request_context.get().detach_request();
     }
 }
 
@@ -701,11 +698,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         method: Option<bun_http_types::Method::Method>,
     ) -> Option<PreparedRequest<SSL, DEBUG>> {
         jsc::mark_binding!();
-        // SAFETY: `this`/`resp` are live for the duration of the uWS callback.
-        // Shared reborrow: everything below only needs `&Self` (the pending-
-        // request counter is a `Cell`), and `ctx.create()` stores `this` — the
-        // raw pointer, not this borrow — as the backref.
-        let server = unsafe { &*this };
+        // SAFETY: `this` is the live heap server registered as the uWS
+        // userdata (write provenance); it owns the request pool and outlives
+        // every context, which is the backref `create()` stores. Everything
+        // below only needs `&Self` (the pending-request counter is a `Cell`).
+        let server = unsafe { bun_ptr::BackRef::from_raw_mut(this) };
         // S008: `Response<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
         let resp_ref = bun_opaque::opaque_deref_mut(resp);
 
@@ -764,27 +761,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // SAFETY: `request_pool` points at a process-static (or
         // server-owned) `HiveArray::Fallback`; valid for the server's lifetime.
-        // The `HiveSlot` token is leaked deliberately: the slot is recycled by
-        // `RequestContext::deinit` via `put_raw`, never via `HiveSlot::Drop`.
-        let ctx_slot = std::mem::ManuallyDrop::new(unsafe { (*server.request_pool).claim() })
-            .addr()
-            .as_ptr();
-        // SAFETY: `claim` hands out an uninitialized slot; `create()` fully
-        // initializes it via `MaybeUninit::write`.
-        let ctx_uninit = unsafe {
-            &mut *ctx_slot.cast::<core::mem::MaybeUninit<ServerRequestContext<SSL, DEBUG>>>()
-        };
-        ServerRequestContext::<SSL, DEBUG>::create(
-            ctx_uninit,
-            this,
-            std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
+        // The slot is recycled by the context's last ref (`RequestContext::destroy`).
+        let ctx_slot = unsafe { (*server.request_pool).claim() };
+        let ctx = ServerRequestContext::<SSL, DEBUG>::create(
+            ctx_slot,
+            server,
+            uws::AnyRequest::H1(req),
             any_response_from::<SSL>(resp),
             should_deinit_context,
             method,
         );
-        let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
-        // SAFETY: fully initialized by `create()`.
-        let ctx_ref = unsafe { &*ctx };
+        let ctx_ref = ctx.get();
 
         server
             .vm()
@@ -795,10 +782,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // Allocate the pooled body slot (ref_count = 1).
         let body_hive = crate::webcore::body::hive_alloc(crate::webcore::body::Value::Null);
-        // Raw payload pointer for the deferred Locked write below.
-        // SAFETY: slot stays live — both `ctx.request_body` and `Request.body` hold a +1.
-        let body_value: *mut crate::webcore::body::Value =
-            unsafe { core::ptr::addr_of_mut!((*body_hive.as_ptr()).value) };
         // Bump once so the ctx and JS Request each
         // own a +1 on the same slot (streamed bytes buffered into the ctx
         // surface on `request.body`/`request.json()`).
@@ -814,7 +797,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // ownership: `Request::new` is `bun.TrivialNew` — the heap
         // allocation is handed to the JS GC via `to_js`/`to_js_for_bake` (C++
         // wrapper finalizer frees it), or, for `CreateJsRequest::No`, retained
-        // by `ctx.request_weakref` until `RequestContext::deinit` releases it.
+        // by `ctx.request_weakref` until the context's teardown releases it.
         // `body_hive` (the original +1) moves into the Request — paired drop in
         // `Request::finalize`.
         let request_object: *mut crate::webcore::Request =
@@ -826,10 +809,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 body_hive,
             )));
         // SAFETY: freshly leaked from `heap::into_raw`, so `request_object`
-        // carries the allocation's provenance, as `init_ref` requires.
-        ctx_ref
-            .request_weakref
-            .set(unsafe { bun_ptr::WeakPtr::init_ref(request_object) });
+        // carries the allocation's provenance, as `init_ref` requires; kept
+        // alive by `ctx.request_weakref` until the context's teardown
+        // releases it, so the shared view is valid for this frame.
+        let request_ref = unsafe {
+            ctx_ref
+                .request_weakref
+                .set(bun_ptr::WeakPtr::init_ref(request_object));
+            &*request_object
+        };
 
         // (H3 eager-url/header population is unreachable on this path.)
 
@@ -852,36 +840,27 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // we defer pre-allocating the body until we receive the first chunk
                 // that way if the client is lying about how big the body is or the client aborts
                 // we don't waste memory
-                // SAFETY: `body_value` is the freshly-initialized hive payload.
-                unsafe {
-                    *body_value =
-                        crate::webcore::body::Value::Locked(crate::webcore::body::PendingValue {
-                            task: Some(core::ptr::NonNull::new(ctx).unwrap().cast::<c_void>()),
-                            global: std::ptr::from_ref(global),
-                            on_start_buffering: Some(
-                                ServerRequestContext::<SSL, DEBUG>::on_start_buffering_callback,
-                            ),
-                            on_start_streaming: Some(
-                                ServerRequestContext::<SSL, DEBUG>::on_start_streaming_request_body_callback,
-                            ),
-                            on_readable_stream_available: Some(
-                                ServerRequestContext::<SSL, DEBUG>::on_request_body_readable_stream_available,
-                            ),
-                            producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
-                                AnyRequestContext::init(ctx),
-                            ),
-                            ..Default::default()
-                        });
-                }
+                ctx_ref.set_pending_request_body(crate::webcore::body::PendingValue {
+                    task: Some(core::ptr::NonNull::from(ctx).cast::<c_void>()),
+                    global: std::ptr::from_ref(global),
+                    on_start_buffering: Some(
+                        ServerRequestContext::<SSL, DEBUG>::on_start_buffering_callback,
+                    ),
+                    on_start_streaming: Some(
+                        ServerRequestContext::<SSL, DEBUG>::on_start_streaming_request_body_callback,
+                    ),
+                    on_readable_stream_available: Some(
+                        ServerRequestContext::<SSL, DEBUG>::on_request_body_readable_stream_available,
+                    ),
+                    producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
+                        AnyRequestContext::init(ctx),
+                    ),
+                    ..Default::default()
+                });
                 ctx_ref.flags.set_is_waiting_for_request_body(true);
 
-                resp_ref.on_data(
-                    |u: *mut ServerRequestContext<SSL, DEBUG>,
-                     _: &mut uws_sys::NewAppResponse<SSL>,
-                     chunk: &[u8],
-                     last: bool| {
-                        ServerRequestContext::<SSL, DEBUG>::on_buffered_body_chunk(u, chunk, last)
-                    },
+                any_response_from::<SSL>(resp).on_data_this(
+                    ServerRequestContext::<SSL, DEBUG>::on_buffered_body_chunk,
                     ctx,
                 );
             }
@@ -889,18 +868,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         Some(PreparedRequest {
             js_request: match create_js_request {
-                // SAFETY: `request_object` is the freshly-allocated heap
-                // `Request`; ownership transfers to the JS wrapper.
-                CreateJsRequest::Yes => unsafe { (*request_object).to_js(global) },
-                CreateJsRequest::Bake => {
-                    // SAFETY: `request_object` is the freshly-allocated heap
-                    // `Request`; ownership transfers to the JS wrapper.
-                    match unsafe { (*request_object).to_js_for_bake(global) } {
-                        Ok(v) => v,
-                        Err(jsc::JsError::OutOfMemory) => bun_core::out_of_memory(),
-                        Err(_) => return None,
-                    }
-                }
+                // Ownership of the heap `Request` transfers to the JS wrapper.
+                CreateJsRequest::Yes => request_ref.to_js(global),
+                CreateJsRequest::Bake => match request_ref.to_js_for_bake(global) {
+                    Ok(v) => v,
+                    Err(jsc::JsError::OutOfMemory) => bun_core::out_of_memory(),
+                    Err(_) => return None,
+                },
                 CreateJsRequest::No => JSValue::ZERO,
             },
             request_object,
@@ -954,9 +928,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     .get()
                     .expect("Request was unexpectedly freed"),
                 request_object: data.request,
-                // SAFETY: `SavedRequest` was produced by `PreparedRequest::save`
-                // for this exact (SSL,DEBUG) monomorphization, so the erased
-                // `AnyRequestContext` payload is `ServerRequestContext<SSL,DEBUG>`.
+                // `SavedRequest` was produced by `PreparedRequest::save` for
+                // this exact (SSL,DEBUG) monomorphization (the tag says so), and
+                // holds a ref on the context.
                 ctx: data
                     .ctx
                     .get::<ServerRequestContext<SSL, DEBUG>>()
@@ -991,9 +965,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // the request's lifetime.
         let _detach_guard = is_stack.then(|| unsafe { DetachRequestOnDrop::new(request_object) });
 
-        // SAFETY: `ctx` was just allocated (or saved) by this server; the
-        // `defer_deinit_...` flag set below keeps it alive across `on_response`.
-        let ctx_ref = unsafe { &*ctx };
+        // `ctx` was just allocated (or saved) by this server; the
+        // `defer_deinit_...` flag set below keeps it allocated across `on_response`.
+        let ctx_ref = ctx.get();
         let original_state = ctx_ref.defer_deinit_until_callback_completes.get();
         let should_deinit_context = core::cell::Cell::new(false);
         ctx_ref
@@ -1008,7 +982,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         prepared.js_request.ensure_still_alive();
 
         if should_deinit_context.get() {
-            ctx_ref.deinit();
+            ServerRequestContext::<SSL, DEBUG>::deinit(ctx);
             return;
         }
 
@@ -1024,10 +998,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // SAFETY: `r` is the live stack `uws::Request`; `request_object`
                 // is the heap `Request` kept alive by `ctx.request_weakref`.
                 ctx_ref.to_async(
-                    std::ptr::from_ref::<uws::Request>(r)
-                        .cast_mut()
-                        .cast::<c_void>(),
-                    unsafe { &mut *request_object },
+                    uws::AnyRequest::H1(std::ptr::from_ref::<uws::Request>(r).cast_mut()),
+                    unsafe { &*request_object },
                 );
             }
             SavedRequestUnion::Saved(_) => {} // info already copied
@@ -1056,13 +1028,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // uWS request will not live longer than this function
         // SAFETY: `request_object` is the heap allocation produced by
         // `Request::new`; kept alive by `ctx.request_weakref` until
-        // `RequestContext::deinit` releases it.
+        // the context's teardown releases it.
         let _detach_guard = unsafe { DetachRequestOnDrop::new(request_object) };
 
-        // SAFETY: `ctx` was allocated by `prepare_js_request_context` for this
-        // frame and cannot be freed while `defer_deinit_...` is set (it is set
-        // by the caller until cleared below).
-        let (ctx_ref, this) = unsafe { (&*ctx, &*this) };
+        // `ctx` was allocated by `prepare_js_request_context` for this frame
+        // and stays allocated while `defer_deinit_...` is set (it is set by the
+        // caller until cleared below).
+        // SAFETY: `this` is the live server backref for this request.
+        let (ctx_ref, this) = (ctx.get(), unsafe { &*this });
         ctx_ref.on_response(this, prepared.js_request, response_value);
         // Reference in the stack here in case it is not for whatever reason
         prepared.js_request.ensure_still_alive();
@@ -1070,7 +1043,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         ctx_ref.defer_deinit_until_callback_completes.set(None);
 
         if should_deinit_context.get() {
-            ctx_ref.deinit();
+            ServerRequestContext::<SSL, DEBUG>::deinit(ctx);
             return;
         }
 
@@ -1083,10 +1056,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // copied since the provided uws.Request will be re-used for future
         // requests (stack allocated).
         // SAFETY: `request_object` is the live heap `Request` (see above).
-        ctx_ref.to_async(
-            std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-            unsafe { &mut *request_object },
-        );
+        ctx_ref.to_async(uws::AnyRequest::H1(req), unsafe { &*request_object });
     }
 
     /// Dispatch the user `fetch` handler.
@@ -3482,7 +3452,7 @@ mod trampoline {
 // Fallback::{get,put,claim}` take `&mut self` with no internal synchronization;
 // a process-static would race when two `Bun.serve` instances run on distinct
 // Worker threads (each Worker has its own event loop and may host a server).
-pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
+pub trait ServerPools<const SSL: bool, const DEBUG: bool>: ServerLike + 'static {
     fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
     fn mux_request_pool()
     -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>;
@@ -3604,14 +3574,24 @@ fn throw_ssl_error_if_necessary(global: &JSGlobalObject) -> bool {
     false
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl<const SSL: bool, const DEBUG: bool> Sealed for super::NewServer<SSL, DEBUG> {}
+}
+
 // `RequestContext` reaches back into its server via this; mirrors the
 // field/method surface the per-request state machine needs without naming
-// `NewServer` (avoids a generic-parameter cycle).
-pub trait ServerLike {
-    fn global_this(&self) -> &jsc::JSGlobalObject;
+// `NewServer` (avoids a generic-parameter cycle). Sealed: `RequestContext`'s
+// `NativePromiseContext` tag identifies its type by `(SSL, DEBUG, H3)` alone.
+pub trait ServerLike: sealed::Sealed + Sized {
+    const SSL: bool;
+    const DEBUG: bool;
+    fn global_this(&self) -> &'static jsc::JSGlobalObject;
     fn vm(&self) -> &jsc::VirtualMachine;
     fn config(&self) -> &ServerConfig;
-    fn on_request_complete(&mut self);
+    /// A request the server was counting finished. Runs the server's idle
+    /// pass, which may free it.
+    fn on_request_complete(this: bun_ptr::BackRef<Self, bun_ptr::Mut>);
     fn dev_server(&self) -> Option<&crate::bake::DevServer::DevServer>;
     fn js_value(&self) -> &jsc::JsRef;
     fn h3_alt_svc(&self) -> Option<&[u8]>;
@@ -3624,14 +3604,16 @@ pub trait ServerLike {
 }
 
 impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
+    const SSL: bool = SSL;
+    const DEBUG: bool = DEBUG;
     // These trait-method forwards are on the per-request hot path (called via
     // `RequestContext::server.vm()` etc.). Without `#[inline]` a generic trait
     // impl is not eligible for cross-crate inlining at all, so each accessor
     // would compile to a real `call` even though the inherent method it
     // forwards to is itself one instruction.
     #[inline(always)]
-    fn global_this(&self) -> &jsc::JSGlobalObject {
-        Self::global_this(self)
+    fn global_this(&self) -> &'static jsc::JSGlobalObject {
+        bun_opaque::opaque_deref(self.global_this)
     }
     #[inline(always)]
     fn vm(&self) -> &jsc::VirtualMachine {
@@ -3642,8 +3624,8 @@ impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
         &self.config
     }
     #[inline]
-    fn on_request_complete(&mut self) {
-        Self::on_request_complete(self)
+    fn on_request_complete(this: bun_ptr::BackRef<Self, bun_ptr::Mut>) {
+        AnyServer::from(this.as_ptr().cast_const()).on_request_complete()
     }
     #[inline]
     fn dev_server(&self) -> Option<&crate::bake::DevServer::DevServer> {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -28,7 +28,7 @@ use bun_jsc::{
     JsResult, Node, StringJsc as _, VirtualMachine, host_fn,
 };
 use bun_paths as paths;
-use bun_ptr::RefPtr;
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_resolver::fs::FileSystem;
 use bun_standalone_graph::StandaloneModuleGraph;
 use bun_sys as sys;
@@ -56,7 +56,8 @@ pub(super) use super::any_request_context::AnyRequestContext;
 pub(super) use super::file_route::FileRoute;
 pub(super) use super::node_http_response::NodeHTTPResponse;
 pub(super) use super::request_context::{
-    DeferDeinitFlag, RequestContext as NewRequestContext, UpgradeState,
+    DeferDeinitFlag, REQUEST_CONTEXT_POOL_CAPACITY, RequestContext as NewRequestContext,
+    UpgradeState,
 };
 pub(super) use super::server_config::{self as server_config, ServerConfig};
 pub(super) use super::server_web_socket::ServerWebSocket;
@@ -70,25 +71,53 @@ pub(super) use super::static_route::StaticRoute;
 // response handle is a separate generic (`R: RespLike`) at each dispatch
 // entry point: the MUX instantiation serves both `h2::Response` and
 // `h3::Response`.
-trait RequestCtx: super::any_request_context::CtxKind {
+trait RequestCtx: super::any_request_context::CtxKind + Sized {
     type Req: ReqLike;
+    type PoolOwner;
     const IS_MUX: bool;
+    /// A slot in `server`'s pool for this transport.
+    fn claim_slot(
+        server: &Self::PoolOwner,
+    ) -> bun_collections::hive_array::HiveSlot<'_, Self, REQUEST_CONTEXT_POOL_CAPACITY>;
 }
-impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
-    for NewRequestContext<ThisServer, SSL, DBG, false>
+impl<const SSL: bool, const DBG: bool> RequestCtx
+    for NewRequestContext<NewServer<SSL, DBG>, SSL, DBG, false>
 where
-    NewRequestContext<ThisServer, SSL, DBG, false>: super::any_request_context::CtxKind,
+    Self: super::any_request_context::CtxKind,
 {
     type Req = uws_sys::Request;
+    type PoolOwner = NewServer<SSL, DBG>;
     const IS_MUX: bool = false;
+    #[inline]
+    fn claim_slot(
+        server: &NewServer<SSL, DBG>,
+    ) -> bun_collections::hive_array::HiveSlot<'_, Self, REQUEST_CONTEXT_POOL_CAPACITY> {
+        // SAFETY: `request_pool` points at the thread's process-lifetime pool
+        // (`ServerPools::request_pool`), set at construction.
+        unsafe { (*server.request_pool).claim() }
+    }
 }
-impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
-    for NewRequestContext<ThisServer, SSL, DBG, true>
+impl<const SSL: bool, const DBG: bool> RequestCtx
+    for NewRequestContext<NewServer<SSL, DBG>, SSL, DBG, true>
 where
-    NewRequestContext<ThisServer, SSL, DBG, true>: super::any_request_context::CtxKind,
+    Self: super::any_request_context::CtxKind,
 {
     type Req = uws_sys::h3::Request;
+    type PoolOwner = NewServer<SSL, DBG>;
     const IS_MUX: bool = true;
+    #[inline]
+    fn claim_slot(
+        server: &NewServer<SSL, DBG>,
+    ) -> bun_collections::hive_array::HiveSlot<'_, Self, REQUEST_CONTEXT_POOL_CAPACITY> {
+        debug_assert!(
+            !server.mux_request_pool.is_null(),
+            "HTTP/2 or HTTP/3 request dispatched but mux_request_pool was never allocated"
+        );
+        // SAFETY: `mux_request_pool` points at the thread's process-lifetime
+        // pool once `listen()` created an HTTP/2 or HTTP/3 app, which precedes
+        // any such request.
+        unsafe { (*server.mux_request_pool).claim() }
+    }
 }
 
 /// Field/method surface needed on the generic `Ctx` so the bodies of
@@ -96,37 +125,33 @@ where
 /// can be written without naming the concrete `RequestContext<_, SSL, DBG, MUX>`
 /// type. Implemented via blanket impl below for every `NewRequestContext<..>`.
 #[allow(clippy::too_many_arguments)]
-trait RequestCtxOps: RequestCtx {
+trait RequestCtxOps: RequestCtx<PoolOwner = <Self as RequestCtxOps>::Server> + Sized {
     type Server;
     fn create_in(
-        slot: *mut Self,
-        server: *mut Self::Server,
+        slot: bun_collections::hive_array::HiveSlot<'_, Self, REQUEST_CONTEXT_POOL_CAPACITY>,
+        server: bun_ptr::BackRef<Self::Server, bun_ptr::Mut>,
         req: &mut Self::Req,
         resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<http::Method>,
-    );
+    ) -> ThisPtr<Self>;
     fn on_response(&self, server: &Self::Server, request_value: JSValue, response_value: JSValue);
-    fn deinit(&self);
+    fn deinit(this: ThisPtr<Self>);
     fn should_render_missing(&self) -> bool;
     fn render_missing(&self);
-    fn to_async(&self, req: &mut Self::Req, request_object: &mut Request);
+    fn to_async(&self, req: &mut Self::Req, request_object: &Request);
     fn ctx_method(&self) -> http::Method;
     fn set_defer_deinit(&self, flag: Option<DeferDeinitFlag>);
     fn set_request_body(&self, body: Option<crate::webcore::body::BodyHiveHandle>);
-    #[allow(
-        clippy::mut_from_ref,
-        reason = "the body slot is a separate pooled allocation, not a field of *self (R-2)"
-    )]
-    fn request_body_mut(&self) -> Option<&mut BodyValue>;
+    fn set_pending_request_body(&self, pending: crate::webcore::body::PendingValue);
     fn set_signal(&self, sig: *mut AbortSignal);
-    fn set_request_weakref(&self, req: *mut Request);
+    fn set_request_weakref(&self, req: ThisPtr<Request>);
     fn clear_req(&self);
     fn set_is_web_browser_navigation(&self, v: bool);
     fn set_request_body_content_len(&self, len: usize);
     fn set_is_transfer_encoding(&self, v: bool);
     fn set_is_waiting_for_request_body(&self, v: bool);
-    fn arm_on_data(&self, resp: uws::AnyResponse);
+    fn arm_on_data(this: ThisPtr<Self>, resp: uws::AnyResponse);
     // body-streaming callback hooks (type-erased, stored on `Body::PendingValue`).
     // `this` must be a live `*mut Self::RequestCtx` cast to `*mut c_void`.
     fn on_start_buffering_callback(this: NonNull<c_void>);
@@ -141,37 +166,35 @@ trait RequestCtxOps: RequestCtx {
 impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> RequestCtxOps
     for NewRequestContext<ThisServer, SSL, DBG, MUX>
 where
-    Self: RequestCtx,
+    Self: RequestCtx<PoolOwner = ThisServer>,
     ThisServer: super::ServerLike + 'static,
 {
     type Server = ThisServer;
     #[inline]
     fn create_in(
-        slot: *mut Self,
-        server: *mut ThisServer,
+        slot: bun_collections::hive_array::HiveSlot<'_, Self, REQUEST_CONTEXT_POOL_CAPACITY>,
+        server: bun_ptr::BackRef<ThisServer, bun_ptr::Mut>,
         req: &mut Self::Req,
         any_resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<http::Method>,
-    ) {
-        // SAFETY: `slot` points at a fresh HiveArray pool entry; treat as
-        // MaybeUninit for in-place construction — `&mut` scoped to this call.
+    ) -> ThisPtr<Self> {
         Self::create(
-            unsafe { &mut *slot.cast::<core::mem::MaybeUninit<Self>>() },
+            slot,
             server,
-            std::ptr::from_mut(req).cast(),
+            ReqLike::to_any_request(req),
             any_resp,
             should_deinit_context,
             method,
-        );
+        )
     }
     #[inline]
     fn on_response(&self, server: &ThisServer, rq: JSValue, rv: JSValue) {
         Self::on_response(self, server, rq, rv)
     }
     #[inline]
-    fn deinit(&self) {
-        Self::deinit(self)
+    fn deinit(this: ThisPtr<Self>) {
+        Self::deinit(this)
     }
     #[inline]
     fn should_render_missing(&self) -> bool {
@@ -182,8 +205,8 @@ where
         Self::render_missing(self)
     }
     #[inline]
-    fn to_async(&self, req: &mut Self::Req, ro: &mut Request) {
-        Self::to_async(self, std::ptr::from_mut(req).cast(), ro)
+    fn to_async(&self, req: &mut Self::Req, ro: &Request) {
+        Self::to_async(self, ReqLike::to_any_request(req), ro)
     }
     #[inline]
     fn ctx_method(&self) -> http::Method {
@@ -198,13 +221,8 @@ where
         self.request_body.set(body)
     }
     #[inline]
-    fn request_body_mut(&self) -> Option<&mut BodyValue> {
-        // SAFETY: R-2 invariant — slot shared with `Request.body`, never
-        // `&mut`-borrowed concurrently (single-threaded event loop).
-        self.request_body
-            .get()
-            .as_ref()
-            .map(|h| unsafe { &mut (*h.as_ptr()).value })
+    fn set_pending_request_body(&self, pending: crate::webcore::body::PendingValue) {
+        Self::set_pending_request_body(self, pending)
     }
     #[inline]
     fn set_signal(&self, sig: *mut AbortSignal) {
@@ -215,11 +233,9 @@ where
         self.signal.set(NonNull::new(sig));
     }
     #[inline]
-    fn set_request_weakref(&self, req: *mut Request) {
-        // SAFETY: `req` is a freshly-boxed Request (live for the request
-        // duration) still carrying its `heap::into_raw` provenance.
+    fn set_request_weakref(&self, req: ThisPtr<Request>) {
         self.request_weakref
-            .set(unsafe { bun_ptr::WeakPtr::<Request>::init_ref(req) });
+            .set(bun_ptr::WeakPtr::<Request>::from_this(req));
     }
     #[inline]
     fn clear_req(&self) {
@@ -242,17 +258,8 @@ where
         self.flags.set_is_waiting_for_request_body(v)
     }
     #[inline]
-    fn arm_on_data(&self, resp: uws::AnyResponse) {
-        fn handler<S, const SSL_: bool, const DBG_: bool, const MUX_: bool>(
-            ctx: *mut NewRequestContext<S, SSL_, DBG_, MUX_>,
-            chunk: &[u8],
-            last: bool,
-        ) where
-            S: super::ServerLike + 'static,
-        {
-            NewRequestContext::<S, SSL_, DBG_, MUX_>::on_buffered_body_chunk(ctx, chunk, last);
-        }
-        resp.on_data(handler::<ThisServer, SSL, DBG, MUX>, self.as_ctx_ptr());
+    fn arm_on_data(this: ThisPtr<Self>, resp: uws::AnyResponse) {
+        resp.on_data_this(Self::on_buffered_body_chunk, this);
     }
     #[inline]
     fn on_start_buffering_callback(this: NonNull<c_void>) {
@@ -284,8 +291,13 @@ trait ReqLike {
     fn method(&mut self) -> &[u8];
     fn url(&mut self) -> &[u8];
     fn set_yield(&mut self, y: bool);
+    fn to_any_request(&mut self) -> uws::AnyRequest;
 }
 impl ReqLike for uws_sys::Request {
+    #[inline]
+    fn to_any_request(&mut self) -> uws::AnyRequest {
+        uws::AnyRequest::H1(self)
+    }
     #[inline]
     fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
         uws_sys::Request::header(self, name)
@@ -308,6 +320,10 @@ impl ReqLike for uws_sys::Request {
     }
 }
 impl ReqLike for uws_sys::h3::Request {
+    #[inline]
+    fn to_any_request(&mut self) -> uws::AnyRequest {
+        uws::AnyRequest::H3(self)
+    }
     #[inline]
     fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
         uws_sys::h3::Request::header(self, name)
@@ -1246,7 +1262,7 @@ pub(super) use super::{
 pub(crate) struct PreparedRequestFor<Ctx> {
     pub(crate) js_request: JSValue,
     pub(crate) request_object: *mut Request,
-    pub ctx: *mut Ctx,
+    pub ctx: ThisPtr<Ctx>,
 }
 
 // `WebSocketUpgradeServer<SSL>` so `ServerWebSocket::behavior::<Self, SSL>` and
@@ -1530,7 +1546,7 @@ where
         if matches!(self.config.address, server_config::Address::Unix(_)) {
             return Ok(JSValue::NULL);
         }
-        let Some(info) = request.request_context.get_remote_socket_info() else {
+        let Some(info) = request.request_context.get().get_remote_socket_info() else {
             return Ok(JSValue::NULL);
         };
         crate::socket::socket_address::SocketAddress::create_dto(
@@ -1567,7 +1583,10 @@ where
 
         if let Some(request) = <Request as bun_jsc::JsClass>::from_js(arguments[0]) {
             // SAFETY: from_js returns a live *mut Request; shared access only.
-            let _ = unsafe { (*request).request_context.set_timeout(value) };
+            let _ = unsafe { &*request }
+                .request_context
+                .get()
+                .set_timeout(value);
         } else if let Some(response) = <NodeHTTPResponse as bun_jsc::JsClass>::from_js(arguments[0])
         {
             // SAFETY: from_js returns a live *mut NodeHTTPResponse
@@ -1789,18 +1808,16 @@ where
             );
         };
         // SAFETY: from_js returns a live *mut Request (rooted by the caller's
-        // argument). Shared, re-derived after each JS re-entry point below; the
-        // one field write at the end goes through `request_ptr`.
+        // argument). Shared, re-derived after each JS re-entry point below.
         let request = unsafe { &*request_ptr };
 
-        let Some(upgrader_ptr) = request
+        let Some(upgrader) = request
             .request_context
+            .get()
             .get::<ServerRequestContext<SSL, DEBUG>>()
         else {
             return Ok(JSValue::FALSE);
         };
-        // SAFETY: tagged pointer just matched this monomorphization.
-        let upgrader = unsafe { &*upgrader_ptr };
 
         if upgrader.is_aborted_or_ended() {
             return Ok(JSValue::FALSE);
@@ -1816,14 +1833,13 @@ where
 
         // Keep the upgrader alive across option getters below, which run
         // arbitrary user JS. A re-entrant server.upgrade(req) from a getter
-        // would otherwise be able to deref this context out from under us.
-        upgrader.ref_();
-        let _upgrader_guard = scopeguard::guard(upgrader_ptr, |p| {
-            // SAFETY: `p` is the live `upgrader_ptr` whose refcount was bumped by
-            // the `ref_()` above; this guard pairs it with a single `deref()`.
-            unsafe { (*p).deref() }
-        });
+        // would otherwise be able to release this context out from under us.
+        let _upgrader_guard = bun_ptr::RefPtr::from_this(upgrader);
 
+        // `server.upgrade()` is HTTP/1-only — H3 contexts have a distinct
+        // generic param and `request_context.get` above would have returned
+        // None. Live while `RequestContext.req` is Some.
+        let uws_req = upgrader.req.get();
         let mut sec_websocket_key = Utf8Bytes::EMPTY;
         let mut sec_websocket_protocol = Utf8Bytes::EMPTY;
         let mut sec_websocket_extensions = Utf8Bytes::EMPTY;
@@ -1856,17 +1872,7 @@ where
             }
         }
 
-        // SAFETY: upgrader_ptr is live (ref_() above)
-        let upgrader = unsafe { &*upgrader_ptr };
-        if let Some(req_ptr) = upgrader.req.get() {
-            // NOTE: `RequestContext.req` is type-erased to `*mut c_void`
-            // (RequestContext.rs:82). `server.upgrade()` is HTTP/1-only — H3
-            // contexts have a distinct generic param and `request_context.get`
-            // above would have returned None — so the concrete `Req` is always
-            // `uws_sys::Request` here.
-            // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref
-            // (BACKREF; live while RequestContext.req is Some).
-            let r = bun_opaque::opaque_deref(req_ptr.cast::<uws_sys::Request>().cast_const());
+        if let Some(r) = &uws_req {
             for (value, name) in [
                 (&mut sec_websocket_key, b"sec-websocket-key".as_slice()),
                 (&mut sec_websocket_protocol, b"sec-websocket-protocol"),
@@ -1898,8 +1904,6 @@ where
         if sec_websocket_version.slice() != b"13" {
             resp.write_status(b"426 Upgrade Required");
             resp.write_header(b"Sec-WebSocket-Version", b"13");
-            // SAFETY: upgrader_ptr is live (ref_() above)
-            let upgrader = unsafe { &*upgrader_ptr };
             upgrader.flags.set_has_written_status(true);
             upgrader.end_without_body(true);
             return Ok(JSValue::FALSE);
@@ -1967,8 +1971,6 @@ where
             }
         }
 
-        // SAFETY: upgrader_ptr is live (ref_() above)
-        let upgrader = unsafe { &*upgrader_ptr };
         // Option getters may have run a re-entrant server.upgrade(req).
         if upgrader.is_aborted_or_ended() || upgrader.did_upgrade_web_socket() {
             return Ok(JSValue::FALSE);
@@ -2019,14 +2021,13 @@ where
             request.url.set(BunString::EMPTY);
         }
         if !request.has_fetch_headers() {
-            if let Some(req_ptr) = upgrader.req.get() {
-                request.set_fetch_headers(Some(HeadersRef::create_from_uws(req_ptr)));
+            if let Some(uws::AnyRequest::H1(req_ptr)) = upgrader.req.get() {
+                request
+                    .set_fetch_headers(Some(HeadersRef::create_from_uws(req_ptr.cast::<c_void>())));
             }
         }
 
-        // SAFETY: plain-field detach through the root pointer; the shared
-        // borrow above is not used past this point.
-        unsafe { (*request_ptr).request_context = AnyRequestContext::NULL };
+        request.request_context.set(AnyRequestContext::NULL);
         upgrader.request_weakref.set(request::WeakRef::EMPTY);
 
         data_value.ensure_still_alive();
@@ -2044,9 +2045,9 @@ where
 
         // The upgrade detaches the response and disarms onAborted, so neither
         // on_abort nor an end path can reclaim a parked handler promise's
-        // claim later. Reclaim it here.
+        // ref later. Reclaim it here.
         upgrader.reclaim_promise_cell();
-        upgrader.deref();
+        upgrader.release_in_flight();
 
         resp.upgrade(
             ws,
@@ -2819,13 +2820,14 @@ where
         scopeguard::defer! {
             // uWS request will not live longer than this function
             // SAFETY: request_object outlives this stack frame (boxed on the request).
-            unsafe { (*detach_ptr).request_context.detach_request() };
+            unsafe { &*detach_ptr }.request_context.get().detach_request();
         }
 
-        // SAFETY: `prepared.ctx` was allocated by `prepare_js_request_context_for`
-        // for this frame and cannot be freed while `defer_deinit_...` is set (set
-        // by the caller until cleared below); `this` is the live server backref.
-        let (ctx, server) = unsafe { (&*prepared.ctx, &*this) };
+        // `prepared.ctx` was allocated by `prepare_js_request_context_for`
+        // for this frame and stays allocated while `defer_deinit_...` is set (set
+        // by the caller until cleared below).
+        // SAFETY: `this` is the live server backref.
+        let (ctx, server) = (prepared.ctx.get(), unsafe { &*this });
         RequestCtxOps::on_response(ctx, server, prepared.js_request, response_value);
         // Reference in the stack here in case it is not for whatever reason
         prepared.js_request.ensure_still_alive();
@@ -2833,7 +2835,7 @@ where
         RequestCtxOps::set_defer_deinit(ctx, None);
 
         if should_deinit_context.get() {
-            RequestCtxOps::deinit(ctx);
+            <Ctx as RequestCtxOps>::deinit(prepared.ctx);
             return;
         }
 
@@ -2845,7 +2847,7 @@ where
         // The request is asynchronous, and all information from `req` must be copied
         // since the provided uws.Request will be re-used for future requests (stack allocated).
         // SAFETY: `request_object_ptr` is the live heap `Request` (see above).
-        RequestCtxOps::to_async(ctx, req, unsafe { &mut *request_object_ptr });
+        RequestCtxOps::to_async(ctx, req, unsafe { &*request_object_ptr });
     }
 
     fn on_request_for<Ctx: RequestCtxOps<Server = Self>, R: RespLike>(
@@ -2903,8 +2905,8 @@ where
     ) -> Option<PreparedRequestFor<Ctx>> {
         jsc::mark_binding!();
         // SAFETY: `this` is the live heap server registered as the callback
-        // user-data; everything below only needs `&Self`.
-        let server = unsafe { &*this };
+        // user-data (write provenance); it owns the request pool and outlives every context, which is the backref `create_in` stores. Everything below only needs `&Self`.
+        let server = unsafe { bun_ptr::BackRef::from_raw_mut(this) };
 
         // We need to register the handler immediately since uSockets will not buffer.
         //
@@ -2968,49 +2970,18 @@ where
         }
 
         let any_resp = RespLike::to_any_response(resp);
-        // SAFETY: both allocators hand out `*mut RequestContext<_, SSL, DEBUG, _>`; the
-        // const-bool MUX parameter only affects associated consts/types, not layout, so
-        // reinterpreting the slot pointer as the caller's `Ctx` monomorphization is sound.
-        //
-        // `claim()` reserves the slot as a `HiveSlot`; `create_in` does
-        // `MaybeUninit::write` placement-new through the slot's stable
-        // address, after which `assume_init()` consumes the token.
-        // `RequestContext` carries the heaviest drop glue in the codebase, so
-        // a panic inside `create_in` now releases the slot via
-        // `HiveSlot::drop` without running `RequestContext::drop` on garbage.
-        let ctx_slot: *mut Ctx = unsafe {
-            if Ctx::IS_MUX {
-                debug_assert!(
-                    !server.mux_request_pool.is_null(),
-                    "HTTP/2 or HTTP/3 request dispatched but mux_request_pool was never allocated"
-                );
-                let slot = (*server.mux_request_pool).claim();
-                Ctx::create_in(
-                    slot.addr().as_ptr().cast(),
-                    this,
-                    req,
-                    any_resp,
-                    should_deinit_context,
-                    method,
-                );
-                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-                slot.assume_init().as_ptr().cast()
-            } else {
-                let slot = (*server.request_pool).claim();
-                Ctx::create_in(
-                    slot.addr().as_ptr().cast(),
-                    this,
-                    req,
-                    any_resp,
-                    should_deinit_context,
-                    method,
-                );
-                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-                slot.assume_init().as_ptr().cast()
-            }
-        };
-        // SAFETY: ctx_slot was just initialized by create_in.
-        let ctx = unsafe { &*ctx_slot };
+        // `claim()` reserves the slot as a `HiveSlot`; `create_in` writes it. A
+        // panic inside `create_in` releases the slot via `HiveSlot::drop`
+        // without running `RequestContext::drop` on garbage.
+        let ctx_slot: ThisPtr<Ctx> = Ctx::create_in(
+            Ctx::claim_slot(&server),
+            server,
+            req,
+            any_resp,
+            should_deinit_context,
+            method,
+        );
+        let ctx = ctx_slot.get();
 
         server
             .vm()
@@ -3020,7 +2991,7 @@ where
         // Pooled body slot, ref_count = 1.
         let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
         // The ctx and Request each own a +1 on the
-        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
+        // same slot. Paired drop in `RequestContext::teardown` / `Request::finalize`.
         ctx.set_request_body(Some(body_hive.clone()));
 
         let signal = AbortSignal::new(&server.global());
@@ -3032,20 +3003,22 @@ where
         let signal_for_req = bun_opaque::opaque_deref_mut(signal).ref_();
         let request_object_box = Request::new(Request::init(
             ctx.ctx_method(),
-            AnyRequestContext::init(std::ptr::from_ref::<Ctx>(ctx)),
+            AnyRequestContext::init(ctx_slot),
             SSL,
             Some(signal_for_req),
             body_hive,
         ));
         // Leak so the ctx (which outlives this stack frame) can hold the
-        // pointer; Request is freed via ctx.deinit's request_weakref. The weak
-        // handle takes the raw pointer, not a reborrow of `request_object`:
+        // pointer; Request is freed via the ctx's request_weakref. The weak
+        // handle takes the root pointer, not a reborrow of `request_object`:
         // writes through `request_object` below would otherwise invalidate it.
         let request_object_ptr: *mut Request = bun_core::heap::into_raw(request_object_box);
-        ctx.set_request_weakref(request_object_ptr);
-        // SAFETY: freshly leaked; shared view — everything below (headers/url
-        // population, `to_js`) takes `&Request`.
-        let request_object: &Request = unsafe { &*request_object_ptr };
+        // SAFETY: freshly leaked; live until the JS wrapper / weakref release it.
+        let request_this = unsafe { ThisPtr::new(request_object_ptr) };
+        ctx.set_request_weakref(request_this);
+        // Shared view — everything below (headers/url population, `to_js`)
+        // takes `&Request`.
+        let request_object: &Request = request_this.get();
 
         // The lazy `getRequest()` path that backs Request.url / .headers
         // is `*uws.Request`-typed; for HTTP/2 and HTTP/3 we populate both
@@ -3116,23 +3089,21 @@ where
                 // we defer pre-allocating the body until we receive the first chunk
                 // that way if the client is lying about how big the body is or the client aborts
                 // we don't waste memory
-                if let Some(body) = ctx.request_body_mut() {
-                    *body = BodyValue::Locked(crate::webcore::body::PendingValue {
-                        task: Some(NonNull::new(ctx_slot).unwrap().cast::<c_void>()),
-                        global: server.global_this,
-                        on_start_buffering: Some(Ctx::on_start_buffering_callback),
-                        on_start_streaming: Some(Ctx::on_start_streaming_request_body_callback),
-                        on_readable_stream_available: Some(
-                            Ctx::on_request_body_readable_stream_available,
-                        ),
-                        producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
-                            AnyRequestContext::init(ctx_slot),
-                        ),
-                        ..Default::default()
-                    });
-                }
+                ctx.set_pending_request_body(crate::webcore::body::PendingValue {
+                    task: Some(NonNull::from(ctx_slot).cast::<c_void>()),
+                    global: server.global_this,
+                    on_start_buffering: Some(Ctx::on_start_buffering_callback),
+                    on_start_streaming: Some(Ctx::on_start_streaming_request_body_callback),
+                    on_readable_stream_available: Some(
+                        Ctx::on_request_body_readable_stream_available,
+                    ),
+                    producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
+                        AnyRequestContext::init(ctx_slot),
+                    ),
+                    ..Default::default()
+                });
                 ctx.set_is_waiting_for_request_body(true);
-                ctx.arm_on_data(any_resp);
+                Ctx::arm_on_data(ctx_slot, any_resp);
             }
         }
 
@@ -3186,12 +3157,10 @@ where
         ) else {
             return;
         };
-        // SAFETY: `prepared.ctx` is the freshly-allocated RequestContext slot.
-        unsafe {
-            (*prepared.ctx)
-                .upgrade_context
-                .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)))
-        };
+        prepared
+            .ctx
+            .upgrade_context
+            .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)));
         let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
         // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe deref.
@@ -3250,10 +3219,12 @@ where
         debug_assert!(id == 0);
         let self_ptr: *mut Self = this;
         // SAFETY: for `id == 0` the registered user-data IS `*mut Self`
-        // (mod.rs `app.ws("/*", self_ptr, 0, ..)`); live for the request's
-        // duration. Shared — the `on_request` call below re-enters JS, so no
-        // `&mut` may span it (pending-request accounting is a `Cell`).
-        let this = unsafe { &*self_ptr };
+        // (mod.rs `app.ws("/*", self_ptr, 0, ..)`); the server outlives every
+        // request context (the backref `create_in` stores). Shared — the
+        // `on_request` call below re-enters JS, so no `&mut` may span it
+        // (pending-request accounting is a `Cell`).
+        let server = unsafe { bun_ptr::BackRef::from_raw_mut(self_ptr) };
+        let this = server.get();
         // Guards both branches below: the `on_request` fallthrough has no
         // other gate, and the node:http branch's own re-check (mod.rs:
         // `on_node_http_request_with_upgrade_ctx`) is redundant on this path
@@ -3278,25 +3249,21 @@ where
         let _entered = this.vm().enter_event_loop_scope_without_checkpoint();
         this.on_pending_request();
         req.set_yield(false);
-        // SAFETY: `request_pool` is non-null while the server is alive; `claim()`
-        // reserves a fresh slot whose `Drop` releases it on panic before init.
-        let ctx_slot = unsafe { (*this.request_pool).claim() };
         let should_deinit_context = core::cell::Cell::new(false);
-        <ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create_in(
-            ctx_slot.addr().as_ptr(),
-            self_ptr,
+        let ctx_this = <ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create_in(
+            <ServerRequestContext<SSL, DEBUG> as RequestCtx>::claim_slot(this),
+            server,
             req,
             RespLike::to_any_response(resp),
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             None,
         );
-        // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-        let ctx = unsafe { &*ctx_slot.assume_init().as_ptr() };
+        let ctx = ctx_this.get();
 
         // Pooled body slot, ref_count = 1.
         let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
         // The ctx and Request each own a +1 on the
-        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
+        // same slot. Paired drop in `RequestContext::teardown` / `Request::finalize`.
         ctx.request_body.set(Some(body_hive.clone()));
 
         let signal = AbortSignal::new(&this.global());
@@ -3310,7 +3277,7 @@ where
         let signal_for_req = bun_opaque::opaque_deref_mut(signal).ref_();
         let request_object_box = Request::new(Request::init(
             ctx.method,
-            AnyRequestContext::init(std::ptr::from_ref(ctx)),
+            AnyRequestContext::init(ctx_this),
             SSL,
             Some(signal_for_req),
             body_hive,
@@ -3318,30 +3285,27 @@ where
         ctx.upgrade_context
             .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)));
         // Leaked so the ctx (which outlives this stack frame) can hold the
-        // pointer; freed via ctx.deinit's request_weakref. Everything below
-        // goes through this raw pointer rather than a `&mut Request` reborrow:
-        // the weak handle and the deferred `detach_request` both alias it.
+        // pointer; freed via the ctx's request_weakref. The weak handle
+        // takes the root pointer; everything below is a shared view of it.
         let request_object_ptr: *mut Request = bun_core::heap::into_raw(request_object_box);
-        // SAFETY: freshly leaked, so it carries the allocation's provenance.
+        // SAFETY: freshly leaked; live until the JS wrapper / weakref release it.
+        let request_this = unsafe { ThisPtr::new(request_object_ptr) };
         ctx.request_weakref
-            .set(unsafe { bun_ptr::WeakPtr::<Request>::init_ref(request_object_ptr) });
+            .set(bun_ptr::WeakPtr::<Request>::from_this(request_this));
+        let request_object = request_this.get();
 
         // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
         let global = this.global();
-        // SAFETY: `request_object_ptr` is live; no other borrow is outstanding.
-        let args = [unsafe { (*request_object_ptr).to_js(&global) }, server_js];
+        let args = [request_object.to_js(&global), server_js];
         args[0].ensure_still_alive();
 
         let response_value = match this.config.on_request.call(&global, server_js, &args) {
             Ok(v) => v,
             Err(err) => global.take_exception(err),
         };
-        // Its own copy, so the closure's capture does not pin `request_object_ptr`.
-        let detach_ptr = request_object_ptr;
         scopeguard::defer! {
             // uWS request will not live longer than this function
-            // SAFETY: see request_object_ptr above.
-            unsafe { (*detach_ptr).request_context.detach_request() };
+            request_object.request_context.get().detach_request();
         }
 
         ctx.on_response(this, args[0], response_value);
@@ -3349,7 +3313,7 @@ where
         ctx.defer_deinit_until_callback_completes.set(None);
 
         if should_deinit_context.get() {
-            ctx.deinit();
+            ServerRequestContext::<SSL, DEBUG>::deinit(ctx_this);
             return;
         }
 
@@ -3358,12 +3322,7 @@ where
             return;
         }
 
-        ctx.to_async(
-            std::ptr::from_mut::<uws::Request>(req).cast::<c_void>(),
-            // SAFETY: `request_object_ptr` is live (the ctx's weakref owns it)
-            // and no other borrow of the Request is outstanding here.
-            unsafe { &mut *request_object_ptr },
-        );
+        ctx.to_async(uws::AnyRequest::H1(req), request_object);
     }
 
     // https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5075,7 +5075,9 @@ pub(crate) fn write_file_internal(
                     };
                     let producer_hook = locked.on_start_buffering.take().zip(locked.task);
                     locked.task = Some(NonNull::new(task).unwrap().cast::<c_void>());
-                    locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
+                    locked.on_receive_value = Some(crate::webcore::body::ReceiveValue::Ctx(
+                        WriteFileWaitFromLockedValueTask::then_wrap,
+                    ));
                     // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.
                     let promise = unsafe { (*task).promise.value() };
                     // Signalled last (see `PendingValue::on_start_buffering`):

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5074,10 +5074,10 @@ pub(crate) fn write_file_internal(
                         unreachable!()
                     };
                     let producer_hook = locked.on_start_buffering.take().zip(locked.task);
-                    locked.task = Some(NonNull::new(task).unwrap().cast::<c_void>());
-                    locked.on_receive_value = Some(crate::webcore::body::ReceiveValue::Ctx(
-                        WriteFileWaitFromLockedValueTask::then_wrap,
-                    ));
+                    locked.on_receive_value = Some(crate::webcore::body::ReceiveValue::Ctx {
+                        callback: WriteFileWaitFromLockedValueTask::then_wrap,
+                        ctx: NonNull::new(task).unwrap().cast::<c_void>(),
+                    });
                     // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.
                     let promise = unsafe { (*task).promise.value() };
                     // Signalled last (see `PendingValue::on_start_buffering`):

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -870,9 +870,8 @@ impl Value {
             unreachable!("locked_to_native_stream on non-Locked Value");
         };
         // A registered `on_receive_value` means a native consumer (Bun.write,
-        // the server's render-wait) owns this body and has retargeted `task`
-        // to its own context; materializing a stream here would dispatch the
-        // producer's remaining callbacks with that foreign context.
+        // the server's render-wait) already owns this body; a stream created
+        // here would be a second consumer competing for the same bytes.
         if locked.promise.is_some() || !locked.action.is_none() || locked.on_receive_value.is_some()
         {
             return ReadableStream::used(global_this);
@@ -1463,7 +1462,7 @@ impl Value {
             }));
         }
 
-        // `on_receive_value`: same consumer-owned-task guard as
+        // `on_receive_value`: a native consumer already owns the body, as in
         // `locked_to_native_stream`.
         if locked.promise.is_some()
             || !locked.action.is_none()

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -224,7 +224,7 @@ pub struct PendingValue {
     pub task: Option<NonNull<c_void>>,
 
     /// runs after the data is available.
-    pub(crate) on_receive_value: Option<fn(ctx: NonNull<c_void>, value: &mut Value)>,
+    pub(crate) on_receive_value: Option<ReceiveValue>,
 
     /// A consumer that wants the whole body (`.text()`/`.json()`/…,
     /// `Bun.write`) has started waiting on it without realising a stream.
@@ -244,6 +244,25 @@ pub struct PendingValue {
 
     pub(crate) deinit: bool,
     pub(crate) action: Action,
+}
+
+/// The native consumer waiting on a [`PendingValue`] (`on_receive_value`).
+pub(crate) enum ReceiveValue {
+    /// Called with [`PendingValue::task`], which the registrant retargeted to
+    /// its own context.
+    Ctx(fn(ctx: NonNull<c_void>, value: &mut Value)),
+    /// `Bun.serve` waiting to render a `Response` whose body was still
+    /// pending; the context's `body_value_ref` is the ref this holds.
+    Server(crate::server::AnyRequestContext),
+}
+
+impl ReceiveValue {
+    fn call(self, task: Option<NonNull<c_void>>, value: &mut Value) {
+        match self {
+            ReceiveValue::Ctx(callback) => callback(task.unwrap(), value),
+            ReceiveValue::Server(ctx) => ctx.render_pending_body_value(value),
+        }
+    }
 }
 
 impl PendingValue {
@@ -283,8 +302,8 @@ impl PendingValue {
         self.on_start_buffering = None;
         self.on_start_streaming = None;
         self.on_readable_stream_available = None;
-        if self.on_receive_value.is_none() {
-            // A registered `on_receive_value` means `task` is the consumer's
+        if !matches!(self.on_receive_value, Some(ReceiveValue::Ctx(_))) {
+            // A registered `ReceiveValue::Ctx` means `task` is the consumer's
             // ctx (overwriting the producer), read by `resolve()`.
             self.task = None;
         }
@@ -535,9 +554,11 @@ const POOL_SIZE: usize = if bun_alloc::heap_breakdown::ENABLED {
 } else {
     256
 };
-pub(crate) type HiveRef = bun_collections::HiveRef<Value, POOL_SIZE>;
+/// The pooled slot is shared by a `Request` and the `RequestContext` serving
+/// it (each holds a `+1`), so the value sits in a `JsCell`.
+pub(crate) type HiveRef = bun_collections::HiveRef<JsCell<Value>, POOL_SIZE>;
 pub(crate) type HiveAllocator = bun_collections::hive_array::Fallback<HiveRef, POOL_SIZE>;
-pub(crate) type BodyHiveHandle = bun_collections::HiveRefHandle<Value, POOL_SIZE>;
+pub(crate) type BodyHiveHandle = bun_collections::HiveRefHandle<JsCell<Value>, POOL_SIZE>;
 
 /// Moves `value` into a pooled `HiveRef` slot and returns an owning handle
 /// (ref_count = 1).
@@ -548,7 +569,7 @@ pub(crate) fn hive_alloc(value: Value) -> BodyHiveHandle {
     // heap-stable `Box<HiveAllocator>` for the VM lifetime.
     let pool = unsafe { &raw const **(*state).body_value_pool };
     // SAFETY: `pool` outlives every handle (process lifetime).
-    unsafe { BodyHiveHandle::new(value, pool) }
+    unsafe { BodyHiveHandle::new(JsCell::new(value), pool) }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
@@ -1073,7 +1094,7 @@ impl Value {
             }
 
             if let Some(callback) = locked.on_receive_value.take() {
-                callback(locked.task.unwrap(), new);
+                callback.call(locked.task, new);
                 return Ok(());
             }
 
@@ -1346,9 +1367,9 @@ impl Value {
             }
 
             if let Some(on_receive_value) = locked.on_receive_value.take() {
-                // `task` is the live request-ctx pointer registered alongside
-                // this callback.
-                on_receive_value(locked.task.unwrap(), self);
+                // For `ReceiveValue::Ctx`, `task` is the live consumer pointer
+                // registered alongside this callback.
+                on_receive_value.call(locked.task, self);
             }
 
             if was_disturbed {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -248,18 +248,20 @@ pub struct PendingValue {
 
 /// The native consumer waiting on a [`PendingValue`] (`on_receive_value`).
 pub(crate) enum ReceiveValue {
-    /// Called with [`PendingValue::task`], which the registrant retargeted to
-    /// its own context.
-    Ctx(fn(ctx: NonNull<c_void>, value: &mut Value)),
+    /// The registrant's own context, handed back to `callback`.
+    Ctx {
+        callback: fn(ctx: NonNull<c_void>, value: &mut Value),
+        ctx: NonNull<c_void>,
+    },
     /// `Bun.serve` waiting to render a `Response` whose body was still
     /// pending; the context's `body_value_ref` is the ref this holds.
     Server(crate::server::AnyRequestContext),
 }
 
 impl ReceiveValue {
-    fn call(self, task: Option<NonNull<c_void>>, value: &mut Value) {
+    fn call(self, value: &mut Value) {
         match self {
-            ReceiveValue::Ctx(callback) => callback(task.unwrap(), value),
+            ReceiveValue::Ctx { callback, ctx } => callback(ctx, value),
             ReceiveValue::Server(ctx) => ctx.render_pending_body_value(value),
         }
     }
@@ -302,11 +304,7 @@ impl PendingValue {
         self.on_start_buffering = None;
         self.on_start_streaming = None;
         self.on_readable_stream_available = None;
-        if !matches!(self.on_receive_value, Some(ReceiveValue::Ctx(_))) {
-            // A registered `ReceiveValue::Ctx` means `task` is the consumer's
-            // ctx (overwriting the producer), read by `resolve()`.
-            self.task = None;
-        }
+        self.task = None;
         self.producer = streams::SourceHandle::None;
     }
 
@@ -1094,7 +1092,7 @@ impl Value {
             }
 
             if let Some(callback) = locked.on_receive_value.take() {
-                callback.call(locked.task, new);
+                callback.call(new);
                 return Ok(());
             }
 
@@ -1367,9 +1365,7 @@ impl Value {
             }
 
             if let Some(on_receive_value) = locked.on_receive_value.take() {
-                // For `ReceiveValue::Ctx`, `task` is the live consumer pointer
-                // registered alongside this callback.
-                on_receive_value.call(locked.task, self);
+                on_receive_value.call(self);
             }
 
             if was_disturbed {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -76,9 +76,9 @@ const _: () = {
 /// `&mut Request`) so re-entrant JS calls cannot stack two `&mut` to the same
 /// instance. Fields mutated by host-fns are wrapped in `Cell` (Copy scalars)
 /// or `JsCell` (Drop types). Both are `#[repr(transparent)]`, so `#[repr(C)]`
-/// field layout is unchanged. `method`/`flags`/`request_context`/`body`/
-/// `weak_ptr_data` are only written during construction or via raw-ptr
-/// `finalize`, so stay plain.
+/// field layout is unchanged. `method`/`flags`/`body`/`weak_ptr_data` are only
+/// written during construction or via raw-ptr `finalize`, so stay plain;
+/// `request_context` is a `Cell` the serving `RequestContext` clears.
 #[repr(C)]
 pub struct Request {
     pub(crate) url: JsCell<BunString>,
@@ -98,7 +98,7 @@ pub struct Request {
     js_ref: JsCell<JsRef>,
     pub method: Method,
     pub(crate) flags: Flags,
-    pub(crate) request_context: AnyRequestContext,
+    pub(crate) request_context: Cell<AnyRequestContext>,
     pub(crate) weak_ptr_data: WeakPtrData,
     // We must report a consistent value for this
     reported_estimated_size: Cell<usize>,
@@ -200,17 +200,17 @@ impl Request {
     /// Immutable view of the body value.
     #[inline]
     fn body_value(&self) -> &BodyValue {
-        &self.body
+        self.body.get()
     }
 
-    /// R-2: `&self` → `&mut` through the slot's raw pointer. The slot is shared
+    /// R-2: `&self` → `&mut` through the slot's `JsCell`. The slot is shared
     /// with `RequestContext.request_body` but never `&mut`-borrowed concurrently
     /// (single-threaded event-loop sequencing). Keep the borrow short.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     fn body_value_mut(&self) -> &mut BodyValue {
         // SAFETY: see R-2 invariant above.
-        unsafe { &mut (*self.body.as_ptr()).value }
+        unsafe { self.body.get_mut() }
     }
 
     /// R-2: short-hand for `unsafe { self.headers.get_mut() }`. The
@@ -249,7 +249,7 @@ impl Request {
             return Ok(self.headers_mut().as_mut().unwrap());
         }
 
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // we have a request context, so we can get the headers from it
             self.headers.set(Some(HeadersRef::create_from_uws(
                 req.cast::<core::ffi::c_void>(),
@@ -298,7 +298,7 @@ impl Request {
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn get_fetch_headers_unless_empty(&self) -> Option<&mut HeadersRef> {
         if self.headers.get().is_none() {
-            if let Some(req) = self.request_context.get_request() {
+            if let Some(req) = self.request_context.get().get_request() {
                 // we have a request context, so we can get the headers from it
                 self.headers.set(Some(HeadersRef::create_from_uws(
                     req.cast::<core::ffi::c_void>(),
@@ -323,7 +323,7 @@ impl Request {
         global_this: &JSGlobalObject,
     ) -> JsResult<Option<HeadersRef>> {
         if self.headers.get().is_none() {
-            if let Some(uws_req) = self.request_context.get_request() {
+            if let Some(uws_req) = self.request_context.get().get_request() {
                 self.headers.set(Some(HeadersRef::create_from_uws(
                     uws_req.cast::<core::ffi::c_void>(),
                 )));
@@ -342,7 +342,7 @@ impl Request {
     }
 
     pub(crate) fn get_content_type(&self) -> JsResult<Option<bun_core::Utf8Bytes<'_>>> {
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             if let Some(value) = req.header(b"content-type") {
@@ -370,7 +370,7 @@ impl Request {
 impl Request {
     pub(crate) fn memory_cost(&self) -> usize {
         core::mem::size_of::<Request>()
-            + self.request_context.memory_cost()
+            + self.request_context.get().memory_cost()
             + self.url.get().byte_slice().len()
             + self.body_value().memory_cost()
     }
@@ -378,6 +378,7 @@ impl Request {
     #[bun_uws::uws_callback(export = "Request__setCookiesOnRequestContext")]
     pub fn ffi_set_cookies_on_request_context(&self, cookie_map: Option<&CookieMap>) {
         self.request_context
+            .get()
             .set_cookies(cookie_map.map(|c| std::ptr::from_ref::<CookieMap>(c).cast_mut()));
     }
 
@@ -428,7 +429,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::empty()),
             method,
             flags: Flags::default(),
-            request_context: AnyRequestContext::NULL,
+            request_context: Cell::new(AnyRequestContext::NULL),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         }
@@ -771,7 +772,7 @@ impl Request {
             return url.byte_slice().len();
         }
 
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             let req_url = Self::request_target_path(req.url());
@@ -863,7 +864,7 @@ impl Request {
             return Ok(());
         }
 
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             let req_url = Self::request_target_path(req.url());
@@ -992,7 +993,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::init_weak(this_value)),
             method: Method::GET,
             flags: Flags::default(),
-            request_context: AnyRequestContext::NULL,
+            request_context: Cell::new(AnyRequestContext::NULL),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         };
@@ -1499,7 +1500,7 @@ impl Request {
                     js_ref: JsCell::new(JsRef::empty()),
                     method: self.method,
                     flags: self.flags,
-                    request_context: AnyRequestContext::NULL,
+                    request_context: Cell::new(AnyRequestContext::NULL),
                     weak_ptr_data: WeakPtrData::EMPTY,
                     reported_estimated_size: Cell::new(0),
                 },
@@ -1531,7 +1532,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::empty()),
             method: Method::GET,
             flags: Flags::default(),
-            request_context: AnyRequestContext::NULL,
+            request_context: Cell::new(AnyRequestContext::NULL),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         });
@@ -1560,7 +1561,7 @@ impl Request {
                 https,
                 ..Flags::default()
             },
-            request_context,
+            request_context: Cell::new(request_context),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1338,7 +1338,7 @@ impl WriteFileWaitFromLockedValueTask {
                 // Re-registering for a future callback — `this` stays alive.
                 // Restore the moved-out blob so the next `then()` has its store.
                 this.file_blob = file_blob;
-                locked.on_receive_value = Some(Self::then_wrap);
+                locked.on_receive_value = Some(body::ReceiveValue::Ctx(Self::then_wrap));
                 locked.task = Some(
                     NonNull::new(bun_core::heap::into_raw(this))
                         .unwrap()

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1338,12 +1338,12 @@ impl WriteFileWaitFromLockedValueTask {
                 // Re-registering for a future callback — `this` stays alive.
                 // Restore the moved-out blob so the next `then()` has its store.
                 this.file_blob = file_blob;
-                locked.on_receive_value = Some(body::ReceiveValue::Ctx(Self::then_wrap));
-                locked.task = Some(
-                    NonNull::new(bun_core::heap::into_raw(this))
+                locked.on_receive_value = Some(body::ReceiveValue::Ctx {
+                    callback: Self::then_wrap,
+                    ctx: NonNull::new(bun_core::heap::into_raw(this))
                         .unwrap()
                         .cast::<c_void>(),
-                );
+                });
             }
         }
         Ok(())

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -81,6 +81,29 @@ pub(crate) fn stat(
     )
 }
 
+/// [`stat`] answering to a `Bun.serve` request context.
+pub(crate) fn stat_for_request_context(
+    this: &S3Credentials,
+    path: &[u8],
+    ctx: crate::server::AnyRequestContext,
+    proxy_url: Option<&[u8]>,
+    request_payer: bool,
+) -> JsResult<()> {
+    s3_simple_request::execute_simple_s3_request(
+        this,
+        s3_simple_request::Options {
+            path,
+            method: bun_http::Method::HEAD,
+            proxy_url,
+            body: b"",
+            request_payer,
+            ..Default::default()
+        },
+        s3_simple_request::Callback::StatRequestContext(ctx),
+        core::ptr::null_mut(),
+    )
+}
+
 pub(crate) fn download(
     this: &S3Credentials,
     path: &[u8],

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -37,6 +37,20 @@ pub struct S3StatSuccess<'a> {
     pub(crate) content_type: &'a [u8],
 }
 
+impl<'a> S3StatSuccess<'a> {
+    fn from_headers(headers: &picohttp::HeaderList<'a>) -> Self {
+        Self {
+            etag: headers.get(b"etag").unwrap_or(b""),
+            last_modified: headers.get(b"last-modified").unwrap_or(b""),
+            content_type: headers.get(b"content-type").unwrap_or(b""),
+            size: headers
+                .get(b"content-length")
+                .map(bun_http_types::parse_content_length)
+                .unwrap_or(0),
+        }
+    }
+}
+
 pub enum S3StatResult<'a> {
     Success(S3StatSuccess<'a>),
     NotFound(S3Error<'a>),
@@ -311,16 +325,7 @@ impl S3HttpSimpleTask {
             Callback::Stat(callback) => match response.status_code {
                 200 => {
                     callback(
-                        S3StatResult::Success(S3StatSuccess {
-                            etag: response.headers.get(b"etag").unwrap_or(b""),
-                            last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                            content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                            size: response
-                                .headers
-                                .get(b"content-length")
-                                .map(bun_http_types::parse_content_length)
-                                .unwrap_or(0),
-                        }),
+                        S3StatResult::Success(S3StatSuccess::from_headers(&response.headers)),
                         this.callback_context,
                     )?;
                 }
@@ -328,16 +333,9 @@ impl S3HttpSimpleTask {
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
             Callback::StatRequestContext(ctx) => match response.status_code {
-                200 => ctx.on_s3_size_resolved(S3StatResult::Success(S3StatSuccess {
-                    etag: response.headers.get(b"etag").unwrap_or(b""),
-                    last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                    content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                    size: response
-                        .headers
-                        .get(b"content-length")
-                        .map(bun_http_types::parse_content_length)
-                        .unwrap_or(0),
-                })),
+                200 => ctx.on_s3_size_resolved(S3StatResult::Success(S3StatSuccess::from_headers(
+                    &response.headers,
+                ))),
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -151,6 +151,8 @@ impl Taskable for S3HttpSimpleTask {
 
 pub enum Callback {
     Stat(fn(S3StatResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
+    /// A `Bun.serve` HEAD response sizing its S3 body; ignores `context`.
+    StatRequestContext(crate::server::AnyRequestContext),
     Download(fn(S3DownloadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
     Upload(fn(S3UploadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
     Delete(fn(S3DeleteResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
@@ -166,6 +168,9 @@ impl Callback {
             Callback::Upload(callback) => callback(S3UploadResult::Failure(err), context)?,
             Callback::Download(callback) => callback(S3DownloadResult::Failure(err), context)?,
             Callback::Stat(callback) => callback(S3StatResult::Failure(err), context)?,
+            Callback::StatRequestContext(ctx) => {
+                ctx.on_s3_size_resolved(S3StatResult::Failure(err))
+            }
             Callback::Delete(callback) => callback(S3DeleteResult::Failure(err), context)?,
             Callback::ListObjects(callback) => {
                 callback(S3ListObjectsResult::Failure(err), context)?
@@ -186,6 +191,9 @@ impl Callback {
         match self {
             Callback::Download(callback) => callback(S3DownloadResult::NotFound(err), context)?,
             Callback::Stat(callback) => callback(S3StatResult::NotFound(err), context)?,
+            Callback::StatRequestContext(ctx) => {
+                ctx.on_s3_size_resolved(S3StatResult::NotFound(err))
+            }
             Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err), context)?,
             Callback::ListObjects(callback) => {
                 callback(S3ListObjectsResult::NotFound(err), context)?
@@ -316,6 +324,20 @@ impl S3HttpSimpleTask {
                         this.callback_context,
                     )?;
                 }
+                404 => this.error_with_body(ErrorType::NotFound)?,
+                _ => this.error_with_body(ErrorType::Failure)?,
+            },
+            Callback::StatRequestContext(ctx) => match response.status_code {
+                200 => ctx.on_s3_size_resolved(S3StatResult::Success(S3StatSuccess {
+                    etag: response.headers.get(b"etag").unwrap_or(b""),
+                    last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
+                    content_type: response.headers.get(b"content-type").unwrap_or(b""),
+                    size: response
+                        .headers
+                        .get(b"content-length")
+                        .map(bun_http_types::parse_content_length)
+                        .unwrap_or(0),
+                })),
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1046,8 +1046,10 @@ pub struct HTTPServerWritable<const SSL: bool> {
     /// `Http3Response::markDone()` makes the H3 `resp` still safe to use.
     pub(crate) ended_response: bool,
 
-    pub(crate) on_first_write: Option<fn(Option<*mut c_void>)>,
-    pub ctx: Option<*mut c_void>,
+    /// The owning `RequestContext`, until the first write has flushed its
+    /// status and headers (or it decides to render them itself). The context
+    /// owns this sink and destroys it before it is released.
+    pub(crate) first_write_ctx: Option<crate::server::AnyRequestContext>,
 
     pub(crate) auto_flusher: AutoFlusher,
 }
@@ -1072,8 +1074,7 @@ impl<const SSL: bool> Default for HTTPServerWritable<SSL> {
             source_pending_pull: false,
             end_len: 0,
             ended_response: false,
-            on_first_write: None,
-            ctx: None,
+            first_write_ctx: None,
             auto_flusher: AutoFlusher::default(),
         }
     }
@@ -1113,6 +1114,14 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
 /// `pub const JSSink = Sink.JSSink(@This(), name)`.
 pub type HTTPServerWritableJSSink<const SSL: bool> =
     crate::webcore::sink::JSSink<HTTPServerWritable<SSL>>;
+
+/// The heap sink as its `RequestContext` owns it. The JS controller
+/// (`JSSink::assign_to_stream`) and the auto-flusher hold the same address and
+/// re-enter it from JS, so the owner reaches it through the `JsCell` in short,
+/// closure-scoped borrows rather than through a `Box<Self>` it would have to
+/// keep unaliased.
+pub type OwnedHTTPServerWritable<const SSL: bool> =
+    Box<bun_ptr::JsCell<HTTPServerWritable<SSL>>>;
 
 // `HTTPServerWritable` is exposed to JS via `Sink.JSSink(@This(), name)` where
 // `name` ∈ {HTTPResponseSink, HTTPSResponseSink}. Const-generics
@@ -1178,9 +1187,8 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
     }
 
     fn handle_first_write_if_necessary(&mut self) {
-        if let Some(on_first_write) = self.on_first_write.take() {
-            let ctx = self.ctx.take();
-            on_first_write(ctx);
+        if let Some(ctx) = self.first_write_ctx.take() {
+            ctx.on_first_stream_write();
         }
     }
 
@@ -1248,7 +1256,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         // callback (RequestContext.renderMetadata) writes status/headers through
         // the same uWS response. `AnyResponse` is `Copy` and dispatches to
         // zero-sized opaque handles, so reusing `res` across the re-entrant
-        // `on_first_write` invocation cannot alias any Rust-visible memory.
+        // first-write callback cannot alias any Rust-visible memory.
 
         if self.requested_end && !res.state().is_http_write_called() {
             self.handle_first_write_if_necessary();
@@ -1300,7 +1308,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
     /// of `self.buffer` through `from_raw_parts` to dodge the `&mut self`
     /// borrow. Mirrors `send_without_auto_flusher` but re-slices `self.buffer`
     /// after each `&mut self` step; `unregister_auto_flusher` and the
-    /// `on_first_write` callback (RequestContext.renderMetadata) only touch
+    /// first-write callback (RequestContext.renderMetadata) only touch
     /// uWS response state, never `self.buffer`/`self.offset`, so the re-slice
     /// observes the same bytes the laundered slice would have.
     fn send_readable(&mut self, from: usize) -> bool {
@@ -1322,7 +1330,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             return false;
         };
         // `res` is `Copy` (raw uWS handle); see the note in
-        // `send_without_auto_flusher` re: holding it across `on_first_write`.
+        // `send_without_auto_flusher` re: holding it across the first-write callback.
 
         if self.requested_end && !res.state().is_http_write_called() {
             self.handle_first_write_if_necessary();
@@ -1843,33 +1851,19 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         bun_sys::Result::Ok(JSValue::from(self.wrote))
     }
 
-    /// Takes `*mut Self`, not `&mut self`: closing the signal runs the controller's
-    /// JS `onClose`, which can cancel the stream, drain microtasks, and free this
-    /// sink. A `&mut self` argument protector must not be live across that free.
-    ///
-    /// # Safety
-    /// `this` must point at the live sink owned by the `RequestContext`.
-    pub(crate) unsafe fn abort(this: *mut Self) {
+    /// The response was aborted: mark the sink dead and settle what is parked
+    /// on it. Returns the source for the caller to `close(None)` once no borrow
+    /// of this sink is live: the close fires the JS `onClose` callback, and the
+    /// teardown it can re-enter (cancel, microtask drain) frees this sink.
+    #[must_use = "close the returned source after releasing the sink borrow"]
+    pub(crate) fn abort(&mut self) -> SourceHandle {
         bun_core::scoped_log!(HTTPServerWritableLog, "onAborted()");
-        // SAFETY: caller contract — `this` is live, and every access here is scoped
-        // so no borrow spans the signal close below, which may free `*this`.
-        unsafe {
-            (*this).state = HTTPServerWritableState::Aborted;
-            (*this).res = None;
-            (*this).unregister_auto_flusher();
-        }
-
-        // SAFETY: nothing above freed `*this`; exclusive borrow scoped to the call.
-        unsafe { (*this).flush_promise() };
-        // SAFETY: as above.
-        unsafe { (*this).finalize() };
-
-        // Close the source last and through a stack copy: the close fires the JS
-        // onClose callback, and the teardown it can re-enter frees this sink, so
-        // no reference into the allocation may be live across the call.
-        // SAFETY: as above; `source` is copied out before the close.
-        let mut source = unsafe { (*this).source };
-        source.close(None);
+        self.state = HTTPServerWritableState::Aborted;
+        self.res = None;
+        self.unregister_auto_flusher();
+        self.flush_promise();
+        self.finalize();
+        self.source
     }
 
     fn unregister_auto_flusher(&mut self) {
@@ -1927,29 +1921,24 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         false
     }
 
-    /// # Safety
-    /// `this` must be a valid, uniquely-owned heap pointer to `Self` produced
-    /// by `bun_core::heap::into_raw`; the caller transfers ownership.
-    // Forwards `this` to `bun_core::heap::take` without dereferencing it here;
-    // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn destroy(this: *mut Self) {
+    /// Tear down the sink its owning `RequestContext` allocated (as
+    /// [`OwnedHTTPServerWritable`]); the JS controller must already be
+    /// detached (`JSSink::detach`).
+    pub(crate) fn destroy(this: OwnedHTTPServerWritable<SSL>) {
         bun_core::scoped_log!(HTTPServerWritableLog, "destroy()");
-        // SAFETY: this was heap-allocated; destroy takes sole ownership. Reclaim
-        // the Box first so we never hold a `&mut *this` alongside the Box's
-        // unique pointer.
-        let mut this = unsafe { bun_core::heap::take(this) };
-        // Callers may tear this sink down without routing through
-        // flushPromise() (e.g. handleResolveStream / handleRejectStream).
-        // Drop the GC root so the promise can be collected.
-        this.pending.result = Writable::Done;
-        this.pending.run();
-        if let Some(prom) = this.pending_flush.take() {
-            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-            JSPromise::opaque_ref(prom).to_js().unprotect();
-        }
-        this.buffer.clear_and_free();
-        this.unregister_auto_flusher();
+        this.with_mut(|this| {
+            // Callers may tear this sink down without routing through
+            // flushPromise() (e.g. handleResolveStream / handleRejectStream).
+            // Drop the GC root so the promise can be collected.
+            this.pending.result = Writable::Done;
+            this.pending.run();
+            if let Some(prom) = this.pending_flush.take() {
+                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+                JSPromise::opaque_ref(prom).to_js().unprotect();
+            }
+            this.buffer.clear_and_free();
+            this.unregister_auto_flusher();
+        });
         drop(this);
     }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1120,8 +1120,7 @@ pub type HTTPServerWritableJSSink<const SSL: bool> =
 /// re-enter it from JS, so the owner reaches it through the `JsCell` in short,
 /// closure-scoped borrows rather than through a `Box<Self>` it would have to
 /// keep unaliased.
-pub type OwnedHTTPServerWritable<const SSL: bool> =
-    Box<bun_ptr::JsCell<HTTPServerWritable<SSL>>>;
+pub type OwnedHTTPServerWritable<const SSL: bool> = Box<bun_ptr::JsCell<HTTPServerWritable<SSL>>>;
 
 // `HTTPServerWritable` is exposed to JS via `Sink.JSSink(@This(), name)` where
 // `name` ∈ {HTTPResponseSink, HTTPSResponseSink}. Const-generics

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -5,6 +5,7 @@ use crate::h3::Request as H3Request;
 /// Transport-agnostic request handle. Static/file routes (and RangeRequest)
 /// take this so the same handler body serves HTTP/1.1 and HTTP/3 without
 /// `anytype` — `inline else` keeps dispatch monomorphic.
+#[derive(Clone, Copy)]
 pub enum AnyRequest {
     H1(*mut Request),
     H3(*mut H3Request),

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -567,27 +567,6 @@ impl<const SSL: bool> Response<SSL> {
         );
     }
 
-    pub(crate) fn run_corked_with_type<U>(&mut self, handler: fn(*mut U), optional_data: *mut U) {
-        // cork is synchronous, so we can stack-allocate the (handler, data) pair
-        // and recover it inside the trampoline.
-        type Ctx<U> = (fn(*mut U), *mut U);
-        // Safe fn item: nested local thunk, only coerced to the C-ABI
-        // fn-pointer type passed to C; body wraps its raw-ptr op explicitly.
-        extern "C" fn handle<U>(user_data: *mut c_void) {
-            // SAFETY: user_data points at a stack Ctx<U> valid for this synchronous call.
-            let ctx = unsafe { &*user_data.cast::<Ctx<U>>() };
-            (ctx.0)(ctx.1);
-        }
-        let mut ctx: Ctx<U> = (handler, optional_data);
-        // cork is synchronous so the stack-allocated ctx outlives the FFI call.
-        c::uws_res_cork(
-            Self::ssl_flag(),
-            self.as_raw(),
-            (&raw mut ctx).cast::<c_void>(),
-            handle::<U>,
-        );
-    }
-
     pub fn upgrade<D>(
         &mut self,
         data: *mut D,
@@ -1033,10 +1012,6 @@ impl AnyResponse {
 
     pub fn corked<F: FnOnce()>(self, f: F) {
         any_dispatch!(self, |r| r.corked(f))
-    }
-
-    pub fn run_corked_with_type<U>(self, handler: fn(*mut U), optional_data: *mut U) {
-        any_dispatch!(self, |r| r.run_corked_with_type(handler, optional_data))
     }
 
     pub fn upgrade<D>(

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -984,6 +984,21 @@ impl AnyResponse {
         )
     }
 
+    /// [`on_data`](Self::on_data) counterpart of
+    /// [`on_writable_this`](Self::on_writable_this).
+    pub fn on_data_this<U: 'static, H>(self, _handler: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, &[u8], bool) + Copy + 'static,
+    {
+        self.on_data(
+            |u: *mut U, chunk: &[u8], last: bool| {
+                // SAFETY: `u` is the `ThisPtr` registered below; the registrant holds a ref on it until the handler is cleared.
+                thunk::zst::<H>()(unsafe { ThisPtr::new(u) }, chunk, last)
+            },
+            this.as_ptr(),
+        )
+    }
+
     pub fn clear_aborted(self) {
         any_dispatch!(self, |r| r.clear_aborted())
     }

--- a/src/uws_sys/h2.rs
+++ b/src/uws_sys/h2.rs
@@ -269,21 +269,6 @@ impl Response {
         let mut f = core::mem::ManuallyDrop::new(f);
         c::uws_h2_res_cork(self, (&raw mut *f).cast::<c_void>(), handle::<F>);
     }
-    pub(crate) fn run_corked_with_type<UD>(&mut self, handler: fn(*mut UD), ud: *mut UD) {
-        // cork is synchronous, so we stack-allocate the (handler, ud) pair and
-        // recover it inside the trampoline — same shape as H1's
-        // `Response::run_corked_with_type` so `AnyResponse` can dispatch uniformly.
-        type Ctx<UD> = (fn(*mut UD), *mut UD);
-        // Safe fn item: nested local thunk, only coerced to the C-ABI
-        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn cb<UD>(p: *mut c_void) {
-            // SAFETY: p points at a stack Ctx<UD> valid for this synchronous call.
-            let ctx = unsafe { &*p.cast::<Ctx<UD>>() };
-            (ctx.0)(ctx.1);
-        }
-        let mut ctx: Ctx<UD> = (handler, ud);
-        c::uws_h2_res_cork(self, (&raw mut ctx).cast(), cb::<UD>)
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -310,25 +310,14 @@ impl Response {
     pub(crate) fn clear_on_data(&mut self) {
         c::uws_h3_res_on_data(self, None, ptr::null_mut())
     }
-    pub(crate) fn corked(&mut self, handler: impl FnOnce()) {
-        // H3 has no corking; call the handler immediately.
-        let _ = self;
-        handler();
-    }
-    pub(crate) fn run_corked_with_type<UD>(&mut self, handler: fn(*mut UD), ud: *mut UD) {
-        // cork is synchronous, so we stack-allocate the (handler, ud) pair and
-        // recover it inside the trampoline — same shape as H1's
-        // `Response::run_corked_with_type` so `AnyResponse` can dispatch uniformly.
-        type Ctx<UD> = (fn(*mut UD), *mut UD);
-        // Safe fn item: nested local thunk, only coerced to the C-ABI
-        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn cb<UD>(p: *mut c_void) {
-            // SAFETY: p points at a stack Ctx<UD> valid for this synchronous call.
-            let ctx = unsafe { &*p.cast::<Ctx<UD>>() };
-            (ctx.0)(ctx.1);
+    pub(crate) fn corked<F: FnOnce()>(&mut self, f: F) {
+        extern "C" fn handle<F: FnOnce()>(user_data: *mut c_void) {
+            // SAFETY: user_data points at a stack `ManuallyDrop<F>` valid for this synchronous call.
+            let f = unsafe { core::ptr::read(user_data.cast::<F>()) };
+            f();
         }
-        let mut ctx: Ctx<UD> = (handler, ud);
-        c::uws_h3_res_cork(self, (&raw mut ctx).cast(), cb::<UD>)
+        let mut f = core::mem::ManuallyDrop::new(f);
+        c::uws_h3_res_cork(self, (&raw mut *f).cast::<c_void>(), handle::<F>);
     }
 }
 


### PR DESCRIPTION
### What

Same programme as #40055 / #40135 / #40136 / #40139 / #40187 / #40190 / #40200 / #40202, applied to `Bun.serve`'s per-request state: `src/runtime/server/RequestContext.rs` 63 → **0** (incidental: `server/mod.rs` 99 → 92, `server_body.rs` 83 → 68, `webcore/streams.rs` 28 → 22). Stacked on #40192 (`BackRef<T, Root>`), whose commit is included.

- **RequestContext is created into its hive slot as a `RefPtr`** (`HiveSlot::write_ref`) and every uws / stream / promise / S3 / file callback receives `ThisPtr<Self>` (`AnyResponse::on_data_this` joins `on_writable_this`/`on_aborted_this`); the refs the context holds on its own behalf are typed slots released at their terminal events (`release_in_flight`), `deinit(this: ThisPtr)` returns the slot to the pool through the `#[ref_count(destroy = …)]` hook (`bun_ptr::destroy_with`, sibling of `destroy_box_with`). `req`, `sink`, pending body etc. are `Cell`/`JsCell`; `ServerLike` is sealed with `const SSL/DEBUG` and `on_request_complete(this: BackRef<Self, Mut>)`.
- **`AnyRequestContext`** carries `ThisPtr<T>` (`init(ThisPtr<T>)`, `get<T>() -> Option<ThisPtr<T>>`, sealed `CtxKind`); `Request.request_context: Cell<AnyRequestContext>`; `Body::ReceiveValue::Server(AnyRequestContext)`; `HTTPServerWritable.first_write_ctx: Option<AnyRequestContext>`, `StreamOwner::RequestContext(AnyRequestContext)`; `s3::client::stat_for_request_context`.
- **`bun_jsc::native_promise_context`**: `unsafe trait NativePromiseContextType { const TAG }` + `native_promise_context_type!`, `create(global, RefPtr<T>, held)` (the GC cell owns the ref), `take<T>(cell) -> Option<RefPtr<T>>`; C++ `Bun__NativePromiseContext__take` now takes the expected tag and does a checked downcast (nullptr on mismatch/empty). The previously untyped runtime create/take are now `create_html_rewriter_suspension`/`take_html_rewriter_suspension` with a fixed tag, so tag ↔ type is injective.
- `WeakPtr::{from_this, get_ref, is}`, `From<RefPtr<T>> for ScopedRef<T>`, `From<ThisPtr<T>> for NonNull<T>`, `uws_sys::AnyRequest: Copy`.

Residual (zero `unsafe`, noted for a follow-up): `Body::PendingValue`'s three producer hooks still receive `task: NonNull<c_void>` (decoded via `BackRef` as `html_rewriter.rs` does); making them a typed dispatch on `producer: SourceHandle` touches fetch/html_rewriter/Blob and is left for the PR that unifies those.

### Testing

Debug+ASAN: serve.test.ts 296/297 (uid-0 port case), serve-body-leak 8/8, bun-serve-{static,html,file,routes,date,args,body-json-async,cookies,headers,propagate-errors}, bun-server, async-iterator-stream, request-smuggling, serve-request-extra-memory, fetch.stream, body-stream, fetch-abort-stream-body, request-cyclic-reference, test/js/web/request, web/html, static-stress, websocket-server-{upgrade-reentrant,upgrade-signal-gc,stop-retained-ws,reload-leak}, websocket-server.test.ts 128/128 (`--max-concurrency=1`; at default concurrency the tests adjacent to the 300k-message benchmark case time out on a loaded box and pass individually), serve-http3, node-http, hono. Hand-driven: string/Response/promise/reject/throw/null returns, HEAD, file + Range, body text/stream/ignored, JS and direct streaming with client abort, `req.signal` abort, raw-socket abort mid-body, 2200 keep-alive requests → `pendingRequests` back to 0, `reload()`, `stop()` with in-flight requests — exit 0, no ASAN output. clippy clean on bun_runtime/bun_ptr/bun_jsc/bun_uws_sys/bun_collections; `rust-check-all` windows-msvc + apple-darwin pass.