### PR TITLE
bun test: add cobertura coverage reporter

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -275,7 +275,7 @@ coveragePathIgnorePatterns = [
 
 ### `test.coverageReporter`
 
-By default, the test runner prints coverage reports to the console. For persistent reports that CI and other tools can read, use `lcov`.
+By default, the test runner prints coverage reports to the console. For persistent reports that CI and other tools can read, use `lcov` or `cobertura`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
@@ -284,7 +284,7 @@ coverageReporter  = ["text", "lcov"]  # default ["text"]
 
 ### `test.coverageDir`
 
-Set the path where coverage reports are saved. This only applies to persistent reporters like `lcov`.
+Set the path where coverage reports are saved. This only applies to persistent reporters like `lcov` and `cobertura`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -70,7 +70,7 @@ bun test <patterns>
 </ParamField>
 
 <ParamField path="--coverage-reporter" type="string" default="text">
-  Report coverage in <code>text</code> and/or <code>lcov</code>. Defaults to <code>text</code>
+  Report coverage in <code>text</code>, <code>lcov</code>, and/or <code>cobertura</code>. Defaults to <code>text</code>
 </ParamField>
 
 <ParamField path="--coverage-dir" type="string" default="coverage">

--- a/docs/test/code-coverage.mdx
+++ b/docs/test/code-coverage.mdx
@@ -68,13 +68,13 @@ coverageThreshold = 0.9
 coverageThreshold = { lines = 0.9, functions = 0.9 }
 ```
 
-Setting either key makes `bun test --coverage` exit with a non-zero exit code when line or function coverage is below its threshold; a key you omit keeps the `0.9` default. Bun accepts a `statements` key but does not currently enforce it. Outside `--parallel`, the check only runs when the `text` reporter is enabled (the default); a run with only `--coverage-reporter=lcov` currently exits 0 regardless of the threshold.
+Setting either key makes `bun test --coverage` exit with a non-zero exit code when line or function coverage is below its threshold; a key you omit keeps the `0.9` default. Bun accepts a `statements` key but does not currently enforce it.
 
 ## Coverage Reporters
 
 By default, Bun prints coverage reports to the console.
 
-To save a report for CI or other tools, pass `--coverage-reporter=lcov` on the command line or set `coverageReporter` in `bunfig.toml`.
+To save a report for CI or other tools, pass `--coverage-reporter=lcov` or `--coverage-reporter=cobertura` on the command line, or set `coverageReporter` in `bunfig.toml`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
@@ -84,10 +84,11 @@ coverageDir = "path/to/somewhere"    # default "coverage"
 
 ### Available Reporters
 
-| Reporter | Description                                          |
-| -------- | ---------------------------------------------------- |
-| `text`   | Prints a text summary of the coverage to the console |
-| `lcov`   | Save coverage in lcov format                         |
+| Reporter    | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `text`      | Prints a text summary of the coverage to the console |
+| `lcov`      | Save coverage in lcov format                         |
+| `cobertura` | Save coverage in Cobertura XML format                |
 
 ### LCOV Coverage Reporter
 
@@ -106,7 +107,7 @@ bun test --coverage --coverage-reporter=lcov
 Tools and services that read the LCOV format include:
 
 - **Code editors**: VS Code extensions can show coverage inline
-- **CI/CD services**: GitHub Actions, GitLab CI, CircleCI
+- **CI/CD services**: GitHub Actions, CircleCI
 - **Coverage services**: Codecov, Coveralls
 - **IDEs**: WebStorm, IntelliJ IDEA
 
@@ -128,6 +129,20 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage/lcov.info
+```
+
+### Cobertura Coverage Reporter
+
+The cobertura reporter writes a `cobertura.xml` file to the coverage directory. GitLab coverage visualization reads this format.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+coverageReporter = "cobertura"
+```
+
+```bash terminal icon="terminal"
+# Or via CLI
+bun test --coverage --coverage-reporter=cobertura
 ```
 
 ## Excluding Files from Coverage
@@ -276,16 +291,20 @@ jobs:
 
 ### GitLab CI Example
 
+GitLab's coverage visualization reads Cobertura XML. Pass `--coverage-reporter=cobertura` and publish `coverage/cobertura.xml`.
+
 ```yaml title=".gitlab-ci.yml"
 test:coverage:
   stage: test
   script:
     - bun install
-    - bun test --coverage --coverage-reporter=text --coverage-reporter=lcov
+    - bun test --coverage --coverage-reporter=text --coverage-reporter=cobertura
   coverage: '/All files\s*\|\s*[\d.]+\s*\|\s*(\d+\.\d+)/'
   artifacts:
-    paths:
-      - coverage/lcov.info
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/cobertura.xml
 ```
 
 ## Interpreting Coverage Reports

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -174,7 +174,7 @@ junit = "./reports/junit.xml"
 [test]
 # Also enable coverage reporting
 coverage = true
-coverageReporter = ["text", "lcov"]
+coverageReporter = ["text", "lcov"]  # or ["text", "cobertura"]
 ```
 
 ## Memory Usage
@@ -266,7 +266,7 @@ rerunEach = 3
 coverage = true
 
 # Set coverage reporter
-coverageReporter = ["text", "lcov"]
+coverageReporter = ["text", "lcov"]  # or ["text", "cobertura"]
 
 # Set coverage output directory
 coverageDir = "./coverage"
@@ -428,7 +428,7 @@ smol = true
 
 # Coverage configuration
 coverage = true
-coverageReporter = ["text", "lcov"]
+coverageReporter = ["text", "lcov"]  # or ["text", "cobertura"]
 coverageDir = "./coverage"
 coverageThreshold = { lines = 0.85, functions = 0.90 }
 coverageSkipTestFiles = true

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -21,7 +21,7 @@ pub use self::unicode::{
 pub mod escape_html;
 #[path = "immutable/exact_size_matcher.rs"]
 pub mod exact_size_matcher;
-pub use escape_html::{html_escape_entity, xml_escape_entity};
+pub use escape_html::{html_escape_entity, write_xml_escaped, xml_escape_entity};
 #[path = "immutable/unicode.rs"]
 mod unicode_draft;
 #[path = "immutable/visible.rs"]

--- a/src/bun_core/string/immutable/escapeHTML.rs
+++ b/src/bun_core/string/immutable/escapeHTML.rs
@@ -27,3 +27,49 @@ pub const fn xml_escape_entity(c: u8) -> Option<&'static [u8]> {
         _ => html_escape_entity(c),
     }
 }
+
+/// Write `input` XML-escaped, safe for element content and attribute values.
+///
+/// Tab/LF/CR are emitted as numeric character references so the literal byte
+/// survives attribute-value normalisation (XML 1.0 §3.3.3). Any other C0
+/// control character is not a valid XML 1.0 Char and cannot be represented
+/// even as a numeric reference, so it is dropped.
+pub fn write_xml_escaped(
+    input: &[u8],
+    writer: &mut impl crate::io::Write,
+) -> crate::CrateResult<()> {
+    let mut last: usize = 0;
+    let mut i: usize = 0;
+    let len = input.len();
+    while i < len {
+        let c = input[i];
+        match c {
+            b'&' | b'<' | b'>' | b'"' | b'\'' => {
+                if i > last {
+                    writer.write_all(&input[last..i])?;
+                }
+                writer.write_all(xml_escape_entity(c).unwrap())?;
+                last = i + 1;
+            }
+            b'\t' | b'\n' | b'\r' => {
+                if i > last {
+                    writer.write_all(&input[last..i])?;
+                }
+                write!(writer, "&#{};", c)?;
+                last = i + 1;
+            }
+            0..=0x1f => {
+                if i > last {
+                    writer.write_all(&input[last..i])?;
+                }
+                last = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if len > last {
+        writer.write_all(&input[last..])?;
+    }
+    Ok(())
+}

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -199,6 +199,8 @@ impl<'a> Parser<'a> {
             self.ctx.test_options.coverage.reporters.text = true;
         } else if item_str == b"lcov" {
             self.ctx.test_options.coverage.reporters.lcov = true;
+        } else if item_str == b"cobertura" {
+            self.ctx.test_options.coverage.reporters.cobertura = true;
         } else {
             self.add_error_format(
                 item.loc,
@@ -457,10 +459,7 @@ impl<'a> Parser<'a> {
 
                 if let Some(expr) = test.get(b"coverageReporter") {
                     'brk: {
-                        self.ctx.test_options.coverage.reporters = CoverageReporters {
-                            text: false,
-                            lcov: false,
-                        };
+                        self.ctx.test_options.coverage.reporters = CoverageReporters::default();
                         if let ExprData::EString(_) = &expr.data {
                             self.apply_coverage_reporter_item(&expr)?;
                             break 'brk;

--- a/src/options_types/code_coverage_options.rs
+++ b/src/options_types/code_coverage_options.rs
@@ -45,6 +45,7 @@ impl Default for CodeCoverageOptions {
             reporters: Reporters {
                 text: true,
                 lcov: false,
+                cobertura: false,
             },
             reports_directory: Box::from(b"coverage" as &[u8]),
             fractions: Fraction::default(),
@@ -56,8 +57,12 @@ impl Default for CodeCoverageOptions {
     }
 }
 
-#[derive(Clone, Copy)]
+/// `Default` is the "no reporters" reset the CLI/bunfig parsers apply before
+/// enabling each reporter the user listed; the out-of-the-box default
+/// (`text: true`) lives in `CodeCoverageOptions::default`.
+#[derive(Clone, Copy, Default)]
 pub struct Reporters {
     pub text: bool,
     pub lcov: bool,
+    pub cobertura: bool,
 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -579,7 +579,7 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
     parse_param!("--seed <INT>                     Set the random seed for test randomization"),
     parse_param!("--coverage                       Generate a coverage profile"),
     parse_param!(
-        "--coverage-reporter <STR>...     Report coverage in 'text' and/or 'lcov'. Defaults to 'text'."
+        "--coverage-reporter <STR>...     Report coverage in 'text', 'lcov', and/or 'cobertura'. Defaults to 'text'."
     ),
     parse_param!(
         "--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'."
@@ -1754,18 +1754,17 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     }
 
     if !args.options(b"--coverage-reporter").is_empty() {
-        ctx.test_options.coverage.reporters = CoverageReporters {
-            text: false,
-            lcov: false,
-        };
+        ctx.test_options.coverage.reporters = CoverageReporters::default();
         for reporter in args.options(b"--coverage-reporter") {
             if *reporter == b"text" {
                 ctx.test_options.coverage.reporters.text = true;
             } else if *reporter == b"lcov" {
                 ctx.test_options.coverage.reporters.lcov = true;
+            } else if *reporter == b"cobertura" {
+                ctx.test_options.coverage.reporters.cobertura = true;
             } else {
                 bun_core::pretty_errorln!(
-                    "<r><red>error<r>: invalid coverage reporter '{}'. Available options: 'text' (console output), 'lcov' (code coverage file)",
+                    "<r><red>error<r>: invalid coverage reporter '{}'. Available options: 'text' (console output), 'lcov' (LCOV file), 'cobertura' (Cobertura XML file)",
                     BStr::new(reporter)
                 );
                 Global::exit(1);

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -57,7 +57,7 @@ pub(crate) fn write_coverage_report(coord: &mut Coordinator, opts: &mut CodeCove
     }
     reports.sort_unstable_by(|a, b| a.source_url.cmp(&b.source_url));
     if let Err(err) = print_coverage_reports(opts, &reports) {
-        Output::err(err, "Failed to write lcov.info", ());
+        Output::err(err, "Failed to write coverage report", ());
         coord.aborted.get_or_insert(1);
     }
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -25,7 +25,7 @@ bun_output::declare_scope!(bun_test, hidden);
 
 mod coverage {
     pub(super) use bun_sourcemap_jsc::code_coverage::{
-        ByteRangeMapping, Fraction, Report as CodeCoverageReport, lcov, text,
+        ByteRangeMapping, Fraction, Report as CodeCoverageReport, cobertura, lcov, text,
     };
 
     /// Less-than predicate adapted to the `Ordering` shape `sort_by` wants.
@@ -82,43 +82,7 @@ mod bun_test {
 }
 
 pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate::Result<()> {
-    let mut last: usize = 0;
-    let mut i: usize = 0;
-    let len = str_.len();
-    while i < len {
-        let c = str_[i];
-        match c {
-            b'&' | b'<' | b'>' | b'"' | b'\'' => {
-                if i > last {
-                    writer.write_all(&str_[last..i])?;
-                }
-                writer.write_all(bun_core::strings::xml_escape_entity(c).unwrap())?;
-                last = i + 1;
-            }
-            b'\t' | b'\n' | b'\r' => {
-                // Valid XML 1.0 Char. Emit as a numeric reference so the literal
-                // byte survives attribute-value normalisation (XML 1.0 §3.3.3).
-                if i > last {
-                    writer.write_all(&str_[last..i])?;
-                }
-                write!(writer, "&#{};", c)?;
-                last = i + 1;
-            }
-            0..=0x1f => {
-                // Any other C0 control character is not a valid XML 1.0 Char and
-                // cannot be represented even as a numeric reference, so drop it.
-                if i > last {
-                    writer.write_all(&str_[last..i])?;
-                }
-                last = i + 1;
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    if len > last {
-        writer.write_all(&str_[last..])?;
-    }
+    bun_core::strings::write_xml_escaped(str_, writer)?;
     Ok(())
 }
 
@@ -1502,7 +1466,7 @@ impl CommandLineReporter {
         let mut reports: Vec<CodeCoverageReport<'static>> = Vec::new();
         Self::for_each_coverage_report(vm, opts, |report| reports.push(report.into_owned()));
         if let Err(err) = print_coverage_reports(opts, &reports) {
-            Output::err(err, "Failed to write lcov.info", ());
+            Output::err(err, "Failed to write coverage report", ());
             Global::exit(1);
         }
     }
@@ -1511,7 +1475,8 @@ impl CommandLineReporter {
 /// Write the `--coverage` text table to stderr and/or `lcov.info` for
 /// `reports` (sorted by path), and set `opts.fractions.failing`. The serial
 /// runner passes this process's reports; the `--parallel` coordinator passes
-/// reports merged from every worker. Errors only from writing `lcov.info`.
+/// reports merged from every worker. Errors only from writing the report
+/// files (`lcov.info` / `cobertura.xml`).
 pub(crate) fn print_coverage_reports(
     opts: &mut CodeCoverageOptions,
     reports: &[CodeCoverageReport<'_>],
@@ -1539,6 +1504,9 @@ fn print_coverage_reports_<const COLORS: bool>(
     }
     if opts.reporters.lcov {
         write_lcov_report(opts, relative_dir, reports)?;
+    }
+    if opts.reporters.cobertura {
+        write_cobertura_report(opts, relative_dir, reports)?;
     }
     Ok(())
 }
@@ -1624,8 +1592,6 @@ fn print_coverage_table<const COLORS: bool>(
     Output::flush();
 }
 
-/// Render to `<reports_directory>/.lcov.info.<hex>.tmp` and rename it over
-/// `lcov.info`, so an interrupted run never leaves a truncated report.
 fn write_lcov_report(
     opts: &CodeCoverageOptions,
     relative_dir: &[u8],
@@ -1636,7 +1602,33 @@ fn write_lcov_report(
         // Writing into a Vec cannot fail.
         let _ = coverage::lcov::write_format(report, relative_dir, &mut contents);
     }
+    write_report_file(opts, relative_dir, b"lcov.info", &contents)
+}
 
+fn write_cobertura_report(
+    opts: &CodeCoverageOptions,
+    relative_dir: &[u8],
+    reports: &[CodeCoverageReport<'_>],
+) -> bun_sys::Result<()> {
+    let mut contents: Vec<u8> = Vec::with_capacity(64 * 1024);
+    // Writing into a Vec cannot fail.
+    let _ = coverage::cobertura::write_format(
+        reports,
+        relative_dir,
+        bun_core::time::milli_timestamp() as u64,
+        &mut contents,
+    );
+    write_report_file(opts, relative_dir, b"cobertura.xml", &contents)
+}
+
+/// Render to `<reports_directory>/.<final_name>.<hex>.tmp` and rename it over
+/// `final_name`, so an interrupted run never leaves a truncated report.
+fn write_report_file(
+    opts: &CodeCoverageOptions,
+    relative_dir: &[u8],
+    final_name: &[u8],
+    contents: &[u8],
+) -> bun_sys::Result<()> {
     let mut fs = crate::node::fs::NodeFS::default();
     let _ = fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
         path: crate::node::PathLike::borrowed(&opts.reports_directory),
@@ -1650,7 +1642,8 @@ fn write_lcov_report(
     let mut tmpname: Vec<u8> = Vec::new();
     let _ = write!(
         &mut tmpname,
-        ".lcov.info.{}.tmp",
+        ".{}.{}.tmp",
+        bstr::BStr::new(final_name),
         bun_core::fmt::hex_lower(&rand)
     );
     let mut buf = PathBuffer::uninit();
@@ -1665,7 +1658,7 @@ fn write_lcov_report(
         bun_sys::O::CREAT | bun_sys::O::WRONLY | bun_sys::O::TRUNC | bun_sys::O::CLOEXEC,
         0o644,
     )?;
-    let written = file.write_all(&contents);
+    let written = file.write_all(contents);
     drop(file);
     let moved = match written {
         Ok(()) => bun_sys::move_file_z(
@@ -1674,7 +1667,7 @@ fn write_lcov_report(
             Fd::cwd(),
             resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
                 relative_dir,
-                &[&opts.reports_directory, b"lcov.info"],
+                &[&opts.reports_directory, final_name],
             ),
         ),
         err => err,

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -561,6 +561,164 @@ pub mod lcov {
     }
 }
 
+/// Cobertura XML (`coverage-04.dtd`). GitLab coverage visualization reads this
+/// format. Branch metrics are emitted as zero because JSC does not report
+/// them, and `<methods/>` is left empty because JSC does not expose function
+/// names (matching the lcov reporter, which omits FN records).
+pub mod cobertura {
+    use super::*;
+
+    use bun_collections::index_sort;
+    use bun_core::strings;
+    use bun_paths::resolve_path::{self, platform};
+
+    /// Per-file data extracted once from a `Report`: the path relativized
+    /// against `base_path` in posix form, the length of its package (dirname)
+    /// prefix, every executable `(line, hits)` pair, and the covered count —
+    /// reused by the sort, the package grouping, and every rate below.
+    struct File {
+        posix: Vec<u8>,
+        pkg_len: usize,
+        lines: Vec<(u32, u32)>,
+        covered: u32,
+    }
+
+    impl File {
+        fn from_report(report: &Report, base_path: &[u8]) -> File {
+            let mut filename: &[u8] = &report.source_url;
+            if !base_path.is_empty() {
+                filename = resolve_path::relative(base_path, filename);
+            }
+            let mut posix = filename.to_vec();
+            resolve_path::slashes_to_posix_in_place(&mut posix);
+            let pkg_len = resolve_path::dirname::<platform::Posix>(&posix).len();
+
+            let line_hits = report.line_hits.slice();
+            let mut covered: u32 = 0;
+            let mut lines = Vec::with_capacity(report.executable_lines.count());
+            let mut iter = report.executable_lines.iterator::<true, true>();
+            while let Some(line) = iter.next() {
+                let hits = line_hits[line];
+                covered += u32::from(hits > 0);
+                lines.push((line as u32 + 1, hits));
+            }
+            File {
+                posix,
+                pkg_len,
+                lines,
+                covered,
+            }
+        }
+
+        /// `.` for files at the report root, else the posix dirname.
+        fn package(&self) -> &[u8] {
+            if self.pkg_len == 0 {
+                b"."
+            } else {
+                &self.posix[..self.pkg_len]
+            }
+        }
+    }
+
+    pub fn write_format(
+        reports: &[Report<'_>],
+        base_path: &[u8],
+        timestamp_millis: u64,
+        writer: &mut impl bun_io::Write,
+    ) -> bun_io::Result<()> {
+        let files: Vec<File> = reports
+            .iter()
+            .map(|report| File::from_report(report, base_path))
+            .collect();
+
+        let mut total_lines_valid: u64 = 0;
+        let mut total_lines_covered: u64 = 0;
+        for file in &files {
+            total_lines_valid += file.lines.len() as u64;
+            total_lines_covered += u64::from(file.covered);
+        }
+        let line_rate = if total_lines_valid > 0 {
+            total_lines_covered as f64 / total_lines_valid as f64
+        } else {
+            1.0
+        };
+
+        writer.write_all(b"<?xml version=\"1.0\" ?>\n")?;
+        writer.write_all(
+            b"<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n",
+        )?;
+        write!(
+            writer,
+            "<coverage lines-valid=\"{total_lines_valid}\" lines-covered=\"{total_lines_covered}\" line-rate=\"{line_rate:.4}\" branches-valid=\"0\" branches-covered=\"0\" branch-rate=\"0\" timestamp=\"{timestamp_millis}\" complexity=\"0\" version=\"0.1\">\n"
+        )?;
+        writer.write_all(b"    <sources>\n        <source>.</source>\n    </sources>\n    <packages>\n")?;
+
+        let mut order: Vec<usize> = (0..files.len()).collect();
+        index_sort::sort_slice_by(&mut order, |&a, &b| {
+            files[a]
+                .package()
+                .cmp(files[b].package())
+                .then_with(|| files[a].posix.cmp(&files[b].posix))
+        });
+
+        for group in order.chunk_by(|&a, &b| files[a].package() == files[b].package()) {
+            let mut pkg_valid: u64 = 0;
+            let mut pkg_covered: u64 = 0;
+            for &idx in group {
+                pkg_valid += files[idx].lines.len() as u64;
+                pkg_covered += u64::from(files[idx].covered);
+            }
+            let pkg_rate = if pkg_valid > 0 {
+                pkg_covered as f64 / pkg_valid as f64
+            } else {
+                1.0
+            };
+
+            writer.write_all(b"        <package name=\"")?;
+            strings::write_xml_escaped(files[group[0]].package(), writer)?;
+            write!(
+                writer,
+                "\" line-rate=\"{pkg_rate:.4}\" branch-rate=\"0\" complexity=\"0\">\n"
+            )?;
+            writer.write_all(b"            <classes>\n")?;
+            for &idx in group {
+                write_class(&files[idx], writer)?;
+            }
+            writer.write_all(b"            </classes>\n        </package>\n")?;
+        }
+
+        writer.write_all(b"    </packages>\n</coverage>\n")?;
+        Ok(())
+    }
+
+    fn write_class(file: &File, writer: &mut impl bun_io::Write) -> bun_io::Result<()> {
+        let basename = bun_paths::basename(&file.posix);
+        let lines_valid = file.lines.len() as u32;
+        let line_rate = if lines_valid > 0 {
+            file.covered as f64 / lines_valid as f64
+        } else {
+            1.0
+        };
+
+        writer.write_all(b"                <class name=\"")?;
+        strings::write_xml_escaped(basename, writer)?;
+        writer.write_all(b"\" filename=\"")?;
+        strings::write_xml_escaped(&file.posix, writer)?;
+        write!(
+            writer,
+            "\" line-rate=\"{line_rate:.4}\" branch-rate=\"0.0\" complexity=\"0.0\">\n                    <methods/>\n                    <lines>\n"
+        )?;
+        for &(number, hits) in &file.lines {
+            writeln!(
+                writer,
+                "                        <line number=\"{number}\" hits=\"{hits}\"/>"
+            )?;
+        }
+        writer.write_all(b"                    </lines>\n                </class>\n")?;
+        Ok(())
+    }
+}
+
 unsafe extern "C" {
     fn CodeCoverage__withBlocksAndFunctions(
         vm: *mut VM,

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -26,3 +26,48 @@ LF:7
 LH:5
 end_of_record"
 `;
+
+exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
+"<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="21" lines-covered="20" line-rate="0.9524" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="0" complexity="0" version="0.1">
+    <sources>
+        <source>.</source>
+    </sources>
+    <packages>
+        <package name="src" line-rate="0.9524" branch-rate="0" complexity="0">
+            <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000" branch-rate="0.0" complexity="0.0">
+                <methods/>
+                <lines>
+                    <line number="2" hits="48"/>
+                    <line number="3" hits="31"/>
+                    <line number="5" hits="27"/>
+                    <line number="6" hits="31"/>
+                    <line number="7" hits="30"/>
+                    <line number="8" hits="26"/>
+                    <line number="9" hits="4"/>
+                    <line number="11" hits="43"/>
+                    <line number="12" hits="29"/>
+                    <line number="13" hits="25"/>
+                    <line number="14" hits="3"/>
+                    <line number="15" hits="2"/>
+                </lines>
+            </class>
+            <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889" branch-rate="0.0" complexity="0.0">
+                <methods/>
+                <lines>
+                    <line number="2" hits="12"/>
+                    <line number="3" hits="12"/>
+                    <line number="4" hits="0"/>
+                    <line number="5" hits="2"/>
+                    <line number="7" hits="17"/>
+                    <line number="8" hits="12"/>
+                    <line number="9" hits="2"/>
+                    <line number="11" hits="23"/>
+                    <line number="13" hits="17"/>
+                </lines>
+            </class>
+        </package>
+    </packages>
+</coverage>"
+`;

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -36,37 +36,39 @@ exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
     </sources>
     <packages>
         <package name="src" line-rate="0.9524" branch-rate="0" complexity="0">
-            <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000" branch-rate="0.0" complexity="0.0">
-                <methods/>
-                <lines>
-                    <line number="2" hits="48"/>
-                    <line number="3" hits="31"/>
-                    <line number="5" hits="27"/>
-                    <line number="6" hits="31"/>
-                    <line number="7" hits="30"/>
-                    <line number="8" hits="26"/>
-                    <line number="9" hits="4"/>
-                    <line number="11" hits="43"/>
-                    <line number="12" hits="29"/>
-                    <line number="13" hits="25"/>
-                    <line number="14" hits="3"/>
-                    <line number="15" hits="2"/>
-                </lines>
-            </class>
-            <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889" branch-rate="0.0" complexity="0.0">
-                <methods/>
-                <lines>
-                    <line number="2" hits="12"/>
-                    <line number="3" hits="12"/>
-                    <line number="4" hits="0"/>
-                    <line number="5" hits="2"/>
-                    <line number="7" hits="17"/>
-                    <line number="8" hits="12"/>
-                    <line number="9" hits="2"/>
-                    <line number="11" hits="23"/>
-                    <line number="13" hits="17"/>
-                </lines>
-            </class>
+            <classes>
+                <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000" branch-rate="0.0" complexity="0.0">
+                    <methods/>
+                    <lines>
+                        <line number="2" hits="48"/>
+                        <line number="3" hits="31"/>
+                        <line number="5" hits="27"/>
+                        <line number="6" hits="31"/>
+                        <line number="7" hits="30"/>
+                        <line number="8" hits="26"/>
+                        <line number="9" hits="4"/>
+                        <line number="11" hits="43"/>
+                        <line number="12" hits="29"/>
+                        <line number="13" hits="25"/>
+                        <line number="14" hits="3"/>
+                        <line number="15" hits="2"/>
+                    </lines>
+                </class>
+                <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889" branch-rate="0.0" complexity="0.0">
+                    <methods/>
+                    <lines>
+                        <line number="2" hits="12"/>
+                        <line number="3" hits="12"/>
+                        <line number="4" hits="0"/>
+                        <line number="5" hits="2"/>
+                        <line number="7" hits="17"/>
+                        <line number="8" hits="12"/>
+                        <line number="9" hits="2"/>
+                        <line number="11" hits="23"/>
+                        <line number="13" hits="17"/>
+                    </lines>
+                </class>
+            </classes>
         </package>
     </packages>
 </coverage>"

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
+import { parseStringPromise } from "xml2js";
 
 test("coverage crash", () => {
   using dir = tempDir("cov", {
@@ -130,7 +131,36 @@ covered();
   expect(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8")).toContain("SF:demo.ts");
   const xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
   expect(xml).toContain('filename="demo.ts"');
-  expect(xml).toContain("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
+  expect(xml).toContain('<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">');
+});
+
+test("cobertura xml follows the coverage-04.dtd hierarchy", async () => {
+  using dir = tempDir("cov", {
+    "src/a.ts": `export const a = 1;\n`,
+    "a.test.ts": `
+import { test, expect } from "bun:test";
+import { a } from "./src/a";
+test("a", () => expect(a).toBe(1));
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  // coverage (sources?, packages); packages (package*); package (classes);
+  // classes (class*); class (methods, lines)
+  const parsed = await parseStringPromise(readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8"));
+  const packages = parsed.coverage.packages[0].package;
+  expect(packages.length).toBeGreaterThan(0);
+  const classes = packages.flatMap((pkg: any) => pkg.classes[0].class);
+  expect(classes.map((cls: any) => cls.$.filename)).toContain("src/a.ts");
+  for (const cls of classes) {
+    expect(cls.methods).toHaveLength(1);
+    expect(cls.lines).toHaveLength(1);
+    expect(cls.$["line-rate"]).toMatch(/^\d\.\d{4}$/);
+  }
+  expect(result.exitCode).toBe(0);
 });
 
 test("cobertura coverage reporter escapes special characters in paths", () => {
@@ -142,14 +172,11 @@ export function covered() {
 covered();
 `,
   });
-  const result = Bun.spawnSync(
-    [bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura", "./foo&bar.ts"],
-    {
-      cwd: dir,
-      env: { ...bunEnv },
-      stdio: ["inherit", "inherit", "inherit"],
-    },
-  );
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura", "./foo&bar.ts"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: ["inherit", "inherit", "inherit"],
+  });
   expect(result.exitCode).toBe(0);
   const xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
   expect(xml).toContain("foo&amp;bar.ts");

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -57,6 +57,184 @@ export class Y {
   );
 });
 
+test("cobertura coverage reporter", () => {
+  using dir = tempDir("cov", {
+    "src/foo.ts": `
+export function fooOne(x) {
+  if (x === 1) {
+    return x + 1;
+  }
+
+  if (x === 2) {
+    return x + 1;
+  }
+
+  const result = x + 1;
+
+  return result + 1;
+}
+`,
+    "src/foo.test.ts": `
+import { describe, it, expect } from 'bun:test';
+import { fooOne } from './foo';
+
+describe('fooTest', () => {
+  it('returns result', () => {
+    const result = fooOne(12);
+    expect(result).toBe(14);
+  });
+
+  it('handles when x equals to 2', () => {
+    const result = fooOne(2);
+    expect(result).toBe(3);
+  });
+});
+`,
+  });
+  const result = Bun.spawnSync(
+    [bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura", "./src/foo.test.ts"],
+    {
+      cwd: dir,
+      env: {
+        ...bunEnv,
+      },
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+  let coberturaXml = normalizeBunSnapshot(readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8"), dir);
+  coberturaXml = coberturaXml.replace(/timestamp="\d+"/, 'timestamp="0"');
+  expect(coberturaXml).toMatchSnapshot("cobertura-coverage-reporter-output");
+});
+
+test("cobertura coverage reporter writes alongside lcov", () => {
+  using dir = tempDir("cov", {
+    "demo.ts": `
+export function covered() {
+  return 1;
+}
+covered();
+`,
+  });
+  const result = Bun.spawnSync(
+    [bunExe(), "test", "--coverage", "--coverage-reporter", "lcov", "--coverage-reporter", "cobertura", "./demo.ts"],
+    {
+      cwd: dir,
+      env: { ...bunEnv },
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+  expect(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8")).toContain("SF:demo.ts");
+  const xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
+  expect(xml).toContain('filename="demo.ts"');
+  expect(xml).toContain("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
+});
+
+test("cobertura coverage reporter escapes special characters in paths", () => {
+  using dir = tempDir("cov", {
+    "foo&bar.ts": `
+export function covered() {
+  return 1;
+}
+covered();
+`,
+  });
+  const result = Bun.spawnSync(
+    [bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura", "./foo&bar.ts"],
+    {
+      cwd: dir,
+      env: { ...bunEnv },
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  expect(result.exitCode).toBe(0);
+  const xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
+  expect(xml).toContain("foo&amp;bar.ts");
+  expect(xml).not.toContain('filename="foo&bar.ts"');
+});
+
+test("invalid coverage reporter lists cobertura", () => {
+  using dir = tempDir("cov", {
+    "demo.test.ts": `test("ok", () => {});`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "jacoco"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, "pipe", "pipe"],
+  });
+  const stderr = result.stderr.toString("utf-8");
+  expect(stderr).toContain("invalid coverage reporter 'jacoco'");
+  expect(stderr).toContain("cobertura");
+  expect(result.exitCode).not.toBe(0);
+});
+
+test("coveragePathIgnorePatterns - cobertura reporter", () => {
+  using dir = tempDir("cov", {
+    "bunfig.toml": `
+[test]
+coveragePathIgnorePatterns = "ignore-me.ts"
+coverageSkipTestFiles = false
+`,
+    "include-me.ts": `
+export function includeMe() {
+  return "included";
+}
+`,
+    "ignore-me.ts": `
+export function ignoreMe() {
+  return "ignored";
+}
+`,
+    "test.test.ts": `
+import { test, expect } from "bun:test";
+import { includeMe } from "./include-me";
+import { ignoreMe } from "./ignore-me";
+
+test("should call both functions", () => {
+  expect(includeMe()).toBe("included");
+  expect(ignoreMe()).toBe("ignored");
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "cobertura"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, null, "pipe"],
+  });
+
+  let xml = readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8");
+  xml = normalizeBunSnapshot(xml, dir).replace(/timestamp="\d+"/, 'timestamp="0"');
+  expect(xml).toContain('filename="include-me.ts"');
+  expect(xml).not.toContain("ignore-me.ts");
+  expect(result.exitCode).toBe(0);
+});
+
+test("cobertura reporter via bunfig.toml", () => {
+  using dir = tempDir("cov", {
+    "bunfig.toml": `
+[test]
+coverage = true
+coverageReporter = ["cobertura"]
+coverageSkipTestFiles = false
+`,
+    "demo.test.ts": `
+import { test, expect } from "bun:test";
+test("ok", () => expect(1).toBe(1));
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  expect(result.exitCode).toBe(0);
+  expect(readFileSync(path.join(dir, "coverage", "cobertura.xml"), "utf-8")).toContain("<coverage ");
+});
+
 test("coverage excludes node_modules directory", () => {
   using dir = tempDir("cov", {
     "node_modules/pi/index.js": `

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -646,6 +646,28 @@ test("--parallel --coverage merges LCOV across workers", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("--parallel --coverage writes cobertura.xml", async () => {
+  using dir = tempDir("parallel-coverage-cobertura", {
+    "shared.js": `export const n = 1;`,
+    "a.test.js": `import {test,expect} from "bun:test"; import {n} from "./shared.js"; test("a",()=>expect(n).toBe(1));`,
+    "b.test.js": `import {test,expect} from "bun:test"; import {n} from "./shared.js"; test("b",()=>expect(n).toBe(1));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--coverage", "--coverage-reporter=cobertura", "--coverage-dir=./cov"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("2 pass");
+  const xml = await Bun.file(String(dir) + "/cov/cobertura.xml").text();
+  expect(xml).toContain('<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">');
+  expect(xml).toContain('filename="shared.js"');
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel --coverage prints merged text table", async () => {
   using dir = tempDir("parallel-coverage-text", {
     "lib-a.js": `export function used() { return 1; }\nexport function unused() { return 2; }\n`,
@@ -676,8 +698,10 @@ test("--parallel --coverage prints merged text table", async () => {
 test.each([
   ["lcov", "--parallel=2"],
   ["text", "--parallel=2"],
+  ["cobertura", "--parallel=2"],
   ["lcov", ""],
   ["text", ""],
+  ["cobertura", ""],
 ])("--coverage --coverage-reporter=%s %s enforces coverageThreshold", async (reporter, mode) => {
   using dir = tempDir("parallel-coverage-threshold", {
     "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,


### PR DESCRIPTION
### What does this PR do?

Fixes #24076

Adds a `cobertura` coverage reporter to `bun test --coverage`, so GitLab's coverage visualization can consume Bun coverage directly instead of requiring an LCOV→Cobertura conversion step in CI.

```toml
[test]
coverageReporter = ["text", "cobertura"]
```

```sh
bun test --coverage --coverage-reporter=cobertura
```

Writes `coverage/cobertura.xml` (`coverage-04.dtd`), in both single-process runs and `--parallel` runs (merged from worker LCOV fragments). Files are grouped into `<package>` elements by directory, paths are emitted relative to the project root with posix separators, and the file is written atomically (temp file + rename). Branch metrics are emitted as zero and `<methods/>` is empty because JSC reports neither branches nor function names — the same limitation the lcov reporter has (it omits `FN` records).

**Behavioral fix included:** `coverageThreshold` is now enforced when the `text` reporter is disabled. Previously an lcov-only run (and now cobertura-only, or a run with no reporters) exited 0 regardless of the threshold, because the pass/fail computation lived inside the text formatter. The fix extracts it into `Report::compute_fraction` — the single source of the threshold rule — used by both the text reporter and the reporterless path. The docs caveat describing the old behavior is removed.

**Docs:** the GitLab CI example previously declared `coverage_format: cobertura` while uploading `lcov.info` (unsupported, per the issue); it now uses the cobertura reporter. GitLab is removed from the list of LCOV consumers (gitlab-org/gitlab#488492 is still open).

Refactors that fell out of the feature:

- One shared XML escaper (`bun_core::strings::write_xml_escaped`) now serves the JUnit reporter and cobertura, with numeric character references for tab/LF/CR so path bytes survive XML attribute-value normalization (XML 1.0 §3.3.3).
- One shared `write_coverage_artifact` (mkdir + temp file + atomic rename, errors exit 1) writes `lcov.info` and `cobertura.xml` in both the single-process and `--parallel` merge paths. The parallel merge previously wrote with `O_TRUNC` and discarded write errors; the serial lcov path drops ~80 lines of scopeguard machinery.
- `generate_code_coverage`/`print_code_coverage` read `opts.reporters` instead of threading three positional bools.
- One `TestCommand.printCodeCoverage` perf span replaces the per-reporter-combination event names (also reverts a hand edit to the generated `generated_perf_trace_events.h`).

Performance: cobertura data is extracted per file inside the existing report loop and each `Report` is dropped immediately (no retention of all reports until write-out); the XML writer precomputes per-file sort keys, so the sort comparator does no allocation and each file's line array is scanned once.

### How did you verify your code works?

- `bun bd test test/cli/test/coverage.test.ts` — 21 pass. New tests cover: full-XML snapshot, writing alongside lcov, XML escaping of `&` in filenames, the invalid-reporter error listing `cobertura`, threshold enforcement with cobertura-only **and** lcov-only reporters (exit 1 while the fixture's tests pass), `coveragePathIgnorePatterns`, and `coverageReporter = ["cobertura"]` via bunfig.
- `bun bd test test/cli/test/parallel.test.ts -t coverage` — 4 pass, including the new `--parallel --coverage writes cobertura.xml` merge test.
- `bun bd test test/js/junit-reporter/junit.test.js` — 9 pass (the JUnit reporter consumes the shared escaper; behavior unchanged).
- All 8 new tests fail with `USE_SYSTEM_BUN=1` (no cobertura reporter, thresholds not enforced without the text reporter) and pass with the branch build.