### PR TITLE
bun_ptr: RefPtr::new_cyclic; a BackRef<_, Root> can no longer be dangling

### DIFF
--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -162,7 +162,48 @@ impl<T: ?Sized> BackRef<T, Mut> {
     }
 }
 
-impl<T, P> BackRef<T, P> {
+/// The root pointer of a value built by [`RefPtr::new_cyclic`], stored inside
+/// that value. It has no accessors of its own: the only way to use it is
+/// [`SelfRoot::this_ptr`], which takes the enclosing `&T` — so it cannot be
+/// followed before the value exists or after it is gone.
+#[repr(transparent)]
+pub struct SelfRoot<T>(pub(crate) core::ptr::NonNull<T>);
+
+impl<T> SelfRoot<T> {
+    /// The enclosing value as a [`ThisPtr`]. `owner` must be the value this
+    /// token is stored in (checked).
+    #[inline]
+    pub fn this_ptr(&self, owner: &T) -> ThisPtr<T> {
+        assert!(
+            core::ptr::eq(self.0.as_ptr().cast_const(), owner),
+            "SelfRoot used from a value it does not belong to"
+        );
+        // SAFETY: `owner` is a live `&T` at `self.0` (asserted), so the value is
+        // constructed; `self.0` keeps the allocation-root provenance a last
+        // release needs.
+        unsafe { ThisPtr::new(self.0.as_ptr()) }
+    }
+
+    /// The enclosing value as a root back-reference.
+    #[inline]
+    pub fn backref(&self, owner: &T) -> BackRef<T, Root> {
+        self.this_ptr(owner).into()
+    }
+}
+
+/// Provenance markers a placeholder [`BackRef::dangling`] may carry. Not
+/// [`Root`]: a `Root` back-reference can hand out a [`ThisPtr`], so it is
+/// only ever minted from a real one (see [`RefPtr::new_cyclic`]).
+pub trait DanglingOk: sealed::Sealed {}
+impl DanglingOk for Shared {}
+impl DanglingOk for Mut {}
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Shared {}
+    impl Sealed for super::Mut {}
+}
+
+impl<T, P: DanglingOk> BackRef<T, P> {
     #[inline]
     pub const fn dangling() -> Self {
         BackRef(core::ptr::NonNull::dangling(), core::marker::PhantomData)

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -545,6 +545,21 @@ impl<T: AnyRefCounted> RefPtr<T> {
     ///
     /// # Safety
     /// `raw_ptr` must point to a live `T`.
+    /// [`new`](Self::new) for a `T` that stores its own root pointer (to hand
+    /// out [`ThisPtr`](crate::ThisPtr)s from `&self` entry points). `init`
+    /// receives a [`SelfRoot`](crate::SelfRoot) to store in the value; the
+    /// token cannot be dereferenced on its own, only through the `&T` that
+    /// exists once construction is done.
+    pub fn new_cyclic(init: impl FnOnce(crate::SelfRoot<T>) -> T) -> Self {
+        let raw: NonNull<T> = bun_core::heap::into_raw_nn(Box::<T>::new_uninit()).cast::<T>();
+        let value = init(crate::SelfRoot(raw));
+        // SAFETY: `raw` is a live, uninitialized, properly aligned `T` slot.
+        unsafe { raw.as_ptr().write(value) };
+        // SAFETY: freshly written, so live.
+        debug_assert!(unsafe { T::rc_has_one_ref(raw.as_ptr()) });
+        Self(raw)
+    }
+
     #[inline]
     pub unsafe fn init_ref(raw_ptr: *mut T) -> Self {
         // SAFETY: caller contract
@@ -974,5 +989,58 @@ mod tests {
         assert_eq!(type_base_name("a::b::Foo"), "Foo");
         assert_eq!(type_base_name("a::b::Foo<c::Bar>"), "Foo<c::Bar>");
         assert_eq!(type_base_name("Foo"), "Foo");
+    }
+
+    struct Cyclic {
+        ref_count: RefCount<Cyclic>,
+        self_ref: crate::SelfRoot<Cyclic>,
+        payload: Box<u32>,
+    }
+
+    impl Drop for Cyclic {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl RefCounted for Cyclic {
+        unsafe fn get_ref_count(this: *mut Self) -> *mut RefCount<Self> {
+            // SAFETY: caller contract — field projection on a live allocation.
+            unsafe { &raw mut (*this).ref_count }
+        }
+        unsafe fn destructor(this: *mut Self) {
+            // SAFETY: caller contract — refcount hit zero, sole owner.
+            drop(unsafe { bun_core::heap::take(this) });
+        }
+    }
+
+    #[test]
+    fn new_cyclic_self_root_round_trip() {
+        let _serial = serial();
+        let before = drops();
+        let p = RefPtr::new_cyclic(|self_ref| Cyclic {
+            ref_count: RefCount::init(),
+            self_ref,
+            payload: Box::new(9),
+        });
+        assert_eq!(*p.payload, 9);
+        {
+            // The token hands back a `ThisPtr` to the same allocation; a ref
+            // taken through it bumps and releases the count.
+            let this = p.self_ref.this_ptr(&*p);
+            assert_eq!(this.as_ptr().cast_const(), p.as_ptr().cast_const());
+            let _guard = RefPtr::from_this(this);
+            assert_eq!(*this.payload, 9);
+            assert_eq!(p.ref_count.get(), 2);
+        }
+        assert_eq!(p.ref_count.get(), 1);
+        assert_eq!(drops(), before);
+        // Last release goes through the root the token stored.
+        let this = p.self_ref.this_ptr(&*p);
+        let guard = RefPtr::from_this(this);
+        drop(p);
+        assert_eq!(drops(), before);
+        drop(guard);
+        assert_eq!(drops(), before + 1);
     }
 }

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -541,10 +541,6 @@ impl<T: AnyRefCounted> RefPtr<T> {
         Self(ptr)
     }
 
-    /// Take a new ref on `*raw_ptr`.
-    ///
-    /// # Safety
-    /// `raw_ptr` must point to a live `T`.
     /// [`new`](Self::new) for a `T` that stores its own root pointer (to hand
     /// out [`ThisPtr`](crate::ThisPtr)s from `&self` entry points). `init`
     /// receives a [`SelfRoot`](crate::SelfRoot) to store in the value; the
@@ -560,6 +556,10 @@ impl<T: AnyRefCounted> RefPtr<T> {
         Self(raw)
     }
 
+    /// Take a new ref on `*raw_ptr`.
+    ///
+    /// # Safety
+    /// `raw_ptr` must point to a live `T`.
     #[inline]
     pub unsafe fn init_ref(raw_ptr: *mut T) -> Self {
         // SAFETY: caller contract

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -28,7 +28,7 @@ use bun_jsc::{
     JSGlobalObject, JSObject, JSValue, JsCell, JsRef, JsResult,
 };
 use bun_paths as path;
-use bun_ptr::{BackRef, RefPtr, ThisPtr};
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_resolver::fs::FileSystem;
 #[cfg(not(target_os = "macos"))]
 use bun_resolver::fs::RealFS;
@@ -1372,7 +1372,7 @@ pub struct CronJob {
     ref_count: Cell<u32>,
     /// Set from the allocating `RefPtr` so `&self` host fns can reach the
     /// `ThisPtr`-taking paths that may release refs.
-    self_ref: Cell<BackRef<CronJob, bun_ptr::Root>>,
+    self_ref: bun_ptr::SelfRoot<CronJob>,
     // pub: `bun_core::from_field_ptr!(CronJob, event_loop_timer)` needs `offset_of!` visibility.
     // `JsCell` is `#[repr(transparent)]`, so the byte offset of the inner
     // `EventLoopTimer` is identical and the dispatch.rs `owner!` macro works
@@ -1654,7 +1654,7 @@ impl CronJob {
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn stop(&self, _global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        Self::self_stop(self.self_ref.get().this_ptr(), self.global.bun_vm());
+        Self::self_stop(self.self_ref.this_ptr(self), self.global.bun_vm());
         Ok(frame.this())
     }
 
@@ -1708,9 +1708,9 @@ impl CronJob {
 
         let vm = global.bun_vm().as_mut();
 
-        let job = RefPtr::new(CronJob {
+        let job = RefPtr::new_cyclic(|self_ref| CronJob {
             ref_count: Cell::new(1),
-            self_ref: Cell::new(BackRef::dangling()),
+            self_ref,
             event_loop_timer: JsCell::new(EventLoopTimer::init_paused(EventLoopTimerTag::CronJob)),
             global: GlobalRef::from(global),
             parsed,
@@ -1722,7 +1722,6 @@ impl CronJob {
             pending_ref: JsCell::new(None),
             in_fire: Cell::new(false),
         });
-        job.self_ref.set(BackRef::from(job.this_ptr()));
 
         let Some(next_time) = job.compute_next_timespec() else {
             return Err(global.throw_invalid_arguments(format_args!(


### PR DESCRIPTION
### What

Follow-up to #40192 (raised in review of #40203): `BackRef::dangling()` was generic over the provenance marker, so a `BackRef<T, Root>` — which can hand out a `ThisPtr` — could be created dangling and "patched later" (`CronJob::self_ref` did exactly that: `Cell::new(BackRef::dangling())` then `set(BackRef::from(job.this_ptr()))` after `RefPtr::new`).

- `RefPtr::new_cyclic(|this: SelfRoot<T>| -> T)` (à la `Arc::new_cyclic`): allocates the slot, hands `init` an opaque `SelfRoot<T>` token to store, writes the value, adopts the ref. `SelfRoot` has no accessors of its own — `this_ptr(&self, owner: &T)` / `backref(&self, owner: &T)` need the constructed `&T`, so the pointer cannot be followed inside `init`.
- `BackRef::dangling()` is now only available for `Shared`/`Mut` (sealed `DanglingOk` bound), so a `Root` back-reference is always minted from a real root (`From<ThisPtr>`, `from_root`, or `new_cyclic`).
- `CronJob::self_ref` becomes a `SelfRoot<CronJob>` field initialised through `new_cyclic` (`self.self_ref.this_ptr(self)`); no `Cell`, no two-phase init.

### Testing

`test/js/bun/cron` 162/162 on debug+ASAN; clippy clean on bun_ptr / bun_runtime / bun_bundler (the two bundler `BackRef::dangling()` placeholders are `Shared` and unchanged).
