### PR TITLE
spawn/shell/Terminal: remove unsafe from subprocess.rs, shell/subproc.rs and Terminal.rs

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -354,11 +354,12 @@ materialize `&self`/`&mut self` at the boundary — a `&self`-derived raw
 pointer carries `SharedReadOnly` provenance, and `Box::from_raw`/dealloc
 through it is UB. Pass and dispatch off `*mut Self` until the body proves
 ownership. `src/io/PipeWriter.rs`'s `impl_streaming_writer_parent!` macro
-encodes the three modes:
+encodes these modes:
 
 - `borrow = mut` — body forms `&mut *this`; safe when nothing re-enters
 - `borrow = shared` — body forms `&*this`; safe when re-entrant code only needs `&Self`
-- `borrow = ptr` — body calls `Self::method(this, ..)` with `this: *mut Self`; required when the callback may free `self`
+- `borrow = ptr` — body calls `Self::method(this, ..)` with `this: *mut Self` (legacy raw-pointer form for callbacks that may free `self`; new parents use `this`)
+- `borrow = this` — body calls `Self::method(this, ..)` with `this: ThisPtr<Self>`; the typed form of `ptr` for intrusively-refcounted parents (hold a `RefPtr::from_this(this)` guard across anything that may drop the last ref)
 
 ### `Strong` / `Weak` JS handles
 

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2018,13 +2018,23 @@ function generateRust(
 
       if (names.getter) {
         const id = rustSnakeIdent(getter);
-        thunk(
-          names.getter,
-          `(this: ${recv}, ${thisValue ? "this_value: JSValue, " : ""}global: &JSGlobalObject) -> JSValue`,
-          thisValue
-            ? `    host_fn::host_fn_getter_this_shared(this, this_value, global, |t, v, g| ${T}::${id}(t, v, g))`
-            : `    ${helper("host_fn_getter")}(this, global, |t, g| ${T}::${id}(t, g))`,
-        );
+        if (sharedThis && !thisValue) {
+          // Receiver-generic, as for `fn` below (see `HostReceiver`).
+          thunk(
+            names.getter,
+            `(this: *mut ${T}, global: &JSGlobalObject) -> JSValue`,
+            `    // SAFETY: C++ passes the wrapper's live \`m_ctx\`.\n    ` +
+              `    unsafe { host_fn::host_fn_getter_ptr(this, global, |t, g| ${T}::${id}(t, g)) }`,
+          );
+        } else {
+          thunk(
+            names.getter,
+            `(this: ${recv}, ${thisValue ? "this_value: JSValue, " : ""}global: &JSGlobalObject) -> JSValue`,
+            thisValue
+              ? `    host_fn::host_fn_getter_this_shared(this, this_value, global, |t, v, g| ${T}::${id}(t, v, g))`
+              : `    ${helper("host_fn_getter")}(this, global, |t, g| ${T}::${id}(t, g))`,
+          );
+        }
       }
 
       if (names.setter) {
@@ -2051,13 +2061,26 @@ function generateRust(
             `    ${T}::${fastId}(this, global${args.length ? ", " + argFwd : ""})`,
           );
         }
-        thunk(
-          names.fn,
-          `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
-          passThis
-            ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
-            : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
-        );
+        if (sharedThis) {
+          // `*mut T` + receiver-generic helper: the method takes `&self` or
+          // `this: ThisPtr<Self>` and inference picks (see `HostReceiver`).
+          thunk(
+            names.fn,
+            `(this: *mut ${T}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            `    // SAFETY: C++ passes the wrapper's live \`m_ctx\`.\n    ` +
+              (passThis
+                ? `    unsafe { host_fn::host_fn_this_value_ptr(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v)) }`
+                : `    unsafe { host_fn::host_fn_this_ptr(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c)) }`),
+          );
+        } else {
+          thunk(
+            names.fn,
+            `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            passThis
+              ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
+              : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
+          );
+        }
       }
     }
   }

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -1123,6 +1123,16 @@ use bun_jsc::{self, host_fn, CallFrame, JSGlobalObject, JSValue};
 #[allow(dead_code, unreachable_pub, unused)]
 pub use ${rustPath} as ${name};
 
+/// The live \`m_sinkPtr\` of the \`JS${name}\` wrapper \`value\` encodes, or \`None\`
+/// if it is not one or is detached. Frame-scoped like \`JSValue::as_class_this_ptr\`:
+/// \`value\` keeps the payload alive while it is on the stack.
+#[allow(dead_code, unreachable_pub, unused)]
+pub fn ${name}__fromJSThis(value: JSValue) -> Option<bun_ptr::ThisPtr<${name}>> {
+    // SAFETY: \`from_js\` returns the wrapper's live, non-null payload (\`JSSink<T>\`
+    // is \`repr(transparent)\` over \`T\`).
+    ${JSSinkT}::from_js(value).map(|p| unsafe { bun_ptr::ThisPtr::new(p.cast::<${name}>()) })
+}
+
 `;
 
     const hostFns = ["construct", "write", "end", "flush", "start"] as const;

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -494,13 +494,18 @@ impl EventLoopHandle {
         }
     }
 
-    /// `f($key)` from the loop's dotenv loader; the value is borrowed only for
-    /// the call (the map is mutable at runtime).
+    /// `f($key)` from the loop's dotenv loader (`None` if unset or the loader
+    /// is not initialised yet). The value is borrowed from the loader's map
+    /// only for the call: `f` must not set or remove environment variables.
     pub fn with_env_var<R>(self, key: &[u8], f: impl FnOnce(Option<&[u8]>) -> R) -> R {
-        // SAFETY: `env()` is the non-null loader both arms are created with
-        // (`VirtualMachine::env_loader`; `MiniEventLoop::env_ptr`), live for
-        // the loop's lifetime; the borrow ends with `f`.
-        f(unsafe { (*self.env()).get(key) })
+        let env = self.env();
+        if env.is_null() {
+            return f(None);
+        }
+        // SAFETY: non-null `env()` is the loader the loop was created with
+        // (`VirtualMachine.transpiler.env`; `MiniEventLoop::env_ptr`), live
+        // for the loop's lifetime; the borrow ends with `f`.
+        f(unsafe { (*env).get(key) })
     }
 
     pub fn top_level_dir(self) -> &'static [u8] {

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -494,6 +494,15 @@ impl EventLoopHandle {
         }
     }
 
+    /// `f($key)` from the loop's dotenv loader; the value is borrowed only for
+    /// the call (the map is mutable at runtime).
+    pub fn with_env_var<R>(self, key: &[u8], f: impl FnOnce(Option<&[u8]>) -> R) -> R {
+        // SAFETY: `env()` is the non-null loader both arms are created with
+        // (`VirtualMachine::env_loader`; `MiniEventLoop::env_ptr`), live for
+        // the loop's lifetime; the borrow ends with `f`.
+        f(unsafe { (*self.env()).get(key) })
+    }
+
     pub fn top_level_dir(self) -> &'static [u8] {
         match self {
             // SAFETY: slice borrowed for VM lifetime.

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -24,7 +24,7 @@ use bun_io::Loop as AsyncLoop;
 #[cfg(unix)]
 use bun_io::pipe_reader::PosixFlags;
 use bun_io::{BufferedReader, ReadState};
-use bun_ptr::{RefCount, RefPtr};
+use bun_ptr::RefPtr;
 #[cfg(not(windows))]
 use bun_spawn::SpawnResultExt as _;
 use bun_spawn::subprocess::{self, StdioResult};
@@ -969,12 +969,12 @@ pub(crate) type StaticPipeWriter = subprocess::StaticPipeWriter<SecurityScanSubp
 // the stack (small JSON fits the pipe buffer → write completes → close).
 impl<'a> subprocess::StaticPipeWriterProcess for SecurityScanSubprocess<'a> {
     const POLL_OWNER_TAG: bun_io::PollTag = bun_io::PollTag::SecurityScanStaticPipeWriter;
-    unsafe fn on_close_io(this: *mut Self, kind: subprocess::StdioKind) {
+    fn on_close_io(this: bun_ptr::ThisPtr<Self>, kind: subprocess::StdioKind) {
         // SAFETY: `this` is the `parent` backref passed to `StaticPipeWriter::create`;
         // the subprocess outlives its writer (it owns the writer ref in `json_writer`).
         // `finish_spawn` holds no Rust borrow on `self.json_writer` across `start()`
         // (it clones the `RefPtr` first), so this `&mut` is unique for the call.
-        unsafe { (*this).on_close_io(kind) };
+        unsafe { (*this.as_ptr()).on_close_io(kind) };
     }
 }
 
@@ -1296,8 +1296,10 @@ impl<'a> SecurityScanSubprocess<'a> {
         // `on_close_io` via the `parent` backref; that callback must observe
         // `json_writer.is_some()` to decrement `remaining_fds`, otherwise
         // `is_done()` never returns true and `sleep_until` hangs.
+        // SAFETY: `parent` is the live boxed `self` (see note above).
+        let parent_this = unsafe { bun_ptr::ThisPtr::new(parent.cast()) };
         let writer =
-            StaticPipeWriter::create(event_loop, parent.cast(), make_json_stdio(), json_source);
+            StaticPipeWriter::create(event_loop, parent_this, make_json_stdio(), json_source);
         // Keep a duped ref locally so no borrow on `(*parent).json_writer` is
         // held across `start()` — `on_close_io` may `.take()` the field.
         let writer_local = writer.clone();
@@ -1312,15 +1314,15 @@ impl<'a> SecurityScanSubprocess<'a> {
             // SAFETY: `parent` points at the live `self` of `finish_spawn`; the
             // guard only fires on early return inside this fn.
             if let Some(w) = unsafe { (*parent).json_writer.take() } {
-                // SAFETY: `w` holds the field's ref; sole live access path.
-                unsafe { (*w.as_ptr()).source.detach() };
+                StaticPipeWriter::detach_source(w.this_ptr());
             }
         });
 
-        let writer_ptr = writer_local.as_ptr();
-        // SAFETY: `writer_local` holds a live ref; `start()` mutates the writer
-        // in place (raw intrusive object — no Rust aliasing across the RefPtr).
-        let start_result = unsafe { (*writer_ptr).start() };
+        let start_result = StaticPipeWriter::start(writer_local.this_ptr());
+        // This type tracks completion via `on_close_io`, not the in-flight
+        // ref: release `start()`'s ref now (absent if `start()` failed).
+        drop(StaticPipeWriter::take_start_ref(writer_local.this_ptr()));
+        drop(writer_local);
         if let Err(e) = start_result {
             Output::err_generic(
                 "Failed to start security scanner JSON pipe writer: {}",
@@ -1328,15 +1330,6 @@ impl<'a> SecurityScanSubprocess<'a> {
             );
             return Err(crate::Error::JSONPipeWriterFailed);
         }
-        // The writer's lifetime is owned by `json_writer`, not by its own
-        // `started` ref: release the ref `start()` took and clear the flag so
-        // its close path doesn't release it again.
-        // SAFETY: `writer_local` keeps `*writer_ptr` live.
-        unsafe {
-            RefCount::<StaticPipeWriter>::deref(writer_ptr);
-            (*writer_ptr).started = false;
-        }
-        drop(writer_local);
 
         // SAFETY: `process` is live (we hold a ref); reached via the local raw
         // ptr per the single-provenance note. `watch_or_reap` may re-enter
@@ -1352,9 +1345,7 @@ impl<'a> SecurityScanSubprocess<'a> {
 
     pub(crate) fn on_close_io(&mut self, _: subprocess::StdioKind) {
         if let Some(writer) = self.json_writer.take() {
-            // SAFETY: `writer` holds the field's intrusive ref; sole access path
-            // (single-threaded event loop callback).
-            unsafe { (*writer.as_ptr()).source.detach() };
+            StaticPipeWriter::detach_source(writer.this_ptr());
             self.remaining_fds -= 1;
         }
     }

--- a/src/io/MaxBuf.rs
+++ b/src/io/MaxBuf.rs
@@ -32,6 +32,73 @@ pub struct Owner {
     pub on_overflow: unsafe fn(NonNull<()>, NonNull<MaxBuf>),
 }
 
+/// The subprocess type an [`Owner`] dispatches to.
+pub trait MaxBufOwner {
+    /// See [`Owner`]: clear the matching slot, then kill the child.
+    fn on_max_buffer_overflow(&self, maxbuf: NonNull<MaxBuf>);
+}
+
+impl Owner {
+    /// `owner` must call [`MaxBuf::remove_from_subprocess`] on every slot
+    /// created with the result before it is freed; [`MaxBufSlot`] makes that
+    /// structural.
+    fn new<T: MaxBufOwner>(owner: bun_ptr::ThisPtr<T>) -> Owner {
+        unsafe fn on_overflow<T: MaxBufOwner>(ptr: NonNull<()>, maxbuf: NonNull<MaxBuf>) {
+            // SAFETY: `ptr` came from a live `ThisPtr<T>` in `Owner::new`; the
+            // owner clears `owned_by_subprocess` before it is freed, and this
+            // is only reached while that slot is `Some`.
+            unsafe { ptr.cast::<T>().as_ref() }.on_max_buffer_overflow(maxbuf)
+        }
+        Owner {
+            ptr: NonNull::from(owner).cast(),
+            on_overflow: on_overflow::<T>,
+        }
+    }
+}
+
+/// The subprocess's side of a [`MaxBuf`], as a field of the owner: created
+/// against the owner, disowned on [`release`](Self::release) or drop — so the
+/// `MaxBuf`'s back-pointer to the owner cannot outlive the owner holding this.
+pub struct MaxBufSlot(Cell<Option<NonNull<MaxBuf>>>);
+
+impl MaxBufSlot {
+    pub const fn empty() -> Self {
+        MaxBufSlot(Cell::new(None))
+    }
+
+    /// Allocate the budget (`initial = None` leaves the slot empty). `self`
+    /// is a field of `*owner`.
+    pub fn create<T: MaxBufOwner>(&self, owner: bun_ptr::ThisPtr<T>, initial: Option<i64>) {
+        self.release();
+        let mut mb = None;
+        MaxBuf::create_for_subprocess(&mut mb, initial, Owner::new(owner));
+        self.0.set(mb);
+    }
+
+    /// The budget, to hand to a pipe reader ([`MaxBuf::add_to_pipereader`]).
+    #[inline]
+    pub fn get(&self) -> Option<NonNull<MaxBuf>> {
+        self.0.get()
+    }
+
+    #[inline]
+    pub fn is(&self, maxbuf: NonNull<MaxBuf>) -> bool {
+        self.0.get() == Some(maxbuf)
+    }
+
+    /// Disown the budget (freed once the reader side lets go too).
+    pub fn release(&self) {
+        let mut mb = self.0.take();
+        MaxBuf::remove_from_subprocess(&mut mb);
+    }
+}
+
+impl Drop for MaxBufSlot {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
 /// How far the read that crosses `maxBuffer` may overshoot it: one Node-sized
 /// stdio read. Must stay nonzero, Node's `spawnSync` documents `stdout`
 /// exceeding `maxBuffer` by up to one read.

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -91,6 +91,67 @@ pub trait BufferedReaderParent {
     }
 }
 
+/// A [`BufferedReaderParent`] that holds its reader in a by-value field, so a
+/// live parent is a live reader. Implemented by `impl_buffered_reader_parent!`
+/// (`reader = <field>;`); lets the parent drive the raw-pointer entry points
+/// ([`BufferedReader::read`], [`BufferedReader::on_error`]) from a
+/// [`ThisPtr`](bun_ptr::ThisPtr) without materialising a reference that the
+/// re-entrant dispatch could invalidate.
+///
+/// # Safety
+/// `reader` must be a place projection to a field inside `*this` (same
+/// allocation), performing no reads.
+pub unsafe trait BufferedReaderOwner: Sized {
+    fn reader(this: *mut Self) -> *mut BufferedReader;
+}
+
+/// The field types `impl_buffered_reader_parent!`'s `reader = <field>;` accepts.
+pub trait ReaderSlot {
+    fn raw(slot: *mut Self) -> *mut BufferedReader;
+}
+impl ReaderSlot for BufferedReader {
+    #[inline(always)]
+    fn raw(slot: *mut Self) -> *mut BufferedReader {
+        slot
+    }
+}
+impl ReaderSlot for bun_ptr::JsCell<BufferedReader> {
+    #[inline(always)]
+    fn raw(slot: *mut Self) -> *mut BufferedReader {
+        // `JsCell<T>` is `repr(transparent)` over `UnsafeCell<T>`.
+        slot.cast()
+    }
+}
+
+/// Place projection for `impl_buffered_reader_parent!`'s `reader = <field>;`:
+/// `this + offset`, typed by the (never called) field accessor.
+#[doc(hidden)]
+#[inline(always)]
+pub fn reader_slot_ptr<T, S: ReaderSlot>(
+    this: *mut T,
+    offset: usize,
+    _field: fn(&T) -> &S,
+) -> *mut BufferedReader {
+    S::raw(this.wrapping_byte_add(offset).cast::<S>())
+}
+
+impl BufferedReader {
+    /// [`read`](Self::read) on the reader embedded in `parent`.
+    #[inline]
+    pub fn read_from<P: BufferedReaderOwner>(parent: bun_ptr::ThisPtr<P>) {
+        // SAFETY: `parent` is live (`ThisPtr` invariant), so its embedded
+        // reader is; no reference to either is held across the dispatch.
+        unsafe { Self::read(P::reader(parent.as_ptr())) }
+    }
+
+    /// [`on_error`](Self::on_error) on the reader embedded in `parent`.
+    #[inline]
+    pub fn on_error_from<P: BufferedReaderOwner>(parent: bun_ptr::ThisPtr<P>, err: sys::Error) {
+        // SAFETY: as `read_from`.
+        unsafe { Self::on_error(P::reader(parent.as_ptr()), err) }
+    }
+}
+
 impl BufferedReaderVTable {
     fn init<T: BufferedReaderParent>() -> BufferedReaderVTable {
         BufferedReaderVTable {

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2589,15 +2589,21 @@ pub type StreamingWriter<P> = WindowsStreamingWriter<P>;
 //                     freeing callback (the callback may run `Box::from_raw`
 //                     on `this`, so a `&self`-derived ptr would carry only
 //                     SharedReadOnly provenance and dealloc through it is UB).
+// `borrow = this`   → bodies call `Self::method(ThisPtr::new(this), ..)` —
+//                     the `ptr` mode for parents whose handlers are safe fns
+//                     taking `bun_ptr::ThisPtr<Self>` (intrusively refcounted
+//                     parents that may drop their last ref mid-callback).
 //
 // Accessor args use closure-literal syntax (`|this| expr`) purely as a binder
-// for the macro — no actual closure is created; `expr` is pasted into an
-// `unsafe` block with `this: *mut Self` in scope.
+// for the macro — no actual closure is created. For `mut`/`shared`/`ptr`,
+// `expr` is pasted into an `unsafe` block with `this: *mut Self` in scope;
+// for `this`, `expr` is pasted as-is with `this: ThisPtr<Self>` in scope.
 
 /// Re-exports for `$crate::`-qualified use inside the macro bodies so callers
 /// need no extra `use` items.
 #[doc(hidden)]
 pub mod __parent_macro {
+    pub use ::bun_ptr::ThisPtr;
     pub use ::bun_sys::Error as SysError;
     #[cfg(windows)]
     pub use ::bun_sys::windows::libuv::Loop as UvLoop;
@@ -2612,6 +2618,22 @@ macro_rules! impl_streaming_writer_parent {
     (@call mut    $p:expr; $m:ident($($a:tt)*)) => { (&mut *$p).$m($($a)*) };
     (@call shared $p:expr; $m:ident($($a:tt)*)) => { (&*$p).$m($($a)*) };
     (@call ptr    $p:expr; $m:ident($($a:tt)*)) => { <Self>::$m($p, $($a)*) };
+    (@call this   $p:expr; $m:ident($($a:tt)*)) => {
+        <Self>::$m($crate::pipe_writer::__parent_macro::ThisPtr::<Self>::new($p), $($a)*)
+    };
+
+    // Internal: evaluate an accessor body with `$id` bound per `borrow` mode.
+    (@acc this $id:ident = $p:ident; $e:expr) => {{
+        // SAFETY: `$p` is the BACKREF set via `set_parent` — the live parent's
+        // root pointer for as long as the writer it embeds is being called.
+        let $id = unsafe { $crate::pipe_writer::__parent_macro::ThisPtr::<Self>::new($p) };
+        $e
+    }};
+    (@acc $borrow:tt $id:ident = $p:ident; $e:expr) => {{
+        let $id = $p;
+        #[allow(unused_unsafe)]
+        unsafe { $e }
+    }};
 
     // Internal: expand the three impls once generics are normalized.
     (@emit
@@ -2635,7 +2657,7 @@ macro_rules! impl_streaming_writer_parent {
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
                 // StreamingWriter never materializes `&mut Parent`. The handler
-                // is dispatched per the `borrow` mode (`mut`/`shared`/`ptr` —
+                // is dispatched per the `borrow` mode (`mut`/`shared`/`ptr`/`this` —
                 // see the module comment); `ptr` keeps full write/dealloc
                 // provenance through re-entrant, freeing callbacks.
                 unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) }
@@ -2658,16 +2680,12 @@ macro_rules! impl_streaming_writer_parent {
             #[inline]
             unsafe fn event_loop(this: *mut Self) -> $crate::EventLoopHandle {
                 // SAFETY: see on_write. Shared-only read.
-                let $el_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $el }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $el_this = this; $el)
             }
             #[inline]
             unsafe fn loop_(this: *mut Self) -> *mut $crate::pipe_writer::__parent_macro::UwsLoop {
                 // SAFETY: see on_write. Shared-only read.
-                let $uws_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $uws }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $uws_this = this; $uws)
             }
         }
 
@@ -2676,23 +2694,17 @@ macro_rules! impl_streaming_writer_parent {
             #[inline]
             unsafe fn loop_(this: *mut Self) -> *mut $crate::pipe_writer::__parent_macro::UvLoop {
                 // SAFETY: BACKREF set via `set_parent`; shared-only read.
-                let $uv_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $uv }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $uv_this = this; $uv)
             }
             #[inline]
             unsafe fn ref_(this: *mut Self) {
                 // SAFETY: see loop_. Intrusive refcount bump.
-                let $ref_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $ref_ };
+                $crate::impl_streaming_writer_parent!(@acc $borrow $ref_this = this; $ref_)
             }
             #[inline]
             unsafe fn deref(this: *mut Self) {
                 // SAFETY: see loop_. May free `this`.
-                let $deref_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $deref };
+                $crate::impl_streaming_writer_parent!(@acc $borrow $deref_this = this; $deref)
             }
         }
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2796,16 +2796,12 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {
                 // SAFETY: see on_write. Shared-only borrow of the buffer storage.
-                let $gb_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $gb }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $gb_this = this; $gb)
             }
             #[inline]
             unsafe fn event_loop(this: *mut Self) -> $crate::EventLoopHandle {
                 // SAFETY: see on_write.
-                let $el_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $el }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $el_this = this; $el)
             }
         }
 
@@ -2814,23 +2810,17 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn loop_(this: *mut Self) -> *mut $crate::pipe_writer::__parent_macro::UvLoop {
                 // SAFETY: BACKREF set via `set_parent`; shared-only read.
-                let $uv_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $uv }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $uv_this = this; $uv)
             }
             #[inline]
             unsafe fn ref_(this: *mut Self) {
                 // SAFETY: see loop_. Intrusive refcount bump.
-                let $ref_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $ref_ };
+                $crate::impl_streaming_writer_parent!(@acc $borrow $ref_this = this; $ref_)
             }
             #[inline]
             unsafe fn deref(this: *mut Self) {
                 // SAFETY: see loop_. May free `this`.
-                let $deref_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $deref };
+                $crate::impl_streaming_writer_parent!(@acc $borrow $deref_this = this; $deref)
             }
         }
 
@@ -2855,9 +2845,7 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {
                 // SAFETY: see on_write.
-                let $gb_this = this;
-                #[allow(unused_unsafe)]
-                unsafe { $gb }
+                $crate::impl_streaming_writer_parent!(@acc $borrow $gb_this = this; $gb)
             }
             const HAS_ON_WRITABLE: bool = false;
         }

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2758,9 +2758,6 @@ macro_rules! impl_streaming_writer_parent {
 /// `WindowsBufferedWriterParent` for a parent type. See module comment above.
 #[macro_export]
 macro_rules! impl_buffered_writer_parent {
-    (@borrow mut    $p:expr) => { &mut *$p };
-    (@borrow shared $p:expr) => { &*$p };
-
     (@emit
         [$($gen:tt)*] $Ty:ty;
         poll_tag   = $poll_tag:expr,
@@ -2780,20 +2777,21 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
-                // BufferedWriter never materializes `&mut Parent`, so this is
-                // the unique access path for the callback's duration.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_write(amount, status) };
+                // BufferedWriter never materializes `&mut Parent`. The handler
+                // is dispatched per the `borrow` mode (`mut`/`shared`/`ptr`/`this` —
+                // see the module comment).
+                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) };
             }
             #[inline]
             unsafe fn on_error(this: *mut Self, err: $crate::pipe_writer::__parent_macro::SysError) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_error(&err) };
+                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_error(&err)) };
             }
             const HAS_ON_CLOSE: bool = true;
             #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_close() };
+                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_close()) };
             }
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {
@@ -2841,18 +2839,18 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: BACKREF set via `set_parent`; see borrow-mode note.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_write(amount, status) };
+                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) };
             }
             #[inline]
             unsafe fn on_error(this: *mut Self, err: $crate::pipe_writer::__parent_macro::SysError) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_error(&err) };
+                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_error(&err)) };
             }
             const HAS_ON_CLOSE: bool = true;
             #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_close() };
+                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_close()) };
             }
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -542,23 +542,145 @@ bun_dispatch::link_interface! {
 /// case where the inherent takes `&self`/`&mut self`; sites whose inherent must
 /// stay raw-pointer (e.g. `Arc::from_raw` keepalive in shell `PipeReader`)
 /// forward as `<Self>::method(this)` instead.
+///
+/// With a leading `borrow = this;` the bodies instead get `this` bound as a
+/// [`bun_ptr::ThisPtr<Self>`] and are pasted as-is (no `unsafe` block) — for
+/// intrusively refcounted parents whose handlers are safe fns taking
+/// `ThisPtr<Self>` and may drop their last ref mid-callback. An optional
+/// `reader = <field>;` names the by-value field (a `BufferedReader` or a
+/// `JsCell<BufferedReader>`) holding the reader; it implements
+/// [`pipe_reader::BufferedReaderOwner`] so the parent can drive the reader
+/// through [`BufferedReader::read_from`] / [`BufferedReader::on_error_from`].
 #[macro_export]
 macro_rules! impl_buffered_reader_parent {
     // Single-lifetime generic: trait impl over `<'lt>`, link registered at `'static`.
     (
         $variant:ident for $T:ident<$lt:lifetime>;
-        $($rest:tt)*
+        borrow = this;
+        $( reader = $reader:ident; )?
+        has_on_read_chunk = $($rest:tt)*
     ) => {
         $crate::buffered_reader_parent_link!($variant for $T<'static>);
-        $crate::__impl_buffered_reader_parent_body! { [$lt] [$T<$lt>] $variant; $($rest)* }
+        $( $crate::__impl_buffered_reader_owner! { [$lt] [$T<$lt>] $reader } )?
+        $crate::__impl_buffered_reader_parent_body_this! { [$lt] [$T<$lt>] $variant; has_on_read_chunk = $($rest)* }
+    };
+    (
+        $variant:ident for $T:ident<$lt:lifetime>;
+        $( reader = $reader:ident; )?
+        has_on_read_chunk = $($rest:tt)*
+    ) => {
+        $crate::buffered_reader_parent_link!($variant for $T<'static>);
+        $( $crate::__impl_buffered_reader_owner! { [$lt] [$T<$lt>] $reader } )?
+        $crate::__impl_buffered_reader_parent_body! { [$lt] [$T<$lt>] $variant; has_on_read_chunk = $($rest)* }
     };
     // Non-generic.
     (
         $variant:ident for $T:ty;
-        $($rest:tt)*
+        borrow = this;
+        $( reader = $reader:ident; )?
+        has_on_read_chunk = $($rest:tt)*
     ) => {
         $crate::buffered_reader_parent_link!($variant for $T);
-        $crate::__impl_buffered_reader_parent_body! { [] [$T] $variant; $($rest)* }
+        $( $crate::__impl_buffered_reader_owner! { [] [$T] $reader } )?
+        $crate::__impl_buffered_reader_parent_body_this! { [] [$T] $variant; has_on_read_chunk = $($rest)* }
+    };
+    (
+        $variant:ident for $T:ty;
+        $( reader = $reader:ident; )?
+        has_on_read_chunk = $($rest:tt)*
+    ) => {
+        $crate::buffered_reader_parent_link!($variant for $T);
+        $( $crate::__impl_buffered_reader_owner! { [] [$T] $reader } )?
+        $crate::__impl_buffered_reader_parent_body! { [] [$T] $variant; has_on_read_chunk = $($rest)* }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_buffered_reader_owner {
+    ([$($lt:lifetime)?] [$T:ty] $reader:ident) => {
+        // SAFETY: `$reader` is a by-value field of `$T`, so the projection
+        // stays inside `*this`'s allocation.
+        unsafe impl $(<$lt>)? $crate::pipe_reader::BufferedReaderOwner for $T {
+            #[inline]
+            fn reader(this: *mut Self) -> *mut $crate::BufferedReader {
+                $crate::pipe_reader::reader_slot_ptr(
+                    this,
+                    ::core::mem::offset_of!(Self, $reader),
+                    |p: &Self| &p.$reader,
+                )
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_buffered_reader_parent_body_this {
+    (
+        [$($lt:lifetime)?] [$T:ty] $variant:ident;
+        has_on_read_chunk = $has:expr;
+        $( on_read_chunk = |$rc_this:ident, $rc_chunk:ident, $rc_more:ident| $rc:expr; )?
+        on_reader_done = |$rd_this:ident| $rd:expr;
+        on_reader_error = |$re_this:ident, $re_err:ident| $re:expr;
+        loop_ = |$l_this:ident| $lp:expr;
+        event_loop = |$e_this:ident| $ev:expr;
+        $( ref_ = |$rf_this:ident| $rf:expr; )?
+        $( deref = |$dr_this:ident| $dr:expr; )?
+    ) => {
+        // SAFETY (all generated methods): `this` is the `*mut Self` registered
+        // via `set_parent` — the live parent's root pointer for as long as the
+        // reader it embeds is being called, which is `ThisPtr::new`'s contract.
+        impl $(<$lt>)? $crate::pipe_reader::BufferedReaderParent for $T {
+            const KIND: $crate::BufferedReaderParentLinkKind =
+                $crate::BufferedReaderParentLinkKind::$variant;
+            const HAS_ON_READ_CHUNK: bool = $has;
+            $(
+                unsafe fn on_read_chunk(
+                    this: *mut Self,
+                    $rc_chunk: $crate::Chunk<'_>,
+                    $rc_more: $crate::ReadState,
+                ) -> bool {
+                    // SAFETY: see impl-level note.
+                    let $rc_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                    $rc
+                }
+            )?
+            unsafe fn on_reader_done(this: *mut Self) {
+                // SAFETY: see impl-level note.
+                let $rd_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                $rd
+            }
+            unsafe fn on_reader_error(this: *mut Self, $re_err: $crate::__bun_sys::Error) {
+                // SAFETY: see impl-level note.
+                let $re_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                $re
+            }
+            unsafe fn loop_(this: *mut Self) -> *mut $crate::pipe_reader::Loop {
+                // SAFETY: see impl-level note.
+                let $l_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                $lp
+            }
+            unsafe fn event_loop(this: *mut Self) -> $crate::EventLoopHandle {
+                // SAFETY: see impl-level note.
+                let $e_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                $ev
+            }
+            $(
+                unsafe fn ref_(this: *mut Self) {
+                    // SAFETY: see impl-level note.
+                    let $rf_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                    $rf
+                }
+            )?
+            $(
+                unsafe fn deref(this: *mut Self) {
+                    // SAFETY: see impl-level note.
+                    let $dr_this = unsafe { $crate::__bun_ptr::ThisPtr::<Self>::new(this) };
+                    $dr
+                }
+            )?
+        }
     };
 }
 
@@ -626,6 +748,8 @@ macro_rules! __impl_buffered_reader_parent_body {
 }
 
 #[doc(hidden)]
+pub use bun_ptr as __bun_ptr;
+#[doc(hidden)]
 pub use bun_sys as __bun_sys;
 
 /// Generates the `link_impl_BufferedReaderParentLink!` body for a type that
@@ -663,7 +787,7 @@ pub use source::Source;
 // Stub for never-constructed-on-POSIX `Source` so cross-platform sigs
 // (`Option<Source>`) typecheck.
 
-pub use pipe_reader::{BufferedReader, BufferedReaderParent, PosixFlags};
+pub use pipe_reader::{BufferedReader, BufferedReaderOwner, BufferedReaderParent, PosixFlags};
 
 pub use open_for_writing_mod::{open_for_writing, open_for_writing_impl};
 

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -571,3 +571,34 @@ extern "C" fn Source__setRawModeStdin(uv_loop: *mut uv::Loop, raw: bool) -> c_in
     }
     0
 }
+
+/// An object that holds bare uv pipes (no reader/writer in front of them) and
+/// closes them itself when its VM's thread is torn down.
+pub trait UvPipeOwner {
+    /// `uv::open_handles` entry point: close every pipe still held.
+    fn close_pipes_for_vm_teardown(&self);
+}
+
+/// Record `owner` as the one a thread teardown closes `pipe` through (`pipe`
+/// is used as the registry key only). `owner` takes the pipe off the list —
+/// by closing it, e.g. [`close_and_destroy_pipe`], at the latest from its own
+/// `Drop` — so the entry never outlives it.
+pub fn set_pipe_owner<T: UvPipeOwner>(pipe: &Pipe, owner: bun_ptr::ThisPtr<T>) {
+    unsafe fn close<T: UvPipeOwner>(owner: *mut c_void) {
+        // SAFETY: `owner` was recorded from a live `ThisPtr<T>` and every pipe
+        // it owns leaves the list before the owner is freed (fn contract).
+        unsafe { &*owner.cast::<T>() }.close_pipes_for_vm_teardown()
+    }
+    uv::open_handles::set_owner(
+        core::ptr::from_ref::<Pipe>(pipe).cast_mut().cast(),
+        owner.as_ptr().cast(),
+        Some(close::<T>),
+    );
+}
+
+/// `uv_close` (if the pipe was ever initialised) and free it from the close
+/// callback; see [`Pipe::close_and_destroy`].
+pub fn close_and_destroy_pipe(pipe: Box<Pipe>) {
+    // SAFETY: `pipe` is the `Box` the contract asks for; ownership moves in.
+    unsafe { Pipe::close_and_destroy(Box::into_raw(pipe)) }
+}

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -574,19 +574,24 @@ extern "C" fn Source__setRawModeStdin(uv_loop: *mut uv::Loop, raw: bool) -> c_in
 
 /// An object that holds bare uv pipes (no reader/writer in front of them) and
 /// closes them itself when its VM's thread is torn down.
-pub trait UvPipeOwner {
+///
+/// # Safety
+/// Every pipe registered against an implementor with [`set_pipe_owner`] must
+/// leave `uv::open_handles` (by being closed, e.g. [`close_and_destroy_pipe`])
+/// before that implementor is freed — at the latest from its own `Drop` — so a
+/// thread teardown never reaches a dead owner through the registry.
+pub unsafe trait UvPipeOwner {
     /// `uv::open_handles` entry point: close every pipe still held.
     fn close_pipes_for_vm_teardown(&self);
 }
 
 /// Record `owner` as the one a thread teardown closes `pipe` through (`pipe`
-/// is used as the registry key only). `owner` takes the pipe off the list —
-/// by closing it, e.g. [`close_and_destroy_pipe`], at the latest from its own
-/// `Drop` — so the entry never outlives it.
+/// is used as the registry key only); see the trait's contract for when the
+/// entry goes away.
 pub fn set_pipe_owner<T: UvPipeOwner>(pipe: &Pipe, owner: bun_ptr::ThisPtr<T>) {
     unsafe fn close<T: UvPipeOwner>(owner: *mut c_void) {
-        // SAFETY: `owner` was recorded from a live `ThisPtr<T>` and every pipe
-        // it owns leaves the list before the owner is freed (fn contract).
+        // SAFETY: `owner` was recorded from a live `ThisPtr<T>` and, per the
+        // `UvPipeOwner` contract, is still live while any of its pipes is listed.
         unsafe { &*owner.cast::<T>() }.close_pipes_for_vm_teardown()
     }
     uv::open_handles::set_owner(

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -73,6 +73,11 @@ pub trait AbortListener {
     fn on_abort(&mut self, reason: JSValue);
 }
 
+/// [`AbortListener`] for [`AbortListenerHandle`].
+pub trait AbortListenerRef {
+    fn on_abort(&self, reason: JSValue);
+}
+
 impl AbortSignal {
     pub fn listen<C: AbortListener>(&self, ctx: *mut C) -> &AbortSignal {
         extern "C" fn callback<C: AbortListener>(ptr: *mut c_void, reason: JSValue) {
@@ -250,6 +255,44 @@ impl AbortSignal {
     pub fn ref_from_js(value: JSValue) -> Option<AbortSignalRef> {
         // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
         AbortSignal::from_js(value).map(|p| bun_opaque::opaque_deref(p).ref_())
+    }
+}
+
+/// A native listener registration on an `AbortSignal` for a re-entrant
+/// listener `C` (the abort may fire from inside JS that `C` itself is
+/// running, so dispatch goes through `&C`). Holds a ref and a pending-activity
+/// count on the signal; dropping it unregisters, then releases both. `C` keeps
+/// the handle, so the registration cannot outlive it.
+pub struct AbortListenerHandle {
+    signal: AbortSignalRef,
+    ctx: *mut c_void,
+}
+
+impl AbortListenerHandle {
+    /// May synchronously call `C::on_abort` (already-aborted signal).
+    pub fn new<C: AbortListenerRef>(signal: AbortSignalRef, listener: bun_ptr::ThisPtr<C>) -> Self {
+        extern "C" fn callback<C: AbortListenerRef>(ptr: *mut c_void, reason: JSValue) {
+            // SAFETY: `ptr` was registered below from a live `ThisPtr<C>`; the
+            // handle `C` holds unregisters this callback before `C` is freed.
+            C::on_abort(unsafe { &*ptr.cast::<C>() }, reason);
+        }
+        let ctx = listener.as_ptr().cast::<c_void>();
+        signal.pending_activity_ref();
+        signal.add_listener(ctx, callback::<C>);
+        Self { signal, ctx }
+    }
+
+    #[inline]
+    pub fn signal(&self) -> &AbortSignal {
+        &self.signal
+    }
+}
+
+impl Drop for AbortListenerHandle {
+    fn drop(&mut self) {
+        self.signal.pending_activity_unref();
+        self.signal.clean_native_bindings(self.ctx);
+        // `signal`'s own drop releases the ref.
     }
 }
 

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -269,8 +269,15 @@ pub struct AbortListenerHandle {
 }
 
 impl AbortListenerHandle {
-    /// May synchronously call `C::on_abort` (already-aborted signal).
-    pub fn new<C: AbortListenerRef>(signal: AbortSignalRef, listener: bun_ptr::ThisPtr<C>) -> Self {
+    /// Hands the new handle to `store` (which puts it in `C`'s slot) and then
+    /// registers the listener. An already-aborted signal calls `C::on_abort`
+    /// synchronously from here instead, after `store`, so `C` may drop the
+    /// stored handle from inside that call.
+    pub fn install<C: AbortListenerRef>(
+        signal: AbortSignalRef,
+        listener: bun_ptr::ThisPtr<C>,
+        store: impl FnOnce(Self),
+    ) {
         extern "C" fn callback<C: AbortListenerRef>(ptr: *mut c_void, reason: JSValue) {
             // SAFETY: `ptr` was registered below from a live `ThisPtr<C>`; the
             // handle `C` holds unregisters this callback before `C` is freed.
@@ -278,8 +285,11 @@ impl AbortListenerHandle {
         }
         let ctx = listener.as_ptr().cast::<c_void>();
         signal.pending_activity_ref();
-        signal.add_listener(ctx, callback::<C>);
-        Self { signal, ctx }
+        // Keeps the signal alive across `add_listener` even if `on_abort`
+        // drops the stored handle.
+        let signal_for_call = signal.clone();
+        store(Self { signal, ctx });
+        signal_for_call.add_listener(ctx, callback::<C>);
     }
 
     #[inline]

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -537,40 +537,80 @@ pub fn host_fn_construct_this<R: IntoHostConstructReturn>(
 // (Phase 3 of `R-2-design.md` deletes them and drops the `_shared` suffix).
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Prototype method (`sharedThis`): `fn(&self, &JSGlobalObject, &CallFrame) -> R`.
+/// How a `sharedThis` prototype method receives the wrapper's `m_ctx`: as a
+/// plain `&T`, or as a [`ThisPtr<T>`](bun_ptr::ThisPtr) when the method needs
+/// the allocation's root pointer (to take/release intrusive refs on itself or
+/// hand itself to a dispatch path that may). The generated thunk is generic
+/// over this, so the method's own signature picks.
+pub trait HostReceiver<'a, T: 'a>: Sized {
+    /// # Safety
+    /// `this` is the live, non-null `m_ctx` of a JS wrapper that stays rooted
+    /// for `'a`.
+    unsafe fn from_m_ctx(this: *mut T) -> Self;
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for &'a T {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { &*this }
+    }
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for bun_ptr::ThisPtr<T> {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { bun_ptr::ThisPtr::new(this) }
+    }
+}
+
+/// Prototype method (`sharedThis`) taking `&self` or `this: ThisPtr<Self>`.
+///
+/// # Safety
+/// `this` is the live `m_ctx` of the JS wrapper the call was dispatched on.
 #[track_caller]
 #[inline]
-pub fn host_fn_this_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame) -> R,
+pub unsafe fn host_fn_this_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe))
 }
 
-/// Prototype method (`sharedThis`, passThis):
-/// `fn(&self, &JSGlobalObject, &CallFrame, JSValue) -> R`.
+/// [`host_fn_this_ptr`] with `passThis`.
+///
+/// # Safety
+/// As [`host_fn_this_ptr`].
 #[track_caller]
 #[inline]
-pub fn host_fn_this_value_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
+pub unsafe fn host_fn_this_value_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
     js_this: JSValue,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame, JSValue) -> R,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame, JSValue) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe, js_this))
 }
 
-/// Prototype getter (`sharedThis`): `fn(&self, &JSGlobalObject) -> R`.
+/// Prototype getter (`sharedThis`) taking `&self` or `this: ThisPtr<Self>`.
+///
+/// # Safety
+/// As [`host_fn_this_ptr`].
 #[track_caller]
 #[inline]
-pub fn host_fn_getter_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    f: impl FnOnce(&T, &JSGlobalObject) -> R,
+pub unsafe fn host_fn_getter_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global))
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -765,7 +765,7 @@ pub use self::dom_form_data::DOMFormData;
 pub use self::url::{URL, URLJsc};
 pub use self::zig_stack_frame::ZigStackFrame;
 pub use self::zig_stack_trace::ZigStackTrace;
-pub use abort_signal::{AbortSignal, AbortSignalRef};
+pub use abort_signal::{AbortListenerHandle, AbortSignal, AbortSignalRef};
 
 // `VM` / `JSGlobalObject` — opaque FFI handles to C++-owned objects. Defined
 // once in their dedicated port files (`VM.rs` / `JSGlobalObject.rs`) and

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -136,7 +136,22 @@ fn expand_host_fn(args: &HostFnArgs, func: &ItemFn) -> syn::Result<TokenStream2>
         .inputs
         .first()
         .is_some_and(|a| matches!(a, FnArg::Receiver(r) if r.mutability.is_none()));
-    let this_reborrow = if receiver_is_shared {
+    // A typed `this: ThisPtr<Self>` first parameter gets the root pointer
+    // wrapped instead of reborrowed.
+    let first_is_this_ptr = func.sig.inputs.first().is_some_and(|a| match a {
+        FnArg::Typed(pt) => match &*pt.ty {
+            syn::Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "ThisPtr"),
+            _ => false,
+        },
+        _ => false,
+    });
+    let this_reborrow = if first_is_this_ptr {
+        quote! { let __t = unsafe { ::bun_ptr::ThisPtr::new(__this) }; }
+    } else if receiver_is_shared {
         quote! { let __t = unsafe { &*__this }; }
     } else {
         quote! { let __t = unsafe { &mut *__this }; }

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -235,6 +235,13 @@ impl<T> From<ThisPtr<T>> for BackRef<T, Root> {
     }
 }
 
+impl<T> From<ThisPtr<T>> for core::ptr::NonNull<T> {
+    #[inline]
+    fn from(p: ThisPtr<T>) -> Self {
+        p.0
+    }
+}
+
 impl<T: ?Sized, P> Copy for BackRef<T, P> {}
 impl<T: ?Sized, P> Clone for BackRef<T, P> {
     #[inline]
@@ -639,6 +646,49 @@ impl<T> core::ops::Deref for ThisPtr<T> {
     #[inline]
     fn deref(&self) -> &T {
         self.get()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OwnedThis<T> — single-owner heap allocation that hands out `ThisPtr`s.
+//
+// `Box<T>` asserts unique access on every touch, which is wrong for a callback
+// hub whose address is also held by C / JS / a task queue and re-entered while
+// a method on it is running. `OwnedThis` keeps the ownership (drop frees) but
+// only ever lends the pointee as `ThisPtr<T>` / `&T`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The unique owner of a heap-allocated `T` that is otherwise reached through
+/// [`ThisPtr`] copies. Dropping it drops and frees the `T`; every `ThisPtr`
+/// lent from it must be dead by then (the usual back-reference obligation).
+pub struct OwnedThis<T>(core::ptr::NonNull<T>);
+
+impl<T> OwnedThis<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
+    }
+
+    /// A dispatch handle to the pointee (root provenance).
+    #[inline]
+    pub fn this_ptr(&self) -> ThisPtr<T> {
+        ThisPtr(self.0)
+    }
+}
+
+impl<T> core::ops::Deref for OwnedThis<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: we own the live allocation.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Drop for OwnedThis<T> {
+    fn drop(&mut self) {
+        // SAFETY: `new` leaked exactly this `Box`; we are its unique owner.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
     }
 }
 

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -661,12 +661,15 @@ impl<T> core::ops::Deref for ThisPtr<T> {
 /// The unique owner of a heap-allocated `T` that is otherwise reached through
 /// [`ThisPtr`] copies. Dropping it drops and frees the `T`; every `ThisPtr`
 /// lent from it must be dead by then (the usual back-reference obligation).
-pub struct OwnedThis<T>(core::ptr::NonNull<T>);
+pub struct OwnedThis<T>(core::ptr::NonNull<T>, core::marker::PhantomData<T>);
 
 impl<T> OwnedThis<T> {
     #[inline]
     pub fn new(value: T) -> Self {
-        OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
+        OwnedThis(
+            core::ptr::NonNull::from(Box::leak(Box::new(value))),
+            core::marker::PhantomData,
+        )
     }
 
     /// A dispatch handle to the pointee (root provenance).

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -642,6 +642,16 @@ impl Terminal {
         }
     }
 
+    /// The Windows writer's `deref`: release the ref its matching `ref_`
+    /// parked in `pending_write_refs` (may be the last). Runs under a libuv
+    /// callback, so an imbalance asserts in debug instead of unwinding.
+    #[cfg(windows)]
+    fn release_pending_write_ref(this: bun_ptr::ThisPtr<Self>) {
+        let released = this.pending_write_refs.with_mut(|v| v.pop());
+        debug_assert!(released.is_some(), "unbalanced writer deref");
+        drop(released);
+    }
+
     /// Windows analogue of `drain_and_close_slave_fd`'s tail: once the direct
     /// child has exited the writer no longer pins the event loop. The reader
     /// stays ref'd so the loop keeps running until conhost delivers the final
@@ -1610,5 +1620,5 @@ bun_io::impl_streaming_writer_parent! {
     // Called from inside writer methods while a `&mut self.writer` borrow is
     // live: touch only the `pending_write_refs` cell.
     ref_       = |this| this.pending_write_refs.with_mut(|v| v.push(RefPtr::from_this(this))),
-    deref      = |this| drop(this.pending_write_refs.with_mut(|v| v.pop()).expect("unbalanced writer deref")),
+    deref      = |this| Terminal::release_pending_write_ref(this),
 }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -10,15 +10,11 @@
 //! - Callbacks are stored via `values` in classes.ts, accessed via js.gc
 
 use core::cell::Cell;
-use core::ffi::{c_int, c_void};
-#[cfg(windows)]
-use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::node::StringOrBuffer;
 use bun_core::EncodedSlice;
 use bun_core::SignalCode;
 use bun_io::Loop as AsyncLoop;
-use bun_io::pipe_reader::BufferedReaderParent;
 #[cfg(unix)]
 use bun_io::pipe_reader::PosixFlags;
 use bun_io::{BufferedReader, ReadState, StreamingWriter, WriteStatus};
@@ -27,6 +23,9 @@ use bun_jsc::{
     self as jsc, CallFrame, EventLoopHandle, JSGlobalObject, JSValue, JsCell, JsRef, JsResult,
     MarkedArrayBuffer, SysErrorJsc,
 };
+use bun_ptr::{RefPtr, ThisPtr};
+#[cfg(windows)]
+use bun_sys::pty::PseudoConsole;
 use bun_sys::{self as sys, Fd, FdExt};
 
 #[cfg(windows)]
@@ -86,23 +85,32 @@ pub mod js {
 /// Reference counting for Terminal.
 /// Refs are held by:
 /// 1. JS side (released in finalize)
-/// 2. Reader (released in onReaderDone/onReaderError)
-/// 3. Writer (released in onWriterClose)
+/// 2. Reader (`reader_ref`, released in onReaderDone/onReaderError)
+/// 3. Writer (`writer_ref`, released in onWriterClose)
 ///
+// Intrusive single-thread refcount; never `Rc`/`Arc` here: `*mut Terminal`
+// crosses FFI as the `.classes.ts` m_ctx payload.
+//
 // `no_construct, no_finalize`: this class uses `constructNeedsThis: true` (3-arg
 // constructor) and intrusive refcounting (finalize → deref, not heap::take),
-// neither of which the macro's default hooks support. The C-ABI shims live in
-// `mod js` above and `extern "C" fn finalize` below.
+// neither of which the macro's default hooks support.
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
-// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). The codegen
-// shim still emits `this: &mut Terminal` — `&mut T` auto-derefs to `&T`
-// so the impls below compile against either. The
-// BufferedReader/StreamingWriter parent-vtable thunks deref `*mut Self` as
-// `&*this` (shared); all field mutation routes through the cells.
+// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). The
+// BufferedReader/StreamingWriter parent callbacks get `this: ThisPtr<Self>`;
+// all field mutation routes through the cells.
 #[bun_jsc::JsClass(no_construct, no_finalize)]
 #[derive(bun_ptr::RefCounted)]
 pub struct Terminal {
     ref_count: bun_ptr::RefCount<Terminal>,
+    /// The reader's ref (see above).
+    reader_ref: Cell<Option<RefPtr<Terminal>>>,
+    /// The writer's ref (see above).
+    writer_ref: Cell<Option<RefPtr<Terminal>>>,
+    /// Windows: the writer's in-flight async writes (`WindowsWriterParent`);
+    /// the next write is submitted before the completed one's ref is dropped,
+    /// so up to two are outstanding.
+    #[cfg(windows)]
+    pending_write_refs: JsCell<Vec<RefPtr<Terminal>>>,
 
     /// The master side of the PTY (original fd, used for ioctl operations)
     /// On Windows this is always invalid_fd; ConPTY uses hpcon for control.
@@ -120,7 +128,7 @@ pub struct Terminal {
     /// Windows ConPTY handle. Used for resize and passed to uv_spawn via
     /// uv_process_options_t.pseudoconsole.
     #[cfg(windows)]
-    hpcon: Cell<Option<windows::HPCON>>,
+    hpcon: JsCell<Option<PseudoConsole>>,
 
     /// Current terminal size
     cols: Cell<u16>,
@@ -292,11 +300,11 @@ impl Options {
     }
 }
 
-/// Result from creating a Terminal
+/// Result from creating a Terminal for `Bun.spawn`.
 pub(crate) struct CreateResult {
     /// The new terminal; its initial ref belongs to the JS wrapper (`js_value`),
     /// which holds itself strong until the terminal closes.
-    pub terminal: bun_ptr::BackRef<Terminal, bun_ptr::Mut>,
+    pub terminal: bun_ptr::BackRef<Terminal, bun_ptr::Root>,
     pub js_value: JSValue,
 }
 
@@ -342,83 +350,32 @@ impl Terminal {
         self.flags.set(v);
     }
 
-    /// `self`'s address as `*mut Self` for intrusive backref / refcount slots.
-    /// Callers deref it as `&*const` (shared) — see the `BufferedReaderParent`
-    /// / `*StreamingWriterParent` thunks below — so no write provenance is
-    /// required; the `*mut` spelling is purely to match the C-shaped vtable
-    /// signatures. All field mutation routes through `Cell`/`JsCell`.
-    #[inline]
-    fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
-    }
-
-    /// Recover `&Terminal` from the parent back-pointer stashed via
-    /// [`as_ctx_ptr`](Self::as_ctx_ptr) in `init_terminal` (handed to
-    /// `reader.set_parent` / `writer.parent`). Centralises the set-once
-    /// `*mut Self → &Self` deref so the I/O-vtable trampolines below stay
-    /// safe at the call site (one `unsafe` here, N safe callers).
-    ///
-    /// Only valid for the `BufferedReaderParent` /
-    /// `{Posix,Windows}StreamingWriterParent` thunks where `this` is the
-    /// registered BACKREF — do NOT call from `WindowsWriterParent::ref_` /
-    /// `deref` (those run while a `&mut self.writer` borrow is live and must
-    /// avoid forming `&Terminal`; see Stacked-Borrows note there).
-    #[inline]
-    fn from_parent_ptr<'a>(this: *mut Self) -> &'a Self {
-        // SAFETY: `this` is the BACKREF set via `reader.set_parent` /
-        // `writer.parent = …` in `init_terminal`. The Terminal is heap-stable
-        // (`heap::into_raw`) and outlives every reader/writer callback (the
-        // intrusive +1 ref held by the I/O machinery is dropped only after the
-        // last callback fires). R-2: shared borrow only — bodies take `&self`;
-        // field writes go through `Cell`/`JsCell`, so re-entrant JS forming a
-        // fresh `&Self` from `m_ctx` aliases soundly.
-        unsafe { &*this }
-    }
-
     // ─────────────────────────────────────────────────────────────────────────
 
-    fn ref_(&self) {
-        // SAFETY: `self` derived from a heap-allocated allocation; intrusive
-        // refcount mixin only reads/writes the `ref_count` field via shared
-        // access (Cell), so the &T→*mut cast is sound for `ref_` (no &mut
-        // materialized).
-        unsafe { bun_ptr::RefCount::<Terminal>::ref_(self.as_ctx_ptr()) };
-    }
-
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant JS).
-    #[cfg(unix)]
-    fn ref_guard(&self) -> bun_ptr::RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { bun_ptr::RefPtr::init_ref(self.as_ctx_ptr()) }
-    }
-
-    fn deref_(&self) {
-        // SAFETY: `self` derived from a heap-allocated allocation; the RefCount
-        // mixin's `deref` reads/writes `ref_count` via Cell and drops the Box
-        // iff the count hits zero. Callers must treat `self` as
-        // potentially-freed on return (always tail-position in this file).
-        unsafe { bun_ptr::RefCount::<Terminal>::deref(self.as_ctx_ptr()) };
-    }
-
-    /// Internal initialization - shared by constructor and createFromSpawn
+    /// Internal initialization - shared by constructor and createFromSpawn.
+    /// Returns the initial (JS wrapper's) ref and the wrapper.
     fn init_terminal(
         global_object: &JSGlobalObject,
         options: &Options,
         // If provided, use this JSValue; otherwise create one via toJS
         existing_js_value: Option<JSValue>,
-    ) -> Result<CreateResult, InitError> {
+    ) -> Result<(RefPtr<Terminal>, JSValue), InitError> {
         // Create PTY
         let pty_result = create_pty(options.cols, options.rows)?;
 
         // The intrusive ref_count starts at 1: the JS wrapper's ref.
-        let terminal: *mut Terminal = bun_core::heap::into_raw(Box::new(Terminal {
+        let terminal = RefPtr::new(Terminal {
             ref_count: bun_ptr::RefCount::init(),
+            reader_ref: Cell::new(None),
+            writer_ref: Cell::new(None),
+            #[cfg(windows)]
+            pending_write_refs: JsCell::new(Vec::new()),
             master_fd: Cell::new(pty_result.master),
             read_fd: Cell::new(pty_result.read_fd),
             write_fd: Cell::new(pty_result.write_fd),
             slave_fd: Cell::new(pty_result.slave),
             #[cfg(windows)]
-            hpcon: Cell::new(Some(pty_result.hpcon)),
+            hpcon: JsCell::new(Some(pty_result.hpcon)),
             cols: Cell::new(if cfg!(windows) {
                 u16::try_from(clamp_to_coord(options.cols)).expect("int cast")
             } else {
@@ -440,17 +397,13 @@ impl Terminal {
             writer_has_buffered: Cell::new(false),
             #[cfg(unix)]
             tty_state: Cell::new(bun_core::tty::State::new()),
-        }));
-        let parent_ptr = terminal;
-        // SAFETY: just allocated, non-null, exclusively owned here. R-2: `&`
-        // (not `&mut`) — every method below takes `&self`; field writes go
-        // through `Cell`/`JsCell`.
-        let terminal = unsafe { &*terminal };
+        });
 
         // Set reader parent
+        let parent_ptr: *mut Terminal = terminal.as_ptr();
         terminal
             .reader
-            .with_mut(|r| r.set_parent(parent_ptr.cast::<c_void>()));
+            .with_mut(|r| r.set_parent(parent_ptr.cast()));
 
         // Set writer parent
         terminal.writer.with_mut(|w| w.parent = parent_ptr);
@@ -460,7 +413,7 @@ impl Terminal {
             .writer
             .with_mut(|w| w.start(pty_result.write_fd, true))
         {
-            sys::Result::Ok(()) => terminal.ref_(),
+            sys::Result::Ok(()) => terminal.writer_ref.set(Some(terminal.clone())),
             sys::Result::Err(_) => {
                 // The writer took neither its ref nor write_fd, and the reader never started.
                 terminal.update_flags(|f| f.insert(Flags::WRITER_DONE));
@@ -469,28 +422,30 @@ impl Terminal {
                 terminal.write_fd.get().close();
                 terminal.write_fd.set(Fd::INVALID);
                 terminal.close_internal();
-                terminal.deref_();
                 return Err(InitError::WriterStartFailed);
             }
         }
 
-        // Start reader with the read fd - adds a ref
+        // Start reader with the read fd - holds a ref. Taken first: `start`
+        // may dispatch `on_reader_error` synchronously (poll registration
+        // failure), which releases it.
+        terminal.reader_ref.set(Some(terminal.clone()));
         match terminal
             .reader
             .with_mut(|r| r.start(pty_result.read_fd, true))
         {
             sys::Result::Err(_) => {
                 // Reader never started: closeInternal skips reader.close() but
-                // runs writer.close() → onWriterClose → deref (2→1). Then drop
-                // the initial ref (1→0).
+                // runs writer.close() → onWriterClose, releasing the writer's
+                // ref (2→1); `terminal` going out of scope drops the initial
+                // ref (1→0).
+                drop(terminal.reader_ref.take());
                 terminal.read_fd.get().close();
                 terminal.read_fd.set(Fd::INVALID);
                 terminal.close_internal();
-                terminal.deref_();
                 return Err(InitError::ReaderStartFailed);
             }
             sys::Result::Ok(()) => {
-                terminal.ref_();
                 #[cfg(unix)]
                 {
                     terminal.reader.with_mut(|r| {
@@ -506,10 +461,9 @@ impl Terminal {
             }
         }
 
-        // Start reading data
-        // SAFETY: the reader cell is live for the terminal's lifetime; `read`
-        // is the raw re-entrancy-safe entry (its dispatch runs user JS).
-        unsafe { IOReader::read(terminal.reader.as_ptr()) };
+        // Start reading data (`read`'s dispatch runs user JS, hence the
+        // root-pointer entry).
+        IOReader::read_from(terminal.this_ptr());
 
         // Get or create the JS wrapper
         let this_value = existing_js_value.unwrap_or_else(|| js::to_js(parent_ptr, global_object));
@@ -533,11 +487,7 @@ impl Terminal {
             js::gc::set(js::GcValue::Drain, this_value, global_object, cb);
         }
 
-        Ok(CreateResult {
-            // SAFETY: `parent_ptr` is the live `heap::into_raw` pointer above.
-            terminal: unsafe { bun_ptr::BackRef::from_raw_mut(parent_ptr) },
-            js_value: this_value,
-        })
+        Ok((terminal, this_value))
     }
 
     /// Constructor for Terminal - called from JavaScript
@@ -562,10 +512,10 @@ impl Terminal {
         let options = Options::parse_from_js(global_object, js_options)?;
 
         match Self::init_terminal(global_object, &options, Some(this_value)) {
-            Ok(result) => {
+            Ok((terminal, _)) => {
                 // Hand the intrusive ref to the JS wrapper as m_ctx; finalize()
-                // releases it via deref_().
-                Ok(result.terminal.as_ptr())
+                // releases it.
+                Ok(RefPtr::into_raw(terminal))
             }
             Err(err) => Err(match err {
                 InitError::OpenPtyFailed => global_object.throw(format_args!("Failed to open PTY")),
@@ -592,7 +542,12 @@ impl Terminal {
         global_object: &JSGlobalObject,
         options: &Options,
     ) -> Result<CreateResult, InitError> {
-        Self::init_terminal(global_object, options, None)
+        let (terminal, js_value) = Self::init_terminal(global_object, options, None)?;
+        // `init_terminal` created the wrapper, which owns this ref as `m_ctx`.
+        Ok(CreateResult {
+            terminal: bun_ptr::BackRef::from(terminal.into_this_ptr()),
+            js_value,
+        })
     }
 
     /// Get the slave fd for subprocess to use
@@ -628,7 +583,7 @@ impl Terminal {
     /// uv_process_options_t.pseudoconsole.
     #[cfg(windows)]
     pub(crate) fn get_pseudoconsole(&self) -> Option<windows::HPCON> {
-        self.hpcon.get()
+        self.hpcon.get().as_ref().map(PseudoConsole::raw)
     }
 
     /// Mark a terminal created inline by `Bun.spawn` so it cannot be reused
@@ -653,39 +608,38 @@ impl Terminal {
     /// EOF and unref both polls so the event loop can exit. BSD kernels flush
     /// the output queue on last slave close; holding ours until
     /// Subprocess::on_process_exit keeps a fast child's writes.
+    /// `this: ThisPtr` because both reads below re-enter user JS and may
+    /// release refs; a local guard keeps `this` live for the trailing field
+    /// accesses.
     #[cfg(unix)]
-    pub(crate) fn drain_and_close_slave_fd(&self) {
-        let flags = self.flags.get();
+    pub(crate) fn drain_and_close_slave_fd(this: ThisPtr<Self>) {
+        let flags = this.flags.get();
         if flags.contains(Flags::CLOSED) {
             return;
         }
-        // Both reader callbacks below re-enter user JS and may deref; hold a
-        // +1 so `self` stays live for the trailing field accesses.
-        let guard = self.ref_guard();
+        let _guard = RefPtr::from_this(this);
         if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
-            // SAFETY: single JS thread; re-entrant user JS (data callback may
-            // call `terminal.close()`) is handled by `read`'s raw dispatch.
-            unsafe { IOReader::read(self.reader.as_ptr()) };
-            if self.flags.get().contains(Flags::CLOSED) {
+            // Single JS thread; re-entrant user JS (data callback may call
+            // `terminal.close()`) is handled by `read`'s raw dispatch.
+            IOReader::read_from(this);
+            if this.flags.get().contains(Flags::CLOSED) {
                 return;
             }
         }
-        self.close_slave_fd();
+        this.close_slave_fd();
         // Read again so the exit callback fires now (EOF on macOS, EIO on
         // Linux) instead of on the next tick when nothing may wake the loop.
         // A grandchild holding the slave keeps this at EAGAIN and re-arms.
-        let flags = self.flags.get();
+        let flags = this.flags.get();
         if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
-            // SAFETY: same as the `read()` call above.
-            unsafe { IOReader::read(self.reader.as_ptr()) };
+            IOReader::read_from(this);
         }
         // An inline terminal whose child has exited no longer keeps the event
         // loop alive; the polls stay registered so grandchild output still
         // arrives while anything else keeps the loop running.
-        if !self.flags.get().contains(Flags::CLOSED) {
-            self.update_ref(false);
+        if !this.flags.get().contains(Flags::CLOSED) {
+            this.update_ref(false);
         }
-        drop(guard);
     }
 
     /// Windows analogue of `drain_and_close_slave_fd`'s tail: once the direct
@@ -713,19 +667,8 @@ impl Terminal {
     /// spawns against this pseudoconsole are impossible afterwards.
     #[cfg(windows)]
     pub(crate) fn release_pseudoconsole_reference(&self) {
-        let Some(hpcon) = self.hpcon.get() else {
-            return;
-        };
-        // SAFETY: `hpcon` was returned from inbox `CreatePseudoConsole`, which
-        // heap-allocates a `PseudoConsole` and returns it as HPCON.
-        // `ClosePseudoConsole` later skips the field when it reads null.
-        let pc = hpcon.cast::<PseudoConsole>();
-        unsafe {
-            let r#ref = (*pc).h_pty_reference;
-            if !r#ref.is_null() && r#ref != windows::INVALID_HANDLE_VALUE {
-                let _ = windows::CloseHandle(r#ref);
-                (*pc).h_pty_reference = core::ptr::null_mut();
-            }
+        if let Some(hpcon) = self.hpcon.get() {
+            hpcon.release_reference();
         }
     }
 
@@ -736,15 +679,11 @@ impl Terminal {
     /// hpcon is passed to the thread by value so the Terminal struct may be freed
     /// before the thread completes.
     #[cfg(windows)]
-    fn close_pseudoconsole_off_thread(&self, hpcon: windows::HPCON) {
+    fn close_pseudoconsole_off_thread(&self, hpcon: PseudoConsole) {
         // PORTING.md bans std::process but not std::thread; a raw detached OS
         // thread is intentional here (no event-loop integration needed).
-        let hpcon_addr = hpcon as usize;
-        match std::thread::Builder::new().spawn(move || {
-            // SAFETY: hpcon was a valid HPCON when taken; ClosePseudoConsole is
-            // safe to call from any thread per Win32 docs.
-            unsafe { windows::ClosePseudoConsole(hpcon_addr as windows::HPCON) };
-        }) {
+        // `ClosePseudoConsole` is safe to call from any thread per Win32 docs.
+        match std::thread::Builder::new().spawn(move || hpcon.close()) {
             Ok(_t) => {
                 // detached: JoinHandle dropped without join → thread runs to completion.
             }
@@ -770,7 +709,7 @@ pub struct PtyResult {
     pub(crate) write_fd: Fd,
     pub(crate) slave: Fd,
     #[cfg(windows)]
-    pub(crate) hpcon: windows::HPCON,
+    pub(crate) hpcon: PseudoConsole,
 }
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
@@ -796,118 +735,10 @@ fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
     Err(CreatePtyError::NotSupported)
 }
 
-// OpenPtyTermios is required for the openpty() extern signature even though we pass null.
-// Kept for type correctness of the C function declaration.
-#[repr(C)]
-pub struct OpenPtyTermios {
-    pub c_iflag: u32,
-    pub c_oflag: u32,
-    pub c_cflag: u32,
-    pub c_lflag: u32,
-    pub c_cc: [u8; 20],
-    pub c_ispeed: u32,
-    pub c_ospeed: u32,
-}
-
 pub use bun_core::Winsize;
-
-pub type OpenPtyFn = unsafe extern "C" fn(
-    amaster: *mut c_int,
-    aslave: *mut c_int,
-    name: *mut u8,
-    termp: *const OpenPtyTermios,
-    winp: *const Winsize,
-) -> c_int;
-
-/// Dynamic loading of openpty on Linux (it's in libutil which may not be linked)
-#[cfg(any(target_os = "linux", target_os = "android"))]
-mod lib_util {
-    use super::*;
-    use bun_core::ZStr;
-
-    // Per PORTING.md §Global mutable state: the flag is an AtomicBool and the
-    // handle slot an AtomicPtr (null ⇔ None — dlopen never yields a null Some).
-    // JS-thread-only.
-    static HANDLE: core::sync::atomic::AtomicPtr<c_void> =
-        core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
-    static LOADED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
-
-    fn get_handle() -> Option<*mut c_void> {
-        use core::sync::atomic::Ordering::Relaxed;
-        if LOADED.load(Relaxed) {
-            let h = HANDLE.load(Relaxed);
-            return if h.is_null() { None } else { Some(h) };
-        }
-        LOADED.store(true, Relaxed);
-
-        // Try libutil.so first (most common), then libutil.so.1
-        const LIB_NAMES: [&ZStr; 3] = [
-            bun_core::zstr!("libutil.so"),
-            bun_core::zstr!("libutil.so.1"),
-            bun_core::zstr!("libc.so.6"),
-        ];
-        for lib_name in LIB_NAMES {
-            if let Some(h) = sys::dlopen(lib_name, sys::RTLD::LAZY) {
-                HANDLE.store(h, Relaxed);
-                return Some(h);
-            }
-        }
-        None
-    }
-
-    pub(super) fn get_open_pty() -> Option<OpenPtyFn> {
-        sys::dlsym_with_handle!(OpenPtyFn, "openpty", get_handle())
-    }
-}
-
-#[cfg(unix)]
-fn get_open_pty_fn() -> Option<OpenPtyFn> {
-    // openpty is linked directly on macOS (libc) and FreeBSD (libutil, see
-    // scripts/build/bun.ts).
-    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-    {
-        // Declared locally (not via the `libc` crate) so the `OpenPtyFn`
-        // type unifies with the Linux dlsym path.
-        unsafe extern "C" {
-            // SAFETY precondition: out-param fd pointers must be writable and
-            // termp/winp must be null or valid — raw-pointer contract. Kept
-            // `unsafe` so the fn item coerces to `OpenPtyFn` (unsafe fn ptr).
-            pub(crate) fn openpty(
-                amaster: *mut c_int,
-                aslave: *mut c_int,
-                name: *mut u8,
-                termp: *const OpenPtyTermios,
-                winp: *const Winsize,
-            ) -> c_int;
-        }
-        return Some(openpty);
-    }
-
-    // On Linux, openpty is in libutil, which may not be linked
-    // Load it dynamically via dlopen
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    {
-        return lib_util::get_open_pty();
-    }
-
-    #[cfg(not(any(
-        target_os = "macos",
-        target_os = "linux",
-        target_os = "android",
-        target_os = "freebsd"
-    )))]
-    None
-}
 
 #[cfg(unix)]
 fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
-    let Some(openpty_fn) = get_open_pty_fn() else {
-        return Err(CreatePtyError::NotSupported);
-    };
-
-    let mut master_fd: c_int = -1;
-    let mut slave_fd: c_int = -1;
-
     let winsize = Winsize {
         row: rows,
         col: cols,
@@ -915,22 +746,17 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
         ypixel: 0,
     };
 
-    // SAFETY: openpty writes to master_fd/slave_fd; name/termp are null (allowed).
-    let result = unsafe {
-        openpty_fn(
-            &raw mut master_fd,
-            &raw mut slave_fd,
-            core::ptr::null_mut(),
-            core::ptr::null(),
-            &raw const winsize,
-        )
+    // On Linux openpty is in libutil, which may not be linked; `sys::pty`
+    // resolves it at runtime there.
+    let sys::pty::PtyPair {
+        master: master_fd_desc,
+        slave: slave_fd_desc,
+    } = match sys::pty::openpty(&winsize) {
+        Ok(pair) => pair,
+        Err(sys::pty::OpenPtyError::NotSupported) => return Err(CreatePtyError::NotSupported),
+        Err(sys::pty::OpenPtyError::Failed) => return Err(CreatePtyError::OpenPtyFailed),
     };
-    if result != 0 {
-        return Err(CreatePtyError::OpenPtyFailed);
-    }
-
-    let master_fd_desc = Fd::from_native(master_fd);
-    let slave_fd_desc = Fd::from_native(slave_fd);
+    let slave_fd = slave_fd_desc.native();
 
     // Configure sensible terminal defaults matching node-pty behavior.
     // These are "cooked mode" defaults that most terminal applications expect.
@@ -989,11 +815,7 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
             // Set baud rate to 38400 (standard for PTYs)
             // libc termios on Linux encodes speed in c_cflag; use
             // cfsetispeed/cfsetospeed (the portable way to set both).
-            // SAFETY: `t` is a fully-initialized termios from tcgetattr.
-            unsafe {
-                libc::cfsetispeed(&raw mut t, libc::B38400);
-                libc::cfsetospeed(&raw mut t, libc::B38400);
-            }
+            sys::pty::cfsetspeed(&mut t, libc::B38400);
 
             let _ = sys::posix::tcsetattr(slave_fd, sys::posix::TCSA::Now, &t);
         }
@@ -1045,235 +867,23 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
 }
 
 #[cfg(windows)]
-struct PipePair {
-    pub server: windows::HANDLE,
-    pub client: windows::HANDLE,
-}
-
-/// Inbox kernel32's HPCON layout. Stable ABI since build 17763: documented as
-/// "part of an ABI shared with the rest of the operating system" in
-/// microsoft/terminal `src/winconpty/winconpty.h`.
-#[cfg(windows)]
-#[repr(C)]
-struct PseudoConsole {
-    h_signal: windows::HANDLE,
-    h_pty_reference: windows::HANDLE,
-    h_conpty_process: windows::HANDLE,
-}
-
-/// Create one end of a pipe pair as an overlapped named pipe (server) and the
-/// other as a synchronous client. Returns both raw HANDLEs. Caller closes
-/// both on error. The "server" end is suitable for libuv (uv_pipe_open) and
-/// the "client" end is suitable for ConPTY (which uses synchronous I/O).
-#[cfg(windows)]
-fn create_overlapped_pipe_pair(
-    // PIPE_ACCESS_INBOUND: server reads, client writes.
-    // PIPE_ACCESS_OUTBOUND: server writes, client reads.
-    server_access: u32,
-) -> Result<PipePair, CreatePtyError> {
-    use windows::kernel32 as k32;
-    const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x00080000;
-
-    let pid: u32 = windows::GetCurrentProcessId();
-    let counter = PIPE_SERIAL.fetch_add(1, Ordering::Relaxed);
-    let mut name_utf8_buf = [0u8; 96];
-    let name = {
-        use std::io::Write;
-        let mut cursor = &mut name_utf8_buf[..];
-        // An AppContainer may only create server pipes under `\\.\pipe\LOCAL\`;
-        // insert the segment only then so the name is unchanged outside one
-        // (matches libuv's uv__unique_pipe_name).
-        let local = if windows::is_app_container() {
-            r"LOCAL\"
-        } else {
-            ""
-        };
-        if write!(cursor, r"\\.\pipe\{local}bun-conpty-{pid}-{counter}").is_err() {
-            return Err(CreatePtyError::OpenPtyFailed);
-        }
-        let written = 96 - cursor.len();
-        &name_utf8_buf[..written]
-    };
-    let mut name_w_buf = [0u16; 97]; // [96:0]u16
-    let name_w_len = bun_core::convert_utf8_to_utf16_in_buffer(&mut name_w_buf, name).len();
-    name_w_buf[name_w_len] = 0;
-    // SAFETY: name_w_buf[name_w_len] == 0 written above.
-    let name_w = bun_core::WStr::from_buf(&name_w_buf[..], name_w_len);
-
-    // SAFETY: name_w is NUL-terminated; all other params are valid per Win32.
-    let server = unsafe {
-        k32::CreateNamedPipeW(
-            name_w.as_ptr(),
-            server_access | windows::FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
-            windows::PIPE_TYPE_BYTE | windows::PIPE_READMODE_BYTE | windows::PIPE_WAIT,
-            1,
-            65536,
-            65536,
-            0,
-            core::ptr::null_mut(),
-        )
-    };
-    if server == windows::INVALID_HANDLE_VALUE {
-        return Err(CreatePtyError::OpenPtyFailed);
-    }
-    let server_guard = scopeguard::guard(server, |h| unsafe {
-        // SAFETY: h is a valid open HANDLE on the error path.
-        let _ = windows::CloseHandle(h);
-    });
-
-    let client_access: u32 = if server_access == windows::PIPE_ACCESS_INBOUND {
-        windows::GENERIC_WRITE
-    } else {
-        windows::GENERIC_READ
-    };
-
-    // SAFETY: name_w is NUL-terminated; all other params are valid per Win32.
-    let client = unsafe {
-        k32::CreateFileW(
-            name_w.as_ptr(),
-            client_access,
-            0,
-            core::ptr::null_mut(),
-            windows::OPEN_EXISTING,
-            0,
-            core::ptr::null_mut(),
-        )
-    };
-    if client == windows::INVALID_HANDLE_VALUE {
-        return Err(CreatePtyError::OpenPtyFailed);
-    }
-
-    let server = scopeguard::ScopeGuard::into_inner(server_guard);
-    Ok(PipePair { server, client })
-}
-
-#[cfg(windows)]
-static PIPE_SERIAL: AtomicU32 = AtomicU32::new(0);
-
-#[cfg(windows)]
 fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
-    // Track ownership explicitly: handles are nulled out as they are closed or
-    // transferred so the errdefer cleanup never double-closes.
-    let mut out_server: Option<windows::HANDLE> = None;
-    let mut out_client: Option<windows::HANDLE> = None;
-    let mut in_server: Option<windows::HANDLE> = None;
-    let mut in_client: Option<windows::HANDLE> = None;
-    let mut hpcon: Option<windows::HPCON> = None;
-
-    // errdefer block: scopeguard captures &mut to all of the above.
-    // Cleanup is inlined at each early-return point (a single drop-time
-    // closure reading the Option cells would require interior mutability);
-    // it must run on every `return Err`.
-    macro_rules! cleanup {
-        () => {
-            // SAFETY: every Some(h) is a valid open Win32 handle still owned by
-            // this fn (not yet transferred); ClosePseudoConsole/CloseHandle are
-            // safe on those values.
-            unsafe {
-                if let Some(h) = hpcon {
-                    windows::ClosePseudoConsole(h);
-                }
-                if let Some(h) = out_server {
-                    let _ = windows::CloseHandle(h);
-                }
-                if let Some(h) = out_client {
-                    let _ = windows::CloseHandle(h);
-                }
-                if let Some(h) = in_server {
-                    let _ = windows::CloseHandle(h);
-                }
-                if let Some(h) = in_client {
-                    let _ = windows::CloseHandle(h);
-                }
-            }
-        };
-    }
-
-    // Output pipe: ConPTY writes (client), we read (overlapped server).
-    {
-        let pair = match create_overlapped_pipe_pair(windows::PIPE_ACCESS_INBOUND) {
-            Ok(p) => p,
-            Err(e) => {
-                cleanup!();
-                return Err(e);
-            }
-        };
-        out_server = Some(pair.server);
-        out_client = Some(pair.client);
-    }
-
-    // Input pipe: we write (overlapped server), ConPTY reads (client).
-    {
-        let pair = match create_overlapped_pipe_pair(windows::PIPE_ACCESS_OUTBOUND) {
-            Ok(p) => p,
-            Err(e) => {
-                cleanup!();
-                return Err(e);
-            }
-        };
-        in_server = Some(pair.server);
-        in_client = Some(pair.client);
-    }
-
-    let size = windows::COORD {
-        X: clamp_to_coord(cols),
-        Y: clamp_to_coord(rows),
-    };
-    {
-        let mut pc: windows::HPCON = core::ptr::null_mut();
-        // SAFETY: in_client/out_client are valid open HANDLEs; pc is a valid out-ptr.
-        if unsafe {
-            windows::CreatePseudoConsole(size, in_client.unwrap(), out_client.unwrap(), 0, &mut pc)
-        } < 0
-        {
-            cleanup!();
-            return Err(CreatePtyError::OpenPtyFailed);
-        }
-        hpcon = Some(pc);
-    }
-
-    // ConPTY duplicated the client handles internally; close our copies.
-    // SAFETY: in_client/out_client are valid open HANDLEs.
-    unsafe {
-        let _ = windows::CloseHandle(in_client.take().unwrap());
-        let _ = windows::CloseHandle(out_client.take().unwrap());
-    }
-
-    // Wrap server (overlapped) ends as libuv-owned FDs so they can be passed
-    // to BufferedReader/StreamingWriter.start() which calls uv_pipe_open.
-    // Do not .take() until after success — on Err the cleanup! must still see
-    // Some(h) so the HANDLE isn't leaked; clear `out_server` only after the
-    // fallible call succeeds.
-    let read_fd = match Fd::from_system(out_server.unwrap()).make_libuv_owned() {
-        Ok(fd) => {
-            out_server = None;
-            fd
-        }
-        Err(_) => {
-            cleanup!();
-            return Err(CreatePtyError::DupFailed);
-        }
-    };
-    // errdefer read_fd.close()
-    let read_fd_guard = scopeguard::guard(read_fd, |fd| fd.close());
-
-    let write_fd = match Fd::from_system(in_server.unwrap()).make_libuv_owned() {
-        Ok(fd) => fd,
-        Err(_) => {
-            cleanup!();
-            return Err(CreatePtyError::DupFailed);
-        }
-    };
-
-    let result_hpcon = hpcon.take().unwrap();
-    let read_fd = scopeguard::ScopeGuard::into_inner(read_fd_guard);
-
+    // Server (overlapped) pipe ends come back as libuv-owned FDs so they can
+    // be passed to BufferedReader/StreamingWriter.start() (uv_pipe_open).
+    let sys::pty::ConPty {
+        read_fd,
+        write_fd,
+        hpcon,
+    } = sys::pty::create_conpty(cols, rows).map_err(|e| match e {
+        sys::pty::CreatePtyError::OpenPtyFailed => CreatePtyError::OpenPtyFailed,
+        sys::pty::CreatePtyError::DupFailed => CreatePtyError::DupFailed,
+    })?;
     Ok(PtyResult {
         master: Fd::INVALID,
         read_fd,
         write_fd,
         slave: Fd::INVALID,
-        hpcon: result_hpcon,
+        hpcon,
     })
 }
 
@@ -1519,16 +1129,7 @@ impl Terminal {
                 ypixel: 0,
             };
 
-            // SAFETY: master_fd is open (closed flag checked above), TIOCSWINSZ
-            // takes a *const winsize.
-            let ioctl_result = unsafe {
-                libc::ioctl(
-                    self.master_fd.get().native(),
-                    libc::TIOCSWINSZ as _,
-                    &raw const winsize,
-                )
-            };
-            if ioctl_result != 0 {
+            if sys::pty::set_winsize(self.master_fd.get(), &winsize).is_err() {
                 return Err(global_object.throw(format_args!("Failed to resize terminal")));
             }
         }
@@ -1544,12 +1145,7 @@ impl Terminal {
             const HR_NO_DATA: i32 = 0x8007_00E8u32 as i32;
             const HR_BROKEN_PIPE: i32 = 0x8007_006Du32 as i32;
             if let Some(hpcon) = self.hpcon.get() {
-                let size = windows::COORD {
-                    X: clamp_to_coord(new_cols),
-                    Y: clamp_to_coord(new_rows),
-                };
-                // SAFETY: hpcon is a valid open HPCON.
-                let hr = unsafe { windows::ResizePseudoConsole(hpcon, size) };
+                let hr = hpcon.resize(new_cols, new_rows);
                 if hr < 0 && hr != HR_NO_DATA && hr != HR_BROKEN_PIPE {
                     return Err(global_object.throw(format_args!("Failed to resize terminal")));
                 }
@@ -1696,7 +1292,7 @@ impl Terminal {
             // pipe is drained on Windows < 11 24H2) and leave the reader open so
             // the event loop can keep draining; conhost flushes the final frame,
             // closes its pipe end, and the reader observes EOF → onReaderDone.
-            if let Some(hpcon) = self.hpcon.take() {
+            if let Some(hpcon) = self.hpcon.replace(None) {
                 self.close_pseudoconsole_off_thread(hpcon);
             }
             // Leave the reader open; onReaderDone closes it on EOF.
@@ -1728,15 +1324,28 @@ impl Terminal {
     }
 
     // IOWriter callbacks
-    fn on_writer_close(&self) {
+    fn on_writer_close(this: ThisPtr<Self>) {
         bun_output::scoped_log!(Terminal, "onWriterClose");
-        if !self.flags.get().contains(Flags::WRITER_DONE) {
-            self.update_flags(|f| f.insert(Flags::WRITER_DONE));
-            // Must run before the deref below, which may free `self`.
-            self.maybe_downgrade_after_eof();
+        if !this.flags.get().contains(Flags::WRITER_DONE) {
+            this.update_flags(|f| f.insert(Flags::WRITER_DONE));
+            // Must run before the deref below, which may free `this`.
+            this.maybe_downgrade_after_eof();
             // Release writer's ref
-            self.deref_();
+            drop(this.writer_ref.take());
         }
+    }
+
+    #[allow(clippy::needless_pass_by_value)] // signature fixed by `impl_streaming_writer_parent!`
+    fn on_writer_error(this: ThisPtr<Self>, err: sys::Error) {
+        this.on_writer_error_ref(&err);
+    }
+
+    fn on_write_this(this: ThisPtr<Self>, amount: usize, status: WriteStatus) {
+        this.on_write(amount, status);
+    }
+
+    fn on_writer_ready_this(this: ThisPtr<Self>) {
+        this.on_writer_ready();
     }
 
     fn on_writer_ready(&self) {
@@ -1756,7 +1365,7 @@ impl Terminal {
         self.maybe_downgrade_after_eof();
     }
 
-    fn on_writer_error(&self, err: &sys::Error) {
+    fn on_writer_error_ref(&self, err: &sys::Error) {
         bun_output::scoped_log!(Terminal, "onWriterError: {:?}", err);
         // On write error, close the terminal to prevent further operations
         // This handles cases like broken pipe when the child process exits
@@ -1783,36 +1392,37 @@ impl Terminal {
     }
 
     // IOReader callbacks
-    fn on_reader_done(&self) {
+    fn on_reader_done(this: ThisPtr<Self>) {
         bun_output::scoped_log!(Terminal, "onReaderDone");
         // exit_code 0 = clean EOF on PTY stream (not subprocess exit code)
-        self.on_reader_finished(0);
+        Self::on_reader_finished(this, 0);
     }
 
-    fn on_reader_error(&self, err: &sys::Error) {
+    fn on_reader_error(this: ThisPtr<Self>, err: &sys::Error) {
         bun_output::scoped_log!(Terminal, "onReaderError: {:?}", err);
         // exit_code 1 = I/O error on PTY stream (not subprocess exit code)
-        self.on_reader_finished(1);
+        Self::on_reader_finished(this, 1);
     }
 
     /// Shared tail of `on_reader_done`/`on_reader_error`: claim `READER_DONE`
     /// before the exit callback so re-entry (`terminal.close()` from the
-    /// callback) sees the flag and no-ops, then release the reader's +1.
-    fn on_reader_finished(&self, exit_code: i32) {
-        if self.flags.get().contains(Flags::READER_DONE) {
+    /// callback) sees the flag and no-ops, then release the reader's ref
+    /// (which may free `this`).
+    fn on_reader_finished(this: ThisPtr<Self>, exit_code: i32) {
+        if this.flags.get().contains(Flags::READER_DONE) {
             return;
         }
-        self.update_flags(|f| {
+        this.update_flags(|f| {
             f.insert(Flags::READER_DONE);
             f.remove(Flags::CONNECTED);
         });
         // EOF from master - downgrade to weak ref to allow GC.
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
-        if !self.flags.get().contains(Flags::FINALIZED) {
-            self.maybe_downgrade_after_eof();
-            self.call_exit_callback(exit_code, None);
+        if !this.flags.get().contains(Flags::FINALIZED) {
+            this.maybe_downgrade_after_eof();
+            this.call_exit_callback(exit_code, None);
         }
-        self.deref_();
+        drop(this.reader_ref.take());
     }
 
     /// Downgrade `this_value` once no further callback can fire: reader hit
@@ -1951,6 +1561,8 @@ impl Terminal {
     }
 }
 
+/// Runs when the last ref is released (JS finalize, reader done, writer
+/// close), before the allocation is freed.
 impl Drop for Terminal {
     fn drop(&mut self) {
         bun_output::scoped_log!(Terminal, "deinit");
@@ -1965,98 +1577,38 @@ impl Drop for Terminal {
 
 // BufferedReader vtable parent: Terminal declares
 // `onReadChunk`/`onReaderDone`/`onReaderError`/`loop`/`eventLoop`.
-bun_io::buffered_reader_parent_link!(Terminal for Terminal);
-impl BufferedReaderParent for Terminal {
-    const KIND: bun_io::BufferedReaderParentLinkKind =
-        bun_io::BufferedReaderParentLinkKind::Terminal;
-    const HAS_ON_READ_CHUNK: bool = true;
-
-    unsafe fn on_read_chunk(
-        this: *mut Self,
-        chunk: bun_io::Chunk<'_>,
-        has_more: ReadState,
-    ) -> bool {
-        Self::from_parent_ptr(this).on_read_chunk(&chunk, has_more)
-    }
-    unsafe fn on_reader_done(this: *mut Self) {
-        Self::from_parent_ptr(this).on_reader_done();
-    }
-    unsafe fn on_reader_error(this: *mut Self, err: sys::Error) {
-        Self::from_parent_ptr(this).on_reader_error(&err);
-    }
-    unsafe fn loop_(this: *mut Self) -> *mut bun_io::pipe_reader::Loop {
-        // Delegate to the inherent `Terminal::loop_()` which is cfg-split:
-        // on Windows it projects `.uv_loop()` (the `*mut uv_loop_t` field of
-        // `WindowsLoop`), NOT a raw cast of the `bun_uws::Loop` wrapper.
-        Self::from_parent_ptr(this).loop_().cast()
-    }
-    unsafe fn event_loop(this: *mut Self) -> bun_io::EventLoopHandle {
-        Self::from_parent_ptr(this)
-            .event_loop_handle
-            .as_event_loop_ctx()
-    }
+bun_io::impl_buffered_reader_parent! {
+    Terminal for Terminal;
+    borrow = this;
+    reader = reader;
+    has_on_read_chunk = true;
+    on_read_chunk   = |this, chunk, has_more| this.on_read_chunk(&chunk, has_more);
+    on_reader_done  = |this| Terminal::on_reader_done(this);
+    on_reader_error = |this, err| Terminal::on_reader_error(this, &err);
+    // Delegate to the inherent `Terminal::loop_()` which is cfg-split: on
+    // Windows it projects `.uv_loop()` (the `*mut uv_loop_t` field of
+    // `WindowsLoop`), NOT a raw cast of the `bun_uws::Loop` wrapper.
+    loop_           = |this| this.loop_().cast();
+    event_loop      = |this| this.event_loop_handle.as_event_loop_ctx();
 }
 
 // `bun.io.StreamingWriter(@This(), struct { onClose, onWritable, onError, onWrite })`
-// → trait impl on `Terminal`. All methods take `*mut Self` because the writer
-// is an intrusive *field of* the parent — see PipeWriter.rs PosixStreamingWriterParent.
-#[cfg(unix)]
-impl bun_io::pipe_writer::PosixStreamingWriterParent for Terminal {
-    const POLL_OWNER_TAG: bun_io::PollTag = bun_io::posix_event_loop::poll_tag::TERMINAL_POLL;
-    unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus) {
-        Self::from_parent_ptr(this).on_write(amount, status);
-    }
-    unsafe fn on_error(this: *mut Self, err: sys::Error) {
-        Self::from_parent_ptr(this).on_writer_error(&err);
-    }
-    unsafe fn on_ready(this: *mut Self) {
-        Self::from_parent_ptr(this).on_writer_ready();
-    }
-    unsafe fn on_close(this: *mut Self) {
-        Self::from_parent_ptr(this).on_writer_close();
-    }
-    unsafe fn event_loop(this: *mut Self) -> bun_io::EventLoopHandle {
-        Self::from_parent_ptr(this)
-            .event_loop_handle
-            .as_event_loop_ctx()
-    }
-    unsafe fn loop_(this: *mut Self) -> *mut bun_uws_sys::Loop {
-        Self::from_parent_ptr(this).event_loop_handle.r#loop()
-    }
-}
-
-#[cfg(windows)]
-impl bun_io::pipe_writer::WindowsWriterParent for Terminal {
-    unsafe fn loop_(this: *mut Self) -> *mut bun_libuv_sys::Loop {
-        // SAFETY: BACKREF set via writer.parent; shared-only read.
-        unsafe { (*this).event_loop_handle.uv_loop() }
-    }
-    unsafe fn ref_(this: *mut Self) {
-        // SAFETY: see loop_. Intrusive refcount bump via raw pointer — do NOT
-        // form &Terminal here: this is called from inside writer methods while
-        // a &mut self.writer borrow is live (Stacked-Borrows aliasing).
-        unsafe { bun_ptr::RefCount::<Terminal>::ref_(this) };
-    }
-    unsafe fn deref(this: *mut Self) {
-        // SAFETY: see loop_. Intrusive refcount drop via raw pointer; may free
-        // `this`. See ref_ for aliasing rationale.
-        unsafe { bun_ptr::RefCount::<Terminal>::deref(this) };
-    }
-}
-
-#[cfg(windows)]
-impl bun_io::pipe_writer::WindowsStreamingWriterParent for Terminal {
-    const HAS_ON_WRITABLE: bool = true;
-    unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus) {
-        Self::from_parent_ptr(this).on_write(amount, status);
-    }
-    unsafe fn on_error(this: *mut Self, err: sys::Error) {
-        Self::from_parent_ptr(this).on_writer_error(&err);
-    }
-    unsafe fn on_writable(this: *mut Self) {
-        Self::from_parent_ptr(this).on_writer_ready();
-    }
-    unsafe fn on_close(this: *mut Self) {
-        Self::from_parent_ptr(this).on_writer_close();
-    }
+// → the writer-parent trait impls. `borrow = this`: the writer is an
+// intrusive *field of* the parent and `on_close` may release the last ref, so
+// the callbacks get `ThisPtr<Terminal>` rather than a receiver.
+bun_io::impl_streaming_writer_parent! {
+    Terminal;
+    poll_tag   = bun_io::posix_event_loop::poll_tag::TERMINAL_POLL,
+    borrow     = this,
+    on_write   = on_write_this,
+    on_error   = on_writer_error,
+    on_ready   = on_writer_ready_this,
+    on_close   = on_writer_close,
+    event_loop = |this| this.event_loop_handle.as_event_loop_ctx(),
+    uws_loop   = |this| this.event_loop_handle.r#loop(),
+    uv_loop    = |this| this.event_loop_handle.uv_loop(),
+    // Called from inside writer methods while a `&mut self.writer` borrow is
+    // live: touch only the `pending_write_refs` cell.
+    ref_       = |this| this.pending_write_refs.with_mut(|v| v.push(RefPtr::from_this(this))),
+    deref      = |this| drop(this.pending_write_refs.with_mut(|v| v.pop()).expect("unbalanced writer deref")),
 }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -377,12 +377,12 @@ impl Terminal {
             #[cfg(windows)]
             hpcon: JsCell::new(Some(pty_result.hpcon)),
             cols: Cell::new(if cfg!(windows) {
-                u16::try_from(clamp_to_coord(options.cols)).expect("int cast")
+                u16::try_from(sys::pty::clamp_to_coord(options.cols)).expect("int cast")
             } else {
                 options.cols
             }),
             rows: Cell::new(if cfg!(windows) {
-                u16::try_from(clamp_to_coord(options.rows)).expect("int cast")
+                u16::try_from(sys::pty::clamp_to_coord(options.rows)).expect("int cast")
             } else {
                 options.rows
             }),
@@ -897,12 +897,6 @@ fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError>
     })
 }
 
-/// COORD.X/Y are i16; clamp the u16 cols/rows to its range.
-#[inline]
-fn clamp_to_coord(v: u16) -> i16 {
-    i16::try_from(v.min(u16::try_from(i16::MAX).expect("int cast"))).unwrap()
-}
-
 #[derive(Clone, Copy, PartialEq, Eq, core::marker::ConstParamTy)]
 enum TermiosField {
     Iflag,
@@ -1163,12 +1157,12 @@ impl Terminal {
         }
 
         self.cols.set(if cfg!(windows) {
-            u16::try_from(clamp_to_coord(new_cols)).expect("int cast")
+            u16::try_from(sys::pty::clamp_to_coord(new_cols)).expect("int cast")
         } else {
             new_cols
         });
         self.rows.set(if cfg!(windows) {
-            u16::try_from(clamp_to_coord(new_rows)).expect("int cast")
+            u16::try_from(sys::pty::clamp_to_coord(new_rows)).expect("int cast")
         } else {
             new_rows
         });

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1652,7 +1652,7 @@ fn spawn_maybe_sync(
             if proc.has_exited() {
                 // process has already exited, we called wait4(), but we did not call onProcessExit()
                 // SAFETY: all-zero is a valid Rusage (POD).
-                let status = proc.status();
+                let status = proc.status.clone();
                 proc.on_exit(status, &bun_core::ffi::zeroed::<Rusage>());
             } else {
                 // process has already exited, but we haven't called wait4() yet
@@ -1741,7 +1741,7 @@ fn spawn_maybe_sync(
     if !is_sync {
         if !subprocess.has_exited() {
             // SAFETY: jsc_vm_ptr points to the live thread VM.
-            unsafe { (*jsc_vm_ptr).on_subprocess_spawn(subprocess.process().as_ptr()) };
+            unsafe { (*jsc_vm_ptr).on_subprocess_spawn(subprocess.process().as_non_null()) };
         }
         return Ok(out);
     }
@@ -1778,7 +1778,7 @@ fn spawn_maybe_sync(
 
     if !subprocess.has_exited() {
         // SAFETY: jsc_vm_ptr points to the live thread VM.
-        unsafe { (*jsc_vm_ptr).on_subprocess_spawn(subprocess.process().as_ptr()) };
+        unsafe { (*jsc_vm_ptr).on_subprocess_spawn(subprocess.process().as_non_null()) };
     }
 
     let mut did_timeout = false;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1731,11 +1731,12 @@ fn spawn_maybe_sync(
     // Therefore, we must do this at the very end.
     if let Some(signal) = abort_signal.take() {
         // Ownership of the ref taken above transfers to `subprocess.abort_signal`.
-        // Registering may synchronously fire `on_abort` (already aborted),
-        // which re-enters via `subprocess_this`; no `&mut Subprocess` is held
-        // across the call.
-        let handle = jsc::AbortListenerHandle::new(signal, subprocess_this);
-        subprocess.abort_signal.set(Some(handle));
+        // The handle is stored before registering: an already-aborted signal
+        // fires `on_abort` synchronously, which re-enters via `subprocess_this`
+        // and clears the slot; no `&mut Subprocess` is held across the call.
+        jsc::AbortListenerHandle::install(signal, subprocess_this, |handle| {
+            subprocess.abort_signal.set(Some(handle))
+        });
     }
 
     if !is_sync {
@@ -1767,8 +1768,9 @@ fn spawn_maybe_sync(
             // Therefore, we must do this at the very end.
             if let Some(signal) = abort_signal.take() {
                 // See the matching block above.
-                let handle = jsc::AbortListenerHandle::new(signal, subprocess_this);
-                subprocess.abort_signal.set(Some(handle));
+                jsc::AbortListenerHandle::install(signal, subprocess_this, |handle| {
+                    subprocess.abort_signal.set(Some(handle))
+                });
             }
         }
         sys::Result::Err(_) => {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -9,7 +9,6 @@ use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
 use bun_core::{String as BunString, ZStr, strings};
 use bun_event_loop::SpawnSyncEventLoop::TickState;
-use bun_io::max_buf::MaxBuf;
 use bun_jsc::{
     self as jsc, EventLoopHandle, JSGlobalObject, JSObject, JSPropertyIterator, JSValue, JsError,
     JsResult, SystemError,
@@ -67,13 +66,6 @@ type SpawnOptionsStdio = spawn::PosixStdio;
 #[cfg(windows)]
 type SpawnOptionsStdio = spawn::WindowsStdio;
 
-// Reading the symbol address has no precondition (the value itself is a
-// rodata `const char*`); kept `safe` to match the identical declaration in
-// `runtime/shell/subproc.rs` so the two extern blocks don't diverge.
-unsafe extern "C" {
-    safe static BUN_DEFAULT_PATH_FOR_SPAWN: *const c_char;
-}
-
 struct Argv0Result {
     /// Was arena-owned `[:0]const u8`; caller stashes in its `Vec<ZBox>` backing
     /// store so the pointer outlives `spawn_process`.
@@ -122,8 +114,7 @@ fn get_argv0(
         path
     } else if cfg!(unix) {
         // If the user explicitly passed an empty $PATH, we fallback to the OS-specific default (which libuv also does)
-        // SAFETY: BUN_DEFAULT_PATH_FOR_SPAWN is a NUL-terminated static C string.
-        unsafe { bun_core::ffi::cstr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes()
+        bun_spawn::default_search_path()
     } else {
         b""
     };
@@ -376,7 +367,7 @@ fn spawn_maybe_sync(
     let mut windows_verbatim_arguments: bool = false;
     let mut abort_signal: Option<bun_jsc::AbortSignalRef> = None;
     let mut terminal_info: Option<terminal_body::CreateResult> = None;
-    let mut existing_terminal: Option<bun_ptr::BackRef<Terminal, bun_ptr::Mut>> = None; // Existing terminal passed by user
+    let mut existing_terminal: Option<bun_ptr::BackRef<Terminal, bun_ptr::Root>> = None; // Existing terminal passed by user
     let mut terminal_js_value: JSValue = JSValue::ZERO;
     let mut defer_guard = scopeguard::guard(
         &mut terminal_info,
@@ -506,15 +497,11 @@ fn spawn_maybe_sync(
             }
 
             if let Some(signal_val) = args.get_truthy(global_this, "signal")? {
-                if let Some(signal) = WebCore::AbortSignal::from_js(signal_val) {
-                    // `from_js` returns a live FFI handle owned by JS.
-                    // `AbortSignal` is an `opaque_ffi!` ZST handle; `opaque_ref`
-                    // is the centralised non-null deref proof.
-                    let sig = WebCore::AbortSignal::opaque_ref(signal);
+                if let Some(sig) = WebCore::AbortSignal::ref_from_js(signal_val) {
                     if let Some(abort_error) = sig.node_abort_error_if_aborted(global_this) {
                         return Err(global_this.throw_value(abort_error));
                     }
-                    abort_signal = Some(sig.ref_());
+                    abort_signal = Some(sig);
                 } else {
                     return Err(global_this.throw_invalid_argument_type_value(
                         b"signal",
@@ -779,15 +766,10 @@ fn spawn_maybe_sync(
             if !is_sync {
                 if let Some(terminal_val) = args.get_truthy(global_this, "terminal")? {
                     // Check if it's an existing Terminal object
-                    if let Some(terminal) = terminal_body::js::from_js(terminal_val) {
-                        // `from_js` returns the live `m_ctx` pointer borrowed
-                        // from the JS wrapper; it stays valid for as long as
-                        // `terminal_val` is reachable (kept alive below via
-                        // `terminal_js_value`), so the `BackRef` invariant
-                        // (pointee outlives holder) holds for this scope.
-                        // SAFETY: `terminal` is the wrapper's live `m_ctx` heap pointer
-                        // (write provenance from its original allocation).
-                        let term = unsafe { bun_ptr::BackRef::from_raw_mut(terminal.as_ptr()) };
+                    if let Some(terminal) = terminal_val.as_class_this_ptr::<Terminal>() {
+                        // Kept alive for this scope (and beyond, via
+                        // `terminal_js_value`) by the JS wrapper.
+                        let term = bun_ptr::BackRef::from(terminal);
                         if term.is_closed() {
                             return Err(global_this
                                 .throw_invalid_arguments(format_args!("terminal is closed")));
@@ -1251,7 +1233,10 @@ fn spawn_maybe_sync(
     let spawned_stdout = spawned.stdout.take();
     let spawned_stderr = spawned.stderr.take();
     let mut spawned_extra_pipes = core::mem::take(&mut spawned.extra_pipes);
-    let process = spawned.to_process(loop_handle);
+    // The owning handle on the freshly allocated `Process`; released when the
+    // `Subprocess` drops (detached earlier in `Subprocess::finalize` or the
+    // error path below).
+    let process = spawned.to_process_handle(loop_handle);
 
     #[cfg(unix)]
     let posix_ipc_fd = if !is_sync && maybe_ipc_mode.is_some() {
@@ -1265,9 +1250,11 @@ fn spawn_maybe_sync(
     // Note: build
     // the struct once with its final field values, then fill in the
     // address-dependent fields (maxbufs, ipc_data on Windows) afterward.
-    let subprocess_ptr = bun_core::heap::into_raw(Box::new(SubprocessT {
+    // The JS wrapper's ref (handed over in `to_js_from_ptr` / `finalize`).
+    let subprocess_ref: bun_ptr::RefPtr<SubprocessT<'static>> = bun_ptr::RefPtr::new(SubprocessT {
         global_this: bun_ptr::BackRef::new(global_this),
         process,
+        exit_ref: Cell::new(None),
         pid_rusage: Cell::new(None),
         // stdin/stdout/stderr are assigned immediately after this literal.
         // `Writable.init()` writes to `subprocess.weak_file_sink_stdin_ptr`,
@@ -1282,9 +1269,7 @@ fn spawn_maybe_sync(
         stdin: JsCell::new(Writable::Ignore),
         stdout: JsCell::new(Readable::Ignore),
         stderr: JsCell::new(Readable::Ignore),
-        // 1=JS (released in Subprocess::finalize), 2=Process exit handler
-        // (released in Subprocess::on_process_exit; stranded if child outlives VM teardown).
-        ref_count: bun_ptr::RefCount::init_exact_refs(2),
+        ref_count: bun_ptr::RefCount::init(),
         stdio_pipes: JsCell::new(core::mem::take(&mut spawned_extra_pipes)),
         ipc_data: JsCell::new(None),
         flags: Cell::new(if is_sync {
@@ -1293,47 +1278,41 @@ fn spawn_maybe_sync(
             Subprocess::Flags::empty()
         }),
         kill_signal,
-        stderr_maxbuf: Cell::new(None),
-        stdout_maxbuf: Cell::new(None),
+        stderr_maxbuf: bun_io::max_buf::MaxBufSlot::empty(),
+        stdout_maxbuf: bun_io::max_buf::MaxBufSlot::empty(),
         terminal: Cell::new(
-            existing_terminal
-                .map(|t| t.as_ptr())
-                .or_else(|| terminal_info.as_ref().map(|info| info.terminal.as_ptr()))
-                .and_then(NonNull::new),
+            existing_terminal.or_else(|| terminal_info.as_ref().map(|info| info.terminal)),
         ),
         observable_getters: Default::default(),
         closed: Default::default(),
         this_value: Default::default(),
         weak_file_sink_stdin_ptr: Cell::new(None),
+        stdin_sink_ref: Cell::new(None),
         abort_signal: JsCell::new(None),
         event_loop_timer_refd: Cell::new(false),
         event_loop_timer: JsCell::new(crate::timer::EventLoopTimer::init_paused(
             crate::timer::EventLoopTimerTag::SubprocessTimeout,
         )),
         exited_due_to_maxbuf: Cell::new(None),
-    }));
-    // SAFETY: subprocess_ptr is a freshly-boxed Subprocess; we hold the only reference.
-    let subprocess = unsafe { &mut *subprocess_ptr };
+    });
+    // The `Process` exit handler's ref (released in Subprocess::on_process_exit;
+    // stranded if the child outlives VM teardown).
+    subprocess_ref.exit_ref.set(Some(subprocess_ref.clone()));
+    let subprocess_this = subprocess_ref.this_ptr();
+    let subprocess_ptr: *mut SubprocessT<'_> = subprocess_this.as_ptr();
+    let subprocess: &SubprocessT<'_> = subprocess_this.get();
+    // Taken by whichever path hands the JS ref on (`to_js_from_ptr` /
+    // `finalize` / the error path).
+    let mut subprocess_js_ref = Some(subprocess_ref);
     #[cfg(windows)]
-    SubprocessT::record_stdio_pipe_ownership(subprocess_ptr);
+    SubprocessT::record_stdio_pipe_ownership(subprocess_this);
     // Erase the borrow lifetime to 'static for the intrusive back-pointer
-    // (PipeReader stores it as raw NonNull). subprocess_ptr is non-null (just boxed).
-    let subprocess_nn: NonNull<SubprocessT<'static>> =
-        NonNull::new(subprocess_ptr.cast()).expect("Box::into_raw returned null");
+    // (PipeReader stores it as raw NonNull).
+    let subprocess_nn: NonNull<SubprocessT<'static>> = NonNull::from(subprocess_this).cast();
 
     // Address-dependent fields, filled now that `subprocess` has a stable address.
-    {
-        let owner = bun_io::max_buf::Owner {
-            ptr: subprocess_nn.cast::<()>(),
-            on_overflow: SubprocessT::on_max_buffer_overflow,
-        };
-        let mut mb = None;
-        MaxBuf::create_for_subprocess(&mut mb, max_buffer, owner);
-        subprocess.stderr_maxbuf.set(mb);
-        let mut mb = None;
-        MaxBuf::create_for_subprocess(&mut mb, max_buffer, owner);
-        subprocess.stdout_maxbuf.set(mb);
-    }
+    subprocess.stderr_maxbuf.create(subprocess_this, max_buffer);
+    subprocess.stdout_maxbuf.create(subprocess_this, max_buffer);
 
     #[cfg(windows)]
     if !is_sync {
@@ -1352,7 +1331,7 @@ fn spawn_maybe_sync(
         &mut stdio[0],
         // SAFETY: event_loop points to the live JSC EventLoop for this thread.
         unsafe { &*event_loop },
-        subprocess,
+        subprocess_this,
         spawned_stdin,
         &mut promise_for_stream,
     ) {
@@ -1380,16 +1359,13 @@ fn spawn_maybe_sync(
             }
             #[cfg(not(unix))]
             {
-                use bun_libuv_sys::UvHandle as _;
                 for r in [spawned_stdout, spawned_stderr] {
                     match r {
                         spawn::WindowsStdioResult::Buffer(pipe) => {
                             // `uv_close` is async — libuv keeps the raw handle pointer
-                            // until the next loop tick and then calls `on_pipe_close`,
-                            // which reclaims the allocation via `heap::take`. Leak the
-                            // Box so it outlives this scope; dropping it here would be
-                            // a use-after-free + double-free when the callback fires.
-                            Box::leak(pipe).close(Subprocess::on_pipe_close)
+                            // until the next loop tick; the pipe is freed from the
+                            // close callback.
+                            bun_io::source::close_and_destroy_pipe(pipe)
                         }
                         spawn::WindowsStdioResult::BufferFd(fd) => fd.close(),
                         spawn::WindowsStdioResult::UnownedFd(_)
@@ -1398,19 +1374,18 @@ fn spawn_maybe_sync(
                 }
             }
             subprocess.finalize_streams();
-            subprocess.process_mut().detach();
-            if let Some(ipc_data) = subprocess.ipc_data.take() {
-                // Nothing else holds it yet (no socket wired, no task scheduled).
+            subprocess.process().detach();
+            if let Some(ipc_data) = subprocess.ipc_data.replace(None) {
+                // Owned ref from `SendQueue::new` above; nothing else holds it
+                // yet (no socket wired, no task scheduled).
                 ipc_data.detach();
             }
-            let mut mb = subprocess.stdout_maxbuf.get();
-            MaxBuf::remove_from_subprocess(&mut mb);
-            subprocess.stdout_maxbuf.set(mb);
-            let mut mb = subprocess.stderr_maxbuf.get();
-            MaxBuf::remove_from_subprocess(&mut mb);
-            subprocess.stderr_maxbuf.set(mb);
-            subprocess.deref();
-            subprocess.deref();
+            subprocess.stdout_maxbuf.release();
+            subprocess.stderr_maxbuf.release();
+            drop(subprocess.exit_ref.take());
+            // Frees the Subprocess (and with it releases the `Process`);
+            // finalize() won't run on this error path.
+            drop(subprocess_js_ref.take());
             // Note: `Writable::init` returns
             // `crate::Error`. Map non-thrown to OOM.
             if global_this.has_exception() {
@@ -1461,11 +1436,9 @@ fn spawn_maybe_sync(
     }
     // existing_terminal: don't close slave_fd - user manages lifecycle and can reuse
 
-    // SAFETY: `subprocess_ptr` is the live JSC-allocated Subprocess that owns
-    // `process` and outlives it (handler ctx invariant).
-    subprocess.process_mut().set_exit_handler(unsafe {
-        bun_spawn::ProcessExit::new(bun_spawn::ProcessExitKind::Subprocess, subprocess_ptr)
-    });
+    // The Subprocess owns `process` and detaches the handler before it is
+    // freed (handler ctx invariant).
+    subprocess.process().set_exit_handler(subprocess_this);
 
     promise_for_stream.ensure_still_alive();
     subprocess.update_flags(|f| {
@@ -1485,6 +1458,9 @@ fn spawn_maybe_sync(
         let err = global_this.take_exception(JsError::Thrown);
         // Ensure we kill the process so we don't leave things in an unexpected state.
         let _ = subprocess.try_kill(subprocess.kill_signal);
+        // Handles wired above still point into it and `finalize` never runs on
+        // this path: the never-wrapped Subprocess stays alive (pre-existing leak).
+        let _ = subprocess_js_ref.take().map(bun_ptr::RefPtr::into_raw);
 
         if global_this.has_exception() {
             return Err(JsError::Thrown);
@@ -1573,33 +1549,28 @@ fn spawn_maybe_sync(
                     .as_err()
             {
                 let err_js = err.to_js(global_this);
-                subprocess.deref();
+                drop(subprocess_js_ref.take());
                 return Err(global_this.throw_value(err_js));
             }
         }
         ipc_data.write_version_packet(global_this);
     }
 
-    if matches!(subprocess.stdin.get(), Writable::Pipe(_)) && promise_for_stream == JSValue::ZERO {
-        // Store the whole-allocation `*mut Subprocess` so Writable::on_close can raw-project stdin.
-        // SAFETY: `subprocess_ptr` is the stable boxed Subprocess; stdin was just confirmed `Pipe`.
-        unsafe {
-            if let Writable::Pipe(pipe) = (*subprocess_ptr).stdin.get() {
-                (*pipe.as_ptr())
-                    .source
-                    .set(WebCore::streams::SourceHandle::Subprocess(
-                        bun_ptr::BackRef::from_raw(subprocess_ptr.cast::<SubprocessT<'static>>()),
-                    ));
-            }
+    if promise_for_stream == JSValue::ZERO {
+        // Store the whole-allocation `Subprocess` so Writable::on_close can project stdin.
+        if let Writable::Pipe(pipe) = subprocess.stdin.get() {
+            pipe.source.set(WebCore::streams::SourceHandle::Subprocess(
+                subprocess_nn.into(),
+            ));
         }
     }
 
     let out = if !is_sync {
-        // `subprocess_ptr` came from `heap::alloc` above and has not yet been
-        // wrapped; ownership transfers to the C++ JS cell (released via
+        // The allocation has not yet been wrapped; the JS wrapper's ref
+        // transfers to the C++ JS cell (released via
         // `SubprocessClass__finalize`). Use the raw-ptr entrypoint instead of
         // the by-value `JsClass::to_js` (which would re-box).
-        SubprocessT::to_js_from_ptr(subprocess_ptr, global_this)
+        SubprocessT::to_js_from_ptr(subprocess_js_ref.take().unwrap().into_raw(), global_this)
     } else {
         JSValue::ZERO
     };
@@ -1666,7 +1637,7 @@ fn spawn_maybe_sync(
             Subprocess::js::terminal_set_cached(out, global_this, terminal_js_value);
         }
 
-        match subprocess.process_mut().watch() {
+        match subprocess.process().watch() {
             sys::Result::Ok(()) => {}
             sys::Result::Err(_) => {
                 send_exit_notification = true;
@@ -1675,18 +1646,13 @@ fn spawn_maybe_sync(
         }
     }
 
-    // Note: reshaped for borrowck — copy `subprocess_ptr` so the
-    // non-`move` `defer!` closure captures a disjoint place from the
-    // `(*subprocess_ptr).abort_signal = …` writes that follow.
-    let subprocess_ptr_exit = subprocess_ptr;
     scopeguard::defer! {
         if send_exit_notification {
-            // SAFETY: subprocess_ptr is live for the lifetime of this defer.
-            let proc = unsafe { &*subprocess_ptr_exit }.process_mut();
+            let proc = subprocess_this.get().process();
             if proc.has_exited() {
                 // process has already exited, we called wait4(), but we did not call onProcessExit()
                 // SAFETY: all-zero is a valid Rusage (POD).
-                let status = proc.status.clone();
+                let status = proc.status();
                 proc.on_exit(status, &bun_core::ffi::zeroed::<Rusage>());
             } else {
                 // process has already exited, but we haven't called wait4() yet
@@ -1723,7 +1689,7 @@ fn spawn_maybe_sync(
     }
 
     let stdin_start_err = match subprocess.stdin.get() {
-        Writable::Buffer(buffer) => Writable::buffer_writer_mut(buffer).start().err(),
+        Writable::Buffer(buffer) => Subprocess::StaticPipeWriter::start(buffer.this_ptr()).err(),
         _ => None,
     };
     if let Some(err) = stdin_start_err {
@@ -1731,6 +1697,8 @@ fn spawn_maybe_sync(
         #[cfg(not(windows))] // Windows adopts the pipe at create and start() cannot fail there.
         subprocess.on_close_io(Subprocess::StdioKind::Stdin);
         let _ = subprocess.try_kill(subprocess.kill_signal);
+        // As in the `has_exception` path above: stays alive (pre-existing leak).
+        let _ = subprocess_js_ref.take().map(bun_ptr::RefPtr::into_raw);
         return Err(global_this.throw_value(err.to_js(global_this)));
     }
 
@@ -1762,27 +1730,18 @@ fn spawn_maybe_sync(
     // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
     // Therefore, we must do this at the very end.
     if let Some(signal) = abort_signal.take() {
-        // Ownership of the ref transfers to `subprocess.abort_signal`.
-        // `add_listener` may synchronously fire `on_abort_signal` (already
-        // aborted), which re-enters via `subprocess_ptr` and may take the
-        // field, so store it first and hold no `&mut Subprocess` across the call.
-        let sig: *mut WebCore::AbortSignal = signal.get();
-        // SAFETY: `subprocess_ptr` is live; `sig` is kept alive by the ref just stored.
-        unsafe {
-            (*subprocess_ptr).abort_signal.set(Some(signal));
-            (*sig).pending_activity_ref();
-            let _ = (*sig).add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-        }
+        // Ownership of the ref taken above transfers to `subprocess.abort_signal`.
+        // Registering may synchronously fire `on_abort` (already aborted),
+        // which re-enters via `subprocess_this`; no `&mut Subprocess` is held
+        // across the call.
+        let handle = jsc::AbortListenerHandle::new(signal, subprocess_this);
+        subprocess.abort_signal.set(Some(handle));
     }
 
     if !is_sync {
         if !subprocess.has_exited() {
-            // SAFETY: jsc_vm_ptr points to the live thread VM; `subprocess.process`
-            // is a `BackRef` (wraps `NonNull`), so its pointer is non-null.
-            unsafe {
-                (*jsc_vm_ptr)
-                    .on_subprocess_spawn(NonNull::new_unchecked(subprocess.process.as_ptr()))
-            };
+            // SAFETY: jsc_vm_ptr points to the live thread VM.
+            unsafe { (*jsc_vm_ptr).on_subprocess_spawn(subprocess.process().as_ptr()) };
         }
         return Ok(out);
     }
@@ -1795,38 +1754,31 @@ fn spawn_maybe_sync(
             .counters
             .mark(jsc::counters::Field::SpawnSyncBlocking);
         let debug_timer = Output::DebugTimer::start();
-        subprocess.process_mut().wait(true);
+        subprocess.process().wait(true);
         bun_output::scoped_log!(Subprocess, "spawnSync fast path took {}", debug_timer);
 
         // watchOrReap will handle the already exited case for us.
     }
 
-    match subprocess.process_mut().watch_or_reap() {
+    match subprocess.process().watch_or_reap() {
         sys::Result::Ok(_) => {
             // Once everything is set up, we can add the abort listener
             // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
             // Therefore, we must do this at the very end.
             if let Some(signal) = abort_signal.take() {
-                let sig: *mut WebCore::AbortSignal = signal.get();
-                // SAFETY: see the matching block above.
-                unsafe {
-                    (*subprocess_ptr).abort_signal.set(Some(signal));
-                    (*sig).pending_activity_ref();
-                    let _ = (*sig).add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-                }
+                // See the matching block above.
+                let handle = jsc::AbortListenerHandle::new(signal, subprocess_this);
+                subprocess.abort_signal.set(Some(handle));
             }
         }
         sys::Result::Err(_) => {
-            subprocess.process_mut().wait(true);
+            subprocess.process().wait(true);
         }
     }
 
     if !subprocess.has_exited() {
-        // SAFETY: jsc_vm_ptr points to the live thread VM; `subprocess.process`
-        // is a `BackRef` (wraps `NonNull`), so its pointer is non-null.
-        unsafe {
-            (*jsc_vm_ptr).on_subprocess_spawn(NonNull::new_unchecked(subprocess.process.as_ptr()))
-        };
+        // SAFETY: jsc_vm_ptr points to the live thread VM.
+        unsafe { (*jsc_vm_ptr).on_subprocess_spawn(subprocess.process().as_ptr()) };
     }
 
     let mut did_timeout = false;
@@ -1905,7 +1857,7 @@ fn spawn_maybe_sync(
             let has_timespec = !absolute_timespec.eql(&Timespec::EPOCH);
 
             if let Writable::Buffer(buffer) = subprocess.stdin.get() {
-                Writable::buffer_writer_mut(buffer).watch();
+                Subprocess::StaticPipeWriter::watch(buffer.this_ptr());
             }
 
             if let Readable::Pipe(pipe) = subprocess.stderr.get() {
@@ -1969,11 +1921,10 @@ fn spawn_maybe_sync(
         }
     }
     if global_this.has_exception() {
-        // e.g. a termination exception.
-        // SAFETY: same as below; `subprocess` is not used after this line.
-        unsafe {
-            bun_jsc::host_fn::host_fn_finalize_ref_counted(subprocess_ptr, SubprocessT::finalize)
-        };
+        // e.g. a termination exception. As below; `subprocess` is not used
+        // after this.
+        subprocess.finalize();
+        drop(subprocess_js_ref.take());
         return Ok(JSValue::ZERO);
     }
 
@@ -1995,12 +1946,11 @@ fn spawn_maybe_sync(
     let exited_due_to_timeout = did_timeout;
     let exited_due_to_max_buffer = subprocess.exited_due_to_maxbuf.get();
     let result_pid = JSValue::js_number_from_int32(subprocess.pid());
-    // SAFETY: `subprocess_ptr` was produced by `heap::into_raw(Box::new(...))`
-    // above (spawnSync path: never handed to a JS wrapper); do what the
-    // wrapper's finalizer would have. `subprocess` is not used after this line.
-    unsafe {
-        bun_jsc::host_fn::host_fn_finalize_ref_counted(subprocess_ptr, SubprocessT::finalize)
-    };
+    // `subprocess_js_ref` is the never-wrapped JS ref (spawnSync path): do
+    // what the wrapper's finalizer would have. `subprocess` is not used after
+    // this.
+    subprocess.finalize();
+    drop(subprocess_js_ref.take());
     let (stdout, stderr, resource_usage) = output?;
 
     let sync_value = JSValue::create_empty_object(global_this, 0);

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -2,16 +2,15 @@
 //! code for `Bun.spawnSync`
 
 use core::cell::Cell;
-use core::ffi::c_void;
 use core::ptr::NonNull;
 
-use bun_ptr::{RefCount, RefPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 
+use bun_jsc::SysErrorJsc;
 use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsRef, JsResult,
     VirtualMachine,
 };
-use bun_jsc::{JsClass, SysErrorJsc};
 #[cfg(not(windows))]
 use bun_sys::FdExt as _;
 use bun_sys::{self, SignalCode};
@@ -21,11 +20,9 @@ use enumset::{EnumSet, EnumSetType};
 // external `bun_spawn` crate. The `bun_spawn` workspace crate only carries the
 // platform-thin `Stdio`/`Status` shims used by `bun.spawnSync` callers.
 use crate::api::bun::Terminal;
-#[cfg(windows)]
-use crate::api::bun_process as spawn_process;
 #[cfg(not(windows))]
 use crate::api::bun_process::ExtraPipe;
-use crate::api::bun_process::{Process, Rusage, Status};
+use crate::api::bun_process::{ProcessHandle, Rusage, Status};
 use crate::ipc as IPC;
 use crate::node::node_cluster_binding;
 use crate::timer::{EventLoopTimer, EventLoopTimerState};
@@ -87,9 +84,8 @@ pub type StaticPipeWriter<'a> = NewStaticPipeWriter<Subprocess<'a>>;
 
 impl<'a> static_pipe_writer::StaticPipeWriterProcess for Subprocess<'a> {
     const POLL_OWNER_TAG: bun_io::PollTag = bun_io::posix_event_loop::poll_tag::STATIC_PIPE_WRITER;
-    unsafe fn on_close_io(this: *mut Self, kind: StdioKind) {
-        // SAFETY: caller (StaticPipeWriter) guarantees `this` is live.
-        unsafe { (*this).on_close_io(kind) }
+    fn on_close_io(this: ThisPtr<Self>, kind: StdioKind) {
+        this.on_close_io(kind)
     }
 }
 
@@ -113,21 +109,28 @@ pub use bun_spawn::process::StdioKind;
 // codegen shim hands to whichever method JS calls next. `UnsafeCell`-backed
 // fields suppress `noalias` on the outer `&Subprocess`, making the miscompile
 // structurally impossible.
-// Intrusive ref-count: `RefPtr<Subprocess>` provides ref/deref and frees the
-// Box when ref_count → 0; `deinit` runs when the last ref drops.
+// Intrusive ref-count: the Box is freed when `ref_count` → 0. Refs are held
+// by the JS wrapper (released in `finalize`), the `Process` exit handler
+// (`exit_ref`) and, while a stdin `FileSink` points back here, that sink's
+// destructor (`stdin_sink_ref`).
 #[derive(bun_ptr::RefCounted)]
 pub struct Subprocess<'a> {
-    pub(crate) ref_count: RefCount<Subprocess<'a>>,
-    /// The construction ref on the `Process` (detached in [`Subprocess::finalize`]).
-    pub(crate) process: RefPtr<Process>,
+    pub(crate) ref_count: bun_ptr::RefCount<Subprocess<'a>>,
+    /// The exit-handler owner's handle on the spawned `Process`; detached in
+    /// [`Subprocess::finalize`], released when this struct drops.
+    pub(crate) process: ProcessHandle,
+    /// The ref the `Process` exit handler holds; released at the end of
+    /// `on_process_exit` (stranded if the child outlives VM teardown).
+    pub(crate) exit_ref: Cell<Option<RefPtr<Subprocess<'a>>>>,
     pub(crate) stdin: JsCell<Writable<'a>>,
     pub(crate) stdout: JsCell<Readable>,
     pub(crate) stderr: JsCell<Readable>,
     pub(crate) stdio_pipes: JsCell<Vec<StdioPipeItem>>,
     pub(crate) pid_rusage: Cell<Option<Rusage>>,
 
-    /// Terminal attached to this subprocess (if spawned with terminal option)
-    pub(crate) terminal: Cell<Option<NonNull<Terminal>>>,
+    /// Terminal attached to this subprocess (if spawned with terminal
+    /// option). Kept alive by its JS wrapper, which is cached on ours.
+    pub(crate) terminal: Cell<Option<BackRef<Terminal, bun_ptr::Root>>>,
 
     // The JSC global outlives every Subprocess.
     pub global_this: bun_ptr::BackRef<JSGlobalObject>,
@@ -135,14 +138,20 @@ pub struct Subprocess<'a> {
     pub closed: Cell<EnumSet<StdioKind>>,
     pub this_value: JsCell<JsRef>,
 
+    /// Our ref on the IPC send queue; detached and released in `finalize`.
     pub(crate) ipc_data: JsCell<Option<RefPtr<IPC::SendQueue>>>,
     pub(crate) flags: Cell<Flags>,
 
-    /// Weak observer of the stdin `FileSink` — holds no ownership/ref. `onStdinDestroyed`
+    /// Weak observer of the stdin `FileSink` — holds no ref. `on_stdin_destroyed`
     /// nulls this before the sink is freed, so it is never dereferenced after the sink dies.
-    pub(crate) weak_file_sink_stdin_ptr: Cell<Option<NonNull<FileSink>>>,
-    /// Our ref on the `signal` option; released in `clear_abort_signal`.
-    pub(crate) abort_signal: JsCell<Option<bun_jsc::AbortSignalRef>>,
+    pub(crate) weak_file_sink_stdin_ptr: Cell<Option<BackRef<FileSink, bun_ptr::Root>>>,
+    /// The ref held while a stdin `FileSink` points back at us; its JS
+    /// destructor or close signal reaches `on_stdin_destroyed`, which releases
+    /// it.
+    pub(crate) stdin_sink_ref: Cell<Option<RefPtr<Subprocess<'a>>>>,
+    /// Our listener registration (holds a ref on the signal); dropped in
+    /// `clear_abort_signal`.
+    pub(crate) abort_signal: JsCell<Option<bun_jsc::AbortListenerHandle>>,
 
     pub(crate) event_loop_timer_refd: Cell<bool>,
     /// Intrusive timer node. `JsCell` so `&self` can hand `*mut EventLoopTimer`
@@ -152,8 +161,8 @@ pub struct Subprocess<'a> {
     pub(crate) event_loop_timer: JsCell<EventLoopTimer>,
     pub(crate) kill_signal: SignalCode,
 
-    pub(crate) stdout_maxbuf: Cell<Option<NonNull<MaxBuf::MaxBuf>>>,
-    pub(crate) stderr_maxbuf: Cell<Option<NonNull<MaxBuf::MaxBuf>>>,
+    pub(crate) stdout_maxbuf: MaxBuf::MaxBufSlot,
+    pub(crate) stderr_maxbuf: MaxBuf::MaxBufSlot,
     pub(crate) exited_due_to_maxbuf: Cell<Option<MaxBuf::Kind>>,
 }
 
@@ -161,7 +170,7 @@ bun_event_loop::impl_timer_owner!(Subprocess<'_>; from_timer_ptr => event_loop_t
 
 // Note: no `Default` impl for `Subprocess`. `js_bun_spawn_bindings::
 // spawn_maybe_sync` fills every field explicitly (see note there), and
-// `*mut Process` has no sound placeholder anyway.
+// `ProcessHandle` has no placeholder anyway.
 
 // ── manual `#[bun_jsc::JsClass]` expansion (generic struct) ──────────────────
 // Routes through the codegen'd `crate::generated_classes::js_Subprocess`
@@ -171,15 +180,15 @@ const _: () = {
     use crate::generated_classes::js_Subprocess as js;
 
     impl<'a> Subprocess<'a> {
-        /// Wrap an already-heap-allocated `Subprocess` (via `heap::alloc`) in
+        /// Wrap an already-heap-allocated `Subprocess` (`RefPtr::new`) in
         /// its JS cell. `Bun.spawn` boxes early so address-dependent
         /// back-pointers (`stdin.pipe.signal`, MaxBuf owner, IPC owner) can be
         /// wired before `subprocess.toJS(globalThis)` runs; this is the raw-ptr
         /// entrypoint that avoids re-boxing.
         ///
-        /// `ptr` must come from `heap::alloc(Box::new(Subprocess { .. }))` and
-        /// not yet be owned by any JS wrapper; ownership transfers to the C++
-        /// side (released via `SubprocessClass__finalize`). Thin forwarder to
+        /// `ptr` is the JS wrapper's ref (`RefPtr::into_raw`), not yet owned by
+        /// any wrapper; ownership transfers to the C++ side (released via
+        /// `SubprocessClass__finalize`). Thin forwarder to
         /// the (already safe) generated `js_Subprocess::to_js`, which
         /// encapsulates the FFI `__create` call internally.
         #[inline]
@@ -200,36 +209,18 @@ const _: () = {
 };
 
 impl<'a> Subprocess<'a> {
-    /// Claim `start()`'s outstanding +1 on the buffer-stdin writer (if any) for
-    /// the caller to `deref()` after closing the writer; see `StaticPipeWriter`.
-    fn take_pending_start_writer(&self) -> Option<*mut StaticPipeWriter<'a>> {
+    /// Claim `start()`'s outstanding ref on the buffer-stdin writer (if any)
+    /// for the caller to release after closing the writer; see `StaticPipeWriter`.
+    fn take_pending_start_writer(&self) -> Option<RefPtr<StaticPipeWriter<'a>>> {
         match self.stdin.get() {
-            Writable::Buffer(buffer) => {
-                let writer = Writable::buffer_writer_mut(buffer);
-                if writer.started {
-                    writer.started = false;
-                    Some(buffer.as_ptr())
-                } else {
-                    None
-                }
-            }
+            Writable::Buffer(buffer) => StaticPipeWriter::take_start_ref(buffer.this_ptr()),
             _ => None,
         }
     }
 
     #[inline]
-    pub(crate) fn process(&self) -> &Process {
+    pub(crate) fn process(&self) -> &ProcessHandle {
         &self.process
-    }
-
-    /// Mutably borrow the [`Process`]. Caller must be on the owning JS thread
-    /// with no other live `&mut Process`.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(super) fn process_mut(&self) -> &mut Process {
-        // SAFETY: single JS-mutator thread; `Process` lives in a separate
-        // allocation so the returned `&mut` never aliases `*self`.
-        unsafe { &mut *self.process.as_ptr() }
     }
 
     /// Borrow the stored JSC global. The global is guaranteed to outlive
@@ -239,10 +230,8 @@ impl<'a> Subprocess<'a> {
         self.global_this.get()
     }
 
-    /// `self`'s address as `*mut Self` for C-callback ctx slots / abort-signal
-    /// native bindings. Callbacks deref it as `&*const` (shared) — see the
-    /// `*_c` thunks below — so no write provenance is required; the `*mut`
-    /// spelling is purely to match the C signature.
+    /// `self`'s address, for identity comparisons and as the key the JSSink
+    /// destructor registration uses.
     #[inline]
     pub(crate) fn as_ctx_ptr(&self) -> *mut Self {
         std::ptr::from_ref::<Self>(self).cast_mut()
@@ -255,23 +244,6 @@ impl<'a> Subprocess<'a> {
         f(&mut v);
         self.flags.set(v);
     }
-
-    /// Intrusive `ref()`.
-    #[inline]
-    pub fn ref_(&self) {
-        // SAFETY: `&self` → live `*const Self`; `RefCount::ref_` only touches
-        // the intrusive counter via `addr_of_mut!`.
-        unsafe { RefCount::<Self>::ref_(self.as_ctx_ptr()) }
-    }
-    /// Intrusive `deref()`.
-    /// May free `self`; do not use `self` after calling.
-    #[inline]
-    pub fn deref(&self) {
-        // SAFETY: `&self` → live `*const Self`; destructor handles the Box.
-        // R-2: `&self` so callers can deref at scope exit without holding a
-        // unique borrow across re-entrant JS.
-        unsafe { RefCount::<Self>::deref(self.as_ctx_ptr()) }
-    }
 }
 
 bitflags::bitflags! {
@@ -281,7 +253,6 @@ bitflags::bitflags! {
         const IS_SYNC                      = 1 << 0;
         const HAS_STDIN_DESTRUCTOR_CALLED  = 1 << 2;
         const FINALIZED                    = 1 << 3;
-        const DEREF_ON_STDIN_DESTROYED     = 1 << 4;
         const IS_STDIN_A_READABLE_STREAM   = 1 << 5;
         /// Terminal was created inline by spawn (vs. an existing Terminal passed
         /// by the caller). Owned terminals are closed when the subprocess exits
@@ -306,9 +277,9 @@ macro_rules! assert_stdio_result {
 }
 pub(crate) use assert_stdio_result;
 
-impl Subprocess<'_> {
-    #[bun_uws::uws_callback(thunk = "on_abort_signal_c")]
-    fn handle_abort_signal(&self, _reason: JSValue) {
+/// Registered through `abort_signal`'s `AbortListenerHandle`.
+impl bun_jsc::abort_signal::AbortListenerRef for Subprocess<'_> {
+    fn on_abort(&self, _reason: JSValue) {
         self.clear_abort_signal();
         if !self.has_exited() {
             self.update_flags(|f| f.insert(Flags::ABORT_SIGNAL_KILLED));
@@ -317,27 +288,10 @@ impl Subprocess<'_> {
     }
 }
 
-/// Module-level wrapper so callers in `js_bun_spawn_bindings` (which alias the
-/// module as `Subprocess`) keep their existing `Subprocess::on_abort_signal`
-/// path. Forwards to the macro-emitted `unsafe extern "C" fn` thunk.
-///
-/// # Safety
-/// `ctx` must be the `*mut Subprocess` that was registered with
-/// `AbortSignal::add_listener`; the AbortSignal guarantees it is live for the
-/// duration of the callback.
-pub(crate) unsafe extern "C" fn on_abort_signal(ctx: *mut c_void, reason: JSValue) {
-    // SAFETY: caller upholds the `# Safety` contract above — `ctx` is the live
-    // `*mut Subprocess` registered with the AbortSignal.
-    unsafe { Subprocess::on_abort_signal_c(ctx, reason) }
-}
-
 bun_spawn::link_impl_ProcessExit! {
     Subprocess for Subprocess<'static> => |this| {
-        // `process` forwarded raw (not reborrowed) so `on_process_exit` can
-        // hand it to `VirtualMachine::on_subprocess_exit` without a const→mut
-        // provenance cast.
-        on_process_exit(process, status, rusage) =>
-            (*this).on_process_exit(process, &status, rusage),
+        on_process_exit(_process, status, rusage) =>
+            Subprocess::on_process_exit(ThisPtr::new(this), &status, rusage),
     }
 }
 
@@ -345,7 +299,7 @@ impl Subprocess<'_> {
     /// Shared borrow of the attached `AbortSignal`, if any.
     #[inline]
     pub(crate) fn abort_signal_ref(&self) -> Option<&AbortSignal> {
-        self.abort_signal.get().as_deref()
+        self.abort_signal.get().as_ref().map(|h| h.signal())
     }
 
     #[bun_jsc::host_fn(method)]
@@ -368,13 +322,7 @@ impl Subprocess<'_> {
 
             #[cfg(windows)]
             {
-                let rusage =
-                    if let spawn_process::Poller::Uv(uv_proc) = &mut self.process_mut().poller {
-                        Some(spawn_process::uv_getrusage(uv_proc))
-                    } else {
-                        None
-                    };
-                if let Some(r) = rusage {
+                if let Some(r) = self.process.uv_rusage() {
                     self.pid_rusage.set(Some(r));
                     break 'brk r;
                 }
@@ -467,7 +415,7 @@ impl Subprocess<'_> {
                     else {
                         unreachable!()
                     };
-                    Writable::buffer_writer_mut(&buffer).source.detach();
+                    StaticPipeWriter::detach_source(buffer.this_ptr());
                 }
                 _ => {}
             }),
@@ -515,7 +463,7 @@ impl Subprocess<'_> {
     }
 
     pub(crate) fn js_ref(&self) {
-        self.process_mut().enable_keeping_event_loop_alive();
+        self.process.enable_keeping_event_loop_alive();
 
         if !self.has_called_getter(ObservableGetter::Stdin) {
             self.stdin.with_mut(|s| s.r#ref());
@@ -534,7 +482,7 @@ impl Subprocess<'_> {
 
     /// This disables the keeping process alive flag on the poll and also in the stdin, stdout, and stderr
     pub(crate) fn js_unref(&self) {
-        self.process_mut().disable_keeping_event_loop_alive();
+        self.process.disable_keeping_event_loop_alive();
 
         if !self.has_called_getter(ObservableGetter::Stdin) {
             self.stdin.with_mut(|s| s.unref());
@@ -563,8 +511,13 @@ impl Subprocess<'_> {
         this.stderr.with_mut(|s| s.to_js(global_this, exited))
     }
 
+    /// `this: ThisPtr` because handing stdin to JS may take a ref on us for
+    /// the sink's destructor (`stdin_sink_ref`).
     #[bun_jsc::host_fn(getter)]
-    pub(crate) fn get_stdin(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+    pub(crate) fn get_stdin(
+        this: ThisPtr<Self>,
+        global_this: &JSGlobalObject,
+    ) -> JsResult<JSValue> {
         // When terminal is used, stdin goes through the terminal
         if this.terminal.get().is_some() {
             return Ok(JSValue::NULL);
@@ -594,7 +547,7 @@ impl Subprocess<'_> {
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_terminal(this: &Self, global_this: &JSGlobalObject) -> JSValue {
         if let Some(terminal) = this.terminal.get() {
-            return crate::api::bun_terminal_body::to_js(terminal.as_ptr(), global_this);
+            return crate::api::bun_terminal_body::to_js(terminal.this_ptr().as_ptr(), global_this);
         }
         JSValue::UNDEFINED
     }
@@ -666,32 +619,6 @@ impl Subprocess<'_> {
         let _ = self.try_kill(self.kill_signal);
     }
 
-    /// `MaxBuf::Owner::on_overflow` target. Routes straight from the `MaxBuf`
-    /// allocation to this `Subprocess`, independent of whichever pipe reader
-    /// currently holds the budget (the `.stdout`/`.stderr` getter transfers it
-    /// to a `FileReader`).
-    ///
-    /// # Safety
-    /// `sp` is the `Subprocess` passed to `MaxBuf::create_for_subprocess`; it
-    /// is live while the matching `*_maxbuf` slot is `Some` (cleared in
-    /// `finalize` and below).
-    pub(crate) unsafe fn on_max_buffer_overflow(sp: NonNull<()>, maxbuf: NonNull<MaxBuf::MaxBuf>) {
-        // SAFETY: caller contract; all accessed fields are `Cell<_>`.
-        let sp = unsafe { sp.cast::<Subprocess<'static>>().as_ref() };
-        let kind = if sp.stdout_maxbuf.get() == Some(maxbuf) {
-            let mut mb = sp.stdout_maxbuf.get();
-            MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
-            sp.stdout_maxbuf.set(mb);
-            MaxBuf::Kind::Stdout
-        } else {
-            let mut mb = sp.stderr_maxbuf.get();
-            MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
-            sp.stderr_maxbuf.set(mb);
-            MaxBuf::Kind::Stderr
-        };
-        sp.on_max_buffer(kind);
-    }
-
     /// Close still-open stdout/stderr pipe readers after a timeout/maxBuffer
     /// kill; a grandchild may still hold the write end (Node.js
     /// `SyncProcessRunner::Kill()`). Called outside any reader callback.
@@ -739,7 +666,7 @@ impl Subprocess<'_> {
         if self.has_exited() {
             return bun_sys::Result::Ok(());
         }
-        self.process_mut().kill(sig.0)
+        self.process.kill(sig.0)
     }
 
     fn has_called_getter(&self, getter: ObservableGetter) -> bool {
@@ -753,7 +680,7 @@ impl Subprocess<'_> {
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            self.process_mut().close();
+            self.process.close();
         }
     }
 
@@ -778,11 +705,8 @@ impl Subprocess<'_> {
     }
 
     pub(crate) fn on_stdin_destroyed(&self) {
-        let must_deref = self.flags.get().contains(Flags::DEREF_ON_STDIN_DESTROYED);
-        self.update_flags(|f| {
-            f.remove(Flags::DEREF_ON_STDIN_DESTROYED);
-            f.insert(Flags::HAS_STDIN_DESTRUCTOR_CALLED);
-        });
+        let stdin_sink_ref = self.stdin_sink_ref.take();
+        self.update_flags(|f| f.insert(Flags::HAS_STDIN_DESTRUCTOR_CALLED));
         self.weak_file_sink_stdin_ptr.set(None);
 
         if !self.flags.get().contains(Flags::FINALIZED) {
@@ -790,9 +714,8 @@ impl Subprocess<'_> {
             self.update_has_pending_activity();
         }
 
-        if must_deref {
-            self.deref();
-        }
+        // May free `self`; last use.
+        drop(stdin_sink_ref);
     }
 
     #[bun_jsc::host_fn(method)]
@@ -808,8 +731,7 @@ impl Subprocess<'_> {
         } else {
             crate::ipc_host::FromEnum::Subprocess
         };
-        // `ipc()` centralises the single unsafe `JsCell` deref; `do_send` may
-        // re-enter JS, but only the SendQueue is borrowed, not `*self`.
+        // `do_send` may re-enter JS, but only the SendQueue is borrowed, not `*self`.
         crate::ipc_host::do_send(this.ipc(), global, call_frame, context, this.pid() as u32)
     }
 
@@ -837,7 +759,7 @@ impl Subprocess<'_> {
     }
 
     pub(crate) fn pid(&self) -> i32 {
-        self.process().pid
+        self.process().pid()
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -881,10 +803,8 @@ impl Subprocess<'_> {
                         *slot = StdioResult::UnownedFd(dup);
                     }
                 }
-                // `uv_close` is async; `close_and_destroy` frees the pipe from
-                // the close callback.
-                // SAFETY: Box-allocated uv::Pipe owned by this slot until now.
-                unsafe { bun_sys::windows::libuv::Pipe::close_and_destroy(Box::into_raw(buffer)) };
+                // `uv_close` is async; the pipe is freed from the close callback.
+                bun_io::source::close_and_destroy_pipe(buffer);
             }
         });
 
@@ -933,43 +853,32 @@ impl Subprocess<'_> {
             + self.stderr.get().memory_cost()
     }
 
-    /// # Safety
-    /// `process` must be the live `*mut Process` threaded from the
-    /// `link_impl_ProcessExit!` vtable thunk (mutable provenance, valid for the
-    /// duration of the call).
-    // Forwards `process` to `VirtualMachine::on_subprocess_exit` without
-    // dereferencing it; not_unsafe_ptr_arg_deref is a false positive on
-    // opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn on_process_exit(&self, process: *mut Process, status: &Status, rusage: &Rusage) {
+    /// `this: ThisPtr` because the tail releases the exit handler's ref, which
+    /// may be the last.
+    pub(crate) fn on_process_exit(this: ThisPtr<Self>, status: &Status, rusage: &Rusage) {
         bun_output::scoped_log!(Subprocess, "onProcessExit()");
-        let this_jsvalue = self.this_value.get().try_get().unwrap_or_default();
-        // Copy the BackRef out so the `&JSGlobalObject` borrow is detached from `&self`
-        // (mirrors the original `&'a` return — the global outlives `self`).
-        let global_this = self.global_this;
+        let this_jsvalue = this.this_value.get().try_get().unwrap_or_default();
+        // Copy the BackRef out so the `&JSGlobalObject` borrow is detached from `this`
+        // (the global outlives us).
+        let global_this = this.global_this;
         let global_this = global_this.get();
-        let jsc_vm = global_this.bun_vm().as_mut();
+        let jsc_vm = global_this.bun_vm();
         this_jsvalue.ensure_still_alive();
-        self.pid_rusage.set(Some(*rusage));
-        let is_sync = self.flags.get().contains(Flags::IS_SYNC);
-        self.clear_abort_signal();
+        this.pid_rusage.set(Some(*rusage));
+        let is_sync = this.flags.get().contains(Flags::IS_SYNC);
+        this.clear_abort_signal();
 
-        // `deref()` and `disconnect_ipc(true)` run at the tail of this body.
-        // R-2: now that both take `&self`, scopeguard would no longer alias —
-        // kept explicit at the tail for now (no early returns in this body).
+        // `exit_ref` release and `disconnect_ipc(true)` run at the tail of this
+        // body (no early returns).
 
-        if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            Self::timer_all().remove(self.event_loop_timer.as_ptr());
+        if this.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+            Self::timer_all().remove(this.event_loop_timer.as_ptr());
         }
-        self.set_event_loop_timer_refd(false);
+        this.set_event_loop_timer_refd(false);
 
-        // SAFETY: `jsc_vm` is the live VM owning `global_this`; mutator-thread
-        // only. `process` is the raw `*mut Process` threaded from the vtable
-        // thunk so the auto-killer's `(*process).deref()` keeps mutable
-        // provenance (no `&Process → *mut` round-trip).
-        unsafe { (*jsc_vm).on_subprocess_exit(NonNull::new_unchecked(process)) };
+        jsc_vm.as_mut().on_subprocess_exit(this.process.as_ptr());
 
-        if self.flags.get().contains(Flags::OWNS_TERMINAL) {
+        if this.flags.get().contains(Flags::OWNS_TERMINAL) {
             // Deliver EOF to the terminal reader without closing the Terminal.
             // POSIX drains then releases slave_fd (BSD kernels flush on last
             // slave close). Windows: the ConDrv \Reference handle was released
@@ -977,40 +886,34 @@ impl Subprocess<'_> {
             // its last client (this child, or a grandchild it left behind) has
             // disconnected; unref the writer here and leave the reader ref'd
             // until that EOF arrives.
-            if let Some(terminal) = self.terminal.get() {
-                // `BackRef` invariant holds: the terminal is owned by (or
-                // borrowed from a JS wrapper kept live by) this subprocess and
-                // outlives this scope; single JS thread.
-                let term = bun_ptr::BackRef::from(terminal);
+            if let Some(term) = this.terminal.get() {
                 #[cfg(unix)]
-                term.drain_and_close_slave_fd();
+                Terminal::drain_and_close_slave_fd(term.this_ptr());
                 #[cfg(windows)]
                 term.unref_after_inline_child_exit();
             }
         }
 
-        let mut stdin: Option<NonNull<FileSink>> = if matches!(self.stdin.get(), Writable::Pipe(_))
-            && self.flags.get().contains(Flags::IS_STDIN_A_READABLE_STREAM)
+        let mut stdin: Option<ThisPtr<FileSink>> = if matches!(this.stdin.get(), Writable::Pipe(_))
+            && this.flags.get().contains(Flags::IS_STDIN_A_READABLE_STREAM)
         {
-            if let Writable::Pipe(pipe) = self.stdin.get() {
-                Some(pipe.as_non_null())
+            if let Writable::Pipe(pipe) = this.stdin.get() {
+                Some(pipe.this_ptr())
             } else {
                 unreachable!()
             }
         } else {
-            self.weak_file_sink_stdin_ptr.get()
+            this.weak_file_sink_stdin_ptr.get().map(|p| p.this_ptr())
         };
         let mut existing_stdin_value = JSValue::ZERO;
         if !this_jsvalue.is_empty() {
             if let Some(existing_value) = js::stdin_get_cached(this_jsvalue) {
                 if existing_value.is_cell() {
                     if stdin.is_none() {
-                        // TODO: review this cast
-                        stdin = crate::webcore::file_sink::JSSink::from_js(existing_value)
-                            .and_then(|p| NonNull::new(p.cast::<FileSink>()));
+                        stdin = crate::generated_jssink::FileSink__fromJSThis(existing_value);
                     }
 
-                    if !self.flags.get().contains(Flags::IS_STDIN_A_READABLE_STREAM) {
+                    if !this.flags.get().contains(Flags::IS_STDIN_A_READABLE_STREAM) {
                         existing_stdin_value = existing_value;
                     }
                 }
@@ -1018,14 +921,11 @@ impl Subprocess<'_> {
         }
 
         // We won't be sending any more data.
-        let pending_start = self.take_pending_start_writer();
-        if let Writable::Buffer(buffer) = self.stdin.get() {
-            Writable::buffer_writer_mut(buffer).close();
+        let pending_start = this.take_pending_start_writer();
+        if let Writable::Buffer(buffer) = this.stdin.get() {
+            StaticPipeWriter::close(buffer.this_ptr());
         }
-        if let Some(writer) = pending_start {
-            // SAFETY: `started` ⇒ start +1 was live entering; last use.
-            unsafe { RefCount::deref(writer) };
-        }
+        drop(pending_start);
 
         if !existing_stdin_value.is_empty() {
             crate::webcore::file_sink::JSSink::set_destroy_callback(existing_stdin_value, 0);
@@ -1035,93 +935,66 @@ impl Subprocess<'_> {
         // is reaped (a grandchild may still be writing). Sync and async both
         // resume reads here; timeout/maxBuffer bound the sync wait. A lazy
         // reader is paused until JS pulls, so unpause it first; backpressure
-        // is moot once the direct child has exited.
-        if let Readable::Pipe(pipe) = self.stdout.get() {
+        // is moot once the direct child has exited. `read` dispatch runs user
+        // JS, hence the root-pointer entry.
+        if let Readable::Pipe(pipe) = this.stdout.get() {
             if !pipe.reader.is_done() {
-                let reader = &raw mut Readable::pipe_reader_mut(pipe).reader;
-                // SAFETY: live pipe reader; `read` is the raw re-entrancy-safe
-                // entry (its dispatch runs user JS).
-                unsafe {
-                    (*reader).unpause();
-                    bun_io::BufferedReader::read(reader);
-                }
+                Readable::pipe_reader_mut(pipe).reader.unpause();
+                bun_io::BufferedReader::read_from(pipe.this_ptr());
             }
         }
 
-        if let Readable::Pipe(pipe) = self.stderr.get() {
+        if let Readable::Pipe(pipe) = this.stderr.get() {
             if !pipe.reader.is_done() {
-                let reader = &raw mut Readable::pipe_reader_mut(pipe).reader;
-                // SAFETY: as the stdout arm above.
-                unsafe {
-                    (*reader).unpause();
-                    bun_io::BufferedReader::read(reader);
-                }
+                Readable::pipe_reader_mut(pipe).reader.unpause();
+                bun_io::BufferedReader::read_from(pipe.this_ptr());
             }
         }
 
         // When Bun itself killed the child (timeout/maxBuffer/AbortSignal) stop
         // waiting on pipe EOF after the drain above: a grandchild may still
         // hold the write end and the caller already opted into a bounded wait.
-        if self.event_loop_timer.get().state == EventLoopTimerState::FIRED
-            || self.exited_due_to_maxbuf.get().is_some()
-            || self.flags.get().contains(Flags::ABORT_SIGNAL_KILLED)
+        if this.event_loop_timer.get().state == EventLoopTimerState::FIRED
+            || this.exited_due_to_maxbuf.get().is_some()
+            || this.flags.get().contains(Flags::ABORT_SIGNAL_KILLED)
         {
-            self.close_readable_pipes();
+            this.close_readable_pipes();
         }
 
-        if let Some(pipe_ptr) = stdin {
-            self.weak_file_sink_stdin_ptr.set(None);
-            self.update_flags(|f| f.insert(Flags::HAS_STDIN_DESTRUCTOR_CALLED));
+        if let Some(pipe) = stdin {
+            this.weak_file_sink_stdin_ptr.set(None);
+            this.update_flags(|f| f.insert(Flags::HAS_STDIN_DESTRUCTOR_CALLED));
 
-            // `pipe_ptr` came from a live FileSink (either `self.stdin.pipe`'s
-            // +1-intrusive ref or the cached JS sink kept live by GC) and
-            // outlives this scope on the single mutator thread — `BackRef`
-            // invariant. Shared deref via `BackRef::Deref`; the one mutable
-            // call below stays unsafe.
-            let pipe = bun_ptr::BackRef::from(pipe_ptr);
-
+            // `pipe` is a live FileSink (either `stdin.pipe`'s ref or the
+            // cached JS sink kept live by GC).
+            //
             // Detach the source first so onAttachedProcessExit's sync FileSink.onClose cannot
-            // re-enter Writable.onClose → pipe.deref() on the still-running pipe.
-            let self_ptr = self.as_ctx_ptr().cast::<Subprocess<'static>>();
+            // re-enter Writable.onClose → release the still-running pipe.
+            let self_ptr = this.as_ctx_ptr().cast::<Subprocess<'static>>();
             if matches!(
                 *pipe.source.get(),
                 crate::webcore::streams::SourceHandle::Subprocess(p) if p.as_const_ptr() == self_ptr.cast_const()
             ) {
-                // `source` is a `JsCell`; `with_mut` takes `&self`, so the
-                // shared `pipe: &FileSink` deref above is sufficient.
                 pipe.source.with_mut(|s| s.clear());
             }
-            let must_deref = self.flags.get().contains(Flags::DEREF_ON_STDIN_DESTROYED);
-            self.update_flags(|f| f.remove(Flags::DEREF_ON_STDIN_DESTROYED));
+            let stdin_sink_ref = this.stdin_sink_ref.take();
 
-            // `pipe_ptr` is live (see `pipe` borrow above) and is the canonical
-            // `*mut FileSink` from `FileSink::create*`; pass it straight through —
-            // `on_attached_process_exit` re-enters via the writer backref and may
-            // free `this`, so no `&mut FileSink` is materialized at the boundary.
-            // SAFETY: `pipe_ptr` is the canonical heap pointer with write+dealloc
-            // provenance, held live by the `Writable::Pipe`/cache +1.
-            unsafe { FileSink::on_attached_process_exit(pipe_ptr.as_ptr(), status) };
+            // Re-enters via the writer backref and may release refs on us, so
+            // no `&mut FileSink` is materialized at the boundary.
+            FileSink::on_attached_process_exit(pipe, status);
 
-            if must_deref {
-                self.deref();
-            }
+            drop(stdin_sink_ref);
         }
 
         let mut did_update_has_pending_activity = false;
 
-        // Kept as raw `*mut` so the enter guard and the body can both call
-        // `&mut`-taking methods without tripping borrowck.
-        let event_loop = (*jsc_vm).event_loop();
-
         if !is_sync {
             if !this_jsvalue.is_empty() {
                 if let Some(promise) = js::exited_promise_take_cached(this_jsvalue, global_this) {
-                    // SAFETY: event_loop points into the live VM and outlives this scope.
-                    let _exit_guard =
-                        unsafe { bun_jsc::event_loop::EventLoop::enter_scope(event_loop) };
+                    let _exit_guard = jsc_vm.enter_event_loop_scope();
 
                     if !did_update_has_pending_activity {
-                        self.update_has_pending_activity();
+                        this.update_has_pending_activity();
                         did_update_has_pending_activity = true;
                     }
 
@@ -1173,27 +1046,29 @@ impl Subprocess<'_> {
 
                     let args = [
                         this_value,
-                        self.get_exit_code(global_this),
-                        self.get_signal_code(global_this),
+                        this.get_exit_code(global_this),
+                        this.get_signal_code(global_this),
                         waitpid_value,
                     ];
 
                     if !did_update_has_pending_activity {
-                        self.update_has_pending_activity();
+                        this.update_has_pending_activity();
                         did_update_has_pending_activity = true;
                     }
 
-                    // SAFETY: event_loop points into the live VM.
-                    unsafe { (*event_loop).run_callback(callback, global_this, this_value, &args) };
+                    jsc_vm
+                        .event_loop_mut()
+                        .run_callback(callback, global_this, this_value, &args);
                 }
             }
         }
 
         if !did_update_has_pending_activity {
-            self.update_has_pending_activity();
+            this.update_has_pending_activity();
         }
-        self.disconnect_ipc(true);
-        self.deref();
+        this.disconnect_ipc(true);
+        // May free `this`; last use.
+        drop(this.exit_ref.take());
     }
 
     fn close_io(&self, io: StdioKind) {
@@ -1219,19 +1094,15 @@ impl Subprocess<'_> {
         match io {
             StdioKind::Stdin => {
                 let pending_start = self.take_pending_start_writer();
-                if let Some(writer) = pending_start {
-                    // SAFETY: live StaticPipeWriter with >= 2 refs.
-                    unsafe { (*writer).close() };
+                if let Some(writer) = &pending_start {
+                    StaticPipeWriter::close(writer.this_ptr());
                 }
                 if !called {
                     Writable::finalize(self);
                 } else {
                     self.stdin.with_mut(|s| s.close());
                 }
-                if let Some(writer) = pending_start {
-                    // SAFETY: `started` ⇒ start +1 was live entering; last use.
-                    unsafe { RefCount::deref(writer) };
-                }
+                drop(pending_start);
             }
             StdioKind::Stdout => {
                 if !called {
@@ -1263,10 +1134,9 @@ impl Subprocess<'_> {
         for item in self.stdio_pipes.replace(Vec::new()) {
             if let StdioResult::Buffer(buffer) = item {
                 // `uv_close` is async — the pipe must outlive this scope until the
-                // close callback reclaims the allocation; `close_and_destroy` also
-                // copes with a pipe that never got `uv_pipe_init`'d.
-                // SAFETY: Box-allocated uv::Pipe owned by this slot until now.
-                unsafe { bun_sys::windows::libuv::Pipe::close_and_destroy(Box::into_raw(buffer)) };
+                // close callback reclaims the allocation; this also copes with a
+                // pipe that never got `uv_pipe_init`'d.
+                bun_io::source::close_and_destroy_pipe(buffer);
             }
         }
         #[cfg(not(windows))]
@@ -1282,14 +1152,13 @@ impl Subprocess<'_> {
         self.stdio_pipes.with_mut(|v| v.shrink_to_fit());
     }
 
+    /// Unregisters the listener and releases the signal.
     fn clear_abort_signal(&self) {
-        if let Some(signal) = self.abort_signal.take() {
-            signal.pending_activity_unref();
-            signal.clean_native_bindings(self.as_ctx_ptr().cast::<c_void>());
-            // Dropping `signal` unrefs it.
-        }
+        drop(self.abort_signal.replace(None));
     }
 
+    /// The JS wrapper's ref is released by the generated finalize thunk after
+    /// this returns; the allocation may outlive this call if other refs remain.
     pub fn finalize(&self) {
         bun_output::scoped_log!(Subprocess, "finalize");
         // Ensure any code which references the "this" value doesn't attempt to
@@ -1305,9 +1174,8 @@ impl Subprocess<'_> {
         );
         self.finalize_streams();
 
-        // `Writable::init()` took a +1 (`subprocess.ref_()`, guarded by
-        // `DEREF_ON_STDIN_DESTROYED`) for the stdin pipe back-pointer. The
-        // balancing `deref()` lives in `on_stdin_destroyed()`, reached either
+        // `Writable::init()` took a ref (`stdin_sink_ref`) for the stdin pipe
+        // back-pointer, released by `on_stdin_destroyed()`, reached either
         // via the FileSink's signal (which `Writable::finalize` — called from
         // `close_io` above when the `.stdin` getter never ran — clears *before*
         // releasing the pipe) or via the JSFileSink's `m_onDestroy` callback
@@ -1318,31 +1186,25 @@ impl Subprocess<'_> {
         // the JSFileSink may be swept after us in the same
         // `lastChanceToFinalize` pass and would otherwise call
         // `on_stdin_destroyed()` against a freed Box.
-        if self.flags.get().contains(Flags::DEREF_ON_STDIN_DESTROYED)
-            && !self.has_called_getter(ObservableGetter::Stdin)
-        {
-            self.update_flags(|f| f.remove(Flags::DEREF_ON_STDIN_DESTROYED));
-            self.deref();
+        if !self.has_called_getter(ObservableGetter::Stdin) {
+            drop(self.stdin_sink_ref.take());
         }
 
-        let exit_handler_pending = self.process().exit_handler.is_some();
-        self.process_mut().detach();
+        let exit_handler_pending = self.process.exit_handler.is_some();
+        self.process.detach();
         if exit_handler_pending {
-            self.deref();
+            drop(self.exit_ref.take());
         }
+
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
             Self::timer_all().remove(self.event_loop_timer.as_ptr());
         }
         self.set_event_loop_timer_refd(false);
 
-        let mut mb = self.stdout_maxbuf.get();
-        MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
-        self.stdout_maxbuf.set(mb);
-        let mut mb = self.stderr_maxbuf.get();
-        MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
-        self.stderr_maxbuf.set(mb);
+        self.stdout_maxbuf.release();
+        self.stderr_maxbuf.release();
 
-        if let Some(ipc_data) = self.ipc_data.take() {
+        if let Some(ipc_data) = self.ipc_data.replace(None) {
             // In normal operation the socket is already `.closed` by the time we
             // get here (that is what allowed `compute_has_pending_activity` to drop
             // to false and let GC collect us). Detach and release our ref; any
@@ -1359,15 +1221,13 @@ impl Subprocess<'_> {
             return promise;
         }
 
-        match &self.process().status {
+        match self.process().status() {
             Status::Exited(exit) => {
                 JSPromise::resolved_promise_value(global_this, JSValue::js_number(exit.code as f64))
             }
             Status::Signaled(signal) => JSPromise::resolved_promise_value(
                 global_this,
-                JSValue::js_number(
-                    bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(254) as f64
-                ),
+                JSValue::js_number(bun_sys::SignalCode(signal).to_exit_code().unwrap_or(254) as f64),
             ),
             Status::Err(err) => {
                 let js_err = err.to_js(global_this);
@@ -1383,7 +1243,7 @@ impl Subprocess<'_> {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_exit_code(&self, _global: &JSGlobalObject) -> JSValue {
-        if let Status::Exited(exited) = &self.process().status {
+        if let Status::Exited(exited) = self.process().status() {
             return JSValue::js_number(exited.code as f64);
         }
         JSValue::NULL
@@ -1426,17 +1286,12 @@ impl Subprocess<'_> {
                 if !this_jsvalue.is_empty() {
                     if let Some(cb) = js::ipc_callback_get_cached(this_jsvalue) {
                         let global_this = self.global_this();
-                        let event_loop = global_this.bun_vm().as_mut().event_loop();
-                        // SAFETY: `event_loop` is the live VM's owned event loop,
-                        // accessed on the single JS mutator thread.
-                        unsafe {
-                            (*event_loop).run_callback(
-                                cb,
-                                global_this,
-                                this_jsvalue,
-                                &[*data, this_jsvalue, handle],
-                            )
-                        };
+                        global_this.bun_vm().event_loop_mut().run_callback(
+                            cb,
+                            global_this,
+                            this_jsvalue,
+                            &[*data, this_jsvalue, handle],
+                        );
                     }
                 }
             }
@@ -1467,23 +1322,34 @@ impl Subprocess<'_> {
             if let Some(callback) =
                 js::on_disconnect_callback_take_cached(this_jsvalue, global_this)
             {
-                let event_loop = global_this.bun_vm().as_mut().event_loop();
-                // SAFETY: `event_loop` is the live VM's owned event loop,
-                // accessed on the single JS mutator thread.
-                unsafe {
-                    (*event_loop).run_callback(
-                        callback,
-                        global_this,
-                        this_jsvalue,
-                        &[JSValue::TRUE],
-                    )
-                };
+                global_this.bun_vm().event_loop_mut().run_callback(
+                    callback,
+                    global_this,
+                    this_jsvalue,
+                    &[JSValue::TRUE],
+                );
             }
         }
     }
 
     pub(crate) fn ipc(&self) -> Option<&IPC::SendQueue> {
         self.ipc_data.get().as_deref()
+    }
+}
+
+/// Routes straight from the `MaxBuf` allocation to this `Subprocess`,
+/// independent of whichever pipe reader currently holds the budget (the
+/// `.stdout`/`.stderr` getter transfers it to a `FileReader`).
+impl bun_io::max_buf::MaxBufOwner for Subprocess<'_> {
+    fn on_max_buffer_overflow(&self, maxbuf: NonNull<MaxBuf::MaxBuf>) {
+        let kind = if self.stdout_maxbuf.is(maxbuf) {
+            self.stdout_maxbuf.release();
+            MaxBuf::Kind::Stdout
+        } else {
+            self.stderr_maxbuf.release();
+            MaxBuf::Kind::Stderr
+        };
+        self.on_max_buffer(kind);
     }
 }
 
@@ -1514,41 +1380,35 @@ pub(crate) fn source_from_blob(b: webcore::AnyBlob) -> Source {
 /// the slots empty) instead of anyone closing them twice.
 #[cfg(windows)]
 impl Subprocess<'_> {
-    pub(crate) fn record_stdio_pipe_ownership(this: *mut Self) {
-        // SAFETY: `this` is the live boxed Subprocess (stable address).
-        let me = unsafe { &*this };
-        for item in me.stdio_pipes.get().iter() {
+    pub(crate) fn record_stdio_pipe_ownership(this: ThisPtr<Self>) {
+        for item in this.stdio_pipes.get().iter() {
             if let StdioResult::Buffer(buffer) = item {
-                bun_sys::windows::libuv::open_handles::set_owner(
-                    core::ptr::from_ref::<bun_sys::windows::libuv::Pipe>(&**buffer)
-                        .cast_mut()
-                        .cast(),
-                    this.cast(),
-                    Some(Self::stop_for_vm_teardown),
-                );
-            }
-        }
-    }
-
-    /// `uv::open_handles` entry point: close every stdio pipe still held here.
-    unsafe fn stop_for_vm_teardown(this: *mut core::ffi::c_void) {
-        // SAFETY: recorded by `record_stdio_pipe_ownership` for this live
-        // Subprocess; each pipe leaves the list as its uv_close is issued.
-        let me = unsafe { &*this.cast::<Self>() };
-        for item in me.stdio_pipes.replace(Vec::new()) {
-            if let StdioResult::Buffer(buffer) = item {
-                // SAFETY: Box-allocated uv::Pipe owned by this slot until now.
-                unsafe { bun_sys::windows::libuv::Pipe::close_and_destroy(Box::into_raw(buffer)) };
+                bun_io::source::set_pipe_owner(buffer, this);
             }
         }
     }
 }
 
+/// Each pipe leaves the `uv::open_handles` list as its uv_close is issued
+/// (here, in `finalize_streams`, or at the latest on drop).
 #[cfg(windows)]
-pub(crate) extern "C" fn on_pipe_close(this: *mut bun_sys::windows::libuv::Pipe) {
-    // safely free the pipes
-    // SAFETY: pipe was heap-allocated when created; we are the close callback owner.
-    drop(unsafe { bun_core::heap::take(this) });
+impl bun_io::source::UvPipeOwner for Subprocess<'_> {
+    fn close_pipes_for_vm_teardown(&self) {
+        for item in self.stdio_pipes.replace(Vec::new()) {
+            if let StdioResult::Buffer(buffer) = item {
+                bun_io::source::close_and_destroy_pipe(buffer);
+            }
+        }
+    }
+}
+
+impl Drop for Subprocess<'_> {
+    fn drop(&mut self) {
+        // Normally emptied by `finalize_streams`; closing here keeps the
+        // `uv::open_handles` owner entries from outliving us.
+        #[cfg(windows)]
+        bun_io::source::UvPipeOwner::close_pipes_for_vm_teardown(self);
+    }
 }
 
 pub mod testing_apis {
@@ -1569,12 +1429,9 @@ pub mod testing_apis {
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let [subprocess_value, kind_value] = callframe.arguments_as_array::<2>();
-        let Some(subprocess_ptr) = Subprocess::from_js(subprocess_value) else {
+        let Some(subprocess) = subprocess_value.as_class_ref::<Subprocess<'static>>() else {
             return Err(global_this.throw(format_args!("first argument must be a Subprocess")));
         };
-        // SAFETY: `from_js` returned a live `*mut Subprocess` owned by the JS wrapper.
-        // R-2: deref as shared (`&*const`) — fields are interior-mutable.
-        let subprocess = unsafe { &*subprocess_ptr };
         let kind_str = kind_value.to_bun_string(global_this)?;
 
         let out: &JsCell<Readable> = if kind_str.eq_ascii(b"stdout") {
@@ -1598,10 +1455,8 @@ pub mod testing_apis {
         {
             let _ = Readable::pipe_reader_mut(pipe).reader.stop_reading();
         }
-        let reader = &raw mut Readable::pipe_reader_mut(pipe).reader;
-        // SAFETY: live pipe reader; `on_error` is the raw entry so the
-        // (maybe-freeing) error dispatch runs under no receiver protector.
-        unsafe { bun_io::BufferedReader::on_error(reader, fake_err) };
+        // The (maybe-freeing) error dispatch runs under no receiver protector.
+        bun_io::BufferedReader::on_error_from(pipe.this_ptr(), fake_err);
         Ok(JSValue::TRUE)
     }
 }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1393,10 +1393,12 @@ impl Subprocess<'_> {
     }
 }
 
-/// Each pipe leaves the `uv::open_handles` list as its uv_close is issued
-/// (here, in `finalize_streams`, or at the latest on drop).
+// SAFETY: each pipe in `stdio_pipes` leaves the `uv::open_handles` list as its
+// uv_close is issued — here, in `finalize_streams`, when a taker re-owns it
+// (the IPC channel), or at the latest from `Drop` below — so no entry names a
+// freed Subprocess.
 #[cfg(windows)]
-impl bun_io::source::UvPipeOwner for Subprocess<'_> {
+unsafe impl bun_io::source::UvPipeOwner for Subprocess<'_> {
     fn close_pipes_for_vm_teardown(&self) {
         for item in self.stdio_pipes.replace(Vec::new()) {
             if let StdioResult::Buffer(buffer) = item {

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -759,7 +759,7 @@ impl Subprocess<'_> {
     }
 
     pub(crate) fn pid(&self) -> i32 {
-        self.process().pid()
+        self.process().pid
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -876,7 +876,9 @@ impl Subprocess<'_> {
         }
         this.set_event_loop_timer_refd(false);
 
-        jsc_vm.as_mut().on_subprocess_exit(this.process.as_ptr());
+        jsc_vm
+            .as_mut()
+            .on_subprocess_exit(this.process.as_non_null());
 
         if this.flags.get().contains(Flags::OWNS_TERMINAL) {
             // Deliver EOF to the terminal reader without closing the Terminal.
@@ -1221,13 +1223,15 @@ impl Subprocess<'_> {
             return promise;
         }
 
-        match self.process().status() {
+        match &self.process().status {
             Status::Exited(exit) => {
                 JSPromise::resolved_promise_value(global_this, JSValue::js_number(exit.code as f64))
             }
             Status::Signaled(signal) => JSPromise::resolved_promise_value(
                 global_this,
-                JSValue::js_number(bun_sys::SignalCode(signal).to_exit_code().unwrap_or(254) as f64),
+                JSValue::js_number(
+                    bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(254) as f64
+                ),
             ),
             Status::Err(err) => {
                 let js_err = err.to_js(global_this);
@@ -1243,7 +1247,7 @@ impl Subprocess<'_> {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_exit_code(&self, _global: &JSGlobalObject) -> JSValue {
-        if let Status::Exited(exited) = self.process().status() {
+        if let Status::Exited(exited) = &self.process().status {
             return JSValue::js_number(exited.code as f64);
         }
         JSValue::NULL

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -50,8 +50,7 @@ pub struct PipeReader {
     pub(crate) stdio_result: StdioResult,
 }
 
-// `pub const ref/deref = RefCount.ref/deref` — thin forwarders so existing call
-// sites (`self.r#ref()` / `PipeReader::deref(ptr)`) keep working.
+// Thin forwarders to the intrusive `RefCount` for this file's own call sites.
 impl PipeReader {
     #[inline]
     fn r#ref(&self) {
@@ -398,6 +397,7 @@ impl Drop for PipeReader {
 // with `self`), so `&mut *this` autoref is OK.
 bun_io::impl_buffered_reader_parent! {
     SubprocessPipeReader for PipeReader;
+    reader = reader;
     has_on_read_chunk = false;
     on_reader_done  = |this| (*this).on_reader_done();
     on_reader_error = |this, err| (*this).on_reader_error(err);

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_void;
 
 use bun_jsc::{JSGlobalObject, JSValue, event_loop::EventLoop};
-use bun_ptr::RefPtr;
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_sys::{self, Fd, FdExt};
 
 use crate::api::bun_spawn::stdio::Stdio;
@@ -15,6 +15,8 @@ use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use super::{Flags, StaticPipeWriter, StdioResult, Subprocess, js};
 
 pub enum Writable<'a> {
+    /// The ref `FileSink::create*` returned; released when the variant is
+    /// replaced.
     Pipe(RefPtr<FileSink>),
     Fd(Fd),
     Buffer(RefPtr<StaticPipeWriter<'a>>),
@@ -24,30 +26,6 @@ pub enum Writable<'a> {
 }
 
 impl<'a> Writable<'a> {
-    /// Mutable borrow of the `Pipe` payload's `FileSink`.
-    ///
-    /// `RefPtr` deliberately has no `DerefMut`; what makes `&mut` sound here
-    /// is that `Writable::Pipe` holds a ref for the variant's lifetime, the
-    /// sink lives in its own heap allocation disjoint from
-    /// `Writable`/`Subprocess`, and access is single-JS-mutator-thread.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn pipe_sink_mut(pipe: &RefPtr<FileSink>) -> &mut FileSink {
-        // SAFETY: see fn doc.
-        unsafe { &mut *pipe.as_ptr() }
-    }
-
-    /// Mutable borrow of the `Buffer` payload's `StaticPipeWriter`; same
-    /// invariant as [`pipe_sink_mut`](Self::pipe_sink_mut).
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(in crate::api) fn buffer_writer_mut<'b>(
-        buffer: &'b RefPtr<StaticPipeWriter<'a>>,
-    ) -> &'b mut StaticPipeWriter<'a> {
-        // SAFETY: see fn doc.
-        unsafe { &mut *buffer.as_ptr() }
-    }
-
     pub(crate) fn memory_cost(&self) -> usize {
         match self {
             Writable::Pipe(pipe) => pipe.memory_cost(),
@@ -73,7 +51,7 @@ impl<'a> Writable<'a> {
                 pipe.update_ref(true);
             }
             Writable::Buffer(buffer) => {
-                Self::buffer_writer_mut(buffer).update_ref(true);
+                StaticPipeWriter::update_ref(buffer.this_ptr(), true);
             }
             _ => {}
         }
@@ -85,7 +63,7 @@ impl<'a> Writable<'a> {
                 pipe.update_ref(false);
             }
             Writable::Buffer(buffer) => {
-                Self::buffer_writer_mut(buffer).update_ref(false);
+                StaticPipeWriter::update_ref(buffer.this_ptr(), false);
             }
             _ => {}
         }
@@ -112,15 +90,15 @@ impl<'a> Writable<'a> {
         // immediately after anyway.
         process.stdin.set(Writable::Ignore);
 
-        // `on_stdin_destroyed` may `deref()` and free `process` as its last
-        // act, so this must be the final access.
+        // `on_stdin_destroyed` may release a ref on `process` and free it as
+        // its last act, so this must be the final access.
         process.on_stdin_destroyed();
     }
 
     pub(crate) fn init(
         stdio: &mut Stdio,
         event_loop: &EventLoop,
-        subprocess: &mut Subprocess<'a>,
+        subprocess: ThisPtr<Subprocess<'a>>,
         result: StdioResult,
         promise_for_stream: &mut JSValue,
     ) -> crate::Result<Writable<'a>> {
@@ -145,11 +123,8 @@ impl<'a> Writable<'a> {
                 Stdio::Pipe | Stdio::ReadableStream(_) => {
                     if let StdioResult::Buffer(buffer) = result {
                         // Ownership of the `Box<uv::Pipe>` transfers to the
-                        // FileSink's writer (the sink takes over the heap
-                        // pointer).
-                        let uv_pipe: *mut _ = bun_core::heap::into_raw(buffer);
-                        let pipe_ref = FileSink::create_with_pipe(evtloop, uv_pipe);
-                        let pipe = Self::pipe_sink_mut(&pipe_ref);
+                        // FileSink's writer.
+                        let pipe = FileSink::create_with_pipe(evtloop, buffer);
 
                         match pipe.writer.with_mut(|w| w.start_with_current_pipe()) {
                             bun_sys::Result::Ok(()) => {}
@@ -160,31 +135,33 @@ impl<'a> Writable<'a> {
                                 return Err(crate::Error::UnexpectedCreatingStdin);
                             }
                         }
-                        pipe.writer.with_mut(|w| w.set_parent(pipe_ref.as_ptr()));
+                        let pipe_root = pipe.as_ptr();
+                        pipe.writer.with_mut(|w| w.set_parent(pipe_root));
                         subprocess
                             .weak_file_sink_stdin_ptr
-                            .set(Some(pipe_ref.as_non_null()));
-                        subprocess.ref_();
+                            .set(Some(BackRef::from(pipe.this_ptr())));
+                        subprocess
+                            .stdin_sink_ref
+                            .set(Some(RefPtr::from_this(subprocess)));
                         subprocess.update_flags(|f| {
-                            f.set(Flags::DEREF_ON_STDIN_DESTROYED, true);
                             f.set(Flags::HAS_STDIN_DESTRUCTOR_CALLED, false);
                         });
 
                         if let Stdio::ReadableStream(rs) = stdio {
-                            let assign_result = pipe.assign_to_stream(rs, global);
+                            let assign_result =
+                                FileSink::assign_to_stream(pipe.this_ptr(), rs, global);
                             if let Some(err_val) = assign_result.to_error() {
                                 subprocess.weak_file_sink_stdin_ptr.set(None);
-                                subprocess.update_flags(|f| {
-                                    f.set(Flags::DEREF_ON_STDIN_DESTROYED, false)
-                                });
-                                subprocess.deref();
+                                let stdin_sink_ref = subprocess.stdin_sink_ref.take();
+                                drop(pipe);
+                                drop(stdin_sink_ref);
                                 let _ = global.throw_value(err_val);
                                 return Err(crate::Error::JSError);
                             }
                             *promise_for_stream = assign_result;
                         }
 
-                        return Ok(Writable::Pipe(pipe_ref));
+                        return Ok(Writable::Pipe(pipe));
                     }
                     return Ok(Writable::Inherit);
                 }
@@ -201,7 +178,7 @@ impl<'a> Writable<'a> {
                     };
                     return Ok(Writable::Buffer(StaticPipeWriter::create(
                         evtloop,
-                        subprocess as *mut Subprocess<'a>,
+                        subprocess,
                         result,
                         super::source_from_blob(blob),
                     )));
@@ -238,8 +215,7 @@ impl<'a> Writable<'a> {
             Stdio::Dup2(_) => panic!("TODO dup2 stdio"),
             Stdio::Pipe | Stdio::ReadableStream(_) => {
                 let fd = result.unwrap();
-                let pipe_ref = FileSink::create(evtloop, fd);
-                let pipe = Self::pipe_sink_mut(&pipe_ref);
+                let pipe = FileSink::create(evtloop, fd);
 
                 match pipe.writer.with_mut(|w| w.start(fd, true)) {
                     bun_sys::Result::Ok(()) => {}
@@ -263,26 +239,28 @@ impl<'a> Writable<'a> {
 
                 subprocess
                     .weak_file_sink_stdin_ptr
-                    .set(Some(pipe_ref.as_non_null()));
-                subprocess.ref_();
+                    .set(Some(BackRef::from(pipe.this_ptr())));
+                subprocess
+                    .stdin_sink_ref
+                    .set(Some(RefPtr::from_this(subprocess)));
                 subprocess.update_flags(|f| {
                     f.set(Flags::HAS_STDIN_DESTRUCTOR_CALLED, false);
-                    f.set(Flags::DEREF_ON_STDIN_DESTROYED, true);
                 });
 
                 if let Stdio::ReadableStream(rs) = stdio {
-                    let assign_result = pipe.assign_to_stream(rs, global);
+                    let assign_result = FileSink::assign_to_stream(pipe.this_ptr(), rs, global);
                     if let Some(err_val) = assign_result.to_error() {
                         subprocess.weak_file_sink_stdin_ptr.set(None);
-                        subprocess.update_flags(|f| f.set(Flags::DEREF_ON_STDIN_DESTROYED, false));
-                        subprocess.deref();
+                        let stdin_sink_ref = subprocess.stdin_sink_ref.take();
+                        drop(pipe);
+                        drop(stdin_sink_ref);
                         let _ = global.throw_value(err_val);
                         return Err(crate::Error::JSError);
                     }
                     *promise_for_stream = assign_result;
                 }
 
-                Ok(Writable::Pipe(pipe_ref))
+                Ok(Writable::Pipe(pipe))
             }
 
             Stdio::Blob(_) => {
@@ -298,7 +276,7 @@ impl<'a> Writable<'a> {
                 };
                 Ok(Writable::Buffer(StaticPipeWriter::create(
                     evtloop,
-                    std::ptr::from_mut::<Subprocess<'a>>(subprocess),
+                    subprocess,
                     result,
                     super::source_from_blob(blob),
                 )))
@@ -324,7 +302,7 @@ impl<'a> Writable<'a> {
         }
     }
 
-    pub fn to_js(subprocess: &Subprocess<'a>, global_this: &JSGlobalObject) -> JSValue {
+    pub fn to_js(subprocess: ThisPtr<Subprocess<'a>>, global_this: &JSGlobalObject) -> JSValue {
         // Take only the parent and project `stdin` here so no two `&mut`
         // overlap at any point.
         match subprocess.stdin.replace(Writable::Ignore) {
@@ -345,57 +323,53 @@ impl<'a> Writable<'a> {
                 subprocess.stdin.set(Writable::Inherit);
                 JSValue::UNDEFINED
             }
-            Writable::Pipe(pipe_ref) => {
+            Writable::Pipe(pipe) => {
+                // stdin already replaced with Ignore above;
+                // pipe is live (this enum's ref); separate allocation
+                // from `*subprocess` so the borrows are disjoint.
                 if subprocess.has_exited()
                     && !subprocess
                         .flags
                         .get()
                         .contains(Flags::HAS_STDIN_DESTRUCTOR_CALLED)
                 {
-                    // `Writable::init()` already called `subprocess.ref()` and
-                    // set `DEREF_ON_STDIN_DESTROYED`. `on_attached_process_exit()`
-                    // → `writer.close()` → `pipe.source` → `Writable::on_close`
-                    // → `on_stdin_destroyed()` balances that ref, so a ref-count
-                    // drop across this call is expected (previously these
-                    // writes were clobbered by the struct-literal reassignment
-                    // in spawn_maybe_sync and this path asserted no ref change;
-                    // see https://github.com/oven-sh/bun/pull/14092).
+                    // `Writable::init()` already took `stdin_sink_ref`.
+                    // `on_attached_process_exit()` → `writer.close()` →
+                    // `pipe.source` → `Writable::on_close` → `on_stdin_destroyed()`
+                    // releases that ref, so a ref-count drop across this call
+                    // is expected (previously these writes were clobbered by
+                    // the struct-literal reassignment in spawn_maybe_sync and
+                    // this path asserted no ref change; see
+                    // https://github.com/oven-sh/bun/pull/14092).
                     //
-                    // The call re-enters via the writer backref, so no `&mut
-                    // FileSink` is materialized across it.
-                    // SAFETY: `pipe_ref` keeps the sink live.
-                    unsafe {
-                        FileSink::on_attached_process_exit(
-                            pipe_ref.as_ptr(),
-                            &subprocess.process().status,
-                        )
-                    };
-                    // The wrapper takes its own ref; `pipe_ref` drops after.
-                    Self::pipe_sink_mut(&pipe_ref).to_js(global_this)
+                    // The call re-enters via the writer backref and may release
+                    // refs, so no `&mut FileSink` is materialized across it.
+                    FileSink::on_attached_process_exit(
+                        pipe.this_ptr(),
+                        &subprocess.process().status(),
+                    );
+                    // The wrapper takes its own ref; `pipe` drops after.
+                    FileSink::to_js(pipe.this_ptr(), global_this)
                 } else {
-                    let pipe = Self::pipe_sink_mut(&pipe_ref);
                     subprocess.update_flags(|f| f.set(Flags::HAS_STDIN_DESTRUCTOR_CALLED, false));
                     subprocess
                         .weak_file_sink_stdin_ptr
-                        .set(Some(pipe_ref.as_non_null()));
-                    if !subprocess
-                        .flags
-                        .get()
-                        .contains(Flags::DEREF_ON_STDIN_DESTROYED)
-                    {
-                        // `Writable::init()` already did this for fresh pipes;
-                        // only take a new ref if `on_stdin_destroyed()` has since
-                        // consumed it.
-                        subprocess.ref_();
-                        subprocess.update_flags(|f| f.set(Flags::DEREF_ON_STDIN_DESTROYED, true));
-                    }
+                        .set(Some(BackRef::from(pipe.this_ptr())));
+                    // `Writable::init()` already took this for fresh pipes;
+                    // only take a new ref if `on_stdin_destroyed()` has since
+                    // consumed it.
+                    let held = subprocess.stdin_sink_ref.take();
+                    subprocess
+                        .stdin_sink_ref
+                        .set(Some(held.unwrap_or_else(|| RefPtr::from_this(subprocess))));
                     let parent_ptr = subprocess.as_ctx_ptr().cast::<Subprocess<'static>>();
                     if matches!(*pipe.source.get(), SourceHandle::Subprocess(p) if p.as_const_ptr() == parent_ptr.cast_const())
                     {
                         pipe.source.with_mut(|s| s.clear());
                     }
-                    // The wrapper takes its own ref; `pipe_ref` drops after.
-                    pipe.to_js_with_destructor(
+                    // The wrapper takes its own ref; `pipe` drops after.
+                    FileSink::to_js_with_destructor(
+                        pipe.this_ptr(),
                         global_this,
                         Some(sink::destructor_ptr_subprocess(
                             subprocess.as_ctx_ptr().cast::<c_void>(),
@@ -425,7 +399,7 @@ impl<'a> Writable<'a> {
                 }
             }
             Writable::Buffer(buffer) => {
-                Self::buffer_writer_mut(&buffer).update_ref(false);
+                StaticPipeWriter::update_ref(buffer.this_ptr(), false);
             }
             Writable::Memfd(fd) => {
                 fd.close();
@@ -453,7 +427,7 @@ impl<'a> Writable<'a> {
                 *self = Writable::Ignore;
             }
             Writable::Buffer(buffer) => {
-                Self::buffer_writer_mut(buffer).close();
+                StaticPipeWriter::close(buffer.this_ptr());
             }
             Writable::Ignore => {}
             Writable::Inherit => {}

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -346,7 +346,7 @@ impl<'a> Writable<'a> {
                     // refs, so no `&mut FileSink` is materialized across it.
                     FileSink::on_attached_process_exit(
                         pipe.this_ptr(),
-                        &subprocess.process().status(),
+                        &subprocess.process().status,
                     );
                     // The wrapper takes its own ref; `pipe` drops after.
                     FileSink::to_js(pipe.this_ptr(), global_this)

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -40,7 +40,7 @@ use crate::shell::yield_::Yield;
 pub struct ChildPtr {
     pub node: NodeId,
     pub(crate) tag: WriterTag,
-    /// Only meaningful when `tag == Subproc` — `*mut subproc::CapturedWriter`.
+    /// Only meaningful when `tag == Subproc` — `*mut subproc::PipeReader`.
     /// `core::ptr::null_mut()` otherwise. Stored untyped to keep this header
     /// free of a `subproc` dependency.
     pub(crate) raw: *mut core::ffi::c_void,
@@ -62,8 +62,8 @@ impl ChildPtr {
         }
     }
 
-    /// Construct a `ChildPtr` targeting a `subproc::CapturedWriter` (lives
-    /// outside the NodeId arena).
+    /// Construct a `ChildPtr` targeting a `subproc::PipeReader`'s captured
+    /// writer (lives outside the NodeId arena).
     #[inline]
     pub(crate) fn subproc_capture(cw: *mut core::ffi::c_void) -> ChildPtr {
         ChildPtr {
@@ -1230,13 +1230,15 @@ pub(crate) fn on_io_writer_chunk(
         WriterTag::Subproc => {
             let _ = interp;
             debug_assert!(!child.raw.is_null());
-            // SAFETY: `raw` was set from `&mut CapturedWriter` in
-            // `CapturedWriter::do_write`; the PipeReader (and the embedded
-            // CapturedWriter) is kept alive by the `Readable::Pipe` Arc on
-            // the owning ShellSubprocess until `on_close_io` runs, which only
-            // happens after the writer has finished draining. Single-threaded.
-            let cw = unsafe { &mut *child.raw.cast::<crate::shell::subproc::CapturedWriter>() };
-            cw.on_iowriter_chunk(written, err)
+            // SAFETY: `raw` is the `PipeReader` root set in
+            // `PipeReader::captured_child_ptr`; the reader is kept alive by
+            // the `Readable::Pipe` ref on the owning ShellSubprocess until
+            // `on_close_io` runs, which only happens after the writer has
+            // finished draining (or `cancel_chunks` removed this entry).
+            let pipe = unsafe {
+                bun_ptr::ThisPtr::new(child.raw.cast::<crate::shell::subproc::PipeReader>())
+            };
+            crate::shell::subproc::PipeReader::on_captured_iowriter_chunk(pipe, written, err)
         }
     }
 }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -587,10 +587,12 @@ impl Cmd {
         // moved out of the Cmd for the call (argv borrows its storage).
         let args = core::mem::take(&mut interp.as_cmd_mut(this).args);
         let spawn_result = {
+            // Every arg ends in NUL; an interior NUL (e.g. from a JS string)
+            // truncates the entry there, as it would in C.
             let argv: Vec<&core::ffi::CStr> = args
                 .iter()
                 .map(|arg| {
-                    core::ffi::CStr::from_bytes_with_nul(arg).expect("args are NUL-terminated")
+                    core::ffi::CStr::from_bytes_until_nul(arg).expect("args are NUL-terminated")
                 })
                 .collect();
             ShellSubprocess::spawn_async(event_loop, &mut shellio, spawn_args, &argv, cmd_parent)

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -642,7 +642,7 @@ impl Cmd {
             // `watch()` failed → process already gone.
             let process = subproc.get().proc();
             if process.has_exited() {
-                let status = process.status();
+                let status = process.status.clone();
                 process.on_exit(status, &crate::api::bun::process::rusage_zeroed());
             } else {
                 process.wait(false);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -66,7 +66,8 @@ impl Cmd {
 }
 
 pub struct SubprocExec {
-    pub(crate) child: *mut ShellSubprocess,
+    /// `None` until `spawn_async` succeeds.
+    pub(crate) child: Option<bun_ptr::OwnedThis<ShellSubprocess>>,
     pub(crate) buffered_closed: BufferedIoClosed,
     /// NodeId-arena backrefs so the legacy `&mut self` subprocess callbacks
     /// (`buffered_output_close` / `on_exit`) can hand a [`Yield`] back to the
@@ -169,7 +170,7 @@ impl BufferedIoClosed {
     /// command-substitution aggregate buffer.
     fn close_out(
         slot: &mut Option<BufferedIoState>,
-        readable: &mut Readable,
+        readable: &Readable,
         io_is_pipe: bool,
         redirects_elsewhere: bool,
         shell_buf: *mut Vec<u8>,
@@ -190,10 +191,7 @@ impl BufferedIoClosed {
             // of the command. Single-threaded.
             unsafe { (*shell_buf).append_slice(the_slice) };
         }
-        // SAFETY: `Arc<PipeReader>` interior mutability — the shell is
-        // single-threaded and this is the same pattern `subproc::on_close_io`
-        // uses to take the done buffer.
-        let buffer = unsafe { &mut *(std::sync::Arc::as_ptr(pipe).cast_mut()) }.take_buffer();
+        let buffer = pipe.take_buffer();
         *state = BufferedIoState::Closed(Vec::<u8>::move_from_list(buffer));
     }
 }
@@ -455,7 +453,7 @@ impl Cmd {
         let event_loop = interp.event_loop;
 
         let arena = bun_alloc::Arena::new();
-        let mut spawn_args = SpawnArgs::default::<false>(&arena, interp.as_ctx_ptr(), event_loop);
+        let mut spawn_args = SpawnArgs::default::<false>(&arena, interp, event_loop);
         // Cache the raw `*mut ShellExecEnv` and deref it directly so the
         // `cwd: &[u8]` stored in `spawn_args` is decoupled from any borrow of
         // `*interp` — `Base::shell()` would tie the slice's lifetime to
@@ -556,99 +554,95 @@ impl Cmd {
             }
         }
 
-        // Stage the exec slot *before* spawning so PipeReader / process-exit
-        // callbacks (which deref `cmd_parent.exec`) see a populated `Subproc`
-        // with the correct `child` once `spawn_async` writes through
-        // `out_subproc`. `interp` is left null until `spawn_async` and the
-        // `did_exit_immediately` handling have returned: a synchronous
-        // `Cmd::on_exit` (process exit handler) or `Cmd::buffered_output_close`
-        // (an eager `read_all` on a pipe erroring inside the spawn) would
-        // otherwise drive the trampoline (`Yield::run(&*interp)`) while this
-        // frame still holds `&Interpreter`, tearing the Cmd down (and freeing
-        // `child`) underneath the live `subproc` borrow. With `interp` null,
-        // both record `exit_code`/`state = Done` and return; we resume via
-        // the Yield we hand back below.
+        // Stage the exec slot *before* starting the subprocess so PipeReader
+        // / process-exit callbacks (which deref `cmd_parent.exec`) see a
+        // populated `Subproc` with the correct `child`. `interp` is left null
+        // until `start` and the `did_exit_immediately` handling have returned:
+        // a synchronous `Cmd::on_exit` (process exit handler) or
+        // `Cmd::buffered_output_close` (an eager `read_all` on a pipe erroring
+        // inside the start) would otherwise drive the trampoline
+        // (`Yield::run(&*interp)`) while this frame still holds
+        // `&Interpreter`, tearing the Cmd down (and freeing `child`)
+        // underneath us. With `interp` null, both record `exit_code`/`state =
+        // Done` and return; we resume via the Yield we hand back below.
         let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
-            child: core::ptr::null_mut(),
+            child: None,
             buffered_closed,
             interp: core::ptr::null_mut(),
             this_id: this,
         }));
 
-        // Derive the raw backrefs `spawn_async` needs from a single
-        // short-lived `&mut Cmd` borrow, then let it end before the call so no
-        // `&Interpreter` is live across the re-entrant spawn. `child_out`
-        // points into the `Box<SubprocExec>` heap allocation, which is
-        // address-stable for the lifetime of the Cmd (only dropped in
-        // `deinit`). argv pointers borrow `cmd.args[i]` storage, which is not
-        // reallocated between here and `spawn_process`.
-        //
         // `cmd_parent` is `(interp, NodeId)` rather than the spec's `*ShellCmd`
         // — the Cmd lives inline in `interp.nodes: Vec<Node>`, and a raw
         // `*mut Cmd` would dangle on the next `alloc_node` reallocation.
-        let child_out: *mut *mut ShellSubprocess = {
-            let cmd = interp.as_cmd_mut(this);
-            spawn_args.argv.reserve_exact(cmd.args.len() + 1);
-            for arg in &cmd.args {
-                debug_assert_eq!(arg.last(), Some(&0));
-                spawn_args.argv.push(arg.as_ptr().cast());
-            }
-            spawn_args.argv.push(core::ptr::null());
-            match &mut cmd.exec {
-                Exec::Subproc(sub) => core::ptr::addr_of_mut!(sub.child),
-                _ => unreachable!(),
-            }
-        };
         let cmd_parent = crate::shell::subproc::CmdHandle {
-            // SAFETY: `interp_ptr` is the live owning Interpreter (from
-            // `&mut Interpreter` above); single-threaded, write provenance.
-            interp: unsafe { bun_ptr::ParentRef::from_raw_mut(interp_ptr) },
+            interp: bun_ptr::ParentRef::new(interp),
             id: this,
         };
 
+        let mut lazy = spawn_args.lazy;
+        // `spawn_async` does not re-enter the interpreter, so `args` can be
+        // moved out of the Cmd for the call (argv borrows its storage).
+        let args = core::mem::take(&mut interp.as_cmd_mut(this).args);
+        let spawn_result = {
+            let argv: Vec<&core::ffi::CStr> = args
+                .iter()
+                .map(|arg| {
+                    core::ffi::CStr::from_bytes_with_nul(arg).expect("args are NUL-terminated")
+                })
+                .collect();
+            ShellSubprocess::spawn_async(event_loop, &mut shellio, spawn_args, &argv, cmd_parent)
+        };
+        interp.as_cmd_mut(this).args = args;
+        drop(shellio);
+        drop(arena);
+
+        let child = match spawn_result {
+            Err(e) => {
+                // Revert exec so `deinit` has no child to free.
+                interp.as_cmd_mut(this).exec = Exec::None;
+                return Builtin::cmd_write_failing_error(interp, this, format_args!("{}\n", e));
+            }
+            Ok(child) => child,
+        };
+        let subproc = child.this_ptr();
+        match &mut interp.as_cmd_mut(this).exec {
+            Exec::Subproc(sub) => sub.child = Some(child),
+            _ => unreachable!(),
+        }
+
         let mut did_exit_immediately = false;
-        // `spawn_async` is re-entrant: `watch()`/`read_all()` may fire
+        // `start` is re-entrant: `watch()`/`read_all()` may fire
         // `on_process_exit` / `buffered_output_close` which reach back into
-        // `interp` via the raw backrefs on `SubprocExec`. By NLL the `interp`
+        // `interp` via the backrefs on `SubprocExec`. By NLL the `interp`
         // borrow above is dead here, so those callbacks do not alias a live
         // `&mut`.
-        let spawn_result = ShellSubprocess::spawn_async(
-            event_loop,
-            &mut shellio,
-            spawn_args,
-            cmd_parent,
-            child_out,
-            &mut did_exit_immediately,
-        );
-        drop(shellio);
-
-        if let Err(e) = spawn_result {
-            drop(arena);
-            // Revert exec so `deinit` doesn't free a null `child`.
-            interp.as_cmd_mut(this).exec = Exec::None;
+        if let Err(e) =
+            ShellSubprocess::start(subproc, event_loop, &mut lazy, &mut did_exit_immediately)
+        {
+            match core::mem::take(&mut interp.as_cmd_mut(this).exec) {
+                // Windows: dropping would trip PipeReader's not-closed assert
+                // on a possibly-uninitialized uv source; leak instead
+                // (pre-existing behavior).
+                #[cfg(windows)]
+                Exec::Subproc(sub) => core::mem::forget(sub.child),
+                // Runs `ShellSubprocess::drop` → `finalize_sync`.
+                #[cfg(not(windows))]
+                Exec::Subproc(sub) => drop(sub),
+                _ => unreachable!(),
+            }
             return Builtin::cmd_write_failing_error(interp, this, format_args!("{}\n", e));
         }
 
-        // Read the subprocess back via the arena instead of holding `child_out`
-        // across the call.
-        let child: *mut ShellSubprocess = match &interp.as_cmd(this).exec {
-            Exec::Subproc(sub) => sub.child,
-            _ => unreachable!(),
-        };
-        // SAFETY: `spawn_async` Ok ⇒ wrote a live `heap::alloc` subprocess
-        // pointer into `*child_out` (== `sub.child`); valid until `Cmd::deinit`
-        // reclaims the box. Single-threaded.
-        let subproc = unsafe { &mut *child };
         subproc.r#ref();
-        drop(arena);
 
         if did_exit_immediately {
             // `watch()` failed → process already gone.
-            let process = subproc.proc();
+            let process = subproc.get().proc();
             if process.has_exited() {
-                let status = process.status.clone();
+                let status = process.status();
                 process.on_exit(status, &crate::api::bun::process::rusage_zeroed());
             } else {
                 process.wait(false);
@@ -868,10 +862,10 @@ impl Cmd {
             let me = interp.as_cmd_mut(this);
             match &mut me.exec {
                 Exec::Builtin(b) => b.defuse_array_buf_pins(),
-                Exec::Subproc(sub) if !sub.child.is_null() => {
-                    // SAFETY: `child` is the live heap::alloc'd subprocess;
-                    // the call only writes its own fields.
-                    unsafe { ShellSubprocess::defuse_array_buffer_unpins(sub.child) };
+                Exec::Subproc(sub) => {
+                    if let Some(child) = &sub.child {
+                        child.defuse_array_buffer_unpins();
+                    }
                 }
                 _ => {}
             }
@@ -897,29 +891,24 @@ impl Cmd {
         match exec {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
-            Exec::Subproc(sub) if !sub.child.is_null() => {
-                // SAFETY: `child` was set by `spawn_async` from a
-                // `heap::alloc(ShellSubprocess)` and stays valid until this
-                // drop. Single-threaded. Reclaiming the box runs
-                // `ShellSubprocess::drop` → `finalize_sync` (closes stdio).
-                unsafe {
-                    let child = sub.child;
-                    if !(*child).has_exited() {
-                        let _ = (*child).try_kill(9);
+            Exec::Subproc(mut sub) => {
+                // `None`: spawn failed before the subprocess was returned;
+                // nothing to tear down.
+                if let Some(child) = sub.child.take() {
+                    if !child.has_exited() {
+                        let _ = child.try_kill(9);
                     }
-                    (*child).unref::<true>();
+                    child.unref::<true>();
                     // Stop any still-active stdio before the drop (only the
                     // VM-shutdown path reaches here in flight).
                     #[cfg(not(windows))]
-                    ShellSubprocess::deinit_in_flight_io(child);
-                    drop(bun_core::heap::take(child));
+                    child.deinit_in_flight_io();
+                    // Runs `ShellSubprocess::drop` → `finalize_sync` (closes stdio).
+                    drop(child);
                 }
                 // `sub.buffered_closed` drops here, freeing any captured
                 // `Vec<u8>`s (spec `buffered_closed.deinit()`).
             }
-            // `Exec::Subproc` with null `child`: spawn failed before the
-            // subprocess box was returned. Nothing to tear down.
-            Exec::Subproc(_) => {}
         }
         // Argv/env are heap-owned `Vec`s; there is no spawn arena to free.
         // `base.shell` is borrowed (or, when parent is Pipeline, freed by
@@ -1009,9 +998,7 @@ impl Cmd {
         let Exec::Subproc(sub) = &mut self.exec else {
             return;
         };
-        // Raw deref keeps the borrow disjoint from `sub.buffered_closed` below.
-        // SAFETY: `child` is the live subprocess owned by this Cmd.
-        let child = unsafe { &mut *sub.child };
+        let child = sub.child.as_ref().expect("spawned").this_ptr();
         // Tee into the JS-side captured buffer if stdout is an fd with a
         // `captured` slot and the redirect didn't send stdout elsewhere.
         if let IoOutKind::Fd(fd) = &self.io.stdout {
@@ -1019,7 +1006,7 @@ impl Cmd {
             // owning `ShellExecEnv` and no other borrow of it is live here.
             if let Some(captured) = unsafe { fd.captured_mut() } {
                 if !redirect.redirects_elsewhere(ast::IoKind::Stdout) {
-                    if let Readable::Pipe(pipe) = &child.stdout {
+                    if let Readable::Pipe(pipe) = child.stdout.get() {
                         captured.append_slice(pipe.slice());
                     }
                 }
@@ -1027,7 +1014,7 @@ impl Cmd {
         }
         BufferedIoClosed::close_out(
             &mut sub.buffered_closed.stdout,
-            &mut child.stdout,
+            child.stdout.get(),
             matches!(self.io.stdout, IoOutKind::Pipe),
             redirect.redirects_elsewhere(ast::IoKind::Stdout),
             self.base.shell_mut().buffered_stdout(),
@@ -1045,15 +1032,13 @@ impl Cmd {
         let Exec::Subproc(sub) = &mut self.exec else {
             return;
         };
-        // Raw deref keeps the borrow disjoint from `sub.buffered_closed` below.
-        // SAFETY: `child` is the live subprocess owned by this Cmd.
-        let child = unsafe { &mut *sub.child };
+        let child = sub.child.as_ref().expect("spawned").this_ptr();
         if let IoOutKind::Fd(fd) = &self.io.stderr {
             // SAFETY: single-threaded; the captured `Vec<u8>` lives in the
             // owning `ShellExecEnv` and no other borrow of it is live here.
             if let Some(captured) = unsafe { fd.captured_mut() } {
                 if !redirect.redirects_elsewhere(ast::IoKind::Stderr) {
-                    if let Readable::Pipe(pipe) = &child.stderr {
+                    if let Readable::Pipe(pipe) = child.stderr.get() {
                         captured.append_slice(pipe.slice());
                     }
                 }
@@ -1061,7 +1046,7 @@ impl Cmd {
         }
         BufferedIoClosed::close_out(
             &mut sub.buffered_closed.stderr,
-            &mut child.stderr,
+            child.stderr.get(),
             matches!(self.io.stderr, IoOutKind::Pipe),
             redirect.redirects_elsewhere(ast::IoKind::Stderr),
             self.base.shell_mut().buffered_stderr(),

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -610,6 +610,13 @@ impl Expansion {
                 .buffered_stdout_mut()
         }
         .clone();
+        // Like bash, drop NUL bytes from command-substitution output: the words
+        // become NUL-terminated argv entries.
+        let stdout = if stdout.contains(&0) {
+            stdout.into_iter().filter(|&b| b != 0).collect()
+        } else {
+            stdout
+        };
 
         // Propagate the exit code if the *whole* atom was a single `$(...)`
         // (so `$(false)` as argv0 fails the command).

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -612,7 +612,7 @@ impl Expansion {
         .clone();
         // Like bash, drop NUL bytes from command-substitution output: the words
         // become NUL-terminated argv entries.
-        let stdout = if stdout.contains(&0) {
+        let stdout = if bun_core::strings::contains_char(&stdout, 0) {
             stdout.into_iter().filter(|&b| b != 0).collect()
         } else {
             stdout

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -279,10 +279,14 @@ impl ShellSubprocess {
     /// Windows: `PipeReader`'s drop asserts the libuv source is closed, and
     /// whether the source is uv-initialized depends on how far
     /// startWithCurrentPipe got, so the caller leaks the Subprocess instead
-    /// (pre-existing behavior); only the Ctrl+C accounting is released.
+    /// (pre-existing behavior); the Ctrl+C accounting is released and the
+    /// exit handler cleared without closing the poller.
     fn abort_after_failed_start(&self) {
         #[cfg(windows)]
-        self.ctrl_c_child.set(None);
+        {
+            self.ctrl_c_child.set(None);
+            self.process.process_mut().set_exit_handler_default();
+        }
         #[cfg(not(windows))]
         {
             for r in [&self.stdout, &self.stderr] {
@@ -543,8 +547,9 @@ impl ShellSubprocess {
 
         let stdin = match Writable::init(stdio0, event_loop, subprocess, spawn_stdin) {
             Ok(w) => w,
-            Err(WritableInitError::UnexpectedCreatingStdin) => {
-                panic!("unexpected error while creating stdin");
+            Err(WritableInitError::UnexpectedCreatingStdin(err)) => {
+                let _ = subprocess.try_kill(SignalCode::SIGTERM as i32);
+                return Err(ShellErr::new_sys(&err));
             }
         };
         subprocess.stdin.set(stdin);
@@ -689,7 +694,7 @@ impl ShellSubprocess {
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum WritableInitError {
     #[error("UnexpectedCreatingStdin")]
-    UnexpectedCreatingStdin,
+    UnexpectedCreatingStdin(bun_sys::Error),
 }
 
 pub enum Writable {
@@ -731,10 +736,10 @@ impl Writable {
                         // Ownership of the `Box<uv::Pipe>` transfers into the
                         // FileSink's writer.
                         let pipe = FileSink::create_with_pipe(event_loop, buf);
-                        if let bun_sys::Result::Err(_err) =
+                        if let bun_sys::Result::Err(err) =
                             pipe.writer.with_mut(|w| w.start_with_current_pipe())
                         {
-                            return Err(WritableInitError::UnexpectedCreatingStdin);
+                            return Err(WritableInitError::UnexpectedCreatingStdin(err));
                         }
 
                         // TODO: uncoment this when is ready, commented because was not compiling
@@ -1670,12 +1675,11 @@ impl PipeReader {
         );
         let _guard = RefPtr::from_this(this);
         this.state.with_mut(|state| {
-            if let PipeReaderState::Done(buf) =
-                core::mem::replace(state, PipeReaderState::Err(None))
-            {
-                drop(buf);
+            match core::mem::replace(state, PipeReaderState::Err(None)) {
+                // Keep the first recorded error, as `take_captured_error` does.
+                old @ PipeReaderState::Err(Some(_)) => *state = old,
+                _ => *state = PipeReaderState::Err(Some(Box::new(err.to_system_error()))),
             }
-            *state = PipeReaderState::Err(Some(Box::new(err.to_system_error())));
         });
         if !this.is_done() {
             return;

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1,9 +1,11 @@
-use core::ffi::{c_char, c_void};
+use core::cell::Cell;
 use std::sync::Arc;
 
 #[cfg(unix)]
 use crate::api::bun::process::SpawnResultExt as _;
-use crate::api::bun::process::{self as bun_process, Process, SignalCodeExt, SpawnOptions, Status};
+use crate::api::bun::process::{
+    self as bun_process, ProcessHandle, SignalCodeExt, SpawnOptions, Status,
+};
 #[cfg(windows)]
 use crate::api::bun::process::{WindowsOptions, WindowsStdioResult};
 use crate::api::bun::subprocess as JscSubprocess;
@@ -18,8 +20,8 @@ use bun_io::Loop as AsyncLoop;
 #[cfg(windows)]
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{BufferedReader, ReadState};
-use bun_jsc::{self as jsc, EventLoopHandle};
-use bun_ptr::RefPtr;
+use bun_jsc::{self as jsc, EventLoopHandle, JsCell};
+use bun_ptr::{BackRef, OwnedThis, ParentRef, RefCount, RefPtr, ThisPtr};
 use bun_sys::{self, Fd, FdExt, SystemError};
 use enumset::EnumSet;
 
@@ -33,74 +35,6 @@ fn out_kind_str(k: OutKind) -> &'static str {
         OutKind::Stdout => "stdout",
         OutKind::Stderr => "stderr",
     }
-}
-
-/// Raw `*mut T` into an `Arc<T>` payload.
-///
-/// Returns a **raw pointer**, not `&mut T`: an `(&Arc<T>) -> &mut T` accessor
-/// is unsound by construction — it lets two `&mut T` (or a `&mut T` and a
-/// sibling-clone `Arc::deref` `&T`) coexist, which the compiler treats as
-/// `noalias`. Callers must materialise `&mut *p` only for a scope that does
-/// **not** re-enter code that derefs another `Arc<PipeReader>` to the same
-/// allocation (e.g. `Cmd::buffered_output_close` reading `pipe.slice()`).
-///
-/// **Thread-confinement (no data race):** `PipeReader` holds raw
-/// `*mut ShellSubprocess` / `*mut Interpreter` fields and is therefore
-/// auto-`!Send + !Sync`; consequently `Arc<PipeReader>` is `!Send + !Sync`
-/// too and cannot escape the JS thread. See the `static_assertions` below.
-///
-/// **Provenance:** `Arc::as_ptr` projects from the `NonNull<ArcInner<T>>`
-/// stored by value (originating from `Box::into_raw`), so the returned
-/// pointer carries the allocation's write permission — `cast_mut` is not a
-/// shared-ref→mut laundering.
-///
-/// # Safety
-/// - The `Arc` must be live for every use of the returned pointer.
-/// - Any `&mut *result` borrow must not overlap a `&T` reached via another
-///   `Arc` clone / `Arc::deref` of the same allocation.
-#[inline]
-fn arc_as_mut_ptr<T>(a: &Arc<T>) -> *mut T {
-    Arc::as_ptr(a).cast_mut()
-}
-
-// Compile-time thread-confinement proof: `PipeReader`'s raw-pointer fields
-// make it (and hence `Arc<PipeReader>`) `!Send + !Sync`, so the "Arc clone
-// reaches another thread" data-race is structurally impossible. Stable Rust
-// has no negative trait bounds, so this is the auto-trait-ambiguity trick:
-// if `Arc<PipeReader>` ever gains `Send`/`Sync`, both blanket impls apply
-// and `_NOT_SEND`/`_NOT_SYNC` fail to compile with "conflicting impls".
-mod __pipe_reader_thread_confined {
-    use super::{Arc, PipeReader};
-    trait _NotSendCheck<A> {
-        const OK: () = ();
-    }
-    impl<T: ?Sized> _NotSendCheck<()> for T {}
-    impl<T: ?Sized + Send> _NotSendCheck<u8> for T {}
-    trait _NotSyncCheck<A> {
-        const OK: () = ();
-    }
-    impl<T: ?Sized> _NotSyncCheck<()> for T {}
-    impl<T: ?Sized + Sync> _NotSyncCheck<u8> for T {}
-    const _NOT_SEND: () = <Arc<PipeReader> as _NotSendCheck<_>>::OK;
-    const _NOT_SYNC: () = <Arc<PipeReader> as _NotSyncCheck<_>>::OK;
-}
-
-/// Mutably borrow a `RefPtr<StaticPipeWriter>` payload.
-///
-/// `RefPtr` only exposes `&T` via `Deref`; the shell is single-threaded.
-/// Localises the `(*buffer.as_ptr()).method()` pattern at the five
-/// `Writable::Buffer` callsites.
-///
-/// # Safety
-/// Caller must ensure no other `&`/`&mut StaticPipeWriter` to the same
-/// payload is live for the returned borrow. The `(&RefPtr<T>) -> &mut T`
-/// shape cannot encode this; `unsafe fn` keeps the obligation at the callsite.
-#[inline]
-#[allow(clippy::mut_from_ref)]
-unsafe fn buffer_mut(buf: &RefPtr<StaticPipeWriter>) -> &mut StaticPipeWriter {
-    // SAFETY: caller contract — single-threaded shell; `RefPtr` data is live
-    // while the handle exists.
-    unsafe { &mut *buf.as_ptr() }
 }
 
 /// Local helper: `ReadState` → tag-name string for logs.
@@ -154,46 +88,39 @@ pub(crate) const DEFAULT_MAX_BUFFER_SIZE: u32 = 1024 * 1024 * 4;
 /// each use site.
 #[derive(Clone, Copy)]
 pub struct CmdHandle {
-    pub(crate) interp: bun_ptr::ParentRef<Interpreter, bun_ptr::Mut>,
+    pub(crate) interp: ParentRef<Interpreter>,
     pub(crate) id: NodeId,
 }
 
 impl CmdHandle {
     /// Resolve to the live `Cmd` slot. Single-threaded; the caller must not
-    /// hold another `&Interpreter` across this borrow.
-    ///
-    /// # Safety
-    /// `interp` must be live and `id` must still index a `Node::Cmd` slot
-    /// (i.e. the Cmd has not yet been `free_node`d). Both hold for every call
-    /// site: the subprocess / PipeReader callbacks fire strictly before
-    /// `Cmd::deinit` recycles the slot.
+    /// hold the result across a call that re-enters the interpreter. `id`
+    /// indexes a `Node::Cmd` slot for every caller: the subprocess /
+    /// PipeReader callbacks fire strictly before `Cmd::deinit` recycles it.
     #[inline]
-    pub(crate) unsafe fn cmd_mut(self) -> &'static mut ShellCmd {
-        // SAFETY: per fn contract — `interp` constructed via `from_raw_mut`
-        // (write provenance), single-threaded, no overlapping `&mut`.
-        // `&'static mut T` forge — `bun_ptr::Interned` is read-only by
-        // construction so does NOT cover this; tracked under the sibling
-        // `static-widen-mut` pattern. Routed through `detach_lifetime_mut` so
-        // the widen is centralised in `bun_ptr` and grep-able. The `'static` is
-        // a lie scoped to the (3) callers, all of which drop the borrow before
-        // `free_node` recycles the slot.
-        unsafe { bun_ptr::detach_lifetime_mut(self.interp.assume_mut().as_cmd_mut(self.id)) }
+    pub(crate) fn cmd_mut(&self) -> &mut ShellCmd {
+        self.interp.get().as_cmd_mut(self.id)
     }
 }
 
+/// Owned by its `Cmd` (`SubprocExec::child`) as an [`OwnedThis`]; the stdin
+/// writer, the pipe readers and the process exit handler hold back-references
+/// that the `Cmd` clears (by dropping this, whose `Drop` closes them) before
+/// it goes away.
 pub struct ShellSubprocess {
     pub(crate) cmd_parent: CmdHandle,
 
-    /// `None` once closed.
-    pub(crate) process: Option<bun_process::ProcessHandle>,
+    /// Owning handle on the intrusively ref-counted process; detached in
+    /// `finalize_sync`, released on drop.
+    pub(crate) process: ProcessHandle,
 
-    pub(crate) stdin: Writable,
-    pub(crate) stdout: Readable,
-    pub(crate) stderr: Readable,
+    pub(crate) stdin: JsCell<Writable>,
+    pub(crate) stdout: JsCell<Readable>,
+    pub(crate) stderr: JsCell<Readable>,
 
-    pub closed: EnumSet<StdioKind>,
+    pub closed: Cell<EnumSet<StdioKind>>,
 
-    ctrl_c_child: Option<bun_spawn::ctrl_c::Child>,
+    ctrl_c_child: Cell<Option<bun_spawn::ctrl_c::Child>>,
 }
 
 pub(crate) type SignalCode = bun_core::SignalCode;
@@ -205,131 +132,96 @@ impl Drop for ShellSubprocess {
     }
 }
 
-// pub const Pipe = struct {
-//     writer: Writer = Writer{},
-//     parent: *Subprocess,
-//     src: WriterSrc,
-//
-//     writer: ?CapturedBufferedWriter = null,
-//
-//     status: Status = .{
-//         .pending = {},
-//     },
-// };
-
 pub type StaticPipeWriter = JscSubprocess::NewStaticPipeWriter<ShellSubprocess>;
 
 impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubprocess {
     const POLL_OWNER_TAG: bun_io::PollTag =
         bun_io::posix_event_loop::poll_tag::SHELL_STATIC_PIPE_WRITER;
-    unsafe fn on_close_io(this: *mut Self, kind: StdioKind) {
+    fn on_close_io(this: ThisPtr<Self>, kind: StdioKind) {
         // `Writable::init` only creates the writer for stdin.
         debug_assert!(matches!(kind, StdioKind::Stdin));
-        // SAFETY: `StaticPipeWriter::on_close` passes its live process backref
-        // and does not touch it afterwards. Forwarded raw, not autoref'd: the
-        // callee may free `*this`.
-        unsafe { Self::on_stdin_writer_close(this) }
+        Self::on_stdin_writer_close(this)
     }
 }
 
 bun_spawn::link_impl_ProcessExit! {
     Shell for ShellSubprocess => |this| {
-        // Forwarded raw, not autoref'd: the callee may free `*this`.
         on_process_exit(_process, status, _rusage) =>
-            ShellSubprocess::on_process_exit(this, &status),
+            ShellSubprocess::on_process_exit(ThisPtr::new(this), &status),
     }
 }
 
 impl ShellSubprocess {
-    /// The shell is single-threaded; `process` is set for the lifetime of
-    /// `ShellSubprocess` until `close_process`.
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) fn proc(&self) -> &mut Process {
-        self.process.as_ref().expect("process closed").process_mut()
+    pub(crate) fn proc(&self) -> &ProcessHandle {
+        &self.process
     }
 
     /// The `< ${buffer}` stdin writer closed: release it and let the `Cmd`
-    /// finish.
-    ///
-    /// # Safety
-    /// `this` must be live and unborrowed; the Yield run here may free it.
-    unsafe fn on_stdin_writer_close(this: *mut Self) {
-        {
-            // SAFETY: caller contract; the borrow ends before the Yield runs.
-            let slot = unsafe { &mut (*this).stdin };
-            match core::mem::replace(slot, Writable::Ignore) {
-                // Drops `create()`'s ref; `start()`'s ref outlives this call.
-                Writable::Buffer(buffer) => {
-                    // SAFETY: single-threaded; sole borrow of the payload.
-                    unsafe { buffer_mut(&buffer) }.source.detach();
-                }
-                other => {
-                    *slot = other;
-                    return;
-                }
+    /// finish. `this: ThisPtr` because the Yield run here may free us.
+    fn on_stdin_writer_close(this: ThisPtr<Self>) {
+        match this.stdin.replace(Writable::Ignore) {
+            // Drops `create()`'s ref; `start()`'s ref outlives this call.
+            Writable::Buffer(buffer) => StaticPipeWriter::detach_source(buffer.this_ptr()),
+            other => {
+                this.stdin.set(other);
+                return;
             }
         }
-        // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
-        let handle = unsafe { (*this).cmd_parent };
+        let handle = this.cmd_parent;
         log!(
             "Subproc(0x{:x}) onStdinWriterClose(cmd={})",
-            this as usize,
+            this.as_ptr() as usize,
             handle.id
         );
-        // SAFETY: the owning Cmd outlives its subprocess; the `&mut Cmd` ends
-        // before the Yield runs.
-        let y = unsafe { handle.cmd_mut() }.buffered_input_close();
-        // May free `*this`.
-        y.run(&handle.interp);
+        // No borrow of `this` is live past this point; the `&mut Cmd` ends
+        // before the Yield runs, which may free `this`.
+        let y = handle.cmd_mut().buffered_input_close();
+        y.run(handle.interp.get());
     }
 
     pub(crate) fn has_exited(&self) -> bool {
-        self.proc().has_exited()
+        self.process.has_exited()
     }
 
-    pub(crate) fn r#ref(&mut self) {
-        self.proc().enable_keeping_event_loop_alive();
+    pub(crate) fn r#ref(&self) {
+        self.process.enable_keeping_event_loop_alive();
 
         // self.stdin.ref();
         // }
 
         // if (!self.hasCalledGetter(.stdout)) {
-        self.stdout.r#ref();
+        self.stdout.get().r#ref();
         // }
 
         // if (!self.hasCalledGetter(.stderr)) {
-        self.stderr.r#ref();
+        self.stderr.get().r#ref();
         // }
     }
 
     /// This disables the keeping process alive flag on the poll and also in the stdin, stdout, and stderr
-    pub(crate) fn unref<const _DEREF: bool>(&mut self) {
-        self.proc().disable_keeping_event_loop_alive();
+    pub(crate) fn unref<const _DEREF: bool>(&self) {
+        self.process.disable_keeping_event_loop_alive();
 
-        self.stdout.unref();
+        self.stdout.get().unref();
 
-        self.stderr.unref();
+        self.stderr.get().unref();
     }
 
-    pub(crate) fn try_kill(&mut self, sig: i32) -> bun_sys::Result<()> {
+    pub(crate) fn try_kill(&self, sig: i32) -> bun_sys::Result<()> {
         if self.has_exited() {
             return Ok(());
         }
 
-        self.proc().kill(u8::try_from(sig).expect("int cast"))
+        self.process.kill(u8::try_from(sig).expect("int cast"))
     }
 
-    fn close_process(&mut self) {
-        self.process = None;
-    }
-
-    pub(crate) fn close_io(&mut self, io: StdioKind) {
-        if self.closed.contains(io) {
+    pub(crate) fn close_io(&self, io: StdioKind) {
+        if self.closed.get().contains(io) {
             return;
         }
         log!("close IO {}", <&'static str>::from(io));
-        self.closed.insert(io);
+        self.closed.set(self.closed.get() | io);
 
         // If you never referenced stdout/stderr, they won't be garbage collected.
         //
@@ -339,15 +231,21 @@ impl ShellSubprocess {
         //   3. We need to halt any pending reads (1)
         // if (!self.hasCalledGetter(io)) {
         match io {
-            StdioKind::Stdin => self.stdin.finalize(),
-            StdioKind::Stdout => self.stdout.finalize(),
-            StdioKind::Stderr => self.stderr.finalize(),
+            StdioKind::Stdin => {
+                // Outside the cell: releasing a `Buffer` writer can re-enter
+                // `on_close_io`.
+                let mut stdin = self.stdin.replace(Writable::Ignore);
+                stdin.finalize();
+                self.stdin.set(stdin);
+            }
+            StdioKind::Stdout => self.stdout.with_mut(|s| s.finalize()),
+            StdioKind::Stderr => self.stderr.with_mut(|s| s.finalize()),
         }
     }
 
     // This must only be run once per Subprocess
-    pub(crate) fn finalize_sync(&mut self) {
-        self.close_process();
+    pub(crate) fn finalize_sync(&self) {
+        self.process.detach();
 
         self.close_io(StdioKind::Stdin);
         self.close_io(StdioKind::Stdout);
@@ -356,146 +254,83 @@ impl ShellSubprocess {
 
     /// A stdout/stderr `PipeReader` finished: swap it out of its slot for its
     /// buffered bytes.
-    pub(crate) fn on_close_io(&mut self, kind: StdioKind) {
-        let out: &mut Readable = match kind {
-            StdioKind::Stdout => &mut self.stdout,
-            StdioKind::Stderr => &mut self.stderr,
+    pub(crate) fn on_close_io(&self, kind: StdioKind) {
+        let out: &JsCell<Readable> = match kind {
+            StdioKind::Stdout => &self.stdout,
+            StdioKind::Stderr => &self.stderr,
             StdioKind::Stdin => unreachable!("stdin closes through on_stdin_writer_close"),
         };
-        if let Readable::Pipe(pipe) = core::mem::replace(out, Readable::Ignore) {
-            // The only callers reach here from inside
-            // `PipeReader::on_reader_done`/`on_reader_error`, which still
-            // hold a raw `*mut PipeReader` to this same allocation.
-            // Route every read/write through `Arc::as_ptr` (no `Deref`)
-            // so we never materialise a `&PipeReader` that would alias
-            // those callers' access; see `PipeReader::take_done_buffer`.
-            let pp = Arc::as_ptr(&pipe).cast_mut();
-            // SAFETY: `pp` projects from the Arc allocation's NonNull;
-            // raw place read of the discriminant + raw-ptr write
-            // through `take_done_buffer` (see its doc).
-            let buf = unsafe {
-                if matches!(&(*pp).state, PipeReaderState::Done(_)) {
-                    Some(PipeReader::take_done_buffer(pp))
-                } else {
-                    None
-                }
+        if matches!(out.get(), Readable::Pipe(_)) {
+            let Readable::Pipe(pipe) = out.replace(Readable::Ignore) else {
+                unreachable!()
             };
-            if let Some(buf) = buf {
-                *out = Readable::Buffer(buf);
-            } else {
-                *out = Readable::Ignore;
+            // The only callers reach here from inside
+            // `PipeReader::on_reader_done`/`on_reader_error`, which hold
+            // their own ref on this same reader.
+            if matches!(pipe.state.get(), PipeReaderState::Done(_)) {
+                out.set(Readable::Buffer(pipe.take_done_buffer()));
             }
-            drop(pipe); // deref
         }
     }
 
-    /// Tear down a subprocess whose stdio start() failed. Marks pending pipe readers as
-    /// errored so PipeReader.deinit's done-assert passes, drops the exit handler so a
-    /// later onProcessExit doesn't touch the freed Subprocess, then deinits.
-    ///
-    /// Windows: PipeReader.deinit asserts the libuv source is closed. Whether the source
-    /// is uv-initialized depends on how far startWithCurrentPipe got, so a blind close or
-    /// destroy is unsafe. Fall back to leaking the Subprocess (pre-existing behavior)
-    /// rather than risk closing an uninitialized handle.
-    fn abort_after_failed_start(this: *mut Self) {
+    /// Tear-down prep for a subprocess whose stdio start() failed: marks
+    /// pending pipe readers as errored so `PipeReader`'s done-assert passes
+    /// and clears the exit handler so a later exit doesn't reach the `Cmd`.
+    /// Windows: `PipeReader`'s drop asserts the libuv source is closed, and
+    /// whether the source is uv-initialized depends on how far
+    /// startWithCurrentPipe got, so the caller leaks the Subprocess instead
+    /// (pre-existing behavior); only the Ctrl+C accounting is released.
+    fn abort_after_failed_start(&self) {
         #[cfg(windows)]
-        {
-            // SAFETY: `this` is the live allocation; it is deliberately leaked below,
-            // so release the Ctrl+C accounting by hand.
-            unsafe { (*this).ctrl_c_child = None };
-            return;
-        }
+        self.ctrl_c_child.set(None);
         #[cfg(not(windows))]
         {
-            // SAFETY: `this` was created via `heap::alloc` in `spawn` and is
-            // uniquely owned here; reclaim and tear down.
-            let mut subproc = unsafe { bun_core::heap::take(this) };
-            for r in [&mut subproc.stdout, &mut subproc.stderr] {
-                if let Readable::Pipe(pipe) = r {
-                    // `start()` failed before any reader callback registered,
-                    // so the `Arc` is expected to be uniquely held. Write
-                    // unconditionally rather than via
-                    // `Arc::get_mut`, which would silently skip the state
-                    // transition if a future change bumped the strong count.
-                    debug_assert_eq!(Arc::strong_count(pipe), 1);
-                    let p = arc_as_mut_ptr(pipe);
-                    // SAFETY: see `arc_as_mut_ptr` — single-threaded shell; no
-                    // other borrow live. Accesses scoped to this statement.
-                    unsafe {
-                        if matches!((*p).state, PipeReaderState::Pending) {
-                            (*p).state = PipeReaderState::Err(None);
+            for r in [&self.stdout, &self.stderr] {
+                if let Readable::Pipe(pipe) = r.get() {
+                    pipe.state.with_mut(|s| {
+                        if matches!(s, PipeReaderState::Pending) {
+                            *s = PipeReaderState::Err(None);
                         }
-                    }
+                    });
                 }
             }
-            subproc.proc().set_exit_handler_default();
-            // Dropping `subproc` runs `ShellSubprocess::drop` → `finalize_sync`.
+            self.process.detach();
         }
     }
 
     /// Stop stdio still active because the `Cmd` is deinited mid-flight (VM
     /// shutdown); a no-op after a normal close. Readers stop without firing
     /// `on_reader_done`, queued capture chunks are cancelled (the `IOWriter`
-    /// queue holds a raw pointer into the freed `PipeReader`), a pending
-    /// buffer-stdin writer is closed. POSIX-only, same tradeoff as
+    /// queue holds a pointer to the `PipeReader`), a pending buffer-stdin
+    /// writer is closed. POSIX-only, same tradeoff as
     /// [`Self::abort_after_failed_start`].
-    ///
-    /// # Safety
-    /// `this` must be the live `heap::alloc`'d subprocess with no outstanding
-    /// borrows; single-threaded shell. Raw (not `&mut self`) because the
-    /// stdin close re-enters `on_stdin_writer_close` through the writer's
-    /// process backref.
     #[cfg(not(windows))]
-    pub(crate) unsafe fn deinit_in_flight_io(this: *mut Self) {
-        // Claim `start()`'s +1, `close()` (fires `on_close` → `on_stdin_writer_close`:
+    pub(crate) fn deinit_in_flight_io(&self) {
+        // Claim `start()`'s ref, `close()` (fires `on_close` → `on_stdin_writer_close`:
         // slot → `Ignore`, `create()`'s ref released), release the claimed
         // ref — the JS `Subprocess::close_io` stdin shape.
-        // SAFETY: caller contract; the `stdin` borrow ends before `close()`.
-        let pending_start: *mut StaticPipeWriter = match unsafe { &(*this).stdin } {
-            Writable::Buffer(buffer) => {
-                // SAFETY: single-threaded; temporary `&mut` for the flag swap.
-                let writer = unsafe { buffer_mut(buffer) };
-                if core::mem::replace(&mut writer.started, false) {
-                    buffer.as_ptr()
-                } else {
-                    core::ptr::null_mut()
-                }
-            }
-            _ => core::ptr::null_mut(),
+        let pending_start = match self.stdin.get() {
+            Writable::Buffer(buffer) => StaticPipeWriter::take_start_ref(buffer.this_ptr()),
+            _ => None,
         };
-        if !pending_start.is_null() {
-            // SAFETY: live writer holding `create()`'s ref plus the claimed
-            // start ref.
-            unsafe { (*pending_start).close() };
-            // SAFETY: releases the claimed start ref; last use of the pointer.
-            unsafe { bun_ptr::RefCount::deref(pending_start) };
+        if let Some(writer) = pending_start {
+            StaticPipeWriter::close(writer.this_ptr());
         }
 
-        // SAFETY: disjoint field projections of the live subprocess.
-        let slots = unsafe { [&raw mut (*this).stdout, &raw mut (*this).stderr] };
-        for slot in slots {
-            // SAFETY: `slot` projects from `this`; borrow scoped to the match.
-            let pipe: *mut PipeReader = match unsafe { &*slot } {
-                Readable::Pipe(pipe) => arc_as_mut_ptr(pipe),
-                _ => continue,
+        for slot in [&self.stdout, &self.stderr] {
+            let Readable::Pipe(pipe) = slot.get() else {
+                continue;
             };
-            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell, no other
-            // borrow of the `PipeReader` is live; neither `reader.deinit()`
-            // nor `cancel_chunks` fires a callback.
-            unsafe {
-                if matches!((*pipe).state, PipeReaderState::Pending) {
-                    // Deregisters the poll and closes the fd without
-                    // `on_reader_done`; `Err` satisfies the drop's done-assert.
-                    (*pipe).reader.deinit();
-                    (*pipe).state = PipeReaderState::Err(None);
-                }
-                let captured: *mut CapturedWriter = &raw mut (*pipe).captured_writer;
-                if let Some(writer) = (*captured).writer.take() {
-                    writer.cancel_chunks(io_writer::ChildPtr::subproc_capture(
-                        captured.cast::<c_void>(),
-                    ));
-                    (*captured).dead = true;
-                }
+            // Neither `reader.deinit()` nor `cancel_chunks` fires a callback.
+            if matches!(pipe.state.get(), PipeReaderState::Pending) {
+                // Deregisters the poll and closes the fd without
+                // `on_reader_done`; `Err` satisfies the drop's done-assert.
+                pipe.reader.with_mut(|r| r.deinit());
+                pipe.state.set(PipeReaderState::Err(None));
+            }
+            if let Some(writer) = pipe.captured_writer.writer.replace(None) {
+                writer.cancel_chunks(PipeReader::captured_child_ptr(pipe.this_ptr()));
+                pipe.captured_writer.dead.set(true);
             }
         }
     }
@@ -503,61 +338,39 @@ impl ShellSubprocess {
     /// `Heap::lastChanceToFinalize` deletes the `JSC::ArrayBuffer` impls
     /// before the sweep that reaches us, so dropping the redirect target's
     /// [`PinnedArrayBuffer`](jsc::PinnedArrayBuffer) would write to a
-    /// freed impl; defuse it.
-    ///
-    /// # Safety
-    /// Same contract as [`Self::deinit_in_flight_io`]; VM-shutdown finalizer
-    /// only (on a live heap this would leak the pin and GC root).
+    /// freed impl; defuse it. VM-shutdown finalizer only (on a live heap this
+    /// would leak the pin and GC root).
     #[cfg(not(windows))]
-    pub(crate) unsafe fn defuse_array_buffer_unpins(this: *mut Self) {
-        // SAFETY: disjoint field projections of the live subprocess.
-        let slots = unsafe { [&raw mut (*this).stdout, &raw mut (*this).stderr] };
-        for slot in slots {
-            // SAFETY: `slot` projects from `this`; borrow scoped to the match.
-            let pipe: *mut PipeReader = match unsafe { &*slot } {
-                Readable::Pipe(pipe) => arc_as_mut_ptr(pipe),
-                _ => continue,
+    pub(crate) fn defuse_array_buffer_unpins(&self) {
+        for slot in [&self.stdout, &self.stderr] {
+            let Readable::Pipe(pipe) = slot.get() else {
+                continue;
             };
-            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell, no other
-            // borrow of the `PipeReader` is live.
-            unsafe {
-                if let BufferedOutput::ArrayBuffer { buf, .. } = &mut (*pipe).buffered_output {
+            pipe.buffered_output.with_mut(|b| {
+                if let BufferedOutput::ArrayBuffer { buf, .. } = b {
                     buf.defuse();
                 }
-            }
+            });
         }
     }
 
     // `sh::Result`'s `ShellErr` is a shared shell-wide error type defined in
     // `shell_body.rs`; boxing it here would change `pub fn` signatures across
     // every `?`-propagating shell caller.
+    //
+    /// Spawn the process and wire its stdio. The caller stores the result in
+    /// `Cmd.exec.subproc.child` and then calls [`Self::start`], whose reader
+    /// / process callbacks expect to find it there.
     #[allow(clippy::result_large_err)]
     pub(crate) fn spawn_async(
         event_loop: EventLoopHandle,
         shellio: &mut ShellIO,
         spawn_args_: SpawnArgs<'_>,
+        argv: &[&core::ffi::CStr],
         cmd_parent: CmdHandle,
-        // We have to use an out pointer because this function may invoke callbacks that expect a
-        // fully initialized parent object. Writing to this out pointer may be the last step needed
-        // to initialize the object. Raw (not `&mut`) so the caller can pass an
-        // address inside the `Cmd` arena slot without holding a `&mut` borrow
-        // across this re-entrant call.
-        out: *mut *mut Self,
-        notify_caller_process_already_exited: &mut bool,
-    ) -> sh::Result<()> {
+    ) -> sh::Result<OwnedThis<Self>> {
         let mut spawn_args = spawn_args_;
-
-        match Self::spawn_maybe_sync_impl(
-            event_loop,
-            &mut spawn_args,
-            shellio,
-            cmd_parent,
-            out,
-            notify_caller_process_already_exited,
-        ) {
-            Ok(()) => Ok(()),
-            Err(err) => Err(err),
-        }
+        Self::spawn_maybe_sync_impl(event_loop, &mut spawn_args, argv, shellio, cmd_parent)
     }
 
     // See `spawn_async`: `sh::Result`'s `ShellErr` is shared shell-wide; not
@@ -566,31 +379,24 @@ impl ShellSubprocess {
     fn spawn_maybe_sync_impl(
         event_loop: EventLoopHandle,
         spawn_args: &mut SpawnArgs<'_>,
+        argv: &[&core::ffi::CStr],
         shellio: &mut ShellIO,
         cmd_parent: CmdHandle,
-        // We have to use an out pointer because this function may invoke callbacks that expect a
-        // fully initialized parent object. Writing to this out pointer may be the last step needed
-        // to initialize the object.
-        out_subproc: *mut *mut Self,
-        notify_caller_process_already_exited: &mut bool,
-    ) -> sh::Result<()> {
-        // Owns the `K=V\0` storage when inheriting the parent env. The struct
-        // keeps the buffers alive until after `spawn_process` returns (the raw
-        // pointers pushed into `env_array` borrow `inherited_env_storage.storage`).
+    ) -> sh::Result<OwnedThis<Self>> {
+        // Owns the `K=V\0` storage when inheriting the parent env; kept alive
+        // until after `spawn_process` returns.
         let inherited_env_storage: Option<bun_dotenv::NullDelimitedEnvMap> =
             if !spawn_args.override_env && spawn_args.env_array.is_empty() {
-                let envmap = bun_core::handle_oom(event_loop.create_null_delimited_env_map());
-                // Note: `as_slice()` *includes* the trailing null; strip it —
-                // the common tail below re-appends one null terminator.
-                let entries = envmap.as_slice();
-                spawn_args
-                    .env_array
-                    .extend_from_slice(&entries[..entries.len().saturating_sub(1)]);
-                Some(envmap)
+                Some(bun_core::handle_oom(
+                    event_loop.create_null_delimited_env_map(),
+                ))
             } else {
                 None
             };
-        let _ = &inherited_env_storage;
+        let env: Vec<&core::ffi::CStr> = match &inherited_env_storage {
+            Some(envmap) => envmap.iter().collect(),
+            None => spawn_args.env_array.clone(),
+        };
 
         // Until ownership transfers into Writable/Readable, deinit any caller-provided
         // stdio resources (memfd, Blob) on early return so they aren't leaked
@@ -662,25 +468,14 @@ impl ShellSubprocess {
         // Backref so PipeReader callbacks can drive `Yield::run` from async I/O
         // completion; plumbed explicitly through `SpawnArgs`.
         let interp = spawn_args.interp;
-        // argv is built by the caller (Cmd::transition_to_exec) from
-        // `Cmd.args`, NUL-terminated and null-sentinel-terminated, so this
-        // function never needs to borrow the `Cmd` arena slot.
-        debug_assert!(matches!(spawn_args.argv.last(), Some(p) if p.is_null()));
 
-        spawn_args.env_array.push(core::ptr::null());
-
-        // SAFETY: `interp` is the live owning interpreter (see `SpawnArgs::interp`).
-        let foreground = !unsafe { &*interp }.in_background(cmd_parent.id);
+        let foreground = !cmd_parent.interp.get().in_background(cmd_parent.id);
         let ctrl_c_child = foreground.then(bun_spawn::ctrl_c::Child::enter);
-        // SAFETY: `spawn_args.argv` / `env_array` are local null-terminated
-        // C-string arrays with argv[0] non-null; valid for this call.
-        let spawn_result = match unsafe {
-            bun_process::spawn_process(
-                &spawn_options,
-                spawn_args.argv.as_ptr(),
-                spawn_args.env_array.as_ptr(),
-            )
-        } {
+        let spawn_result = match bun_process::spawn_process_cstr(
+            &spawn_options,
+            argv,
+            bun_process::SpawnEnv::Strings(&env),
+        ) {
             Err(err) => {
                 // WindowsSpawnOptions has no Drop
                 // (its Stdio::Buffer/Ipc carry FFI-owned `*mut uv::Pipe` already
@@ -727,23 +522,24 @@ impl ShellSubprocess {
         let stdio1 = core::mem::replace(&mut stdio_guard[1], Stdio::Ignore);
         let stdio2 = core::mem::replace(&mut stdio_guard[2], Stdio::Ignore);
 
-        // `to_process` consumes the result for pid/pidfd; pull the fd handles out first.
+        // `to_process_handle` consumes the result for pid/pidfd; pull the fd handles out first.
         let spawn_stdin = spawn_result.stdin.take();
         let spawn_stdout = spawn_result.stdout.take();
         let spawn_stderr = spawn_result.stderr.take();
 
-        // Two-phase init: allocate the Subprocess slot first so the stable
-        // `*mut Subprocess` is available to `Writable::init` / `Readable::init`
-        // (they store it on StaticPipeWriter / PipeReader as a backref).
-        let mut slot = Box::<Subprocess>::new_uninit();
-        let subprocess: *mut Subprocess = slot.as_mut_ptr();
-        // SAFETY: `out_subproc` points at the `SubprocExec.child` slot inside
-        // the heap-stable `Box<SubprocExec>` staged by the caller before this
-        // call; no `&` to that slot is live (the caller's `&mut Cmd` borrow
-        // ended before the call). Written *before* any callback below
-        // (`watch`/`start`/`read_all`) so re-entrant `Cmd` callbacks see a
-        // populated `exec.subproc.child`.
-        unsafe { *out_subproc = subprocess };
+        // Two-phase init: allocate the Subprocess first so its stable address
+        // is available to `Writable::init` / `Readable::init` (they store it on
+        // StaticPipeWriter / PipeReader as a backref), then fill the stdio slots.
+        let owned = OwnedThis::new(Subprocess {
+            process: spawn_result.to_process_handle(event_loop),
+            stdin: JsCell::new(Writable::Ignore),
+            stdout: JsCell::new(Readable::Ignore),
+            stderr: JsCell::new(Readable::Ignore),
+            cmd_parent,
+            closed: Cell::new(EnumSet::empty()),
+            ctrl_c_child: Cell::new(ctrl_c_child),
+        });
+        let subprocess: ThisPtr<Subprocess> = owned.this_ptr();
 
         let stdin = match Writable::init(stdio0, event_loop, subprocess, spawn_stdin) {
             Ok(w) => w,
@@ -751,7 +547,8 @@ impl ShellSubprocess {
                 panic!("unexpected error while creating stdin");
             }
         };
-        let stdout = Readable::init(
+        subprocess.stdin.set(stdin);
+        subprocess.stdout.set(Readable::init(
             OutKind::Stdout,
             stdio1,
             spawn_args.redirect_stdout.take(),
@@ -762,8 +559,8 @@ impl ShellSubprocess {
             interp,
             DEFAULT_MAX_BUFFER_SIZE,
             true,
-        );
-        let stderr = Readable::init(
+        ));
+        subprocess.stderr.set(Readable::init(
             OutKind::Stderr,
             stdio2,
             spawn_args.redirect_stderr.take(),
@@ -774,127 +571,70 @@ impl ShellSubprocess {
             interp,
             DEFAULT_MAX_BUFFER_SIZE,
             true,
-        );
+        ));
 
-        // SAFETY: `subprocess` points to uninitialised memory of the right
-        // size/align (Box::new_uninit). `ptr::write` populates it without
-        // dropping garbage.
-        unsafe {
-            subprocess.write(Subprocess {
-                process: Some(spawn_result.to_process_handle(event_loop)),
-                stdin,
-                stdout,
-                stderr,
-                cmd_parent,
-                closed: EnumSet::empty(),
-                ctrl_c_child,
-            });
-        }
-        // Ownership of the now-initialised Box is released as a raw pointer
-        // (freed via `heap::take` in `abort_after_failed_start` / Cmd
-        // teardown). `MaybeUninit<T>` and `T` share layout, so the cast is
-        // sound.
-        // SAFETY: fully initialised by the `write` above.
-        let _ = bun_core::heap::into_raw(unsafe { slot.assume_init() });
-        // SAFETY: `subprocess` is the just-allocated `ShellSubprocess`; the
-        // owning `Cmd` outlives the `Process` exit callback. All accesses
-        // below are scoped so no borrow of the Subprocess spans the
-        // re-entrant `watch`/`start`/`read_all` calls.
-        unsafe {
-            (*subprocess)
-                .proc()
-                .set_exit_handler(bun_spawn::ProcessExit::new(
-                    bun_spawn::ProcessExitKind::Shell,
-                    subprocess,
-                ));
-        }
+        // The owning `Cmd` outlives the `Process` exit callback (it drops the
+        // subprocess, which detaches the handler, before it goes away).
+        subprocess.process.set_exit_handler(subprocess);
         let _ = scopeguard::ScopeGuard::into_inner(stdio_guard);
 
-        // Wire the FileSink's close-signal back to the enclosing `Writable` so
-        // `Writable::on_close` (drops the `Arc<FileSink>`) runs when the sink
-        // finishes. `stdin` lives inside the Box-allocated `Subprocess` at a
-        // stable address, so the self-referential raw pointer is sound for the
-        // life of the subprocess. Only reachable on Windows (POSIX
-        // `Writable::init` never returns `Pipe` for shell stdio).
-        {
-            // Derive `stdin_ptr` from the raw heap pointer (`subprocess`), not
-            // the local `subproc: &mut` reborrow — the pointer is stored
-            // long-term in `FileSink::source` and dereferenced from
-            // `Writable::on_close` after this frame returns. Under Stacked
-            // Borrows a child of `subproc`'s tag would be invalidated when
-            // that borrow ends; rooting in the allocation's provenance keeps
-            // it valid for the box's lifetime.
-            // SAFETY: `subprocess` is the live, fully-initialised heap alloc.
-            let stdin_ptr: *mut Writable = unsafe { &raw mut (*subprocess).stdin };
-            // SAFETY: reborrow as a child of `stdin_ptr` so it does not
-            // invalidate the sibling we store in `source`.
-            if let Writable::Pipe(pipe) = unsafe { &mut *stdin_ptr } {
-                // SAFETY: shell is single-threaded; the FileSink allocation is
-                // disjoint from `*stdin_ptr`. `stdin_ptr` outlives the sink —
-                // the Subprocess owns both and `Writable::on_close` is the only
-                // path that drops it.
-                pipe.source
-                    .set(webcore::streams::SourceHandle::ShellWritable(
-                        // SAFETY: `stdin_ptr` is the live `&raw mut` writable (write provenance).
-                        unsafe { bun_ptr::BackRef::from_raw_mut(stdin_ptr) },
-                    ));
-            }
+        // Wire the FileSink's close-signal back to us so `Writable::on_close`
+        // (drops the sink ref) runs when the sink finishes. Only reachable on
+        // Windows (POSIX `Writable::init` never returns `Pipe` for shell stdio).
+        if let Writable::Pipe(pipe) = subprocess.stdin.get() {
+            pipe.source
+                .set(webcore::streams::SourceHandle::ShellSubprocess(
+                    BackRef::from(subprocess),
+                ));
         }
 
-        // SAFETY: scoped access; `watch` does not re-enter the subprocess.
-        match unsafe { (*subprocess).proc().watch() } {
+        Ok(owned)
+    }
+
+    /// Watch the process and start the stdio streams. Runs after the `Cmd`
+    /// has stored `this`: `watch`/`start`/`read_all` may synchronously fire the
+    /// exit handler or reader callbacks, which reach back into the `Cmd`.
+    ///
+    /// On error the pending pipe readers have been marked errored and the exit
+    /// handler cleared (see [`Self::abort_after_failed_start`]); the caller
+    /// drops `this` (POSIX) or leaks it (Windows).
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn start(
+        this: ThisPtr<Self>,
+        event_loop: EventLoopHandle,
+        lazy: &mut bool,
+        notify_caller_process_already_exited: &mut bool,
+    ) -> sh::Result<()> {
+        match this.process.watch() {
             bun_sys::Result::Ok(()) => {}
             bun_sys::Result::Err(_) => {
                 *notify_caller_process_already_exited = true;
-                spawn_args.lazy = false;
+                *lazy = false;
             }
         }
 
-        // SAFETY: borrow of the stdin slot scoped to this match; single-threaded.
-        let stdin_start_err = match unsafe { &(*subprocess).stdin } {
-            // SAFETY: single-threaded; the writer is uniquely reachable here.
-            Writable::Buffer(buffer) => unsafe { buffer_mut(buffer) }.start().err(),
+        let stdin_start_err = match this.stdin.get() {
+            Writable::Buffer(buffer) => StaticPipeWriter::start(buffer.this_ptr()).err(),
             _ => None,
         };
         if let Some(err) = stdin_start_err {
             let sys_err = err.to_shell_system_error();
-            // SAFETY: scoped `&mut` for the kill; `abort_after_failed_start`
-            // then consumes the allocation.
-            let _ = unsafe { (*subprocess).try_kill(SignalCode::SIGTERM as i32) };
-            Self::abort_after_failed_start(subprocess);
+            let _ = this.try_kill(SignalCode::SIGTERM as i32);
+            this.abort_after_failed_start();
             return Err(ShellErr::Sys(sys_err));
         }
 
-        // SAFETY: `subprocess` is live; the slot is passed raw because the
-        // reader can complete synchronously and overwrite it via `on_close_io`.
-        if let Err(err) = unsafe {
-            Readable::start_pipe_reader(
-                &raw mut (*subprocess).stdout,
-                subprocess,
-                event_loop,
-                !spawn_args.lazy,
-            )
-        } {
+        if let Err(err) = Readable::start_pipe_reader(&this.stdout, this, event_loop, !*lazy) {
             let sys_err = err.to_shell_system_error();
-            // SAFETY: scoped `&mut` for the kill; see above.
-            let _ = unsafe { (*subprocess).try_kill(SignalCode::SIGTERM as i32) };
-            Self::abort_after_failed_start(subprocess);
+            let _ = this.try_kill(SignalCode::SIGTERM as i32);
+            this.abort_after_failed_start();
             return Err(ShellErr::Sys(sys_err));
         }
 
-        // SAFETY: as for stdout above.
-        if let Err(err) = unsafe {
-            Readable::start_pipe_reader(
-                &raw mut (*subprocess).stderr,
-                subprocess,
-                event_loop,
-                !spawn_args.lazy,
-            )
-        } {
+        if let Err(err) = Readable::start_pipe_reader(&this.stderr, this, event_loop, !*lazy) {
             let sys_err = err.to_shell_system_error();
-            // SAFETY: scoped `&mut` for the kill; see above.
-            let _ = unsafe { (*subprocess).try_kill(SignalCode::SIGTERM as i32) };
-            Self::abort_after_failed_start(subprocess);
+            let _ = this.try_kill(SignalCode::SIGTERM as i32);
+            this.abort_after_failed_start();
             return Err(ShellErr::Sys(sys_err));
         }
 
@@ -903,13 +643,12 @@ impl ShellSubprocess {
         Ok(())
     }
 
-    /// # Safety
-    /// `this` must be live and unborrowed; the Yield run here may free it.
-    unsafe fn on_process_exit(this: *mut Self, status: &Status) {
-        log!("onProcessExit({:x})", this as usize);
-        // SAFETY: caller contract; the borrow ends at the `;`.
-        let interrupted = unsafe { (*this).ctrl_c_child.take() }.is_some()
-            && bun_spawn::ctrl_c::child_died_of_it(status);
+    /// `this: ThisPtr` because `Cmd::on_exit` may drive the interpreter, whose
+    /// `Cmd::deinit` frees us.
+    pub(crate) fn on_process_exit(this: ThisPtr<Self>, status: &Status) {
+        log!("onProcessExit({:x})", this.as_ptr() as usize);
+        let interrupted =
+            this.ctrl_c_child.take().is_some() && bun_spawn::ctrl_c::child_died_of_it(status);
         let exit_code: Option<u8> = 'brk: {
             if let Status::Exited(exited) = &status {
                 #[cfg(windows)]
@@ -933,15 +672,13 @@ impl ShellSubprocess {
         };
 
         let Some(code) = exit_code else { return };
-        // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
-        let handle = unsafe { (*this).cmd_parent };
-        // SAFETY: the owning Cmd outlives its subprocess; the `&mut Cmd` ends
-        // before the Yield runs.
-        let cmd = unsafe { handle.cmd_mut() };
+        let handle = this.cmd_parent;
+        // No borrow of `this` is live past this point; the `&mut Cmd` ends
+        // before the Yield runs, which may free `this`.
+        let cmd = handle.cmd_mut();
         cmd.base.interrupted |= interrupted;
         let y = cmd.on_exit(code.into());
-        // May free `*this`.
-        y.run(&handle.interp);
+        y.run(handle.interp.get());
     }
 }
 
@@ -964,17 +701,12 @@ pub enum Writable {
     Ignore,
 }
 
-impl Writable {
+impl ShellSubprocess {
     // When the stream has closed we need to be notified to prevent a use-after-free
     // We can test for this use-after-free by enabling hot module reloading on a file and then saving it twice
-    pub fn on_close(&mut self, _: Option<bun_sys::Error>) {
-        match self {
-            Writable::Buffer(_) | Writable::Pipe(_) => {
-                // Dropping the Arc on reassignment below derefs.
-            }
-            _ => {}
-        }
-        *self = Writable::Ignore;
+    pub fn on_stdin_close(&self, _: Option<bun_sys::Error>) {
+        // Dropping the payload releases the Pipe/Buffer ref.
+        drop(self.stdin.replace(Writable::Ignore));
     }
 }
 
@@ -982,14 +714,14 @@ impl Writable {
     pub(crate) fn init(
         stdio: Stdio,
         event_loop: EventLoopHandle,
-        subprocess: *mut Subprocess,
+        subprocess: ThisPtr<Subprocess>,
         result: StdioResult,
     ) -> Result<Writable, WritableInitError> {
         assert_stdio_result!(result);
 
         // Note: `Stdio` impls Drop, so we cannot partially move out via
-        // match (E0509). Dispatch on `&mut` and `mem::take` / ManuallyDrop the
-        // non-Copy payloads.
+        // match (E0509). Dispatch on `&mut` and `mem::take` the non-Copy
+        // payloads.
         let mut stdio = stdio;
         #[cfg(windows)]
         {
@@ -998,8 +730,7 @@ impl Writable {
                     if let StdioResult::Buffer(buf) = result {
                         // Ownership of the `Box<uv::Pipe>` transfers into the
                         // FileSink's writer.
-                        let uv_pipe: *mut _ = bun_core::heap::into_raw(buf);
-                        let pipe = FileSink::create_with_pipe(event_loop, uv_pipe);
+                        let pipe = FileSink::create_with_pipe(event_loop, buf);
                         if let bun_sys::Result::Err(_err) =
                             pipe.writer.with_mut(|w| w.start_with_current_pipe())
                         {
@@ -1015,24 +746,12 @@ impl Writable {
                     return Ok(Writable::Inherit);
                 }
 
-                Stdio::Blob(_) => {
-                    // E0509: `Stdio` impls `Drop`, so the payload cannot be
-                    // destructure-moved out. Take ownership via ManuallyDrop +
-                    // ptr::read; the wrapper suppresses the Stdio destructor so
-                    // the blob is moved exactly once.
-                    let old =
-                        core::mem::ManuallyDrop::new(core::mem::replace(&mut stdio, Stdio::Ignore));
-                    // SAFETY: `old` is Blob (matched above) and ManuallyDrop
-                    // prevents its Drop from running, so this is the sole move.
-                    let blob = match &*old {
-                        Stdio::Blob(b) => unsafe { core::ptr::read(b) },
-                        _ => unreachable!(),
-                    };
+                Stdio::Blob(blob) => {
                     return Ok(Writable::Buffer(StaticPipeWriter::create(
                         event_loop,
                         subprocess,
                         result,
-                        JscSubprocess::source_from_blob(blob),
+                        JscSubprocess::source_from_blob(core::mem::take(blob)),
                     )));
                 }
                 Stdio::Fd(fd) => {
@@ -1068,26 +787,12 @@ impl Writable {
                     panic!("Unimplemented stdin pipe");
                 }
 
-                Stdio::Blob(_) => {
-                    // E0509: `Stdio` impls `Drop`, so the payload cannot be
-                    // destructure-moved out. Take ownership via ManuallyDrop +
-                    // ptr::read; the wrapper suppresses the Stdio destructor so
-                    // the blob is moved exactly once.
-                    let old =
-                        core::mem::ManuallyDrop::new(core::mem::replace(&mut stdio, Stdio::Ignore));
-                    let blob = match &*old {
-                        // SAFETY: `old` is Blob (matched above) and ManuallyDrop
-                        // prevents its Drop from running, so this is the sole move.
-                        Stdio::Blob(b) => unsafe { core::ptr::read(b) },
-                        _ => unreachable!(),
-                    };
-                    Ok(Writable::Buffer(StaticPipeWriter::create(
-                        event_loop,
-                        subprocess,
-                        result,
-                        JscSubprocess::source_from_blob(blob),
-                    )))
-                }
+                Stdio::Blob(blob) => Ok(Writable::Buffer(StaticPipeWriter::create(
+                    event_loop,
+                    subprocess,
+                    result,
+                    JscSubprocess::source_from_blob(core::mem::take(blob)),
+                ))),
                 Stdio::Memfd(memfd) => {
                     debug_assert!(memfd.is_valid());
                     let fd = *memfd;
@@ -1120,26 +825,14 @@ impl Writable {
     // exposes its stdin Writable to JS.
 
     pub fn finalize(&mut self) {
-        match self {
-            Writable::Pipe(_) => {
-                // deref via drop-on-reassign
-                *self = Writable::Ignore;
+        match core::mem::replace(self, Writable::Ignore) {
+            Writable::Pipe(pipe) => drop(pipe),
+            Writable::Buffer(buffer) => {
+                StaticPipeWriter::update_ref(buffer.this_ptr(), false);
+                drop(buffer);
             }
-            Writable::Buffer(_) => {
-                let Writable::Buffer(buffer) = core::mem::replace(self, Writable::Ignore) else {
-                    unreachable!()
-                };
-                // SAFETY: single-threaded; temporary `&mut` for the call only.
-                unsafe { buffer_mut(&buffer) }.update_ref(false);
-                // `buffer` drops here with the variant already `Ignore`, so a
-                // re-entrant `on_stdin_writer_close` from the writer's drop is a no-op.
-            }
-            Writable::Memfd(fd) => {
-                fd.close();
-                *self = Writable::Ignore;
-            }
-            Writable::Ignore => {}
-            Writable::Fd(_) | Writable::Inherit => {}
+            Writable::Memfd(fd) => fd.close(),
+            other @ (Writable::Ignore | Writable::Fd(_) | Writable::Inherit) => *self = other,
         }
     }
 }
@@ -1151,7 +844,8 @@ impl Writable {
 pub enum Readable {
     Fd(Fd),
     Memfd(Fd),
-    Pipe(Arc<PipeReader>),
+    /// One ref; released by `finalize` (`detach`) or `on_close_io`.
+    Pipe(RefPtr<PipeReader>),
     Inherit,
     Ignore,
     Closed,
@@ -1160,54 +854,36 @@ pub enum Readable {
 
 impl Readable {
     /// If the slot is a `Pipe`, start its `BufferedReader` against `process`
-    /// and (when `eager`) immediately drain it. Factors out the per-stream
-    /// stdout/stderr start blocks in `spawn_maybe_sync_impl` so the
-    /// `arc_as_mut_ptr` invariant is localised once.
-    ///
-    /// # Safety
-    /// `slot` must point to a live `Readable`. Raw because `start`/`read_all`
-    /// can complete the reader synchronously, which runs `close_io` →
-    /// `Readable::finalize` and overwrites the slot — no reference to it may
-    /// span those calls.
-    unsafe fn start_pipe_reader(
-        slot: *mut Readable,
-        process: *mut ShellSubprocess,
+    /// and (when `eager`) immediately drain it. `start`/`read_all` can
+    /// complete the reader synchronously, which runs `close_io` →
+    /// `Readable::finalize` and overwrites the slot, so no borrow of it is held
+    /// across those calls; a local ref keeps the reader alive meanwhile.
+    fn start_pipe_reader(
+        slot: &JsCell<Readable>,
+        process: ThisPtr<ShellSubprocess>,
         event_loop: EventLoopHandle,
         eager: bool,
     ) -> bun_sys::Result<()> {
-        // The reader must outlive the re-entrant calls below even if they
-        // drop this slot's `Arc`; clone it as a keepalive.
-        // SAFETY: caller contract; borrow scoped to the clone.
-        let keepalive = match unsafe { &*slot } {
-            Readable::Pipe(pipe) => Arc::clone(pipe),
+        let keepalive = match slot.get() {
+            Readable::Pipe(pipe) => pipe.clone(),
             _ => return Ok(()),
         };
-        let p = arc_as_mut_ptr(&keepalive);
-        // SAFETY: see `arc_as_mut_ptr` — single-threaded shell; the
-        // re-entrant reader callbacks only hold raw `*mut PipeReader`, and
-        // each `&mut` below is scoped to its own call.
-        unsafe { (*p).start(process, event_loop) }?;
-        if eager {
-            // SAFETY: as above.
-            unsafe { (*p).read_all() };
+        let result = keepalive.start(process, event_loop);
+        if result.is_ok() && eager {
+            PipeReader::read_all(keepalive.this_ptr());
         }
-        Ok(())
+        result
     }
 
-    pub(crate) fn r#ref(&mut self) {
+    pub(crate) fn r#ref(&self) {
         if let Readable::Pipe(pipe) = self {
-            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell; Windows
-            // `BufferedReader::update_ref` needs `&mut` to touch the libuv
-            // `Source` ref/unref. `update_ref` does not re-enter shell code.
-            unsafe { &mut *arc_as_mut_ptr(pipe) }.update_ref(true);
+            pipe.update_ref(true);
         }
     }
 
-    pub(crate) fn unref(&mut self) {
+    pub(crate) fn unref(&self) {
         if let Readable::Pipe(pipe) = self {
-            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell;
-            // `update_ref` does not re-enter shell code.
-            unsafe { &mut *arc_as_mut_ptr(pipe) }.update_ref(false);
+            pipe.update_ref(false);
         }
     }
 
@@ -1221,9 +897,9 @@ impl Readable {
         redirect_buf: Option<jsc::PinnedArrayBuffer>,
         shellio: Option<Arc<IOWriter>>,
         event_loop: EventLoopHandle,
-        process: *mut ShellSubprocess,
+        process: ThisPtr<ShellSubprocess>,
         result: StdioResult,
-        interp: *mut crate::shell::interpreter::Interpreter,
+        interp: Option<ParentRef<Interpreter>>,
         _max_size: u32,
         _is_sync: bool,
     ) -> Readable {
@@ -1328,7 +1004,7 @@ impl Readable {
             }
             Readable::Pipe(pipe) => {
                 *self = Readable::Closed;
-                pipe.detach();
+                PipeReader::detach(pipe);
             }
             other => {
                 *self = other;
@@ -1344,21 +1020,15 @@ impl Readable {
 pub struct SpawnArgs<'a> {
     /// Shared borrow: arena alloc methods take `&self`, and a `&'a Arena`
     /// (being `Copy`) lets `fill_env` hand back `&'a [u8]` slices without
-    /// the unsafe pointer round-trip the `&'a mut Arena` reborrow forced.
+    /// the raw-pointer round-trip the `&'a mut Arena` reborrow forced.
     pub(crate) arena: &'a Arena,
-    /// `[*:null]?[*:0]const u8` argv view for `spawn_process`. Built by the
-    /// caller from `Cmd.args` (each `Vec<u8>` NUL-terminated) so this struct
-    /// never needs to borrow the `Cmd` arena slot — passing the whole `Cmd`
-    /// would alias the `out_subproc` write into `cmd.exec.subproc.child`.
-    /// Must include the trailing null sentinel.
-    pub(crate) argv: Vec<*const c_char>,
     /// Backref so [`PipeReader`] async-I/O callbacks can drive
     /// [`Yield::run`]. The spawning `Cmd` passes it explicitly here and it is
     /// plumbed through `Readable::init` → `PipeReader::create`.
-    pub(crate) interp: *mut crate::shell::interpreter::Interpreter,
+    pub(crate) interp: Option<ParentRef<Interpreter>>,
 
     pub(crate) override_env: bool,
-    pub(crate) env_array: Vec<*const c_char>,
+    pub(crate) env_array: Vec<&'a core::ffi::CStr>,
     pub(crate) cwd: &'a [u8],
     pub(crate) stdio: [Stdio; 3],
     /// `> ${arraybuffer}` redirect targets; the matching `stdio` slot is `Pipe`.
@@ -1373,13 +1043,12 @@ pub struct SpawnArgs<'a> {
 impl<'a> SpawnArgs<'a> {
     pub(crate) fn default<const IS_SYNC: bool>(
         arena: &'a Arena,
-        interp: *mut crate::shell::interpreter::Interpreter,
+        interp: &Interpreter,
         event_loop: EventLoopHandle,
     ) -> SpawnArgs<'a> {
         let mut out = SpawnArgs {
             arena,
-            interp,
-            argv: Vec::new(),
+            interp: Some(ParentRef::new(interp)),
 
             override_env: false,
             env_array: Vec::new(),
@@ -1392,18 +1061,10 @@ impl<'a> SpawnArgs<'a> {
             // has no PATH). PATH="" (explicit empty) is preserved — that's a
             // deliberate "search nothing" and substituting a default would
             // change argv[0] resolution on existing platforms.
-            // SAFETY: `event_loop.env()` returns the long-lived `*mut Loader`
-            // owned by the VM (valid for the lifetime of the spawn args), and
-            // `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string constant.
-            path: unsafe {
-                if let Some(p) = (*event_loop.env()).get(b"PATH") {
-                    p
-                } else if cfg!(unix) {
-                    core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN).to_bytes()
-                } else {
-                    b""
-                }
-            },
+            path: event_loop.with_env_var(b"PATH", |p| match p {
+                Some(p) => &*arena.alloc_slice_copy(p),
+                None => bun_spawn::default_search_path(),
+            }),
             // .ipc_mode = IPCMode.none,
             // .ipc_callback = .zero,
         };
@@ -1454,7 +1115,8 @@ impl<'a> SpawnArgs<'a> {
                 self.path = &line[b"PATH=".len()..len];
             }
 
-            self.env_array.push(line.as_ptr().cast::<c_char>());
+            self.env_array
+                .push(core::ffi::CStr::from_bytes_until_nul(line).expect("NUL-terminated above"));
         }
     }
 }
@@ -1471,22 +1133,29 @@ pub enum PipeReaderState {
     Err(Option<Box<SystemError>>),
 }
 
+/// Intrusively ref-counted: `Readable::Pipe` holds the create ref;
+/// `start_pipe_reader` and the terminal reader callbacks hold short-lived
+/// keepalives. Every field is interior-mutable so the reader callbacks, the
+/// `IOWriter` chunk callback and the owning `Cmd` (via `Readable::Pipe`) can
+/// all reach the same reader through `&PipeReader`.
+#[derive(bun_ptr::RefCounted)]
 pub struct PipeReader {
-    pub(crate) reader: IOReader,
-    pub(crate) process: Option<*mut ShellSubprocess>,
-    pub(crate) event_loop: EventLoopHandle,
-    pub(crate) state: PipeReaderState,
+    ref_count: RefCount<PipeReader>,
+    pub(crate) reader: JsCell<IOReader>,
+    /// Cleared by `detach` (from the subprocess's own teardown) before the
+    /// subprocess is freed.
+    pub(crate) process: Cell<Option<BackRef<ShellSubprocess, bun_ptr::Root>>>,
+    pub(crate) event_loop: Cell<EventLoopHandle>,
+    pub(crate) state: JsCell<PipeReaderState>,
     #[cfg_attr(windows, allow(dead_code))]
-    pub(crate) stdio_result: StdioResult,
+    stdio_result: Cell<StdioResult>,
     pub(crate) out_type: OutKind,
     pub(crate) captured_writer: CapturedWriter,
-    pub(crate) buffered_output: BufferedOutput,
+    pub(crate) buffered_output: JsCell<BufferedOutput>,
     /// Backref so async read/write callbacks can drive `Yield::run`. See
     /// `IOWriter::interp` / `IOReader::interp` for the same pattern. Wired
     /// from `Cmd::interp` at `PipeReader::create` time.
-    pub(crate) interp: *mut crate::shell::interpreter::Interpreter,
-    // ref_count: handled by Arc<PipeReader>; mutation through shared handles
-    // goes via the `arc_as_mut_ptr` interior-mutability helper below.
+    interp: Option<ParentRef<Interpreter>>,
 }
 
 pub enum BufferedOutput {
@@ -1537,127 +1206,124 @@ impl BufferedOutput {
 }
 
 pub struct CapturedWriter {
-    pub(crate) dead: bool,
+    pub(crate) dead: Cell<bool>,
     /// `None` iff `dead == true`.
-    pub(crate) writer: Option<Arc<IOWriter>>,
-    pub(crate) written: usize,
-    pub(crate) err: Option<SystemError>,
+    pub(crate) writer: JsCell<Option<Arc<IOWriter>>>,
+    pub(crate) written: Cell<usize>,
+    pub(crate) err: JsCell<Option<SystemError>>,
 }
 
 impl Default for CapturedWriter {
     fn default() -> Self {
         CapturedWriter {
-            dead: true,
-            writer: None,
-            written: 0,
-            err: None,
+            dead: Cell::new(true),
+            writer: JsCell::new(None),
+            written: Cell::new(0),
+            err: JsCell::new(None),
         }
     }
 }
 
-bun_core::impl_field_parent! { CapturedWriter => PipeReader.captured_writer; fn parent; fn mut parent_mut; }
+impl PipeReader {
+    /// The `IOWriter` child handle for this reader's captured-output tee.
+    #[inline]
+    pub(crate) fn captured_child_ptr(this: ThisPtr<Self>) -> io_writer::ChildPtr {
+        io_writer::ChildPtr::subproc_capture(this.as_ptr().cast())
+    }
 
-impl CapturedWriter {
-    pub(crate) fn do_write(&mut self, chunk: &[u8]) {
-        if self.dead || self.err.is_some() {
+    fn captured_do_write(this: ThisPtr<Self>, chunk: &[u8]) {
+        let cw = &this.captured_writer;
+        if cw.dead.get() || cw.err.get().is_some() {
             return;
         }
 
-        let addr = std::ptr::from_mut(self) as usize;
-        let parent = self.parent();
         log!(
             "CapturedWriter(0x{:x}, {}) doWrite len={} parent_amount={}",
-            addr,
-            out_kind_str(parent.out_type),
+            std::ptr::from_ref(cw) as usize,
+            out_kind_str(this.out_type),
             chunk.len(),
-            parent.buffered_output.len()
+            this.buffered_output.get().len()
         );
         // `dead == false` ⇒ writer.is_some() (set in PipeReader::create).
-        let writer = self
+        let writer = cw
             .writer
+            .get()
             .clone()
             .expect("CapturedWriter live without writer");
-        // The CapturedWriter lives outside the NodeId arena (embedded in a
-        // heap-allocated PipeReader), so dispatch is by raw pointer — see
-        // `io_writer::ChildPtr::subproc_capture` / `WriterTag::Subproc`.
-        let child = io_writer::ChildPtr::subproc_capture(std::ptr::from_mut(self).cast::<c_void>());
-        let y = writer.enqueue(child, None, chunk);
-        self.parent().run_yield(y);
+        let y = writer.enqueue(Self::captured_child_ptr(this), None, chunk);
+        Self::run_yield_with(this.interp, y);
     }
 
-    pub(crate) fn on_iowriter_chunk(&mut self, amount: usize, err: Option<SystemError>) -> Yield {
-        let addr = std::ptr::from_mut(self) as usize;
-        let written = self.written + amount;
-        let parent = self.parent();
+    /// `IOWriter` chunk callback for the captured-output tee (dispatched via
+    /// `WriterTag::Subproc`).
+    pub(crate) fn on_captured_iowriter_chunk(
+        this: ThisPtr<Self>,
+        amount: usize,
+        err: Option<SystemError>,
+    ) -> Yield {
+        let cw = &this.captured_writer;
+        let written = cw.written.get() + amount;
         log!(
             "CapturedWriter({:x}, {}) onWrite({}, has_err={}) total_written={} total_to_write={}",
-            addr,
-            out_kind_str(parent.out_type),
+            std::ptr::from_ref(cw) as usize,
+            out_kind_str(this.out_type),
             amount,
             err.is_some(),
             written,
-            parent.buffered_output.len()
+            this.buffered_output.get().len()
         );
-        let all_written = written >= parent.buffered_output.len()
-            && !matches!(parent.state, PipeReaderState::Pending);
-        self.written = written;
+        let all_written = written >= this.buffered_output.get().len()
+            && !matches!(this.state.get(), PipeReaderState::Pending);
+        cw.written.set(written);
         if let Some(e) = err {
             log!(
                 "CapturedWriter(0x{:x}, {}) onWrite errno={} errmsg={} errfd={:?} syscall={}",
-                addr,
-                out_kind_str(self.parent().out_type),
+                std::ptr::from_ref(cw) as usize,
+                out_kind_str(this.out_type),
                 e.errno,
                 e.message,
                 e.fd,
                 e.syscall
             );
-            self.err = Some(e);
+            cw.err.set(Some(e));
         } else if !all_written {
             return Yield::Suspended;
         }
-        // SAFETY: `parent_mut` recovers the embedding `PipeReader`; raw-ptr
-        // form per `try_signal_done_to_cmd` contract (no `&mut PipeReader`
-        // held across the Cmd re-entry).
-        unsafe { PipeReader::try_signal_done_to_cmd(self.parent_mut()) }
+        Self::try_signal_done_to_cmd(this)
     }
-}
 
-impl PipeReader {
     fn captured_writer_done(&self, just_written: usize) -> bool {
         let cw = &self.captured_writer;
         log!(
             "CapturedWriter(0x{:x}, {}) isDone(has_err={}, parent_state={}, written={}, parent_amount={})",
             std::ptr::from_ref(cw) as usize,
             out_kind_str(self.out_type),
-            cw.err.is_some(),
-            <&'static str>::from(&self.state),
-            cw.written,
-            self.buffered_output.len()
+            cw.err.get().is_some(),
+            <&'static str>::from(self.state.get()),
+            cw.written.get(),
+            self.buffered_output.get().len()
         );
-        if cw.dead || cw.err.is_some() {
+        if cw.dead.get() || cw.err.get().is_some() {
             return true;
         }
-        if matches!(self.state, PipeReaderState::Pending) {
+        if matches!(self.state.get(), PipeReaderState::Pending) {
             return false;
         }
-        cw.written + just_written >= self.buffered_output.len()
+        cw.written.get() + just_written >= self.buffered_output.get().len()
     }
 }
 
 impl PipeReader {
-    pub(crate) fn detach(self: Arc<Self>) {
+    /// Clear the backref so any late `on_reader_done`/`on_reader_error`
+    /// after the Subprocess is freed can't follow it, and release the ref.
+    #[allow(clippy::needless_pass_by_value)] // consumes the ref
+    pub(crate) fn detach(this: RefPtr<Self>) {
         log!(
             "PipeReader(0x{:x}, {}) detach()",
-            Arc::as_ptr(&self) as usize,
-            out_kind_str(self.out_type)
+            this.as_ptr() as usize,
+            out_kind_str(this.out_type)
         );
-        // Clear the backref so any
-        // late `on_reader_done`/`on_reader_error` after the Subprocess is freed
-        // can't follow it. Arc only yields `&Self`; write through the
-        // allocation pointer (single-threaded shell, no live `&`/`&mut` here).
-        // SAFETY: see `arc_as_mut_ptr` rationale; field is a plain `Option<*mut _>`.
-        unsafe { (*arc_as_mut_ptr(&self)).process = None };
-        // Dropping `self` releases the strong ref.
+        this.process.set(None);
     }
 
     pub(crate) fn is_done(&self) -> bool {
@@ -1665,10 +1331,10 @@ impl PipeReader {
             "PipeReader(0x{:x}, {}) isDone() state={} captured_writer_done={}",
             std::ptr::from_ref(self) as usize,
             out_kind_str(self.out_type),
-            <&'static str>::from(&self.state),
+            <&'static str>::from(self.state.get()),
             self.captured_writer_done(0)
         );
-        if matches!(self.state, PipeReaderState::Pending) {
+        if matches!(self.state.get(), PipeReaderState::Pending) {
             return false;
         }
         self.captured_writer_done(0)
@@ -1676,41 +1342,37 @@ impl PipeReader {
 
     /// Drive a `Yield` from inside an async I/O callback. Mirrors
     /// `IOWriter::run_yield` / `IOReader::run_yield`. `interp` is wired at
-    /// `create` time from the spawning `Cmd`; the null guard is a defensive
-    /// debug-assert for tests that construct a PipeReader without a Cmd.
-    fn run_yield(&self, y: Yield) {
-        Self::run_yield_with(self.interp, y);
-    }
-
-    /// Free-function form of [`run_yield`] for callers that must not hold any
-    /// `&PipeReader` borrow across the interpreter trampoline (which can
-    /// re-derive `&PipeReader` via the `Readable::Pipe` `Arc`).
-    fn run_yield_with(interp: *mut crate::shell::interpreter::Interpreter, y: Yield) {
-        if interp.is_null() {
+    /// `create` time from the spawning `Cmd`; the `None` guard is a defensive
+    /// debug-assert for tests that construct a PipeReader without a Cmd. A
+    /// free function so no `&PipeReader` borrow is held across the
+    /// interpreter trampoline (which can reach this reader via
+    /// `Readable::Pipe`).
+    fn run_yield_with(interp: Option<ParentRef<Interpreter>>, y: Yield) {
+        let Some(interp) = interp else {
             debug_assert!(
                 matches!(y, Yield::Done | Yield::Suspended | Yield::Failed),
                 "PipeReader async callback fired without interp backref"
             );
             return;
-        }
-        // SAFETY: interp outlives every PipeReader (it owns the Cmd that
-        // spawned the subprocess holding this reader). Single-threaded.
-        y.run(unsafe { &*interp });
+        };
+        // interp outlives every PipeReader (it owns the Cmd that spawned the
+        // subprocess holding this reader). Single-threaded.
+        y.run(interp.get());
     }
 
     pub(crate) fn create(
         event_loop: EventLoopHandle,
-        process: *mut ShellSubprocess,
+        process: ThisPtr<ShellSubprocess>,
         result: StdioResult,
         capture: Option<Arc<IOWriter>>,
         buffered_output: BufferedOutput,
         out_type: OutKind,
-        interp: *mut crate::shell::interpreter::Interpreter,
-    ) -> Arc<PipeReader> {
-        let mut captured_writer = CapturedWriter::default();
+        interp: Option<ParentRef<Interpreter>>,
+    ) -> RefPtr<PipeReader> {
+        let captured_writer = CapturedWriter::default();
         if let Some(cap) = capture {
-            captured_writer.writer = Some(cap); // dupeRef → Arc clone already happened on pass-in
-            captured_writer.dead = false;
+            captured_writer.writer.set(Some(cap)); // dupeRef → Arc clone already happened on pass-in
+            captured_writer.dead.set(false);
         }
 
         #[allow(unused_mut)]
@@ -1733,235 +1395,172 @@ impl PipeReader {
             StdioResult::UnownedFd(_) | StdioResult::Unavailable => panic!("Shouldn't happen."),
         };
 
-        // Allocate directly into the Arc so the address is stable BEFORE we
-        // hand it to `reader.set_parent` / `container_of` consumers.
-        // `Arc::from(Box<T>)` would reallocate into a new ArcInner and leave
-        // every BufferedReader callback with a dangling parent pointer.
-        //
-        // `PipeReader` is deliberately `!Send + !Sync` (raw `*mut Interpreter`
-        // / `*mut ShellSubprocess` fields); thread confinement is enforced at
-        // compile time by `__pipe_reader_thread_confined`, so the `Arc` is a
-        // refcount, not a cross-thread handle. `Rc` would
-        // change the `pub fn create -> Arc<PipeReader>` ABI.
-        #[allow(clippy::arc_with_non_send_sync)]
-        let arc = Arc::new(PipeReader {
-            process: Some(process),
-            reader,
-            event_loop,
-            stdio_result,
+        // Allocate before handing the address to `reader.set_parent`.
+        let this = RefPtr::new(PipeReader {
+            ref_count: RefCount::init(),
+            process: Cell::new(Some(BackRef::from(process))),
+            reader: JsCell::new(reader),
+            event_loop: Cell::new(event_loop),
+            stdio_result: Cell::new(stdio_result),
             out_type,
-            state: PipeReaderState::Pending,
+            state: JsCell::new(PipeReaderState::Pending),
             captured_writer,
-            buffered_output,
+            buffered_output: JsCell::new(buffered_output),
             interp,
         });
-        let this_ptr: *mut PipeReader = Arc::as_ptr(&arc).cast_mut();
         log!(
             "PipeReader(0x{:x}, {}) create()",
-            this_ptr as usize,
+            this.as_ptr() as usize,
             out_kind_str(out_type)
         );
-        // SAFETY: `arc` is uniquely held; `&mut` scoped to registering the
-        // parent backref. Single-threaded shell.
-        unsafe { (*this_ptr).reader.set_parent(this_ptr.cast::<c_void>()) };
+        let root = this.as_ptr();
+        this.reader.with_mut(|r| r.set_parent(root.cast()));
 
-        arc
+        this
     }
 
-    pub(crate) fn read_all(&mut self) {
-        if matches!(self.state, PipeReaderState::Pending) {
-            // SAFETY: `self.reader` is live; `read` is the raw
-            // re-entrancy-safe entry (its dispatch runs user JS).
-            unsafe { IOReader::read(&raw mut self.reader) };
+    pub(crate) fn read_all(this: ThisPtr<Self>) {
+        if matches!(this.state.get(), PipeReaderState::Pending) {
+            // `read`'s dispatch re-enters `on_read_chunk` / the terminal
+            // callbacks, hence the root-pointer entry.
+            IOReader::read_from(this);
         }
     }
 
     pub(crate) fn start(
-        &mut self,
-        process: *mut ShellSubprocess,
+        &self,
+        process: ThisPtr<ShellSubprocess>,
         event_loop: EventLoopHandle,
     ) -> bun_sys::Result<()> {
         // self.ref();
-        self.process = Some(process);
-        self.event_loop = event_loop;
+        self.process.set(Some(BackRef::from(process)));
+        self.event_loop.set(event_loop);
         #[cfg(windows)]
         {
-            return self.reader.start_with_current_pipe();
+            return self.reader.with_mut(|r| r.start_with_current_pipe());
         }
 
         // `reader` owns the fd from here; `Drop` closes an un-started one.
         #[cfg(not(windows))]
-        match self.reader.start(self.stdio_result.take().unwrap(), true) {
+        match self
+            .reader
+            .with_mut(|r| r.start(self.stdio_result.take().unwrap(), true))
+        {
             bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             bun_sys::Result::Ok(()) => {
                 // `reader.start` reports a poll-registration failure through
                 // `on_reader_error` (not its return value), so the reader may
                 // already be errored/torn down here; same guard as
                 // `SubprocessPipeReader::start`.
-                if matches!(self.state, PipeReaderState::Err(_)) {
+                if matches!(self.state.get(), PipeReaderState::Err(_)) {
                     return Ok(());
                 }
                 #[cfg(unix)]
-                {
+                self.reader.with_mut(|r| {
                     // TODO: are these flags correct
-                    if let Some(poll) = self.reader.handle.get_poll() {
+                    if let Some(poll) = r.handle.get_poll() {
                         poll.set_flag(bun_io::FilePollFlag::Socket);
                     }
-                    self.reader
-                        .flags
-                        .insert(bun_io::pipe_reader::PosixFlags::SOCKET);
-                }
+                    r.flags.insert(bun_io::pipe_reader::PosixFlags::SOCKET);
+                });
 
                 Ok(())
             }
         }
     }
 
-    /// `BufferedReaderParent::on_read_chunk` adapter — invoked with the
-    /// `PipeReader` registered via `reader.set_parent(self)`.
-    pub(crate) fn on_read_chunk(&mut self, chunk: &[u8], has_more: ReadState) -> bool {
-        self.buffered_output.append(chunk);
+    /// `BufferedReaderParent::on_read_chunk` — invoked with the `PipeReader`
+    /// registered via `reader.set_parent`.
+    pub(crate) fn on_read_chunk(this: ThisPtr<Self>, chunk: &[u8], has_more: ReadState) -> bool {
+        this.buffered_output.with_mut(|b| b.append(chunk));
         log!(
             "PipeReader(0x{:x}, {}) onReadChunk(chunk_len={}, has_more={})",
-            std::ptr::from_mut(self) as usize,
-            out_kind_str(self.out_type),
+            this.as_ptr() as usize,
+            out_kind_str(this.out_type),
             chunk.len(),
             read_state_str(has_more)
         );
 
-        self.captured_writer.do_write(chunk);
+        Self::captured_do_write(this, chunk);
 
         // No explicit re-arm here (`register_poll()` on POSIX /
         // `start_with_current_pipe()` on Windows). This callback runs from
-        // inside the bun_io read loop, which still holds `&mut self.reader`
-        // on its stack and re-registers the poll itself based on the bool we
-        // return (`IOReader::on_read_chunk_cb` and
-        // `WindowsBufferedReader::on_read` document the same contract).
+        // inside the bun_io read loop, which is still working on `reader` and
+        // re-registers the poll itself based on the bool we return
+        // (`IOReader::on_read_chunk_cb` and `WindowsBufferedReader::on_read`
+        // document the same contract).
         //
         // Re-arming from here also violates `BufferedReaderParent`'s
         // requirement that `on_read_chunk` never frees the reader:
         // `register_poll()`'s failure path dispatches `on_reader_error`,
-        // which drops the last `Arc<PipeReader>` and frees the
-        // `PosixBufferedReader` the loop is still reading through.
+        // which drops the last ref and frees the `PosixBufferedReader` the
+        // loop is still reading through.
         has_more != ReadState::Eof
-    }
-
-    /// Reconstruct an owning `Arc<Self>` from the raw parent pointer the
-    /// `BufferedReader` stored at `set_parent` time. Keepalive for
-    /// `on_reader_done` / `on_reader_error`:
-    /// the returned guard keeps the allocation alive across
-    /// `run_yield` (which may free the owning `Cmd`) and `on_close_io` (which
-    /// drops the `Readable::Pipe` strong ref). Dropping the guard is the
-    /// matching deref and may free `self`.
-    ///
-    /// # Safety
-    /// `this` must point into a live `Arc<PipeReader>` allocation.
-    #[inline]
-    unsafe fn guard_from_raw(this: *mut Self) -> Arc<Self> {
-        // SAFETY: caller contract.
-        unsafe {
-            Arc::increment_strong_count(this.cast_const());
-            Arc::from_raw(this.cast_const())
-        }
     }
 
     /// Tail shared by [`on_reader_done`] / [`on_reader_error`]: signal the
     /// owning `Cmd`, drive its `Yield`, then notify the `ShellSubprocess` to
-    /// drop its `Readable::Pipe` handle. `guard` keeps `self` alive across
-    /// the latter. No `&`/`&mut PipeReader` is held across the re-entrant
-    /// `try_signal_done_to_cmd` / `run_yield_with` calls — both reach back
-    /// into this same allocation via the `Readable::Pipe` `Arc` clone.
-    /// Callers gate on `is_done()` first so the captured-writer tee has
-    /// drained before `on_close_io` drops the `Readable::Pipe` Arc.
-    fn finish_after_state_set(guard: &Arc<Self>) {
-        let me = arc_as_mut_ptr(guard);
+    /// drop its `Readable::Pipe` handle. The caller's keepalive ref keeps
+    /// `this` alive across the latter. No `&PipeReader` is held across the
+    /// re-entrant `try_signal_done_to_cmd` / `run_yield_with` calls — both
+    /// reach back into this same allocation via `Readable::Pipe`. Callers
+    /// gate on `is_done()` first so the captured-writer tee has drained before
+    /// `on_close_io` drops the `Readable::Pipe` ref.
+    fn finish_after_state_set(this: ThisPtr<Self>) {
         // Snapshot `interp` *before* the Cmd call: `try_signal_done_to_cmd`
         // → `Cmd::buffered_output_close` → `close_io` may overwrite the
-        // `Readable::Pipe` slot, and the trampoline must not re-read `*me`.
-        // SAFETY: see `arc_as_mut_ptr`; raw read, no borrow held.
-        let interp = unsafe { (*me).interp };
-        // SAFETY: see `arc_as_mut_ptr` + `try_signal_done_to_cmd` contract —
-        // raw `*mut`, no `&mut PipeReader` protector across the Cmd re-entry.
-        let y = unsafe { Self::try_signal_done_to_cmd(me) };
+        // `Readable::Pipe` slot.
+        let interp = this.interp;
+        let y = Self::try_signal_done_to_cmd(this);
         // Once the Cmd has taken the output it detaches this reader (`process`
         // is `None`) and nothing reads `buffered_output` again. Drop it now
         // rather than with `guard`: `y` can settle the shell promise, and its
         // microtask checkpoint must not see a `> ${arraybuffer}` target that
         // is still pinned.
-        // SAFETY: see `arc_as_mut_ptr`; raw accesses, no borrow held.
-        unsafe {
-            if (*me).process.is_none() {
-                (*me).buffered_output = BufferedOutput::default();
-            }
+        if this.process.get().is_none() {
+            this.buffered_output.set(BufferedOutput::default());
         }
         Self::run_yield_with(interp, y);
-        if let Some(process) = guard.process {
-            // SAFETY: `process` is the heap-allocated `ShellSubprocess` (stable
-            // address), freed only by `Cmd::deinit` after every PipeReader has
-            // signalled done (this call). Shared borrow scoped to `kind`.
-            let kind = guard.kind(unsafe { &*process });
-            // SAFETY: as above; `&mut` scoped to this call. `on_close_io`
-            // drops the `Readable::Pipe` Arc — `guard` keeps `self` live past
-            // that.
-            unsafe { (*process).on_close_io(kind) };
+        if let Some(process) = this.process.get() {
+            // `process` is the `ShellSubprocess` (stable address), freed only
+            // by `Cmd::deinit` after every PipeReader has signalled done (this
+            // call). `on_close_io` drops the `Readable::Pipe` ref — the
+            // caller's keepalive keeps `this` live past that.
+            let kind = this.kind(process.get());
+            process.on_close_io(kind);
         }
     }
 
-    /// # Safety
-    /// `this` must point into a live `Arc<PipeReader>` allocation (the pointer
-    /// registered via `reader.set_parent`). Takes a raw pointer rather than
-    /// `&mut self` because `on_close_io` below drops the `Readable::Pipe`
-    /// `Arc` — holding a `&mut self` across that drop would dangle, and the
-    /// `Arc::deref` inside `on_close_io` would alias it.
-    pub(crate) unsafe fn on_reader_done(this: *mut Self) {
-        // SAFETY: caller contract.
-        let guard = unsafe { Self::guard_from_raw(this) };
+    /// `this: ThisPtr` because `on_close_io` below drops the `Readable::Pipe`
+    /// ref; the local guard holds our own.
+    pub(crate) fn on_reader_done(this: ThisPtr<Self>) {
+        let _guard = RefPtr::from_this(this);
         log!(
             "onReaderDone(0x{:x}, {})",
-            this as usize,
-            out_kind_str(guard.out_type)
+            this.as_ptr() as usize,
+            out_kind_str(this.out_type)
         );
-        {
-            let me = arc_as_mut_ptr(&guard);
-            // SAFETY: see `arc_as_mut_ptr`; each access is scoped, and none
-            // survive into `finish_after_state_set`'s re-entry below.
-            unsafe {
-                let owned = (*me).to_owned_slice();
-                (*me).state = PipeReaderState::Done(owned);
-                if !(*me).is_done() {
-                    return;
-                }
-            }
+        let owned = this.to_owned_slice();
+        this.state.set(PipeReaderState::Done(owned));
+        if !this.is_done() {
+            return;
         }
-        Self::finish_after_state_set(&guard);
-        // Dropping `guard` is the matching `deref()`; may free `this`.
+        Self::finish_after_state_set(this);
+        // Dropping `_guard` releases our ref; may free `this`.
     }
 
-    /// Spec `signalDoneToCmd`. Takes `*mut Self` (not `&mut self`) because
-    /// the tail call into `Cmd::buffered_output_close` re-derives a
-    /// `&PipeReader` to *this same allocation* via the `Readable::Pipe`
-    /// `Arc` (for `pipe.slice()` and `close_io`). With a `&mut self`
-    /// argument the Stacked-Borrows function-argument protector would make
-    /// that re-derive UB; the raw pointer carries no protector, so all
-    /// `&mut *this` borrows below are explicitly ended before the Cmd call.
-    ///
-    /// # Safety
-    /// `this` must point to a live `PipeReader` inside its `Arc` allocation
-    /// (single JS-thread; see [`arc_as_mut_ptr`]). No `&`/`&mut PipeReader`
-    /// to the same object may be live across this call.
-    pub(crate) unsafe fn try_signal_done_to_cmd(this: *mut Self) -> Yield {
-        let (done, out_type, process) = {
-            // SAFETY: caller contract — short-lived shared borrow for the
-            // read-only `is_done()` / log; no Cmd re-entry yet.
-            let me = unsafe { &*this };
-            (me.is_done(), me.out_type, me.process)
-        };
+    /// Spec `signalDoneToCmd`. The tail call into `Cmd::buffered_output_close`
+    /// re-derives a `&PipeReader` to *this same allocation* via the
+    /// `Readable::Pipe` ref (for `pipe.slice()` and `close_io`), so no borrow
+    /// of `this` is held across it.
+    pub(crate) fn try_signal_done_to_cmd(this: ThisPtr<Self>) -> Yield {
+        let (done, out_type, process) = (this.is_done(), this.out_type, this.process.get());
         if !done {
             return Yield::Suspended;
         }
         log!(
             "signalDoneToCmd ({:x}: {}) isDone={}",
-            this as usize,
+            this.as_ptr() as usize,
             out_kind_str(out_type),
             done
         );
@@ -1969,56 +1568,54 @@ impl PipeReader {
         // reader already signalled its Cmd. The reader can still deliver terminal
         // callbacks after that (see `read_with_fn`'s EAGAIN arm), so no-op here.
         if let Some(proc) = process {
-            // SAFETY: `proc` is the heap-allocated `ShellSubprocess` (stable
-            // address) freed only by `Cmd::deinit`, which runs strictly after
-            // every PipeReader has signalled done. `cmd_mut` resolves through
-            // the node arena (see `CmdHandle`).
-            let cmd = unsafe { (*proc).cmd_parent.cmd_mut() };
-            // SAFETY: caller contract — the `&mut` is scoped to this call and
-            // ends *before* the `cmd` call below.
-            let e: Option<SystemError> = unsafe { (*this).take_captured_error() };
-            // No `&`/`&mut PipeReader` is live here; `buffered_output_close`
-            // is free to deref the sibling `Arc<PipeReader>` in
-            // `Readable::Pipe` for `pipe.slice()` / `close_io`.
-            return cmd.buffered_output_close(out_type, e);
+            let e: Option<SystemError> = this.take_captured_error();
+            // `proc` is the `ShellSubprocess` freed only by `Cmd::deinit`,
+            // which runs strictly after every PipeReader has signalled done.
+            // `cmd_mut` resolves through the node arena (see `CmdHandle`).
+            let handle = proc.cmd_parent;
+            return handle.cmd_mut().buffered_output_close(out_type, e);
         }
         Yield::Suspended
     }
 
-    fn take_captured_error(&mut self) -> Option<SystemError> {
-        if let Some(e) = self.captured_writer.err.take() {
-            match core::mem::replace(&mut self.state, PipeReaderState::Pending) {
-                PipeReaderState::Done(buf) => {
-                    drop(buf);
-                    self.state = PipeReaderState::Err(Some(Box::new(e)));
+    fn take_captured_error(&self) -> Option<SystemError> {
+        if let Some(e) = self.captured_writer.err.replace(None) {
+            self.state.with_mut(|state| {
+                match core::mem::replace(state, PipeReaderState::Pending) {
+                    PipeReaderState::Done(buf) => {
+                        drop(buf);
+                        *state = PipeReaderState::Err(Some(Box::new(e)));
+                    }
+                    old @ PipeReaderState::Err(_) => {
+                        *state = old;
+                    }
+                    PipeReaderState::Pending => {
+                        *state = PipeReaderState::Err(Some(Box::new(e)));
+                    }
                 }
-                old @ PipeReaderState::Err(_) => {
-                    self.state = old;
-                }
-                PipeReaderState::Pending => {
-                    self.state = PipeReaderState::Err(Some(Box::new(e)));
-                }
-            }
+            });
         }
         // `bun_sys::SystemError` isn't ref-counted nor `Clone`.
         // Move it out (the only reader of
         // `state.Err` after this point is `Drop`, which tolerates `None`).
-        if let PipeReaderState::Err(slot) = &mut self.state {
-            slot.take().map(|b| *b)
-        } else {
-            None
-        }
+        self.state.with_mut(|state| {
+            if let PipeReaderState::Err(slot) = state {
+                slot.take().map(|b| *b)
+            } else {
+                None
+            }
+        })
     }
 
     pub(crate) fn kind(&self, process: &ShellSubprocess) -> StdioKind {
-        if let Readable::Pipe(p) = &process.stdout {
-            if Arc::as_ptr(p).cast() == std::ptr::from_ref(self) {
+        if let Readable::Pipe(p) = process.stdout.get() {
+            if core::ptr::eq(p.as_ptr(), self) {
                 return StdioKind::Stdout;
             }
         }
 
-        if let Readable::Pipe(p) = &process.stderr {
-            if Arc::as_ptr(p).cast() == std::ptr::from_ref(self) {
+        if let Readable::Pipe(p) = process.stderr.get() {
+            if core::ptr::eq(p.as_ptr(), self) {
                 return StdioKind::Stderr;
             }
         }
@@ -2026,20 +1623,23 @@ impl PipeReader {
         panic!("We should be either stdout or stderr");
     }
 
-    pub(crate) fn take_buffer(&mut self) -> Vec<u8> {
-        self.reader.take_buffer()
+    pub(crate) fn take_buffer(&self) -> Vec<u8> {
+        self.reader.with_mut(|r| r.take_buffer())
     }
 
     pub(crate) fn slice(&self) -> &[u8] {
-        self.buffered_output.slice()
+        self.buffered_output.get().slice()
     }
 
-    pub(crate) fn to_owned_slice(&mut self) -> Box<[u8]> {
-        if let PipeReaderState::Done(buf) = &mut self.state {
-            return core::mem::take(buf);
+    pub(crate) fn to_owned_slice(&self) -> Box<[u8]> {
+        if let Some(buf) = self.state.with_mut(|s| match s {
+            PipeReaderState::Done(buf) => Some(core::mem::take(buf)),
+            _ => None,
+        }) {
+            return buf;
         }
         // we do not use .toOwnedSlice() because we don't want to reallocate memory.
-        let out = core::mem::take(&mut self.reader._buffer);
+        let out = self.reader.with_mut(|r| core::mem::take(&mut r._buffer));
 
         if out.capacity() > 0 && out.is_empty() {
             drop(out);
@@ -2049,72 +1649,50 @@ impl PipeReader {
         // PERF: into_boxed_slice may realloc to shrink. Profile if hot.
     }
 
-    pub(crate) fn update_ref(&mut self, add: bool) {
-        self.reader.update_ref(add);
+    /// Swap the done buffer out, leaving an empty one in its place.
+    fn take_done_buffer(&self) -> Box<[u8]> {
+        match self.state.replace(PipeReaderState::Done(Box::default())) {
+            PipeReaderState::Done(buf) => buf,
+            _ => Box::default(),
+        }
     }
 
-    /// # Safety
+    pub(crate) fn update_ref(&self, add: bool) {
+        self.reader.with_mut(|r| r.update_ref(add));
+    }
+
     /// See [`Self::on_reader_done`].
-    pub(crate) unsafe fn on_reader_error(this: *mut Self, err: &bun_sys::Error) {
-        log!("PipeReader(0x{:x}) onReaderError {:?}", this as usize, err);
-        // SAFETY: caller contract.
-        let guard = unsafe { Self::guard_from_raw(this) };
-        {
-            let me = arc_as_mut_ptr(&guard);
-            // SAFETY: see `arc_as_mut_ptr`; accesses scoped to the `state`
-            // writes, ending before `finish_after_state_set` re-enters.
-            unsafe {
-                if let PipeReaderState::Done(buf) =
-                    core::mem::replace(&mut (*me).state, PipeReaderState::Err(None))
-                {
-                    drop(buf);
-                }
-                (*me).state = PipeReaderState::Err(Some(Box::new(err.to_system_error())));
-                if !(*me).is_done() {
-                    return;
-                }
+    pub(crate) fn on_reader_error(this: ThisPtr<Self>, err: &bun_sys::Error) {
+        log!(
+            "PipeReader(0x{:x}) onReaderError {:?}",
+            this.as_ptr() as usize,
+            err
+        );
+        let _guard = RefPtr::from_this(this);
+        this.state.with_mut(|state| {
+            if let PipeReaderState::Done(buf) =
+                core::mem::replace(state, PipeReaderState::Err(None))
+            {
+                drop(buf);
             }
+            *state = PipeReaderState::Err(Some(Box::new(err.to_system_error())));
+        });
+        if !this.is_done() {
+            return;
         }
-        Self::finish_after_state_set(&guard);
-        // Dropping `guard` is the matching `deref()`; may free `this`.
+        Self::finish_after_state_set(this);
+        // Dropping `_guard` releases our ref; may free `this`.
     }
 
     pub(crate) fn r#loop(&self) -> *mut AsyncLoop {
         #[cfg(windows)]
         {
-            self.event_loop.uv_loop()
+            self.event_loop.get().uv_loop()
         }
         #[cfg(not(windows))]
         {
-            self.event_loop.r#loop()
+            self.event_loop.get().r#loop()
         }
-    }
-
-    // Helper accessor used above to paper over Arc<PipeReader> interior mutability.
-    //
-    // Takes `*mut Self` (not `&self`) because `Arc<PipeReader>` only yields
-    // `&Self`, and casting `&Self as *const Self as *mut Self` to write through is
-    // immediate UB — shared-ref provenance is read-only. Callers obtain the pointer
-    // via `Arc::as_ptr(&arc).cast_mut()`, which projects from the Arc allocation's
-    // original `NonNull` without materializing a `&Self`.
-    // The JS-thread single-mutator invariant means no live `&`/`&mut` to these
-    // fields exists when this runs.
-    unsafe fn take_done_buffer(this: *mut Self) -> Box<[u8]> {
-        // SAFETY: see block comment above. Swaps the done buffer out, leaving
-        // an empty one in its place.
-        // `ptr::replace` reads/writes through the raw field pointer without
-        // materializing a `&mut Self` (on_reader_done may still hold one on the
-        // caller's stack via the BufferedReader parent backref).
-        let old = unsafe {
-            core::ptr::replace(
-                core::ptr::addr_of_mut!((*this).state),
-                PipeReaderState::Done(Box::default()),
-            )
-        };
-        if let PipeReaderState::Done(buf) = old {
-            return buf;
-        }
-        Box::default()
     }
 }
 
@@ -2127,7 +1705,9 @@ impl Drop for PipeReader {
         );
         #[cfg(unix)]
         {
-            debug_assert!(self.reader.is_done() || matches!(self.state, PipeReaderState::Err(_)));
+            debug_assert!(
+                self.reader.get().is_done() || matches!(self.state.get(), PipeReaderState::Err(_))
+            );
             // Never started: the parent end is still ours to close.
             if let Some(fd) = self.stdio_result.take() {
                 fd.close();
@@ -2136,38 +1716,39 @@ impl Drop for PipeReader {
 
         #[cfg(windows)]
         {
-            debug_assert!(
-                self.reader.source.is_none() || self.reader.source.as_ref().unwrap().is_closed()
-            );
+            let r = self.reader.get();
+            debug_assert!(r.source.is_none() || r.source.as_ref().unwrap().is_closed());
         }
 
         // PipeReaderState::Done(Box<[u8]>) drops its buffer automatically.
 
-        if !self.captured_writer.dead {
-            // CapturedWriter::drop handles err.deref() and writer Arc drop.
-        }
+        // CapturedWriter's fields drop the err and writer Arc.
 
-        if let PipeReaderState::Err(slot) = &mut self.state {
-            *slot = None;
-        }
+        self.state.with_mut(|s| {
+            if let PipeReaderState::Err(slot) = s {
+                *slot = None;
+            }
+        });
 
         // buffered_output drops automatically.
         // reader drops automatically.
-        // Box dealloc handled by Arc.
+        // Box dealloc handled by the refcount destructor.
     }
 }
 
-// `on_reader_done`/`on_reader_error` forward the raw `*mut Self` (NOT
-// autoref) — see their doc-comments: the body builds an `Arc` keepalive that
-// may free `this` on drop, so a `&mut self` protector would be UB.
+// The reader callbacks get `this: ThisPtr<PipeReader>`: `on_reader_done` /
+// `on_reader_error` take a keepalive ref that may free `this` on drop, so no
+// `&self`/`&mut self` receiver may span them.
 bun_io::impl_buffered_reader_parent! {
     ShellPipeReader for PipeReader;
+    borrow = this;
+    reader = reader;
     has_on_read_chunk = true;
-    on_read_chunk   = |this, chunk, has_more| (*this).on_read_chunk(&chunk, has_more);
+    on_read_chunk   = |this, chunk, has_more| PipeReader::on_read_chunk(this, &chunk, has_more);
     on_reader_done  = |this| PipeReader::on_reader_done(this);
     on_reader_error = |this, err| PipeReader::on_reader_error(this, &err);
-    loop_           = |this| (*this).r#loop();
-    event_loop      = |this| (*this).event_loop.as_event_loop_ctx();
+    loop_           = |this| this.r#loop();
+    event_loop      = |this| this.event_loop.get().as_event_loop_ctx();
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -2190,12 +1771,6 @@ macro_rules! assert_stdio_result {
     }};
 }
 pub(crate) use assert_stdio_result;
-
-unsafe extern "C" {
-    // `_PATH_DEFPATH` string literal emitted from C; immutable, load-time
-    // initialized, never null. Reading the pointer value has no precondition.
-    pub safe static BUN_DEFAULT_PATH_FOR_SPAWN: *const c_char;
-}
 
 // IntoStaticStr for PipeReaderState (used in logs as the variant name).
 impl From<&PipeReaderState> for &'static str {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1807,8 +1807,7 @@ impl BlobExt for Blob {
                 return Err(global_this.throw_value(err.to_js(global_this)));
             }
 
-            // SAFETY: `&mut` scoped to the call.
-            let js = unsafe { (*sink.as_ptr()).to_js(global_this) };
+            let js = webcore::FileSink::to_js(sink.this_ptr(), global_this);
             return Ok(js);
         }
 
@@ -1854,8 +1853,7 @@ impl BlobExt for Blob {
                 return Err(global_this.throw_value(err.to_js(global_this)));
             }
 
-            // SAFETY: `&mut` scoped to the call.
-            let js = unsafe { (*sink.as_ptr()).to_js(global_this) };
+            let js = webcore::FileSink::to_js(sink.this_ptr(), global_this);
             Ok(js)
         }
     }
@@ -6120,6 +6118,13 @@ pub enum Any {
     Blob(Blob),
     InternalBlob(Internal),
     WTFStringImpl(bun_core::WTFStringImpl),
+}
+
+impl Default for Any {
+    /// The detached state (see [`Any::detach`]).
+    fn default() -> Self {
+        Any::Blob(Blob::default())
+    }
 }
 
 impl Any {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -275,21 +275,17 @@ pub(crate) extern "C" fn Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(
 impl FileSink {
     /// `bun.spawn`'s subprocess exited while this `FileSink` was its stdin.
     ///
-    /// Takes the canonical `*mut FileSink` (not `&mut self`): `writer.close()`
+    /// Takes the root pointer (not `&mut self`): `writer.close()`
     /// re-enters `on_close` via the writer backref and `stream.cancel`/
     /// `run_pending` drain microtasks — any of which may drop the last ref and
     /// free `this`. A `&mut self` held across those calls would (a) carry a
     /// `noalias` LLVM attribute the re-entry violates and (b) place a Unique
     /// Stacked-Borrows tag on the whole struct, popping the writer's own
     /// `*mut Self` tag. The four PipeWriter callbacks have the same shape.
-    ///
-    /// # Safety
-    /// `this` must be the canonical heap-allocation pointer (the one threaded
-    /// through `set_parent` by `init`/`create*`), live, with write+dealloc
-    /// provenance over the allocation.
-    pub(crate) unsafe fn on_attached_process_exit(this: *mut FileSink, status: &SpawnStatus) {
+    pub(crate) fn on_attached_process_exit(this: bun_ptr::ThisPtr<FileSink>, status: &SpawnStatus) {
         bun_core::scoped_log!(FileSink, "onAttachedProcessExit()");
-        // SAFETY: caller contract — `this` is live with write+dealloc provenance.
+        let this: *mut FileSink = this.as_ptr();
+        // SAFETY: `ThisPtr` invariant — `this` is the live allocation root.
         unsafe {
             // `writer.close()` below re-enters `onClose` which releases the
             // keep-alive ref, and `stream.cancel`/`runPending` drain microtasks
@@ -581,24 +577,24 @@ impl FileSink {
     #[cfg(windows)]
     pub(crate) fn create_with_pipe(
         event_loop_: impl Into<EventLoopHandle>,
-        pipe: *mut uv::Pipe,
+        pipe: Box<uv::Pipe>,
     ) -> RefPtr<FileSink> {
         let evtloop: EventLoopHandle = event_loop_.into();
 
-        // SAFETY: `pipe` is a live `*mut uv::Pipe` provided by the caller.
         // `UvHandle::fd()` returns the raw `uv_os_fd_t` (HANDLE on Windows);
         // INVALID_HANDLE_VALUE maps to `Fd::INVALID`, anything else is
         // tagged as a system handle.
-        let fd = match unsafe { (*pipe).fd() } {
+        let fd = match pipe.fd() {
             h if h == uv::INVALID_HANDLE_VALUE => Fd::INVALID,
             h => Fd::from_system(h),
         };
         let this = RefPtr::new(FileSink::new(evtloop, fd));
-        // SAFETY: `this` was just allocated above and is the sole reference.
-        unsafe {
-            (*this.as_ptr()).writer.get_mut().set_pipe(pipe);
-            (*this.as_ptr()).writer.get_mut().set_parent(this.as_ptr());
-        }
+        let root = this.as_ptr();
+        this.writer.with_mut(|w| {
+            // SAFETY: `pipe` is Box-allocated; ownership transfers to the writer.
+            unsafe { w.set_pipe(bun_core::heap::into_raw(pipe)) };
+            w.set_parent(root);
+        });
         this
     }
 
@@ -1006,10 +1002,9 @@ impl FileSink {
         // via `self.ref_()`, and `finalize`'s `deref()` below releases it.
         // `JsSinkType::construct` allocates with `ref_count=1` and that +1
         // belongs to the wrapper it's about to be stored in, so no extra
-        // `ref_()` there. Callers that allocate via `init`/`create` and then
-        // `to_js()` must `deref()` once to release init's +1 (see
-        // `Blob::get_writer`). `pending`/`readable_stream` are left for
-        // `deinit` (Box drop) since in-flight IO may still need them.
+        // `ref_()` there. `init`/`create*` hand their initial ref back as a
+        // `RefPtr` the caller drops after `to_js()`. `pending`/`readable_stream`
+        // are left for `Drop` since in-flight IO may still need them.
         // SAFETY: as above; the `deref` is the last use of `this`.
         unsafe {
             (*this).js_sink_ref.with_mut(|r| r.deinit());
@@ -1029,8 +1024,8 @@ impl FileSink {
 
     pub(crate) fn init(fd: Fd, event_loop_handle: impl Into<EventLoopHandle>) -> RefPtr<FileSink> {
         let this = RefPtr::new(FileSink::new(event_loop_handle.into(), fd));
-        // SAFETY: `this` was just allocated above and is the sole reference.
-        unsafe { (*this.as_ptr()).writer.get_mut().set_parent(this.as_ptr()) };
+        let root = this.as_ptr();
+        this.writer.with_mut(|w| w.set_parent(root));
         this
     }
 
@@ -1211,14 +1206,14 @@ impl FileSink {
         }
     }
 
-    pub fn to_js(&mut self, global_this: &JSGlobalObject) -> JSValue {
+    pub fn to_js(this: bun_ptr::ThisPtr<FileSink>, global_this: &JSGlobalObject) -> JSValue {
         // Wrapper's +1; balanced by `finalize` → `deref()`.
-        self.ref_();
-        JSSink::create_object(global_this, self, 0)
+        this.ref_();
+        JSSink::create_object_this(global_this, this, 0)
     }
 
     pub(crate) fn to_js_with_destructor(
-        &mut self,
+        this: bun_ptr::ThisPtr<FileSink>,
         global_this: &JSGlobalObject,
         // `sink::DestructorPtr` is `TaggedPtrUnion<(Detached, Detached)>`
         // which does not satisfy `bun_ptr::TypeList` yet (sibling Sink.rs); accept
@@ -1226,8 +1221,8 @@ impl FileSink {
         destructor: Option<usize>,
     ) -> JSValue {
         // Wrapper's +1; balanced by `finalize` → `deref()`.
-        self.ref_();
-        JSSink::create_object(global_this, self, destructor.unwrap_or(0))
+        this.ref_();
+        JSSink::create_object_this(global_this, this, destructor.unwrap_or(0))
     }
 
     pub(crate) fn end_from_js(&self, global_this: &JSGlobalObject) -> sys::Result<JSValue> {
@@ -1650,44 +1645,48 @@ impl FileSink {
         }
     }
 
+    /// `this: ThisPtr` because the wrapper / native sink handle / promise
+    /// reaction each keep the sink's address past this call.
     pub fn assign_to_stream(
-        &mut self,
+        this: bun_ptr::ThisPtr<FileSink>,
         stream: &mut ReadableStream,
         global_this: &JSGlobalObject,
     ) -> JSValue {
-        // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
-        let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
+        let _guard = RefPtr::from_this(this);
+        let self_: &FileSink = this.get();
 
-        self.readable_stream
+        self_
+            .readable_stream
             .set(readable_stream::Strong::init(*stream, global_this));
 
         // Native ByteStream/FileReader fast-path: wire the SinkHandle
         // directly, skipping the JS pump.
         match stream.wire_native_sink(
             global_this,
-            webcore::SinkHandle::FileSink(bun_ptr::BackRef::new(&*self)),
+            webcore::SinkHandle::FileSink(bun_ptr::BackRef::new(self_)),
             JSValue::UNDEFINED,
-            |src| self.source.set(src),
+            |src| self_.source.set(src),
         ) {
             readable_stream::NativeWireResult::Wired => {
                 // A synchronous producer may have driven `end_from_stream`
                 // (clears `source`) inline; no keepalive then.
-                if !matches!(self.source.get(), streams::SourceHandle::None) {
-                    self.writer
-                        .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
-                    if !self.must_be_kept_alive_until_eof.get() {
-                        self.must_be_kept_alive_until_eof.set(true);
-                        self.ref_();
+                if !matches!(self_.source.get(), streams::SourceHandle::None) {
+                    self_
+                        .writer
+                        .with_mut(|w| w.enable_keeping_process_alive(self_.io_evtloop()));
+                    if !self_.must_be_kept_alive_until_eof.get() {
+                        self_.must_be_kept_alive_until_eof.set(true);
+                        self_.ref_();
                     }
                 }
                 return JSValue::UNDEFINED;
             }
             readable_stream::NativeWireResult::EndedInline(err) => {
-                self.source.set(streams::SourceHandle::None);
+                self_.source.set(streams::SourceHandle::None);
                 match err {
-                    Some(err) => self.end_from_stream(Some(err)),
+                    Some(err) => self_.end_from_stream(Some(err)),
                     None => {
-                        let _ = self.end(None);
+                        let _ = self_.end(None);
                     }
                 }
                 return JSValue::UNDEFINED;
@@ -1699,14 +1698,13 @@ impl FileSink {
         // above): the JS builtins always call `controller.end()`/`.close()`
         // (`${controller}__end/close` → `controller->detach()` → m_sinkPtr=null)
         // before GC, so the controller's dtor never reaches `finalize`.
-        let promise_result = JSSink::assign_to_stream(
-            global_this,
-            stream.value,
-            core::ptr::NonNull::from(&mut *self),
-        );
+        let promise_result =
+            JSSink::assign_to_stream(global_this, stream.value, core::ptr::NonNull::from(this));
 
         if let Some(err) = promise_result.to_error() {
-            self.readable_stream.set(readable_stream::Strong::default());
+            self_
+                .readable_stream
+                .set(readable_stream::Strong::default());
             return err;
         }
 
@@ -1723,29 +1721,30 @@ impl FileSink {
                 // SAFETY: `as_any_promise` returned non-null.
                 match unsafe { (*js_promise).status() } {
                     bun_jsc::js_promise::Status::Pending => {
-                        self.writer
-                            .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
-                        self.ref_();
+                        self_
+                            .writer
+                            .with_mut(|w| w.enable_keeping_process_alive(self_.io_evtloop()));
+                        self_.ref_();
                         // TODO: properly propagate exception upwards
                         // `JSValue::then` takes already-wrapped C-ABI
                         // host fns; the `toJSHostFunction` step is the manual
                         // shims at the bottom of this file.
                         promise_result.then(
                             global_this,
-                            std::ptr::from_mut::<FileSink>(self),
+                            this.as_ptr(),
                             on_resolve_stream_shim,
                             on_reject_stream_shim,
                         );
                     }
                     bun_jsc::js_promise::Status::Fulfilled => {
                         // These don't ref().
-                        self.handle_resolve_stream();
+                        self_.handle_resolve_stream();
                     }
                     bun_jsc::js_promise::Status::Rejected => {
                         // These don't ref().
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         let result = unsafe { (*js_promise).result(global_this.vm()) };
-                        crate::dispatch::fold(self.handle_reject_stream(global_this, result));
+                        crate::dispatch::fold(self_.handle_reject_stream(global_this, result));
                     }
                 }
             }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -206,6 +206,16 @@ impl<T: JsSinkAbi> JSSink<T> {
         )
     }
 
+    /// [`create_object`](Self::create_object) for a sink reached through its
+    /// root pointer.
+    pub fn create_object_this(
+        global: &crate::webcore::jsc::JSGlobalObject,
+        object: bun_ptr::ThisPtr<T>,
+        destructor: usize,
+    ) -> crate::webcore::jsc::JSValue {
+        T::create_object_extern(global, object.as_ptr().cast::<c_void>(), destructor)
+    }
+
     pub fn set_destroy_callback(value: crate::webcore::jsc::JSValue, callback: usize) {
         T::set_destroy_callback_extern(value, callback)
     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -865,7 +865,7 @@ pub enum SourceHandle {
     /// The `'static` bound erases the `&JSGlobalObject` borrow carried in
     /// `Subprocess<'a>`; the pointed-at allocation outlives this handle.
     Subprocess(BackRef<crate::api::bun::subprocess::Subprocess<'static>>),
-    ShellWritable(BackRef<crate::shell::subproc::Writable, bun_ptr::Mut>),
+    ShellSubprocess(BackRef<crate::shell::subproc::ShellSubprocess, bun_ptr::Root>),
     FetchResponseBody(BackRef<crate::webcore::fetch::fetch_tasklet::FetchTasklet, bun_ptr::Mut>),
     ServerRequestBody(crate::server::AnyRequestContext),
     S3DownloadBody(BackRef<crate::webcore::s3::client::S3DownloadStreamWrapper>),
@@ -910,8 +910,7 @@ impl SourceHandle {
             SourceHandle::ByteStream(p) => p.on_close(err),
             SourceHandle::FileReader(p) => p.on_close(err),
             SourceHandle::Subprocess(p) => p.on_close(err),
-            // SAFETY: live backref; cleared before the pointee is freed.
-            SourceHandle::ShellWritable(mut p) => unsafe { p.get_mut() }.on_close(err),
+            SourceHandle::ShellSubprocess(p) => p.on_stdin_close(err),
             SourceHandle::FetchResponseBody(p) => p.on_stream_cancelled(),
             SourceHandle::S3DownloadBody(p) => p.on_stream_cancelled(),
             SourceHandle::ServerRequestBody(_) => {}
@@ -942,7 +941,7 @@ impl SourceHandle {
                 p.on_cancel();
             }
             // Remaining variants leave `on_ready` at the trait default (no-op).
-            SourceHandle::Subprocess(_) | SourceHandle::ShellWritable(_) => {}
+            SourceHandle::Subprocess(_) | SourceHandle::ShellSubprocess(_) => {}
         }
     }
 
@@ -959,7 +958,7 @@ impl SourceHandle {
             | SourceHandle::ByteStream(_)
             | SourceHandle::FileReader(_)
             | SourceHandle::Subprocess(_)
-            | SourceHandle::ShellWritable(_)
+            | SourceHandle::ShellSubprocess(_)
             | SourceHandle::HTMLRewriter(_)
             | SourceHandle::TestingCancelOnDrain(_) => {}
         }
@@ -976,7 +975,7 @@ impl SourceHandle {
             | SourceHandle::ByteStream(_)
             | SourceHandle::FileReader(_)
             | SourceHandle::Subprocess(_)
-            | SourceHandle::ShellWritable(_)
+            | SourceHandle::ShellSubprocess(_)
             | SourceHandle::HTMLRewriter(_)
             | SourceHandle::TestingCancelOnDrain(_) => {}
         }
@@ -2048,7 +2047,6 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             // SAFETY: `this` is the live heap payload (refcounted via the JS
             // wrapper); momentary access only.
             unsafe { (*this).wrote_at_start_of_flush = (*this).wrote };
-            // SAFETY: as above.
             crate::dispatch::fold(result);
         }
     }

--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -92,6 +92,25 @@ bun_dispatch::link_interface! {
 /// `None` = no handler set (the default for `Process::exit_handler`).
 pub type ProcessExitHandler = Option<ProcessExit>;
 
+/// `_PATH_DEFPATH`: the `PATH` to search for `argv[0]` when the environment
+/// has none (empty on Windows).
+pub fn default_search_path() -> &'static [u8] {
+    #[cfg(unix)]
+    {
+        unsafe extern "C" {
+            // `_PATH_DEFPATH` string literal emitted from C; immutable,
+            // load-time initialized, never null.
+            safe static BUN_DEFAULT_PATH_FOR_SPAWN: *const core::ffi::c_char;
+        }
+        // SAFETY: NUL-terminated static C string (see decl).
+        unsafe { core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes()
+    }
+    #[cfg(not(unix))]
+    {
+        b""
+    }
+}
+
 // In-crate `link_impl_*!` calls must be textually after the `link_interface!`
 // that emits the macro (`#[macro_export]` is path-addressable from *other*
 // crates only; same-crate use is textual-scope). POSIX `spawn_sync` waits

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -206,7 +206,8 @@ impl ProcessHandle {
         self.process_mut().watch()
     }
 
-    /// See [`Process::wait`]; may synchronously run the exit handler.
+    /// See [`Process::wait`]; may synchronously run the exit handler (same
+    /// rule as [`watch_or_reap`](Self::watch_or_reap)).
     pub fn wait(&self, sync_: bool) {
         self.process_mut().wait(sync_)
     }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -200,6 +200,51 @@ impl ProcessHandle {
     pub fn as_ptr(&self) -> *mut Process {
         self.0.as_ptr()
     }
+
+    /// See [`Process::watch`].
+    pub fn watch(&self) -> bun_sys::Result<()> {
+        self.process_mut().watch()
+    }
+
+    /// See [`Process::wait`]; may synchronously run the exit handler.
+    pub fn wait(&self, sync_: bool) {
+        self.process_mut().wait(sync_)
+    }
+
+    /// See [`Process::close`].
+    pub fn close(&self) {
+        self.process_mut().close()
+    }
+
+    /// See [`Process::detach`]: closes the poller and clears the exit handler
+    /// now; the owned ref is still released on drop.
+    pub fn detach(&self) {
+        self.process_mut().detach()
+    }
+
+    pub fn enable_keeping_event_loop_alive(&self) {
+        self.process_mut().enable_keeping_event_loop_alive()
+    }
+
+    pub fn disable_keeping_event_loop_alive(&self) {
+        self.process_mut().disable_keeping_event_loop_alive()
+    }
+
+    /// `uv_getrusage` on the live `uv_process_t`, if this process is still
+    /// polled through libuv.
+    #[cfg(windows)]
+    pub fn uv_rusage(&self) -> Option<Rusage> {
+        match &mut self.process_mut().poller {
+            Poller::Uv(uv_proc) => Some(uv_getrusage(uv_proc)),
+            _ => None,
+        }
+    }
+
+    /// [`as_ptr`](Self::as_ptr), for registries keyed by it (`ProcessAutoKiller`).
+    #[inline]
+    pub fn as_non_null(&self) -> core::ptr::NonNull<Process> {
+        self.0.as_non_null()
+    }
 }
 
 impl Drop for ProcessHandle {

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -72,7 +72,7 @@ pub type Poll<P> = IOWriter<P>;
 bun_io::impl_buffered_writer_parent! {
     for<P: StaticPipeWriterProcess> StaticPipeWriter<P>;
     poll_tag   = P::POLL_OWNER_TAG,
-    borrow     = mut,
+    borrow     = ptr,
     on_write   = on_write,
     on_error   = on_error,
     on_close   = on_close,
@@ -250,11 +250,17 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         }
     }
 
-    pub(crate) fn on_write(&mut self, amount: usize, status: WriteStatus) {
+    /// Writer callback (`borrow = ptr`): completing the write may release the
+    /// last ref, so no `&mut Self` argument (which would have to stay valid
+    /// for the whole call) is formed — fields are reached through `this`.
+    ///
+    /// # Safety
+    /// `this` is the writer's parent back-reference: the live root pointer.
+    pub(crate) unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onWrite(amount={} {})",
-            std::ptr::from_ref(self) as usize,
+            this as usize,
             amount,
             // Local stringify — `WriteStatus` (upstream bun_io) has no `Debug` impl.
             match status {
@@ -263,55 +269,70 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                 WriteStatus::Pending => "pending",
             }
         );
-        let len = self.buffer.len();
-        self.buffer = RawSlice::new(&self.buffer.slice()[amount.min(len)..]);
-        if status == WriteStatus::EndOfFile {
-            // The buffered writer closes itself (-> `on_close`) after this
-            // returns, so don't close here. Not the final ref: the owner's slot
-            // still holds one until that `on_close`.
-            self.start_ref = None;
-            return;
-        }
-        if self.buffer.is_empty() {
-            // Taken before `close()` so start()'s ref outlives the owner's.
-            let start_ref = self.start_ref.take();
-            self.writer.close();
-            // May be the final ref; last use of `self`.
-            drop(start_ref);
+        // SAFETY: fn contract; each access below is a momentary field projection.
+        unsafe {
+            let len = (*this).buffer.len();
+            (*this).buffer = RawSlice::new(&(*this).buffer.slice()[amount.min(len)..]);
+            if status == WriteStatus::EndOfFile {
+                // The buffered writer closes itself (-> `on_close`) after this
+                // returns, so don't close here. Not the final ref: the owner's slot
+                // still holds one until that `on_close`.
+                (*this).start_ref = None;
+                return;
+            }
+            if (*this).buffer.is_empty() {
+                // Taken before `close()` so start()'s ref outlives the owner's.
+                let start_ref = (*this).start_ref.take();
+                (*this).writer.close();
+                // May be the final ref; nothing touches `this` after.
+                drop(start_ref);
+            }
         }
     }
 
-    pub(crate) fn on_error(&mut self, err: &bun_sys::Error) {
+    /// # Safety
+    /// As [`Self::on_write`].
+    pub(crate) unsafe fn on_error(this: *mut Self, err: &bun_sys::Error) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onError(err={})",
-            std::ptr::from_ref(self) as usize,
+            this as usize,
             err
         );
         // `buffer` aliases `self.source`'s storage, which `detach()` frees.
         // start()'s ref is released by the `on_close` the writer pairs with
         // every error.
-        self.buffer = RawSlice::EMPTY;
-        self.source.detach();
+        // SAFETY: fn contract; momentary field projections.
+        unsafe {
+            (*this).buffer = RawSlice::EMPTY;
+            (*this).source.detach();
+        }
     }
 
-    pub(crate) fn on_close(&mut self) {
+    /// # Safety
+    /// As [`Self::on_write`].
+    pub(crate) unsafe fn on_close(this: *mut Self) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onClose()",
-            std::ptr::from_ref(self) as usize
+            this as usize
         );
-        // Still set only after a failed write (every other path takes it before
-        // closing). Must be taken before `on_close_io` empties the slot:
-        // nothing can reach this writer afterwards.
-        let start_ref = self.start_ref.take();
-        // `buffer` aliases `self.source`'s storage; clear it before detach()
-        // frees that storage so no dangling slice survives the close.
-        self.buffer = RawSlice::EMPTY;
-        self.source.detach();
-        P::on_close_io(self.process.this_ptr(), StdioKind::Stdin);
-        // On POSIX this frees `self`: it is the last use here, and the
-        // writer's `close()` frames below do nothing after this callback.
+        // SAFETY: fn contract; momentary field projections (all disjoint from
+        // `writer`, whose `close()` frame may be live below us).
+        let (start_ref, process) = unsafe {
+            // Still set only after a failed write (every other path takes it
+            // before closing). Must be taken before `on_close_io` empties the
+            // slot: nothing can reach this writer afterwards.
+            let start_ref = (*this).start_ref.take();
+            // `buffer` aliases `self.source`'s storage; clear it before detach()
+            // frees that storage so no dangling slice survives the close.
+            (*this).buffer = RawSlice::EMPTY;
+            (*this).source.detach();
+            (start_ref, (*this).process)
+        };
+        P::on_close_io(process.this_ptr(), StdioKind::Stdin);
+        // On POSIX this frees the writer: nothing touches `this` after, and
+        // the writer's `close()` frames below do nothing after this callback.
         // On Windows the in-flight write's ref outlives it.
         drop(start_ref);
     }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -18,23 +18,22 @@ bun_output::declare_scope!(StaticPipeWriter, hidden);
 /// generic `BufferedWriter<StaticPipeWriter<P>>` field satisfy its
 /// `PosixBufferedWriterParent`/`WindowsBufferedWriterParent` bound for all `P`.
 ///
-/// Method takes `*mut Self` (not `&mut self`) because the writer is a field of
-/// the process — materializing `&mut P` while `&mut writer` is live would alias.
-pub trait StaticPipeWriterProcess {
+/// `on_close_io` gets the process as a [`ThisPtr`](bun_ptr::ThisPtr), not
+/// `&mut self`: it runs from inside the writer's callbacks — possibly
+/// re-entrantly from `start()` — while the writer (held in one of the
+/// process's slots) is itself borrowed.
+pub trait StaticPipeWriterProcess: Sized {
     const POLL_OWNER_TAG: bun_io::PollTag;
-    /// # Safety
-    /// `this` must point to a live `Self`.
-    unsafe fn on_close_io(this: *mut Self, kind: StdioKind);
+    fn on_close_io(this: bun_ptr::ThisPtr<Self>, kind: StdioKind);
 }
 
 /// Generic over the owning process type (e.g. `Subprocess`, `ShellSubprocess`).
-/// `P` must expose `fn on_close_io(&mut self, kind: StdioKind)`.
 ///
 /// Two refs: `create()`'s, held in the owner's stdin slot and released by its
-/// `on_close_io`, and `start()`'s, held while the write is in flight. `started`
-/// is the token for the latter: whoever swaps it to `false` releases the ref,
-/// which is `on_write` on completion, `on_close` after a failed write (the one
-/// ending with no completion report), or an owner closing the writer itself.
+/// `on_close_io`, and `start()`'s, held in `start_ref` while the write is in
+/// flight. Whoever takes `start_ref` releases it: `on_write` on completion,
+/// `on_close` after a failed write (the one ending with no completion report),
+/// or an owner closing the writer itself.
 // Cleanup lives in `impl Drop` below; the final Box free is
 // the derive's default destructor (`drop(heap::take(this))`).
 #[derive(bun_ptr::RefCounted)]
@@ -44,11 +43,12 @@ pub struct StaticPipeWriter<P: StaticPipeWriterProcess> {
     pub(crate) writer: IOWriter<P>,
     pub(crate) stdio_result: StdioResult,
     pub source: Source,
-    /// BACKREF: parent process is notified on close; never owned/destroyed here.
-    pub(crate) process: *mut P,
+    /// The owning process, notified on close. It holds this writer in its
+    /// stdin slot and closes it (firing `on_close`) before it is itself freed.
+    pub(crate) process: bun_ptr::BackRef<P, bun_ptr::Root>,
     pub(crate) event_loop: EventLoopHandle,
-    /// True while `start()`'s `+1` ref is outstanding (see the type docs).
-    pub started: bool,
+    /// `start()`'s ref while the write is in flight (see the type docs).
+    start_ref: Option<RefPtr<Self>>,
     /// Slice into `self.source`'s storage, advanced as bytes are written.
     ///
     /// Self-borrow invariant: this aliases `self.source`'s storage, which
@@ -85,30 +85,77 @@ bun_io::impl_buffered_writer_parent! {
     deref      = |this| RefCount::<Self>::deref(this),
 }
 
+// Owner-facing entry points. The owner holds the writer by `RefPtr` (its
+// own heap allocation, event-loop thread only) and drives it through these
+// with `rc.this_ptr()` — by value, so no borrow of the owner's slot is live
+// while the writer's callbacks re-enter the *owner* (`P::on_close_io`, which
+// empties that slot and may come back through `take_start_ref` /
+// `detach_source` — fields disjoint from the `writer` borrowed by `close`).
+// Each projects the one field it needs through the root pointer for the
+// duration of the call.
 impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
     #[inline]
     fn io_evtloop(&self) -> bun_io::EventLoopHandle {
         self.event_loop.as_event_loop_ctx()
     }
 
-    pub fn update_ref(&mut self, add: bool) {
-        self.writer.update_ref(self.io_evtloop(), add);
+    pub fn update_ref(this: bun_ptr::ThisPtr<Self>, add: bool) {
+        let evl = this.io_evtloop();
+        // SAFETY: see impl-level note; `update_ref` runs no callbacks.
+        unsafe { (*this.as_ptr()).writer.update_ref(evl, add) };
     }
 
-    pub fn close(&mut self) {
+    pub fn close(this: bun_ptr::ThisPtr<Self>) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) close()",
-            std::ptr::from_ref(self) as usize
+            this.as_ptr() as usize
         );
-        self.writer.close();
+        // SAFETY: see impl-level note.
+        unsafe { (*this.as_ptr()).writer.close() };
+    }
+
+    pub fn watch(this: bun_ptr::ThisPtr<Self>) {
+        if this.buffer.len() > 0 {
+            // SAFETY: see impl-level note.
+            unsafe { (*this.as_ptr()).writer.watch() };
+        }
+    }
+
+    /// `start()`'s in-flight ref, for an owner closing the writer itself (it
+    /// releases the ref after the close).
+    pub fn take_start_ref(this: bun_ptr::ThisPtr<Self>) -> Option<RefPtr<Self>> {
+        // SAFETY: see impl-level note; momentary field access.
+        unsafe { (*this.as_ptr()).start_ref.take() }
+    }
+
+    /// Free the source now (the owner is discarding the writer).
+    pub fn detach_source(this: bun_ptr::ThisPtr<Self>) {
+        // SAFETY: see impl-level note; momentary field accesses. `buffer`
+        // aliases `source`'s storage, so it is cleared first.
+        unsafe {
+            (*this.as_ptr()).buffer = RawSlice::EMPTY;
+            (*this.as_ptr()).source.detach();
+        }
+    }
+
+    pub fn start(this: bun_ptr::ThisPtr<Self>) -> bun_sys::Result<()> {
+        // A synchronous failure inside `start_impl` can run `on_close`, which
+        // releases both the owner's ref and `start_ref`; hold one more so the
+        // error path below it still has a live writer.
+        let _guard = RefPtr::from_this(this);
+        // SAFETY: see impl-level note; momentary field access. The in-flight
+        // ref is minted from the root pointer (it may be released as the last).
+        unsafe { (*this.as_ptr()).start_ref = Some(RefPtr::from_this(this)) };
+        // SAFETY: see impl-level note.
+        unsafe { (*this.as_ptr()).start_impl() }
     }
 
     /// Callers resolve to an `EventLoopHandle` before calling and we accept
     /// it directly.
     pub fn create(
         event_loop: EventLoopHandle,
-        subprocess: *mut P,
+        subprocess: bun_ptr::ThisPtr<P>,
         result: StdioResult,
         source: Source,
     ) -> RefPtr<Self> {
@@ -118,9 +165,9 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             writer: IOWriter::<P>::default(),
             stdio_result: result,
             source,
-            process: subprocess,
+            process: bun_ptr::BackRef::from(subprocess),
             event_loop,
-            started: false,
+            start_ref: None,
             buffer: RawSlice::EMPTY,
         });
         #[cfg(windows)]
@@ -153,28 +200,22 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         unsafe { RefPtr::from_raw(this) }
     }
 
-    pub fn start(&mut self) -> bun_sys::Result<()> {
+    /// `start_ref` is already set by [`Self::start`].
+    fn start_impl(&mut self) -> bun_sys::Result<()> {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) start()",
             std::ptr::from_ref(self) as usize
         );
-        // Intrusive-refcount increment.
-        // SAFETY: `self` is a live `Self` (created via `create()`/`heap::alloc`).
-        unsafe { RefCount::<Self>::ref_(std::ptr::from_mut::<Self>(self)) };
         // Self-borrow into `self.source` — see `buffer` field invariant.
         self.buffer = RawSlice::new(self.source.slice());
         #[cfg(windows)]
         {
             let r = self.writer.start_with_current_pipe();
-            self.started = r.is_ok();
             if r.is_err() {
-                // start() failed: `started` stays false so no release site
-                // fires — release start()'s `+1` here.
-                // SAFETY: `self` is the live `Self` we ref'd at the top of
-                // `start()`; the caller's `RefPtr` keeps it alive and
-                // `started` is false so no other site re-derefs.
-                unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+                // start() failed: no release site fires — release start()'s
+                // ref here (not the last: the caller's slot holds one).
+                self.start_ref = None;
             }
             return r;
         }
@@ -188,16 +229,13 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                     // The writer did not take `fd`; nothing else closes it.
                     self.stdio_result = None;
                     fd.close();
-                    // start() failed: `started` stays false so no release
-                    // site fires — release start()'s `+1` here.
-                    // SAFETY: `self` is the live `Self` we ref'd at the top
-                    // of `start()`; the caller's `RefPtr` keeps it alive
-                    // and `started` is false so no other site re-derefs.
-                    unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+                    // start() failed: no release site fires — release
+                    // start()'s ref here (not the last: the caller's slot
+                    // holds one).
+                    self.start_ref = None;
                     bun_sys::Result::Err(err)
                 }
                 bun_sys::Result::Ok(()) => {
-                    self.started = true;
                     #[cfg(unix)]
                     {
                         // `handle` is `PollOrFd` (enum); flag mutation goes
@@ -229,22 +267,17 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         self.buffer = RawSlice::new(&self.buffer.slice()[amount.min(len)..]);
         if status == WriteStatus::EndOfFile {
             // The buffered writer closes itself (-> `on_close`) after this
-            // returns, so don't close here.
-            if core::mem::replace(&mut self.started, false) {
-                // SAFETY: token taken above; not the final ref, the owner's slot
-                // still holds one until that `on_close`.
-                unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
-            }
+            // returns, so don't close here. Not the final ref: the owner's slot
+            // still holds one until that `on_close`.
+            self.start_ref = None;
             return;
         }
         if self.buffer.is_empty() {
-            // Token taken before `close()` so start()'s ref outlives the owner's.
-            let release_start_ref = core::mem::replace(&mut self.started, false);
+            // Taken before `close()` so start()'s ref outlives the owner's.
+            let start_ref = self.start_ref.take();
             self.writer.close();
-            if release_start_ref {
-                // SAFETY: token taken above; may be the final ref, last use of `self`.
-                unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
-            }
+            // May be the final ref; last use of `self`.
+            drop(start_ref);
         }
     }
 
@@ -268,33 +301,23 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             "StaticPipeWriter(0x{:x}) onClose()",
             std::ptr::from_ref(self) as usize
         );
-        // Still set only after a failed write (every other path takes the token
-        // before closing). Must be taken before `on_close_io` empties the slot:
+        // Still set only after a failed write (every other path takes it before
+        // closing). Must be taken before `on_close_io` empties the slot:
         // nothing can reach this writer afterwards.
-        let release_start_ref = core::mem::replace(&mut self.started, false);
+        let start_ref = self.start_ref.take();
         // `buffer` aliases `self.source`'s storage; clear it before detach()
         // frees that storage so no dangling slice survives the close.
         self.buffer = RawSlice::EMPTY;
         self.source.detach();
-        // SAFETY: `process` is a backref to the owning process, guaranteed alive
-        // for the lifetime of this writer (the process owns/outlives its stdio writers).
-        unsafe { P::on_close_io(self.process, StdioKind::Stdin) };
-        if release_start_ref {
-            // SAFETY: token taken above. On POSIX this frees `self`: it is the
-            // last use here, and the writer's `close()` frames below do nothing
-            // after this callback. On Windows the in-flight write's ref outlives it.
-            unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
-        }
+        P::on_close_io(self.process.this_ptr(), StdioKind::Stdin);
+        // On POSIX this frees `self`: it is the last use here, and the
+        // writer's `close()` frames below do nothing after this callback.
+        // On Windows the in-flight write's ref outlives it.
+        drop(start_ref);
     }
 
     pub fn memory_cost(&self) -> usize {
         size_of::<Self>() + self.source.memory_cost() + self.writer.memory_cost()
-    }
-
-    pub fn watch(&mut self) {
-        if self.buffer.len() > 0 {
-            self.writer.watch();
-        }
     }
 }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -904,6 +904,7 @@ pub(crate) mod libuv_error_map;
 #[path = "SignalCode.rs"]
 pub mod signal_code;
 pub use signal_code::SignalCode;
+pub mod pty;
 pub mod tmp;
 pub use tmp::Tmpfile;
 // `windows/mod.rs` is `#![cfg(windows)]`-gated internally; on POSIX this
@@ -6091,6 +6092,7 @@ macro_rules! dlsym_with_handle {
         if p.is_null() {
             None
         } else {
+            // SAFETY: see above.
             Some(unsafe { ::core::mem::transmute_copy::<*mut ::core::ffi::c_void, $T>(&p) })
         }
     }};

--- a/src/sys/pty.rs
+++ b/src/sys/pty.rs
@@ -1,0 +1,393 @@
+//! Pseudo-terminal creation: `openpty(3)` on POSIX, ConPTY on Windows.
+
+#[cfg(unix)]
+pub use posix::*;
+#[cfg(windows)]
+pub use win::*;
+
+#[cfg(unix)]
+mod posix {
+    use core::ffi::c_int;
+
+    use bun_core::Winsize;
+
+    use crate::Fd;
+
+    // `openpty` accepts a `termios*`; only ever passed as null here, so the
+    // layout is never relied on.
+    #[repr(C)]
+    pub struct OpenPtyTermios {
+        _opaque: [u8; 0],
+    }
+
+    type OpenPtyFn = unsafe extern "C" fn(
+        amaster: *mut c_int,
+        aslave: *mut c_int,
+        name: *mut u8,
+        termp: *const OpenPtyTermios,
+        winp: *const Winsize,
+    ) -> c_int;
+
+    /// `openpty` lives in libutil on glibc, which may not be linked; resolve
+    /// it at runtime.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn openpty_fn() -> Option<OpenPtyFn> {
+        use core::ffi::c_void;
+        use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering::Relaxed};
+
+        static HANDLE: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
+        static LOADED: AtomicBool = AtomicBool::new(false);
+
+        fn handle() -> Option<*mut c_void> {
+            if LOADED.load(Relaxed) {
+                let h = HANDLE.load(Relaxed);
+                return if h.is_null() { None } else { Some(h) };
+            }
+            LOADED.store(true, Relaxed);
+            const LIB_NAMES: [&bun_core::ZStr; 3] = [
+                bun_core::zstr!("libutil.so"),
+                bun_core::zstr!("libutil.so.1"),
+                bun_core::zstr!("libc.so.6"),
+            ];
+            for lib_name in LIB_NAMES {
+                if let Some(h) = crate::dlopen(lib_name, crate::RTLD::LAZY) {
+                    HANDLE.store(h, Relaxed);
+                    return Some(h);
+                }
+            }
+            None
+        }
+
+        crate::dlsym_with_handle!(OpenPtyFn, "openpty", handle())
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn openpty_fn() -> Option<OpenPtyFn> {
+        // libc on macOS, libutil (linked) on FreeBSD.
+        unsafe extern "C" {
+            fn openpty(
+                amaster: *mut c_int,
+                aslave: *mut c_int,
+                name: *mut u8,
+                termp: *const OpenPtyTermios,
+                winp: *const Winsize,
+            ) -> c_int;
+        }
+        Some(openpty)
+    }
+
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd"
+    )))]
+    fn openpty_fn() -> Option<OpenPtyFn> {
+        None
+    }
+
+    pub enum OpenPtyError {
+        /// `openpty` could not be resolved on this system.
+        NotSupported,
+        Failed,
+    }
+
+    pub struct PtyPair {
+        pub master: Fd,
+        pub slave: Fd,
+    }
+
+    /// `openpty(3)` with the given initial window size.
+    pub fn openpty(winsize: &Winsize) -> Result<PtyPair, OpenPtyError> {
+        let Some(openpty) = openpty_fn() else {
+            return Err(OpenPtyError::NotSupported);
+        };
+        let mut master: c_int = -1;
+        let mut slave: c_int = -1;
+        // SAFETY: out-params are live locals; name/termp may be null.
+        let rc = unsafe {
+            openpty(
+                &raw mut master,
+                &raw mut slave,
+                core::ptr::null_mut(),
+                core::ptr::null(),
+                core::ptr::from_ref(winsize),
+            )
+        };
+        if rc != 0 {
+            return Err(OpenPtyError::Failed);
+        }
+        Ok(PtyPair {
+            master: Fd::from_native(master),
+            slave: Fd::from_native(slave),
+        })
+    }
+
+    /// `cfsetispeed` + `cfsetospeed`.
+    pub fn cfsetspeed(t: &mut crate::posix::Termios, speed: libc::speed_t) {
+        // SAFETY: `t` is a valid termios.
+        unsafe {
+            libc::cfsetispeed(core::ptr::from_mut(t), speed);
+            libc::cfsetospeed(core::ptr::from_mut(t), speed);
+        }
+    }
+
+    /// `ioctl(fd, TIOCSWINSZ, winsize)`.
+    pub fn set_winsize(fd: Fd, winsize: &Winsize) -> Result<(), crate::Error> {
+        // SAFETY: TIOCSWINSZ reads a `struct winsize` from the pointer.
+        let rc = unsafe {
+            libc::ioctl(
+                fd.native(),
+                libc::TIOCSWINSZ as _,
+                core::ptr::from_ref(winsize),
+            )
+        };
+        if rc != 0 {
+            return Err(crate::err_with(crate::Tag::ioctl));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+mod win {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    use crate::Fd;
+    use crate::windows;
+
+    /// Inbox kernel32's HPCON layout. Stable ABI since build 17763: documented
+    /// as "part of an ABI shared with the rest of the operating system" in
+    /// microsoft/terminal `src/winconpty/winconpty.h`.
+    #[repr(C)]
+    struct PseudoConsoleLayout {
+        h_signal: windows::HANDLE,
+        h_pty_reference: windows::HANDLE,
+        h_conpty_process: windows::HANDLE,
+    }
+
+    /// An open ConPTY handle from `CreatePseudoConsole`. `Send`: may be closed
+    /// from another thread.
+    pub struct PseudoConsole(windows::HPCON);
+
+    // SAFETY: an HPCON is a process-wide kernel32 object; Close/Resize are
+    // documented as callable from any thread.
+    unsafe impl Send for PseudoConsole {}
+
+    impl PseudoConsole {
+        /// The raw handle, for `uv_process_options_t.pseudoconsole`.
+        #[inline]
+        pub fn raw(&self) -> windows::HPCON {
+            self.0
+        }
+
+        /// `ResizePseudoConsole`; returns the HRESULT.
+        pub fn resize(&self, cols: u16, rows: u16) -> i32 {
+            let size = windows::COORD {
+                X: clamp_to_coord(cols),
+                Y: clamp_to_coord(rows),
+            };
+            // SAFETY: `self.0` is an open HPCON.
+            unsafe { windows::ResizePseudoConsole(self.0, size) }
+        }
+
+        /// Close this HPCON's ConDrv `\Reference` handle so conhost exits on
+        /// its own once the last attached client disconnects. Equivalent to
+        /// kernel32's `ReleasePseudoConsole` (Windows 11 24H2+) /
+        /// conpty.dll's `ConptyReleasePseudoConsole`; neither is exported from
+        /// the inbox kernel32 on older builds so this reaches into the struct
+        /// directly. `ClosePseudoConsole` later skips the field when it reads
+        /// null. Further spawns against this pseudoconsole are impossible
+        /// afterwards.
+        pub fn release_reference(&self) {
+            let pc = self.0.cast::<PseudoConsoleLayout>();
+            // SAFETY: inbox `CreatePseudoConsole` heap-allocates a
+            // `PseudoConsole` and returns it as the HPCON.
+            unsafe {
+                let r#ref = (*pc).h_pty_reference;
+                if !r#ref.is_null() && r#ref != windows::INVALID_HANDLE_VALUE {
+                    let _ = windows::CloseHandle(r#ref);
+                    (*pc).h_pty_reference = core::ptr::null_mut();
+                }
+            }
+        }
+
+        /// `ClosePseudoConsole`. On Windows < 11 24H2 this blocks until the
+        /// output pipe is drained.
+        pub fn close(self) {
+            // SAFETY: `self.0` is an open HPCON, consumed here.
+            unsafe { windows::ClosePseudoConsole(self.0) };
+        }
+    }
+
+    /// COORD.X/Y are i16; clamp the u16 cols/rows to its range.
+    #[inline]
+    pub fn clamp_to_coord(v: u16) -> i16 {
+        i16::try_from(v.min(i16::MAX as u16)).unwrap()
+    }
+
+    pub struct ConPty {
+        /// Overlapped server end we read the console's output from (libuv-owned).
+        pub read_fd: Fd,
+        /// Overlapped server end we write the console's input to (libuv-owned).
+        pub write_fd: Fd,
+        pub hpcon: PseudoConsole,
+    }
+
+    pub enum CreatePtyError {
+        OpenPtyFailed,
+        DupFailed,
+    }
+
+    struct PipePair {
+        server: windows::HANDLE,
+        client: windows::HANDLE,
+    }
+
+    static PIPE_SERIAL: AtomicU32 = AtomicU32::new(0);
+
+    fn close_handle(h: windows::HANDLE) {
+        // SAFETY: `h` is an open handle owned by the caller.
+        let _ = unsafe { windows::CloseHandle(h) };
+    }
+
+    /// Create one end of a pipe pair as an overlapped named pipe (server) and
+    /// the other as a synchronous client. The "server" end is suitable for
+    /// libuv (uv_pipe_open) and the "client" end for ConPTY (synchronous I/O).
+    fn create_overlapped_pipe_pair(
+        // PIPE_ACCESS_INBOUND: server reads, client writes.
+        // PIPE_ACCESS_OUTBOUND: server writes, client reads.
+        server_access: u32,
+    ) -> Result<PipePair, CreatePtyError> {
+        use windows::kernel32 as k32;
+        const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x00080000;
+
+        let pid: u32 = windows::GetCurrentProcessId();
+        let counter = PIPE_SERIAL.fetch_add(1, Ordering::Relaxed);
+        let mut name_utf8_buf = [0u8; 96];
+        let name = {
+            use std::io::Write;
+            let mut cursor = &mut name_utf8_buf[..];
+            // An AppContainer may only create server pipes under
+            // `\\.\pipe\LOCAL\`; insert the segment only then so the name is
+            // unchanged outside one (matches libuv's uv__unique_pipe_name).
+            let local = if windows::is_app_container() {
+                r"LOCAL\"
+            } else {
+                ""
+            };
+            if write!(cursor, r"\\.\pipe\{local}bun-conpty-{pid}-{counter}").is_err() {
+                return Err(CreatePtyError::OpenPtyFailed);
+            }
+            let written = 96 - cursor.len();
+            &name_utf8_buf[..written]
+        };
+        let mut name_w_buf = [0u16; 97];
+        let name_w_len = bun_core::convert_utf8_to_utf16_in_buffer(&mut name_w_buf, name).len();
+        name_w_buf[name_w_len] = 0;
+        let name_w = bun_core::WStr::from_buf(&name_w_buf[..], name_w_len);
+
+        // SAFETY: name_w is NUL-terminated; all other params are valid per Win32.
+        let server = unsafe {
+            k32::CreateNamedPipeW(
+                name_w.as_ptr(),
+                server_access | windows::FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                windows::PIPE_TYPE_BYTE | windows::PIPE_READMODE_BYTE | windows::PIPE_WAIT,
+                1,
+                65536,
+                65536,
+                0,
+                core::ptr::null_mut(),
+            )
+        };
+        if server == windows::INVALID_HANDLE_VALUE {
+            return Err(CreatePtyError::OpenPtyFailed);
+        }
+
+        let client_access: u32 = if server_access == windows::PIPE_ACCESS_INBOUND {
+            windows::GENERIC_WRITE
+        } else {
+            windows::GENERIC_READ
+        };
+
+        // SAFETY: name_w is NUL-terminated; all other params are valid per Win32.
+        let client = unsafe {
+            k32::CreateFileW(
+                name_w.as_ptr(),
+                client_access,
+                0,
+                core::ptr::null_mut(),
+                windows::OPEN_EXISTING,
+                0,
+                core::ptr::null_mut(),
+            )
+        };
+        if client == windows::INVALID_HANDLE_VALUE {
+            close_handle(server);
+            return Err(CreatePtyError::OpenPtyFailed);
+        }
+
+        Ok(PipePair { server, client })
+    }
+
+    /// Create a ConPTY of `cols`×`rows` with overlapped named-pipe server ends
+    /// for reading its output and writing its input.
+    pub fn create_conpty(cols: u16, rows: u16) -> Result<ConPty, CreatePtyError> {
+        // Output pipe: ConPTY writes (client), we read (overlapped server).
+        let out = create_overlapped_pipe_pair(windows::PIPE_ACCESS_INBOUND)?;
+        // Input pipe: we write (overlapped server), ConPTY reads (client).
+        let inp = match create_overlapped_pipe_pair(windows::PIPE_ACCESS_OUTBOUND) {
+            Ok(p) => p,
+            Err(e) => {
+                close_handle(out.server);
+                close_handle(out.client);
+                return Err(e);
+            }
+        };
+
+        let size = windows::COORD {
+            X: clamp_to_coord(cols),
+            Y: clamp_to_coord(rows),
+        };
+        let mut pc: windows::HPCON = core::ptr::null_mut();
+        // SAFETY: inp.client/out.client are valid open HANDLEs; pc is a valid out-ptr.
+        let hr = unsafe { windows::CreatePseudoConsole(size, inp.client, out.client, 0, &mut pc) };
+        // ConPTY duplicated the client handles internally (or failed); close
+        // our copies either way.
+        close_handle(inp.client);
+        close_handle(out.client);
+        if hr < 0 {
+            close_handle(out.server);
+            close_handle(inp.server);
+            return Err(CreatePtyError::OpenPtyFailed);
+        }
+        let hpcon = PseudoConsole(pc);
+
+        // Wrap server (overlapped) ends as libuv-owned FDs so they can be
+        // passed to BufferedReader/StreamingWriter.start() (uv_pipe_open).
+        let read_fd = match Fd::from_system(out.server).make_libuv_owned() {
+            Ok(fd) => fd,
+            Err(_) => {
+                hpcon.close();
+                close_handle(out.server);
+                close_handle(inp.server);
+                return Err(CreatePtyError::DupFailed);
+            }
+        };
+        let write_fd = match Fd::from_system(inp.server).make_libuv_owned() {
+            Ok(fd) => fd,
+            Err(_) => {
+                hpcon.close();
+                crate::FdExt::close(read_fd);
+                close_handle(inp.server);
+                return Err(CreatePtyError::DupFailed);
+            }
+        };
+
+        Ok(ConPty {
+            read_fd,
+            write_fd,
+            hpcon,
+        })
+    }
+}

--- a/src/sys/pty.rs
+++ b/src/sys/pty.rs
@@ -33,29 +33,17 @@ mod posix {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn openpty_fn() -> Option<OpenPtyFn> {
         use core::ffi::c_void;
-        use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering::Relaxed};
 
-        static HANDLE: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-        static LOADED: AtomicBool = AtomicBool::new(false);
-
+        /// Evaluated once, inside `dlsym_with_handle!`'s `Once`.
         fn handle() -> Option<*mut c_void> {
-            if LOADED.load(Relaxed) {
-                let h = HANDLE.load(Relaxed);
-                return if h.is_null() { None } else { Some(h) };
-            }
-            LOADED.store(true, Relaxed);
             const LIB_NAMES: [&bun_core::ZStr; 3] = [
                 bun_core::zstr!("libutil.so"),
                 bun_core::zstr!("libutil.so.1"),
                 bun_core::zstr!("libc.so.6"),
             ];
-            for lib_name in LIB_NAMES {
-                if let Some(h) = crate::dlopen(lib_name, crate::RTLD::LAZY) {
-                    HANDLE.store(h, Relaxed);
-                    return Some(h);
-                }
-            }
-            None
+            LIB_NAMES
+                .into_iter()
+                .find_map(|lib_name| crate::dlopen(lib_name, crate::RTLD::LAZY))
         }
 
         crate::dlsym_with_handle!(OpenPtyFn, "openpty", handle())
@@ -267,6 +255,7 @@ mod win {
         let mut name_utf8_buf = [0u8; 96];
         let name = {
             use std::io::Write;
+            let capacity = name_utf8_buf.len();
             let mut cursor = &mut name_utf8_buf[..];
             // An AppContainer may only create server pipes under
             // `\\.\pipe\LOCAL\`; insert the segment only then so the name is
@@ -279,7 +268,7 @@ mod win {
             if write!(cursor, r"\\.\pipe\{local}bun-conpty-{pid}-{counter}").is_err() {
                 return Err(CreatePtyError::OpenPtyFailed);
             }
-            let written = 96 - cursor.len();
+            let written = capacity - cursor.len();
             &name_utf8_buf[..written]
         };
         let mut name_w_buf = [0u16; 97];

--- a/src/sys/pty.rs
+++ b/src/sys/pty.rs
@@ -5,6 +5,12 @@ pub use posix::*;
 #[cfg(windows)]
 pub use win::*;
 
+/// ConPTY's `COORD.X/Y` are i16; clamp the u16 cols/rows to its range.
+#[inline]
+pub fn clamp_to_coord(v: u16) -> i16 {
+    i16::try_from(v.min(i16::MAX as u16)).unwrap()
+}
+
 #[cfg(unix)]
 mod posix {
     use core::ffi::c_int;
@@ -139,6 +145,7 @@ mod posix {
 
 #[cfg(windows)]
 mod win {
+    use super::clamp_to_coord;
     use core::sync::atomic::{AtomicU32, Ordering};
 
     use crate::Fd;
@@ -206,12 +213,6 @@ mod win {
             // SAFETY: `self.0` is an open HPCON, consumed here.
             unsafe { windows::ClosePseudoConsole(self.0) };
         }
-    }
-
-    /// COORD.X/Y are i16; clamp the u16 cols/rows to its range.
-    #[inline]
-    pub fn clamp_to_coord(v: u16) -> i16 {
-        i16::try_from(v.min(i16::MAX as u16)).unwrap()
     }
 
     pub struct ConPty {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1496,6 +1496,11 @@ describe("deno_task", () => {
   describe("command substitution", async () => {
     TestBuilder.command`echo $(echo 1)`.stdout("1\n").runAsTest("nested echo cmd subst");
     TestBuilder.command`echo $(echo 1 && echo 2)`.stdout("1 2\n").runAsTest("nested echo cmd subst with conditional");
+    // NUL bytes in the substituted output are dropped (bash prints a warning
+    // and does the same); they cannot be part of an argv word.
+    TestBuilder.command`echo x$(${BUN} -e ${"process.stdout.write('a\\0b')"})y | cat`
+      .stdout("xaby\n")
+      .runAsTest("cmd subst drops NUL bytes");
     // TODO Sleep tests
   });
 


### PR DESCRIPTION
### What

Same programme as #40055 / #40135 / #40136 / #40139 / #40187 / #40190 / #40200 / #40202 / #40203, applied to the subprocess family: `src/runtime/api/bun/subprocess.rs` 35 → **0**, `src/runtime/shell/subproc.rs` 87 → **0**, `src/runtime/api/bun/Terminal.rs` 47 → **0** (incidental: `js_bun_spawn_bindings.rs` 33 → 21, `shell/states/Cmd.rs` 14 → 7, `Writable.rs` 8 → 2). No new `unsafe` under `src/runtime` / `src/install`; what remains lives in typed primitives one layer down:

- **`bun_io`**: `impl_buffered_reader_parent!` gains `borrow = this` + `reader = <field>` (emits `unsafe trait BufferedReaderOwner`, `offset_of` projection; `BufferedReader::read_from(ThisPtr<P>)` / `on_error_from`), `impl_streaming_writer_parent!` `borrow = this`; `MaxBufOwner` + RAII `MaxBufSlot` replacing the raw `Owner { ptr, unsafe fn }`; Windows `UvPipeOwner` / `set_pipe_owner(&Pipe, ThisPtr<T>)` / `close_and_destroy_pipe(Box<Pipe>)`, and `Subprocess: Drop` closes leftover pipes so a registry entry can't outlive it.
- **`bun_spawn`**: `ProcessHandle` methods by value (no `Deref`, so no `&Process` spans a `&mut`-projecting call); `StaticPipeWriter` entry points take `ThisPtr<Self>`, `process: BackRef<P, Mut>`, `started: bool` → `start_ref: Option<RefPtr<Self>>`.
- **`bun_jsc`**: `AbortListenerRef` + RAII `AbortListenerHandle`; `host_fn_getter_ptr` + generate-classes getter thunk so getters can take `this: ThisPtr<Self>`; generate-jssink emits `${name}__fromJSThis(JSValue) -> Option<ThisPtr<_>>`.
- **`bun_sys::pty`** (new): posix `openpty` (dlsym on Linux) / `cfsetspeed` / `set_winsize`; Windows `create_conpty` + `PseudoConsole` — moved out of Terminal.rs.
- `bun_ptr::OwnedThis<T>`; `EventLoopHandle::with_env_var(key, f)`; `FileSink::create*/SendQueue::new → RefPtr`; `FileSink::to_js/assign_to_stream/on_attached_process_exit(this: ThisPtr<FileSink>, ..)`; `Writable::Pipe(RefPtr<FileSink>)`; `ShellSubprocess::spawn_async → OwnedThis<Self>`; `SpawnArgs` takes argv/env as `&[&CStr]`; `Terminal::create_from_spawn → CreateResult { terminal: BackRef<Terminal, Mut>, .. }`.

Pre-existing bugs fixed in passing: `security_scanner.rs` released `start()`'s ref even when `start()` failed (over-release → UAF via the error guard; the typed `take_start_ref` returns `None` there now); the Terminal reader ref is taken before `reader.start()` (the synchronous `on_reader_error` path leaked it). Shares the `host_fn` `ThisPtr`-receiver and `BackRef::this_ptr` hunks with #40139 / #40192 (identical text; flips to `BackRef<_, Root>` when #40192 lands).

### Testing

Debug+ASAN: all 44 `test/js/bun/spawn/*.test.ts`, `test/js/bun/terminal/*`, 28 shell + 15 shell/commands files, 8 `node/child_process`, run-shell / shell-keepalive, 26 `test-child-process-*` node parallel tests — pass, except cases reproduced identically on a main debug build (`spawn_waiter_thread` CPU budget, `spawn-pipe-leak` 30 s wall budget, `shell/leak.test.ts` + `shell-load` 90–100 s budgets, root-user permission cases). Instruction counts for 3000× `` $`true` `` + 300× `Bun.spawn`: main 101.0 G / 97.8 G vs branch 100.3 G / 100.6 G (noise). Hand-driven: stdin pipe → cat, partial stdout read + kill, `unref` + parent exit, spawnSync 3 MB, IPC ping-pong, `$` pipelines/redirects/`> ${buffer}`, inline pty echo + standalone `Bun.Terminal` write/resize/close, GC while running, worker spawn + terminate — correct output, no ASAN reports. clippy clean on bun_runtime/bun_spawn/bun_io/bun_ptr/bun_jsc/bun_sys/bun_event_loop/bun_install; `rust-check-all` windows-msvc + apple-darwin pass.