### PR TITLE
Bun.serve: remove unsafe from server/mod.rs and server_body.rs

### DIFF
--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -443,7 +443,7 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
 
     /// Move `value` into the slot and return the stable initialized pointer.
     /// Consumes the token (its `Drop` does not run).
-    #[inline]
+    #[inline(always)]
     pub fn write(self, value: T) -> NonNull<T> {
         let this = ManuallyDrop::new(self);
         let p = this.slot.cast::<T>();
@@ -587,10 +587,9 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// buffer is left untouched (uninitialized bytes are a valid bit-pattern
     /// for `MaybeUninit`).
     ///
-    /// The returned allocation is leaked — callers stash it in a per-thread
-    /// static for the process lifetime.
+    /// Callers typically `Box::leak` the result into a per-thread static.
     #[inline]
-    pub fn new_boxed() -> NonNull<Self> {
+    pub fn new_boxed() -> Box<Self> {
         let mut boxed = Box::<Self>::new_uninit();
         // SAFETY: `boxed` is a fresh heap allocation — non-null, aligned for
         // `Self`, and valid for writes of `size_of::<Self>()` bytes.
@@ -598,7 +597,19 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
         // SAFETY: `init_in_place` fully initialized `hive.used`; `hive.buffer`
         // is `[MaybeUninit<T>; CAPACITY]`, for which uninitialized bytes are a
         // valid representation. Every field of `Self` is therefore valid.
-        NonNull::from(Box::leak(unsafe { boxed.assume_init() }))
+        unsafe { boxed.assume_init() }
+    }
+
+    /// Claim a slot, build its value from the slot's (stable) address, and
+    /// return the owning handle. Infallible like [`claim`](Self::claim).
+    #[inline(always)]
+    pub fn claim_init(&self, init: impl FnOnce(NonNull<T>) -> T) -> Pooled<'_, T, CAPACITY> {
+        let slot = self.claim();
+        let value = init(slot.addr());
+        Pooled {
+            slot: slot.write(value),
+            owner: self,
+        }
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
@@ -645,6 +656,40 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
         // `get()` (it is not in the hive), and the caller has since fully
         // initialized it. `destroy` reconstructs the `Box<T>` and runs `T::drop`.
         unsafe { bun_core::heap::destroy(value) };
+    }
+}
+
+/// Owning handle to an initialized [`Fallback`] slot (inline or heap spill):
+/// `Drop` runs `T::drop` and returns the slot to the pool. Single-owner, so it
+/// only lends `&T`; the stable address is available via [`as_ptr`](Self::as_ptr)
+/// for registration as callback user-data.
+pub struct Pooled<'a, T, const CAPACITY: usize> {
+    slot: NonNull<T>,
+    owner: &'a Fallback<T, CAPACITY>,
+}
+
+impl<T, const CAPACITY: usize> Pooled<'_, T, CAPACITY> {
+    #[inline]
+    pub fn as_ptr(&self) -> NonNull<T> {
+        self.slot
+    }
+}
+
+impl<T, const CAPACITY: usize> Deref for Pooled<'_, T, CAPACITY> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: `slot` was initialized by `claim_init` and is owned by this handle.
+        unsafe { self.slot.as_ref() }
+    }
+}
+
+impl<T, const CAPACITY: usize> Drop for Pooled<'_, T, CAPACITY> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: `slot` is an initialized `T` claimed from `owner` by
+        // `claim_init`; this handle is its sole owner, so it is put exactly once.
+        unsafe { self.owner.put(self.slot.as_ptr()) };
     }
 }
 
@@ -961,10 +1006,9 @@ mod tests {
     fn fallback_new_boxed_and_init_in_place() {
         const CAP: usize = 4;
 
-        let boxed = Fallback::<u64, CAP>::new_boxed();
-        // SAFETY: `new_boxed` returns a valid heap allocation.
+        let f = Fallback::<u64, CAP>::new_boxed();
+        // SAFETY: every pointer read/put below is a slot `get_init` just filled.
         unsafe {
-            let f = &*boxed.as_ptr();
             for i in 0..CAP {
                 let p = f.get_init(i as u64 * 10);
                 assert!(f.hive.index_of(p.as_ptr()).is_some());
@@ -974,9 +1018,12 @@ mod tests {
             let p = f.get_init(999);
             assert!(f.hive.index_of(p.as_ptr()).is_none());
             f.put(p.as_ptr());
-            // `new_boxed` is leaked by design; reclaim for the test.
-            drop(Box::from_raw(boxed.as_ptr()));
         }
+        // `claim_init` hands back an owning slot that puts itself.
+        let pooled = f.claim_init(|_| 7);
+        assert!(f.hive.index_of(pooled.as_ptr().as_ptr()).is_none());
+        assert_eq!(*pooled, 7);
+        drop(pooled);
     }
 
     #[test]

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -6,6 +6,14 @@ use core::ptr::NonNull;
 
 use crate::{JsResult, Task};
 
+/// The context of a [`ManagedTask::new_boxed`] task.
+pub trait RunOnce: Sized {
+    fn run(self) -> JsResult<()>;
+    /// The task was released unrun (its VM is tearing down: script is
+    /// forbidden, the JSC heap is still alive). Default: just drop.
+    fn cancelled(self) {}
+}
+
 pub struct ManagedTask {
     // Opaque userdata pointer round-tripped through `new`/`run`; raw by design.
     pub ctx: Option<NonNull<c_void>>,
@@ -59,6 +67,26 @@ impl ManagedTask {
             },
             ctx: NonNull::new(ctx.cast::<c_void>()),
             cleanup: None,
+        }));
+        ManagedTask::task(managed)
+    }
+
+    /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
+    /// the queue is released unrun).
+    pub fn new_boxed<T: RunOnce>(ctx: Box<T>) -> Task {
+        fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
+            // passes it back exactly once.
+            T::run(*unsafe { Box::from_raw(p.cast::<T>()) })
+        }
+        fn drop_ctx<T: RunOnce>(p: *mut c_void) {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`.
+            T::cancelled(*unsafe { Box::from_raw(p.cast::<T>()) });
+        }
+        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
+            callback: run::<T>,
+            ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
+            cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)
     }

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -303,6 +303,102 @@ impl FetchHeaders {
     }
 }
 
+/// RAII handle to a C++-owned `WebCore::FetchHeaders`.
+///
+/// Holds exactly one ref on the C++ intrusive refcount; `Drop` releases it via
+/// `WebCore__FetchHeaders__deref`. NOT a `std::rc::Rc` (the payload lives on
+/// the C++ heap and is opaque here).
+///
+/// Intentionally not `Clone`: the only "share" operation the surface
+/// exposes is `clone_this()`, which deep-copies a fresh `FetchHeaders` on the
+/// C++ side. Transferring ownership is by-move.
+#[repr(transparent)]
+pub struct HeadersRef(NonNull<FetchHeaders>);
+
+impl HeadersRef {
+    /// Adopt a freshly-created `FetchHeaders*` (refcount already 1).
+    ///
+    /// # Safety
+    /// `ptr` must be a valid `WebCore::FetchHeaders*` and the caller must
+    /// transfer ownership of one ref.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<FetchHeaders>) -> Self {
+        Self(ptr)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut FetchHeaders {
+        self.0.as_ptr()
+    }
+
+    /// `FetchHeaders.createEmpty()` — fresh C++ allocation, refcount 1.
+    #[inline]
+    pub fn create_empty() -> Self {
+        Self(FetchHeaders::create_empty())
+    }
+
+    /// `FetchHeaders.createFromUWS(req)` — fresh C++ allocation, refcount 1.
+    #[inline]
+    pub fn create_from_uws(uws_request: *mut c_void) -> Self {
+        Self(FetchHeaders::create_from_uws(uws_request))
+    }
+
+    /// `FetchHeaders.createFromH3(req)` — fresh C++ allocation, refcount 1.
+    #[inline]
+    pub fn create_from_h3(h3_request: *mut c_void) -> Self {
+        Self(FetchHeaders::create_from_h3(h3_request))
+    }
+
+    /// `FetchHeaders.createFromJS(global, value)` — may throw, may return null.
+    #[inline]
+    pub fn create_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Self>> {
+        Ok(FetchHeaders::create_from_js(global, value)?.map(Self))
+    }
+
+    /// `FetchHeaders.cloneThis(global)` — deep copy on the C++ side.
+    #[inline]
+    pub fn clone_this(&self, global: &JSGlobalObject) -> JsResult<Option<Self>> {
+        bun_opaque::opaque_deref_mut(self.0.as_ptr()).clone_this_ref(global)
+    }
+}
+
+impl FetchHeaders {
+    /// [`clone_this`](Self::clone_this), owning the copy.
+    #[inline]
+    pub fn clone_this_ref(&mut self, global: &JSGlobalObject) -> JsResult<Option<HeadersRef>> {
+        Ok(self.clone_this(global)?.map(HeadersRef))
+    }
+}
+
+impl core::ops::Deref for HeadersRef {
+    type Target = FetchHeaders;
+    #[inline]
+    fn deref(&self) -> &FetchHeaders {
+        // `FetchHeaders` is an opaque ZST FFI handle (S008); `self.0` is live
+        // for the lifetime of `self` — safe `*const → &` via `opaque_deref`.
+        bun_opaque::opaque_deref(self.0.as_ptr())
+    }
+}
+
+impl core::ops::DerefMut for HeadersRef {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut FetchHeaders {
+        // `FetchHeaders` is an opaque ZST FFI handle (S008); `self.0` is live
+        // for the lifetime of `self` — safe `*mut → &mut` via `opaque_deref_mut`.
+        bun_opaque::opaque_deref_mut(self.0.as_ptr())
+    }
+}
+
+impl Drop for HeadersRef {
+    #[inline]
+    fn drop(&mut self) {
+        // `self.0` is live; releasing our +1 ref via WebCore__FetchHeaders__deref.
+        // Explicit UFCS to avoid `core::ops::Deref::deref` resolution ambiguity.
+        // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
+        FetchHeaders::deref(bun_opaque::opaque_deref_mut(self.0.as_ptr()));
+    }
+}
+
 // Canonical enum lives in `bun_http_types::Method::HeaderName` (same 92
 // `#[repr(u8)]` discriminants mirroring WebCore's `HTTPHeaderNames.in`). The
 // `WebCore__FetchHeaders__put` extern decl above and the `fast_*` methods take

--- a/src/jsc/HTTPServerAgent.rs
+++ b/src/jsc/HTTPServerAgent.rs
@@ -86,16 +86,15 @@ bun_opaque::opaque_ffi! {
 // `[[ZIG_EXPORT(nothrow)]]` — declared once in `crate::cpp::raw` (cppbind),
 // called below with explicit casts to the codegen's opaque param types.
 impl InspectorHTTPServerAgent {
-    /// # Safety
-    /// `server_instance` is forwarded to C++ as an opaque token; caller must
-    /// ensure it remains valid for the duration of the FFI call.
-    pub unsafe fn notify_server_started(
+    /// `server_instance` is forwarded to C++ as an opaque token (never
+    /// dereferenced there).
+    pub fn notify_server_started(
         agent: *mut InspectorHTTPServerAgent,
         server_id: ServerId,
         hot_reload_id: HotReloadId,
         address: &BunString,
         start_time: f64,
-        server_instance: *mut c_void,
+        server_instance: usize,
     ) {
         // `opaque_mut` is the centralised ZST-handle deref proof (panics on
         // null). The C++ side never reads `server_instance` as anything but an
@@ -110,7 +109,7 @@ impl InspectorHTTPServerAgent {
                 hot_reload_id as _,
                 address,
                 start_time,
-                server_instance,
+                server_instance as *mut c_void,
             );
         }
     }

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -284,19 +284,16 @@ extern "C" void NodeHTTP_setUsingCustomExpectHandler(bool is_ssl, void* uws_app,
     }
 }
 
-extern "C" EncodedJSValue NodeHTTPResponse__createForJS(size_t any_server, JSC::JSGlobalObject* globalObject, bool* hasBody, uWS::HttpRequest* request, int isSSL, void* response_ptr, void* upgrade_ctx, void** nodeHttpResponsePtr);
-
 template<bool isSSL>
 static EncodedJSValue NodeHTTPServer__onRequest(
-    size_t any_server,
     Zig::GlobalObject* globalObject,
     JSValue thisValue,
     JSValue callback,
     JSValue methodString,
     uWS::HttpRequest* request,
     uWS::HttpResponse<isSSL>* response,
-    void* upgrade_ctx,
-    void** nodeHttpResponsePtr)
+    JSValue nodeResponseObject,
+    bool hasBody)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -310,10 +307,9 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     WTF::Vector<uint8_t, 1024> flatHeaders;
     assignHeadersFromUWebSocketsForCall(request, methodString, args, flatHeaders, globalObject, vm);
 
-    bool hasBody = false;
-    WebCore::JSNodeHTTPResponse* nodeHTTPResponseObject = uncheckedDowncast<WebCore::JSNodeHTTPResponse>(JSValue::decode(NodeHTTPResponse__createForJS(any_server, globalObject, &hasBody, request, isSSL, response, upgrade_ctx, nodeHttpResponsePtr)));
+    WebCore::JSNodeHTTPResponse* nodeHTTPResponseObject = uncheckedDowncast<WebCore::JSNodeHTTPResponse>(nodeResponseObject);
     if (!flatHeaders.isEmpty()) {
-        NodeHTTPResponse__adoptRawRequestHeaders(*nodeHttpResponsePtr, flatHeaders.span().data(), flatHeaders.size());
+        NodeHTTPResponse__adoptRawRequestHeaders(nodeHTTPResponseObject->wrapped(), flatHeaders.span().data(), flatHeaders.size());
     }
 
     args.append(nodeHTTPResponseObject);
@@ -709,49 +705,45 @@ extern "C" void NodeHTTPServer__writeHead_https(
 }
 
 extern "C" EncodedJSValue NodeHTTPServer__onRequest_http(
-    size_t any_server,
     Zig::GlobalObject* globalObject,
     EncodedJSValue thisValue,
     EncodedJSValue callback,
     EncodedJSValue methodString,
     uWS::HttpRequest* request,
     uWS::HttpResponse<false>* response,
-    void* upgrade_ctx,
-    void** nodeHttpResponsePtr)
+    EncodedJSValue nodeResponseObject,
+    bool hasBody)
 {
     return NodeHTTPServer__onRequest<false>(
-        any_server,
         globalObject,
         JSValue::decode(thisValue),
         JSValue::decode(callback),
         JSValue::decode(methodString),
         request,
         response,
-        upgrade_ctx,
-        nodeHttpResponsePtr);
+        JSValue::decode(nodeResponseObject),
+        hasBody);
 }
 
 extern "C" EncodedJSValue NodeHTTPServer__onRequest_https(
-    size_t any_server,
     Zig::GlobalObject* globalObject,
     EncodedJSValue thisValue,
     EncodedJSValue callback,
     EncodedJSValue methodString,
     uWS::HttpRequest* request,
     uWS::HttpResponse<true>* response,
-    void* upgrade_ctx,
-    void** nodeHttpResponsePtr)
+    EncodedJSValue nodeResponseObject,
+    bool hasBody)
 {
     return NodeHTTPServer__onRequest<true>(
-        any_server,
         globalObject,
         JSValue::decode(thisValue),
         JSValue::decode(callback),
         JSValue::decode(methodString),
         request,
         response,
-        upgrade_ctx,
-        nodeHttpResponsePtr);
+        JSValue::decode(nodeResponseObject),
+        hasBody);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -895,7 +895,7 @@ pub use self::resolved_source_tag::ResolvedSourceTag;
 // ──────────────────────────────────────────────────────────────────────────
 #[path = "FetchHeaders.rs"]
 pub mod fetch_headers;
-pub use self::fetch_headers::{FetchHeaders, HTTPHeaderName};
+pub use self::fetch_headers::{FetchHeaders, HTTPHeaderName, HeadersRef};
 
 /// `BuiltinName` — fast-path property keys preallocated as `JSC::Identifier`s
 /// in C++ (`BunBuiltinNames.h`). Passed to `JSValue::fast_get` as a `u8` index

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -235,6 +235,13 @@ impl<T> From<ThisPtr<T>> for BackRef<T, Root> {
     }
 }
 
+impl<T> From<ThisPtr<T>> for core::ptr::NonNull<T> {
+    #[inline]
+    fn from(p: ThisPtr<T>) -> Self {
+        p.0
+    }
+}
+
 impl<T: ?Sized, P> Copy for BackRef<T, P> {}
 impl<T: ?Sized, P> Clone for BackRef<T, P> {
     #[inline]
@@ -639,6 +646,49 @@ impl<T> core::ops::Deref for ThisPtr<T> {
     #[inline]
     fn deref(&self) -> &T {
         self.get()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OwnedThis<T> — single-owner heap allocation that hands out `ThisPtr`s.
+//
+// `Box<T>` asserts unique access on every touch, which is wrong for a callback
+// hub whose address is also held by C / JS / a task queue and re-entered while
+// a method on it is running. `OwnedThis` keeps the ownership (drop frees) but
+// only ever lends the pointee as `ThisPtr<T>` / `&T`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The unique owner of a heap-allocated `T` that is otherwise reached through
+/// [`ThisPtr`] copies. Dropping it drops and frees the `T`; every `ThisPtr`
+/// lent from it must be dead by then (the usual back-reference obligation).
+pub struct OwnedThis<T>(core::ptr::NonNull<T>);
+
+impl<T> OwnedThis<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
+    }
+
+    /// A dispatch handle to the pointee (root provenance).
+    #[inline]
+    pub fn this_ptr(&self) -> ThisPtr<T> {
+        ThisPtr(self.0)
+    }
+}
+
+impl<T> core::ops::Deref for OwnedThis<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: we own the live allocation.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Drop for OwnedThis<T> {
+    fn drop(&mut self) {
+        // SAFETY: `new` leaked exactly this `Box`; we are its unique owner.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
     }
 }
 

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -1,44 +1,48 @@
+use core::cell::Cell;
 use core::ptr::NonNull;
 
 /// Bit layout:
 ///   bits 0..=30 → reference_count
 ///   bit  31     → finalized
+///
+/// Interior-mutable so weak handles can adjust the count through a shared
+/// borrow of the (possibly `&`-borrowed) pointee.
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct WeakPtrData(u32);
+pub struct WeakPtrData(Cell<u32>);
 
 impl WeakPtrData {
-    pub const EMPTY: Self = Self(0); // reference_count = 0, finalized = false
+    pub const EMPTY: Self = Self(Cell::new(0)); // reference_count = 0, finalized = false
 
     const REF_MASK: u32 = 0x7FFF_FFFF; // low 31 bits
     const FINALIZED_BIT: u32 = 0x8000_0000; // bit 31
 
     #[inline]
-    pub(crate) fn reference_count(self) -> u32 {
-        self.0 & Self::REF_MASK
+    pub(crate) fn reference_count(&self) -> u32 {
+        self.0.get() & Self::REF_MASK
     }
 
     #[inline]
-    pub(crate) fn set_reference_count(&mut self, n: u32) {
+    pub(crate) fn set_reference_count(&self, n: u32) {
         debug_assert!(n <= Self::REF_MASK);
-        self.0 = (self.0 & Self::FINALIZED_BIT) | (n & Self::REF_MASK);
+        self.0
+            .set((self.0.get() & Self::FINALIZED_BIT) | (n & Self::REF_MASK));
     }
 
     #[inline]
-    pub(crate) fn finalized(self) -> bool {
-        (self.0 & Self::FINALIZED_BIT) != 0
+    pub(crate) fn finalized(&self) -> bool {
+        (self.0.get() & Self::FINALIZED_BIT) != 0
     }
 
     #[inline]
-    pub(crate) fn set_finalized(&mut self, v: bool) {
+    pub(crate) fn set_finalized(&self, v: bool) {
         if v {
-            self.0 |= Self::FINALIZED_BIT;
+            self.0.set(self.0.get() | Self::FINALIZED_BIT);
         } else {
-            self.0 &= !Self::FINALIZED_BIT;
+            self.0.set(self.0.get() & !Self::FINALIZED_BIT);
         }
     }
 
-    pub fn on_finalize(&mut self) -> bool {
+    pub fn on_finalize(&self) -> bool {
         debug_assert!(!self.finalized());
         self.set_finalized(true);
         self.reference_count() == 0
@@ -95,12 +99,37 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
         // SAFETY: caller contract — `this` points to a live `T`. Projecting
         // straight to the embedded field means no whole-struct `&mut T` is
         // formed, so `this`'s provenance reaches the stored pointer intact.
-        let d = unsafe { &mut *T::weak_ptr_data(this) };
+        let d = unsafe { &*T::weak_ptr_data(this) };
         debug_assert!(!d.finalized());
         d.set_reference_count(d.reference_count() + 1);
         Self {
             // SAFETY: caller contract — `this` is non-null.
             raw_ptr: Some(unsafe { NonNull::new_unchecked(this) }),
+        }
+    }
+
+    /// Move `owned` to the heap as the object's owning allocation and take the
+    /// first weak reference to it. Also returns the allocation's root pointer
+    /// for handing the object to its eventual owner.
+    pub fn init_leaked(owned: Box<T>) -> (Self, NonNull<T>) {
+        let this = NonNull::from(Box::leak(owned));
+        // SAFETY: `this` is the freshly-leaked allocation: live, not finalized,
+        // root provenance.
+        (unsafe { Self::init_ref(this.as_ptr()) }, this)
+    }
+
+    /// Borrow the pointee without releasing this handle, or `None` once the
+    /// owner has finalized it. The owner must not finalize it while the borrow
+    /// is live (e.g. keep its JS wrapper reachable).
+    pub fn peek(&self) -> Option<&T> {
+        let value = self.raw_ptr?;
+        // SAFETY: the allocation is live while this handle holds a weak ref
+        // (`raw_ptr` is `Some`); its contents are intact while not finalized.
+        unsafe {
+            if (*T::weak_ptr_data(value.as_ptr())).finalized() {
+                return None;
+            }
+            Some(&*value.as_ptr())
         }
     }
 
@@ -130,7 +159,7 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
         self.raw_ptr = None;
         // SAFETY: caller guarantees `value` points to a live allocation;
         // projecting to the embedded `WeakPtrData` field.
-        let weak_data = unsafe { &mut *T::weak_ptr_data(value.as_ptr()) };
+        let weak_data = unsafe { &*T::weak_ptr_data(value.as_ptr()) };
         let count = weak_data.reference_count() - 1;
         weak_data.set_reference_count(count);
         let finalized = weak_data.finalized();
@@ -157,6 +186,22 @@ impl<T: HasWeakPtrData> Drop for WeakPtr<T> {
 impl<T: HasWeakPtrData> Default for WeakPtr<T> {
     fn default() -> Self {
         Self::EMPTY
+    }
+}
+
+/// Another weak reference to the same allocation (empty if this one is).
+impl<T: HasWeakPtrData> Clone for WeakPtr<T> {
+    fn clone(&self) -> Self {
+        let Some(value) = self.raw_ptr else {
+            return Self::EMPTY;
+        };
+        // SAFETY: the allocation is live while this handle holds a weak ref;
+        // projecting straight to the embedded field forms no whole-struct borrow.
+        let d = unsafe { &*T::weak_ptr_data(value.as_ptr()) };
+        d.set_reference_count(d.reference_count() + 1);
+        Self {
+            raw_ptr: Some(value),
+        }
     }
 }
 
@@ -212,7 +257,7 @@ mod tests {
 
     #[test]
     fn bit_layout() {
-        let mut d = WeakPtrData::EMPTY;
+        let d = WeakPtrData::EMPTY;
         assert_eq!(d.reference_count(), 0);
         assert!(!d.finalized());
 
@@ -234,10 +279,10 @@ mod tests {
 
     #[test]
     fn on_finalize_reports_last_ref() {
-        let mut d = WeakPtrData::EMPTY;
+        let d = WeakPtrData::EMPTY;
         assert!(d.on_finalize());
 
-        let mut d = WeakPtrData::EMPTY;
+        let d = WeakPtrData::EMPTY;
         d.set_reference_count(1);
         assert!(!d.on_finalize());
     }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1431,12 +1431,12 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
         ($ServerType:ty, $tag:ident) => {{
             let server = <$ServerType>::init(&mut config, global_object)?;
             if global_object.has_exception() {
-                server.deref();
+                drop(server);
                 return Ok(JSValue::ZERO);
             }
             let route_list_object = <$ServerType>::listen(server.this_ptr());
             if global_object.has_exception() {
-                server.deref();
+                drop(server);
                 return Ok(JSValue::ZERO);
             }
             let any = AnyServer::from(&*server);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1401,10 +1401,15 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
             if let Some(entry) = hot.get_entry(&config.id) {
                 macro_rules! reload {
                     ($T:ty) => {{
-                        // SAFETY: tag was matched; ptr was inserted as `*mut $T` below.
-                        let server: &mut $T = unsafe { &mut *entry.ptr.cast::<$T>() };
+                        // SAFETY: tag was matched; ptr was inserted as `*mut $T` below
+                        // and the entry is removed (`stop()`) before the server frees.
+                        let server: &$T = unsafe { &*entry.ptr.cast::<$T>() };
                         server.on_reload_from_zig(&mut config, global_object);
-                        return Ok(server.js_value.try_get().unwrap_or(JSValue::UNDEFINED));
+                        return Ok(server
+                            .js_value
+                            .get()
+                            .try_get()
+                            .unwrap_or(JSValue::UNDEFINED));
                     }};
                 }
                 match entry.tag {
@@ -1423,19 +1428,24 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
     }
 
     macro_rules! serve_with {
-        ($ServerType:ty, $tag:expr) => {{
+        ($ServerType:ty, $tag:ident) => {{
             let server = <$ServerType>::init(&mut config, global_object)?;
             if global_object.has_exception() {
+                server.deref();
                 return Ok(JSValue::ZERO);
             }
-            // SAFETY: `init` returned a live heap-allocated server pointer.
-            let server_ref: &mut $ServerType = unsafe { &mut *server };
-            // SAFETY: `server` is the live heap-allocated server returned by `init`.
-            let route_list_object = <$ServerType>::listen(server);
+            let route_list_object = <$ServerType>::listen(server.this_ptr());
             if global_object.has_exception() {
+                server.deref();
                 return Ok(JSValue::ZERO);
             }
+            let any = AnyServer::from(&*server);
+            // The JS wrapper takes over our ref; `any` (like every route the
+            // server registered) is a back-reference it outlives.
             let obj = <$ServerType>::ptr_to_js(server, global_object);
+            let AnyServer::$tag(server_ref) = any else {
+                unreachable!()
+            };
             if route_list_object != JSValue::ZERO {
                 // NOTE: `ServerType.js.routeListSetCached` (codegen
                 // `.classes.ts`) — routed through the typed helper in
@@ -1447,64 +1457,40 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
             // / `Handler` only hold raw `JSValue` shadows for hot-path dispatch.
             // The async-context wrap is applied here (not in `from_js`) so the
             // freshly-allocated wrapper fn is rooted by the slot immediately.
-            crate::server::wrap_handler_slot(
-                &mut server_ref.config.on_request,
-                obj,
-                global_object,
-                <$ServerType>::js_gc_on_request_set,
-            );
-            crate::server::wrap_handler_slot(
-                &mut server_ref.config.on_error,
-                obj,
-                global_object,
-                <$ServerType>::js_gc_on_error_set,
-            );
-            crate::server::wrap_handler_slot(
-                &mut server_ref.config.on_node_http_request,
-                obj,
-                global_object,
-                <$ServerType>::js_gc_on_node_http_request_set,
-            );
+            server_ref.write_request_handler_slots(obj, global_object);
             // Skip the 7-slot write when there's no websocket config: the
             // slots default ZERO so `write_ws_handler_slots`'s clear path
             // would be 7 wasted FFI calls.
-            if server_ref.config.websocket.is_some() {
+            if server_ref.config().websocket.is_some() {
                 server_ref.write_ws_handler_slots(obj, global_object);
             }
-            server_ref.js_value.set_strong(obj, global_object);
+            server_ref
+                .js_value
+                .with_mut(|v| v.set_strong(obj, global_object));
             // Slots are rooted; release the scoped gcProtects and run the
             // "server just started" GC nudge split out of `listen()`.
             drop(_handler_pins);
             server_ref.gc_hint_after_listen();
 
-            if let Some(handles) = crate::jsc_hooks::active_handles() {
-                bun_core::handle_oom(handles.put(
-                    crate::jsc_hooks::ActiveHandle::Server(AnyServer::from(server.cast_const())),
-                    (),
-                ));
-            }
+            crate::jsc_hooks::ActiveHandle::Server(any).register();
 
             // `init` moved `config` into the server (`mem::take`), so the
             // local `config` is defaulted from here on — read `allow_hot`
             // and `id` from the server's own config or the registration is
             // keyed on the wrong (empty) id.
-            if server_ref.config.allow_hot {
-                // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
-                // borrow was released by the `hot_map()` arm above.
+            if server_ref.config().allow_hot {
                 if let Some(hot) = global_object.bun_vm().as_mut().hot_map() {
                     hot.insert_raw(
-                        &server_ref.config.id,
+                        &server_ref.config().id,
                         HotMapEntry {
-                            tag: $tag as u8,
-                            ptr: server.cast::<()>(),
+                            tag: AnyServerTag::$tag as u8,
+                            ptr: any.as_opaque_ptr(),
                         },
                     );
                 }
             }
 
-            // SAFETY: bun_vm() returns the live thread-local VM.
             if let Some(debugger) = global_object.bun_vm().as_mut().debugger.as_deref_mut() {
-                let any = AnyServer::from(server.cast_const());
                 crate::server::http_server_agent::notify_server_started(
                     &mut debugger.http_server_agent,
                     any,
@@ -1525,10 +1511,10 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
     let has_ssl_config = config.ssl_config.is_some();
     let development = config.is_development();
     match (development, has_ssl_config) {
-        (true, true) => serve_with!(crate::api::DebugHTTPSServer, AnyServerTag::DebugHTTPSServer),
-        (true, false) => serve_with!(crate::api::DebugHTTPServer, AnyServerTag::DebugHTTPServer),
-        (false, true) => serve_with!(crate::api::HTTPSServer, AnyServerTag::HTTPSServer),
-        (false, false) => serve_with!(crate::api::HTTPServer, AnyServerTag::HTTPServer),
+        (true, true) => serve_with!(crate::api::DebugHTTPSServer, DebugHTTPSServer),
+        (true, false) => serve_with!(crate::api::DebugHTTPServer, DebugHTTPServer),
+        (false, true) => serve_with!(crate::api::HTTPSServer, HTTPSServer),
+        (false, false) => serve_with!(crate::api::HTTPServer, HTTPServer),
     }
 }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7625,15 +7625,12 @@ impl H2FrameParser {
         let this: *mut H2FrameParser = if ENABLE_ALLOCATOR_POOL {
             POOL.with_borrow_mut(|pool| {
                 let pool = pool.get_or_insert_with(|| {
-                    // SAFETY: `new_boxed` returns a `Box::leak`ed, fully
-                    // initialized allocation; `from_raw` reclaims that exact
-                    // pointer back into an owning `Box`. `ManuallyDrop<T>` is
-                    // `repr(transparent)` over `T`, so the pointer cast is a
+                    // SAFETY: `ManuallyDrop<T>` is `repr(transparent)` over
+                    // `T`, so re-boxing the same allocation at that type is a
                     // layout no-op.
                     unsafe {
                         Box::from_raw(
-                            H2FrameParserHiveAllocator::new_boxed()
-                                .as_ptr()
+                            Box::into_raw(H2FrameParserHiveAllocator::new_boxed())
                                 .cast::<ManuallyDrop<H2FrameParserHiveAllocator>>(),
                         )
                     }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1267,11 +1267,11 @@ impl DevServer {
     /// Returns true if a catch-all handler was attached.
     pub(crate) fn set_routes<const SSL: bool, const DEBUG: bool>(
         &mut self,
-        server: &mut crate::server::NewServer<SSL, DEBUG>,
+        server: &crate::server::NewServer<SSL, DEBUG>,
     ) -> crate::Result<bool> {
         // TODO: all paths here must be prefixed with publicPath if set.
         self.server = Some(AnyServer::from(server));
-        let app = server.app.unwrap();
+        let app = server.app_ptr().expect("server app is live");
         let dev = std::ptr::from_mut::<Self>(self).cast::<c_void>();
 
         // The ZST-fn-item trampoline pattern used by
@@ -1314,13 +1314,17 @@ impl DevServer {
         );
         route!(any, INTERNAL_PREFIX.as_bytes(), DevHandlerId::NotFound);
 
-        // SAFETY: see `route!` — statement-scoped reborrow of the live app.
-        unsafe { &mut *app }.ws(
-            const_format::concatcp!(INTERNAL_PREFIX, "/hmr").as_bytes(),
-            dev,
-            0,
-            hmr_socket_behavior::<SSL>(),
-        );
+        // SAFETY: see `route!` — statement-scoped reborrow of the live app;
+        // `dev` is this `DevServer`, the `hmr_socket_behavior` upgrade server,
+        // which outlives the route (routes are cleared before it drops).
+        unsafe {
+            (*app).ws(
+                const_format::concatcp!(INTERNAL_PREFIX, "/hmr").as_bytes(),
+                dev,
+                0,
+                hmr_socket_behavior::<SSL>(),
+            )
+        };
 
         // Only attach a catch-all handler if the framework has filesystem
         // router types. Otherwise, this can just be Bun.serve's default handler.
@@ -1604,50 +1608,43 @@ impl bun_uws_sys::web_socket::WebSocketHandler for HmrSocket {
     unsafe fn on_pong(_this: *mut Self, _ws: bun_uws_sys::AnyWebSocket, _message: &[u8]) {}
 }
 impl<const SSL: bool> bun_uws_sys::web_socket::WebSocketUpgradeServer<SSL> for DevServer {
-    unsafe fn on_websocket_upgrade(
-        this: *mut Self,
-        res: *mut bun_uws_sys::NewAppResponse<SSL>,
+    fn on_websocket_upgrade(
+        this: bun_ptr::ThisPtr<Self>,
+        res: &mut bun_uws_sys::NewAppResponse<SSL>,
         req: &mut Request,
         upgrade_ctx: &mut WebSocketUpgradeContext,
         id: usize,
     ) {
         debug_assert_eq!(id, 0);
+        let this: *mut Self = this.as_ptr();
         // Note: DevServer always registers `*mut Self` with `id == 0`
         // (`set_routes` → `app.ws(prefix, this, 0, ..)`); live for the upgrade
         // callback's duration. `res.upgrade(..)` synchronously runs `on_open`
         // → `HmrSocket::dev()`, which materializes a second `&mut DevServer`
         // from the socket's backref, so no `&mut DevServer` may span it — the
-        // pre-upgrade borrows below are scoped to their statements. uWS
-        // guarantees `res` is non-null and live for the upgrade callback
-        // (`Response<SSL>` is an opaque handle); every `&mut *res` below is
-        // likewise statement-scoped.
+        // pre-upgrade borrows below are scoped to their statements.
         //
         // SAFETY: `this` is the live DevServer registered for the upgrade callback.
         if !is_allowed_dev_host(unsafe { &*this }, req) {
-            // SAFETY: `res` is live for this callback (see Note above).
-            host_forbidden(unsafe { &mut *res }.as_any_response());
+            host_forbidden(res.as_any_response());
             return;
         }
         if !is_allowed_dev_origin(req) {
-            // SAFETY: `res` is live for this callback (see Note above).
-            origin_forbidden(unsafe { &mut *res }.as_any_response());
+            origin_forbidden(res.as_any_response());
             return;
         }
         // SAFETY: as above; the borrow is statement-scoped, ending before `upgrade`.
         let dw = bun_core::heap::into_raw(HmrSocket::new(unsafe { &mut *this }));
         // SAFETY: `this` is live (see above).
         let _ = unsafe { (*this).active_websocket_connections.insert(dw, ()) };
-        // SAFETY: `res` is live for this callback (see Note above); `on_open`
-        // (run synchronously inside `upgrade`) re-derives DevServer, not `res`.
-        let _ = unsafe {
-            (&mut *res).upgrade(
-                dw,
-                req.header(b"sec-websocket-key").unwrap_or(b""),
-                req.header(b"sec-websocket-protocol").unwrap_or(b""),
-                req.header(b"sec-websocket-extension").unwrap_or(b""),
-                Some(upgrade_ctx),
-            )
-        };
+        // `on_open` (run synchronously inside `upgrade`) re-derives DevServer, not `res`.
+        let _ = res.upgrade(
+            dw,
+            req.header(b"sec-websocket-key").unwrap_or(b""),
+            req.header(b"sec-websocket-protocol").unwrap_or(b""),
+            req.header(b"sec-websocket-extension").unwrap_or(b""),
+            Some(upgrade_ctx),
+        );
     }
 }
 
@@ -1965,7 +1962,7 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
                                     .as_ref()
                                     .expect("infallible: server bound")
                                     .get_or_load_plugins(
-                                        crate::server::ServePluginsCallback::DevServer(dev),
+                                        crate::server::ServePluginsCallback::DevServer,
                                     );
                                 match load_result {
                                     crate::server::GetOrStartLoadResult::Pending => {
@@ -2589,10 +2586,10 @@ impl DevServer {
             let url_bunstr = match &req {
                 // SAFETY: r is a uws Request ptr valid for the duration of the handler callback
                 SavedRequestUnion::Stack(r) => bun_core::StringView::borrow_utf8((**r).url()),
-                SavedRequestUnion::Saved(data) => {
-                    // SAFETY: data.request is a live *mut webcore::Request (held strong by ctx)
-                    bun_core::StringView::new(unsafe { (*data.request).url.get() })
-                }
+                SavedRequestUnion::Saved(data) => match data.request() {
+                    Some(r) => bun_core::StringView::new(r.url.get()),
+                    None => bun_core::StringView::EMPTY,
+                },
             };
             let url = url_bunstr.to_utf8();
             // Extract pathname from URL (remove protocol, host, query, hash)
@@ -3072,8 +3069,7 @@ impl DeferredRequest {
             Handler::ServerHandler(saved) => {
                 deferred_request::debug_log_dr!(
                     "  request url: {}",
-                    // SAFETY: saved.request is a live *mut webcore::Request (held strong by ctx)
-                    bstr::BStr::new(unsafe { (*saved.request).url.get() }.byte_slice())
+                    bstr::BStr::new(saved.request().map_or(&b""[..], |r| r.url.get().byte_slice()))
                 );
                 saved
                     .ctx
@@ -6510,7 +6506,7 @@ fn bundle_new_route_js_function_impl(
 
     // SAFETY: request_ptr is a *bun.webcore.Request from C++
     let request: &mut WebRequest = unsafe { &mut *request_ptr.cast::<WebRequest>() };
-    let Some(dev) = request.request_context.dev_server() else {
+    let Some(dev) = request.request_context.get().dev_server() else {
         return Err(global.throw(format_args!(
             "Request context does not belong to dev server"
         )));
@@ -6536,7 +6532,7 @@ fn bundle_new_route_js_function_impl(
     let _exit = dev.vm().enter_event_loop_scope();
 
     let _ = dev;
-    let Some(dev_ptr) = request.request_context.dev_server_mut() else {
+    let Some(dev_ptr) = request.request_context.get().dev_server_mut() else {
         return Err(global.throw(format_args!(
             "Request context does not belong to dev server"
         )));
@@ -6650,7 +6646,7 @@ fn new_route_params_for_bundle_promise_for_js(
     };
     // SAFETY: `from_js` returned a live native pointer; JS holds the GC ref.
     let request: &mut WebRequest = unsafe { &mut *request_ptr };
-    let Some(dev_ptr) = request.request_context.dev_server_mut() else {
+    let Some(dev_ptr) = request.request_context.get().dev_server_mut() else {
         return Err(global.throw(format_args!(
             "Request context does not belong to dev server"
         )));

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3069,7 +3069,11 @@ impl DeferredRequest {
             Handler::ServerHandler(saved) => {
                 deferred_request::debug_log_dr!(
                     "  request url: {}",
-                    bstr::BStr::new(saved.request().map_or(&b""[..], |r| r.url.get().byte_slice()))
+                    bstr::BStr::new(
+                        saved
+                            .request()
+                            .map_or(&b""[..], |r| r.url.get().byte_slice())
+                    )
                 );
                 saved
                     .ctx

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -459,9 +459,10 @@ pub(crate) fn run_task(
 
         // ── server / bundler / streams ───────────────────────────────────
         task_tag::ServerAllConnectionsClosedTask => {
-            ServerAllConnectionsClosedTask::run_from_js_thread(cast_ptr!(
-                ServerAllConnectionsClosedTask
-            ))?;
+            // SAFETY: `ServerAllConnectionsClosedTask::schedule` boxed it; the arm consumes the box.
+            ServerAllConnectionsClosedTask::run_from_js_thread(*unsafe {
+                bun_core::heap::take(cast_ptr!(ServerAllConnectionsClosedTask))
+            })?;
         }
         task_tag::BundleV2DeferredBatchTask => {
             // `bun_bundler` is JSC-free so the exception-scope check is hoisted
@@ -1270,7 +1271,10 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::S3HttpDownloadStreamingTask => release!(S3HttpDownloadStreamingTask),
         task_tag::S3HttpSimpleTask => release!(S3HttpSimpleTask),
         task_tag::SendQueueDeferred => release!(crate::ipc::SendQueue),
-        task_tag::ServerAllConnectionsClosedTask => release!(ServerAllConnectionsClosedTask),
+        task_tag::ServerAllConnectionsClosedTask => ServerAllConnectionsClosedTask::release_unrun(
+            // SAFETY: as `release!`; `schedule` boxed it.
+            *unsafe { bun_core::heap::take(task.ptr.cast::<ServerAllConnectionsClosedTask>()) },
+        ),
         task_tag::ShellAsync => release!(crate::shell::dispatch_tasks::ShellAsyncTask),
         task_tag::ShellCondExprStatTask => release!(ShellCondExprStatTask),
         task_tag::ShellCpTask => release!(ShellCpTask),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -394,14 +394,13 @@ unsafe fn init_runtime_state(
             // `HiveArray::new_boxed`). Allocate it on the heap and initialize it in
             // place instead — only the occupancy bitset is written.
             let pool = crate::webcore::body::HiveAllocator::new_boxed();
-            // SAFETY: `new_boxed` leaks a `Box<HiveAllocator>`; reclaim ownership of
-            // that same allocation. `ManuallyDrop` is `repr(transparent)`, so
+            // SAFETY: re-box the same allocation. `ManuallyDrop` is `repr(transparent)`, so
             // `Box<ManuallyDrop<T>>` and `Box<T>` have identical layout — the wrapper
             // only suppresses the inner drop, which is the behavior documented on the
             // field.
             unsafe {
                 Box::from_raw(
-                    pool.as_ptr()
+                    Box::into_raw(pool)
                         .cast::<core::mem::ManuallyDrop<crate::webcore::body::HiveAllocator>>(),
                 )
             }
@@ -1776,7 +1775,7 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             // registered entry implies `close()` has not run, and `deinit`
             // cannot fire before `close()` drops the wrapper's Strong ref.
             ActiveHandle::StatWatcher(w) => bun_ptr::ParentRef::from(w).close(),
-            ActiveHandle::Server(mut s) => s.stop(true),
+            ActiveHandle::Server(s) => s.stop(true),
             ActiveHandle::Listener(l) => {
                 // SAFETY: live until it unregisters in `do_stop`/`finalize`.
                 crate::socket::Listener::stop_for_vm_teardown(unsafe { l.as_ref() })

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -238,13 +238,19 @@ impl AnyRequestContext {
     /// JS thread.
     pub(crate) fn dev_server_mut(self) -> Option<*mut crate::bake::DevServer::DevServer> {
         dispatch!(self, None, |_T, ctx| {
-            let server = ctx.server.get()?.as_ptr();
-            // SAFETY: `ctx.server` is a non-null backref that outlives this context
-            // and `dev_server` is a `Box` field never moved while requests are in
-            // flight, so dereferencing for exclusive access on the JS thread is sound.
-            let ds = unsafe { (*server).dev_server.as_deref_mut()? };
+            let server = ctx.server.get()?;
+            // SAFETY: `dev_server` is a `Box` field never moved while requests
+            // are in flight, so dereferencing the slot for exclusive access on
+            // the JS thread is sound.
+            let ds = unsafe { (*server.dev_server.as_ptr()).as_deref_mut()? };
             Some(core::ptr::from_mut(ds))
         })
+    }
+
+    /// The context behind this handle if it is a `T`.
+    pub(crate) fn get_ref<T: CtxKind + 'static>(&self) -> Option<&T> {
+        dispatch!(*self, None, |_T, ctx| (ctx as &dyn core::any::Any)
+            .downcast_ref::<T>())
     }
 
     pub fn deref(self) {

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -112,7 +112,7 @@ impl DirectoryRoute {
             route: Some(RefPtr::from_this(this)),
             resp,
         };
-        if let Some(mut server) = this.server.get() {
+        if let Some(server) = this.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
         }
@@ -355,7 +355,7 @@ impl DirectoryRoute {
         resp.clear_aborted();
         resp.clear_on_writable();
         resp.clear_timeout();
-        if let Some(mut server) = self.server.get() {
+        if let Some(server) = self.server.get() {
             server.on_static_request_complete();
         }
     }

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -244,7 +244,7 @@ impl FileRoute {
         // Held until `on_response_complete`; a reload can drop the route
         // table's ref while a `FileResponseStream` is still streaming.
         let route = RefPtr::from_this(this);
-        if let Some(mut server) = route.server.get() {
+        if let Some(server) = route.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
         }
@@ -464,7 +464,7 @@ impl FileRoute {
         resp.clear_aborted();
         resp.clear_on_writable();
         resp.clear_timeout();
-        if let Some(mut server) = self.server.get() {
+        if let Some(server) = self.server.get() {
             server.on_static_request_complete();
         }
     }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -221,7 +221,7 @@ impl Route {
         };
 
         if server.config().is_development() {
-            if let Some(dev) = server.dev_server_mut() {
+            let handled = server.with_dev_server_mut(|dev| {
                 // DevServer's HMR path is *uws.Request-typed; H3 isn't routed
                 // there (no h3_app on plain-HTTP debug servers in practice),
                 // but stay defensive.
@@ -239,6 +239,8 @@ impl Route {
                         resp.end(b"DevServer HMR is HTTP/1.1 only", true);
                     }
                 }
+            });
+            if handled.is_some() {
                 return;
             }
 
@@ -327,7 +329,7 @@ impl Route {
     /// on the route's behalf; the clients waiting in `pending_responses` only
     /// count as connections and can disconnect at any time. `finish_building`
     /// releases the pending request when the route leaves `State::Building`.
-    fn schedule_bundle(this: ThisPtr<Self>, mut server: AnyServer) -> Result<(), crate::Error> {
+    fn schedule_bundle(this: ThisPtr<Self>, server: AnyServer) -> Result<(), crate::Error> {
         match server.get_or_load_plugins(ServePluginsCallback::HtmlBundleRoute(this)) {
             GetOrStartLoadResult::Err => {
                 this.state.set(State::Err(Log::init()));

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -16,7 +16,7 @@ use bun_uws_sys as uws_sys;
 use crate::server::jsc::{
     self, CallFrame, ErrorCode, JSGlobalObject, JSValue, JsResult, StrongOptional, VirtualMachine,
 };
-use crate::server::{AnyServer, AnyServerTag, HTTPStatusText, ServerWebSocket};
+use crate::server::{AnyServer, HTTPStatusText, ServerWebSocket};
 use crate::webcore::AutoFlusher;
 
 bun_core::declare_scope!(NodeHTTPResponse, visible);
@@ -326,28 +326,6 @@ extern "C" fn on_auto_flush_trampoline(ctx: *mut c_void) -> bool {
     unsafe { (*(ctx.cast_const().cast::<NodeHTTPResponse>())).on_auto_flush() }
 }
 
-/// Unpack the `AnyServer` tagged-pointer u64 handed across FFI from C++.
-///
-/// The packed repr is bits 0..49 = ptr,
-/// bits 49..64 = tag, with tag = `1024 - index` (see `bun_ptr::tagged_pointer`).
-/// The Rust `AnyServer` stores `(tag, ptr)` unpacked, so map the wire tag back
-/// to `AnyServerTag` here.
-#[inline]
-fn any_server_from_packed(packed: u64) -> AnyServer {
-    let repr = bun_ptr::TaggedPtr::from(packed);
-    let tag = match repr.data() {
-        1024 => AnyServerTag::HTTPServer,
-        1023 => AnyServerTag::HTTPSServer,
-        1022 => AnyServerTag::DebugHTTPServer,
-        1021 => AnyServerTag::DebugHTTPSServer,
-        _ => unreachable!("Invalid pointer tag"),
-    };
-    AnyServer {
-        tag,
-        ptr: repr.get::<()>(),
-    }
-}
-
 /// `jsc.Codegen.JSNodeHTTPResponse` cached-property accessors.
 /// `codegen_cached_accessors!` emits `on_{data,aborted,writable}_{get,set}_cached`
 /// thin wrappers over the C++ `NodeHTTPResponsePrototype__on*{Get,Set}CachedValue`
@@ -534,17 +512,11 @@ impl NodeHTTPResponse {
         if upgrade_ctx.is_null() {
             return false;
         }
-        // `AnyServer` is a `Copy` type-erased pointer; copy it so the
-        // `&mut self`-taking accessor can be called from this `&self` body.
-        // The pointee is the long-lived server, not `*self`.
-        let mut server = self.server;
-        let Some(ws_handler) = server.web_socket_handler() else {
+        // The pointee is the long-lived server (and its websocket config), not `*self`.
+        let server = self.server;
+        let Some(ws_handler) = server.config().websocket.as_ref().map(|ws| &ws.handler) else {
             return false;
         };
-        // Lifetime-extend the handler past the method calls below.
-        // SAFETY: JS-thread only; the server (and its websocket config) outlives this call.
-        let ws_handler: &mut crate::server::WebSocketServerHandler =
-            unsafe { &mut *std::ptr::from_mut(ws_handler) };
         let socket_value = self.get_server_socket_value();
         if socket_value.is_empty() {
             return false;
@@ -725,7 +697,7 @@ impl NodeHTTPResponse {
 
         self.buffered_request_body_data_during_pause
             .with_mut(|b| b.clear_and_free());
-        let mut server = self.server;
+        let server = self.server;
         self.poll_ref.with_mut(|r| r.unref(vm));
         self.unregister_auto_flush();
 
@@ -2557,17 +2529,14 @@ impl Drop for NodeHTTPResponse {
 }
 
 /// # Safety
-/// `response` is the pointer written to `node_response_ptr` by
-/// `NodeHTTPResponse__createForJS` earlier in the same dispatch and is live;
-/// `data`/`length` describe a caller-owned buffer valid for the call.
+/// `response` is the JS wrapper's `m_ctx`; `data`/`length` describe a
+/// caller-owned buffer valid for the call.
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn NodeHTTPResponse__adoptRawRequestHeaders(
-    response: *mut NodeHTTPResponse,
+    response: &NodeHTTPResponse,
     data: *const u8,
     length: usize,
 ) {
-    // SAFETY: see the function-level contract above.
-    let response = unsafe { &*response };
     // SAFETY: `data`/`length` describe a caller-owned buffer valid for the
     // call (function-level contract above).
     let bytes = unsafe { core::slice::from_raw_parts(data, length) };
@@ -2576,96 +2545,87 @@ pub(crate) unsafe extern "C" fn NodeHTTPResponse__adoptRawRequestHeaders(
         .with_mut(|v| v.append_slice(bytes));
 }
 
-/// # Safety
-/// `has_body`, `request`, `response_ptr`, `upgrade_ctx`, and `node_response_ptr`
-/// are provided by C++ NodeHTTPServer and must be valid for the duration of the
-/// call; `has_body` and `node_response_ptr` must be writable.
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn NodeHTTPResponse__createForJS(
-    any_server_tag: u64,
-    global_object: &JSGlobalObject,
-    has_body: *mut bool,
-    request: *mut uws_sys::Request,
-    is_ssl: i32,
-    response_ptr: *mut c_void,
-    upgrade_ctx: *mut uws_sys::WebSocketUpgradeContext,
-    node_response_ptr: *mut *mut NodeHTTPResponse,
-) -> JSValue {
-    // SAFETY: all pointers are provided by C++ NodeHTTPServer and are live for the call.
-    let has_body = unsafe { &mut *has_body };
-    // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-    let request_ref = bun_opaque::opaque_deref(request.cast_const());
+impl NodeHTTPResponse {
+    /// Allocate the native response (three refs: the HTTP response, the JS
+    /// object, the server's request handler — the last one returned) and its JS
+    /// wrapper for a `node:http` request. Also reports whether a body follows.
+    pub(crate) fn create(
+        server: AnyServer,
+        global_object: &JSGlobalObject,
+        request: &mut uws_sys::Request,
+        is_ssl: bool,
+        raw_response: uws::AnyResponse,
+        upgrade_ctx: *mut uws_sys::WebSocketUpgradeContext,
+    ) -> (bun_ptr::RefPtr<NodeHTTPResponse>, JSValue, bool) {
+        let _ = is_ssl;
+        let mut has_body = false;
+        let request_ptr: *mut uws_sys::Request = request;
+        let request_ref = &*request;
 
-    let vm = bun_vm_mut(global_object);
-    let method = HttpMethod::which(request_ref.method()).unwrap_or(HttpMethod::OPTIONS);
-    // GET in node.js can have a body
-    if method.has_request_body() || method == HttpMethod::GET {
-        let req_len: usize = 'brk: {
-            if let Some(content_length) = request_ref.header(b"content-length") {
-                scoped_log!(
-                    NodeHTTPResponse,
-                    "content-length: {}",
-                    BStr::new(content_length)
-                );
-                break 'brk bun_http_types::parse_content_length(content_length);
-            }
-            break 'brk 0;
-        };
+        let vm = bun_vm_mut(global_object);
+        let method = HttpMethod::which(request_ref.method()).unwrap_or(HttpMethod::OPTIONS);
+        // GET in node.js can have a body
+        if method.has_request_body() || method == HttpMethod::GET {
+            let req_len: usize = 'brk: {
+                if let Some(content_length) = request_ref.header(b"content-length") {
+                    scoped_log!(
+                        NodeHTTPResponse,
+                        "content-length: {}",
+                        BStr::new(content_length)
+                    );
+                    break 'brk bun_http_types::parse_content_length(content_length);
+                }
+                break 'brk 0;
+            };
 
-        *has_body = req_len > 0 || request_ref.has_transfer_encoding();
+            has_body = req_len > 0 || request_ref.has_transfer_encoding();
+        }
+
+        let response = bun_core::heap::into_raw(Box::new(NodeHTTPResponse {
+            // 1 - the HTTP response
+            // 1 - the JS object
+            // 1 - the Server handler.
+            ref_count: bun_ptr::RefCount::init_exact_refs(3),
+            upgrade_context: JsCell::new(UpgradeCTX {
+                context: upgrade_ctx,
+                request: request_ptr,
+                sec_websocket_key: Box::default(),
+                sec_websocket_protocol: Box::default(),
+                sec_websocket_extensions: Box::default(),
+            }),
+            server,
+            raw_response: Cell::new(Some(raw_response)),
+            body_read_state: Cell::new(if has_body {
+                BodyReadState::Pending
+            } else {
+                BodyReadState::None
+            }),
+            flags: Cell::new(Flags::default()),
+            poll_ref: JsCell::new(jsc::Ref::default()),
+            body_read_ref: JsCell::new(jsc::Ref::default()),
+            promise: JsCell::new(StrongOptional::empty()),
+            buffered_request_body_data_during_pause: JsCell::new(Vec::new()),
+            request_trailers: JsCell::new(Vec::new()),
+            armed_this_value: Cell::new(JSValue::ZERO),
+            raw_request_headers: JsCell::new(Vec::new()),
+            bytes_written: Cell::new(0),
+            pending_pinned_write: Cell::new(PendingPinnedWrite::default()),
+            pending_pinned_write_owner: JsCell::new(crate::node::StringOrBuffer::EMPTY),
+            auto_flusher: JsCell::new(AutoFlusher::default()),
+        }));
+
+        // The server handler's ref (one of the initial 3).
+        // SAFETY: `response` was just allocated and leaked with that ref counted in.
+        let response = unsafe { bun_ptr::RefPtr::from_raw(response) };
+        if has_body {
+            response.body_read_ref.with_mut(|r| r.r#ref(vm));
+        }
+        response.poll_ref.with_mut(|r| r.r#ref(vm));
+        // SAFETY: `response` is a fresh `heap::alloc` heap payload; ownership of
+        // the +1 wrapper ref transfers to the GC (`NodeHTTPResponseClass__finalize`
+        // calls `finalize` → `deref`). `to_js_ptr` is the `#[JsClass]`-generated
+        // no-rebox wrapper around `NodeHTTPResponse__create`.
+        let js_this = unsafe { NodeHTTPResponse::to_js_ptr(response.as_ptr(), global_object) };
+        (response, js_this, has_body)
     }
-
-    let raw_response = if is_ssl != 0 {
-        uws::AnyResponse::SSL(response_ptr.cast())
-    } else {
-        uws::AnyResponse::TCP(response_ptr.cast())
-    };
-
-    let response = bun_core::heap::into_raw(Box::new(NodeHTTPResponse {
-        // 1 - the HTTP response
-        // 1 - the JS object
-        // 1 - the Server handler.
-        ref_count: bun_ptr::RefCount::init_exact_refs(3),
-        upgrade_context: JsCell::new(UpgradeCTX {
-            context: upgrade_ctx,
-            request,
-            sec_websocket_key: Box::default(),
-            sec_websocket_protocol: Box::default(),
-            sec_websocket_extensions: Box::default(),
-        }),
-        server: any_server_from_packed(any_server_tag),
-        raw_response: Cell::new(Some(raw_response)),
-        body_read_state: Cell::new(if *has_body {
-            BodyReadState::Pending
-        } else {
-            BodyReadState::None
-        }),
-        flags: Cell::new(Flags::default()),
-        poll_ref: JsCell::new(jsc::Ref::default()),
-        body_read_ref: JsCell::new(jsc::Ref::default()),
-        promise: JsCell::new(StrongOptional::empty()),
-        buffered_request_body_data_during_pause: JsCell::new(Vec::new()),
-        request_trailers: JsCell::new(Vec::new()),
-        armed_this_value: Cell::new(JSValue::ZERO),
-        raw_request_headers: JsCell::new(Vec::new()),
-        bytes_written: Cell::new(0),
-        pending_pinned_write: Cell::new(PendingPinnedWrite::default()),
-        pending_pinned_write_owner: JsCell::new(crate::node::StringOrBuffer::EMPTY),
-        auto_flusher: JsCell::new(AutoFlusher::default()),
-    }));
-
-    // SAFETY: `response` was just allocated and leaked; we hold the only reference.
-    let response_ref = unsafe { &*response };
-    if *has_body {
-        response_ref.body_read_ref.with_mut(|r| r.r#ref(vm));
-    }
-    response_ref.poll_ref.with_mut(|r| r.r#ref(vm));
-    // SAFETY: `response` is a fresh `heap::alloc` heap payload; ownership of
-    // the +1 wrapper ref transfers to the GC (`NodeHTTPResponseClass__finalize`
-    // calls `finalize` → `deref`). `to_js_ptr` is the `#[JsClass]`-generated
-    // no-rebox wrapper around `NodeHTTPResponse__create`.
-    let js_this = unsafe { NodeHTTPResponse::to_js_ptr(response, global_object) };
-    // SAFETY: out-param provided by caller.
-    unsafe { *node_response_ptr = response };
-    js_this
 }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -257,8 +257,7 @@ fn vm_get<'a>() -> &'a mut VirtualMachine {
 /// call-site symmetry but reads the thread-local directly:
 /// `VirtualMachine::as_mut()` ignores its receiver and re-reads the TLS slot,
 /// so routing through `global.bun_vm()` was pure overhead on the per-request
-/// path (`NodeHTTPResponse__createForJS` disasm showed the `bunVM` FFI result
-/// dropped on the floor).
+/// path (`NodeHTTPResponse::create`).
 #[inline(always)]
 fn bun_vm_mut(_global: &JSGlobalObject) -> &mut VirtualMachine {
     VirtualMachine::get_mut()

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2553,11 +2553,9 @@ impl NodeHTTPResponse {
         server: AnyServer,
         global_object: &JSGlobalObject,
         request: &mut uws_sys::Request,
-        is_ssl: bool,
         raw_response: uws::AnyResponse,
         upgrade_ctx: *mut uws_sys::WebSocketUpgradeContext,
     ) -> (bun_ptr::RefPtr<NodeHTTPResponse>, JSValue, bool) {
-        let _ = is_ssl;
         let mut has_body = false;
         let request_ptr: *mut uws_sys::Request = request;
         let request_ref = &*request;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4596,8 +4596,13 @@ struct HeaderResponseSizePair<
     pub(crate) size: usize,
 }
 
-struct HeaderResponsePair<'a, ThisServer: 'static, const SSL: bool, const DBG: bool, const MUX: bool>
-{
+struct HeaderResponsePair<
+    'a,
+    ThisServer: 'static,
+    const SSL: bool,
+    const DBG: bool,
+    const MUX: bool,
+> {
     pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
     /// The JS wrapper's cell pointer, not a `&mut Response`: the receiving
     /// frame hands it to `set_response`, which stores it in a `WeakPtr` that

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -71,7 +71,7 @@ type ResponseStreamJSSink<const SSL_ENABLED: bool> =
 /// It costs about 655,632 bytes.
 // Capacity 0 when heap-breakdown is enabled routes every allocation through
 // the fallback heap path so the per-type malloc zones can attribute them.
-const REQUEST_CONTEXT_POOL_CAPACITY: usize = if bun_alloc::heap_breakdown::ENABLED {
+pub(crate) const REQUEST_CONTEXT_POOL_CAPACITY: usize = if bun_alloc::heap_breakdown::ENABLED {
     0
 } else {
     2048
@@ -102,7 +102,7 @@ pub(crate) enum UpgradeState {
 /// type tag into the low bits of a pointer to this.
 #[repr(align(16))]
 pub struct RequestContext<
-    ThisServer,
+    ThisServer: 'static,
     const SSL_ENABLED: bool,
     const DEBUG_MODE: bool,
     const MUX: bool,
@@ -110,7 +110,7 @@ pub struct RequestContext<
     /// BACKREF to the embedding `Server` — the server owns this request
     /// context (allocated from its `HiveArray` pool) and outlives it, so the
     /// pointee is live for the holder's entire lifetime. `None` once detached.
-    pub(crate) server: Cell<Option<bun_ptr::BackRef<ThisServer, bun_ptr::Mut>>>,
+    pub(crate) server: Cell<Option<bun_ptr::BackRef<ThisServer, bun_ptr::Root>>>,
     pub(crate) resp: Cell<Option<uws::AnyResponse>>,
     pub(crate) req: Cell<Option<*mut Req<SSL_ENABLED, MUX>>>,
     pub(crate) request_weakref: JsCell<request::WeakRef>,
@@ -139,6 +139,10 @@ pub struct RequestContext<
     // here would root the Response unconditionally and change GC behavior.
     pub(crate) response_jsvalue: Cell<JSValue>,
     root: Cell<*mut Self>,
+    /// This context's own pool slot; dropping it (in `deinit`) frees `self`.
+    pub(crate) pool_slot: Cell<
+        Option<bun_collections::hive_array::Pooled<'static, Self, REQUEST_CONTEXT_POOL_CAPACITY>>,
+    >,
     pub(crate) ref_count: Cell<u8>,
     pub(crate) pin_count: Cell<u8>,
 
@@ -227,7 +231,7 @@ where
     pub(crate) fn dev_server(&self) -> Option<&crate::bake::DevServer::DevServer> {
         let server = self.server.get()?;
         // SAFETY: BACKREF — the server outlives every context it allocates.
-        unsafe { &*server.as_ptr() }.dev_server()
+        unsafe { &*server.as_const_ptr() }.dev_server()
     }
 }
 
@@ -577,7 +581,7 @@ where
                 .server
                 .get()
                 .expect("infallible: server bound")
-                .as_ptr()
+                .as_const_ptr()
         }
     }
 
@@ -983,10 +987,8 @@ where
         }
 
         if let Some(server) = self.server.take() {
-            server.release_request_context(self.as_ctx_ptr().cast::<c_void>(), MUX);
-            // SAFETY: `&mut` through the backref — the server outlives this
-            // context and no other borrow of it is live here.
-            unsafe { (*server.as_ptr()).on_request_complete() };
+            drop(self.pool_slot.take());
+            server.on_request_complete();
         }
     }
 
@@ -1402,28 +1404,28 @@ where
         }
     }
 
-    pub(crate) fn create(
-        this: &mut core::mem::MaybeUninit<Self>,
-        server: *mut ThisServer,
+    // Inlined so the value is built directly in the pool slot.
+    #[inline(always)]
+    pub(crate) fn init(
+        slot: NonNull<Self>,
+        server: bun_ptr::BackRef<ThisServer, bun_ptr::Root>,
         req: *mut Req<SSL_ENABLED, MUX>,
         resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<Method>,
-    ) {
+    ) -> Self {
         let resolved_method = method
             .or_else(|| Method::which(Self::req_method(req)))
             .unwrap_or(Method::GET);
-        let slot: *mut Self = this.as_mut_ptr();
-        // SAFETY: writing to MaybeUninit slot
-        unsafe {
-            slot.write(Self {
-                root: Cell::new(slot),
+        ctx_log!("create<d> ({:p})<r>", slot);
+        {
+            Self {
+                root: Cell::new(slot.as_ptr()),
+                pool_slot: Cell::new(None),
                 resp: Cell::new(Some(resp)),
                 req: Cell::new(Some(req)),
                 method: resolved_method,
-                server: Cell::new(
-                    NonNull::new(server).map(|p| bun_ptr::BackRef::from_raw_mut(p.as_ptr())),
-                ),
+                server: Cell::new(Some(server)),
                 defer_deinit_until_callback_completes: Cell::new(should_deinit_context),
                 range: RangeRequest::raw_from_request(&Self::any_request(req)),
                 request_weakref: JsCell::new(request::WeakRef::EMPTY),
@@ -1449,10 +1451,8 @@ where
                 response_buf_owned: JsCell::new(Vec::new()),
                 additional_on_abort: JsCell::new(None),
                 promise_cell: Cell::new(JSValue::ZERO),
-            });
+            }
         }
-
-        ctx_log!("create<d> ({:p})<r>", this.as_ptr());
     }
 
     fn on_abort(this: *mut Self, resp: uws::AnyResponse) {
@@ -1500,7 +1500,7 @@ where
         }
 
         if let Some(request) = this.request_mut() {
-            request.request_context = AnyRequestContext::NULL;
+            request.request_context.set(AnyRequestContext::NULL);
             this.request_weakref.set(request::WeakRef::EMPTY);
         }
         // if signal is not aborted, abort the signal
@@ -1614,7 +1614,7 @@ where
         drop(self.cookies.replace(None));
 
         if let Some(request) = self.request_mut() {
-            request.request_context = AnyRequestContext::NULL;
+            request.request_context.set(AnyRequestContext::NULL);
             self.request_weakref.set(request::WeakRef::EMPTY);
         }
 
@@ -2354,7 +2354,7 @@ where
     fn to_async_without_abort_handler(
         &self,
         req: *mut Req<SSL_ENABLED, MUX>,
-        request_object: &mut Request,
+        request_object: &Request,
     ) {
         debug_assert!(self.server.get().is_some());
 
@@ -2366,6 +2366,7 @@ where
             // type is `uws::Request`, so the cast is nominal.
             request_object
                 .request_context
+                .get()
                 .set_request(req.cast::<uws::Request>());
         }
 
@@ -2383,10 +2384,10 @@ where
 
         // This object dies after the stack frame is popped
         // so we have to clear it in here too
-        request_object.request_context.detach_request();
+        request_object.request_context.get().detach_request();
     }
 
-    pub(crate) fn to_async(&self, req: *mut Req<SSL_ENABLED, MUX>, request_object: &mut Request) {
+    pub(crate) fn to_async(&self, req: *mut Req<SSL_ENABLED, MUX>, request_object: &Request) {
         ctx_log!("toAsync");
         self.to_async_without_abort_handler(req, request_object);
         if DEBUG_MODE {
@@ -4579,17 +4580,24 @@ request_ctx_exports! {
         Bun__HTTPRequestContextDebugMuxTLS__onRejectStream;
 }
 
-struct StreamPair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
+struct StreamPair<'a, ThisServer: 'static, const SSL: bool, const DBG: bool, const MUX: bool> {
     pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
     pub stream: WebCore::ReadableStream,
 }
 
-struct HeaderResponseSizePair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
+struct HeaderResponseSizePair<
+    'a,
+    ThisServer: 'static,
+    const SSL: bool,
+    const DBG: bool,
+    const MUX: bool,
+> {
     pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
     pub(crate) size: usize,
 }
 
-struct HeaderResponsePair<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
+struct HeaderResponsePair<'a, ThisServer: 'static, const SSL: bool, const DBG: bool, const MUX: bool>
+{
     pub this: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
     /// The JS wrapper's cell pointer, not a `&mut Response`: the receiving
     /// frame hands it to `set_response`, which stores it in a `WeakPtr` that
@@ -4597,7 +4605,8 @@ struct HeaderResponsePair<'a, ThisServer, const SSL: bool, const DBG: bool, cons
     pub(crate) response: *mut Response,
 }
 
-struct PathnameFormatter<'a, ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> {
+struct PathnameFormatter<'a, ThisServer: 'static, const SSL: bool, const DBG: bool, const MUX: bool>
+{
     ctx: &'a RequestContext<ThisServer, SSL, DBG, MUX>,
 }
 

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -6,8 +6,8 @@ use core::ptr::NonNull;
 use bun_core::Utf8Bytes;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{ComptimeStringMapExt as _, JsCell};
-use bun_uws::{self as uws, AnyWebSocket, WebSocketBehavior};
-use bun_uws_sys::web_socket::{WebSocketHandler, WebSocketUpgradeServer, Wrap};
+use bun_uws::{self as uws, AnyWebSocket};
+use bun_uws_sys::web_socket::WebSocketHandler;
 use bun_uws_sys::{Opcode, SendStatus};
 
 use crate::server::WebSocketServerHandler;
@@ -792,15 +792,6 @@ impl ServerWebSocket {
             }
         }
         Ok(())
-    }
-
-    pub(crate) fn behavior<ServerType, const SSL: bool>(
-        opts: &WebSocketBehavior,
-    ) -> WebSocketBehavior
-    where
-        ServerType: WebSocketUpgradeServer<SSL>,
-    {
-        Wrap::<ServerType, Self, SSL>::apply(opts)
     }
 
     // No `#[bun_jsc::host_fn]` here — the constructor extern shim is

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -263,7 +263,7 @@ impl StaticRoute {
     pub(crate) fn on_head(this: ThisPtr<Self>, resp: AnyResponse) {
         debug_assert!(this.server.get().is_some());
         Self::retain_for_response(this);
-        if let Some(mut server) = this.server.get() {
+        if let Some(server) = this.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
         }
@@ -318,7 +318,7 @@ impl StaticRoute {
     pub(crate) fn on(this: ThisPtr<Self>, resp: AnyResponse) {
         debug_assert!(this.server.get().is_some());
         Self::retain_for_response(this);
-        if let Some(mut server) = this.server.get() {
+        if let Some(server) = this.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
         }
@@ -356,7 +356,7 @@ impl StaticRoute {
         resp.clear_aborted();
         resp.clear_on_writable();
         resp.clear_timeout();
-        if let Some(mut server) = this.server.get() {
+        if let Some(server) = this.server.get() {
             server.on_static_request_complete();
         }
         let n = this.pending_responses.get() - 1;
@@ -549,7 +549,7 @@ impl StaticRoute {
     ) -> bool {
         req.set_yield(false);
         Self::retain_for_response(this);
-        if let Some(mut server) = this.server.get() {
+        if let Some(server) = this.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -322,7 +322,6 @@ impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
         // user_routes, all_closed_promise) drop automatically.
         if let Some(p) = self.plugins.replace(None) {
             p.forget_server(AnyServer::from(&*self));
-            p.deref();
         }
     }
 }
@@ -853,8 +852,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         let global = server.global_this();
-        let is_transfer_encoding =
-            request_body_length.is_some() && req.has_transfer_encoding();
+        let is_transfer_encoding = request_body_length.is_some() && req.has_transfer_encoding();
         let expects_body =
             matches!(request_body_length, Some(len) if len > 0 || is_transfer_encoding);
         let mut prepared = Self::create_request_context::<ServerRequestContext<SSL, DEBUG>>(
@@ -1435,7 +1433,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // (`node_http_request_on_resolve` / `_on_reject` release it).
             let _ = nhr.into_raw();
         } else {
-            nhr.deref();
+            drop(nhr);
         }
     }
 
@@ -1821,7 +1819,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             .get()
             .as_ref()
             .expect("server app is live")
-            .dupe_ref();
+            .clone();
         vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new_boxed(
             Box::new(DeinitTask(this)),
         ));
@@ -1949,9 +1947,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
     // ─── teardown ────────────────────────────────────────────────────────────
     /// Destroy the uws app handles and hand back the ref they held (if still
-    /// held), for the caller to release. Called from `schedule_deinit`'s task,
-    /// on listen-failure, or from `finalize()` at VM shutdown.
-    #[must_use = "the returned ref must be released"]
+    /// held); dropping it releases it, which may free `self`. Called from
+    /// `schedule_deinit`'s task, on listen-failure, or from `finalize()` at VM
+    /// shutdown.
     pub(super) fn teardown(&self) -> Option<RefPtr<Self>> {
         httplog!("teardown");
         // This should've already been handled in stop_listening; however, when
@@ -2045,7 +2043,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         match dev {
             Ok(dev) => server.dev_server.set(dev),
             Err(e) => {
-                server.deref();
+                drop(server);
                 return Err(e);
             }
         }
@@ -2436,9 +2434,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if !global.has_exception() && !(check_ssl_error && throw_ssl_error_if_necessary(global)) {
             let _ = global.throw(msg);
         }
-        if let Some(r) = this.teardown() {
-            r.deref();
-        }
+        drop(this.teardown());
         JSValue::ZERO
     }
 
@@ -2806,9 +2802,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         if global.has_exception() {
-            if let Some(r) = this.teardown() {
-                r.deref();
-            }
+            drop(this.teardown());
             return JSValue::ZERO;
         }
 
@@ -2846,10 +2840,8 @@ impl<const SSL: bool, const DEBUG: bool> bun_event_loop::ManagedTask::RunOnce
     for DeinitTask<SSL, DEBUG>
 {
     fn run(self) -> JsResult<()> {
-        if let Some(extra) = self.0.teardown() {
-            extra.deref();
-        }
-        self.0.deref();
+        drop(self.0.teardown());
+        drop(self.0);
         Ok(())
     }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -16,8 +16,8 @@ fn server_js_create(
     debug: bool,
 ) -> jsc::JSValue {
     use crate::generated_classes as gc;
-    // `ptr` is a fresh `NewServer<SSL,DEBUG>` heap allocation; the C++
-    // wrapper takes ownership. Cast through the concrete monomorphization
+    // `ptr` is a `NewServer<SSL,DEBUG>` whose ref the C++ wrapper takes
+    // over (released via `finalize`). Cast through the concrete monomorphization
     // each codegen module is typed against.
     match (ssl, debug) {
         (false, false) => gc::js_HTTPServer::to_js(ptr.cast(), global),
@@ -28,9 +28,12 @@ fn server_js_create(
 }
 
 use bun_io::KeepAlive;
+use bun_ptr::{JsCell, RefPtr, ThisPtr};
 use bun_uws as uws;
 use bun_uws_sys as uws_sys;
 use bun_uws_sys::app::c as uws_app_c;
+use core::cell::Cell;
+use core::ptr::NonNull;
 
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
@@ -116,16 +119,10 @@ macro_rules! for_each_mux_app {
     ($self:expr, |$mux:ident| $body:block) => {{
         #[allow(unused_imports)]
         use server_config::MuxApp as _;
-        if Self::HAS_H3 {
-            if let Some(app) = $self.h3_app {
-                // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
-                let $mux = bun_opaque::opaque_deref_mut(app);
-                $body
-            }
+        if let Some($mux) = $self.h3_app_mut() {
+            $body
         }
-        if let Some(app) = $self.h2_app {
-            // S008: `h2::App` is an `opaque_ffi!` ZST — safe deref.
-            let $mux = bun_opaque::opaque_deref_mut(app);
+        if let Some($mux) = $self.h2_app_mut() {
             $body
         }
     }};
@@ -135,7 +132,7 @@ macro_rules! for_each_mux_app {
 // route setup, …) split out to keep this module declaration file readable.
 
 #[path = "server_body.rs"]
-mod server_body;
+pub mod server_body;
 pub use server_body::{GetOrStartLoadResult, ServePluginsCallback};
 
 // ─── write_status ────────────────────────────────────────────────────────────
@@ -193,9 +190,8 @@ impl AnyRoute {
 }
 
 // ─── ServePlugins ────────────────────────────────────────────────────────────
-// Full state machine + intrusive refcount lives in `server_body.rs` (the
-// `*mut ServePlugins` is smuggled through `JSValue::then` as a promise context,
-// so `Rc` is unsuitable). Re-exported here for `AnyServer` callers.
+// Full state machine (intrusively refcounted; a `ThisPtr<ServePlugins>` rides
+// through `JSValue::then` as the promise context) lives in `server_body.rs`.
 pub use server_body::ServePlugins;
 
 // ─── ServerFlags ─────────────────────────────────────────────────────────────
@@ -216,31 +212,31 @@ bitflags::bitflags! {
 /// not a correctness invariant.
 const N_HTTP_METHODS: usize = 36;
 
+#[derive(bun_ptr::CellRefCounted)]
 pub struct NewServer<const SSL: bool, const DEBUG: bool> {
-    pub(crate) app: Option<*mut uws_sys::NewApp<SSL>>,
-    pub(crate) listener: Option<*mut uws_sys::app::ListenSocket<SSL>>,
+    /// Held by: the creator (`init()` → `serve()`), then the JS wrapper's
+    /// `m_ctx` (released in `finalize`); and [`Self::self_ref`].
+    ref_count: Cell<u32>,
+    /// The uWS app's route / filter / ws registrations carry a `ThisPtr<Self>`
+    /// as their user-data: this ref is taken when the app is created in
+    /// `listen()` and released by `teardown()` right after the app is destroyed.
+    self_ref: JsCell<Option<RefPtr<Self>>>,
+    pub(crate) app: JsCell<Option<uws_sys::app::OwnedApp<SSL>>>,
+    pub(crate) listener: Cell<Option<NonNull<uws_sys::app::ListenSocket<SSL>>>>,
     // Never set when !SSL.
-    pub(crate) h3_app: Option<*mut uws_sys::h3::App>,
+    pub(crate) h3_app: JsCell<Option<uws_sys::h3::OwnedApp>>,
     /// Attached to `app` when `config.http2`; serves connections that
     /// negotiate "h2" (ALPN) or open with the cleartext preface.
-    pub(crate) h2_app: Option<*mut uws_sys::h2::App>,
-    pub(crate) h3_listener: Option<*mut uws_sys::h3::ListenSocket>,
+    pub(crate) h2_app: JsCell<Option<uws_sys::h2::OwnedApp>>,
+    pub(crate) h3_listener: Cell<Option<NonNull<uws_sys::h3::ListenSocket>>>,
     /// Cached `h3=":<port>"; ma=86400` for Alt-Svc on H1 responses; formatted
     /// once in onH3Listen so renderMetadata doesn't reformat per-request.
-    pub(crate) h3_alt_svc: Box<[u8]>,
-    pub(crate) js_value: jsc::JsRef,
-    /// Potentially null before listen() is called, and once .destroy() is called.
+    pub(crate) h3_alt_svc: JsCell<Box<[u8]>>,
+    pub(crate) js_value: JsCell<jsc::JsRef>,
     // LIFETIMES.tsv = STATIC → `&'static VirtualMachine`. `BackRef` for safe
     // `Deref` while keeping the struct `'static` (process-lifetime VM).
     pub(crate) vm: bun_ptr::BackRef<jsc::VirtualMachine>,
     pub global_this: *const jsc::JSGlobalObject,
-    /// Packed tagged-pointer wire-format `AnyServer` for this
-    /// server (`u49` heap addr | `u15` variant tag), computed once in
-    /// [`Self::init`]. The C++ `node:http` request path needs it on every
-    /// request to reconstruct `AnyServer`; it's a pure function of the (stable)
-    /// heap address and the const variant tag, so cache it rather than
-    /// recompute `AnyServer::from(self).to_packed()` in the per-request prologue.
-    pub(crate) any_server_packed: usize,
     /// Lazily-filled cache of the interned JS method-name string per HTTP
     /// method token. The `node:http` request prologue reads this so each request
     /// after the first for a given method skips the FFI hop into
@@ -249,81 +245,87 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// object's GC-rooted common strings (visited by `CommonStrings::visit`), so
     /// it stays live for as long as this server's global object — which always
     /// outlives the server itself.
-    pub(crate) method_name_cache: [core::cell::Cell<jsc::JSValue>; N_HTTP_METHODS],
+    pub(crate) method_name_cache: [Cell<jsc::JSValue>; N_HTTP_METHODS],
     pub(crate) base_url_string_for_joining: Box<[u8]>,
-    pub(crate) config: ServerConfig,
-    pub(crate) pending_requests: core::cell::Cell<usize>,
+    pub(crate) config: JsCell<ServerConfig>,
+    pub(crate) pending_requests: Cell<usize>,
     /// Live HTTP connections (accepted, not yet closed or upgraded), fed by
     /// the uWS filter in [`NewServer::listen`]. Any of them can still dispatch
     /// a handler, so the wrapper stays `Strong` until this drains
     /// ([`NewServer::is_drained`]); for Bun.serve it also holds the
     /// graceful-stop promise open ([`NewServer::is_closed`]).
-    pub(crate) active_connection_count: core::cell::Cell<u32>,
+    pub(crate) active_connection_count: Cell<u32>,
     /// Live `ServerWebSocket` count. Lives on the server (not the websocket
-    /// context) so a reload's context swap cannot reset it, and sits in a
-    /// `Cell` because the open/close accounting arrives through shared
-    /// `AnyServer` handles on the JS thread.
-    pub(crate) active_websocket_count: core::cell::Cell<u32>,
+    /// context) so a reload's context swap cannot reset it.
+    pub(crate) active_websocket_count: Cell<u32>,
     /// Set across [`NewServer::deinit_if_we_can`] and the synchronous
-    /// `app.close()` drain in `stop_listening`; lets a nested call (reached
+    /// `app.close()` drains in `stop_listening`; lets a nested call (reached
     /// via a callback the body fires) early-return instead of re-running the
-    /// downgrade/teardown while the outer frame still holds `&mut self`.
-    deinit_running: core::cell::Cell<bool>,
+    /// downgrade/teardown while the outer frame is mid-way through it.
+    deinit_running: Cell<bool>,
     pub(crate) request_pool:
-        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
-    /// Null until `listen()` creates an HTTP/2 or HTTP/3 app. Kept as a raw
-    /// nullable pointer rather than a conditional field so the struct stays
-    /// uniform across monomorphizations.
-    pub(crate) mux_request_pool:
-        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>,
+        &'static request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
+    /// `None` until `listen()` creates an HTTP/2 or HTTP/3 app.
+    pub(crate) mux_request_pool: Cell<
+        Option<&'static request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>>,
+    >,
     /// Authoritative GC root for the `server.stop()` promise. Lazily filled by
     /// `get_all_closed_promise`; read in `deinit_if_we_can` (which can run
     /// after the wrapper is collected, so a wrapper-traced slot would not
     /// suffice — this Strong is what keeps the cell live across that window).
     /// The cycle through a user `.then(cb)` is broken by resolving the
     /// promise in `deinit_if_we_can`, after which the Strong is dropped.
-    pub(crate) all_closed_promise: jsc::JSPromiseStrong,
+    pub(crate) all_closed_promise: JsCell<jsc::JSPromiseStrong>,
 
-    pub poll_ref: KeepAlive,
+    pub poll_ref: JsCell<KeepAlive>,
 
-    pub(crate) flags: ServerFlags,
+    pub(crate) flags: Cell<ServerFlags>,
 
-    /// Shared plugin state; also passed through `JSValue::then` as a promise context.
-    pub(crate) plugins: Option<bun_ptr::RefPtr<ServePlugins>>,
+    /// The server's counted ref on the plugin state; released in `Drop`.
+    pub(crate) plugins: JsCell<Option<RefPtr<ServePlugins>>>,
 
-    pub(crate) dev_server: Option<Box<crate::bake::DevServer::DevServer>>,
+    pub(crate) dev_server: JsCell<Option<Box<crate::bake::DevServer::DevServer>>>,
 
     /// Route → index in RouteList.cpp. User routes may be applied multiple
-    /// times due to SNI, so we have to store them.
-    pub(crate) user_routes: Vec<UserRoute<SSL, DEBUG>>,
+    /// times due to SNI, so we have to store them. Each is its own allocation:
+    /// its address is the uWS route user-data.
+    pub(crate) user_routes: JsCell<Vec<bun_ptr::OwnedThis<UserRoute<SSL, DEBUG>>>>,
 
     /// Raw shadow of the wrapper's `m_onClientError` WriteBarrier slot.
     /// `JSValue::ZERO` when unset; written by `server_set_on_client_error`.
-    pub(crate) on_clienterror: JSValue,
+    pub(crate) on_clienterror: Cell<JSValue>,
 
     /// Raw shadow of the wrapper's `m_onConnection` WriteBarrier slot.
     /// `JSValue::ZERO` when unset; written by `server_set_on_connection`.
-    pub(crate) on_connection: JSValue,
+    pub(crate) on_connection: Cell<JSValue>,
 
-    pub(crate) inspector_server_id: jsc::DebuggerId,
+    pub(crate) inspector_server_id: Cell<jsc::DebuggerId>,
 }
 
 pub struct UserRoute<const SSL: bool, const DEBUG: bool> {
     pub(crate) id: u32,
-    pub(crate) server: *mut NewServer<SSL, DEBUG>,
+    /// The server owns this route (in `user_routes`) and outlives it.
+    pub(crate) server: bun_ptr::BackRef<NewServer<SSL, DEBUG>, bun_ptr::Root>,
     pub(crate) route: server_config::RouteDeclaration,
 }
 
 impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
     fn drop(&mut self) {
+        httplog!("deinit");
+        // The apps' registrations point at `self` / `user_routes`; gone first.
+        drop(self.h3_app.replace(None));
+        self.drop_h2_app();
+        drop(self.app.replace(None));
         // Before `config`, which owns the arena the dev server's transpilers and views live in.
-        drop(self.dev_server.take());
+        drop(self.dev_server.replace(None));
         // The remaining owned fields (config, base_url, h3_alt_svc,
         // user_routes, all_closed_promise) drop automatically.
+        if let Some(p) = self.plugins.replace(None) {
+            p.forget_server(AnyServer::from(&*self));
+            p.deref();
+        }
     }
 }
-
-// `UserRoute` needs no explicit `impl Drop`: every field drops automatically.
 
 /// Const-generic adapter: `AnyResponse: From<*mut Response<SSL>>` is only
 /// implemented for the two concrete `SSL` values (overlap rules forbid a
@@ -351,18 +353,49 @@ pub enum CreateJsRequest {
     Bake,
 }
 
-/// Bundle of the JS-side `Request`, the heap
-/// `webcore::Request`, and the per-request `RequestContext`. Only the HTTP/1
-/// instantiation is materialized; H3
-/// callers never `save()` and the H3 dispatch
-/// path is private to `set_routes`.
-pub struct PreparedRequest<const SSL: bool, const DEBUG: bool> {
+/// Bundle of the JS-side `Request`, the heap `webcore::Request`, and the
+/// per-request `RequestContext` (`Ctx`: HTTP/1 or HTTP/3 flavour).
+pub struct PreparedRequestFor<Ctx> {
     pub(crate) js_request: JSValue,
-    pub(crate) request_object: *mut crate::webcore::Request,
-    pub ctx: *mut ServerRequestContext<SSL, DEBUG>,
+    /// The heap `Request` (owned by its JS wrapper once created): a weak
+    /// handle of our own, so the dispatch frame can still reach it after the
+    /// context lets go of its one (`server.upgrade()`), borrowed only at each
+    /// point of use.
+    pub(crate) request: crate::webcore::request::WeakRef,
+    /// The `Request` allocation's root pointer, for the C++ route-list call
+    /// that wraps it.
+    pub(crate) request_ptr: NonNull<crate::webcore::Request>,
+    /// Self-owned (refcounted, pool-slot token inside); outlives the dispatch
+    /// frame that holds this.
+    pub ctx: bun_ptr::BackRef<Ctx>,
 }
 
+impl<Ctx> PreparedRequestFor<Ctx> {
+    /// The heap `Request`, unless its owner already finalized it.
+    #[inline]
+    pub(crate) fn request(&self) -> Option<&crate::webcore::Request> {
+        self.request.peek()
+    }
+}
+
+/// The HTTP/1 instantiation; H3 callers never `save()`.
+pub type PreparedRequest<const SSL: bool, const DEBUG: bool> =
+    PreparedRequestFor<ServerRequestContext<SSL, DEBUG>>;
+
 impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
+    /// `ctx.to_async(..)`, or — if the `Request` is already gone — just arm the
+    /// abort handler it would have.
+    fn to_async(
+        ctx: &ServerRequestContext<SSL, DEBUG>,
+        req: *mut c_void,
+        request: &crate::webcore::request::WeakRef,
+    ) {
+        match request.peek() {
+            Some(request) => ctx.to_async(req, request),
+            None => ctx.set_abort_handler(),
+        }
+    }
+
     /// Used by DevServer to defer calling
     /// the JS handler until the bundle is actually ready.
     pub(crate) fn save(
@@ -374,20 +407,17 @@ impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
         // By saving a request, all information from `req` must be
         // copied since the provided uws.Request will be re-used for
         // future requests (stack allocated).
-        // SAFETY: `ctx`/`request_object` are the freshly-allocated
-        // `RequestContext` slot and heap `Request` produced by
-        // `prepare_js_request_context` for this frame.
-        unsafe {
-            (*self.ctx).to_async(
-                std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-                &mut *self.request_object,
-            );
-        }
+        Self::to_async(
+            self.ctx.get(),
+            std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
+            &self.request,
+        );
 
         SavedRequest {
             js_request: jsc::StrongOptional::create(self.js_request, global),
-            request: self.request_object,
-            ctx: AnyRequestContext::init(self.ctx),
+            request: self.request.clone(),
+            request_ptr: self.request_ptr,
+            ctx: AnyRequestContext::init(self.ctx.as_const_ptr()),
             response: any_response_from::<SSL>(resp),
         }
     }
@@ -396,33 +426,41 @@ impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
 /// RAII: on drop, detaches the borrowed stack `uws::Request` from the heap
 /// `webcore::Request` so the JS request
 /// object never dangles a pointer past the uWS frame it borrowed.
-pub(crate) struct DetachRequestOnDrop(*mut crate::webcore::Request);
+pub(crate) struct DetachRequestOnDrop<'a>(&'a crate::webcore::request::WeakRef);
 
-impl DetachRequestOnDrop {
-    /// # Safety
-    /// `request_object` must point to a live heap `webcore::Request` (the one
-    /// produced by `Request::new` / `PreparedRequest::save`) and remain valid
-    /// for the guard's lifetime — kept alive by `ctx.request_weakref`.
+impl Drop for DetachRequestOnDrop<'_> {
     #[inline]
-    unsafe fn new(request_object: *mut crate::webcore::Request) -> Self {
-        Self(request_object)
+    fn drop(&mut self) {
+        if let Some(request) = self.0.peek() {
+            request.request_context.get().detach_request();
+        }
     }
 }
 
-impl Drop for DetachRequestOnDrop {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: per `new()` contract — `self.0` is the heap allocation
-        // produced by `Request::new`; kept alive by `ctx.request_weakref`
-        // until `RequestContext::deinit` releases it.
-        unsafe { (*self.0).request_context.detach_request() };
-    }
+/// The `(request, response)` handles of an HTTP/1 route callback on `App<SSL>`.
+#[inline]
+fn h1_parts<'a, const SSL: bool>(
+    req: uws_sys::AnyRequest,
+    resp: uws::AnyResponse,
+) -> (&'a mut uws_sys::Request, *mut uws_sys::NewAppResponse<SSL>) {
+    let uws_sys::AnyRequest::H1(req) = req else {
+        unreachable!("H1 route dispatched a non-H1 request")
+    };
+    let resp: *mut uws_sys::NewAppResponse<SSL> = match resp {
+        uws::AnyResponse::SSL(r) => r.cast(),
+        uws::AnyResponse::TCP(r) => r.cast(),
+        uws::AnyResponse::H3(_) | uws::AnyResponse::H2(_) => {
+            unreachable!("H1 route dispatched an H2/H3 response")
+        }
+    };
+    // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
+    (bun_opaque::opaque_deref_mut(req), resp)
 }
 
 impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub(crate) const HAS_H3: bool = SSL;
 
-    // ── raw-field accessors ──────────────────────────────────────────────────
+    // ── accessors ────────────────────────────────────────────────────────────
 
     /// `global_this` is a STATIC backref (LIFETIMES.tsv) set in `init()`;
     /// non-null and outlives the server. S008: `JSGlobalObject` is an
@@ -440,23 +478,117 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.vm.get()
     }
 
-    /// Raw mutable pointer to the process-static VM. Returned as `*mut` (not
-    /// `&mut`) because the VM is mutated across re-entrant JS callbacks
-    /// (`drain_microtasks`, event-loop ticks) while other `&VirtualMachine`
-    /// borrows may be live; handing out `&mut` here would alias.
-    ///
-    /// Routes through [`jsc::VirtualMachine::get_mut_ptr`] (the thread-local
-    /// raw `*mut`) rather than casting `self.vm` — the field is `*const`
-    /// derived from a `&'static VirtualMachine`, so casting it to `*mut` would
-    /// carry read-only Stacked-Borrows provenance and make any write through
-    /// the result UB.
-    #[inline(always)]
-    pub(crate) fn vm_mut(&self) -> *mut jsc::VirtualMachine {
-        debug_assert!(core::ptr::eq(
-            self.vm.as_const_ptr(),
-            jsc::VirtualMachine::get_mut_ptr()
-        ));
-        jsc::VirtualMachine::get_mut_ptr()
+    /// The dispatch handle the uWS registrations carry; available while the
+    /// app exists (`listen()` .. `teardown()`).
+    #[inline]
+    fn this_ptr(&self) -> ThisPtr<Self> {
+        self.self_ref
+            .get()
+            .as_ref()
+            .expect("server app is live")
+            .this_ptr()
+    }
+
+    /// The live uWS app handle, if created (`listen()`) and not yet torn down.
+    #[inline]
+    pub(crate) fn app_ptr(&self) -> Option<*mut uws_sys::NewApp<SSL>> {
+        self.app.get().as_ref().map(uws_sys::app::OwnedApp::as_ptr)
+    }
+
+    /// `&mut` view of the live uWS app (an opaque ZST handle — S008).
+    #[inline]
+    pub(crate) fn app_mut(&self) -> Option<&mut uws_sys::NewApp<SSL>> {
+        self.app_ptr().map(bun_opaque::opaque_deref_mut)
+    }
+
+    #[inline]
+    pub(crate) fn h3_app_ptr(&self) -> Option<*mut uws_sys::h3::App> {
+        if !Self::HAS_H3 {
+            return None;
+        }
+        self.h3_app
+            .get()
+            .as_ref()
+            .map(uws_sys::h3::OwnedApp::as_ptr)
+    }
+
+    /// `&mut` view of the live H3 app (an `opaque_ffi!` ZST handle — S008).
+    #[inline]
+    pub(crate) fn h3_app_mut(&self) -> Option<&mut uws_sys::h3::App> {
+        self.h3_app_ptr().map(bun_opaque::opaque_deref_mut)
+    }
+
+    #[inline]
+    pub(crate) fn h2_app_ptr(&self) -> Option<*mut uws_sys::h2::App> {
+        self.h2_app
+            .get()
+            .as_ref()
+            .map(uws_sys::h2::OwnedApp::as_ptr)
+    }
+
+    /// `&mut` view of the live H2 app (an `opaque_ffi!` ZST handle — S008).
+    #[inline]
+    pub(crate) fn h2_app_mut(&self) -> Option<&mut uws_sys::h2::App> {
+        self.h2_app_ptr().map(bun_opaque::opaque_deref_mut)
+    }
+
+    /// Destroy the H2 app; a drain may still be queued for it.
+    fn drop_h2_app(&self) {
+        if let Some(h2a) = self.h2_app.replace(None) {
+            self.vm()
+                .event_loop_ref()
+                .deferred_tasks
+                .unregister_task(NonNull::new(h2a.as_ptr().cast::<c_void>()));
+            drop(h2a);
+        }
+    }
+
+    /// S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
+    #[inline]
+    pub(crate) fn listener_mut(&self) -> Option<&mut uws_sys::app::ListenSocket<SSL>> {
+        self.listener
+            .get()
+            .map(|l| bun_opaque::opaque_deref_mut(l.as_ptr()))
+    }
+
+    /// S012: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+    #[inline]
+    pub(crate) fn h3_listener_mut(&self) -> Option<&mut uws_sys::h3::ListenSocket> {
+        if !Self::HAS_H3 {
+            return None;
+        }
+        self.h3_listener
+            .get()
+            .map(|l| bun_opaque::opaque_deref_mut(l.as_ptr()))
+    }
+
+    #[inline]
+    pub(crate) fn config(&self) -> &ServerConfig {
+        self.config.get()
+    }
+
+    #[inline]
+    fn insert_flags(&self, f: ServerFlags) {
+        self.flags.set(self.flags.get() | f);
+    }
+
+    #[inline]
+    fn has_flags(&self, f: ServerFlags) -> bool {
+        self.flags.get().contains(f)
+    }
+
+    /// Clear the websocket handler's app/server back-links.
+    fn detach_websocket_handler(&self, app: bool, server: bool) {
+        self.config.with_mut(|c| {
+            if let Some(ws) = c.websocket.as_mut() {
+                if app {
+                    ws.handler.app = None;
+                }
+                if server {
+                    ws.handler.server = None;
+                }
+            }
+        });
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -464,15 +596,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub(crate) fn memory_cost(&self) -> usize {
         core::mem::size_of::<Self>()
             + self.base_url_string_for_joining.len()
-            + self.config.memory_cost()
-            + self.dev_server.as_ref().map_or(0, |d| d.memory_cost())
+            + self.config().memory_cost()
+            + self
+                .dev_server
+                .get()
+                .as_ref()
+                .map_or(0, |d| d.memory_cost())
     }
 
     pub(crate) fn h3_alt_svc(&self) -> Option<&[u8]> {
-        if !Self::HAS_H3 || self.h3_alt_svc.is_empty() {
+        let alt = self.h3_alt_svc.get();
+        if !Self::HAS_H3 || alt.is_empty() {
             return None;
         }
-        Some(&self.h3_alt_svc)
+        Some(alt)
     }
 
     pub(crate) fn on_pending_request(&self) {
@@ -482,35 +619,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// uWS filter: `+2` at TCP accept (before any TLS handshake), `-2` on
     /// `HttpContext::onClose` / `HttpResponse::upgrade()` — see
     /// `AsyncSocketData::filteredAccept`. Feeds [`Self::active_connection_count`].
-    extern "C" fn on_connection_filter(
-        _socket: *mut uws_sys::us_socket_t,
-        opened: i32,
-        user_data: *mut c_void,
-    ) {
-        let drained = {
-            // SAFETY: `user_data` is the `*mut Self` registered in `listen()`;
-            // the server outlives every socket in its app. Only `&Self` is
-            // formed (the count is a `Cell`), so this is sound when reached
-            // from inside `app.close()` while `stop_listening` holds `&mut`.
-            let this = unsafe { &*user_data.cast::<Self>() };
-            // Count from accept (2 / -2), not from open (1 / -1): a TLS socket accepted but still
-            // handshaking is a connection too — it will dispatch once the handshake completes.
-            match opened {
-                2 => {
-                    this.note_connection_opened();
-                    return;
-                }
-                -2 => {}
-                _ => return,
+    fn on_connection_filter(this: ThisPtr<Self>, _socket: *mut uws_sys::us_socket_t, opened: i32) {
+        // Count from accept (2 / -2), not from open (1 / -1): a TLS socket accepted but still
+        // handshaking is a connection too — it will dispatch once the handshake completes.
+        match opened {
+            2 => {
+                this.note_connection_opened();
+                return;
             }
-            this.note_connection_closed() && !this.has_listener() && !this.deinit_running.get()
-        };
-        if drained {
-            // SAFETY: no `&Self` outlives the block above; `deinit_running`
-            // rules out re-entrance under an outer `&mut self` (the abrupt
-            // `app.close()` drain). `deinit_if_we_can` itself also
-            // early-returns under that guard.
-            unsafe { &mut *user_data.cast::<Self>() }.deinit_if_we_can();
+            -2 => {}
+            _ => return,
+        }
+        if this.note_connection_closed() && !this.has_listener() && !this.deinit_running.get() {
+            this.deinit_if_we_can();
         }
     }
 
@@ -520,7 +641,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub(crate) fn get_url_as_string(&self) -> Result<bun_core::String, bun_alloc::AllocError> {
         use bun_core::fmt::{URLFormatter, URLProto};
         use std::io::Write as _;
-        let fmt = match &self.config.address {
+        let config = self.config();
+        let fmt = match &config.address {
             server_config::Address::Unix(unix) => {
                 let unix = unix.as_bytes();
                 if unix.len() > 1 && unix[0] == 0 {
@@ -540,18 +662,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
             server_config::Address::Tcp { port, hostname } => {
                 let mut port = *port;
-                if let Some(listener) = self.listener {
-                    // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                    port = bun_opaque::opaque_deref_mut(listener)
-                        .get_local_port()
-                        .unwrap_or(port);
-                } else if Self::HAS_H3 {
-                    if let Some(h3l) = self.h3_listener {
-                        // S012: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                        port = bun_opaque::opaque_deref_mut(h3l)
-                            .get_local_port()
-                            .unwrap_or(port);
-                    }
+                if let Some(listener) = self.listener_mut() {
+                    port = listener.get_local_port().unwrap_or(port);
+                } else if let Some(h3l) = self.h3_listener_mut() {
+                    port = h3l.get_local_port().unwrap_or(port);
                 }
                 URLFormatter {
                     proto: if SSL { URLProto::Https } else { URLProto::Http },
@@ -570,8 +684,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// alive (callers must only use this while the server JS object is kept
     /// alive elsewhere).
     pub(crate) fn js_value_assert_alive(&self) -> JSValue {
-        debug_assert!(self.js_value.is_not_empty());
-        self.js_value.try_get().expect("js_value alive")
+        let js_value = self.js_value.get();
+        debug_assert!(js_value.is_not_empty());
+        js_value.try_get().expect("js_value alive")
     }
 
     /// Returns the wrapper while it is alive (`Strong` or `Weak`) and its VM may still run script,
@@ -586,12 +701,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if !self.vm().script_allowed() {
             return None;
         }
+        let js_value = self.js_value.get();
         // HTTP/3 connections are not counted yet, so a stream on one can still arrive after the drain.
         debug_assert!(
-            self.h3_app.is_some() || self.js_value.is_strong() || self.js_value.try_get().is_none(),
+            self.h3_app.get().is_some() || js_value.is_strong() || js_value.try_get().is_none(),
             "a socket outlived the server's connection accounting"
         );
-        self.js_value.try_get()
+        js_value.try_get()
     }
 }
 
@@ -674,7 +790,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             if !Self::did_send_idletimeout_warning_once().load(Ordering::Relaxed)
                 && !crate::cli::Command::get().debug.silent
             {
-                return !self.config.has_idle_timeout;
+                return !self.config().has_idle_timeout;
             }
         }
         false
@@ -687,13 +803,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// other instantiation (H3) populates url/headers eagerly via a separate
     /// codepath. The bake/saved-request callers reached through `AnyServer`
     /// are HTTP/1-only by construction.
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `NewServer` for the duration
-    /// of the uWS callback frame; `resp` must be the live response handle for
-    /// the same frame.
     fn prepare_js_request_context(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         req: &mut uws_sys::Request,
         resp: *mut uws_sys::NewAppResponse<SSL>,
         should_deinit_context: Option<request_context::DeferDeinitFlag>,
@@ -701,11 +812,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         method: Option<bun_http_types::Method::Method>,
     ) -> Option<PreparedRequest<SSL, DEBUG>> {
         jsc::mark_binding!();
-        // SAFETY: `this`/`resp` are live for the duration of the uWS callback.
-        // Shared reborrow: everything below only needs `&Self` (the pending-
-        // request counter is a `Cell`), and `ctx.create()` stores `this` — the
-        // raw pointer, not this borrow — as the backref.
-        let server = unsafe { &*this };
+        let server = this.get();
         // S008: `Response<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
         let resp_ref = bun_opaque::opaque_deref_mut(resp);
 
@@ -716,10 +823,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // (RFC 9114 §4.2 transfer-encoding check is H3-only — skipped here.)
 
         // Resolve once, reuse for both `has_request_body()` here and the
-        // forward to `RequestContext::create` below. With `Method::which` now
-        // a length-gated match (316a83f) the
-        // second call is cheap, but the resolved value is also what `create`
-        // wants — passing `None` made it parse a second time.
+        // forward to `RequestContext::init` below.
         let method = method.or_else(|| bun_http_types::Method::Method::which(req.method()));
 
         let request_body_length: Option<usize> = 'len: {
@@ -734,7 +838,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 };
 
                 // Abort the request very early.
-                if len > server.config.max_request_body_size {
+                if len > server.config().max_request_body_size {
                     resp_ref.write_status(b"413 Request Entity Too Large");
                     resp_ref.end_without_body(true);
                     return None;
@@ -748,7 +852,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         server.on_pending_request();
 
         req.set_yield(false);
-        resp_ref.timeout(server.config.idle_timeout);
+        resp_ref.timeout(server.config().idle_timeout);
 
         // Since we do timeouts by default, we should tell the user when
         // this happens - but limit it to only warn once.
@@ -762,74 +866,23 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
 
-        // SAFETY: `request_pool` points at a process-static (or
-        // server-owned) `HiveArray::Fallback`; valid for the server's lifetime.
-        // The `HiveSlot` token is leaked deliberately: the slot is recycled by
-        // `RequestContext::deinit` via `put_raw`, never via `HiveSlot::Drop`.
-        let ctx_slot = std::mem::ManuallyDrop::new(unsafe { (*server.request_pool).claim() })
-            .addr()
-            .as_ptr();
-        // SAFETY: `claim` hands out an uninitialized slot; `create()` fully
-        // initializes it via `MaybeUninit::write`.
-        let ctx_uninit = unsafe {
-            &mut *ctx_slot.cast::<core::mem::MaybeUninit<ServerRequestContext<SSL, DEBUG>>>()
-        };
-        ServerRequestContext::<SSL, DEBUG>::create(
-            ctx_uninit,
+        let global = server.global_this();
+        let is_transfer_encoding =
+            request_body_length.is_some() && req.has_transfer_encoding();
+        let expects_body =
+            matches!(request_body_length, Some(len) if len > 0 || is_transfer_encoding);
+        let mut prepared = Self::create_request_context::<ServerRequestContext<SSL, DEBUG>>(
             this,
-            std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
+            req,
             any_response_from::<SSL>(resp),
             should_deinit_context,
             method,
+            expects_body,
         );
-        let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
-        // SAFETY: fully initialized by `create()`.
-        let ctx_ref = unsafe { &*ctx };
-
-        server
-            .vm()
-            .jsc_vm()
-            .deprecated_report_extra_memory(
-                core::mem::size_of::<ServerRequestContext<SSL, DEBUG>>(),
-            );
-
-        // Allocate the pooled body slot (ref_count = 1).
-        let body_hive = crate::webcore::body::hive_alloc(crate::webcore::body::Value::Null);
-        // Raw payload pointer for the deferred Locked write below.
-        // SAFETY: slot stays live — both `ctx.request_body` and `Request.body` hold a +1.
-        let body_value: *mut crate::webcore::body::Value =
-            unsafe { core::ptr::addr_of_mut!((*body_hive.as_ptr()).value) };
-        // Bump once so the ctx and JS Request each
-        // own a +1 on the same slot (streamed bytes buffered into the ctx
-        // surface on `request.body`/`request.json()`).
-        ctx_ref.request_body.set(Some(body_hive.clone()));
-
-        let global = server.global_this();
-        let signal = jsc::AbortSignal::new(global);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        ctx_ref.signal.set(core::ptr::NonNull::new(signal));
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-
-        let signal_ref = bun_opaque::opaque_deref_mut(signal).ref_();
-        // ownership: `Request::new` is `bun.TrivialNew` — the heap
-        // allocation is handed to the JS GC via `to_js`/`to_js_for_bake` (C++
-        // wrapper finalizer frees it), or, for `CreateJsRequest::No`, retained
-        // by `ctx.request_weakref` until `RequestContext::deinit` releases it.
-        // `body_hive` (the original +1) moves into the Request — paired drop in
-        // `Request::finalize`.
-        let request_object: *mut crate::webcore::Request =
-            bun_core::heap::into_raw(crate::webcore::Request::new(crate::webcore::Request::init(
-                ctx_ref.method,
-                AnyRequestContext::init(ctx),
-                SSL,
-                Some(signal_ref),
-                body_hive,
-            )));
-        // SAFETY: freshly leaked from `heap::into_raw`, so `request_object`
-        // carries the allocation's provenance, as `init_ref` requires.
-        ctx_ref
-            .request_weakref
-            .set(unsafe { bun_ptr::WeakPtr::init_ref(request_object) });
+        let ctx_ref = prepared.ctx.get();
+        let Some(request_object) = prepared.request() else {
+            unreachable!("just created");
+        };
 
         // (H3 eager-url/header population is unreachable on this path.)
 
@@ -846,33 +899,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if let Some(req_len) = request_body_length {
             ctx_ref.request_body_content_len.set(req_len);
-            let is_transfer_encoding = req.has_transfer_encoding();
             ctx_ref.flags.set_is_transfer_encoding(is_transfer_encoding);
-            if req_len > 0 || is_transfer_encoding {
-                // we defer pre-allocating the body until we receive the first chunk
-                // that way if the client is lying about how big the body is or the client aborts
-                // we don't waste memory
-                // SAFETY: `body_value` is the freshly-initialized hive payload.
-                unsafe {
-                    *body_value =
-                        crate::webcore::body::Value::Locked(crate::webcore::body::PendingValue {
-                            task: Some(core::ptr::NonNull::new(ctx).unwrap().cast::<c_void>()),
-                            global: std::ptr::from_ref(global),
-                            on_start_buffering: Some(
-                                ServerRequestContext::<SSL, DEBUG>::on_start_buffering_callback,
-                            ),
-                            on_start_streaming: Some(
-                                ServerRequestContext::<SSL, DEBUG>::on_start_streaming_request_body_callback,
-                            ),
-                            on_readable_stream_available: Some(
-                                ServerRequestContext::<SSL, DEBUG>::on_request_body_readable_stream_available,
-                            ),
-                            producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
-                                AnyRequestContext::init(ctx),
-                            ),
-                            ..Default::default()
-                        });
-                }
+            if expects_body {
                 ctx_ref.flags.set_is_waiting_for_request_body(true);
 
                 resp_ref.on_data(
@@ -882,40 +910,28 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                      last: bool| {
                         ServerRequestContext::<SSL, DEBUG>::on_buffered_body_chunk(u, chunk, last)
                     },
-                    ctx,
+                    ctx_ref.as_ctx_ptr(),
                 );
             }
         }
 
-        Some(PreparedRequest {
-            js_request: match create_js_request {
-                // SAFETY: `request_object` is the freshly-allocated heap
-                // `Request`; ownership transfers to the JS wrapper.
-                CreateJsRequest::Yes => unsafe { (*request_object).to_js(global) },
-                CreateJsRequest::Bake => {
-                    // SAFETY: `request_object` is the freshly-allocated heap
-                    // `Request`; ownership transfers to the JS wrapper.
-                    match unsafe { (*request_object).to_js_for_bake(global) } {
-                        Ok(v) => v,
-                        Err(jsc::JsError::OutOfMemory) => bun_core::out_of_memory(),
-                        Err(_) => return None,
-                    }
-                }
-                CreateJsRequest::No => JSValue::ZERO,
+        let js_request = match create_js_request {
+            CreateJsRequest::Yes => request_object.to_js(global),
+            CreateJsRequest::Bake => match request_object.to_js_for_bake(global) {
+                Ok(v) => v,
+                Err(jsc::JsError::OutOfMemory) => bun_core::out_of_memory(),
+                Err(_) => return None,
             },
-            request_object,
-            ctx,
-        })
+            CreateJsRequest::No => JSValue::ZERO,
+        };
+        prepared.js_request = js_request;
+        Some(prepared)
     }
 
     /// Invoke the user's route handler for a
     /// request that was deferred (bake bundle-then-serve flow).
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `NewServer`; `resp` must be
-    /// the live response handle for the request being resumed.
     fn on_saved_request<const ARG_COUNT: usize>(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         req: SavedRequestUnion<'_>,
         resp: *mut uws_sys::NewAppResponse<SSL>,
         callback: JSValue,
@@ -925,8 +941,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // `pending_requests` increment keeps the wrapper `Strong` (so it is
         // never `Finalized` here), but the VM's script gate can have closed
         // while the bundle was being built.
-        // SAFETY: `this` is the live server backref for this request.
-        let Some(server_js) = unsafe { &*this }.js_value_for_dispatch() else {
+        let Some(server_js) = this.js_value_for_dispatch() else {
             server_body::respond_stopped_503(bun_opaque::opaque_deref_mut(resp));
             return;
         };
@@ -948,22 +963,24 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     None => return,
                 }
             }
-            SavedRequestUnion::Saved(data) => PreparedRequest {
+            SavedRequestUnion::Saved(data) => PreparedRequestFor {
                 js_request: data
                     .js_request
                     .get()
                     .expect("Request was unexpectedly freed"),
-                request_object: data.request,
-                // SAFETY: `SavedRequest` was produced by `PreparedRequest::save`
+                request: data.request.clone(),
+                request_ptr: data.request_ptr,
+                // `SavedRequest` was produced by `PreparedRequest::save`
                 // for this exact (SSL,DEBUG) monomorphization, so the erased
-                // `AnyRequestContext` payload is `ServerRequestContext<SSL,DEBUG>`.
+                // `AnyRequestContext` payload is `ServerRequestContext<SSL,DEBUG>`;
+                // the saved request's ref keeps it alive.
                 ctx: data
                     .ctx
-                    .get::<ServerRequestContext<SSL, DEBUG>>()
+                    .get_ref::<ServerRequestContext<SSL, DEBUG>>()
+                    .map(bun_ptr::BackRef::new)
                     .expect("ctx tag mismatch"),
             },
         };
-        let ctx = prepared.ctx;
 
         debug_assert!(!callback.is_empty());
         // PERF: stable Rust forbids `ARG_COUNT + 1` in const-generic array lengths.
@@ -973,8 +990,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         args.push(prepared.js_request);
         args.extend_from_slice(&extra_args);
 
-        // SAFETY: `this` is the live server backref for this request.
-        let server = unsafe { &*this };
+        let server = this.get();
         let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
         let global = server.global_this();
         let response_value = match callback.call(global, server_js, &args) {
@@ -983,19 +999,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         };
 
         let is_stack = matches!(req, SavedRequestUnion::Stack(_));
-        let request_object = prepared.request_object;
+        let ctx_ref = prepared.ctx.get();
         // uWS request will not live longer than this function — only detach
         // when it's the stack-allocated original (a saved request already
         // copied everything it needs).
-        // SAFETY: `request_object` is kept alive by `ctx.request_weakref` for
-        // the request's lifetime.
-        let _detach_guard = is_stack.then(|| unsafe { DetachRequestOnDrop::new(request_object) });
+        let _detach_guard = is_stack.then(|| DetachRequestOnDrop(&prepared.request));
 
-        // SAFETY: `ctx` was just allocated (or saved) by this server; the
-        // `defer_deinit_...` flag set below keeps it alive across `on_response`.
-        let ctx_ref = unsafe { &*ctx };
         let original_state = ctx_ref.defer_deinit_until_callback_completes.get();
-        let should_deinit_context = core::cell::Cell::new(false);
+        let should_deinit_context = Cell::new(false);
         ctx_ref
             .defer_deinit_until_callback_completes
             .set(Some(bun_ptr::BackRef::new(&should_deinit_context)));
@@ -1021,13 +1032,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // since the provided uws.Request will be re-used for future requests (stack allocated).
         match req {
             SavedRequestUnion::Stack(r) => {
-                // SAFETY: `r` is the live stack `uws::Request`; `request_object`
-                // is the heap `Request` kept alive by `ctx.request_weakref`.
-                ctx_ref.to_async(
+                PreparedRequest::<SSL, DEBUG>::to_async(
+                    ctx_ref,
                     std::ptr::from_ref::<uws::Request>(r)
                         .cast_mut()
                         .cast::<c_void>(),
-                    unsafe { &mut *request_object },
+                    &prepared.request,
                 );
             }
             SavedRequestUnion::Saved(_) => {} // info already copied
@@ -1041,29 +1051,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     ///
     /// `should_deinit_context` is the same `Cell<bool>` already stored in
     /// `ctx.defer_deinit_until_callback_completes` by
-    /// `prepare_js_request_context`; `&Cell` (shared) and the stored `BackRef`
-    /// can coexist under Stacked Borrows, so no raw-pointer dance is needed.
+    /// `prepare_js_request_context`.
     fn handle_request(
-        this: *mut Self,
-        should_deinit_context: &core::cell::Cell<bool>,
+        &self,
+        should_deinit_context: &Cell<bool>,
         prepared: &PreparedRequest<SSL, DEBUG>,
         req: &mut uws_sys::Request,
         response_value: JSValue,
     ) {
-        let ctx = prepared.ctx;
-        let request_object = prepared.request_object;
+        let ctx_ref = prepared.ctx.get();
 
         // uWS request will not live longer than this function
-        // SAFETY: `request_object` is the heap allocation produced by
-        // `Request::new`; kept alive by `ctx.request_weakref` until
-        // `RequestContext::deinit` releases it.
-        let _detach_guard = unsafe { DetachRequestOnDrop::new(request_object) };
+        let _detach_guard = DetachRequestOnDrop(&prepared.request);
 
-        // SAFETY: `ctx` was allocated by `prepare_js_request_context` for this
-        // frame and cannot be freed while `defer_deinit_...` is set (it is set
-        // by the caller until cleared below).
-        let (ctx_ref, this) = unsafe { (&*ctx, &*this) };
-        ctx_ref.on_response(this, prepared.js_request, response_value);
+        ctx_ref.on_response(self, prepared.js_request, response_value);
         // Reference in the stack here in case it is not for whatever reason
         prepared.js_request.ensure_still_alive();
 
@@ -1082,33 +1083,28 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // The request is asynchronous, and all information from `req` must be
         // copied since the provided uws.Request will be re-used for future
         // requests (stack allocated).
-        // SAFETY: `request_object` is the live heap `Request` (see above).
-        ctx_ref.to_async(
+        PreparedRequest::<SSL, DEBUG>::to_async(
+            ctx_ref,
             std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-            unsafe { &mut *request_object },
+            &prepared.request,
         );
+        prepared.js_request.ensure_still_alive();
     }
 
     /// Dispatch the user `fetch` handler.
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `NewServer` (the userdata
-    /// registered with uWS); `resp` must be the live response handle for this
-    /// request frame.
     fn on_request(
-        this: *mut Self,
+        this: ThisPtr<Self>,
         req: &mut uws_sys::Request,
         resp: *mut uws_sys::NewAppResponse<SSL>,
     ) {
         // Idle keep-alive sockets aren't counted in pending_requests, so the
         // wrapper can have been finalized before this fires. Refuse and close
         // rather than dispatching with a stale handler shadow.
-        // SAFETY: `this` is the live server backref for this request.
-        let Some(js_value) = unsafe { &*this }.js_value_for_dispatch() else {
+        let Some(js_value) = this.js_value_for_dispatch() else {
             server_body::respond_stopped_503(bun_opaque::opaque_deref_mut(resp));
             return;
         };
-        let should_deinit_context = core::cell::Cell::new(false);
+        let should_deinit_context = Cell::new(false);
         let Some(prepared) = Self::prepare_js_request_context(
             this,
             req,
@@ -1120,10 +1116,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             return;
         };
 
-        // SAFETY: `this` is the live server backref for this request.
-        let server = unsafe { &*this };
+        let server = this.get();
         let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
-        let on_request = server.config.on_request;
+        let on_request = server.config().on_request;
         debug_assert!(!on_request.is_empty());
 
         let global = server.global_this();
@@ -1133,47 +1128,45 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 Err(err) => global.take_exception(err),
             };
 
-        Self::handle_request(this, &should_deinit_context, &prepared, req, response_value);
+        server.handle_request(&should_deinit_context, &prepared, req, response_value);
+    }
+
+    /// Route-callback form of [`Self::on_request`].
+    fn on_request_route(this: ThisPtr<Self>, req: uws_sys::AnyRequest, resp: uws::AnyResponse) {
+        let (req, resp) = h1_parts::<SSL>(req, resp);
+        Self::on_request(this, req, resp);
     }
 
     /// Dispatch a per-route handler
     /// (`routes: { "/path": handler }`).
-    ///
-    /// # Safety
-    /// `user_route` must point to a live entry in `server.user_routes` (the
-    /// address registered as the uWS callback userdata); `resp` must be the
-    /// live response handle for this request frame.
     fn on_user_route_request(
-        user_route: *const UserRoute<SSL, DEBUG>,
-        req: &mut uws_sys::Request,
-        resp: *mut uws_sys::NewAppResponse<SSL>,
+        user_route: ThisPtr<UserRoute<SSL, DEBUG>>,
+        req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
     ) {
-        // SAFETY: `user_route` is the live entry in `server.user_routes` whose
-        // address was registered as the uws callback userdata.
-        let user_route = unsafe { &*user_route };
+        let (req, resp) = h1_parts::<SSL>(req, resp);
         let server = user_route.server;
         let index = user_route.id;
 
-        // SAFETY: `server` is the live backref stored in `user_route`.
-        let Some(server_js) = unsafe { &*server }.js_value_for_dispatch() else {
+        let Some(server_js) = server.js_value_for_dispatch() else {
             server_body::respond_stopped_503(bun_opaque::opaque_deref_mut(resp));
             return;
         };
 
-        let should_deinit_context = core::cell::Cell::new(false);
+        let should_deinit_context = Cell::new(false);
+        let method = user_route.route.method.specific();
         let Some(mut prepared) = Self::prepare_js_request_context(
-            server,
+            server.this_ptr(),
             req,
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             CreateJsRequest::No,
-            user_route.route.method.specific(),
+            method,
         ) else {
             return;
         };
 
-        // SAFETY: `server` is the live backref stored in `user_route`.
-        let server_ref = unsafe { &*server };
+        let server_ref = server.get();
         let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
         let global = server_ref.global_this();
         let server_request_list =
@@ -1182,7 +1175,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             Bun__ServerRouteList__callRoute(
                 global,
                 index,
-                prepared.request_object,
+                prepared.request_ptr.as_ptr(),
                 server_js,
                 server_request_list,
                 &mut prepared.js_request,
@@ -1191,48 +1184,32 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         })
         .unwrap_or_else(|err| global.take_exception(err));
 
-        Self::handle_request(
-            server,
-            &should_deinit_context,
-            &prepared,
-            req,
-            response_value,
-        );
+        server_ref.handle_request(&should_deinit_context, &prepared, req, response_value);
     }
 
     /// node:http compat path; thin wrapper
     /// over [`Self::on_node_http_request_with_upgrade_ctx`] with no WS upgrade.
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `NewServer` (the userdata
-    /// registered with uWS).
     pub(crate) fn on_node_http_request(
-        this: *mut Self,
-        req: &mut uws_sys::Request,
-        resp: &mut uws_sys::NewAppResponse<SSL>,
+        this: ThisPtr<Self>,
+        req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
     ) {
         jsc::mark_binding!();
+        let (req, resp) = h1_parts::<SSL>(req, resp);
         // `upgrade_ctx` null is valid (no upgrade).
-        Self::on_node_http_request_with_upgrade_ctx(this, req, resp, core::ptr::null_mut());
+        this.on_node_http_request_with_upgrade_ctx(
+            req,
+            bun_opaque::opaque_deref_mut(resp),
+            core::ptr::null_mut(),
+        );
     }
 
     /// Invoke the JS-side
     /// `node:http` request handler (`NodeHTTPServer__onRequest_{http,https}`),
     /// then drive the returned promise / [`NodeHTTPResponse`] through the
     /// completion / abort / error paths.
-    ///
-    /// receiver is `*mut Self` (not `&mut self`) — the body
-    /// re-enters JS (`drain_microtasks`, `then2`) which may call back into
-    /// other server methods, so a long-lived `&mut Self` would alias. Each use
-    /// site below derives a short-lived borrow that ends before the next
-    /// re-entry point.
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `NewServer` (the userdata
-    /// registered with uWS); `upgrade_ctx` must be null or a live uWS upgrade
-    /// context for this request.
     fn on_node_http_request_with_upgrade_ctx(
-        this: *mut Self,
+        &self,
         req: &mut uws_sys::Request,
         resp: &mut uws_sys::NewAppResponse<SSL>,
         upgrade_ctx: *mut uws_sys::WebSocketUpgradeContext,
@@ -1240,28 +1217,18 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         use bun_http_jsc::method_jsc::MethodJsc as _;
         use node_http_response::Flags as NhrFlags;
 
-        // SAFETY: `this` is the live server backref registered as the uws
-        // userdata; only one borrow derived from it is alive at a time.
-        let this_ref = unsafe { &*this };
-        if this_ref.js_value_for_dispatch().is_none() {
+        if self.js_value_for_dispatch().is_none() {
             server_body::respond_stopped_503(resp);
             return;
         }
-        // SAFETY: same `this` as above.
-        unsafe { (*this).on_pending_request() };
-        // Read-only access goes through `BackRef` (safe `Deref`); each use
-        // materialises a fresh short-lived `&Self`, so the JS-reentrant calls
-        // below never see an outstanding shared borrow.
-        let this_ref = bun_ptr::BackRef::from(
-            core::ptr::NonNull::new(this).expect("on_node_http_request: this non-null"),
-        );
-        let vm = this_ref.vm_mut();
-        let _entered = this_ref.vm().enter_event_loop_scope_without_checkpoint();
+        self.on_pending_request();
+        let vm = self.vm();
+        let _entered = vm.enter_event_loop_scope_without_checkpoint();
         req.set_yield(false);
-        resp.timeout(this_ref.config.idle_timeout);
+        resp.timeout(self.config().idle_timeout);
 
-        let global = this_ref.global_this();
-        let this_object = this_ref.js_value.try_get().unwrap_or(JSValue::UNDEFINED);
+        let global = self.global_this();
+        let this_object = self.js_value.get().try_get().unwrap_or(JSValue::UNDEFINED);
 
         // Compute the JS method-name string up front so the FFI closure
         // doesn't need to reborrow `req` (it's already `&mut`-borrowed below).
@@ -1271,7 +1238,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // into `Bun__HTTPMethod__toJS`. (`get(..)` falls back to a fresh intern
         // if a future method variant ever indexes past the cache.)
         let method_string = match bun_http::Method::find(req.method()) {
-            Some(m) => match this_ref.method_name_cache.get(m as usize) {
+            Some(m) => match self.method_name_cache.get(m as usize) {
                 Some(slot) => {
                     let cached = slot.get();
                     if cached == JSValue::ZERO {
@@ -1286,15 +1253,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             },
             None => JSValue::UNDEFINED,
         };
-        let callback = this_ref.config.on_node_http_request;
-        // C++ forwards `any_server` to `NodeHTTPResponse::create`, which
-        // unpacks it via `any_server_from_packed` (bits 49..64 = variant tag);
-        // a raw `*mut Self` would zero those bits and trip the dispatch
-        // `unreachable!`, so the packed tagged-pointer wire format is needed.
-        // Computed once in `init()` (stable heap address) — just load it.
-        let any_server_packed = this_ref.any_server_packed;
+        let callback = self.config().on_node_http_request;
 
-        let mut node_http_response: *mut NodeHTTPResponse = core::ptr::null_mut();
+        let (nhr, node_response_object, has_body) = NodeHTTPResponse::create(
+            AnyServer::from(self),
+            global,
+            req,
+            SSL,
+            any_response_from::<SSL>(resp),
+            upgrade_ctx,
+        );
         let mut is_async = false;
 
         let on_request_ffi = if SSL {
@@ -1304,33 +1272,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         };
         let result: JSValue = bun_jsc::host_fn::from_js_host_call(global, || {
             on_request_ffi(
-                any_server_packed,
                 global,
                 this_object,
                 callback,
                 method_string,
                 req,
                 std::ptr::from_mut::<uws_sys::NewAppResponse<SSL>>(resp).cast(),
-                upgrade_ctx.cast(),
-                &mut node_http_response,
+                node_response_object,
+                has_body,
             )
         })
         .unwrap_or_else(|err| global.take_exception(err));
-
-        if node_http_response.is_null() {
-            // The request never reached the handler: an exception (in practice
-            // a termination request landing in the header conversion) unwound
-            // before the response object existed. Nothing adopted the response;
-            // answer it natively as above.
-            if !result.is_empty() && !result.is_termination_exception() {
-                // SAFETY: `vm` is the process-static VirtualMachine.
-                let _ = unsafe { (*vm).uncaught_exception(global, result, false) };
-            }
-            server_body::respond_stopped_503(resp);
-            // SAFETY: same `this`; balances `on_pending_request` above.
-            unsafe { (*this).on_static_request_complete() };
-            return;
-        }
 
         enum HttpResult {
             Rejection(JSValue),
@@ -1353,8 +1305,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 if status == jsc::js_promise::Status::Pending {
                     strong_promise.set(global, result);
                     needs_to_drain = false;
-                    // SAFETY: `vm` is the process-static VirtualMachine.
-                    unsafe { (*vm).drain_microtasks() };
+                    vm.as_mut().drain_microtasks();
                     // The drain ran script: an exception it left (a termination
                     // request landing in it) ends this dispatch like a throw
                     // from the handler; nothing below may enter script over it.
@@ -1377,43 +1328,37 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     }
                     jsc::js_promise::Status::Pending => {
                         let _ = global.handle_rejected_promises();
-                        if !node_http_response.is_null() {
-                            // SAFETY: out-param written by `on_request_ffi`;
-                            // owned ref held until `deref()` below. Shared —
-                            // `NodeHTTPResponse` state is `Cell`/`JsCell`.
-                            let nhr = unsafe { &*node_http_response };
-                            // Single `Cell` load for all three flag checks (no
-                            // re-entry between them).
-                            let nhr_flags = nhr.flags.get();
-                            if nhr_flags.contains(NhrFlags::REQUEST_HAS_COMPLETED)
-                                || nhr_flags.contains(NhrFlags::SOCKET_CLOSED)
-                                || nhr_flags.contains(NhrFlags::UPGRADED)
-                            {
-                                strong_promise.deinit();
-                                break 'brk HttpResult::Success;
-                            }
-
-                            let strong_self = nhr.get_this_value();
-                            if strong_self.is_empty_or_undefined_or_null() {
-                                strong_promise.deinit();
-                                break 'brk HttpResult::Success;
-                            }
-
-                            nhr.promise.set(core::mem::replace(
-                                &mut strong_promise,
-                                jsc::StrongOptional::empty(),
-                            ));
-                            // `#[host_fn(export = …)]` emits its
-                            // C-ABI shim as `__jsc_host_<fn>`; the export name
-                            // is link-only.
-                            result.then2(
-                                global,
-                                strong_self,
-                                node_http_response::__jsc_host_node_http_request_on_resolve,
-                                node_http_response::__jsc_host_node_http_request_on_reject,
-                            );
-                            is_async = true;
+                        // Single `Cell` load for all three flag checks (no
+                        // re-entry between them).
+                        let nhr_flags = nhr.flags.get();
+                        if nhr_flags.contains(NhrFlags::REQUEST_HAS_COMPLETED)
+                            || nhr_flags.contains(NhrFlags::SOCKET_CLOSED)
+                            || nhr_flags.contains(NhrFlags::UPGRADED)
+                        {
+                            strong_promise.deinit();
+                            break 'brk HttpResult::Success;
                         }
+
+                        let strong_self = nhr.get_this_value();
+                        if strong_self.is_empty_or_undefined_or_null() {
+                            strong_promise.deinit();
+                            break 'brk HttpResult::Success;
+                        }
+
+                        nhr.promise.set(core::mem::replace(
+                            &mut strong_promise,
+                            jsc::StrongOptional::empty(),
+                        ));
+                        // `#[host_fn(export = …)]` emits its
+                        // C-ABI shim as `__jsc_host_<fn>`; the export name
+                        // is link-only.
+                        result.then2(
+                            global,
+                            strong_self,
+                            node_http_response::__jsc_host_node_http_request_on_resolve,
+                            node_http_response::__jsc_host_node_http_request_on_reject,
+                        );
+                        is_async = true;
 
                         break 'brk HttpResult::Pending;
                     }
@@ -1425,95 +1370,84 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         match &http_result {
             HttpResult::Exception(err) | HttpResult::Rejection(err) => {
-                // SAFETY: `vm` is the process-static VirtualMachine; `&mut`
-                // scoped to this call.
-                let _ = unsafe {
-                    (*vm).uncaught_exception(
-                        global,
-                        *err,
-                        matches!(http_result, HttpResult::Rejection(_)),
-                    )
-                };
+                let _ = vm.as_mut().uncaught_exception(
+                    global,
+                    *err,
+                    matches!(http_result, HttpResult::Rejection(_)),
+                );
 
-                if !node_http_response.is_null() {
-                    // SAFETY: see `nhr` above.
-                    let nhr = unsafe { &*node_http_response };
-                    let nhr_flags = nhr.flags.get();
-                    if !nhr_flags.contains(NhrFlags::UPGRADED) {
-                        if let Some(raw) = nhr.raw_response.get() {
-                            if !nhr_flags.contains(NhrFlags::REQUEST_HAS_COMPLETED)
-                                && raw.state().is_response_pending()
-                            {
-                                if raw.state().is_http_status_called() {
-                                    raw.write_status(b"500 Internal Server Error");
-                                    raw.end_without_body(true);
-                                } else {
-                                    raw.end_stream(true);
-                                }
+                let nhr_flags = nhr.flags.get();
+                if !nhr_flags.contains(NhrFlags::UPGRADED) {
+                    if let Some(raw) = nhr.raw_response.get() {
+                        if !nhr_flags.contains(NhrFlags::REQUEST_HAS_COMPLETED)
+                            && raw.state().is_response_pending()
+                        {
+                            if raw.state().is_http_status_called() {
+                                raw.write_status(b"500 Internal Server Error");
+                                raw.end_without_body(true);
+                            } else {
+                                raw.end_stream(true);
                             }
                         }
                     }
-                    // The handler threw before `res.end()`; we just ended (or
-                    // will never end) the raw response above. Mark ENDED so
-                    // `on_request_complete()` → `mark_request_as_done()` runs
-                    // and releases the `IS_REQUEST_PENDING` ref (one of the
-                    // initial 3). Without this the box leaks: the later
-                    // `on_abort` socket-close path early-returns once
-                    // `REQUEST_HAS_COMPLETED` is set and never balances it.
-                    nhr.flags.set(nhr.flags.get() | NhrFlags::ENDED);
-                    nhr.on_request_complete();
                 }
+                // The handler threw before `res.end()`; we just ended (or
+                // will never end) the raw response above. Mark ENDED so
+                // `on_request_complete()` → `mark_request_as_done()` runs
+                // and releases the `IS_REQUEST_PENDING` ref (one of the
+                // initial 3). Without this the box leaks: the later
+                // `on_abort` socket-close path early-returns once
+                // `REQUEST_HAS_COMPLETED` is set and never balances it.
+                nhr.flags.set(nhr.flags.get() | NhrFlags::ENDED);
+                nhr.on_request_complete();
             }
             HttpResult::Success | HttpResult::Pending => {}
         }
 
-        if !node_http_response.is_null() {
-            // SAFETY: see `nhr` above.
-            let nhr = unsafe { &*node_http_response };
-            let nhr_flags = nhr.flags.get();
-            if !nhr_flags.contains(NhrFlags::UPGRADED) {
-                if let Some(raw) = nhr.raw_response.get() {
-                    if !nhr_flags.contains(NhrFlags::REQUEST_HAS_COMPLETED)
-                        && raw.state().is_response_pending()
-                    {
-                        nhr.set_on_aborted_handler();
-                    }
-                    // If we ended the response without attaching an ondata handler, we discard the body read stream
-                    else if !matches!(http_result, HttpResult::Pending) {
-                        let this_value = nhr.get_this_value();
-                        // SAFETY: `vm` is the process-static VirtualMachine.
-                        nhr.maybe_stop_reading_body(unsafe { &mut *vm }, this_value);
-                    }
+        let nhr_flags = nhr.flags.get();
+        if !nhr_flags.contains(NhrFlags::UPGRADED) {
+            if let Some(raw) = nhr.raw_response.get() {
+                if !nhr_flags.contains(NhrFlags::REQUEST_HAS_COMPLETED)
+                    && raw.state().is_response_pending()
+                {
+                    nhr.set_on_aborted_handler();
                 }
-                if nhr_flags.contains(NhrFlags::TUNNELED) {
-                    // Raw 'upgrade'/'connect' handoff: the exchange left HTTP, so
-                    // release the pending-request accounting now - a half-open
-                    // tunnel never closes, which stranded `pending_requests`.
-                    nhr.mark_request_as_done_if_necessary();
+                // If we ended the response without attaching an ondata handler, we discard the body read stream
+                else if !matches!(http_result, HttpResult::Pending) {
+                    let this_value = nhr.get_this_value();
+                    nhr.maybe_stop_reading_body(vm.as_mut(), this_value);
                 }
-            } else if nhr_flags.contains(NhrFlags::IS_REQUEST_PENDING) {
-                // The socket was adopted by the WebSocket context inside the
-                // handler; `raw_response` is gone and no further uws abort/end
-                // callback will fire on it, so the IS_REQUEST_PENDING ref
-                // (one of the initial 3) would otherwise strand and leak the
-                // box. Release it now and balance the server's
-                // pending-request counter via `mark_request_as_done()`.
-                // `should_request_be_pending()` returns false once UPGRADED
-                // is set, so this reaches `mark_request_as_done()`.
-                nhr.on_request_complete();
             }
+            if nhr_flags.contains(NhrFlags::TUNNELED) {
+                // Raw 'upgrade'/'connect' handoff: the exchange left HTTP, so
+                // release the pending-request accounting now - a half-open
+                // tunnel never closes, which stranded `pending_requests`.
+                nhr.mark_request_as_done_if_necessary();
+            }
+        } else if nhr_flags.contains(NhrFlags::IS_REQUEST_PENDING) {
+            // The socket was adopted by the WebSocket context inside the
+            // handler; `raw_response` is gone and no further uws abort/end
+            // callback will fire on it, so the IS_REQUEST_PENDING ref
+            // (one of the initial 3) would otherwise strand and leak the
+            // box. Release it now and balance the server's
+            // pending-request counter via `mark_request_as_done()`.
+            // `should_request_be_pending()` returns false once UPGRADED
+            // is set, so this reaches `mark_request_as_done()`.
+            nhr.on_request_complete();
         }
 
         // Cleanup, hoisted out of scopeguards (no early
         // returns above). Reverse-decl order: strong_promise, drain, deref.
         strong_promise.deinit();
         if needs_to_drain {
-            // SAFETY: `vm` is the process-static VirtualMachine.
-            unsafe { (*vm).drain_microtasks() };
+            vm.as_mut().drain_microtasks();
         }
-        if !is_async && !node_http_response.is_null() {
-            // SAFETY: out-param ref taken in C++; synchronous path drops it.
-            unsafe { &*node_http_response }.deref();
+        if is_async {
+            // Our ref now belongs to the pending promise's reactions
+            // (`node_http_request_on_resolve` / `_on_reject` release it).
+            let _ = nhr.into_raw();
+        } else {
+            nhr.deref();
         }
     }
 
@@ -1524,21 +1458,21 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     // `js_gc_route_list_set` and the per-callback slot setters live with the
     // `slot_setter!` invocations below (alongside `cached_values`).
 
-    /// Wrap an already-heap-allocated server pointer in its JS object.
-    /// Ownership transfers to the C++ wrapper (freed via `finalize`).
-    pub(crate) fn ptr_to_js(this: *mut Self, global: &JSGlobalObject) -> JSValue {
-        server_js_create(this.cast(), global, SSL, DEBUG)
+    /// Wrap the server in its JS object. The C++ wrapper takes over `this`'s
+    /// ref (released via `finalize`).
+    pub(crate) fn ptr_to_js(this: RefPtr<Self>, global: &JSGlobalObject) -> JSValue {
+        server_js_create(this.into_raw().cast(), global, SSL, DEBUG)
     }
 
     // `on_reload_from_zig` body lives in `server_body.rs` (`impl NewServer { … }`);
     // same crate, separate file, alongside `on_reload`/`reload_static_routes`.
 
-    pub(crate) fn on_static_request_complete(&mut self) {
+    pub(crate) fn on_static_request_complete(&self) {
         self.on_request_complete();
     }
 
     #[inline]
-    pub(crate) fn on_request_complete(&mut self) {
+    pub(crate) fn on_request_complete(&self) {
         self.pending_requests.set(self.pending_requests.get() - 1);
         self.deinit_if_we_can();
     }
@@ -1598,7 +1532,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.pending_requests.get() == 0
             && !self.has_listener()
             && !self.has_active_web_sockets()
-            && (self.config.is_node_http_server || !self.has_active_connections())
+            && (self.config().is_node_http_server || !self.has_active_connections())
     }
 
     /// Nothing is left that can dispatch a handler: [`Self::is_closed`] and
@@ -1609,19 +1543,18 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     }
 
     pub(crate) fn has_listener(&self) -> bool {
-        self.listener.is_some() || (Self::HAS_H3 && self.h3_listener.is_some())
+        self.listener.get().is_some() || (Self::HAS_H3 && self.h3_listener.get().is_some())
     }
 
     pub(crate) fn set_flags(
-        &mut self,
+        &self,
         require_host_header: bool,
         use_strict_method_validation: bool,
         lenient_http_flags: u8,
         http_allow_half_open: bool,
     ) {
-        if let Some(app) = self.app {
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(app).set_flags(
+        if let Some(app) = self.app_mut() {
+            app.set_flags(
                 require_host_header,
                 use_strict_method_validation,
                 lenient_http_flags,
@@ -1630,57 +1563,49 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
     }
 
-    pub(crate) fn set_max_http_header_size(&mut self, max_header_size: u64) {
-        if let Some(app) = self.app {
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(app).set_max_http_header_size(max_header_size);
+    pub(crate) fn set_max_http_header_size(&self, max_header_size: u64) {
+        if let Some(app) = self.app_mut() {
+            app.set_max_http_header_size(max_header_size);
         }
     }
 
-    pub fn ref_(&mut self) {
-        if self.poll_ref.is_active() {
+    pub fn ref_event_loop(&self) {
+        if self.poll_ref.get().is_active() {
             return;
         }
-        self.poll_ref.ref_(self.vm.loop_ctx());
+        self.poll_ref.with_mut(|p| p.ref_(self.vm.loop_ctx()));
     }
 
-    pub(crate) fn unref(&mut self) {
-        self.poll_ref.unref(self.vm.loop_ctx());
+    pub(crate) fn unref_event_loop(&self) {
+        self.poll_ref.with_mut(|p| p.unref(self.vm.loop_ctx()));
     }
 
-    pub(crate) fn stop_listening(&mut self, abrupt: bool) {
+    pub(crate) fn stop_listening(&self, abrupt: bool) {
         // httplog!("stopListening", .{});
 
-        if let Some(handles) = crate::jsc_hooks::active_handles() {
-            handles.swap_remove(&crate::jsc_hooks::ActiveHandle::Server(AnyServer::from(
-                core::ptr::from_ref(self),
-            )));
-        }
+        crate::jsc_hooks::ActiveHandle::Server(AnyServer::from(self)).unregister();
 
-        if Self::HAS_H3 {
-            if let Some(h3l) = self.h3_listener.take() {
-                // Graceful: GOAWAY + drain via the still-open UDP socket; the
-                // engine rejects new conns and the timer keeps in-flight streams
-                // progressing until deinit. Abrupt: close the fd now.
-                if !abrupt {
-                    if let Some(h3a) = self.h3_app {
-                        // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
-                        bun_opaque::opaque_deref_mut(h3a).close();
-                    }
-                } else {
-                    // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                    bun_opaque::opaque_deref_mut(h3l).close();
+        if let Some(h3l) = self.h3_listener.take() {
+            // Graceful: GOAWAY + drain via the still-open UDP socket; the
+            // engine rejects new conns and the timer keeps in-flight streams
+            // progressing until deinit. Abrupt: close the fd now.
+            if !abrupt {
+                if let Some(h3a) = self.h3_app_mut() {
+                    h3a.close();
                 }
+            } else {
+                // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+                bun_opaque::opaque_deref_mut(h3l.as_ptr()).close();
             }
         }
 
-        let already_terminated = self.flags.contains(ServerFlags::TERMINATED);
+        let already_terminated = self.has_flags(ServerFlags::TERMINATED);
         let Some(listener) = self.listener.take() else {
-            if Self::HAS_H3 && self.h3_app.is_some() {
-                self.unref();
+            if self.h3_app_ptr().is_some() {
+                self.unref_event_loop();
                 self.notify_inspector_server_stopped();
                 if abrupt {
-                    self.flags.insert(ServerFlags::TERMINATED);
+                    self.insert_flags(ServerFlags::TERMINATED);
                 }
             }
             // An earlier graceful stop already took the listener. An abrupt
@@ -1688,43 +1613,36 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // pre-call `TERMINATED` so the H3 arm's insert above does not
             // mask the TCP teardown.
             if abrupt && !already_terminated {
-                self.unref();
-                if let Some(ws) = self.config.websocket.as_mut() {
-                    ws.handler.app = None;
-                }
-                self.flags.insert(ServerFlags::TERMINATED);
-                if let Some(app) = self.app {
+                self.unref_event_loop();
+                self.detach_websocket_handler(true, false);
+                self.insert_flags(ServerFlags::TERMINATED);
+                if let Some(app) = self.app_mut() {
                     self.deinit_running.set(true);
-                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).close();
+                    app.close();
                     self.deinit_running.set(false);
                 }
-                if let Some(ws) = self.config.websocket.as_mut() {
-                    ws.handler.server = None;
-                }
+                self.detach_websocket_handler(false, true);
             }
             return;
         };
+        // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
+        let listener = bun_opaque::opaque_deref_mut(listener.as_ptr());
         if abrupt || self.is_closed() {
-            self.unref();
+            self.unref_event_loop();
         }
         // A graceful stop with work in flight keeps the ref (deinit_if_we_can
         // unrefs when the drain completes): on Windows uv_run skips I/O with
         // zero ref'd handles, so unrefing here wedged server.close() teardown.
 
         if !SSL {
-            // SAFETY: `listener` is a live uws ListenSocket FFI handle just taken
-            // from `self.listener`; deref'd once to read the socket fd. `vm` is a
-            // STATIC ref (see `NewServer::vm_mut`) — non-null for the server's
-            // lifetime, so the raw→`&mut` deref is sound.
-            unsafe {
-                let fd = (*listener).socket().fd();
-                (*self.vm_mut()).remove_listening_socket_for_watch_mode(fd);
-            }
+            let fd = listener.socket().fd();
+            self.vm()
+                .as_mut()
+                .remove_listening_socket_for_watch_mode(fd);
         }
         self.notify_inspector_server_stopped();
 
-        if let server_config::Address::Unix(path) = &self.config.address {
+        if let server_config::Address::Unix(path) = &self.config().address {
             let bytes = path.as_bytes();
             if !bytes.is_empty() && bytes[0] != 0 {
                 let _ = bun_sys::unlink(path.as_zstr());
@@ -1732,62 +1650,51 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         if !abrupt {
-            // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            bun_opaque::opaque_deref_mut(listener).close();
+            listener.close();
             // Close idle keep-alive connections now and mark busy ones to
             // close once their in-flight work completes; open websockets are
             // untouched and drain on their own. Each close reaches
             // `on_connection_filter(-2)` synchronously, so hold the guard so
-            // that path cannot form a second `&mut self` under this frame —
-            // `stop()` runs `deinit_if_we_can` right after this returns.
+            // that path skips its `deinit_if_we_can` — `stop()` runs it right
+            // after this returns.
             //
             // node:http servers are exempt: Node's `close()` sweeps idle
             // connections exactly once (the JS layer already called
             // `closeIdleConnections()`), and a connection whose response
             // completes after `close()` stays keep-alive until its timeout
             // reaps it — verified against Node v26.
-            if !self.config.is_node_http_server {
-                if let Some(app) = self.app {
+            if !self.config().is_node_http_server {
+                if let Some(app) = self.app_mut() {
                     self.deinit_running.set(true);
-                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    let _closed = bun_opaque::opaque_deref_mut(app).close_idle_connections(true);
+                    let _closed = app.close_idle_connections(true);
                     self.deinit_running.set(false);
                 }
             }
-        } else if !self.flags.contains(ServerFlags::TERMINATED) {
-            if let Some(ws) = self.config.websocket.as_mut() {
-                ws.handler.app = None;
-            }
-            self.flags.insert(ServerFlags::TERMINATED);
+        } else if !self.has_flags(ServerFlags::TERMINATED) {
+            self.detach_websocket_handler(true, false);
+            self.insert_flags(ServerFlags::TERMINATED);
             // `app.close()` synchronously drains every open websocket; their
-            // `on_close` defers call `on_websocket_closed`, which would
-            // dispatch `deinit_if_we_can` through a fresh `&mut NewServer`
-            // while this frame still holds `&mut self`. Hold the re-entrance
-            // guard across the drain so that nested call early-returns —
-            // `stop()` runs `deinit_if_we_can` itself right after this returns.
+            // `on_close` defers call `on_websocket_closed`, which would run
+            // `deinit_if_we_can` mid-drain. Hold the re-entrance guard across
+            // the drain so that nested call early-returns — `stop()` runs
+            // `deinit_if_we_can` itself right after this returns.
             self.deinit_running.set(true);
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(self.app.unwrap()).close();
+            self.app_mut().expect("server app is live").close();
             self.deinit_running.set(false);
             // Only clear after the drain — `on_close` defers reach
             // `on_websocket_closed` through `handler.server`, so wiping it
             // earlier would strand the live-socket count and the idle pass
             // would never see it drained.
-            if let Some(ws) = self.config.websocket.as_mut() {
-                ws.handler.server = None;
-            }
+            self.detach_websocket_handler(false, true);
         }
     }
 
-    pub(crate) fn stop(&mut self, abrupt: bool) {
-        if self.config.allow_hot && !self.config.id.is_empty() {
-            // `hot_map()` is reached via the thread-local VM singleton (raw ptr
-            // deref) and does not borrow `self`, so it cannot overlap with the
-            // `&self.config.id` borrow.
-            // SAFETY: `vm_mut()` is the non-null process-static VM pointer.
-            unsafe {
-                if let Some(hot) = (*self.vm_mut()).hot_map() {
-                    hot.remove(&self.config.id);
+    pub(crate) fn stop(&self, abrupt: bool) {
+        {
+            let config = self.config();
+            if config.allow_hot && !config.id.is_empty() {
+                if let Some(hot) = self.vm().as_mut().hot_map() {
+                    hot.remove(&config.id);
                 }
             }
         }
@@ -1797,32 +1704,23 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     }
 
     #[inline]
-    pub(crate) fn deinit_if_we_can(&mut self) {
-        // Re-entrance guard. The websocket-close trigger reaches this through
-        // an `AnyServer` raw-ptr dispatch and can land here while an outer
-        // `&mut self` frame is already on the stack (abrupt `app.close()`
-        // drains sockets synchronously; their close defers call back in). The
-        // body is idempotent, so the outer call will finish the work — skip
-        // the nested run rather than mutate under the aliased borrow.
-        // This replaces the old `!TERMINATED` proxy in `on_websocket_closed`,
-        // which was permanent and so also blocked the *post*-stop close defer
-        // that should fire the downgrade.
+    pub(crate) fn deinit_if_we_can(&self) {
+        // Re-entrance guard. The websocket-close / connection-close triggers
+        // can land here while an outer frame is inside one of the synchronous
+        // `app.close()` drains. The body is idempotent, so the outer call will
+        // finish the work — skip the nested run.
         if self.deinit_running.get() {
             return;
         }
         self.deinit_running.set(true);
-        // Cleared inline at the tail (no early returns below). Not a
-        // scopeguard: the body forms `&mut self` reborrows for
-        // `unref()`/`schedule_deinit()`, and a guard holding either `&Cell` or
-        // a raw `*mut` into `*self` across those would either fail
-        // borrow-check or have its provenance tag popped under Stacked
-        // Borrows. A panic mid-body leaves the flag set — acceptable, the idle
-        // pass panicking means this server is unrecoverable anyway.
+        // Cleared inline at the tail (no early returns below). A panic
+        // mid-body leaves the flag set — acceptable, the idle pass panicking
+        // means this server is unrecoverable anyway.
 
         httplog!(
             "deinitIfWeCan. requests={}, listener={}, connections={}, websockets={}, has_handled_all_closed_promise={}, all_closed_promise={}, has_js_deinited={}",
             self.pending_requests.get(),
-            if self.listener.is_none() {
+            if self.listener.get().is_none() {
                 "null"
             } else {
                 "some"
@@ -1833,22 +1731,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             } else {
                 "no"
             },
-            self.flags
-                .contains(ServerFlags::HAS_HANDLED_ALL_CLOSED_PROMISE),
-            if self.all_closed_promise.has_value() {
+            self.has_flags(ServerFlags::HAS_HANDLED_ALL_CLOSED_PROMISE),
+            if self.all_closed_promise.get().has_value() {
                 "has"
             } else {
                 "no"
             },
-            matches!(self.js_value, jsc::JsRef::Finalized),
+            matches!(self.js_value.get(), jsc::JsRef::Finalized),
         );
 
         let closed = self.is_closed();
         if closed
-            && !self
-                .flags
-                .contains(ServerFlags::HAS_HANDLED_ALL_CLOSED_PROMISE)
-            && self.all_closed_promise.has_value()
+            && !self.has_flags(ServerFlags::HAS_HANDLED_ALL_CLOSED_PROMISE)
+            && self.all_closed_promise.get().has_value()
             // `ServerAllConnectionsClosedTask::run_from_js_thread` early-returns
             // (without resolving the promise) when the VM is shutting down —
             // see the `if !vm.is_shutting_down()` gate there. Skip the
@@ -1860,8 +1755,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             httplog!("schedule other promise");
             // use a flag here instead of `this.all_closed_promise.get().isHandled(vm)` to prevent the race condition of this block being called
             // again before the task has run.
-            self.flags
-                .insert(ServerFlags::HAS_HANDLED_ALL_CLOSED_PROMISE);
+            self.insert_flags(ServerFlags::HAS_HANDLED_ALL_CLOSED_PROMISE);
 
             let global = self.global_this();
             let vm_ref = jsc::VirtualMachine::get_mut();
@@ -1870,7 +1764,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     global_object: self.global_this,
                     // Duplicate the Strong handle so that we can hold two independent strong references to it.
                     promise: jsc::JSPromiseStrong::from_value(
-                        self.all_closed_promise.value(),
+                        self.all_closed_promise.get().value(),
                         global,
                     ),
                     tracker: jsc::AsyncTaskTracker::init(vm_ref),
@@ -1879,101 +1773,83 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
         if closed {
-            self.unref();
+            self.unref_event_loop();
         }
         if self.is_drained() {
             // No handler is dispatched from here on (`js_value_for_dispatch`), so the wrapper —
             // the handlers' only GC root — may become collectible.
-            self.js_value.downgrade();
-            if let Some(ws) = self.config.websocket.as_mut() {
-                ws.handler.app = None;
-                ws.handler.server = None;
-            }
+            self.js_value.with_mut(|v| v.downgrade());
+            self.detach_websocket_handler(true, true);
 
             // Detach DevServer. This is needed because there are aggressive
             // tests that check for DevServer memory soundness. Keeping the JS
             // binding alive should not pin `dev.memory_cost()` bytes.
-            if let Some(dev) = self.dev_server.take() {
-                if let Some(app) = self.app {
-                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).clear_routes();
+            if let Some(dev) = self.dev_server.replace(None) {
+                if let Some(app) = self.app_mut() {
+                    app.clear_routes();
                 }
                 drop(dev); // dev.deinit()
             }
 
             // Only free the memory if the JS reference has been freed too.
-            if matches!(self.js_value, jsc::JsRef::Finalized) {
+            if matches!(self.js_value.get(), jsc::JsRef::Finalized) {
                 self.schedule_deinit();
             }
         }
         self.deinit_running.set(false);
     }
 
-    pub(crate) fn schedule_deinit(&mut self) {
-        if self.flags.contains(ServerFlags::DEINIT_SCHEDULED) {
+    pub(crate) fn schedule_deinit(&self) {
+        if self.has_flags(ServerFlags::DEINIT_SCHEDULED) {
             httplog!("scheduleDeinit (again)");
             return;
         }
-        self.flags.insert(ServerFlags::DEINIT_SCHEDULED);
+        self.insert_flags(ServerFlags::DEINIT_SCHEDULED);
         httplog!("scheduleDeinit");
 
-        // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine` (non-null
-        // for the server's lifetime); single-threaded JS context, borrow scoped
-        // to this call.
-        if unsafe { (*self.vm_mut()).is_shutting_down() } {
-            // No more ticks; `finalize()` frees via `DEINIT_SCHEDULED` instead.
+        let vm = self.vm().as_mut();
+        if vm.is_shutting_down() {
+            // No more ticks; `finalize()` tears down via `DEINIT_SCHEDULED` instead.
             return;
         }
 
-        if !self.flags.contains(ServerFlags::TERMINATED) {
+        if !self.has_flags(ServerFlags::TERMINATED) {
             // App.close can cause finalizers to run.
             // scheduleDeinit can be called inside a finalizer.
             // Therefore, we split it into two tasks.
-            self.flags.insert(ServerFlags::TERMINATED);
-            let app = self.app.unwrap();
-            // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine`
-            // (non-null for the server's lifetime); single-threaded JS
-            // context, `&mut` scoped to this call.
-            unsafe {
-                (*self.vm_mut()).enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
-                    app,
-                    |app| {
-                        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                        bun_opaque::opaque_deref_mut(app).close();
-                        Ok(())
-                    },
-                ));
-            }
+            self.insert_flags(ServerFlags::TERMINATED);
+            let app = self.app_ptr().expect("server app is live");
+            vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(app, |app| {
+                // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                bun_opaque::opaque_deref_mut(app).close();
+                Ok(())
+            }));
         }
 
-        // SAFETY: as above — `&mut` scoped to this call.
-        unsafe {
-            (*self.vm_mut()).enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
-                std::ptr::from_mut::<Self>(self),
-                |this| {
-                    // SAFETY: `this` is the unique owning server pointer enqueued
-                    // above; the task runs once on the JS thread.
-                    Self::deinit(this);
-                    Ok(())
-                },
-            ));
-        }
+        // The queued task holds its own ref; `self_ref` stays (the app's
+        // registrations are live) until the task's `teardown()` releases it.
+        let this = self
+            .self_ref
+            .get()
+            .as_ref()
+            .expect("server app is live")
+            .dupe_ref();
+        vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new_boxed(
+            Box::new(DeinitTask(this)),
+        ));
     }
 
-    pub(crate) fn on_listen(&mut self, socket: Option<*mut uws_sys::app::ListenSocket<SSL>>) {
+    pub(crate) fn on_listen(&self, socket: Option<NonNull<uws_sys::app::ListenSocket<SSL>>>) {
         let Some(socket) = socket else {
             return self.on_listen_failed();
         };
-        self.listener = Some(socket);
-        // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine` (non-null
-        // for the server's lifetime); single-threaded JS context.
-        unsafe { (*self.vm_mut()).event_loop_handle = Some(bun_io::Loop::get()) };
+        self.listener.set(Some(socket));
+        let vm = self.vm().as_mut();
+        vm.event_loop_handle = Some(bun_io::Loop::get());
         if !SSL {
             // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            let fd = bun_opaque::opaque_deref_mut(socket).socket().fd();
-            // SAFETY: `vm` is a STATIC ref (see `NewServer::vm_mut`) — non-null
-            // for the server's lifetime, so the raw→`&mut` deref is sound.
-            unsafe { (*self.vm_mut()).add_listening_socket_for_watch_mode(fd) };
+            let fd = bun_opaque::opaque_deref_mut(socket.as_ptr()).socket().fd();
+            vm.add_listening_socket_for_watch_mode(fd);
         }
     }
 
@@ -1982,11 +1858,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// error-stack drain is still TODO; the EADDRINUSE/
     /// EACCES paths below cover the node:http `server.listen` error contract.
     #[cold]
-    pub(crate) fn on_listen_failed(&mut self) {
-        self.listener = None;
+    pub(crate) fn on_listen_failed(&self) {
+        self.listener.set(None);
         let global = self.global_this();
 
-        let error_instance = match &self.config.address {
+        let error_instance = match &self.config().address {
             server_config::Address::Tcp {
                 port,
                 hostname: _hostname,
@@ -2064,71 +1940,45 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         let _ = global.throw_value(error_instance);
     }
 
-    pub(crate) fn on_h3_listen(&mut self, socket: Option<*mut uws_sys::h3::ListenSocket>) {
+    pub(crate) fn on_h3_listen(&self, socket: Option<NonNull<uws_sys::h3::ListenSocket>>) {
         if !Self::HAS_H3 {
             return;
         }
         let Some(socket) = socket else { return };
         // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-        let port = bun_opaque::opaque_deref_mut(socket).get_local_port();
-        self.h3_listener = Some(socket);
+        let port = bun_opaque::opaque_deref_mut(socket.as_ptr()).get_local_port();
+        self.h3_listener.set(Some(socket));
         if let Some(port) = port {
-            self.h3_alt_svc = format!("h3=\":{port}\"; ma=86400")
-                .into_bytes()
-                .into_boxed_slice();
+            self.h3_alt_svc.set(
+                format!("h3=\":{port}\"; ma=86400")
+                    .into_bytes()
+                    .into_boxed_slice(),
+            );
         }
         // An `http3_server` feature counter is not (yet) declared in
         // `bun_analytics`. No-op until it is.
     }
 
-    // ─── deinit ──────────────────────────────────────────────────────────────
-    /// Tear down the uws app handles and free the boxed server. Only called
-    /// from `schedule_deinit`'s task, on listen-failure, or from `finalize()` at VM shutdown.
-    ///
-    /// # Safety
-    /// `this` must be the unique owning pointer to a heap-allocated `NewServer`
-    /// produced by [`Self::init`]; no other reference may be live, and `this`
-    /// must not be used after this returns.
-    pub(super) fn deinit(this: *mut Self) {
-        httplog!("deinit");
-        // SAFETY: paired with heap::alloc in `init()`; `this` is uniquely
-        // owned here, so reclaim the Box up front and let its `&mut` drive
-        // the teardown (dropped — and freed — at scope exit).
-        let mut server = unsafe { bun_core::heap::take(this) };
-
+    // ─── teardown ────────────────────────────────────────────────────────────
+    /// Destroy the uws app handles and hand back the ref they held (if still
+    /// held), for the caller to release. Called from `schedule_deinit`'s task,
+    /// on listen-failure, or from `finalize()` at VM shutdown.
+    #[must_use = "the returned ref must be released"]
+    pub(super) fn teardown(&self) -> Option<RefPtr<Self>> {
+        httplog!("teardown");
         // This should've already been handled in stop_listening; however, when
         // the JS VM terminates, it hypothetically might not call stop_listening.
-        server.notify_inspector_server_stopped();
-        if let Some(handles) = crate::jsc_hooks::active_handles() {
-            handles.swap_remove(&crate::jsc_hooks::ActiveHandle::Server(AnyServer::from(
-                this.cast_const(),
-            )));
-        }
+        self.notify_inspector_server_stopped();
+        crate::jsc_hooks::ActiveHandle::Server(AnyServer::from(self)).unregister();
 
-        if Self::HAS_H3 {
-            if let Some(h3a) = server.h3_app.take() {
-                // SAFETY: live H3::App handle owned by this server.
-                unsafe { uws_sys::h3::App::destroy(h3a) };
-            }
-        }
-        if let Some(h2a) = server.h2_app.take() {
-            // A drain may still be queued for it.
-            server
-                .vm()
-                .event_loop_ref()
-                .deferred_tasks
-                .unregister_task(core::ptr::NonNull::new(h2a.cast::<c_void>()));
-            // SAFETY: live h2::App handle owned by this server; detaches from `app`.
-            unsafe { uws_sys::h2::App::destroy(h2a) };
-        }
-        if let Some(app) = server.app.take() {
-            // SAFETY: live uws App handle owned by this server.
-            unsafe { uws_sys::NewApp::<SSL>::destroy(app) };
-        }
+        drop(self.h3_app.replace(None));
+        self.drop_h2_app();
+        drop(self.app.replace(None));
+        self.self_ref.replace(None)
     }
 
-    pub(crate) fn set_using_custom_expect_handler(&mut self, value: bool) {
-        if let Some(app) = self.app {
+    pub(crate) fn set_using_custom_expect_handler(&self, value: bool) {
+        if let Some(app) = self.app_ptr() {
             ffi::NodeHTTP_setUsingCustomExpectHandler(SSL, app.cast::<c_void>(), value);
         }
     }
@@ -2137,76 +1987,61 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// Allocate and populate a `NewServer` from `config`. The config is moved
     /// into the server (left as `Default` in the caller's slot). Route
     /// registration and the listen socket happen later in `listen()`.
-    pub(crate) fn init(config: &mut ServerConfig, global: &JSGlobalObject) -> JsResult<*mut Self>
+    pub(crate) fn init(config: &mut ServerConfig, global: &JSGlobalObject) -> JsResult<RefPtr<Self>>
     where
         Self: ServerPools<SSL, DEBUG>,
     {
         let base_url: Box<[u8]> = bun_core::trim(&config.base_uri, b"/")
             .to_vec()
             .into_boxed_slice();
-        // `base_url` drops on Err automatically.
 
-        let server = bun_core::heap::into_raw(Box::new(Self {
+        let server = RefPtr::new(Self {
+            ref_count: Cell::new(1),
+            self_ref: JsCell::new(None),
             global_this: std::ptr::from_ref(global),
-            // Set below, once the server has its final (stable) heap address.
-            any_server_packed: 0,
-            method_name_cache: [const { core::cell::Cell::new(JSValue::ZERO) }; N_HTTP_METHODS],
-            config: core::mem::take(config),
+            method_name_cache: [const { Cell::new(JSValue::ZERO) }; N_HTTP_METHODS],
+            config: JsCell::new(core::mem::take(config)),
             base_url_string_for_joining: base_url,
             vm: bun_ptr::BackRef::new(jsc::VirtualMachine::get()),
-            dev_server: None,
-            app: None,
-            listener: None,
-            h3_app: None,
-            h2_app: None,
-            h3_listener: None,
-            h3_alt_svc: Box::<[u8]>::default(),
-            js_value: jsc::JsRef::empty(),
-            pending_requests: core::cell::Cell::new(0),
-            active_connection_count: core::cell::Cell::new(0),
-            active_websocket_count: core::cell::Cell::new(0),
-            deinit_running: core::cell::Cell::new(false),
+            dev_server: JsCell::new(None),
+            app: JsCell::new(None),
+            listener: Cell::new(None),
+            h3_app: JsCell::new(None),
+            h2_app: JsCell::new(None),
+            h3_listener: Cell::new(None),
+            h3_alt_svc: JsCell::new(Box::<[u8]>::default()),
+            js_value: JsCell::new(jsc::JsRef::empty()),
+            pending_requests: Cell::new(0),
+            active_connection_count: Cell::new(0),
+            active_websocket_count: Cell::new(0),
+            deinit_running: Cell::new(false),
             request_pool: <Self as ServerPools<SSL, DEBUG>>::request_pool(),
             // Servers that enable neither HTTP/2 nor HTTP/3 never allocate the
             // ~816 KB mux pool; `listen()` materializes it on demand.
-            mux_request_pool: core::ptr::null_mut(),
-            all_closed_promise: jsc::JSPromiseStrong::default(),
-            poll_ref: KeepAlive::default(),
-            flags: ServerFlags::default(),
-            plugins: None,
-            user_routes: Vec::new(),
-            on_clienterror: JSValue::ZERO,
-            on_connection: JSValue::ZERO,
-            inspector_server_id: jsc::DebuggerId::init(0),
-        }));
-
-        // The packed `AnyServer` is a pure function of the (now-stable) heap
-        // address and the const variant tag; cache it so the per-request
-        // `node:http` prologue is a plain field load instead of a tag match +
-        // `TaggedPtr::init`.
-        // SAFETY: `server` is the freshly-boxed `*mut Self`; uniquely owned here.
-        unsafe {
-            (*server).any_server_packed = AnyServer::from(server.cast_const()).to_packed() as usize;
-        }
+            mux_request_pool: Cell::new(None),
+            all_closed_promise: JsCell::new(jsc::JSPromiseStrong::default()),
+            poll_ref: JsCell::new(KeepAlive::default()),
+            flags: Cell::new(ServerFlags::default()),
+            plugins: JsCell::new(None),
+            user_routes: JsCell::new(Vec::new()),
+            on_clienterror: Cell::new(JSValue::ZERO),
+            on_connection: Cell::new(JSValue::ZERO),
+            inspector_server_id: Cell::new(jsc::DebuggerId::init(0)),
+        });
 
         // The bake options (and the arena that backs `root`) live in
-        // `(*server).config.bake` for the server's lifetime. Initialise
-        // DevServer AFTER the server box exists so the `Options::arena` borrow
+        // `server.config.bake` for the server's lifetime. Initialise
+        // DevServer AFTER the server exists so the `Options::arena` borrow
         // points into the heap-allocated config rather than the caller's
-        // (since-moved) stack slot. On Err, the `Box<Self>` drop frees the
+        // (since-moved) stack slot. On Err, releasing the ref frees the
         // half-built server.
-        // SAFETY: `server` is the freshly-boxed `*mut Self`; uniquely owned here.
-        if let Some(bake_options) = unsafe { &mut (*server).config.bake } {
-            // SAFETY: `server` is the freshly-boxed `*mut Self`; uniquely owned here.
-            let broadcast = unsafe {
-                (*server)
-                    .config
-                    .broadcast_console_log_from_browser_to_server_for_bake
+        let dev = server.config.with_mut(|config| {
+            let Some(bake_options) = &mut config.bake else {
+                return Ok(None);
             };
-            let dev = match crate::bake::DevServer::init(crate::bake::DevServer::Options {
+            crate::bake::DevServer::init(crate::bake::DevServer::Options {
                 arena: &bake_options.arena,
                 root: bake_options.root,
-                // SAFETY: per-thread VM singleton; STATIC lifetime.
                 vm: jsc::VirtualMachine::get(),
                 // LAYERING: `UserOptions` carries the `bake_body` shapes;
                 // `DevServer::Options` consumes the keystone shapes;
@@ -2214,17 +2049,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // until the duplicates are collapsed.
                 framework: core::mem::take(&mut bake_options.framework).into(),
                 bundler_options: core::mem::take(&mut bake_options.bundler_options).into(),
-                broadcast_console_log_from_browser_to_server: broadcast,
-            }) {
-                Ok(d) => d,
-                Err(e) => {
-                    // SAFETY: paired with heap::alloc above.
-                    drop(unsafe { bun_core::heap::take(server) });
-                    return Err(e);
-                }
-            };
-            // SAFETY: `server` is uniquely owned here.
-            unsafe { (*server).dev_server = Some(dev) };
+                broadcast_console_log_from_browser_to_server: config
+                    .broadcast_console_log_from_browser_to_server_for_bake,
+            })
+            .map(Some)
+        });
+        match dev {
+            Ok(dev) => server.dev_server.set(dev),
+            Err(e) => {
+                server.deref();
+                return Err(e);
+            }
         }
 
         if SSL {
@@ -2240,48 +2075,47 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// Register HTTP routes on `self.app` (and `h2_app`/`h3_app` when present). Returns
     /// the JS `RouteList` value for codegen-backed user routes, or `.zero` when
     /// there are none.
-    fn set_routes(&mut self) -> JSValue {
+    fn set_routes(&self) -> JSValue {
         use bun_http_types::Method as http_method;
         let mut route_list_value = JSValue::ZERO;
-        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-        // set_routes is only called after `self.app = Some(..)` in listen().
-        let app = bun_opaque::opaque_deref_mut(self.app.unwrap());
-        let self_ptr: *mut Self = self;
-        let any_server = AnyServer::from(self_ptr.cast_const());
-        // reshaped for borrowck — `dev_server` is `Option<Box<..>>`;
-        // snapshot the raw `*mut DevServer` so per-iteration `&mut` derives
-        // don't conflict with `&mut self.config` / `&mut self.user_routes`.
-        let dev_server: Option<*mut crate::bake::DevServer::DevServer> =
-            self.dev_server.as_deref_mut().map(std::ptr::from_mut);
+        // set_routes is only called after `self.app` is created in listen().
+        let app = self.app_mut().expect("server app is live");
+        let this = self.this_ptr();
+        let any_server = AnyServer::from(self);
+        let has_dev_server = self.dev_server.get().is_some();
 
         // https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
         // Only enable this when we're using the dev server.
         let mut should_add_chrome_devtools_json_route = DEBUG
-            && self.config.allow_hot
-            && dev_server.is_some()
+            && self.config().allow_hot
+            && has_dev_server
             && self
-                .config
+                .config()
                 .enable_chrome_devtools_automatic_workspace_folders;
         const CHROME_DEVTOOLS_ROUTE: &[u8] = b"/.well-known/appspecific/com.chrome.devtools.json";
 
         // --- 1. user_routes_to_build → user_routes + RouteList JS object ---
-        if !self.config.user_routes_to_build.is_empty() {
-            let mut to_build = core::mem::take(&mut self.config.user_routes_to_build);
+        if !self.config().user_routes_to_build.is_empty() {
+            let mut to_build = self
+                .config
+                .with_mut(|c| core::mem::take(&mut c.user_routes_to_build));
             let len = to_build.len();
-            let _old = core::mem::replace(&mut self.user_routes, Vec::with_capacity(len));
             let mut callbacks: Vec<JSValue> = Vec::with_capacity(len);
+            let mut user_routes = Vec::with_capacity(len);
             for (i, builder) in to_build.iter_mut().enumerate() {
                 callbacks.push(builder.callback.get());
-                self.user_routes.push(UserRoute {
+                user_routes.push(bun_ptr::OwnedThis::new(UserRoute {
                     id: i as u32,
-                    server: self_ptr,
+                    server: this.into(),
                     route: core::mem::take(&mut builder.route),
-                });
+                }));
             }
+            self.user_routes.set(user_routes);
             // Scratch array for the C++ factory; borrows the route paths now
             // owned by `self.user_routes` (validated ASCII by ServerConfig).
             let mut paths: Vec<bun_core::EncodedSlice<'_>> = self
                 .user_routes
+                .get()
                 .iter()
                 .map(|r| bun_core::EncodedSlice::latin1(r.route.path.as_bytes()))
                 .collect();
@@ -2300,32 +2134,27 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         // --- 2. WebSocket handler app reference ---
-        if let Some(websocket) = self.config.websocket.as_mut() {
-            websocket.handler.app = Some(std::ptr::from_mut(app).cast::<c_void>());
-            websocket.handler.server = Some(any_server);
-            websocket
-                .handler
-                .flags
-                .set(web_socket_server_context::HandlerFlags::SSL, SSL);
-        }
+        self.config.with_mut(|c| {
+            if let Some(websocket) = c.websocket.as_mut() {
+                websocket.handler.app = Some(std::ptr::from_mut(app).cast::<c_void>());
+                websocket.handler.server = Some(any_server);
+                websocket
+                    .handler
+                    .flags
+                    .set(web_socket_server_context::HandlerFlags::SSL, SSL);
+            }
+        });
 
         // --- 3. Register compiled user routes & track "/*" coverage ---
         let mut star_methods_covered_by_user = http_method::Set::empty();
         let mut has_any_user_route_for_star_path = false;
         let mut has_any_ws_route_for_star_path = false;
 
-        // reshaped for borrowck — `app.ws(..)` reads `to_behavior()`
-        // (borrows `self.config.websocket`) while iterating `self.user_routes`.
-        // Snapshot as a `BackRef` (pointee = `self.config.websocket`, which is
-        // pinned in the server allocation and outlives every use below — the
-        // BackRef invariant) so the two `&mut self.*` accesses do not overlap
-        // from rustc's POV. Replaces the `Option<*mut _>` + per-site
-        // `unsafe { &*p }` pattern with one safe accessor.
-        let websocket_ptr: Option<bun_ptr::BackRef<WebSocketServerContext>> =
-            self.config.websocket.as_ref().map(bun_ptr::BackRef::new);
+        let ws_behavior: Option<uws_sys::WebSocketBehavior> =
+            self.config().websocket.as_ref().map(|ws| ws.to_behavior());
 
-        for user_route in self.user_routes.iter_mut() {
-            let ud: *mut c_void = std::ptr::from_mut::<UserRoute<SSL, DEBUG>>(user_route).cast();
+        for user_route in self.user_routes.get().iter() {
+            let ud = user_route.this_ptr();
             let path = user_route.route.path.as_bytes();
             let is_star_path = path == b"/*";
             if is_star_path {
@@ -2340,60 +2169,37 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // Register HTTP routes
             match user_route.route.method {
                 server_config::RouteMethod::Any => {
-                    app.any(
-                        path,
-                        Some(trampoline::on_user_route_request::<SSL, DEBUG>),
-                        ud,
-                    );
+                    app.any_this(path, Self::on_user_route_request, ud);
                     for_each_mux_app!(self, |mux| {
-                        mux.any(
-                            path,
-                            ud.cast::<UserRoute<SSL, DEBUG>>(),
-                            Self::on_mux_user_route_request,
-                        );
+                        mux.any_this(path, Self::on_mux_user_route_request, ud);
                     });
                     if is_star_path {
                         star_methods_covered_by_user = http_method::Set::all();
                     }
-                    if let Some(websocket) = websocket_ptr {
+                    if let Some(behavior) = &ws_behavior {
                         if is_star_path {
                             has_any_ws_route_for_star_path = true;
                         }
-                        app.ws(
-                            path,
-                            ud,
-                            1, // id 1 means is a user route
-                            ServerWebSocket::behavior::<Self, SSL>(&websocket.to_behavior()),
+                        // id 1 means is a user route
+                        app.ws_this::<UserRoute<SSL, DEBUG>, ServerWebSocket>(
+                            path, ud, 1, behavior,
                         );
                     }
                 }
                 server_config::RouteMethod::Specific(method_val) => {
-                    app.method(
-                        method_val,
-                        path,
-                        Some(trampoline::on_user_route_request::<SSL, DEBUG>),
-                        ud,
-                    );
+                    app.method_this(method_val, path, Self::on_user_route_request, ud);
                     for_each_mux_app!(self, |mux| {
-                        mux.method(
-                            method_val,
-                            path,
-                            ud.cast::<UserRoute<SSL, DEBUG>>(),
-                            Self::on_mux_user_route_request,
-                        );
+                        mux.method_this(method_val, path, Self::on_mux_user_route_request, ud);
                     });
                     if is_star_path {
                         star_methods_covered_by_user.insert(method_val);
                     }
                     // Setup user websocket in the route if needed.
-                    if let Some(websocket) = websocket_ptr {
+                    if let Some(behavior) = &ws_behavior {
                         // Websocket upgrade is a GET request
                         if method_val == http_method::Method::GET {
-                            app.ws(
-                                path,
-                                ud,
-                                1, // id 1 means is a user route
-                                ServerWebSocket::behavior::<Self, SSL>(&websocket.to_behavior()),
+                            app.ws_this::<UserRoute<SSL, DEBUG>, ServerWebSocket>(
+                                path, ud, 1, behavior,
                             );
                         }
                     }
@@ -2405,28 +2211,42 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // A `false` route means "fall through to the default handler": same
         // ladder as the `/*` fallback in step 9. H2/H3 stay on on_mux_request,
         // which already falls back to on_mux_404 when on_request is empty.
-        let negative_h1 = if !self.config.on_node_http_request.is_empty() {
-            trampoline::on_node_http_request::<SSL, DEBUG>
-        } else if !self.config.on_request.is_empty() {
-            trampoline::on_request::<SSL, DEBUG>
-        } else {
-            trampoline::on_404::<SSL, DEBUG>
-        };
-        for route_path in self.config.negative_routes.iter() {
+        let has_node_http = !self.config().on_node_http_request.is_empty();
+        let has_on_request = !self.config().on_request.is_empty();
+        // The default handler for a method (or `None` = any) on `path`.
+        let fallback_h1 =
+            |app: &mut uws_sys::NewApp<SSL>, method: Option<http_method::Method>, path: &[u8]| {
+                macro_rules! reg {
+                    ($h:expr) => {
+                        match method {
+                            Some(m) => app.method_this(m, path, $h, this),
+                            None => app.any_this(path, $h, this),
+                        }
+                    };
+                }
+                if has_node_http {
+                    reg!(Self::on_node_http_request)
+                } else if has_on_request {
+                    reg!(Self::on_request_route)
+                } else {
+                    reg!(Self::on_404)
+                }
+            };
+        for route_path in self.config().negative_routes.iter() {
             let p = route_path.as_bytes();
-            app.head(p, Some(negative_h1), self_ptr.cast());
-            app.any(p, Some(negative_h1), self_ptr.cast());
+            fallback_h1(app, Some(http_method::Method::HEAD), p);
+            fallback_h1(app, None, p);
             for_each_mux_app!(self, |mux| {
-                mux.head(p, self_ptr, Self::on_mux_request);
-                mux.any(p, self_ptr, Self::on_mux_request);
+                mux.method_this(http_method::Method::HEAD, p, Self::on_mux_request, this);
+                mux.any_this(p, Self::on_mux_request, this);
             });
         }
 
         // --- 5. Register static routes & track "/*" coverage ---
-        let mut needs_plugins = dev_server.is_some();
+        let mut needs_plugins = has_dev_server;
         let mut has_static_route_for_star_path = false;
 
-        for entry in &self.config.static_routes {
+        for entry in &self.config().static_routes {
             if &*entry.path == b"/*" {
                 has_static_route_for_star_path = true;
                 match &entry.method {
@@ -2448,109 +2268,52 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // An explicit HEAD handler route must stay the HEAD handler for its
             // path: uWS keeps the last registration for a method and path, and
             // static routes register after user routes.
-            let path_has_user_head_route =
-                self.user_routes
-                    .iter()
-                    .any(|route| match &route.route.method {
-                        server_config::RouteMethod::Specific(method) => {
-                            *method == http_method::Method::HEAD
-                                && route.route.path.as_bytes() == &*entry.path
-                        }
-                        server_config::RouteMethod::Any => false,
-                    });
+            let path_has_user_head_route = self.user_routes.get().iter().any(|route| match &route
+                .route
+                .method
+            {
+                server_config::RouteMethod::Specific(method) => {
+                    *method == http_method::Method::HEAD
+                        && route.route.path.as_bytes() == &*entry.path
+                }
+                server_config::RouteMethod::Any => false,
+            });
 
-            // Each `p`/`r` is the live `RefPtr<_>` stored in `entry.route`;
-            // `app`/`h2_app`/`h3_app` are the live uWS app handles owned by `self`.
+            macro_rules! apply {
+                ($T:ty, $r:expr) => {{
+                    server_config::apply_static_route::<SSL, $T>(
+                        any_server,
+                        app,
+                        $r.this_ptr(),
+                        &entry.path,
+                        entry.method,
+                        path_has_user_head_route,
+                    );
+                    for_each_mux_app!(self, |mux| {
+                        server_config::apply_static_route_mux::<$T, _>(
+                            any_server,
+                            mux,
+                            $r.this_ptr(),
+                            &entry.path,
+                            entry.method,
+                            path_has_user_head_route,
+                        );
+                    });
+                }};
+            }
             match &entry.route {
-                AnyRoute::Static(r) => {
-                    server_config::apply_static_route::<SSL, StaticRoute>(
-                        any_server,
-                        app,
-                        r.this_ptr(),
-                        &entry.path,
-                        entry.method,
-                        path_has_user_head_route,
-                    );
-                    for_each_mux_app!(self, |mux| {
-                        server_config::apply_static_route_mux::<StaticRoute, _>(
-                            any_server,
-                            mux,
-                            r.this_ptr(),
-                            &entry.path,
-                            entry.method,
-                            path_has_user_head_route,
-                        );
-                    });
-                }
-                AnyRoute::File(r) => {
-                    server_config::apply_static_route::<SSL, FileRoute>(
-                        any_server,
-                        app,
-                        r.this_ptr(),
-                        &entry.path,
-                        entry.method,
-                        path_has_user_head_route,
-                    );
-                    for_each_mux_app!(self, |mux| {
-                        server_config::apply_static_route_mux::<FileRoute, _>(
-                            any_server,
-                            mux,
-                            r.this_ptr(),
-                            &entry.path,
-                            entry.method,
-                            path_has_user_head_route,
-                        );
-                    });
-                }
-                AnyRoute::Directory(r) => {
-                    server_config::apply_static_route::<SSL, DirectoryRoute>(
-                        any_server,
-                        app,
-                        r.this_ptr(),
-                        &entry.path,
-                        entry.method,
-                        path_has_user_head_route,
-                    );
-                    for_each_mux_app!(self, |mux| {
-                        server_config::apply_static_route_mux::<DirectoryRoute, _>(
-                            any_server,
-                            mux,
-                            r.this_ptr(),
-                            &entry.path,
-                            entry.method,
-                            path_has_user_head_route,
-                        );
-                    });
-                }
+                AnyRoute::Static(r) => apply!(StaticRoute, r),
+                AnyRoute::File(r) => apply!(FileRoute, r),
+                AnyRoute::Directory(r) => apply!(DirectoryRoute, r),
                 AnyRoute::Html(r) => {
-                    server_config::apply_static_route::<SSL, html_bundle::Route>(
-                        any_server,
-                        app,
-                        r.this_ptr(),
-                        &entry.path,
-                        entry.method,
-                        path_has_user_head_route,
-                    );
-                    for_each_mux_app!(self, |mux| {
-                        server_config::apply_static_route_mux::<html_bundle::Route, _>(
-                            any_server,
-                            mux,
-                            r.this_ptr(),
-                            &entry.path,
-                            entry.method,
-                            path_has_user_head_route,
-                        );
+                    apply!(html_bundle::Route, r);
+                    self.dev_server.with_mut(|dev| {
+                        if let Some(dev) = dev {
+                            bun_core::handle_oom(
+                                dev.html_router.put(&entry.path, r.this_ptr().into()),
+                            );
+                        }
                     });
-                    if let Some(dev) = dev_server {
-                        // SAFETY: `dev` is the live `*mut DevServer` snapshotted
-                        // from `self.dev_server` above; no other `&mut` to it
-                        // is live in this loop.
-                        bun_core::handle_oom(
-                            unsafe { &mut *dev }
-                                .html_router
-                                .put(&entry.path, r.this_ptr().into()),
-                        );
-                    }
                     needs_plugins = true;
                 }
                 AnyRoute::FrameworkRouter(_) => {}
@@ -2558,9 +2321,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         // --- 6. Initialize plugins if needed ---
-        if needs_plugins && self.plugins.is_none() {
-            // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine`
-            // (non-null for the server's lifetime); single-threaded JS context.
+        if needs_plugins && self.plugins.get().is_none() {
             // Cloning here (not `.take()`) so subsequent `Bun.serve()` calls in
             // the same process — and `DevServer`'s tailwind-hack probe of the
             // same field — still see the bunfig-configured plugin list.
@@ -2571,17 +2332,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 .as_ref()
             {
                 if !serve_plugins_config.is_empty() {
-                    self.plugins = Some(ServePlugins::init(serve_plugins_config.clone()));
+                    self.plugins
+                        .set(Some(ServePlugins::init(serve_plugins_config.clone())));
                 }
             }
         }
 
         // --- 7. Debug-mode specific routes ---
         if DEBUG {
-            app.get(
+            app.method_this(
+                http_method::Method::GET,
                 b"/bun:info",
-                Some(trampoline::on_bun_info_request::<SSL, DEBUG>),
-                self_ptr.cast(),
+                Self::on_bun_info_request,
+                this,
             );
         }
 
@@ -2591,14 +2354,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // --- 8. Handle DevServer routes & track "/*" coverage ---
         let mut has_dev_server_for_star_path = false;
-        if let Some(dev) = dev_server {
+        if has_dev_server {
             // dev.setRoutes might register its own "/*" HTTP handler
-            // SAFETY: `dev` is the live `*mut DevServer` snapshotted from
-            // `self.dev_server` above; `self_ptr` is the live server. The two
-            // allocations are disjoint so the `&mut` borrows do not alias.
-            has_dev_server_for_star_path = bun_core::handle_oom(
-                unsafe { &mut *dev }.set_routes::<SSL, DEBUG>(unsafe { &mut *self_ptr }),
-            );
+            has_dev_server_for_star_path = self.dev_server.with_mut(|dev| {
+                bun_core::handle_oom(
+                    dev.as_deref_mut()
+                        .expect("checked above")
+                        .set_routes::<SSL, DEBUG>(self),
+                )
+            });
             if has_dev_server_for_star_path {
                 // Assume dev server "/*" covers all methods if it exists
                 star_methods_covered_by_user = http_method::Set::all();
@@ -2608,20 +2372,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // Setup user websocket fallback route aka fetch function; if fetch is
         // not provided will respond with 403.
         if !has_any_ws_route_for_star_path {
-            if let Some(websocket) = websocket_ptr {
-                app.ws(
-                    b"/*",
-                    self_ptr.cast(),
-                    0, // id 0 means is a fallback route and ctx is the server
-                    ServerWebSocket::behavior::<Self, SSL>(&websocket.to_behavior()),
-                );
+            if let Some(behavior) = &ws_behavior {
+                // id 0 means is a fallback route and ctx is the server
+                app.ws_this::<Self, ServerWebSocket>(b"/*", this, 0, behavior);
             }
         }
 
         // --- 9. Consolidated "/*" HTTP fallback registration ---
-        let ud = self_ptr.cast::<c_void>();
-        let has_node_http = !self.config.on_node_http_request.is_empty();
-        let has_on_request = !self.config.on_request.is_empty();
         if star_methods_covered_by_user == http_method::Set::all() {
             // User/Static/Dev has already provided a "/*" handler for ALL methods.
             // No further global "/*" HTTP fallback needed.
@@ -2632,98 +2389,91 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // A "/*" route exists, but doesn't cover all methods. Apply the
             // global handler to the *remaining* methods for "/*".
             for method_to_cover in !star_methods_covered_by_user {
-                if has_node_http {
-                    app.method(
-                        method_to_cover,
-                        b"/*",
-                        Some(trampoline::on_node_http_request::<SSL, DEBUG>),
-                        ud,
-                    );
-                } else if has_on_request {
-                    app.method(
-                        method_to_cover,
-                        b"/*",
-                        Some(trampoline::on_request::<SSL, DEBUG>),
-                        ud,
-                    );
-                } else {
-                    app.method(
-                        method_to_cover,
-                        b"/*",
-                        Some(trampoline::on_404::<SSL, DEBUG>),
-                        ud,
-                    );
-                }
+                fallback_h1(app, Some(method_to_cover), b"/*");
             }
-        } else if has_node_http {
-            app.any(
-                b"/*",
-                Some(trampoline::on_node_http_request::<SSL, DEBUG>),
-                ud,
-            );
-        } else if has_on_request {
-            app.any(b"/*", Some(trampoline::on_request::<SSL, DEBUG>), ud);
         } else {
-            app.any(b"/*", Some(trampoline::on_404::<SSL, DEBUG>), ud);
+            fallback_h1(app, None, b"/*");
         }
 
         // H2/H3 fallback — same three-way as H1 above, but driven by user/static
         // "/*" coverage only (DevServer routes are not mirrored to H2/H3).
+        let mux_fallback = if has_on_request {
+            Self::on_mux_request
+        } else {
+            Self::on_mux_404
+        };
         for_each_mux_app!(self, |mux| {
             if mux_star_covered == http_method::Set::all() {
                 // user/static "/*" already covers every method
             } else if has_any_user_route_for_star_path || has_static_route_for_star_path {
                 for m in !mux_star_covered {
-                    if has_on_request {
-                        mux.method(m, b"/*", self_ptr, Self::on_mux_request);
-                    } else {
-                        mux.method(m, b"/*", self_ptr, Self::on_mux_404);
-                    }
+                    mux.method_this(m, b"/*", mux_fallback, this);
                 }
-            } else if has_on_request {
-                mux.any(b"/*", self_ptr, Self::on_mux_request);
             } else {
-                mux.any(b"/*", self_ptr, Self::on_mux_404);
+                mux.any_this(b"/*", mux_fallback, this);
             }
         });
 
         if should_add_chrome_devtools_json_route {
-            app.get(
+            app.method_this(
+                http_method::Method::GET,
                 CHROME_DEVTOOLS_ROUTE,
-                Some(trampoline::on_chrome_devtools_json_request::<SSL, DEBUG>),
-                ud,
+                Self::on_chrome_dev_tools_json_request,
+                this,
             );
         }
 
         // Idempotent, so re-running set_routes on reload() is fine.
-        if self.config.is_node_http_server {
+        if self.config().is_node_http_server {
             ffi::NodeHTTP_assignOnNodeJSCompat(SSL, std::ptr::from_mut(app).cast::<c_void>());
         }
 
         route_list_value
     }
 
-    // ─── listen ──────────────────────────────────────────────────────────────
-    /// `config.http2`: attach an HTTP/2 context to `app`. On failure the
-    /// server is `deinit()`ed with an exception pending and `false` returned.
-    fn attach_http2(this: *mut Self, app: *mut uws_sys::NewApp<SSL>) -> bool
+    fn on_404(_this: ThisPtr<Self>, _req: uws_sys::AnyRequest, resp: uws::AnyResponse) {
+        resp.write_status(b"404 Not Found");
+        resp.end(b"", false);
+    }
+
+    /// Throw `msg` unless an exception (or a BoringSSL error) is already
+    /// pending, then tear the half-built server down. `listen()`'s failure tail.
+    #[cold]
+    fn fail_listen(
+        this: ThisPtr<Self>,
+        msg: core::fmt::Arguments<'_>,
+        check_ssl_error: bool,
+    ) -> JSValue {
+        let global = this.global_this();
+        if !global.has_exception() && !(check_ssl_error && throw_ssl_error_if_necessary(global)) {
+            let _ = global.throw(msg);
+        }
+        if let Some(r) = this.teardown() {
+            r.deref();
+        }
+        JSValue::ZERO
+    }
+
+    /// `config.http2`: attach an HTTP/2 context to `app`. On failure returns
+    /// the message for `fail_listen` (empty when an exception is already
+    /// pending).
+    fn attach_http2(&self) -> Result<(), core::fmt::Arguments<'static>>
     where
         Self: ServerPools<SSL, DEBUG>,
     {
-        // SAFETY: `this` is the live boxed server from `init()`; short-lived shared read.
-        let (http2, is_node_http, http1, idle_timeout, has_dev_server) = unsafe {
-            let cfg = &(*this).config;
+        let (http2, is_node_http, http1, idle_timeout) = {
+            let cfg = self.config();
             (
                 cfg.http2,
                 cfg.is_node_http_server || !cfg.on_node_http_request.is_empty(),
                 cfg.http1,
                 u32::from(cfg.idle_timeout),
-                (*this).dev_server.is_some(),
             )
         };
         if !http2 {
-            return true;
+            return Ok(());
         }
+        let has_dev_server = self.dev_server.get().is_some();
         // node:http compat servers and DevServer's HMR/asset routes are HTTP/1-only.
         if is_node_http || has_dev_server {
             let why = if has_dev_server {
@@ -2732,28 +2482,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 "for node:http servers"
             };
             if !http1 {
-                // SAFETY: `this` is live; `global_this()` borrows the STATIC global, not `*this`.
-                let global = unsafe { (*this).global_this() };
-                let _ = global.throw_invalid_arguments(format_args!(
+                let _ = self.global_this().throw_invalid_arguments(format_args!(
                     "http1: false with http2: true is not supported {why}"
                 ));
-                Self::deinit(this);
-                return false;
+                return Err(format_args!(""));
             }
             bun_core::warn!("http2: true is ignored {}", why);
-            return true;
+            return Ok(());
         }
-        // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-        let Some(h2) =
-            uws_sys::h2::App::create::<SSL>(bun_opaque::opaque_deref_mut(app), http1, idle_timeout)
-        else {
-            // SAFETY: `this` is live; `global_this()` borrows the STATIC global, not `*this`.
-            let global = unsafe { (*this).global_this() };
-            if !global.has_exception() {
-                let _ = global.throw(format_args!("Failed to create HTTP/2 server"));
-            }
-            Self::deinit(this);
-            return false;
+        let app = self.app_mut().expect("created before attach_http2");
+        let Some(h2) = uws_sys::h2::OwnedApp::create::<SSL>(app, http1, idle_timeout) else {
+            return Err(format_args!("Failed to create HTTP/2 server"));
         };
         // Streams parked on socket backpressure by a JS-driven write get their
         // next drain pass from the event loop's deferred task queue (after the
@@ -2767,333 +2506,233 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             jsc::VirtualMachine::get()
                 .event_loop_ref()
                 .deferred_tasks
-                .post_task(core::ptr::NonNull::new(app), drain);
+                .post_task(NonNull::new(app), drain);
         }
-        bun_opaque::opaque_deref_mut(h2).on_schedule_drain(schedule_h2_drain, h2.cast::<c_void>());
-        // SAFETY: `this` is the live boxed server; uniquely owned here.
-        unsafe {
-            (*this).h2_app = Some(h2);
-            if (*this).mux_request_pool.is_null() {
-                (*this).mux_request_pool = <Self as ServerPools<SSL, DEBUG>>::mux_request_pool();
-            }
+        let h2_ptr = h2.as_ptr();
+        bun_opaque::opaque_deref_mut(h2_ptr).on_schedule_drain(schedule_h2_drain, h2_ptr.cast::<c_void>());
+        self.h2_app.set(Some(h2));
+        if self.mux_request_pool.get().is_none() {
+            self.mux_request_pool
+                .set(Some(<Self as ServerPools<SSL, DEBUG>>::mux_request_pool()));
         }
-        true
+        Ok(())
     }
 
+    // ─── listen ──────────────────────────────────────────────────────────────
     /// Create the uws `App<SSL>` (and optional H2/H3 apps), register routes via
-    /// `set_routes()`, and bind the listen socket. On any failure the server
-    /// is `deinit()`ed synchronously and `.zero` is returned with an exception
-    /// pending on `global_this`.
-    /// # Safety
-    /// `this` must point to the live heap-allocated `NewServer` returned by
-    /// [`Self::init`], with no other `&`/`&mut` borrow live for the duration
-    /// of this call. On listen failure `this` is freed (via [`Self::deinit`])
-    /// and must not be used after a `JSValue::ZERO` return.
-    pub(crate) fn listen(this: *mut Self) -> JSValue
+    /// `set_routes()`, and bind the listen socket. On any failure the apps are
+    /// torn down synchronously and `.zero` is returned with an exception
+    /// pending on `global_this`; the caller still owns its ref.
+    pub(crate) fn listen(this: ThisPtr<Self>) -> JSValue
     where
         Self: ServerPools<SSL, DEBUG>,
     {
         httplog!("listen");
-        // reshaped for borrowck (PORTING.md §Forbidden — aliased
-        // `&mut`). No long-lived `&mut Self` is held across re-derives from
-        // `this`; each use site reborrows fresh and the borrow ends before the
-        // next derive. The serverName / SNI loop extracts raw `(ptr, len)` so
-        // no `&self.config` outlives the per-domain `set_routes()` call.
-        //
-        // SAFETY (applies to every `&mut *this` below): `this` was produced by
-        // `init()` and is live for this call; only one reference derived from
-        // it is alive at a time. Read-only access goes through `this_ref`
-        // (`BackRef<Self>`) — each `Deref` materialises a fresh short-lived
-        // `&Self` from the same raw provenance, so the listen-trampoline /
-        // `set_routes()` `&mut *this` re-derives never overlap an outstanding
-        // shared borrow.
-        let this_ref = bun_ptr::BackRef::from(
-            core::ptr::NonNull::new(this).expect("listen: this non-null (from init())"),
-        );
+        // `set_routes()` and the listen callbacks mutate `config` through its
+        // `JsCell`, so nothing below holds a `&ServerConfig` across them: each
+        // read re-derives, and names/addresses are copied out first.
+        let server = this.get();
+        let global = server.global_this();
 
-        // `global_this()` returns a borrow of the separate STATIC allocation,
-        // not `*this`.
-        let global = this_ref.global_this();
-
-        if let server_config::Address::Tcp {
-            hostname: Some(hostname),
-            ..
-        } = &this_ref.config.address
-        {
-            let hostname = hostname.as_bytes();
-            if !bun_dns::is_valid_hostname(strip_ipv6_brackets(hostname)) {
-                let _ = global.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(
-                    global, hostname,
-                ));
-                // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                Self::deinit(this);
-                return JSValue::ZERO;
+        let bad_hostname: Option<Vec<u8>> = match &server.config().address {
+            server_config::Address::Tcp {
+                hostname: Some(hostname),
+                ..
+            } if !bun_dns::is_valid_hostname(strip_ipv6_brackets(hostname.as_bytes())) => {
+                Some(hostname.as_bytes().to_vec())
             }
+            _ => None,
+        };
+        if let Some(hostname) = bad_hostname {
+            let _ = global.throw_value(crate::dns_jsc::cares_jsc::not_a_hostname_error(
+                global, &hostname,
+            ));
+            return Self::fail_listen(this, format_args!(""), false);
         }
 
-        let app: *mut uws_sys::NewApp<SSL>;
         let route_list_value;
 
         if SSL {
             bun_boringssl::load();
-            let Some(ssl_options) = this_ref.config.ssl_config.as_ref().map(|c| c.as_usockets())
+            let Some(ssl_options) = server.config().ssl_config.as_ref().map(|c| c.as_usockets())
             else {
                 // unreachable in practice — fromJS guarantees ssl_config when SSL.
-                let _ = global.throw(format_args!(
-                    "Failed to create HTTPS server: missing tls config"
-                ));
-                // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                Self::deinit(this);
-                return JSValue::ZERO;
+                return Self::fail_listen(
+                    this,
+                    format_args!("Failed to create HTTPS server: missing tls config"),
+                    false,
+                );
             };
 
-            app = match uws_sys::NewApp::<SSL>::create(&ssl_options) {
-                Some(a) => a,
-                None => {
-                    if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
-                        let _ = global.throw(format_args!("Failed to create HTTP server"));
-                    }
-                    // SAFETY: `this` is the live boxed server from `init()`; no other borrow is live.
-                    unsafe { (*this).app = None };
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
-                }
+            let Some(app) = uws_sys::app::OwnedApp::<SSL>::create(&ssl_options) else {
+                return Self::fail_listen(this, format_args!("Failed to create HTTP server"), true);
             };
-            // SAFETY: `this` is the live boxed server from `init()`; no other borrow is live.
-            unsafe { (*this).app = Some(app) };
+            server.app.set(Some(app));
+            server.self_ref.set(Some(RefPtr::from_this(this)));
 
-            if Self::HAS_H3 && this_ref.config.http3 {
-                let idle_timeout = this_ref.config.idle_timeout as u32;
-                let h3 = match uws_sys::h3::App::create(&ssl_options, idle_timeout) {
-                    Some(a) => Some(a),
-                    None => {
-                        if !global.has_exception() {
-                            let _ = global.throw(format_args!("Failed to create HTTP/3 server"));
-                        }
-                        // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                        Self::deinit(this);
-                        return JSValue::ZERO;
-                    }
+            if Self::HAS_H3 && server.config().http3 {
+                let idle_timeout = server.config().idle_timeout as u32;
+                let Some(h3) = uws_sys::h3::OwnedApp::create(&ssl_options, idle_timeout) else {
+                    return Self::fail_listen(
+                        this,
+                        format_args!("Failed to create HTTP/3 server"),
+                        false,
+                    );
                 };
-                // SAFETY: `this` is the live boxed server; uniquely owned here.
-                unsafe {
-                    (*this).h3_app = h3;
-                    (*this).mux_request_pool =
-                        <Self as ServerPools<SSL, DEBUG>>::mux_request_pool();
-                }
+                server.h3_app.set(Some(h3));
+                server
+                    .mux_request_pool
+                    .set(Some(<Self as ServerPools<SSL, DEBUG>>::mux_request_pool()));
             }
-            if !Self::attach_http2(this, app) {
-                return JSValue::ZERO;
+            if let Err(msg) = server.attach_http2() {
+                return Self::fail_listen(this, msg, false);
             }
 
-            // SAFETY: `this` is the live boxed server from `init()`; no other
-            // borrow is live — `&mut` scoped to this call.
-            route_list_value = unsafe { (*this).set_routes() };
+            route_list_value = server.set_routes();
+            let app = server.app_mut().expect("just created");
 
             // add serverName to the SSL context using the default ssl options
-            // extract raw (ptr, len) so no `&self.config` borrow
-            // outlives the `set_routes()` call below. set_routes() does not
-            // touch `config.ssl_config`, so the bytes remain valid.
-            let server_name_raw = this_ref
-                .config
+            let server_name: Option<std::ffi::CString> = server
+                .config()
                 .ssl_config
                 .as_ref()
                 .and_then(|c| c.server_name_cstr())
                 .filter(|n| !n.to_bytes().is_empty())
-                .map(|n| (n.as_ptr(), n.to_bytes().len()));
-            if let Some((name_ptr, name_len)) = server_name_raw {
-                // SAFETY: name_ptr/name_len were just extracted from the live
-                // `config.ssl_config.server_name` CString; valid + NUL-terminated.
-                let server_name = unsafe { bun_core::ffi::cstr(name_ptr) };
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                if bun_opaque::opaque_deref_mut(app)
+                .map(core::ffi::CStr::to_owned);
+            if let Some(server_name) = server_name.as_deref() {
+                if app
                     .add_server_name_with_options(server_name, &ssl_options, false)
                     .is_err()
                 {
-                    if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
-                        let _ = global.throw(format_args!(
+                    return Self::fail_listen(
+                        this,
+                        format_args!(
                             "Failed to add serverName: {}",
                             bstr::BStr::new(server_name.to_bytes())
-                        ));
-                    }
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
+                        ),
+                        true,
+                    );
                 }
                 if throw_ssl_error_if_necessary(global) {
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
+                    return Self::fail_listen(this, format_args!(""), false);
                 }
 
-                // SAFETY: server_name is a CStr; ZStr::from_raw upholds the NUL invariant.
-                let z = unsafe { bun_core::ZStr::from_raw(name_ptr.cast(), name_len) };
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).domain(z);
+                app.domain(bun_core::ZStr::from_cstr(server_name));
                 if throw_ssl_error_if_necessary(global) {
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
+                    return Self::fail_listen(this, format_args!(""), false);
                 }
 
                 // Ensure routes are set for that domain name.
-                // SAFETY: `this` is the live boxed server from `init()`; no
-                // other borrow is live — `&mut` scoped to this call.
-                let _ = unsafe { (*this).set_routes() };
+                let _ = server.set_routes();
             }
 
             // SNI: per-hostname contexts
-            // iterate by index and reborrow `&*this` per iteration so
-            // the `set_routes()` `&mut` at the bottom of the loop body never
-            // overlaps an outstanding `&self.config.sni` borrow.
-            let sni_len = this_ref.config.sni.as_ref().map_or(0, |s| s.slice().len());
+            let sni_len = server.config().sni.as_ref().map_or(0, |s| s.slice().len());
             for i in 0..sni_len {
-                let (name_ptr, name_len, sni_opts) = {
-                    let cfg = this_ref.get();
-                    let sni_ssl_config = &cfg.config.sni.as_ref().unwrap().slice()[i];
-                    let Some(sni_name) = sni_ssl_config.server_name_cstr() else {
-                        continue;
-                    };
-                    if sni_name.to_bytes().is_empty() {
-                        continue;
-                    }
-                    (
-                        sni_name.as_ptr(),
-                        sni_name.to_bytes().len(),
-                        sni_ssl_config.as_usockets(),
-                    )
+                let named = {
+                    let sni = server.config().sni.as_ref().expect("counted above");
+                    let sni_ssl_config = &sni.slice()[i];
+                    sni_ssl_config
+                        .server_name_cstr()
+                        .filter(|n| !n.to_bytes().is_empty())
+                        .map(|n| (n.to_owned(), sni_ssl_config.as_usockets()))
                 };
-                // SAFETY: name_ptr/name_len point into config.sni[i].server_name;
-                // set_routes() does not mutate config.sni so the bytes are valid.
-                let sni_name = unsafe { bun_core::ffi::cstr(name_ptr) };
-                // SAFETY: sni_name is a CStr; NUL invariant holds for ZStr.
-                let z = unsafe { bun_core::ZStr::from_raw(name_ptr.cast(), name_len) };
+                let Some((sni_name, sni_opts)) = named else {
+                    continue;
+                };
+                let z = bun_core::ZStr::from_cstr(&sni_name);
 
-                if Self::HAS_H3 {
-                    if let Some(h3_app) = this_ref.h3_app {
-                        // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
-                        if bun_opaque::opaque_deref_mut(h3_app)
-                            .add_server_name_with_options(z, &sni_opts)
-                            .is_err()
-                        {
-                            if !global.has_exception() {
-                                let _ = global.throw(format_args!(
-                                    "Failed to add serverName \"{}\" for HTTP/3",
-                                    bstr::BStr::new(sni_name.to_bytes())
-                                ));
-                            }
-                            // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                            Self::deinit(this);
-                            return JSValue::ZERO;
-                        }
+                if let Some(h3_app) = server.h3_app_mut() {
+                    if h3_app.add_server_name_with_options(z, &sni_opts).is_err() {
+                        return Self::fail_listen(
+                            this,
+                            format_args!(
+                                "Failed to add serverName \"{}\" for HTTP/3",
+                                bstr::BStr::new(sni_name.to_bytes())
+                            ),
+                            false,
+                        );
                     }
                 }
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                if bun_opaque::opaque_deref_mut(app)
-                    .add_server_name_with_options(sni_name, &sni_opts, true)
+                if app
+                    .add_server_name_with_options(&sni_name, &sni_opts, true)
                     .is_err()
                 {
-                    if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
-                        let _ = global.throw(format_args!(
+                    return Self::fail_listen(
+                        this,
+                        format_args!(
                             "Failed to add serverName: {}",
                             bstr::BStr::new(sni_name.to_bytes())
-                        ));
-                    }
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
+                        ),
+                        true,
+                    );
                 }
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).domain(z);
+                app.domain(z);
                 if throw_ssl_error_if_necessary(global) {
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
+                    return Self::fail_listen(this, format_args!(""), false);
                 }
-                // SAFETY: `this` is the live boxed server from `init()`; no
-                // other borrow is live — `&mut` scoped to this call.
-                let _ = unsafe { (*this).set_routes() };
+                let _ = server.set_routes();
             }
         } else {
-            app = match uws_sys::NewApp::<SSL>::create(&uws_sys::BunSocketContextOptions::default())
-            {
-                Some(a) => a,
-                None => {
-                    if !global.has_exception() {
-                        let _ = global.throw(format_args!("Failed to create HTTP server"));
-                    }
-                    // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
-                    return JSValue::ZERO;
-                }
+            let Some(app) =
+                uws_sys::app::OwnedApp::<SSL>::create(&uws_sys::BunSocketContextOptions::default())
+            else {
+                return Self::fail_listen(
+                    this,
+                    format_args!("Failed to create HTTP server"),
+                    false,
+                );
             };
-            // SAFETY: `this` is the live boxed server from `init()`; no other borrow is live.
-            unsafe { (*this).app = Some(app) };
-            if !Self::attach_http2(this, app) {
-                return JSValue::ZERO;
+            server.app.set(Some(app));
+            server.self_ref.set(Some(RefPtr::from_this(this)));
+            if let Err(msg) = server.attach_http2() {
+                return Self::fail_listen(this, msg, false);
             }
-            // SAFETY: `this` is the live boxed server from `init()`; no other
-            // borrow is live — `&mut` scoped to this call.
-            route_list_value = unsafe { (*this).set_routes() };
+            route_list_value = server.set_routes();
         }
 
-        // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-        bun_opaque::opaque_deref_mut(app).filter(Self::on_connection_filter, this.cast::<c_void>());
+        let app = server.app_mut().expect("just created");
+        app.filter_this(Self::on_connection_filter, this);
 
-        if this_ref.config.is_node_http_server {
-            // SAFETY: `this` is the live boxed server from `init()`; no other
-            // borrow is live — `&mut` scoped to this call.
-            unsafe { (*this).set_using_custom_expect_handler(true) };
+        if server.config().is_node_http_server {
+            server.set_using_custom_expect_handler(true);
         }
 
-        // the listen_* trampolines re-derive `&mut *this` synchronously
-        // inside the C callback (writing `self.listener` / `self.h3_listener`).
-        // Under Stacked Borrows, holding any `&*this` / `&mut *this` across a
-        // listen call would have its tag popped by that re-derive and become UB
-        // on the next access. So: hoist every config read into a local via a
-        // short-lived `&*this` BEFORE the call, drop the borrow, call listen,
-        // then re-derive fresh for each post-listen field access.
-
-        // Owns the bracket-stripped copy of an IPv6 literal hostname; `host`
-        // points into it, so it has to outlive the listen calls below.
-        let mut stripped_hostname: Option<bun_core::ZBox> = None;
-        // Extract (discriminant, raw payload) and drop the `&*this` borrow at `;`.
-        // The raw pointers reference `config.address`'s backing storage,
-        // which the trampolines never touch (they only write `listener`/
-        // `h3_listener`), so the bytes remain valid through the listen calls.
+        // Copy the address out of `config`: the listen callbacks run
+        // synchronously inside the calls below.
         enum Addr {
-            Tcp { port: u16, host: *const c_char },
-            Unix { ptr: *const u8, len: usize },
+            Tcp {
+                port: u16,
+                host: Option<bun_core::ZBox>,
+            },
+            Unix(bun_core::ZBox),
         }
         let (addr, tcp, options) = {
-            let cfg = &this_ref.get().config;
-            let addr = match &cfg.address {
-                server_config::Address::Tcp { port, hostname } => {
-                    let mut host: *const c_char = core::ptr::null();
-                    if let Some(existing) = hostname.as_deref() {
+            let config = server.config();
+            let addr = match &config.address {
+                server_config::Address::Tcp { port, hostname } => Addr::Tcp {
+                    port: *port,
+                    host: hostname.as_deref().map(|existing| {
                         let bytes = existing.as_bytes();
                         let bare = strip_ipv6_brackets(bytes);
-                        host = if bare.len() == bytes.len() {
-                            existing.as_ptr()
+                        if bare.len() == bytes.len() {
+                            bun_core::ZBox::from_bytes(bytes)
                         } else {
-                            stripped_hostname
-                                .insert(bun_core::ZBox::from_bytes(bare))
-                                .as_ptr()
-                        };
-                    }
-                    Addr::Tcp { port: *port, host }
-                }
-                server_config::Address::Unix(unix) => Addr::Unix {
-                    ptr: unix.as_ptr().cast(),
-                    len: unix.as_bytes().len(),
+                            bun_core::ZBox::from_bytes(bare)
+                        }
+                    }),
                 },
+                server_config::Address::Unix(unix) => {
+                    Addr::Unix(bun_core::ZBox::from_bytes(unix.as_bytes()))
+                }
             };
-            (addr, cfg.http1 || cfg.http2, cfg.get_usockets_options())
+            (addr, config.http1 || config.http2, config.get_usockets_options())
         };
 
-        match addr {
+        match &addr {
             Addr::Tcp { port, host } => {
+                let port = *port;
+                let host: *const c_char = host.as_ref().map_or(core::ptr::null(), |h| h.as_ptr());
                 // With `{port: 0, http3: true}` we bind TCP:0 (kernel picks N),
                 // then must bind UDP:N for QUIC so Alt-Svc works. UDP:N may
                 // already be held by an unrelated process. When the user asked
@@ -3109,115 +2748,83 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 loop {
                     attempt += 1;
                     if tcp {
-                        // SAFETY: app is a live uws handle owned by this server. No
-                        // `&*this` is live across this call; the trampoline's
-                        // `&mut *this` is the sole borrow while it runs.
-                        unsafe {
-                            (*app).listen_with_config(
-                                Some(trampoline::on_listen::<SSL, DEBUG>),
-                                this.cast::<c_void>(),
-                                uws_app_c::uws_app_listen_config_t {
-                                    port: port as c_int,
-                                    host,
-                                    options,
-                                },
-                            );
-                        }
+                        app.listen_with_config_this(
+                            |s: ThisPtr<Self>, socket| s.on_listen(socket),
+                            this,
+                            uws_app_c::uws_app_listen_config_t {
+                                port: port as c_int,
+                                host,
+                                options,
+                            },
+                        );
                     }
 
-                    if Self::HAS_H3 {
-                        // Re-derive: `listener` was just written by `on_listen`.
-                        if let Some(h3_app) = this_ref.h3_app {
-                            // Same UDP port as the TCP listener so Alt-Svc works.
-                            let h3_port: u16 = match this_ref.listener {
-                                // SAFETY: ls is a live uws ListenSocket FFI handle
-                                // (just set by on_listen).
-                                Some(ls) => bun_opaque::opaque_deref_mut(ls)
-                                    .get_local_port()
-                                    .unwrap_or(port),
-                                None => port,
-                            };
-                            // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
-                            // No `&*this` is live across this call; the h3
-                            // trampoline's `&mut *this` is the sole borrow while it
-                            // runs (the closure is capture-less).
-                            bun_opaque::opaque_deref_mut(h3_app).listen_with_config(
-                                this,
-                                |s: &mut Self, ls: Option<&mut uws_sys::h3::ListenSocket>| {
-                                    s.on_h3_listen(ls.map(std::ptr::from_mut));
-                                },
-                                &uws_sys::h3::ListenConfig {
-                                    port: h3_port,
-                                    host,
-                                    options,
-                                },
-                            );
-                            // Re-derive: `h3_listener` was just written by `on_h3_listen`.
-                            if this_ref.h3_listener.is_none() {
-                                if attempt < max_attempts {
-                                    // UDP:N is taken — release TCP:N so the next
-                                    // attempt gets a fresh kernel-chosen port.
-                                    // Only retry if TCP actually succeeded.
-                                    // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
-                                    if let Some(ls) = unsafe { (*this).listener.take() } {
-                                        bun_opaque::opaque_deref_mut(ls).close();
-                                        continue;
-                                    }
-                                }
-                                if !global.has_exception() {
-                                    let _ = global.throw(format_args!(
-                                        "Failed to listen on UDP port {h3_port} for HTTP/3"
-                                    ));
-                                    // post-match `has_exception()` check below handles
-                                    // deinit + return ZERO.
+                    if let Some(h3_app) = server.h3_app_mut() {
+                        // Same UDP port as the TCP listener so Alt-Svc works.
+                        let h3_port: u16 = match server.listener_mut() {
+                            Some(ls) => ls.get_local_port().unwrap_or(port),
+                            None => port,
+                        };
+                        h3_app.listen_with_config_this(
+                            this,
+                            |s: ThisPtr<Self>, ls| s.on_h3_listen(ls),
+                            &uws_sys::h3::ListenConfig {
+                                port: h3_port,
+                                host,
+                                options,
+                            },
+                        );
+                        if server.h3_listener.get().is_none() {
+                            if attempt < max_attempts {
+                                // UDP:N is taken — release TCP:N so the next
+                                // attempt gets a fresh kernel-chosen port.
+                                // Only retry if TCP actually succeeded.
+                                if let Some(ls) = server.listener.take() {
+                                    bun_opaque::opaque_deref_mut(ls.as_ptr()).close();
+                                    continue;
                                 }
                             }
-                            if !tcp {
-                                // SAFETY: per-thread VM singleton; no aliasing `&mut`.
-                                jsc::VirtualMachine::get().as_mut().event_loop_handle =
-                                    Some(bun_io::Loop::get());
+                            if !global.has_exception() {
+                                let _ = global.throw(format_args!(
+                                    "Failed to listen on UDP port {h3_port} for HTTP/3"
+                                ));
+                                // post-match `has_exception()` check below handles
+                                // teardown + return ZERO.
                             }
+                        }
+                        if !tcp {
+                            jsc::VirtualMachine::get().as_mut().event_loop_handle =
+                                Some(bun_io::Loop::get());
                         }
                     }
                     break;
                 }
             }
-            Addr::Unix { ptr, len } => {
-                if Self::HAS_H3 {
-                    // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
-                    if let Some(h3a) = unsafe { (*this).h3_app.take() } {
-                        // QUIC over AF_UNIX is non-standard and Alt-Svc can't
-                        // advertise it; drop the H3 listener instead of wiring
-                        // an exotic transport nobody can reach.
-                        bun_core::warn!("http3: true with a unix socket — HTTP/3 listener skipped");
-                        // SAFETY: h3a is a live H3::App handle just taken from self.h3_app.
-                        unsafe { uws_sys::h3::App::destroy(h3a) };
-                    }
+            Addr::Unix(unix) => {
+                if let Some(h3a) = server.h3_app.replace(None) {
+                    // QUIC over AF_UNIX is non-standard and Alt-Svc can't
+                    // advertise it; drop the H3 listener instead of wiring
+                    // an exotic transport nobody can reach.
+                    bun_core::warn!("http3: true with a unix socket — HTTP/3 listener skipped");
+                    drop(h3a);
                 }
-                // SAFETY: ptr/len reference `config.address`'s ZBox; NUL
-                // sentinel at `ptr[len]` holds for ZStr::from_raw.
-                let z = unsafe { bun_core::ZStr::from_raw(ptr, len) };
-                // SAFETY: app is a live uws handle owned by this server. No
-                // `&*this` is live across this call.
-                unsafe {
-                    (*app).listen_on_unix_socket(
-                        trampoline::on_listen_unix::<SSL, DEBUG>,
-                        this.cast::<c_void>(),
-                        z,
-                        options,
-                    );
-                }
+                app.listen_on_unix_socket_this(
+                    |s: ThisPtr<Self>, socket| s.on_listen(socket),
+                    this,
+                    unix.as_zstr(),
+                    options,
+                );
             }
         }
 
         if global.has_exception() {
-            // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-            Self::deinit(this);
+            if let Some(r) = this.teardown() {
+                r.deref();
+            }
             return JSValue::ZERO;
         }
 
-        // SAFETY: `this` is the live boxed server from `init()`; no other borrow is live.
-        unsafe { &mut *this }.ref_();
+        server.ref_event_loop();
 
         // NOTE: the "starting an HTTP server is a good time to GC" nudge runs
         // from the caller (`serve_with!` in BunObject.rs) after the handler
@@ -3241,6 +2848,31 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         } else {
             vm.event_loop_ref().perform_gc();
         }
+    }
+}
+
+/// The queued second half of `schedule_deinit` (holds its own ref).
+struct DeinitTask<const SSL: bool, const DEBUG: bool>(RefPtr<NewServer<SSL, DEBUG>>);
+
+impl<const SSL: bool, const DEBUG: bool> bun_event_loop::ManagedTask::RunOnce
+    for DeinitTask<SSL, DEBUG>
+{
+    fn run(self) -> JsResult<()> {
+        if let Some(extra) = self.0.teardown() {
+            extra.deref();
+        }
+        self.0.deref();
+        Ok(())
+    }
+
+    /// The VM is going away without running us (nor, maybe, the `close` task
+    /// queued ahead of us): close and tear down all the same so the server and
+    /// its app do not outlive it.
+    fn cancelled(self) {
+        if let Some(app) = self.0.app_mut() {
+            app.close();
+        }
+        let _ = Self::run(self);
     }
 }
 
@@ -3326,203 +2958,98 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// [`wrap_handler_slot`]; called after `ptr_to_js` in `serve()` and after
     /// the websocket-context swap in `on_reload_from_zig`; dispatch keeps
     /// reading the shadow.
-    pub(crate) fn write_ws_handler_slots(&mut self, server_js: JSValue, global: &JSGlobalObject) {
+    pub(crate) fn write_ws_handler_slots(&self, server_js: JSValue, global: &JSGlobalObject) {
         // No websocket config: route a throwaway ZERO through each slot so a
         // transition to "no websocket" drops the previous roots. Redundant on
         // initial serve (slots default ZERO) — `serve()` gates this call on
         // `websocket.is_some()` — but the doc'd contract is "writes all slots
         // unconditionally" so a future call site can't leave stale roots behind.
-        let mut zeros = [JSValue::ZERO; 7];
-        let [open, message, close, drain, error, ping, pong] = match self.config.websocket.as_mut()
-        {
-            Some(ws) => {
-                let h = &mut ws.handler;
-                [
-                    &mut h.on_open,
-                    &mut h.on_message,
-                    &mut h.on_close,
-                    &mut h.on_drain,
-                    &mut h.on_error,
-                    &mut h.on_ping,
-                    &mut h.on_pong,
-                ]
-            }
-            None => zeros.each_mut(),
-        };
-        wrap_handler_slot(open, server_js, global, Self::js_gc_ws_on_open_set);
-        wrap_handler_slot(message, server_js, global, Self::js_gc_ws_on_message_set);
-        wrap_handler_slot(close, server_js, global, Self::js_gc_ws_on_close_set);
-        wrap_handler_slot(drain, server_js, global, Self::js_gc_ws_on_drain_set);
-        wrap_handler_slot(error, server_js, global, Self::js_gc_ws_on_error_set);
-        wrap_handler_slot(ping, server_js, global, Self::js_gc_ws_on_ping_set);
-        wrap_handler_slot(pong, server_js, global, Self::js_gc_ws_on_pong_set);
-    }
-}
-
-// ─── extern "C" trampolines ──────────────────────────────────────────────────
-// Monomorphized on the const-generic server params;
-// the bodies downcast `user_data` and forward into the typed method.
-mod trampoline {
-    use super::*;
-    use bun_uws_sys::{ListenSocket as UwsListenSocket, Request as UwsRequest, uws_res};
-
-    pub(super) extern "C" fn on_listen<const SSL: bool, const DEBUG: bool>(
-        socket: *mut UwsListenSocket,
-        user_data: *mut c_void,
-    ) {
-        // SAFETY: user_data is the `*mut NewServer<..>` passed to listen_with_config.
-        let server = unsafe { bun_ptr::callback_ctx::<NewServer<SSL, DEBUG>>(user_data) };
-        let socket = if socket.is_null() {
-            None
-        } else {
-            Some(socket.cast::<uws_sys::app::ListenSocket<SSL>>())
-        };
-        server.on_listen(socket);
+        self.config.with_mut(|config| {
+            let mut zeros = [JSValue::ZERO; 7];
+            let [open, message, close, drain, error, ping, pong] = match config.websocket.as_mut() {
+                Some(ws) => {
+                    let h = &mut ws.handler;
+                    [
+                        &mut h.on_open,
+                        &mut h.on_message,
+                        &mut h.on_close,
+                        &mut h.on_drain,
+                        &mut h.on_error,
+                        &mut h.on_ping,
+                        &mut h.on_pong,
+                    ]
+                }
+                None => zeros.each_mut(),
+            };
+            wrap_handler_slot(open, server_js, global, Self::js_gc_ws_on_open_set);
+            wrap_handler_slot(message, server_js, global, Self::js_gc_ws_on_message_set);
+            wrap_handler_slot(close, server_js, global, Self::js_gc_ws_on_close_set);
+            wrap_handler_slot(drain, server_js, global, Self::js_gc_ws_on_drain_set);
+            wrap_handler_slot(error, server_js, global, Self::js_gc_ws_on_error_set);
+            wrap_handler_slot(ping, server_js, global, Self::js_gc_ws_on_ping_set);
+            wrap_handler_slot(pong, server_js, global, Self::js_gc_ws_on_pong_set);
+        });
     }
 
-    pub(super) extern "C" fn on_listen_unix<const SSL: bool, const DEBUG: bool>(
-        socket: *mut UwsListenSocket,
-        _domain: *const c_char,
-        _flags: i32,
-        user_data: *mut c_void,
-    ) {
-        on_listen::<SSL, DEBUG>(socket, user_data);
-    }
-
-    pub(super) extern "C" fn on_404<const SSL: bool, const DEBUG: bool>(
-        res: *mut uws_res,
-        _req: *mut UwsRequest,
-        _user_data: *mut c_void,
-    ) {
-        // S008: `Response<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-        let resp = bun_opaque::opaque_deref_mut(res.cast::<uws_sys::NewAppResponse<SSL>>());
-        resp.write_status(b"404 Not Found");
-        resp.end(b"", false);
-    }
-
-    pub(super) extern "C" fn on_request<const SSL: bool, const DEBUG: bool>(
-        res: *mut uws_res,
-        req: *mut UwsRequest,
-        user_data: *mut c_void,
-    ) {
-        // user_data is the `*mut NewServer<..>` registered in set_routes.
-        // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-        NewServer::<SSL, DEBUG>::on_request(
-            user_data.cast(),
-            bun_opaque::opaque_deref_mut(req),
-            res.cast(),
-        );
-    }
-
-    pub(super) extern "C" fn on_user_route_request<const SSL: bool, const DEBUG: bool>(
-        res: *mut uws_res,
-        req: *mut UwsRequest,
-        user_data: *mut c_void,
-    ) {
-        // user_data is the `*mut UserRoute<..>` registered in set_routes.
-        // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-        NewServer::<SSL, DEBUG>::on_user_route_request(
-            user_data.cast::<UserRoute<SSL, DEBUG>>(),
-            bun_opaque::opaque_deref_mut(req),
-            res.cast(),
-        );
-    }
-
-    pub(super) extern "C" fn on_node_http_request<const SSL: bool, const DEBUG: bool>(
-        res: *mut uws_res,
-        req: *mut UwsRequest,
-        user_data: *mut c_void,
-    ) {
-        // user_data is the `*mut NewServer<..>` registered in set_routes.
-        // S008: `Request` / `Response<SSL>` are ZST opaques — safe deref.
-        NewServer::<SSL, DEBUG>::on_node_http_request(
-            user_data.cast(),
-            bun_opaque::opaque_deref_mut(req),
-            bun_opaque::opaque_deref_mut(res.cast::<uws_sys::NewAppResponse<SSL>>()),
-        );
-    }
-
-    pub(super) extern "C" fn on_bun_info_request<const SSL: bool, const DEBUG: bool>(
-        res: *mut uws_res,
-        req: *mut UwsRequest,
-        user_data: *mut c_void,
-    ) {
-        // SAFETY: user_data is the `*mut NewServer<..>` registered in set_routes.
-        // S008: `Request` / `Response<SSL>` are ZST opaques — safe deref.
-        unsafe {
-            (*user_data.cast::<NewServer<SSL, DEBUG>>()).on_bun_info_request(
-                bun_opaque::opaque_deref_mut(req),
-                bun_opaque::opaque_deref_mut(res.cast::<uws_sys::NewAppResponse<SSL>>()),
-            )
-        };
-    }
-
-    pub(super) extern "C" fn on_chrome_devtools_json_request<const SSL: bool, const DEBUG: bool>(
-        res: *mut uws_res,
-        req: *mut UwsRequest,
-        user_data: *mut c_void,
-    ) {
-        // SAFETY: user_data is the `*mut NewServer<..>` registered in set_routes.
-        // S008: `Request` / `Response<SSL>` are ZST opaques — safe deref.
-        unsafe {
-            (*user_data.cast::<NewServer<SSL, DEBUG>>()).on_chrome_dev_tools_json_request(
-                bun_opaque::opaque_deref_mut(req),
-                bun_opaque::opaque_deref_mut(res.cast::<uws_sys::NewAppResponse<SSL>>()),
-            )
-        };
+    /// [`wrap_handler_slot`] for the three request-handler shadows in `config`.
+    pub(crate) fn write_request_handler_slots(&self, server_js: JSValue, global: &JSGlobalObject) {
+        self.config.with_mut(|config| {
+            wrap_handler_slot(
+                &mut config.on_request,
+                server_js,
+                global,
+                Self::js_gc_on_request_set,
+            );
+            wrap_handler_slot(
+                &mut config.on_error,
+                server_js,
+                global,
+                Self::js_gc_on_error_set,
+            );
+            wrap_handler_slot(
+                &mut config.on_node_http_request,
+                server_js,
+                global,
+                Self::js_gc_on_node_http_request_set,
+            );
+        });
     }
 }
 
 // ─── per-monomorphization request pools ──────────────────────────────────────
 // Rust generics cannot own statics, so
 // declare one `thread_local!` per concrete (SSL, DEBUG, H3) combo via macro and
-// hand the leaked pointer back through a trait.
+// hand the leaked pool back through a trait.
 //
 // THREAD-SAFETY: this MUST be thread-local, not process-global. `hive_array::
-// Fallback::{get,put,claim}` take `&mut self` with no internal synchronization;
-// a process-static would race when two `Bun.serve` instances run on distinct
-// Worker threads (each Worker has its own event loop and may host a server).
-pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
-    fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
+// Fallback` has no internal synchronization; a process-static would race when
+// two `Bun.serve` instances run on distinct Worker threads (each Worker has
+// its own event loop and may host a server).
+pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized + 'static {
+    fn request_pool()
+    -> &'static request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
     fn mux_request_pool()
-    -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>;
+    -> &'static request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>;
 }
 
 macro_rules! impl_server_pools {
     ($(($ssl:literal, $debug:literal)),* $(,)?) => {$(
         impl ServerPools<$ssl, $debug> for NewServer<$ssl, $debug> {
-            fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, false> {
+            fn request_pool() -> &'static request_context::RequestContextStackAllocator<Self, $ssl, $debug, false> {
                 type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, false>;
                 thread_local! {
-                    static POOL: core::cell::Cell<*mut Pool> =
-                        const { core::cell::Cell::new(core::ptr::null_mut()) };
+                    // `new_boxed` writes only the 256 B bitset in place
+                    // (the ~816 KB slot buffer stays uninitialized).
+                    static POOL: &'static Pool = Box::leak(Pool::new_boxed());
                 }
-                POOL.with(|cell| {
-                    let mut p = cell.get();
-                    if p.is_null() {
-                        // `Box::new(Pool::init())` builds the ~816 KB pool on
-                        // the stack and `memcpy`s it into the heap (no NRVO);
-                        // `new_boxed` writes only the 256 B bitset in place.
-                        p = Pool::new_boxed().as_ptr();
-                        cell.set(p);
-                    }
-                    p
-                })
+                POOL.with(|p| *p)
             }
-            fn mux_request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, true> {
+            fn mux_request_pool() -> &'static request_context::RequestContextStackAllocator<Self, $ssl, $debug, true> {
                 type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, true>;
                 thread_local! {
-                    static POOL: core::cell::Cell<*mut Pool> =
-                        const { core::cell::Cell::new(core::ptr::null_mut()) };
+                    static POOL: &'static Pool = Box::leak(Pool::new_boxed());
                 }
-                POOL.with(|cell| {
-                    let mut p = cell.get();
-                    if p.is_null() {
-                        p = Pool::new_boxed().as_ptr();
-                        cell.set(p);
-                    }
-                    p
-                })
+                POOL.with(|p| *p)
             }
         }
     )*};
@@ -3532,11 +3059,6 @@ impl_server_pools!((false, false), (true, false), (false, true), (true, true));
 // ─── FFI ─────────────────────────────────────────────────────────────────────
 mod ffi {
     use super::*;
-    // `*mut *mut NodeHTTPResponse` is an out-param: C++ writes back the
-    // Rust-allocated pointer (via `NodeHTTPResponse__createForJS`) without ever
-    // dereferencing the struct itself. The ctypes lint fires because the struct
-    // has Rust-layout fields (Vec, Cell, …); irrelevant for an opaque handle.
-    #[allow(improper_ctypes)]
     unsafe extern "C" {
         // `app` is the opaque `uws::App<SSL>*`; C++ only flips a flag / assigns a
         // handler. Callers pass the live `self.app` handle, so no precondition.
@@ -3548,36 +3070,33 @@ mod ffi {
         pub(super) safe fn NodeHTTP_assignOnNodeJSCompat(ssl: bool, app: *mut c_void);
 
         /// `src/jsc/bindings/NodeHTTP.cpp` — constructs the JS
-        /// `IncomingMessage`/`ServerResponse` pair, allocates a
-        /// [`NodeHTTPResponse`] (returned via `node_response_ptr` with one ref
-        /// taken), and invokes `callback(req, res)`. The plain-HTTP and HTTPS
-        /// monomorphizations differ only in the `Response<SSL>` opaque type.
+        /// `IncomingMessage` argument list around the `NodeHTTPResponse` the
+        /// caller created and invokes `callback(req, res)`. The plain-HTTP and
+        /// HTTPS monomorphizations differ only in the `Response<SSL>` opaque type.
         ///
-        /// `&JSGlobalObject` / `&mut *mut _` discharge the deref'd-param
-        /// preconditions; `request`/`response`/`upgrade_ctx` are opaque uws
-        /// handles (module-private — sole caller passes live pointers).
+        /// `&JSGlobalObject`/`&mut uws_sys::Request` discharge the deref'd-param
+        /// preconditions; `response` is the opaque uws handle (module-private —
+        /// sole caller passes the live pointer).
         pub(super) safe fn NodeHTTPServer__onRequest_http(
-            any_server: usize,
             global: &jsc::JSGlobalObject,
             this_value: jsc::JSValue,
             callback: jsc::JSValue,
             method_string: jsc::JSValue,
-            request: *mut uws_sys::Request,
+            request: &mut uws_sys::Request,
             response: *mut c_void, // *uws.NewApp(false).Response
-            upgrade_ctx: *mut c_void,
-            node_response_ptr: &mut *mut NodeHTTPResponse,
+            node_response_object: jsc::JSValue,
+            has_body: bool,
         ) -> jsc::JSValue;
 
         pub(super) safe fn NodeHTTPServer__onRequest_https(
-            any_server: usize,
             global: &jsc::JSGlobalObject,
             this_value: jsc::JSValue,
             callback: jsc::JSValue,
             method_string: jsc::JSValue,
-            request: *mut uws_sys::Request,
+            request: &mut uws_sys::Request,
             response: *mut c_void, // *uws.NewApp(true).Response
-            upgrade_ctx: *mut c_void,
-            node_response_ptr: &mut *mut NodeHTTPResponse,
+            node_response_object: jsc::JSValue,
+            has_body: bool,
         ) -> jsc::JSValue;
     }
 }
@@ -3611,16 +3130,11 @@ pub trait ServerLike {
     fn global_this(&self) -> &jsc::JSGlobalObject;
     fn vm(&self) -> &jsc::VirtualMachine;
     fn config(&self) -> &ServerConfig;
-    fn on_request_complete(&mut self);
+    fn on_request_complete(&self);
     fn dev_server(&self) -> Option<&crate::bake::DevServer::DevServer>;
     fn js_value(&self) -> &jsc::JsRef;
     fn h3_alt_svc(&self) -> Option<&[u8]>;
     fn terminated(&self) -> bool;
-    /// Return `ctx` to the per-server HiveArray pool for the matching transport.
-    /// Erased to `*mut c_void` so the trait stays object-safe and doesn't need
-    /// to name `RequestContext<Self, ..>` (which would re-introduce the
-    /// generic-parameter cycle this trait exists to break).
-    fn release_request_context(&self, ctx: *mut c_void, is_mux: bool);
 }
 
 impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
@@ -3639,19 +3153,19 @@ impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
     }
     #[inline(always)]
     fn config(&self) -> &ServerConfig {
-        &self.config
+        Self::config(self)
     }
     #[inline]
-    fn on_request_complete(&mut self) {
+    fn on_request_complete(&self) {
         Self::on_request_complete(self)
     }
     #[inline]
     fn dev_server(&self) -> Option<&crate::bake::DevServer::DevServer> {
-        self.dev_server.as_deref()
+        self.dev_server.get().as_deref()
     }
     #[inline(always)]
     fn js_value(&self) -> &jsc::JsRef {
-        &self.js_value
+        self.js_value.get()
     }
     #[inline]
     fn h3_alt_svc(&self) -> Option<&[u8]> {
@@ -3659,28 +3173,7 @@ impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
     }
     #[inline(always)]
     fn terminated(&self) -> bool {
-        self.flags.contains(ServerFlags::TERMINATED)
-    }
-    fn release_request_context(&self, ctx: *mut c_void, is_mux: bool) {
-        // SAFETY: ctx was allocated from this exact pool by `prepare_js_request_context`;
-        // it is `RequestContext<Self, SSL, DEBUG, is_mux>` by construction.
-        unsafe {
-            if is_mux {
-                (*self.mux_request_pool).put(&raw mut *ctx.cast::<request_context::RequestContext<
-                    Self,
-                    SSL,
-                    DEBUG,
-                    true,
-                >>());
-            } else {
-                (*self.request_pool).put(&raw mut *ctx.cast::<request_context::RequestContext<
-                    Self,
-                    SSL,
-                    DEBUG,
-                    false,
-                >>());
-            }
-        }
+        self.has_flags(ServerFlags::TERMINATED)
     }
 }
 
@@ -3691,12 +3184,6 @@ pub type DebugHTTPServer = NewServer<false, true>;
 pub type DebugHTTPSServer = NewServer<true, true>;
 
 // ─── AnyServer ───────────────────────────────────────────────────────────────
-// §Dispatch: the
-// `bun_ptr::impl_tagged_ptr_union!` macro would impl a foreign trait for a
-// foreign tuple type (orphan rule), so it can only be invoked from inside
-// `bun_ptr`. Per §Dispatch ("store `(tag: u8, ptr: *mut ())` as two fields"),
-// hand-roll the tag here. AnyServer is cold-path (per-request, not per-tick).
-// Two fields cost 16 bytes vs 8 for a packed tagged pointer; ~handful of instances.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AnyServerTag {
@@ -3706,113 +3193,47 @@ pub enum AnyServerTag {
     DebugHTTPSServer = 3,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AnyServer {
-    pub(crate) tag: AnyServerTag,
-    pub ptr: *mut (),
+/// Back-reference to one of the four `NewServer` monomorphizations. Held by
+/// the routes, request contexts, websockets and `NodeHTTPResponse`s a server
+/// creates — all of which it outlives (it is freed only once drained).
+#[derive(Clone, Copy)]
+pub enum AnyServer {
+    HTTPServer(bun_ptr::BackRef<HTTPServer>),
+    HTTPSServer(bun_ptr::BackRef<HTTPSServer>),
+    DebugHTTPServer(bun_ptr::BackRef<DebugHTTPServer>),
+    DebugHTTPSServer(bun_ptr::BackRef<DebugHTTPSServer>),
 }
 
-impl AnyServer {
-    // ─── tag-checked downcasts ───────────────────────────────────────────────
-    // Centralize the `unsafe { &*self.ptr.cast() }` pattern that the dispatch
-    // macro and `h3_alt_svc` open-coded. Each accessor debug-asserts the tag
-    // so a mismatched call trips in debug builds rather than silently aliasing
-    // the wrong monomorphization.
-    //
-    // No `&mut`-returning variants: dispatch-mut bodies re-enter JS
-    // (`on_request`, `get_or_load_plugins`, `stop`, …) which can observe the
-    // same server through another `AnyServer` handle, so a safe
-    // `fn(&self) -> &mut NewServer` accessor would invite overlapping `&mut`
-    // under Stacked Borrows. `any_server_dispatch_mut!` keeps its inline
-    // `unsafe` with the existing caller-upheld exclusivity contract.
-
-    #[inline(always)]
-    fn as_http(&self) -> &HTTPServer {
-        debug_assert!(matches!(self.tag, AnyServerTag::HTTPServer));
-        // SAFETY: `ptr` was produced by `AnyServer::from::<false, false>` and
-        // is non-null while the server is alive (heap-allocated `NewServer`,
-        // freed only after all `AnyServer` handles are dropped).
-        unsafe { &*self.ptr.cast::<HTTPServer>() }
+impl PartialEq for AnyServer {
+    fn eq(&self, other: &Self) -> bool {
+        core::ptr::eq(self.as_opaque_ptr(), other.as_opaque_ptr())
     }
-
-    #[inline(always)]
-    fn as_https(&self) -> &HTTPSServer {
-        debug_assert!(matches!(self.tag, AnyServerTag::HTTPSServer));
-        // SAFETY: tag-matched non-null `NewServer<true, false>`; see `as_http`.
-        unsafe { &*self.ptr.cast::<HTTPSServer>() }
-    }
-
-    #[inline(always)]
-    fn as_debug_http(&self) -> &DebugHTTPServer {
-        debug_assert!(matches!(self.tag, AnyServerTag::DebugHTTPServer));
-        // SAFETY: tag-matched non-null `NewServer<false, true>`; see `as_http`.
-        unsafe { &*self.ptr.cast::<DebugHTTPServer>() }
-    }
-
-    #[inline(always)]
-    fn as_debug_https(&self) -> &DebugHTTPSServer {
-        debug_assert!(matches!(self.tag, AnyServerTag::DebugHTTPSServer));
-        // SAFETY: tag-matched non-null `NewServer<true, true>`; see `as_http`.
-        unsafe { &*self.ptr.cast::<DebugHTTPSServer>() }
+}
+impl Eq for AnyServer {}
+impl core::hash::Hash for AnyServer {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_opaque_ptr().hash(state);
     }
 }
 
-/// Dispatch over the four `NewServer` monomorphizations (shared `&` borrow).
-/// Read-only accessors MUST use this form so holding the returned reference
-/// while calling another dispatch method does not materialize an aliasing
-/// `&mut NewServer` (Stacked-Borrows UB).
+/// Dispatch over the four `NewServer` monomorphizations (`$s: &NewServer<..>`).
 macro_rules! any_server_dispatch {
     ($self:expr, |$s:ident| $body:expr) => {{
-        let this = $self;
-        match this.tag {
-            AnyServerTag::HTTPServer => {
-                let $s = this.as_http();
+        match $self {
+            AnyServer::HTTPServer(s) => {
+                let $s: &$crate::server::HTTPServer = s.get();
                 $body
             }
-            AnyServerTag::HTTPSServer => {
-                let $s = this.as_https();
+            AnyServer::HTTPSServer(s) => {
+                let $s: &$crate::server::HTTPSServer = s.get();
                 $body
             }
-            AnyServerTag::DebugHTTPServer => {
-                let $s = this.as_debug_http();
+            AnyServer::DebugHTTPServer(s) => {
+                let $s: &$crate::server::DebugHTTPServer = s.get();
                 $body
             }
-            AnyServerTag::DebugHTTPSServer => {
-                let $s = this.as_debug_https();
-                $body
-            }
-        }
-    }};
-}
-
-/// Dispatch over the four `NewServer` monomorphizations (exclusive `&mut`
-/// borrow). Only for callers that mutate server state — never use this for
-/// read-only accessors (see `any_server_dispatch!`).
-macro_rules! any_server_dispatch_mut {
-    ($self:expr, |$s:ident| $body:expr) => {{
-        let this = $self;
-        // SAFETY: ptr was produced by `AnyServer::from` for the matching tag
-        // and is non-null while the server is alive. Caller upholds that no
-        // other reference into the same `NewServer` is live for this scope.
-        match this.tag {
-            AnyServerTag::HTTPServer => {
-                // SAFETY: tag == HTTPServer so `ptr` was created from a live `*mut HTTPServer`; caller holds exclusive access.
-                let $s = unsafe { &mut *this.ptr.cast::<HTTPServer>() };
-                $body
-            }
-            AnyServerTag::HTTPSServer => {
-                // SAFETY: tag == HTTPSServer so `ptr` was created from a live `*mut HTTPSServer`; caller holds exclusive access.
-                let $s = unsafe { &mut *this.ptr.cast::<HTTPSServer>() };
-                $body
-            }
-            AnyServerTag::DebugHTTPServer => {
-                // SAFETY: tag == DebugHTTPServer so `ptr` was created from a live `*mut DebugHTTPServer`; caller holds exclusive access.
-                let $s = unsafe { &mut *this.ptr.cast::<DebugHTTPServer>() };
-                $body
-            }
-            AnyServerTag::DebugHTTPSServer => {
-                // SAFETY: tag == DebugHTTPSServer so `ptr` was created from a live `*mut DebugHTTPSServer`; caller holds exclusive access.
-                let $s = unsafe { &mut *this.ptr.cast::<DebugHTTPSServer>() };
+            AnyServer::DebugHTTPSServer(s) => {
+                let $s: &$crate::server::DebugHTTPSServer = s.get();
                 $body
             }
         }
@@ -3822,36 +3243,30 @@ macro_rules! any_server_dispatch_mut {
 /// Dispatch over the four `NewServer` monomorphizations, simultaneously
 /// downcasting an [`uws::AnyResponse`] to the matching `*mut Response<SSL>`.
 ///
-/// Binds `$s: *mut NewServer<SSL, DEBUG>` (raw, NOT `&`/`&mut` — the target
-/// fns take `this: *mut Self` and may re-enter JS) and `$r: *mut
+/// Binds `$s: ThisPtr<NewServer<SSL, DEBUG>>` and `$r: *mut
 /// uws_sys::Response<SSL>`. Tag↔SSL invariant is enforced by
-/// `assert_ssl`/`assert_no_ssl` (panics on `AnyResponse::H3`, matching the
-/// hand-written arms this replaces). The body is monomorphized four times, so
-/// `NewServer::method($s, …, $r, …)` infers `<SSL, DEBUG>` from `$s`.
+/// `assert_ssl`/`assert_no_ssl` (panics on `AnyResponse::H3`).
 macro_rules! any_server_dispatch_resp {
     ($self:expr, $resp:expr, |$s:ident, $r:ident| $body:expr) => {{
-        let this = $self;
         let __resp = $resp;
-        // SAFETY: ptr was produced by `AnyServer::from` for the matching tag
-        // and is non-null while the server is alive.
-        match this.tag {
-            AnyServerTag::HTTPServer => {
-                let $s = this.ptr.cast::<HTTPServer>();
+        match $self {
+            AnyServer::HTTPServer(s) => {
+                let $s = s.get().this_ptr();
                 let $r = __resp.assert_no_ssl();
                 $body
             }
-            AnyServerTag::HTTPSServer => {
-                let $s = this.ptr.cast::<HTTPSServer>();
+            AnyServer::HTTPSServer(s) => {
+                let $s = s.get().this_ptr();
                 let $r = __resp.assert_ssl();
                 $body
             }
-            AnyServerTag::DebugHTTPServer => {
-                let $s = this.ptr.cast::<DebugHTTPServer>();
+            AnyServer::DebugHTTPServer(s) => {
+                let $s = s.get().this_ptr();
                 let $r = __resp.assert_no_ssl();
                 $body
             }
-            AnyServerTag::DebugHTTPSServer => {
-                let $s = this.ptr.cast::<DebugHTTPSServer>();
+            AnyServer::DebugHTTPSServer(s) => {
+                let $s = s.get().this_ptr();
                 let $r = __resp.assert_ssl();
                 $body
             }
@@ -3861,34 +3276,28 @@ macro_rules! any_server_dispatch_resp {
 
 impl AnyServer {
     pub(crate) fn from<const SSL: bool, const DEBUG: bool>(
-        server: *const NewServer<SSL, DEBUG>,
+        server: &NewServer<SSL, DEBUG>,
     ) -> AnyServer {
-        let tag = match (SSL, DEBUG) {
-            (false, false) => AnyServerTag::HTTPServer,
-            (true, false) => AnyServerTag::HTTPSServer,
-            (false, true) => AnyServerTag::DebugHTTPServer,
-            (true, true) => AnyServerTag::DebugHTTPSServer,
-        };
-        AnyServer {
-            tag,
-            ptr: server.cast::<()>().cast_mut(),
+        // `NewServer<SSL, DEBUG>` *is* the alias named in each arm; the cast
+        // only renames the const parameters rustc cannot unify syntactically.
+        let p = NonNull::from(server);
+        match (SSL, DEBUG) {
+            (false, false) => AnyServer::HTTPServer(p.cast::<HTTPServer>().into()),
+            (true, false) => AnyServer::HTTPSServer(p.cast::<HTTPSServer>().into()),
+            (false, true) => AnyServer::DebugHTTPServer(p.cast::<DebugHTTPServer>().into()),
+            (true, true) => AnyServer::DebugHTTPSServer(p.cast::<DebugHTTPSServer>().into()),
         }
     }
 
-    /// Re-pack into the tagged-pointer wire format
-    /// (`u49` ptr | `u15` tag) for the C++ FFI boundary. Inverse of
-    /// [`NodeHTTPResponse::any_server_from_packed`]. Tag values are
-    /// `1024 - index` in declaration order
-    /// (HTTP, HTTPS, DebugHTTP, DebugHTTPS).
-    pub(crate) fn to_packed(self) -> u64 {
-        let tag: u16 = match self.tag {
-            AnyServerTag::HTTPServer => 1024,
-            AnyServerTag::HTTPSServer => 1023,
-            AnyServerTag::DebugHTTPServer => 1022,
-            AnyServerTag::DebugHTTPSServer => 1021,
-        };
-        // `TaggedPtr::to()` bit-casts the full packed word through `*mut c_void`.
-        bun_ptr::TaggedPtr::init(self.ptr, tag).to() as u64
+    /// The server's address as an opaque token (inspector / hot-map keys).
+    #[inline]
+    pub(crate) fn as_opaque_ptr(&self) -> *mut () {
+        match self {
+            AnyServer::HTTPServer(s) => s.as_const_ptr().cast::<()>().cast_mut(),
+            AnyServer::HTTPSServer(s) => s.as_const_ptr().cast::<()>().cast_mut(),
+            AnyServer::DebugHTTPServer(s) => s.as_const_ptr().cast::<()>().cast_mut(),
+            AnyServer::DebugHTTPSServer(s) => s.as_const_ptr().cast::<()>().cast_mut(),
+        }
     }
 
     /// Shared borrow of the process-static VM. Routes through
@@ -3916,7 +3325,7 @@ impl AnyServer {
 
     #[inline]
     pub(crate) fn config(&self) -> &ServerConfig {
-        any_server_dispatch!(self, |s| &s.config)
+        any_server_dispatch!(self, |s| s.config())
     }
 
     /// Same gate as [`NewServer::js_value_for_dispatch`].
@@ -3926,15 +3335,15 @@ impl AnyServer {
     }
 
     pub(crate) fn h3_alt_svc(&self) -> Option<&[u8]> {
-        match self.tag {
-            AnyServerTag::HTTPSServer => self.as_https().h3_alt_svc(),
-            AnyServerTag::DebugHTTPSServer => self.as_debug_https().h3_alt_svc(),
+        match self {
+            AnyServer::HTTPSServer(s) => s.get().h3_alt_svc(),
+            AnyServer::DebugHTTPSServer(s) => s.get().h3_alt_svc(),
             _ => None,
         }
     }
 
     pub(crate) fn inspector_server_id(&self) -> jsc::DebuggerId {
-        any_server_dispatch!(self, |s| s.inspector_server_id)
+        any_server_dispatch!(self, |s| s.inspector_server_id.get())
     }
 
     fn on_websocket_opened(&self) {
@@ -3953,52 +3362,50 @@ impl AnyServer {
     /// handler (the socket whose handler ran decrements only after `stop`
     /// returns, so `stop`'s own idle pass still sees it live).
     fn on_websocket_closed(&self) {
-        let drained =
-            any_server_dispatch!(self, |s| s.note_websocket_closed() && !s.has_listener());
-        if drained {
-            any_server_dispatch_mut!(self, |s| s.deinit_if_we_can());
-        }
+        any_server_dispatch!(self, |s| {
+            if s.note_websocket_closed() && !s.has_listener() {
+                s.deinit_if_we_can();
+            }
+        });
     }
 
-    pub(crate) fn set_inspector_server_id(&mut self, id: jsc::DebuggerId) {
-        any_server_dispatch_mut!(self, |s| {
-            s.inspector_server_id = id;
-            if let Some(dev_server) = s.dev_server.as_deref_mut() {
-                dev_server.inspector_server_id = id;
-            }
+    pub(crate) fn set_inspector_server_id(&self, id: jsc::DebuggerId) {
+        any_server_dispatch!(self, |s| {
+            s.inspector_server_id.set(id);
+            s.dev_server.with_mut(|dev| {
+                if let Some(dev_server) = dev.as_deref_mut() {
+                    dev_server.inspector_server_id = id;
+                }
+            });
         })
     }
 
-    pub(crate) fn on_pending_request(&mut self) {
-        any_server_dispatch_mut!(self, |s| s.on_pending_request())
+    pub(crate) fn on_pending_request(&self) {
+        any_server_dispatch!(self, |s| s.on_pending_request())
     }
 
     /// Dispatch the user `fetch` handler:
     /// un-erase the SSL bool from the tag and downcast
     /// `AnyResponse` to the matching `NewAppResponse<SSL>` variant.
     pub(crate) fn on_request(&self, req: &mut uws_sys::Request, resp: uws::AnyResponse) {
-        // `s` is the live `*mut NewServer` carried in `self.ptr`,
-        // tagged at construction in `AnyServer::from`.
         any_server_dispatch_resp!(self, resp, |s, r| NewServer::on_request(s, req, r))
     }
 
-    pub(crate) fn on_request_complete(&mut self) {
-        any_server_dispatch_mut!(self, |s| s.on_request_complete())
+    pub(crate) fn on_request_complete(&self) {
+        any_server_dispatch!(self, |s| s.on_request_complete())
     }
 
-    pub(crate) fn on_static_request_complete(&mut self) {
-        any_server_dispatch_mut!(self, |s| s.on_static_request_complete())
+    pub(crate) fn on_static_request_complete(&self) {
+        any_server_dispatch!(self, |s| s.on_static_request_complete())
     }
 
-    pub(crate) fn stop(&mut self, abrupt: bool) {
-        any_server_dispatch_mut!(self, |s| s.stop(abrupt))
+    pub(crate) fn stop(&self, abrupt: bool) {
+        any_server_dispatch!(self, |s| s.stop(abrupt))
     }
 
     pub(crate) fn num_subscribers(&self, topic: &[u8]) -> u32 {
-        any_server_dispatch!(self, |s| match s.app {
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
-            // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
-            Some(app) => bun_opaque::opaque_deref_mut(app).num_subscribers(topic),
+        any_server_dispatch!(self, |s| match s.app_mut() {
+            Some(app) => app.num_subscribers(topic),
             // Defensive 0
             // here for the post-stop window; assert in debug to catch misuse.
             None => {
@@ -4015,25 +3422,14 @@ impl AnyServer {
         opcode: uws::Opcode,
         compress: bool,
     ) -> uws::SendStatus {
-        any_server_dispatch!(self, |s| match s.app {
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
-            // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
-            Some(app) =>
-                bun_opaque::opaque_deref_mut(app).publish(topic, message, opcode, compress),
+        any_server_dispatch!(self, |s| match s.app_mut() {
+            Some(app) => app.publish(topic, message, opcode, compress),
             // Defensive for the post-stop window; assert in debug to catch misuse.
             None => {
                 debug_assert!(false, "publish on server with no app");
                 uws::SendStatus::Dropped
             }
         })
-    }
-
-    pub(crate) fn web_socket_handler(&mut self) -> Option<&mut WebSocketServerHandler> {
-        any_server_dispatch_mut!(self, |s| s
-            .config
-            .websocket
-            .as_mut()
-            .map(|ws| &mut ws.handler))
     }
 
     /// Wraps a stack-lifetime µWS request into a
@@ -4048,8 +3444,6 @@ impl AnyServer {
     ) -> jsc::JsResult<Option<SavedRequest>> {
         let req: &mut uws_sys::Request = req;
         Ok(any_server_dispatch_resp!(self, resp, |s, r| {
-            // `s` is the live `*mut NewServer` carried in `self.ptr`,
-            // tagged at construction in `AnyServer::from`.
             let Some(p) = NewServer::prepare_js_request_context(
                 s,
                 req,
@@ -4073,18 +3467,20 @@ impl AnyServer {
         callback: jsc::JSValue,
         extra_args: [jsc::JSValue; EXTRA_ARG_COUNT],
     ) {
-        // `s` is the live `*mut NewServer` carried in `self.ptr`,
-        // tagged at construction in `AnyServer::from`.
         any_server_dispatch_resp!(self, resp, |s, r| {
             NewServer::on_saved_request(s, req, r, callback, extra_args)
         })
     }
 
-    /// Mutable handle to the DevServer (when configured). HTMLBundle's request
-    /// path mutates DevServer state (`respond_for_html_bundle`).
-    #[allow(clippy::mut_from_ref)] // dispatched through the tagged raw `self.ptr`
-    pub(crate) fn dev_server_mut(&self) -> Option<&mut crate::bake::DevServer::DevServer> {
-        any_server_dispatch_mut!(self, |s| s.dev_server.as_deref_mut())
+    /// Run `f` on the DevServer (when configured). HTMLBundle's request path
+    /// mutates DevServer state (`respond_for_html_bundle`).
+    pub(crate) fn with_dev_server_mut<R>(
+        &self,
+        f: impl FnOnce(&mut crate::bake::DevServer::DevServer) -> R,
+    ) -> Option<R> {
+        any_server_dispatch!(self, |s| s
+            .dev_server
+            .with_mut(|dev| dev.as_deref_mut().map(f)))
     }
 
     /// Returns:
@@ -4093,9 +3489,9 @@ impl AnyServer {
     /// - `Pending` if `callback` was stored. It will call `on_plugins_resolved` or `on_plugins_rejected` later.
     pub(crate) fn get_or_load_plugins(
         &self,
-        callback: ServePluginsCallback<'_>,
+        callback: ServePluginsCallback,
     ) -> GetOrStartLoadResult<'_> {
-        any_server_dispatch_mut!(self, |s| s.get_or_load_plugins(callback))
+        any_server_dispatch!(self, |s| s.get_or_load_plugins(callback))
     }
 
     pub(crate) fn append_static_route(
@@ -4104,11 +3500,13 @@ impl AnyServer {
         route: AnyRoute,
         method: server_config::MethodOptional,
     ) -> Result<(), crate::Error> {
-        any_server_dispatch_mut!(self, |s| s.config.append_static_route(path, route, method))
+        any_server_dispatch!(self, |s| s
+            .config
+            .with_mut(|c| c.append_static_route(path, route, method)))
     }
 
     pub(crate) fn reload_static_routes(&self) -> Result<bool, crate::Error> {
-        any_server_dispatch_mut!(self, |s| s.reload_static_routes())
+        any_server_dispatch!(self, |s| s.reload_static_routes())
     }
 
     pub(crate) fn get_url_as_string(&self) -> Result<bun_core::String, bun_alloc::AllocError> {
@@ -4122,7 +3520,7 @@ impl AnyServer {
 /// `bun_jsc::http_server_agent`; the bodies live here because they reach into
 /// `AnyServer`/`ServerConfig` (forward dep from `bun_jsc`'s point of view).
 pub(crate) mod http_server_agent {
-    use super::{AnyRoute, AnyServer, AnyServerTag};
+    use super::{AnyRoute, AnyServer};
 
     use bun_core::String as BunString;
     use bun_jsc::debugger::DebuggerId;
@@ -4130,25 +3528,20 @@ pub(crate) mod http_server_agent {
 
     /// Assign the server a fresh inspector id and tell the C++ inspector
     /// agent (if attached) that it started, passing its URL and start time.
-    pub(crate) fn notify_server_started(this: &mut HTTPServerAgent, mut instance: AnyServer) {
+    pub(crate) fn notify_server_started(this: &mut HTTPServerAgent, instance: AnyServer) {
         let Some(agent) = this.agent else { return };
         this.next_server_id = DebuggerId::init(this.next_server_id.get() + 1);
         instance.set_inspector_server_id(this.next_server_id);
         let url = bun_core::handle_oom(instance.get_url_as_string());
 
-        // SAFETY: `agent` is a non-null C++ InspectorHTTPServerAgent handle
-        // (set via `Bun__HTTPServerAgent__setEnabled`); `vm()` is the live
-        // process VM backref.
-        unsafe {
-            InspectorHTTPServerAgent::notify_server_started(
-                agent.as_ptr(),
-                this.next_server_id,
-                (*instance.vm()).hot_reload_counter as i32,
-                &url,
-                bun_core::time::milli_timestamp() as f64,
-                instance.ptr.cast(),
-            );
-        }
+        InspectorHTTPServerAgent::notify_server_started(
+            agent.as_ptr(),
+            this.next_server_id,
+            instance.vm().hot_reload_counter as i32,
+            &url,
+            bun_core::time::milli_timestamp() as f64,
+            instance.as_opaque_ptr() as usize,
+        );
     }
 
     /// Tell the C++ inspector agent (if attached) that the server stopped,
@@ -4177,11 +3570,12 @@ pub(crate) mod http_server_agent {
 
         // Monomorphized over the four `UserRoute<SSL,DEBUG>` slice types.
         // Dispatch through the same macro the rest of `AnyServer` uses.
-        any_server_dispatch!(&server, |s| {
+        any_server_dispatch!(server, |s| {
+            let user_routes = s.user_routes.get();
             routes
-                .try_reserve(s.user_routes.len())
+                .try_reserve(user_routes.len())
                 .map_err(|_| bun_alloc::AllocError)?;
-            for user_route in &s.user_routes {
+            for user_route in user_routes {
                 max_id = max_id.max(user_route.id);
                 routes.push(Route {
                     route_id: user_route.id as i32,
@@ -4227,14 +3621,21 @@ pub struct SavedRequest {
     /// `prepare_js_request_context` populates it; `deinit` must tolerate the
     /// empty state.
     pub(crate) js_request: jsc::StrongOptional,
-    pub(crate) request: *mut crate::webcore::Request,
+    /// Weak: `js_request` keeps the Request itself alive.
+    pub(crate) request: crate::webcore::request::WeakRef,
+    pub(crate) request_ptr: NonNull<crate::webcore::Request>,
     pub ctx: AnyRequestContext,
     pub(crate) response: uws::AnyResponse,
 }
 
 impl SavedRequest {
+    /// The saved `Request`, unless its owner already finalized it.
+    pub(crate) fn request(&self) -> Option<&crate::webcore::Request> {
+        self.request.peek()
+    }
+
     /// Release the JS strong ref and
-    /// drop the request-context refcount. `request`/`response` are non-owning.
+    /// drop the request-context refcount. `response` is non-owning.
     pub(crate) fn deinit(&mut self) {
         self.js_request.deinit();
         self.ctx.deref();
@@ -4255,43 +3656,31 @@ pub struct ServerAllConnectionsClosedTask {
     pub(crate) tracker: jsc::AsyncTaskTracker,
 }
 
-impl bun_event_loop::Taskable for ServerAllConnectionsClosedTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ServerAllConnectionsClosedTask;
-    /// A `server.stop()` whose all-closed notification will not run: drop the
-    /// promise handle with the box.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box `schedule` queued.
-        drop(unsafe { bun_core::heap::take(this) });
-    }
-}
-
 impl ServerAllConnectionsClosedTask {
     pub(crate) fn schedule(this: Self, vm: &mut jsc::VirtualMachine) {
-        vm.enqueue_task(bun_event_loop::Task::from_boxed(Box::new(this)));
+        vm.enqueue_task(bun_event_loop::Task::new(
+            bun_event_loop::task_tag::ServerAllConnectionsClosedTask,
+            bun_core::heap::into_raw(Box::new(this)).cast(),
+        ));
     }
+
+    /// A `server.stop()` whose all-closed notification will not run: drop the
+    /// promise handle with the box.
+    pub(crate) fn release_unrun(self) {}
 
     /// Resolve the `server.stop()` promise
     /// once uws reports all sockets closed.
-    ///
-    /// # Safety
-    /// `this` must be the unique owning pointer heap-allocated in
-    /// [`Self::schedule`]; ownership is reclaimed and `this` must not be used
-    /// after this returns.
-    pub(crate) fn run_from_js_thread(this: *mut Self) -> JsResult<()> {
+    pub(crate) fn run_from_js_thread(mut self) -> JsResult<()> {
         httplog!("ServerAllConnectionsClosedTask runFromJSThread");
 
-        // SAFETY: `this` was `heap::alloc`'d in `schedule()`; reclaim
-        // ownership. Keep the `Box` because `Self` has a `Drop`
-        // impl, which forbids per-field moves.
-        let mut this = unsafe { bun_core::heap::take(this) };
         // S008: `JSGlobalObject` is an `opaque_ffi!` ZST handle — safe
         // `*const → &` via `opaque_deref` (set from the live per-VM global in
         // `schedule()`; the task is only dispatched on that VM's JS thread).
-        let global_object: &jsc::JSGlobalObject = bun_opaque::opaque_deref(this.global_object);
-        let _dispatch = this.tracker.dispatch(global_object);
+        let global_object: &jsc::JSGlobalObject = bun_opaque::opaque_deref(self.global_object);
+        let _dispatch = self.tracker.dispatch(global_object);
 
-        // `JSPromiseStrong`'s Drop runs when `this` falls out of scope.
-        this.promise.resolve(global_object, JSValue::UNDEFINED)?;
+        // `JSPromiseStrong`'s Drop runs when `self` falls out of scope.
+        self.promise.resolve(global_object, JSValue::UNDEFINED)?;
         Ok(())
     }
 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -357,25 +357,13 @@ pub enum CreateJsRequest {
 /// per-request `RequestContext` (`Ctx`: HTTP/1 or HTTP/3 flavour).
 pub struct PreparedRequestFor<Ctx> {
     pub(crate) js_request: JSValue,
-    /// The heap `Request` (owned by its JS wrapper once created): a weak
-    /// handle of our own, so the dispatch frame can still reach it after the
-    /// context lets go of its one (`server.upgrade()`), borrowed only at each
-    /// point of use.
-    pub(crate) request: crate::webcore::request::WeakRef,
     /// The `Request` allocation's root pointer, for the C++ route-list call
-    /// that wraps it.
+    /// that wraps it. The `Request` itself is reached through
+    /// `ctx.request_weakref`, which pins it for the request's lifetime.
     pub(crate) request_ptr: NonNull<crate::webcore::Request>,
     /// Self-owned (refcounted, pool-slot token inside); outlives the dispatch
     /// frame that holds this.
     pub ctx: bun_ptr::BackRef<Ctx>,
-}
-
-impl<Ctx> PreparedRequestFor<Ctx> {
-    /// The heap `Request`, unless its owner already finalized it.
-    #[inline]
-    pub(crate) fn request(&self) -> Option<&crate::webcore::Request> {
-        self.request.peek()
-    }
 }
 
 /// The HTTP/1 instantiation; H3 callers never `save()`.
@@ -383,14 +371,26 @@ pub type PreparedRequest<const SSL: bool, const DEBUG: bool> =
     PreparedRequestFor<ServerRequestContext<SSL, DEBUG>>;
 
 impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
-    /// `ctx.to_async(..)`, or — if the `Request` is already gone — just arm the
-    /// abort handler it would have.
-    fn to_async(
-        ctx: &ServerRequestContext<SSL, DEBUG>,
-        req: *mut c_void,
-        request: &crate::webcore::request::WeakRef,
-    ) {
-        match request.peek() {
+    /// The heap `Request`, while the context still holds it.
+    #[inline]
+    pub(crate) fn request(&self) -> Option<&crate::webcore::Request> {
+        self.ctx.get().request_weakref.get().peek()
+    }
+
+    /// Detach the borrowed stack `uws::Request` from the heap `Request` so the
+    /// JS object never dangles a pointer past the uWS frame it borrowed.
+    #[inline]
+    fn detach_uws_request(ctx: &ServerRequestContext<SSL, DEBUG>) {
+        if let Some(request) = ctx.request_weakref.get().peek() {
+            request.request_context.get().detach_request();
+        }
+    }
+
+    /// `ctx.to_async(..)` (which also detaches the stack `uws::Request`), or —
+    /// if the `Request` is already gone — just arm the abort handler.
+    #[inline]
+    fn to_async(ctx: &ServerRequestContext<SSL, DEBUG>, req: *mut c_void) {
+        match ctx.request_weakref.get().peek() {
             Some(request) => ctx.to_async(req, request),
             None => ctx.set_abort_handler(),
         }
@@ -407,32 +407,18 @@ impl<const SSL: bool, const DEBUG: bool> PreparedRequest<SSL, DEBUG> {
         // By saving a request, all information from `req` must be
         // copied since the provided uws.Request will be re-used for
         // future requests (stack allocated).
+        let ctx = self.ctx.get();
         Self::to_async(
-            self.ctx.get(),
+            ctx,
             std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-            &self.request,
         );
 
         SavedRequest {
             js_request: jsc::StrongOptional::create(self.js_request, global),
-            request: self.request.clone(),
+            request: ctx.request_weakref.get().clone(),
             request_ptr: self.request_ptr,
             ctx: AnyRequestContext::init(self.ctx.as_const_ptr()),
             response: any_response_from::<SSL>(resp),
-        }
-    }
-}
-
-/// RAII: on drop, detaches the borrowed stack `uws::Request` from the heap
-/// `webcore::Request` so the JS request
-/// object never dangles a pointer past the uWS frame it borrowed.
-pub(crate) struct DetachRequestOnDrop<'a>(&'a crate::webcore::request::WeakRef);
-
-impl Drop for DetachRequestOnDrop<'_> {
-    #[inline]
-    fn drop(&mut self) {
-        if let Some(request) = self.0.peek() {
-            request.request_context.get().detach_request();
         }
     }
 }
@@ -968,7 +954,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     .js_request
                     .get()
                     .expect("Request was unexpectedly freed"),
-                request: data.request.clone(),
                 request_ptr: data.request_ptr,
                 // `SavedRequest` was produced by `PreparedRequest::save`
                 // for this exact (SSL,DEBUG) monomorphization, so the erased
@@ -998,12 +983,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             Err(err) => global.take_exception(err),
         };
 
+        // The uWS request will not live longer than this function: on every
+        // exit below it is detached from the `Request` — only when it's the
+        // stack-allocated original (a saved request already copied everything).
         let is_stack = matches!(req, SavedRequestUnion::Stack(_));
         let ctx_ref = prepared.ctx.get();
-        // uWS request will not live longer than this function — only detach
-        // when it's the stack-allocated original (a saved request already
-        // copied everything it needs).
-        let _detach_guard = is_stack.then(|| DetachRequestOnDrop(&prepared.request));
 
         let original_state = ctx_ref.defer_deinit_until_callback_completes.get();
         let should_deinit_context = Cell::new(false);
@@ -1019,11 +1003,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         prepared.js_request.ensure_still_alive();
 
         if should_deinit_context.get() {
+            if is_stack {
+                PreparedRequest::<SSL, DEBUG>::detach_uws_request(ctx_ref);
+            }
             ctx_ref.deinit();
             return;
         }
 
         if ctx_ref.should_render_missing() {
+            if is_stack {
+                PreparedRequest::<SSL, DEBUG>::detach_uws_request(ctx_ref);
+            }
             ctx_ref.render_missing();
             return;
         }
@@ -1037,7 +1027,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     std::ptr::from_ref::<uws::Request>(r)
                         .cast_mut()
                         .cast::<c_void>(),
-                    &prepared.request,
                 );
             }
             SavedRequestUnion::Saved(_) => {} // info already copied
@@ -1061,9 +1050,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     ) {
         let ctx_ref = prepared.ctx.get();
 
-        // uWS request will not live longer than this function
-        let _detach_guard = DetachRequestOnDrop(&prepared.request);
-
+        // The uWS request will not live longer than this function: on every
+        // exit below it is detached from the `Request`.
         ctx_ref.on_response(self, prepared.js_request, response_value);
         // Reference in the stack here in case it is not for whatever reason
         prepared.js_request.ensure_still_alive();
@@ -1071,11 +1059,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         ctx_ref.defer_deinit_until_callback_completes.set(None);
 
         if should_deinit_context.get() {
+            PreparedRequest::<SSL, DEBUG>::detach_uws_request(ctx_ref);
             ctx_ref.deinit();
             return;
         }
 
         if ctx_ref.should_render_missing() {
+            PreparedRequest::<SSL, DEBUG>::detach_uws_request(ctx_ref);
             ctx_ref.render_missing();
             return;
         }
@@ -1086,7 +1076,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         PreparedRequest::<SSL, DEBUG>::to_async(
             ctx_ref,
             std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-            &prepared.request,
         );
         prepared.js_request.ensure_still_alive();
     }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1248,7 +1248,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             AnyServer::from(self),
             global,
             req,
-            SSL,
             any_response_from::<SSL>(resp),
             upgrade_ctx,
         );

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2383,20 +2383,26 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // H2/H3 fallback — same three-way as H1 above, but driven by user/static
         // "/*" coverage only (DevServer routes are not mirrored to H2/H3).
-        let mux_fallback = if has_on_request {
-            Self::on_mux_request
-        } else {
-            Self::on_mux_404
-        };
         for_each_mux_app!(self, |mux| {
+            // The default handler for a method (or `None` = any) on "/*".
+            macro_rules! fallback_mux {
+                ($method:expr) => {
+                    match ($method, has_on_request) {
+                        (Some(m), true) => mux.method_this(m, b"/*", Self::on_mux_request, this),
+                        (Some(m), false) => mux.method_this(m, b"/*", Self::on_mux_404, this),
+                        (None, true) => mux.any_this(b"/*", Self::on_mux_request, this),
+                        (None, false) => mux.any_this(b"/*", Self::on_mux_404, this),
+                    }
+                };
+            }
             if mux_star_covered == http_method::Set::all() {
                 // user/static "/*" already covers every method
             } else if has_any_user_route_for_star_path || has_static_route_for_star_path {
                 for m in !mux_star_covered {
-                    mux.method_this(m, b"/*", mux_fallback, this);
+                    fallback_mux!(Some(m));
                 }
             } else {
-                mux.any_this(b"/*", mux_fallback, this);
+                fallback_mux!(None::<http_method::Method>);
             }
         });
 
@@ -2441,7 +2447,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// `config.http2`: attach an HTTP/2 context to `app`. On failure returns
     /// the message for `fail_listen` (empty when an exception is already
     /// pending).
-    fn attach_http2(&self) -> Result<(), core::fmt::Arguments<'static>>
+    fn attach_http2(&self) -> Result<(), &'static str>
     where
         Self: ServerPools<SSL, DEBUG>,
     {
@@ -2469,14 +2475,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let _ = self.global_this().throw_invalid_arguments(format_args!(
                     "http1: false with http2: true is not supported {why}"
                 ));
-                return Err(format_args!(""));
+                return Err("");
             }
             bun_core::warn!("http2: true is ignored {}", why);
             return Ok(());
         }
         let app = self.app_mut().expect("created before attach_http2");
         let Some(h2) = uws_sys::h2::OwnedApp::create::<SSL>(app, http1, idle_timeout) else {
-            return Err(format_args!("Failed to create HTTP/2 server"));
+            return Err("Failed to create HTTP/2 server");
         };
         // Streams parked on socket backpressure by a JS-driven write get their
         // next drain pass from the event loop's deferred task queue (after the
@@ -2493,7 +2499,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 .post_task(NonNull::new(app), drain);
         }
         let h2_ptr = h2.as_ptr();
-        bun_opaque::opaque_deref_mut(h2_ptr).on_schedule_drain(schedule_h2_drain, h2_ptr.cast::<c_void>());
+        bun_opaque::opaque_deref_mut(h2_ptr)
+            .on_schedule_drain(schedule_h2_drain, h2_ptr.cast::<c_void>());
         self.h2_app.set(Some(h2));
         if self.mux_request_pool.get().is_none() {
             self.mux_request_pool
@@ -2569,7 +2576,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     .set(Some(<Self as ServerPools<SSL, DEBUG>>::mux_request_pool()));
             }
             if let Err(msg) = server.attach_http2() {
-                return Self::fail_listen(this, msg, false);
+                return Self::fail_listen(this, format_args!("{msg}"), false);
             }
 
             route_list_value = server.set_routes();
@@ -2670,7 +2677,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             server.app.set(Some(app));
             server.self_ref.set(Some(RefPtr::from_this(this)));
             if let Err(msg) = server.attach_http2() {
-                return Self::fail_listen(this, msg, false);
+                return Self::fail_listen(this, format_args!("{msg}"), false);
             }
             route_list_value = server.set_routes();
         }
@@ -2710,7 +2717,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     Addr::Unix(bun_core::ZBox::from_bytes(unix.as_bytes()))
                 }
             };
-            (addr, config.http1 || config.http2, config.get_usockets_options())
+            (
+                addr,
+                config.http1 || config.http2,
+                config.get_usockets_options(),
+            )
         };
 
         match &addr {

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -84,7 +84,7 @@ function generate(name) {
       },
     },
     klass: {},
-    finalize: true,
+    refCounted: true,
     construct: true,
     noConstructor: true,
     values: [

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -3,9 +3,6 @@ import { define } from "../../codegen/class-definitions.ts";
 function generate(name) {
   return define({
     name,
-    // R-2 Phase 3 opt-out: `Server<SSL, DEBUG>` host-fns still take
-    // `&mut self`. Remove once the server impl is Cell/JsCell-migrated.
-    sharedThis: false,
     memoryCost: true,
     proto: {
       fetch: {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -130,7 +130,7 @@ pub(super) trait RequestCtx<const SSL: bool, const DEBUG: bool>:
     fn set_request_body_content_len(&self, len: usize);
     fn set_is_transfer_encoding(&self, v: bool);
     fn set_is_waiting_for_request_body(&self, v: bool);
-    fn arm_on_data(this: NonNull<Self>, resp: uws::AnyResponse);
+    fn arm_on_data(&self, resp: uws::AnyResponse);
     // body-streaming callback hooks (type-erased, stored on `Body::PendingValue`).
     // `this` must be a live `*mut Self` cast to `*mut c_void`.
     fn on_start_buffering_callback(this: NonNull<c_void>);
@@ -249,12 +249,12 @@ macro_rules! impl_request_ctx {
                 self.flags.set_is_waiting_for_request_body(v)
             }
             #[inline]
-            fn arm_on_data(this: NonNull<Self>, resp: uws::AnyResponse) {
+            fn arm_on_data(&self, resp: uws::AnyResponse) {
                 resp.on_data(
                     |ctx: *mut Self, chunk: &[u8], last: bool| {
                         Self::on_buffered_body_chunk(ctx, chunk, last)
                     },
-                    this.as_ptr(),
+                    self.as_ctx_ptr(),
                 );
             }
             #[inline]
@@ -2967,7 +2967,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             ctx.set_is_transfer_encoding(is_te);
             if expects_body {
                 ctx.set_is_waiting_for_request_body(true);
-                Ctx::arm_on_data(NonNull::from(ctx), any_resp);
+                ctx.arm_on_data(any_resp);
             }
         }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1,18 +1,16 @@
-use core::ffi::{c_int, c_void};
-use core::mem;
+use core::cell::Cell;
+use core::ffi::c_void;
 use core::ptr::NonNull;
 use std::io::Write as _;
 
 use crate::api::js_bundler::PluginJscExt as _;
 use crate::api::{SocketAddress, js_bundler as JSBundler};
-use crate::bake::dev_server::DevServer;
 use crate::bake::framework_router as FrameworkRouter;
 use crate::bake::{self as bake};
 use crate::node::types::PathLikeExt as _;
 use crate::webcore::BlobExt;
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::fetch as Fetch;
-use crate::webcore::response::HeadersRef;
 use crate::webcore::{
     self as WebCore, AbortSignal, AnyBlob, Blob, FetchHeaders, Request, Response, request,
 };
@@ -22,13 +20,14 @@ use bun_core::{EncodedSlice, String as BunString, strings};
 use bun_core::{Output, fmt as bun_fmt};
 use bun_http::{self as http, Method, MimeType};
 use bun_jsc::Debugger::DebuggerId;
+use bun_jsc::HeadersRef;
 use bun_jsc::uuid::UUID;
 use bun_jsc::{
     self as jsc, ArrayBuffer, CallFrame, GlobalRef, JSGlobalObject, JSPromise, JSValue, JsError,
     JsResult, Node, StringJsc as _, VirtualMachine, host_fn,
 };
 use bun_paths as paths;
-use bun_ptr::RefPtr;
+use bun_ptr::{JsCell, RefPtr, ThisPtr};
 use bun_resolver::fs::FileSystem;
 use bun_standalone_graph::StandaloneModuleGraph;
 use bun_sys as sys;
@@ -56,79 +55,74 @@ pub(super) use super::any_request_context::AnyRequestContext;
 pub(super) use super::file_route::FileRoute;
 pub(super) use super::node_http_response::NodeHTTPResponse;
 pub(super) use super::request_context::{
-    DeferDeinitFlag, RequestContext as NewRequestContext, UpgradeState,
+    DeferDeinitFlag, REQUEST_CONTEXT_POOL_CAPACITY, RequestContext as NewRequestContext,
+    UpgradeState,
 };
 pub(super) use super::server_config::{self as server_config, ServerConfig};
 pub(super) use super::server_web_socket::ServerWebSocket;
 pub(super) use super::static_route::StaticRoute;
 
 // ─── RequestCtx trait ────────────────────────────────────────────────────────
-// NOTE: Stable Rust has no inherent
-// associated types, so the per-monomorphization request handle type is
-// surfaced via this local trait. Only `IS_MUX` is consumed for control flow;
-// `Req` is erased to `c_void` to match `super::request_context::Req`. The
-// response handle is a separate generic (`R: RespLike`) at each dispatch
-// entry point: the MUX instantiation serves both `h2::Response` and
-// `h3::Response`.
-trait RequestCtx: super::any_request_context::CtxKind {
+// NOTE: Stable Rust has no inherent associated types, so the per-transport
+// request handle type of `RequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, MUX>`
+// is surfaced via this local trait: it lets one generic body serve HTTP/1,
+// HTTP/2 and HTTP/3 without naming the concrete context type. The response
+// handle is a separate generic (`R: RespLike`) at each dispatch entry point:
+// the MUX instantiation serves both `h2::Response` and `h3::Response`.
+type CtxPool<Ctx> = bun_collections::hive_array::Fallback<Ctx, { REQUEST_CONTEXT_POOL_CAPACITY }>;
+type CtxSlot<Ctx> =
+    bun_collections::hive_array::Pooled<'static, Ctx, { REQUEST_CONTEXT_POOL_CAPACITY }>;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) trait RequestCtx<const SSL: bool, const DEBUG: bool>:
+    super::any_request_context::CtxKind + Sized + 'static
+{
     type Req: ReqLike;
     const IS_MUX: bool;
-}
-impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
-    for NewRequestContext<ThisServer, SSL, DBG, false>
-where
-    NewRequestContext<ThisServer, SSL, DBG, false>: super::any_request_context::CtxKind,
-{
-    type Req = uws_sys::Request;
-    const IS_MUX: bool = false;
-}
-impl<ThisServer, const SSL: bool, const DBG: bool> RequestCtx
-    for NewRequestContext<ThisServer, SSL, DBG, true>
-where
-    NewRequestContext<ThisServer, SSL, DBG, true>: super::any_request_context::CtxKind,
-{
-    type Req = uws_sys::h3::Request;
-    const IS_MUX: bool = true;
-}
 
-/// Field/method surface needed on the generic `Ctx` so the bodies of
-/// `handle_request_for` / `prepare_js_request_context_for` / `on_saved_request`
-/// can be written without naming the concrete `RequestContext<_, SSL, DBG, MUX>`
-/// type. Implemented via blanket impl below for every `NewRequestContext<..>`.
-#[allow(clippy::too_many_arguments)]
-trait RequestCtxOps: RequestCtx {
-    type Server;
-    fn create_in(
-        slot: *mut Self,
-        server: *mut Self::Server,
+    /// The server's pool for this transport.
+    fn pool(server: &NewServer<SSL, DEBUG>) -> &'static CtxPool<Self>;
+
+    fn init(
+        slot: NonNull<Self>,
+        server: bun_ptr::BackRef<NewServer<SSL, DEBUG>, bun_ptr::Root>,
         req: &mut Self::Req,
         resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<http::Method>,
+    ) -> Self;
+    fn adopt_pool_slot(&self, slot: CtxSlot<Self>);
+    fn on_response(
+        &self,
+        server: &NewServer<SSL, DEBUG>,
+        request_value: JSValue,
+        response_value: JSValue,
     );
-    fn on_response(&self, server: &Self::Server, request_value: JSValue, response_value: JSValue);
     fn deinit(&self);
     fn should_render_missing(&self) -> bool;
     fn render_missing(&self);
-    fn to_async(&self, req: &mut Self::Req, request_object: &mut Request);
+    fn to_async(&self, req: &mut Self::Req, request_object: &Request);
+    /// `to_async`, or just its abort-handler arming when the `Request` is gone.
+    fn arm_async(&self, req: &mut Self::Req, request: &crate::webcore::request::WeakRef) {
+        match request.peek() {
+            Some(request) => self.to_async(req, request),
+            None => self.set_abort_handler(),
+        }
+    }
+    fn set_abort_handler(&self);
     fn ctx_method(&self) -> http::Method;
     fn set_defer_deinit(&self, flag: Option<DeferDeinitFlag>);
     fn set_request_body(&self, body: Option<crate::webcore::body::BodyHiveHandle>);
-    #[allow(
-        clippy::mut_from_ref,
-        reason = "the body slot is a separate pooled allocation, not a field of *self (R-2)"
-    )]
-    fn request_body_mut(&self) -> Option<&mut BodyValue>;
-    fn set_signal(&self, sig: *mut AbortSignal);
-    fn set_request_weakref(&self, req: *mut Request);
+    fn set_signal(&self, sig: NonNull<AbortSignal>);
+    fn set_request_weakref(&self, weak: crate::webcore::request::WeakRef);
     fn clear_req(&self);
     fn set_is_web_browser_navigation(&self, v: bool);
     fn set_request_body_content_len(&self, len: usize);
     fn set_is_transfer_encoding(&self, v: bool);
     fn set_is_waiting_for_request_body(&self, v: bool);
-    fn arm_on_data(&self, resp: uws::AnyResponse);
+    fn arm_on_data(this: NonNull<Self>, resp: uws::AnyResponse);
     // body-streaming callback hooks (type-erased, stored on `Body::PendingValue`).
-    // `this` must be a live `*mut Self::RequestCtx` cast to `*mut c_void`.
+    // `this` must be a live `*mut Self` cast to `*mut c_void`.
     fn on_start_buffering_callback(this: NonNull<c_void>);
     fn on_start_streaming_request_body_callback(this: NonNull<c_void>) -> WebCore::DrainResult;
     fn on_request_body_readable_stream_available(
@@ -138,145 +132,159 @@ trait RequestCtxOps: RequestCtx {
     );
 }
 
-impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> RequestCtxOps
-    for NewRequestContext<ThisServer, SSL, DBG, MUX>
-where
-    Self: RequestCtx,
-    ThisServer: super::ServerLike + 'static,
-{
-    type Server = ThisServer;
-    #[inline]
-    fn create_in(
-        slot: *mut Self,
-        server: *mut ThisServer,
-        req: &mut Self::Req,
-        any_resp: uws::AnyResponse,
-        should_deinit_context: Option<DeferDeinitFlag>,
-        method: Option<http::Method>,
-    ) {
-        // SAFETY: `slot` points at a fresh HiveArray pool entry; treat as
-        // MaybeUninit for in-place construction — `&mut` scoped to this call.
-        Self::create(
-            unsafe { &mut *slot.cast::<core::mem::MaybeUninit<Self>>() },
-            server,
-            std::ptr::from_mut(req).cast(),
-            any_resp,
-            should_deinit_context,
-            method,
-        );
-    }
-    #[inline]
-    fn on_response(&self, server: &ThisServer, rq: JSValue, rv: JSValue) {
-        Self::on_response(self, server, rq, rv)
-    }
-    #[inline]
-    fn deinit(&self) {
-        Self::deinit(self)
-    }
-    #[inline]
-    fn should_render_missing(&self) -> bool {
-        Self::should_render_missing(self)
-    }
-    #[inline]
-    fn render_missing(&self) {
-        Self::render_missing(self)
-    }
-    #[inline]
-    fn to_async(&self, req: &mut Self::Req, ro: &mut Request) {
-        Self::to_async(self, std::ptr::from_mut(req).cast(), ro)
-    }
-    #[inline]
-    fn ctx_method(&self) -> http::Method {
-        self.method
-    }
-    #[inline]
-    fn set_defer_deinit(&self, flag: Option<DeferDeinitFlag>) {
-        self.defer_deinit_until_callback_completes.set(flag)
-    }
-    #[inline]
-    fn set_request_body(&self, body: Option<crate::webcore::body::BodyHiveHandle>) {
-        self.request_body.set(body)
-    }
-    #[inline]
-    fn request_body_mut(&self) -> Option<&mut BodyValue> {
-        // SAFETY: R-2 invariant — slot shared with `Request.body`, never
-        // `&mut`-borrowed concurrently (single-threaded event loop).
-        self.request_body
-            .get()
-            .as_ref()
-            .map(|h| unsafe { &mut (*h.as_ptr()).value })
-    }
-    #[inline]
-    fn set_signal(&self, sig: *mut AbortSignal) {
-        // `AbortSignal::new` returns a raw +1 ref to a C++-refcounted opaque;
-        // `RequestContext.signal` stores it as `Option<NonNull<AbortSignal>>`
-        // and pairs the unref in RequestContext cleanup (`shim::signal_release`,
-        // which drops both the pending-activity count and the intrusive ref).
-        self.signal.set(NonNull::new(sig));
-    }
-    #[inline]
-    fn set_request_weakref(&self, req: *mut Request) {
-        // SAFETY: `req` is a freshly-boxed Request (live for the request
-        // duration) still carrying its `heap::into_raw` provenance.
-        self.request_weakref
-            .set(unsafe { bun_ptr::WeakPtr::<Request>::init_ref(req) });
-    }
-    #[inline]
-    fn clear_req(&self) {
-        self.req.set(None)
-    }
-    #[inline]
-    fn set_is_web_browser_navigation(&self, v: bool) {
-        self.flags.set_is_web_browser_navigation(v)
-    }
-    #[inline]
-    fn set_request_body_content_len(&self, len: usize) {
-        self.request_body_content_len.set(len)
-    }
-    #[inline]
-    fn set_is_transfer_encoding(&self, v: bool) {
-        self.flags.set_is_transfer_encoding(v)
-    }
-    #[inline]
-    fn set_is_waiting_for_request_body(&self, v: bool) {
-        self.flags.set_is_waiting_for_request_body(v)
-    }
-    #[inline]
-    fn arm_on_data(&self, resp: uws::AnyResponse) {
-        fn handler<S, const SSL_: bool, const DBG_: bool, const MUX_: bool>(
-            ctx: *mut NewRequestContext<S, SSL_, DBG_, MUX_>,
-            chunk: &[u8],
-            last: bool,
-        ) where
-            S: super::ServerLike + 'static,
+macro_rules! impl_request_ctx {
+    ($mux:literal, $Req:ty, $pool:ident) => {
+        impl<const SSL: bool, const DEBUG: bool> RequestCtx<SSL, DEBUG>
+            for NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, $mux>
         {
-            NewRequestContext::<S, SSL_, DBG_, MUX_>::on_buffered_body_chunk(ctx, chunk, last);
+            type Req = $Req;
+            const IS_MUX: bool = $mux;
+
+            #[inline]
+            fn pool(server: &NewServer<SSL, DEBUG>) -> &'static CtxPool<Self> {
+                $pool(server)
+            }
+            #[inline]
+            fn init(
+                slot: NonNull<Self>,
+                server: bun_ptr::BackRef<NewServer<SSL, DEBUG>, bun_ptr::Root>,
+                req: &mut Self::Req,
+                resp: uws::AnyResponse,
+                should_deinit_context: Option<DeferDeinitFlag>,
+                method: Option<http::Method>,
+            ) -> Self {
+                Self::init(
+                    slot,
+                    server,
+                    std::ptr::from_mut(req).cast(),
+                    resp,
+                    should_deinit_context,
+                    method,
+                )
+            }
+            #[inline]
+            fn adopt_pool_slot(&self, slot: CtxSlot<Self>) {
+                self.pool_slot.set(Some(slot));
+            }
+            #[inline]
+            fn on_response(&self, server: &NewServer<SSL, DEBUG>, rq: JSValue, rv: JSValue) {
+                Self::on_response(self, server, rq, rv)
+            }
+            #[inline]
+            fn deinit(&self) {
+                Self::deinit(self)
+            }
+            #[inline]
+            fn should_render_missing(&self) -> bool {
+                Self::should_render_missing(self)
+            }
+            #[inline]
+            fn render_missing(&self) {
+                Self::render_missing(self)
+            }
+            #[inline]
+            fn to_async(&self, req: &mut Self::Req, ro: &Request) {
+                Self::to_async(self, std::ptr::from_mut(req).cast(), ro)
+            }
+            #[inline]
+            fn set_abort_handler(&self) {
+                Self::set_abort_handler(self)
+            }
+            #[inline]
+            fn ctx_method(&self) -> http::Method {
+                self.method
+            }
+            #[inline]
+            fn set_defer_deinit(&self, flag: Option<DeferDeinitFlag>) {
+                self.defer_deinit_until_callback_completes.set(flag)
+            }
+            #[inline]
+            fn set_request_body(&self, body: Option<crate::webcore::body::BodyHiveHandle>) {
+                self.request_body.set(body)
+            }
+            #[inline]
+            fn set_signal(&self, sig: NonNull<AbortSignal>) {
+                // `AbortSignal::new` returns a raw +1 ref to a C++-refcounted opaque;
+                // `RequestContext.signal` stores it and pairs the unref in
+                // RequestContext cleanup (which drops both the pending-activity
+                // count and the intrusive ref).
+                self.signal.set(Some(sig));
+            }
+            #[inline]
+            fn set_request_weakref(&self, weak: crate::webcore::request::WeakRef) {
+                self.request_weakref.set(weak);
+            }
+            #[inline]
+            fn clear_req(&self) {
+                self.req.set(None)
+            }
+            #[inline]
+            fn set_is_web_browser_navigation(&self, v: bool) {
+                self.flags.set_is_web_browser_navigation(v)
+            }
+            #[inline]
+            fn set_request_body_content_len(&self, len: usize) {
+                self.request_body_content_len.set(len)
+            }
+            #[inline]
+            fn set_is_transfer_encoding(&self, v: bool) {
+                self.flags.set_is_transfer_encoding(v)
+            }
+            #[inline]
+            fn set_is_waiting_for_request_body(&self, v: bool) {
+                self.flags.set_is_waiting_for_request_body(v)
+            }
+            #[inline]
+            fn arm_on_data(this: NonNull<Self>, resp: uws::AnyResponse) {
+                resp.on_data(
+                    |ctx: *mut Self, chunk: &[u8], last: bool| {
+                        Self::on_buffered_body_chunk(ctx, chunk, last)
+                    },
+                    this.as_ptr(),
+                );
+            }
+            #[inline]
+            fn on_start_buffering_callback(this: NonNull<c_void>) {
+                Self::on_start_buffering_callback(this)
+            }
+            #[inline]
+            fn on_start_streaming_request_body_callback(
+                this: NonNull<c_void>,
+            ) -> WebCore::DrainResult {
+                Self::on_start_streaming_request_body_callback(this)
+            }
+            #[inline]
+            fn on_request_body_readable_stream_available(
+                this: NonNull<c_void>,
+                global_this: &JSGlobalObject,
+                readable: WebCore::ReadableStream,
+            ) {
+                Self::on_request_body_readable_stream_available(this, global_this, readable)
+            }
         }
-        resp.on_data(handler::<ThisServer, SSL, DBG, MUX>, self.as_ctx_ptr());
-    }
-    #[inline]
-    fn on_start_buffering_callback(this: NonNull<c_void>) {
-        Self::on_start_buffering_callback(this)
-    }
-    #[inline]
-    fn on_start_streaming_request_body_callback(this: NonNull<c_void>) -> WebCore::DrainResult {
-        Self::on_start_streaming_request_body_callback(this)
-    }
-    #[inline]
-    fn on_request_body_readable_stream_available(
-        this: NonNull<c_void>,
-        global_this: &JSGlobalObject,
-        readable: WebCore::ReadableStream,
-    ) {
-        Self::on_request_body_readable_stream_available(this, global_this, readable)
-    }
+    };
 }
+
+fn h1_pool<const SSL: bool, const DEBUG: bool>(
+    server: &NewServer<SSL, DEBUG>,
+) -> &'static CtxPool<ServerRequestContext<SSL, DEBUG>> {
+    server.request_pool
+}
+fn mux_pool<const SSL: bool, const DEBUG: bool>(
+    server: &NewServer<SSL, DEBUG>,
+) -> &'static CtxPool<ServerMuxRequestContext<SSL, DEBUG>> {
+    server.mux_request_pool.get().expect(
+        "HTTP/2 or HTTP/3 request dispatched but mux_request_pool was never allocated",
+    )
+}
+impl_request_ctx!(false, uws_sys::Request, h1_pool);
+impl_request_ctx!(true, uws_sys::h3::Request, mux_pool);
 
 // NOTE: local request/response traits so generic `Ctx::Req` / `R: RespLike`
 // call sites can dispatch to any uWS HTTP/1, HTTP/2 or HTTP/3 handle type without
 // touching `bun_uws_sys`. Only the surface `prepare_js_request_context_for`
 // actually needs is exposed.
-trait ReqLike {
+pub(super) trait ReqLike {
     fn header(&mut self, name: &[u8]) -> Option<&[u8]>;
     /// Whether the transport frames the body with a Transfer-Encoding header.
     /// This is the parser's verdict, not a lookup of the first header field.
@@ -908,28 +916,27 @@ pub struct ServerInitContext<'a> {
 /// State machine to handle loading plugins asynchronously. This structure is not thread-safe.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct ServePlugins {
-    state: ServePluginsState,
-    ref_count: core::cell::Cell<u32>,
+    state: JsCell<ServePluginsState>,
+    /// Reference count is incremented while there are other objects waiting on plugin loads.
+    ref_count: Cell<u32>,
+    /// The ref the pending plugin-load promise's reactions hold (taken before
+    /// `.then()`, released by `on_resolve_plugins` / `on_reject_plugins`).
+    promise_ref: Cell<Option<RefPtr<ServePlugins>>>,
 }
 
-// Reference count is incremented while there are other objects waiting on plugin loads.
 pub(crate) enum ServePluginsState {
     Unqueued(Box<[Box<[u8]>]>),
     Pending {
+        /// The (GC-protected) `JSBundlerPlugin` cell.
+        plugin: NonNull<JSBundler::Plugin>,
         /// Promise may be empty if the plugin load finishes synchronously.
-        plugin: Box<JSBundler::Plugin>,
         promise: jsc::JSPromiseStrong,
         /// Each holds a ref, released once the route is told the outcome.
         html_bundle_routes: Vec<RefPtr<html_bundle::Route>>,
-        // LIFETIMES.tsv classifies this BORROW_PARAM (`Option<&'a DevServer>`),
-        // but `ServePlugins` is a refcounted heap object handed across FFI as
-        // a raw promise-context pointer with dynamic lifetime, so a borrowed
-        // `&'a DevServer` cannot be expressed here. Back-reference invariant:
-        // the DevServer outlives the pending plugin load (see the SAFETY
-        // comments at the deref sites in `on_plugins_resolved`/`_rejected`).
-        dev_server: Option<NonNull<DevServer>>,
+        /// The server whose DevServer is waiting on the load.
+        dev_server: Option<AnyServer>,
     },
-    Loaded(Box<JSBundler::Plugin>),
+    Loaded(NonNull<JSBundler::Plugin>),
     /// Error information is not stored as it is already reported.
     Err,
 }
@@ -942,111 +949,121 @@ pub enum GetOrStartLoadResult<'a> {
 }
 
 #[derive(Clone, Copy)]
-pub enum ServePluginsCallback<'a> {
+pub enum ServePluginsCallback {
     HtmlBundleRoute(bun_ptr::ThisPtr<html_bundle::Route>),
-    DevServer(&'a DevServer),
+    /// The calling server's DevServer.
+    DevServer,
 }
 
 impl ServePlugins {
     pub(crate) fn init(plugins: Box<[Box<[u8]>]>) -> RefPtr<ServePlugins> {
         RefPtr::new(ServePlugins {
-            ref_count: core::cell::Cell::new(1),
-            state: ServePluginsState::Unqueued(plugins),
+            ref_count: Cell::new(1),
+            state: JsCell::new(ServePluginsState::Unqueued(plugins)),
+            promise_ref: Cell::new(None),
         })
     }
 
-    pub(crate) fn get_or_start_load(
-        &mut self,
+    pub(crate) fn get_or_start_load<'a>(
+        this: bun_ptr::ThisPtr<Self>,
         global: &JSGlobalObject,
-        cb: ServePluginsCallback<'_>,
-    ) -> JsResult<GetOrStartLoadResult<'_>> {
-        loop {
-            match &mut self.state {
-                ServePluginsState::Unqueued(_) => {
-                    self.load_and_resolve_plugins(global)?;
-                    // could jump to any branch if synchronously resolved
-                    continue;
-                }
-                ServePluginsState::Pending {
-                    html_bundle_routes,
-                    dev_server,
-                    ..
-                } => {
+        cb: ServePluginsCallback,
+        server: AnyServer,
+    ) -> JsResult<GetOrStartLoadResult<'a>> {
+        if matches!(this.state.get(), ServePluginsState::Unqueued(_)) {
+            // could end up in any state if synchronously resolved
+            Self::load_and_resolve_plugins(this, global)?;
+        }
+        enum Now {
+            Pending,
+            Loaded(NonNull<JSBundler::Plugin>),
+            Err,
+        }
+        let now = match this.state.get() {
+            ServePluginsState::Unqueued(_) => unreachable!(),
+            ServePluginsState::Pending { .. } => Now::Pending,
+            ServePluginsState::Loaded(plugin) => Now::Loaded(*plugin),
+            ServePluginsState::Err => Now::Err,
+        };
+        match now {
+            Now::Pending => {
+                this.state.with_mut(|state| {
+                    let ServePluginsState::Pending {
+                        html_bundle_routes,
+                        dev_server,
+                        ..
+                    } = state
+                    else {
+                        unreachable!()
+                    };
                     match cb {
                         ServePluginsCallback::HtmlBundleRoute(route) => {
                             html_bundle_routes.push(RefPtr::from_this(route));
                         }
-                        ServePluginsCallback::DevServer(server) => {
-                            debug_assert!(
-                                dev_server.is_none()
-                                    || dev_server.map(|p| p.as_ptr().cast_const())
-                                        == Some(std::ptr::from_ref(server))
-                            ); // one dev server per server
-                            *dev_server = Some(NonNull::from(server));
+                        ServePluginsCallback::DevServer => {
+                            // one dev server per server
+                            debug_assert!(dev_server.is_none_or(|s| s == server));
+                            *dev_server = Some(server);
                         }
                     }
-                    return Ok(GetOrStartLoadResult::Pending);
-                }
-                ServePluginsState::Loaded(_) => break,
-                ServePluginsState::Err => return Ok(GetOrStartLoadResult::Err),
+                });
+                Ok(GetOrStartLoadResult::Pending)
             }
-        }
-        // NOTE: split out of the loop so the `Loaded` arm's borrow of
-        // `self.state` doesn't conflict with the `Unqueued` arm's `&mut self`.
-        match &mut self.state {
-            ServePluginsState::Loaded(plugins) => Ok(GetOrStartLoadResult::Ready(Some(plugins))),
-            _ => unreachable!(),
+            // S008: `Plugin` is an `opaque_ffi!` ZST handle (a protected JS
+            // cell) — safe deref.
+            Now::Loaded(plugin) => Ok(GetOrStartLoadResult::Ready(Some(bun_opaque::opaque_deref(
+                plugin.as_ptr(),
+            )))),
+            Now::Err => Ok(GetOrStartLoadResult::Err),
         }
     }
 
-    fn load_and_resolve_plugins(&mut self, global: &JSGlobalObject) -> JsResult<()> {
-        debug_assert!(matches!(self.state, ServePluginsState::Unqueued(_)));
-        let ServePluginsState::Unqueued(plugin_list) = &self.state else {
-            unreachable!()
+    fn load_and_resolve_plugins(
+        this: bun_ptr::ThisPtr<Self>,
+        global: &JSGlobalObject,
+    ) -> JsResult<()> {
+        let (plugin_js_array, bunfig_folder_bunstr) = {
+            let ServePluginsState::Unqueued(plugin_list) = this.state.get() else {
+                unreachable!()
+            };
+            let bunfig_path: &[u8] = &global.bun_vm().transpiler.options.bunfig_path;
+            let bunfig_folder: &[u8] = bun_paths::resolve_path::dirname::<
+                bun_paths::resolve_path::platform::Auto,
+            >(bunfig_path);
+            let mut bunstring_array: Vec<BunString> = Vec::with_capacity(plugin_list.len());
+            for raw_plugin in plugin_list.iter() {
+                bunstring_array.push(BunString::from_bytes(raw_plugin));
+            }
+            (
+                bun_string_jsc::to_js_array(global, &bunstring_array)?,
+                bun_string_jsc::create_utf8_for_js(global, bunfig_folder)?,
+            )
         };
-        // NOTE: reshaped for borrowck — clone the slice refs so we can mutate self.state below
-        let plugin_list: Vec<_> = plugin_list.iter().collect();
-        let bunfig_path: &[u8] = &global.bun_vm().transpiler.options.bunfig_path;
-        let bunfig_folder: &[u8] = bun_paths::resolve_path::dirname::<
-            bun_paths::resolve_path::platform::Auto,
-        >(bunfig_path);
 
-        // NOTE: the keep-alive ref/deref pair
-        // lives in the caller (`get_or_load_plugins`), which holds the heap-allocated
-        // `*mut ServePlugins` directly. Deriving the guard's pointer from `&mut self`
-        // here would give it a tag that is invalidated by the writes to `self.state`
-        // below (Stacked Borrows), making the eventual `heap::take` in `deref_` UB.
-
-        let plugin = JSBundler::Plugin::create(global, bun_jsc::BunPluginTarget::Browser);
-        // SAFETY: `Plugin::create` returns a freshly-boxed `*mut Plugin` (single owner).
-        let plugin: Box<JSBundler::Plugin> = unsafe { bun_core::heap::take(plugin) };
-        let mut bunstring_array: Vec<BunString> = Vec::with_capacity(plugin_list.len());
-        for raw_plugin in &plugin_list {
-            bunstring_array.push(BunString::from_bytes(raw_plugin));
-        }
-        let plugin_js_array = bun_string_jsc::to_js_array(global, &bunstring_array)?;
-        let bunfig_folder_bunstr = bun_string_jsc::create_utf8_for_js(global, bunfig_folder)?;
-
-        self.state = ServePluginsState::Pending {
+        let plugin = NonNull::new(JSBundler::Plugin::create(
+            global,
+            bun_jsc::BunPluginTarget::Browser,
+        ))
+        .expect("JSBundlerPlugin__create returns a non-null protected JSCell");
+        this.state.set(ServePluginsState::Pending {
             promise: jsc::JSPromiseStrong::init(global),
             plugin,
             html_bundle_routes: Vec::new(),
             dev_server: None,
-        };
+        });
 
         global.bun_vm().event_loop_mut().enter();
         let result = jsc::host_fn::from_js_host_call(global, || {
-            match &self.state {
-                ServePluginsState::Pending { plugin, .. } => plugin.as_ref(),
-                _ => unreachable!(),
-            }
-            .load_and_resolve_plugins_for_serve(plugin_js_array, bunfig_folder_bunstr)
-        })?;
+            // S008: opaque ZST handle to the protected cell — safe deref.
+            bun_opaque::opaque_deref(plugin.as_ptr())
+                .load_and_resolve_plugins_for_serve(plugin_js_array, bunfig_folder_bunstr)
+        });
         global.bun_vm().event_loop_mut().exit();
+        let result = result?;
 
         // handle the case where js synchronously throws an error
         if let Some(e) = global.try_take_exception() {
-            self.handle_on_reject(global, e);
+            this.handle_on_reject(global, e);
             return Ok(());
         }
 
@@ -1056,145 +1073,158 @@ impl ServePlugins {
                 match promise.status() {
                     // promise not fulfilled yet
                     jsc::js_promise::Status::Pending => {
-                        // The reaction's ref, adopted by `on_resolve_impl`/`on_reject_impl`.
-                        self.ref_();
+                        this.promise_ref.set(Some(RefPtr::from_this(this)));
                         let promise_value = promise.as_value();
-                        if let ServePluginsState::Pending {
-                            promise: pending_promise,
-                            ..
-                        } = &mut self.state
-                        {
-                            pending_promise.set(global, promise_value);
-                        }
+                        this.state.with_mut(|state| {
+                            if let ServePluginsState::Pending {
+                                promise: pending_promise,
+                                ..
+                            } = state
+                            {
+                                pending_promise.set(global, promise_value);
+                            }
+                        });
                         promise_value.then(
                             global,
-                            std::ptr::from_mut::<Self>(self),
-                            __jsc_host_on_resolve_impl,
-                            __jsc_host_on_reject_impl,
+                            this.as_ptr(),
+                            crate::generated_host_exports::BunServe__onResolvePlugins,
+                            crate::generated_host_exports::BunServe__onRejectPlugins,
                         );
                         return Ok(());
                     }
                     jsc::js_promise::Status::Fulfilled => {
-                        self.handle_on_resolve();
+                        this.handle_on_resolve();
                         return Ok(());
                     }
                     jsc::js_promise::Status::Rejected => {
                         let value = promise.result(global.vm());
-                        self.handle_on_reject(global, value);
+                        this.handle_on_reject(global, value);
                         return Ok(());
                     }
                 }
             }
 
             if let Some(e) = result.to_error() {
-                self.handle_on_reject(global, e);
+                this.handle_on_reject(global, e);
             } else {
-                self.handle_on_resolve();
+                this.handle_on_resolve();
             }
         }
         Ok(())
     }
 
-    pub(crate) fn handle_on_resolve(&mut self) {
-        debug_assert!(matches!(self.state, ServePluginsState::Pending { .. }));
+    pub(crate) fn handle_on_resolve(&self) {
         let ServePluginsState::Pending {
             plugin,
             dev_server,
             html_bundle_routes,
             promise,
-        } = mem::replace(&mut self.state, ServePluginsState::Err)
+        } = self.state.replace(ServePluginsState::Err)
         else {
             unreachable!()
         };
         drop(promise); // Drop on JscStrong releases the slot.
 
-        self.state = ServePluginsState::Loaded(plugin);
-        let plugin_ref = match &self.state {
-            ServePluginsState::Loaded(p) => &**p,
-            _ => unreachable!(),
-        };
+        self.state.set(ServePluginsState::Loaded(plugin));
 
         for route in html_bundle_routes {
             bun_core::handle_oom(html_bundle::Route::on_plugins_resolved(
                 route.this_ptr(),
-                Some(NonNull::from(plugin_ref)),
+                Some(plugin),
             ));
         }
-        if let Some(mut server) = dev_server {
-            // SAFETY: dev_server outlives plugin load (stored as a back-reference
-            // by `get_or_start_load`; the owning Box<DevServer> is held by the
-            // server instance, which itself holds a counted ref on `self`).
-            bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_resolved(Some(
-                std::ptr::from_ref::<JSBundler::Plugin>(plugin_ref).cast_mut(),
-            )));
+        if let Some(server) = dev_server {
+            if let Some(r) =
+                server.with_dev_server_mut(|dev| dev.on_plugins_resolved(Some(plugin.as_ptr())))
+            {
+                bun_core::handle_oom(r);
+            }
         }
     }
 
-    pub(crate) fn handle_on_reject(&mut self, global: &JSGlobalObject, err: JSValue) {
-        debug_assert!(matches!(self.state, ServePluginsState::Pending { .. }));
+    pub(crate) fn handle_on_reject(&self, global: &JSGlobalObject, err: JSValue) {
         let ServePluginsState::Pending {
             plugin,
             dev_server,
             html_bundle_routes,
             promise,
-        } = mem::replace(&mut self.state, ServePluginsState::Err)
+        } = self.state.replace(ServePluginsState::Err)
         else {
             unreachable!()
         };
-        drop(plugin); // pending.plugin.deinit()
+        // The (protected) plugin cell is left as is: a bundle already running
+        // with it releases it itself.
+        let _ = plugin;
         drop(promise); // Drop on JscStrong releases the slot.
 
         for route in html_bundle_routes {
             bun_core::handle_oom(route.on_plugins_rejected());
         }
-        if let Some(mut server) = dev_server {
-            // SAFETY: dev_server outlives plugin load
-            bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_rejected());
+        if let Some(server) = dev_server {
+            if let Some(r) = server.with_dev_server_mut(|dev| dev.on_plugins_rejected()) {
+                bun_core::handle_oom(r);
+            }
         }
 
         Output::err_generic("Failed to load plugins for Bun.serve:", ());
         global.bun_vm().as_mut().run_error_handler(err, None);
     }
+
+    fn release_promise_ref(&self) {
+        if let Some(r) = self.promise_ref.take() {
+            r.deref();
+        }
+    }
+
+    /// `server` (whose DevServer may be waiting on a pending load) is going away.
+    pub(crate) fn forget_server(&self, server: AnyServer) {
+        self.state.with_mut(|state| {
+            if let ServePluginsState::Pending { dev_server, .. } = state {
+                if *dev_server == Some(server) {
+                    *dev_server = None;
+                }
+            }
+        });
+    }
 }
 
 impl Drop for ServePlugins {
     fn drop(&mut self) {
-        match &self.state {
+        match self.state.get() {
             ServePluginsState::Unqueued(_) => {}
             ServePluginsState::Pending { .. } => debug_assert!(false), // should have one ref while pending!
-            ServePluginsState::Loaded(_) => {}                         // Box<Plugin> drops
+            // The plugin cell may still be in use by (and is released by) a
+            // bundle running with it.
+            ServePluginsState::Loaded(_) => {}
             ServePluginsState::Err => {}
         }
     }
 }
 
-#[bun_jsc::host_fn(export = "BunServe__onResolvePlugins")]
-fn on_resolve_impl(_global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+// HOST_EXPORT(BunServe__onResolvePlugins)
+pub fn on_resolve_plugins(
+    this: bun_ptr::ThisPtr<ServePlugins>,
+    _global: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
     ctx_log!("onResolve");
-
-    let [plugins_result, plugins_js] = callframe.arguments_as_array::<2>();
-    let plugins = plugins_js.as_promise_ptr::<ServePlugins>();
-    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); this adopts that ref.
-    let _guard = unsafe { RefPtr::from_raw(plugins) };
+    let [plugins_result, _] = callframe.arguments_as_array::<2>();
+    let _guard = scopeguard::guard(this, |p| p.release_promise_ref());
     plugins_result.ensure_still_alive();
-
-    // SAFETY: pointer was passed via .then() above
-    unsafe { &mut *plugins }.handle_on_resolve();
-
+    this.handle_on_resolve();
     Ok(JSValue::UNDEFINED)
 }
 
-#[bun_jsc::host_fn(export = "BunServe__onRejectPlugins")]
-fn on_reject_impl(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+// HOST_EXPORT(BunServe__onRejectPlugins)
+pub fn on_reject_plugins(
+    this: bun_ptr::ThisPtr<ServePlugins>,
+    global: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
     ctx_log!("onReject");
-
-    let [error_js, plugin_js] = callframe.arguments_as_array::<2>();
-    let plugins = plugin_js.as_promise_ptr::<ServePlugins>();
-    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); this adopts that ref.
-    let _guard = unsafe { RefPtr::from_raw(plugins) };
-    // SAFETY: pointer was passed via .then() above
-    unsafe { &mut *plugins }.handle_on_reject(global, error_js);
-
+    let [error_js, _] = callframe.arguments_as_array::<2>();
+    let _guard = scopeguard::guard(this, |p| p.release_promise_ref());
+    this.handle_on_reject(global, error_js);
     Ok(JSValue::UNDEFINED)
 }
 
@@ -1234,44 +1264,40 @@ fn on_timeout_for_idle_warn() {
 // defined once in `super` (mod.rs). This file contributes additional inherent
 // methods on the same type — there is no separate Phase-A struct.
 pub(super) use super::{
-    CreateJsRequest, DebugHTTPSServer, DebugHTTPServer, HTTPSServer, HTTPServer, NewServer,
-    ServerFlags, UserRoute,
+    AnyServer, CreateJsRequest, DebugHTTPSServer, DebugHTTPServer, HTTPSServer, HTTPServer,
+    NewServer, PreparedRequestFor, ServerFlags, UserRoute,
 };
 
-/// Generic over the
-/// per-transport `RequestContext` so the same body serves HTTP/1 and HTTP/3.
-/// `super::PreparedRequest<SSL,DEBUG>` is the HTTP/1-concrete instantiation
-/// used by the bake/saved-request path; the generic form here is only reached
-/// from the `_for<Ctx>` dispatch helpers below.
-pub(crate) struct PreparedRequestFor<Ctx> {
-    pub(crate) js_request: JSValue,
-    pub(crate) request_object: *mut Request,
-    pub ctx: *mut Ctx,
-}
-
-// `WebSocketUpgradeServer<SSL>` so `ServerWebSocket::behavior::<Self, SSL>` and
-// `app.ws(...)` accept `*mut Self` / `*mut UserRoute<..>` as the upgrade ctx.
+// `WebSocketUpgradeServer<SSL>`: the `/*` websocket fallback route registers
+// the server itself; per-route websockets register their `UserRoute`.
 impl<const SSL: bool, const DEBUG: bool> uws_sys::web_socket::WebSocketUpgradeServer<SSL>
     for NewServer<SSL, DEBUG>
-where
-    // NOTE: see the bounded `impl NewServer` below for why these are
-    // spelled out — `on_web_socket_upgrade` lives in that impl.
-    NewRequestContext<Self, SSL, DEBUG, false>: super::request_context::RequestContextHostFns,
-    NewRequestContext<Self, SSL, DEBUG, true>: super::request_context::RequestContextHostFns,
 {
-    unsafe fn on_websocket_upgrade(
-        this: *mut Self,
-        res: *mut uws_sys::NewAppResponse<SSL>,
+    fn on_websocket_upgrade(
+        this: ThisPtr<Self>,
+        res: &mut uws_sys::NewAppResponse<SSL>,
         req: &mut uws_sys::Request,
         context: &mut WebSocketUpgradeContext,
         id: usize,
     ) {
-        // S008: `Response<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-        // SAFETY: forwarded raw — `this` is only dereferenced after the `id`
-        // dispatch inside `on_web_socket_upgrade`.
-        unsafe {
-            Self::on_web_socket_upgrade(this, bun_opaque::opaque_deref_mut(res), req, context, id)
-        };
+        debug_assert!(id == 0);
+        Self::on_web_socket_upgrade(this, res, req, context);
+    }
+}
+
+impl<const SSL: bool, const DEBUG: bool> uws_sys::web_socket::WebSocketUpgradeServer<SSL>
+    for UserRoute<SSL, DEBUG>
+{
+    fn on_websocket_upgrade(
+        this: ThisPtr<Self>,
+        res: &mut uws_sys::NewAppResponse<SSL>,
+        req: &mut uws_sys::Request,
+        context: &mut WebSocketUpgradeContext,
+        id: usize,
+    ) {
+        debug_assert!(id == 1);
+        jsc::mark_binding!();
+        NewServer::<SSL, DEBUG>::upgrade_web_socket_user_route(this, res, req, context, None);
     }
 }
 
@@ -1280,8 +1306,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// (StaticRoute/FileRoute/HTMLBundle) store this so they can call back
     /// into `on_pending_request` / `on_static_request_complete`.
     #[inline]
-    fn as_any_server(&self) -> super::AnyServer {
-        super::AnyServer::from(std::ptr::from_ref::<Self>(self))
+    fn as_any_server(&self) -> AnyServer {
+        AnyServer::from(self)
     }
 
     /// Shared `&VirtualMachine` accessor.
@@ -1300,22 +1326,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         GlobalRef::from(bun_opaque::opaque_deref(self.global_this))
     }
 
-    /// `&mut` accessor for the live uws App. Only call from paths where the
-    /// server is running (`self.app` set in `listen()`).
-    #[inline]
-    fn app_mut(&self) -> &mut uws_sys::NewApp<SSL> {
-        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref via
-        // const-asserted `bun_opaque::opaque_deref_mut`. `self.app` is `Some`
-        // for the lifetime of any JS-reachable `Server` (set in `listen()`,
-        // freed in `deinit()` after the JS wrapper is gone).
-        bun_opaque::opaque_deref_mut(self.app.expect("server not listening"))
-    }
-
-    /// Unbounded so `deinit()` (in
+    /// Unbounded so `teardown()` (in
     /// the unbounded `impl NewServer` in mod.rs) can call it without naming
     /// the per-transport `RequestContext` bounds.
-    pub(super) fn notify_inspector_server_stopped(&mut self) {
-        if self.inspector_server_id.get() != 0 {
+    pub(super) fn notify_inspector_server_stopped(&self) {
+        if self.inspector_server_id.get().get() != 0 {
             bun_core::hint::cold();
             if let Some(debugger) = &self.vm().as_mut().debugger {
                 bun_core::hint::cold();
@@ -1330,22 +1345,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // Only clear the id once the agent has been notified, so a
                 // call that races a not-yet-attached debugger leaves the id set
                 // for a later retry.
-                self.inspector_server_id = DebuggerId::init(0);
+                self.inspector_server_id.set(DebuggerId::init(0));
             }
         }
     }
-}
 
-impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG>
-where
-    // NOTE (const-generic dispatch): `RequestContextHostFns` (the host-fn
-    // export table) is blanket-impl'd per (SSL,DBG,H3) tuple in
-    // `RequestContext.rs` for `ThisServer: ServerLike`; restating it here lets
-    // method bodies name `<NewRequestContext<..> as RequestContextHostFns>::ON_*`
-    // without each method repeating the bound.
-    NewRequestContext<Self, SSL, DEBUG, false>: super::request_context::RequestContextHostFns,
-    NewRequestContext<Self, SSL, DEBUG, true>: super::request_context::RequestContextHostFns,
-{
     // NOTE: there is no `getPluginsAsync` method or `AnyServer` dispatcher;
     // the live HTMLBundle path goes through `get_or_load_plugins`.
 
@@ -1354,31 +1358,28 @@ where
     /// - .err if there is a cached failure. Currently, this requires restarting the entire server.
     /// - .pending if `callback` was stored. It will call `onPluginsResolved` or `onPluginsRejected` later.
     pub(crate) fn get_or_load_plugins(
-        &mut self,
-        callback: ServePluginsCallback<'_>,
+        &self,
+        callback: ServePluginsCallback,
     ) -> GetOrStartLoadResult<'_> {
-        if let Some(p) = &self.plugins {
-            // Keep `*p` alive across re-entrant JS in `load_and_resolve_plugins`.
-            let p = p.clone();
-            let global = self.global();
-            // SAFETY: intrusive refcount permits mutation through any owner. No
-            // other `&mut ServePlugins` is live on this (single-threaded) JS
-            // thread for the call's duration.
-            return match unsafe { &mut *p.as_ptr() }.get_or_start_load(&global, callback) {
-                Ok(r) => r,
-                Err(JsError::Thrown | JsError::Terminated) => {
-                    panic!("unhandled exception from ServePlugins.getStartOrLoad")
-                }
-                Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
-            };
+        let Some(p) = self.plugins.get().as_ref().map(RefPtr::this_ptr) else {
+            // no plugins
+            return GetOrStartLoadResult::Ready(None);
+        };
+        let global = self.global();
+        // Keep `*p` alive across re-entrant JS in `load_and_resolve_plugins`.
+        let _keep_alive = p.ref_guard();
+        match ServePlugins::get_or_start_load(p, &global, callback, self.as_any_server()) {
+            Ok(r) => r,
+            Err(JsError::Thrown | JsError::Terminated) => {
+                panic!("unhandled exception from ServePlugins.getStartOrLoad")
+            }
+            Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
         }
-        // no plugins
-        GetOrStartLoadResult::Ready(None)
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_subscriber_count(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1401,21 +1402,18 @@ where
         }
 
         Ok(JSValue::js_number(f64::from(
-            self.app_mut().num_subscribers(topic.slice()),
+            self.app_mut()
+                .expect("server not listening")
+                .num_subscribers(topic.slice()),
         )))
     }
 
     // ── host_fn.wrapInstanceMethod hand-expansions ───────────────────────
-    //
-    // NOTE: the `#[bun_jsc::host_fn(method)]` proc-macro that will eventually
-    // replace these hand-expansions hasn't landed, so the per-type decode arms
-    // used by the server (`EncodedSlice`, `JSValue`, `Option<JSValue>`, `&Request`)
-    // are open-coded here.
 
     /// `pub const doStop = host_fn.wrapInstanceMethod(ThisServer, "stopFromJS", false)`
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_stop(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1428,7 +1426,7 @@ where
     /// `pub const dispose = host_fn.wrapInstanceMethod(ThisServer, "disposeFromJS", false)`
     #[bun_jsc::host_fn(method)]
     pub(crate) fn dispose(
-        &mut self,
+        &self,
         _global: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1438,7 +1436,7 @@ where
     /// `pub const doUpgrade = host_fn.wrapInstanceMethod(ThisServer, "onUpgrade", false)`
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_upgrade(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1455,7 +1453,7 @@ where
     /// `pub const doPublish = host_fn.wrapInstanceMethod(ThisServer, "publish", false)`
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_publish(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1482,7 +1480,7 @@ where
     /// `pub const doRequestIP = host_fn.wrapInstanceMethod(ThisServer, "requestIP", false)`
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_request_ip(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1499,7 +1497,7 @@ where
     /// `pub const doReload = onReload`
     #[inline]
     pub(crate) fn do_reload(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1509,7 +1507,7 @@ where
     /// `pub const doFetch = onFetch`
     #[inline]
     pub(crate) fn do_fetch(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1519,7 +1517,7 @@ where
     /// `pub const doTimeout = timeout`
     #[inline]
     pub(crate) fn do_timeout(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1527,10 +1525,10 @@ where
     }
 
     pub(crate) fn request_ip(&self, request: &Request) -> JsResult<JSValue> {
-        if matches!(self.config.address, server_config::Address::Unix(_)) {
+        if matches!(self.config().address, server_config::Address::Unix(_)) {
             return Ok(JSValue::NULL);
         }
-        let Some(info) = request.request_context.get_remote_socket_info() else {
+        let Some(info) = request.request_context.get().get_remote_socket_info() else {
             return Ok(JSValue::NULL);
         };
         crate::socket::socket_address::SocketAddress::create_dto(
@@ -1543,7 +1541,7 @@ where
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn timeout(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -1554,7 +1552,7 @@ where
 
         let seconds = arguments[1];
 
-        if matches!(self.config.address, server_config::Address::Unix(_)) {
+        if matches!(self.config().address, server_config::Address::Unix(_)) {
             return Ok(JSValue::NULL);
         }
 
@@ -1565,13 +1563,10 @@ where
         }
         let value = seconds.to_u32();
 
-        if let Some(request) = <Request as bun_jsc::JsClass>::from_js(arguments[0]) {
-            // SAFETY: from_js returns a live *mut Request; shared access only.
-            let _ = unsafe { (*request).request_context.set_timeout(value) };
-        } else if let Some(response) = <NodeHTTPResponse as bun_jsc::JsClass>::from_js(arguments[0])
-        {
-            // SAFETY: from_js returns a live *mut NodeHTTPResponse
-            unsafe { (*response).set_timeout((value % 255) as u8) };
+        if let Some(request) = arguments[0].as_class_ref::<Request>() {
+            let _ = request.request_context.get().set_timeout(value);
+        } else if let Some(response) = arguments[0].as_class_ref::<NodeHTTPResponse>() {
+            response.set_timeout((value % 255) as u8);
         } else {
             return Err(self
                 .global()
@@ -1582,13 +1577,13 @@ where
     }
 
     pub(crate) fn publish(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         topic: &[u8],
         message_value: JSValue,
         compress_value: Option<JSValue>,
     ) -> JsResult<JSValue> {
-        if self.config.websocket.is_none() {
+        if self.config().websocket.is_none() {
             return Ok(JSValue::js_number(0.0));
         }
 
@@ -1618,7 +1613,7 @@ where
             (string_slice.slice(), uws_sys::Opcode::Text)
         };
 
-        let Some(app) = self.app else {
+        let Some(app) = self.app_ptr() else {
             return Ok(JSValue::js_number(0.0));
         };
         let status = AnyWebSocket::publish_with_options(
@@ -1636,7 +1631,7 @@ where
     }
 
     pub(crate) fn on_upgrade(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         object: JSValue,
         optional: Option<JSValue>,
@@ -1645,13 +1640,13 @@ where
         use bun_core::Utf8Bytes;
         use bun_jsc::HTTPHeaderName;
 
-        if self.config.websocket.is_none() {
+        if self.config().websocket.is_none() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "To enable websocket support, set the \"websocket\" object in Bun.serve({{}})"
             )));
         }
 
-        if self.flags.contains(ServerFlags::TERMINATED) {
+        if self.has_flags(ServerFlags::TERMINATED) {
             return Ok(JSValue::FALSE);
         }
 
@@ -1661,7 +1656,7 @@ where
         // `schedule_deinit`: accepting an upgrade there would create a
         // `ServerWebSocket` whose open/close accounting is skipped.
         if self
-            .config
+            .config()
             .websocket
             .as_ref()
             .is_some_and(|ws| ws.handler.server.is_none())
@@ -1669,10 +1664,7 @@ where
             return Ok(JSValue::FALSE);
         }
 
-        if let Some(node_http_response) = <NodeHTTPResponse as bun_jsc::JsClass>::from_js(object) {
-            // SAFETY: from_js returns a live *mut NodeHTTPResponse; shared —
-            // its mutable state is `Cell`/`JsCell` and `upgrade` takes `&self`.
-            let node_http_response = unsafe { &*node_http_response };
+        if let Some(node_http_response) = object.as_class_ref::<NodeHTTPResponse>() {
             if node_http_response
                 .flags
                 .get()
@@ -1687,15 +1679,8 @@ where
 
             let mut data_value = JSValue::ZERO;
 
-            // if we converted a HeadersInit to a Headers object, we need to free it
-            let fetch_headers_to_deref: core::cell::Cell<Option<*mut FetchHeaders>> =
-                core::cell::Cell::new(None);
-            let _fh_guard = scopeguard::guard(&fetch_headers_to_deref, |cell| {
-                if let Some(fh) = cell.get() {
-                    // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
-                    bun_opaque::opaque_deref_mut(fh).deref();
-                }
-            });
+            // if we converted a HeadersInit to a Headers object, this owns (and frees) it
+            let mut created_headers: Option<HeadersRef> = None;
 
             // Copied out of `options.headers` because `fast_remove` frees the
             // entry they would otherwise borrow.
@@ -1729,11 +1714,11 @@ where
                                 None => 'brk: {
                                     if headers_value.is_object() {
                                         if let Some(fetch_headers) =
-                                            FetchHeaders::create_from_js(global, headers_value)?
+                                            HeadersRef::create_from_js(global, headers_value)?
                                         {
-                                            fetch_headers_to_deref
-                                                .set(Some(fetch_headers.as_ptr()));
-                                            break 'brk fetch_headers.as_ptr();
+                                            break 'brk created_headers
+                                                .insert(fetch_headers)
+                                                .as_ptr();
                                         }
                                     }
                                     return Err(global.throw_invalid_arguments(format_args!(
@@ -1783,24 +1768,16 @@ where
             )));
         }
 
-        let Some(request_ptr) = <Request as bun_jsc::JsClass>::from_js(object) else {
+        let Some(request) = object.as_class_ref::<Request>() else {
             return Err(
                 global.throw_invalid_arguments(format_args!("upgrade requires a Request object"))
             );
         };
-        // SAFETY: from_js returns a live *mut Request (rooted by the caller's
-        // argument). Shared, re-derived after each JS re-entry point below; the
-        // one field write at the end goes through `request_ptr`.
-        let request = unsafe { &*request_ptr };
 
-        let Some(upgrader_ptr) = request
-            .request_context
-            .get::<ServerRequestContext<SSL, DEBUG>>()
-        else {
+        let request_ctx = request.request_context.get();
+        let Some(upgrader) = request_ctx.get_ref::<ServerRequestContext<SSL, DEBUG>>() else {
             return Ok(JSValue::FALSE);
         };
-        // SAFETY: tagged pointer just matched this monomorphization.
-        let upgrader = unsafe { &*upgrader_ptr };
 
         if upgrader.is_aborted_or_ended() {
             return Ok(JSValue::FALSE);
@@ -1818,11 +1795,7 @@ where
         // arbitrary user JS. A re-entrant server.upgrade(req) from a getter
         // would otherwise be able to deref this context out from under us.
         upgrader.ref_();
-        let _upgrader_guard = scopeguard::guard(upgrader_ptr, |p| {
-            // SAFETY: `p` is the live `upgrader_ptr` whose refcount was bumped by
-            // the `ref_()` above; this guard pairs it with a single `deref()`.
-            unsafe { (*p).deref() }
-        });
+        let _upgrader_guard = scopeguard::guard(upgrader, |u| u.deref());
 
         let mut sec_websocket_key = Utf8Bytes::EMPTY;
         let mut sec_websocket_protocol = Utf8Bytes::EMPTY;
@@ -1856,14 +1829,11 @@ where
             }
         }
 
-        // SAFETY: upgrader_ptr is live (ref_() above)
-        let upgrader = unsafe { &*upgrader_ptr };
         if let Some(req_ptr) = upgrader.req.get() {
-            // NOTE: `RequestContext.req` is type-erased to `*mut c_void`
-            // (RequestContext.rs:82). `server.upgrade()` is HTTP/1-only — H3
-            // contexts have a distinct generic param and `request_context.get`
-            // above would have returned None — so the concrete `Req` is always
-            // `uws_sys::Request` here.
+            // NOTE: `RequestContext.req` is type-erased to `*mut c_void`.
+            // `server.upgrade()` is HTTP/1-only — H3 contexts have a distinct
+            // generic param and `request_context.get_ref` above would have
+            // returned None — so the concrete `Req` is always `uws_sys::Request`.
             // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref
             // (BACKREF; live while RequestContext.req is Some).
             let r = bun_opaque::opaque_deref(req_ptr.cast::<uws_sys::Request>().cast_const());
@@ -1898,21 +1868,13 @@ where
         if sec_websocket_version.slice() != b"13" {
             resp.write_status(b"426 Upgrade Required");
             resp.write_header(b"Sec-WebSocket-Version", b"13");
-            // SAFETY: upgrader_ptr is live (ref_() above)
-            let upgrader = unsafe { &*upgrader_ptr };
             upgrader.flags.set_has_written_status(true);
             upgrader.end_without_body(true);
             return Ok(JSValue::FALSE);
         }
         let mut data_value = JSValue::ZERO;
-        // Non-unit guard state: holds the temporarily-created FetchHeaders (if
-        // any) and derefs it on scope exit. Populated below via DerefMut.
-        let mut fetch_headers_to_deref = scopeguard::guard(None::<*mut FetchHeaders>, |fh| {
-            // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
-            if let Some(h) = fh {
-                bun_opaque::opaque_deref_mut(h).deref()
-            }
-        });
+        // Holds the temporarily-created FetchHeaders (if any); its `Drop` derefs it.
+        let mut created_headers: Option<HeadersRef> = None;
         let mut fetch_headers_to_use: Option<*mut FetchHeaders> = None;
 
         if let Some(opts) = optional {
@@ -1939,10 +1901,9 @@ where
                         None => 'brk: {
                             if headers_value.is_object() {
                                 if let Some(created) =
-                                    FetchHeaders::create_from_js(global, headers_value)?
+                                    HeadersRef::create_from_js(global, headers_value)?
                                 {
-                                    *fetch_headers_to_deref = Some(created.as_ptr());
-                                    break 'brk created.as_ptr();
+                                    break 'brk created_headers.insert(created).as_ptr();
                                 }
                             }
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -1967,8 +1928,6 @@ where
             }
         }
 
-        // SAFETY: upgrader_ptr is live (ref_() above)
-        let upgrader = unsafe { &*upgrader_ptr };
         // Option getters may have run a re-entrant server.upgrade(req).
         if upgrader.is_aborted_or_ended() || upgrader.did_upgrade_web_socket() {
             return Ok(JSValue::FALSE);
@@ -2004,6 +1963,7 @@ where
                 )?;
             }
         }
+        drop(created_headers);
 
         // --- After this point, do not throw an exception
         // See https://github.com/oven-sh/bun/issues/1339
@@ -2012,9 +1972,6 @@ where
         upgrader.resp.set(None);
 
         // Snapshot lazy url/headers before detaching (mirrors to_async_without_abort_handler).
-        // SAFETY: re-derived after the JS-running option getters above; still
-        // the live JsClass payload for `object`.
-        let request = unsafe { &*request_ptr };
         if request.ensure_url().is_err() {
             request.url.set(BunString::EMPTY);
         }
@@ -2024,14 +1981,12 @@ where
             }
         }
 
-        // SAFETY: plain-field detach through the root pointer; the shared
-        // borrow above is not used past this point.
-        unsafe { (*request_ptr).request_context = AnyRequestContext::NULL };
+        request.request_context.set(AnyRequestContext::NULL);
         upgrader.request_weakref.set(request::WeakRef::EMPTY);
 
         data_value.ensure_still_alive();
         let ws = ServerWebSocket::init(
-            &self.config.websocket.as_mut().unwrap().handler,
+            &self.config().websocket.as_ref().unwrap().handler,
             data_value,
             signal,
         );
@@ -2069,15 +2024,15 @@ where
     /// Any `Some(ws)` is adopted unconditionally — `Handler::from_js` already
     /// rejected configs with no non-error callback.
     pub(crate) fn on_reload_from_zig(
-        &mut self,
+        &self,
         new_config: &mut ServerConfig,
         global: &JSGlobalObject,
     ) {
         httplog!("onReload");
 
-        // SAFETY: `on_reload` is only reachable while the server is running
-        // (`self.app` set in `listen()`).
-        self.app_mut().clear_routes();
+        // `on_reload` is only reachable while the server is running (`self.app`
+        // created in `listen()`).
+        self.app_mut().expect("server not listening").clear_routes();
         for_each_mux_app!(self, |mux| {
             mux.clear_routes();
         });
@@ -2098,7 +2053,8 @@ where
                 global,
                 Self::js_gc_on_request_set,
             );
-            self.config.on_request = new_config.on_request;
+            let v = new_config.on_request;
+            self.config.with_mut(|c| c.on_request = v);
         }
         // Swap on any change, *including* clearing to ZERO when the reload
         // config omits the handler, so subsequent `on_web_socket_upgrade` /
@@ -2111,8 +2067,8 @@ where
         // and set_routes would swap the context onto the node:http handler
         // instantiation under those already-sized allocations, so the node
         // request path would construct and index past them.
-        if self.config.is_node_http_server
-            && self.config.on_node_http_request != new_config.on_node_http_request
+        if self.config().is_node_http_server
+            && self.config().on_node_http_request != new_config.on_node_http_request
         {
             super::wrap_handler_slot(
                 &mut new_config.on_node_http_request,
@@ -2120,7 +2076,8 @@ where
                 global,
                 Self::js_gc_on_node_http_request_set,
             );
-            self.config.on_node_http_request = new_config.on_node_http_request;
+            let v = new_config.on_node_http_request;
+            self.config.with_mut(|c| c.on_node_http_request = v);
         }
         if !new_config.on_error.is_empty_or_undefined_or_null() {
             super::wrap_handler_slot(
@@ -2129,7 +2086,8 @@ where
                 global,
                 Self::js_gc_on_error_set,
             );
-            self.config.on_error = new_config.on_error;
+            let v = new_config.on_error;
+            self.config.with_mut(|c| c.on_error = v);
         }
 
         if let Some(mut ws) = new_config.websocket.take() {
@@ -2139,27 +2097,32 @@ where
             ws.handler
                 .flags
                 .set(super::web_socket_server_context::HandlerFlags::SSL, SSL);
-            self.config.websocket = Some(ws);
+            self.config.with_mut(|c| c.websocket = Some(ws));
             self.write_ws_handler_slots(server_js, global);
         }
 
         // These get re-applied when we set the static routes again.
-        if let Some(dev_server) = self.dev_server.as_deref_mut() {
-            // Prevent a use-after-free in the hash table keys.
-            dev_server.html_router.clear();
-            dev_server.html_router.fallback = None;
-        }
+        self.dev_server.with_mut(|dev| {
+            if let Some(dev_server) = dev.as_deref_mut() {
+                // Prevent a use-after-free in the hash table keys.
+                dev_server.html_router.clear();
+                dev_server.html_router.fallback = None;
+            }
+        });
 
-        // NOTE: `Vec<StaticRouteEntry>` impls `Drop`, so
-        // a move-assign frees the old `static_routes`.
-        self.config.static_routes = core::mem::take(&mut new_config.static_routes);
-        self.config.negative_routes = core::mem::take(&mut new_config.negative_routes);
+        self.config.with_mut(|c| {
+            // NOTE: `Vec<StaticRouteEntry>` impls `Drop`, so
+            // a move-assign frees the old `static_routes`.
+            c.static_routes = core::mem::take(&mut new_config.static_routes);
+            c.negative_routes = core::mem::take(&mut new_config.negative_routes);
 
+            if new_config.had_routes_object {
+                c.user_routes_to_build = core::mem::take(&mut new_config.user_routes_to_build);
+            }
+        });
         if new_config.had_routes_object {
-            self.config.user_routes_to_build =
-                core::mem::take(&mut new_config.user_routes_to_build);
-            // `UserRoute`'s owned `RouteDeclaration` drops via `Vec::clear`.
-            self.user_routes.clear();
+            // Registrations were cleared above; each `UserRoute` drops here.
+            self.user_routes.set(Vec::new());
         }
 
         let route_list_value = self.set_routes();
@@ -2167,7 +2130,7 @@ where
             Self::js_gc_route_list_set(server_js, global, route_list_value);
         }
 
-        if self.inspector_server_id.get() != 0 {
+        if self.inspector_server_id.get().get() != 0 {
             if let Some(debugger) = self.vm().as_mut().debugger.as_deref_mut() {
                 bun_core::handle_oom(super::http_server_agent::notify_server_routes_updated(
                     &debugger.http_server_agent,
@@ -2177,13 +2140,16 @@ where
         }
     }
 
-    pub(crate) fn reload_static_routes(&mut self) -> Result<bool, crate::Error> {
-        if self.app.is_none() {
+    pub(crate) fn reload_static_routes(&self) -> Result<bool, crate::Error> {
+        let Some(app) = self.app_mut() else {
             // Static routes will get cleaned up when the server is stopped
             return Ok(false);
-        }
-        self.config = self.config.clone_for_reloading_static_routes()?;
-        self.app_mut().clear_routes();
+        };
+        let new_config = self
+            .config
+            .with_mut(|c| c.clone_for_reloading_static_routes())?;
+        self.config.set(new_config);
+        app.clear_routes();
         for_each_mux_app!(self, |mux| {
             mux.clear_routes();
         });
@@ -2198,7 +2164,7 @@ where
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn on_reload(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
@@ -2207,7 +2173,6 @@ where
             return Err(global.throw_not_enough_arguments("reload", 1, 0));
         }
 
-        // SAFETY: bun_vm() returns the live per-thread VM singleton.
         let mut args_slice = jsc::ArgumentsSlice::init(global.bun_vm(), arguments);
 
         let mut new_config = ServerConfig::from_js(
@@ -2216,8 +2181,8 @@ where
             server_config::FromJSOptions {
                 allow_bake_config: false,
                 is_fetch_required: true,
-                previous_fetch: !self.config.on_request.is_empty_or_undefined_or_null(),
-                previous_routes: !self.user_routes.is_empty(),
+                previous_fetch: !self.config().on_request.is_empty_or_undefined_or_null(),
+                previous_routes: !self.user_routes.get().is_empty(),
             },
         )?;
 
@@ -2228,18 +2193,18 @@ where
         let _handler_pins = super::protect_handler_shadows(&new_config);
         self.on_reload_from_zig(&mut new_config, global);
 
-        Ok(self.js_value.try_get().unwrap_or(JSValue::UNDEFINED))
+        Ok(self.js_value.get().try_get().unwrap_or(JSValue::UNDEFINED))
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn on_fetch(
-        &mut self,
+        &self,
         ctx: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
 
-        if self.config.on_request.is_empty() {
+        if self.config().on_request.is_empty() {
             return Ok(JSPromise::rejected_promise(
                 ctx,
                 ctx.create_error_instance(format_args!(
@@ -2262,7 +2227,6 @@ where
 
         let mut headers: Option<HeadersRef> = None;
         let mut method = Method::GET;
-        // SAFETY: bun_vm() returns the live per-thread VM singleton.
         let mut args = jsc::ArgumentsSlice::init(ctx.bun_vm(), arguments);
 
         let first_arg = args.next_eat().unwrap();
@@ -2308,22 +2272,13 @@ where
 
                 if let Some(headers_) = opts.fast_get(ctx, jsc::BuiltinName::Headers)? {
                     if let Some(headers__) = FetchHeaders::cast_(headers_, ctx.vm()) {
-                        // NOTE: `cast_` returns the `FetchHeaders*` held by the
-                        // JS `Headers` wrapper (`JSFetchHeaders`'s internal
-                        // `Ref<FetchHeaders>`) without bumping the refcount —
-                        // the FFI surface has `WebCore__FetchHeaders__deref` but
-                        // no `ref()`, so a +1 cannot be taken here. Adopting
-                        // hands that wrapper-held ref to the constructed
-                        // `Request` (via `Request::init2` below): the eventual
-                        // single deref happens when the Request's finalizer
-                        // drops its `headers` field (`HeadersRef::Drop`,
-                        // Response.rs), pairing with the wrapper's +1.
-                        // SAFETY: `headers__` is live (rooted by `headers_`),
-                        // and ownership of one ref transfers as described above.
-                        headers = Some(unsafe { HeadersRef::adopt(headers__) });
-                    } else if let Some(headers__) = FetchHeaders::create_from_js(ctx, headers_)? {
-                        // SAFETY: create_from_js returns a +1 ref.
-                        headers = Some(unsafe { HeadersRef::adopt(headers__) });
+                        // A JS `Headers`: the `Request` gets its own copy (as
+                        // `new Request(url, { headers })` does).
+                        // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
+                        headers =
+                            bun_opaque::opaque_deref_mut(headers__.as_ptr()).clone_this_ref(ctx)?;
+                    } else if let Some(headers__) = HeadersRef::create_from_js(ctx, headers_)? {
+                        headers = Some(headers__);
                     }
                 }
 
@@ -2349,31 +2304,27 @@ where
             ))
         } else if let Some(request_) = first_arg
             .is_object()
-            .then(|| <Request as bun_jsc::JsClass>::from_js(first_arg))
+            .then(|| first_arg.as_class_ref::<Request>())
             .flatten()
         {
-            // SAFETY: JsClass::from_js returns a live *mut Request.
-            // NOTE: `Request::clone()` (Request.rs:1627) seeds a fully-initialized
-            // sentinel and calls `clone_into(.., preserve_url=false)`.
-            unsafe { (*request_).clone(ctx)? }
+            // NOTE: `Request::clone()` seeds a fully-initialized sentinel and
+            // calls `clone_into(.., preserve_url=false)`.
+            request_.clone(ctx)?
         } else {
             let fetch_error = Fetch::fetch_type_error_string(first_arg);
             let err = jsc::ErrorCode::INVALID_ARG_TYPE.fmt(ctx, format_args!("{}", fetch_error));
             return Ok(JSPromise::rejected_promise(ctx, err).to_js());
         };
 
-        // `Request::to_js` stores `self as *mut
-        // Request` into the JS wrapper, which adopts ownership and frees the
-        // allocation in its GC finalizer. Relinquish the `Box` here so the
-        // local going out of scope does not also drop it (double-free / UAF).
-        let request: *mut Request = bun_core::heap::into_raw(existing_request);
+        // `Request::to_js` stores the request as the JS wrapper's `m_ctx`,
+        // which adopts ownership and frees the allocation in its GC finalizer;
+        // `request_value` keeps it alive for the rest of this frame.
+        let request: &Request = Box::leak(existing_request);
 
-        debug_assert!(!self.config.on_request.is_empty()); // confirmed above
+        debug_assert!(!self.config().on_request.is_empty()); // confirmed above
         let global_this = self.global();
-        let on_request = self.config.on_request;
-        // SAFETY: `request` was just allocated via `heap::alloc`; ownership
-        // transfers to the JS wrapper inside `to_js`.
-        let request_value = unsafe { (*request).to_js(&global_this) };
+        let on_request = self.config().on_request;
+        let request_value = request.to_js(&global_this);
         let response_value =
             match on_request.call(&global_this, self.js_value_assert_alive(), &[request_value]) {
                 Ok(v) => v,
@@ -2398,47 +2349,45 @@ where
             return Ok(response_value);
         }
 
-        if let Some(resp) = <Response as bun_jsc::JsClass>::from_js(response_value) {
-            // SAFETY: `from_js` returns a live `*mut Response` (owned by its
-            // JS wrapper, which `response_value` keeps alive). `request` is
-            // kept alive by `request_value` (its JS wrapper) for the duration
-            // of this synchronous frame.
-            unsafe { (*resp).set_url((*request).url.get().clone()) };
+        if let Some(resp) = response_value.as_class_ref::<Response>() {
+            resp.set_url(request.url.get().clone());
         }
+        request_value.ensure_still_alive();
         Ok(JSPromise::resolved_promise_value(ctx, response_value))
     }
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn close_idle_connections(
-        &mut self,
+        &self,
         _global: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        if self.app.is_none() || self.deinit_running.get() {
+        let Some(app) = self.app_mut() else {
+            return Ok(JSValue::js_number(0.0));
+        };
+        if self.deinit_running.get() {
             return Ok(JSValue::js_number(0.0));
         }
         // Each close reaches `on_connection_filter(-2)` synchronously; hold
-        // the guard so it cannot re-derive `&mut self` while this frame owns
-        // it. One-shot sweep (Node semantics): busy connections are spared
+        // the guard so its `deinit_if_we_can` is skipped while this frame
+        // sweeps. One-shot sweep (Node semantics): busy connections are spared
         // and are NOT marked to close later.
         self.deinit_running.set(true);
-        let closed = self.app_mut().close_idle_connections(false);
+        let closed = app.close_idle_connections(false);
         self.deinit_running.set(false);
         self.deinit_if_we_can();
         Ok(JSValue::js_number(closed as f64))
     }
 
-    pub(crate) fn stop_from_js(&mut self, abruptly: Option<JSValue>) -> JSValue {
+    pub(crate) fn stop_from_js(&self, abruptly: Option<JSValue>) -> JSValue {
         let rc = self.get_all_closed_promise(&self.global());
 
         let abrupt = matches!(abruptly, Some(v) if v.is_boolean() && v.to_boolean());
         // `!deinit_running`: a `server.stop()` reached from a close callback
-        // that an outer `stop()`'s drain fired would re-enter `stop_listening`
-        // with a fresh `&mut self` under the outer frame's borrow.
+        // that an outer `stop()`'s drain fired must not re-run `stop_listening`
+        // under the outer frame's drain.
         if self.has_listener()
-            || (abrupt
-                && !self.flags.contains(ServerFlags::TERMINATED)
-                && !self.deinit_running.get())
+            || (abrupt && !self.has_flags(ServerFlags::TERMINATED) && !self.deinit_running.get())
         {
             self.stop(abrupt);
         }
@@ -2446,9 +2395,9 @@ where
         rc
     }
 
-    pub(crate) fn dispose_from_js(&mut self) -> JSValue {
+    pub(crate) fn dispose_from_js(&self) -> JSValue {
         if self.has_listener()
-            || (!self.flags.contains(ServerFlags::TERMINATED) && !self.deinit_running.get())
+            || (!self.has_flags(ServerFlags::TERMINATED) && !self.deinit_running.get())
         {
             self.stop(true);
         }
@@ -2457,23 +2406,19 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_port(&self, _: &JSGlobalObject) -> JSValue {
-        let config_port = match &self.config.address {
+        let config_port = match &self.config().address {
             server_config::Address::Unix(_) => return JSValue::UNDEFINED,
             server_config::Address::Tcp { port, .. } => *port,
         };
 
-        if let Some(listener) = self.listener {
-            // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            if let Some(p) = bun_opaque::opaque_deref_mut(listener).get_local_port() {
+        if let Some(listener) = self.listener_mut() {
+            if let Some(p) = listener.get_local_port() {
                 return JSValue::js_number(p as f64);
             }
         }
-        if Self::HAS_H3 {
-            if let Some(h3l) = self.h3_listener {
-                // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                if let Some(p) = bun_opaque::opaque_deref_mut(h3l).get_local_port() {
-                    return JSValue::js_number(p as f64);
-                }
+        if let Some(h3l) = self.h3_listener_mut() {
+            if let Some(p) = h3l.get_local_port() {
+                return JSValue::js_number(p as f64);
             }
         }
         JSValue::js_number(config_port as f64)
@@ -2481,7 +2426,7 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_id(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        bun_string_jsc::create_utf8_for_js(global, &self.config.id)
+        bun_string_jsc::create_utf8_for_js(global, &self.config().id)
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -2496,16 +2441,14 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_address(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        match &self.config.address {
+        match &self.config().address {
             server_config::Address::Unix(unix) => {
                 bun_string_jsc::create_utf8_for_js(global, unix.as_bytes())
             }
             server_config::Address::Tcp { port: tcp_port, .. } => {
                 let mut port: u16 = *tcp_port;
 
-                if let Some(listener) = self.listener {
-                    // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                    let listener = bun_opaque::opaque_deref_mut(listener);
+                if let Some(listener) = self.listener_mut() {
                     port = listener.get_local_port().unwrap_or(port);
 
                     let mut buf = [0u8; 64];
@@ -2521,24 +2464,20 @@ where
                     };
                     return addr.into_dto(&self.global());
                 }
-                if Self::HAS_H3 {
-                    if let Some(h3l) = self.h3_listener {
-                        // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                        let h3l = bun_opaque::opaque_deref_mut(h3l);
-                        port = h3l.get_local_port().unwrap_or(port);
-                        let mut buf = [0u8; 64];
-                        let Some(address_bytes) = h3l.get_local_address(&mut buf) else {
+                if let Some(h3l) = self.h3_listener_mut() {
+                    port = h3l.get_local_port().unwrap_or(port);
+                    let mut buf = [0u8; 64];
+                    let Some(address_bytes) = h3l.get_local_address(&mut buf) else {
+                        return Ok(JSValue::NULL);
+                    };
+                    let addr = match SocketAddress::init(address_bytes, port) {
+                        Ok(a) => a,
+                        Err(_) => {
+                            bun_core::hint::cold();
                             return Ok(JSValue::NULL);
-                        };
-                        let addr = match SocketAddress::init(address_bytes, port) {
-                            Ok(a) => a,
-                            Err(_) => {
-                                bun_core::hint::cold();
-                                return Ok(JSValue::NULL);
-                            }
-                        };
-                        return addr.into_dto(&self.global());
-                    }
+                        }
+                    };
+                    return addr.into_dto(&self.global());
                 }
                 let _ = port;
                 Ok(JSValue::NULL)
@@ -2556,25 +2495,21 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_hostname(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        match &self.config.address {
+        match &self.config().address {
             server_config::Address::Unix(_) => return Ok(JSValue::UNDEFINED),
             server_config::Address::Tcp { .. } => {}
         }
         {
-            if let Some(listener) = self.listener {
+            if let Some(listener) = self.listener_mut() {
                 let mut buf = [0u8; 1024];
-                // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                if let Some(addr) = bun_opaque::opaque_deref_mut(listener)
-                    .socket()
-                    .remote_address(&mut buf[..1024])
-                {
+                if let Some(addr) = listener.socket().remote_address(&mut buf[..1024]) {
                     if !addr.is_empty() {
                         return bun_string_jsc::create_utf8_for_js(global, addr);
                     }
                 }
             }
             {
-                match &self.config.address {
+                match &self.config().address {
                     server_config::Address::Tcp { hostname, .. } => {
                         if let Some(hostname) = hostname {
                             return bun_string_jsc::create_utf8_for_js(global, hostname.as_bytes());
@@ -2605,99 +2540,113 @@ where
 
     pub fn finalize(self: Box<Self>) {
         httplog!("finalize");
-        let this_ptr = bun_core::heap::into_raw(self);
-        // SAFETY: just unboxed; uniquely owned here until either the inline
-        // `deinit()` below or `schedule_deinit()`'s enqueued task reclaims it.
-        // `deinit_if_we_can` may defer (pending requests), so the free is not
-        // unconditional. `Box::into_raw` (not `heap::release`) keeps raw-owner
-        // provenance for the `deinit()` dealloc — a `&mut self`-derived tag
-        // there would be Stacked-Borrows UB. JSC-handle Drops are no-ops past
-        // `is_shutting_down()`; `TERMINATED` means `app.close()` already ran,
-        // so `NewApp::destroy` can't orphan a keep-alive socket.
-        unsafe {
-            (*this_ptr).js_value.finalize();
-            (*this_ptr).deinit_if_we_can();
-            if (*this_ptr).flags.contains(ServerFlags::DEINIT_SCHEDULED)
-                && (*this_ptr).flags.contains(ServerFlags::TERMINATED)
-                && (*this_ptr).vm().is_shutting_down()
+        bun_ptr::finalize_js_box(self, |this| {
+            this.js_value.with_mut(|v| v.finalize());
+            this.deinit_if_we_can();
+            // `deinit_if_we_can` may defer (pending requests), so teardown is not
+            // unconditional. JSC-handle Drops are no-ops past `is_shutting_down()`;
+            // `TERMINATED` means `app.close()` already ran, so destroying the app
+            // can't orphan a keep-alive socket.
+            if this.has_flags(ServerFlags::DEINIT_SCHEDULED)
+                && this.has_flags(ServerFlags::TERMINATED)
+                && this.vm().is_shutting_down()
             {
-                Self::deinit(this_ptr);
+                if let Some(r) = this.teardown() {
+                    // Not the last ref: `finalize_js_box` still holds the wrapper's.
+                    r.deref();
+                }
+            }
+        });
+    }
+
+    pub(crate) fn get_all_closed_promise(&self, global: &JSGlobalObject) -> JSValue {
+        if self.is_closed() {
+            return JSPromise::resolved_promise(global, JSValue::UNDEFINED).to_js();
+        }
+        let existing = self.all_closed_promise.get();
+        if existing.has_value() {
+            return existing.value();
+        }
+        let promise = jsc::JSPromiseStrong::init(global);
+        let value = promise.value();
+        self.all_closed_promise.set(promise);
+        value
+    }
+
+    /// Route handler for the HTTP/2 and HTTP/3 apps; both hand us the same
+    /// decoded-header request.
+    pub(crate) fn on_mux_request(
+        this: ThisPtr<Self>,
+        req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
+    ) {
+        if this.config().on_request.is_empty() {
+            return Self::on_mux_404(this, req, resp);
+        }
+        match mux_parts(req, resp) {
+            MuxParts::H2(req, resp) => {
+                Self::on_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(this, req, resp)
+            }
+            MuxParts::H3(req, resp) => {
+                Self::on_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(this, req, resp)
             }
         }
     }
 
-    pub(crate) fn get_all_closed_promise(&mut self, global: &JSGlobalObject) -> JSValue {
-        if self.is_closed() {
-            return JSPromise::resolved_promise(global, JSValue::UNDEFINED).to_js();
-        }
-        if self.all_closed_promise.has_value() {
-            return self.all_closed_promise.value();
-        }
-        self.all_closed_promise = jsc::JSPromiseStrong::init(global);
-        self.all_closed_promise.value()
-    }
-
-    // `notify_inspector_server_stopped` lives in the unbounded impl block
-    // above so the unbounded `deinit()` (mod.rs) can call it.
-
-    /// Route handler for the HTTP/2 and HTTP/3 apps (`R` = `uws::H2::Response`
-    /// or `uws::H3::Response`); both hand us the same decoded-header request.
-    pub(super) fn on_mux_request<R: RespLike>(&mut self, req: &mut uws::H3::Request, resp: &mut R) {
-        if self.config.on_request.is_empty() {
-            return Self::on_mux_404(self, req, resp);
-        }
-        self.on_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(req, resp);
-    }
-
-    pub(super) fn on_mux_user_route_request<R: RespLike>(
-        user_route: &mut UserRoute<SSL, DEBUG>,
-        req: &mut uws::H3::Request,
-        resp: &mut R,
+    pub(crate) fn on_mux_user_route_request(
+        user_route: ThisPtr<UserRoute<SSL, DEBUG>>,
+        req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
     ) {
-        Self::on_user_route_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(
-            user_route, req, resp,
-        );
+        match mux_parts(req, resp) {
+            MuxParts::H2(req, resp) => {
+                Self::on_user_route_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(
+                    user_route, req, resp,
+                )
+            }
+            MuxParts::H3(req, resp) => {
+                Self::on_user_route_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(
+                    user_route, req, resp,
+                )
+            }
+        }
     }
 
-    pub(super) fn on_mux_404<R: RespLike>(
-        _this: &mut Self,
-        _req: &mut uws::H3::Request,
-        resp: &mut R,
+    pub(crate) fn on_mux_404(
+        _this: ThisPtr<Self>,
+        _req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
     ) {
         resp.write_status(b"404 Not Found");
         resp.end_without_body(false);
     }
 
     #[bun_jsc::host_fn(method)]
-    pub(crate) fn do_ref(
-        &mut self,
-        _: &JSGlobalObject,
-        callframe: &CallFrame,
-    ) -> JsResult<JSValue> {
+    pub(crate) fn do_ref(&self, _: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let this_value = callframe.this();
-        self.ref_();
+        self.ref_event_loop();
         Ok(this_value)
     }
 
     #[bun_jsc::host_fn(method)]
-    pub(crate) fn do_unref(
-        &mut self,
-        _: &JSGlobalObject,
-        callframe: &CallFrame,
-    ) -> JsResult<JSValue> {
+    pub(crate) fn do_unref(&self, _: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let this_value = callframe.this();
-        self.unref();
+        self.unref_event_loop();
         Ok(this_value)
     }
 
     pub(crate) fn on_bun_info_request(
-        &mut self,
-        req: &mut uws::Request,
-        resp: &mut uws_sys::NewAppResponse<SSL>,
+        this: ThisPtr<Self>,
+        req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
     ) {
         jsc::mark_binding!();
-        if !matches!(self.config.address, server_config::Address::Unix(_))
-            && (!bake::is_allowed_host_header(req, Some(&self.config.address))
+        let (req, resp) = super::h1_parts::<SSL>(req, resp);
+        // S008: `Response<SSL>` is a ZST opaque — safe deref.
+        let resp = bun_opaque::opaque_deref_mut(resp);
+        let server = this.get();
+        if !matches!(server.config().address, server_config::Address::Unix(_))
+            && (!bake::is_allowed_host_header(req, Some(&server.config().address))
                 || !resp
                     .get_remote_socket_info()
                     .is_some_and(|address| address.is_loopback()))
@@ -2705,7 +2654,7 @@ where
             req.set_yield(true);
             return;
         }
-        self.on_pending_request();
+        server.on_pending_request();
         req.set_yield(false);
 
         let buffer_writer = bun_js_printer::BufferWriter::init();
@@ -2728,57 +2677,52 @@ where
         resp.write_header_int(b"Age", 0);
         let buffer = writer.ctx.written();
         resp.end(buffer, false);
-        self.pending_requests.set(self.pending_requests.get() - 1);
+        server
+            .pending_requests
+            .set(server.pending_requests.get() - 1);
     }
 
-    // `on_chrome_dev_tools_json_request` is defined once below (next to
-    // `on404`); a second copy here was a concurrent-port duplicate and has
-    // been removed.
-
-    fn on_user_route_request_for<Ctx: RequestCtxOps<Server = Self>, R: RespLike>(
-        user_route: &UserRoute<SSL, DEBUG>,
+    fn on_user_route_request_for<Ctx: RequestCtx<SSL, DEBUG>, R: RespLike>(
+        user_route: ThisPtr<UserRoute<SSL, DEBUG>>,
         req: &mut Ctx::Req,
         resp: &mut R,
     ) {
-        debug_assert!(!user_route.server.is_null());
-        // SAFETY: `UserRoute.server` is the owning `*mut NewServer` (write
-        // provenance), a back-pointer to the owning server, which outlives
-        // every route it registered.
-        let server_ref = unsafe { bun_ptr::BackRef::from_raw_mut(user_route.server) };
-        let server_ptr = server_ref.as_ptr();
+        // Read everything up front: the route handler may `reload()` and drop this route.
+        let server = user_route.server;
+        let server = server.get();
         let index = user_route.id;
+        let method = user_route.route.method.specific();
 
-        let Some(server_js) = server_ref.js_value_for_dispatch() else {
+        let Some(server_js) = server.js_value_for_dispatch() else {
             respond_stopped_503(resp);
             return;
         };
 
-        let should_deinit_context = core::cell::Cell::new(false);
+        let should_deinit_context = Cell::new(false);
         let Some(mut prepared) = Self::prepare_js_request_context_for::<Ctx, R>(
-            server_ptr,
+            server.this_ptr(),
             req,
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             CreateJsRequest::No,
-            user_route.route.method.specific(),
+            method,
         ) else {
             return;
         };
 
-        let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
+        let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
         let call_route = if Ctx::IS_MUX {
             Bun__ServerRouteList__callRouteH3
         } else {
             Bun__ServerRouteList__callRoute
         };
-        // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe deref.
-        let global = bun_opaque::opaque_deref(server_ref.global_this);
+        let global = server.global_this();
         let response_value = match jsc::from_js_host_call(global, || {
             call_route(
                 global,
                 index,
-                prepared.request_object,
+                prepared.request_ptr.as_ptr(),
                 server_js,
                 server_request_list,
                 &mut prepared.js_request,
@@ -2789,69 +2733,54 @@ where
             Err(err) => global.take_exception(err),
         };
 
-        Self::handle_request_for::<Ctx>(
-            server_ptr,
-            &should_deinit_context,
-            &prepared,
-            req,
-            response_value,
-        );
+        server.handle_request_for::<Ctx>(&should_deinit_context, &prepared, req, response_value);
     }
 
-    fn handle_request_for<Ctx: RequestCtxOps<Server = Self>>(
-        this: *mut Self,
-        should_deinit_context: &core::cell::Cell<bool>,
+    fn handle_request_for<Ctx: RequestCtx<SSL, DEBUG>>(
+        &self,
+        should_deinit_context: &Cell<bool>,
         prepared: &PreparedRequestFor<Ctx>,
         req: &mut Ctx::Req,
         response_value: JSValue,
     ) {
-        let request_object_ptr: *mut Request = prepared.request_object;
-        let detach_ptr = request_object_ptr;
-        scopeguard::defer! {
-            // uWS request will not live longer than this function
-            // SAFETY: request_object outlives this stack frame (boxed on the request).
-            unsafe { (*detach_ptr).request_context.detach_request() };
-        }
+        let ctx = prepared.ctx.get();
+        // uWS request will not live longer than this function
+        let _detach_guard = super::DetachRequestOnDrop(&prepared.request);
 
-        // SAFETY: `prepared.ctx` was allocated by `prepare_js_request_context_for`
-        // for this frame and cannot be freed while `defer_deinit_...` is set (set
-        // by the caller until cleared below); `this` is the live server backref.
-        let (ctx, server) = unsafe { (&*prepared.ctx, &*this) };
-        RequestCtxOps::on_response(ctx, server, prepared.js_request, response_value);
+        ctx.on_response(self, prepared.js_request, response_value);
         // Reference in the stack here in case it is not for whatever reason
         prepared.js_request.ensure_still_alive();
 
-        RequestCtxOps::set_defer_deinit(ctx, None);
+        ctx.set_defer_deinit(None);
 
         if should_deinit_context.get() {
-            RequestCtxOps::deinit(ctx);
+            ctx.deinit();
             return;
         }
 
-        if RequestCtxOps::should_render_missing(ctx) {
-            RequestCtxOps::render_missing(ctx);
+        if ctx.should_render_missing() {
+            ctx.render_missing();
             return;
         }
 
         // The request is asynchronous, and all information from `req` must be copied
         // since the provided uws.Request will be re-used for future requests (stack allocated).
-        // SAFETY: `request_object_ptr` is the live heap `Request` (see above).
-        RequestCtxOps::to_async(ctx, req, unsafe { &mut *request_object_ptr });
+        ctx.arm_async(req, &prepared.request);
+        prepared.js_request.ensure_still_alive();
     }
 
-    fn on_request_for<Ctx: RequestCtxOps<Server = Self>, R: RespLike>(
-        &mut self,
+    fn on_request_for<Ctx: RequestCtx<SSL, DEBUG>, R: RespLike>(
+        this: ThisPtr<Self>,
         req: &mut Ctx::Req,
         resp: &mut R,
     ) {
-        let Some(js_value) = self.js_value_for_dispatch() else {
+        let Some(js_value) = this.js_value_for_dispatch() else {
             respond_stopped_503(resp);
             return;
         };
-        let self_ptr: *mut Self = self;
-        let should_deinit_context = core::cell::Cell::new(false);
+        let should_deinit_context = Cell::new(false);
         let Some(prepared) = Self::prepare_js_request_context_for::<Ctx, R>(
-            self_ptr,
+            this,
             req,
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
@@ -2861,11 +2790,9 @@ where
             return;
         };
 
-        // SAFETY: `self_ptr` is `self`, live for this frame. Shared — the
-        // handler call below re-enters JS, so no `&mut` may span it.
-        let server = unsafe { &*self_ptr };
+        let server = this.get();
         let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
-        let on_request_fn = server.config.on_request;
+        let on_request_fn = server.config().on_request;
         debug_assert!(!on_request_fn.is_empty());
 
         let global = server.global_this();
@@ -2875,17 +2802,11 @@ where
                 Err(err) => global.take_exception(err),
             };
 
-        Self::handle_request_for::<Ctx>(
-            self_ptr,
-            &should_deinit_context,
-            &prepared,
-            req,
-            response_value,
-        );
+        server.handle_request_for::<Ctx>(&should_deinit_context, &prepared, req, response_value);
     }
 
-    fn prepare_js_request_context_for<Ctx: RequestCtxOps<Server = Self>, R: RespLike>(
-        this: *mut Self,
+    fn prepare_js_request_context_for<Ctx: RequestCtx<SSL, DEBUG>, R: RespLike>(
+        this: ThisPtr<Self>,
         req: &mut Ctx::Req,
         resp: &mut R,
         should_deinit_context: Option<DeferDeinitFlag>,
@@ -2893,9 +2814,7 @@ where
         method: Option<http::Method>,
     ) -> Option<PreparedRequestFor<Ctx>> {
         jsc::mark_binding!();
-        // SAFETY: `this` is the live heap server registered as the callback
-        // user-data; everything below only needs `&Self`.
-        let server = unsafe { &*this };
+        let server = this.get();
 
         // We need to register the handler immediately since uSockets will not buffer.
         //
@@ -2912,7 +2831,7 @@ where
         }
 
         // Resolve once, reuse for both `has_request_body()` and the forward to
-        // `Ctx::create`.
+        // `Ctx::init`.
         let method = method.or_else(|| http::Method::which(ReqLike::method(req)));
 
         let request_body_length: Option<usize> = 'request_body_length: {
@@ -2927,7 +2846,7 @@ where
                 // Abort the request very early. For H2/H3 a per-request error
                 // is a stream error; close_connection would take down every
                 // sibling stream on the connection.
-                if len > server.config.max_request_body_size {
+                if len > server.config().max_request_body_size {
                     RespLike::write_status(resp, b"413 Request Entity Too Large");
                     RespLike::end_without_body(resp, !Ctx::IS_MUX);
                     return None;
@@ -2941,15 +2860,14 @@ where
         server.on_pending_request();
 
         ReqLike::set_yield(req, false);
-        RespLike::timeout(resp, server.config.idle_timeout);
+        RespLike::timeout(resp, server.config().idle_timeout);
 
         // Since we do timeouts by default, we should tell the user when
         // this happens - but limit it to only warn once.
         if server.should_add_timeout_handler_for_warning() {
-            // We need to pass it a pointer, any pointer should do.
-            // SAFETY: the user-data pointer is an opaque sentinel — `on_timeout_for_idle_warn`
-            // ignores it and reads the static directly. `AtomicBool::as_ptr` yields a `*mut`
-            // with interior-mutability provenance, so no `&T as *const _ as *mut _` cast is needed.
+            // We need to pass it a pointer, any pointer should do: the handler
+            // ignores it and reads the static directly. `AtomicBool::as_ptr`
+            // yields a `*mut` with interior-mutability provenance.
             RespLike::on_timeout_warn(
                 resp,
                 did_send_idletimeout_warning_once()
@@ -2958,97 +2876,33 @@ where
             );
         }
 
+        let is_te =
+            request_body_length.is_some() && ReqLike::has_transfer_encoding(req);
+        // HTTP/2 and HTTP/3 frame the body by END_STREAM or QUIC FIN, not Content-Length.
+        let expects_body = matches!(request_body_length, Some(req_len)
+            if req_len > 0 || is_te || (Ctx::IS_MUX && !RespLike::request_body_ended(resp)));
         let any_resp = RespLike::to_any_response(resp);
-        // SAFETY: both allocators hand out `*mut RequestContext<_, SSL, DEBUG, _>`; the
-        // const-bool MUX parameter only affects associated consts/types, not layout, so
-        // reinterpreting the slot pointer as the caller's `Ctx` monomorphization is sound.
-        //
-        // `claim()` reserves the slot as a `HiveSlot`; `create_in` does
-        // `MaybeUninit::write` placement-new through the slot's stable
-        // address, after which `assume_init()` consumes the token.
-        // `RequestContext` carries the heaviest drop glue in the codebase, so
-        // a panic inside `create_in` now releases the slot via
-        // `HiveSlot::drop` without running `RequestContext::drop` on garbage.
-        let ctx_slot: *mut Ctx = unsafe {
-            if Ctx::IS_MUX {
-                debug_assert!(
-                    !server.mux_request_pool.is_null(),
-                    "HTTP/2 or HTTP/3 request dispatched but mux_request_pool was never allocated"
-                );
-                let slot = (*server.mux_request_pool).claim();
-                Ctx::create_in(
-                    slot.addr().as_ptr().cast(),
-                    this,
-                    req,
-                    any_resp,
-                    should_deinit_context,
-                    method,
-                );
-                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-                slot.assume_init().as_ptr().cast()
-            } else {
-                let slot = (*server.request_pool).claim();
-                Ctx::create_in(
-                    slot.addr().as_ptr().cast(),
-                    this,
-                    req,
-                    any_resp,
-                    should_deinit_context,
-                    method,
-                );
-                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-                slot.assume_init().as_ptr().cast()
-            }
+        let mut prepared = Self::create_request_context::<Ctx>(
+            this,
+            req,
+            any_resp,
+            should_deinit_context,
+            method,
+            expects_body,
+        );
+        let ctx: &Ctx = prepared.ctx.get();
+        let Some(request_object) = prepared.request() else {
+            unreachable!("just created");
         };
-        // SAFETY: ctx_slot was just initialized by create_in.
-        let ctx = unsafe { &*ctx_slot };
-
-        server
-            .vm()
-            .jsc_vm()
-            .deprecated_report_extra_memory(core::mem::size_of::<Ctx>());
-
-        // Pooled body slot, ref_count = 1.
-        let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
-        // The ctx and Request each own a +1 on the
-        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
-        ctx.set_request_body(Some(body_hive.clone()));
-
-        let signal = AbortSignal::new(&server.global());
-        ctx.set_signal(signal);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-
-        // The Request's own ref.
-        let signal_for_req = bun_opaque::opaque_deref_mut(signal).ref_();
-        let request_object_box = Request::new(Request::init(
-            ctx.ctx_method(),
-            AnyRequestContext::init(std::ptr::from_ref::<Ctx>(ctx)),
-            SSL,
-            Some(signal_for_req),
-            body_hive,
-        ));
-        // Leak so the ctx (which outlives this stack frame) can hold the
-        // pointer; Request is freed via ctx.deinit's request_weakref. The weak
-        // handle takes the raw pointer, not a reborrow of `request_object`:
-        // writes through `request_object` below would otherwise invalidate it.
-        let request_object_ptr: *mut Request = bun_core::heap::into_raw(request_object_box);
-        ctx.set_request_weakref(request_object_ptr);
-        // SAFETY: freshly leaked; shared view — everything below (headers/url
-        // population, `to_js`) takes `&Request`.
-        let request_object: &Request = unsafe { &*request_object_ptr };
 
         // The lazy `getRequest()` path that backs Request.url / .headers
         // is `*uws.Request`-typed; for HTTP/2 and HTTP/3 we populate both
         // eagerly so the rest of the pipeline never needs to know which
         // transport delivered the bytes.
         if Ctx::IS_MUX {
-            // SAFETY: create_from_h3 returns a +1-ref FetchHeaders; adopt into RAII wrapper.
-            request_object.set_fetch_headers(Some(unsafe {
-                crate::webcore::response::HeadersRef::adopt(FetchHeaders::create_from_h3(
-                    std::ptr::from_mut(req).cast::<c_void>(),
-                ))
-            }));
+            request_object.set_fetch_headers(Some(HeadersRef::create_from_h3(
+                std::ptr::from_mut(req).cast::<c_void>(),
+            )));
             // NOTE: `ReqLike::{url,header}` both borrow `&mut req`; the
             // returned slices alias the same uWS-owned header buffer. Format
             // the `https://{host}` prefix while `host` is borrowed so the
@@ -3100,75 +2954,126 @@ where
 
         if let Some(req_len) = request_body_length {
             ctx.set_request_body_content_len(req_len);
-            let is_te = ReqLike::has_transfer_encoding(req);
             ctx.set_is_transfer_encoding(is_te);
-            // HTTP/2 and HTTP/3 frame the body by END_STREAM or QUIC FIN, not Content-Length.
-            if req_len > 0 || is_te || (Ctx::IS_MUX && !RespLike::request_body_ended(resp)) {
-                // we defer pre-allocating the body until we receive the first chunk
-                // that way if the client is lying about how big the body is or the client aborts
-                // we don't waste memory
-                if let Some(body) = ctx.request_body_mut() {
-                    *body = BodyValue::Locked(crate::webcore::body::PendingValue {
-                        task: Some(NonNull::new(ctx_slot).unwrap().cast::<c_void>()),
-                        global: server.global_this,
-                        on_start_buffering: Some(Ctx::on_start_buffering_callback),
-                        on_start_streaming: Some(Ctx::on_start_streaming_request_body_callback),
-                        on_readable_stream_available: Some(
-                            Ctx::on_request_body_readable_stream_available,
-                        ),
-                        producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
-                            AnyRequestContext::init(ctx_slot),
-                        ),
-                        ..Default::default()
-                    });
-                }
+            if expects_body {
                 ctx.set_is_waiting_for_request_body(true);
-                ctx.arm_on_data(any_resp);
+                Ctx::arm_on_data(NonNull::from(ctx), any_resp);
             }
         }
 
-        Some(PreparedRequestFor {
-            js_request: match create_js_request {
-                CreateJsRequest::Yes => request_object.to_js(&server.global()),
-                CreateJsRequest::Bake => match request_object.to_js_for_bake(&server.global()) {
-                    Ok(v) => v,
-                    Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
-                    Err(_) => return None,
-                },
-                CreateJsRequest::No => JSValue::ZERO,
+        let js_request = match create_js_request {
+            CreateJsRequest::Yes => request_object.to_js(&server.global()),
+            CreateJsRequest::Bake => match request_object.to_js_for_bake(&server.global()) {
+                Ok(v) => v,
+                Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
+                Err(_) => return None,
             },
-            request_object: request_object_ptr,
-            ctx: ctx_slot,
-        })
+            CreateJsRequest::No => JSValue::ZERO,
+        };
+        prepared.js_request = js_request;
+        Some(prepared)
+    }
+
+    /// The core of every dispatch path: allocate the request context from its
+    /// transport's pool, its body slot and abort signal, and the heap `Request`.
+    /// `js_request` is left `ZERO` for the caller to fill.
+    #[inline]
+    pub(super) fn create_request_context<Ctx: RequestCtx<SSL, DEBUG>>(
+        this: ThisPtr<Self>,
+        req: &mut Ctx::Req,
+        resp: uws::AnyResponse,
+        should_deinit_context: Option<DeferDeinitFlag>,
+        method: Option<http::Method>,
+        expects_body: bool,
+    ) -> PreparedRequestFor<Ctx> {
+        let server = this.get();
+        let pooled = Ctx::pool(server).claim_init(|slot| {
+            Ctx::init(slot, this.into(), req, resp, should_deinit_context, method)
+        });
+        let ctx_ptr: NonNull<Ctx> = pooled.as_ptr();
+        let ctx_ref = bun_ptr::BackRef::new(&*pooled);
+        ctx_ref.adopt_pool_slot(pooled);
+        let ctx: &Ctx = ctx_ref.get();
+
+        server
+            .vm()
+            .jsc_vm()
+            .deprecated_report_extra_memory(core::mem::size_of::<Ctx>());
+
+        // Pooled body slot, ref_count = 1. The ctx and Request each own a +1
+        // on the same slot (streamed bytes buffered into the ctx surface on
+        // `request.body`/`request.json()`). Paired drop in
+        // `RequestContext::deinit` / `Request::finalize`.
+        let body_hive = crate::webcore::body::hive_alloc(if expects_body {
+            // we defer pre-allocating the body until we receive the first chunk
+            // that way if the client is lying about how big the body is or the client aborts
+            // we don't waste memory
+            BodyValue::Locked(crate::webcore::body::PendingValue {
+                task: Some(ctx_ptr.cast::<c_void>()),
+                global: server.global_this,
+                on_start_buffering: Some(Ctx::on_start_buffering_callback),
+                on_start_streaming: Some(Ctx::on_start_streaming_request_body_callback),
+                on_readable_stream_available: Some(Ctx::on_request_body_readable_stream_available),
+                producer: crate::webcore::streams::SourceHandle::ServerRequestBody(
+                    AnyRequestContext::init(ctx_ptr.as_ptr()),
+                ),
+                ..Default::default()
+            })
+        } else {
+            BodyValue::Null
+        });
+        ctx.set_request_body(Some(body_hive.clone()));
+
+        // The context owns one ref (plus a pending-activity count) so aborts
+        // propagate; the Request's own counted ref pairs with `Request::Drop`.
+        let signal =
+            NonNull::new(AbortSignal::new(&server.global())).expect("AbortSignal::new is non-null");
+        ctx.set_signal(signal);
+        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
+        let signal = bun_opaque::opaque_deref(signal.as_ptr());
+        signal.pending_activity_ref();
+
+        // Leaked to the heap: owned by its JS wrapper once created (or by the
+        // C++ route-list caller that wraps it), reachable from the ctx through
+        // its weak handle until `RequestContext::deinit` lets go.
+        let (request_weak, request_ptr) =
+            bun_ptr::WeakPtr::init_leaked(Request::new(Request::init(
+                ctx.ctx_method(),
+                AnyRequestContext::init(ctx_ptr.as_ptr()),
+                SSL,
+                Some(signal.ref_()),
+                body_hive,
+            )));
+        let request = request_weak.clone();
+        ctx.set_request_weakref(request_weak);
+        PreparedRequestFor {
+            js_request: JSValue::ZERO,
+            request,
+            request_ptr,
+            ctx: ctx_ref,
+        }
     }
 
     fn upgrade_web_socket_user_route(
-        this: &UserRoute<SSL, DEBUG>,
+        this: ThisPtr<UserRoute<SSL, DEBUG>>,
         resp: &mut uws_sys::NewAppResponse<SSL>,
         req: &mut uws::Request,
         upgrade_ctx: &mut WebSocketUpgradeContext,
         method: Option<http::Method>,
     ) {
-        // BACKREF: `UserRoute.server` is set at construction from the owning
-        // `NewServer` (which outlives every `UserRoute` in its `user_routes`
-        // vec); non-null by invariant.
-        debug_assert!(!this.server.is_null());
-        // SAFETY: `UserRoute.server` is the owning `*mut NewServer` (write provenance),
-        // set at construction and non-null while the route is registered.
-        let server_ref = unsafe { bun_ptr::BackRef::from_raw_mut(this.server) };
-        let server_ptr = server_ref.as_ptr();
+        // Read everything up front: the route handler may `reload()` and drop this route.
+        let server = this.server;
+        let server = server.get();
         let index = this.id;
 
-        let Some(server_js) = server_ref.js_value_for_dispatch() else {
+        let Some(server_js) = server.js_value_for_dispatch() else {
             respond_stopped_503(resp);
             return;
         };
 
-        let should_deinit_context = core::cell::Cell::new(false);
-        // SAFETY: `server_ptr` is the live heap server registered for this route;
-        // `req`/`resp` are the live uWS handles passed to the route handler.
+        let should_deinit_context = Cell::new(false);
         let Some(mut prepared) = Self::prepare_js_request_context(
-            server_ptr,
+            server.this_ptr(),
             req,
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
@@ -3177,21 +3082,18 @@ where
         ) else {
             return;
         };
-        // SAFETY: `prepared.ctx` is the freshly-allocated RequestContext slot.
-        unsafe {
-            (*prepared.ctx)
-                .upgrade_context
-                .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)))
-        };
-        let _entered = server_ref.vm().enter_event_loop_scope_without_checkpoint();
+        prepared
+            .ctx
+            .upgrade_context
+            .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)));
+        let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
-        // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe deref.
-        let global = bun_opaque::opaque_deref(server_ref.global_this);
+        let global = server.global_this();
         let response_value = match jsc::from_js_host_call(global, || {
             Bun__ServerRouteList__callRoute(
                 global,
                 index,
-                prepared.request_object,
+                prepared.request_ptr.as_ptr(),
                 server_js,
                 server_request_list,
                 &mut prepared.js_request,
@@ -3202,140 +3104,70 @@ where
             Err(err) => global.take_exception(err),
         };
 
-        Self::handle_request(
-            server_ptr,
-            &should_deinit_context,
-            &prepared,
-            req,
-            response_value,
-        );
+        server.handle_request(&should_deinit_context, &prepared, req, response_value);
     }
 
-    /// # Safety
-    /// `this` is the raw user-data pointer registered with `app.ws(...)` cast
-    /// to `*mut Self`. Its **actual pointee type depends on `id`**: `id == 1`
-    /// registers a `*mut UserRoute<SSL,DEBUG>` (mod.rs per-route ws), `id == 0`
-    /// registers `*mut Self` (mod.rs `/*` fallback). The receiver is therefore
-    /// kept raw and only dereferenced *after* dispatching on `id`, so no
-    /// wrong-typed `&mut Self` reference is ever materialized (which would be
-    /// instant UB regardless of whether it is read).
-    pub(crate) unsafe fn on_web_socket_upgrade(
-        this: *mut Self,
+    /// The `/*` websocket fallback route: `this` is the server itself.
+    pub(crate) fn on_web_socket_upgrade(
+        this: ThisPtr<Self>,
         resp: &mut uws_sys::NewAppResponse<SSL>,
         req: &mut uws::Request,
         upgrade_ctx: &mut WebSocketUpgradeContext,
-        id: usize,
     ) {
         jsc::mark_binding!();
-        if id == 1 {
-            // SAFETY: for `id == 1` the registered user-data IS
-            // `*mut UserRoute<SSL,DEBUG>` (mod.rs `app.ws(path, ud, 1, ..)`);
-            // live for the request's duration. Raw-ptr cast only — no
-            // intermediate `&mut Self` was ever created; shared suffices (the
-            // route entry is only read).
-            let user_route = unsafe { &*this.cast::<UserRoute<SSL, DEBUG>>() };
-            Self::upgrade_web_socket_user_route(user_route, resp, req, upgrade_ctx, None);
-            return;
-        }
-        // Access `this` as *ThisServer only if id is 0
-        debug_assert!(id == 0);
-        let self_ptr: *mut Self = this;
-        // SAFETY: for `id == 0` the registered user-data IS `*mut Self`
-        // (mod.rs `app.ws("/*", self_ptr, 0, ..)`); live for the request's
-        // duration. Shared — the `on_request` call below re-enters JS, so no
-        // `&mut` may span it (pending-request accounting is a `Cell`).
-        let this = unsafe { &*self_ptr };
+        let server = this.get();
         // Guards both branches below: the `on_request` fallthrough has no
         // other gate, and the node:http branch's own re-check (mod.rs:
         // `on_node_http_request_with_upgrade_ctx`) is redundant on this path
         // but load-bearing for its other caller (`on_node_http_request`).
-        let Some(server_js) = this.js_value_for_dispatch() else {
+        let Some(server_js) = server.js_value_for_dispatch() else {
             respond_stopped_503(resp);
             return;
         };
-        if !this.config.on_node_http_request.is_empty() {
-            // NOTE: receiver is `*mut Self` (mod.rs) — the callee re-enters
-            // JS, so a long-lived `&mut self` here would alias on callback.
-            Self::on_node_http_request_with_upgrade_ctx(self_ptr, req, resp, upgrade_ctx);
+        if !server.config().on_node_http_request.is_empty() {
+            server.on_node_http_request_with_upgrade_ctx(req, resp, upgrade_ctx);
             return;
         }
-        if this.config.on_request.is_empty() {
+        if server.config().on_request.is_empty() {
             // require fetch method to be set otherwise we dont know what route to call
             // this should be the fallback in case no route is provided to upgrade
             resp.write_status(b"403 Forbidden");
             resp.end_without_body(true);
             return;
         }
-        let _entered = this.vm().enter_event_loop_scope_without_checkpoint();
-        this.on_pending_request();
+        let _entered = server.vm().enter_event_loop_scope_without_checkpoint();
+        server.on_pending_request();
         req.set_yield(false);
-        // SAFETY: `request_pool` is non-null while the server is alive; `claim()`
-        // reserves a fresh slot whose `Drop` releases it on panic before init.
-        let ctx_slot = unsafe { (*this.request_pool).claim() };
-        let should_deinit_context = core::cell::Cell::new(false);
-        <ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create_in(
-            ctx_slot.addr().as_ptr(),
-            self_ptr,
+        let should_deinit_context = Cell::new(false);
+        let prepared = Self::create_request_context::<ServerRequestContext<SSL, DEBUG>>(
+            this,
             req,
             RespLike::to_any_response(resp),
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             None,
+            false,
         );
-        // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-        let ctx = unsafe { &*ctx_slot.assume_init().as_ptr() };
-
-        // Pooled body slot, ref_count = 1.
-        let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
-        // The ctx and Request each own a +1 on the
-        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
-        ctx.request_body.set(Some(body_hive.clone()));
-
-        let signal = AbortSignal::new(&this.global());
-        // The
-        // RequestContext owns one ref so aborts during the WS-upgrade fallback
-        // fetch path propagate.
-        ctx.signal.set(NonNull::new(signal));
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-        // The Request's own ref.
-        let signal_for_req = bun_opaque::opaque_deref_mut(signal).ref_();
-        let request_object_box = Request::new(Request::init(
-            ctx.method,
-            AnyRequestContext::init(std::ptr::from_ref(ctx)),
-            SSL,
-            Some(signal_for_req),
-            body_hive,
-        ));
+        let ctx = prepared.ctx.get();
         ctx.upgrade_context
             .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)));
-        // Leaked so the ctx (which outlives this stack frame) can hold the
-        // pointer; freed via ctx.deinit's request_weakref. Everything below
-        // goes through this raw pointer rather than a `&mut Request` reborrow:
-        // the weak handle and the deferred `detach_request` both alias it.
-        let request_object_ptr: *mut Request = bun_core::heap::into_raw(request_object_box);
-        // SAFETY: freshly leaked, so it carries the allocation's provenance.
-        ctx.request_weakref
-            .set(unsafe { bun_ptr::WeakPtr::<Request>::init_ref(request_object_ptr) });
+        let Some(request_object) = prepared.request() else {
+            unreachable!("just created");
+        };
 
         // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
-        let global = this.global();
-        // SAFETY: `request_object_ptr` is live; no other borrow is outstanding.
-        let args = [unsafe { (*request_object_ptr).to_js(&global) }, server_js];
+        let global = server.global();
+        let args = [request_object.to_js(&global), server_js];
         args[0].ensure_still_alive();
 
-        let response_value = match this.config.on_request.call(&global, server_js, &args) {
+        let on_request = server.config().on_request;
+        let response_value = match on_request.call(&global, server_js, &args) {
             Ok(v) => v,
             Err(err) => global.take_exception(err),
         };
-        // Its own copy, so the closure's capture does not pin `request_object_ptr`.
-        let detach_ptr = request_object_ptr;
-        scopeguard::defer! {
-            // uWS request will not live longer than this function
-            // SAFETY: see request_object_ptr above.
-            unsafe { (*detach_ptr).request_context.detach_request() };
-        }
+        // uWS request will not live longer than this function
+        let _detach_guard = super::DetachRequestOnDrop(&prepared.request);
 
-        ctx.on_response(this, args[0], response_value);
+        ctx.on_response(server, args[0], response_value);
 
         ctx.defer_deinit_until_callback_completes.set(None);
 
@@ -3349,20 +3181,20 @@ where
             return;
         }
 
-        ctx.to_async(
-            std::ptr::from_mut::<uws::Request>(req).cast::<c_void>(),
-            // SAFETY: `request_object_ptr` is live (the ctx's weakref owns it)
-            // and no other borrow of the Request is outstanding here.
-            unsafe { &mut *request_object_ptr },
-        );
+        ctx.arm_async(req, &prepared.request);
+        args[0].ensure_still_alive();
     }
 
     // https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
     pub(super) fn on_chrome_dev_tools_json_request(
-        &mut self,
-        req: &mut uws::Request,
-        resp: &mut uws_sys::NewAppResponse<SSL>,
+        this: ThisPtr<Self>,
+        req: uws_sys::AnyRequest,
+        resp: uws::AnyResponse,
     ) {
+        let (req, resp) = super::h1_parts::<SSL>(req, resp);
+        // S008: `Response<SSL>` is a ZST opaque — safe deref.
+        let resp = bun_opaque::opaque_deref_mut(resp);
+        let server = this.get();
         if cfg!(debug_assertions) {
             // NOTE: scoped_log! expands each arg twice (ANSI/no-ANSI branches);
             // copy to owned buffers so the two `&req` borrows in the expansion
@@ -3372,8 +3204,9 @@ where
             httplog!("{} - {}", BStr::new(&m), BStr::new(&u));
         }
 
+        let dev_server_guard = server.dev_server.get();
         let authorized = 'brk: {
-            let Some(dev_server) = self.dev_server.as_deref() else {
+            let Some(dev_server) = dev_server_guard.as_deref() else {
                 break 'brk false;
             };
 
@@ -3399,13 +3232,14 @@ where
             req.set_yield(true);
             return;
         }
+        let root: &[u8] = &dev_server_guard.as_deref().expect("authorized").root;
 
         // They need a 16 byte uuid. It needs to be somewhat consistent. We don't want to store this field anywhere.
 
         // So we first use a hash of the main field:
         let first_hash_segment: [u8; 8] = 'brk: {
             let mut buffer = paths::path_buffer_pool::get();
-            let main = self.vm_ref().main();
+            let main = server.vm_ref().main();
             let len = main.len().min(buffer.len());
             break 'brk hash(strings::copy_lowercase(&main[..len], &mut buffer[..len]))
                 .to_ne_bytes();
@@ -3414,7 +3248,6 @@ where
         // And then we use a hash of their project root directory:
         let second_hash_segment: [u8; 8] = 'brk: {
             let mut buffer = paths::path_buffer_pool::get();
-            let root = &self.dev_server.as_ref().unwrap().root;
             let len = root.len().min(buffer.len());
             break 'brk hash(strings::copy_lowercase(&root[..len], &mut buffer[..len]))
                 .to_ne_bytes();
@@ -3436,10 +3269,7 @@ where
         let _ = write!(
             &mut json_string,
             "{{ \"workspace\": {{ \"root\": {}, \"uuid\": \"{}\" }} }}",
-            bun_fmt::format_json_string_utf8(
-                &self.dev_server.as_ref().unwrap().root,
-                Default::default()
-            ),
+            bun_fmt::format_json_string_utf8(root, Default::default()),
             uuid,
         );
 
@@ -3457,7 +3287,7 @@ where
         if self.js_value_for_dispatch().is_none() {
             return Ok(());
         }
-        let callback = self.on_clienterror;
+        let callback = self.on_clienterror.get();
         if callback.is_empty() {
             return Ok(());
         }
@@ -3477,9 +3307,7 @@ where
 
             let error_code_value = JSValue::js_number(error_code as f64);
             let raw_packet_value = ArrayBuffer::create_buffer(&global, raw_packet)?;
-            // SAFETY: event_loop() returns a live raw pointer tied to the global.
-            let _scope =
-                unsafe { jsc::event_loop::EventLoop::enter_scope(global.bun_vm().event_loop()) };
+            let _scope = global.bun_vm().enter_event_loop_scope();
             callback.call(
                 &global,
                 JSValue::UNDEFINED,
@@ -3502,7 +3330,7 @@ where
         if self.js_value_for_dispatch().is_none() {
             return Ok(());
         }
-        let callback = self.on_connection;
+        let callback = self.on_connection.get();
         if callback.is_empty() {
             return Ok(());
         }
@@ -3513,15 +3341,36 @@ where
         if node_socket.is_undefined_or_null() {
             return Ok(());
         }
-        // SAFETY: event_loop() returns a live raw pointer tied to the global.
-        let _scope =
-            unsafe { jsc::event_loop::EventLoop::enter_scope(global.bun_vm().event_loop()) };
+        let _scope = global.bun_vm().enter_event_loop_scope();
         callback.call(&global, JSValue::UNDEFINED, &[node_socket])?;
         Ok(())
     }
 
     // `js_gc_route_list_set` / `ptr_to_js` live on the unbounded
     // `impl NewServer` in mod.rs; do not redefine them here.
+}
+
+/// The `(request, response)` handles of an HTTP/2 or HTTP/3 route callback;
+/// both transports hand over the same decoded-header request type.
+enum MuxParts<'a> {
+    H2(&'a mut uws_sys::h3::Request, &'a mut uws_sys::h2::Response),
+    H3(&'a mut uws_sys::h3::Request, &'a mut uws_sys::h3::Response),
+}
+
+#[inline]
+fn mux_parts<'a>(req: uws_sys::AnyRequest, resp: uws::AnyResponse) -> MuxParts<'a> {
+    let uws_sys::AnyRequest::H3(req) = req else {
+        unreachable!("H2/H3 route dispatched an H1 request")
+    };
+    // S008: all three are `opaque_ffi!` ZST handles — safe deref.
+    let req = bun_opaque::opaque_deref_mut(req);
+    match resp {
+        uws::AnyResponse::H2(resp) => MuxParts::H2(req, bun_opaque::opaque_deref_mut(resp)),
+        uws::AnyResponse::H3(resp) => MuxParts::H3(req, bun_opaque::opaque_deref_mut(resp)),
+        uws::AnyResponse::SSL(_) | uws::AnyResponse::TCP(_) => {
+            unreachable!("H2/H3 route dispatched an H1 response")
+        }
+    }
 }
 
 // JsClass impls for the four server monomorphizations. Forward into the
@@ -3541,292 +3390,196 @@ bun_jsc::impl_js_class_via_generated!(DebugHTTPServer => crate::generated_classe
 bun_jsc::impl_js_class_via_generated!(DebugHTTPSServer => crate::generated_classes::js_DebugHTTPSServer, no_constructor);
 
 // ─── Exported fns ────────────────────────────────────────────────────────────
-fn server_set_on_client_error(
+/// Run `$body` with `$s` bound to the `&NewServer<..>` behind `server`, or
+/// evaluate to `$otherwise` if it is not a server wrapper.
+macro_rules! with_any_server_js {
+    ($server:expr, |$s:ident| $body:expr, $otherwise:expr) => {{
+        let server = $server;
+        if let Some($s) = server.as_class_ref::<HTTPServer>() {
+            $body
+        } else if let Some($s) = server.as_class_ref::<HTTPSServer>() {
+            $body
+        } else if let Some($s) = server.as_class_ref::<DebugHTTPServer>() {
+            $body
+        } else if let Some($s) = server.as_class_ref::<DebugHTTPSServer>() {
+            $body
+        } else {
+            $otherwise
+        }
+    }};
+}
+
+impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
+    fn set_on_client_error_from_js(
+        &self,
+        server: JSValue,
+        global: &JSGlobalObject,
+        callback: JSValue,
+    ) {
+        let Some(app) = self.app_mut() else { return };
+        let mut shadow = callback;
+        super::wrap_handler_slot(&mut shadow, server, global, Self::js_gc_on_client_error_set);
+        self.on_clienterror.set(shadow);
+        app.on_client_error_this(
+            |this: ThisPtr<Self>,
+             socket: *mut uws_sys::us_socket_t,
+             error_code: u8,
+             packet: &[u8]| {
+                // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
+                crate::dispatch::fold(this.on_client_error_callback(
+                    bun_opaque::opaque_deref_mut(socket),
+                    error_code,
+                    packet,
+                ));
+            },
+            self.this_ptr(),
+        );
+    }
+
+    fn set_on_connection_from_js(
+        &self,
+        server: JSValue,
+        global: &JSGlobalObject,
+        callback: JSValue,
+    ) {
+        let Some(app) = self.app_mut() else { return };
+        let mut shadow = callback;
+        super::wrap_handler_slot(&mut shadow, server, global, Self::js_gc_on_connection_set);
+        self.on_connection.set(shadow);
+        // uws filters fire with `1` when an HTTP connection is opened
+        // (for TLS, when its handshake completes) and `-1` on close;
+        // only the open notification is forwarded to JS.
+        app.filter_this(
+            |this: ThisPtr<Self>, socket: *mut uws_sys::us_socket_t, opened: i32| {
+                if opened != 1 {
+                    return;
+                }
+                crate::dispatch::fold(this.on_connection_callback(socket.cast::<c_void>()));
+            },
+            self.this_ptr(),
+        );
+    }
+}
+
+// Signatures match the C++ callers in `node:http`/`node:https`
+// (`bindings/NodeHTTP.cpp`), which declare them as bare `extern "C"` (no
+// `SYSV_ABI`) — hence the `c` calling convention.
+
+// HOST_EXPORT(Server__setOnClientError, c)
+pub fn server_set_on_client_error(
     global: &JSGlobalObject,
     server: JSValue,
     callback: JSValue,
-) -> JsResult<JSValue> {
-    if !server.is_object() {
-        return Err(global.throw(format_args!(
-            "Failed to set clientError: The 'this' value is not a Server."
-        )));
-    }
-
-    if !callback.is_function() {
-        return Err(global.throw(format_args!(
-            "Failed to set clientError: The provided value is not a function."
-        )));
-    }
-
-    macro_rules! handle {
-        ($T:ty) => {
-            if let Some(this_ptr) = server.as_::<$T>() {
-                // SAFETY: as_ returned a non-null *mut to a live server; nothing
-                // here re-enters through it, so each scoped access is exclusive.
-                if let Some(app) = unsafe { (*this_ptr).app } {
-                    // SAFETY: see above — `&mut` scoped to this statement.
-                    unsafe {
-                        (*this_ptr).on_clienterror = callback;
-                        super::wrap_handler_slot(
-                            &mut (*this_ptr).on_clienterror,
-                            server,
-                            global,
-                            <$T>::js_gc_on_client_error_set,
-                        );
-                    }
-                    // uws_sys::App::on_client_error takes the raw C-ABI handler shape;
-                    // wrap our typed callback in an extern "C" thunk that slices raw_packet.
-                    extern "C" fn thunk(
-                        user_data: *mut c_void,
-                        _ssl: c_int,
-                        socket: *mut uws_sys::us_socket_t,
-                        error_code: u8,
-                        raw_packet: *mut u8,
-                        raw_packet_len: c_int,
-                    ) {
-                        // SAFETY: user_data is the `*mut Self` registered below; socket is a live
-                        // uWS socket; raw_packet/raw_packet_len describe a valid (possibly empty)
-                        // buffer. Shared — the callback re-enters JS.
-                        let this = unsafe { &*user_data.cast::<$T>() };
-                        let packet: &[u8] = if raw_packet_len > 0 {
-                            // SAFETY: uWS guarantees `raw_packet` points to `raw_packet_len`
-                            // readable bytes when `raw_packet_len > 0`.
-                            unsafe { bun_core::ffi::slice(raw_packet, raw_packet_len as usize) }
-                        } else {
-                            &[]
-                        };
-                        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-                        crate::dispatch::fold(this.on_client_error_callback(
-                            bun_opaque::opaque_deref_mut(socket),
-                            error_code,
-                            packet,
-                        ));
-                    }
-                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app)
-                        .on_client_error(thunk, this_ptr.cast::<c_void>());
-                }
-                return Ok(JSValue::UNDEFINED);
-            }
-        };
-    }
-    handle!(HTTPServer);
-    handle!(HTTPSServer);
-    handle!(DebugHTTPServer);
-    handle!(DebugHTTPSServer);
-    debug_assert!(false);
-    Ok(JSValue::UNDEFINED)
-}
-
-fn server_set_on_connection(
-    global: &JSGlobalObject,
-    server: JSValue,
-    callback: JSValue,
-) -> JsResult<JSValue> {
-    if !server.is_object() {
-        return Err(global.throw(format_args!(
-            "Failed to set onConnection: The 'this' value is not a Server."
-        )));
-    }
-
-    if !callback.is_function() {
-        return Err(global.throw(format_args!(
-            "Failed to set onConnection: The provided value is not a function."
-        )));
-    }
-
-    macro_rules! handle {
-        ($T:ty) => {
-            if let Some(this_ptr) = server.as_::<$T>() {
-                // SAFETY: as_ returned a non-null *mut to a live server; nothing
-                // here re-enters through it, so each scoped access is exclusive.
-                if let Some(app) = unsafe { (*this_ptr).app } {
-                    // SAFETY: see above — `&mut` scoped to this statement.
-                    unsafe {
-                        (*this_ptr).on_connection = callback;
-                        super::wrap_handler_slot(
-                            &mut (*this_ptr).on_connection,
-                            server,
-                            global,
-                            <$T>::js_gc_on_connection_set,
-                        );
-                    }
-                    // uws filters fire with `1` when an HTTP connection is opened
-                    // (for TLS, when its handshake completes) and `-1` on close;
-                    // only the open notification is forwarded to JS.
-                    extern "C" fn thunk(
-                        socket: *mut uws_sys::us_socket_t,
-                        opened: i32,
-                        user_data: *mut c_void,
-                    ) {
-                        if opened != 1 {
-                            return;
-                        }
-                        // SAFETY: user_data is the `*mut Self` registered below;
-                        // socket is a live uWS socket for this server's group.
-                        // Shared — the callback re-enters JS.
-                        let this = unsafe { &*user_data.cast::<$T>() };
-                        crate::dispatch::fold(this.on_connection_callback(socket.cast::<c_void>()));
-                    }
-                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).filter(thunk, this_ptr.cast::<c_void>());
-                }
-                return Ok(JSValue::UNDEFINED);
-            }
-        };
-    }
-    handle!(HTTPServer);
-    handle!(HTTPSServer);
-    handle!(DebugHTTPServer);
-    handle!(DebugHTTPSServer);
-    debug_assert!(false);
-    Ok(JSValue::UNDEFINED)
-}
-
-fn server_set_app_flags(
-    global: &JSGlobalObject,
-    server: JSValue,
-    require_host_header: bool,
-    use_strict_method_validation: bool,
-    lenient_http_flags: u8,
-    http_allow_half_open: bool,
-) -> JsResult<JSValue> {
-    if !server.is_object() {
-        return Err(global.throw(format_args!(
-            "Failed to set requireHostHeader: The 'this' value is not a Server."
-        )));
-    }
-
-    if let Some(this) = server.as_::<HTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_flags(
-            require_host_header,
-            use_strict_method_validation,
-            lenient_http_flags,
-            http_allow_half_open,
-        );
-    } else if let Some(this) = server.as_::<HTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_flags(
-            require_host_header,
-            use_strict_method_validation,
-            lenient_http_flags,
-            http_allow_half_open,
-        );
-    } else if let Some(this) = server.as_::<DebugHTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_flags(
-            require_host_header,
-            use_strict_method_validation,
-            lenient_http_flags,
-            http_allow_half_open,
-        );
-    } else if let Some(this) = server.as_::<DebugHTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_flags(
-            require_host_header,
-            use_strict_method_validation,
-            lenient_http_flags,
-            http_allow_half_open,
-        );
-    } else {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The 'this' value is not a Server."
-        )));
-    }
-    Ok(JSValue::UNDEFINED)
-}
-
-fn server_set_max_http_header_size(
-    global: &JSGlobalObject,
-    server: JSValue,
-    max_header_size: u64,
-) -> JsResult<JSValue> {
-    if !server.is_object() {
-        return Err(global.throw(format_args!(
-            "Failed to set maxHeaderSize: The 'this' value is not a Server."
-        )));
-    }
-
-    if let Some(this) = server.as_::<HTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_max_http_header_size(max_header_size);
-    } else if let Some(this) = server.as_::<HTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_max_http_header_size(max_header_size);
-    } else if let Some(this) = server.as_::<DebugHTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_max_http_header_size(max_header_size);
-    } else if let Some(this) = server.as_::<DebugHTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_max_http_header_size(max_header_size);
-    } else {
-        return Err(global.throw(format_args!(
-            "Failed to set maxHeaderSize: The 'this' value is not a Server."
-        )));
-    }
-    Ok(JSValue::UNDEFINED)
-}
-
-// `host_fn.wrap{3,4}` C-ABI shims: each forwards through `to_js_host_call`
-// (= `host_fn::to_js_host_fn_result`) so a `JsError` becomes `.zero` with the
-// exception left on the global. Signatures match the C++ callers in
-// `node:http`/`node:https` (`bindings/NodeHTTP.cpp`).
-//
-// NOTE: these are plain `extern "C"` (NOT `#[bun_jsc::host_call]` / sysv64).
-// The C++ declarations in
-// NodeHTTP.cpp are bare `extern "C"` with no `SYSV_ABI`, so on Windows the
-// caller uses Win64 ABI. Using `host_call` here forced sysv64 on the Rust
-// side, scrambling the `server` argument and tripping the `is_object()` guard.
-#[unsafe(export_name = "Server__setAppFlags")]
-extern "C" fn server_set_app_flags_shim(
-    global: &JSGlobalObject,
-    server: JSValue,
-    require_host_header: bool,
-    use_strict_method_validation: bool,
-    lenient_http_flags: u8,
-    http_allow_half_open: bool,
 ) -> JSValue {
     host_fn::to_js_host_fn_result(
         global,
-        server_set_app_flags(
-            global,
-            server,
-            require_host_header,
-            use_strict_method_validation,
-            lenient_http_flags,
-            http_allow_half_open,
-        ),
+        (|| -> JsResult<JSValue> {
+            if !server.is_object() {
+                return Err(global.throw(format_args!(
+                    "Failed to set clientError: The 'this' value is not a Server."
+                )));
+            }
+            if !callback.is_function() {
+                return Err(global.throw(format_args!(
+                    "Failed to set clientError: The provided value is not a function."
+                )));
+            }
+            with_any_server_js!(
+                server,
+                |s| s.set_on_client_error_from_js(server, global, callback),
+                debug_assert!(false)
+            );
+            Ok(JSValue::UNDEFINED)
+        })(),
     )
 }
 
-#[unsafe(export_name = "Server__setOnClientError")]
-extern "C" fn server_set_on_client_error_shim(
+// HOST_EXPORT(Server__setOnConnection, c)
+pub fn server_set_on_connection(
     global: &JSGlobalObject,
     server: JSValue,
     callback: JSValue,
 ) -> JSValue {
-    host_fn::to_js_host_fn_result(global, server_set_on_client_error(global, server, callback))
+    host_fn::to_js_host_fn_result(
+        global,
+        (|| -> JsResult<JSValue> {
+            if !server.is_object() {
+                return Err(global.throw(format_args!(
+                    "Failed to set onConnection: The 'this' value is not a Server."
+                )));
+            }
+            if !callback.is_function() {
+                return Err(global.throw(format_args!(
+                    "Failed to set onConnection: The provided value is not a function."
+                )));
+            }
+            with_any_server_js!(
+                server,
+                |s| s.set_on_connection_from_js(server, global, callback),
+                debug_assert!(false)
+            );
+            Ok(JSValue::UNDEFINED)
+        })(),
+    )
 }
 
-#[unsafe(export_name = "Server__setOnConnection")]
-extern "C" fn server_set_on_connection_shim(
+// HOST_EXPORT(Server__setAppFlags, c)
+pub fn server_set_app_flags(
     global: &JSGlobalObject,
     server: JSValue,
-    callback: JSValue,
+    require_host_header: bool,
+    use_strict_method_validation: bool,
+    lenient_http_flags: u8,
+    http_allow_half_open: bool,
 ) -> JSValue {
-    host_fn::to_js_host_fn_result(global, server_set_on_connection(global, server, callback))
+    host_fn::to_js_host_fn_result(
+        global,
+        (|| -> JsResult<JSValue> {
+            if !server.is_object() {
+                return Err(global.throw(format_args!(
+                    "Failed to set requireHostHeader: The 'this' value is not a Server."
+                )));
+            }
+            with_any_server_js!(
+                server,
+                |s| s.set_flags(
+                    require_host_header,
+                    use_strict_method_validation,
+                    lenient_http_flags,
+                    http_allow_half_open,
+                ),
+                return Err(global.throw(format_args!(
+                    "Failed to set timeout: The 'this' value is not a Server."
+                )))
+            );
+            Ok(JSValue::UNDEFINED)
+        })(),
+    )
 }
 
-#[unsafe(export_name = "Server__setMaxHTTPHeaderSize")]
-extern "C" fn server_set_max_http_header_size_shim(
+// HOST_EXPORT(Server__setMaxHTTPHeaderSize, c)
+pub fn server_set_max_http_header_size(
     global: &JSGlobalObject,
     server: JSValue,
     max_header_size: u64,
 ) -> JSValue {
     host_fn::to_js_host_fn_result(
         global,
-        server_set_max_http_header_size(global, server, max_header_size),
+        (|| -> JsResult<JSValue> {
+            if !server.is_object() {
+                return Err(global.throw(format_args!(
+                    "Failed to set maxHeaderSize: The 'this' value is not a Server."
+                )));
+            }
+            with_any_server_js!(
+                server,
+                |s| s.set_max_http_header_size(max_header_size),
+                return Err(global.throw(format_args!(
+                    "Failed to set maxHeaderSize: The 'this' value is not a Server."
+                )))
+            );
+            Ok(JSValue::UNDEFINED)
+        })(),
     )
 }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -102,11 +102,21 @@ pub(super) trait RequestCtx<const SSL: bool, const DEBUG: bool>:
     fn should_render_missing(&self) -> bool;
     fn render_missing(&self);
     fn to_async(&self, req: &mut Self::Req, request_object: &Request);
-    /// `to_async`, or just its abort-handler arming when the `Request` is gone.
-    fn arm_async(&self, req: &mut Self::Req, request: &crate::webcore::request::WeakRef) {
-        match request.peek() {
+    /// The heap `Request`, while the context still holds it.
+    fn request(&self) -> Option<&Request>;
+    /// `to_async` (which also detaches the stack request), or just its
+    /// abort-handler arming when the `Request` is gone.
+    fn arm_async(&self, req: &mut Self::Req) {
+        match self.request() {
             Some(request) => self.to_async(req, request),
             None => self.set_abort_handler(),
+        }
+    }
+    /// Detach the borrowed stack request from the heap `Request` so the JS
+    /// object never dangles a pointer past the uWS frame it borrowed.
+    fn detach_uws_request(&self) {
+        if let Some(request) = self.request() {
+            request.request_context.get().detach_request();
         }
     }
     fn set_abort_handler(&self);
@@ -185,6 +195,10 @@ macro_rules! impl_request_ctx {
             #[inline]
             fn to_async(&self, req: &mut Self::Req, ro: &Request) {
                 Self::to_async(self, std::ptr::from_mut(req).cast(), ro)
+            }
+            #[inline]
+            fn request(&self) -> Option<&Request> {
+                self.request_weakref.get().peek()
             }
             #[inline]
             fn set_abort_handler(&self) {
@@ -2744,9 +2758,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         response_value: JSValue,
     ) {
         let ctx = prepared.ctx.get();
-        // uWS request will not live longer than this function
-        let _detach_guard = super::DetachRequestOnDrop(&prepared.request);
-
+        // The uWS request will not live longer than this function: on every
+        // exit below it is detached from the `Request`.
         ctx.on_response(self, prepared.js_request, response_value);
         // Reference in the stack here in case it is not for whatever reason
         prepared.js_request.ensure_still_alive();
@@ -2754,18 +2767,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         ctx.set_defer_deinit(None);
 
         if should_deinit_context.get() {
+            ctx.detach_uws_request();
             ctx.deinit();
             return;
         }
 
         if ctx.should_render_missing() {
+            ctx.detach_uws_request();
             ctx.render_missing();
             return;
         }
 
         // The request is asynchronous, and all information from `req` must be copied
         // since the provided uws.Request will be re-used for future requests (stack allocated).
-        ctx.arm_async(req, &prepared.request);
+        ctx.arm_async(req);
         prepared.js_request.ensure_still_alive();
     }
 
@@ -2891,7 +2906,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             expects_body,
         );
         let ctx: &Ctx = prepared.ctx.get();
-        let Some(request_object) = prepared.request() else {
+        let Some(request_object) = ctx.request() else {
             unreachable!("just created");
         };
 
@@ -3044,11 +3059,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 Some(signal.ref_()),
                 body_hive,
             )));
-        let request = request_weak.clone();
         ctx.set_request_weakref(request_weak);
         PreparedRequestFor {
             js_request: JSValue::ZERO,
-            request,
             request_ptr,
             ctx: ctx_ref,
         }
@@ -3150,7 +3163,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         let ctx = prepared.ctx.get();
         ctx.upgrade_context
             .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)));
-        let Some(request_object) = prepared.request() else {
+        let Some(request_object) = ctx.request_weakref.get().peek() else {
             unreachable!("just created");
         };
 
@@ -3164,24 +3177,25 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             Ok(v) => v,
             Err(err) => global.take_exception(err),
         };
-        // uWS request will not live longer than this function
-        let _detach_guard = super::DetachRequestOnDrop(&prepared.request);
-
+        // The uWS request will not live longer than this function: on every
+        // exit below it is detached from the `Request`.
         ctx.on_response(server, args[0], response_value);
 
         ctx.defer_deinit_until_callback_completes.set(None);
 
         if should_deinit_context.get() {
+            RequestCtx::detach_uws_request(ctx);
             ctx.deinit();
             return;
         }
 
         if ctx.should_render_missing() {
+            RequestCtx::detach_uws_request(ctx);
             ctx.render_missing();
             return;
         }
 
-        ctx.arm_async(req, &prepared.request);
+        ctx.arm_async(req);
         args[0].ensure_still_alive();
     }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -287,9 +287,10 @@ fn h1_pool<const SSL: bool, const DEBUG: bool>(
 fn mux_pool<const SSL: bool, const DEBUG: bool>(
     server: &NewServer<SSL, DEBUG>,
 ) -> &'static CtxPool<ServerMuxRequestContext<SSL, DEBUG>> {
-    server.mux_request_pool.get().expect(
-        "HTTP/2 or HTTP/3 request dispatched but mux_request_pool was never allocated",
-    )
+    server
+        .mux_request_pool
+        .get()
+        .expect("HTTP/2 or HTTP/3 request dispatched but mux_request_pool was never allocated")
 }
 impl_request_ctx!(false, uws_sys::Request, h1_pool);
 impl_request_ctx!(true, uws_sys::h3::Request, mux_pool);
@@ -2550,23 +2551,22 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         JSValue::from(DEBUG)
     }
 
-    pub fn finalize(self: Box<Self>) {
+    /// Runs before the wrapper's ref is dropped (`refCounted` class).
+    pub fn finalize(&self) {
         httplog!("finalize");
-        bun_ptr::finalize_js_box(self, |this| {
-            this.js_value.with_mut(|v| v.finalize());
-            this.deinit_if_we_can();
-            // `deinit_if_we_can` may defer (pending requests), so teardown is not
-            // unconditional. JSC-handle Drops are no-ops past `is_shutting_down()`;
-            // `TERMINATED` means `app.close()` already ran, so destroying the app
-            // can't orphan a keep-alive socket.
-            if this.has_flags(ServerFlags::DEINIT_SCHEDULED)
-                && this.has_flags(ServerFlags::TERMINATED)
-                && this.vm().is_shutting_down()
-            {
-                // Not the last ref: `finalize_js_box` still holds the wrapper's.
-                drop(this.teardown());
-            }
-        });
+        self.js_value.with_mut(|v| v.finalize());
+        self.deinit_if_we_can();
+        // `deinit_if_we_can` may defer (pending requests), so teardown is not
+        // unconditional. JSC-handle Drops are no-ops past `is_shutting_down()`;
+        // `TERMINATED` means `app.close()` already ran, so destroying the app
+        // can't orphan a keep-alive socket.
+        if self.has_flags(ServerFlags::DEINIT_SCHEDULED)
+            && self.has_flags(ServerFlags::TERMINATED)
+            && self.vm().is_shutting_down()
+        {
+            // Not the last ref: the caller still holds the wrapper's.
+            drop(self.teardown());
+        }
     }
 
     pub(crate) fn get_all_closed_promise(&self, global: &JSGlobalObject) -> JSValue {
@@ -2609,16 +2609,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         resp: uws::AnyResponse,
     ) {
         match mux_parts(req, resp) {
-            MuxParts::H2(req, resp) => {
-                Self::on_user_route_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(
-                    user_route, req, resp,
-                )
-            }
-            MuxParts::H3(req, resp) => {
-                Self::on_user_route_request_for::<ServerMuxRequestContext<SSL, DEBUG>, _>(
-                    user_route, req, resp,
-                )
-            }
+            MuxParts::H2(req, resp) => Self::on_user_route_request_for::<
+                ServerMuxRequestContext<SSL, DEBUG>,
+                _,
+            >(user_route, req, resp),
+            MuxParts::H3(req, resp) => Self::on_user_route_request_for::<
+                ServerMuxRequestContext<SSL, DEBUG>,
+                _,
+            >(user_route, req, resp),
         }
     }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1185,9 +1185,7 @@ impl ServePlugins {
     }
 
     fn release_promise_ref(&self) {
-        if let Some(r) = self.promise_ref.take() {
-            r.deref();
-        }
+        drop(self.promise_ref.take());
     }
 
     /// `server` (whose DevServer may be waiting on a pending load) is going away.
@@ -1381,7 +1379,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         };
         let global = self.global();
         // Keep `*p` alive across re-entrant JS in `load_and_resolve_plugins`.
-        let _keep_alive = p.ref_guard();
+        let _keep_alive = RefPtr::from_this(p);
         match ServePlugins::get_or_start_load(p, &global, callback, self.as_any_server()) {
             Ok(r) => r,
             Err(JsError::Thrown | JsError::Terminated) => {
@@ -2565,10 +2563,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 && this.has_flags(ServerFlags::TERMINATED)
                 && this.vm().is_shutting_down()
             {
-                if let Some(r) = this.teardown() {
-                    // Not the last ref: `finalize_js_box` still holds the wrapper's.
-                    r.deref();
-                }
+                // Not the last ref: `finalize_js_box` still holds the wrapper's.
+                drop(this.teardown());
             }
         });
     }
@@ -2891,8 +2887,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
 
-        let is_te =
-            request_body_length.is_some() && ReqLike::has_transfer_encoding(req);
+        let is_te = request_body_length.is_some() && ReqLike::has_transfer_encoding(req);
         // HTTP/2 and HTTP/3 frame the body by END_STREAM or QUIC FIN, not Content-Length.
         let expects_body = matches!(request_body_length, Some(req_len)
             if req_len > 0 || is_te || (Ctx::IS_MUX && !RespLike::request_body_ended(resp)));

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -76,7 +76,7 @@ const _: () = {
 /// `&mut Request`) so re-entrant JS calls cannot stack two `&mut` to the same
 /// instance. Fields mutated by host-fns are wrapped in `Cell` (Copy scalars)
 /// or `JsCell` (Drop types). Both are `#[repr(transparent)]`, so `#[repr(C)]`
-/// field layout is unchanged. `method`/`flags`/`request_context`/`body`/
+/// field layout is unchanged. `method`/`flags`/`body`/
 /// `weak_ptr_data` are only written during construction or via raw-ptr
 /// `finalize`, so stay plain.
 #[repr(C)]
@@ -98,7 +98,7 @@ pub struct Request {
     js_ref: JsCell<JsRef>,
     pub method: Method,
     pub(crate) flags: Flags,
-    pub(crate) request_context: AnyRequestContext,
+    pub(crate) request_context: Cell<AnyRequestContext>,
     pub(crate) weak_ptr_data: WeakPtrData,
     // We must report a consistent value for this
     reported_estimated_size: Cell<usize>,
@@ -249,7 +249,7 @@ impl Request {
             return Ok(self.headers_mut().as_mut().unwrap());
         }
 
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // we have a request context, so we can get the headers from it
             self.headers.set(Some(HeadersRef::create_from_uws(
                 req.cast::<core::ffi::c_void>(),
@@ -298,7 +298,7 @@ impl Request {
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn get_fetch_headers_unless_empty(&self) -> Option<&mut HeadersRef> {
         if self.headers.get().is_none() {
-            if let Some(req) = self.request_context.get_request() {
+            if let Some(req) = self.request_context.get().get_request() {
                 // we have a request context, so we can get the headers from it
                 self.headers.set(Some(HeadersRef::create_from_uws(
                     req.cast::<core::ffi::c_void>(),
@@ -323,7 +323,7 @@ impl Request {
         global_this: &JSGlobalObject,
     ) -> JsResult<Option<HeadersRef>> {
         if self.headers.get().is_none() {
-            if let Some(uws_req) = self.request_context.get_request() {
+            if let Some(uws_req) = self.request_context.get().get_request() {
                 self.headers.set(Some(HeadersRef::create_from_uws(
                     uws_req.cast::<core::ffi::c_void>(),
                 )));
@@ -342,7 +342,7 @@ impl Request {
     }
 
     pub(crate) fn get_content_type(&self) -> JsResult<Option<bun_core::Utf8Bytes<'_>>> {
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             if let Some(value) = req.header(b"content-type") {
@@ -370,7 +370,7 @@ impl Request {
 impl Request {
     pub(crate) fn memory_cost(&self) -> usize {
         core::mem::size_of::<Request>()
-            + self.request_context.memory_cost()
+            + self.request_context.get().memory_cost()
             + self.url.get().byte_slice().len()
             + self.body_value().memory_cost()
     }
@@ -378,6 +378,7 @@ impl Request {
     #[bun_uws::uws_callback(export = "Request__setCookiesOnRequestContext")]
     pub fn ffi_set_cookies_on_request_context(&self, cookie_map: Option<&CookieMap>) {
         self.request_context
+            .get()
             .set_cookies(cookie_map.map(|c| std::ptr::from_ref::<CookieMap>(c).cast_mut()));
     }
 
@@ -428,7 +429,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::empty()),
             method,
             flags: Flags::default(),
-            request_context: AnyRequestContext::NULL,
+            request_context: Cell::new(AnyRequestContext::NULL),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         }
@@ -771,7 +772,7 @@ impl Request {
             return url.byte_slice().len();
         }
 
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             let req_url = Self::request_target_path(req.url());
@@ -863,7 +864,7 @@ impl Request {
             return Ok(());
         }
 
-        if let Some(req) = self.request_context.get_request() {
+        if let Some(req) = self.request_context.get().get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             let req_url = Self::request_target_path(req.url());
@@ -992,7 +993,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::init_weak(this_value)),
             method: Method::GET,
             flags: Flags::default(),
-            request_context: AnyRequestContext::NULL,
+            request_context: Cell::new(AnyRequestContext::NULL),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         };
@@ -1499,7 +1500,7 @@ impl Request {
                     js_ref: JsCell::new(JsRef::empty()),
                     method: self.method,
                     flags: self.flags,
-                    request_context: AnyRequestContext::NULL,
+                    request_context: Cell::new(AnyRequestContext::NULL),
                     weak_ptr_data: WeakPtrData::EMPTY,
                     reported_estimated_size: Cell::new(0),
                 },
@@ -1531,7 +1532,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::empty()),
             method: Method::GET,
             flags: Flags::default(),
-            request_context: AnyRequestContext::NULL,
+            request_context: Cell::new(AnyRequestContext::NULL),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         });
@@ -1560,7 +1561,7 @@ impl Request {
                 https,
                 ..Flags::default()
             },
-            request_context,
+            request_context: Cell::new(request_context),
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1,7 +1,6 @@
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::mem;
-use core::ptr::NonNull;
 
 use bun_jsc::JsCell;
 use bun_jsc::{AbortSignal, AbortSignalRef, GlobalRef};
@@ -24,96 +23,7 @@ use super::{FetchHeaders, ReadableStream, Request};
 pub use super::blob::Blob;
 use bun_ptr::weak_ptr::WeakPtrData;
 
-/// RAII handle to a C++-owned `WebCore::FetchHeaders`.
-///
-/// Holds exactly one ref on the C++ intrusive refcount; `Drop` releases it via
-/// `WebCore__FetchHeaders__deref`. NOT a `std::rc::Rc` (the payload lives on
-/// the C++ heap and is opaque here).
-///
-/// Intentionally not `Clone`: the only "share" operation the surface
-/// exposes is `clone_this()`, which deep-copies a fresh `FetchHeaders` on the
-/// C++ side. Transferring ownership is by-move.
-#[repr(transparent)]
-pub struct HeadersRef(NonNull<FetchHeaders>);
-
-impl HeadersRef {
-    /// Adopt a freshly-created `FetchHeaders*` (refcount already 1).
-    ///
-    /// # Safety
-    /// `ptr` must be a valid `WebCore::FetchHeaders*` and the caller must
-    /// transfer ownership of one ref.
-    #[inline]
-    pub(crate) unsafe fn adopt(ptr: NonNull<FetchHeaders>) -> Self {
-        Self(ptr)
-    }
-
-    #[inline]
-    pub(crate) fn as_ptr(&self) -> *mut FetchHeaders {
-        self.0.as_ptr()
-    }
-
-    /// `FetchHeaders.createEmpty()` — fresh C++ allocation, refcount 1.
-    #[inline]
-    pub(crate) fn create_empty() -> Self {
-        // SAFETY: C++ allocates a new FetchHeaders with refcount 1; never null.
-        unsafe { Self::adopt(FetchHeaders::create_empty()) }
-    }
-
-    /// `FetchHeaders.createFromUWS(req)` — fresh C++ allocation, refcount 1.
-    #[inline]
-    pub(crate) fn create_from_uws(uws_request: *mut core::ffi::c_void) -> Self {
-        // SAFETY: C++ allocates a new FetchHeaders with refcount 1; never null.
-        unsafe { Self::adopt(FetchHeaders::create_from_uws(uws_request)) }
-    }
-
-    /// `FetchHeaders.createFromJS(global, value)` — may throw, may return null.
-    #[inline]
-    pub(crate) fn create_from_js(
-        global: &JSGlobalObject,
-        value: JSValue,
-    ) -> JsResult<Option<Self>> {
-        // SAFETY: C++ returns a +1 ref or null.
-        Ok(FetchHeaders::create_from_js(global, value)?.map(|p| unsafe { Self::adopt(p) }))
-    }
-
-    /// `FetchHeaders.cloneThis(global)` — deep copy on the C++ side.
-    #[inline]
-    pub(crate) fn clone_this(&self, global: &JSGlobalObject) -> JsResult<Option<Self>> {
-        // SAFETY: C++ returns a +1 ref or null.
-        Ok(bun_opaque::opaque_deref_mut(self.0.as_ptr())
-            .clone_this(global)?
-            .map(|p| unsafe { Self::adopt(p) }))
-    }
-}
-
-impl core::ops::Deref for HeadersRef {
-    type Target = FetchHeaders;
-    #[inline]
-    fn deref(&self) -> &FetchHeaders {
-        // `FetchHeaders` is an opaque ZST FFI handle (S008); `self.0` is live
-        // for the lifetime of `self` — safe `*const → &` via `opaque_deref`.
-        bun_opaque::opaque_deref(self.0.as_ptr())
-    }
-}
-
-impl core::ops::DerefMut for HeadersRef {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut FetchHeaders {
-        // `FetchHeaders` is an opaque ZST FFI handle (S008); `self.0` is live
-        // for the lifetime of `self` — safe `*mut → &mut` via `opaque_deref_mut`.
-        bun_opaque::opaque_deref_mut(self.0.as_ptr())
-    }
-}
-
-impl Drop for HeadersRef {
-    #[inline]
-    fn drop(&mut self) {
-        // `self.0` is live; releasing our +1 ref via WebCore__FetchHeaders__deref.
-        // Explicit UFCS to avoid `core::ops::Deref::deref` resolution ambiguity.
-        // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
-        FetchHeaders::deref(bun_opaque::opaque_deref_mut(self.0.as_ptr()));
-    }
-}
+pub use bun_jsc::HeadersRef;
 
 /// Errors the owning fetch `Response`'s body on abort (Fetch spec "abort a fetch" step 4).
 pub(crate) struct BodyAbortListener {

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -8,11 +8,13 @@ use bun_http_types::Method::Method;
 use crate::response::Response;
 use crate::socket_context::BunSocketContextOptions;
 use crate::web_socket::c::uws_ws;
+use crate::web_socket::{WebSocketHandler, WebSocketUpgradeServer, Wrap};
 use crate::{
     AnyRequest, AnyResponse, ListenSocket as UwsListenSocket, Opcode, Request, SendStatus,
     WebSocketBehavior, thunk, us_socket_t, uws_res,
 };
 use bun_ptr::ThisPtr;
+use core::ptr::NonNull;
 
 // This file provides Rust bindings for the uWebSockets App class.
 // It wraps the C API exposed in libuwsockets.cpp which provides a C interface
@@ -57,6 +59,28 @@ pub struct App<const SSL: bool> {
 
 /// Legacy name alias.
 pub type NewApp<const SSL: bool> = App<SSL>;
+
+/// Owning handle to a `uWS::TemplatedApp<SSL>`: dropping it destroys the app
+/// (and with it every route/filter registration and their user-data pointers).
+pub struct OwnedApp<const SSL: bool>(NonNull<App<SSL>>);
+
+impl<const SSL: bool> OwnedApp<SSL> {
+    pub fn create(opts: &BunSocketContextOptions) -> Option<Self> {
+        App::<SSL>::create(opts).and_then(NonNull::new).map(Self)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut App<SSL> {
+        self.0.as_ptr()
+    }
+}
+
+impl<const SSL: bool> Drop for OwnedApp<SSL> {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from `App::create` and is destroyed exactly once, here.
+        unsafe { App::<SSL>::destroy(self.0.as_ptr()) }
+    }
+}
 
 /// Stamps one `pub fn $name(&mut self, pattern, handler, user_data)` per HTTP
 /// verb. Bodies are byte-identical modulo the C symbol — see `uws_app_get` &co
@@ -313,6 +337,37 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_on_clienterror(Self::SSL_FLAG, self.as_raw(), handler, user_data)
     }
 
+    /// [`on_client_error`](Self::on_client_error) whose handler receives the
+    /// registered `this`, the socket, the error code and the raw packet. The
+    /// registrant keeps `this` alive while the app exists.
+    pub fn on_client_error_this<U: 'static, H>(&mut self, _handler: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, *mut us_socket_t, u8, &[u8]) + Copy + 'static,
+    {
+        extern "C" fn cb<U: 'static, H>(
+            user_data: *mut c_void,
+            _ssl: c_int,
+            socket: *mut us_socket_t,
+            error_code: u8,
+            raw_packet: *mut u8,
+            raw_packet_len: c_int,
+        ) where
+            H: Fn(ThisPtr<U>, *mut us_socket_t, u8, &[u8]) + Copy + 'static,
+        {
+            // SAFETY: `user_data` is the `ThisPtr<U>` registered below, kept alive
+            // by the registrant while the app exists; uWS hands a valid
+            // (possibly empty) `raw_packet[..raw_packet_len]`.
+            let (this, packet) = unsafe {
+                (
+                    ThisPtr::new(user_data.cast::<U>()),
+                    thunk::c_slice(raw_packet, usize::try_from(raw_packet_len).unwrap_or(0)),
+                )
+            };
+            thunk::zst::<H>()(this, socket, error_code, packet)
+        }
+        self.on_client_error(cb::<U, H>, this.as_ptr().cast())
+    }
+
     pub fn listen_with_config(
         &mut self,
         handler: c::uws_listen_handler,
@@ -332,6 +387,34 @@ impl<const SSL: bool> App<SSL> {
                 user_data,
             )
         }
+    }
+
+    /// [`listen_with_config`](Self::listen_with_config) whose (synchronous)
+    /// handler receives `this` and the listen socket (`None` on failure).
+    pub fn listen_with_config_this<U: 'static, H>(
+        &mut self,
+        _handler: H,
+        this: ThisPtr<U>,
+        config: c::uws_app_listen_config_t,
+    ) where
+        H: Fn(ThisPtr<U>, Option<NonNull<ListenSocket<SSL>>>) + Copy + 'static,
+    {
+        self.listen_with_config(
+            Some(Self::listen_this_thunk::<U, H>),
+            this.as_ptr().cast(),
+            config,
+        )
+    }
+
+    extern "C" fn listen_this_thunk<U: 'static, H>(
+        socket: *mut UwsListenSocket,
+        user_data: *mut c_void,
+    ) where
+        H: Fn(ThisPtr<U>, Option<NonNull<ListenSocket<SSL>>>) + Copy + 'static,
+    {
+        // SAFETY: `user_data` is the `ThisPtr<U>` handed to `listen_*_this`, live across this synchronous callback.
+        let this = unsafe { ThisPtr::new(user_data.cast::<U>()) };
+        thunk::zst::<H>()(this, NonNull::new(socket.cast::<ListenSocket<SSL>>()))
     }
 
     pub fn listen_on_unix_socket(
@@ -354,6 +437,30 @@ impl<const SSL: bool> App<SSL> {
                 user_data,
             )
         }
+    }
+
+    /// [`listen_on_unix_socket`](Self::listen_on_unix_socket) counterpart of
+    /// [`listen_with_config_this`](Self::listen_with_config_this).
+    pub fn listen_on_unix_socket_this<U: 'static, H>(
+        &mut self,
+        _handler: H,
+        this: ThisPtr<U>,
+        domain_name: &ZStr,
+        flags: i32,
+    ) where
+        H: Fn(ThisPtr<U>, Option<NonNull<ListenSocket<SSL>>>) + Copy + 'static,
+    {
+        extern "C" fn cb<const SSL: bool, U: 'static, H>(
+            socket: *mut UwsListenSocket,
+            _domain: *const c_char,
+            _flags: i32,
+            user_data: *mut c_void,
+        ) where
+            H: Fn(ThisPtr<U>, Option<NonNull<ListenSocket<SSL>>>) + Copy + 'static,
+        {
+            App::<SSL>::listen_this_thunk::<U, H>(socket, user_data)
+        }
+        self.listen_on_unix_socket(cb::<SSL, U, H>, this.as_ptr().cast(), domain_name, flags)
     }
 
     pub fn num_subscribers(&mut self, topic: &[u8]) -> u32 {
@@ -423,7 +530,53 @@ impl<const SSL: bool> App<SSL> {
         c::uws_filter(Self::SSL_FLAG, self.as_raw(), Some(handler), user_data)
     }
 
-    pub fn ws(
+    /// [`filter`](Self::filter) whose handler receives the registered `this`.
+    /// The registrant keeps `this` alive while the app exists.
+    pub fn filter_this<U: 'static, H>(&mut self, _handler: H, this: ThisPtr<U>)
+    where
+        H: Fn(ThisPtr<U>, *mut us_socket_t, i32) + Copy + 'static,
+    {
+        extern "C" fn cb<U: 'static, H>(
+            socket: *mut us_socket_t,
+            opened: i32,
+            user_data: *mut c_void,
+        ) where
+            H: Fn(ThisPtr<U>, *mut us_socket_t, i32) + Copy + 'static,
+        {
+            // SAFETY: `user_data` is the `ThisPtr<U>` registered below, kept alive
+            // by the registrant while the app exists.
+            let this = unsafe { ThisPtr::new(user_data.cast::<U>()) };
+            thunk::zst::<H>()(this, socket, opened)
+        }
+        self.filter(cb::<U, H>, this.as_ptr().cast())
+    }
+
+    /// `.ws()` route whose upgrade handler is `S` and whose per-socket handler
+    /// is `T`. The registrant keeps `this` alive while the route is registered.
+    pub fn ws_this<S: WebSocketUpgradeServer<SSL>, T: WebSocketHandler>(
+        &mut self,
+        pattern: &[u8],
+        this: ThisPtr<S>,
+        id: usize,
+        behavior: &WebSocketBehavior,
+    ) {
+        // SAFETY: `this` is a live `S`, the upgrade-server type `Wrap::<S, ..>`
+        // recovers it as; the registrant keeps it alive while the route exists.
+        unsafe {
+            self.ws(
+                pattern,
+                this.as_ptr().cast(),
+                id,
+                Wrap::<S, T, SSL>::apply(behavior),
+            )
+        }
+    }
+
+    /// # Safety
+    /// `ctx` must point to a live value of the upgrade-server type `behavior_`
+    /// was built for (see [`WebSocketUpgradeServer`]) and stay live while the
+    /// route is registered.
+    pub unsafe fn ws(
         &mut self,
         pattern: &[u8],
         ctx: *mut c_void,

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -5,6 +5,7 @@ use crate::h3::Request as H3Request;
 /// Transport-agnostic request handle. Static/file routes (and RangeRequest)
 /// take this so the same handler body serves HTTP/1.1 and HTTP/3 without
 /// `anytype` — `inline else` keeps dispatch monomorphic.
+#[derive(Clone, Copy)]
 pub enum AnyRequest {
     H1(*mut Request),
     H3(*mut H3Request),

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -321,20 +321,13 @@ pub trait WebSocketHandler: Sized + 'static {
     unsafe fn on_close(this: *mut Self, ws: AnyWebSocket, code: i32, message: &[u8]);
 }
 
-/// Server type that handles the HTTP→WS upgrade.
+/// Server type that handles the HTTP→WS upgrade. `this` is the user-data
+/// registered with the `.ws()` route ([`crate::app::App::ws_this`] ties its
+/// type to `Self`; the raw [`crate::app::App::ws`] leaves that to its caller).
 pub trait WebSocketUpgradeServer<const SSL: bool>: Sized + 'static {
-    /// # Safety
-    /// `this` is the raw user-data pointer passed to `uws_ws()` at registration
-    /// time, cast to `*mut Self`. **Its actual pointee type is discriminated by
-    /// `id`** — `Bun.serve` registers `*mut UserRoute` for `id == 1` and
-    /// `*mut Self` for `id == 0` (see `runtime/server/mod.rs`). Implementers
-    /// MUST dispatch on `id` *before* dereferencing `this`; the trampoline
-    /// deliberately forwards the raw pointer (no `&mut Self` is ever
-    /// materialized) so that the wrong-typed reference is never created when
-    /// `id != 0`.
-    unsafe fn on_websocket_upgrade(
-        this: *mut Self,
-        res: *mut uws::NewAppResponse<SSL>,
+    fn on_websocket_upgrade(
+        this: bun_ptr::ThisPtr<Self>,
+        res: &mut uws::NewAppResponse<SSL>,
         req: &mut Request,
         context: &mut WebSocketUpgradeContext,
         id: usize,
@@ -445,16 +438,13 @@ where
         if ptr.is_null() {
             return;
         }
-        // SAFETY: `ptr` is the user-data passed to `uws_ws()` at registration
-        // time; uWS passes non-null req/context valid for the duration of the
-        // upgrade callback. We forward `ptr` as a *raw* `*mut Server` without
-        // creating a `&mut Server` — the actual pointee type is discriminated
-        // by `id` inside the implementer (see trait docs), and materializing a
-        // typed reference here would be UB when `id` selects a different type.
+        // SAFETY: `ptr` is the `Server` user-data registered with this
+        // behavior's `.ws()` route, kept alive by the registrant while the route
+        // exists; uWS passes non-null req/context valid for the callback.
         unsafe {
             Server::on_websocket_upgrade(
-                ptr.cast::<Server>(),
-                res.cast::<uws::NewAppResponse<SSL>>(),
+                bun_ptr::ThisPtr::new(ptr.cast::<Server>()),
+                thunk::handle_mut(res.cast::<uws::NewAppResponse<SSL>>()),
                 thunk::handle_mut(req),
                 thunk::handle_mut(context),
                 id,

--- a/src/uws_sys/h2.rs
+++ b/src/uws_sys/h2.rs
@@ -496,6 +496,34 @@ impl App {
     }
 }
 
+/// Owning handle to an HTTP/2 `App`: dropping it destroys the app (and every
+/// route registration with it) and detaches it from its parent.
+pub struct OwnedApp(ptr::NonNull<App>);
+
+impl OwnedApp {
+    pub fn create<const SSL: bool>(
+        parent: &mut crate::app::App<SSL>,
+        allow_http1: bool,
+        idle_timeout_s: u32,
+    ) -> Option<Self> {
+        App::create::<SSL>(parent, allow_http1, idle_timeout_s)
+            .and_then(ptr::NonNull::new)
+            .map(Self)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut App {
+        self.0.as_ptr()
+    }
+}
+
+impl Drop for OwnedApp {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from `App::create` and is destroyed exactly once, here.
+        unsafe { App::destroy(self.0.as_ptr()) }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // extern "C"
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -4,6 +4,7 @@
 
 use core::ffi::{c_char, c_int, c_void};
 use core::ptr;
+use core::ptr::NonNull;
 
 use crate::SocketAddress;
 use crate::response::{State, WriteResult};
@@ -529,24 +530,23 @@ impl App {
         Self::route_this::<U, H>(RouteKind::Any, self, p, this);
     }
 
-    pub fn listen_with_config<UD, H>(&mut self, ud: *mut UD, _handler: H, config: &ListenConfig)
-    where
-        H: Fn(&mut UD, Option<&mut ListenSocket>) + Copy + 'static,
+    /// [`listen_with_config`](Self::listen_with_config) whose (synchronous)
+    /// handler receives `this` and the listen socket (`None` on failure).
+    pub fn listen_with_config_this<U: 'static, H>(
+        &mut self,
+        this: ThisPtr<U>,
+        _handler: H,
+        config: &ListenConfig,
+    ) where
+        H: Fn(ThisPtr<U>, Option<NonNull<ListenSocket>>) + Copy + 'static,
     {
-        // Safe fn item: nested local thunk, only coerced to the C-ABI
-        // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn cb<UD, H>(ls: *mut ListenSocket, p: *mut c_void)
+        extern "C" fn cb<U: 'static, H>(ls: *mut ListenSocket, p: *mut c_void)
         where
-            H: Fn(&mut UD, Option<&mut ListenSocket>) + Copy + 'static,
+            H: Fn(ThisPtr<U>, Option<NonNull<ListenSocket>>) + Copy + 'static,
         {
-            // SAFETY: uWS callback contract — `p` is the registered `*mut UD`;
-            // `ls` (when non-null) is a live listen-socket for this call.
-            unsafe {
-                let Some(ud) = thunk::user_mut::<UD>(p) else {
-                    return;
-                };
-                thunk::zst::<H>()(ud, ls.as_mut());
-            }
+            // SAFETY: `p` is the `ThisPtr<U>` handed to `listen_with_config_this`, live across this synchronous callback.
+            let this = unsafe { ThisPtr::new(p.cast::<U>()) };
+            thunk::zst::<H>()(this, NonNull::new(ls));
         }
         // SAFETY: self is a live FFI handle; config fields valid; trampoline is `extern "C"`
         unsafe {
@@ -555,10 +555,34 @@ impl App {
                 config.host,
                 config.port,
                 config.options,
-                Some(cb::<UD, H>),
-                ud.cast(),
+                Some(cb::<U, H>),
+                this.as_ptr().cast(),
             )
         }
+    }
+}
+
+/// Owning handle to an HTTP/3 `App`: dropping it destroys the app (and every
+/// route registration with it).
+pub struct OwnedApp(NonNull<App>);
+
+impl OwnedApp {
+    pub fn create(opts: &BunSocketContextOptions, idle_timeout_s: u32) -> Option<Self> {
+        App::create(opts, idle_timeout_s)
+            .and_then(NonNull::new)
+            .map(Self)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut App {
+        self.0.as_ptr()
+    }
+}
+
+impl Drop for OwnedApp {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from `App::create` and is destroyed exactly once, here.
+        unsafe { App::destroy(self.0.as_ptr()) }
     }
 }
 

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -530,8 +530,8 @@ impl App {
         Self::route_this::<U, H>(RouteKind::Any, self, p, this);
     }
 
-    /// [`listen_with_config`](Self::listen_with_config) whose (synchronous)
-    /// handler receives `this` and the listen socket (`None` on failure).
+    /// Listen with `config`; the (synchronous) handler receives `this` and the
+    /// listen socket (`None` on failure).
     pub fn listen_with_config_this<U: 'static, H>(
         &mut self,
         this: ThisPtr<U>,


### PR DESCRIPTION
### What

Same programme as #40055 / #40135 / #40136 / #40139 / #40187 / #40190 / #40200 / #40202 / #40203 / #40204 / #40212 / #40213, applied to the `Bun.serve` core: `src/runtime/server/mod.rs` 99 → 1 and `server_body.rs` 83 → 1 (each residual is an `unsafe extern "C" {` block whose items are all `safe fn` and name runtime types, so it can't move to `uws_sys`). Incidental: NodeHTTPResponse.rs 31 → 25, DevServer.rs 203 → 197, Response.rs 29 → 25. Overlaps #40203 in `RequestContext.rs` (hunk list in the commit message); I'll rebase whichever lands second.

- **`NewServer<SSL, DEBUG>`** is `#[derive(CellRefCounted)]`, all fields `Cell`/`JsCell`, all methods `&self`/`ThisPtr<Self>` (the `sharedThis: false` opt-out in `server.classes.ts` is gone). Two refs: the creator's (transferred to the JS wrapper by `ptr_to_js`, released by `finalize_js_box`) and `self_ref` held on behalf of the uWS app's registrations (taken when the app is created in `listen()`, released by `teardown()`, which destroys the apps first). `schedule_deinit` queues `DeinitTask(RefPtr)` whose `RunOnce::cancelled` also tears down, so a released-unrun deinit doesn't leak the server. `AnyServer` is an enum of `BackRef<NewServer<..>>`; `UserRoute` is `OwnedThis` carrying `BackRef<NewServer, Root>`; `ServePlugins` is `CellRefCounted` with a typed `promise_ref` and `HOST_EXPORT`ed reactions (keeps main's behaviour of never destroying the shared plugin cell).
- **uws registrations**: `bun_uws_sys::app::{OwnedApp<SSL>, filter_this, on_client_error_this, listen_with_config_this, listen_on_unix_socket_this, ws_this<S: WebSocketUpgradeServer, T>}` and `h3::{OwnedApp, listen_with_config_this}` — `ThisPtr<U>` userdata trampolines with the same contract as #40136's `method_this/any_this`; `App::ws` (raw userdata) becomes `unsafe fn`; dead `h3::App::listen_with_config` removed; `WebSocketUpgradeServer::on_websocket_upgrade(this: ThisPtr<Self>, ..)` is a safe trait fn.
- **Request contexts**: `hive_array::Fallback::claim_init(&self, FnOnce(NonNull<T>) -> T) -> Pooled<'_, T, N>` (owning slot handle) + `new_boxed()`; `RequestContext::init(slot, server: BackRef<_, Root>, ..) -> Self` and the context owns its `pool_slot`; `PreparedRequestFor<Ctx>` carries `BackRef<Ctx>` + the root `NonNull<Request>` for C++ and reaches the `Request` through `ctx.request_weakref.peek()` at point of use (`request() -> Option<&Request>`); `WeakPtr` gains `init_leaked(Box<T>) -> (Self, NonNull<T>)`, `peek`, `Clone`, `Drop` (`WeakPtrData` is `Cell<u32>`).
- **node:http**: Rust creates the `NodeHTTPResponse` (`NodeHTTPResponse::create`) and passes its JS object + `has_body` into `NodeHTTPServer__onRequest_*` — no packed tagged pointer / out-slot round-trip through C++ (`NodeHTTP.cpp` updated). `HeadersRef` moves to `bun_jsc` (`FetchHeaders::clone_this_ref`); `Server__set*` / `BunServe__on*Plugins` are `HOST_EXPORT`s.

Pre-existing bugs fixed in passing: `server.fetch(url, { headers })` adopted the JS `Headers` wrapper's ref without incrementing it (double deref) — now deep-copies; `Bun.serve()` throwing after `init()` leaked the half-built server — now freed.

**Perf** (release, `perf stat -e instructions:u,cycles:u` on the server process, `taskset`-pinned 8 cores per side, client in a separate pinned process, interleaved runs): keep-alive 100 k × `fetch → new Response("hi")`, 8 runs each — main 1591.2 M instr / branch 1591.9 M (**+0.04 %**, σ ≈ 0.4 %), cycles +0.3 % (σ ≈ 2 %); connection-close 30 k requests, 6 runs each — main 540.6 M / branch 541.7 M (+0.19 %, σ ≈ 0.2 %), cycles −0.7 %. `PreparedRequestFor` carries only `js_request`, the `Request` root pointer for C++ and `BackRef<Ctx>`; the `Request` is reached through `ctx.request_weakref.peek()` at each point of use — no per-request refcount traffic.

### Testing

Debug+ASAN: serve.test.ts 296/297 (uid-0 port case), bun-serve-{args,body-json-async,cookies,date,fetch-invalid-args,file,headers,html-*,propagate-errors,routes,ssl,static,static-stress-*}, bun-server, serve-body-leak, serve-http3, websocket-server*.test.ts (the `it.concurrent` timeouts adjacent to the 300k-message benchmark case reproduce identically on a main debug build), 19 node-http*.test.ts files, node-https-checkServerIdentity, express 296/296, hono, bake dev html/plugins/react-spa/hot/request-cookies/response-to-bake-response/ssg-pages-router; fetch.test.ts unchanged vs main. Hand-driven: sync/promise/throw handlers, ws upgrade+close, graceful/abrupt `stop()` with in-flight requests, `reload()`, `using`, unix socket, TLS, routes, node:http, listen failures; native `NewServer` drop verified (20/20 servers freed after stop+GC, and on listen/TLS failure). clippy clean; `rust-check-all` windows-msvc + apple-darwin pass.
