### PR TITLE
Response(asyncIterable): do not write the value of a done iterator result

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -120,6 +120,19 @@ const response = new Response({
 await response.text(); // "helloworld"
 ```
 
+The body contains the yielded values only. As with `for await`, the generator's return value is not part of the body.
+
+```ts
+const response = new Response(
+  (async function* () {
+    yield "hello";
+    return "ignored";
+  })(),
+);
+
+await response.text(); // "hello"
+```
+
 For more control over the stream, `yield` returns the direct `ReadableStream` controller.
 
 ```ts

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -214,8 +214,9 @@ enum class NextStep : uint8_t {
     Finished,
 };
 
-// One iteration result: write the value (a final `return v` is still written), honor the
-// sink's backpressure protocol (`wrote < 0` -> await flush(true)), then finish when done.
+// One iteration result: write the value, honor the sink's backpressure protocol (`wrote < 0`
+// -> await flush(true)), then finish when done. IteratorStepValue semantics, like `for await`
+// and ReadableStream.from(): a done result's value (a generator's `return v`) is not a chunk.
 static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncIteratorSourceOperation* op, JSValue result)
 {
     auto& vm = getVM(globalObject);
@@ -227,15 +228,17 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
         throwTypeError(globalObject, scope, "Async iterator result is not an object"_s);
         return NextStep::Finished;
     }
-    auto [doneValue, value] = Bun::getIteratorResult(globalObject, asObject(result));
+    auto [doneValue, value] = Bun::getIteratorResult(globalObject, asObject(result), Bun::IteratorDoneValue::Skip);
     RETURN_IF_EXCEPTION(scope, NextStep::Finished);
-
-    if (doneValue.toBoolean(globalObject))
-        op->m_iteratorDone = true;
 
     // The done/value getters run user JS that can cancel the stream.
     if (op->m_cancelled) {
         asyncIterReturnIteratorAndSettle(globalObject, op);
+        RELEASE_AND_RETURN(scope, NextStep::Finished);
+    }
+
+    if (doneValue.toBoolean(globalObject)) {
+        asyncIterFinishSuccess(globalObject, op);
         RELEASE_AND_RETURN(scope, NextStep::Finished);
     }
 
@@ -271,11 +274,6 @@ static NextStep asyncIterHandleNextResult(JSGlobalObject* globalObject, JSAsyncI
             }
         }
     }
-
-    if (op->m_iteratorDone) {
-        asyncIterFinishSuccess(globalObject, op);
-        RELEASE_AND_RETURN(scope, NextStep::Finished);
-    }
     return NextStep::ContinueLoop;
 }
 
@@ -289,7 +287,7 @@ static void driveAsyncIterator(JSGlobalObject* globalObject, JSAsyncIteratorSour
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
     while (true) {
-        if (op->m_done || op->m_iteratorDone) {
+        if (op->m_done) {
             op->m_running = false;
             return;
         }
@@ -365,8 +363,6 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onAsyncIterableSourceFlushFulfilled
             return;
         if (op->m_cancelled)
             return asyncIterReturnIteratorAndSettle(globalObject, op);
-        if (op->m_iteratorDone) // The drained write may have been the iterator's final value.
-            return asyncIterFinishSuccess(globalObject, op);
         driveAsyncIterator(globalObject, op); }, [&](JSValue error) { asyncIterFinishWithError(globalObject, op, error); }, [&](JSValue error) { asyncIterAbandon(globalObject, op, error); });
 }
 

--- a/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
@@ -43,9 +43,6 @@ public:
     bool m_cancelled : 1 { false };
     bool m_done : 1 { false };
     bool m_running : 1 { false };
-    // {done:true, value} still writes the value first; this remembers the done across a
-    // backpressure suspension on that final write.
-    bool m_iteratorDone : 1 { false };
 
 private:
     JSAsyncIteratorSourceOperation(JSC::VM&, JSC::Structure*);

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -12,7 +12,7 @@ describe.concurrent("Streaming body via", () => {
           yield "Hello, ";
           await Bun.sleep(30);
           yield Buffer.from("world!");
-          return "!";
+          return "not a chunk";
         });
       },
     });
@@ -23,7 +23,7 @@ describe.concurrent("Streaming body via", () => {
       chunks.push(chunk);
     }
 
-    expect(Buffer.concat(chunks).toString()).toBe("Hello, world!!");
+    expect(Buffer.concat(chunks).toString()).toBe("Hello, world!");
     expect(chunks).toHaveLength(2);
   });
 
@@ -178,7 +178,7 @@ describe.concurrent("Streaming body via", () => {
             if (controller !== controller2 || typeof controller.sinkId !== "number") {
               throw new Error("Controller mismatch");
             }
-            return "!";
+            return "not a chunk";
           },
         });
       },
@@ -190,7 +190,7 @@ describe.concurrent("Streaming body via", () => {
       chunks.push(chunk);
     }
 
-    expect(Buffer.concat(chunks).toString()).toBe("my string goes here\nmy buffer goes here\nend!\n!");
+    expect(Buffer.concat(chunks).toString()).toBe("my string goes here\nmy buffer goes here\nend!\n");
     expect(chunks).toHaveLength(2);
   });
 
@@ -199,19 +199,17 @@ describe.concurrent("Streaming body via", () => {
       port: 0,
 
       async fetch(req) {
-        var hasRun = false;
+        const results = [
+          { value: "Hello, ", done: false },
+          { value: Buffer.from("world!"), done: false },
+          { value: Buffer.from("not a chunk"), done: true },
+        ];
         return new Response({
           [Symbol.asyncIterator]() {
             return {
               async next() {
                 await Bun.sleep(30);
-
-                if (hasRun) {
-                  return { value: Buffer.from("world!"), done: true };
-                }
-
-                hasRun = true;
-                return { value: "Hello, ", done: false };
+                return results.shift();
               },
             };
           },
@@ -226,8 +224,6 @@ describe.concurrent("Streaming body via", () => {
     }
 
     expect(Buffer.concat(chunks).toString()).toBe("Hello, world!");
-    // TODO:
-    // expect(chunks).toHaveLength(2);
   });
 
   test("yield", async () => {
@@ -239,6 +235,50 @@ describe.concurrent("Streaming body via", () => {
     });
 
     expect(await response.text()).toBe("hello");
+  });
+
+  // IteratorStepValue semantics, like `for await`, ReadableStream.from() and node: once `done`
+  // is true the result's `value` is the iterator's return value, not a chunk of the body.
+  describe("the value of a done result is not part of the body", () => {
+    async function* gen() {
+      yield "chunk;";
+      return "RETURN-VALUE";
+    }
+
+    test("async generator return value", async () => {
+      expect(await new Response(gen()).text()).toBe("chunk;");
+      expect(await new Response(gen).text()).toBe("chunk;");
+      expect(await new Request("https://example.com", { method: "POST", body: gen() }).text()).toBe("chunk;");
+    });
+
+    test("hand-written async iterator", async () => {
+      let i = 0;
+      const body = {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => (i++ === 0 ? { value: "a", done: false } : { value: "X", done: true }),
+        }),
+      };
+      expect(await new Response(body).text()).toBe("a");
+    });
+
+    test("sync generator under Symbol.asyncIterator", async () => {
+      const body = {
+        [Symbol.asyncIterator]: function* () {
+          yield "s1";
+          return "SYNC-RETURN";
+        },
+      };
+      expect(await new Response(body).text()).toBe("s1");
+    });
+
+    test("Bun.serve response body", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch: () => new Response(gen()),
+      });
+      const res = await fetch(server.url);
+      expect(await res.text()).toBe("chunk;");
+    });
   });
 
   const callbacks = [
@@ -272,7 +312,8 @@ describe.concurrent("Streaming body via", () => {
       fn: async function* () {
         yield '"Hello, ';
         await 42;
-        return Buffer.from('world! #4"');
+        yield Buffer.from('world! #4"');
+        return "not a chunk";
       },
       expected: '"Hello, world! #4"',
     },

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2963,9 +2963,10 @@ describe("iterator result consumers", () => {
       },
     };
     const text = await new Response(iterable).text();
+    // IteratorStepValue: the value of a done result is never read.
     expect({ text, reads }).toEqual({
       text: "chunk0chunk1",
-      reads: ["done0", "value0", "done1", "value1", "done2", "value2"],
+      reads: ["done0", "value0", "done1", "value1", "done2"],
     });
   });
 
@@ -2983,8 +2984,8 @@ describe("iterator result consumers", () => {
         };
       },
     };
-    // A final result that is done still carries its value, like `return v` in a generator.
-    expect(await new Response(iterable).text()).toBe("m0m1");
+    // The value of a done result is the iterator's return value, not a chunk.
+    expect(await new Response(iterable).text()).toBe("m0");
   });
 
   test("ReadableStream.from over generators", async () => {


### PR DESCRIPTION
### Problem
- `new Response(asyncIterable)` and `new Request(url, { body: asyncIterable })` append the value of the final `{ done: true, value }` result to the body. An async generator's return value becomes part of the HTTP response: `async function* g() { yield "chunk;"; return "RETURN-VALUE"; }` gives `"chunk;RETURN-VALUE"`. Node gives `"chunk;"`. So do `for await`, `ReadableStream.from`, `Readable.from` and `Array.fromAsync` in Bun.
- The cause is `asyncIterHandleNextResult` in `src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp`. It wrote the value of every result and only then checked `done`. The JS version from #8941 did the same, and the C++ port (#33193, #40047) kept it.

### Fix
- The source reads the result with `IteratorDoneValue::Skip` (the mode `ReadableStream.from` uses) and finishes the stream on a done result without a write. A done result's `value` getter is no longer read.
- `m_iteratorDone` only carried the done state across a backpressure suspension on that final write. A done result no longer writes, so the flag and its two checks go away.
- This is a behavior change. Four tests from #8941 asserted the old behavior and are updated. `docs/runtime/streams.mdx` now states that the return value is not part of the body.
- Verified: `test/js/bun/http/async-iterator-stream.test.ts` (new block "the value of a done result is not part of the body", plus the four updated cases) and `test/js/web/streams/streams.test.js` ("iterator result consumers"). Both fail on 1.4.0 and pass with this change. Also ran `bun-server.test.ts`, `body.test.ts`, `body-stream.test.ts`, `body-async-iterator.test.ts`, `node-http-nested-cork.test.ts` and `spawn-stdin-readable-stream-integration.test.ts`.

### Background
- The async-iterable body is a Bun extension to `BodyInit`. `readableStreamFromAsyncIterator` wraps the iterator in a `type: "direct"` `ReadableStream`. Its `pull` drives `iterator.next(controller)` in a loop and writes each value to the controller (the HTTP sink when the response is served).
- IteratorStepValue is the ECMAScript operation behind `for await`. It reads `done` first and reads `value` only when `done` is false. A generator's `return v` produces `{ done: true, value: v }`, so `v` is the result of the iteration, not an element.
- `Bun::getIteratorResult` (`src/jsc/bindings/ObjectBindings.h`) reads both slots directly when the result has the realm's iterator result structure. For any other object it calls the getters. `IteratorDoneValue::Skip` skips the `value` getter when `done` is true. The caller still has to ignore the value on a done result, which the source now does.

<details><summary>Notes</summary>

Reproduction on bun 1.4.0, canary and main (3e347b3e):

```js
async function* g() { yield "chunk;"; return "RETURN-VALUE"; }
await new Response(g()).text();                              // "chunk;RETURN-VALUE", node 26: "chunk;"
(await Array.fromAsync(ReadableStream.from(g()))).join("");  // "chunk;" on bun too
```

The same happens for a hand-written iterator whose last result is `{ done: true, value: "X" }` (body `"aX"`), for a sync generator under `Symbol.asyncIterator` (body `"s1SYNC-RETURN"`), and over the wire from a `Bun.serve` handler that returns `new Response(g())`.

The change is in a single function. The rest of the diff removes the state that only the old behavior needed:

- `m_iteratorDone` in `JSAsyncIteratorSourceOperation.h`.
- The `m_iteratorDone` exit in `driveAsyncIterator` and the finish-after-drain check in `onAsyncIterableSourceFlushFulfilled`. A write now happens only for a result that is not done, so the drain of a write can never be the end of the iterator.

Test changes:

- `async-iterator-stream.test.ts`: the four cases that returned a value (`return "!"`, `return Buffer.from(...)`, `{ value: Buffer.from("world!"), done: true }`) now assert that the value is not in the body, and still assert the yielded chunks. New cases cover the generator (object, function and `Request` forms), a hand-written iterator, a sync generator under `Symbol.asyncIterator`, and a `Bun.serve` response.
- `streams.test.js`: the accessor-order test for `Response` now expects `["done0", "value0", "done1", "value1", "done2"]` (no `value2`), which matches the `ReadableStream.from` test next to it. The `{value, done}`-with-a-done-accessor test expects `"m0"`.

Four tests in `bun-server.test.ts` fail in this container with and without the change (IPv6 and `localhost` resolution). They are not related.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->