### PR TITLE
node:fs: stop a readFile of a pipe or device when its worker is terminated

### DIFF
--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -262,6 +262,12 @@ impl Ticket {
     pub fn cancelled(&self) -> bool {
         self.shared.state() >= State::Draining
     }
+
+    /// The uncounted handle of this ticket's VM (any thread): for code the
+    /// work calls that reads the gate but must not hold a ticket itself.
+    pub fn handle(&self) -> VmHandle {
+        VmHandle(Arc::clone(&self.shared))
+    }
 }
 
 impl Clone for Ticket {

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -263,8 +263,7 @@ impl Ticket {
         self.shared.state() >= State::Draining
     }
 
-    /// The uncounted handle of this ticket's VM (any thread): for code the
-    /// work calls that reads the gate but must not hold a ticket itself.
+    /// The uncounted handle of this ticket's VM (any thread).
     pub fn handle(&self) -> VmHandle {
         VmHandle(Arc::clone(&self.shared))
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1331,6 +1331,8 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
     };
     bun_core::heap::into_raw(Box::new(NodeFS {
         vm: vm_field,
+        // SAFETY: per fn contract.
+        vm_handle: Some(unsafe { &*vm }.handle()),
         ..NodeFS::default()
     }))
     .cast::<c_void>()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1330,8 +1330,8 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
         None
     };
     bun_core::heap::into_raw(Box::new(NodeFS {
-        sync_error_buf: bun_paths::PathBuffer::uninit(),
         vm: vm_field,
+        ..NodeFS::default()
     }))
     .cast::<c_void>()
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -144,6 +144,8 @@ use bun_event_loop::ConcurrentTask;
 type BlobSizeType = u64;
 /// `maxInt(u52)` == 2^52 - 1.
 const BLOB_SIZE_MAX: u64 = (1u64 << 52) - 1;
+/// One `read` of a readFile's read-until-EOF tail (Node reads 64 KiB there).
+const TAIL_READ_CHUNK: usize = 1024 * 1024;
 
 /// `webcore.RefPtr<AbortSignal>` — JSC's intrusive ref-counted pointer.
 /// Backed by `bun_ptr::ExternalShared<AbortSignal>` (alias re-exported
@@ -6889,13 +6891,23 @@ impl NodeFS {
         }
     }
 
-    /// Nobody wants the next chunk: the caller's `signal` aborted, or the VM this read serves stopped.
-    fn read_abandoned(&self, args: &args::ReadFile) -> bool {
-        args.aborted()
-            || self
-                .vm_handle
-                .as_ref()
-                .is_some_and(|vm| !vm.script_allowed())
+    /// Nobody wants the next chunk: the caller's `signal` aborted, or the VM this read serves
+    /// stopped (`EINTR`: the read was interrupted, as by a signal).
+    fn read_interrupted(&self, args: &args::ReadFile) -> Option<sys::Error> {
+        if args.aborted() {
+            return Some(abort_err());
+        }
+        if self
+            .vm_handle
+            .as_ref()
+            .is_some_and(|vm| !vm.script_allowed())
+        {
+            return Some(with_path_like(
+                sys::Error::from_code(E::EINTR, sys::Tag::read),
+                &args.path,
+            ));
+        }
+        None
     }
 
     pub(crate) fn read_file_with_options(
@@ -6904,6 +6916,10 @@ impl NodeFS {
         flavor: Flavor,
         string_type: ReadFileStringType,
     ) -> Maybe<ret::ReadFileWithOptions> {
+        // Before `open` as well: a FIFO with no writer blocks there for good.
+        if let Some(err) = self.read_interrupted(args) {
+            return Err(err);
+        }
         let path_is_path = matches!(args.path, PathOrFileDescriptor::Path(_));
         let fd_maybe_windows: FD = match &args.path {
             PathOrFileDescriptor::Path(p) => {
@@ -6974,8 +6990,8 @@ impl NodeFS {
             }
         });
 
-        if self.read_abandoned(args) {
-            return Err(abort_err());
+        if let Some(err) = self.read_interrupted(args) {
+            return Err(err);
         }
 
         // Only used in DOMFormData
@@ -7027,8 +7043,8 @@ impl NodeFS {
                 }
                 total += amt;
                 available = &mut available[amt..];
-                if self.read_abandoned(args) {
-                    return Err(abort_err());
+                if let Some(err) = self.read_interrupted(args) {
+                    return Err(err);
                 }
             }
             &pre_stat_buf[..total]
@@ -7155,17 +7171,22 @@ impl NodeFS {
         unsafe { buf.expand_to_capacity() };
 
         // Two-phase read: first up to `size`, then keep going until EOF.
-        // `phase == 0` is the size-bounded loop, `phase == 1` is the unbounded tail.
-        let mut phase: u8 = if (total as u64) < size { 0 } else { 1 };
         loop {
-            if self.read_abandoned(args) {
-                return Err(abort_err());
+            if let Some(err) = self.read_interrupted(args) {
+                return Err(err);
             }
             // When `total == min(buf.capacity, max_size)`
             // the next read receives an empty slice → returns 0 → `did_succeed = true; break`.
             // Do NOT pre-grow here; growth happens only in the `total > size && amt != 0 &&
             // !has_max_size` arm below.
             let upper = (buf.capacity() as u64).min(max_size) as usize;
+            // Past `size` the tail reads a pipe, a device or a file that outgrew its stat size:
+            // one chunk at a time, so the stop check above is never further away than one chunk.
+            let upper = if (total as u64) >= size {
+                upper.min(total + TAIL_READ_CHUNK)
+            } else {
+                upper
+            };
             let amt = Syscall::read(fd, &mut buf[total..upper])?;
             total += amt;
 
@@ -7202,13 +7223,7 @@ impl NodeFS {
                 did_succeed = true;
                 break;
             }
-
-            if phase == 0 && (total as u64) >= size {
-                // fall through into the unbounded tail loop
-                phase = 1;
-            }
         }
-        let _ = phase; // silence the unused-assignment lint on the final phase value
 
         let final_len = if string_type == ReadFileStringType::NullTerminated {
             total + 1

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4496,8 +4496,7 @@ pub struct NodeFS {
     /// the heap allocated buffer on the NodeFS struct
     pub(crate) sync_error_buf: PathBuffer, // must be align_of::<u16>()-aligned — enforced via #[repr(C)] + field order, see above
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
-    /// The VM this operation serves: a read-until-EOF loop stops at the next
-    /// chunk once it stops. `None` for the internal callers.
+    /// The VM this operation serves; a read-until-EOF loop stops once it stops.
     pub(crate) vm_handle: Option<bun_jsc::VmHandle>,
 }
 
@@ -6890,9 +6889,7 @@ impl NodeFS {
         }
     }
 
-    /// Between two reads: nobody wants the bytes once the caller's `signal`
-    /// aborted or the VM this read serves was asked to stop. A pipe or a
-    /// device has no EOF, and the worker's teardown waits for this loop.
+    /// Nobody wants the next chunk: the caller's `signal` aborted, or the VM this read serves stopped.
     fn read_abandoned(&self, args: &args::ReadFile) -> bool {
         args.aborted()
             || self

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4496,9 +4496,8 @@ pub struct NodeFS {
     /// the heap allocated buffer on the NodeFS struct
     pub(crate) sync_error_buf: PathBuffer, // must be align_of::<u16>()-aligned — enforced via #[repr(C)] + field order, see above
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
-    /// The VM whose script asked for this operation (the `node:fs` binding's
-    /// own VM, or the VM a pool job serves). A read-until-EOF loop stops at
-    /// the next chunk once that VM stops. `None` for the internal callers.
+    /// The VM this operation serves: a read-until-EOF loop stops at the next
+    /// chunk once it stops. `None` for the internal callers.
     pub(crate) vm_handle: Option<bun_jsc::VmHandle>,
 }
 
@@ -6891,13 +6890,9 @@ impl NodeFS {
         }
     }
 
-    /// Between two reads of a read-until-EOF loop: does anyone still want the
-    /// bytes? Not once the caller's `signal` aborted, and not once the VM this
-    /// read serves has been asked to stop (`worker.terminate()`,
-    /// `process.exit()`). A pipe or a device has no EOF to reach, and the
-    /// worker's teardown waits for the pool job, so the loop has to give up
-    /// on its own. Node stops at the same point: it issues one request per
-    /// chunk, and a stopping environment runs no continuation.
+    /// Between two reads: nobody wants the bytes once the caller's `signal`
+    /// aborted or the VM this read serves was asked to stop. A pipe or a
+    /// device has no EOF, and the worker's teardown waits for this loop.
     fn read_abandoned(&self, args: &args::ReadFile) -> bool {
         args.aborted()
             || self

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6891,8 +6891,7 @@ impl NodeFS {
         }
     }
 
-    /// Nobody wants the next chunk: the caller's `signal` aborted, or the VM this read serves
-    /// stopped (`EINTR`: the read was interrupted, as by a signal).
+    /// Nobody wants the next chunk: the caller's `signal` aborted, or the VM this read serves stopped.
     fn read_interrupted(&self, args: &args::ReadFile) -> Option<sys::Error> {
         if args.aborted() {
             return Some(abort_err());
@@ -7180,8 +7179,7 @@ impl NodeFS {
             // Do NOT pre-grow here; growth happens only in the `total > size && amt != 0 &&
             // !has_max_size` arm below.
             let upper = (buf.capacity() as u64).min(max_size) as usize;
-            // Past `size` the tail reads a pipe, a device or a file that outgrew its stat size:
-            // one chunk at a time, so the stop check above is never further away than one chunk.
+            // Past `size` (a pipe, a device, a file that outgrew its stat size): one chunk per stop check.
             let upper = if (total as u64) >= size {
                 upper.min(total + TAIL_READ_CHUNK)
             } else {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1255,7 +1255,10 @@ mod _async_tasks {
             this: &mut Self,
             done: bun_jsc::Completion<Self>,
         ) -> Option<bun_jsc::Completion<Self>> {
-            let mut node_fs = NodeFS::default();
+            let mut node_fs = NodeFS {
+                vm_handle: Some(done.ticket().handle()),
+                ..NodeFS::default()
+            };
             this.result = NodeFS::dispatch::<R, A, F>(&mut node_fs, &this.args, Flavor::Async);
             // `sys::Error::path` is `Box<[u8]>` boxed at the `errno_sys_p`
             // construction site, so no clone is needed — `node_fs` may drop.
@@ -4493,6 +4496,10 @@ pub struct NodeFS {
     /// the heap allocated buffer on the NodeFS struct
     pub(crate) sync_error_buf: PathBuffer, // must be align_of::<u16>()-aligned — enforced via #[repr(C)] + field order, see above
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
+    /// The VM whose script asked for this operation (the `node:fs` binding's
+    /// own VM, or the VM a pool job serves). A read-until-EOF loop stops at
+    /// the next chunk once that VM stops. `None` for the internal callers.
+    pub(crate) vm_handle: Option<bun_jsc::VmHandle>,
 }
 
 impl Default for NodeFS {
@@ -4500,6 +4507,7 @@ impl Default for NodeFS {
         Self {
             sync_error_buf: PathBuffer::uninit(),
             vm: None,
+            vm_handle: None,
         }
     }
 }
@@ -6883,6 +6891,21 @@ impl NodeFS {
         }
     }
 
+    /// Between two reads of a read-until-EOF loop: does anyone still want the
+    /// bytes? Not once the caller's `signal` aborted, and not once the VM this
+    /// read serves has been asked to stop (`worker.terminate()`,
+    /// `process.exit()`). A pipe or a device has no EOF to reach, and the
+    /// worker's teardown waits for the pool job, so the loop has to give up
+    /// on its own. Node stops at the same point: it issues one request per
+    /// chunk, and a stopping environment runs no continuation.
+    fn read_abandoned(&self, args: &args::ReadFile) -> bool {
+        args.aborted()
+            || self
+                .vm_handle
+                .as_ref()
+                .is_some_and(|vm| !vm.script_allowed())
+    }
+
     pub(crate) fn read_file_with_options(
         &mut self,
         args: &args::ReadFile,
@@ -6959,7 +6982,7 @@ impl NodeFS {
             }
         });
 
-        if args.aborted() {
+        if self.read_abandoned(args) {
             return Err(abort_err());
         }
 
@@ -7012,6 +7035,9 @@ impl NodeFS {
                 }
                 total += amt;
                 available = &mut available[amt..];
+                if self.read_abandoned(args) {
+                    return Err(abort_err());
+                }
             }
             &pre_stat_buf[..total]
         };
@@ -7086,10 +7112,6 @@ impl NodeFS {
         }
         // ----------------------------
 
-        if args.aborted() {
-            return Err(abort_err());
-        }
-
         let stat_ = Syscall::fstat(fd)?;
 
         // For certain files, the size might be 0 but the file might still have contents.
@@ -7144,7 +7166,7 @@ impl NodeFS {
         // `phase == 0` is the size-bounded loop, `phase == 1` is the unbounded tail.
         let mut phase: u8 = if (total as u64) < size { 0 } else { 1 };
         loop {
-            if args.aborted() {
+            if self.read_abandoned(args) {
                 return Err(abort_err());
             }
             // When `total == min(buf.capacity, max_size)`

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -357,7 +357,10 @@ pub(crate) fn create_binding(global: &JSGlobalObject) -> JSValue {
     let vm = global.bun_vm_ptr();
     // R-2: init-time write before the JS wrapper exists; `with_mut` here is
     // trivially un-aliased (sole owner of the fresh `Box`).
-    module.node_fs.with_mut(|nfs| nfs.vm = NonNull::new(vm));
+    module.node_fs.with_mut(|nfs| {
+        nfs.vm = NonNull::new(vm);
+        nfs.vm_handle = Some(global.bun_vm().handle());
+    });
 
     // `module` was `Box::new`-allocated; ownership transfers to the GC
     // wrapper, which calls `Binding::finalize` to reclaim it.

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -85,7 +85,10 @@ fn read_from_blob(
         StoreData::File(f) => f,
         _ => return Err(ReadFromBlobError::NotAFile),
     };
-    let mut fs = node_fs::NodeFS::default();
+    let mut fs = node_fs::NodeFS {
+        vm_handle: Some(global.bun_vm().handle()),
+        ..node_fs::NodeFS::default()
+    };
     // `ReadFile` has a `Drop` impl (releases its `signal` ref), so functional
     // record update from `..Default::default()` would partially move out of a
     // `Drop` type. Mutate-after-default instead.

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -494,18 +494,32 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     using dir = tempDir("fs-abort-readfile-fifo", {});
     const fifo = join(String(dir), "fifo");
     mkfifo(fifo, 0o666);
-    // Both ends are held here: the pool thread's open() does not block, and its read() never sees EOF.
-    const fd = fs.openSync(fifo, "r+");
+    // Both ends are held here, so the pool thread's open() does not block and its read() never sees
+    // EOF. The writes go through a non-blocking end, so this thread is never stuck on a full pipe.
+    const hold = fs.openSync(fifo, "r+");
+    const out = fs.openSync(fifo, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+    const write = (buf, off) => {
+      try {
+        return fs.writeSync(out, buf, off);
+      } catch (e) {
+        if (e.code !== "EAGAIN") throw e;
+        return 0;
+      }
+    };
     try {
       const ac = new AbortController();
       const reason = new Error("stop");
       const promise = fsPromises.readFile(fifo, { signal: ac.signal });
-      // A blocking write of more than the pipe holds returns once the read loop has drained the rest,
-      // so the read is in flight, blocked on the next chunk, from here on.
+      // More bytes than the pipe holds only go through once the read loop has drained the rest, so
+      // from here on the read is in flight, blocked on the next chunk.
       const chunk = Buffer.alloc(192 * 1024, 0x78);
-      for (let off = 0; off < chunk.length; ) off += fs.writeSync(fd, chunk, off);
+      for (let off = 0; off < chunk.length; ) {
+        const n = write(chunk, off);
+        if (n === 0) await Bun.sleep(1);
+        off += n;
+      }
       ac.abort(reason);
-      fs.writeSync(fd, "x");
+      write(Buffer.from("x"), 0);
       expect.assertions(4);
       try {
         await promise;
@@ -513,7 +527,8 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
         expectNodeAbortError(err, reason);
       }
     } finally {
-      fs.closeSync(fd);
+      fs.closeSync(out);
+      fs.closeSync(hold);
     }
   });
 

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -1,4 +1,5 @@
-import { tempDir, tempDirWithFiles } from "harness";
+import { isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkfifo } from "mkfifo";
 import { join } from "path";
 const assert = require("assert");
 const os = require("os");
@@ -482,6 +483,37 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
       await promise;
     } catch (err) {
       expectNodeAbortError(err, ac.signal.reason);
+    }
+  });
+
+  // A FIFO has no size and no EOF while a writer holds it, so readFile reads it
+  // chunk by chunk. The first 256 KiB went through a loop that never looked at
+  // the signal: an abort there was only seen once 256 KiB had arrived. Node
+  // checks the signal before every chunk.
+  test.skipIf(isWindows)("readFile of a FIFO aborted between chunks rejects at the next chunk", async () => {
+    using dir = tempDir("fs-abort-readfile-fifo", {});
+    const fifo = join(String(dir), "fifo");
+    mkfifo(fifo, 0o666);
+    // Both ends are held here: the pool thread's open() does not block, and its read() never sees EOF.
+    const fd = fs.openSync(fifo, "r+");
+    try {
+      const ac = new AbortController();
+      const reason = new Error("stop");
+      const promise = fsPromises.readFile(fifo, { signal: ac.signal });
+      // A blocking write of more than the pipe holds returns once the read loop has drained the rest,
+      // so the read is in flight, blocked on the next chunk, from here on.
+      const chunk = Buffer.alloc(192 * 1024, 0x78);
+      for (let off = 0; off < chunk.length; ) off += fs.writeSync(fd, chunk, off);
+      ac.abort(reason);
+      fs.writeSync(fd, "x");
+      expect.assertions(4);
+      try {
+        await promise;
+      } catch (err) {
+        expectNodeAbortError(err, reason);
+      }
+    } finally {
+      fs.closeSync(fd);
     }
   });
 

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -513,9 +513,13 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
       // More bytes than the pipe holds only go through once the read loop has drained the rest, so
       // from here on the read is in flight, blocked on the next chunk.
       const chunk = Buffer.alloc(192 * 1024, 0x78);
+      const deadline = Date.now() + 4000;
       for (let off = 0; off < chunk.length; ) {
         const n = write(chunk, off);
-        if (n === 0) await Bun.sleep(1);
+        if (n === 0) {
+          if (Date.now() > deadline) throw new Error(`the read loop took only ${off} of ${chunk.length} bytes`);
+          await Bun.sleep(1);
+        }
         off += n;
       }
       ac.abort(reason);

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -1,4 +1,4 @@
-import { isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "path";
 const assert = require("assert");
@@ -520,16 +520,46 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
       }
       ac.abort(reason);
       write(Buffer.from("x"), 0);
-      expect.assertions(4);
-      try {
-        await promise;
-      } catch (err) {
-        expectNodeAbortError(err, reason);
-      }
+      // A deadline, not a wait: a loop that ignores the abort keeps the pool thread in read()
+      // until the FIFO is closed below, and the test has to get there to close it.
+      const outcome = await Promise.race([
+        promise.then(
+          () => "resolved",
+          err => err,
+        ),
+        Bun.sleep(4000),
+      ]);
+      expect(outcome).toBeInstanceOf(Error);
+      expectNodeAbortError(outcome, reason);
     } finally {
       fs.closeSync(out);
       fs.closeSync(hold);
     }
+  });
+
+  // The same loop holds up the exit of the main thread when the VM is torn down on exit
+  // (BUN_DESTRUCT_VM_ON_EXIT=1, the CI runner's setting): teardown waits for the pool job, and a
+  // device never reaches EOF. Teardown closes the gate the loop now checks.
+  test.skipIf(isWindows)("process.exit() with a readFile of /dev/urandom in flight exits", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fs = require("node:fs");
+        fs.promises.readFile("/dev/urandom").then(() => console.log("resolved"), () => console.log("rejected"));
+        // The pool thread is into the read by the time the next loop turn runs.
+        setImmediate(() => { console.log("exiting"); process.exit(0); });
+      `,
+      ],
+      env: { ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("exiting\n");
+    expect(exitCode).toBe(0);
   });
 
   test("appendFile with a pre-aborted signal", async () => {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -957,26 +957,47 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
         const { Worker } = require("node:worker_threads");
         const fifo = ${JSON.stringify(fifo)};
         require("node:child_process").execFileSync("mkfifo", [fifo]);
-        // Both ends are held here: the worker's open() does not block, and its read() never sees EOF.
-        const fd = fs.openSync(fifo, "r+");
+        // Both ends are held here, so the worker's open() does not block and its read() never sees
+        // EOF. The writes go through a non-blocking end: this loop must stay free to run the
+        // worker's 'exit' and the terminate() settlement whatever the worker does with the pipe.
+        const hold = fs.openSync(fifo, "r+");
+        const out = fs.openSync(fifo, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+        const write = (buf, off) => {
+          try {
+            return fs.writeSync(out, buf, off);
+          } catch (e) {
+            if (e.code !== "EAGAIN") throw e;
+            return 0;
+          }
+        };
         const w = new Worker(
           'const fs = require("node:fs"); const { parentPort, workerData: fifo } = require("node:worker_threads");' +
           'parentPort.postMessage("reading"); ${read}',
           { eval: true, workerData: fifo },
         );
         w.on("error", e => { console.error("worker error:", e); process.exit(1); });
+        w.on("exit", code => console.log("exit", code));
         w.on("message", async m => {
-          if (m !== "reading") { console.log("unexpected:", m); process.exit(1); }
-          // A blocking write of more than the pipe holds returns once the worker's read loop has
-          // drained the rest, so the worker is inside that loop, blocked in read(), from here on.
+          console.log(m);
+          if (m !== "reading") process.exit(1);
+          // More bytes than the pipe holds only go through once the worker's read loop has drained
+          // the rest, so from here on the worker is inside that loop, blocked in read().
           const chunk = Buffer.alloc(${fed}, 0x78);
-          for (let off = 0; off < chunk.length; ) off += fs.writeSync(fd, chunk, off);
+          for (let off = 0; off < chunk.length; ) {
+            const n = write(chunk, off);
+            if (n === 0) await Bun.sleep(1);
+            off += n;
+          }
+          console.log("fed");
           // Keep the data flowing: the loop can only notice the stop when a read returns.
-          const feed = setInterval(() => fs.writeSync(fd, "x"), 1);
-          const code = await w.terminate();
+          const x = Buffer.from("x");
+          const feed = setInterval(() => write(x, 0), 1);
+          // A watchdog, not a wait: the unfixed build never settles terminate(), and the test is
+          // more useful failing on this line than on its timeout.
+          const code = await Promise.race([w.terminate(), Bun.sleep(${timeout / 2}).then(() => "hung")]);
           clearInterval(feed);
-          fs.closeSync(fd);
           console.log("terminated", code);
+          process.exit(code === "hung" ? 2 : 0);
         });
       `,
         ],
@@ -986,7 +1007,7 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(stdout).toBe("terminated 1\n");
+      expect(stdout).toBe("reading\nfed\nexit 1\nterminated 1\n");
       expect(exitCode).toBe(0);
     },
     timeout,

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -926,6 +926,73 @@ test(
   timeout,
 );
 
+// fs.readFile / readFileSync read until EOF, and a FIFO (or /dev/urandom) never reaches one. The
+// native read loop checked only the caller's AbortSignal between chunks, never whether the worker
+// had been asked to stop: the sync form never came back to JS for the termination to land, and the
+// async form kept its pool job alive, which the worker's teardown waits for. terminate() hung for as
+// long as the data flowed (node: ~5ms). The loop now gives up at the next chunk once the worker
+// is stopping. Two data points per flavor: less than 256 KiB read so far (the pre-stat read), and
+// more (the read-until-EOF tail, where the buffer grows).
+describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never ends", () => {
+  test.concurrent.each([
+    ["readFileSync", 192 * 1024],
+    ["readFileSync", 512 * 1024],
+    ["promises.readFile", 192 * 1024],
+    ["promises.readFile", 512 * 1024],
+  ])(
+    "%s after %d bytes",
+    async (api, fed) => {
+      using dir = tempDir("worker-terminate-readfile-fifo", {});
+      const fifo = join(String(dir), "fifo");
+      const read =
+        api === "readFileSync"
+          ? `fs.readFileSync(fifo); parentPort.postMessage("returned");`
+          : `fs.promises.readFile(fifo).then(() => parentPort.postMessage("resolved"), e => parentPort.postMessage("rejected " + e.code));`;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+        const fs = require("node:fs");
+        const { Worker } = require("node:worker_threads");
+        const fifo = ${JSON.stringify(fifo)};
+        require("node:child_process").execFileSync("mkfifo", [fifo]);
+        // Both ends are held here: the worker's open() does not block, and its read() never sees EOF.
+        const fd = fs.openSync(fifo, "r+");
+        const w = new Worker(
+          'const fs = require("node:fs"); const { parentPort, workerData: fifo } = require("node:worker_threads");' +
+          'parentPort.postMessage("reading"); ${read}',
+          { eval: true, workerData: fifo },
+        );
+        w.on("error", e => { console.error("worker error:", e); process.exit(1); });
+        w.on("message", async m => {
+          if (m !== "reading") { console.log("unexpected:", m); process.exit(1); }
+          // A blocking write of more than the pipe holds returns once the worker's read loop has
+          // drained the rest, so the worker is inside that loop, blocked in read(), from here on.
+          const chunk = Buffer.alloc(${fed}, 0x78);
+          for (let off = 0; off < chunk.length; ) off += fs.writeSync(fd, chunk, off);
+          // Keep the data flowing: the loop can only notice the stop when a read returns.
+          const feed = setInterval(() => fs.writeSync(fd, "x"), 1);
+          const code = await w.terminate();
+          clearInterval(feed);
+          fs.closeSync(fd);
+          console.log("terminated", code);
+        });
+      `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("terminated 1\n");
+      expect(exitCode).toBe(0);
+    },
+    timeout,
+  );
+});
+
 // A worker exiting while a Bun.spawn() child still has a pending pipe-backed stdin (a Blob the child
 // never reads; the default stdin path on Windows, BUN_FEATURE_FLAG_DISABLE_MEMFD elsewhere): the
 // Subprocess finalizer closed that writer, whose close path re-evaluated pending activity and tried to

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -983,9 +983,13 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
           // More bytes than the pipe holds only go through once the worker's read loop has drained
           // the rest, so from here on the worker is inside that loop, blocked in read().
           const chunk = Buffer.alloc(${fed}, 0x78);
+          const deadline = Date.now() + ${timeout / 2};
           for (let off = 0; off < chunk.length; ) {
             const n = write(chunk, off);
-            if (n === 0) await Bun.sleep(1);
+            if (n === 0) {
+              if (Date.now() > deadline) { console.log("the worker took only", off, "bytes"); process.exit(3); }
+              await Bun.sleep(1);
+            }
             off += n;
           }
           console.log("fed");
@@ -1037,7 +1041,6 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
         const fs = require("node:fs");
         const { Worker } = require("node:worker_threads");
         const io = () => {
-          if (process.platform !== "linux") return { bytes: 0, reads: 1 };
           const text = fs.readFileSync("/proc/self/io", "utf8");
           return { bytes: Number(/rchar: (\\d+)/.exec(text)[1]), reads: Number(/syscr: (\\d+)/.exec(text)[1]) };
         };
@@ -1051,12 +1054,19 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
         w.on("message", async m => {
           console.log(m);
           if (m !== "reading") process.exit(1);
-          // A window of reading: long enough that a doubling read size would have passed 2 MiB.
-          const a = io();
-          await Bun.sleep(200);
-          const b = io();
+          // A window of reading: 32 MiB, past which a doubling read size averages above 2 MiB.
+          let perRead = 0;
+          if (process.platform === "linux") {
+            const a = io();
+            let b = a;
+            for (const deadline = Date.now() + ${timeout / 4}; b.bytes - a.bytes < 32 * 1024 * 1024 && Date.now() < deadline; ) {
+              await Bun.sleep(10);
+              b = io();
+            }
+            perRead = Math.round((b.bytes - a.bytes) / Math.max(1, b.reads - a.reads));
+          }
           const code = await Promise.race([w.terminate(), Bun.sleep(${timeout / 2}).then(() => "hung")]);
-          console.log("terminated", code, "bytes per read:", Math.round((b.bytes - a.bytes) / Math.max(1, b.reads - a.reads)));
+          console.log("terminated", code, "bytes per read:", perRead);
           process.exit(code === "hung" ? 2 : 0);
         });
       `,

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -997,6 +997,10 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
           const code = await Promise.race([w.terminate(), Bun.sleep(${timeout / 2}).then(() => "hung")]);
           clearInterval(feed);
           console.log("terminated", code);
+          // Both ends closed: a worker still in its read loop gets EOF, so the exit's VM teardown
+          // (BUN_DESTRUCT_VM_ON_EXIT=1 joins it) does not wait on the FIFO.
+          fs.closeSync(out);
+          fs.closeSync(hold);
           process.exit(code === "hung" ? 2 : 0);
         });
       `,
@@ -1008,6 +1012,64 @@ describe.skipIf(isWindows)("terminate() stops a readFile of a FIFO that never en
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(stdout).toBe("reading\nfed\nexit 1\nterminated 1\n");
+      expect(exitCode).toBe(0);
+    },
+    timeout,
+  );
+
+  // A device never blocks, so the loop only sees the stop between two reads, and the tail's read
+  // size used to double with the buffer (a 2 GiB read of /dev/urandom takes seconds). The tail now
+  // reads 1 MiB at a time. /proc/self/io gives the process's read count and bytes, so the average
+  // read size over a window of reading is observable (Linux only; reported as 0 elsewhere).
+  // Sequential: a build without the stop reads gigabytes before the watchdog fires.
+  test.each(["readFileSync", "promises.readFile"])(
+    "%s of /dev/urandom",
+    async api => {
+      const read =
+        api === "readFileSync"
+          ? `fs.readFileSync("/dev/urandom"); parentPort.postMessage("returned");`
+          : `fs.promises.readFile("/dev/urandom").then(() => parentPort.postMessage("resolved"), e => parentPort.postMessage("rejected " + e.code));`;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+        const fs = require("node:fs");
+        const { Worker } = require("node:worker_threads");
+        const io = () => {
+          if (process.platform !== "linux") return { bytes: 0, reads: 1 };
+          const text = fs.readFileSync("/proc/self/io", "utf8");
+          return { bytes: Number(/rchar: (\\d+)/.exec(text)[1]), reads: Number(/syscr: (\\d+)/.exec(text)[1]) };
+        };
+        const w = new Worker(
+          'const fs = require("node:fs"); const { parentPort } = require("node:worker_threads");' +
+          'parentPort.postMessage("reading"); ${read}',
+          { eval: true },
+        );
+        w.on("error", e => { console.error("worker error:", e); process.exit(1); });
+        w.on("exit", code => console.log("exit", code));
+        w.on("message", async m => {
+          console.log(m);
+          if (m !== "reading") process.exit(1);
+          // A window of reading: long enough that a doubling read size would have passed 2 MiB.
+          const a = io();
+          await Bun.sleep(200);
+          const b = io();
+          const code = await Promise.race([w.terminate(), Bun.sleep(${timeout / 2}).then(() => "hung")]);
+          console.log("terminated", code, "bytes per read:", Math.round((b.bytes - a.bytes) / Math.max(1, b.reads - a.reads)));
+          process.exit(code === "hung" ? 2 : 0);
+        });
+      `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const m = /^reading\nexit 1\nterminated 1 bytes per read: (\d+)\n$/.exec(stdout);
+      expect(m, stdout).not.toBeNull();
+      expect(Number(m![1])).toBeLessThanOrEqual(1024 * 1024);
       expect(exitCode).toBe(0);
     },
     timeout,


### PR DESCRIPTION
### Problem
- `worker.terminate()` never settles while the worker reads a FIFO or `/dev/urandom` with `fs.readFileSync` or `fs.promises.readFile`. Neither has an EOF. Node settles in a few ms. `process.exit()` under `BUN_DESTRUCT_VM_ON_EXIT=1` hangs the same way.
- The read loop in `NodeFS::read_file_with_options` (`src/runtime/node/node_fs.rs:7217`) checks only the caller's `AbortSignal` between chunks, never whether the VM is stopping. The sync form never returns to JS. The async form keeps its pool job alive, and the VM's teardown (`src/jsc/VmHandle.rs:440`) waits for that job.

### Fix
- `NodeFS` carries the `VmHandle` of the VM it serves (the binding's own, the job ticket's via the new `Ticket::handle()`, the TLS cert reader's). The loop gives up before `open()` and between chunks once `script_allowed()` is false or the signal aborted. A read the stop interrupts fails with `EINTR` on the path.
- Past the stat size the loop reads 1 MiB at a time (Node reads 64 KiB there), so the stop is never more than one chunk away. The request used to double with the buffer: on a device one read could take seconds.
- Correct because the gate closes exactly when `terminate()`, `process.exit()` or teardown was requested, and never reopens. The async completion is released unrun. The sync errno reaches script only until the armed trap lands at the next safepoint.
- Verified: `worker-terminate-lifetime.test.ts` (6 new cases: FIFO and `/dev/urandom`, both forms) and `fs/promises.test.js` (2 new cases), all fail on 1.4.0. Suites run are in the notes.

### Background
- A `VmHandle` is the thread-safe handle of a VM. Its gate, `script_allowed()`, closes when `terminate()`, `process.exit()` or teardown calls `stop()`. A `Ticket` is the counted form that off-thread work holds. Teardown waits until none is outstanding.
- A `bun_jsc::Job` runs an `fs.promises.*` body on the work pool under a ticket and posts the completion to the JS thread. A completion that arrives under a closed gate is released unrun.

<details><summary>Notes</summary>

- Repro: `mkfifo /tmp/p; (trap '' PIPE; while :; do echo x 2>/dev/null; sleep .02; done > /tmp/p) &`, then a worker that posts a message and calls `readFileSync("/tmp/p")` or `fs.promises.readFile("/tmp/p")`, and a parent that calls `terminate()` 300 ms after the message. 1.4.0: never settles, both forms. With the fix: settles at the next chunk. 1.3.14 settled the async form in a few ms (it did not wait for pool jobs) and hung on the sync form too, so the async row is a 1.4 regression.
- `/dev/urandom` on 1.4.0: the loop reads at about 400 MB/s until the 4.7 GB typed-array cap (ENOMEM) or the OOM killer. With the fix the read stops after the chunk in flight. Before the 1 MiB chunk, that in-flight read doubled with the buffer: `terminate()` during `fs.promises.readFile("/dev/urandom")` settled after 5.5 s for a 2 GiB read (the review's probe). The sync form looked bounded only because JSC's trap signal interrupts the kernel read on the JS thread; the pool thread gets no signal. The `/dev/urandom` tests read `/proc/self/io` and assert an average read size of at most 1 MiB over a window of reading (0 where the file is absent). They run sequentially: a build without the stop reads gigabytes before the watchdog fires.
- A writer that dies of SIGPIPE between runs leaves the worker blocked in `open(2)` with no writer. That case cannot be interrupted without a signal, and Node hangs there too. The check before `open()` only spares a job that the pool dequeues after the stop. The `trap '' PIPE` in the repro avoids the case.
- The FIFO tests hold both ends (`openSync(fifo, "r+")`), so `open()` does not block and `read()` never sees EOF, and feed through a non-blocking end so the parent's loop, which has to settle `terminate()`, never blocks on the pipe. More bytes than the pipe holds go through only once the reader drained the rest, which proves the reader is inside the loop. The two sizes (192 KiB and 512 KiB) land in the pre-stat read (first 256 KiB) and in the tail. Both ends are closed before the parent exits, so a worker still in its loop gets EOF and the exit's VM teardown (`BUN_DESTRUCT_VM_ON_EXIT=1` joins it) does not wait.
- The sync form throws the `EINTR` error into script. An earlier revision turned it into the TerminationException (`Stopped::throw`) so that script could not catch it. That was dropped: the trap `request_termination()` armed lands at the next safepoint anyway, the mapping sat in the binding for all sync ops, and throwing the termination from a host function inside a JSC `DeferTermination` scope (user JS under a lazy property builder) asserts in debug builds. `EINTR` reads as what happened: the read was interrupted.
- The `limit_size_for_javascript` cap (ENOMEM past the typed-array maximum) is unchanged. Node does not cap the total of an unknown-size read either (it checks `kIoMaxLength` once at the end).
- Other loops of the same shape: `SSLConfig::read_from_blob` (a `Bun.file()` TLS cert or key, no size bound, JS thread) carries the VM's handle too, and so does the `vm.node_fs()` singleton (`jsc_hooks.rs`), although it only serves `mkdir_recursive` today. `Blob.rs:3916` and `fetch.rs:1798` read with `max_size = blob.size`, which disables the growth arm, so they stop at about 256 KiB on their own. `write_file`'s loop is bounded by the data it writes.
- `Bun.file("/dev/zero").bytes()` in a worker hangs `terminate()` the same way. That read loop is `src/runtime/webcore/blob/read_file.rs` (`do_read_loop`), a different code path, and is not covered here. `Bun.file(fifo).bytes()` parks on the io loop and is cancelled fine.
- Suites run on the debug build: `fs.test.ts`, `promises.test.js`, `worker-late-completion`, `worker-terminate-funnels`, `worker-terminate-lifetime`, `worker_threads.test.ts`, `bun-serve-ssl.test.ts`, `tls-bunfile-leak.test.ts`, `test/internal/source-lints`, `cargo clippy -p bun_jsc -p bun_runtime`.
- Pre-existing failures in this container, reproduced on main without this diff: the LSan report of the `node:fs` Binding in the `dns.lookup()` terminate test (#35159), the two debug-build timing cases in `worker.test.ts` (message flood, preload with an un-awaited import), and `abort-signal-leak-read-write-file.test.ts`, whose 100k iterations need about 410 s on a debug ASAN build.
- #36259 (AbortSignal between chunks of a regular file) and #38312 (pool jobs without a VM borrow) touch the same area but not this loop's stop check. #38312 keeps the `node:fs` jobs on the waited path, so this fix is needed with or without it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts, test/js/node/fs/promises.test.js

<!-- robobun:evidence:end -->
