### PR TITLE
undici: add dump() and bytes() to the request() response body

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -110,9 +110,7 @@ class BodyReadable extends ReadableFromWeb {
     return await this.#response.bytes();
   }
 
-  // Discards the body without buffering it, destroying the stream once `limit`
-  // bytes have been received. Mirrors undici's BodyReadable.dump():
-  // https://github.com/nodejs/undici/blob/v6.21.3/lib/api/readable.js#L158-L199
+  // Port of https://github.com/nodejs/undici/blob/v6.21.3/lib/api/readable.js#L158-L199
   async dump(opts) {
     const signal = opts?.signal;
 

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -3,6 +3,7 @@ const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapt
 
 const ObjectCreate = Object.create;
 const kEmptyObject = ObjectCreate(null);
+const noop = () => {};
 
 var fetch = Bun.fetch;
 const bindings = $cpp("Undici.cpp", "createUndiciInternalBinding");
@@ -102,6 +103,61 @@ class BodyReadable extends ReadableFromWeb {
   async text() {
     this.#consume();
     return await this.#response.text();
+  }
+
+  async bytes() {
+    this.#consume();
+    return await this.#response.bytes();
+  }
+
+  // Discards the body without buffering it, destroying the stream once `limit`
+  // bytes have been received. Mirrors undici's BodyReadable.dump():
+  // https://github.com/nodejs/undici/blob/v6.21.3/lib/api/readable.js#L158-L199
+  async dump(opts) {
+    const signal = opts?.signal;
+
+    if (signal != null && (typeof signal !== "object" || !("aborted" in signal))) {
+      throw new InvalidArgumentError("signal must be an AbortSignal");
+    }
+
+    let limit = Number.isFinite(opts?.limit) ? opts.limit : 128 * 1024;
+
+    signal?.throwIfAborted();
+
+    if (this._readableState.closeEmitted) {
+      return null;
+    }
+
+    return await new Promise((resolve, reject) => {
+      this.#bodyUsed = true;
+
+      const contentLength = Number(this.#response.headers.get("content-length"));
+      if (contentLength > limit) {
+        this.destroy(new AbortError());
+      }
+
+      const onAbort = () => {
+        this.destroy(signal.reason ?? new AbortError());
+      };
+      signal?.addEventListener("abort", onAbort);
+
+      this.on("close", function () {
+        signal?.removeEventListener("abort", onAbort);
+        if (signal?.aborted) {
+          reject(signal.reason ?? new AbortError());
+        } else {
+          resolve(null);
+        }
+      })
+        .on("error", noop)
+        .on("data", function (chunk) {
+          limit -= chunk.length;
+          if (limit <= 0) {
+            this.destroy();
+          }
+        })
+        .resume();
+    });
   }
 }
 

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -125,6 +125,8 @@ class BodyReadable extends ReadableFromWeb {
     signal?.throwIfAborted();
 
     if (this._readableState.closeEmitted) {
+      // A closed stream is disturbed, so real undici reports bodyUsed as true.
+      this.#bodyUsed = true;
       return null;
     }
 

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -229,6 +229,25 @@ describe("undici", () => {
         body.destroy();
       });
 
+      it("destroys the body past the limit when there is no Content-Length", async () => {
+        // A ReadableStream body is sent chunked, so the data handler is the
+        // only limit enforcement.
+        await using server = Bun.serve({
+          port: 0,
+          fetch: () =>
+            new Response(
+              new ReadableStream({
+                async pull(controller) {
+                  controller.enqueue(Buffer.alloc(4096, "x"));
+                },
+              }),
+            ),
+        });
+        const { body } = await request(server.url.href);
+        expect(await body.dump({ limit: 1024 })).toBeNull();
+        expect(body.destroyed).toBe(true);
+      });
+
       it("marks an already-closed body as used", async () => {
         const { body } = await request(`${hostUrl}/get`);
         const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -202,6 +202,54 @@ describe("undici", () => {
       expect(json.headers["x-foo"]).toBe("bar");
     });
 
+    describe("body.dump()", () => {
+      it("drains the body and resolves null", async () => {
+        const { body } = await request(`${hostUrl}/get`);
+        expect(typeof body.dump).toBe("function");
+        expect(await body.dump()).toBeNull();
+        // A second dump after close resolves null as well.
+        expect(await body.dump()).toBeNull();
+      });
+
+      it("destroys the body past the limit but still resolves null", async () => {
+        await using server = Bun.serve({
+          port: 0,
+          fetch: () => new Response(Buffer.alloc(1024 * 1024, "x")),
+        });
+        const { body } = await request(server.url.href);
+        expect(await body.dump({ limit: 1024 })).toBeNull();
+      });
+
+      it("rejects with the signal reason when the signal is already aborted", async () => {
+        const { body } = await request(`${hostUrl}/get`);
+        const reason = new Error("stop");
+        const controller = new AbortController();
+        controller.abort(reason);
+        await expect(body.dump({ signal: controller.signal })).rejects.toBe(reason);
+        body.destroy();
+      });
+
+      it("rejects a value that is not an AbortSignal", async () => {
+        const { body } = await request(`${hostUrl}/get`);
+        await expect(body.dump({ signal: 42 })).rejects.toThrow("signal must be an AbortSignal");
+        body.destroy();
+      });
+    });
+
+    it("body.bytes() returns the body as a Uint8Array", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () => new Response("hello bytes"),
+      });
+      const { body } = await request(server.url.href);
+      expect(typeof body.bytes).toBe("function");
+      const bytes = await body.bytes();
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(new TextDecoder().decode(bytes)).toBe("hello bytes");
+      expect(body.bodyUsed).toBe(true);
+      await expect(body.bytes()).rejects.toThrow("unusable");
+    });
+
     // it("should allow the use of FormData", async () => {
     //   const form = new FormData();
     //   form.append("foo", "bar");

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -229,6 +229,18 @@ describe("undici", () => {
         body.destroy();
       });
 
+      it("marks an already-closed body as used", async () => {
+        const { body } = await request(`${hostUrl}/get`);
+        const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+        body.on("close", onClose);
+        for await (const _ of body) {
+        }
+        await closed;
+        expect(await body.dump()).toBeNull();
+        expect(body.bodyUsed).toBe(true);
+        await expect(body.text()).rejects.toThrow("unusable");
+      });
+
       it("rejects a value that is not an AbortSignal", async () => {
         const { body } = await request(`${hostUrl}/get`);
         await expect(body.dump({ signal: 42 })).rejects.toThrow("signal must be an AbortSignal");

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -243,7 +243,8 @@ describe("undici", () => {
               }),
             ),
         });
-        const { body } = await request(server.url.href);
+        const { body, headers } = await request(server.url.href);
+        expect(headers["content-length"]).toBeUndefined();
         expect(await body.dump({ limit: 1024 })).toBeNull();
         expect(body.destroyed).toBe(true);
       });


### PR DESCRIPTION
### Problem
- The undici shim's `request()` body is a class named `BodyReadable`, the same name real undici uses, but it has no `dump()` or `bytes()`. A call fails with `TypeError: res.body.dump is not a function`.
- The common recovery, `body.destroy(err)` inside the catch, re-emits the error as an unhandled stream `error` event and exits the process. Fixes #40205.
- `BodyReadable` in `src/js/thirdparty/undici.js:59` defined only `arrayBuffer`, `blob`, `formData`, `json`, `text`, and `bodyUsed`.

### Fix
- Add `bytes()`. It consumes the body and returns a `Uint8Array` from the wrapped Response.
- Add `dump(opts)` with undici v6 semantics: validate `opts.signal`, default limit of 128 KiB, destroy the stream once the limit is passed, resolve `null` on close, reject only on signal abort, and swallow stream errors.
- `dump()` marks the body as used, so a later `text()` or `json()` throws `unusable`, as real undici does.
- Verified: `test/js/first_party/undici/undici.test.ts` (5 new tests, all fail on bun 1.4.1). The reporter's repro script now prints `dump resolved` and survives.

### Background
- Bun ships a builtin shim for `undici` (`src/js/thirdparty/undici.js`). Its `request()` wraps `fetch()` and hands out the Response body as a node `Readable` adapter.
- Real undici's `dump()` (`lib/api/readable.js`) discards a response body without buffering it. Libraries call it for redirect bodies and for `Content-Length` cap rejection, then `destroy(err)` on failure.
- `bytes()` is part of the same body mixin since undici v6.

<details><summary>Notes</summary>

- Repro (issue #40205): `await res.body.dump({ limit: 1024 })` throws, the catch calls `res.body.destroy(err)`, and the process exits 1 before the trailing `setTimeout` callback runs. With this change the script exits 0.
- The `dump()` port follows `nodejs/undici` v6.21.3 `lib/api/readable.js` (vendored in `test/node_modules`): same signal validation, same `Number.isFinite` limit handling, same content-length early destroy, same `on('error', noop)` swallow so a destroyed dump still resolves `null`.
- `destroy(err)` on a body with no `error` listener still raises an uncaught error. Real undici behaves the same way under Node, so that is not papered over here.
- The issue also lists other shim gaps (#37110, #39247, #14498, #7920) and the policy question of resolving an installed undici (#17799, PR #36102). Those are out of scope. This PR closes the `dump`/`bytes` instance.
- Full suite run: `bun bd test test/js/first_party/undici/undici.test.ts`, 18 pass, 0 fail.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.1 (4448a2e21)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [72.56ms]
(pass) undici > request > should error when body has already been consumed [18.02ms]
(pass) undici > request > should make a POST request when provided a body and POST method [11.62ms]
(pass) undici > request > should stream a node:stream Readable body [253.81ms]
(pass) undici > request > should accept a URL class object [10.49ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.76ms]
(pass) undici > request > a 204 has no body [51.90ms]
(pass) undici > request > the response to a HEAD request has no body [19.50ms]
(pass) undici > request > should allow a query string to be passed [20.19ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [18.59ms]
(pass) undici > request > should allow us to abort the request with a signal [531.76ms]
(pass) undici > req
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (514b4e1db)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [4.78ms]
(pass) undici > request > should error when body has already been consumed [0.39ms]
(pass) undici > request > should make a POST request when provided a body and POST method [0.25ms]
(pass) undici > request > should stream a node:stream Readable body [5.09ms]
(pass) undici > request > should accept a URL class object [0.27ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [0.19ms]
(pass) undici > request > a 204 has no body [1.06ms]
(pass) undici > request > the response to a HEAD request has no body [0.41ms]
(pass) undici > request > should allow a query string to be passed [0.42ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [0.35ms]
(pass) undici > request > should allow us to abort the request with a signal [501.34ms]
(pass) undici > request > should properly append headers to the request [0.91ms]
(pass) undici > request > body.dump() > drains the body and resolves null [0.88ms]
(pass) undici > request > body.d
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.1 (4448a2e21)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [73.97ms]
(pass) undici > request > should error when body has already been consumed [17.87ms]
(pass) undici > request > should make a POST request when provided a body and POST method [15.70ms]
(pass) undici > request > should stream a node:stream Readable body [249.88ms]
(pass) undici > request > should accept a URL class object [10.62ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.80ms]
(pass) undici > request > a 204 has no body [53.55ms]
(pass) undici > request > the response to a HEAD request has no body [19.21ms]
(pass) undici > request > should allow a query string to be passed [19.01ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [16.43ms]
(pass) undici > request > should allow us to abort the request with a signal [532.23ms]
(pass) undici > req
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 632ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7713ms)
Bundle modules (52ms)
Postprocesss modules (44ms)
Bundle Functions (464ms)
Generate Code (20ms)

[8.30s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 24s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+d803b9121
[build] done
bun test v1.4.1-canary.1 (d803b9121)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [3.65ms]
(pass) undici > request > should error when body has already been consumed [0.36ms]
(pass) undici > requ
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/undici.js               | 56 ++++++++++++++++++++++
 test/js/first_party/undici/undici.test.ts | 80 +++++++++++++++++++++++++++++++
 2 files changed, 136 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/thirdparty/undici.js                    2      5      0
test/js/first_party/undici/undici.test.ts      2      4      0
```

</details>

**root cause** · written by the author bot

Bun's undici shim exposed a BodyReadable class under the same name as real Undici's but without the dump() and bytes() methods, so code relying on dump() to discard a body threw a TypeError, and the idiomatic recovery of body.destroy(err) re-emitted that error as an unhandled stream error and crashed the process. The fix implements dump() and bytes() on the shim's BodyReadable with Undici-compatible semantics, where dump() drains the body up to a configurable limit, destroys the stream past the limit while still resolving null, and rejects with the abort reason when given an already aborted…

<!-- robobun:evidence:end -->