### PR TITLE
Claude/add cobertura coverage

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -275,7 +275,7 @@ coveragePathIgnorePatterns = [
 
 ### `test.coverageReporter`
 
-By default, the test runner prints coverage reports to the console. For persistent reports that CI and other tools can read, use `lcov`.
+By default, the test runner prints coverage reports to the console. For persistent reports that CI and other tools can read, use `lcov` or `cobertura`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
@@ -284,7 +284,7 @@ coverageReporter  = ["text", "lcov"]  # default ["text"]
 
 ### `test.coverageDir`
 
-Set the path where coverage reports are saved. This only applies to persistent reporters like `lcov`.
+Set the path where coverage reports are saved. This only applies to persistent reporters like `lcov` and `cobertura`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -70,7 +70,7 @@ bun test <patterns>
 </ParamField>
 
 <ParamField path="--coverage-reporter" type="string" default="text">
-  Report coverage in <code>text</code> and/or <code>lcov</code>. Defaults to <code>text</code>
+  Report coverage in <code>text</code>, <code>lcov</code>, and/or <code>cobertura</code>. Defaults to <code>text</code>
 </ParamField>
 
 <ParamField path="--coverage-dir" type="string" default="coverage">

--- a/docs/test/code-coverage.mdx
+++ b/docs/test/code-coverage.mdx
@@ -68,13 +68,13 @@ coverageThreshold = 0.9
 coverageThreshold = { lines = 0.9, functions = 0.9 }
 ```
 
-Setting either key makes `bun test --coverage` exit with a non-zero exit code when line or function coverage is below its threshold; a key you omit keeps the `0.9` default. Bun accepts a `statements` key but does not currently enforce it. Outside `--parallel`, the check only runs when the `text` reporter is enabled (the default); a run with only `--coverage-reporter=lcov` currently exits 0 regardless of the threshold.
+Setting either key makes `bun test --coverage` exit with a non-zero exit code when line or function coverage is below its threshold; a key you omit keeps the `0.9` default. Bun accepts a `statements` key but does not currently enforce it.
 
 ## Coverage Reporters
 
 By default, Bun prints coverage reports to the console.
 
-To save a report for CI or other tools, pass `--coverage-reporter=lcov` on the command line or set `coverageReporter` in `bunfig.toml`.
+To save a report for CI or other tools, pass `--coverage-reporter=lcov` or `--coverage-reporter=cobertura` on the command line, or set `coverageReporter` in `bunfig.toml`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
@@ -84,10 +84,11 @@ coverageDir = "path/to/somewhere"    # default "coverage"
 
 ### Available Reporters
 
-| Reporter | Description                                          |
-| -------- | ---------------------------------------------------- |
-| `text`   | Prints a text summary of the coverage to the console |
-| `lcov`   | Save coverage in lcov format                         |
+| Reporter    | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `text`      | Prints a text summary of the coverage to the console |
+| `lcov`      | Save coverage in lcov format                         |
+| `cobertura` | Save coverage in Cobertura XML format                |
 
 ### LCOV Coverage Reporter
 
@@ -106,7 +107,7 @@ bun test --coverage --coverage-reporter=lcov
 Tools and services that read the LCOV format include:
 
 - **Code editors**: VS Code extensions can show coverage inline
-- **CI/CD services**: GitHub Actions, GitLab CI, CircleCI
+- **CI/CD services**: GitHub Actions, CircleCI
 - **Coverage services**: Codecov, Coveralls
 - **IDEs**: WebStorm, IntelliJ IDEA
 
@@ -128,6 +129,20 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage/lcov.info
+```
+
+### Cobertura Coverage Reporter
+
+The cobertura reporter writes a `cobertura.xml` file to the coverage directory. GitLab coverage visualization reads this format.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+coverageReporter = "cobertura"
+```
+
+```bash terminal icon="terminal"
+# Or via CLI
+bun test --coverage --coverage-reporter=cobertura
 ```
 
 ## Excluding Files from Coverage
@@ -276,16 +291,20 @@ jobs:
 
 ### GitLab CI Example
 
+GitLab's coverage visualization reads Cobertura XML. Pass `--coverage-reporter=cobertura` and publish `coverage/cobertura.xml`.
+
 ```yaml title=".gitlab-ci.yml"
 test:coverage:
   stage: test
   script:
     - bun install
-    - bun test --coverage --coverage-reporter=text --coverage-reporter=lcov
+    - bun test --coverage --coverage-reporter=text --coverage-reporter=cobertura
   coverage: '/All files\s*\|\s*[\d.]+\s*\|\s*(\d+\.\d+)/'
   artifacts:
-    paths:
-      - coverage/lcov.info
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/cobertura.xml
 ```
 
 ## Interpreting Coverage Reports

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -174,7 +174,7 @@ junit = "./reports/junit.xml"
 [test]
 # Also enable coverage reporting
 coverage = true
-coverageReporter = ["text", "lcov"]
+coverageReporter = ["text", "lcov"]  # or ["text", "cobertura"]
 ```
 
 ## Memory Usage
@@ -266,7 +266,7 @@ rerunEach = 3
 coverage = true
 
 # Set coverage reporter
-coverageReporter = ["text", "lcov"]
+coverageReporter = ["text", "lcov"]  # or ["text", "cobertura"]
 
 # Set coverage output directory
 coverageDir = "./coverage"
@@ -428,7 +428,7 @@ smol = true
 
 # Coverage configuration
 coverage = true
-coverageReporter = ["text", "lcov"]
+coverageReporter = ["text", "lcov"]  # or ["text", "cobertura"]
 coverageDir = "./coverage"
 coverageThreshold = { lines = 0.85, functions = 0.90 }
 coverageSkipTestFiles = true

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -21,7 +21,7 @@ pub use self::unicode::{
 pub mod escape_html;
 #[path = "immutable/exact_size_matcher.rs"]
 pub mod exact_size_matcher;
-pub use escape_html::{html_escape_entity, xml_escape_entity};
+pub use escape_html::{html_escape_entity, write_xml_escaped, xml_escape_entity};
 #[path = "immutable/unicode.rs"]
 mod unicode_draft;
 #[path = "immutable/visible.rs"]

--- a/src/bun_core/string/immutable/escapeHTML.rs
+++ b/src/bun_core/string/immutable/escapeHTML.rs
@@ -27,3 +27,49 @@ pub const fn xml_escape_entity(c: u8) -> Option<&'static [u8]> {
         _ => html_escape_entity(c),
     }
 }
+
+/// Write `input` XML-escaped, safe for element content and attribute values.
+///
+/// Tab/LF/CR are emitted as numeric character references so the literal byte
+/// survives attribute-value normalisation (XML 1.0 §3.3.3). Any other C0
+/// control character is not a valid XML 1.0 Char and cannot be represented
+/// even as a numeric reference, so it is dropped.
+pub fn write_xml_escaped(
+    input: &[u8],
+    writer: &mut impl crate::io::Write,
+) -> crate::CrateResult<()> {
+    let mut last: usize = 0;
+    let mut i: usize = 0;
+    let len = input.len();
+    while i < len {
+        let c = input[i];
+        match c {
+            b'&' | b'<' | b'>' | b'"' | b'\'' => {
+                if i > last {
+                    writer.write_all(&input[last..i])?;
+                }
+                writer.write_all(xml_escape_entity(c).unwrap())?;
+                last = i + 1;
+            }
+            b'\t' | b'\n' | b'\r' => {
+                if i > last {
+                    writer.write_all(&input[last..i])?;
+                }
+                write!(writer, "&#{};", c)?;
+                last = i + 1;
+            }
+            0..=0x1f => {
+                if i > last {
+                    writer.write_all(&input[last..i])?;
+                }
+                last = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if len > last {
+        writer.write_all(&input[last..])?;
+    }
+    Ok(())
+}

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -199,6 +199,8 @@ impl<'a> Parser<'a> {
             self.ctx.test_options.coverage.reporters.text = true;
         } else if item_str == b"lcov" {
             self.ctx.test_options.coverage.reporters.lcov = true;
+        } else if item_str == b"cobertura" {
+            self.ctx.test_options.coverage.reporters.cobertura = true;
         } else {
             self.add_error_format(
                 item.loc,
@@ -457,10 +459,7 @@ impl<'a> Parser<'a> {
 
                 if let Some(expr) = test.get(b"coverageReporter") {
                     'brk: {
-                        self.ctx.test_options.coverage.reporters = CoverageReporters {
-                            text: false,
-                            lcov: false,
-                        };
+                        self.ctx.test_options.coverage.reporters = CoverageReporters::default();
                         if let ExprData::EString(_) = &expr.data {
                             self.apply_coverage_reporter_item(&expr)?;
                             break 'brk;

--- a/src/options_types/code_coverage_options.rs
+++ b/src/options_types/code_coverage_options.rs
@@ -45,6 +45,7 @@ impl Default for CodeCoverageOptions {
             reporters: Reporters {
                 text: true,
                 lcov: false,
+                cobertura: false,
             },
             reports_directory: Box::from(b"coverage" as &[u8]),
             fractions: Fraction::default(),
@@ -56,8 +57,12 @@ impl Default for CodeCoverageOptions {
     }
 }
 
-#[derive(Clone, Copy)]
+/// `Default` is the "no reporters" reset the CLI/bunfig parsers apply before
+/// enabling each reporter the user listed; the out-of-the-box default
+/// (`text: true`) lives in `CodeCoverageOptions::default`.
+#[derive(Clone, Copy, Default)]
 pub struct Reporters {
     pub text: bool,
     pub lcov: bool,
+    pub cobertura: bool,
 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -567,7 +567,7 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
     parse_param!("--seed <INT>                     Set the random seed for test randomization"),
     parse_param!("--coverage                       Generate a coverage profile"),
     parse_param!(
-        "--coverage-reporter <STR>...     Report coverage in 'text' and/or 'lcov'. Defaults to 'text'."
+        "--coverage-reporter <STR>...     Report coverage in 'text', 'lcov', and/or 'cobertura'. Defaults to 'text'."
     ),
     parse_param!(
         "--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'."
@@ -1738,18 +1738,17 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     }
 
     if !args.options(b"--coverage-reporter").is_empty() {
-        ctx.test_options.coverage.reporters = CoverageReporters {
-            text: false,
-            lcov: false,
-        };
+        ctx.test_options.coverage.reporters = CoverageReporters::default();
         for reporter in args.options(b"--coverage-reporter") {
             if *reporter == b"text" {
                 ctx.test_options.coverage.reporters.text = true;
             } else if *reporter == b"lcov" {
                 ctx.test_options.coverage.reporters.lcov = true;
+            } else if *reporter == b"cobertura" {
+                ctx.test_options.coverage.reporters.cobertura = true;
             } else {
                 bun_core::pretty_errorln!(
-                    "<r><red>error<r>: invalid coverage reporter '{}'. Available options: 'text' (console output), 'lcov' (code coverage file)",
+                    "<r><red>error<r>: invalid coverage reporter '{}'. Available options: 'text' (console output), 'lcov' (LCOV file), 'cobertura' (Cobertura XML file)",
                     BStr::new(reporter)
                 );
                 Global::exit(1);

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -7,15 +7,12 @@ use bstr::BStr;
 
 use bun_collections::{ArrayHashMap, StringArrayHashMap};
 use bun_core::strings;
-use bun_core::{self, Output, ZBox};
+use bun_core::{self, Global, Output, ZBox};
 use bun_options_types::code_coverage_options::{CodeCoverageOptions, Fraction as CoverageFraction};
-use bun_paths::{self, PathBuffer};
-use bun_sourcemap_jsc::code_coverage::text as CoverageReportText;
+use bun_sourcemap_jsc::code_coverage::{cobertura, text as CoverageReportText};
 use bun_sys::{self, Fd, File, O};
 
 use crate::cli::test::parallel::coordinator::Coordinator;
-use crate::node::PathLike;
-use crate::node::fs::{NodeFS, args as fs_args};
 use crate::test_command;
 use crate::test_runner::jest::Summary;
 use bun_collections::index_sort;
@@ -245,53 +242,63 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
         .collect();
 
     if opts.reporters.lcov {
-        let mut fs = NodeFS::default();
-        let _ = fs.mkdir_recursive(&fs_args::Mkdir {
-            path: PathLike::EncodedSlice(bun_core::zig_string::Slice::from_utf8_never_free(
-                &opts.reports_directory,
-            )),
-            always_return_none: true,
-            ..Default::default()
-        });
-        let mut path_buf = PathBuffer::uninit();
-        let out_path = bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Auto>(
-            bun_paths::fs::FileSystem::instance().top_level_dir(),
-            &mut path_buf.0,
-            &[&opts.reports_directory, b"lcov.info"],
-        );
-        match File::openat(
-            Fd::cwd(),
-            out_path,
-            O::CREAT | O::WRONLY | O::TRUNC | O::CLOEXEC,
-            0o644,
-        ) {
-            bun_sys::Result::Err(e) => Output::err(
+        // Build the whole report in a Vec, then write it atomically.
+        let mut w: Vec<u8> = Vec::with_capacity(64 * 1024);
+        for &i in &order {
+            let fc = &by_file.values()[i];
+            let lines = &merged[i];
+            let _ = write!(
+                &mut w,
+                "TN:\nSF:{}\nFNF:{}\nFNH:{}\n",
+                BStr::new(&fc.path),
+                fc.fnf,
+                fc.fnh
+            );
+            let mut lh: u32 = 0;
+            for &(ln, hits) in lines {
+                lh += (hits > 0) as u32;
+                let _ = writeln!(&mut w, "DA:{},{}", ln, hits);
+            }
+            let _ = write!(&mut w, "LF:{}\nLH:{}\nend_of_record\n", lines.len(), lh);
+        }
+        if let Err(e) = test_command::write_coverage_artifact(&opts.reports_directory, b"lcov.info", &w)
+        {
+            Output::err(
                 crate::Error::lcovCoverageError,
                 "Failed to write merged lcov.info\n{}",
                 (e,),
-            ),
-            bun_sys::Result::Ok(f) => {
-                // Build the whole report in a Vec, then issue one write_all.
-                let mut w: Vec<u8> = Vec::with_capacity(64 * 1024);
-                for &i in &order {
-                    let fc = &by_file.values()[i];
-                    let lines = &merged[i];
-                    let _ = write!(
-                        &mut w,
-                        "TN:\nSF:{}\nFNF:{}\nFNH:{}\n",
-                        BStr::new(&fc.path),
-                        fc.fnf,
-                        fc.fnh
-                    );
-                    let mut lh: u32 = 0;
-                    for &(ln, hits) in lines {
-                        lh += (hits > 0) as u32;
-                        let _ = writeln!(&mut w, "DA:{},{}", ln, hits);
-                    }
-                    let _ = write!(&mut w, "LF:{}\nLH:{}\nend_of_record\n", lines.len(), lh);
-                }
-                let _ = File::write_all(&f, &w);
-            }
+            );
+            Global::exit(1);
+        }
+    }
+
+    if opts.reporters.cobertura {
+        let files: Vec<cobertura::FileCoverage<'_>> = order
+            .iter()
+            .map(|&i| cobertura::FileCoverage {
+                path: &by_file.values()[i].path,
+                lines: &merged[i],
+            })
+            .collect();
+        let mut w: Vec<u8> = Vec::with_capacity(64 * 1024);
+        if cobertura::write_files(&files, bun_core::time::milli_timestamp() as u64, &mut w).is_err()
+        {
+            Output::err(
+                crate::Error::coberturaCoverageError,
+                "Failed to render merged cobertura.xml",
+                (),
+            );
+            Global::exit(1);
+        }
+        if let Err(e) =
+            test_command::write_coverage_artifact(&opts.reports_directory, b"cobertura.xml", &w)
+        {
+            Output::err(
+                crate::Error::coberturaCoverageError,
+                "Failed to write merged cobertura.xml\n{}",
+                (e,),
+            );
+            Global::exit(1);
         }
     }
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -36,7 +36,7 @@ bun_output::declare_scope!(bun_test, hidden);
 // directly with `<ENABLE_ANSI_COLORS>`.
 mod coverage {
     pub(super) use bun_sourcemap_jsc::code_coverage::{
-        ByteRangeMapping, Fraction, Report as CodeCoverageReport, lcov as Lcov,
+        ByteRangeMapping, Fraction, Report as CodeCoverageReport, cobertura, lcov as Lcov,
     };
 
     /// Less-than predicate adapted to the `Ordering` shape `sort_by` wants.
@@ -142,44 +142,106 @@ mod bun_test {
     }
 }
 
+/// Atomically write a coverage artifact: ensure `reports_directory` exists
+/// under the project root, write to a random `.tmp` sibling, then rename over
+/// `final_name`. Shared by the lcov and cobertura reporters in both the
+/// single-process and `--parallel` merge paths.
+pub(crate) fn write_coverage_artifact(
+    reports_directory: &[u8],
+    final_name: &[u8],
+    bytes: &[u8],
+) -> bun_sys::Result<()> {
+    let mut fs = crate::node::fs::NodeFS::default();
+    let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
+        path: crate::node::PathLike::EncodedSlice(ZigStringSlice::from_utf8_never_free(
+            reports_directory,
+        )),
+        always_return_none: true,
+        recursive: true,
+        ..Default::default()
+    });
+
+    let top_level_dir = FileSystem::get().top_level_dir;
+
+    let mut random = [0u8; 8];
+    bun_boringssl_sys::rand_bytes(&mut random);
+    let mut shortname_buf = [0u8; 512];
+    // Temp name: `.<final_name>.<lowercase hex of 8 random bytes>.tmp`.
+    let tmpname = {
+        use std::io::Write as _;
+        let mut cursor = &mut shortname_buf[..];
+        let _ = cursor.write_all(b".");
+        let _ = cursor.write_all(final_name);
+        let _ = cursor.write_all(b".");
+        let _ = write!(cursor, "{}", bun_core::fmt::hex_lower(&random));
+        let _ = cursor.write_all(b".tmp\0");
+        let s = bun_core::slice_to_nul(&shortname_buf);
+        bun_core::ZStr::from_buf(&shortname_buf[..], s.len())
+    };
+
+    let mut name_buf = PathBuffer::uninit();
+    let tmp_path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
+        top_level_dir,
+        &mut name_buf,
+        &[reports_directory, tmpname.as_bytes()],
+    );
+    let file = File::openat(
+        Fd::cwd(),
+        tmp_path,
+        bun_sys::O::CREAT | bun_sys::O::WRONLY | bun_sys::O::TRUNC | bun_sys::O::CLOEXEC,
+        0o644,
+    )?;
+    if let Err(err) = file.write_all(bytes) {
+        let _ = file.close();
+        let _ = bun_sys::unlink(tmp_path);
+        return Err(err);
+    }
+    let _ = file.close();
+    if let Err(err) = bun_sys::move_file_z(
+        Fd::cwd(),
+        tmp_path,
+        Fd::cwd(),
+        resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
+            top_level_dir,
+            &[reports_directory, final_name],
+        ),
+    ) {
+        let _ = bun_sys::unlink(tmp_path);
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn write_cobertura_report(
+    opts: &CodeCoverageOptions,
+    files: &[coverage::cobertura::OwnedFileCoverage],
+) -> crate::Result<()> {
+    let borrowed: Vec<coverage::cobertura::FileCoverage<'_>> = files
+        .iter()
+        .map(|file| coverage::cobertura::FileCoverage {
+            path: &file.path,
+            lines: &file.lines,
+        })
+        .collect();
+    let mut xml: Vec<u8> = Vec::with_capacity(64 * 1024);
+    coverage::cobertura::write_files(
+        &borrowed,
+        bun_core::time::milli_timestamp() as u64,
+        &mut xml,
+    )?;
+    if let Err(err) = write_coverage_artifact(&opts.reports_directory, b"cobertura.xml", &xml) {
+        Output::err(
+            crate::Error::coberturaCoverageError,
+            "Failed to save cobertura.xml file\n{}",
+            (err,),
+        );
+        Global::exit(1);
+    }
+    Ok(())
+}
+
 pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate::Result<()> {
-    let mut last: usize = 0;
-    let mut i: usize = 0;
-    let len = str_.len();
-    while i < len {
-        let c = str_[i];
-        match c {
-            b'&' | b'<' | b'>' | b'"' | b'\'' => {
-                if i > last {
-                    writer.write_all(&str_[last..i])?;
-                }
-                writer.write_all(bun_core::strings::xml_escape_entity(c).unwrap())?;
-                last = i + 1;
-            }
-            b'\t' | b'\n' | b'\r' => {
-                // Valid XML 1.0 Char. Emit as a numeric reference so the literal
-                // byte survives attribute-value normalisation (XML 1.0 §3.3.3).
-                if i > last {
-                    writer.write_all(&str_[last..i])?;
-                }
-                write!(writer, "&#{};", c)?;
-                last = i + 1;
-            }
-            0..=0x1f => {
-                // Any other C0 control character is not a valid XML 1.0 Char and
-                // cannot be represented even as a numeric reference, so drop it.
-                if i > last {
-                    writer.write_all(&str_[last..i])?;
-                }
-                last = i + 1;
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    if len > last {
-        writer.write_all(&str_[last..])?;
-    }
+    bun_core::strings::write_xml_escaped(str_, writer)?;
     Ok(())
 }
 
@@ -1581,11 +1643,11 @@ impl CommandLineReporter {
         &mut self,
         vm: &mut VirtualMachine,
         opts: &mut CodeCoverageOptions,
-        reporters_text: bool,
-        reporters_lcov: bool,
         enable_ansi_colors: bool,
     ) -> crate::Result<()> {
-        if !reporters_text && !reporters_lcov {
+        let reporters = opts.reporters;
+        if !reporters.text && !reporters.lcov && !reporters.cobertura && !opts.fail_on_low_coverage
+        {
             return Ok(());
         }
 
@@ -1609,14 +1671,7 @@ impl CommandLineReporter {
 
         index_sort::sort_slice_by(&mut byte_ranges, coverage::is_less_than_cmp);
 
-        self.print_code_coverage(
-            vm,
-            opts,
-            &mut byte_ranges,
-            reporters_text,
-            reporters_lcov,
-            enable_ansi_colors,
-        )
+        self.print_code_coverage(vm, opts, &mut byte_ranges, enable_ansi_colors)
     }
 
     pub(crate) fn render_lcov(
@@ -1675,10 +1730,11 @@ impl CommandLineReporter {
         vm: &mut VirtualMachine,
         opts: &mut CodeCoverageOptions,
         byte_ranges: &mut [&mut ByteRangeMapping],
-        reporters_text: bool,
-        reporters_lcov: bool,
         enable_ansi_colors: bool,
     ) -> crate::Result<()> {
+        let reporters_text = opts.reporters.text;
+        let reporters_lcov = opts.reporters.lcov;
+        let reporters_cobertura = opts.reporters.cobertura;
         // Both spellings are compile-time constants; pick one by the runtime flag.
         macro_rules! pretty_lit {
             ($fmt:literal) => {
@@ -1690,20 +1746,7 @@ impl CommandLineReporter {
             };
         }
         // `perf::Ctx` ends its span on Drop.
-        let _trace = if reporters_text && reporters_lcov {
-            bun::perf::trace("TestCommand.printCodeCoverageLCovAndText")
-        } else if reporters_text {
-            bun::perf::trace("TestCommand.printCodeCoverageText")
-        } else if reporters_lcov {
-            bun::perf::trace("TestCommand.printCodeCoverageLCov")
-        } else {
-            // Unreachable by construction.
-            unreachable!("No reporters enabled")
-        };
-
-        if !reporters_text && !reporters_lcov {
-            unreachable!("No reporters enabled");
-        }
+        let _trace = bun::perf::trace("TestCommand.printCodeCoverage");
 
         let relative_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
 
@@ -1807,86 +1850,16 @@ impl CommandLineReporter {
         let mut avg_count: f64 = 0.0;
         // --- Text ---
 
-        // --- LCOV ---
-        let mut lcov_name_buf = PathBuffer::uninit();
-        let mut lcov_state: Option<(File, &bun_core::ZStr, /*buffered*/ Vec<u8>)> =
-            if reporters_lcov {
-                'brk: {
-                    // Ensure the directory exists
-                    let mut fs = crate::node::fs::NodeFS::default();
-                    let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
-                        path: crate::node::PathLike::EncodedSlice(
-                            ZigStringSlice::from_utf8_never_free(&opts.reports_directory),
-                        ),
-                        always_return_none: true,
-                        recursive: true,
-                        ..Default::default()
-                    });
-
-                    // Write the lcov.info file to a temporary file we atomically rename to the final name after it succeeds
-                    let mut base64_bytes = [0u8; 8];
-                    let mut shortname_buf = [0u8; 512];
-                    bun_boringssl_sys::rand_bytes(&mut base64_bytes);
-                    // Temp name: `.lcov.info.<lowercase hex of 8 random bytes>.tmp`.
-                    let tmpname = {
-                        use std::io::Write as _;
-                        let mut cursor = &mut shortname_buf[..];
-                        let _ = cursor.write_all(b".lcov.info.");
-                        let _ = write!(cursor, "{}", bun_core::fmt::hex_lower(&base64_bytes));
-                        let _ = cursor.write_all(b".tmp\0");
-                        let s = bun_core::slice_to_nul(&shortname_buf);
-                        // NUL written above; `slice_to_nul` returns the prefix before it.
-                        bun_core::ZStr::from_buf(&shortname_buf[..], s.len())
-                    };
-                    let path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
-                        relative_dir,
-                        &mut lcov_name_buf,
-                        &[&opts.reports_directory, tmpname.as_bytes()],
-                    );
-                    let file = File::openat(
-                        Fd::cwd(),
-                        path,
-                        bun_sys::O::CREAT
-                            | bun_sys::O::WRONLY
-                            | bun_sys::O::TRUNC
-                            | bun_sys::O::CLOEXEC,
-                        0o644,
-                    );
-
-                    match file {
-                        bun_sys::Result::Err(err) => {
-                            Output::err(
-                                crate::Error::lcovCoverageError,
-                                "Failed to create lcov file",
-                                (),
-                            );
-                            Output::print_error(format_args!("\n{}", err));
-                            Global::exit(1);
-                        }
-                        bun_sys::Result::Ok(f) => {
-                            // Accumulate in a `Vec<u8>` (impl `bun_io::Write`)
-                            // and flush to the fd via `write_all` on success
-                            // below.
-                            let buffered: Vec<u8> = Vec::with_capacity(64 * 1024);
-                            break 'brk Some((f, path, buffered));
-                        }
-                    }
-                }
-            } else {
-                None
-            };
-        let mut lcov_guard = scopeguard::guard(
-            &mut lcov_state,
-            |s: &mut Option<(File, &bun_core::ZStr, Vec<u8>)>| {
-                if reporters_lcov {
-                    if let Some((file, name, _)) = s.take() {
-                        let _ = file.close(); // close error is non-actionable
-                        let _ = bun_sys::unlink(name);
-                    }
-                }
-            },
-        );
-        // --- LCOV ---
+        // --- LCOV / Cobertura ---
+        // Both persistent reporters accumulate in a `Vec<u8>` per file inside
+        // the loop and are written atomically (temp file + rename) at the end
+        // via `write_coverage_artifact`.
+        let mut lcov_buffer: Vec<u8> = if reporters_lcov {
+            Vec::with_capacity(64 * 1024)
+        } else {
+            Vec::new()
+        };
+        let mut cobertura_files: Vec<coverage::cobertura::OwnedFileCoverage> = Vec::new();
 
         for entry in byte_ranges.iter_mut() {
             // Check if this file should be ignored based on coveragePathIgnorePatterns
@@ -1913,40 +1886,46 @@ impl CommandLineReporter {
                 continue;
             };
 
-            if reporters_text {
+            if reporters_text || opts.fail_on_low_coverage {
                 let mut fraction = base_fraction;
-                if coverage::Text::write_format(
-                    &report,
-                    max_filepath_length,
-                    &mut fraction,
-                    relative_dir,
-                    console_writer,
-                    enable_ansi_colors,
-                )
-                .is_err()
-                {
-                    continue;
+                if reporters_text {
+                    if coverage::Text::write_format(
+                        &report,
+                        max_filepath_length,
+                        &mut fraction,
+                        relative_dir,
+                        console_writer,
+                        enable_ansi_colors,
+                    )
+                    .is_err()
+                    {
+                        continue;
+                    }
+                    console_writer.extend_from_slice(b"\n");
+                    avg.functions += fraction.functions;
+                    avg.lines += fraction.lines;
+                    avg.stmts += fraction.stmts;
+                    avg_count += 1.0;
+                } else {
+                    fraction = report.compute_fraction(&base_fraction);
                 }
-                avg.functions += fraction.functions;
-                avg.lines += fraction.lines;
-                avg.stmts += fraction.stmts;
-                avg_count += 1.0;
                 if fraction.failing {
                     failing = true;
                 }
-
-                console_writer.extend_from_slice(b"\n");
             }
 
-            if reporters_lcov {
-                if let Some((_, _, buffered)) = lcov_guard.as_mut() {
-                    if coverage::Lcov::write_format(&report, relative_dir, buffered).is_err() {
-                        continue;
-                    }
-                }
+            if reporters_lcov
+                && coverage::Lcov::write_format(&report, relative_dir, &mut lcov_buffer).is_err()
+            {
+                continue;
             }
 
-            drop(report);
+            if reporters_cobertura {
+                cobertura_files.push(coverage::cobertura::OwnedFileCoverage::from_report(
+                    &report,
+                    relative_dir,
+                ));
+            }
         }
 
         if reporters_text {
@@ -1988,56 +1967,40 @@ impl CommandLineReporter {
 
             console.write_all(&console_buffer)?;
             console.write_all(pretty_lit!("<r><d>"))?;
-            // Disarm the lcov cleanup guard before the early `Ok(())`; the
-            // temp file is left for the OS.
             if console
                 .splat_byte_all(b'-', max_filepath_length + 2)
                 .is_err()
             {
-                let _ = scopeguard::ScopeGuard::into_inner(lcov_guard);
                 return Ok(());
             }
             if console
                 .write_all(pretty_lit!("|---------|---------|-------------------<r>\n"))
                 .is_err()
             {
-                let _ = scopeguard::ScopeGuard::into_inner(lcov_guard);
                 return Ok(());
             }
 
             opts.fractions.failing = failing;
             Output::flush();
+        } else if opts.fail_on_low_coverage {
+            opts.fractions.failing = failing;
         }
 
         if reporters_lcov {
-            // `try lcov_writer.flush()` — keep the errdefer guard armed across the
-            // write so an error here still closes + unlinks the temp file.
-            if let Some((lcov_file, _, buffered)) = &mut **lcov_guard {
-                if let bun_sys::Result::Err(e) = lcov_file.write_all(buffered) {
-                    // `lcov_guard` drops on this early return → close + unlink.
-                    return Err(crate::Error::from(e));
-                }
+            if let Err(err) =
+                write_coverage_artifact(&opts.reports_directory, b"lcov.info", &lcov_buffer)
+            {
+                Output::err(
+                    crate::Error::lcovCoverageError,
+                    "Failed to save lcov.info file\n{}",
+                    (err,),
+                );
+                Global::exit(1);
             }
-            // Flush succeeded — disarm the errdefer cleanup.
-            let state = scopeguard::ScopeGuard::into_inner(lcov_guard);
-            if let Some((lcov_file, lcov_name, _)) = state.take() {
-                let _ = lcov_file.close();
-                let cwd = Fd::cwd();
-                if let Err(err) = bun_sys::move_file_z(
-                    cwd,
-                    lcov_name,
-                    cwd,
-                    resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
-                        relative_dir,
-                        &[&opts.reports_directory, b"lcov.info"],
-                    ),
-                ) {
-                    Output::err(err, "Failed to save lcov.info file", ());
-                    Global::exit(1);
-                }
-            }
-        } else {
-            let _ = scopeguard::ScopeGuard::into_inner(lcov_guard);
+        }
+
+        if reporters_cobertura {
+            write_cobertura_report(opts, &cobertura_files)?;
         }
         Ok(())
     }
@@ -2841,15 +2804,9 @@ impl TestCommand {
             pretty_error!("\n");
 
             if coverage_options.enabled && !ran_parallel {
-                let (text, lcov) = (
-                    coverage_options.reporters.text,
-                    coverage_options.reporters.lcov,
-                );
                 reporter.generate_code_coverage(
                     vm,
                     &mut coverage_options,
-                    text,
-                    lcov,
                     Output::enable_ansi_colors_stderr(),
                 )?;
             }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -266,6 +266,8 @@ pub enum Error {
     JUnitReportFailed,
     #[error("lcovCoverageError")]
     lcovCoverageError,
+    #[error("coberturaCoverageError")]
+    coberturaCoverageError,
     #[error("HTTP404")]
     HTTP404,
     #[error("GitHubIsDown")]
@@ -701,6 +703,7 @@ impl Error {
             Self::ProcessWatchFailed => "ProcessWatchFailed",
             Self::JUnitReportFailed => "JUnitReportFailed",
             Self::lcovCoverageError => "lcovCoverageError",
+            Self::coberturaCoverageError => "coberturaCoverageError",
             Self::HTTP404 => "HTTP404",
             Self::GitHubIsDown => "GitHubIsDown",
             Self::UpgradeFailedMissingExecutable => "UpgradeFailedMissingExecutable",

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -40,6 +40,19 @@ pub struct Report {
 }
 
 impl Report {
+    /// Coverage fractions for this report, marked failing against `base`.
+    /// The single source of the threshold pass/fail rule: statement coverage
+    /// is computed but deliberately excluded from the decision.
+    pub fn compute_fraction(&self, base: &Fraction) -> Fraction {
+        let mut fraction = *base;
+        fraction.functions = self.function_coverage_fraction();
+        fraction.lines = self.lines_coverage_fraction();
+        fraction.stmts = self.stmts_coverage_fraction();
+        fraction.failing =
+            fraction.functions < base.functions || fraction.lines < base.lines;
+        fraction
+    }
+
     pub(crate) fn lines_coverage_fraction(&self) -> f64 {
         let mut intersected = self
             .executable_lines
@@ -192,15 +205,8 @@ pub mod text {
         writer: &mut impl bun_io::Write,
     ) -> bun_io::Result<()> {
         let failing = *fraction;
-        let fns = report.function_coverage_fraction();
-        let lines = report.lines_coverage_fraction();
-        let stmts = report.stmts_coverage_fraction();
-        fraction.functions = fns;
-        fraction.lines = lines;
-        fraction.stmts = stmts;
-
-        let failed = fns < failing.functions || lines < failing.lines; // || stmts < failing.stmts;
-        fraction.failing = failed;
+        *fraction = report.compute_fraction(&failing);
+        let failed = fraction.failing;
 
         let mut filename = report.source_url.slice();
         if !base_path.is_empty() {
@@ -349,6 +355,189 @@ pub mod lcov {
         writeln!(writer, "LH:{}", report.lines_which_have_executed.count())?;
 
         writer.write_all(b"end_of_record\n")?;
+        Ok(())
+    }
+}
+
+/// Cobertura XML (`coverage-04.dtd`). GitLab coverage visualization reads this
+/// format. Branch metrics are emitted as zero because JSC does not report
+/// them, and `<methods/>` is left empty because JSC does not expose function
+/// names (matching the lcov reporter, which omits FN records).
+pub mod cobertura {
+    use super::*;
+    use std::borrow::Cow;
+
+    use bun_collections::index_sort;
+    use bun_core::strings;
+    use bun_paths::resolve_path::{self, platform};
+
+    pub struct FileCoverage<'a> {
+        pub path: &'a [u8],
+        pub lines: &'a [(u32, u32)],
+    }
+
+    /// Per-file coverage extracted from a [`Report`], with the path
+    /// relativized against `base_path` and converted to posix separators.
+    /// Lets the caller drop each `Report` as soon as it is extracted instead
+    /// of retaining every report until the XML is written.
+    pub struct OwnedFileCoverage {
+        pub path: Vec<u8>,
+        pub lines: Vec<(u32, u32)>,
+    }
+
+    impl OwnedFileCoverage {
+        pub fn from_report(report: &Report, base_path: &[u8]) -> OwnedFileCoverage {
+            let mut filename = report.source_url.slice();
+            if !base_path.is_empty() {
+                filename = resolve_path::relative(base_path, filename);
+            }
+            let mut path = filename.to_vec();
+            resolve_path::slashes_to_posix_in_place(&mut path);
+
+            let line_hits = report.line_hits.slice();
+            let mut lines = Vec::with_capacity(report.executable_lines.count());
+            let mut iter = report.executable_lines.iterator::<true, true>();
+            while let Some(line) = iter.next() {
+                lines.push((line as u32 + 1, line_hits[line]));
+            }
+            OwnedFileCoverage { path, lines }
+        }
+    }
+
+    fn to_posix(path: &[u8]) -> Cow<'_, [u8]> {
+        if !strings::contains_char(path, b'\\') {
+            return Cow::Borrowed(path);
+        }
+        let mut owned = path.to_vec();
+        resolve_path::slashes_to_posix_in_place(&mut owned);
+        Cow::Owned(owned)
+    }
+
+    /// Sort/grouping key, computed once per file: posix path, the length of
+    /// its package (dirname) prefix, and the covered-line count.
+    struct Key<'a> {
+        posix: Cow<'a, [u8]>,
+        pkg_len: usize,
+        covered: u32,
+    }
+
+    impl Key<'_> {
+        fn package(&self) -> &[u8] {
+            if self.pkg_len == 0 {
+                b"."
+            } else {
+                &self.posix[..self.pkg_len]
+            }
+        }
+    }
+
+    pub fn write_files(
+        files: &[FileCoverage<'_>],
+        timestamp_millis: u64,
+        writer: &mut impl bun_io::Write,
+    ) -> bun_io::Result<()> {
+        let keys: Vec<Key<'_>> = files
+            .iter()
+            .map(|file| {
+                let posix = to_posix(file.path);
+                let pkg_len = resolve_path::dirname::<platform::Posix>(&posix).len();
+                let covered = file.lines.iter().filter(|&&(_, hits)| hits > 0).count() as u32;
+                Key {
+                    posix,
+                    pkg_len,
+                    covered,
+                }
+            })
+            .collect();
+
+        let mut total_lines_valid: u64 = 0;
+        let mut total_lines_covered: u64 = 0;
+        for (file, key) in files.iter().zip(&keys) {
+            total_lines_valid += file.lines.len() as u64;
+            total_lines_covered += u64::from(key.covered);
+        }
+        let line_rate = if total_lines_valid > 0 {
+            total_lines_covered as f64 / total_lines_valid as f64
+        } else {
+            1.0
+        };
+
+        writer.write_all(b"<?xml version=\"1.0\" ?>\n")?;
+        writer.write_all(
+            b"<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n",
+        )?;
+        write!(
+            writer,
+            "<coverage lines-valid=\"{total_lines_valid}\" lines-covered=\"{total_lines_covered}\" line-rate=\"{line_rate:.4}\" branches-valid=\"0\" branches-covered=\"0\" branch-rate=\"0\" timestamp=\"{timestamp_millis}\" complexity=\"0\" version=\"0.1\">\n"
+        )?;
+        writer.write_all(b"    <sources>\n        <source>.</source>\n    </sources>\n    <packages>\n")?;
+
+        let mut order: Vec<usize> = (0..files.len()).collect();
+        index_sort::sort_slice_by(&mut order, |&a, &b| {
+            keys[a]
+                .package()
+                .cmp(keys[b].package())
+                .then_with(|| keys[a].posix.as_ref().cmp(keys[b].posix.as_ref()))
+        });
+
+        for group in order.chunk_by(|&a, &b| keys[a].package() == keys[b].package()) {
+            let mut pkg_valid: u64 = 0;
+            let mut pkg_covered: u64 = 0;
+            for &idx in group {
+                pkg_valid += files[idx].lines.len() as u64;
+                pkg_covered += u64::from(keys[idx].covered);
+            }
+            let pkg_rate = if pkg_valid > 0 {
+                pkg_covered as f64 / pkg_valid as f64
+            } else {
+                1.0
+            };
+
+            writer.write_all(b"        <package name=\"")?;
+            strings::write_xml_escaped(keys[group[0]].package(), writer)?;
+            write!(
+                writer,
+                "\" line-rate=\"{pkg_rate:.4}\" branch-rate=\"0\" complexity=\"0\">\n"
+            )?;
+
+            for &idx in group {
+                write_class(&files[idx], &keys[idx], writer)?;
+            }
+            writer.write_all(b"        </package>\n")?;
+        }
+
+        writer.write_all(b"    </packages>\n</coverage>\n")?;
+        Ok(())
+    }
+
+    fn write_class(
+        file: &FileCoverage<'_>,
+        key: &Key<'_>,
+        writer: &mut impl bun_io::Write,
+    ) -> bun_io::Result<()> {
+        let basename = bun_paths::basename(&key.posix);
+        let lines_valid = file.lines.len() as u32;
+        let line_rate = if lines_valid > 0 {
+            key.covered as f64 / lines_valid as f64
+        } else {
+            1.0
+        };
+
+        writer.write_all(b"            <class name=\"")?;
+        strings::write_xml_escaped(basename, writer)?;
+        writer.write_all(b"\" filename=\"")?;
+        strings::write_xml_escaped(&key.posix, writer)?;
+        write!(
+            writer,
+            "\" line-rate=\"{line_rate:.4}\" branch-rate=\"0.0\" complexity=\"0.0\">\n                <methods/>\n                <lines>\n"
+        )?;
+        for &(number, hits) in file.lines {
+            writeln!(
+                writer,
+                "                    <line number=\"{number}\" hits=\"{hits}\"/>"
+            )?;
+        }
+        writer.write_all(b"                </lines>\n            </class>\n")?;
         Ok(())
     }
 }

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -26,3 +26,48 @@ LF:7
 LH:5
 end_of_record"
 `;
+
+exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
+"<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="21" lines-covered="20" line-rate="0.9524" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="0" complexity="0" version="0.1">
+    <sources>
+        <source>.</source>
+    </sources>
+    <packages>
+        <package name="src" line-rate="0.9524" branch-rate="0" complexity="0">
+            <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000" branch-rate="0.0" complexity="0.0">
+                <methods/>
+                <lines>
+                    <line number="2" hits="48"/>
+                    <line number="3" hits="31"/>
+                    <line number="5" hits="27"/>
+                    <line number="6" hits="31"/>
+                    <line number="7" hits="30"/>
+                    <line number="8" hits="26"/>
+                    <line number="9" hits="4"/>
+                    <line number="11" hits="43"/>
+                    <line number="12" hits="29"/>
+                    <line number="13" hits="25"/>
+                    <line number="14" hits="3"/>
+                    <line number="15" hits="2"/>
+                </lines>
+            </class>
+            <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889" branch-rate="0.0" complexity="0.0">
+                <methods/>
+                <lines>
+                    <line number="2" hits="12"/>
+                    <line number="3" hits="12"/>
+                    <line number="4" hits="0"/>
+                    <line number="5" hits="2"/>
+                    <line number="7" hits="17"/>
+                    <line number="8" hits="12"/>
+                    <line number="9" hits="2"/>
+                    <line number="11" hits="23"/>
+                    <line number="13" hits="17"/>
+                </lines>
+            </class>
+        </package>
+    </packages>
+</coverage>"
+`;

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -57,6 +57,238 @@ export class Y {
   );
 });
 
+test("cobertura coverage reporter", () => {
+  using dir = tempDir("cov", {
+    "src/foo.ts": `
+export function fooOne(x) {
+  if (x === 1) {
+    return x + 1;
+  }
+
+  if (x === 2) {
+    return x + 1;
+  }
+
+  const result = x + 1;
+
+  return result + 1;
+}
+`,
+    "src/foo.test.ts": `
+import { describe, it, expect } from 'bun:test';
+import { fooOne } from './foo';
+
+describe('fooTest', () => {
+  it('returns result', () => {
+    const result = fooOne(12);
+    expect(result).toBe(14);
+  });
+
+  it('handles when x equals to 2', () => {
+    const result = fooOne(2);
+    expect(result).toBe(3);
+  });
+});
+`,
+  });
+  const result = Bun.spawnSync(
+    [bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura", "./src/foo.test.ts"],
+    {
+      cwd: dir,
+      env: {
+        ...bunEnv,
+      },
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+  let coberturaXml = normalizeBunSnapshot(readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8"), dir);
+  coberturaXml = coberturaXml.replace(/timestamp="\d+"/, 'timestamp="0"');
+  expect(coberturaXml).toMatchSnapshot("cobertura-coverage-reporter-output");
+});
+
+test("cobertura coverage reporter writes alongside lcov", () => {
+  using dir = tempDir("cov", {
+    "demo.ts": `
+export function covered() {
+  return 1;
+}
+covered();
+`,
+  });
+  const result = Bun.spawnSync(
+    [bunExe(), "test", "--coverage", "--coverage-reporter", "lcov", "--coverage-reporter", "cobertura", "./demo.ts"],
+    {
+      cwd: dir,
+      env: { ...bunEnv },
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+  expect(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8")).toContain("SF:demo.ts");
+  const xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
+  expect(xml).toContain('filename="demo.ts"');
+  expect(xml).toContain("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
+});
+
+test("cobertura coverage reporter escapes special characters in paths", () => {
+  using dir = tempDir("cov", {
+    "foo&bar.ts": `
+export function covered() {
+  return 1;
+}
+covered();
+`,
+  });
+  const result = Bun.spawnSync(
+    [bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura", "./foo&bar.ts"],
+    {
+      cwd: dir,
+      env: { ...bunEnv },
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  expect(result.exitCode).toBe(0);
+  const xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
+  expect(xml).toContain("foo&amp;bar.ts");
+  expect(xml).not.toContain('filename="foo&bar.ts"');
+});
+
+test("invalid coverage reporter lists cobertura", () => {
+  using dir = tempDir("cov", {
+    "demo.test.ts": `test("ok", () => {});`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "jacoco"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, "pipe", "pipe"],
+  });
+  const stderr = result.stderr.toString("utf-8");
+  expect(stderr).toContain("invalid coverage reporter 'jacoco'");
+  expect(stderr).toContain("cobertura");
+  expect(result.exitCode).not.toBe(0);
+});
+
+test("cobertura-only reporter enforces coverageThreshold", () => {
+  using dir = tempDir("cov", {
+    "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,
+    "lib.ts": `
+export function used() { return 1; }
+export function unused() { return 2; }
+export function alsoUnused() { return 3; }
+`,
+    "lib.test.ts": `
+import { test, expect } from "bun:test";
+import { used } from "./lib";
+test("used", () => expect(used()).toBe(1));
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, null, "pipe"],
+  });
+  // The fixture's only test passes, so exit code 1 can only come from the
+  // coverage threshold.
+  const stderr = result.stderr.toString("utf-8");
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8")).toContain('filename="lib.ts"');
+  expect(result.exitCode).toBe(1);
+});
+
+test("lcov-only reporter enforces coverageThreshold", () => {
+  using dir = tempDir("cov", {
+    "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,
+    "lib.ts": `
+export function used() { return 1; }
+export function unused() { return 2; }
+export function alsoUnused() { return 3; }
+`,
+    "lib.test.ts": `
+import { test, expect } from "bun:test";
+import { used } from "./lib";
+test("used", () => expect(used()).toBe(1));
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "lcov"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, null, "pipe"],
+  });
+  const stderr = result.stderr.toString("utf-8");
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8")).toContain("SF:lib.ts");
+  expect(result.exitCode).toBe(1);
+});
+
+test("coveragePathIgnorePatterns - cobertura reporter", () => {
+  using dir = tempDir("cov", {
+    "bunfig.toml": `
+[test]
+coveragePathIgnorePatterns = "ignore-me.ts"
+coverageSkipTestFiles = false
+`,
+    "include-me.ts": `
+export function includeMe() {
+  return "included";
+}
+`,
+    "ignore-me.ts": `
+export function ignoreMe() {
+  return "ignored";
+}
+`,
+    "test.test.ts": `
+import { test, expect } from "bun:test";
+import { includeMe } from "./include-me";
+import { ignoreMe } from "./ignore-me";
+
+test("should call both functions", () => {
+  expect(includeMe()).toBe("included");
+  expect(ignoreMe()).toBe("ignored");
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, null, "pipe"],
+  });
+
+  let xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
+  xml = normalizeBunSnapshot(xml, dir).replace(/timestamp="\d+"/, 'timestamp="0"');
+  expect(xml).toContain('filename="include-me.ts"');
+  expect(xml).not.toContain("ignore-me.ts");
+  expect(result.exitCode).toBe(0);
+});
+
+test("cobertura reporter via bunfig.toml", () => {
+  using dir = tempDir("cov", {
+    "bunfig.toml": `
+[test]
+coverage = true
+coverageReporter = ["cobertura"]
+coverageSkipTestFiles = false
+`,
+    "demo.test.ts": `
+import { test, expect } from "bun:test";
+test("ok", () => expect(1).toBe(1));
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  expect(result.exitCode).toBe(0);
+  expect(readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8")).toContain("<coverage ");
+});
+
 test("coverage excludes node_modules directory", () => {
   using dir = tempDir("cov", {
     "node_modules/pi/index.js": `

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -621,6 +621,28 @@ test("--parallel --coverage prints merged text table", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("--parallel --coverage writes cobertura.xml", async () => {
+  using dir = tempDir("parallel-coverage-cobertura", {
+    "shared.js": `export const n = 1;`,
+    "a.test.js": `import {test,expect} from "bun:test"; import {n} from "./shared.js"; test("a",()=>expect(n).toBe(1));`,
+    "b.test.js": `import {test,expect} from "bun:test"; import {n} from "./shared.js"; test("b",()=>expect(n).toBe(1));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--coverage", "--coverage-reporter=cobertura", "--coverage-dir=./cov"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("2 pass");
+  const xml = await Bun.file(String(dir) + "/cov/cobertura.xml").text();
+  expect(xml).toContain("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
+  expect(xml).toContain('filename="shared.js"');
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel --coverage enforces coverageThreshold with lcov-only reporter", async () => {
   using dir = tempDir("parallel-coverage-threshold", {
     "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,


### PR DESCRIPTION
### What does this PR do?

Fixes #24076

Adds a `cobertura` coverage reporter to `bun test --coverage`, so GitLab's coverage visualization can consume Bun coverage directly instead of requiring an LCOV→Cobertura conversion step in CI.

```toml
[test]
coverageReporter = ["text", "cobertura"]
```

```sh
bun test --coverage --coverage-reporter=cobertura
```

Writes `coverage/cobertura.xml` (`coverage-04.dtd`), in both single-process runs and `--parallel` runs (merged from worker LCOV fragments). Files are grouped into `<package>` elements by directory, paths are emitted relative to the project root with posix separators, and the file is written atomically (temp file + rename). Branch metrics are emitted as zero and `<methods/>` is empty because JSC reports neither branches nor function names — the same limitation the lcov reporter has (it omits `FN` records).

**Behavioral fix included:** `coverageThreshold` is now enforced when the `text` reporter is disabled. Previously an lcov-only run (and now cobertura-only, or a run with no reporters) exited 0 regardless of the threshold, because the pass/fail computation lived inside the text formatter. The fix extracts it into `Report::compute_fraction` — the single source of the threshold rule — used by both the text reporter and the reporterless path. The docs caveat describing the old behavior is removed.

**Docs:** the GitLab CI example previously declared `coverage_format: cobertura` while uploading `lcov.info` (unsupported, per the issue); it now uses the cobertura reporter. GitLab is removed from the list of LCOV consumers (gitlab-org/gitlab#488492 is still open).

Refactors that fell out of the feature:

- One shared XML escaper (`bun_core::strings::write_xml_escaped`) now serves the JUnit reporter and cobertura, with numeric character references for tab/LF/CR so path bytes survive XML attribute-value normalization (XML 1.0 §3.3.3).
- One shared `write_coverage_artifact` (mkdir + temp file + atomic rename, errors exit 1) writes `lcov.info` and `cobertura.xml` in both the single-process and `--parallel` merge paths. The parallel merge previously wrote with `O_TRUNC` and discarded write errors; the serial lcov path drops ~80 lines of scopeguard machinery.
- `generate_code_coverage`/`print_code_coverage` read `opts.reporters` instead of threading three positional bools.
- One `TestCommand.printCodeCoverage` perf span replaces the per-reporter-combination event names (also reverts a hand edit to the generated `generated_perf_trace_events.h`).

Performance: cobertura data is extracted per file inside the existing report loop and each `Report` is dropped immediately (no retention of all reports until write-out); the XML writer precomputes per-file sort keys, so the sort comparator does no allocation and each file's line array is scanned once.

### How did you verify your code works?

- `bun bd test test/cli/test/coverage.test.ts` — 21 pass. New tests cover: full-XML snapshot, writing alongside lcov, XML escaping of `&` in filenames, the invalid-reporter error listing `cobertura`, threshold enforcement with cobertura-only **and** lcov-only reporters (exit 1 while the fixture's tests pass), `coveragePathIgnorePatterns`, and `coverageReporter = ["cobertura"]` via bunfig.
- `bun bd test test/cli/test/parallel.test.ts -t coverage` — 4 pass, including the new `--parallel --coverage writes cobertura.xml` merge test.
- `bun bd test test/js/junit-reporter/junit.test.js` — 9 pass (the JUnit reporter consumes the shared escaper; behavior unchanged).
- All 8 new tests fail with `USE_SYSTEM_BUN=1` (no cobertura reporter, thresholds not enforced without the text reporter) and pass with the branch build.