### PR TITLE
http: deliver the chunked body when an empty Transfer-Encoding field precedes chunked

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -191,6 +191,8 @@ struct HttpResponseData;
         } headers[UWS_HTTP_MAX_HEADERS_COUNT];
         bool ancientHttp;
         bool didYield;
+        /* Written right before the request handler runs; see getHasTransferEncoding(). */
+        bool hasTransferEncoding;
         unsigned int querySeparator;
         BloomFilter bf;
         std::pair<int, std::string_view *> currentParameters;
@@ -211,6 +213,18 @@ struct HttpResponseData;
         bool getYield()
         {
             return didYield;
+        }
+
+        /* The parser's verdict on the Transfer-Encoding header: the same one that
+         * selects chunked body framing, taken from every field of that name (in
+         * node:http mode a header whose values are all empty counts as absent).
+         * getHeader("transfer-encoding") returns only the first field's value,
+         * which is empty for "Transfer-Encoding:" followed by
+         * "Transfer-Encoding: chunked", so a has-body test on that value drops
+         * the chunked body. */
+        bool getHasTransferEncoding()
+        {
+            return hasTransferEncoding;
         }
 
         /* Iteration over headers (key, value) */
@@ -1283,6 +1297,9 @@ struct HttpResponseData;
              * WebSockets or otherwise closed the socket. */
             /* Store any remaining data as head for Node.js compat (connect/upgrade events) */
             req->head = std::span<const char>(data, length);
+            /* Same verdict that selects chunked framing below, so the handler's
+             * has-body decision cannot disagree with how the body is consumed. */
+            req->hasTransferEncoding = transferEncoding.has;
             void *returnedUser = requestHandler(user, req);
             if (returnedUser != user) {
                 /* We are upgraded to WebSocket or otherwise broken */

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2688,7 +2688,7 @@ pub(crate) unsafe extern "C" fn NodeHTTPResponse__createForJS(
             break 'brk 0;
         };
 
-        *has_body = req_len > 0 || request_ref.header(b"transfer-encoding").is_some();
+        *has_body = req_len > 0 || request_ref.has_transfer_encoding();
     }
 
     let raw_response = if is_ssl != 0 {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -842,7 +842,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if let Some(req_len) = request_body_length {
             ctx_ref.request_body_content_len.set(req_len);
-            let is_transfer_encoding = req.header(b"transfer-encoding").is_some();
+            let is_transfer_encoding = req.has_transfer_encoding();
             ctx_ref.flags.set_is_transfer_encoding(is_transfer_encoding);
             if req_len > 0 || is_transfer_encoding {
                 // we defer pre-allocating the body until we receive the first chunk

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -283,6 +283,9 @@ where
 // actually needs is exposed.
 trait ReqLike {
     fn header(&mut self, name: &[u8]) -> Option<&[u8]>;
+    /// Whether the transport frames the body with a Transfer-Encoding header.
+    /// This is the parser's verdict, not a lookup of the first header field.
+    fn has_transfer_encoding(&mut self) -> bool;
     fn method(&mut self) -> &[u8];
     fn url(&mut self) -> &[u8];
     fn set_yield(&mut self, y: bool);
@@ -291,6 +294,10 @@ impl ReqLike for uws_sys::Request {
     #[inline]
     fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
         uws_sys::Request::header(self, name)
+    }
+    #[inline]
+    fn has_transfer_encoding(&mut self) -> bool {
+        uws_sys::Request::has_transfer_encoding(self)
     }
     #[inline]
     fn method(&mut self) -> &[u8] {
@@ -309,6 +316,13 @@ impl ReqLike for uws_sys::h3::Request {
     #[inline]
     fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
         uws_sys::h3::Request::header(self, name)
+    }
+    /// HTTP/3 has no transfer codings (RFC 9114 4.2): the body ends at the
+    /// QUIC stream FIN, and a request that carries the header is rejected
+    /// before this is consulted.
+    #[inline]
+    fn has_transfer_encoding(&mut self) -> bool {
+        false
     }
     #[inline]
     fn method(&mut self) -> &[u8] {
@@ -3240,7 +3254,7 @@ where
 
         if let Some(req_len) = request_body_length {
             ctx.set_request_body_content_len(req_len);
-            let is_te = ReqLike::header(req, b"transfer-encoding").is_some();
+            let is_te = ReqLike::has_transfer_encoding(req);
             ctx.set_is_transfer_encoding(is_te);
             // HTTP/3 (RFC 9114 §4.2.2): Content-Length is optional and
             // Transfer-Encoding is forbidden; the body is terminated by

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -75,6 +75,14 @@ impl Request {
         // SAFETY: ptr/len describe a valid slice owned by the request for its lifetime
         Some(unsafe { bun_core::ffi::slice(ptr, len) })
     }
+    /// The parser's verdict on the Transfer-Encoding header, the one that
+    /// selects chunked body framing. `header(b"transfer-encoding")` sees only
+    /// the first field and reports an empty value as `None`, so it disagrees
+    /// with the framing for "Transfer-Encoding:" followed by
+    /// "Transfer-Encoding: chunked".
+    pub fn has_transfer_encoding(&self) -> bool {
+        c::uws_req_has_transfer_encoding(self)
+    }
     pub fn parameter(&self, index: u16) -> &[u8] {
         let mut ptr: *const u8 = core::ptr::null();
         let len = c::uws_req_get_parameter(self, c_ushort::try_from(index).unwrap(), &mut ptr);
@@ -106,5 +114,6 @@ mod c {
             index: c_ushort,
             dest: &mut *const u8,
         ) -> usize;
+        pub(super) safe fn uws_req_has_transfer_encoding(res: &Request) -> bool;
     }
 }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1464,6 +1464,12 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     return value.length();
   }
 
+  bool uws_req_has_transfer_encoding(uws_req_t *res)
+  {
+    uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;
+    return uwsReq->getHasTransferEncoding();
+  }
+
   us_socket_t *uws_res_upgrade(int ssl, uws_res_r res, void *data,
                              const char *sec_web_socket_key,
                              size_t sec_web_socket_key_length,

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1628,6 +1628,48 @@ test("rejects Transfer-Encoding header with empty value", async () => {
   expect(seen).not.toContain("GET /admin");
 });
 
+// RFC 9110 5.6.1: empty list members are ignored, so these two fields combine
+// to just "chunked". The parser frames the body as chunked, and the handler
+// must receive that body: a has-body decision that reads only the first
+// Transfer-Encoding field sees an empty value and drops the chunk data.
+test.each([
+  ["empty", ""],
+  ["whitespace-only", "   "],
+])("delivers the chunked body when a %s Transfer-Encoding field precedes chunked", async (name, te) => {
+  const seen: string[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      seen.push(`${req.method} ${new URL(req.url).pathname} body=${JSON.stringify(await req.text())}`);
+      return new Response("OK");
+    },
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const client = net.connect(server.port, "127.0.0.1", () => {
+    client.write(
+      "POST /a HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        `Transfer-Encoding:${te}\r\n` +
+        "Transfer-Encoding: chunked\r\n" +
+        "\r\n" +
+        "5\r\nhello\r\n0\r\n\r\n" +
+        "GET /after HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Connection: close\r\n" +
+        "\r\n",
+    );
+  });
+  let raw = "";
+  client.on("data", chunk => (raw += chunk.toString()));
+  client.on("error", reject);
+  client.on("close", () => resolve(raw));
+  const response = await promise;
+
+  expect(seen).toEqual(['POST /a body="hello"', 'GET /after body=""']);
+  expect(response.match(/HTTP\/1\.1 200/g)).toHaveLength(2);
+});
+
 describe("Host header field values in request.url", () => {
   // Windows refuses connections under accept-backlog/TIME_WAIT churn even while the
   // server is listening, so a refused connect (before anything was read) is retried.

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -169,6 +169,47 @@ test("empty Transfer-Encoding with Content-Length frames the body like node", as
   expect(response).toStartWith("HTTP/1.1 200");
 });
 
+// An empty field followed by "Transfer-Encoding: chunked" combines to just
+// "chunked" (RFC 9110 5.6.1). llhttp frames the body as chunked and node
+// delivers it. The has-body decision must look at every Transfer-Encoding
+// field: reading only the first one sees an empty value and drops the body.
+test.each([
+  ["empty", ""],
+  ["whitespace-only", "   "],
+])("%s Transfer-Encoding field followed by chunked delivers the body like node", async (name, te) => {
+  const events: string[] = [];
+  await using server = createServer((req, res) => {
+    let body = "";
+    req.on("data", d => (body += d));
+    req.on("end", () => {
+      events.push(`request ${req.url} body=${body}`);
+      res.end("ok");
+    });
+  });
+  server.on("clientError", (err: any, socket) => {
+    events.push(`clientError ${err.code}`);
+    socket.destroy();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(
+      `POST /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding:${te}\r\nTransfer-Encoding: chunked\r\n\r\n` +
+        "5\r\nhello\r\n0\r\n\r\n" +
+        "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+    );
+  });
+  let raw = "";
+  socket.on("data", chunk => (raw += chunk.toString()));
+  socket.on("error", () => {});
+  socket.on("close", () => resolve(raw));
+  const response = await promise;
+  expect(events).toEqual(["request /a body=hello", "request /b body="]);
+  expect(response.match(/HTTP\/1\.1 200/g)).toHaveLength(2);
+});
+
 // Boundary of the leniency: node errors once any non-whitespace value byte
 // arrives, even one that names no coding.
 test("comma-only Transfer-Encoding value still fires clientError like node", async () => {


### PR DESCRIPTION
### Problem
- A request with `Transfer-Encoding:` (empty value) followed by `Transfer-Encoding: chunked` reaches the handler with an empty body. The wire framing is correct: the parser consumes the chunked body and dispatches the pipelined request after it. The chunk data is dropped. `Bun.serve` and node:http are both affected (1.4.0 and main). Node delivers the body.
- The cause: the has-body decision in Rust reads `req.header(b"transfer-encoding").is_some()` (`src/runtime/server/server_body.rs:3243`, `src/runtime/server/mod.rs:845`, `src/runtime/server/NodeHTTPResponse.rs:2691`). `Request::header` returns the first field only, and maps a zero-length value to `None` (`src/uws_sys/Request.rs:72`). The parser frames the body from `getTransferEncoding()`, which walks every field. The two sides disagree, so no body handler is armed.

### Fix
- The parser records its verdict on `HttpRequest` (`hasTransferEncoding`) right before it calls the request handler. It is the same `transferEncoding.has` value that selects chunked framing a few lines later, after the node:http empty-value adjustment.
- A new C shim `uws_req_has_transfer_encoding` exposes it. The three has-body sites read it instead of the first header field. The HTTP/3 `ReqLike` returns `false`: HTTP/3 has no transfer codings, and a request that carries the header is rejected earlier.
- Correct because the handler and the framing now share one decision. Every other input gives the same answer as before: a lone empty field still gets 400 on `Bun.serve` and is still treated as absent on node:http.
- Verified: `test/js/bun/http/request-smuggling.test.ts` and `test/js/node/http/node-http-transfer-encoding.test.ts` (2 new cases each, stock bun fails all 4). Also `node-http.test.ts`, `serve.test.ts`, `http-server-chunking.test.ts`, and the upstream `test-http-chunked*`, `test-http-invalid-te`, `test-http-transfer-encoding-repeated-chunked` tests.

### Background
- `packages/bun-uws/src/HttpParser.h` parses the request head. After the head it decides the body framing: `Content-Length`, chunked (any honoured `Transfer-Encoding`), or none. It calls the request handler before it consumes the body.
- The request handler (Rust) decides whether to arm a body data handler. With no handler armed, the parser still consumes the chunked body, but the bytes go nowhere.
- RFC 9110 5.6.1: empty list members are ignored, so the two fields combine to `chunked`. `Bun.serve` rejects any list that names a coding other than chunked before dispatch, so for it this flag means the body is chunked.

<details><summary>Notes</summary>

Raw-socket probe, 1.4.0 (before) and this branch (after), `POST /a` with `5\r\nhello\r\n0\r\n\r\n` then a pipelined `GET /after`:

| fields | Bun.serve before | Bun.serve after | node:http before | node:http after | node v26.3.0 |
|---|---|---|---|---|---|
| `TE:` + `TE: chunked` | 200, body `""` | 200, body `hello` | 200, body `""` | 200, body `hello` | body `hello` |
| `TE:   ` + `TE: chunked` | 200, body `""` | 200, body `hello` | 200, body `""` | 200, body `hello` | body `hello` |
| `TE: ,` + `TE: chunked` | body `hello` | same | body `hello` | same | body `hello` |
| `TE: chunked` + `TE:` | 400 | same | 400 | same | n/a |
| `TE:` alone | 400 | same | absent (#40126) | same | absent |

Both pipelined responses arrive in all 200 cases, so there is no desync. The defect is data loss, not smuggling.

`serve.test.ts` has 4 failures in this container with the stock binary too (IPv6, root port range, loopback detection). `node-http.test.ts` has 1 (http proxy, ECONNREFUSED). Neither is related.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/request-smuggling.test.ts test/js/node/http/node-http-transfer-encoding.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [361.41ms]
(pass) rejects Transfer-Encoding with chunked not last [93.13ms]
(pass) rejects duplicate chunked in Transfer-Encoding [48.74ms]
(pass) rejects Transfer-Encoding + Content-Length [58.74ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [73.98ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [47.02ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [73.99ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [331.49ms]
(pass) rejects conflicting duplicate Content-Length headers [40.12ms]
(pass) accepts duplicate Content-Length headers with identical values [49.61ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [44.42ms]
(pass) accepts valid Transfer-Encod
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [7.77ms]
(pass) rejects Transfer-Encoding with chunked not last [2.38ms]
(pass) rejects duplicate chunked in Transfer-Encoding [1.59ms]
(pass) rejects Transfer-Encoding + Content-Length [1.51ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [1.87ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [1.46ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [1.84ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [7.28ms]
(pass) rejects conflicting duplicate Content-Length headers [1.50ms]
(pass) accepts duplicate Content-Length headers with identical values [1.67ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [1.46ms]
(pass) accepts valid Transfer-Encoding: chunked [1.54ms]
(pass) rejects Transfer-Encoding: gzip, chunked [1.61ms]
(pass) accepts Transfer-Encoding with whitespace around chunked [1.58ms]
(pass) rejects malformed Transfer-Encoding with chunked-false [1.54ms]
(pass) prev
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/request-smuggling.test.ts test/js/node/http/node-http-transfer-encoding.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [303.99ms]
(pass) rejects Transfer-Encoding with chunked not last [92.08ms]
(pass) rejects duplicate chunked in Transfer-Encoding [48.93ms]
(pass) rejects Transfer-Encoding + Content-Length [46.84ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [57.58ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [36.76ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [72.89ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [327.91ms]
(pass) rejects conflicting duplicate Content-Length headers [37.38ms]
(pass) accepts duplicate Content-Length headers with identical values [56.13ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [43.89ms]
(pass) accepts valid Transfer-Encod
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     11196137e3
  features     baseline

23 deps, 129 codegen, 1172 objects in 749ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [14.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1243] fetch zlib
[zlib] up to date
[10/1243] gen bindgenv2
[11/1243] esbuild bun-error

  ../../b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h                  | 17 +++++++++
 src/runtime/server/NodeHTTPResponse.rs             |  2 +-
 src/runtime/server/mod.rs                          |  2 +-
 src/runtime/server/server_body.rs                  | 16 ++++++++-
 src/uws_sys/Request.rs                             |  9 +++++
 src/uws_sys/libuwsockets.cpp                       |  6 ++++
 test/js/bun/http/request-smuggling.test.ts         | 42 ++++++++++++++++++++++
 .../node/http/node-http-transfer-encoding.test.ts  | 41 +++++++++++++++++++++
 8 files changed, 132 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-uws/src/HttpParser.h                          6      5      0
src/runtime/server/NodeHTTPResponse.rs                     1      1      0
src/runtime/server/mod.rs                                  3      1      0
src/runtime/server/server_body.rs                          2      2      0
src/uws_sys/Request.rs                                     1      3      0
src/uws_sys/libuwsockets.cpp                               1      2      0
test/js/bun/http/request-smuggling.test.ts                 2      1      0
test/js/node/http/node-http-transfer-encoding.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->