### PR TITLE
test: keep verdaccio users alive across createTestDir() calls

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1895,6 +1895,7 @@ export class VerdaccioRegistry {
 
   async start(silent: boolean = true) {
     await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
+    this.users = {};
     // Bind the IPv4 loopback explicitly: a bare port makes verdaccio listen on
     // whatever `localhost` resolves to, which is `::1` on hosts that list it first,
     // while the install client connects to 127.0.0.1 and every request is refused.
@@ -1993,12 +1994,10 @@ export class VerdaccioRegistry {
       files: {},
     },
   ) {
-    await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
     await rm(join(this.packagesPath, "private-pkg-dont-touch"), { force: true });
     const packageDir = tempDir("verdaccio-test-", opts.files ?? {});
     const packageJson = join(packageDir, "package.json");
     await this.writeBunfig(packageDir, opts.bunfigOpts);
-    this.users = {};
     return { packageDir: String(packageDir), packageJson };
   }
 


### PR DESCRIPTION
### Problem
- `VerdaccioRegistry.createTestDir()` (test/harness.ts) deleted the registry's htpasswd file and reset the harness's user map on every call. Verdaccio checks each authenticated request against that file, so a `createTestDir()` call in one test logged out every other test that ran at the same time.
- This blocks concurrent verdaccio tests that use a token. #40198 works around it by never calling `createTestDir()`. #38504 works around it with a serial `whoami` block.

### Fix
- `createTestDir()` no longer touches htpasswd or the user map. `start()` still begins each file with a fresh htpasswd (and now an empty user map), and `stop()` still removes the file.
- Correct because the reset was not needed: no test file creates the same verdaccio user twice, so the duplicate guard in `generateUser()` never fires. Users now accumulate in htpasswd for the life of one registry process, which is one test file.
- Verified: `bun bd test test/cli/install/npmrc.test.ts test/cli/install/config-precedence.test.ts` (91 pass) and `bun bd test test/cli/install/bun-install-registry.test.ts` (246 pass, 5 skip). These are the files that create verdaccio users. #40198 is rebased on this change.

### Background
- `VerdaccioRegistry` forks one verdaccio process per test file. Its users live in `test/cli/install/registry/htpasswd`. `generateUser()` creates a user through the registry's API and returns a token. `authBunfig()` wraps that token in a `bunfig.toml`.
- Verdaccio's default API tokens are legacy AES tokens. The registry decrypts the token on every request and verifies the user against htpasswd. A missing file makes every request anonymous, and a publish with a token then fails with 401.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->